### PR TITLE
bpo-45723: Add macro for disabling/enabling CC warnings (GH-29466)

### DIFF
--- a/configure
+++ b/configure
@@ -7082,8 +7082,8 @@ yes)
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can enable $CC extra warning" >&5
-$as_echo_n "checking if we can enable $CC extra warning... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can add -Wextra" >&5
+$as_echo_n "checking if we can add -Wextra... " >&6; }
 
   py_cc=$CC
   CC="$CC -Wextra -Werror"

--- a/configure
+++ b/configure
@@ -7184,18 +7184,15 @@ fi
      CC="$ac_save_cc"
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_no_strict_aliasing" >&5
 $as_echo "$ac_cv_no_strict_aliasing" >&6; }
-    if test $ac_cv_no_strict_aliasing = yes
-    then
-      BASECFLAGS="$BASECFLAGS -fno-strict-aliasing"
-    fi
+    if test "x$ac_cv_no_strict_aliasing" = xyes; then :
+  BASECFLAGS="$BASECFLAGS -fno-strict-aliasing"
+fi
 
     # ICC doesn't recognize the option, but only emits a warning
     ## XXX does it emit an unused result warning and can it be disabled?
-    case "$CC" in
-    *icc*)
+    case $CC in #(
+  *icc*) :
     ac_cv_disable_unused_result_warning=no
-    ;;
-    *)
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC unused-result warning" >&5
 $as_echo_n "checking if we can disable $CC unused-result warning... " >&6; }
@@ -7229,9 +7226,10 @@ fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_result_warning" >&5
 $as_echo "$ac_cv_disable_unused_result_warning" >&6; }
 
-
-    ;;
-    esac
+ ;; #(
+  *) :
+     ;;
+esac
 
     if test "x$ac_cv_disable_unused_result_warning" = xyes; then :
   BASECFLAGS="$BASECFLAGS -Wno-unused-result"

--- a/configure
+++ b/configure
@@ -7074,21 +7074,24 @@ fi
 UNIVERSAL_ARCH_FLAGS=
 
 
+
+
 # tweak BASECFLAGS based on compiler and platform
 case $GCC in
 yes)
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for -Wextra" >&5
-$as_echo_n "checking for -Wextra... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Wextra -Werror"
-     if ${ac_cv_extra_warnings+:} false; then :
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can enable $CC extra warning" >&5
+$as_echo_n "checking if we can enable $CC extra warning... " >&6; }
+
+  py_cc=$CC
+  CC="$CC -Wextra -Werror"
+  if ${ac_cv_enable_extra_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 
 int
 main ()
@@ -7097,28 +7100,24 @@ main ()
   ;
   return 0;
 }
-
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_extra_warnings=yes
-
+  ac_cv_enable_extra_warning=yes
 else
-
-           ac_cv_extra_warnings=no
-
+  ac_cv_enable_extra_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 fi
 
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_extra_warnings" >&5
-$as_echo "$ac_cv_extra_warnings" >&6; }
+  CC=$py_cc
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_extra_warning" >&5
+$as_echo "$ac_cv_enable_extra_warning" >&6; }
 
-    if test $ac_cv_extra_warnings = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"
-    fi
+
+    if test $ac_cv_enable_extra_warning = yes; then :
+  CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"
+fi
 
     # Python doesn't violate C99 aliasing rules, but older versions of
     # GCC produce warnings for legal Python code.  Enable
@@ -7197,17 +7196,17 @@ $as_echo "$ac_cv_no_strict_aliasing" >&6; }
     ac_cv_disable_unused_result_warning=no
     ;;
     *)
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can turn off $CC unused result warning" >&5
-$as_echo_n "checking if we can turn off $CC unused result warning... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Wunused-result -Werror"
-     save_CFLAGS="$CFLAGS"
-     if ${ac_cv_disable_unused_result_warning+:} false; then :
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC unused-result warning" >&5
+$as_echo_n "checking if we can disable $CC unused-result warning... " >&6; }
+
+  py_cc=$CC
+  CC="$CC -Wunused-result -Werror"
+  if ${ac_cv_disable_unused_result_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 
 int
 main ()
@@ -7216,43 +7215,40 @@ main ()
   ;
   return 0;
 }
-
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_disable_unused_result_warning=yes
-
+  ac_cv_disable_unused_result_warning=yes
 else
-
-           ac_cv_disable_unused_result_warning=no
-
+  ac_cv_disable_unused_result_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 fi
 
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_result_warning" >&5
+  CC=$py_cc
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_result_warning" >&5
 $as_echo "$ac_cv_disable_unused_result_warning" >&6; }
+
+
     ;;
     esac
 
