### PR TITLE
bpo-45618: Fix documentation build by pinning Docutils version

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -4,8 +4,8 @@
 # won't suddenly cause build failures. Updating the version is fine as long
 # as no warnings are raised by doing so.
 sphinx==3.2.1
-# Docutils version is pinned to a version compatible with the Sphinx
-# version being used. It can be removed after bumping Sphinx version to at
+# Docutils version is pinned to a version compatible with Sphinx
+# version 3.2.1. It can be removed after bumping Sphinx version to at
 # least 3.5.4.
 docutils==0.17.1
 

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -4,6 +4,10 @@
 # won't suddenly cause build failures. Updating the version is fine as long
 # as no warnings are raised by doing so.
 sphinx==3.2.1
+# Docutils version is pinned to a version compatible with the Sphinx
+# version being used. It can be removed after bumping Sphinx version to at
+# least 3.5.4.
+docutils==0.17.1
 
 blurb
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Since the release of Docutils 0.18 today building Python documentation fails.

In CPython repository we have Sphinx pinned to 3.2.1, which has too loose requirement for Docutils version in install_requires – docutils>=0.12.

Example of failing build: https://github.com/python/python-docs-pl/runs/4009459257.

The pin can be removed after bumping Sphinx to at least 3.5.4, which introduced upper limit for docutils version.

https://github.com/sphinx-doc/sphinx/commit/9263eea38379822e053c67ad1d17036d724c5e41


<!-- issue-number: [bpo-45618](https://bugs.python.org/issue45618) -->
https://bugs.python.org/issue45618
<!-- /issue-number -->
