### PR TITLE
bpo-45588: Add a cached_method decorator

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -110,6 +110,30 @@ The :mod:`functools` module defines the following functions:
    .. versionadded:: 3.8
 
 
+.. decorator:: cached_method(func)
+               cached_method(maxsize=None, typed=False)
+
+   Cache a class method on a per-instance basis. The cached method will behave as if each
+   instance of the class had its own :func:`lru_cache`. By default, the cache size is
+   unbounded but the cache size can be limited in the same was as for `lru_cache`::
+
+       class Vector:
+           def __init__(self, coordinates):
+               self.coordinates = coordinates
+
+           @cached_method
+           def norm(self, p=2):
+               return sum(abs(c) ** p for c in self.coordinates) ** (1 / p)
+
+           @cached_method(maxsize=1)
+           def extend_zeros(self, n):
+               return Vector(self.coordinates + [0.0] * n)
+
+   In multi-threading contexts, the cached method may be called multiple times
+   concurrently with the same arguments.
+
+   .. versionadded:: 3.11
+
 .. function:: cmp_to_key(func)
 
    Transform an old-style comparison function to a :term:`key function`.  Used

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1054,6 +1054,7 @@ Xuanji Li
 Zekun Li
 Zheao Li
 Dan Lidral-Porter
+Marten Lienen
 Robert van Liere
 Ross Light
 Shawn Ligocki

--- a/Misc/NEWS.d/next/Library/2021-10-23-14-53-10.bpo-45588.OQZsyw.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-23-14-53-10.bpo-45588.OQZsyw.rst
@@ -1,0 +1,1 @@
+Add :func:`functools.cached_method` to cache methods.


### PR DESCRIPTION
We have `lru_cache` and its simpler cousin `cache` to cache functions and
`cached_property` to cache dynamic properties on objects. This commit extends the
functionality with `cached_method` for caching methods.

While `lru_cache` can be applied to methods, it suffers from two problems which
`cached_method` avoids. First, `lru_cache`ing a method shares a single cache between all
objects. This can increase the hit-rate if the objects have a meaningful hash value but in
the case of `hash(obj) == id(obj)` leads to no additional hits. Furthermore, such a cache
stays around when the objects are freed, potentially accumulating gargabe over time.
`cached_method` on the other hand attaches individual caches to each object, so that they
get freed as the objects get gargabe collected. Second, if a method is annotated with
`lru_cache`, the cache is associated with the class object and practically acts as a
global register of all objects of that class (that had a cached method called on them at
least once). This prohibits gargabe collection without taking extra care to clear the
cache of cached methods. `cached_method` has individual caches per object and uses weak
references internally to avoid reference cycles.

<!-- issue-number: [bpo-45588](https://bugs.python.org/issue45588) -->
https://bugs.python.org/issue45588
<!-- /issue-number -->
