### PR TITLE
bpo-43592: Raise RLIMIT_NOFILE in test.libregrtest

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -649,7 +649,7 @@ class Regrtest:
                 print(f"Raised RLIMIT_NOFILE to {new_fd_limit}.")
             except (ValueError, OSError) as err:
                 print(f"Unable to raise RLIMIT_NOFILE from {fd_limit} to "
-                      f"{new_fd_limit}: {err}".)
+                      f"{new_fd_limit}: {err}.")
 
     def main(self, tests=None, **kwargs):
         self.parse_args(kwargs)

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -661,6 +661,7 @@ class Regrtest:
             sys.exit(0)
 
         test_cwd = self.create_temp_dir()
+        self.adjust_resource_limits()
 
         try:
             # Run the tests in a context manager that temporarily changes the CWD

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -633,26 +633,6 @@ class Regrtest:
                 print("Remove file: %s" % name)
                 os_helper.unlink(name)
 
-    def adjust_resource_limits(self):
-        try:
-            import resource
-            from resource import RLIMIT_NOFILE, RLIM_INFINITY
-        except ImportError:
-            return
-        fd_limit, max_fds = resource.getrlimit(RLIMIT_NOFILE)
-        # On macOS the default fd limit is sometimes too low (256) for our
-        # test suite to succeed.  Raise it to something more reasonable.
-        # 1024 is a common Linux default.
-        desired_fds = 1024
-        if fd_limit < desired_fds and fd_limit < max_fds:
-            new_fd_limit = min(desired_fds, max_fds)
-            try:
-                resource.setrlimit(RLIMIT_NOFILE, (new_fd_limit, max_fds))
-                print(f"Raised RLIMIT_NOFILE: {fd_limit} -> {new_fd_limit}")
-            except (ValueError, OSError) as err:
-                print(f"Unable to raise RLIMIT_NOFILE from {fd_limit} to "
-                      f"{new_fd_limit}: {err}.")
-
     def main(self, tests=None, **kwargs):
         self.parse_args(kwargs)
 
@@ -663,7 +643,6 @@ class Regrtest:
             sys.exit(0)
 
         test_cwd = self.create_temp_dir()
-        self.adjust_resource_limits()
 
         try:
             # Run the tests in a context manager that temporarily changes the CWD

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -640,13 +640,15 @@ class Regrtest:
         except ImportError:
             return
         fd_limit, max_fds = resource.getrlimit(RLIMIT_NOFILE)
-        if fd_limit < 2000 and fd_limit < max_fds:
-            # On macOS the default fd limit is sometimes too low (256) for our
-            # test suite to succeed.  Raise it to something more reasonable.
-            new_fd_limit = min(2000, max_fds)
+        # On macOS the default fd limit is sometimes too low (256) for our
+        # test suite to succeed.  Raise it to something more reasonable.
+        # 1024 is a common Linux default.
+        desired_fds = 1024
+        if fd_limit < desired_fds and fd_limit < max_fds:
+            new_fd_limit = min(desired_fds, max_fds)
             try:
                 resource.setrlimit(RLIMIT_NOFILE, (new_fd_limit, max_fds))
-                print(f"Raised RLIMIT_NOFILE to {new_fd_limit}.")
+                print(f"Raised RLIMIT_NOFILE: {fd_limit} -> {new_fd_limit}")
             except (ValueError, OSError) as err:
                 print(f"Unable to raise RLIMIT_NOFILE from {fd_limit} to "
                       f"{new_fd_limit}: {err}.")

--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -39,6 +39,7 @@ def setup_tests(ns):
         for signum in signals:
             faulthandler.register(signum, chain=True, file=stderr_fd)
 
+    _adjust_resource_limits()
     replace_stdout()
     support.record_original_stdout(sys.stdout)
 
@@ -133,3 +134,26 @@ def replace_stdout():
         sys.stdout.close()
         sys.stdout = stdout
     atexit.register(restore_stdout)
+
+
+def _adjust_resource_limits():
+    """Adjust the system resource limits (ulimit) if needed."""
+    try:
+        import resource
+        from resource import RLIMIT_NOFILE, RLIM_INFINITY
+    except ImportError:
+        return
+    fd_limit, max_fds = resource.getrlimit(RLIMIT_NOFILE)
+    # On macOS the default fd limit is sometimes too low (256) for our
+    # test suite to succeed.  Raise it to something more reasonable.
+    # 1024 is a common Linux default.
+    desired_fds = 1024
+    if fd_limit < desired_fds and fd_limit < max_fds:
+        new_fd_limit = min(desired_fds, max_fds)
+        try:
+            resource.setrlimit(RLIMIT_NOFILE, (new_fd_limit, max_fds))
+            print(f"Raised RLIMIT_NOFILE: {fd_limit} -> {new_fd_limit}")
+        except (ValueError, OSError) as err:
+            print(f"Unable to raise RLIMIT_NOFILE from {fd_limit} to "
+                  f"{new_fd_limit}: {err}.")
+

--- a/Misc/NEWS.d/next/Tests/2021-10-21-17-22-26.bpo-43592.kHRsra.rst
+++ b/Misc/NEWS.d/next/Tests/2021-10-21-17-22-26.bpo-43592.kHRsra.rst
@@ -1,0 +1,3 @@
+:mod:`test.libregrtest` now raises the soft resource limit for the maximum
+number of file descriptors when the default is too low for our test suite as
+was often the case on macOS.


### PR DESCRIPTION
On macOS the default is often too low for our testsuite to succeed.

<!-- issue-number: [bpo-43592](https://bugs.python.org/issue43592) -->
https://bugs.python.org/issue43592
<!-- /issue-number -->
