### PR TITLE
Store actual ints, not pointers to them in the interpreter state.

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -335,7 +335,7 @@ struct _is {
        The integers that are preallocated are those in the range
        -_PY_NSMALLNEGINTS (inclusive) to _PY_NSMALLPOSINTS (not inclusive).
     */
-    PyLongObject* small_ints[_PY_NSMALLNEGINTS + _PY_NSMALLPOSINTS];
+    PyLongObject small_ints[_PY_NSMALLNEGINTS + _PY_NSMALLPOSINTS];
     struct _Py_bytes_state bytes;
     struct _Py_unicode_state unicode;
     struct _Py_float_state float_state;

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -17,7 +17,7 @@ static inline PyObject* __PyLong_GetSmallInt_internal(int value)
     PyInterpreterState *interp = _PyInterpreterState_GET();
     assert(-_PY_NSMALLNEGINTS <= value && value < _PY_NSMALLPOSINTS);
     size_t index = _PY_NSMALLNEGINTS + value;
-    PyObject *obj = (PyObject*)interp->small_ints[index];
+    PyObject *obj = (PyObject*)&interp->small_ints[index];
     // _PyLong_GetZero(), _PyLong_GetOne() and get_small_int() must not be
     // called before _PyLong_Init() nor after _PyLong_Fini().
     assert(obj != NULL);

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -53,7 +53,7 @@ extern PyStatus _PyUnicode_Init(PyInterpreterState *interp);
 extern PyStatus _PyUnicode_InitTypes(void);
 extern PyStatus _PyBytes_Init(PyInterpreterState *interp);
 extern int _PyStructSequence_Init(void);
-extern int _PyLong_Init(PyInterpreterState *interp);
+extern void _PyLong_Init(PyInterpreterState *interp);
 extern int _PyLong_InitTypes(void);
 extern PyStatus _PyTuple_Init(PyInterpreterState *interp);
 extern PyStatus _PyFaulthandler_Init(int enable);

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5827,24 +5827,17 @@ PyLong_GetInfo(void)
     return int_info;
 }
 
-int
+void
 _PyLong_Init(PyInterpreterState *interp)
 {
     for (Py_ssize_t i=0; i < NSMALLNEGINTS + NSMALLPOSINTS; i++) {
         sdigit ival = (sdigit)i - NSMALLNEGINTS;
         int size = (ival < 0) ? -1 : ((ival == 0) ? 0 : 1);
-
-        PyLongObject *v = _PyLong_New(1);
-        if (!v) {
-            return -1;
-        }
-
-        Py_SET_SIZE(v, size);
-        v->ob_digit[0] = (digit)abs(ival);
-
-        interp->small_ints[i] = v;
+        interp->small_ints[i].ob_base.ob_base.ob_refcnt = 1;
+        interp->small_ints[i].ob_base.ob_base.ob_type = &PyLong_Type;
+        interp->small_ints[i].ob_base.ob_size = size;
+        interp->small_ints[i].ob_digit[0] = (digit)abs(ival);
     }
-    return 0;
 }
 
 
@@ -5863,7 +5856,5 @@ _PyLong_InitTypes(void)
 void
 _PyLong_Fini(PyInterpreterState *interp)
 {
-    for (Py_ssize_t i = 0; i < NSMALLNEGINTS + NSMALLPOSINTS; i++) {
-        Py_CLEAR(interp->small_ints[i]);
-    }
+    (void)interp;
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -659,9 +659,7 @@ pycore_init_singletons(PyInterpreterState *interp)
 {
     PyStatus status;
 
-    if (_PyLong_Init(interp) < 0) {
-        return _PyStatus_ERR("can't init longs");
-    }
+    _PyLong_Init(interp);
 
     if (_Py_IsMainInterpreter(interp)) {
         _PyFloat_Init();


### PR DESCRIPTION
Make the array of small ints just that. An array of ints, not an array of pointers.
In theory should be a tiny bit faster, and removes a possible failure mode when creating the interpreter state.

Performance is [about the same](https://gist.github.com/markshannon/19f63e4c945bc7f64175b6e2e6c574da) seemingly slowing down floats a bit, possibly because the float free list is now further from the start of the interpreter state.
