### PR TITLE
bpo-45712: Fix typo in 'control flow' documentation

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -378,7 +378,7 @@ Several other key features of this statement:
 - Mapping patterns: ``{"bandwidth": b, "latency": l}`` captures the
   ``"bandwidth"`` and ``"latency"`` values from a dictionary.  Unlike sequence
   patterns, extra keys are ignored.  An unpacking like ``**rest`` is also
-  supported.  (But ``**_`` would be redundant, so it not allowed.)
+  supported.  (But ``**_`` would be redundant, so it is not allowed.)
 
 - Subpatterns may be captured using the ``as`` keyword::
 


### PR DESCRIPTION
https://bugs.python.org/issue45712

<!-- issue-number: [bpo-45712](https://bugs.python.org/issue45712) -->
https://bugs.python.org/issue45712
<!-- /issue-number -->
