### PR TITLE
gh-89542: raise import error on FROZEN_BAD_NAME

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -627,7 +627,7 @@ Porting to Python 3.11
   been included directly, consider including ``Python.h`` instead.
   (Contributed by Victor Stinner in :issue:`35134`.)
 
-* The :c:func:`PyImport_ImportFrozenModuleObject` functions now raises
+* The :c:func:`PyImport_ImportFrozenModuleObject` function now raises
   :exc:`ImportError` if a bad module name was passed, instead of failing to find
   the module. Code that does not validate the ``modname`` parameter needs to be
   updated to either do so, or handle the exception.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -627,6 +627,11 @@ Porting to Python 3.11
   been included directly, consider including ``Python.h`` instead.
   (Contributed by Victor Stinner in :issue:`35134`.)
 
+* The :c:func:`PyImport_ImportFrozenModuleObject` functions now raises
+  :exc:`ImportError` if a bad module name was passed, instead of failing to find
+  the module. Code that does not validate the ``modname`` parameter needs to be
+  updated to either do so, or handle the exception.
+
 Deprecated
 ----------
 

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -921,7 +921,10 @@ class FrozenImporter:
 
     @classmethod
     def find_spec(cls, fullname, path=None, target=None):
-        info = _call_with_frames_removed(_imp.find_frozen, fullname)
+        try:
+            info = _call_with_frames_removed(_imp.find_frozen, fullname)
+        except ImportError:
+            return None
         if info is None:
             return None
         # We get the marshaled data in exec_module() (the loader

--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-23-00-55-22.bpo-45379.ShZAZ7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-23-00-55-22.bpo-45379.ShZAZ7.rst
@@ -1,0 +1,2 @@
+Raise :exc:`ImportError` in :c:func:`PyImport_ImportFrozenModuleObject` when
+the name object is invalid.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-23-00-55-22.bpo-45379.ShZAZ7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-23-00-55-22.bpo-45379.ShZAZ7.rst
@@ -1,2 +1,2 @@
-Raise :exc:`ImportError` in :c:func:`PyImport_ImportFrozenModuleObject` when
-the name object is invalid.
+Previously :c:func:`PyImport_ImportFrozenModuleObject` treated a bad module name
+the same as if no frozen module were found.  Now it raises :exc:`ImportError` in that case.

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1863,7 +1863,7 @@ static int assert_frozen_module_validation_error(PyObject *name)
 
     if (!PyObject_IsInstance(value, PyExc_ImportError)) {
         if (error_format("invalid error type, expecting ImportError but got %R", value)) {
-            error("invalid error string");
+            error("invalid error type");
         }
         return 1;
     }

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -11,6 +11,7 @@
 #include "pycore_import.h"        // _PyImport_FrozenBootstrap
 #include <Python.h>
 #include <inttypes.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>               // putenv()
 #include <wchar.h>
@@ -36,6 +37,26 @@ static void error(const char *msg)
 {
     fprintf(stderr, "ERROR: %s\n", msg);
     fflush(stderr);
+}
+
+
+static int error_format(const char *format, ...) {
+    PyObject *err_msg, *err_msg_bytes;
+    va_list vargs;
+
+    va_start(vargs, format);
+
+    err_msg = PyUnicode_FromFormatV(format, vargs);
+    if (err_msg) {
+        err_msg_bytes = PyUnicode_EncodeLocale(err_msg, NULL);
+        Py_DECREF(err_msg);
+        if (err_msg_bytes) {
+            error(PyBytes_AsString(err_msg_bytes));
+            Py_DECREF(err_msg_bytes);
+            return 0;
+        }
+    }
+    return 1;
 }
 
 
@@ -1822,6 +1843,78 @@ static int test_frozenmain(void)
 #endif  // !MS_WINDOWS
 
 
+static int assert_frozen_module_validation_error(PyObject *name)
+{
+    PyObject *type, *value, *traceback, *actual, *expected;
+
+    expected = PyUnicode_FromString("Invalid frozen object name (None)");
+    if (!expected) {
+        error("failed to created expected string object");
+        return 1;
+    }
+
+    PyImport_ImportFrozenModuleObject(name);
+
+    PyErr_Fetch(&type, &value, &traceback);
+    if (!value) {
+        error("no error raised");
+        return 1;
+    }
+
+    if (!PyObject_IsInstance(value, PyExc_ImportError)) {
+        if (error_format("invalid error type, expecting ImportError but got %R", value)) {
+            error("invalid error string");
+        }
+        return 1;
+    }
+
+    actual = PyObject_GetAttrString(value, "msg");
+    if (!actual) {
+        error("failed to fetch error message");
+    }
+
+    int rc = PyObject_RichCompareBool(actual, expected, Py_EQ);
+    switch (rc) {
+        case -1:
+            error("failed to compare error string");
+            goto error;
+        case 0:
+            if (error_format("invalid error string, got %R but expected %R", actual, expected)) {
+                error("invalid error string");
+            }
+            goto error;
+    }
+    Py_DECREF(expected);
+    return 0;
+
+error:
+    Py_DECREF(expected);
+    return 1;
+}
+
+
+static int test_import_frozen_module_null(void)
+{
+    int rc;
+
+    _testembed_Py_Initialize();
+    rc = assert_frozen_module_validation_error(NULL);
+    Py_Finalize();
+    return rc;
+}
+
+
+static int test_import_frozen_module_none(void)
+{
+    int rc;
+
+    _testembed_Py_Initialize();
+    rc = assert_frozen_module_validation_error(Py_None);
+    Py_Finalize();
+    return rc;
+}
+
+
 // List frozen modules.
 // Command used by Tools/scripts/generate_stdlib_module_names.py script.
 static int list_frozen(void)
