### PR TITLE
bpo-NNNN: fix[collections.abc.MutableMapping]: let setdefault() return the actual stored value

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -1004,7 +1004,7 @@ class MutableMapping(Mapping):
             return self[key]
         except KeyError:
             self[key] = default
-        return default
+        return self[key]
 
 
 MutableMapping.register(dict)


### PR DESCRIPTION
fix[collections.abc.MutableMapping]: let `setdefault()` return the actual stored value

Reproducer for `AssertionError`:

```
from collections.abc import MutableMapping

class Dict(MutableMapping):
    __slots__ = ('__dict__',)

    def __setitem__(self, key, value):
        self.__dict__[key] = dict(value)

    def __getitem__(self, key):
        return self.__dict__[key]

    def __delitem__(self, key):
        del self.__dict__[key]

    def __iter__(self):
        return iter(self.__dict__)

    def __len__(self):
        return len(self.__dict__)

d = Dict()
foo = d.setdefault('foo', {})
assert foo is d['foo']
```