### PR TITLE
bpo-45723: Add helper macros and more caching to configure.ac (GH-29429)

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-11-05-15-09-49.bpo-45723.gfSxur.rst
+++ b/Misc/NEWS.d/next/Build/2021-11-05-15-09-49.bpo-45723.gfSxur.rst
@@ -1,0 +1,2 @@
+configure.ac now uses custom helper macros and ``AC_CACHE_CHECK`` to
+simplify and speed up configure runs.

--- a/configure
+++ b/configure
@@ -8479,9 +8479,12 @@ done
 
 
 # checks for typedefs
-was_it_defined=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for clock_t in time.h" >&5
 $as_echo_n "checking for clock_t in time.h... " >&6; }
+if ${ac_cv_clock_t_time_h+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <time.h>
@@ -8489,21 +8492,30 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 _ACEOF
 if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
   $EGREP "clock_t" >/dev/null 2>&1; then :
-  was_it_defined=yes
+  ac_cv_clock_t_time_h=yes
 else
+  ac_cv_clock_t_time_h=no
+fi
+rm -f conftest*
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_clock_t_time_h" >&5
+$as_echo "$ac_cv_clock_t_time_h" >&6; }
+if test "x$ac_cv_clock_t_time_h" = xno; then :
 
 
 $as_echo "#define clock_t long" >>confdefs.h
 
 
 fi
-rm -f conftest*
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $was_it_defined" >&5
-$as_echo "$was_it_defined" >&6; }
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for makedev" >&5
 $as_echo_n "checking for makedev... " >&6; }
+if ${ac_cv_func_makedev+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8526,23 +8538,32 @@ main ()
 
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_has_makedev=yes
+  ac_cv_func_makedev=yes
 else
-  ac_cv_has_makedev=no
+  ac_cv_func_makedev=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_has_makedev" >&5
-$as_echo "$ac_cv_has_makedev" >&6; }
-if test "$ac_cv_has_makedev" = "yes"; then
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_makedev" >&5
+$as_echo "$ac_cv_func_makedev" >&6; }
+
+if test "x$ac_cv_func_makedev" = xyes; then :
+
 
 $as_echo "#define HAVE_MAKEDEV 1" >>confdefs.h
+
 
 fi
 
 # byte swapping
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for le64toh" >&5
 $as_echo_n "checking for le64toh... " >&6; }
+if ${ac_cv_func_le64toh+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8563,17 +8584,22 @@ main ()
 
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_has_le64toh=yes
+  ac_cv_func_le64toh=yes
 else
-  ac_cv_has_le64toh=no
+  ac_cv_func_le64toh=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_has_le64toh" >&5
-$as_echo "$ac_cv_has_le64toh" >&6; }
-if test "$ac_cv_has_le64toh" = "yes"; then
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_le64toh" >&5
+$as_echo "$ac_cv_func_le64toh" >&6; }
+
+if test "x$ac_cv_func_le64toh" = xyes; then :
+
 
 $as_echo "#define HAVE_HTOLE64 1" >>confdefs.h
+
 
 fi
 
@@ -9357,7 +9383,10 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_t" >&5
 $as_echo_n "checking for pthread_t... " >&6; }
-have_pthread_t=no
+if ${ac_cv_have_pthread_t+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9372,12 +9401,17 @@ pthread_t x; x = *(pthread_t*)0;
 
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  have_pthread_t=yes
+  ac_cv_have_pthread_t=yes
+else
+  ac_cv_have_pthread_t=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_pthread_t" >&5
-$as_echo "$have_pthread_t" >&6; }
-if test "$have_pthread_t" = yes ; then
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_have_pthread_t" >&5
+$as_echo "$ac_cv_have_pthread_t" >&6; }
+if test "x$ac_cv_have_pthread_t" = xyes; then :
+
   # The cast to long int works around a bug in the HP C Compiler
 # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
 # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
@@ -9414,6 +9448,7 @@ $as_echo "$ac_cv_sizeof_pthread_t" >&6; }
 cat >>confdefs.h <<_ACEOF
 #define SIZEOF_PTHREAD_T $ac_cv_sizeof_pthread_t
 _ACEOF
+
 
 
 fi
@@ -9456,6 +9491,10 @@ _ACEOF
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether pthread_key_t is compatible with int" >&5
 $as_echo_n "checking whether pthread_key_t is compatible with int... " >&6; }
+if ${ac_cv_pthread_key_t_is_arithmetic_type+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 if test "$ac_cv_sizeof_pthread_key_t" -eq "$ac_cv_sizeof_int" ; then
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -9469,23 +9508,27 @@ pthread_key_t k; k * 1;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  ac_pthread_key_t_is_arithmetic_type=yes
+  ac_cv_pthread_key_t_is_arithmetic_type=yes
 else
-  ac_pthread_key_t_is_arithmetic_type=no
+  ac_cv_pthread_key_t_is_arithmetic_type=no
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_pthread_key_t_is_arithmetic_type" >&5
-$as_echo "$ac_pthread_key_t_is_arithmetic_type" >&6; }
-  if test "$ac_pthread_key_t_is_arithmetic_type" = yes ; then
+else
+  ac_cv_pthread_key_t_is_arithmetic_type=no
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_pthread_key_t_is_arithmetic_type" >&5
+$as_echo "$ac_cv_pthread_key_t_is_arithmetic_type" >&6; }
+if test "x$ac_cv_pthread_key_t_is_arithmetic_type" = xyes; then :
+
 
 $as_echo "#define PTHREAD_KEY_T_IS_COMPATIBLE_WITH_INT 1" >>confdefs.h
 
-  fi
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
+
 fi
+
 CC="$ac_save_cc"
 
 
@@ -10131,6 +10174,10 @@ done
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for uuid_generate_time_safe" >&5
 $as_echo_n "checking for uuid_generate_time_safe... " >&6; }
+if ${ac_cv_lib_uuid_uuid_generate_time_safe+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <uuid/uuid.h>
@@ -10147,17 +10194,22 @@ void *x = uuid_generate_time_safe
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_uuid_uuid_generate_time_safe=yes
+else
+  ac_cv_lib_uuid_uuid_generate_time_safe=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_uuid_uuid_generate_time_safe" >&5
+$as_echo "$ac_cv_lib_uuid_uuid_generate_time_safe" >&6; }
+if test "x$ac_cv_lib_uuid_uuid_generate_time_safe" = xyes; then :
+
 
 $as_echo "#define HAVE_UUID_GENERATE_TIME_SAFE 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 # check for libuuid from util-linux
 save_LIBS=$LIBS
@@ -10210,67 +10262,20 @@ LIBS=$save_LIBS
 
 # AIX provides support for RFC4122 (uuid) in libc.a starting with AIX 6.1 (anno 2007)
 # FreeBSD and OpenBSD provides support in libc as well.
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for uuid_create" >&5
-$as_echo_n "checking for uuid_create... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <uuid.h>
-int
-main ()
-{
-
-#ifndef uuid_create
-void *x = uuid_create
-#endif
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-$as_echo "#define HAVE_UUID_CREATE 1" >>confdefs.h
-
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
 # Little-endian FreeBSD, OpenBSD and NetBSD needs encoding into an octet
 # stream in big-endian byte-order
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for uuid_enc_be" >&5
-$as_echo_n "checking for uuid_enc_be... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <uuid.h>
-int
-main ()
-{
-
-#ifndef uuid_enc_be
-void *x = uuid_enc_be
-#endif
-
-  ;
-  return 0;
-}
+for ac_func in uuid_create uuid_enc_be
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-$as_echo "#define HAVE_UUID_ENC_BE 1" >>confdefs.h
-
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+done
+
 
 # 'Real Time' functions on Solaris
 # posix4 on Solaris 2.6
@@ -11681,8 +11686,13 @@ if test "$ipv6" = "yes" -a "$ipv6lib" != "none"; then
 	fi
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for CAN_RAW_FD_FRAMES" >&5
-$as_echo_n "checking for CAN_RAW_FD_FRAMES... " >&6; }
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking CAN_RAW_FD_FRAMES" >&5
+$as_echo_n "checking CAN_RAW_FD_FRAMES... " >&6; }
+if ${ac_cv_can_raw_fd_frames+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
  /* CAN_RAW_FD_FRAMES available check */
@@ -11696,23 +11706,29 @@ int can_raw_fd_frames = CAN_RAW_FD_FRAMES;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_can_raw_fd_frames=yes
+else
+  ac_cv_can_raw_fd_frames=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_can_raw_fd_frames" >&5
+$as_echo "$ac_cv_can_raw_fd_frames" >&6; }
+if test "x$ac_cv_can_raw_fd_frames" = xyes; then :
 
 
 $as_echo "#define HAVE_LINUX_CAN_RAW_FD_FRAMES 1" >>confdefs.h
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-else
-
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for CAN_RAW_JOIN_FILTERS" >&5
 $as_echo_n "checking for CAN_RAW_JOIN_FILTERS... " >&6; }
+if ${ac_cv_can_raw_join_filters+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -11726,20 +11742,22 @@ int can_raw_join_filters = CAN_RAW_JOIN_FILTERS;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_can_raw_join_filters=yes
+else
+  ac_cv_can_raw_join_filters=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_can_raw_join_filters" >&5
+$as_echo "$ac_cv_can_raw_join_filters" >&6; }
+if test "x$ac_cv_can_raw_join_filters" = xyes; then :
 
 
 $as_echo "#define HAVE_LINUX_CAN_RAW_JOIN_FILTERS 1" >>confdefs.h
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-else
-
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 # Check for --with-doc-strings
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-doc-strings" >&5
@@ -12086,11 +12104,18 @@ $as_echo "#define HAVE_DIRFD 1" >>confdefs.h
 fi
 
 
+
+
 # For some functions, having a definition is not sufficient, since
 # we want to take their address.
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for chroot" >&5
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for chroot" >&5
 $as_echo_n "checking for chroot... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_chroot+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <unistd.h>
 int
@@ -12102,20 +12127,31 @@ void *x=chroot
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_chroot=yes
+else
+  ac_cv_func_chroot=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_chroot" >&5
+$as_echo "$ac_cv_func_chroot" >&6; }
+  if test "x$ac_cv_func_chroot" = xyes; then :
 
 $as_echo "#define HAVE_CHROOT 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for link" >&5
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for link" >&5
 $as_echo_n "checking for link... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_link+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <unistd.h>
 int
@@ -12127,20 +12163,31 @@ void *x=link
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_link=yes
+else
+  ac_cv_func_link=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_link" >&5
+$as_echo "$ac_cv_func_link" >&6; }
+  if test "x$ac_cv_func_link" = xyes; then :
 
 $as_echo "#define HAVE_LINK 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for symlink" >&5
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for symlink" >&5
 $as_echo_n "checking for symlink... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_symlink+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <unistd.h>
 int
@@ -12152,20 +12199,31 @@ void *x=symlink
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_symlink=yes
+else
+  ac_cv_func_symlink=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_symlink" >&5
+$as_echo "$ac_cv_func_symlink" >&6; }
+  if test "x$ac_cv_func_symlink" = xyes; then :
 
 $as_echo "#define HAVE_SYMLINK 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for fchdir" >&5
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for fchdir" >&5
 $as_echo_n "checking for fchdir... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_fchdir+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <unistd.h>
 int
@@ -12177,20 +12235,31 @@ void *x=fchdir
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_fchdir=yes
+else
+  ac_cv_func_fchdir=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_fchdir" >&5
+$as_echo "$ac_cv_func_fchdir" >&6; }
+  if test "x$ac_cv_func_fchdir" = xyes; then :
 
 $as_echo "#define HAVE_FCHDIR 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for fsync" >&5
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for fsync" >&5
 $as_echo_n "checking for fsync... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_fsync+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <unistd.h>
 int
@@ -12202,20 +12271,31 @@ void *x=fsync
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_fsync=yes
+else
+  ac_cv_func_fsync=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_fsync" >&5
+$as_echo "$ac_cv_func_fsync" >&6; }
+  if test "x$ac_cv_func_fsync" = xyes; then :
 
 $as_echo "#define HAVE_FSYNC 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for fdatasync" >&5
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for fdatasync" >&5
 $as_echo_n "checking for fdatasync... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_fdatasync+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <unistd.h>
 int
