### PR TITLE
Revert "bpo-44019: Add test_all_exported_names for operator module"

### DIFF
--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -45,18 +45,6 @@ class BadIterable:
 
 
 class OperatorTestCase:
-    def test___all__(self):
-        operator = self.module
-        actual_all = set(operator.__all__)
-        computed_all = set()
-        for name in vars(operator):
-            if name.startswith('__'):
-                continue
-            value = getattr(operator, name)
-            if value.__module__ in ('operator', '_operator'):
-                computed_all.add(name)
-        self.assertSetEqual(computed_all, actual_all)
-
     def test_lt(self):
         operator = self.module
         self.assertRaises(TypeError, operator.lt)


### PR DESCRIPTION
Reverts python/cpython#29124

<!-- issue-number: [bpo-44019](https://bugs.python.org/issue44019) -->
https://bugs.python.org/issue44019
<!-- /issue-number -->
