### PR TITLE
[3.8] bpo-45618: Fix documentation build by pinning Docutils version to 0.17.1 (GH-29230) (GH-29241)

### DIFF
--- a/.azure-pipelines/docs-steps.yml
+++ b/.azure-pipelines/docs-steps.yml
@@ -12,11 +12,12 @@ steps:
   inputs:
     versionSpec: '>=3.6'
 
-- script: python -m pip install sphinx==1.8.2 blurb python-docs-theme
+- script: python -m pip install -r requirements.txt
+  workingDirectory: '$(build.sourcesDirectory)/Doc'
   displayName: 'Install build dependencies'
 
 - ${{ if ne(parameters.latex, 'true') }}:
-  - script: make check suspicious html PYTHON=python
+  - script: make check html PYTHON=python
     workingDirectory: '$(build.sourcesDirectory)/Doc'
     displayName: 'Build documentation'
 
@@ -31,7 +32,7 @@ steps:
 - ${{ if eq(parameters.upload, 'true') }}:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish docs'
-  
+
     inputs:
       PathToPublish: '$(build.sourcesDirectory)/Doc/build'
       ArtifactName: docs

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -4,6 +4,10 @@
 # won't suddenly cause build failures. Updating the version is fine as long
 # as no warnings are raised by doing so.
 sphinx==2.4.4
+# Docutils version is pinned to a version compatible with Sphinx
+# version 2.4.4. It can be removed after bumping Sphinx version to at
+# least 3.5.4.
+docutils==0.17.1
 
 blurb
 


### PR DESCRIPTION
Co-authored-by: Maciej Olko <maciej.olko@yougov.com>
Co-authored-by: Erlend Egeberg Aasland <erlend.aasland@innova.no>


<!-- issue-number: [bpo-45618](https://bugs.python.org/issue45618) -->
https://bugs.python.org/issue45618
<!-- /issue-number -->
