### PR TITLE
bpo-44665: asyncio.create_task() documentation should mention user needs to keep reference to the task

### DIFF
--- a/Doc/library/asyncio-future.rst
+++ b/Doc/library/asyncio-future.rst
@@ -54,6 +54,9 @@ Future Functions
       See also the :func:`create_task` function which is the
       preferred way for creating new Tasks.
 
+      Save a reference to the result of this function, to avoid
+      a task disappearing mid execution.
+
    .. versionchanged:: 3.5.1
       The function accepts any :term:`awaitable` object.
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -271,6 +271,11 @@ Creating Tasks
        task = asyncio.ensure_future(coro())
        ...
 
+   .. important::
+
+      Save a reference to the result of this function, to avoid
+      a task disappearing mid execution.
+
    .. versionadded:: 3.7
 
    .. versionchanged:: 3.8


### PR DESCRIPTION
See https://bugs.python.org/issue42538 also.

<!-- issue-number: [bpo-44665](https://bugs.python.org/issue44665) -->
https://bugs.python.org/issue44665
<!-- /issue-number -->
