### PR TITLE
bpo-24139: Fix sqlite3 test suite on s390x RHEL buildbots

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -317,7 +317,7 @@ class ModuleTests(unittest.TestCase):
         with managed_connect(":memory:", in_mem=True) as con:
             with con:
                 con.execute("create table t(t integer check(t > 0))")
-            errmsg = "CHECK constraint failed"
+            errmsg = "constraint failed"
             with self.assertRaisesRegex(sqlite.IntegrityError, errmsg) as cm:
                 con.execute("insert into t values(-1)")
             exc = cm.exception


### PR DESCRIPTION
GH-28076 broke s390x RHEL buildbots; SQLite check constraint error messages
differ slightly from other distros. Ease the regex a little bit to please s390x buildbots.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-24139](https://bugs.python.org/issue24139) -->
https://bugs.python.org/issue24139
<!-- /issue-number -->
