### PR TITLE
bpo-45727: Make the syntax error for missing comma more consistent

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -618,6 +618,7 @@ expressions[expr_ty]:
 
 expression[expr_ty] (memo):
     | invalid_expression
+    | invalid_legacy_expression
     | a=disjunction 'if' b=disjunction 'else' c=expression { _PyAST_IfExp(b, a, c, EXTRA) }
     | disjunction
     | lambdef
@@ -1078,11 +1079,10 @@ invalid_legacy_expression:
             "Missing parentheses in call to '%U'. Did you mean %U(...)?", a->v.Name.id, a->v.Name.id) : NULL}
 
 invalid_expression:
-   | invalid_legacy_expression
     # !(NAME STRING) is not matched so we don't show this error with some invalid string prefixes like: kf"dsfsdf"
     # Soft keywords need to also be ignored because they can be parsed as NAME NAME
    | !(NAME STRING | SOFT_KEYWORD) a=disjunction b=expression_without_invalid {
-        RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "invalid syntax. Perhaps you forgot a comma?") }
+        _PyPegen_check_legacy_stmt(p, a) ? NULL : RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "invalid syntax. Perhaps you forgot a comma?") }
    | a=disjunction 'if' b=disjunction !('else'|':') { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "expected 'else' after 'if' expression") }
 
 invalid_named_expression:

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -233,6 +233,7 @@ class ExceptionTests(unittest.TestCase):
         check('[file for\n str(file) in []]', 2, 2)
         check("ages = {'Alice'=22, 'Bob'=23}", 1, 16)
         check('match ...:\n    case {**rest, "key": value}:\n        ...', 2, 19)
+        check("a b c d e f", 1, 1)
 
         # Errors thrown by compile.c
         check('class foo:return 1', 1, 11)

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -79,7 +79,9 @@ _PyPegen_check_barry_as_flufl(Parser *p, Token* t) {
 
 int
 _PyPegen_check_legacy_stmt(Parser *p, expr_ty name) {
-    assert(name->kind == Name_kind);
+    if (name->kind != Name_kind) {
+        return 0;
+    }
     const char* candidates[2] = {"print", "exec"};
     for (int i=0; i<2; i++) {
         if (PyUnicode_CompareWithASCIIString(name->v.Name.id, candidates[i]) == 0) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45727](https://bugs.python.org/issue45727) -->
https://bugs.python.org/issue45727
<!-- /issue-number -->
