### PR TITLE
bpo-45548: Remove checks for finite and gamma (GH-29206)

### DIFF
--- a/configure
+++ b/configure
@@ -15092,7 +15092,7 @@ fi
 LIBS_SAVE=$LIBS
 LIBS="$LIBS $LIBM"
 
-for ac_func in acosh asinh atanh erf erfc expm1 finite gamma lgamma log1p log2 tgamma
+for ac_func in acosh asinh atanh erf erfc expm1 log1p log2
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.ac
+++ b/configure.ac
@@ -4693,7 +4693,7 @@ LIBS_SAVE=$LIBS
 LIBS="$LIBS $LIBM"
 
 AC_CHECK_FUNCS(
-  [acosh asinh atanh erf erfc expm1 finite gamma lgamma log1p log2 tgamma],
+  [acosh asinh atanh erf erfc expm1 log1p log2],
   [],
   [AC_MSG_ERROR([Python requires C99 compatible libm])]
 )

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -353,9 +353,6 @@
 /* Define to 1 if you have the `fexecve' function. */
 #undef HAVE_FEXECVE
 
-/* Define to 1 if you have the `finite' function. */
-#undef HAVE_FINITE
-
 /* Define to 1 if you have the `flock' function. */
 #undef HAVE_FLOCK
 
@@ -406,9 +403,6 @@
 
 /* Define to 1 if you have the `gai_strerror' function. */
 #undef HAVE_GAI_STRERROR
-
-/* Define to 1 if you have the `gamma' function. */
-#undef HAVE_GAMMA
 
 /* Define if we can use gcc inline assembler to get and set mc68881 fpcr */
 #undef HAVE_GCC_ASM_FOR_MC68881
@@ -585,9 +579,6 @@
 
 /* Define to 1 if you have the `lchown' function. */
 #undef HAVE_LCHOWN
-
-/* Define to 1 if you have the `lgamma' function. */
-#undef HAVE_LGAMMA
 
 /* Define to 1 if you have the `dl' library (-ldl). */
 #undef HAVE_LIBDL
@@ -1237,9 +1228,6 @@
 
 /* Define to 1 if you have the <term.h> header file. */
 #undef HAVE_TERM_H
-
-/* Define to 1 if you have the `tgamma' function. */
-#undef HAVE_TGAMMA
 
 /* Define to 1 if you have the `timegm' function. */
 #undef HAVE_TIMEGM


### PR DESCRIPTION
HAVE_FINITE and HAVE_*GAMMA are not used any more. This fixes a build
issue. Configure doesn't detect finite and gamma on macOS.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45548](https://bugs.python.org/issue45548) -->
https://bugs.python.org/issue45548
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran