### PR TITLE
[3.9] bpo-45520: Backport __getstate__, __setstate__ methods for `dataclasses` from 3.10 into 3.9 (GH-25786)

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2791,14 +2791,18 @@ class TestSlots(unittest.TestCase):
         # bpo-43999
         # bpo-45520
 
-        assert self.FrozenSlotsClass.__slots__ == ("foo", "bar")
+        self.assertEqual(self.FrozenSlotsClass.__slots__, ("foo", "bar"))
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             with self.subTest(proto=proto):
-                p = pickle.dumps(self.FrozenSlotsClass("a", 1), protocol=proto)
-                assert pickle.loads(p) == self.FrozenSlotsClass("a", 1)
+                obj = self.FrozenSlotsClass("a", 1)
+                p = pickle.loads(pickle.dumps(obj, protocol=proto))
+                self.assertIsNot(obj, p)
+                self.assertEqual(obj, p)
 
-                p = pickle.dumps(self.FrozenWithoutSlotsClass("a", 1), protocol=proto)
-                assert pickle.loads(p) == self.FrozenWithoutSlotsClass("a", 1)
+                obj = self.FrozenWithoutSlotsClass("a", 1)
+                p = pickle.loads(pickle.dumps(obj, protocol=proto))
+                self.assertIsNot(obj, p)
+                self.assertEqual(obj, p)
 
 class TestDescriptors(unittest.TestCase):
     def test_set_name(self):

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2775,6 +2775,31 @@ class TestSlots(unittest.TestCase):
         # We can add a new field to the derived instance.
         d.z = 10
 
+    # Can't be local to test_frozen_pickle.
+    @dataclass(frozen=True)
+    class FrozenSlotsClass:
+        __slots__ = ('foo', 'bar')
+        foo: str
+        bar: int
+
+    @dataclass(frozen=True)
+    class FrozenWithoutSlotsClass:
+        foo: str
+        bar: int
+
+    def test_frozen_pickle(self):
+        # bpo-43999
+        # bpo-45520
+
+        assert self.FrozenSlotsClass.__slots__ == ("foo", "bar")
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(proto=proto):
+                p = pickle.dumps(self.FrozenSlotsClass("a", 1), protocol=proto)
+                assert pickle.loads(p) == self.FrozenSlotsClass("a", 1)
+
+                p = pickle.dumps(self.FrozenWithoutSlotsClass("a", 1), protocol=proto)
+                assert pickle.loads(p) == self.FrozenWithoutSlotsClass("a", 1)
+
 class TestDescriptors(unittest.TestCase):
     def test_set_name(self):
         # See bpo-33141.

--- a/Misc/NEWS.d/next/Library/2021-10-22-11-02-26.bpo-45520._KpfOB.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-22-11-02-26.bpo-45520._KpfOB.rst
@@ -1,0 +1,3 @@
+Fix ``__getstate__`` and ``__setstate__`` methods for frozen
+``dataclasses``. It basically backports a part of 3.10's code to support
+``pickle`` and ``deepcopy``.


### PR DESCRIPTION
Refs https://github.com/python/cpython/commit/823fbf4e0eb66cbef0eacb7e8dbfb5dc8ea83b40

<!-- issue-number: [bpo-45520](https://bugs.python.org/issue45520) -->
https://bugs.python.org/issue45520
<!-- /issue-number -->
