### PR TITLE
gh-89679: improve TraversableResources's documentation

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -859,14 +859,16 @@ ABC hierarchy::
 .. class:: TraversableResources
 
     An abstract base class for resource readers capable of serving
-    the :meth:`importlib.resources.files` interface. Subclasses
-    :class:`importlib.abc.ResourceReader` and provides
-    concrete implementations of the :class:`importlib.abc.ResourceReader`'s
-    abstract methods. Therefore, any loader supplying
-    :class:`importlib.abc.TraversableReader` also supplies ResourceReader.
+    the :meth:`importlib.resources.files` interface. This class inherits from
+    :class:`importlib.abc.ResourceReader` and provides concrete implementations
+    of the :class:`importlib.abc.ResourceReader`'s abstract methods given the
+    provided ``files`` implementation. Therefore, any loader supplying
+    :class:`importlib.abc.TraversableReader` also supplies
+    :class:`importlib.abc.ResourceReader`.
 
     Loaders that wish to support resource reading are expected to
-    implement this interface.
+    implement this interface, instead of implementing
+    :class:`importlib.abc.ResourceReader` directly.
 
     .. versionadded:: 3.9
 

--- a/Misc/NEWS.d/next/Documentation/2021-10-22-22-12-18.bpo-45516.dcghqS.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-10-22-22-12-18.bpo-45516.dcghqS.rst
@@ -1,0 +1,1 @@
+Improve :class:`importlib.abc.TraversableResources`'s documentation.


### PR DESCRIPTION
This was my attempt at rewriting `TraversableResources` description to make it a bit clearer to people who are not familiar with the other protocols. I don't think I did a great job, but hopefully is a bit better.

Does anyone have any suggestions on how to improve this?

<!-- issue-number: [bpo-45516](https://bugs.python.org/issue45516) -->
https://bugs.python.org/issue45516
<!-- /issue-number -->


<!-- gh-issue-number: gh-89679 -->
* Issue: gh-89679
<!-- /gh-issue-number -->
