### PR TITLE
bpo-45535: Improve output of Enum ``dir()``

### DIFF
--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -998,11 +998,12 @@ Plain :class:`Enum` classes always evaluate as :data:`True`.
 """""""""""""""""""""""""""""
 
 If you give your enum subclass extra methods, like the `Planet`_
-class below, those methods will show up in a :func:`dir` of the member,
-but not of the class::
+class below, those methods will show up in a :func:`dir` of the member and the
+class. Attributes defined in an :func:`__init__` method will only show up in a
+:func:`dir` of the member::
 
     >>> dir(Planet)
-    ['EARTH', 'JUPITER', 'MARS', 'MERCURY', 'NEPTUNE', 'SATURN', 'URANUS', 'VENUS', '__class__', '__doc__', '__members__', '__module__']
+    ['EARTH', 'JUPITER', 'MARS', 'MERCURY', 'NEPTUNE', 'SATURN', 'URANUS', 'VENUS', '__class__', '__doc__', '__init__', '__members__', '__module__', 'surface_gravity']
     >>> dir(Planet.EARTH)
     ['__class__', '__doc__', '__module__', 'mass', 'name', 'radius', 'surface_gravity', 'value']
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -162,7 +162,8 @@ Data Types
    .. method:: EnumType.__dir__(cls)
 
       Returns ``['__class__', '__doc__', '__members__', '__module__']`` and the
-      names of the members in *cls*::
+      names of the members in ``cls``. User-defined methods and methods from
+      mixin classes will also be included::
 
         >>> dir(Color)
         ['BLUE', 'GREEN', 'RED', '__class__', '__doc__', '__members__', '__module__']
@@ -260,7 +261,7 @@ Data Types
    .. method:: Enum.__dir__(self)
 
       Returns ``['__class__', '__doc__', '__module__', 'name', 'value']`` and
-      any public methods defined on *self.__class__*::
+      any public methods defined on ``self.__class__`` or a mixin class::
 
          >>> from datetime import date
          >>> class Weekday(Enum):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -643,6 +643,7 @@ class EnumType(type):
         is_from_this_module = lambda cls: any(cls is thing for thing in this_module)
         first_enum_base = next(cls for cls in mro if is_from_this_module(cls))
         enum_dict = Enum.__dict__
+        sentinel = object()
         # special-case __new__
         ignored = {'__new__', *filter(_is_sunder, enum_dict)}
         add_to_ignored = ignored.add
@@ -679,7 +680,7 @@ class EnumType(type):
                 elif attr_name not in enum_dunders:
                     add_to_dir(attr_name)
                 # Is an "enum dunder", and is defined by a class from enum.py? Ignore it.
-                elif getattr(self, attr_name) is getattr(first_enum_base, attr_name, object()):
+                elif getattr(self, attr_name) is getattr(first_enum_base, attr_name, sentinel):
                     add_to_ignored(attr_name)
                 # Is an "enum dunder", and is either user-defined or defined by a mixin class?
                 # Add it to dir() output.

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -4,6 +4,7 @@ from operator import or_ as _or_
 from functools import reduce
 from builtins import property as _bltin_property, bin as _bltin_bin
 
+
 __all__ = [
         'EnumType', 'EnumMeta',
         'Enum', 'IntEnum', 'StrEnum', 'Flag', 'IntFlag',

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1018,15 +1018,9 @@ class Enum(metaclass=EnumType):
         Returns all members and all public methods
         """
         cls = type(self)
-
-        filtered_cls_dir = (
-            name for name in dir(cls)
-            if name not in {'__members__', '__init__', '__new__', *cls._member_names_}
-        )
-
+        to_exclude = {'__members__', '__init__', '__new__', *cls._member_names_}
         filtered_self_dict = (name for name in self.__dict__ if not name.startswith('_'))
