### PR TITLE
gh-89721: shutil.copytree: Allow disabling copystat

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -226,8 +226,8 @@ Directory and files operations
 
 
 .. function:: copytree(src, dst, symlinks=False, ignore=None, \
-              copy_function=copy2, ignore_dangling_symlinks=False, \
-              dirs_exist_ok=False)
+              copy_stat=True, copy_function=copy2, \
+              ignore_dangling_symlinks=False, dirs_exist_ok=False)
 
    Recursively copy an entire directory tree rooted at *src* to a directory
    named *dst* and return the destination directory. *dirs_exist_ok* dictates
@@ -235,7 +235,10 @@ Directory and files operations
    already exists.
 
    Permissions and times of directories are copied with :func:`copystat`,
-   individual files are copied using :func:`~shutil.copy2`.
+   unless *copy_stat* is `False`. Individual files are copied using
+   :func:`~shutil.copy2` by default. Using `copy_stat=False` along with
+   `copy_function=shutil.copyfile` is useful when you wish to not use the
+   source permissions at all.
 
    If *symlinks* is true, symbolic links in the source tree are represented as
    symbolic links in the new tree and the metadata of the original links will

--- a/Misc/NEWS.d/next/Library/2021-10-23-07-16-33.bpo-45558.jGmQIV.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-23-07-16-33.bpo-45558.jGmQIV.rst
@@ -1,0 +1,1 @@
+:func:`shutil.copytree`: Add a ``copy_stat`` boolean option that controls whether permissions will be copied as well from the source directory.


### PR DESCRIPTION
Sometimes it is desirable to not copy any permissions and attributes from the source directory. This change allows disable running `copystat` after a copy.

<!-- issue-number: [bpo-45558](https://bugs.python.org/issue45558) -->
https://bugs.python.org/issue45558
<!-- /issue-number -->

<!-- gh-issue-number: gh-89721 -->
* Issue: gh-89721
<!-- /gh-issue-number -->
