### PR TITLE
bpo-43137: webbrowser: Replace gvfs-open and gnome-open with "gio open"

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -471,10 +471,6 @@ def register_X_browsers():
     if "GNOME_DESKTOP_SESSION_ID" in os.environ and shutil.which("gvfs-open"):
         register("gvfs-open", None, BackgroundBrowser("gvfs-open"))
 
-    # The default GNOME browser before 2008
-    if "GNOME_DESKTOP_SESSION_ID" in os.environ and shutil.which("gnome-open"):
-        register("gnome-open", None, BackgroundBrowser("gnome-open"))
-
     # The default KDE browser
     if "KDE_FULL_SESSION" in os.environ and shutil.which("kfmclient"):
         register("kfmclient", Konqueror, Konqueror("kfmclient"))

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -467,10 +467,6 @@ def register_X_browsers():
     if shutil.which("gio"):
         register("gio", None, BackgroundBrowser(["gio", "open", "--", "%s"]))
 
-    # Equivalent of gio open before 2015
-    if "GNOME_DESKTOP_SESSION_ID" in os.environ and shutil.which("gvfs-open"):
-        register("gvfs-open", None, BackgroundBrowser("gvfs-open"))
-
     # The default KDE browser
     if "KDE_FULL_SESSION" in os.environ and shutil.which("kfmclient"):
         register("kfmclient", Konqueror, Konqueror("kfmclient"))

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -462,11 +462,16 @@ def register_X_browsers():
     if shutil.which("xdg-open"):
         register("xdg-open", None, BackgroundBrowser("xdg-open"))
 
-    # The default GNOME3 browser
+    # Opens an appropriate browser for the URL scheme according to
+    # freedesktop.org settings (GNOME, KDE, XFCE, etc.)
+    if shutil.which("gio"):
+        register("gio", None, BackgroundBrowser(["gio", "open", "--", "%s"]))
+
+    # Equivalent of gio open before 2015
     if "GNOME_DESKTOP_SESSION_ID" in os.environ and shutil.which("gvfs-open"):
         register("gvfs-open", None, BackgroundBrowser("gvfs-open"))
 
-    # The default GNOME browser
+    # The default GNOME browser before 2008
     if "GNOME_DESKTOP_SESSION_ID" in os.environ and shutil.which("gnome-open"):
         register("gnome-open", None, BackgroundBrowser("gnome-open"))
 

--- a/Misc/NEWS.d/next/Library/2021-10-25-12-51-02.bpo-43137.apo7jY.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-25-12-51-02.bpo-43137.apo7jY.rst
@@ -1,0 +1,1 @@
+Launch GNOME web browsers via gio tool instead of obsolete gvfs-open


### PR DESCRIPTION
* [bpo-43137](https://bugs.python.org/issue43137): webbrowser: Prefer gio open over gvfs-open
    
    gvfs-open(1) was superseded by gio(1) in 2015, and removed from GNOME
    releases in 2018. Debian and its derivatives like Ubuntu currently still
    have a compatibility shim for gvfs-open, but we plan to remove it.
    
    webbrowser prefers xdg-settings and xdg-open over gvfs-open, so this
    will only have any practical effect on systems where the xdg-utils
    package is not installed.
    
    Note that we don't check for GNOME_DESKTOP_SESSION_ID before using gio.
    gio does the right thing on any desktop environment that follows
    freedesktop.org specifications, similar to xdg-settings, so it's
    unnecessary to guard in this way. GNOME_DESKTOP_SESSION_ID was deprecated
    in 2008 and removed from upstream gnome-session in 2018 (it's still
    present in Debian/Ubuntu for backward compatibility, but probably
    shouldn't be). The replacement way to detect a desktop environment is
    the XDG_CURRENT_DESKTOP environment variable, which is a colon-separated
    sequence where the first item is the current desktop environment and the
    second and subsequent items (if present) are other desktop environments
    that it resembles or is based on.
    
    Resolves: https://bugs.python.org/issue43137

* [bpo-43137](https://bugs.python.org/issue43137): webbrowser: Never invoke gnome-open
    
    gnome-open was part of GNOME 2, which was superseded in around 2010 and
    is unmaintained. The replacement was gvfs-open, which was subsequently
    replaced by gio(1) (as used in the previous commit).

* [bpo-43137](https://bugs.python.org/issue43137): webbrowser: Don't run gvfs-open on GNOME
    
    gvfs-open was deprecated in 2015 and removed in 2018. The replacement
    is gio(1) (as used in a previous commit).
    
    GNOME_DESKTOP_SESSION_ID was deprecated in 2008 and removed in 2018.
    The replacement is XDG_CURRENT_DESKTOP (as mentioned in a previous
    commit).

---

To test this on a typical modern Linux system, it is necessary to disable the `xdg-settings` and `xdg-open` code paths, for example with this hack:

<details><summary>Hack to disable use of xdg-settings and xdg-open</summary>

```diff
diff --git a/Lib/webbrowser.py b/Lib/webbrowser.py
index 3244f206aa..8f6c09d1d2 100755
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -459,7 +459,7 @@ def open(self, url, new=0, autoraise=True):
 def register_X_browsers():
 
     # use xdg-open if around
-    if shutil.which("xdg-open"):
+    if 0 and shutil.which("xdg-open"):
         register("xdg-open", None, BackgroundBrowser("xdg-open"))
 
     # Opens an appropriate browser for the URL scheme according to
@@ -549,7 +549,7 @@ def register_standard_browsers():
         # Prefer X browsers if present
         if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
             try:
-                cmd = "xdg-settings get default-web-browser".split()
+                cmd = "false xdg-settings get default-web-browser".split()
                 raw_result = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
                 result = raw_result.decode().strip()
             except (FileNotFoundError, subprocess.CalledProcessError, PermissionError, NotADirectoryError) :
```

</details>

I haven't attempted to assess which of the specific web browsers such as Galeon are still extant, and which ones disappeared years ago. They could almost certainly be cleaned up, but that's beyond the scope of this PR.

<!-- issue-number: [bpo-43137](https://bugs.python.org/issue43137) -->
https://bugs.python.org/issue43137
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco