### PR TITLE
Fix `asyncio.wait` code snippets

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -616,22 +616,30 @@ Waiting Primitives
           async def foo():
               return 42
 
-          coro = foo()
-          done, pending = await asyncio.wait({coro})
+          async def main():
+              coro = foo()
+              done, pending = await asyncio.wait({coro})
 
-          if coro in done:
-              # This branch will never be run!
+              if coro in done:
+                  # This branch will never be run!
+                  print('yay!')
+
+          asyncio.run(main())
 
       Here is how the above snippet can be fixed::
 
           async def foo():
               return 42
 
-          task = asyncio.create_task(foo())
-          done, pending = await asyncio.wait({task})
+          async def main():
+              task = asyncio.create_task(foo())
+              done, pending = await asyncio.wait({task})
 
-          if task in done:
-              # Everything will work as expected now.
+              if task in done:
+                  # Everything will work as expected now.
+                  print('yay!')
+
+          asyncio.run(main())
 
    .. deprecated-removed:: 3.8 3.10
 


### PR DESCRIPTION
Minor fix: Fixed `IndentationError: expected an indented block` by adding `print('yay!')`. Note: `print('yay!')` is what the `asyncio.wait_for` code snippet does, so I copied that behavior.

Real fix: Fixed `SyntaxError: 'await' outside async function` by putting most of the statements in their own coroutine, `main`, then executing that coroutine using `asyncio.run(main())`. I'm not sure if this is the proper fix, but it seems to illustrate the issue with passing a coroutine to `asyncio.wait` as the first code snippet doesn't print, but the second one does.

---

Re: the bpo issue number: I tried to create an issue using https://bugs.python.org/issue, but kept getting "Invalid csrf token found" when I trying to submit the issue.

Here is the issue title I used: "SyntaxError: 'await' outside function" in "asyncio-task.html#waiting-primitives" code snippets

Here is the issue comment I used: 

"""
https://docs.python.org/3/library/asyncio-task.html#asyncio.wait has the following two code snippets both of which fail with ""SyntaxError: 'await' outside function" when I run them in Python 3.9.7

Snippet 1:

```
async def foo():
    return 42

coro = foo()
done, pending = await asyncio.wait({coro})

if coro in done:
    # This branch will never be run!
    pass # I added this to prevent IndentationError
```

Snippet 2:

```
async def foo():
    return 42

task = asyncio.create_task(foo())
done, pending = await asyncio.wait({task})

if task in done:
    # Everything will work as expected now.
    pass # I added this to prevent IndentationError
```
"""

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