-    if test $ac_cv_disable_unused_result_warning = yes
-    then
-      BASECFLAGS="$BASECFLAGS -Wno-unused-result"
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"
-    fi
+    if test $ac_cv_disable_unused_result_warning = yes; then :
+  BASECFLAGS="$BASECFLAGS -Wno-unused-result"
+           CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"
+fi
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can turn off $CC unused parameter warning" >&5
-$as_echo_n "checking if we can turn off $CC unused parameter warning... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Wunused-parameter -Werror"
-     if ${ac_cv_disable_unused_parameter_warning+:} false; then :
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC unused-parameter warning" >&5
+$as_echo_n "checking if we can disable $CC unused-parameter warning... " >&6; }
+
+  py_cc=$CC
+  CC="$CC -Wunused-parameter -Werror"
+  if ${ac_cv_disable_unused_parameter_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 
 int
 main ()
@@ -7261,39 +7257,36 @@ main ()
   ;
   return 0;
 }
-
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_disable_unused_parameter_warning=yes
-
+  ac_cv_disable_unused_parameter_warning=yes
 else
-
-           ac_cv_disable_unused_parameter_warning=no
-
+  ac_cv_disable_unused_parameter_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 fi
 
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_parameter_warning" >&5
+  CC=$py_cc
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_parameter_warning" >&5
 $as_echo "$ac_cv_disable_unused_parameter_warning" >&6; }
 
-    if test $ac_cv_disable_unused_parameter_warning = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-parameter"
-    fi
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can turn off $CC missing field initializers warning" >&5
-$as_echo_n "checking if we can turn off $CC missing field initializers warning... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Wmissing-field-initializers -Werror"
-     if ${ac_cv_disable_missing_field_initializers+:} false; then :
+    if test $ac_cv_disable_unused_parameter_warning = yes; then :
+  CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-parameter"
+fi
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC missing-field-initializers warning" >&5
+$as_echo_n "checking if we can disable $CC missing-field-initializers warning... " >&6; }
+
+  py_cc=$CC
+  CC="$CC -Wmissing-field-initializers -Werror"
+  if ${ac_cv_disable_missing_field_initializers_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 
 int
 main ()
@@ -7302,40 +7295,36 @@ main ()
   ;
   return 0;
 }
-
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_disable_missing_field_initializers=yes
-
+  ac_cv_disable_missing_field_initializers_warning=yes
 else
-
-           ac_cv_disable_missing_field_initializers=no
-
+  ac_cv_disable_missing_field_initializers_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 fi
 
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_missing_field_initializers" >&5
-$as_echo "$ac_cv_disable_missing_field_initializers" >&6; }
+  CC=$py_cc
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_missing_field_initializers_warning" >&5
+$as_echo "$ac_cv_disable_missing_field_initializers_warning" >&6; }
 
-    if test $ac_cv_disable_missing_field_initializers = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-missing-field-initializers"
-    fi
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can turn on $CC mixed sign comparison warning" >&5
-$as_echo_n "checking if we can turn on $CC mixed sign comparison warning... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Wsign-compare"
-     save_CFLAGS="$CFLAGS"
-     if ${ac_cv_enable_sign_compare_warning+:} false; then :
+    if test $ac_cv_disable_missing_field_initializers_warning = yes; then :
+  CFLAGS_NODIST="$CFLAGS_NODIST -Wno-missing-field-initializers"
+fi
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can enable $CC sign-compare warning" >&5
+$as_echo_n "checking if we can enable $CC sign-compare warning... " >&6; }
+
+  py_cc=$CC
+  CC="$CC -Wsign-compare -Werror"
+  if ${ac_cv_enable_sign_compare_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 
 int
 main ()
@@ -7344,41 +7333,36 @@ main ()
   ;
   return 0;
 }
-
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_enable_sign_compare_warning=yes
-
+  ac_cv_enable_sign_compare_warning=yes
 else
-
-           ac_cv_enable_sign_compare_warning=no
-
+  ac_cv_enable_sign_compare_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 fi
 
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_sign_compare_warning" >&5
+  CC=$py_cc
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_sign_compare_warning" >&5
 $as_echo "$ac_cv_enable_sign_compare_warning" >&6; }
 
-    if test $ac_cv_enable_sign_compare_warning = yes
-    then
-      BASECFLAGS="$BASECFLAGS -Wsign-compare"
-    fi
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can turn on $CC unreachable code warning" >&5
-$as_echo_n "checking if we can turn on $CC unreachable code warning... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Wunreachable-code"
-     save_CFLAGS="$CFLAGS"
-     if ${ac_cv_enable_unreachable_code_warning+:} false; then :
+    if test $ac_cv_enable_sign_compare_warning = yes; then :
+  BASECFLAGS="$BASECFLAGS -Wsign-compare"
+fi
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can enable $CC unreachable-code warning" >&5
+$as_echo_n "checking if we can enable $CC unreachable-code warning... " >&6; }
+
+  py_cc=$CC
+  CC="$CC -Wunreachable-code -Werror"
+  if ${ac_cv_enable_unreachable_code_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 
 int
 main ()
@@ -7387,22 +7371,20 @@ main ()
   ;
   return 0;
 }
-
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_enable_unreachable_code_warning=yes
-
+  ac_cv_enable_unreachable_code_warning=yes
 else
-
-           ac_cv_enable_unreachable_code_warning=no
-
+  ac_cv_enable_unreachable_code_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 fi
 
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
+  CC=$py_cc
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_unreachable_code_warning" >&5
+$as_echo "$ac_cv_enable_unreachable_code_warning" >&6; }
+
 
     # Don't enable unreachable code warning in debug mode, since it usually
     # results in non-standard code paths.
