### PR TITLE
[doc] bpo-45680: Disambiguate ``__getitem__`` and ``__class_getitem__`` in the  data model.

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -257,6 +257,7 @@ called :class:`TypeVar`.
    def first(l: Sequence[T]) -> T:   # Generic function
        return l[0]
 
+.. _user-defined-generics:
 
 User-defined generic types
 ==========================

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2215,23 +2215,80 @@ case the instance is itself a class.
 Emulating generic types
 -----------------------
 
-One can implement the generic class syntax as specified by :pep:`484`
-(for example ``List[int]``) by defining a special method:
+When using :term:`type annotations<annotation>`, it is often useful to
+*parameterize* a generic type using Python's square-brackets notation.
+For example, the annotation ``list[int]`` might be used to signify a
+:class:`list` in which all the elements are of type :class:`int`.
+
+.. seealso::
+
+   :pep:`484` - Type Hints
+      Introducing Python's framework for type annotations
+
+   :ref:`Generic Alias Types<types-genericalias>`
+      Documentation for objects representing parameterized generic classes
+
+   :class:`typing.Generic`
+      Inherit from :class:`typing.Generic` to implement generic classes that
+      can be parameterized at runtime and understood by static type-checkers.
+
+A class can generally only be parameterized if it defines the special
+classmethod ``__class_getitem__()``.
 
 .. classmethod:: object.__class_getitem__(cls, key)
 
    Return an object representing the specialization of a generic class
    by type arguments found in *key*.
 
-This method is looked up on the class object itself, and when defined in
-the class body, this method is implicitly a class method.  Note, this
-mechanism is primarily reserved for use with static type hints, other usage
-is discouraged.
+``__getitem__`` *versus* ``__class_getitem__``
 
-.. seealso::
+   Usually, the :ref:`subscription <subscriptions>` of an object in Python
+   using the square-brackets notation will call the :meth:`~object.__getitem__`
+   instance method defined on the object's class.
 
-   :pep:`560` - Core support for typing module and generic types
+   For example, if we have a list ``food`` as follows::
 
+      food = ['spam', 'eggs', 'bacon']
+
+   Calling ``food[0]`` will return the same value as calling::
+
+      type(food).__getitem__(food, 0)
+
+   However, if a class defines the classmethod ``__class_getitem__()``, then
+   the subscription of that class may call the class's implementation of
+   ``__class_getitem__()`` rather than :meth:`~object.__getitem__`.
+   ``__class_getitem__()`` should return a
+   :ref:`GenericAlias<types-genericalias>` object if it is properly defined.
+
+   For example, because the :class:`list` class defines
+   ``__class_getitem__()``, calling ``list[str]`` is equivalent to calling::
+
+      list.__class_getitem__(str)
+
+   rather than::
+
+      type(list).__getitem__(list, str)
+
+.. note::
+   If :meth:`~object.__getitem__` is defined by a class's :term:`metaclass`, it
+   will take precedence over a ``__class_getitem__()`` classmethod
+   defined by the class. See :pep:`560` for more details.
+
+.. note::
+   ``__class_getitem__()`` was introduced to implement runtime parameterization
+   of standard-library generic classes in order to more easily apply
+   :term:`type-hints<type hint>` to these classes.
+
+   To implement custom generic classes that can be parameterized at runtime and
+   understood by static type-checkers, users should either inherit from a
+   standard library class that already implements ``__class_getitem__()``, or
+   inherit from :class:`typing.Generic`, which has its own implementation of
+   ``__class_getitem__()``.
+
+   Custom implementations of ``__class_getitem__()`` on classes defined outside
+   of the standard library may not be understood by third-party type-checkers
+   such as mypy. Using ``__class_getitem__()`` on any class for purposes other
+   than type-hinting is discouraged.
 
 .. _callable-types:
 
@@ -2343,6 +2400,12 @@ through the object's keys; for sequences, it should iterate through the values.
 
       :keyword:`for` loops expect that an :exc:`IndexError` will be raised for illegal
       indexes to allow proper detection of the end of the sequence.
+
+   .. note::
+
+      When :ref:`subscripting<subscriptions>` a *class*, the special
+      classmethod :meth:`~object.__class_getitem__` may be called instead of
+      ``__getitem__()``.
 
 
 .. method:: object.__setitem__(self, key, value)

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2282,7 +2282,11 @@ follows something like the following process to decide whether
 :meth:`~object.__getitem__` or :meth:`~object.__class_getitem__` should be
 called::
 
+   from inspect import isclass
+
    def subscribe(obj, x):
+       """Return the result of the expression `obj[x]`"""
+       
        class_of_obj = type(obj)
 
        # If the class of `obj` defines `__getitem__()`,
@@ -2290,9 +2294,9 @@ called::
        if hasattr(class_of_obj, '__getitem__'):
            return class_of_obj.__getitem__(obj, x)
 
-       # Else, if `obj` defines `__class_getitem__()`,
+       # Else, if `obj` is a class and defines `__class_getitem__()`,
        # call `obj.__class_getitem__()`
-       elif hasattr(obj, '__class_getitem__'):
+       elif isclass(obj) and hasattr(obj, '__class_getitem__'):
            return obj.__class_getitem__(x)
 
        # Else, raise an exception

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2289,13 +2289,13 @@ called::
 
        class_of_obj = type(obj)
 
-       # If the class of `obj` defines `__getitem__()`,
-       # call `type(obj).__getitem__()`
+       # If the class of obj defines __getitem__,
+       # call class_of_obj.__getitem__(obj, x)
        if hasattr(class_of_obj, '__getitem__'):
            return class_of_obj.__getitem__(obj, x)
 
-       # Else, if `obj` is a class and defines `__class_getitem__()`,
-       # call `obj.__class_getitem__()`
+       # Else, if obj is a class and defines __class_getitem__,
+       # call obj.__class_getitem__(x)
        elif isclass(obj) and hasattr(obj, '__class_getitem__'):
            return obj.__class_getitem__(x)
 
@@ -2312,15 +2312,15 @@ a class is known as that class's :term:`metaclass`, and most classes have the
 ``dict[str, float]`` and ``tuple[str, bytes]`` all result in
 :meth:`~object.__class_getitem__` being called::
 
-   >>> # `list` has `type` as its metaclass, like most classes:
+   >>> # list has class "type" as its metaclass, like most classes:
    >>> type(list)
    <class 'type'>
    >>> type(dict) == type(list) == type(tuple) == type(str) == type(bytes)
    True
-   >>> # `list[int]` calls `list.__class_getitem__()`
+   >>> # "list[int]" calls "list.__class_getitem__(int)"
    >>> list[int]
    list[int]
-   >>> # `list.__class_getitem__()` returns a `GenericAlias` object:
+   >>> # list.__class_getitem__ returns a GenericAlias object:
    >>> type(list[int])
    <class 'types.GenericAlias'>
 
@@ -2334,13 +2334,16 @@ behaviour. An example of this can be found in the :mod:`enum` module::
    ...     SPAM = 'spam'
    ...     BACON = 'bacon'
    ...
-   >>> # `Enum` classes have a custom metaclass
+   >>> # Enum classes have a custom metaclass:
    >>> type(Menu)
    <class 'enum.EnumMeta'>
-   >>> # `EnumMeta` defines `__getitem__()`,
-   >>> # so `__class_getitem__()` is not called:
+   >>> # EnumMeta defines __getitem__,
+   >>> # so __class_getitem__ is not called,
+   >>> # and the result is not a GenericAlias object:
    >>> Menu['SPAM']
    <Menu.SPAM: 'spam'>
+   >>> type(Menu['SPAM'])
+   <enum 'Menu'>
 
 
 .. seealso::

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2216,7 +2216,7 @@ Emulating generic types
 -----------------------
 
 When using :term:`type annotations<annotation>`, it is often useful to
-*parameterize* a generic type using Python's square-brackets notation.
+*parameterize* a :term:`generic type` using Python's square-brackets notation.
 For example, the annotation ``list[int]`` might be used to signify a
 :class:`list` in which all the elements are of type :class:`int`.
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2443,27 +2443,27 @@ through the object's keys; for sequences, it should iterate through the values.
 
 .. method:: object.__getitem__(self, key)
 
