### PR TITLE
bpo-45643: Add signal.SIGSTKFLT on platforms where this is defined.

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -197,6 +197,16 @@ The variables defined in the :mod:`signal` module are:
 
    Segmentation fault: invalid memory reference.
 
+.. data:: SIGSTKFLT
+
+    Stack fault on coprocessor. The Linux kernel does not raise this signal: it
+    can only be raised in user space.
+
+   .. availability:: Linux, on architectures where the signal is available. See
+      the man page :manpage:`signal(7)` for further information.
+
+   .. versionadded:: 3.11
+
 .. data:: SIGTERM
 
    Termination signal.

--- a/Misc/NEWS.d/next/Library/2021-10-28-11-40-59.bpo-45643.jeiPiX.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-28-11-40-59.bpo-45643.jeiPiX.rst
@@ -1,0 +1,1 @@
+Added :data:`signal.SIGSTKFLT` on platforms where this signal is defined.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -1547,6 +1547,9 @@ signal_add_constants(PyObject *module)
 #ifdef SIGINFO
     ADD_INT_MACRO(SIGINFO);
 #endif
+#ifdef SIGSTKFLT
+    ADD_INT_MACRO(SIGSTKFLT);
+#endif
 
     // ITIMER_xxx constants
 #ifdef ITIMER_REAL


### PR DESCRIPTION
### Background

On Linux, `man 7 signal` includes `SIGSTKFLT` in its table of "various other signals":
```
Signal     Value   Action  Comment
───────────────────────────────────────────────────────────────
SIGSTKFLT  -,16,-   Term   Stack fault on coprocessor (unused)
```
Here `-,16,-` means that the signal is defined with the value 16 on x86 and ARM but not on Alpha, SPARC or MIPS. I believe that the intention was to use `SIGSTKFLT` for stack faults on the x87 math coprocessor, but this was either removed or never implemented, so that the signal is defined in /usr/include/signal.h but not used by the Linux kernel.


### Use case

`SIGSTKFLT` is one of a handful of signals that are not used by the kernel, so that user-space programs are free to use it for their own purposes, for example for inter-thread or inter-process pre-emptive communication.

Accordingly, it would be nice if the name `SIGSTKFLT` were available in the Python signal module on the platforms where the signal is available, for use and reporting in these cases.


### Note

I didn't add any test coverage because there isn't any behaviour to cover -- the generic behaviour will be covered by `GenericTests.test_enums()` in Lib/test/test_signal.py. I did check by hand that the signal was defined with the correct value:
```
Python 3.11.0a1+ (heads/main-dirty:b1302abcc8, Oct 28 2021, 10:51:05) [GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import signal
>>> int(signal.SIGSTKFLT)
16
```

<!-- issue-number: [bpo-45643](https://bugs.python.org/issue45643) -->
https://bugs.python.org/issue45643
<!-- /issue-number -->
