### PR TITLE
bpo-45711: Use _PyErr_ClearExcState instead of setting only exc_value…

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1377,8 +1377,8 @@ _asyncio_Future__make_cancelled_error_impl(FutureObj *self)
         _PyErr_ClearExcState(exc_state);
     }
     else {
-        assert (exc_state->exc_type == NULL);
-        assert (exc_state->exc_traceback == NULL);
+        assert(exc_state->exc_type == NULL);
+        assert(exc_state->exc_traceback == NULL);
     }
 
     return exc;

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1371,10 +1371,15 @@ _asyncio_Future__make_cancelled_error_impl(FutureObj *self)
 {
     PyObject *exc = create_cancelled_error(self->fut_cancel_msg);
     _PyErr_StackItem *exc_state = &self->fut_cancelled_exc_state;
-    /* Transfer ownership of exc_value from exc_state to exc since we are
-       done with it. */
-    PyException_SetContext(exc, exc_state->exc_value);
-    exc_state->exc_value = NULL;
+
+    if (exc_state->exc_value) {
+        PyException_SetContext(exc, Py_NewRef(exc_state->exc_value));
+        _PyErr_ClearExcState(exc_state);
+    }
+    else {
+        assert (exc_state->exc_type == NULL);
+        assert (exc_state->exc_traceback == NULL);
+    }
 
     return exc;
 }


### PR DESCRIPTION
… to NULL

This PR tidies up exception handling in Future/Task._make_cancelled_error to make it clearer what's happening and pave the way for a refactor of how the interpreter represents exceptions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45711](https://bugs.python.org/issue45711) -->
https://bugs.python.org/issue45711
<!-- /issue-number -->
