### PR TITLE
bpo-45587: Distinguish title and description arguments from **kwargs in add_argument_group methods

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1952,7 +1952,7 @@ Argument groups
    :meth:`add_argument_group` method::
 
      >>> parser = argparse.ArgumentParser(prog='PROG', add_help=False)
-     >>> group = parser.add_argument_group('group')
+     >>> group = parser.add_argument_group(title='group')
      >>> group.add_argument('--foo', help='foo help')
      >>> group.add_argument('bar', help='bar help')
      >>> parser.print_help()
@@ -1971,9 +1971,9 @@ Argument groups
    customize this display::
 
      >>> parser = argparse.ArgumentParser(prog='PROG', add_help=False)
-     >>> group1 = parser.add_argument_group('group1', 'group1 description')
+     >>> group1 = parser.add_argument_group(title='group1', description='group1 description')
      >>> group1.add_argument('foo', help='foo help')
-     >>> group2 = parser.add_argument_group('group2', 'group2 description')
+     >>> group2 = parser.add_argument_group(title='group2', description='group2 description')
      >>> group2.add_argument('--bar', help='bar help')
      >>> parser.print_help()
      usage: PROG [--bar BAR] foo

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1239,6 +1239,7 @@ class _SubParsersAction(Action):
             vars(namespace).setdefault(_UNRECOGNIZED_ARGS_ATTR, [])
             getattr(namespace, _UNRECOGNIZED_ARGS_ATTR).extend(arg_strings)
 
+
 class _ExtendAction(_AppendAction):
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest, None)
@@ -1460,8 +1461,11 @@ class _ActionsContainer(object):
 
         return self._add_action(action)
 
-    def add_argument_group(self, *args, **kwargs):
-        group = _ArgumentGroup(self, *args, **kwargs)
+    def add_argument_group(self, title=None, description=None, **kwargs):
+        group = _ArgumentGroup(self,
+                               title=title,
+                               description=description,
+                               **kwargs)
         self._action_groups.append(group)
         return group
 
@@ -1762,8 +1766,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         self.exit_on_error = exit_on_error
 
         add_group = self.add_argument_group
-        self._positionals = add_group(_('positional arguments'))
-        self._optionals = add_group(_('options'))
+        self._positionals = add_group(title=_('positional arguments'))
+        self._optionals = add_group(title=_('options'))
         self._subparsers = None
 
         # register types
@@ -1817,7 +1821,9 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         if 'title' in kwargs or 'description' in kwargs:
             title = _(kwargs.pop('title', 'subcommands'))
             description = _(kwargs.pop('description', None))
-            self._subparsers = self.add_argument_group(title, description)
+            self._subparsers = self.add_argument_group(
+                title=title,
+                description=description)
         else:
             self._subparsers = self._positionals
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -160,6 +160,7 @@ Brice Berna
 Olivier Bernard
 Vivien Bernet-Rollande
 Maxwell Bernstein
+Jay Berry
 Eric Beser
 Steven Bethard
 Stephen Bevan

--- a/Misc/NEWS.d/next/Library/2021-10-23-14-08-59.bpo-45587.1-DdhN.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-23-14-08-59.bpo-45587.1-DdhN.rst
@@ -1,0 +1,3 @@
+Change :meth:`add_argument_group`'s signature from
+`add_argument_group(*args, **kwargs)` to `add_argument_group(title=None,
+description=None, **kwargs)` for clarity on the important keyword arguments.

--- a/Misc/NEWS.d/next/Library/2021-10-23-14-08-59.bpo-45587.1-DdhN.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-23-14-08-59.bpo-45587.1-DdhN.rst
@@ -1,3 +1,4 @@
-Change :meth:`add_argument_group`'s signature from
-`add_argument_group(*args, **kwargs)` to `add_argument_group(title=None,
-description=None, **kwargs)` for clarity on the important keyword arguments.
+Change :meth:`argparse._ActionsContainer.add_argument_group`'s signature
+from ``add_argument_group(*args, **kwargs)`` to
+``add_argument_group(title=None, description=None, **kwargs)`` for clarity
+on the important keyword arguments.


### PR DESCRIPTION
Hi, this adds clarity to the `add_argument_group` method within the `argparse` module by separating the important `title` and `description` keyword arguments from the other `**kwargs`.

The method signature has been changed from
`add_argument_group(self, *args, **kwargs)` to
`add_argument_group(self, title=None, description=None, **kwargs)`

Observe that `*args` has been removed; it was never used. This is a backwards compatible change as any code that uses eg `parser.add_argument_group('myTitle', 'myDescription')` will fill out the first two correct keyword arguments, which was already the existing behaviour.

The documentation has been made consistent to these changes.

<!-- issue-number: [bpo-45587](https://bugs.python.org/issue45587) -->
https://bugs.python.org/issue45587
<!-- /issue-number -->