-   Called to implement evaluation of ``self[key]``, which is translated by the
-   interpreter to ``type(self).__getitem__(self, key)``. For :term:`sequence`
-   types, the accepted keys should be integers and slice objects.  Note that
-   the special interpretation of negative indexes (if the class wishes to
-   emulate a :term:`sequence` type) is up to the :meth:`__getitem__` method. If
-   *key* is of an inappropriate type, :exc:`TypeError` may be raised; if of a
-   value outside the set of indexes for the sequence (after any special
+   Called to implement evaluation of ``self[key]``. For :term:`sequence` types,
+   the accepted keys should be integers and slice objects.  Note that the
+   special interpretation of negative indexes (if the class wishes to emulate a
+   :term:`sequence` type) is up to the :meth:`__getitem__` method. If *key* is
+   of an inappropriate type, :exc:`TypeError` may be raised; if of a value
+   outside the set of indexes for the sequence (after any special
    interpretation of negative values), :exc:`IndexError` should be raised. For
    :term:`mapping` types, if *key* is missing (not in the container),
    :exc:`KeyError` should be raised.
 
    .. note::
 
-      :keyword:`for` loops expect that an :exc:`IndexError` will be raised for illegal
-      indexes to allow proper detection of the end of the sequence.
+      :keyword:`for` loops expect that an :exc:`IndexError` will be raised for
+      illegal indexes to allow proper detection of the end of the sequence.
 
    .. note::
 
       When :ref:`subscripting<subscriptions>` a *class*, the special
       class method :meth:`~object.__class_getitem__` may be called instead of
-      ``__getitem__()``. See :ref:`classgetitem-versus-getitem`.
+      ``__getitem__()``. See :ref:`classgetitem-versus-getitem` for more
+      details.
 
 
 .. method:: object.__setitem__(self, key, value)

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2240,39 +2240,6 @@ classmethod ``__class_getitem__()``.
    Return an object representing the specialization of a generic class
    by type arguments found in *key*.
 
-``__getitem__`` *versus* ``__class_getitem__``
-
-   Usually, the :ref:`subscription <subscriptions>` of an object in Python
-   using the square-brackets notation will call the :meth:`~object.__getitem__`
-   instance method defined on the object's class.
-
-   For example, if we have a list ``food`` as follows::
-
-      food = ['spam', 'eggs', 'bacon']
-
-   Calling ``food[0]`` will return the same value as calling::
-
-      type(food).__getitem__(food, 0)
-
-   However, if a class defines the classmethod ``__class_getitem__()``, then
-   the subscription of that class may call the class's implementation of
-   ``__class_getitem__()`` rather than :meth:`~object.__getitem__`.
-   ``__class_getitem__()`` should return a
-   :ref:`GenericAlias<types-genericalias>` object if it is properly defined.
-
-   For example, because the :class:`list` class defines
-   ``__class_getitem__()``, calling ``list[str]`` is equivalent to calling::
-
-      list.__class_getitem__(str)
-
-   rather than::
-
-      type(list).__getitem__(list, str)
-
-.. note::
-   If :meth:`~object.__getitem__` is defined by a class's :term:`metaclass`, it
-   will take precedence over a ``__class_getitem__()`` classmethod
-   defined by the class. See :pep:`560` for more details.
 
 .. note::
    ``__class_getitem__()`` was introduced to implement runtime parameterization
@@ -2289,6 +2256,33 @@ classmethod ``__class_getitem__()``.
    of the standard library may not be understood by third-party type-checkers
    such as mypy. Using ``__class_getitem__()`` on any class for purposes other
    than type-hinting is discouraged.
+
+
+*__class_getitem__* versus *__getitem__*
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Usually, the :ref:`subscription <subscriptions>` of an object in Python
+using the square-brackets notation will call the :meth:`~object.__getitem__`
+instance method defined on the object's class. However, if a class defines the
+classmethod ``__class_getitem__()``, then the subscription of that class may
+call the class's implementation of ``__class_getitem__()`` rather than
+:meth:`~object.__getitem__`. ``__class_getitem__()`` should return a
+:ref:`GenericAlias<types-genericalias>` object if it is properly defined.
+
+For example, because the :class:`list` class defines ``__class_getitem__()``,
+calling ``list[str]`` is equivalent to calling::
+
+   list.__class_getitem__(str)
+
+rather than::
+
+   type(list).__getitem__(list, str)
+
+.. note::
+   If :meth:`~object.__getitem__` is defined by a class's :term:`metaclass`, it
+   will take precedence over a ``__class_getitem__()`` classmethod defined by
+   the class. See :pep:`560` for more details.
+
 
 .. _callable-types:
 
@@ -2387,14 +2381,16 @@ through the object's keys; for sequences, it should iterate through the values.
 
 .. method:: object.__getitem__(self, key)
 
-   Called to implement evaluation of ``self[key]``. For sequence types, the
-   accepted keys should be integers and slice objects.  Note that the special
-   interpretation of negative indexes (if the class wishes to emulate a sequence
-   type) is up to the :meth:`__getitem__` method. If *key* is of an inappropriate
-   type, :exc:`TypeError` may be raised; if of a value outside the set of indexes
-   for the sequence (after any special interpretation of negative values),
-   :exc:`IndexError` should be raised. For mapping types, if *key* is missing (not
-   in the container), :exc:`KeyError` should be raised.
+   Called to implement evaluation of ``self[key]``, which is translated by the
+   interpreter to ``type(self).__getitem__(self, key)``. For :term:`sequence`
+   types, the accepted keys should be integers and slice objects.  Note that
+   the special interpretation of negative indexes (if the class wishes to
+   emulate a :term:`sequence` type) is up to the :meth:`__getitem__` method. If
+   *key* is of an inappropriate type, :exc:`TypeError` may be raised; if of a
+   value outside the set of indexes for the sequence (after any special
+   interpretation of negative values), :exc:`IndexError` should be raised. For
+   :term:`mapping` types, if *key* is missing (not in the container),
+   :exc:`KeyError` should be raised.
 
    .. note::
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2286,7 +2286,7 @@ called::
 
    def subscribe(obj, x):
        """Return the result of the expression `obj[x]`"""
-       
+
        class_of_obj = type(obj)
 
        # If the class of `obj` defines `__getitem__()`,

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2228,9 +2228,9 @@ For example, the annotation ``list[int]`` might be used to signify a
    :ref:`Generic Alias Types<types-genericalias>`
       Documentation for objects representing parameterized generic classes
 
-   :class:`typing.Generic`
-      Inherit from :class:`typing.Generic` to implement generic classes that
-      can be parameterized at runtime and understood by static type-checkers.
+   :ref:`Generics`, :ref:`user-defined generics<user-defined-generics>` and :class:`typing.Generic`
+      Documentation on how to implement generic classes that can be
+      parameterized at runtime and understood by static type-checkers.
 
 A class can generally only be parameterized if it defines the special
 classmethod ``__class_getitem__()``.

--- a/Misc/NEWS.d/next/Documentation/2021-11-03-14-30-55.bpo-45680.UBpWzY.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-11-03-14-30-55.bpo-45680.UBpWzY.rst
@@ -1,2 +1,2 @@
-Disambiguate the differences between ``__getitem__`` and __class_getitem__``
+Disambiguate the differences between ``__getitem__`` and ``__class_getitem__``
 in the documentation for the data model. Patch by Alex Waygood.

--- a/Misc/NEWS.d/next/Documentation/2021-11-03-14-30-55.bpo-45680.UBpWzY.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-11-03-14-30-55.bpo-45680.UBpWzY.rst
@@ -1,2 +1,0 @@
-Disambiguate the differences between ``__getitem__`` and ``__class_getitem__``
-in the documentation for the data model. Patch by Alex Waygood.

--- a/Misc/NEWS.d/next/Documentation/2021-11-03-14-30-55.bpo-45680.UBpWzY.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-11-03-14-30-55.bpo-45680.UBpWzY.rst
@@ -1,0 +1,2 @@
+Disambiguate the differences between ``__getitem__`` and __class_getitem__``
+in the documentation for the data model. Patch by Alex Waygood.


### PR DESCRIPTION
The documentation explaining Python's data model does not adequately explain
the differences between ``__getitem__`` and ``__class_getitem__``, nor does it
explain when each is called. There is an attempt at explaining
``__class_getitem__`` in the documentation for ``GenericAlias`` objects, but
this does not give sufficient clarity into how the method works. Moreover, it
is the wrong place for that information to be found; the explanation of
``__class_getitem__`` should be in the documentation explaining the data model.

This PR has been split off from #29335.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45680](https://bugs.python.org/issue45680) -->
https://bugs.python.org/issue45680
<!-- /issue-number -->
