### PR TITLE
[3.9] bpo-45678: Fix `singledispatchmethod` `classmethod`/`staticmethod` bug

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -904,12 +904,10 @@ class singledispatchmethod:
         # bpo-45678: special-casing for classmethod/staticmethod in Python <=3.9,
         # as functools.update_wrapper doesn't work properly in singledispatchmethod.__get__
         # if it is applied to an unbound classmethod/staticmethod
-        self._wrapped_func = (
-            func.__func__
-            if isinstance(func, (staticmethod, classmethod))
-            else func
-        )
-
+        if isinstance(func, (staticmethod, classmethod)):
+            self._wrapped_func = func.__func__
+        else:
+            self._wrapped_func = func
     def register(self, cls, method=None):
         """generic_method.register(cls, func) -> func
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -901,6 +901,15 @@ class singledispatchmethod:
         self.dispatcher = singledispatch(func)
         self.func = func
 
+        # bpo-45678: special-casing for classmethod/staticmethod in Python <=3.9,
+        # as functools.update_wrapper doesn't work properly in singledispatchmethod.__get__
+        # if it is applied to an unbound classmethod/staticmethod
+        self._wrapped_func = (
+            func.__func__
+            if isinstance(func, (staticmethod, classmethod))
+            else func
+        )
+
     def register(self, cls, method=None):
         """generic_method.register(cls, func) -> func
 
@@ -921,7 +930,7 @@ class singledispatchmethod:
 
         _method.__isabstractmethod__ = self.__isabstractmethod__
         _method.register = self.register
-        update_wrapper(_method, self.func)
+        update_wrapper(_method, self._wrapped_func)
         return _method
 
     @property

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2401,7 +2401,7 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(A.t(0.0).arg, "base")
 
     def test_abstractmethod_register(self):
-        class Abstract(abc.ABCMeta):
+        class Abstract(metaclass=abc.ABCMeta):
 
             @functools.singledispatchmethod
             @abc.abstractmethod
@@ -2409,6 +2409,10 @@ class TestSingleDispatch(unittest.TestCase):
                 pass
 
         self.assertTrue(Abstract.add.__isabstractmethod__)
+        self.assertTrue(Abstract.__dict__['add'].__isabstractmethod__)
+
+        with self.assertRaises(TypeError):
+            Abstract()
 
     def test_type_ann_register(self):
         class A:
@@ -2468,6 +2472,137 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(A.t(0).arg, "int")
         self.assertEqual(A.t('').arg, "str")
         self.assertEqual(A.t(0.0).arg, "base")
