### PR TITLE
gh-89708: premptively fail on contextlib.chdir if we can't chdir back

### DIFF
--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -774,7 +774,12 @@ class chdir(AbstractContextManager):
         self._old_cwd = []
 
     def __enter__(self):
-        self._old_cwd.append(os.getcwd())
+        # try to chdir to the current cwd so that we preemptively fail if we are
+        # unnable to chdir back to it, see bpo-45545
+        old_cwd = os.getcwd()
+        os.chdir(old_cwd)
+
+        self._old_cwd.append(old_cwd)
         os.chdir(self.path)
 
     def __exit__(self, *excinfo):

--- a/Misc/NEWS.d/next/Library/2021-10-26-01-22-33.bpo-45545.QvsfXK.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-26-01-22-33.bpo-45545.QvsfXK.rst
@@ -1,0 +1,2 @@
+Premptively fail in :func:`contextdir.chdir` if we can't change back to the
+original directory.


### PR DESCRIPTION
Alternative to #29218

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45545](https://bugs.python.org/issue45545) -->
https://bugs.python.org/issue45545
<!-- /issue-number -->

<!-- gh-issue-number: gh-89708 -->
* Issue: gh-89708
<!-- /gh-issue-number -->
