### PR TITLE
bpo-45126: Ensure sqlite3.Connection is unusable if __init__ fails

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-10-22-15-05-10.bpo-45126.roRvx-.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-22-15-05-10.bpo-45126.roRvx-.rst
@@ -1,0 +1,6 @@
+Prevent segfault if :class:`sqlite3.Connection` reinitialisation fails.
+
+.. warning::
+
+  :class:`sqlite3.Connection` is not adviced, as it may produce undesired
+  side-effects. Creating a new object is preferred to reinitialisation.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -160,9 +160,8 @@ pysqlite_connection_init_impl(pysqlite_Connection *self,
     Py_XSETREF(self->text_factory, (PyObject*)&PyUnicode_Type);
 
     self->db = NULL;
-    sqlite3 *db;
     Py_BEGIN_ALLOW_THREADS
-    rc = sqlite3_open_v2(database, &db,
+    rc = sqlite3_open_v2(database, &self->db,
                          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE |
                          (uri ? SQLITE_OPEN_URI : 0), NULL);
     Py_END_ALLOW_THREADS
@@ -171,7 +170,6 @@ pysqlite_connection_init_impl(pysqlite_Connection *self,
         _pysqlite_seterror(state, self->db);
         goto error;
     }
-    self->db = db;
 
     if (!isolation_level) {
         isolation_level = PyUnicode_FromString("");


### PR DESCRIPTION
If `sqlite3.Connection.__init__()` fails, explicitly set `self->db` and
`self->initialized` to NULL/zero.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45126](https://bugs.python.org/issue45126) -->
https://bugs.python.org/issue45126
<!-- /issue-number -->
