### PR TITLE
[3.9] bpo-45679: Fix caching of multi-value typing.Literal (GH-29334)

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -562,6 +562,8 @@ class LiteralTests(BaseTestCase):
         self.assertNotEqual(Literal[True], Literal[1])
         self.assertNotEqual(Literal[1], Literal[2])
         self.assertNotEqual(Literal[1, True], Literal[1])
+        self.assertNotEqual(Literal[1, True], Literal[1, 1])
+        self.assertNotEqual(Literal[1, 2], Literal[True, 2])
         self.assertEqual(Literal[1], Literal[1])
         self.assertEqual(Literal[1, 2], Literal[2, 1])
         self.assertEqual(Literal[1, 2, 3], Literal[1, 2, 3, 3])

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -355,9 +355,10 @@ class _SpecialForm(_Final, _root=True):
 
 
 class _LiteralSpecialForm(_SpecialForm, _root=True):
-    @_tp_cache(typed=True)
     def __getitem__(self, parameters):
-        return self._getitem(self, parameters)
+        if not isinstance(parameters, tuple):
+            parameters = (parameters,)
+        return self._getitem(self, *parameters)
 
 
 @_SpecialForm
@@ -478,7 +479,8 @@ def Optional(self, parameters):
     return Union[arg, type(None)]
 
 @_LiteralSpecialForm
-def Literal(self, parameters):
+@_tp_cache(typed=True)
+def Literal(self, *parameters):
     """Special typing form to define literal types (a.k.a. value types).
 
     This form can be used to indicate to type checkers that the corresponding
@@ -501,9 +503,6 @@ def Literal(self, parameters):
     """
     # There is no '_type_check' call because arguments to Literal[...] are
     # values, not types.
-    if not isinstance(parameters, tuple):
-        parameters = (parameters,)
-
     parameters = _flatten_literal_params(parameters)
 
     try:

--- a/Misc/NEWS.d/next/Library/2021-10-30-21-11-37.bpo-45679.Dq8Cpu.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-30-21-11-37.bpo-45679.Dq8Cpu.rst
@@ -1,0 +1,2 @@
+Fix caching of multi-value :data:`typing.Literal`. ``Literal[True, 2]`` is no
+longer equal to ``Literal[1, 2]``.


### PR DESCRIPTION
Literal[True, 2] is no longer equal to Literal[1, 2].
(cherry picked from commit 634984d7dbdd91e0a51a793eed4d870e139ae1e0)


<!-- issue-number: [bpo-45679](https://bugs.python.org/issue45679) -->
https://bugs.python.org/issue45679
<!-- /issue-number -->
