### PR TITLE
[3.9] bpo-30570: Fix segfault on buildbots caused by stack overflow from recursion in tests (GH-29258)

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2371,7 +2371,8 @@ class AbstractPickleTests:
         # Issue #3514: crash when there is an infinite loop in __getattr__
         x = BadGetattr()
         for proto in protocols:
-            self.assertRaises(RuntimeError, self.dumps, x, proto)
+            with support.infinite_recursion():
+                self.assertRaises(RuntimeError, self.dumps, x, proto)
 
     def test_reduce_bad_iterator(self):
         # Issue4176: crash when 4th and 5th items of __reduce__()

--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -4,6 +4,7 @@
 
 import unittest
 import sys
+from test import support
 
 
 
@@ -244,12 +245,14 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
     def test_subclass_recursion_limit(self):
         # make sure that issubclass raises RecursionError before the C stack is
         # blown
-        self.assertRaises(RecursionError, blowstack, issubclass, str, str)
+        with support.infinite_recursion():
+            self.assertRaises(RecursionError, blowstack, issubclass, str, str)
 
     def test_isinstance_recursion_limit(self):
         # make sure that issubclass raises RecursionError before the C stack is
         # blown
-        self.assertRaises(RecursionError, blowstack, isinstance, '', str)
+        with support.infinite_recursion():
+            self.assertRaises(RecursionError, blowstack, isinstance, '', str)
 
     def test_issubclass_refcount_handling(self):
         # bpo-39382: abstract_issubclass() didn't hold item reference while
@@ -276,19 +279,19 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
             @property
             def __bases__(self):
                 return self.__bases__
-
-        self.assertRaises(RecursionError, issubclass, X(), int)
-        self.assertRaises(RecursionError, issubclass, int, X())
-        self.assertRaises(RecursionError, isinstance, 1, X())
+        with support.infinite_recursion():
+            self.assertRaises(RecursionError, issubclass, X(), int)
+            self.assertRaises(RecursionError, issubclass, int, X())
+            self.assertRaises(RecursionError, isinstance, 1, X())
 
     def test_infinite_recursion_via_bases_tuple(self):
         """Regression test for bpo-30570."""
         class Failure(object):
             def __getattr__(self, attr):
                 return (self, None)
-
-        with self.assertRaises(RecursionError):
-            issubclass(Failure(), int)
+        with support.infinite_recursion():
+            with self.assertRaises(RecursionError):
+                issubclass(Failure(), int)
 
     def test_infinite_cycle_in_bases(self):
         """Regression test for bpo-30570."""
@@ -296,7 +299,8 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
             @property
             def __bases__(self):
                 return (self, self, self)
-        self.assertRaises(RecursionError, issubclass, X(), int)
+        with support.infinite_recursion():
+            self.assertRaises(RecursionError, issubclass, X(), int)
 
     def test_infinitely_many_bases(self):
         """Regression test for bpo-30570."""
@@ -309,7 +313,8 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
                     pass
                 A.__getattr__ = B.__getattr__ = X.__getattr__
                 return (A(), B())
-        self.assertRaises(RecursionError, issubclass, X(), int)
+        with support.infinite_recursion():
+            self.assertRaises(RecursionError, issubclass, X(), int)
 
 
 def blowstack(fxn, arg, compare_to):


### PR DESCRIPTION
(cherry picked from commit d56375a0dd4cee162081b173310298a3d32af293)

Co-authored-by: Dennis Sweeney <36520290+sweeneyde@users.noreply.github.com>


<!-- issue-number: [bpo-30570](https://bugs.python.org/issue30570) -->
https://bugs.python.org/issue30570
<!-- /issue-number -->
