### PR TITLE
bpo-42280: Clarify docs on standard generic collections

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4921,8 +4921,8 @@ in the ``GenericAlias`` object's :attr:`__args__ <genericalias.__args__>`. ::
 Standard Generic Collections
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The list of standard-library collections supporting parameterized generics
-includes the following objects:
+These standard library collections support parameterized generics (this list
+is non-exhaustive):
 
 * :class:`tuple`
 * :class:`list`

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4921,8 +4921,8 @@ in the ``GenericAlias`` object's :attr:`__args__ <genericalias.__args__>`. ::
 Standard Generic Collections
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-These standard library collections support parameterized generics (this list
-is non-exhaustive):
+The following standard library collections support parameterized generics.
+This list is non-exhaustive.
 
 * :class:`tuple`
 * :class:`list`

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4921,7 +4921,8 @@ in the ``GenericAlias`` object's :attr:`__args__ <genericalias.__args__>`. ::
 Standard Generic Collections
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-These standard library collections support parameterized generics.
+The list of standard-library collections supporting parameterized generics
+includes the following objects:
 
 * :class:`tuple`
 * :class:`list`
@@ -4961,6 +4962,8 @@ These standard library collections support parameterized generics.
 * :class:`contextlib.AbstractAsyncContextManager`
 * :ref:`re.Pattern <re-objects>`
 * :ref:`re.Match <match-objects>`
+* :class:`shelve.Shelf`
+* :class:`types.MappingProxyType`
 
 
 Special Attributes of Generic Alias


### PR DESCRIPTION
This PR proposes adding two classes to the list of standard generic collections in the docs. These classes can be parametrised at runtime, but are currently omitted from the list.

The PR also tweaks the wording introducing the list, to make clear that the docs are not promising that this is an exhaustive list.

The PR does not add any of the classes from the ``queue`` module (``queue.Queue``, ``queue.LifoQueue``, ``queue.PriorityQueue``, ``queue.SimpleQueue``), even though these can be parametrised. I have excluded these from the PR, as the documentation states that this is a list of "standard-library collections", and the ``queue`` classes are not collections (they are neither sized, nor iterable). However, ``re.Pattern`` is included in this list, and ``re.Pattern`` objects are also not collections -- so, perhaps the ``queue`` classes should also be added to this list.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-42280](https://bugs.python.org/issue42280) -->
https://bugs.python.org/issue42280
<!-- /issue-number -->