-
-        return sorted({'name', 'value', *filtered_cls_dir, *filtered_self_dict})
+        return sorted({'name', 'value', *dir(cls), *filtered_self_dict} - to_exclude)
 
     def __format__(self, format_spec):
         """

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -7,9 +7,10 @@ import sys
 import unittest
 import threading
 from collections import OrderedDict
+from datetime import date
 from enum import Enum, IntEnum, StrEnum, EnumType, Flag, IntFlag, unique, auto
 from enum import STRICT, CONFORM, EJECT, KEEP, _simple_enum, _test_simple_enum
-from enum import verify, UNIQUE, CONTINUOUS, NAMED_FLAGS
+from enum import verify, UNIQUE, CONTINUOUS, NAMED_FLAGS, _is_sunder, _is_dunder
 from io import StringIO
 from pickle import dumps, loads, PicklingError, HIGHEST_PROTOCOL
 from test import support
@@ -176,6 +177,10 @@ class TestEnum(unittest.TestCase):
             WINTER = 4
         self.Season = Season
 
+        class FloatEnum(float, Enum):
+            pass
+        self.FloatEnum = FloatEnum
+
         class Konstants(float, Enum):
             E = 2.7182818
             PI = 3.1415926
@@ -197,65 +202,296 @@ class TestEnum(unittest.TestCase):
             SOUTH = 'south'
         self.Directional = Directional
 
-        from datetime import date
+        class DateEnum(date, Enum):
+            pass
+        self.DateEnum = DateEnum
+
         class Holiday(date, Enum):
             NEW_YEAR = 2013, 1, 1
             IDES_OF_MARCH = 2013, 3, 15
         self.Holiday = Holiday
 
-    def test_dir_on_class(self):
-        Season = self.Season
-        self.assertEqual(
-            set(dir(Season)),
-            set(['__class__', '__doc__', '__members__', '__module__',
-                'SPRING', 'SUMMER', 'AUTUMN', 'WINTER']),
-            )
-
-    def test_dir_on_item(self):
-        Season = self.Season
-        self.assertEqual(
-            set(dir(Season.WINTER)),
-            set(['__class__', '__doc__', '__module__', 'name', 'value']),
-            )
-
-    def test_dir_with_added_behavior(self):
-        class Test(Enum):
+        class Wowser(Enum):
             this = 'that'
             these = 'those'
             def wowser(self):
+                """Wowser docstring"""
                 return ("Wowser! I'm %s!" % self.name)
-        self.assertEqual(
-                set(dir(Test)),
-                set(['__class__', '__doc__', '__members__', '__module__', 'this', 'these']),
-                )
-        self.assertEqual(
-                set(dir(Test.this)),
-                set(['__class__', '__doc__', '__module__', 'name', 'value', 'wowser']),
-                )
+        self.Wowser = Wowser
 
-    def test_dir_on_sub_with_behavior_on_super(self):
+        class IntWowser(IntEnum):
+            this = 1
+            these = 2
+            def wowser(self):
+                """Wowser docstring"""
+                return ("Wowser! I'm %s!" % self.name)
+        self.IntWowser = IntWowser
+
+        class FloatWowser(float, Enum):
+            this = 3.14
+            these = 4.2
+            def wowser(self):
+                """Wowser docstring"""
+                return ("Wowser! I'm %s!" % self.name)
+        self.FloatWowser = FloatWowser
+
+        class WowserNoMembers(Enum):
+            def wowser(self):
+                return ("Wowser! I'm %s!" % self.name)
+        self.WowserNoMembers = WowserNoMembers
+
+        class IntWowserNoMembers(IntEnum):
+            def wowser(self):
+                return ("Wowser! I'm %s!" % self.name)
+        self.IntWowserNoMembers = IntWowserNoMembers
+
+        class FloatWowserNoMembers(float, Enum):
+            def wowser(self):
+                return ("Wowser! I'm %s!" % self.name)
+        self.FloatWowserNoMembers = FloatWowserNoMembers
+
+        class EnumWithInit(Enum):
+            def __init__(self, greeting, farewell):
+                self.greeting = greeting
+                self.farewell = farewell
+            ENGLISH = 'hello', 'goodbye'
+            GERMAN = 'Guten Morgen', 'Auf Wiedersehen'
+            def some_method(self):
+                pass
+        self.EnumWithInit = EnumWithInit
+
         # see issue22506
-        class SuperEnum(Enum):
+        class SuperEnum1(Enum):
             def invisible(self):
                 return "did you see me?"
-        class SubEnum(SuperEnum):
+        class SubEnum1(SuperEnum1):
             sample = 5
-        self.assertEqual(
-                set(dir(SubEnum.sample)),
-                set(['__class__', '__doc__', '__module__', 'name', 'value', 'invisible']),
-                )
+        self.SubEnum1 = SubEnum1
 
-    def test_dir_on_sub_with_behavior_including_instance_dict_on_super(self):
-        # see issue40084
-        class SuperEnum(IntEnum):
+        class SuperEnum2(IntEnum):
             def __new__(cls, value, description=""):
                 obj = int.__new__(cls, value)
                 obj._value_ = value
                 obj.description = description
                 return obj
-        class SubEnum(SuperEnum):
+        class SubEnum2(SuperEnum2):
             sample = 5
-        self.assertTrue({'description'} <= set(dir(SubEnum.sample)))
+        self.SubEnum2 = SubEnum2
+
+    def test_dir_basics_for_all_enums(self):
+        enums_for_tests = (
+            # Generic enums in enum.py
+            Enum,
+            IntEnum,
+            StrEnum,
+            # Generic enums defined outside of enum.py
+            self.DateEnum,
+            self.FloatEnum,
+            # Concrete enums derived from enum.py generics
+            self.Grades,
+            self.Season,
+            # Concrete enums derived from generics defined outside of enum.py
+            self.Konstants,
+            self.Holiday,
+            # Standard enum with added behaviour & members
+            self.Wowser,
+            # Mixin-enum-from-enum.py with added behaviour & members
+            self.IntWowser,
+            # Mixin-enum-from-oustide-enum.py with added behaviour & members
+            self.FloatWowser,
+            # Equivalents of the three immediately above, but with no members
+            self.WowserNoMembers,
+            self.IntWowserNoMembers,
+            self.FloatWowserNoMembers,
+            # Enum with members and an __init__ method
+            self.EnumWithInit,
+            # Special cases to test
+            self.SubEnum1,
+            self.SubEnum2
+        )
+
+        for cls in enums_for_tests:
+            with self.subTest(cls=cls):
+                cls_dir = dir(cls)
+                # test that dir is deterministic
+                self.assertEqual(cls_dir, dir(cls))
+                # test that dir is sorted
+                self.assertEqual(list(cls_dir), sorted(cls_dir))
+                # test that there are no dupes in dir
+                self.assertEqual(len(cls_dir), len(set(cls_dir)))
+                # test that there are no sunders in dir
+                self.assertFalse(any(_is_sunder(attr) for attr in cls_dir))
+                self.assertNotIn('__new__', cls_dir)
+
+                for attr in ('__class__', '__doc__', '__members__', '__module__'):
+                    with self.subTest(attr=attr):
+                        self.assertIn(attr, cls_dir)
+
+    def test_dir_for_enum_with_members(self):
+        enums_for_test = (
+            # Enum with members
+            self.Season,
+            # IntEnum with members
+            self.Grades,
+            # Two custom-mixin enums with members
+            self.Konstants,
+            self.Holiday,
+            # several enums-with-added-behaviour and members
+            self.Wowser,
+            self.IntWowser,
+            self.FloatWowser,
+            # An enum with an __init__ method and members
+            self.EnumWithInit,
+            # Special cases to test
+            self.SubEnum1,
+            self.SubEnum2
+        )
+
+        for cls in enums_for_test:
+            cls_dir = dir(cls)
+            member_names = cls._member_names_
+            with self.subTest(cls=cls):
+                self.assertTrue(all(member_name in cls_dir for member_name in member_names))
+                for member in cls:
+                    member_dir = dir(member)
+                    # test that dir is deterministic
+                    self.assertEqual(member_dir, dir(member))
+                    # test that dir is sorted
+                    self.assertEqual(list(member_dir), sorted(member_dir))
+                    # test that there are no dupes in dir
+                    self.assertEqual(len(member_dir), len(set(member_dir)))
+
+                    for attr_name in cls_dir:
+                        with self.subTest(attr_name=attr_name):
+                            if attr_name in {'__members__', '__init__', '__new__', *member_names}:
+                                self.assertNotIn(attr_name, member_dir)
+                            else:
+                                self.assertIn(attr_name, member_dir)
+
+                    self.assertFalse(any(_is_sunder(attr) for attr in member_dir))
+
+    def test_dir_for_enums_with_added_behaviour(self):
+        enums_for_test = (
+            self.Wowser,
+            self.IntWowser,
+            self.FloatWowser,
+            self.WowserNoMembers,
+            self.IntWowserNoMembers,
+            self.FloatWowserNoMembers
+        )
+
+        for cls in enums_for_test:
+            with self.subTest(cls=cls):
+                self.assertIn('wowser', dir(cls))
+                self.assertTrue(all('wowser' in dir(member) for member in cls))
+
+    def test_help_output_on_enum_members(self):
+        added_behaviour_enums = (
+            self.Wowser,
+            self.IntWowser,
+            self.FloatWowser
+        )
+
+        for cls in added_behaviour_enums:
+            with self.subTest(cls=cls):
+                rendered_doc = pydoc.render_doc(cls.this)
+                self.assertIn('Wowser docstring', rendered_doc)
+                if cls in {self.IntWowser, self.FloatWowser}:
+                    self.assertIn('float(self)', rendered_doc)
+
+    def test_dir_for_enum_with_init(self):
+        EnumWithInit = self.EnumWithInit
+
+        cls_dir = dir(EnumWithInit)
+        self.assertIn('__init__', cls_dir)
+        self.assertIn('some_method', cls_dir)
+        self.assertNotIn('greeting', cls_dir)
+        self.assertNotIn('farewell', cls_dir)
+
+        member_dir = dir(EnumWithInit.ENGLISH)
+        self.assertNotIn('__init__', member_dir)
+        self.assertIn('some_method', member_dir)
+        self.assertIn('greeting', member_dir)
+        self.assertIn('farewell', member_dir)
+
+    def test_mixin_dirs(self):
+        enums_for_test = (
+            # generic mixins from enum.py
+            (IntEnum, int),
+            (StrEnum, str),
+            # generic mixins from outside enum.py
+            (self.FloatEnum, float),
+            (self.DateEnum, date),
+            # concrete mixin from enum.py
+            (self.Grades, int),
+            # concrete mixin from outside enum.py
+            (self.Holiday, date),
+            # concrete mixin from enum.py with added behaviour
+            (self.IntWowser, int),
+            # concrete mixin from outside enum.py with added behaviour
+            (self.FloatWowser, float)
+        )
+
+        enum_dict = Enum.__dict__
+        enum_dir = dir(Enum)
+        enum_module_names = enum.__all__
+        is_from_enum_module = lambda cls: cls.__name__ in enum_module_names
+        is_enum_dunder = lambda attr: _is_dunder(attr) and attr in enum_dict
+
+        # General tests
+        for enum_cls, mixin_cls in enums_for_test:
+            with self.subTest(enum_cls=enum_cls):
+                cls_dir = dir(enum_cls)
+                mixin_dir = dir(mixin_cls)
+                cls_dict = enum_cls.__dict__
+
+                first_enum_base = next(
+                    base for base in enum_cls.__mro__
+                    if is_from_enum_module(base)
+                )
+
+                for attr in mixin_dir:
+                    with self.subTest(attr=attr):
+                        if _is_sunder(attr):
+                            # Unlikely, but no harm in testing
+                            self.assertNotIn(attr, cls_dir)
+                        elif attr in ('__class__', '__doc__', '__members__', '__module__'):
+                            self.assertIn(attr, cls_dir)
+                        elif is_enum_dunder(attr):
+                            if is_from_enum_module(enum_cls):
+                                self.assertNotIn(attr, cls_dir)
+                            elif getattr(enum_cls, attr) is getattr(first_enum_base, attr):
+                                self.assertNotIn(attr, cls_dir)
+                            else:
+                                self.assertIn(attr, cls_dir)
+                        else:
+                            self.assertIn(attr, cls_dir)
+
+        # Some specific examples
+        int_enum_dir = dir(IntEnum)
+        self.assertIn('imag', int_enum_dir)
+        self.assertIn('__rfloordiv__', int_enum_dir)
+        self.assertNotIn('__format__', int_enum_dir)
+        self.assertNotIn('__hash__', int_enum_dir)
+
+        class OverridesFormatOutsideEnumModule(Enum):
+            def __format__(self, *args, **kwargs):
+                return super().__format__(*args, **kwargs)
+            SOME_MEMBER = 1
+
+        self.assertIn('__format__', dir(OverridesFormatOutsideEnumModule))
+        self.assertIn('__format__', dir(OverridesFormatOutsideEnumModule.SOME_MEMBER))
+
+    def test_dir_on_sub_with_behavior_on_super(self):
+        # see issue22506
+        self.assertEqual(
+                set(dir(self.SubEnum1.sample)),
+                set(['__class__', '__doc__', '__module__', 'name', 'value', 'invisible']),
+                )
+
+    def test_dir_on_sub_with_behavior_including_instance_dict_on_super(self):
+        # see issue40084
+        self.assertTrue({'description'} <= set(dir(self.SubEnum2.sample)))
 
     def test_enum_in_enum_out(self):
         Season = self.Season
@@ -4154,9 +4390,11 @@ class TestIntEnumConvert(unittest.TestCase):
         self.assertEqual(test_type.CONVERT_TEST_NAME_C, 5)
         self.assertEqual(test_type.CONVERT_TEST_NAME_D, 5)
         self.assertEqual(test_type.CONVERT_TEST_NAME_E, 5)
+        int_enum_dir = set(dir(IntEnum))
         # Ensure that test_type only picked up names matching the filter.
         self.assertEqual([name for name in dir(test_type)
-                          if name[0:2] not in ('CO', '__')],
+                          if name[0:2] not in ('CO', '__')
+                          and name not in int_enum_dir],
                          [], msg='Names other than CONVERT_TEST_* found.')
 
     @unittest.skipUnless(python_version == (3, 8),
@@ -4205,9 +4443,11 @@ class TestStrEnumConvert(unittest.TestCase):
         # Ensure that test_type has all of the desired names and values.
         self.assertEqual(test_type.CONVERT_STR_TEST_1, 'hello')
         self.assertEqual(test_type.CONVERT_STR_TEST_2, 'goodbye')
+        str_enum_dir = set(dir(StrEnum))
         # Ensure that test_type only picked up names matching the filter.
         self.assertEqual([name for name in dir(test_type)
-                          if name[0:2] not in ('CO', '__')],
+                          if name[0:2] not in ('CO', '__')
+                          and name not in str_enum_dir],
                          [], msg='Names other than CONVERT_STR_* found.')
 
     def test_convert_repr_and_str(self):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -176,10 +176,6 @@ class TestEnum(unittest.TestCase):
             WINTER = 4
         self.Season = Season
 
-        class FloatEnum(float, Enum):
-            pass
-        self.FloatEnum = FloatEnum
-
         class Konstants(float, Enum):
             E = 2.7182818
             PI = 3.1415926
@@ -202,14 +198,16 @@ class TestEnum(unittest.TestCase):
         self.Directional = Directional
 
         from datetime import date
-        class DateEnum(date, Enum):
-            pass
-        self.DateEnum = DateEnum
-
         class Holiday(date, Enum):
             NEW_YEAR = 2013, 1, 1
             IDES_OF_MARCH = 2013, 3, 15
         self.Holiday = Holiday
+
+        class DateEnum(date, Enum): pass
+        self.DateEnum = DateEnum
+
+        class FloatEnum(float, Enum): pass
+        self.FloatEnum = FloatEnum
 
         class Wowser(Enum):
             this = 'that'
@@ -236,18 +234,15 @@ class TestEnum(unittest.TestCase):
         self.FloatWowser = FloatWowser
 
         class WowserNoMembers(Enum):
-            def wowser(self):
-                return ("Wowser! I'm %s!" % self.name)
+            def wowser(self): pass
         self.WowserNoMembers = WowserNoMembers
 
         class IntWowserNoMembers(IntEnum):
-            def wowser(self):
-                return ("Wowser! I'm %s!" % self.name)
+            def wowser(self): pass
         self.IntWowserNoMembers = IntWowserNoMembers
 
         class FloatWowserNoMembers(float, Enum):
-            def wowser(self):
-                return ("Wowser! I'm %s!" % self.name)
+            def wowser(self): pass
         self.FloatWowserNoMembers = FloatWowserNoMembers
 
         class EnumWithInit(Enum):
@@ -256,8 +251,7 @@ class TestEnum(unittest.TestCase):
                 self.farewell = farewell
             ENGLISH = 'hello', 'goodbye'
             GERMAN = 'Guten Morgen', 'Auf Wiedersehen'
-            def some_method(self):
-                pass
+            def some_method(self): pass
         self.EnumWithInit = EnumWithInit
 
         # see issue22506
@@ -4392,11 +4386,10 @@ class TestIntEnumConvert(unittest.TestCase):
         self.assertEqual(test_type.CONVERT_TEST_NAME_C, 5)
         self.assertEqual(test_type.CONVERT_TEST_NAME_D, 5)
         self.assertEqual(test_type.CONVERT_TEST_NAME_E, 5)
-        int_enum_dir = set(dir(IntEnum))
         # Ensure that test_type only picked up names matching the filter.
         self.assertEqual([name for name in dir(test_type)
                           if name[0:2] not in ('CO', '__')
-                          and name not in int_enum_dir],
+                          and name not in dir(IntEnum)],
                          [], msg='Names other than CONVERT_TEST_* found.')
 
     @unittest.skipUnless(python_version == (3, 8),
@@ -4445,11 +4438,10 @@ class TestStrEnumConvert(unittest.TestCase):
         # Ensure that test_type has all of the desired names and values.
         self.assertEqual(test_type.CONVERT_STR_TEST_1, 'hello')
         self.assertEqual(test_type.CONVERT_STR_TEST_2, 'goodbye')
-        str_enum_dir = set(dir(StrEnum))
         # Ensure that test_type only picked up names matching the filter.
         self.assertEqual([name for name in dir(test_type)
                           if name[0:2] not in ('CO', '__')
-                          and name not in str_enum_dir],
+                          and name not in dir(StrEnum)],
                          [], msg='Names other than CONVERT_STR_* found.')
 
     def test_convert_repr_and_str(self):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -411,6 +411,11 @@ class TestEnum(unittest.TestCase):
                     for member in cls
                 ))
 
+        self.assertEqual(dir(self.WowserNoMembers), dir(self.SubclassOfWowserNoMembers))
+        # Check classmethods are present
+        self.assertIn('from_bytes', dir(self.IntWowser))
+        self.assertIn('from_bytes', dir(self.IntWowserNoMembers))
+
     def test_help_output_on_enum_members(self):
         added_behaviour_enums = (
             self.Wowser,

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -438,20 +438,27 @@ class TestEnum(unittest.TestCase):
         for enum_cls, mixin_cls in enums_for_test:
             with self.subTest(enum_cls=enum_cls):
                 cls_dir = dir(enum_cls)
-                mixin_dir = dir(mixin_cls)
                 cls_dict = enum_cls.__dict__
+
+                mixin_attrs = [
+                    x for x in dir(mixin_cls)
+                    if (
+                        getattr(mixin_cls, x) is not getattr(object, x, object())
+                        and x not in {'__init_subclass__', '__subclasshook__'}
+                    )
+                ]
 
                 first_enum_base = next(
                     base for base in enum_cls.__mro__
                     if is_from_enum_module(base)
                 )
 
-                for attr in mixin_dir:
+                for attr in mixin_attrs:
                     with self.subTest(attr=attr):
                         if enum._is_sunder(attr):
                             # Unlikely, but no harm in testing
                             self.assertNotIn(attr, cls_dir)
-                        elif attr in ('__class__', '__doc__', '__members__', '__module__'):
+                        elif attr in {'__class__', '__doc__', '__members__', '__module__'}:
                             self.assertIn(attr, cls_dir)
                         elif is_enum_dunder(attr):
                             if is_from_enum_module(enum_cls):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -7,10 +7,9 @@ import sys
 import unittest
 import threading
 from collections import OrderedDict
-from datetime import date
 from enum import Enum, IntEnum, StrEnum, EnumType, Flag, IntFlag, unique, auto
 from enum import STRICT, CONFORM, EJECT, KEEP, _simple_enum, _test_simple_enum
-from enum import verify, UNIQUE, CONTINUOUS, NAMED_FLAGS, _is_sunder, _is_dunder
+from enum import verify, UNIQUE, CONTINUOUS, NAMED_FLAGS
 from io import StringIO
 from pickle import dumps, loads, PicklingError, HIGHEST_PROTOCOL
 from test import support
@@ -202,6 +201,7 @@ class TestEnum(unittest.TestCase):
             SOUTH = 'south'
         self.Directional = Directional
 
+        from datetime import date
         class DateEnum(date, Enum):
             pass
         self.DateEnum = DateEnum
@@ -320,7 +320,7 @@ class TestEnum(unittest.TestCase):
                 # test that there are no dupes in dir
                 self.assertEqual(len(cls_dir), len(set(cls_dir)))
                 # test that there are no sunders in dir
-                self.assertFalse(any(_is_sunder(attr) for attr in cls_dir))
+                self.assertFalse(any(enum._is_sunder(attr) for attr in cls_dir))
                 self.assertNotIn('__new__', cls_dir)
 
                 for attr in ('__class__', '__doc__', '__members__', '__module__'):
@@ -368,7 +368,7 @@ class TestEnum(unittest.TestCase):
                             else:
                                 self.assertIn(attr_name, member_dir)
 
-                    self.assertFalse(any(_is_sunder(attr) for attr in member_dir))
+                    self.assertFalse(any(enum._is_sunder(attr) for attr in member_dir))
 
     def test_dir_for_enums_with_added_behaviour(self):
         enums_for_test = (
@@ -415,6 +415,8 @@ class TestEnum(unittest.TestCase):
         self.assertIn('farewell', member_dir)
 
     def test_mixin_dirs(self):
+        from datetime import date
+
         enums_for_test = (
             # generic mixins from enum.py
             (IntEnum, int),
@@ -436,7 +438,7 @@ class TestEnum(unittest.TestCase):
         enum_dir = dir(Enum)
         enum_module_names = enum.__all__
         is_from_enum_module = lambda cls: cls.__name__ in enum_module_names
-        is_enum_dunder = lambda attr: _is_dunder(attr) and attr in enum_dict
+        is_enum_dunder = lambda attr: enum._is_dunder(attr) and attr in enum_dict
 
         # General tests
         for enum_cls, mixin_cls in enums_for_test:
@@ -452,7 +454,7 @@ class TestEnum(unittest.TestCase):
 
                 for attr in mixin_dir:
                     with self.subTest(attr=attr):
-                        if _is_sunder(attr):
+                        if enum._is_sunder(attr):
                             # Unlikely, but no harm in testing
                             self.assertNotIn(attr, cls_dir)
                         elif attr in ('__class__', '__doc__', '__members__', '__module__'):

--- a/Misc/NEWS.d/next/Library/2021-10-29-16-28-06.bpo-45535.n8NiOE.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-29-16-28-06.bpo-45535.n8NiOE.rst
@@ -1,0 +1,1 @@
+Improve output of ``dir()`` with Enums.


### PR DESCRIPTION
This PR modifies the ``EnumType.__dir__()`` and ``Enum.__dir__()`` to ensure
that user-defined methods and methods inherited from mixin classes always
show up in the output of `help()`. This change also makes it easier for
IDEs to provide auto-completion.

Apologies for the big diff on the tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45535](https://bugs.python.org/issue45535) -->
https://bugs.python.org/issue45535
<!-- /issue-number -->