@@ -12227,45 +12307,67 @@ void *x=fdatasync
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_fdatasync=yes
+else
+  ac_cv_func_fdatasync=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_fdatasync" >&5
+$as_echo "$ac_cv_func_fdatasync" >&6; }
+  if test "x$ac_cv_func_fdatasync" = xyes; then :
 
 $as_echo "#define HAVE_FDATASYNC 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for epoll" >&5
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for epoll" >&5
 $as_echo_n "checking for epoll... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_epoll+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <sys/epoll.h>
 int
 main ()
 {
-void *x=epoll_create
+void *x=epoll
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_epoll=yes
+else
+  ac_cv_func_epoll=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_epoll" >&5
+$as_echo "$ac_cv_func_epoll" >&6; }
+  if test "x$ac_cv_func_epoll" = xyes; then :
 
 $as_echo "#define HAVE_EPOLL 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for epoll_create1" >&5
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for epoll_create1" >&5
 $as_echo_n "checking for epoll_create1... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_epoll_create1+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <sys/epoll.h>
 int
@@ -12277,20 +12379,31 @@ void *x=epoll_create1
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_epoll_create1=yes
+else
+  ac_cv_func_epoll_create1=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_epoll_create1" >&5
+$as_echo "$ac_cv_func_epoll_create1" >&6; }
+  if test "x$ac_cv_func_epoll_create1" = xyes; then :
 
 $as_echo "#define HAVE_EPOLL_CREATE1 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for kqueue" >&5
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for kqueue" >&5
 $as_echo_n "checking for kqueue... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_kqueue+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <sys/types.h>
@@ -12299,26 +12412,37 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-int x=kqueue()
+void *x=kqueue
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_kqueue=yes
+else
+  ac_cv_func_kqueue=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_kqueue" >&5
+$as_echo "$ac_cv_func_kqueue" >&6; }
+  if test "x$ac_cv_func_kqueue" = xyes; then :
 
 $as_echo "#define HAVE_KQUEUE 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for prlimit" >&5
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for prlimit" >&5
 $as_echo_n "checking for prlimit... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_prlimit+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <sys/time.h>
@@ -12333,20 +12457,32 @@ void *x=prlimit
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_prlimit=yes
+else
+  ac_cv_func_prlimit=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_prlimit" >&5
+$as_echo "$ac_cv_func_prlimit" >&6; }
+  if test "x$ac_cv_func_prlimit" = xyes; then :
 
 $as_echo "#define HAVE_PRLIMIT 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for _dyld_shared_cache_contains_path" >&5
+
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _dyld_shared_cache_contains_path" >&5
 $as_echo_n "checking for _dyld_shared_cache_contains_path... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func__dyld_shared_cache_contains_path+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <mach-o/dyld.h>
 int
@@ -12358,21 +12494,32 @@ void *x=_dyld_shared_cache_contains_path
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-
-$as_echo "#define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH 1" >>confdefs.h
-
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
+  ac_cv_func__dyld_shared_cache_contains_path=yes
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
+  ac_cv_func__dyld_shared_cache_contains_path=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for memfd_create" >&5
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func__dyld_shared_cache_contains_path" >&5
+$as_echo "$ac_cv_func__dyld_shared_cache_contains_path" >&6; }
+  if test "x$ac_cv_func__dyld_shared_cache_contains_path" = xyes; then :
+
+$as_echo "#define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH 1" >>confdefs.h
+
+fi
+
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for memfd_create" >&5
 $as_echo_n "checking for memfd_create... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_memfd_create+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #ifdef HAVE_SYS_MMAN_H
@@ -12391,21 +12538,32 @@ void *x=memfd_create
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-
-$as_echo "#define HAVE_MEMFD_CREATE 1" >>confdefs.h
-
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
+  ac_cv_func_memfd_create=yes
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
+  ac_cv_func_memfd_create=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for eventfd" >&5
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_memfd_create" >&5
+$as_echo "$ac_cv_func_memfd_create" >&6; }
+  if test "x$ac_cv_func_memfd_create" = xyes; then :
+
+$as_echo "#define HAVE_MEMFD_CREATE 1" >>confdefs.h
+
+fi
+
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for eventfd" >&5
 $as_echo_n "checking for eventfd... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_eventfd+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #ifdef HAVE_SYS_EVENTFD_H
@@ -12415,23 +12573,29 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-int x = eventfd(0, EFD_CLOEXEC)
+void *x=eventfd
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_eventfd=yes
+else
+  ac_cv_func_eventfd=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_eventfd" >&5
+$as_echo "$ac_cv_func_eventfd" >&6; }
+  if test "x$ac_cv_func_eventfd" = xyes; then :
 
 $as_echo "#define HAVE_EVENTFD 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+
+
 
 # On some systems (eg. FreeBSD 5), we would find a definition of the
 # functions ctermid_r, setgroups in the library, but no prototype
@@ -12439,33 +12603,42 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 # address to avoid compiler warnings and potential miscompilations
 # because of the missing prototypes.
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for ctermid_r" >&5
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ctermid_r" >&5
 $as_echo_n "checking for ctermid_r... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_ctermid_r+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 #include <stdio.h>
-
 int
 main ()
 {
-void* p = ctermid_r
+void *x=ctermid_r
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_ctermid_r=yes
+else
+  ac_cv_func_ctermid_r=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_ctermid_r" >&5
+$as_echo "$ac_cv_func_ctermid_r" >&6; }
+  if test "x$ac_cv_func_ctermid_r" = xyes; then :
 
 $as_echo "#define HAVE_CTERMID_R 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for flock declaration" >&5
 $as_echo_n "checking for flock declaration... " >&6; }
@@ -12556,41 +12729,51 @@ done
 
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for getpagesize" >&5
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getpagesize" >&5
 $as_echo_n "checking for getpagesize... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_getpagesize+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 #include <unistd.h>
-
 int
 main ()
 {
-void* p = getpagesize
+void *x=getpagesize
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-
-$as_echo "#define HAVE_GETPAGESIZE 1" >>confdefs.h
-
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
+  ac_cv_func_getpagesize=yes
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
+  ac_cv_func_getpagesize=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getpagesize" >&5
+$as_echo "$ac_cv_func_getpagesize" >&6; }
+  if test "x$ac_cv_func_getpagesize" = xyes; then :
+
+$as_echo "#define HAVE_GETPAGESIZE 1" >>confdefs.h
+
+fi
+
+
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for broken unsetenv" >&5
 $as_echo_n "checking for broken unsetenv... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_broken_unsetenv+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 #include <stdlib.h>
-
 int
 main ()
 {
@@ -12600,17 +12783,23 @@ int res = unsetenv("DUMMY")
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
+  ac_cv_broken_unsetenv=no
 else
-
-$as_echo "#define HAVE_BROKEN_UNSETENV 1" >>confdefs.h
-
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
+  ac_cv_broken_unsetenv=yes
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_broken_unsetenv" >&5
+$as_echo "$ac_cv_broken_unsetenv" >&6; }
+if test "x$ac_cv_broken_unsetenv" = xyes; then :
+
+
+$as_echo "#define HAVE_BROKEN_UNSETENV 1" >>confdefs.h
+
+
+fi
 
 for ac_prog in true
 do
@@ -12844,6 +13033,7 @@ $as_echo "#define HAVE_LCHFLAGS 1" >>confdefs.h
 
 fi
 
+# Check for compression libraries
 case $ac_sys_system/$ac_sys_release in
 Darwin/*)
 	_CUR_CFLAGS="${CFLAGS}"
@@ -12903,102 +13093,136 @@ Darwin/*)
 	;;
 esac
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for hstrerror" >&5
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for hstrerror" >&5
 $as_echo_n "checking for hstrerror... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_hstrerror+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 #include <netdb.h>
-
 int
 main ()
 {
-void* p = hstrerror; hstrerror(0)
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-
-$as_echo "#define HAVE_HSTRERROR 1" >>confdefs.h
-
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for inet_aton" >&5
-$as_echo_n "checking for inet_aton... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-int
-main ()
-{
-void* p = inet_aton;inet_aton(0,0)
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-
-$as_echo "#define HAVE_INET_ATON 1" >>confdefs.h
-
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for inet_pton" >&5
-$as_echo_n "checking for inet_pton... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-int
-main ()
-{
-void* p = inet_pton
+void *x=hstrerror
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-
-$as_echo "#define HAVE_INET_PTON 1" >>confdefs.h
-
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
+  ac_cv_func_hstrerror=yes
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
+  ac_cv_func_hstrerror=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_hstrerror" >&5
+$as_echo "$ac_cv_func_hstrerror" >&6; }
+  if test "x$ac_cv_func_hstrerror" = xyes; then :
+
+$as_echo "#define HAVE_HSTRERROR 1" >>confdefs.h
+
+fi
+
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for inet_aton" >&5
+$as_echo_n "checking for inet_aton... " >&6; }
+if ${ac_cv_func_inet_aton+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=inet_aton
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_inet_aton=yes
+else
+  ac_cv_func_inet_aton=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_inet_aton" >&5
+$as_echo "$ac_cv_func_inet_aton" >&6; }
+  if test "x$ac_cv_func_inet_aton" = xyes; then :
+
+$as_echo "#define HAVE_INET_ATON 1" >>confdefs.h
+
+fi
+
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for inet_pton" >&5
+$as_echo_n "checking for inet_pton... " >&6; }
+if ${ac_cv_func_inet_pton+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=inet_pton
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_inet_pton=yes
+else
+  ac_cv_func_inet_pton=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_inet_pton" >&5
+$as_echo "$ac_cv_func_inet_pton" >&6; }
+  if test "x$ac_cv_func_inet_pton" = xyes; then :
+
+$as_echo "#define HAVE_INET_PTON 1" >>confdefs.h
+
+fi
+
+
+
+
 # On some systems, setgroups is in unistd.h, on others, in grp.h
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for setgroups" >&5
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for setgroups" >&5
 $as_echo_n "checking for setgroups... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_setgroups+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <unistd.h>
@@ -13009,23 +13233,29 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void* p = setgroups
+void *x=setgroups
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_setgroups=yes
+else
+  ac_cv_func_setgroups=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_setgroups" >&5
+$as_echo "$ac_cv_func_setgroups" >&6; }
+  if test "x$ac_cv_func_setgroups" = xyes; then :
 
 $as_echo "#define HAVE_SETGROUPS 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+
+
 
 # check for openpty and forkpty
 
@@ -13750,8 +13980,12 @@ fi
 done
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for major" >&5
-$as_echo_n "checking for major... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for major, minor, and makedev" >&5
+$as_echo_n "checking for major, minor, and makedev... " >&6; }
+if ${ac_cv_device_macros+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -13774,26 +14008,36 @@ main ()
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_device_macros=yes
+else
+  ac_cv_device_macros=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_device_macros" >&5
+$as_echo "$ac_cv_device_macros" >&6; }
+if test "x$ac_cv_device_macros" = xyes; then :
 
 
 $as_echo "#define HAVE_DEVICE_MACROS 1" >>confdefs.h
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-else
-
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
 
 fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
+
+
+$as_echo "#define SYS_SELECT_WITH_SYS_TIME 1" >>confdefs.h
+
 
 # On OSF/1 V5.1, getaddrinfo is available, but a define
 # for [no]getaddrinfo in netdb.h.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getaddrinfo" >&5
 $as_echo_n "checking for getaddrinfo... " >&6; }
+if ${ac_cv_func_getaddrinfo+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -13811,16 +14055,19 @@ getaddrinfo(NULL, NULL, NULL, NULL);
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  have_getaddrinfo=yes
+  ac_cv_func_getaddrinfo=yes
 else
-  have_getaddrinfo=no
+  ac_cv_func_getaddrinfo=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_getaddrinfo" >&5
-$as_echo "$have_getaddrinfo" >&6; }
-if test $have_getaddrinfo = yes
-then
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getaddrinfo" >&5
+$as_echo "$ac_cv_func_getaddrinfo" >&6; }
+
+if test "x$ac_cv_func_getaddrinfo" = xyes; then :
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking getaddrinfo bug" >&5
 $as_echo_n "checking getaddrinfo bug... " >&6; }
   if ${ac_cv_buggy_getaddrinfo+:} false; then :
@@ -13938,12 +14185,14 @@ fi
 
 fi
 
+
+
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_buggy_getaddrinfo" >&5
 $as_echo "$ac_cv_buggy_getaddrinfo" >&6; }
 
-if test $have_getaddrinfo = no || test "$ac_cv_buggy_getaddrinfo" = yes
+if test "$ac_cv_func_getaddrinfo" = no -o "$ac_cv_buggy_getaddrinfo" = yes
 then
 	if test $ipv6 = yes
 	then
@@ -14241,36 +14490,6 @@ $as_echo "#define HAVE_ALTZONE 1" >>confdefs.h
 
 fi
 
-was_it_defined=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether sys/select.h and sys/time.h may both be included" >&5
-$as_echo_n "checking whether sys/select.h and sys/time.h may both be included... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <sys/types.h>
-#include <sys/select.h>
-#include <sys/time.h>
-
-int
-main ()
-{
-;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-
-$as_echo "#define SYS_SELECT_WITH_SYS_TIME 1" >>confdefs.h
-
-  was_it_defined=yes
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $was_it_defined" >&5
-$as_echo "$was_it_defined" >&6; }
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for addrinfo" >&5
 $as_echo_n "checking for addrinfo... " >&6; }
 if ${ac_cv_struct_addrinfo+:} false; then :
@@ -14489,9 +14708,12 @@ $as_echo "#define const /**/" >>confdefs.h
 fi
 
 
