### PR TITLE
bpo-45466: Add download feature to urllib.request module

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1354,6 +1354,23 @@ The following example uses no proxies at all, overriding environment settings::
    ...     f.read().decode('utf-8')
    ...
 
+.. _urllib-request-cli:
+
+:mod:`urllib.request` can also be invoked directly using the :option:`-m`
+switch of the interpreter with an ``URL`` argument::
+
+        python -m urllib.request https://python.org/
+
+By default, the downloaded data is printed to stdout.  The option ``-o/--output``
+specifies an output file where the downloaded data is stored instead of being
+printed::
+
+        python -m urllib.request https://python.org/ --output python.html
+
+If the output file already exists, its content is overwritten.
+
+.. versionadded:: 3.11
+
 
 Legacy interface
 ----------------

--- a/Lib/test/test_urllib2_localnet.py
+++ b/Lib/test/test_urllib2_localnet.py
@@ -668,7 +668,7 @@ class TestUrlopen(unittest.TestCase):
         handler = self.start_server([(200, [], content)])
         proc = subprocess.run(
             [sys.executable, "-m", "urllib.request",
-            "http://localhost:%s" % handler.port],
+            f"http://localhost:{handler.port}"],
             capture_output=True
         )
         self.assertEqual(proc.stdout, content)
@@ -681,11 +681,11 @@ class TestUrlopen(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             for option in ["--output", "-o"]:
                 filename = os.path.join(
-                    directory, "download-test%s.txt" % option
+                    directory, f"download-test{option}.txt"
                 )
                 proc = subprocess.run(
                     [sys.executable, "-m", "urllib.request",
-                    "http://localhost:%s" % handler.port,
+                    f"http://localhost:{handler.port}",
                     option, filename],
                     capture_output=True
                 )

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -2781,3 +2781,30 @@ else:
     # By default use environment variables
     getproxies = getproxies_environment
     proxy_bypass = proxy_bypass_environment
+
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser
+    from sys import stdout
+
+    parser = ArgumentParser(
+        description="Download the provided URL (FTP/HTTP/HTTPS supported) "
+        "and print it to stdout by default. If specified, write to OUTPUT "
+        "instead."
+    )
+    parser.add_argument("URL", help="(encoded) URL to download")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="write to OUTPUT instead of stdout"
+    )
+    args = parser.parse_args()
+    out = stdout.buffer if args.output is None else open(args.output, "wb")
+
+    with urlopen(args.URL) as response:
+        while data := response.read(1024 * 1024):
+            out.write(data)
+
+    if out is not stdout.buffer:
+        out.close()

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -2783,7 +2783,7 @@ else:
     proxy_bypass = proxy_bypass_environment
 
 
-if __name__ == "__main__":
+def _download():
     from argparse import ArgumentParser
     from sys import stdout
 
@@ -2808,3 +2808,7 @@ if __name__ == "__main__":
 
     if out is not stdout.buffer:
         out.close()
+
+
+if __name__ == "__main__":
+    _download()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -76,6 +76,7 @@ Jason Asbahr
 David Ascher
 Ammar Askar
 Neil Aspinall
+Peter Åstrand
 Chris AtLee
 Aymeric Augustin
 Andres Ayala
@@ -491,6 +492,7 @@ Daniel Ellis
 Phil Elson
 David Ely
 Victor van den Elzen
+Vlad Emelianov
 Jeff Epler
 Tom Epperly
 Gökcen Eraslan
@@ -1384,6 +1386,7 @@ Jean-François Piéronne
 Oleg Plakhotnyuk
 Anatoliy Platonov
 Marcel Plch
+Thomas Pohl
 Remi Pointel
 Jon Poler
 Ariel Poliak
@@ -1998,8 +2001,5 @@ Tarek Ziadé
 Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
-Peter Åstrand
-Vlad Emelianov
-Andrey Doroschenko
 
 (Entries should be added in rough alphabetical order by last names)

--- a/Misc/NEWS.d/next/Library/2021-10-26-07-02-51.bpo-45466.DOzSv2.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-26-07-02-51.bpo-45466.DOzSv2.rst
@@ -1,0 +1,3 @@
+The :mod:`urllib.request` module can download files (e.g. ``python -m
+urrlib.request https://python.org/``). For more info, call ``python -m
+urrlib.request -h``. Patch by Thomas Pohl.

--- a/Misc/NEWS.d/next/Library/2021-10-26-07-02-51.bpo-45466.DOzSv2.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-26-07-02-51.bpo-45466.DOzSv2.rst
@@ -1,3 +1,3 @@
-The :mod:`urllib.request` module can download files (e.g. ``python -m
-urrlib.request https://python.org/``). For more info, call ``python -m
-urrlib.request -h``. Patch by Thomas Pohl.
+The :mod:`urllib.request` module can now download files (e.g.
+``python -m urllib.request https://python.org/``). For more
+info, see ``python -m urllib.request -h``. Patch by Thomas Pohl.


### PR DESCRIPTION
Similar to http.server, the `urllib.request` could offer a download functionality:

```
python -m urllib.request https://python.org/ --output file.html
```

To keep the code lean, `output` is the only optional parameter.
A typical use case could be downloading some installation scripts or other data from within a container where curl/wget is not available.


<!-- issue-number: [bpo-45466](https://bugs.python.org/issue45466) -->
https://bugs.python.org/issue45466
<!-- /issue-number -->
