### PR TITLE
bpo-45584: Clarify the meaning of `truncate` in documentation

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -298,7 +298,7 @@ Number-theoretic and representation functions
 
 .. function:: trunc(x)
 
-   Given a :class:`~numbers.Real` value *x*, return *x* with the fractional part
+   Return *x* with the fractional part
    removed, leaving the integer part.  This rounds toward 0: ``trunc()`` is
    equivalent to :func:`floor` for positive *x*, and equivalent to :func:`ceil`
    for negative *x*. If *x* is not a float, delegates to :meth:`x.__trunc__

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -32,8 +32,8 @@ Number-theoretic and representation functions
 .. function:: ceil(x)
 
    Return the ceiling of *x*, the smallest integer greater than or equal to *x*.
-   If *x* is not a float, delegates to ``x.__ceil__()``, which should return an
-   :class:`~numbers.Integral` value.
+   If *x* is not a float, delegates to :meth:`x.__ceil__ <object.__ceil__>`,
+   which should return an :class:`~numbers.Integral` value.
 
 
 .. function:: comb(n, k)
@@ -77,9 +77,9 @@ Number-theoretic and representation functions
 
 .. function:: floor(x)
 
-   Return the floor of *x*, the largest integer less than or equal to *x*.
-   If *x* is not a float, delegates to ``x.__floor__()``, which should return an
-   :class:`~numbers.Integral` value.
+   Return the floor of *x*, the largest integer less than or equal to *x*.  If
+   *x* is not a float, delegates to :meth:`x.__ceil__ <object.__floor__>`, which
+   should return an :class:`~numbers.Integral` value.
 
 
 .. function:: fmod(x, y)

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -78,7 +78,7 @@ Number-theoretic and representation functions
 .. function:: floor(x)
 
    Return the floor of *x*, the largest integer less than or equal to *x*.  If
-   *x* is not a float, delegates to :meth:`x.__ceil__ <object.__floor__>`, which
+   *x* is not a float, delegates to :meth:`x.__floor__ <object.__floor__>`, which
    should return an :class:`~numbers.Integral` value.
 
 
@@ -300,10 +300,9 @@ Number-theoretic and representation functions
 
    Given a :class:`~numbers.Real` value *x*, return *x* with the fractional part
    removed, leaving the integer part.  This rounds toward 0: ``trunc()`` is
-   equivalent to :func:`floor` for positive *x*, and equivalent to :func:`ceil` for
-   negative *x*. If *x* is not a float, delegates to
-   :meth:`x.__trunc__ <object.__trunc__>`, which should return an
-   :class:`~numbers.Integral` value.
+   equivalent to :func:`floor` for positive *x*, and equivalent to :func:`ceil`
+   for negative *x*. If *x* is not a float, delegates to :meth:`x.__trunc__
+   <object.__trunc__>`, which should return an :class:`~numbers.Integral` value.
 
 .. function:: ulp(x)
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -298,11 +298,10 @@ Number-theoretic and representation functions
 
 .. function:: trunc(x)
 
-   Return the :class:`~numbers.Real` value *x* truncated to an
-   :class:`~numbers.Integral` (usually an integer). Truncating *x* means
-   removing the digits after the decimal separator, hence rounding toward 0. It
-   is equivalent to floor and ceil for positive and negative numbers
-   respectively.  Delegates to :meth:`x.__trunc__() <object.__trunc__>`.
+   Return *x* with the fractional part removed, leaving the integer part.  This
+   rounds toward 0 and is equivalent to floor and ceil for positive and negative
+   *x* respectively.  If *x* is not a float, delegates to :meth:`x.__trunc__()
+   <object.__trunc__>`, which should return an :class:`~numbers.Integral` value.
 
 .. function:: ulp(x)
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -302,7 +302,7 @@ Number-theoretic and representation functions
    removed, leaving the integer part.  This rounds toward 0: ``trunc()`` is
    equivalent to :func:`floor` for positive *x*, and equivalent to :func:`ceil` for
    negative *x*. If *x* is not a float, ``trunc()`` delegates to
-   :meth:`x.__trunc__()<object.__trunc__>`, which should return an
+   :meth:`x.__trunc__ <object.__trunc__>`, which should return an
    :class:`~numbers.Integral` value if properly defined.
 
 .. function:: ulp(x)

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -301,9 +301,9 @@ Number-theoretic and representation functions
    Given a :class:`~numbers.Real` value *x*, return *x* with the fractional part
    removed, leaving the integer part.  This rounds toward 0: ``trunc()`` is
    equivalent to :func:`floor` for positive *x*, and equivalent to :func:`ceil` for
-   negative *x*. If *x* is not a float, ``trunc()`` delegates to
+   negative *x*. If *x* is not a float, delegates to
    :meth:`x.__trunc__ <object.__trunc__>`, which should return an
-   :class:`~numbers.Integral` value if properly defined.
+   :class:`~numbers.Integral` value.
 
 .. function:: ulp(x)
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -298,10 +298,12 @@ Number-theoretic and representation functions
 
 .. function:: trunc(x)
 
-   Return *x* with the fractional part removed, leaving the integer part.  This
-   rounds toward 0 and is equivalent to floor and ceil for positive and negative
-   *x* respectively.  If *x* is not a float, delegates to :meth:`x.__trunc__()
-   <object.__trunc__>`, which should return an :class:`~numbers.Integral` value.
+   Given a :class:`~numbers.Real` value *x*, return *x* with the fractional part
+   removed, leaving the integer part.  This rounds toward 0: ``trunc()`` is
+   equivalent to :func:`floor` for positive *x*, and equivalent to :func:`ceil` for
+   negative *x*. If *x* is not a float, ``trunc()`` delegates to
+   :meth:`x.__trunc__()<object.__trunc__>`, which should return an
+   :class:`~numbers.Integral` value if properly defined.
 
 .. function:: ulp(x)
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -299,8 +299,10 @@ Number-theoretic and representation functions
 .. function:: trunc(x)
 
    Return the :class:`~numbers.Real` value *x* truncated to an
-   :class:`~numbers.Integral` (usually an integer). Delegates to
-   :meth:`x.__trunc__() <object.__trunc__>`.
+   :class:`~numbers.Integral` (usually an integer). Truncating *x* means
+   removing the digits after the decimal separator, hence rounding toward 0. It
+   is equivalent to floor and ceil for positive and negative numbers
+   respectively.  Delegates to :meth:`x.__trunc__() <object.__trunc__>`.
 
 .. function:: ulp(x)
 


### PR DESCRIPTION
# [bpo-45584](https://bugs.python.org/issue45584): Clarify the meaning of `truncate` in documentation

While floor/ceil 's documentation are very precise, `truncate` was not explained. I actually had to search online to understand the difference between `truncate` and `floor` (admittedly, once I remembered that numbers are signed, and that floating numbers actually uses a bit for negation symbol instead of two complement, it became obvious)

I assume that I won't be the only user having this trouble, especially for people whose mother tongue is not English. So I suggest adding a clarification to help make what should be obvious to most actually explicit

<!-- issue-number: [bpo-45584](https://bugs.python.org/issue45584) -->
https://bugs.python.org/issue45584
<!-- /issue-number -->