-works=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for working signed char" >&5
 $as_echo_n "checking for working signed char... " >&6; }
+if ${ac_cv_working_signed_char_c+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -14504,20 +14726,29 @@ signed char c;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  works=yes
+  ac_cv_working_signed_char_c=yes
 else
+  ac_cv_working_signed_char_c=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_working_signed_char_c" >&5
+$as_echo "$ac_cv_working_signed_char_c" >&6; }
+if test "x$ac_cv_working_signed_char_c" = xno; then :
+
 
 $as_echo "#define signed /**/" >>confdefs.h
 
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $works" >&5
-$as_echo "$works" >&6; }
 
-have_prototypes=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for prototypes" >&5
 $as_echo_n "checking for prototypes... " >&6; }
+if ${ac_cv_function_prototypes+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 int foo(int x) { return 0; }
@@ -14530,18 +14761,30 @@ return foo(10);
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_function_prototypes=yes
+else
+  ac_cv_function_prototypes=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_function_prototypes" >&5
+$as_echo "$ac_cv_function_prototypes" >&6; }
+if test "x$ac_cv_function_prototypes" = xyes; then :
+
 
 $as_echo "#define HAVE_PROTOTYPES 1" >>confdefs.h
 
-   have_prototypes=yes
+
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_prototypes" >&5
-$as_echo "$have_prototypes" >&6; }
 
 works=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for variable length prototypes and stdarg.h" >&5
 $as_echo_n "checking for variable length prototypes and stdarg.h... " >&6; }
+if ${ac_cv_stdarg_prototypes+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -14564,21 +14807,33 @@ return foo(10, "", 3.14);
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_stdarg_prototypes=yes
+else
+  ac_cv_stdarg_prototypes=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_stdarg_prototypes" >&5
+$as_echo "$ac_cv_stdarg_prototypes" >&6; }
+if test "x$ac_cv_stdarg_prototypes" = xyes; then :
 
 
 $as_echo "#define HAVE_STDARG_PROTOTYPES 1" >>confdefs.h
 
-  works=yes
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $works" >&5
-$as_echo "$works" >&6; }
+
 
 # check for socketpair
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for socketpair" >&5
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for socketpair" >&5
 $as_echo_n "checking for socketpair... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_func_socketpair+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <sys/types.h>
@@ -14593,21 +14848,31 @@ void *x=socketpair
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_socketpair=yes
+else
+  ac_cv_func_socketpair=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_socketpair" >&5
+$as_echo "$ac_cv_func_socketpair" >&6; }
+  if test "x$ac_cv_func_socketpair" = xyes; then :
 
 $as_echo "#define HAVE_SOCKETPAIR 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+
+
 
 # check if sockaddr has sa_len member
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if sockaddr has sa_len member" >&5
 $as_echo_n "checking if sockaddr has sa_len member... " >&6; }
+if ${ac_cv_struct_sockaddr_sa_len+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <sys/types.h>
@@ -14622,17 +14887,22 @@ x.sa_len = 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
+  ac_cv_struct_sockaddr_sa_len=yes
+else
+  ac_cv_struct_sockaddr_sa_len=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_struct_sockaddr_sa_len" >&5
+$as_echo "$ac_cv_struct_sockaddr_sa_len" >&6; }
+if test "x$ac_cv_struct_sockaddr_sa_len" = xyes; then :
+
 
 $as_echo "#define HAVE_SOCKADDR_SA_LEN 1" >>confdefs.h
 
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 # sigh -- gethostbyname_r is a mess; it can have 3, 5 or 6 arguments :-(
 
@@ -14899,8 +15169,13 @@ fi
 # * Check for gcc x64 inline assembler *
 # **************************************
 
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x64 gcc inline assembler" >&5
 $as_echo_n "checking for x64 gcc inline assembler... " >&6; }
+if ${ac_cv_gcc_asm_for_x64+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -14915,18 +15190,22 @@ main ()
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  have_gcc_asm_for_x64=yes
+  ac_cv_gcc_asm_for_x64=yes
 else
-  have_gcc_asm_for_x64=no
+  ac_cv_gcc_asm_for_x64=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_gcc_asm_for_x64" >&5
-$as_echo "$have_gcc_asm_for_x64" >&6; }
-if test "$have_gcc_asm_for_x64" = yes
-then
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_gcc_asm_for_x64" >&5
+$as_echo "$ac_cv_gcc_asm_for_x64" >&6; }
+
+if test "x$ac_cv_gcc_asm_for_x64" = xyes; then :
+
 
 $as_echo "#define HAVE_GCC_ASM_FOR_X64 1" >>confdefs.h
+
 
 fi
 
@@ -15022,6 +15301,10 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we can use gcc inline assembler to get and set x87 control word" >&5
 $as_echo_n "checking whether we can use gcc inline assembler to get and set x87 control word... " >&6; }
+if ${ac_cv_gcc_asm_for_x87+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -15038,23 +15321,30 @@ main ()
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  have_gcc_asm_for_x87=yes
+  ac_cv_gcc_asm_for_x87=yes
 else
-  have_gcc_asm_for_x87=no
+  ac_cv_gcc_asm_for_x87=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_gcc_asm_for_x87" >&5
-$as_echo "$have_gcc_asm_for_x87" >&6; }
-if test "$have_gcc_asm_for_x87" = yes
-then
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_gcc_asm_for_x87" >&5
+$as_echo "$ac_cv_gcc_asm_for_x87" >&6; }
+if test "x$ac_cv_gcc_asm_for_x87" = xyes; then :
+
 
 $as_echo "#define HAVE_GCC_ASM_FOR_X87 1" >>confdefs.h
+
 
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we can use gcc inline assembler to get and set mc68881 fpcr" >&5
 $as_echo_n "checking whether we can use gcc inline assembler to get and set mc68881 fpcr... " >&6; }
+if ${ac_cv_gcc_asm_for_mc68881+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -15071,18 +15361,21 @@ main ()
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  have_gcc_asm_for_mc68881=yes
+  ac_cv_gcc_asm_for_mc68881=yes
 else
-  have_gcc_asm_for_mc68881=no
+  ac_cv_gcc_asm_for_mc68881=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_gcc_asm_for_mc68881" >&5
-$as_echo "$have_gcc_asm_for_mc68881" >&6; }
-if test "$have_gcc_asm_for_mc68881" = yes
-then
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_gcc_asm_for_mc68881" >&5
+$as_echo "$ac_cv_gcc_asm_for_mc68881" >&6; }
+if test "x$ac_cv_gcc_asm_for_mc68881" = xyes; then :
+
 
 $as_echo "#define HAVE_GCC_ASM_FOR_MC68881 1" >>confdefs.h
+
 
 fi
 
@@ -15093,6 +15386,10 @@ fi
 # 0 otherwise.  See http://bugs.python.org/issue2937 for more info.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x87-style double rounding" >&5
 $as_echo_n "checking for x87-style double rounding... " >&6; }
+if ${ac_cv_x87_double_rounding+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 # $BASECFLAGS may affect the result
 ac_save_cc="$CC"
 CC="$CC $BASECFLAGS"
@@ -15132,12 +15429,16 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 CC="$ac_save_cc"
+
+fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_x87_double_rounding" >&5
 $as_echo "$ac_cv_x87_double_rounding" >&6; }
-if test "$ac_cv_x87_double_rounding" = yes
-then
+
+if test "x$ac_cv_x87_double_rounding" = xyes; then :
+
 
 $as_echo "#define X87_DOUBLE_ROUNDING 1" >>confdefs.h
+
 
 fi
 
@@ -16733,324 +17034,448 @@ $as_echo "#define WINDOW_HAS_FLAGS 1" >>confdefs.h
 
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for is_pad" >&5
-$as_echo_n "checking for is_pad... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for curses function is_pad" >&5
+$as_echo_n "checking for curses function is_pad... " >&6; }
+if ${ac_cv_lib_curses_is_pad+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
 
-#ifndef is_pad
-void *x=is_pad
-#endif
+        #ifndef is_pad
+        void *x=is_pad
+        #endif
 
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_curses_is_pad=yes
+else
+  ac_cv_lib_curses_is_pad=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_curses_is_pad" >&5
+$as_echo "$ac_cv_lib_curses_is_pad" >&6; }
+  if test "x$ac_cv_lib_curses_is_pad" = xyes; then :
 
 $as_echo "#define HAVE_CURSES_IS_PAD 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for is_term_resized" >&5
-$as_echo_n "checking for is_term_resized... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for curses function is_term_resized" >&5
+$as_echo_n "checking for curses function is_term_resized... " >&6; }
+if ${ac_cv_lib_curses_is_term_resized+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
-void *x=is_term_resized
+
+        #ifndef is_term_resized
+        void *x=is_term_resized
+        #endif
+
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_curses_is_term_resized=yes
+else
+  ac_cv_lib_curses_is_term_resized=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_curses_is_term_resized" >&5
+$as_echo "$ac_cv_lib_curses_is_term_resized" >&6; }
+  if test "x$ac_cv_lib_curses_is_term_resized" = xyes; then :
 
 $as_echo "#define HAVE_CURSES_IS_TERM_RESIZED 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for resize_term" >&5
-$as_echo_n "checking for resize_term... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for curses function resize_term" >&5
+$as_echo_n "checking for curses function resize_term... " >&6; }
+if ${ac_cv_lib_curses_resize_term+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
-void *x=resize_term
+
+        #ifndef resize_term
+        void *x=resize_term
+        #endif
+
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_curses_resize_term=yes
+else
+  ac_cv_lib_curses_resize_term=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_curses_resize_term" >&5
+$as_echo "$ac_cv_lib_curses_resize_term" >&6; }
+  if test "x$ac_cv_lib_curses_resize_term" = xyes; then :
 
 $as_echo "#define HAVE_CURSES_RESIZE_TERM 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for resizeterm" >&5
-$as_echo_n "checking for resizeterm... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for curses function resizeterm" >&5
+$as_echo_n "checking for curses function resizeterm... " >&6; }
+if ${ac_cv_lib_curses_resizeterm+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
-void *x=resizeterm
+
+        #ifndef resizeterm
+        void *x=resizeterm
+        #endif
+
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_curses_resizeterm=yes
+else
+  ac_cv_lib_curses_resizeterm=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_curses_resizeterm" >&5
+$as_echo "$ac_cv_lib_curses_resizeterm" >&6; }
+  if test "x$ac_cv_lib_curses_resizeterm" = xyes; then :
 
 $as_echo "#define HAVE_CURSES_RESIZETERM 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for immedok" >&5
-$as_echo_n "checking for immedok... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for curses function immedok" >&5
+$as_echo_n "checking for curses function immedok... " >&6; }
+if ${ac_cv_lib_curses_immedok+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
 
-#ifndef immedok
-void *x=immedok
-#endif
+        #ifndef immedok
+        void *x=immedok
+        #endif
 
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_curses_immedok=yes
+else
+  ac_cv_lib_curses_immedok=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_curses_immedok" >&5
+$as_echo "$ac_cv_lib_curses_immedok" >&6; }
+  if test "x$ac_cv_lib_curses_immedok" = xyes; then :
 
 $as_echo "#define HAVE_CURSES_IMMEDOK 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for syncok" >&5
-$as_echo_n "checking for syncok... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for curses function syncok" >&5
+$as_echo_n "checking for curses function syncok... " >&6; }
+if ${ac_cv_lib_curses_syncok+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
 
-#ifndef syncok
-void *x=syncok
-#endif
+        #ifndef syncok
+        void *x=syncok
+        #endif
 
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_curses_syncok=yes
+else
+  ac_cv_lib_curses_syncok=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_curses_syncok" >&5
+$as_echo "$ac_cv_lib_curses_syncok" >&6; }
+  if test "x$ac_cv_lib_curses_syncok" = xyes; then :
 
 $as_echo "#define HAVE_CURSES_SYNCOK 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for wchgat" >&5
-$as_echo_n "checking for wchgat... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for curses function wchgat" >&5
+$as_echo_n "checking for curses function wchgat... " >&6; }
+if ${ac_cv_lib_curses_wchgat+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
 
-#ifndef wchgat
-void *x=wchgat
-#endif
+        #ifndef wchgat
+        void *x=wchgat
+        #endif
 
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_curses_wchgat=yes
+else
+  ac_cv_lib_curses_wchgat=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_curses_wchgat" >&5
+$as_echo "$ac_cv_lib_curses_wchgat" >&6; }
+  if test "x$ac_cv_lib_curses_wchgat" = xyes; then :
 
 $as_echo "#define HAVE_CURSES_WCHGAT 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for filter" >&5
