### PR TITLE
bpo-45637: Remove broken fallback in gdb helpers to obtain frame variable

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -823,6 +823,8 @@ Traceback \(most recent call first\):
     foo\(1, 2, 3\)
 ''')
 
+    @unittest.skipIf(python_is_optimized(),
+                     "Python was compiled with optimizations")
     def test_threads(self):
         'Verify that "py-bt" indicates threads that are waiting for the GIL'
         cmd = '''

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1801,17 +1801,13 @@ class Frame(object):
             frame = PyFramePtr(frame)
             if not frame.is_optimized_out():
                 return frame
-            # gdb is unable to get the "frame" argument of PyEval_EvalFrameEx()
-            # because it was "optimized out". Try to get "frame" from the frame
-            # of the caller, _PyEval_Vector().
-            orig_frame = frame
-            caller = self._gdbframe.older()
-            if caller:
-                frame = caller.read_var('frame')
-                frame = PyFramePtr(frame)
-                if not frame.is_optimized_out():
-                    return frame
-            return orig_frame
+            cframe = self._gdbframe.read_var('cframe')
+            if cframe is None:
+                return None
+            frame = PyFramePtr(cframe["current_frame"].dereference())
+            if frame and not frame.is_optimized_out():
+                return frame
+            return None
         except ValueError:
             return None
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45637](https://bugs.python.org/issue45637) -->
https://bugs.python.org/issue45637
<!-- /issue-number -->