+
+    def test_method_wrapping_attributes(self):
+        class A:
+            @functools.singledispatchmethod
+            def func(self, arg: int) -> str:
+                """My function docstring"""
+                return str(arg)
+            @functools.singledispatchmethod
+            @classmethod
+            def cls_func(cls, arg: int) -> str:
+                """My function docstring"""
+                return str(arg)
+            @functools.singledispatchmethod
+            @staticmethod
+            def static_func(arg: int) -> str:
+                """My function docstring"""
+                return str(arg)
+
+        for meth in (
+            A.func,
+            A().func,
+            A.cls_func,
+            A().cls_func,
+            A.static_func,
+            A().static_func
+        ):
+            with self.subTest(meth=meth):
+                self.assertEqual(meth.__doc__, 'My function docstring')
+                self.assertEqual(meth.__annotations__['arg'], int)
+
+        self.assertEqual(A.func.__name__, 'func')
+        self.assertEqual(A().func.__name__, 'func')
+        self.assertEqual(A.cls_func.__name__, 'cls_func')
+        self.assertEqual(A().cls_func.__name__, 'cls_func')
+        self.assertEqual(A.static_func.__name__, 'static_func')
+        self.assertEqual(A().static_func.__name__, 'static_func')
+
+    def test_double_wrapped_methods(self):
+        def classmethod_friendly_decorator(func):
+            wrapped = func.__func__
+            @classmethod
+            @functools.wraps(wrapped)
+            def wrapper(*args, **kwargs):
+                return wrapped(*args, **kwargs)
+            return wrapper
+
+        class WithoutSingleDispatch:
+            @classmethod
+            @contextlib.contextmanager
+            def cls_context_manager(cls, arg: int) -> str:
+                try:
+                    yield str(arg)
+                finally:
+                    return 'Done'
+
+            @classmethod_friendly_decorator
+            @classmethod
+            def decorated_classmethod(cls, arg: int) -> str:
+                return str(arg)
+
+        try:
+            with WithoutSingleDispatch.cls_context_manager(3) as foo:
+                assert foo == '3', (
+                       "Classmethod contextmanager called from class not working"
+                    )
+            with WithoutSingleDispatch().cls_context_manager(3) as bar:
+                assert bar == '3', (
+                       "Classmethod contextmanager called from instance not working"
+                    )
+            assert WithoutSingleDispatch.decorated_classmethod(666) == '666', (
+                   "Wrapped classmethod called from class not working"
+                )
+            assert WithoutSingleDispatch().decorated_classmethod(666) == '666', (
+                   "Wrapped classmethod called from instance not working"
+                )
+        except AssertionError as e:
+            self.fail(f"There's a bug in this test: '{e}'")
+
+        class A:
+            @functools.singledispatchmethod
+            @classmethod
+            @contextlib.contextmanager
+            def cls_context_manager(cls, arg: int) -> str:
+                """My function docstring"""
+                try:
+                    yield str(arg)
+                finally:
+                    return 'Done'
+
+            @functools.singledispatchmethod
+            @classmethod_friendly_decorator
+            @classmethod
+            def decorated_classmethod(cls, arg: int) -> str:
+                """My function docstring"""
+                return str(arg)
+
+        with WithoutSingleDispatch.cls_context_manager(5) as foo:
+            without_single_dispatch_foo = foo
+
+        with A.cls_context_manager(5) as foo:
+            single_dispatch_foo = foo
+
+        self.assertEqual(without_single_dispatch_foo, single_dispatch_foo)
+        self.assertEqual(single_dispatch_foo, '5')
+
+        for method_name in ('cls_context_manager', 'decorated_classmethod'):
+            with self.subTest(method=method_name):
+                self.assertEqual(
+                    getattr(A, method_name).__name__,
+                    getattr(WithoutSingleDispatch, method_name).__name__
+                )
+
+                self.assertEqual(
+                    getattr(A(), method_name).__name__,
+                    getattr(WithoutSingleDispatch(), method_name).__name__
+                )
+
+        for meth in (
+            A.cls_context_manager,
+            A().cls_context_manager,
+            A.decorated_classmethod,
+            A().decorated_classmethod
+        ):
+            with self.subTest(meth=meth):
+                self.assertEqual(meth.__doc__, 'My function docstring')
+                self.assertEqual(meth.__annotations__['arg'], int)
+
+        self.assertEqual(A.cls_context_manager.__name__, 'cls_context_manager')
+        self.assertEqual(A().cls_context_manager.__name__, 'cls_context_manager')
+        self.assertEqual(A.decorated_classmethod.__name__, 'decorated_classmethod')
+        self.assertEqual(A().decorated_classmethod.__name__, 'decorated_classmethod')
 
     def test_invalid_registrations(self):
         msg_prefix = "Invalid first argument to `register()`: "

--- a/Misc/NEWS.d/next/Library/2021-11-03-17-28-43.bpo-45678.Zj_O8j.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-03-17-28-43.bpo-45678.Zj_O8j.rst
@@ -1,0 +1,2 @@
+Fix bug in Python 3.9 that meant ``functools.singledispatchmethod`` failed
+to properly wrap the attributes of the target method. Patch by Alex Waygood.


### PR DESCRIPTION
This PR fixes a bug in the 3.9 branch where
``functools.singledispatchmethod`` did not properly wrap attributes such as
``__name__``, ``__doc__`` and ``__module__`` of the target method. It also
backports tests already merged into the 3.11 and 3.10 branches in #29328 and
#29390.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45678](https://bugs.python.org/issue45678) -->
https://bugs.python.org/issue45678
<!-- /issue-number -->