@@ -7419,19 +7401,18 @@ fi
     else
       ac_cv_enable_unreachable_code_warning=no
     fi
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_unreachable_code_warning" >&5
-$as_echo "$ac_cv_enable_unreachable_code_warning" >&6; }
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can turn on $CC strict-prototypes warning" >&5
-$as_echo_n "checking if we can turn on $CC strict-prototypes warning... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Werror -Wstrict-prototypes"
-     if ${ac_cv_enable_enable_strict_prototypes_warning+:} false; then :
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can enable $CC strict-prototypes warning" >&5
+$as_echo_n "checking if we can enable $CC strict-prototypes warning... " >&6; }
+
+  py_cc=$CC
+  CC="$CC -Wstrict-prototypes -Werror"
+  if ${ac_cv_enable_strict_prototypes_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 
 int
 main ()
@@ -7440,28 +7421,24 @@ main ()
   ;
   return 0;
 }
-
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-
-       ac_cv_enable_strict_prototypes_warning=yes
-
+  ac_cv_enable_strict_prototypes_warning=yes
 else
-
-       ac_cv_enable_strict_prototypes_warning=no
-
+  ac_cv_enable_strict_prototypes_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 fi
 
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_strict_prototypes_warning" >&5
+  CC=$py_cc
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_strict_prototypes_warning" >&5
 $as_echo "$ac_cv_enable_strict_prototypes_warning" >&6; }
 
-    if test $ac_cv_enable_strict_prototypes_warning = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wstrict-prototypes"
-    fi
+
+    if test $ac_cv_enable_strict_prototypes_warning = yes; then :
+  CFLAGS_NODIST="$CFLAGS_NODIST -Wstrict-prototypes"
+fi
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can make implicit function declaration an error in $CC" >&5
 $as_echo_n "checking if we can make implicit function declaration an error in $CC... " >&6; }
@@ -7499,10 +7476,9 @@ fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_implicit_function_declaration_error" >&5
 $as_echo "$ac_cv_enable_implicit_function_declaration_error" >&6; }
 
-    if test $ac_cv_enable_implicit_function_declaration_error = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Werror=implicit-function-declaration"
-    fi
+    if test $ac_cv_enable_implicit_function_declaration_error = yes; then :
+  CFLAGS_NODIST="$CFLAGS_NODIST -Werror=implicit-function-declaration"
+fi
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can use visibility in $CC" >&5
 $as_echo_n "checking if we can use visibility in $CC... " >&6; }
@@ -7540,10 +7516,9 @@ fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_visibility" >&5
 $as_echo "$ac_cv_enable_visibility" >&6; }
 
-    if test $ac_cv_enable_visibility = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -fvisibility=hidden"
-    fi
+    if test $ac_cv_enable_visibility = yes; then :
+  CFLAGS_NODIST="$CFLAGS_NODIST -fvisibility=hidden"
+fi
 
     # if using gcc on alpha, use -mieee to get (near) full IEEE 754
     # support.  Without this, treatment of subnormals doesn't follow

--- a/configure
+++ b/configure
@@ -7085,8 +7085,8 @@ yes)
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can add -Wextra" >&5
 $as_echo_n "checking if we can add -Wextra... " >&6; }
 
-  py_cc=$CC
-  CC="$CC -Wextra -Werror"
+  py_cflags=$CFLAGS
+  CFLAGS="$CFLAGS -Wextra -Werror"
   if ${ac_cv_enable_extra_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
@@ -7110,7 +7110,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
-  CC=$py_cc
+  CFLAGS=$py_cflags
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_extra_warning" >&5
 $as_echo "$ac_cv_enable_extra_warning" >&6; }
 
@@ -7197,8 +7197,8 @@ fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC unused-result warning" >&5
 $as_echo_n "checking if we can disable $CC unused-result warning... " >&6; }
 
-  py_cc=$CC
-  CC="$CC -Wunused-result -Werror"
+  py_cflags=$CFLAGS
+  CFLAGS="$CFLAGS -Wunused-result -Werror"
   if ${ac_cv_disable_unused_result_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
@@ -7222,7 +7222,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
-  CC=$py_cc
+  CFLAGS=$py_cflags
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_result_warning" >&5
 $as_echo "$ac_cv_disable_unused_result_warning" >&6; }
 
@@ -7230,7 +7230,6 @@ $as_echo "$ac_cv_disable_unused_result_warning" >&6; }
   *) :
      ;;
 esac
-
     if test "x$ac_cv_disable_unused_result_warning" = xyes; then :
   BASECFLAGS="$BASECFLAGS -Wno-unused-result"
                CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"
@@ -7240,8 +7239,8 @@ fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC unused-parameter warning" >&5
 $as_echo_n "checking if we can disable $CC unused-parameter warning... " >&6; }
 
