### PR TITLE
bpo-45335: Add note to `sqlite3` docs about "timestamp" converter

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1049,17 +1049,12 @@ If a timestamp stored in SQLite has a fractional part longer than 6
 numbers, its value will be truncated to microsecond precision by the
 timestamp converter.
 
-.. warning::
+.. note::
 
-   The "timestamp" converter ignores UTC offsets in the database and always
-   returns a naive :class:`datetime.datetime` object, so if you read a timestamp
-   from the database with converters enabled and then write it back, any UTC
-   offset will be lost.
-
-   If you need to preserve UTC offsets in timestamps, then either leave
-   converters disabled, or register your own offset-aware converter with
-   :func:`register_converter` to override the default one.
-
+   The default "timestamp" converter ignores UTC offsets in the database and
+   always returns a naive :class:`datetime.datetime` object. To preserve UTC
+   offsets in timestamps, either leave converters disabled, or register an
+   offset-aware converter with :func:`register_converter`.
 
 .. _sqlite3-controlling-transactions:
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1049,6 +1049,17 @@ If a timestamp stored in SQLite has a fractional part longer than 6
 numbers, its value will be truncated to microsecond precision by the
 timestamp converter.
 
+.. warning::
+
+   The "timestamp" converter ignores UTC offsets in the database and always
+   returns a naive :class:`datetime.datetime` object, so if you read a timestamp
+   from the database with converters enabled and then write it back, any UTC
+   offset will be lost.
+
+   If you need to preserve UTC offsets in timestamps, then either leave
+   converters disabled, or register your own offset-aware converter with
+   :func:`register_converter` to override the default one.
+
 
 .. _sqlite3-controlling-transactions:
 


### PR DESCRIPTION
See https://discuss.python.org/t/fixing-sqlite-timestamp-converter-to-handle-utc-offsets/10985 for further discussion of this issue.

<!-- issue-number: [bpo-45335](https://bugs.python.org/issue45335) -->
https://bugs.python.org/issue45335
<!-- /issue-number -->
