### PR TITLE
bpo-45666: fixes warning with `swprintf` and `%s`

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-10-29-12-54-53.bpo-45666.w2G63u.rst
+++ b/Misc/NEWS.d/next/Build/2021-10-29-12-54-53.bpo-45666.w2G63u.rst
@@ -1,0 +1,1 @@
+Fix warning of ``swprintf`` and ``%s`` usage in ``_testembed.c``

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1733,7 +1733,7 @@ static int check_use_frozen_modules(const char *rawval)
     if (rawval == NULL) {
         wcscpy(optval, L"frozen_modules");
     }
-    else if (swprintf(optval, 100, L"frozen_modules=%s", rawval) < 0) {
+    else if (swprintf(optval, 100, L"frozen_modules=%S", rawval) < 0) {
         error("rawval is too long");
         return -1;
     }


### PR DESCRIPTION
Let's find out if that works and is fine with our linter 🤔 

Context https://stackoverflow.com/questions/18715576/behavior-of-swprintf-when-passed-a-char-const-matching-a-ls-specifier

<!-- issue-number: [bpo-45666](https://bugs.python.org/issue45666) -->
https://bugs.python.org/issue45666
<!-- /issue-number -->
