### PR TITLE
bpo-39452: [doc] Change "must" to "can", on relative import style in __main__ modules

### DIFF
--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -231,7 +231,7 @@ students::
     print(f'Found student: {search_students(student_name)}')
 
 Note that ``from .student import search_students`` is an example of a relative
-import.  This import style must be used when referencing modules within a
+import.  This import style can be used when referencing modules within a
 package.  For more details, see :ref:`intra-package-references` in the
 :ref:`tut-modules` section of the tutorial.
 


### PR DESCRIPTION
The referenced link (https://docs.python.org/3.11/tutorial/modules.html#intra-package-references) says nothing about a requirement on the relative import style.

<!-- issue-number: [bpo-39452](https://bugs.python.org/issue39452) -->
https://bugs.python.org/issue39452
<!-- /issue-number -->
