### PR TITLE
bpo-45697: PyType_IsSubtype: Return early for identical type objects

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1547,6 +1547,10 @@ PyType_IsSubtype(PyTypeObject *a, PyTypeObject *b)
 {
     PyObject *mro;
 
+    if (a == b) {
+        return 1;
+    }
+
     mro = a->tp_mro;
     if (mro != NULL) {
         /* Deal with multiple inheritance without recursion


### PR DESCRIPTION
# [bpo-45697](https://bugs.python.org/issue45697): PyType_IsSubtype: Return early for identical type objects

Based on real world profiling data we collected, a vast amount of `PyType_IsSubtype` calls are coming from `type_call`, when it decides whether `__init__` should run or not.

In the common case, the arguments to this call are identical, but the implementation still walks the MRO.

By returning early for identical types, the common case can be optimized with a non-trivial performance gain.

<!-- issue-number: [bpo-45697](https://bugs.python.org/issue45697) -->
https://bugs.python.org/issue45697
<!-- /issue-number -->
