### PR TITLE
bpo-45628: Check all parts of the suffix for an extension match. (GH-29310)

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -371,8 +371,13 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
         for fileName in fileNames:
             if fileName[:plen] == prefix:
                 suffix = fileName[plen:]
-                if self.extMatch.match(suffix):
-                    result.append(os.path.join(dirName, fileName))
+                # See bpo-45628: The date/time suffix could be anywhere in the
+                # filename
+                parts = suffix.split('.')
+                for part in parts:
+                    if self.extMatch.match(part):
+                        result.append(os.path.join(dirName, fileName))
+                        break
         if len(result) < self.backupCount:
             result = []
         else:


### PR DESCRIPTION


<!-- issue-number: [bpo-45628](https://bugs.python.org/issue45628) -->
https://bugs.python.org/issue45628
<!-- /issue-number -->
