### PR TITLE
bpo-45532: Replace 'default' with 'main' as default in sys.version

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-10-20-16-07-39.bpo-45532.kyhvis.rst
+++ b/Misc/NEWS.d/next/Build/2021-10-20-16-07-39.bpo-45532.kyhvis.rst
@@ -1,0 +1,2 @@
+Update :data:`sys.version` to use ``main`` as fallback information.
+Patch by Jeong YunWon.

--- a/Modules/getbuildinfo.c
+++ b/Modules/getbuildinfo.c
@@ -40,8 +40,9 @@ Py_GetBuildInfo(void)
     const char *revision = _Py_gitversion();
     const char *sep = *revision ? ":" : "";
     const char *gitid = _Py_gitidentifier();
-    if (!(*gitid))
-        gitid = "default";
+    if (!(*gitid)) {
+        gitid = "main";
+    }
     PyOS_snprintf(buildinfo, sizeof(buildinfo),
                   "%s%s%s, %.20s, %.9s", gitid, sep, revision,
                   DATE, TIME);


### PR DESCRIPTION


<!-- issue-number: [bpo-45532](https://bugs.python.org/issue45532) -->
https://bugs.python.org/issue45532
<!-- /issue-number -->
