### PR TITLE
bpo-39947: Add PyThreadState_SetTrace() function

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -482,6 +482,11 @@ New Features
   suspend and resume tracing and profiling.
   (Contributed by Victor Stinner in :issue:`43760`.)
 
+* Add new :c:func:`PyThreadState_SetProfile` and
+  :c:func:`PyThreadState_SetTrace` functions to set the profile and the trace
+  function of a Python thread state.
+  (Contributed by Victor Stinner in :issue:`39947`.)
+
 Porting to Python 3.11
 ----------------------
 

--- a/Include/cpython/ceval.h
+++ b/Include/cpython/ceval.h
@@ -5,9 +5,7 @@
 PyAPI_FUNC(PyObject *) _PyEval_CallTracing(PyObject *func, PyObject *args);
 
 PyAPI_FUNC(void) PyEval_SetProfile(Py_tracefunc, PyObject *);
-PyAPI_DATA(int) _PyEval_SetProfile(PyThreadState *tstate, Py_tracefunc func, PyObject *arg);
 PyAPI_FUNC(void) PyEval_SetTrace(Py_tracefunc, PyObject *);
-PyAPI_FUNC(int) _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg);
 PyAPI_FUNC(int) _PyEval_GetCoroutineOriginTrackingDepth(void);
 PyAPI_FUNC(int) _PyEval_SetAsyncGenFirstiter(PyObject *);
 PyAPI_FUNC(PyObject *) _PyEval_GetAsyncGenFirstiter(void);

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -192,6 +192,14 @@ PyAPI_FUNC(void) PyThreadState_EnterTracing(PyThreadState *tstate);
 // function is set, otherwise disable them.
 PyAPI_FUNC(void) PyThreadState_LeaveTracing(PyThreadState *tstate);
 
+PyAPI_FUNC(int) PyThreadState_SetProfile(PyThreadState *tstate,
+    Py_tracefunc func,
+    PyObject *arg);
+
+PyAPI_FUNC(int) PyThreadState_SetTrace(PyThreadState *tstate,
+    Py_tracefunc func,
+    PyObject *arg);
+
 /* PyGILState */
 
 /* Helper/diagnostic function - return 1 if the current thread

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -147,6 +147,16 @@ _PyThreadState_ResumeTracing(PyThreadState *tstate)
     tstate->cframe->use_tracing = (use_tracing ? 255 : 0);
 }
 
+#ifndef NDEBUG
+// Ensure that tstate is valid: sanity check for PyEval_AcquireThread() and
+// PyEval_RestoreThread(). Detect if tstate memory was freed. It can happen
+// when a thread continues to run after Python finalization, especially
+// daemon threads.
+//
+// Usage: assert(_PyThreadState_CheckConsistency(tstate));
+extern int _PyThreadState_CheckConsistency(PyThreadState *tstate);
+#endif
+
 
 /* Other */
 

--- a/Misc/NEWS.d/next/C API/2021-10-21-15-00-43.bpo-39947.KOqrdL.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-21-15-00-43.bpo-39947.KOqrdL.rst
@@ -1,0 +1,3 @@
+Add new :c:func:`PyThreadState_SetProfile` and
+:c:func:`PyThreadState_SetTrace` functions to set the profile and the trace
+function of a Python thread state. Patch by Victor Stinner.

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -674,7 +674,7 @@ profiler_enable(ProfilerObject *self, PyObject *args, PyObject *kwds)
     }
 
     PyThreadState *tstate = _PyThreadState_GET();
