### PR TITLE
bpo-45568: Actually use @asynccontextmanager in usage example

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -130,7 +130,9 @@ Functions and classes provided:
    either as decorators or with :keyword:`async with` statements::
 
      import time
+     from contextlib import asynccontextmanager
 
+     @asynccontextmanager
      async def timeit():
          now = time.monotonic()
          try:


### PR DESCRIPTION
https://bugs.python.org/issue45568

<!-- issue-number: [bpo-45568](https://bugs.python.org/issue45568) -->
https://bugs.python.org/issue45568
<!-- /issue-number -->

Automerge-Triggered-By: GH:asvetlov