-$as_echo_n "checking for filter... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for curses function filter" >&5
+$as_echo_n "checking for curses function filter... " >&6; }
+if ${ac_cv_lib_curses_filter+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
 
-#ifndef filter
-void *x=filter
-#endif
+        #ifndef filter
+        void *x=filter
+        #endif
 
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_curses_filter=yes
+else
+  ac_cv_lib_curses_filter=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_curses_filter" >&5
+$as_echo "$ac_cv_lib_curses_filter" >&6; }
+  if test "x$ac_cv_lib_curses_filter" = xyes; then :
 
 $as_echo "#define HAVE_CURSES_FILTER 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for has_key" >&5
-$as_echo_n "checking for has_key... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for curses function has_key" >&5
+$as_echo_n "checking for curses function has_key... " >&6; }
+if ${ac_cv_lib_curses_has_key+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
 
-#ifndef has_key
-void *x=has_key
-#endif
+        #ifndef has_key
+        void *x=has_key
+        #endif
 
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_curses_has_key=yes
+else
+  ac_cv_lib_curses_has_key=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_curses_has_key" >&5
+$as_echo "$ac_cv_lib_curses_has_key" >&6; }
+  if test "x$ac_cv_lib_curses_has_key" = xyes; then :
 
 $as_echo "#define HAVE_CURSES_HAS_KEY 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for typeahead" >&5
-$as_echo_n "checking for typeahead... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for curses function typeahead" >&5
+$as_echo_n "checking for curses function typeahead... " >&6; }
+if ${ac_cv_lib_curses_typeahead+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
 
-#ifndef typeahead
-void *x=typeahead
-#endif
+        #ifndef typeahead
+        void *x=typeahead
+        #endif
 
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_curses_typeahead=yes
+else
+  ac_cv_lib_curses_typeahead=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_curses_typeahead" >&5
+$as_echo "$ac_cv_lib_curses_typeahead" >&6; }
+  if test "x$ac_cv_lib_curses_typeahead" = xyes; then :
 
 $as_echo "#define HAVE_CURSES_TYPEAHEAD 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for use_env" >&5
-$as_echo_n "checking for use_env... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for curses function use_env" >&5
+$as_echo_n "checking for curses function use_env... " >&6; }
+if ${ac_cv_lib_curses_use_env+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
 
-#ifndef use_env
-void *x=use_env
-#endif
+        #ifndef use_env
+        void *x=use_env
+        #endif
 
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_lib_curses_use_env=yes
+else
+  ac_cv_lib_curses_use_env=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_curses_use_env" >&5
+$as_echo "$ac_cv_lib_curses_use_env" >&6; }
+  if test "x$ac_cv_lib_curses_use_env" = xyes; then :
 
 $as_echo "#define HAVE_CURSES_USE_ENV 1" >>confdefs.h
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-# last curses configure check
+
+
+
 CPPFLAGS=$ac_save_cppflags
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for device files" >&5
@@ -17374,6 +17799,10 @@ $as_echo "done" >&6; }
 # Availability of -O2:
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for -O2" >&5
 $as_echo_n "checking for -O2... " >&6; }
+if ${ac_cv_compile_o2+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 saved_cflags="$CFLAGS"
 CFLAGS="-O2"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -17383,20 +17812,21 @@ int
 main ()
 {
 
-
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  have_O2=yes
+  ac_cv_compile_o2=yes
 else
-  have_O2=no
+  ac_cv_compile_o2=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_O2" >&5
-$as_echo "$have_O2" >&6; }
 CFLAGS="$saved_cflags"
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_compile_o2" >&5
+$as_echo "$ac_cv_compile_o2" >&6; }
 
 # _FORTIFY_SOURCE wrappers for memmove and bcopy are incorrect:
 # http://sourceware.org/ml/libc-alpha/2010-12/msg00009.html
@@ -17404,7 +17834,7 @@ CFLAGS="$saved_cflags"
 $as_echo_n "checking for glibc _FORTIFY_SOURCE/memmove bug... " >&6; }
 saved_cflags="$CFLAGS"
 CFLAGS="-O2 -D_FORTIFY_SOURCE=2"
-if test "$have_O2" = no; then
+if test "$ac_cv_compile_o2" = no; then
     CFLAGS=""
 fi
 if test "$cross_compiling" = yes; then :
@@ -17447,7 +17877,7 @@ $as_echo "#define HAVE_GLIBC_MEMMOVE_BUG 1" >>confdefs.h
 
 fi
 
-if test "$have_gcc_asm_for_x87" = yes; then
+if test "$ac_cv_gcc_asm_for_x87" = yes; then
     # Some versions of gcc miscompile inline asm:
     # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46491
     # http://gcc.gnu.org/ml/gcc/2010-11/msg00366.html
@@ -17504,6 +17934,10 @@ fi
 # Check for stdatomic.h
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for stdatomic.h" >&5
 $as_echo_n "checking for stdatomic.h... " >&6; }
+if ${ac_cv_header_stdatomic_h+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -17521,25 +17955,32 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  have_stdatomic_h=yes
+  ac_cv_header_stdatomic_h=yes
 else
-  have_stdatomic_h=no
+  ac_cv_header_stdatomic_h=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_stdatomic_h" >&5
-$as_echo "$have_stdatomic_h" >&6; }
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_header_stdatomic_h" >&5
+$as_echo "$ac_cv_header_stdatomic_h" >&6; }
 
-if test "$have_stdatomic_h" = yes; then
+if test "x$ac_cv_header_stdatomic_h" = xyes; then :
+
 
 $as_echo "#define HAVE_STD_ATOMIC 1" >>confdefs.h
+
 
 fi
 
 # Check for GCC >= 4.7 and clang __atomic builtin functions
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for builtin __atomic_load_n and __atomic_store_n functions" >&5
 $as_echo_n "checking for builtin __atomic_load_n and __atomic_store_n functions... " >&6; }
+if ${ac_cv_builtin_atomic+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -17554,19 +17995,22 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  have_builtin_atomic=yes
+  ac_cv_builtin_atomic=yes
 else
-  have_builtin_atomic=no
+  ac_cv_builtin_atomic=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_builtin_atomic" >&5
-$as_echo "$have_builtin_atomic" >&6; }
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_builtin_atomic" >&5
+$as_echo "$ac_cv_builtin_atomic" >&6; }
 
-if test "$have_builtin_atomic" = yes; then
+if test "x$ac_cv_builtin_atomic" = xyes; then :
+
 
 $as_echo "#define HAVE_BUILTIN_ATOMIC 1" >>confdefs.h
+
 
 fi
 
@@ -17598,6 +18042,10 @@ $as_echo "$ENSUREPIP" >&6; }
 # check if the dirent structure of a d_type field and DT_UNKNOWN is defined
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if the dirent structure of a d_type field" >&5
 $as_echo_n "checking if the dirent structure of a d_type field... " >&6; }
+if ${ac_cv_dirent_d_type+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -17612,24 +18060,32 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  have_dirent_d_type=yes
+  ac_cv_dirent_d_type=yes
 else
-  have_dirent_d_type=no
+  ac_cv_dirent_d_type=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_dirent_d_type" >&5
-$as_echo "$have_dirent_d_type" >&6; }
 
-if test "$have_dirent_d_type" = yes; then
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_dirent_d_type" >&5
+$as_echo "$ac_cv_dirent_d_type" >&6; }
+
+if test "x$ac_cv_dirent_d_type" = xyes; then :
+
 
 $as_echo "#define HAVE_DIRENT_D_TYPE 1" >>confdefs.h
+
 
 fi
 
 # check if the Linux getrandom() syscall is available
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the Linux getrandom() syscall" >&5
 $as_echo_n "checking for the Linux getrandom() syscall... " >&6; }
+if ${ac_cv_getrandom_syscall+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -17650,18 +18106,22 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  have_getrandom_syscall=yes
+  ac_cv_getrandom_syscall=yes
 else
-  have_getrandom_syscall=no
+  ac_cv_getrandom_syscall=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_getrandom_syscall" >&5
-$as_echo "$have_getrandom_syscall" >&6; }
 
-if test "$have_getrandom_syscall" = yes; then
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_getrandom_syscall" >&5
+$as_echo "$ac_cv_getrandom_syscall" >&6; }
+
+if test "x$ac_cv_getrandom_syscall" = xyes; then :
+
 
 $as_echo "#define HAVE_GETRANDOM_SYSCALL 1" >>confdefs.h
+
 
 fi
 
@@ -17669,6 +18129,10 @@ fi
 # the test was written for the Solaris function of <sys/random.h>
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the getrandom() function" >&5
 $as_echo_n "checking for the getrandom() function... " >&6; }
+if ${ac_cv_func_getrandom+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -17687,18 +18151,22 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  have_getrandom=yes
+  ac_cv_func_getrandom=yes
 else
-  have_getrandom=no
+  ac_cv_func_getrandom=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_getrandom" >&5
-$as_echo "$have_getrandom" >&6; }
 
-if test "$have_getrandom" = yes; then
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getrandom" >&5
+$as_echo "$ac_cv_func_getrandom" >&6; }
+
+if test "x$ac_cv_func_getrandom" = xyes; then :
+
 
 $as_echo "#define HAVE_GETRANDOM 1" >>confdefs.h
+
 
 fi
 
@@ -18042,6 +18510,10 @@ $as_echo "$OPENSSL_RPATH" >&6; }
 # check if OpenSSL libraries work as expected
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL provides required APIs" >&5
 $as_echo_n "checking whether OpenSSL provides required APIs... " >&6; }
+if ${ac_cv_working_openssl+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 save_LIBS="$LIBS"
 save_CFLAGS="$CFLAGS"
 save_LDFLAGS="$LDFLAGS"
@@ -18087,17 +18559,19 @@ EVP_PBE_scrypt(NULL, 0, NULL, 0, 2, 8, 1, 0, NULL, 0);
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
+  ac_cv_working_openssl=yes
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
+  ac_cv_working_openssl=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS="$save_LIBS"
 CFLAGS="$save_CFLAGS"
 LDFLAGS="$save_LDFLAGS"
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_working_openssl" >&5
+$as_echo "$ac_cv_working_openssl" >&6; }
 
 # ssl module default cipher suite string
 

--- a/configure
+++ b/configure
@@ -8485,7 +8485,7 @@ if ${ac_cv_clock_t_time_h+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <time.h>
 

--- a/configure.ac
+++ b/configure.ac
@@ -2315,14 +2315,15 @@ AC_CHECK_HEADERS(linux/can.h linux/can/bcm.h linux/can/j1939.h linux/can/raw.h,,
 ])
 
 # checks for typedefs
-was_it_defined=no
-AC_MSG_CHECKING(for clock_t in time.h)
-AC_EGREP_HEADER(clock_t, time.h, was_it_defined=yes, [
-    AC_DEFINE(clock_t, long, [Define to 'long' if <time.h> doesn't define.])
+AC_CACHE_CHECK([for clock_t in time.h], [ac_cv_clock_t_time_h], [
+AC_EGREP_HEADER([clock_t], [time.h], [ac_cv_clock_t_time_h=yes], [ac_cv_clock_t_time_h=no])
 ])
-AC_MSG_RESULT($was_it_defined)
+dnl checks for "no"
+AS_VAR_IF([ac_cv_clock_t_time_h], [no], [
+  AC_DEFINE(clock_t, long, [Define to 'long' if <time.h> doesn't define.])
+])
 
-AC_MSG_CHECKING(for makedev)
+AC_CACHE_CHECK([for makedev], [ac_cv_func_makedev], [
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #if defined(MAJOR_IN_MKDEV)
 #include <sys/mkdev.h>
@@ -2333,14 +2334,15 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #endif
 ]], [[
   makedev(0, 0) ]])
-],[ac_cv_has_makedev=yes],[ac_cv_has_makedev=no])
-AC_MSG_RESULT($ac_cv_has_makedev)
-if test "$ac_cv_has_makedev" = "yes"; then
+],[ac_cv_func_makedev=yes],[ac_cv_func_makedev=no])
+])
+
+AS_VAR_IF([ac_cv_func_makedev], [yes], [
     AC_DEFINE(HAVE_MAKEDEV, 1, [Define this if you have the makedev macro.])
-fi
+])
 
 # byte swapping
-AC_MSG_CHECKING(for le64toh)
+AC_CACHE_CHECK([for le64toh], [ac_cv_func_le64toh], [
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #ifdef HAVE_ENDIAN_H
 #include <endian.h>
@@ -2349,11 +2351,12 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #endif
 ]], [[
    le64toh(1) ]])
