### PR TITLE
bpo-45644 Make json.tool soak up infile before writing to outfile

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -13,6 +13,18 @@ Usage::
 import argparse
 import json
 import sys
+from pathlib import Path
+
+
+def pathtype(path):
+    class wrapped_fd:
+        'Make stdin and stdout have open() like a `pathlib.Path`'
+        def __init__(self, file_descriptor):
+            self.fd = file_descriptor
+
+        def open(self, *args, **kwargs):
+            return self.fd
+    return wrapped_fd(path) if path in (sys.stdin, sys.stderr) else Path(path)
 
 
 def main():
@@ -21,11 +33,11 @@ def main():
                    'to validate and pretty-print JSON objects.')
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('infile', nargs='?',
-                        type=argparse.FileType(encoding="utf-8"),
+                        type=pathtype,
                         help='a JSON file to be validated or pretty-printed',
                         default=sys.stdin)
     parser.add_argument('outfile', nargs='?',
-                        type=argparse.FileType('w', encoding="utf-8"),
+                        type=pathtype,
                         help='write the output of infile to outfile',
                         default=sys.stdout)
     parser.add_argument('--sort-keys', action='store_true', default=False,
@@ -58,12 +70,17 @@ def main():
         dump_args['indent'] = None
         dump_args['separators'] = ',', ':'
 
-    with options.infile as infile, options.outfile as outfile:
+    with options.infile.open(encoding='utf-8') as infile:
         try:
             if options.json_lines:
                 objs = (json.loads(line) for line in infile)
             else:
-                objs = (json.load(infile), )
+                objs = (json.load(infile),)
+        except ValueError as e:
+            raise SystemExit(e)
+
+    with options.outfile.open('w', encoding='utf-8') as outfile:
+        try:
             for obj in objs:
                 json.dump(obj, outfile, **dump_args)
                 outfile.write('\n')


### PR DESCRIPTION
So that

$ python -m json.tool foo.json foo.json

doens't result in an empty foo.json.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45644](https://bugs.python.org/issue45644) -->
https://bugs.python.org/issue45644
<!-- /issue-number -->