-    if (_PyEval_SetProfile(tstate, profiler_callback, (PyObject*)self) < 0) {
+    if (PyThreadState_SetProfile(tstate, profiler_callback, (PyObject*)self) < 0) {
         return NULL;
     }
 
@@ -708,7 +708,7 @@ static PyObject*
 profiler_disable(ProfilerObject *self, PyObject* noarg)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    if (_PyEval_SetProfile(tstate, NULL, NULL) < 0) {
+    if (PyThreadState_SetProfile(tstate, NULL, NULL) < 0) {
         return NULL;
     }
     self->flags &= ~POF_ENABLED;
@@ -745,7 +745,7 @@ profiler_dealloc(ProfilerObject *op)
 {
     if (op->flags & POF_ENABLED) {
         PyThreadState *tstate = _PyThreadState_GET();
-        if (_PyEval_SetProfile(tstate, NULL, NULL) < 0) {
+        if (PyThreadState_SetProfile(tstate, NULL, NULL) < 0) {
             PyErr_WriteUnraisable((PyObject *)op);
         }
     }

--- a/Python/ceval_gil.h
+++ b/Python/ceval_gil.h
@@ -173,7 +173,7 @@ drop_gil(struct _ceval_runtime_state *ceval, struct _ceval_state *ceval2,
         /* Not switched yet => wait */
         if (((PyThreadState*)_Py_atomic_load_relaxed(&gil->last_holder)) == tstate)
         {
-            assert(is_tstate_valid(tstate));
+            assert(_PyThreadState_CheckConsistency(tstate));
             RESET_GIL_DROP_REQUEST(tstate->interp);
             /* NOTE: if COND_WAIT does not atomically start waiting when
                releasing the mutex, another thread can run through, take
@@ -228,7 +228,7 @@ take_gil(PyThreadState *tstate)
         PyThread_exit_thread();
     }
 
-    assert(is_tstate_valid(tstate));
+    assert(_PyThreadState_CheckConsistency(tstate));
     PyInterpreterState *interp = tstate->interp;
     struct _ceval_runtime_state *ceval = &interp->runtime->ceval;
     struct _ceval_state *ceval2 = &interp->ceval;
@@ -264,7 +264,7 @@ take_gil(PyThreadState *tstate)
                 MUTEX_UNLOCK(gil->mutex);
                 PyThread_exit_thread();
             }
-            assert(is_tstate_valid(tstate));
+            assert(_PyThreadState_CheckConsistency(tstate));
 
             SET_GIL_DROP_REQUEST(interp);
         }
@@ -302,7 +302,7 @@ _ready:
         drop_gil(ceval, ceval2, tstate);
         PyThread_exit_thread();
     }
-    assert(is_tstate_valid(tstate));
+    assert(_PyThreadState_CheckConsistency(tstate));
 
     if (_Py_atomic_load_relaxed(&ceval2->gil_drop_request)) {
         RESET_GIL_DROP_REQUEST(interp);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -980,7 +980,7 @@ profile_trampoline(PyObject *self, PyFrameObject *frame,
     PyThreadState *tstate = _PyThreadState_GET();
     PyObject *result = call_trampoline(tstate, self, frame, what, arg);
     if (result == NULL) {
-        _PyEval_SetProfile(tstate, NULL, NULL);
+        PyThreadState_SetProfile(tstate, NULL, NULL);
         return -1;
     }
 
@@ -1006,7 +1006,7 @@ trace_trampoline(PyObject *self, PyFrameObject *frame,
     PyThreadState *tstate = _PyThreadState_GET();
     PyObject *result = call_trampoline(tstate, callback, frame, what, arg);
     if (result == NULL) {
-        _PyEval_SetTrace(tstate, NULL, NULL);
+        PyThreadState_SetTrace(tstate, NULL, NULL);
         Py_CLEAR(frame->f_trace);
         return -1;
     }
@@ -1029,12 +1029,12 @@ sys_settrace(PyObject *self, PyObject *args)
 
     PyThreadState *tstate = _PyThreadState_GET();
     if (args == Py_None) {
-        if (_PyEval_SetTrace(tstate, NULL, NULL) < 0) {
+        if (PyThreadState_SetTrace(tstate, NULL, NULL) < 0) {
             return NULL;
         }
     }
     else {
-        if (_PyEval_SetTrace(tstate, trace_trampoline, args) < 0) {
+        if (PyThreadState_SetTrace(tstate, trace_trampoline, args) < 0) {
             return NULL;
         }
     }
@@ -1078,12 +1078,12 @@ sys_setprofile(PyObject *self, PyObject *args)
 
     PyThreadState *tstate = _PyThreadState_GET();
     if (args == Py_None) {
-        if (_PyEval_SetProfile(tstate, NULL, NULL) < 0) {
+        if (PyThreadState_SetProfile(tstate, NULL, NULL) < 0) {
             return NULL;
         }
     }
     else {
-        if (_PyEval_SetProfile(tstate, profile_trampoline, args) < 0) {
+        if (PyThreadState_SetProfile(tstate, profile_trampoline, args) < 0) {
             return NULL;
         }
     }


### PR DESCRIPTION
Add new PyThreadState_SetProfile() and PyThreadState_SetTrace()
functions to set the profile and the trace function of a Python
thread state.

* Rename _PyEval_SetProfile() to PyThreadState_SetProfile().
* Rename _PyEval_SetTrace() to PyThreadState_SetTrace().
* Rename is_tstate_valid() to _PyThreadState_CheckConsistency().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-39947](https://bugs.python.org/issue39947) -->
https://bugs.python.org/issue39947
<!-- /issue-number -->
