### PR TITLE
bpo-45688: Add _scproxy to sys.stdlib_module_names (GH-29358)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-11-02-09-27-46.bpo-45688.v5Der1.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-11-02-09-27-46.bpo-45688.v5Der1.rst
@@ -1,0 +1,2 @@
+:data:`sys.stdlib_module_names` now contains the macOS-specific module
+:mod:`_scproxy`.

--- a/Python/stdlib_module_names.h
+++ b/Python/stdlib_module_names.h
@@ -61,6 +61,7 @@ static const char* _Py_stdlib_module_names[] = {
 "_pyio",
 "_queue",
 "_random",
+"_scproxy",
 "_sha1",
 "_sha256",
 "_sha3",

--- a/Tools/scripts/generate_stdlib_module_names.py
+++ b/Tools/scripts/generate_stdlib_module_names.py
@@ -54,6 +54,10 @@ WINDOWS_MODULES = (
     'winsound'
 )
 
+# macOS extension modules
+MACOS_MODULES = (
+    '_scproxy',
+)
 
 # Pure Python modules (Lib/*.py)
 def list_python_modules(names):
@@ -136,7 +140,7 @@ def list_frozen(names):
 
 
 def list_modules():
-    names = set(sys.builtin_module_names) | set(WINDOWS_MODULES)
+    names = set(sys.builtin_module_names) | set(WINDOWS_MODULES) | set(MACOS_MODULES)
     list_modules_setup_extensions(names)
     list_setup_extensions(names)
     list_packages(names)


### PR DESCRIPTION
Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45688](https://bugs.python.org/issue45688) -->
https://bugs.python.org/issue45688
<!-- /issue-number -->
