### PR TITLE
bpo-45619: documentation of execution model: clarify and update binding summary

### DIFF
--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -62,7 +62,7 @@ The following constructs bind names:
 * class definitions,
 * function definitions,
 * assignment expressions,
-* :token:`targets <python-grammar:target>` that are identifiers if occurring in
+* :ref:`targets <assignment>` that are identifiers if occurring in
   an assignment:
 
   + :keyword:`for` loop header,

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -56,15 +56,25 @@ Binding of names
 
 .. index:: single: from; import statement
 
-The following constructs bind names: formal parameters to functions,
-:keyword:`import` statements, class and function definitions (these bind the
-class or function name in the defining block), and targets that are identifiers
-if occurring in an assignment, :keyword:`for` loop header, or after
-:keyword:`!as` in a :keyword:`with` statement or :keyword:`except` clause.
-The :keyword:`!import` statement
-of the form ``from ... import *`` binds all names defined in the imported
-module, except those beginning with an underscore.  This form may only be used
-at the module level.
+The following constructs bind names:
+
+* formal parameters to functions,
+* class definitions,
+* function definitions,
+* assignment expressions,
+* :token:`targets <python-grammar:target>` that are identifiers if occurring in
+  an assignment:
+
+  + :keyword:`for` loop header,
+  + after :keyword:`!as` in a :keyword:`with` statement, :keyword:`except`
+    clause or in the as-pattern in structural pattern matching,
+  + in a capture pattern in structural pattern matching
+
+* :keyword:`import` statements.
+
+The :keyword:`!import` statement of the form ``from ... import *`` binds all
+names defined in the imported module, except those beginning with an underscore.
+This form may only be used at the module level.
 
 A target occurring in a :keyword:`del` statement is also considered bound for
 this purpose (though the actual semantics are to unbind the name).


### PR DESCRIPTION
# [bpo-45619](https://bugs.python.org/issue45619): updating and improving the list of bindings

This does three changes that are quite related.

0. It breaks a long sentence enumerating things into a list
1. it adds two missing elements to the list:
  a. assignment-expression can also bind a value. This should have been updated in 3.8.
  b. variable binding can occur in pattern matching, an update of 3.10

This PR would be relevant in 3.8 and 3.9, except obviously for the pattern matching part. However, I understand that is not critical and can't be easily cherry-picked, so I assume it won't be backported.

<!-- issue-number: [bpo-45619](https://bugs.python.org/issue45619) -->
https://bugs.python.org/issue45619
<!-- /issue-number -->