-],[ac_cv_has_le64toh=yes],[ac_cv_has_le64toh=no])
-AC_MSG_RESULT($ac_cv_has_le64toh)
-if test "$ac_cv_has_le64toh" = "yes"; then
+],[ac_cv_func_le64toh=yes],[ac_cv_func_le64toh=no])
+])
+
+AS_VAR_IF([ac_cv_func_le64toh], [yes], [
     AC_DEFINE(HAVE_HTOLE64, 1, [Define this if you have le64toh()])
-fi
+])
 
 use_lfs=yes
 # Don't use largefile support for GNU/Hurd
@@ -2455,38 +2458,38 @@ elif test "$ac_cv_pthread" = "yes"
 then CC="$CC -pthread"
 fi
 
-AC_MSG_CHECKING(for pthread_t)
-have_pthread_t=no
+AC_CACHE_CHECK([for pthread_t], [ac_cv_have_pthread_t], [
 AC_COMPILE_IFELSE([
   AC_LANG_PROGRAM([[#include <pthread.h>]], [[pthread_t x; x = *(pthread_t*)0;]])
-],[have_pthread_t=yes],[])
-AC_MSG_RESULT($have_pthread_t)
-if test "$have_pthread_t" = yes ; then
+], [ac_cv_have_pthread_t=yes], [ac_cv_have_pthread_t=no])
+])
+AS_VAR_IF([ac_cv_have_pthread_t], [yes], [
   AC_CHECK_SIZEOF(pthread_t, [], [
 #ifdef HAVE_PTHREAD_H
 #include <pthread.h>
 #endif
   ])
-fi
+])
 
 # Issue #25658: POSIX hasn't defined that pthread_key_t is compatible with int.
 # This checking will be unnecessary after removing deprecated TLS API.
 AC_CHECK_SIZEOF(pthread_key_t, [], [[#include <pthread.h>]])
-AC_MSG_CHECKING(whether pthread_key_t is compatible with int)
+AC_CACHE_CHECK([whether pthread_key_t is compatible with int], [ac_cv_pthread_key_t_is_arithmetic_type], [
 if test "$ac_cv_sizeof_pthread_key_t" -eq "$ac_cv_sizeof_int" ; then
   AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM([[#include <pthread.h>]], [[pthread_key_t k; k * 1;]])],
-    [ac_pthread_key_t_is_arithmetic_type=yes],
-    [ac_pthread_key_t_is_arithmetic_type=no]
+    [ac_cv_pthread_key_t_is_arithmetic_type=yes],
+    [ac_cv_pthread_key_t_is_arithmetic_type=no]
   )
-  AC_MSG_RESULT($ac_pthread_key_t_is_arithmetic_type)
-  if test "$ac_pthread_key_t_is_arithmetic_type" = yes ; then
+else
+  ac_cv_pthread_key_t_is_arithmetic_type=no
+fi
+])
+AS_VAR_IF([ac_cv_pthread_key_t_is_arithmetic_type], [yes], [
     AC_DEFINE(PTHREAD_KEY_T_IS_COMPATIBLE_WITH_INT, 1,
               [Define if pthread_key_t is compatible with int.])
-  fi
-else
-  AC_MSG_RESULT(no)
-fi
+])
+
 CC="$ac_save_cc"
 
 AC_SUBST(OTHER_LIBTOOL_OPT)
@@ -2934,16 +2937,17 @@ AC_CHECK_LIB(dld, shl_load)	# Dynamic linking for HP-UX
 # checks for uuid.h location
 AC_CHECK_HEADERS([uuid/uuid.h uuid.h])
 
-AC_MSG_CHECKING(for uuid_generate_time_safe)
+AC_CACHE_CHECK([for uuid_generate_time_safe], [ac_cv_lib_uuid_uuid_generate_time_safe], [
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <uuid/uuid.h>]], [[
 #ifndef uuid_generate_time_safe
 void *x = uuid_generate_time_safe
 #endif
 ]])],
-  [AC_DEFINE(HAVE_UUID_GENERATE_TIME_SAFE, 1, Define if uuid_generate_time_safe() exists.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
+[ac_cv_lib_uuid_uuid_generate_time_safe=yes], [ac_cv_lib_uuid_uuid_generate_time_safe=no])
+])
+AS_VAR_IF([ac_cv_lib_uuid_uuid_generate_time_safe], [yes], [
+  AC_DEFINE(HAVE_UUID_GENERATE_TIME_SAFE, 1, Define if uuid_generate_time_safe() exists.)
+])
 
 # check for libuuid from util-linux
 save_LIBS=$LIBS
@@ -2952,29 +2956,9 @@ LIBS=$save_LIBS
 
 # AIX provides support for RFC4122 (uuid) in libc.a starting with AIX 6.1 (anno 2007)
 # FreeBSD and OpenBSD provides support in libc as well.
-AC_MSG_CHECKING(for uuid_create)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <uuid.h>]], [[
-#ifndef uuid_create
-void *x = uuid_create
-#endif
-]])],
-  [AC_DEFINE(HAVE_UUID_CREATE, 1, Define if uuid_create() exists.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
-
 # Little-endian FreeBSD, OpenBSD and NetBSD needs encoding into an octet
 # stream in big-endian byte-order
-AC_MSG_CHECKING(for uuid_enc_be)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <uuid.h>]], [[
-#ifndef uuid_enc_be
-void *x = uuid_enc_be
-#endif
-]])],
-  [AC_DEFINE(HAVE_UUID_ENC_BE, 1, Define if uuid_enc_be() exists.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
+AC_CHECK_FUNCS([uuid_create uuid_enc_be])
 
 # 'Real Time' functions on Solaris
 # posix4 on Solaris 2.6
@@ -3574,24 +3558,27 @@ if test "$ipv6" = "yes" -a "$ipv6lib" != "none"; then
 	fi
 fi
 
-AC_MSG_CHECKING(for CAN_RAW_FD_FRAMES)
+
+AC_CACHE_CHECK([CAN_RAW_FD_FRAMES], [ac_cv_can_raw_fd_frames], [
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ /* CAN_RAW_FD_FRAMES available check */
 #include <linux/can/raw.h>]],
-[[int can_raw_fd_frames = CAN_RAW_FD_FRAMES;]])],[
-  AC_DEFINE(HAVE_LINUX_CAN_RAW_FD_FRAMES, 1, [Define if compiling using Linux 3.6 or later.])
-  AC_MSG_RESULT(yes)
-],[
-  AC_MSG_RESULT(no)
+[[int can_raw_fd_frames = CAN_RAW_FD_FRAMES;]])],
+[ac_cv_can_raw_fd_frames=yes],
+[ac_cv_can_raw_fd_frames=no])
+])
+AS_VAR_IF([ac_cv_can_raw_fd_frames], [yes], [
+    AC_DEFINE(HAVE_LINUX_CAN_RAW_FD_FRAMES, 1, [Define if compiling using Linux 3.6 or later.])
 ])
 
-AC_MSG_CHECKING(for CAN_RAW_JOIN_FILTERS)
+AC_CACHE_CHECK([for CAN_RAW_JOIN_FILTERS], [ac_cv_can_raw_join_filters], [
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <linux/can/raw.h>]],
-[[int can_raw_join_filters = CAN_RAW_JOIN_FILTERS;]])],[
-  AC_DEFINE(HAVE_LINUX_CAN_RAW_JOIN_FILTERS, 1, [Define if compiling using Linux 4.1 or later.])
-  AC_MSG_RESULT(yes)
-],[
-  AC_MSG_RESULT(no)
+[[int can_raw_join_filters = CAN_RAW_JOIN_FILTERS;]])],
+[ac_cv_can_raw_join_filters=yes],
+[ac_cv_can_raw_join_filters=no])
+])
+AS_VAR_IF([ac_cv_can_raw_join_filters], [yes], [
+    AC_DEFINE(HAVE_LINUX_CAN_RAW_JOIN_FILTERS, 1, [Define if compiling using Linux 4.1 or later.])
 ])
 
 # Check for --with-doc-strings
@@ -3802,105 +3789,61 @@ AC_CHECK_DECL(dirfd,
       [#include <sys/types.h>
        #include <dirent.h>])
 
-# For some functions, having a definition is not sufficient, since
-# we want to take their address.
-AC_MSG_CHECKING(for chroot)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=chroot]])],
-  [AC_DEFINE(HAVE_CHROOT, 1, Define if you have the 'chroot' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
-AC_MSG_CHECKING(for link)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=link]])],
-  [AC_DEFINE(HAVE_LINK, 1, Define if you have the 'link' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
-AC_MSG_CHECKING(for symlink)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=symlink]])],
-  [AC_DEFINE(HAVE_SYMLINK, 1, Define if you have the 'symlink' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
-AC_MSG_CHECKING(for fchdir)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=fchdir]])],
-  [AC_DEFINE(HAVE_FCHDIR, 1, Define if you have the 'fchdir' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
-AC_MSG_CHECKING(for fsync)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=fsync]])],
-  [AC_DEFINE(HAVE_FSYNC, 1, Define if you have the 'fsync' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
-AC_MSG_CHECKING(for fdatasync)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=fdatasync]])],
-  [AC_DEFINE(HAVE_FDATASYNC, 1, Define if you have the 'fdatasync' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
-AC_MSG_CHECKING(for epoll)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/epoll.h>]], [[void *x=epoll_create]])],
-  [AC_DEFINE(HAVE_EPOLL, 1, Define if you have the 'epoll' functions.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
-AC_MSG_CHECKING(for epoll_create1)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/epoll.h>]], [[void *x=epoll_create1]])],
-  [AC_DEFINE(HAVE_EPOLL_CREATE1, 1, Define if you have the 'epoll_create1' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
-AC_MSG_CHECKING(for kqueue)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <sys/types.h>
-#include <sys/event.h>
-    ]], [[int x=kqueue()]])],
-  [AC_DEFINE(HAVE_KQUEUE, 1, Define if you have the 'kqueue' functions.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
-AC_MSG_CHECKING(for prlimit)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <sys/time.h>
-#include <sys/resource.h>
-    ]], [[void *x=prlimit]])],
-  [AC_DEFINE(HAVE_PRLIMIT, 1, Define if you have the 'prlimit' functions.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
-AC_MSG_CHECKING(for _dyld_shared_cache_contains_path)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <mach-o/dyld.h>]], [[void *x=_dyld_shared_cache_contains_path]])],
-  [AC_DEFINE(HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH, 1, Define if you have the '_dyld_shared_cache_contains_path' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
+dnl PY_CHECK_FUNC(FUNCTION, [INCLUDES], [AC_DEFINE-VAR])
+AC_DEFUN([PY_CHECK_FUNC],
+[ AS_VAR_PUSHDEF([py_var], [ac_cv_func_$1])
+  AS_VAR_PUSHDEF([py_define], m4_ifblank([$3], [[HAVE_]m4_toupper($1)], [$3]))
+  AC_CACHE_CHECK(
+    [for $1],
+    [py_var],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([$2], [void *x=$1])],
+      [AS_VAR_SET([py_var], [yes])],
+      [AS_VAR_SET([py_var], [no])])]
+  )
+  AS_VAR_IF(
+    [py_var],
+    [yes],
+    [AC_DEFINE([py_define], [1], [Define if you have the '$1' function.])])
+  AS_VAR_POPDEF([py_var])
+  AS_VAR_POPDEF([py_define])
 ])
 
