### PR TITLE
bpo-45697: Use PyObject_TypeCheck in type_call and binary_op1

### DIFF
--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -881,7 +881,7 @@ binary_op1(PyObject *v, PyObject *w, const int op_slot
 
     if (slotv) {
         PyObject *x;
-        if (slotw && PyType_IsSubtype(Py_TYPE(w), Py_TYPE(v))) {
+        if (slotw && PyObject_TypeCheck(w, Py_TYPE(v))) {
             x = slotw(v, w);
             if (x != Py_NotImplemented)
                 return x;

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -881,7 +881,7 @@ binary_op1(PyObject *v, PyObject *w, const int op_slot
 
     if (slotv) {
         PyObject *x;
-        if (slotw && PyObject_TypeCheck(w, Py_TYPE(v))) {
+        if (slotw && PyType_IsSubtype(Py_TYPE(w), Py_TYPE(v))) {
             x = slotw(v, w);
             if (x != Py_NotImplemented)
                 return x;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1121,7 +1121,7 @@ type_call(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     /* If the returned object is not an instance of type,
        it won't be initialized. */
-    if (!PyType_IsSubtype(Py_TYPE(obj), type))
+    if (!PyObject_TypeCheck(obj, type))
         return obj;
 
     type = Py_TYPE(obj);


### PR DESCRIPTION
# [bpo-45697](https://bugs.python.org/issue45697): Use PyObject_TypeCheck in type_call and binary_op1

Based on real world profiling data we collected, a vast amount of `PyType_IsSubtype` calls are coming from `type_call`, when it decides whether `__init__` should run or not.

In the common case, the arguments to this call are identical, but the implementation still walks the MRO.

Using `PyObject_TypeCheck` avoids calling `PyType_IsSubtype` in the common case.

This PR supersedes GH-29380 based on discussion on the issue https://bugs.python.org/issue45697

<!-- issue-number: [bpo-45697](https://bugs.python.org/issue45697) -->
https://bugs.python.org/issue45697
<!-- /issue-number -->
