### PR TITLE
[3.10] bpo-43652: Actually update to Tcl/Tk 8.6.11 on Windows (GH-29397)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2021-11-04-00-41-50.bpo-43652.RnqV7I.rst
+++ b/Misc/NEWS.d/next/Windows/2021-11-04-00-41-50.bpo-43652.RnqV7I.rst
@@ -1,0 +1,2 @@
+Update Tcl/Tk to 8.6.11, actually this time. The previous update incorrectly
+included 8.6.10.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -55,8 +55,8 @@ set libraries=%libraries%                                       bzip2-1.0.6
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.3.0
 if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1l
 set libraries=%libraries%                                       sqlite-3.35.5.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.11.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.11.0
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.11.1
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.11.1
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tix-8.4.3.6
 set libraries=%libraries%                                       xz-5.2.2
 set libraries=%libraries%                                       zlib-1.2.11
@@ -78,7 +78,7 @@ echo.Fetching external binaries...
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.3.0
 if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1l
-if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.11.0
+if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.11.1
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 
 for %%b in (%binaries%) do (

--- a/PCbuild/tcltk.props
+++ b/PCbuild/tcltk.props
@@ -5,7 +5,7 @@
     <TclMajorVersion>8</TclMajorVersion>
     <TclMinorVersion>6</TclMinorVersion>
     <TclPatchLevel>11</TclPatchLevel>
-    <TclRevision>0</TclRevision>
+    <TclRevision>1</TclRevision>
     <TkMajorVersion>$(TclMajorVersion)</TkMajorVersion>
     <TkMinorVersion>$(TclMinorVersion)</TkMinorVersion>
     <TkPatchLevel>$(TclPatchLevel)</TkPatchLevel>


### PR DESCRIPTION


<!-- issue-number: [bpo-43652](https://bugs.python.org/issue43652) -->
https://bugs.python.org/issue43652
<!-- /issue-number -->
