### PR TITLE
Add generated artifacts in Mac/ to .gitignore; update copyright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,15 @@ Lib/test/data/*
 !Lib/test/data/README
 /Makefile
 /Makefile.pre
+Mac/Makefile
+Mac/PythonLauncher/Info.plist
+Mac/PythonLauncher/Makefile
+Mac/PythonLauncher/Python Launcher
+Mac/PythonLauncher/Python Launcher.app/*
+Mac/Resources/app/Info.plist
+Mac/Resources/framework/Info.plist
+Mac/pythonw
+/*.framework/
 Misc/python.pc
 Misc/python-embed.pc
 Misc/python-config.sh

--- a/Mac/Resources/framework/Info.plist.in
+++ b/Mac/Resources/framework/Info.plist.in
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>%VERSION%, (c) 2001-2019 Python Software Foundation.</string>
+	<string>%VERSION%, (c) 2001-2021 Python Software Foundation.</string>
 	<key>CFBundleLongVersionString</key>
-	<string>%VERSION%, (c) 2001-2019 Python Software Foundation.</string>
+	<string>%VERSION%, (c) 2001-2021 Python Software Foundation.</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This makes a framework build entirely free of new files that Git considers untracked.