### PR TITLE
bpo-45655: Add "relevant PEPs" section to ``typing`` documentation

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -50,7 +50,7 @@ annotations. These include:
      :func:`@runtime_checkable<runtime_checkable>` decorator
 * :pep:`585`: Type Hinting Generics In Standard Collections
      *Introducing* the ability to use builtin collections and ABCs as
-     :term:`generic types <generic type>` 
+     :term:`generic types<generic type>`
 * :pep:`586`: Literal Types
      *Introducing* :data:`Literal`
 * :pep:`589`: TypedDict: Type Hints for Dictionaries with a Fixed Set of Keys
@@ -61,7 +61,7 @@ annotations. These include:
      *Introducing* :data:`Annotated`
 * :pep:`604`: Allow writing union types as ``X | Y``
      *Introducing* :data:`types.UnionType` and the ability to use
-     the binary-or operator ``|`` as syntactic sugar for the union
+     the binary-or operator ``|`` as syntactic sugar for a union of types
 * :pep:`612`: Parameter Specification Variables
      *Introducing* :class:`ParamSpec` and :data:`Concatenate`
 * :pep:`613`: Explicit Type Aliases

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -38,7 +38,7 @@ arguments.
 Relevant PEPs
 =============
 
-Since the initial introduction of type hints in :pep:`484` and :pep:`483`, a 
+Since the initial introduction of type hints in :pep:`484` and :pep:`483`, a
 number of PEPs have modified and enhanced Python's framework for type
 annotations. These include:
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -17,13 +17,11 @@
 
 --------------
 
-This module provides runtime support for type hints as specified by
-:pep:`484`, :pep:`526`, :pep:`544`, :pep:`586`, :pep:`589`, :pep:`591`,
-:pep:`593`, :pep:`612`, :pep:`613` and :pep:`647`.
-The most fundamental support consists of the types :data:`Any`, :data:`Union`,
-:data:`Tuple`, :data:`Callable`, :class:`TypeVar`, and
-:class:`Generic`.  For full specification please see :pep:`484`.  For
-a simplified introduction to type hints see :pep:`483`.
+This module provides runtime support for type hints. The most fundamental
+support consists of the types :data:`Any`, :data:`Union`, :data:`Tuple`,
+:data:`Callable`, :class:`TypeVar`, and :class:`Generic`. For a full
+specification, please see :pep:`484`. For a simplified introduction to type
+hints, see :pep:`483`.
 
 
 The function below takes and returns a string and is annotated as follows::
@@ -34,6 +32,36 @@ The function below takes and returns a string and is annotated as follows::
 In the function ``greeting``, the argument ``name`` is expected to be of type
 :class:`str` and the return type :class:`str`. Subtypes are accepted as
 arguments.
+
+.. _relevant-peps:
+
+Relevant PEPs
+=============
+
+Since the initial introduction of type hints in :pep:`484` and :pep:`483`, a 
+number of PEPs have modified and enhanced Python's framework for type
+annotations. These include:
+
+* :pep:`526`: Syntax for Variable Annotations
+     *Introducing* syntax for annotating variables outside of function
+     definitions, and :data:`ClassVar`
+* :pep:`544`: Protocols: Structural subtyping (static duck typing)
+     *Introducing* :class:`Protocol` and the
+     :func:`@runtime_checkable<runtime_checkable>` decorator
+* :pep:`586`: Literal Types
+     *Introducing* :data:`Literal`
+* :pep:`589`: TypedDict: Type Hints for Dictionaries with a Fixed Set of Keys
+     *Introducing* :class:`TypedDict`
+* :pep:`591`: Adding a final qualifier to typing
+     *Introducing* :data:`Final` and the :func:`@final<final>` decorator
+* :pep:`593`: Flexible function and variable annotations
+     *Introducing* :data:`Annotated`
+* :pep:`612`: Parameter Specification Variables
+     *Introducing* :class:`ParamSpec` and :data:`Concatenate`
+* :pep:`613`: Explicit Type Aliases
+     *Introducing* :data:`TypeAlias`
+* :pep:`647`: User-Defined Type Guards
+     *Introducing* :data:`TypeGuard`
 
 .. _type-aliases:
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -48,6 +48,9 @@ annotations. These include:
 * :pep:`544`: Protocols: Structural subtyping (static duck typing)
      *Introducing* :class:`Protocol` and the
      :func:`@runtime_checkable<runtime_checkable>` decorator
+* :pep:`585`: Type Hinting Generics In Standard Collections
+     *Introducing* the ability to use builtin collections and ABCs as
+     :term:`generic types <generic type>` 
 * :pep:`586`: Literal Types
      *Introducing* :data:`Literal`
 * :pep:`589`: TypedDict: Type Hints for Dictionaries with a Fixed Set of Keys
@@ -56,6 +59,9 @@ annotations. These include:
      *Introducing* :data:`Final` and the :func:`@final<final>` decorator
 * :pep:`593`: Flexible function and variable annotations
      *Introducing* :data:`Annotated`
+* :pep:`604`: Allow writing union types as ``X | Y``
+     *Introducing* :data:`types.UnionType` and the ability to use
+     the binary-or operator ``|`` as syntactic sugar for the union
 * :pep:`612`: Parameter Specification Variables
      *Introducing* :class:`ParamSpec` and :data:`Concatenate`
 * :pep:`613`: Explicit Type Aliases

--- a/Misc/NEWS.d/next/Documentation/2021-10-28-19-22-55.bpo-45655.aPYGaS.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-10-28-19-22-55.bpo-45655.aPYGaS.rst
@@ -1,0 +1,2 @@
+Add a new "relevant PEPs" section to the top of the documentation for the
+``typing`` module. Patch by Alex Waygood.


### PR DESCRIPTION
The list of PEPs at the top of the documentation for the ``typing`` module has
become too long to be readable. This PR proposes presenting this
information in a more structured and readable way by adding a new "relevant
PEPs" section to the ``typing`` docs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45655](https://bugs.python.org/issue45655) -->
https://bugs.python.org/issue45655
<!-- /issue-number -->
