### PR TITLE
doc: Add link issue 44010

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1173,7 +1173,7 @@ Highlight the new :ref:`soft keywords <soft-keywords>` :keyword:`match`,
 :keyword:`case <match>`, and :keyword:`_ <wildcard-patterns>` in
 pattern-matching statements. However, this highlighting is not perfect
 and will be incorrect in some rare cases, including some ``_``-s in
-``case`` patterns.  (Contributed by Tal Einat in bpo-44010.)
+``case`` patterns.  (Contributed by Tal Einat in :issue:`44010`.)
 
 importlib.metadata
 ------------------


### PR DESCRIPTION
Change Doc/whatsnew/3.10.rst replacing "[bpo-44010](https://bugs.python.org/issue44010)" (no link in the doc) with ``` :issue:`44010` ``` to link 44010, just like normally happens in whatsnew entries.

Backporting to branch 3.10 is recommended.