### PR TITLE
bpo-45506: Re-enable test_embed.

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -58,10 +58,12 @@ class EmbeddingTestsMixin:
             ext = ("_d" if debug_build(sys.executable) else "") + ".exe"
             exename += ext
             exepath = builddir
+            expecteddir = support.REPO_ROOT
         else:
             exepath = os.path.join(builddir, 'Programs')
+            expecteddir = os.path.join(support.REPO_ROOT, 'Programs')
         self.test_exe = exe = os.path.join(exepath, exename)
-        if exepath != support.REPO_ROOT or not os.path.exists(exe):
+        if exepath != expecteddir or not os.path.exists(exe):
             self.skipTest("%r doesn't exist" % exe)
         # This is needed otherwise we get a fatal error:
         # "Py_Initialize: Unable to get the locale encoding


### PR DESCRIPTION
In gh-29063 I ended up disabling test_embed on non-Windows by accident.  This gets it running again.

<!-- issue-number: [bpo-45506](https://bugs.python.org/issue45506) -->
https://bugs.python.org/issue45506
<!-- /issue-number -->
