### PR TITLE
bpo-45392: Update the docstring of the 'type' built-in.

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2021-11-06-10-54-17.bpo-45392.JZnVOz.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-11-06-10-54-17.bpo-45392.JZnVOz.rst
@@ -1,0 +1,2 @@
+Update the docstring of the :class:`type` built-in to remove a redundant
+line and to mention keyword arguments for the constructor.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4268,10 +4268,8 @@ static PyMethodDef type_methods[] = {
 };
 
 PyDoc_STRVAR(type_doc,
-/* this text signature cannot be accurate yet.  will fix.  --larry */
-"type(object_or_name, bases, dict)\n"
 "type(object) -> the object's type\n"
-"type(name, bases, dict) -> a new type");
+"type(name, bases, dict, **kwds) -> a new type");
 
 static int
 type_traverse(PyTypeObject *type, visitproc visit, void *arg)


### PR DESCRIPTION
This PR fixes the docstring of the 'type' built-in to:

- remove a redundant signature line
- include `**kwds` in the constructor signature

<!-- issue-number: [bpo-45392](https://bugs.python.org/issue45392) -->
https://bugs.python.org/issue45392
<!-- /issue-number -->
