### PR TITLE
bpo-45655: Add ref to union-type expressions at top of typing docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -61,7 +61,8 @@ annotations. These include:
      *Introducing* :data:`Annotated`
 * :pep:`604`: Allow writing union types as ``X | Y``
      *Introducing* :data:`types.UnionType` and the ability to use
-     the binary-or operator ``|`` as syntactic sugar for a union of types
+     the binary-or operator ``|`` to signify a
+     :ref:`union of types<types-union>`
 * :pep:`612`: Parameter Specification Variables
      *Introducing* :class:`ParamSpec` and :data:`Concatenate`
 * :pep:`613`: Explicit Type Aliases


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45655](https://bugs.python.org/issue45655) -->
https://bugs.python.org/issue45655
<!-- /issue-number -->