@@ -1953,6 +2046,8 @@ static struct TestCase TestCases[] = {
 #ifndef MS_WINDOWS
     {"test_frozenmain", test_frozenmain},
 #endif
+    {"test_import_frozen_module_null", test_import_frozen_module_null},
+    {"test_import_frozen_module_none", test_import_frozen_module_none},
 
     // Command
     {"list_frozen", list_frozen},

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1857,7 +1857,7 @@ static int assert_frozen_module_validation_error(PyObject *name)
 
     PyErr_Fetch(&type, &value, &traceback);
     if (!value) {
-        error("no error raised");
+        error("no error raised, expecting ImportError");
         return 1;
     }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -1282,11 +1282,6 @@ find_frozen(PyObject *nameobj, struct frozen_info *info)
     }
     const char *name = PyUnicode_AsUTF8(nameobj);
     if (name == NULL) {
-        // Note that this function previously used
-        // _PyUnicode_EqualToASCIIString().  We clear the error here
-        // (instead of propagating it) to match the earlier behavior
-        // more closely.
-        PyErr_Clear();
         return FROZEN_BAD_NAME;
     }
 
@@ -2150,7 +2145,8 @@ _imp_find_frozen_impl(PyObject *module, PyObject *name, int withdata)
         Py_RETURN_NONE;
     }
     else if (status == FROZEN_BAD_NAME) {
-        Py_RETURN_NONE;
+        set_frozen_error(status, name);
+        return NULL;
     }
     else if (status != FROZEN_OKAY) {
         set_frozen_error(status, name);

--- a/Python/import.c
+++ b/Python/import.c
@@ -1354,6 +1354,8 @@ PyImport_ImportFrozenModuleObject(PyObject *name)
         return 0;
     }
     else if (status != FROZEN_OKAY) {
+        /* FYI, FROZEN_BAD_NAME used to be treated like FROZEN_NOT_FOUND.
+            See bpo-45379. */
         if (name == NULL) {
             name = Py_None;
         }

--- a/Python/import.c
+++ b/Python/import.c
@@ -1204,11 +1204,13 @@ set_frozen_error(frozen_status status, PyObject *modname)
             Py_UNREACHABLE();
     }
     if (err != NULL) {
+        PyObject *type, *value, *traceback;
+        PyErr_Fetch(&type, &value, &traceback);
         PyObject *msg = PyUnicode_FromFormat(err, modname);
         if (msg == NULL) {
             PyErr_Clear();
         }
-        PyErr_SetImportError(msg, modname, NULL);
+        PyErr_SetImportError(msg, modname, traceback);
         Py_XDECREF(msg);
     }
 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -1183,6 +1183,8 @@ set_frozen_error(frozen_status status, PyObject *modname)
     const char *err = NULL;
     switch (status) {
         case FROZEN_BAD_NAME:
+            err = "Invalid frozen object name (%R)";
+            break;
         case FROZEN_NOT_FOUND:
             err = "No such frozen object named %R";
             break;
@@ -1351,10 +1353,10 @@ PyImport_ImportFrozenModuleObject(PyObject *name)
     if (status == FROZEN_NOT_FOUND || status == FROZEN_DISABLED) {
         return 0;
     }
-    else if (status == FROZEN_BAD_NAME) {
-        return 0;
-    }
     else if (status != FROZEN_OKAY) {
+        if (name == NULL) {
+            name = Py_None;
+        }
         set_frozen_error(status, name);
         return -1;
     }


### PR DESCRIPTION
```
>>> from ctypes import py_object, pythonapi as capi
>>> capi.PyImport_ImportFrozenModuleObject(py_object(None))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: Invalid frozen object name (None)
```

Signed-off-by: Filipe Laíns <lains@riseup.net>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45379](https://bugs.python.org/issue45379) -->
https://bugs.python.org/issue45379
<!-- /issue-number -->

<!-- gh-issue-number: gh-89542 -->
* Issue: gh-89542
<!-- /gh-issue-number -->
