### PR TITLE
bpo-45256: Don't call at the C level when calling bound-methods from Python code.

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4635,8 +4635,21 @@ check_eval_breaker:
             kwnames = NULL;
             postcall_shrink = 1;
         call_function:
-            // Check if the call can be inlined or not
             function = PEEK(oparg + 1);
+            if (Py_TYPE(function) == &PyMethod_Type) {
+                PyObject *meth = ((PyMethodObject *)function)->im_func;
+                PyObject *self = ((PyMethodObject *)function)->im_self;
+                Py_INCREF(meth);
+                Py_INCREF(self);
+                PEEK(oparg + 1) = self;
+                Py_DECREF(function);
+                function = meth;
+                oparg++;
+                nargs++;
+                assert(postcall_shrink >= 1);
+                postcall_shrink--;
+            }
+            // Check if the call can be inlined or not
             if (Py_TYPE(function) == &PyFunction_Type && tstate->interp->eval_frame == NULL) {
                 int code_flags = ((PyCodeObject*)PyFunction_GET_CODE(function))->co_flags;
                 int is_generator = code_flags & (CO_GENERATOR | CO_COROUTINE | CO_ASYNC_GENERATOR);


### PR DESCRIPTION
Unpacks bound methods on to the stack before doing check to see if call can be inlined.

This PR is not about performance, but making  the behavior of `x.m()` and `t = x.m; t()` the same in terms of stack consumption. 

Performance is [fine](https://gist.github.com/markshannon/2bd1a5a68bb5c504628f5f2384ae8ae0) though.

<!-- issue-number: [bpo-45256](https://bugs.python.org/issue45256) -->
https://bugs.python.org/issue45256
<!-- /issue-number -->
