### PR TITLE
bpo-45570: Simplify setup macros for pyexpat

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-10-22-14-45-40.bpo-45570.61gM2A.rst
+++ b/Misc/NEWS.d/next/Build/2021-10-22-14-45-40.bpo-45570.61gM2A.rst
@@ -1,0 +1,1 @@
+:mod:`pyexpat` and :mod:`_elementtree` no longer define obsolete macros ``HAVE_EXPAT_CONFIG_H`` and ``USE_PYEXPAT_CAPI``. ``XML_POOR_ENTROPY`` is now defined in ``expat_config.h``.

--- a/Modules/Setup
+++ b/Modules/Setup
@@ -149,7 +149,7 @@ time timemodule.c
 #_contextvars _contextvarsmodule.c
 #_csv _csv.c
 #_datetime _datetimemodule.c
-#_elementtree -DHAVE_EXPAT_CONFIG_H -DUSE_PYEXPAT_CAPI -I$(srcdir)/Modules/expat _elementtree.c
+#_elementtree -I$(srcdir)/Modules/expat _elementtree.c
 #_heapq _heapqmodule.c
 #_json _json.c
 #_lsprof _lsprof.c rotatingtree.c
@@ -173,7 +173,7 @@ time timemodule.c
 #binascii binascii.c
 #cmath cmathmodule.c _math.c  # -lm
 #math mathmodule.c _math.c  # -lm
-#pyexpat -DHAVE_EXPAT_CONFIG_H -DXML_POOR_ENTROPY -DUSE_PYEXPAT_CAPI -I$(srcdir)/Modules/expat  expat/xmlparse.c expat/xmlrole.c expat/xmltok.c pyexpat.c
+#pyexpat -I$(srcdir)/Modules/expat  expat/xmlparse.c expat/xmlrole.c expat/xmltok.c pyexpat.c
 #unicodedata  unicodedata.c
 
 # Modules with some UNIX dependencies -- on by default:

--- a/Modules/expat/expat_config.h
+++ b/Modules/expat/expat_config.h
@@ -18,4 +18,8 @@
 #define XML_DTD 1
 #define XML_CONTEXT_BYTES 1024
 
+// bpo-30947: Python uses best available entropy sources to
+// call XML_SetHashSalt(), expat entropy sources are not needed
+#define XML_POOR_ENTROPY 1
+
 #endif /* EXPAT_CONFIG_H */

--- a/PCbuild/_elementtree.vcxproj
+++ b/PCbuild/_elementtree.vcxproj
@@ -94,7 +94,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>..\Modules\expat;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;USE_PYEXPAT_CAPI;XML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;XML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/PCbuild/pyexpat.vcxproj
+++ b/PCbuild/pyexpat.vcxproj
@@ -91,7 +91,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(PySourcePath)Modules\expat;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;PYEXPAT_EXPORTS;HAVE_EXPAT_H;XML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;PYEXPAT_EXPORTS;XML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/setup.py
+++ b/setup.py
@@ -1748,19 +1748,12 @@ class PyBuildExt(build_ext):
         #
         if '--with-system-expat' in sysconfig.get_config_var("CONFIG_ARGS"):
             expat_inc = []
-            define_macros = []
             extra_compile_args = []
             expat_lib = ['expat']
             expat_sources = []
             expat_depends = []
         else:
             expat_inc = [os.path.join(self.srcdir, 'Modules', 'expat')]
-            define_macros = [
-                ('HAVE_EXPAT_CONFIG_H', '1'),
-                # bpo-30947: Python uses best available entropy sources to
-                # call XML_SetHashSalt(), expat entropy sources are not needed
-                ('XML_POOR_ENTROPY', '1'),
-            ]
             extra_compile_args = []
             # bpo-44394: libexpat uses isnan() of math.h and needs linkage
             # against the libm
@@ -1788,7 +1781,6 @@ class PyBuildExt(build_ext):
                 extra_compile_args.append('-Wno-unreachable-code')
 
         self.add(Extension('pyexpat',
-                           define_macros=define_macros,
                            extra_compile_args=extra_compile_args,
                            include_dirs=expat_inc,
                            libraries=expat_lib,
@@ -1799,9 +1791,7 @@ class PyBuildExt(build_ext):
         # uses expat (via the CAPI hook in pyexpat).
 
         if os.path.isfile(os.path.join(self.srcdir, 'Modules', '_elementtree.c')):
-            define_macros.append(('USE_PYEXPAT_CAPI', None))
             self.add(Extension('_elementtree',
-                               define_macros=define_macros,
                                include_dirs=expat_inc,
                                libraries=expat_lib,
                                sources=['_elementtree.c'],


### PR DESCRIPTION
* ``HAVE_EXPAT_CONFIG_H`` is not used by our code and not used by
  system-wide expat header files
* ``USE_PYEXPAT_CAPI`` is no longer used by our code
* ``XML_POOR_ENTROPY`` should be defined in expat_config.h

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45570](https://bugs.python.org/issue45570) -->
https://bugs.python.org/issue45570
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran