### PR TITLE
bpo-45627: handle OPENSSL_NO_SCRYPT and OPENSSL_NO_BLAKE defines (GH-29237)

### DIFF
--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -44,10 +44,14 @@
 
 #define MUNCH_SIZE INT_MAX
 
+#ifndef OPENSSL_NO_SCRYPT
 #define PY_OPENSSL_HAS_SCRYPT 1
+#endif
 #define PY_OPENSSL_HAS_SHA3 1
 #define PY_OPENSSL_HAS_SHAKE 1
+#ifndef OPENSSL_NO_BLAKE2
 #define PY_OPENSSL_HAS_BLAKE2 1
+#endif
 
 static PyModuleDef _hashlibmodule;
 


### PR DESCRIPTION
This follows update https://bugs.python.org/issue43669

Which is present in Python 3.10

Some OpenSSL 1.1.1 can be built without Blake2 support or Scrypt.

SHA3 and SHAKE do not seem to have any enable/disable flags.

This results in compiler errors where EVP_blake2b512, EVP_blake2s256,
EVP_PBE_scrypt and PKCS5_v2_scrypt_keyivgen can be un-defined.

This is unfortunate behavior on the part of OpenSSL 1.1.1.

So, for BLAKE2 and SCRYPT, we should still check that the OPENSSL_NO_SCRYPT
and OPENSSL_NO_BLAKE2 defines are not-define.

Looking into the evp.h header of OpenSSL 1.1.1l, we get:

```
 .........
 # ifndef OPENSSL_NO_BLAKE2
 const EVP_MD *EVP_blake2b512(void);
 const EVP_MD *EVP_blake2s256(void);
 # endif
 .........
 #ifndef OPENSSL_NO_SCRYPT
 int EVP_PBE_scrypt(const char *pass, size_t passlen,
                    const unsigned char *salt, size_t saltlen,
                    uint64_t N, uint64_t r, uint64_t p, uint64_t maxmem,
                    unsigned char *key, size_t keylen);

 int PKCS5_v2_scrypt_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
                              int passlen, ASN1_TYPE *param,
                              const EVP_CIPHER *c, const EVP_MD *md, int en_de);
 #endif
 .........
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>

<!-- issue-number: [bpo-45627](https://bugs.python.org/issue45627) -->
https://bugs.python.org/issue45627
<!-- /issue-number -->
