### PR TITLE
[3.9] bpo-45581: Raise `MemoryError` in `sqlite3.connect` if SQLite signals memory error (GH-29171)

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-10-22-21-57-02.bpo-45581.rlH6ay.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-22-21-57-02.bpo-45581.rlH6ay.rst
@@ -1,0 +1,2 @@
+:meth:`sqlite3.connect` now correctly raises :exc:`MemoryError` if the
+underlying SQLite API signals memory error. Patch by Erlend E. Aasland.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -134,6 +134,10 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
 
     Py_DECREF(database_obj);
 
+    if (self->db == NULL && rc == SQLITE_NOMEM) {
+        PyErr_NoMemory();
+        return -1;
+    }
     if (rc != SQLITE_OK) {
         _pysqlite_seterror(self->db, NULL);
         return -1;


### PR DESCRIPTION
(cherry picked from commit e2e62b3808691e15fa44b883270023e42dcad958)

Co-authored-by: Erlend Egeberg Aasland <erlend.aasland@innova.no>


<!-- issue-number: [bpo-45581](https://bugs.python.org/issue45581) -->
https://bugs.python.org/issue45581
<!-- /issue-number -->
