### PR TITLE
bpo-45679: Do not cache `typing.Literal` with more than one type arg

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3298,6 +3298,24 @@ class GetTypeHintTests(BaseTestCase):
         ):
             get_type_hints(ann_module6)
 
+    def test_hints_with_literal_cache(self):
+        # https://bugs.python.org/issue45679
+        Literal[True]  # to trigger cache
+        def func(arg: Literal[1]):
+            pass
+
+        hints = get_type_hints(func)
+        # We use such complex way of comparing things, because `1 == True`
+        self.assertEqual(str(hints['arg']), "typing.Literal[1]")
+
+        # Two args case, which was causing an issue:
+        Literal[1, 'a']
+        def func(arg: Literal[True, 'a']):
+            pass
+
+        hints = get_type_hints(func)
+        self.assertEqual(str(hints['arg']), "typing.Literal[True, 'a']")
+
 
 class GetUtilitiesTestCase(TestCase):
     def test_get_origin(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -312,10 +312,14 @@ def _tp_cache(func=None, /, *, typed=False):
 
         @functools.wraps(func)
         def inner(*args, **kwds):
-            try:
-                return cached(*args, **kwds)
-            except TypeError:
-                pass  # All real errors (not unhashable args) are raised below.
+            # We call `cached`, only if we don't care about types,
+            # or when we have just a single argument. Otherwise we can confuse
+            # `Literal[1, 'a']` with `Literal[True, 'a']`, see: bpo-45679
+            if not typed or len(args) <= 1:
+                try:
+                    return cached(*args, **kwds)
+                except TypeError:
+                    pass  # All real errors (not unhashable args) are raised below.
             return func(*args, **kwds)
         return inner
 

--- a/Misc/NEWS.d/next/Library/2021-10-30-20-27-59.bpo-45679.gwXa77.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-30-20-27-59.bpo-45679.gwXa77.rst
@@ -1,0 +1,2 @@
+Do not cache :class:`typing.Literal` when it has more than one type
+argument.


### PR DESCRIPTION


<!-- issue-number: [bpo-45679](https://bugs.python.org/issue45679) -->
https://bugs.python.org/issue45679
<!-- /issue-number -->
