### PR TITLE
bpo-45598: Remove ffi header header

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-11-01-08-43-12.bpo-45598.cAHNki.rst
+++ b/Misc/NEWS.d/next/Build/2021-11-01-08-43-12.bpo-45598.cAHNki.rst
@@ -1,0 +1,3 @@
+ctypes now assumes that libffi provides ffi_prep_ciff, ffi_prep_closure_loc,
+and ffi_closure_alloc functions, except when compiling with older macOS
+libffi.

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -419,6 +419,8 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
     }
 #   if USING_APPLE_OS_LIBFFI
 #      define HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
+#   elif defined(MS_WIN32)
+#      define HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME 0
 #   else
 #      define HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME 1
 #   endif

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -417,7 +417,6 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
                      "ffi_prep_cif failed with %d", result);
         goto error;
     }
-#if HAVE_FFI_PREP_CLOSURE_LOC
 #   if USING_APPLE_OS_LIBFFI
 #      define HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
 #   else
@@ -427,9 +426,7 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
         result = ffi_prep_closure_loc(p->pcl_write, &p->cif, closure_fcn,
                                     p,
                                     p->pcl_exec);
-    } else
-#endif
-    {
+    } else {
 #if USING_APPLE_OS_LIBFFI && defined(__arm64__)
         PyErr_Format(PyExc_NotImplementedError, "ffi_prep_closure_loc() is missing");
         goto error;

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -828,6 +828,8 @@ static int _call_function_pointer(int flags,
 
 #   if USING_APPLE_OS_LIBFFI
 #      define HAVE_FFI_PREP_CIF_VAR_RUNTIME __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
+#   elif defined(MS_WIN32)
+#      define HAVE_FFI_PREP_CIF_VAR_RUNTIME false
 #   else
 #      define HAVE_FFI_PREP_CIF_VAR_RUNTIME true
 #   endif

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -828,10 +828,8 @@ static int _call_function_pointer(int flags,
 
 #   if USING_APPLE_OS_LIBFFI
 #      define HAVE_FFI_PREP_CIF_VAR_RUNTIME __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
-#   elif HAVE_FFI_PREP_CIF_VAR
-#      define HAVE_FFI_PREP_CIF_VAR_RUNTIME true
 #   else
-#      define HAVE_FFI_PREP_CIF_VAR_RUNTIME false
+#      define HAVE_FFI_PREP_CIF_VAR_RUNTIME true
 #   endif
 
     /* Even on Apple-arm64 the calling convention for variadic functions coincides
@@ -843,16 +841,12 @@ static int _call_function_pointer(int flags,
     (void) is_variadic;
 
 #if defined(__APPLE__) && defined(__arm64__)
-    if (is_variadic) {
-        if (HAVE_FFI_PREP_CIF_VAR_RUNTIME) {
-        } else {
-            PyErr_SetString(PyExc_NotImplementedError, "ffi_prep_cif_var() is missing");
-            return -1;
-        }
+    if (is_variadic && !HAVE_FFI_PREP_CIF_VAR_RUNTIME) {
+        PyErr_SetString(PyExc_NotImplementedError, "ffi_prep_cif_var() is missing");
+        return -1;
     }
 #endif
 
-#if HAVE_FFI_PREP_CIF_VAR
     if (is_variadic) {
         if (HAVE_FFI_PREP_CIF_VAR_RUNTIME) {
             if (FFI_OK != ffi_prep_cif_var(&cif,
@@ -876,10 +870,7 @@ static int _call_function_pointer(int flags,
                 return -1;
             }
         }
-    } else
-#endif
-
-    {
+    } else {
         if (FFI_OK != ffi_prep_cif(&cif,
                                    cc,
                                    argcount,

--- a/Modules/_ctypes/malloc_closure.c
+++ b/Modules/_ctypes/malloc_closure.c
@@ -91,7 +91,6 @@ static void more_core(void)
 /* put the item back into the free list */
 void Py_ffi_closure_free(void *p)
 {
-#if HAVE_FFI_CLOSURE_ALLOC
 #if USING_APPLE_OS_LIBFFI
     if (__builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)) {
 #endif
@@ -99,7 +98,6 @@ void Py_ffi_closure_free(void *p)
         return;
 #if USING_APPLE_OS_LIBFFI
     }
-#endif
 #endif
     ITEM *item = (ITEM *)p;
     item->next = free_list;
@@ -109,14 +107,12 @@ void Py_ffi_closure_free(void *p)
 /* return one item from the free list, allocating more if needed */
 void *Py_ffi_closure_alloc(size_t size, void** codeloc)
 {
-#if HAVE_FFI_CLOSURE_ALLOC
 #if USING_APPLE_OS_LIBFFI
     if (__builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)) {
 #endif
         return ffi_closure_alloc(size, codeloc);
 #if USING_APPLE_OS_LIBFFI
     }
-#endif
 #endif
     ITEM *item;
     if (!free_list)

--- a/setup.py
+++ b/setup.py
@@ -238,14 +238,6 @@ def is_macosx_sdk_path(path):
                 or path.startswith('/System/iOSSupport') )
 
 
-def grep_headers_for(function, headers):
-    for header in headers:
-        with open(header, 'r', errors='surrogateescape') as f:
-            if function in f.read():
-                return True
-    return False
-
-
 def find_file(filename, std_dirs, paths):
     """Searches for the directory where a given file is located,
     and returns a possibly-empty list of additional directories, or None
@@ -2280,14 +2272,6 @@ class PyBuildExt(build_ext):
                     break
 
         if ffi_inc and ffi_lib:
-            ffi_headers = glob(os.path.join(ffi_inc, '*.h'))
-            if grep_headers_for('ffi_prep_cif_var', ffi_headers):
-                ext.extra_compile_args.append("-DHAVE_FFI_PREP_CIF_VAR=1")
-            if grep_headers_for('ffi_prep_closure_loc', ffi_headers):
-                ext.extra_compile_args.append("-DHAVE_FFI_PREP_CLOSURE_LOC=1")
-            if grep_headers_for('ffi_closure_alloc', ffi_headers):
-                ext.extra_compile_args.append("-DHAVE_FFI_CLOSURE_ALLOC=1")
-
             ext.include_dirs.append(ffi_inc)
             ext.libraries.append(ffi_lib)
             self.use_system_libffi = True


### PR DESCRIPTION
libffi supports ffi_prep_ciff, ffi_prep_closure_loc, and ffi_closure_alloc
for more than a decade. Assume that the feature exists on supported
platforms and only keep checks for old macOS libffi.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45598](https://bugs.python.org/issue45598) -->
https://bugs.python.org/issue45598
<!-- /issue-number -->
