### PR TITLE
bpo-45160: Fix refleak in test_ttk_guionly introduced in GH-28291

### DIFF
--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -310,9 +310,12 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
             self.assertEqual(textvar.get(), items[1])
             success.append(True)
         optmenu = ttk.OptionMenu(self.root, textvar, "a", *items)
-        textvar.trace("w", cb_test)
+        optmenu.pack()
+        cb_name = textvar.trace("w", cb_test)
         optmenu['menu'].invoke(1)
         self.assertEqual(success, [True])
+        textvar.trace_vdelete("w", cb_name)
+        optmenu.destroy()
 
 
 class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):


### PR DESCRIPTION
The closure in `cb_test` was the root cause of the refleak, to address it we're taking the callback handle and deleting it when we don't need it anymore. Additionally, other tests explicitly destroy `OptionMenu` objects to avoid issues with reference cycles.

### Before the change

```
0:00:00 load avg: 4.23 Run tests sequentially
0:00:00 load avg: 4.23 [1/1] test_ttk_guionly
beginning 9 repetitions
123456789
.........
test_ttk_guionly leaked [63, 63, 63, 63] references, sum=252
test_ttk_guionly leaked [31, 31, 31, 31] memory blocks, sum=124
test_ttk_guionly failed (reference leak)

== Tests result: FAILURE ==
```

### After the change
```
0:00:00 load avg: 10.33 Run tests sequentially
0:00:00 load avg: 10.33 [1/1] test_ttk_guionly
beginning 9 repetitions
123456789
.........

== Tests result: SUCCESS ==
```

<!-- issue-number: [bpo-45160](https://bugs.python.org/issue45160) -->
https://bugs.python.org/issue45160
<!-- /issue-number -->
