### PR TITLE
Fix typo in Counter documentation

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -343,7 +343,7 @@ All of those tests treat missing elements as having zero counts so that
 ``Counter(a=1) == Counter(a=1, b=0)`` returns true.
 
 .. versionadded:: 3.10
-   Rich comparison operations we were added
+   Rich comparison operations were added
 
 .. versionchanged:: 3.10
    In equality tests, missing elements are treated as having zero counts.

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -343,7 +343,7 @@ All of those tests treat missing elements as having zero counts so that
 ``Counter(a=1) == Counter(a=1, b=0)`` returns true.
 
 .. versionadded:: 3.10
-   Rich comparison operations were added
+   Rich comparison operations were added.
 
 .. versionchanged:: 3.10
    In equality tests, missing elements are treated as having zero counts.


### PR DESCRIPTION

Fixed a small typo in `collections` documentation related to `Counter`.