### PR TITLE
bpo-20749: Copy security warning to shutil

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -657,6 +657,13 @@ provided.  They rely on the :mod:`zipfile` and :mod:`tarfile` modules.
    registered for that extension.  In case none is found,
    a :exc:`ValueError` is raised.
 
+   .. warning::
+
+      Never extract archives from untrusted sources without prior inspection.
+      It is possible that files are created outside of *path*, e.g. members
+      that have absolute filenames starting with ``"/"`` or filenames with two
+      dots ``".."``.
+
    .. audit-event:: shutil.unpack_archive filename,extract_dir,format shutil.unpack_archive
 
    .. versionchanged:: 3.7

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1727,6 +1727,7 @@ Andrew Svetlov
 Paul Swartz
 Dennis Sweeney
 Al Sweigart
+Christopher Swenson
 Sviatoslav Sydorenko
 Thenault Sylvain
 Péter Szabó

--- a/Misc/NEWS.d/next/Security/2021-10-22-19-07-53.bpo-20749.hi0GfC.rst
+++ b/Misc/NEWS.d/next/Security/2021-10-22-19-07-53.bpo-20749.hi0GfC.rst
@@ -1,2 +1,2 @@
-Copied security warning from ``tarfile.extractall()`` to
-``shutil.unpack_archive()``
+Copied security warning from :func:`tarfile.extractall()` to
+:func:`shutil.unpack_archive()`.

--- a/Misc/NEWS.d/next/Security/2021-10-22-19-07-53.bpo-20749.hi0GfC.rst
+++ b/Misc/NEWS.d/next/Security/2021-10-22-19-07-53.bpo-20749.hi0GfC.rst
@@ -1,0 +1,2 @@
+Copied security warning from ``tarfile.extractall()`` to
+``shutil.unpack_archive()``


### PR DESCRIPTION
* Copied warning from `tarfile.extractall()` to `shutil.unpack_archive`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-20749](https://bugs.python.org/issue20749) -->
https://bugs.python.org/issue20749
<!-- /issue-number -->
