### PR TITLE
bpo-45608: Document missing `sqlite3` DB-API attributes and methods

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -169,7 +169,7 @@ Module functions and constants
      con = sqlite3.connect(":memory:")
      con.execute("""
          select * from pragma_compile_options
-         where compile_options like 'THREADSAFE=%%'
+         where compile_options like 'THREADSAFE=%'
      """).fetchall()
 
    Note that the `SQLITE_THREADSAFE levels

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -748,6 +748,14 @@ Cursor Objects
       The cursor will be unusable from this point forward; a :exc:`ProgrammingError`
       exception will be raised if any operation is attempted with the cursor.
 
+   .. method:: setinputsizes(sizes)
+
+      Required by the DB-API. Is a no-op in :mod:`sqlite3`.
+
+   .. method:: setoutputsize(size [, column])
+
+      Required by the DB-API. Is a no-op in :mod:`sqlite3`.
+
    .. attribute:: rowcount
 
       Although the :class:`Cursor` class of the :mod:`sqlite3` module implements this

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -117,6 +117,24 @@ Module functions and constants
 ------------------------------
 
 
+.. data:: apilevel
+
+   String constant stating the supported DB-API level. Required by the DB-API.
+   Hard-coded to ``"2.0"``.
+
+.. data:: paramstyle
+
+   String constant stating the type of parameter marker formatting expected by
+   the :mod:`sqlite3` module. Required by the DB-API. Hard-coded to
+   ``"qmark"``.
+
+   .. note::
+
+      The :mod:`sqlite3` module supports both ``qmark`` and ``numeric`` DB-API
+      parameter styles, because that is what the underlying SQLite library
+      supports. However, the DB-API does not allow multiple values for
+      the ``paramstyle`` attribute.
+
 .. data:: version
 
    The version number of this module, as a string. This is not the version of
@@ -137,6 +155,26 @@ Module functions and constants
 .. data:: sqlite_version_info
 
    The version number of the run-time SQLite library, as a tuple of integers.
+
+
+.. data:: threadsafety
+
+   Integer constant required by the DB-API, stating the level of thread safety
+   the :mod:`sqlite3` supports. Currently hard-coded to ``1``, meaning
+   _"Threads may share the module, but not connections."_ However, this may not
+   always be true. You can check the underlying SQLite library's compile-time
+   threaded mode using the following query::
+
+     >>> import sqlite3
+     >>> con = sqlite3.connect(":memory:")
+     >>> con.execute("""
+         select * from pragma_compile_options
+         where compile_options like 'THREADSAFE=%'
+     """).fetchall()
+
+   Note that the `SQLITE_THREADSAFE levels
+   <https://sqlite.org/compile.html#threadsafe>`_ do not match the DB-API 2.0
+   ``threadsafety`` levels.
 
 
 .. data:: PARSE_DECLTYPES

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -161,7 +161,7 @@ Module functions and constants
 
    Integer constant required by the DB-API, stating the level of thread safety
    the :mod:`sqlite3` supports. Currently hard-coded to ``1``, meaning
-   _"Threads may share the module, but not connections."_ However, this may not
+   *"Threads may share the module, but not connections."* However, this may not
    always be true. You can check the underlying SQLite library's compile-time
    threaded mode using the following query::
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -168,9 +168,9 @@ Module functions and constants
      >>> import sqlite3
      >>> con = sqlite3.connect(":memory:")
      >>> con.execute("""
-         select * from pragma_compile_options
-         where compile_options like 'THREADSAFE=%'
-     """).fetchall()
+             select * from pragma_compile_options
+             where compile_options like 'THREADSAFE=%'
+         """).fetchall()
 
    Note that the `SQLITE_THREADSAFE levels
    <https://sqlite.org/compile.html#threadsafe>`_ do not match the DB-API 2.0

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -165,12 +165,12 @@ Module functions and constants
    always be true. You can check the underlying SQLite library's compile-time
    threaded mode using the following query::
 
-     >>> import sqlite3
-     >>> con = sqlite3.connect(":memory:")
-     >>> con.execute("""
-             select * from pragma_compile_options
-             where compile_options like 'THREADSAFE=%'
-         """).fetchall()
+     import sqlite3
+     con = sqlite3.connect(":memory:")
+     con.execute("""
+         select * from pragma_compile_options
+         where compile_options like 'THREADSAFE=%%'
+     """).fetchall()
 
    Note that the `SQLITE_THREADSAFE levels
    <https://sqlite.org/compile.html#threadsafe>`_ do not match the DB-API 2.0

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -160,7 +160,7 @@ Module functions and constants
 .. data:: threadsafety
 
    Integer constant required by the DB-API, stating the level of thread safety
-   the :mod:`sqlite3` supports. Currently hard-coded to ``1``, meaning
+   the :mod:`sqlite3` module supports. Currently hard-coded to ``1``, meaning
    *"Threads may share the module, but not connections."* However, this may not
    always be true. You can check the underlying SQLite library's compile-time
    threaded mode using the following query::


### PR DESCRIPTION
Document DB-API required attributes and methods:

- `sqlite3.apilevel`
- `sqlite3.paramstyle`
- `sqlite3.threadsafety`
- `sqlite3.Cursor.setinputsizes()`
- `sqlite3.Cursor.setoutputsize()`

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45608](https://bugs.python.org/issue45608) -->
https://bugs.python.org/issue45608
<!-- /issue-number -->
