### PR TITLE
bpo-45644:  Make json.tool read infile before writing to outfile

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -13,6 +13,18 @@ Usage::
 import argparse
 import json
 import sys
+from pathlib import Path
+
+
+def pathtype(path):
+    class wrapped_fd:
+        'Make stdin and stdout have open() like a `pathlib.Path`'
+        def __init__(self, file_descriptor):
+            self.fd = file_descriptor
+
+        def open(self, *args, **kwargs):
+            return self.fd
+    return wrapped_fd(path) if path in (sys.stdin, sys.stderr) else Path(path)
 
 
 def main():
@@ -21,11 +33,11 @@ def main():
                    'to validate and pretty-print JSON objects.')
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('infile', nargs='?',
-                        type=argparse.FileType(encoding="utf-8"),
+                        type=pathtype,
                         help='a JSON file to be validated or pretty-printed',
                         default=sys.stdin)
     parser.add_argument('outfile', nargs='?',
-                        type=argparse.FileType('w', encoding="utf-8"),
+                        type=pathtype,
                         help='write the output of infile to outfile',
                         default=sys.stdout)
     parser.add_argument('--sort-keys', action='store_true', default=False,
@@ -58,12 +70,17 @@ def main():
         dump_args['indent'] = None
         dump_args['separators'] = ',', ':'
 
-    with options.infile as infile, options.outfile as outfile:
+    with options.infile.open(encoding='utf-8') as infile:
         try:
             if options.json_lines:
                 objs = (json.loads(line) for line in infile)
             else:
-                objs = (json.load(infile), )
+                objs = (json.load(infile),)
+        except ValueError as e:
+            raise SystemExit(e)
+
+    with options.outfile.open('w', encoding='utf-8') as outfile:
+        try:
             for obj in objs:
                 json.dump(obj, outfile, **dump_args)
                 outfile.write('\n')

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -131,6 +131,15 @@ class TestTool(unittest.TestCase):
         self.assertEqual(out, b'')
         self.assertEqual(err, b'')
 
+    def test_writing_in_place(self):
+        infile = self._create_infile()
+        rc, out, err = assert_python_ok('-m', 'json.tool', infile, infile)
+        with open(infile, "r", encoding="utf-8") as fp:
+            self.assertEqual(fp.read(), self.expect)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, b'')
+        self.assertEqual(err, b'')
+
     def test_jsonlines(self):
         args = sys.executable, '-m', 'json.tool', '--json-lines'
         process = subprocess.run(args, input=self.jsonlines_raw, capture_output=True, text=True, check=True)

--- a/Misc/NEWS.d/next/Library/2021-11-06-17-47-46.bpo-45644.ZMqHD_.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-06-17-47-46.bpo-45644.ZMqHD_.rst
@@ -1,0 +1,3 @@
+In-place JSON file formatting using ``python3 -m json.tool infile infile``
+now works correctly, previously it left the file empty.  Patch by Chris
+Wesseling.


### PR DESCRIPTION
So that

$ python -m json.tool foo.json foo.json

doens't result in an empty foo.json, but with a reformatted version of the original.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45644](https://bugs.python.org/issue45644) -->
https://bugs.python.org/issue45644
<!-- /issue-number -->