-AC_MSG_CHECKING(for memfd_create)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+# For some functions, having a definition is not sufficient, since
+# we want to take their address.
+PY_CHECK_FUNC([chroot], [#include <unistd.h>])
+PY_CHECK_FUNC([link], [#include <unistd.h>])
+PY_CHECK_FUNC([symlink], [#include <unistd.h>])
+PY_CHECK_FUNC([fchdir], [#include <unistd.h>])
+PY_CHECK_FUNC([fsync], [#include <unistd.h>])
+PY_CHECK_FUNC([fdatasync], [#include <unistd.h>])
+PY_CHECK_FUNC([epoll], [#include <sys/epoll.h>])
+PY_CHECK_FUNC([epoll_create1], [#include <sys/epoll.h>])
+PY_CHECK_FUNC([kqueue],[[
+#include <sys/types.h>
+#include <sys/event.h>
+]])
+PY_CHECK_FUNC([prlimit], [[
+#include <sys/time.h>
+#include <sys/resource.h>
+]])
+
+PY_CHECK_FUNC([_dyld_shared_cache_contains_path], [#include <mach-o/dyld.h>], [HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH])
+
+PY_CHECK_FUNC([memfd_create], [[
 #ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif
 #ifdef HAVE_SYS_MEMFD_H
 #include <sys/memfd.h>
 #endif
-]], [[void *x=memfd_create]])],
-  [AC_DEFINE(HAVE_MEMFD_CREATE, 1, Define if you have the 'memfd_create' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
+]])
 
-AC_MSG_CHECKING(for eventfd)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+PY_CHECK_FUNC([eventfd], [[
 #ifdef HAVE_SYS_EVENTFD_H
 #include <sys/eventfd.h>
 #endif
-]], [[int x = eventfd(0, EFD_CLOEXEC)]])],
-  [AC_DEFINE(HAVE_EVENTFD, 1, Define if you have the 'eventfd' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
+]])
 
 # On some systems (eg. FreeBSD 5), we would find a definition of the
 # functions ctermid_r, setgroups in the library, but no prototype
@@ -3908,14 +3851,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 # address to avoid compiler warnings and potential miscompilations
 # because of the missing prototypes.
 
-AC_MSG_CHECKING(for ctermid_r)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <stdio.h>
-]], [[void* p = ctermid_r]])],
-  [AC_DEFINE(HAVE_CTERMID_R, 1, Define if you have the 'ctermid_r' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
+PY_CHECK_FUNC([ctermid_r], [#include <stdio.h>])
 
 AC_CACHE_CHECK([for flock declaration], [ac_cv_flock_decl],
   [AC_COMPILE_IFELSE(
@@ -3936,22 +3872,19 @@ if test "x${ac_cv_flock_decl}" = xyes; then
   )
 fi
 
-AC_MSG_CHECKING(for getpagesize)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <unistd.h>
-]], [[void* p = getpagesize]])],
-  [AC_DEFINE(HAVE_GETPAGESIZE, 1, Define if you have the 'getpagesize' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
+PY_CHECK_FUNC([getpagesize], [#include <unistd.h>])
 
-AC_MSG_CHECKING(for broken unsetenv)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <stdlib.h>
-]], [[int res = unsetenv("DUMMY")]])],
-  [AC_MSG_RESULT(no)],
-  [AC_DEFINE(HAVE_BROKEN_UNSETENV, 1, Define if `unsetenv` does not return an int.)
-   AC_MSG_RESULT(yes)
+AC_CACHE_CHECK([for broken unsetenv], [ac_cv_broken_unsetenv],
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+      [#include <stdlib.h>],
+      [int res = unsetenv("DUMMY")])],
+    [ac_cv_broken_unsetenv=no],
+    [ac_cv_broken_unsetenv=yes]
+  )
+])
+AS_VAR_IF([ac_cv_broken_unsetenv], [yes], [
+  AC_DEFINE(HAVE_BROKEN_UNSETENV, 1, Define if `unsetenv` does not return an int.)
 ])
 
 dnl check for true
@@ -4006,6 +3939,7 @@ if test "$ac_cv_have_lchflags" = yes ; then
   AC_DEFINE(HAVE_LCHFLAGS, 1, [Define to 1 if you have the 'lchflags' function.])
 fi
 
+# Check for compression libraries
 dnl Check if system zlib has *Copy() functions
 dnl
 dnl On MacOSX the linker will search for dylibs on the entire linker path
@@ -4035,51 +3969,29 @@ Darwin/*)
 	;;
 esac
 
-AC_MSG_CHECKING(for hstrerror)
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-#include <netdb.h>
-]], [[void* p = hstrerror; hstrerror(0)]])],
-  [AC_DEFINE(HAVE_HSTRERROR, 1, Define if you have the 'hstrerror' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
+PY_CHECK_FUNC([hstrerror], [#include <netdb.h>])
 
-AC_MSG_CHECKING(for inet_aton)
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+PY_CHECK_FUNC([inet_aton], [[
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-]], [[void* p = inet_aton;inet_aton(0,0)]])],
-  [AC_DEFINE(HAVE_INET_ATON, 1, Define if you have the 'inet_aton' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
+]])
 
-AC_MSG_CHECKING(for inet_pton)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+PY_CHECK_FUNC([inet_pton], [[
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-]], [[void* p = inet_pton]])],
-  [AC_DEFINE(HAVE_INET_PTON, 1, Define if you have the 'inet_pton' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
+]])
 
 # On some systems, setgroups is in unistd.h, on others, in grp.h
-AC_MSG_CHECKING(for setgroups)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+PY_CHECK_FUNC([setgroups], [[
 #include <unistd.h>
 #ifdef HAVE_GRP_H
 #include <grp.h>
 #endif
-]], [[void* p = setgroups]])],
-  [AC_DEFINE(HAVE_SETGROUPS, 1, Define if you have the 'setgroups' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)
-])
+]])
 
 # check for openpty and forkpty
 
@@ -4164,7 +4076,7 @@ AC_CHECK_FUNCS(nanosleep, [], [
     ])
 ])
 
-AC_MSG_CHECKING(for major, minor, and makedev)
+AC_CACHE_CHECK([for major, minor, and makedev], [ac_cv_device_macros], [
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #if defined(MAJOR_IN_MKDEV)
 #include <sys/mkdev.h>
@@ -4175,28 +4087,32 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #endif
 ]], [[
   makedev(major(0),minor(0));
-]])],[
+]])],[ac_cv_device_macros=yes], [ac_cv_device_macros=no])
+])
+AS_VAR_IF([ac_cv_device_macros], [yes], [
   AC_DEFINE(HAVE_DEVICE_MACROS, 1,
 	    [Define to 1 if you have the device macros.])
-  AC_MSG_RESULT(yes)
-],[
-  AC_MSG_RESULT(no)
 ])
+
+dnl no longer used, now always defined for backwards compatibility
+AC_DEFINE(SYS_SELECT_WITH_SYS_TIME, 1,
+  [Define if  you can safely include both <sys/select.h> and <sys/time.h>
+   (which you can't on SCO ODT 3.0).])
 
 # On OSF/1 V5.1, getaddrinfo is available, but a define
 # for [no]getaddrinfo in netdb.h.
-AC_MSG_CHECKING(for getaddrinfo)
+AC_CACHE_CHECK([for getaddrinfo], [ac_cv_func_getaddrinfo], [
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
 #include <stdio.h>
 ]], [[getaddrinfo(NULL, NULL, NULL, NULL);]])],
-[have_getaddrinfo=yes],
-[have_getaddrinfo=no])
-AC_MSG_RESULT($have_getaddrinfo)
-if test $have_getaddrinfo = yes
-then
+[ac_cv_func_getaddrinfo=yes],
+[ac_cv_func_getaddrinfo=no])
+])
+
+AS_VAR_IF([ac_cv_func_getaddrinfo], [yes], [
   AC_MSG_CHECKING(getaddrinfo bug)
   AC_CACHE_VAL(ac_cv_buggy_getaddrinfo,
   AC_RUN_IFELSE([AC_LANG_SOURCE([[[
@@ -4297,11 +4213,13 @@ if test "${enable_ipv6+set}" = set; then
 else
   ac_cv_buggy_getaddrinfo=yes
 fi]))
-fi
+
+dnl if ac_cv_func_getaddrinfo
+])
 
 AC_MSG_RESULT($ac_cv_buggy_getaddrinfo)
 
-if test $have_getaddrinfo = no || test "$ac_cv_buggy_getaddrinfo" = yes
+if test "$ac_cv_func_getaddrinfo" = no -o "$ac_cv_buggy_getaddrinfo" = yes
 then
 	if test $ipv6 = yes
 	then
@@ -4343,20 +4261,6 @@ if test $ac_cv_header_time_altzone = yes; then
   AC_DEFINE(HAVE_ALTZONE, 1, [Define this if your time.h defines altzone.])
 fi
 
-was_it_defined=no
-AC_MSG_CHECKING(whether sys/select.h and sys/time.h may both be included)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <sys/types.h>
-#include <sys/select.h>
-#include <sys/time.h>
-]], [[;]])],[
-  AC_DEFINE(SYS_SELECT_WITH_SYS_TIME, 1,
-  [Define if  you can safely include both <sys/select.h> and <sys/time.h>
-   (which you can't on SCO ODT 3.0).])
-  was_it_defined=yes
-],[])
-AC_MSG_RESULT($was_it_defined)
-
 AC_MSG_CHECKING(for addrinfo)
 AC_CACHE_VAL(ac_cv_struct_addrinfo,
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <netdb.h>]], [[struct addrinfo a]])],
@@ -4397,26 +4301,25 @@ fi
 AC_C_CHAR_UNSIGNED
 AC_C_CONST
 
-works=no
-AC_MSG_CHECKING(for working signed char)
+AC_CACHE_CHECK([for working signed char], [ac_cv_working_signed_char_c], [
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[signed char c;]])],
-  [works=yes],
-  [AC_DEFINE(signed, , [Define to empty if the keyword does not work.])]
-)
-AC_MSG_RESULT($works)
+  [ac_cv_working_signed_char_c=yes], [ac_cv_working_signed_char_c=no])
+])
+AS_VAR_IF([ac_cv_working_signed_char_c], [no], [
+  AC_DEFINE(signed, , [Define to empty if the keyword does not work.])
+])
 
-have_prototypes=no
-AC_MSG_CHECKING(for prototypes)
+AC_CACHE_CHECK([for prototypes], [ac_cv_function_prototypes], [
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[int foo(int x) { return 0; }]], [[return foo(10);]])],
-  [AC_DEFINE(HAVE_PROTOTYPES, 1,
+  [ac_cv_function_prototypes=yes], [ac_cv_function_prototypes=no])
+])
+AS_VAR_IF([ac_cv_function_prototypes], [yes], [
+  AC_DEFINE(HAVE_PROTOTYPES, 1,
      [Define if your compiler supports function prototype])
-   have_prototypes=yes],
-  []
-)
-AC_MSG_RESULT($have_prototypes)
+])
 
 works=no
-AC_MSG_CHECKING(for variable length prototypes and stdarg.h)
+AC_CACHE_CHECK([for variable length prototypes and stdarg.h], [ac_cv_stdarg_prototypes], [
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <stdarg.h>
 int foo(int x, ...) {
@@ -4427,34 +4330,32 @@ int foo(int x, ...) {
 	va_arg(va, double);
 	return 0;
 }
-]], [[return foo(10, "", 3.14);]])],[
+]], [[return foo(10, "", 3.14);]])],
+  [ac_cv_stdarg_prototypes=yes], [ac_cv_stdarg_prototypes=no])
+])
+AS_VAR_IF([ac_cv_stdarg_prototypes], [yes], [
   AC_DEFINE(HAVE_STDARG_PROTOTYPES, 1,
    [Define if your compiler supports variable length function prototypes
    (e.g. void fprintf(FILE *, char *, ...);) *and* <stdarg.h>])
-  works=yes
-],[])
-AC_MSG_RESULT($works)
+])
+
 
 # check for socketpair
-AC_MSG_CHECKING(for socketpair)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+PY_CHECK_FUNC([socketpair], [[
 #include <sys/types.h>
 #include <sys/socket.h>
-]], [[void *x=socketpair]])],
-  [AC_DEFINE(HAVE_SOCKETPAIR, 1, [Define if you have the 'socketpair' function.])
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
+]])
 
 # check if sockaddr has sa_len member
-AC_MSG_CHECKING(if sockaddr has sa_len member)
+AC_CACHE_CHECK([if sockaddr has sa_len member], [ac_cv_struct_sockaddr_sa_len], [
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
 #include <sys/socket.h>]], [[struct sockaddr x;
 x.sa_len = 0;]])],
-  [AC_MSG_RESULT(yes)
-   AC_DEFINE(HAVE_SOCKADDR_SA_LEN, 1, [Define if sockaddr has sa_len member])],
-  [AC_MSG_RESULT(no)]
-)
+  [ac_cv_struct_sockaddr_sa_len=yes], [ac_cv_struct_sockaddr_sa_len=no])
+])
+AS_VAR_IF([ac_cv_struct_sockaddr_sa_len], [yes], [
+   AC_DEFINE(HAVE_SOCKADDR_SA_LEN, 1, [Define if sockaddr has sa_len member])
+])
 
 # sigh -- gethostbyname_r is a mess; it can have 3, 5 or 6 arguments :-(
 AH_TEMPLATE(HAVE_GETHOSTBYNAME_R,
@@ -4580,16 +4481,17 @@ fi],
 # * Check for gcc x64 inline assembler *
 # **************************************
 
-AC_MSG_CHECKING(for x64 gcc inline assembler)
-AC_LINK_IFELSE(   [AC_LANG_PROGRAM([[]], [[
+
+AC_CACHE_CHECK([for x64 gcc inline assembler], [ac_cv_gcc_asm_for_x64], [
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[
   __asm__ __volatile__ ("movq %rcx, %rax");
-]])],[have_gcc_asm_for_x64=yes],[have_gcc_asm_for_x64=no])
-AC_MSG_RESULT($have_gcc_asm_for_x64)
-if test "$have_gcc_asm_for_x64" = yes
-then
+]])],[ac_cv_gcc_asm_for_x64=yes],[ac_cv_gcc_asm_for_x64=no])
+])
+
+AS_VAR_IF([ac_cv_gcc_asm_for_x64], [yes], [
     AC_DEFINE(HAVE_GCC_ASM_FOR_X64, 1,
     [Define if we can use x64 gcc inline assembler])
-fi
+])
 
 # **************************************************
 # * Check for various properties of floating point *
@@ -4628,38 +4530,36 @@ fi
 # This inline assembler syntax may also work for suncc and icc,
 # so we try it on all platforms.
 
-AC_MSG_CHECKING(whether we can use gcc inline assembler to get and set x87 control word)
+AC_CACHE_CHECK([whether we can use gcc inline assembler to get and set x87 control word], [ac_cv_gcc_asm_for_x87], [
 AC_LINK_IFELSE(   [AC_LANG_PROGRAM([[]], [[
   unsigned short cw;
   __asm__ __volatile__ ("fnstcw %0" : "=m" (cw));
   __asm__ __volatile__ ("fldcw %0" : : "m" (cw));
-]])],[have_gcc_asm_for_x87=yes],[have_gcc_asm_for_x87=no])
-AC_MSG_RESULT($have_gcc_asm_for_x87)
-if test "$have_gcc_asm_for_x87" = yes
-then
+]])],[ac_cv_gcc_asm_for_x87=yes],[ac_cv_gcc_asm_for_x87=no])
+])
+AS_VAR_IF([ac_cv_gcc_asm_for_x87], [yes], [
     AC_DEFINE(HAVE_GCC_ASM_FOR_X87, 1,
     [Define if we can use gcc inline assembler to get and set x87 control word])
-fi
+])
 
-AC_MSG_CHECKING(whether we can use gcc inline assembler to get and set mc68881 fpcr)
+AC_CACHE_CHECK([whether we can use gcc inline assembler to get and set mc68881 fpcr], [ac_cv_gcc_asm_for_mc68881], [
 AC_LINK_IFELSE(   [AC_LANG_PROGRAM([[]], [[
   unsigned int fpcr;
   __asm__ __volatile__ ("fmove.l %%fpcr,%0" : "=g" (fpcr));
   __asm__ __volatile__ ("fmove.l %0,%%fpcr" : : "g" (fpcr));
-]])],[have_gcc_asm_for_mc68881=yes],[have_gcc_asm_for_mc68881=no])
-AC_MSG_RESULT($have_gcc_asm_for_mc68881)
-if test "$have_gcc_asm_for_mc68881" = yes
-then
+]])],[ac_cv_gcc_asm_for_mc68881=yes],[ac_cv_gcc_asm_for_mc68881=no])
+])
+AS_VAR_IF([ac_cv_gcc_asm_for_mc68881], [yes], [
     AC_DEFINE(HAVE_GCC_ASM_FOR_MC68881, 1,
     [Define if we can use gcc inline assembler to get and set mc68881 fpcr])
-fi
+])
 
 # Detect whether system arithmetic is subject to x87-style double
 # rounding issues.  The result of this test has little meaning on non
 # IEEE 754 platforms.  On IEEE 754, test should return 1 if rounding
 # mode is round-to-nearest and double rounding issues are present, and
 # 0 otherwise.  See http://bugs.python.org/issue2937 for more info.
-AC_MSG_CHECKING(for x87-style double rounding)
+AC_CACHE_CHECK([for x87-style double rounding], [ac_cv_x87_double_rounding], [
 # $BASECFLAGS may affect the result
 ac_save_cc="$CC"
 CC="$CC $BASECFLAGS"
@@ -4687,12 +4587,12 @@ int main() {
 [ac_cv_x87_double_rounding=yes],
 [ac_cv_x87_double_rounding=no])
 CC="$ac_save_cc"
-AC_MSG_RESULT($ac_cv_x87_double_rounding)
-if test "$ac_cv_x87_double_rounding" = yes
-then
+])
+
+AS_VAR_IF([ac_cv_x87_double_rounding], [yes], [
   AC_DEFINE(X87_DOUBLE_ROUNDING, 1,
   [Define if arithmetic is subject to x87-style double rounding issue])
-fi
+])
 
 # ************************************
 # * Check for mathematical functions *
@@ -5360,115 +5260,42 @@ then
   [Define if WINDOW in curses.h offers a field _flags.])
 fi
 
-AC_MSG_CHECKING(for is_pad)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
-#ifndef is_pad
-void *x=is_pad
-#endif
-]])],
-  [AC_DEFINE(HAVE_CURSES_IS_PAD, 1, Define if you have the 'is_pad' function or macro.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
+dnl PY_CHECK_CURSES_FUNC(FUNCTION)
+AC_DEFUN([PY_CHECK_CURSES_FUNC],
+[ AS_VAR_PUSHDEF([py_var], [ac_cv_lib_curses_$1])
+  AS_VAR_PUSHDEF([py_define], [HAVE_CURSES_]m4_toupper($1))
+  AC_CACHE_CHECK(
+    [for curses function $1],
+    [py_var],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM(
+        [#include <curses.h>], [[
+        #ifndef $1
+        void *x=$1
+        #endif
+      ]])],
+      [AS_VAR_SET([py_var], [yes])],
+      [AS_VAR_SET([py_var], [no])])]
+  )
+  AS_VAR_IF(
+    [py_var],
+    [yes],
+    [AC_DEFINE([py_define], [1], [Define if you have the '$1' function.])])
+  AS_VAR_POPDEF([py_var])
+  AS_VAR_POPDEF([py_define])
+])
 
-AC_MSG_CHECKING(for is_term_resized)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[void *x=is_term_resized]])],
-  [AC_DEFINE(HAVE_CURSES_IS_TERM_RESIZED, 1, Define if you have the 'is_term_resized' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
-
-AC_MSG_CHECKING(for resize_term)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[void *x=resize_term]])],
-  [AC_DEFINE(HAVE_CURSES_RESIZE_TERM, 1, Define if you have the 'resize_term' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
-
-AC_MSG_CHECKING(for resizeterm)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[void *x=resizeterm]])],
-  [AC_DEFINE(HAVE_CURSES_RESIZETERM, 1, Define if you have the 'resizeterm' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
-
-AC_MSG_CHECKING(for immedok)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
-#ifndef immedok
-void *x=immedok
-#endif
-]])],
-  [AC_DEFINE(HAVE_CURSES_IMMEDOK, 1, Define if you have the 'immedok' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
-
-AC_MSG_CHECKING(for syncok)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
-#ifndef syncok
-void *x=syncok
-#endif
-]])],
-  [AC_DEFINE(HAVE_CURSES_SYNCOK, 1, Define if you have the 'syncok' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
-
-AC_MSG_CHECKING(for wchgat)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
-#ifndef wchgat
-void *x=wchgat
-#endif
-]])],
-  [AC_DEFINE(HAVE_CURSES_WCHGAT, 1, Define if you have the 'wchgat' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
-
-AC_MSG_CHECKING(for filter)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
-#ifndef filter
-void *x=filter
-#endif
-]])],
-  [AC_DEFINE(HAVE_CURSES_FILTER, 1, Define if you have the 'filter' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
-
-AC_MSG_CHECKING(for has_key)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
-#ifndef has_key
-void *x=has_key
-#endif
-]])],
-  [AC_DEFINE(HAVE_CURSES_HAS_KEY, 1, Define if you have the 'has_key' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
-
-AC_MSG_CHECKING(for typeahead)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
-#ifndef typeahead
-void *x=typeahead
-#endif
-]])],
-  [AC_DEFINE(HAVE_CURSES_TYPEAHEAD, 1, Define if you have the 'typeahead' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
-
-AC_MSG_CHECKING(for use_env)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
-#ifndef use_env
-void *x=use_env
-#endif
-]])],
-  [AC_DEFINE(HAVE_CURSES_USE_ENV, 1, Define if you have the 'use_env' function.)
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)]
-)
-# last curses configure check
+PY_CHECK_CURSES_FUNC([is_pad])
+PY_CHECK_CURSES_FUNC([is_term_resized])
+PY_CHECK_CURSES_FUNC([resize_term])
+PY_CHECK_CURSES_FUNC([resizeterm])
+PY_CHECK_CURSES_FUNC([immedok])
+PY_CHECK_CURSES_FUNC([syncok])
+PY_CHECK_CURSES_FUNC([wchgat])
+PY_CHECK_CURSES_FUNC([filter])
+PY_CHECK_CURSES_FUNC([has_key])
+PY_CHECK_CURSES_FUNC([typeahead])
+PY_CHECK_CURSES_FUNC([use_env])
 CPPFLAGS=$ac_save_cppflags
 
 AC_MSG_NOTICE([checking for device files])
@@ -5671,20 +5498,19 @@ done
 AC_MSG_RESULT(done)
 
 # Availability of -O2:
-AC_MSG_CHECKING(for -O2)
+AC_CACHE_CHECK([for -O2], [ac_cv_compile_o2], [
 saved_cflags="$CFLAGS"
 CFLAGS="-O2"
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
-]])],[have_O2=yes],[have_O2=no])
-AC_MSG_RESULT($have_O2)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])], [ac_cv_compile_o2=yes], [ac_cv_compile_o2=no])
 CFLAGS="$saved_cflags"
+])
 
 # _FORTIFY_SOURCE wrappers for memmove and bcopy are incorrect:
 # http://sourceware.org/ml/libc-alpha/2010-12/msg00009.html
 AC_MSG_CHECKING(for glibc _FORTIFY_SOURCE/memmove bug)
 saved_cflags="$CFLAGS"
 CFLAGS="-O2 -D_FORTIFY_SOURCE=2"
-if test "$have_O2" = no; then
+if test "$ac_cv_compile_o2" = no; then
     CFLAGS=""
 fi
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
@@ -5714,7 +5540,7 @@ if test "$have_glibc_memmove_bug" = yes; then
      for memmove and bcopy.])
 fi
 
-if test "$have_gcc_asm_for_x87" = yes; then
+if test "$ac_cv_gcc_asm_for_x87" = yes; then
     # Some versions of gcc miscompile inline asm:
     # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46491
     # http://gcc.gnu.org/ml/gcc/2010-11/msg00366.html
@@ -5754,7 +5580,7 @@ if test "$have_gcc_asm_for_x87" = yes; then
 fi
 
 # Check for stdatomic.h
-AC_MSG_CHECKING(for stdatomic.h)
+AC_CACHE_CHECK([for stdatomic.h], [ac_cv_header_stdatomic_h], [
 AC_LINK_IFELSE(
 [
   AC_LANG_SOURCE([[
@@ -5768,17 +5594,16 @@ AC_LINK_IFELSE(
       return 0;
     }
   ]])
-],[have_stdatomic_h=yes],[have_stdatomic_h=no])
+],[ac_cv_header_stdatomic_h=yes],[ac_cv_header_stdatomic_h=no])
+])
 
-AC_MSG_RESULT($have_stdatomic_h)
-
-if test "$have_stdatomic_h" = yes; then
+AS_VAR_IF([ac_cv_header_stdatomic_h], [yes], [
     AC_DEFINE(HAVE_STD_ATOMIC, 1,
               [Has stdatomic.h with atomic_int and atomic_uintptr_t])
-fi
+])
 
 # Check for GCC >= 4.7 and clang __atomic builtin functions
-AC_MSG_CHECKING(for builtin __atomic_load_n and __atomic_store_n functions)
+AC_CACHE_CHECK([for builtin __atomic_load_n and __atomic_store_n functions], [ac_cv_builtin_atomic], [
 AC_LINK_IFELSE(
 [
   AC_LANG_SOURCE([[
@@ -5789,13 +5614,12 @@ AC_LINK_IFELSE(
       return 0;
     }
   ]])
-],[have_builtin_atomic=yes],[have_builtin_atomic=no])
+],[ac_cv_builtin_atomic=yes],[ac_cv_builtin_atomic=no])
+])
 
-AC_MSG_RESULT($have_builtin_atomic)
-
-if test "$have_builtin_atomic" = yes; then
+AS_VAR_IF([ac_cv_builtin_atomic], [yes], [
     AC_DEFINE(HAVE_BUILTIN_ATOMIC, 1, [Has builtin __atomic_load_n() and __atomic_store_n() functions])
-fi
+])
 
 # ensurepip option
 AC_MSG_CHECKING(for ensurepip)
@@ -5813,7 +5637,7 @@ AC_MSG_RESULT($ENSUREPIP)
 AC_SUBST(ENSUREPIP)
 
 # check if the dirent structure of a d_type field and DT_UNKNOWN is defined
-AC_MSG_CHECKING(if the dirent structure of a d_type field)
+AC_CACHE_CHECK([if the dirent structure of a d_type field], [ac_cv_dirent_d_type], [
 AC_LINK_IFELSE(
 [
   AC_LANG_SOURCE([[
@@ -5824,16 +5648,16 @@ AC_LINK_IFELSE(
       return entry.d_type == DT_UNKNOWN;
     }
   ]])
-],[have_dirent_d_type=yes],[have_dirent_d_type=no])
-AC_MSG_RESULT($have_dirent_d_type)
+],[ac_cv_dirent_d_type=yes],[ac_cv_dirent_d_type=no])
+])
 
-if test "$have_dirent_d_type" = yes; then
+AS_VAR_IF([ac_cv_dirent_d_type], [yes], [
     AC_DEFINE(HAVE_DIRENT_D_TYPE, 1,
               [Define to 1 if the dirent structure has a d_type field])
-fi
+])
 
 # check if the Linux getrandom() syscall is available
-AC_MSG_CHECKING(for the Linux getrandom() syscall)
+AC_CACHE_CHECK([for the Linux getrandom() syscall], [ac_cv_getrandom_syscall], [
 AC_LINK_IFELSE(
 [
   AC_LANG_SOURCE([[
@@ -5850,17 +5674,17 @@ AC_LINK_IFELSE(
         return 0;
     }
   ]])
-],[have_getrandom_syscall=yes],[have_getrandom_syscall=no])
-AC_MSG_RESULT($have_getrandom_syscall)
+],[ac_cv_getrandom_syscall=yes],[ac_cv_getrandom_syscall=no])
+])
 
-if test "$have_getrandom_syscall" = yes; then
+AS_VAR_IF([ac_cv_getrandom_syscall], [yes], [
     AC_DEFINE(HAVE_GETRANDOM_SYSCALL, 1,
               [Define to 1 if the Linux getrandom() syscall is available])
-fi
+])
 
 # check if the getrandom() function is available
 # the test was written for the Solaris function of <sys/random.h>
-AC_MSG_CHECKING(for the getrandom() function)
+AC_CACHE_CHECK([for the getrandom() function], [ac_cv_func_getrandom], [
 AC_LINK_IFELSE(
 [
   AC_LANG_SOURCE([[
@@ -5875,13 +5699,13 @@ AC_LINK_IFELSE(
         return 0;
     }
   ]])
-],[have_getrandom=yes],[have_getrandom=no])
-AC_MSG_RESULT($have_getrandom)
+],[ac_cv_func_getrandom=yes],[ac_cv_func_getrandom=no])
+])
 
-if test "$have_getrandom" = yes; then
+AS_VAR_IF([ac_cv_func_getrandom], [yes], [
     AC_DEFINE(HAVE_GETRANDOM, 1,
               [Define to 1 if the getrandom() function is available])
-fi
+])
 
 # checks for POSIX shared memory, used by Modules/_multiprocessing/posixshmem.c
 # shm_* may only be available if linking against librt
@@ -5935,7 +5759,7 @@ AC_MSG_RESULT($OPENSSL_RPATH)
 AC_SUBST([OPENSSL_RPATH])
 
 # check if OpenSSL libraries work as expected
-AC_MSG_CHECKING(whether OpenSSL provides required APIs)
+AC_CACHE_CHECK([whether OpenSSL provides required APIs], [ac_cv_working_openssl], [
 save_LIBS="$LIBS"
 save_CFLAGS="$CFLAGS"
 save_LDFLAGS="$LDFLAGS"
@@ -5970,11 +5794,12 @@ OBJ_nid2sn(NID_sha3_512);
 OBJ_nid2sn(NID_blake2b512);
 EVP_PBE_scrypt(NULL, 0, NULL, 0, 2, 8, 1, 0, NULL, 0);
 ]])],
-  [AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)])
+  [ac_cv_working_openssl=yes],
+  [ac_cv_working_openssl=no])
 LIBS="$save_LIBS"
 CFLAGS="$save_CFLAGS"
 LDFLAGS="$save_LDFLAGS"
+])
 
 # ssl module default cipher suite string
 AH_TEMPLATE(PY_SSL_DEFAULT_CIPHERS,

--- a/configure.ac
+++ b/configure.ac
@@ -3819,14 +3819,14 @@ PY_CHECK_FUNC([fsync], [#include <unistd.h>])
 PY_CHECK_FUNC([fdatasync], [#include <unistd.h>])
 PY_CHECK_FUNC([epoll], [#include <sys/epoll.h>])
 PY_CHECK_FUNC([epoll_create1], [#include <sys/epoll.h>])
-PY_CHECK_FUNC([kqueue],[[
+PY_CHECK_FUNC([kqueue],[
 #include <sys/types.h>
 #include <sys/event.h>
-]])
-PY_CHECK_FUNC([prlimit], [[
+])
+PY_CHECK_FUNC([prlimit], [
 #include <sys/time.h>
 #include <sys/resource.h>
-]])
+])
 
 PY_CHECK_FUNC([_dyld_shared_cache_contains_path], [#include <mach-o/dyld.h>], [HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH])
 

--- a/configure.ac
+++ b/configure.ac
@@ -2316,7 +2316,7 @@ AC_CHECK_HEADERS(linux/can.h linux/can/bcm.h linux/can/j1939.h linux/can/raw.h,,
 
 # checks for typedefs
 AC_CACHE_CHECK([for clock_t in time.h], [ac_cv_clock_t_time_h], [
-AC_EGREP_HEADER([clock_t], [time.h], [ac_cv_clock_t_time_h=yes], [ac_cv_clock_t_time_h=no])
+  AC_EGREP_HEADER([clock_t], [time.h], [ac_cv_clock_t_time_h=yes], [ac_cv_clock_t_time_h=no])
 ])
 dnl checks for "no"
 AS_VAR_IF([ac_cv_clock_t_time_h], [no], [
@@ -2946,7 +2946,7 @@ void *x = uuid_generate_time_safe
 [ac_cv_lib_uuid_uuid_generate_time_safe=yes], [ac_cv_lib_uuid_uuid_generate_time_safe=no])
 ])
 AS_VAR_IF([ac_cv_lib_uuid_uuid_generate_time_safe], [yes], [
-  AC_DEFINE(HAVE_UUID_GENERATE_TIME_SAFE, 1, Define if uuid_generate_time_safe() exists.)
+  AC_DEFINE(HAVE_UUID_GENERATE_TIME_SAFE, 1, [Define if uuid_generate_time_safe() exists.])
 ])
 
 # check for libuuid from util-linux
@@ -3830,20 +3830,20 @@ PY_CHECK_FUNC([prlimit], [[
 
 PY_CHECK_FUNC([_dyld_shared_cache_contains_path], [#include <mach-o/dyld.h>], [HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH])
 
-PY_CHECK_FUNC([memfd_create], [[
+PY_CHECK_FUNC([memfd_create], [
 #ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif
 #ifdef HAVE_SYS_MEMFD_H
 #include <sys/memfd.h>
 #endif
-]])
+])
 
-PY_CHECK_FUNC([eventfd], [[
+PY_CHECK_FUNC([eventfd], [
 #ifdef HAVE_SYS_EVENTFD_H
 #include <sys/eventfd.h>
 #endif
-]])
+])
 
 # On some systems (eg. FreeBSD 5), we would find a definition of the
 # functions ctermid_r, setgroups in the library, but no prototype
@@ -3884,7 +3884,7 @@ AC_CACHE_CHECK([for broken unsetenv], [ac_cv_broken_unsetenv],
   )
 ])
 AS_VAR_IF([ac_cv_broken_unsetenv], [yes], [
-  AC_DEFINE(HAVE_BROKEN_UNSETENV, 1, Define if `unsetenv` does not return an int.)
+  AC_DEFINE(HAVE_BROKEN_UNSETENV, 1, [Define if 'unsetenv' does not return an int.])
 ])
 
 dnl check for true
@@ -3971,27 +3971,27 @@ esac
 
 PY_CHECK_FUNC([hstrerror], [#include <netdb.h>])
 
-PY_CHECK_FUNC([inet_aton], [[
+PY_CHECK_FUNC([inet_aton], [
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-]])
+])
 
-PY_CHECK_FUNC([inet_pton], [[
+PY_CHECK_FUNC([inet_pton], [
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-]])
+])
 
 # On some systems, setgroups is in unistd.h, on others, in grp.h
-PY_CHECK_FUNC([setgroups], [[
+PY_CHECK_FUNC([setgroups], [
 #include <unistd.h>
 #ifdef HAVE_GRP_H
 #include <grp.h>
 #endif
-]])
+])
 
 # check for openpty and forkpty
 
@@ -4341,10 +4341,10 @@ AS_VAR_IF([ac_cv_stdarg_prototypes], [yes], [
 
 
 # check for socketpair
-PY_CHECK_FUNC([socketpair], [[
+PY_CHECK_FUNC([socketpair], [
 #include <sys/types.h>
 #include <sys/socket.h>
-]])
+])
 
 # check if sockaddr has sa_len member
 AC_CACHE_CHECK([if sockaddr has sa_len member], [ac_cv_struct_sockaddr_sa_len], [
@@ -5269,11 +5269,11 @@ AC_DEFUN([PY_CHECK_CURSES_FUNC],
     [py_var],
     [AC_COMPILE_IFELSE(
       [AC_LANG_PROGRAM(
-        [#include <curses.h>], [[
+        [#include <curses.h>], [
         #ifndef $1
         void *x=$1
         #endif
-      ]])],
+      ])],
       [AS_VAR_SET([py_var], [yes])],
       [AS_VAR_SET([py_var], [no])])]
   )

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -118,7 +118,7 @@
 /* define to 1 if your sem_getvalue is broken. */
 #undef HAVE_BROKEN_SEM_GETVALUE
 
-/* Define if `unsetenv` does not return an int. */
+/* Define if 'unsetenv' does not return an int. */
 #undef HAVE_BROKEN_UNSETENV
 
 /* Has builtin __atomic_load_n() and __atomic_store_n() functions */

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -187,7 +187,7 @@
 /* Define if you have the 'immedok' function. */
 #undef HAVE_CURSES_IMMEDOK
 
-/* Define if you have the 'is_pad' function or macro. */
+/* Define if you have the 'is_pad' function. */
 #undef HAVE_CURSES_IS_PAD
 
 /* Define if you have the 'is_term_resized' function. */
@@ -290,7 +290,7 @@
 /* Define to 1 if you have the <endian.h> header file. */
 #undef HAVE_ENDIAN_H
 
-/* Define if you have the 'epoll' functions. */
+/* Define if you have the 'epoll' function. */
 #undef HAVE_EPOLL
 
 /* Define if you have the 'epoll_create1' function. */
@@ -559,7 +559,7 @@
 /* Define to 1 if you have the `killpg' function. */
 #undef HAVE_KILLPG
 
-/* Define if you have the 'kqueue' functions. */
+/* Define if you have the 'kqueue' function. */
 #undef HAVE_KQUEUE
 
 /* Define to 1 if you have the <langinfo.h> header file. */
@@ -779,7 +779,7 @@
 /* Define to 1 if you have the `preadv2' function. */
 #undef HAVE_PREADV2
 
-/* Define if you have the 'prlimit' functions. */
+/* Define if you have the 'prlimit' function. */
 #undef HAVE_PRLIMIT
 
 /* Define to 1 if you have the <process.h> header file. */
@@ -1287,10 +1287,10 @@
 /* Define to 1 if you have the <utime.h> header file. */
 #undef HAVE_UTIME_H
 
-/* Define if uuid_create() exists. */
+/* Define to 1 if you have the `uuid_create' function. */
 #undef HAVE_UUID_CREATE
 
-/* Define if uuid_enc_be() exists. */
+/* Define to 1 if you have the `uuid_enc_be' function. */
 #undef HAVE_UUID_ENC_BE
 
 /* Define if uuid_generate_time_safe() exists. */


### PR DESCRIPTION
Almost all checks are now cached by AC_CACHE_CHECK().

Common patterns are replaced by helper macros.

Variable names now use naming scheme ``ac_cv_func_$funcname``,
``ac_cv_lib_$library_$funcname``, or ``ac_cv_header_$headername_h``.

``SYS_SELECT_WITH_SYS_TIME`` is no longer used.

``uuid_create`` and ``uuid_enc_be`` are provided by libc on BSD. It is
safe to use ``AC_CHECK_FUNCS`` here.

Caching speeds up ./configure -C from ~ 4s to 2.6s on my system.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45723](https://bugs.python.org/issue45723) -->
https://bugs.python.org/issue45723
<!-- /issue-number -->
