### PR TITLE
[3.10] bpo-44257: fix "assigment_expr" typo + regenerate the grammar and remove unused imports (GH-29393)

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -512,11 +512,11 @@ star_named_expression[expr_ty]:
     | named_expression
 
 
-assigment_expression[expr_ty]:
+assignment_expression[expr_ty]:
     | a=NAME ':=' ~ b=expression { _PyAST_NamedExpr(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), b, EXTRA) }
 
 named_expression[expr_ty]:
-    | assigment_expression
+    | assignment_expression
     | invalid_named_expression
     | expression !':='
 
@@ -708,7 +708,7 @@ group[expr_ty]:
     | '(' a=(yield_expr | named_expression) ')' { a }
     | invalid_group
 genexp[expr_ty]:
-    | '(' a=( assigment_expression | expression !':=') b=for_if_clauses ')' { _PyAST_GeneratorExp(a, b, EXTRA) }
+    | '(' a=( assignment_expression | expression !':=') b=for_if_clauses ')' { _PyAST_GeneratorExp(a, b, EXTRA) }
     | invalid_comprehension
 set[expr_ty]: '{' a=star_named_expressions '}' { _PyAST_Set(a, EXTRA) }
 setcomp[expr_ty]:
@@ -747,7 +747,7 @@ arguments[expr_ty] (memo):
     | a=args [','] &')' { a }
     | invalid_arguments
 args[expr_ty]:
-    | a[asdl_expr_seq*]=','.(starred_expression | ( assigment_expression | expression !':=') !'=')+ b=[',' k=kwargs {k}] {
+    | a[asdl_expr_seq*]=','.(starred_expression | ( assignment_expression | expression !':=') !'=')+ b=[',' k=kwargs {k}] {
         _PyPegen_collect_call_seqs(p, a, b, EXTRA) }
     | a=kwargs { _PyAST_Call(_PyPegen_dummy_name(p),
                           CHECK_NULL_ALLOWED(asdl_expr_seq*, _PyPegen_seq_extract_starred_exprs(p, a)),

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -170,7 +170,7 @@ static char *soft_keywords[] = {
 #define star_expression_type 1096
 #define star_named_expressions_type 1097
 #define star_named_expression_type 1098
-#define assigment_expression_type 1099
+#define assignment_expression_type 1099
 #define named_expression_type 1100
 #define annotated_rhs_type 1101
 #define expressions_type 1102
@@ -598,7 +598,7 @@ static expr_ty star_expressions_rule(Parser *p);
 static expr_ty star_expression_rule(Parser *p);
 static asdl_expr_seq* star_named_expressions_rule(Parser *p);
 static expr_ty star_named_expression_rule(Parser *p);
-static expr_ty assigment_expression_rule(Parser *p);
+static expr_ty assignment_expression_rule(Parser *p);
 static expr_ty named_expression_rule(Parser *p);
 static expr_ty annotated_rhs_rule(Parser *p);
 static expr_ty expressions_rule(Parser *p);
@@ -10210,9 +10210,9 @@ star_named_expression_rule(Parser *p)
     return _res;
 }
 
-// assigment_expression: NAME ':=' ~ expression
+// assignment_expression: NAME ':=' ~ expression
 static expr_ty
-assigment_expression_rule(Parser *p)
+assignment_expression_rule(Parser *p)
 {
     D(p->level++);
     if (p->error_indicator) {
@@ -10235,7 +10235,7 @@ assigment_expression_rule(Parser *p)
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> assigment_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME ':=' ~ expression"));
+        D(fprintf(stderr, "%*c> assignment_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME ':=' ~ expression"));
         int _cut_var = 0;
         Token * _literal;
         expr_ty a;
@@ -10250,7 +10250,7 @@ assigment_expression_rule(Parser *p)
             (b = expression_rule(p))  // expression
         )
         {
-            D(fprintf(stderr, "%*c+ assigment_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME ':=' ~ expression"));
+            D(fprintf(stderr, "%*c+ assignment_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME ':=' ~ expression"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
                 D(p->level--);
@@ -10269,7 +10269,7 @@ assigment_expression_rule(Parser *p)
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s assigment_expression[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s assignment_expression[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NAME ':=' ~ expression"));
         if (_cut_var) {
             D(p->level--);
@@ -10282,7 +10282,7 @@ assigment_expression_rule(Parser *p)
     return _res;
 }
 
-// named_expression: assigment_expression | invalid_named_expression | expression !':='
+// named_expression: assignment_expression | invalid_named_expression | expression !':='
 static expr_ty
 named_expression_rule(Parser *p)
 {
@@ -10293,24 +10293,24 @@ named_expression_rule(Parser *p)
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
-    { // assigment_expression
+    { // assignment_expression
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> named_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assigment_expression"));
-        expr_ty assigment_expression_var;
+        D(fprintf(stderr, "%*c> named_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
+        expr_ty assignment_expression_var;
         if (
-            (assigment_expression_var = assigment_expression_rule(p))  // assigment_expression
+            (assignment_expression_var = assignment_expression_rule(p))  // assignment_expression
         )
         {
-            D(fprintf(stderr, "%*c+ named_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "assigment_expression"));
-            _res = assigment_expression_var;
+            D(fprintf(stderr, "%*c+ named_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
+            _res = assignment_expression_var;
             goto done;
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s named_expression[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "assigment_expression"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "assignment_expression"));
     }
     if (p->call_invalid_rules) { // invalid_named_expression
         if (p->error_indicator) {
@@ -14919,7 +14919,7 @@ group_rule(Parser *p)
 }
 
 // genexp:
-//     | '(' (assigment_expression | expression !':=') for_if_clauses ')'
+//     | '(' (assignment_expression | expression !':=') for_if_clauses ')'
 //     | invalid_comprehension
 static expr_ty
 genexp_rule(Parser *p)
@@ -14940,12 +14940,12 @@ genexp_rule(Parser *p)
     UNUSED(_start_lineno); // Only used by EXTRA macro
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
-    { // '(' (assigment_expression | expression !':=') for_if_clauses ')'
+    { // '(' (assignment_expression | expression !':=') for_if_clauses ')'
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> genexp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' (assigment_expression | expression !':=') for_if_clauses ')'"));
+        D(fprintf(stderr, "%*c> genexp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' (assignment_expression | expression !':=') for_if_clauses ')'"));
         Token * _literal;
         Token * _literal_1;
         void *a;
@@ -14953,14 +14953,14 @@ genexp_rule(Parser *p)
         if (
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = _tmp_117_rule(p))  // assigment_expression | expression !':='
+            (a = _tmp_117_rule(p))  // assignment_expression | expression !':='
             &&
             (b = for_if_clauses_rule(p))  // for_if_clauses
             &&
             (_literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
-            D(fprintf(stderr, "%*c+ genexp[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' (assigment_expression | expression !':=') for_if_clauses ')'"));
+            D(fprintf(stderr, "%*c+ genexp[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' (assignment_expression | expression !':=') for_if_clauses ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
                 D(p->level--);
@@ -14980,7 +14980,7 @@ genexp_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s genexp[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'(' (assigment_expression | expression !':=') for_if_clauses ')'"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'(' (assignment_expression | expression !':=') for_if_clauses ')'"));
     }
     if (p->call_invalid_rules) { // invalid_comprehension
         if (p->error_indicator) {
@@ -15833,7 +15833,7 @@ arguments_rule(Parser *p)
 }
 
 // args:
-//     | ','.(starred_expression | (assigment_expression | expression !':=') !'=')+ [',' kwargs]
+//     | ','.(starred_expression | (assignment_expression | expression !':=') !'=')+ [',' kwargs]
 //     | kwargs
 static expr_ty
 args_rule(Parser *p)
@@ -15854,21 +15854,21 @@ args_rule(Parser *p)
     UNUSED(_start_lineno); // Only used by EXTRA macro
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
-    { // ','.(starred_expression | (assigment_expression | expression !':=') !'=')+ [',' kwargs]
+    { // ','.(starred_expression | (assignment_expression | expression !':=') !'=')+ [',' kwargs]
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> args[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.(starred_expression | (assigment_expression | expression !':=') !'=')+ [',' kwargs]"));
+        D(fprintf(stderr, "%*c> args[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.(starred_expression | (assignment_expression | expression !':=') !'=')+ [',' kwargs]"));
         asdl_expr_seq* a;
         void *b;
         if (
-            (a = (asdl_expr_seq*)_gather_123_rule(p))  // ','.(starred_expression | (assigment_expression | expression !':=') !'=')+
+            (a = (asdl_expr_seq*)_gather_123_rule(p))  // ','.(starred_expression | (assignment_expression | expression !':=') !'=')+
             &&
             (b = _tmp_125_rule(p), !p->error_indicator)  // [',' kwargs]
         )
         {
-            D(fprintf(stderr, "%*c+ args[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.(starred_expression | (assigment_expression | expression !':=') !'=')+ [',' kwargs]"));
+            D(fprintf(stderr, "%*c+ args[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.(starred_expression | (assignment_expression | expression !':=') !'=')+ [',' kwargs]"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
                 D(p->level--);
@@ -15888,7 +15888,7 @@ args_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s args[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "','.(starred_expression | (assigment_expression | expression !':=') !'=')+ [',' kwargs]"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "','.(starred_expression | (assignment_expression | expression !':=') !'=')+ [',' kwargs]"));
     }
     { // kwargs
         if (p->error_indicator) {
@@ -28292,7 +28292,7 @@ _tmp_116_rule(Parser *p)
     return _res;
 }
 
-// _tmp_117: assigment_expression | expression !':='
+// _tmp_117: assignment_expression | expression !':='
 static void *
 _tmp_117_rule(Parser *p)
 {
@@ -28303,24 +28303,24 @@ _tmp_117_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
-    { // assigment_expression
+    { // assignment_expression
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_117[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assigment_expression"));
-        expr_ty assigment_expression_var;
+        D(fprintf(stderr, "%*c> _tmp_117[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
+        expr_ty assignment_expression_var;
         if (
-            (assigment_expression_var = assigment_expression_rule(p))  // assigment_expression
+            (assignment_expression_var = assignment_expression_rule(p))  // assignment_expression
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_117[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "assigment_expression"));
-            _res = assigment_expression_var;
+            D(fprintf(stderr, "%*c+ _tmp_117[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
+            _res = assignment_expression_var;
             goto done;
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _tmp_117[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "assigment_expression"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "assignment_expression"));
     }
     { // expression !':='
         if (p->error_indicator) {
@@ -28666,7 +28666,7 @@ _loop0_122_rule(Parser *p)
     return _seq;
 }
 
-// _loop0_124: ',' (starred_expression | (assigment_expression | expression !':=') !'=')
+// _loop0_124: ',' (starred_expression | (assignment_expression | expression !':=') !'=')
 static asdl_seq *
 _loop0_124_rule(Parser *p)
 {
@@ -28687,18 +28687,18 @@ _loop0_124_rule(Parser *p)
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
-    { // ',' (starred_expression | (assigment_expression | expression !':=') !'=')
+    { // ',' (starred_expression | (assignment_expression | expression !':=') !'=')
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _loop0_124[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' (starred_expression | (assigment_expression | expression !':=') !'=')"));
+        D(fprintf(stderr, "%*c> _loop0_124[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' (starred_expression | (assignment_expression | expression !':=') !'=')"));
         Token * _literal;
         void *elem;
         while (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = _tmp_190_rule(p))  // starred_expression | (assigment_expression | expression !':=') !'='
+            (elem = _tmp_190_rule(p))  // starred_expression | (assignment_expression | expression !':=') !'='
         )
         {
             _res = elem;
@@ -28724,7 +28724,7 @@ _loop0_124_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_124[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' (starred_expression | (assigment_expression | expression !':=') !'=')"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' (starred_expression | (assignment_expression | expression !':=') !'=')"));
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -28742,7 +28742,7 @@ _loop0_124_rule(Parser *p)
 }
 
 // _gather_123:
-//     | (starred_expression | (assigment_expression | expression !':=') !'=') _loop0_124
+//     | (starred_expression | (assignment_expression | expression !':=') !'=') _loop0_124
 static asdl_seq *
 _gather_123_rule(Parser *p)
 {
@@ -28753,27 +28753,27 @@ _gather_123_rule(Parser *p)
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
-    { // (starred_expression | (assigment_expression | expression !':=') !'=') _loop0_124
+    { // (starred_expression | (assignment_expression | expression !':=') !'=') _loop0_124
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _gather_123[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(starred_expression | (assigment_expression | expression !':=') !'=') _loop0_124"));
+        D(fprintf(stderr, "%*c> _gather_123[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(starred_expression | (assignment_expression | expression !':=') !'=') _loop0_124"));
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_190_rule(p))  // starred_expression | (assigment_expression | expression !':=') !'='
+            (elem = _tmp_190_rule(p))  // starred_expression | (assignment_expression | expression !':=') !'='
             &&
             (seq = _loop0_124_rule(p))  // _loop0_124
         )
         {
-            D(fprintf(stderr, "%*c+ _gather_123[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "(starred_expression | (assigment_expression | expression !':=') !'=') _loop0_124"));
+            D(fprintf(stderr, "%*c+ _gather_123[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "(starred_expression | (assignment_expression | expression !':=') !'=') _loop0_124"));
             _res = _PyPegen_seq_insert_in_front(p, elem, seq);
             goto done;
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _gather_123[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(starred_expression | (assigment_expression | expression !':=') !'=') _loop0_124"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(starred_expression | (assignment_expression | expression !':=') !'=') _loop0_124"));
     }
     _res = NULL;
   done:
@@ -32419,7 +32419,7 @@ _tmp_189_rule(Parser *p)
     return _res;
 }
 
-// _tmp_190: starred_expression | (assigment_expression | expression !':=') !'='
+// _tmp_190: starred_expression | (assignment_expression | expression !':=') !'='
 static void *
 _tmp_190_rule(Parser *p)
 {
@@ -32449,26 +32449,26 @@ _tmp_190_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _tmp_190[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "starred_expression"));
     }
-    { // (assigment_expression | expression !':=') !'='
+    { // (assignment_expression | expression !':=') !'='
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_190[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(assigment_expression | expression !':=') !'='"));
+        D(fprintf(stderr, "%*c> _tmp_190[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(assignment_expression | expression !':=') !'='"));
         void *_tmp_201_var;
         if (
-            (_tmp_201_var = _tmp_201_rule(p))  // assigment_expression | expression !':='
+            (_tmp_201_var = _tmp_201_rule(p))  // assignment_expression | expression !':='
             &&
             _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 22)  // token='='
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_190[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "(assigment_expression | expression !':=') !'='"));
+            D(fprintf(stderr, "%*c+ _tmp_190[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "(assignment_expression | expression !':=') !'='"));
             _res = _tmp_201_var;
             goto done;
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _tmp_190[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(assigment_expression | expression !':=') !'='"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(assignment_expression | expression !':=') !'='"));
     }
     _res = NULL;
   done:
@@ -32912,7 +32912,7 @@ _tmp_200_rule(Parser *p)
     return _res;
 }
 
-// _tmp_201: assigment_expression | expression !':='
+// _tmp_201: assignment_expression | expression !':='
 static void *
 _tmp_201_rule(Parser *p)
 {
@@ -32923,24 +32923,24 @@ _tmp_201_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
-    { // assigment_expression
+    { // assignment_expression
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_201[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assigment_expression"));
-        expr_ty assigment_expression_var;
+        D(fprintf(stderr, "%*c> _tmp_201[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
+        expr_ty assignment_expression_var;
         if (
-            (assigment_expression_var = assigment_expression_rule(p))  // assigment_expression
+            (assignment_expression_var = assignment_expression_rule(p))  // assignment_expression
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_201[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "assigment_expression"));
-            _res = assigment_expression_var;
+            D(fprintf(stderr, "%*c+ _tmp_201[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
+            _res = assignment_expression_var;
             goto done;
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _tmp_201[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "assigment_expression"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "assignment_expression"));
     }
     { // expression !':='
         if (p->error_indicator) {


### PR DESCRIPTION
… 

Co-authored-by: Wim Glenn <wglenn@jumptrading.com>.
(cherry picked from commit 762173c6709f5cf3b59cbbe47d4e6fafbfe7ec2a)

Co-authored-by: wim glenn <wim.glenn@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44257](https://bugs.python.org/issue44257) -->
https://bugs.python.org/issue44257
<!-- /issue-number -->
