### PR TITLE
bpo-23556: Fix discrepancy in raise without argument; Apply patch from Bug Tracker

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -38,13 +38,13 @@ information on defining exceptions is available in the Python Tutorial under
 Exception context
 -----------------
 
-When raising a new exception and an exception
+When raising a new exception while another exception
 is already being handled, the new exception's
-:attr:`__context__` attribute is automatically set to the originating
+:attr:`__context__` attribute is automatically set to the handled
 exception.  An exception may be handled when an :keyword:`except` or
 :keyword:`finally` clause, or a :keyword:`with` statement, is used.  If the
 new exception is not handled, the traceback that is eventually displayed may
-include the originating exception(s) and the final exception.
+include the context exception(s) as well as the final exception.
 
 This implicit exception context can be
 supplemented with an explicit cause by using :keyword:`!from` with

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -42,9 +42,7 @@ When raising a new exception while another exception
 is already being handled, the new exception's
 :attr:`__context__` attribute is automatically set to the handled
 exception.  An exception may be handled when an :keyword:`except` or
-:keyword:`finally` clause, or a :keyword:`with` statement, is used.  If the
-new exception is not handled, the traceback that is eventually displayed may
-include the context exception(s) as well as the final exception.
+:keyword:`finally` clause, or a :keyword:`with` statement, is used.
 
 This implicit exception context can be
 supplemented with an explicit cause by using :keyword:`!from` with

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -38,15 +38,16 @@ information on defining exceptions is available in the Python Tutorial under
 Exception context
 -----------------
 
-When raising (or re-raising) an exception in an :keyword:`except` or
-:keyword:`finally` clause
-:attr:`__context__` is automatically set to the last exception caught; if the
-new exception is not handled the traceback that is eventually displayed will
+When raising a new exception and an exception
+is already being handled, the new exception's
+:attr:`__context__` attribute is automatically set to the originating
+exception.  An exception may be handled when an :keyword:`except` or
+:keyword:`finally` clause, or a :keyword:`with` statement, is used.  If the
+new exception is not handled, the traceback that is eventually displayed may
 include the originating exception(s) and the final exception.
 
-When raising a new exception (rather than using a bare ``raise`` to re-raise
-the exception currently being handled), the implicit exception context can be
-supplemented with an explicit cause by using :keyword:`from<raise>` with
+This implicit exception context can be
+supplemented with an explicit cause by using :keyword:`!from` with
 :keyword:`raise`::
 
    raise new_exc from original_exc

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -564,9 +564,9 @@ The :keyword:`!raise` statement
    raise_stmt: "raise" [`expression` ["from" `expression`]]
 
 If no expressions are present, :keyword:`raise` re-raises the
-exception that is being handled.  If no exception is being handled,
-a :exc:`RuntimeError` exception is raised indicating that this is an
-error.
+exception that is currently being handled, which is also known as the *active exception*.
+If there isn't currently an active exception, a :exc:`RuntimeError` exception is raised
+indicating that this is an error.
 
 Otherwise, :keyword:`raise` evaluates the first expression as the exception
 object.  It must be either a subclass or an instance of :class:`BaseException`.

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -563,9 +563,9 @@ The :keyword:`!raise` statement
 .. productionlist:: python-grammar
    raise_stmt: "raise" [`expression` ["from" `expression`]]
 
-If no expressions are present, :keyword:`raise` re-raises the last exception
-that was active in the current scope.  If no exception is active in the current
-scope, a :exc:`RuntimeError` exception is raised indicating that this is an
+If no expressions are present, :keyword:`raise` re-raises the
+exception that is being handled.  If no exception is being handled,
+a :exc:`RuntimeError` exception is raised indicating that this is an
 error.
 
 Otherwise, :keyword:`raise` evaluates the first expression as the exception
@@ -581,8 +581,8 @@ The :dfn:`type` of the exception is the exception instance's class, the
 A traceback object is normally created automatically when an exception is raised
 and attached to it as the :attr:`__traceback__` attribute, which is writable.
 You can create an exception and set your own traceback in one step using the
-:meth:`with_traceback` exception method (which returns the same exception
-instance, with its traceback set to its argument), like so::
+:meth:`~BaseException.with_traceback` exception method (which returns the
+same exception instance, with its traceback set to its argument), like so::
 
    raise Exception("foo occurred").with_traceback(tracebackobj)
 
@@ -614,8 +614,10 @@ exceptions will be printed::
      File "<stdin>", line 4, in <module>
    RuntimeError: Something bad happened
 
-A similar mechanism works implicitly if an exception is raised inside an
-exception handler or a :keyword:`finally` clause: the previous exception is then
+A similar mechanism works implicitly if a new exception is raised when
+an exception is already being handled.  An exception may be handled
+when an :keyword:`except` or :keyword:`finally` clause, or a
+:keyword:`with` statement, is used.  The previous exception is then
 attached as the new exception's :attr:`__context__` attribute::
 
    >>> try:

--- a/Lib/test/test_raise.py
+++ b/Lib/test/test_raise.py
@@ -303,7 +303,7 @@ class TestContext(unittest.TestCase):
             except:
                 raise OSError()
         except OSError as e:
-            self.assertEqual(e.__context__, context)
+            self.assertIs(e.__context__, context)
         else:
             self.fail("No exception raised")
 
@@ -315,7 +315,7 @@ class TestContext(unittest.TestCase):
             except:
                 raise OSError()
         except OSError as e:
-            self.assertNotEqual(e.__context__, context)
+            self.assertIsNot(e.__context__, context)
             self.assertIsInstance(e.__context__, context)
         else:
             self.fail("No exception raised")
@@ -328,7 +328,7 @@ class TestContext(unittest.TestCase):
             except:
                 raise OSError
         except OSError as e:
-            self.assertNotEqual(e.__context__, context)
+            self.assertIsNot(e.__context__, context)
             self.assertIsInstance(e.__context__, context)
         else:
             self.fail("No exception raised")
@@ -414,6 +414,22 @@ class TestContext(unittest.TestCase):
                     raise a
         except NameError as e:
             self.assertIsNone(e.__context__.__context__)
+
+    def test_not_last(self):
+        # Context is not necessarily the last exception
+        context = Exception("context")
+        try:
+            raise context
+        except Exception:
+            try:
+                raise Exception("caught")
+            except Exception:
+                pass
+            try:
+                raise Exception("new")
+            except Exception as exc:
+                raised = exc
+        self.assertIs(raised.__context__, context)
 
     def test_3118(self):
         # deleting the generator caused the __context__ to be cleared


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Apply Martin's patch for issues in `raise` in https://bugs.python.org/issue23556.
A couple of changes were already made in other PRs, those were skipped.

<!-- issue-number: [bpo-23556](https://bugs.python.org/issue23556) -->
https://bugs.python.org/issue23556
<!-- /issue-number -->
