### PR TITLE
bpo-45220: Remove invalid include from resource definition files on Windows

### DIFF
--- a/PC/pylauncher.rc
+++ b/PC/pylauncher.rc
@@ -4,7 +4,6 @@
 
 // Include the manifest file that indicates we support all
 // current versions of Windows.
-#include <winuser.h>
 1 RT_MANIFEST "python.manifest"
 
 #if defined(PY_ICON)

--- a/PC/pyshellext.rc
+++ b/PC/pyshellext.rc
@@ -4,7 +4,6 @@
 
 // Include the manifest file that indicates we support all
 // current versions of Windows.
-#include <winuser.h>
 1 RT_MANIFEST "python.manifest"
 
 /////////////////////////////////////////////////////////////////////////////

--- a/PC/python_exe.rc
+++ b/PC/python_exe.rc
@@ -4,7 +4,6 @@
 
 // Include the manifest file that indicates we support all
 // current versions of Windows.
-#include <winuser.h>
 1 RT_MANIFEST "python.manifest"
 
 1 ICON DISCARDABLE "icons\python.ico" 

--- a/PC/python_nt.rc
+++ b/PC/python_nt.rc
@@ -4,7 +4,6 @@
 
 // Include the manifest file that indicates we support all
 // current versions of Windows.
-#include <winuser.h>
 2 RT_MANIFEST "python.manifest"
 
 /////////////////////////////////////////////////////////////////////////////

--- a/PC/pythonw_exe.rc
+++ b/PC/pythonw_exe.rc
@@ -4,7 +4,6 @@
 
 // Include the manifest file that indicates we support all
 // current versions of Windows.
-#include <winuser.h>
 1 RT_MANIFEST "python.manifest"
 
 1 ICON DISCARDABLE "icons\pythonw.ico" 

--- a/PC/sqlite3.rc
+++ b/PC/sqlite3.rc
@@ -4,7 +4,6 @@
 
 // Include the manifest file that indicates we support all
 // current versions of Windows.
-#include <winuser.h>
 2 RT_MANIFEST "python.manifest"
 
 /////////////////////////////////////////////////////////////////////////////

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -107,9 +107,6 @@
     <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
     <_RegistryVersion Condition="$(_RegistryVersion) != '' and !$(_RegistryVersion.EndsWith('.0'))">$(_RegistryVersion).0</_RegistryVersion>
 
-    <!-- Avoid upgrading to Windows 11 SDK for now, but assume the latest Win10 SDK is installed -->
-    <_RegistryVersion Condition="$([System.Version]::Parse($(_RegistryVersion))) >= $([System.Version]::Parse(`10.0.22000.0`))">10.0.19041.0</_RegistryVersion>
-
     <!-- The minimum allowed SDK version to use for building -->
     <DefaultWindowsSDKVersion>10.0.10586.0</DefaultWindowsSDKVersion>
     <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) != '' and $([System.Version]::Parse($(_RegistryVersion))) > $([System.Version]::Parse($(DefaultWindowsSDKVersion)))">$(_RegistryVersion)</DefaultWindowsSDKVersion>


### PR DESCRIPTION


<!-- issue-number: [bpo-45220](https://bugs.python.org/issue45220) -->
https://bugs.python.org/issue45220
<!-- /issue-number -->
