### PR TITLE
bpo-45574: fix warning about `print_escape` being unused

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-10-22-23-06-33.bpo-45574.svqA84.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-22-23-06-33.bpo-45574.svqA84.rst
@@ -1,0 +1,1 @@
+Fix warning about ``print_escape`` being unused.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -995,6 +995,7 @@ tok_underflow_file(struct tok_state *tok) {
     return tok->done == E_OK;
 }
 
+#if defined(Py_DEBUG)
 static void
 print_escape(FILE *f, const char *s, Py_ssize_t size)
 {
@@ -1021,6 +1022,7 @@ print_escape(FILE *f, const char *s, Py_ssize_t size)
     }
     putc('"', f);
 }
+#endif
 
 /* Get next char, updating state; error code goes into tok->done */
 


### PR DESCRIPTION
It used to be like this:
<img width="1232" alt="Снимок экрана 2021-10-22 в 23 07 40" src="https://user-images.githubusercontent.com/4660275/138516608-fef6ec01-a96a-40f4-81ef-52265b0f536b.png">

Quick `grep` tells that it is just used in one place under `Py_DEBUG`: https://github.com/python/cpython/blame/f6e8b80d20159596cf641305bad3a833bedd2f4f/Parser/tokenizer.c#L1047-L1051
<img width="752" alt="Снимок экрана 2021-10-22 в 23 08 09" src="https://user-images.githubusercontent.com/4660275/138516684-ea503136-1e92-48a5-95bb-419e190d5866.png">

I am not sure, but it also looks like a private thing, it should not affect other users.

<!-- issue-number: [bpo-45574](https://bugs.python.org/issue45574) -->
https://bugs.python.org/issue45574
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal