### PR TITLE
[doc] Use same character as placeholder for 8-bit, 16-bit and 32-bit hexadecimal characters

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -585,11 +585,11 @@ Escape sequences only recognized in string literals are:
 | ``\N{name}``    | Character named *name* in the   | \(4)  |
 |                 | Unicode database                |       |
 +-----------------+---------------------------------+-------+
-| ``\uxxxx``      | Character with 16-bit hex value | \(5)  |
-|                 | *xxxx*                          |       |
+| ``\uhhhh``      | Character with 16-bit hex value | \(5)  |
+|                 | *hhhh*                          |       |
 +-----------------+---------------------------------+-------+
-| ``\Uxxxxxxxx``  | Character with 32-bit hex value | \(6)  |
-|                 | *xxxxxxxx*                      |       |
+| ``\Uhhhhhhhh``  | Character with 32-bit hex value | \(6)  |
+|                 | *hhhhhhhh*                      |       |
 +-----------------+---------------------------------+-------+
 
 Notes:


### PR DESCRIPTION
This follow suit of 8-bit example. I think this helps with quickly associating these two examples format with the previous one . 