### PR TITLE
bpo-45583: Correct datamodel.rst documentation of int()

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2577,8 +2577,8 @@ left undefined.
    return the value of the object truncated to an :class:`~numbers.Integral`
    (typically an :class:`int`).
 
-   If :meth:`__int__` is not defined then the built-in function :func:`int`
-   falls back to :meth:`__trunc__`.
+   The built-in function :func:`int` falls back to :meth:`__trunc__` if neither
+   :meth:`__int__` nor :meth:`__index__` is defined.
 
 
 .. _context-managers:


### PR DESCRIPTION
# [bpo-45583](https://bugs.python.org/issue45583): Correct datamodel.rst documentation of int()

It should be noted that this part of the documentation is redundant with
function.rst's documentation of int. This one was correctly updated with Python 3.8

<!-- issue-number: [bpo-45583](https://bugs.python.org/issue45583) -->
https://bugs.python.org/issue45583
<!-- /issue-number -->
