### PR TITLE
bpo-45557: Fix underscore_numbers in pprint.pprint().

### DIFF
--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -50,7 +50,8 @@ def pprint(object, stream=None, indent=1, width=80, depth=None, *,
     """Pretty-print a Python object to a stream [default is sys.stdout]."""
     printer = PrettyPrinter(
         stream=stream, indent=indent, width=width, depth=depth,
-        compact=compact, sort_dicts=sort_dicts, underscore_numbers=False)
+        compact=compact, sort_dicts=sort_dicts,
+        underscore_numbers=underscore_numbers)
     printer.pprint(object)
 
 def pformat(object, indent=1, width=80, depth=None, *,

--- a/Misc/NEWS.d/next/Library/2021-10-21-16-18-51.bpo-45557.4MQt4r.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-21-16-18-51.bpo-45557.4MQt4r.rst
@@ -1,0 +1,2 @@
+pprint.pprint() now handles underscore_numbers correctly. Previously it was
+always setting it to False.


### PR DESCRIPTION
pprint.pprint() always passes `underscore_numbers=False` to pformat(), it should use `underscore_numbers=underscore_numbers`.

<!-- issue-number: [bpo-45557](https://bugs.python.org/issue45557) -->
https://bugs.python.org/issue45557
<!-- /issue-number -->
