### PR TITLE
gh-89559: Change -X frozen_modules to -X frozen_stdlib.

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -480,7 +480,7 @@ Miscellaneous options
      objects and pyc files are desired as well as suppressing the extra visual
      location indicators when the interpreter displays tracebacks. See also
      :envvar:`PYTHONNODEBUGRANGES`.
-   * ``-X frozen_modules`` determines whether or not frozen modules are
+   * ``-X frozen_stdlib`` determines whether or not frozen stdlib modules are
      ignored by the import machinery.  A value of "on" means they get
      imported and "off" means they are ignored.  The default is "on"
      if this is an installed Python (the normal case).  If it's under
@@ -526,7 +526,7 @@ Miscellaneous options
       The ``-X no_debug_ranges`` option.
 
    .. versionadded:: 3.11
-      The ``-X frozen_modules`` option.
+      The ``-X frozen_stdlib`` option.
 
 
 Options you shouldn't use

--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -172,7 +172,7 @@ typedef struct PyConfig {
     int legacy_windows_stdio;
 #endif
     wchar_t *check_hash_pycs_mode;
-    int use_frozen_modules;
+    int use_frozen_stdlib;
 
     /* --- Path configuration inputs ------------ */
     int pathconfig_warnings;

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -279,7 +279,7 @@ struct _is {
     PyObject *importlib;
     // override for config->use_frozen_stdlib (for tests)
     // (-1: "off", 1: "on", 0: no override)
-    int override_frozen_modules;
+    int override_frozen_stdlib;
 
     /* Used in Modules/_threadmodule.c. */
     long num_threads;

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -277,7 +277,7 @@ struct _is {
     PyObject *builtins;
     // importlib module
     PyObject *importlib;
-    // override for config->use_frozen_modules (for tests)
+    // override for config->use_frozen_stdlib (for tests)
     // (-1: "off", 1: "on", 0: no override)
     int override_frozen_modules;
 

--- a/Lib/test/support/import_helper.py
+++ b/Lib/test/support/import_helper.py
@@ -97,11 +97,11 @@ def frozen_modules(enabled=True):
     This only applies to modules that haven't been imported yet.
     Also, some essential modules will always be imported frozen.
     """
-    _imp._override_frozen_modules_for_tests(1 if enabled else -1)
+    _imp._override_frozen_stdlib_for_tests(1 if enabled else -1)
     try:
         yield
     finally:
-        _imp._override_frozen_modules_for_tests(0)
+        _imp._override_frozen_stdlib_for_tests(0)
 
 
 def import_fresh_module(name, fresh=(), blocked=(), *,

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -123,7 +123,7 @@ class CmdLineTest(unittest.TestCase):
         else:
             self.assertEqual(err, b'')
 
-    def test_xoption_frozen_modules(self):
+    def test_xoption_frozen_stdlib(self):
         tests = {
             ('=on', 'FrozenImporter'),
             ('=off', 'SourceFileLoader'),
@@ -131,7 +131,7 @@ class CmdLineTest(unittest.TestCase):
             ('', 'FrozenImporter'),
         }
         for raw, expected in tests:
-            cmd = ['-X', f'frozen_modules{raw}',
+            cmd = ['-X', f'frozen_stdlib{raw}',
                    #'-c', 'import os; print(os.__spec__.loader.__name__, end="")']
                    '-c', 'import os; print(os.__spec__.loader, end="")']
             with self.subTest(raw):

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -437,7 +437,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'pathconfig_warnings': 1,
         '_init_main': 1,
         '_isolated_interpreter': 0,
-        'use_frozen_modules': 1,
+        'use_frozen_stdlib': 1,
     }
     if MS_WINDOWS:
         CONFIG_COMPAT.update({
@@ -1149,7 +1149,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
              # The current getpath.c doesn't determine the stdlib dir
              # in this case.
             'stdlib_dir': '',
-            'use_frozen_modules': -1,
+            'use_frozen_stdlib': -1,
         }
         self.default_program_name(config)
         env = {'TESTPATH': os.path.pathsep.join(paths)}
@@ -1173,7 +1173,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
              # The current getpath.c doesn't determine the stdlib dir
              # in this case.
             'stdlib_dir': '',
-            'use_frozen_modules': -1,
+            'use_frozen_stdlib': -1,
             # overridden by PyConfig
             'program_name': 'conf_program_name',
             'base_executable': 'conf_executable',
@@ -1271,7 +1271,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         }
         self.default_program_name(config)
         if not config['executable']:
-            config['use_frozen_modules'] = -1
+            config['use_frozen_stdlib'] = -1
         env = {'TESTHOME': home, 'PYTHONPATH': paths_str}
         self.check_all_configs("test_init_setpythonhome", config,
                                api=API_COMPAT, env=env)
@@ -1310,7 +1310,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 # The current getpath.c doesn't determine the stdlib dir
                 # in this case.
                 'stdlib_dir': None,
-                'use_frozen_modules': -1,
+                'use_frozen_stdlib': -1,
             }
             env = self.copy_paths_by_env(config)
             self.check_all_configs("test_init_compat_config", config,
@@ -1369,7 +1369,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 config['base_prefix'] = pyvenv_home
                 config['prefix'] = pyvenv_home
                 config['stdlib_dir'] = os.path.join(pyvenv_home, 'lib')
-                config['use_frozen_modules'] = 1
+                config['use_frozen_stdlib'] = 1
 
                 ver = sys.version_info
                 dll = f'python{ver.major}'
@@ -1382,7 +1382,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 # The current getpath.c doesn't determine the stdlib dir
                 # in this case.
                 config['stdlib_dir'] = None
-                config['use_frozen_modules'] = -1
+                config['use_frozen_stdlib'] = -1
 
             env = self.copy_paths_by_env(config)
             self.check_all_configs("test_init_compat_config", config,
@@ -1468,7 +1468,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         self.run_embedded_interpreter("test_get_argc_argv")
         # ignore output
 
-    def test_init_use_frozen_modules(self):
+    def test_init_use_frozen_stdlib(self):
         tests = {
             ('=on', 1),
             ('=off', 0),
@@ -1485,11 +1485,11 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 'run_command': 'pass\n',
                 'use_environment': 1,
                 'xoptions': [optval],
-                'use_frozen_modules': expected,
+                'use_frozen_stdlib': expected,
             }
             env = {'TESTFROZEN': raw[1:]} if raw else None
             with self.subTest(repr(raw)):
-                self.check_all_configs("test_init_use_frozen_modules", config,
+                self.check_all_configs("test_init_use_frozen_stdlib", config,
                                        api=API_PYTHON, env=env)
 
 

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1476,7 +1476,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             ('', 1),
         }
         for raw, expected in tests:
-            optval = f'frozen_modules{raw}'
+            optval = f'frozen_stdlib{raw}'
             config = {
                 'parse_argv': 2,
                 'argv': ['-c'],

--- a/Misc/NEWS.d/3.11.0a1.rst
+++ b/Misc/NEWS.d/3.11.0a1.rst
@@ -260,7 +260,7 @@ Compiler now removes trailing unused constants from co_consts.
 .. nonce: ZPI_3L
 .. section: Core and Builtins
 
-Add a new command line option, "-X frozen_modules=[on|off]" to opt out of
+Add a new command line option, "-X frozen_stdlib=[on|off]" to opt out of
 (or into) using optional frozen modules.  This defaults to "on" (or "off" if
 it's running out of the source tree).
 
@@ -4414,7 +4414,7 @@ before building.
 
 Freeze stdlib modules that are imported during startup.  This provides
 significant performance improvements to startup.  If necessary, use the
-previously added "-X frozen_modules=off" commandline option to force
+previously added "-X frozen_stdlib=off" commandline option to force
 importing the source modules.
 
 ..

--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-06-14-27-51.bpo-45396.1xwQeD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-06-14-27-51.bpo-45396.1xwQeD.rst
@@ -1,2 +1,0 @@
-Always import custom frozen modules.  This means "-X frozen_stdlib" is
-ignored for now (see bpo-45395).

--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-06-14-27-51.bpo-45396.1xwQeD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-06-14-27-51.bpo-45396.1xwQeD.rst
@@ -1,0 +1,2 @@
+Always import custom frozen modules.  This means "-X frozen_stdlib" is
+ignored for now (see bpo-45395).

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1727,7 +1727,7 @@ static int test_get_argc_argv(void)
 }
 
 
-static int check_use_frozen_modules(const char *rawval)
+static int check_use_frozen_stdlib(const char *rawval)
 {
     wchar_t optval[100];
     if (rawval == NULL) {
@@ -1764,10 +1764,10 @@ static int check_use_frozen_modules(const char *rawval)
     return 0;
 }
 
-static int test_init_use_frozen_modules(void)
+static int test_init_use_frozen_stdlib(void)
 {
     const char *envvar = getenv("TESTFROZEN");
-    return check_use_frozen_modules(envvar);
+    return check_use_frozen_stdlib(envvar);
 }
 
 
@@ -1942,7 +1942,7 @@ static struct TestCase TestCases[] = {
     {"test_run_main", test_run_main},
     {"test_run_main_loop", test_run_main_loop},
     {"test_get_argc_argv", test_get_argc_argv},
-    {"test_init_use_frozen_modules", test_init_use_frozen_modules},
+    {"test_init_use_frozen_stdlib", test_init_use_frozen_stdlib},
 
     // Audit
     {"test_open_code_hook", test_open_code_hook},

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1731,13 +1731,13 @@ static int check_use_frozen_stdlib(const char *rawval)
 {
     wchar_t optval[100];
     if (rawval == NULL) {
-        wcscpy(optval, L"frozen_modules");
+        wcscpy(optval, L"frozen_stdlib");
     }
     else if (swprintf(optval, 100,
 #if defined(_MSC_VER)
-        L"frozen_modules=%S",
+        L"frozen_stdlib=%S",
 #else
-        L"frozen_modules=%s",
+        L"frozen_stdlib=%s",
 #endif
         rawval) < 0) {
         error("rawval is too long");

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -386,7 +386,7 @@ PyDoc_STRVAR(_imp__override_frozen_modules_for_tests__doc__,
 "_override_frozen_modules_for_tests($module, override, /)\n"
 "--\n"
 "\n"
-"(internal-only) Override PyConfig.use_frozen_modules.\n"
+"(internal-only) Override PyConfig.use_frozen_stdlib.\n"
 "\n"
 "(-1: \"off\", 1: \"on\", 0: no override)\n"
 "See frozen_modules() in Lib/test/support/import_helper.py.");
@@ -565,4 +565,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=adcf787969a11353 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b89f57e69bfecbc9 input=a9049054013a1b77]*/

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -382,8 +382,8 @@ _imp__frozen_module_names(PyObject *module, PyObject *Py_UNUSED(ignored))
     return _imp__frozen_module_names_impl(module);
 }
 
-PyDoc_STRVAR(_imp__override_frozen_modules_for_tests__doc__,
-"_override_frozen_modules_for_tests($module, override, /)\n"
+PyDoc_STRVAR(_imp__override_frozen_stdlib_for_tests__doc__,
+"_override_frozen_stdlib_for_tests($module, override, /)\n"
 "--\n"
 "\n"
 "(internal-only) Override PyConfig.use_frozen_stdlib.\n"
@@ -391,14 +391,14 @@ PyDoc_STRVAR(_imp__override_frozen_modules_for_tests__doc__,
 "(-1: \"off\", 1: \"on\", 0: no override)\n"
 "See frozen_modules() in Lib/test/support/import_helper.py.");
 
-#define _IMP__OVERRIDE_FROZEN_MODULES_FOR_TESTS_METHODDEF    \
-    {"_override_frozen_modules_for_tests", (PyCFunction)_imp__override_frozen_modules_for_tests, METH_O, _imp__override_frozen_modules_for_tests__doc__},
+#define _IMP__OVERRIDE_FROZEN_STDLIB_FOR_TESTS_METHODDEF    \
+    {"_override_frozen_stdlib_for_tests", (PyCFunction)_imp__override_frozen_stdlib_for_tests, METH_O, _imp__override_frozen_stdlib_for_tests__doc__},
 
 static PyObject *
-_imp__override_frozen_modules_for_tests_impl(PyObject *module, int override);
+_imp__override_frozen_stdlib_for_tests_impl(PyObject *module, int override);
 
 static PyObject *
-_imp__override_frozen_modules_for_tests(PyObject *module, PyObject *arg)
+_imp__override_frozen_stdlib_for_tests(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
     int override;
@@ -407,7 +407,7 @@ _imp__override_frozen_modules_for_tests(PyObject *module, PyObject *arg)
     if (override == -1 && PyErr_Occurred()) {
         goto exit;
     }
-    return_value = _imp__override_frozen_modules_for_tests_impl(module, override);
+    return_value = _imp__override_frozen_stdlib_for_tests_impl(module, override);
 
 exit:
     return return_value;
@@ -565,4 +565,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=b89f57e69bfecbc9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d3d8cbfcf4908107 input=a9049054013a1b77]*/

--- a/Python/import.c
+++ b/Python/import.c
@@ -1082,7 +1082,7 @@ use_frozen(void)
         return false;
     }
     else {
-        return interp->config.use_frozen_modules;
+        return interp->config.use_frozen_stdlib;
     }
 }
 
@@ -2308,7 +2308,7 @@ _imp._override_frozen_modules_for_tests
     override: int
     /
 
-(internal-only) Override PyConfig.use_frozen_modules.
+(internal-only) Override PyConfig.use_frozen_stdlib.
 
 (-1: "off", 1: "on", 0: no override)
 See frozen_modules() in Lib/test/support/import_helper.py.
@@ -2316,7 +2316,7 @@ See frozen_modules() in Lib/test/support/import_helper.py.
 
 static PyObject *
 _imp__override_frozen_modules_for_tests_impl(PyObject *module, int override)
-/*[clinic end generated code: output=36d5cb1594160811 input=8f1f95a3ef21aec3]*/
+/*[clinic end generated code: output=36d5cb1594160811 input=501242da72b8ef23]*/
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
     interp->override_frozen_modules = override;

--- a/Python/import.c
+++ b/Python/import.c
@@ -1187,7 +1187,8 @@ set_frozen_error(frozen_status status, PyObject *modname)
             err = "No such frozen object named %R";
             break;
         case FROZEN_DISABLED:
-            err = "Frozen modules are disabled and the frozen object named %R is not essential";
+            err = "Non-essential frozen stdlib modules are disabled.  " \
+                  "See the '-X frozen_stdlib' documentation.";
             break;
         case FROZEN_EXCLUDED:
             err = "Excluded frozen object named %R";

--- a/Python/import.c
+++ b/Python/import.c
@@ -1170,7 +1170,7 @@ typedef enum {
     FROZEN_OKAY,
     FROZEN_BAD_NAME,    // The given module name wasn't valid.
     FROZEN_NOT_FOUND,   // It wasn't in PyImport_FrozenModules.
-    FROZEN_DISABLED,    // -X frozen_modules=off (and not essential)
+    FROZEN_DISABLED,    // -X frozen_stdlib=off (and not essential)
     FROZEN_EXCLUDED,    /* The PyImport_FrozenModules entry has NULL "code"
                            (module is present but marked as unimportable, stops search). */
     FROZEN_INVALID,     /* The PyImport_FrozenModules entry is bogus

--- a/Python/import.c
+++ b/Python/import.c
@@ -1074,7 +1074,7 @@ static bool
 use_frozen_stdlib(void)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    int override = interp->override_frozen_modules;
+    int override = interp->override_frozen_stdlib;
     if (override > 0) {
         return true;
     }
@@ -2303,7 +2303,7 @@ _imp__frozen_module_names_impl(PyObject *module)
 }
 
 /*[clinic input]
-_imp._override_frozen_modules_for_tests
+_imp._override_frozen_stdlib_for_tests
 
     override: int
     /
@@ -2315,11 +2315,11 @@ See frozen_modules() in Lib/test/support/import_helper.py.
 [clinic start generated code]*/
 
 static PyObject *
-_imp__override_frozen_modules_for_tests_impl(PyObject *module, int override)
-/*[clinic end generated code: output=36d5cb1594160811 input=501242da72b8ef23]*/
+_imp__override_frozen_stdlib_for_tests_impl(PyObject *module, int override)
+/*[clinic end generated code: output=3f769bf38d4fd4cf input=8c1be52885465f03]*/
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    interp->override_frozen_modules = override;
+    interp->override_frozen_stdlib = override;
     Py_RETURN_NONE;
 }
 
@@ -2485,7 +2485,7 @@ static PyMethodDef imp_methods[] = {
     _IMP_IS_BUILTIN_METHODDEF
     _IMP_IS_FROZEN_METHODDEF
     _IMP__FROZEN_MODULE_NAMES_METHODDEF
-    _IMP__OVERRIDE_FROZEN_MODULES_FOR_TESTS_METHODDEF
+    _IMP__OVERRIDE_FROZEN_STDLIB_FOR_TESTS_METHODDEF
     _IMP_CREATE_DYNAMIC_METHODDEF
     _IMP_EXEC_DYNAMIC_METHODDEF
     _IMP_EXEC_BUILTIN_METHODDEF

--- a/Python/import.c
+++ b/Python/import.c
@@ -1071,7 +1071,7 @@ resolve_module_alias(const char *name, const struct _module_alias *aliases,
 /* Frozen modules */
 
 static bool
-use_frozen(void)
+use_frozen_stdlib(void)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
     int override = interp->override_frozen_modules;
@@ -1093,7 +1093,7 @@ list_frozen_module_names()
     if (names == NULL) {
         return NULL;
     }
-    bool enabled = use_frozen();
+    bool enabled = use_frozen_stdlib();
     const struct _frozen *p;
 #define ADD_MODULE(name) \
     do { \
@@ -1238,7 +1238,7 @@ look_up_frozen(const char *name)
         }
     }
     // Frozen stdlib modules may be disabled.
-    if (use_frozen()) {
+    if (use_frozen_stdlib()) {
         for (p = _PyImport_FrozenStdlib; ; p++) {
             if (p->name == NULL) {
                 break;

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -102,7 +102,7 @@ static const char usage_3[] = "\
             instruction in code objects. This is useful when smaller code objects and pyc \n\
             files are desired as well as suppressing the extra visual location indicators \n\
             when the interpreter displays tracebacks.\n\
-         -X frozen_modules=[on|off]: whether or not frozen modules should be used.\n\
+         -X frozen_stdlib=[on|off]: whether or not frozen stdlib modules should be used.\n\
             The default is \"on\" (or \"off\" if you are running a local build).\n\
 \n\
 --check-hash-based-pycs always|default|never:\n\
@@ -2139,9 +2139,9 @@ config_init_import(PyConfig *config, int compute_path_config)
         return status;
     }
 
-    /* -X frozen_modules=[on|off] */
+    /* -X frozen_stdlib=[on|off] */
     if (config->use_frozen_stdlib < 0) {
-        const wchar_t *value = config_get_xoption_value(config, L"frozen_modules");
+        const wchar_t *value = config_get_xoption_value(config, L"frozen_stdlib");
         if (value == NULL) {
             int isdev = is_dev_env(config);
             if (isdev >= 0) {
@@ -2155,11 +2155,11 @@ config_init_import(PyConfig *config, int compute_path_config)
             config->use_frozen_stdlib = 0;
         }
         else if (wcslen(value) == 0) {
-            // "-X frozen_modules" and "-X frozen_modules=" both imply "on".
+            // "-X frozen_stdlib" and "-X frozen_stdlib=" both imply "on".
             config->use_frozen_stdlib = 1;
         }
         else {
-            return PyStatus_Error("bad value for option -X frozen_modules "
+            return PyStatus_Error("bad value for option -X frozen_stdlib "
                                   "(expected \"on\" or \"off\")");
         }
     }
@@ -2187,7 +2187,7 @@ const wchar_t* known_xoptions[] = {
     L"pycache_prefix",
     L"warn_default_encoding",
     L"no_debug_ranges",
-    L"frozen_modules",
+    L"frozen_stdlib",
     NULL,
 };
 

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -739,7 +739,7 @@ _PyConfig_InitCompatConfig(PyConfig *config)
 #ifdef MS_WINDOWS
     config->legacy_windows_stdio = -1;
 #endif
-    config->use_frozen_modules = -1;
+    config->use_frozen_stdlib = -1;
 }
 
 
@@ -959,7 +959,7 @@ _PyConfig_Copy(PyConfig *config, const PyConfig *config2)
     COPY_ATTR(pathconfig_warnings);
     COPY_ATTR(_init_main);
     COPY_ATTR(_isolated_interpreter);
-    COPY_ATTR(use_frozen_modules);
+    COPY_ATTR(use_frozen_stdlib);
     COPY_WSTRLIST(orig_argv);
 
 #undef COPY_ATTR
@@ -1064,7 +1064,7 @@ _PyConfig_AsDict(const PyConfig *config)
     SET_ITEM_INT(_init_main);
     SET_ITEM_INT(_isolated_interpreter);
     SET_ITEM_WSTRLIST(orig_argv);
-    SET_ITEM_INT(use_frozen_modules);
+    SET_ITEM_INT(use_frozen_stdlib);
 
     return dict;
 
@@ -1348,7 +1348,7 @@ _PyConfig_FromDict(PyConfig *config, PyObject *dict)
     GET_UINT(_install_importlib);
     GET_UINT(_init_main);
     GET_UINT(_isolated_interpreter);
-    GET_UINT(use_frozen_modules);
+    GET_UINT(use_frozen_stdlib);
 
 #undef CHECK_VALUE
 #undef GET_UINT
@@ -2140,23 +2140,23 @@ config_init_import(PyConfig *config, int compute_path_config)
     }
 
     /* -X frozen_modules=[on|off] */
-    if (config->use_frozen_modules < 0) {
+    if (config->use_frozen_stdlib < 0) {
         const wchar_t *value = config_get_xoption_value(config, L"frozen_modules");
         if (value == NULL) {
             int isdev = is_dev_env(config);
             if (isdev >= 0) {
-                config->use_frozen_modules = !isdev;
+                config->use_frozen_stdlib = !isdev;
             }
         }
         else if (wcscmp(value, L"on") == 0) {
-            config->use_frozen_modules = 1;
+            config->use_frozen_stdlib = 1;
         }
         else if (wcscmp(value, L"off") == 0) {
-            config->use_frozen_modules = 0;
+            config->use_frozen_stdlib = 0;
         }
         else if (wcslen(value) == 0) {
             // "-X frozen_modules" and "-X frozen_modules=" both imply "on".
-            config->use_frozen_modules = 1;
+            config->use_frozen_stdlib = 1;
         }
         else {
             return PyStatus_Error("bad value for option -X frozen_modules "


### PR DESCRIPTION
With gh-28778 `python -X frozen_modules` only applies to stdlib modules, rather than also affecting custom frozen modules (see Tools/freeze).  So we're changing the name to avoid any confusion.

This -X option was added recently and hasn't gone out in any releases, so renaming it shouldn't be a problem.

(See https://github.com/python/cpython/pull/28633#discussion_r720506225.)

<!-- issue-number: [bpo-45396](https://bugs.python.org/issue45396) -->
https://bugs.python.org/issue45396
<!-- /issue-number -->


<!-- gh-issue-number: gh-89559 -->
* Issue: gh-89559
<!-- /gh-issue-number -->
