### PR TITLE
Expand about soft keywords in the docs for keyword.py

### DIFF
--- a/Doc/library/keyword.rst
+++ b/Doc/library/keyword.rst
@@ -9,7 +9,7 @@
 --------------
 
 This module allows a Python program to determine if a string is a
-:ref:`keyword <keywords>`.
+:ref:`keyword <keywords>` or :ref:`soft keyword <soft-keywords>`.
 
 
 .. function:: iskeyword(s)
@@ -26,14 +26,14 @@ This module allows a Python program to determine if a string is a
 
 .. function:: issoftkeyword(s)
 
-   Return ``True`` if *s* is a Python soft :ref:`keyword <keywords>`.
+   Return ``True`` if *s* is a Python :ref:`soft keyword <soft-keywords>`.
 
    .. versionadded:: 3.9
 
 
 .. data:: softkwlist
 
-   Sequence containing all the soft :ref:`keywords <keywords>` defined for the
+   Sequence containing all the :ref:`soft keywords <soft-keywords>` defined for the
    interpreter.  If any soft keywords are defined to only be active when particular
    :mod:`__future__` statements are in effect, these will be included as well.
 


### PR DESCRIPTION
Add link at the top and fix the existing links to point to the "[soft keywords](https://docs.python.org/3.10/reference/lexical_analysis.html#soft-keywords)" section created in the Python 3.10 docs.

Changes should be backported to 3.10 as well.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:pablogsal