-  py_cc=$CC
-  CC="$CC -Wunused-parameter -Werror"
+  py_cflags=$CFLAGS
+  CFLAGS="$CFLAGS -Wunused-parameter -Werror"
   if ${ac_cv_disable_unused_parameter_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
@@ -7265,7 +7264,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
-  CC=$py_cc
+  CFLAGS=$py_cflags
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_parameter_warning" >&5
 $as_echo "$ac_cv_disable_unused_parameter_warning" >&6; }
 
@@ -7278,8 +7277,8 @@ fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC missing-field-initializers warning" >&5
 $as_echo_n "checking if we can disable $CC missing-field-initializers warning... " >&6; }
 
-  py_cc=$CC
-  CC="$CC -Wmissing-field-initializers -Werror"
+  py_cflags=$CFLAGS
+  CFLAGS="$CFLAGS -Wmissing-field-initializers -Werror"
   if ${ac_cv_disable_missing_field_initializers_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
@@ -7303,7 +7302,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
-  CC=$py_cc
+  CFLAGS=$py_cflags
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_missing_field_initializers_warning" >&5
 $as_echo "$ac_cv_disable_missing_field_initializers_warning" >&6; }
 
@@ -7316,8 +7315,8 @@ fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can enable $CC sign-compare warning" >&5
 $as_echo_n "checking if we can enable $CC sign-compare warning... " >&6; }
 
-  py_cc=$CC
-  CC="$CC -Wsign-compare -Werror"
+  py_cflags=$CFLAGS
+  CFLAGS="$CFLAGS -Wsign-compare -Werror"
   if ${ac_cv_enable_sign_compare_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
@@ -7341,7 +7340,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
-  CC=$py_cc
+  CFLAGS=$py_cflags
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_sign_compare_warning" >&5
 $as_echo "$ac_cv_enable_sign_compare_warning" >&6; }
 
@@ -7354,8 +7353,8 @@ fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can enable $CC unreachable-code warning" >&5
 $as_echo_n "checking if we can enable $CC unreachable-code warning... " >&6; }
 
-  py_cc=$CC
-  CC="$CC -Wunreachable-code -Werror"
+  py_cflags=$CFLAGS
+  CFLAGS="$CFLAGS -Wunreachable-code -Werror"
   if ${ac_cv_enable_unreachable_code_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
@@ -7379,7 +7378,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
-  CC=$py_cc
+  CFLAGS=$py_cflags
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_unreachable_code_warning" >&5
 $as_echo "$ac_cv_enable_unreachable_code_warning" >&6; }
 
@@ -7404,8 +7403,8 @@ $as_echo "$ac_cv_enable_unreachable_code_warning" >&6; }
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can enable $CC strict-prototypes warning" >&5
 $as_echo_n "checking if we can enable $CC strict-prototypes warning... " >&6; }
 
-  py_cc=$CC
-  CC="$CC -Wstrict-prototypes -Werror"
+  py_cflags=$CFLAGS
+  CFLAGS="$CFLAGS -Wstrict-prototypes -Werror"
   if ${ac_cv_enable_strict_prototypes_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
@@ -7429,7 +7428,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
-  CC=$py_cc
+  CFLAGS=$py_cflags
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_strict_prototypes_warning" >&5
 $as_echo "$ac_cv_enable_strict_prototypes_warning" >&6; }
 
@@ -7474,7 +7473,7 @@ fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_implicit_function_declaration_error" >&5
 $as_echo "$ac_cv_enable_implicit_function_declaration_error" >&6; }
 
-    if test $ac_cv_enable_implicit_function_declaration_error = yes; then :
+    if test "x$ac_cv_enable_implicit_function_declaration_error" = xyes; then :
   CFLAGS_NODIST="$CFLAGS_NODIST -Werror=implicit-function-declaration"
 fi
 
@@ -7514,7 +7513,7 @@ fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_visibility" >&5
 $as_echo "$ac_cv_enable_visibility" >&6; }
 
-    if test $ac_cv_enable_visibility = yes; then :
+    if test "x$ac_cv_enable_visibility" = xyes; then :
   CFLAGS_NODIST="$CFLAGS_NODIST -fvisibility=hidden"
 fi
 

--- a/configure
+++ b/configure
@@ -7115,7 +7115,7 @@ fi
 $as_echo "$ac_cv_enable_extra_warning" >&6; }
 
 
-    if test $ac_cv_enable_extra_warning = yes; then :
+    if test "x$ac_cv_enable_extra_warning" = xyes; then :
   CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"
 fi
 
@@ -7233,9 +7233,9 @@ $as_echo "$ac_cv_disable_unused_result_warning" >&6; }
     ;;
     esac
 
-    if test $ac_cv_disable_unused_result_warning = yes; then :
+    if test "x$ac_cv_disable_unused_result_warning" = xyes; then :
   BASECFLAGS="$BASECFLAGS -Wno-unused-result"
-           CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"
+               CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"
 fi
 
 
@@ -7272,7 +7272,7 @@ fi
 $as_echo "$ac_cv_disable_unused_parameter_warning" >&6; }
 
 
-    if test $ac_cv_disable_unused_parameter_warning = yes; then :
+    if test "x$ac_cv_disable_unused_parameter_warning" = xyes; then :
   CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-parameter"
 fi
 
@@ -7310,7 +7310,7 @@ fi
 $as_echo "$ac_cv_disable_missing_field_initializers_warning" >&6; }
 
 
-    if test $ac_cv_disable_missing_field_initializers_warning = yes; then :
+    if test "x$ac_cv_disable_missing_field_initializers_warning" = xyes; then :
   CFLAGS_NODIST="$CFLAGS_NODIST -Wno-missing-field-initializers"
 fi
 
@@ -7348,7 +7348,7 @@ fi
 $as_echo "$ac_cv_enable_sign_compare_warning" >&6; }
 
 
-    if test $ac_cv_enable_sign_compare_warning = yes; then :
+    if test "x$ac_cv_enable_sign_compare_warning" = xyes; then :
   BASECFLAGS="$BASECFLAGS -Wsign-compare"
 fi
 
@@ -7436,7 +7436,7 @@ fi
 $as_echo "$ac_cv_enable_strict_prototypes_warning" >&6; }
 
 
-    if test $ac_cv_enable_strict_prototypes_warning = yes; then :
+    if test "x$ac_cv_enable_strict_prototypes_warning" = xyes; then :
   CFLAGS_NODIST="$CFLAGS_NODIST -Wstrict-prototypes"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1698,10 +1698,8 @@ yes)
      CFLAGS="$save_CFLAGS"
      CC="$ac_save_cc"
     AC_MSG_RESULT($ac_cv_no_strict_aliasing)
-    if test $ac_cv_no_strict_aliasing = yes
-    then
-      BASECFLAGS="$BASECFLAGS -fno-strict-aliasing"
-    fi
+    AS_VAR_IF([ac_cv_no_strict_aliasing], [yes],
+              [BASECFLAGS="$BASECFLAGS -fno-strict-aliasing"])
 
     # ICC doesn't recognize the option, but only emits a warning
     ## XXX does it emit an unused result warning and can it be disabled?

--- a/configure.ac
+++ b/configure.ac
@@ -1644,8 +1644,8 @@ dnl PY_CHECK_CC_WARNING(ENABLE, WARNING, [MSG])
 AC_DEFUN([PY_CHECK_CC_WARNING], [
   AC_MSG_CHECKING(m4_ifblank([$3], [if we can $1 $CC $2 warning], [$3]))
   AS_VAR_PUSHDEF([py_var], [ac_cv_$1_]m4_normalize($2)[_warning])
-  AS_VAR_COPY([py_cc], [CC])
-  AS_VAR_SET([CC], ["$CC -W$2 -Werror"])
+  AS_VAR_COPY([py_cflags], [CFLAGS])
+  AS_VAR_SET([CFLAGS], ["$CFLAGS -W$2 -Werror"])
   AC_CACHE_VAL(
     [py_var],
     [AC_COMPILE_IFELSE(
@@ -1654,7 +1654,7 @@ AC_DEFUN([PY_CHECK_CC_WARNING], [
       [AS_VAR_SET([py_var], [no])],
     )]
   )
-  AS_VAR_COPY([CC], [py_cc])
+  AS_VAR_COPY([CFLAGS], [py_cflags])
   AC_MSG_RESULT([$py_var])
   AS_VAR_POPDEF([py_var])
 ])
@@ -1758,8 +1758,8 @@ yes)
      CC="$ac_save_cc"
     AC_MSG_RESULT($ac_cv_enable_implicit_function_declaration_error)
 
-    AS_IF([test $ac_cv_enable_implicit_function_declaration_error = yes],
-          [CFLAGS_NODIST="$CFLAGS_NODIST -Werror=implicit-function-declaration"])
+    AS_VAR_IF([ac_cv_enable_implicit_function_declaration_error], [yes],
+              [CFLAGS_NODIST="$CFLAGS_NODIST -Werror=implicit-function-declaration"])
 
     AC_MSG_CHECKING(if we can use visibility in $CC)
      ac_save_cc="$CC"
@@ -1776,8 +1776,8 @@ yes)
      CC="$ac_save_cc"
     AC_MSG_RESULT($ac_cv_enable_visibility)
 
-    AS_IF([test $ac_cv_enable_visibility = yes],
-          [CFLAGS_NODIST="$CFLAGS_NODIST -fvisibility=hidden"])
+    AS_VAR_IF([ac_cv_enable_visibility], [yes],
+              [CFLAGS_NODIST="$CFLAGS_NODIST -fvisibility=hidden"])
 
     # if using gcc on alpha, use -mieee to get (near) full IEEE 754
     # support.  Without this, treatment of subnormals doesn't follow

--- a/configure.ac
+++ b/configure.ac
@@ -1640,9 +1640,9 @@ AC_SUBST(LDFLAGS_NODIST)
 UNIVERSAL_ARCH_FLAGS=
 AC_SUBST(UNIVERSAL_ARCH_FLAGS)
 
-dnl PY_CHECK_CC_WARNING(ENABLE, WARNING)
+dnl PY_CHECK_CC_WARNING(ENABLE, WARNING, [MSG])
 AC_DEFUN([PY_CHECK_CC_WARNING], [
-  AC_MSG_CHECKING([if we can $1 $CC $2 warning])
+  AC_MSG_CHECKING(m4_ifblank([$3], [if we can $1 $CC $2 warning], [$3]))
   AS_VAR_PUSHDEF([py_var], [ac_cv_$1_]m4_normalize($2)[_warning])
   AS_VAR_COPY([py_cc], [CC])
   AS_VAR_SET([CC], ["$CC -W$2 -Werror"])
@@ -1664,7 +1664,7 @@ case $GCC in
 yes)
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
 
-    PY_CHECK_CC_WARNING([enable], [extra])
+    PY_CHECK_CC_WARNING([enable], [extra], [if we can add -Wextra])
     AS_VAR_IF([ac_cv_enable_extra_warning], [yes],
               [CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1703,14 +1703,9 @@ yes)
 
     # ICC doesn't recognize the option, but only emits a warning
     ## XXX does it emit an unused result warning and can it be disabled?
-    case "$CC" in
-    *icc*)
-    ac_cv_disable_unused_result_warning=no
-    ;;
-    *)
-    PY_CHECK_CC_WARNING([disable], [unused-result])
-    ;;
-    esac
+    AS_CASE([$CC],
+            [*icc*], [ac_cv_disable_unused_result_warning=no]
+            [PY_CHECK_CC_WARNING([disable], [unused-result])])
 
     AS_VAR_IF([ac_cv_disable_unused_result_warning], [yes],
               [BASECFLAGS="$BASECFLAGS -Wno-unused-result"

--- a/configure.ac
+++ b/configure.ac
@@ -1665,7 +1665,7 @@ yes)
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
 
     PY_CHECK_CC_WARNING([enable], [extra])
-    AS_IF([test $ac_cv_enable_extra_warning = yes],
+    AS_VAR_IF([ac_cv_enable_extra_warning], [yes],
           [CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"])
 
     # Python doesn't violate C99 aliasing rules, but older versions of

--- a/configure.ac
+++ b/configure.ac
@@ -1640,30 +1640,33 @@ AC_SUBST(LDFLAGS_NODIST)
 UNIVERSAL_ARCH_FLAGS=
 AC_SUBST(UNIVERSAL_ARCH_FLAGS)
 
+dnl PY_CHECK_CC_WARNING(ENABLE, WARNING)
+AC_DEFUN([PY_CHECK_CC_WARNING], [
+  AC_MSG_CHECKING([if we can $1 $CC $2 warning])
+  AS_VAR_PUSHDEF([py_var], [ac_cv_$1_]m4_normalize($2)[_warning])
+  AS_VAR_COPY([py_cc], [CC])
+  AS_VAR_SET([CC], ["$CC -W$2 -Werror"])
+  AC_CACHE_VAL(
+    [py_var],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[]], [[]])],
+      [AS_VAR_SET([py_var], [yes])],
+      [AS_VAR_SET([py_var], [no])],
+    )]
+  )
+  AS_VAR_COPY([CC], [py_cc])
+  AC_MSG_RESULT([$py_var])
+  AS_VAR_POPDEF([py_var])
+])
+
 # tweak BASECFLAGS based on compiler and platform
 case $GCC in
 yes)
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
 
-    AC_MSG_CHECKING(for -Wextra)
-     ac_save_cc="$CC"
-     CC="$CC -Wextra -Werror"
-     AC_CACHE_VAL(ac_cv_extra_warnings,
-       AC_COMPILE_IFELSE(
-         [
-           AC_LANG_PROGRAM([[]], [[]])
-         ],[
-           ac_cv_extra_warnings=yes
-         ],[
-           ac_cv_extra_warnings=no
-         ]))
-     CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_extra_warnings)
-
-    if test $ac_cv_extra_warnings = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"
-    fi
+    PY_CHECK_CC_WARNING([enable], [extra])
+    AS_IF([test $ac_cv_enable_extra_warning = yes],
+          [CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"])
 
     # Python doesn't violate C99 aliasing rules, but older versions of
     # GCC produce warnings for legal Python code.  Enable
@@ -1707,109 +1710,27 @@ yes)
     ac_cv_disable_unused_result_warning=no
     ;;
     *)
-    AC_MSG_CHECKING(if we can turn off $CC unused result warning)
-     ac_save_cc="$CC"
-     CC="$CC -Wunused-result -Werror"
-     save_CFLAGS="$CFLAGS"
-     AC_CACHE_VAL(ac_cv_disable_unused_result_warning,
-       AC_COMPILE_IFELSE(
-         [
-	   AC_LANG_PROGRAM([[]], [[]])
-	 ],[
-           ac_cv_disable_unused_result_warning=yes
-	 ],[
-           ac_cv_disable_unused_result_warning=no
-	 ]))
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_disable_unused_result_warning)
+    PY_CHECK_CC_WARNING([disable], [unused-result])
     ;;
     esac
 
-    if test $ac_cv_disable_unused_result_warning = yes
-    then
-      BASECFLAGS="$BASECFLAGS -Wno-unused-result"
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"
-    fi
+    AS_IF([test $ac_cv_disable_unused_result_warning = yes],
+          [BASECFLAGS="$BASECFLAGS -Wno-unused-result"
+           CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"])
 
-    AC_MSG_CHECKING(if we can turn off $CC unused parameter warning)
-     ac_save_cc="$CC"
-     CC="$CC -Wunused-parameter -Werror"
-     AC_CACHE_VAL(ac_cv_disable_unused_parameter_warning,
-       AC_COMPILE_IFELSE(
-         [
-           AC_LANG_PROGRAM([[]], [[]])
-         ],[
-           ac_cv_disable_unused_parameter_warning=yes
-         ],[
-           ac_cv_disable_unused_parameter_warning=no
-         ]))
-     CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_disable_unused_parameter_warning)
+    PY_CHECK_CC_WARNING([disable], [unused-parameter])
+    AS_IF([test $ac_cv_disable_unused_parameter_warning = yes],
+          [CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-parameter"])
 
-    if test $ac_cv_disable_unused_parameter_warning = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-parameter"
-    fi
+    PY_CHECK_CC_WARNING([disable], [missing-field-initializers])
+    AS_IF([test $ac_cv_disable_missing_field_initializers_warning = yes],
+          [CFLAGS_NODIST="$CFLAGS_NODIST -Wno-missing-field-initializers"])
 
-    AC_MSG_CHECKING(if we can turn off $CC missing field initializers warning)
-     ac_save_cc="$CC"
-     CC="$CC -Wmissing-field-initializers -Werror"
-     AC_CACHE_VAL(ac_cv_disable_missing_field_initializers,
-       AC_COMPILE_IFELSE(
-         [
-           AC_LANG_PROGRAM([[]], [[]])
-         ],[
-           ac_cv_disable_missing_field_initializers=yes
-         ],[
-           ac_cv_disable_missing_field_initializers=no
-         ]))
-     CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_disable_missing_field_initializers)
+    PY_CHECK_CC_WARNING([enable], [sign-compare])
+    AS_IF([test $ac_cv_enable_sign_compare_warning = yes],
+          [BASECFLAGS="$BASECFLAGS -Wsign-compare"])
 
-    if test $ac_cv_disable_missing_field_initializers = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-missing-field-initializers"
-    fi
-
-    AC_MSG_CHECKING(if we can turn on $CC mixed sign comparison warning)
-     ac_save_cc="$CC"
-     CC="$CC -Wsign-compare"
-     save_CFLAGS="$CFLAGS"
-     AC_CACHE_VAL(ac_cv_enable_sign_compare_warning,
-       AC_COMPILE_IFELSE(
-         [
-	   AC_LANG_PROGRAM([[]], [[]])
-	 ],[
-           ac_cv_enable_sign_compare_warning=yes
-	 ],[
-           ac_cv_enable_sign_compare_warning=no
-	 ]))
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_enable_sign_compare_warning)
-
-    if test $ac_cv_enable_sign_compare_warning = yes
-    then
-      BASECFLAGS="$BASECFLAGS -Wsign-compare"
-    fi
-
-    AC_MSG_CHECKING(if we can turn on $CC unreachable code warning)
-     ac_save_cc="$CC"
-     CC="$CC -Wunreachable-code"
-     save_CFLAGS="$CFLAGS"
-     AC_CACHE_VAL(ac_cv_enable_unreachable_code_warning,
-       AC_COMPILE_IFELSE(
-         [
-	   AC_LANG_PROGRAM([[]], [[]])
-	 ],[
-           ac_cv_enable_unreachable_code_warning=yes
-	 ],[
-           ac_cv_enable_unreachable_code_warning=no
-	 ]))
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
-
+    PY_CHECK_CC_WARNING([enable], [unreachable-code])
     # Don't enable unreachable code warning in debug mode, since it usually
     # results in non-standard code paths.
     # Issue #24324: Unfortunately, the unreachable code warning does not work
@@ -1825,27 +1746,10 @@ yes)
     else
       ac_cv_enable_unreachable_code_warning=no
     fi
-    AC_MSG_RESULT($ac_cv_enable_unreachable_code_warning)
 
-    AC_MSG_CHECKING(if we can turn on $CC strict-prototypes warning)
-     ac_save_cc="$CC"
-     CC="$CC -Werror -Wstrict-prototypes"
-     AC_CACHE_VAL(ac_cv_enable_enable_strict_prototypes_warning,
-       AC_COMPILE_IFELSE(
-         [
-       AC_LANG_PROGRAM([[]], [[]])
-     ],[
-       ac_cv_enable_strict_prototypes_warning=yes
-     ],[
-       ac_cv_enable_strict_prototypes_warning=no
-     ]))
-     CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_enable_strict_prototypes_warning)
-
-    if test $ac_cv_enable_strict_prototypes_warning = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wstrict-prototypes"
-    fi
+    PY_CHECK_CC_WARNING([enable], [strict-prototypes])
+    AS_IF([test $ac_cv_enable_strict_prototypes_warning = yes],
+          [CFLAGS_NODIST="$CFLAGS_NODIST -Wstrict-prototypes"])
 
     AC_MSG_CHECKING(if we can make implicit function declaration an error in $CC)
      ac_save_cc="$CC"
@@ -1862,10 +1766,8 @@ yes)
      CC="$ac_save_cc"
     AC_MSG_RESULT($ac_cv_enable_implicit_function_declaration_error)
 
-    if test $ac_cv_enable_implicit_function_declaration_error = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Werror=implicit-function-declaration"
-    fi
+    AS_IF([test $ac_cv_enable_implicit_function_declaration_error = yes],
+          [CFLAGS_NODIST="$CFLAGS_NODIST -Werror=implicit-function-declaration"])
 
     AC_MSG_CHECKING(if we can use visibility in $CC)
      ac_save_cc="$CC"
@@ -1882,10 +1784,8 @@ yes)
      CC="$ac_save_cc"
     AC_MSG_RESULT($ac_cv_enable_visibility)
 
-    if test $ac_cv_enable_visibility = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -fvisibility=hidden"
-    fi
+    AS_IF([test $ac_cv_enable_visibility = yes],
+          [CFLAGS_NODIST="$CFLAGS_NODIST -fvisibility=hidden"])
 
     # if using gcc on alpha, use -mieee to get (near) full IEEE 754
     # support.  Without this, treatment of subnormals doesn't follow

--- a/configure.ac
+++ b/configure.ac
@@ -1706,7 +1706,6 @@ yes)
     AS_CASE([$CC],
             [*icc*], [ac_cv_disable_unused_result_warning=no]
             [PY_CHECK_CC_WARNING([disable], [unused-result])])
-
     AS_VAR_IF([ac_cv_disable_unused_result_warning], [yes],
               [BASECFLAGS="$BASECFLAGS -Wno-unused-result"
                CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"])

--- a/configure.ac
+++ b/configure.ac
@@ -1666,7 +1666,7 @@ yes)
 
     PY_CHECK_CC_WARNING([enable], [extra])
     AS_VAR_IF([ac_cv_enable_extra_warning], [yes],
-          [CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"])
+              [CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"])
 
     # Python doesn't violate C99 aliasing rules, but older versions of
     # GCC produce warnings for legal Python code.  Enable
@@ -1714,21 +1714,21 @@ yes)
     ;;
     esac
 
-    AS_IF([test $ac_cv_disable_unused_result_warning = yes],
-          [BASECFLAGS="$BASECFLAGS -Wno-unused-result"
-           CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"])
+    AS_VAR_IF([ac_cv_disable_unused_result_warning], [yes],
+              [BASECFLAGS="$BASECFLAGS -Wno-unused-result"
+               CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"])
 
     PY_CHECK_CC_WARNING([disable], [unused-parameter])
-    AS_IF([test $ac_cv_disable_unused_parameter_warning = yes],
-          [CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-parameter"])
+    AS_VAR_IF([ac_cv_disable_unused_parameter_warning], [yes],
+              [CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-parameter"])
 
     PY_CHECK_CC_WARNING([disable], [missing-field-initializers])
-    AS_IF([test $ac_cv_disable_missing_field_initializers_warning = yes],
-          [CFLAGS_NODIST="$CFLAGS_NODIST -Wno-missing-field-initializers"])
+    AS_VAR_IF([ac_cv_disable_missing_field_initializers_warning], [yes],
+              [CFLAGS_NODIST="$CFLAGS_NODIST -Wno-missing-field-initializers"])
 
     PY_CHECK_CC_WARNING([enable], [sign-compare])
-    AS_IF([test $ac_cv_enable_sign_compare_warning = yes],
-          [BASECFLAGS="$BASECFLAGS -Wsign-compare"])
+    AS_VAR_IF([ac_cv_enable_sign_compare_warning], [yes],
+              [BASECFLAGS="$BASECFLAGS -Wsign-compare"])
 
     PY_CHECK_CC_WARNING([enable], [unreachable-code])
     # Don't enable unreachable code warning in debug mode, since it usually
@@ -1748,8 +1748,8 @@ yes)
     fi
 
     PY_CHECK_CC_WARNING([enable], [strict-prototypes])
-    AS_IF([test $ac_cv_enable_strict_prototypes_warning = yes],
-          [CFLAGS_NODIST="$CFLAGS_NODIST -Wstrict-prototypes"])
+    AS_VAR_IF([ac_cv_enable_strict_prototypes_warning], [yes],
+              [CFLAGS_NODIST="$CFLAGS_NODIST -Wstrict-prototypes"])
 
     AC_MSG_CHECKING(if we can make implicit function declaration an error in $CC)
      ac_save_cc="$CC"


### PR DESCRIPTION
- Add `PY_CHECK_CC_WARNING` helper 
- Normalise variable name: `ac_cv_[enable|disable]_[flag_name]_warning`; for example `ac_cv_disable_unused_result_warning`
- Use `AS_IF` to check results and add flags

No new cache vars added, so there is no speedups; only simplified ac code.

Bonus: fixed a misspelling bug (see `ac_cv_enable_enable_strict_prototypes_warning`)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45723](https://bugs.python.org/issue45723) -->
https://bugs.python.org/issue45723
<!-- /issue-number -->
