### PR TITLE
bpo-45438: format of inspect.Signature with generic builtins

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1325,6 +1325,8 @@ def getargvalues(frame):
 def formatannotation(annotation, base_module=None):
     if getattr(annotation, '__module__', None) == 'typing':
         return repr(annotation).replace('typing.', '')
+    if isinstance(annotation, types.GenericAlias):
+        return str(annotation)
     if isinstance(annotation, type):
         if annotation.__module__ in ('builtins', base_module):
             return annotation.__qualname__

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -3236,6 +3236,17 @@ class TestSignatureObject(unittest.TestCase):
             pass
         self.assertEqual(str(inspect.signature(foo)), '()')
 
+        def foo(a: list[str]) -> tuple[str, float]:
+            pass
+        self.assertEqual(str(inspect.signature(foo)),
+                         '(a: list[str]) -> tuple[str, float]')
+
+        from typing import Tuple
+        def foo(a: list[str]) -> Tuple[str, float]:
+            pass
+        self.assertEqual(str(inspect.signature(foo)),
+                         '(a: list[str]) -> Tuple[str, float]')
+
     def test_signature_str_positional_only(self):
         P = inspect.Parameter
         S = inspect.Signature

--- a/Misc/NEWS.d/next/Library/2021-10-27-10-05-39.bpo-45438.Xz5lGU.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-27-10-05-39.bpo-45438.Xz5lGU.rst
@@ -1,0 +1,1 @@
+Fix typing.Signature string representation for generic builtin types.


### PR DESCRIPTION
- Use `isinstance(annotation,types.GenericAlias)` in `inspect.formatannotation` to correctly add type arguments of builtin types to the string representation of Signatures.
- Add test case for generic signature formatting.



<!-- issue-number: [bpo-45438](https://bugs.python.org/issue45438) -->
https://bugs.python.org/issue45438
<!-- /issue-number -->
