### PR TITLE
Updated README for Python 3.11

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,7 +241,7 @@ All current PEPs, as well as guidelines for submitting a new PEP, are listed at
 Release Schedule
 ----------------
 
-See :pep:`619` for Python 3.10 release details.
+See :pep:`664` for Python 3.11 release details.
 
 
 Copyright and License Information


### PR DESCRIPTION
Updated to link to the currently relevant release schedule (Python 3.11) in README.

Similar to #22605.