### PR TITLE
bpo-45604: add `level` argument to `multiprocessing.log_to_stderr` func

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2636,12 +2636,13 @@ handler type) for messages from different processes to get mixed up.
    inherited.
 
 .. currentmodule:: multiprocessing
-.. function:: log_to_stderr()
+.. function:: log_to_stderr(level=None)
 
    This function performs a call to :func:`get_logger` but in addition to
    returning the logger created by get_logger, it adds a handler which sends
    output to :data:`sys.stderr` using format
    ``'[%(levelname)s/%(processName)s] %(message)s'``.
+   You can modify ``levelname`` of the logger by passing a ``level`` argument.
 
 Below is an example session with logging turned on::
 

--- a/Misc/NEWS.d/next/Documentation/2021-10-26-10-00-45.bpo-45604.Dm-YhV.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-10-26-10-00-45.bpo-45604.Dm-YhV.rst
@@ -1,0 +1,1 @@
+Add ``level`` argument to ``multiprocessing.log_to_stderr`` function docs.


### PR DESCRIPTION


<!-- issue-number: [bpo-45604](https://bugs.python.org/issue45604) -->
https://bugs.python.org/issue45604
<!-- /issue-number -->
