### PR TITLE
Add third-party Windows build definitions

### DIFF
--- a/.azure-pipelines/find-tools.yml
+++ b/.azure-pipelines/find-tools.yml
@@ -11,6 +11,16 @@ steps:
           -latest `
           -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
           -find VC\Auxiliary\Build\vcvarsall.bat)
-      Write-Host "Using $vcvarsall"
+      Write-Host "Found vcvarsall at $vcvarsall"
       Write-Host "##vso[task.setVariable variable=vcvarsall]$vcvarsall"
     displayName: 'Find vcvarsall.bat'
+
+  - powershell: |
+      $msbuild = (& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
+          -prerelease `
+          -latest `
+          -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+          -find MSBuild\Current\Bin\msbuild.exe)
+      Write-Host "Found MSBuild at $msbuild"
+      Write-Host "##vso[task.setVariable variable=msbuild]$msbuild"
+    displayName: 'Find MSBuild'

--- a/.azure-pipelines/find-tools.yml
+++ b/.azure-pipelines/find-tools.yml
@@ -1,0 +1,16 @@
+# Locate a set of the tools used for builds
+
+steps:
+  - template: windows-release/find-sdk.yml
+    parameters:
+      toolname: 'signtool.exe'
+
+  - powershell: |
+      $vcvarsall = (& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
+          -prerelease `
+          -latest `
+          -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+          -find VC\Auxiliary\Build\vcvarsall.bat)
+      Write-Host "Using $vcvarsall"
+      Write-Host "##vso[task.setVariable variable=vcvarsall]$vcvarsall"
+    displayName: 'Find vcvarsall.bat'

--- a/.azure-pipelines/libffi-build.yml
+++ b/.azure-pipelines/libffi-build.yml
@@ -78,9 +78,9 @@ jobs:
             /fd sha256 `
             /tr http://timestamp.digicert.com/ /td sha256 `
             /d "LibFFI for Python" `
-            (gci unsigned/*.dll -r)
+            (gci "$(Pipeline.Workspace)\unsigned\*.dll" -r)
       displayName: 'Sign files'
 
-    - publish: 'unsigned'
+    - publish: '$(Pipeline.Workspace)\unsigned'
       artifact: 'libffi'
       displayName: 'Publish libffi'

--- a/.azure-pipelines/libffi-build.yml
+++ b/.azure-pipelines/libffi-build.yml
@@ -66,8 +66,8 @@ jobs:
 
   steps:
     - checkout: none
-    - download: unsigned
-      path: .
+    - download: current
+      artifact: unsigned
 
     - template: ./find-tools.yml
 
@@ -77,9 +77,9 @@ jobs:
             /fd sha256 `
             /tr http://timestamp.digicert.com/ /td sha256 `
             /d "LibFFI for Python"
-            (gci *.dll -r)
+            (gci unsigned/*.dll -r)
       displayName: 'Sign files'
 
-    - publish: '.'
+    - publish: 'unsigned'
       artifact: 'libffi'
       displayName: 'Publish libffi'

--- a/.azure-pipelines/libffi-build.yml
+++ b/.azure-pipelines/libffi-build.yml
@@ -58,6 +58,7 @@ jobs:
 
 - job: Sign_LibFFI
   displayName: Sign LibFFI
+  dependsOn: Build_LibFFI
   pool:
     name: 'Windows Release'
 

--- a/.azure-pipelines/libffi-build.yml
+++ b/.azure-pipelines/libffi-build.yml
@@ -72,11 +72,11 @@ jobs:
     - template: ./find-tools.yml
 
     - powershell: |
-        signtool sign /q /a`
+        signtool sign /q /a `
             /n "Python Software Foundation" `
             /fd sha256 `
             /tr http://timestamp.digicert.com/ /td sha256 `
-            /d "LibFFI for Python"
+            /d "LibFFI for Python" `
             (gci unsigned/*.dll -r)
       displayName: 'Sign files'
 

--- a/.azure-pipelines/libffi-build.yml
+++ b/.azure-pipelines/libffi-build.yml
@@ -1,0 +1,85 @@
+name: $(SourceTag)_$(Date:yyyyMMdd)$(Rev:.rr)
+
+variables:
+  IntDir: '$(Build.BinariesDirectory)'
+  OutDir: '$(Build.ArtifactStagingDirectory)'
+
+  # MUST BE SET AT QUEUE TIME
+  # SigningCertificate: 'Python Software Foundation'
+  # SourcesRepo: 'https://github.com/python/cpython-source-deps'
+  # SourceTag: 'libffi-3.4.2'
+
+jobs:
+- job: Build_LibFFI
+  displayName: LibFFI
+  pool:
+    vmImage: windows-latest
+
+  workspace:
+    clean: all
+
+  steps:
+    - checkout: none
+
+    - template: ./find-tools.yml
+
+    - powershell: |
+       mkdir -Force "$(IntDir)\script"
+       iwr "https://github.com/python/cpython/raw/main/PCbuild/prepare_libffi.bat" `
+           -outfile "$(IntDir)\script\prepare_libffi.bat"
+      displayName: 'Download build script'
+
+    - powershell: |
+        git clone $(SourcesRepo) -b $(SourceTag) --depth 1 -c core.autocrlf=false -c core.eol=lf .
+      displayName: 'Check out LibFFI sources'
+
+    - script: 'prepare_libffi.bat --install-cygwin'
+      workingDirectory: '$(IntDir)\script'
+      displayName: 'Install Cygwin and build'
+      env:
+        VCVARSALL: '$(vcvarsall)'
+        LIBFFI_SOURCE: '$(Build.SourcesDirectory)'
+        LIBFFI_OUT: '$(OutDir)'
+
+    - powershell: |
+       if ((gci *\*.dll).Count -lt 4) {
+           Write-Error "Did not generate enough DLL files"
+       }
+       if ((gci *\Include\ffi.h).Count -lt 4) {
+           Write-Error "Did not generate enough include files"
+       }
+      failOnStderr: true
+      workingDirectory: '$(OutDir)'
+      displayName: 'Verify files were created'
+
+    - publish: '$(OutDir)'
+      artifact: 'unsigned'
+      displayName: 'Publish unsigned build'
+
+- job: Sign_LibFFI
+  displayName: Sign LibFFI
+  pool:
+    name: 'Windows Release'
+
+  workspace:
+    clean: all
+
+  steps:
+    - checkout: none
+    - download: unsigned
+      path: .
+
+    - template: ./find-tools.yml
+
+    - powershell: |
+        signtool sign /q /a`
+            /n "Python Software Foundation" `
+            /fd sha256 `
+            /tr http://timestamp.digicert.com/ /td sha256 `
+            /d "LibFFI for Python"
+            (gci *.dll -r)
+      displayName: 'Sign files'
+
+    - publish: '.'
+      artifact: 'libffi'
+      displayName: 'Publish libffi'

--- a/.azure-pipelines/openssl-build.yml
+++ b/.azure-pipelines/openssl-build.yml
@@ -5,7 +5,7 @@ variables:
   OutDir: '$(Build.ArtifactStagingDirectory)'
 
   # MUST BE SET AT QUEUE TIME
-  # SigningCertificate: ''
+  # SigningCertificate: 'Python Software Foundation'
   # SourcesRepo: 'https://github.com/python/cpython-source-deps'
   # SourceTag: 'openssl-1.1.1k'
 
@@ -13,8 +13,8 @@ jobs:
 - job: Build_SSL
   displayName: OpenSSL
   pool:
-    #name: 'Windows Release'
-    vmImage: windows-latest
+    name: 'Windows Release'
+    #vmImage: windows-latest
 
   strategy:
     matrix:

--- a/.azure-pipelines/openssl-build.yml
+++ b/.azure-pipelines/openssl-build.yml
@@ -1,12 +1,18 @@
 name: OpenSSL_$(SourceTag)_$(Date:yyyyMMdd)$(Rev:.rr)
 
+resources:
+  repositories:
+  - repository: sources
+    type: github
+    name: python/cpython-source-deps
+
 variables:
   IntDir: '$(Build.BinariesDirectory)'
   OutDir: '$(Build.ArtifactStagingDirectory)'
 
   # MUST BE SET AT QUEUE TIME
   # SigningCertificate: ''
-  # SourcesRepo: 'https://github.com/python/cpython-source-deps'
+  # SourceTag: 'openssl-1.1.1k'
 
 jobs:
 - job: Build_SSL
@@ -38,7 +44,7 @@ jobs:
     clean: all
 
   steps:
-    - checkout: $(SourcesRepo)@refs/tags/$(SourceTag)
+    - checkout: sources@refs/tags/$(SourceTag)
       fetchDepth: 1
 
     - template: ./find-tools.yml

--- a/.azure-pipelines/openssl-build.yml
+++ b/.azure-pipelines/openssl-build.yml
@@ -1,0 +1,101 @@
+name: OpenSSL_$(SourceTag)_$(Date:yyyyMMdd)$(Rev:.rr)
+
+variables:
+  IntDir: '$(Build.BinariesDirectory)'
+  OutDir: '$(Build.ArtifactStagingDirectory)'
+
+  # MUST BE SET AT QUEUE TIME
+  # SigningCertificate: ''
+
+jobs:
+- job: Build_SSL
+  displayName: OpenSSL
+  pool:
+    #name: 'Windows Release'
+    vmImage: windows-latest
+
+  strategy:
+    matrix:
+      win32:
+        Platform: 'win32'
+        VCPlatform: 'amd64_x86'
+        OpenSSLPlatform: 'VC-WIN32 no-asm'
+      amd64:
+        Platform: 'amd64'
+        VCPlatform: 'amd64'
+        OpenSSLPlatform: 'VC-WIN64A-masm'
+      arm32:
+        Platform: 'arm32'
+        VCPlatform: 'amd64_arm'
+        OpenSSLPlatform: 'VC-WIN32-ARM'
+      arm64:
+        Platform: 'arm64'
+        VCPlatform: 'amd64_arm64'
+        OpenSSLPlatform: 'VC-WIN64-ARM'
+
+  workspace:
+    clean: all
+
+  steps:
+    - template: ./find-tools.yml
+
+    - powershell: |
+        $f = gi ms\uplink.c
+        $c1 = gc $f
+        $c2 = $c1 -replace '\(\(h = GetModuleHandle\(NULL\)\) == NULL\)', '((h = GetModuleHandleA("_ssl.pyd")) == NULL) if ((h = GetModuleHandleA("_ssl_d.pyd")) == NULL) if ((h = GetModuleHandle(NULL)) == NULL /*patched*/)'
+        if ($c2 -ne $c1) {
+            $c2 | Out-File $f -Encoding ASCII
+        } else {
+            Write-Host '##warning Failed to patch uplink.c'
+        }
+      displayName: 'Apply uplink.c patch'
+
+    - script: |
+        call "$(vcvarsall)" $(VCPlatform)
+        perl "$(Build.SourcesDirectory)\Configure" $(OpenSSLPlatform)
+        nmake
+      workingDirectory: '$(IntDir)'
+      displayName: 'Build OpenSSL'
+
+    - script: |
+        call "$(vcvarsall)" $(VCPlatform)
+        signtool sign /q /a /n "$(SigningCertificate)" /fd sha256 /tr http://timestamp.digicert.com/ /td sha256 /d "OpenSSL for Python" *.dll
+      workingDirectory: '$(IntDir)'
+      displayName: 'Sign OpenSSL Build'
+      condition: and(succeeded(), variables['SigningCertificate'])
+
+    - task: CopyFiles@2
+      displayName: 'Copy built libraries for upload'
+      inputs:
+        SourceFolder: '$(IntDir)'
+        Contents: |
+          lib*.dll
+          lib*.pdb
+          lib*.lib
+          include\openssl\*.h
+        TargetFolder: '$(OutDir)'
+
+    - task: CopyFiles@2
+      displayName: 'Copy header files for upload'
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)'
+        Contents: |
+          include\openssl\*
+        TargetFolder: '$(OutDir)'
+
+    - task: CopyFiles@2
+      displayName: 'Copy applink files for upload'
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)\ms'
+        Contents: applink.c
+        TargetFolder: '$(OutDir)\include'
+
+    - task: CopyFiles@2
+      displayName: 'Copy LICENSE for upload'
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)'
+        Contents: LICENSE
+        TargetFolder: '$(OutDir)'
+
+    - publish: '$(OutDir)'
+      artifact: '$(Platform)'

--- a/.azure-pipelines/openssl-build.yml
+++ b/.azure-pipelines/openssl-build.yml
@@ -4,6 +4,7 @@ resources:
   repositories:
   - repository: sources
     type: github
+    endpoint: ''
     name: python/cpython-source-deps
 
 variables:

--- a/.azure-pipelines/openssl-build.yml
+++ b/.azure-pipelines/openssl-build.yml
@@ -1,12 +1,5 @@
 name: OpenSSL_$(SourceTag)_$(Date:yyyyMMdd)$(Rev:.rr)
 
-resources:
-  repositories:
-  - repository: sources
-    type: github
-    endpoint: null
-    name: python/cpython-source-deps
-
 variables:
   IntDir: '$(Build.BinariesDirectory)'
   OutDir: '$(Build.ArtifactStagingDirectory)'
@@ -45,8 +38,11 @@ jobs:
     clean: all
 
   steps:
-    - checkout: sources@refs/tags/$(SourceTag)
-      fetchDepth: 1
+    - checkout: none
+
+    - powershell: |
+        git clone $(SourcesRepo) -b $(SourceTag) --depth 1 .
+      displayName: 'Check out OpenSSL sources'
 
     - template: ./find-tools.yml
 

--- a/.azure-pipelines/openssl-build.yml
+++ b/.azure-pipelines/openssl-build.yml
@@ -6,6 +6,7 @@ variables:
 
   # MUST BE SET AT QUEUE TIME
   # SigningCertificate: ''
+  # SourcesRepo: 'https://github.com/python/cpython-source-deps'
 
 jobs:
 - job: Build_SSL
@@ -37,6 +38,9 @@ jobs:
     clean: all
 
   steps:
+    - checkout: $(SourcesRepo)@refs/tags/$(SourceTag)
+      fetchDepth: 1
+
     - template: ./find-tools.yml
 
     - powershell: |

--- a/.azure-pipelines/openssl-build.yml
+++ b/.azure-pipelines/openssl-build.yml
@@ -6,6 +6,7 @@ variables:
 
   # MUST BE SET AT QUEUE TIME
   # SigningCertificate: ''
+  # SourcesRepo: 'https://github.com/python/cpython-source-deps'
   # SourceTag: 'openssl-1.1.1k'
 
 jobs:
@@ -106,3 +107,4 @@ jobs:
 
     - publish: '$(OutDir)'
       artifact: '$(Platform)'
+      displayName: 'Publishing $(Platform)'

--- a/.azure-pipelines/openssl-build.yml
+++ b/.azure-pipelines/openssl-build.yml
@@ -4,7 +4,7 @@ resources:
   repositories:
   - repository: sources
     type: github
-    endpoint: ''
+    endpoint: null
     name: python/cpython-source-deps
 
 variables:

--- a/.azure-pipelines/openssl-build.yml
+++ b/.azure-pipelines/openssl-build.yml
@@ -41,11 +41,11 @@ jobs:
   steps:
     - checkout: none
 
+    - template: ./find-tools.yml
+
     - powershell: |
         git clone $(SourcesRepo) -b $(SourceTag) --depth 1 .
       displayName: 'Check out OpenSSL sources'
-
-    - template: ./find-tools.yml
 
     - powershell: |
         $f = gi ms\uplink.c

--- a/.azure-pipelines/openssl-build.yml
+++ b/.azure-pipelines/openssl-build.yml
@@ -1,4 +1,4 @@
-name: OpenSSL_$(SourceTag)_$(Date:yyyyMMdd)$(Rev:.rr)
+name: $(SourceTag)_$(Date:yyyyMMdd)$(Rev:.rr)
 
 variables:
   IntDir: '$(Build.BinariesDirectory)'

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -41,6 +41,7 @@ jobs:
     # This msbuild.rsp file will be picked up automatically by the build and will
     # forcibly override the variables we set in it.
     - powershell: |
+        cd PCbuild
         del -Force -EA 0 msbuild.rsp
         "/p:IntDir=$(IntDir)" >> msbuild.rsp
         "/p:ExternalsDir=$(ExternalsDir)" >> msbuild.rsp

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -1,0 +1,54 @@
+name: TclTk_$(SourceTag)_$(Date:yyyyMMdd)$(Rev:.rr)
+
+variables:
+  IntDir: '$(Build.BinariesDirectory)\obj'
+  ExternalsDir: '$(Build.BinariesDirectory)\externals'
+  OutDir: '$(Build.ArtifactStagingDirectory)'
+  Configuration: 'Release'
+  
+  # MUST BE SET AT QUEUE TIME
+  # SigningCertificate: ''
+  # SourcesRepo: 'https://github.com/python/cpython-source-deps'
+
+jobs:
+- job: Build_TclTk
+  displayName: 'Tcl/Tk'
+  pool:
+    #name: 'Windows Release'
+    vmImage: windows-latest
+
+  workspace:
+    clean: all
+
+  steps:
+    - powershell: |
+        git clone $(SourcesRepo) -b tcl-core-$(SourceTag) --depth 1 "$(ExternalsDir)\tcl-core-$(SourceTag)"
+      displayName: 'Clone Tcl sources'
+
+    - powershell: |
+        git clone $(SourcesRepo) -b tk-$(SourceTag) --depth 1 "$(ExternalsDir)\tk-$(SourceTag)"
+      displayName: 'Clone Tcl sources'
+
+    - powershell: |
+        del -Force -EA 0 msbuild.rsp
+        "/p:IntDir=$(IntDir)" >> msbuild.rsp
+        "/p:ExternalsDir=$(ExternalsDir)" >> msbuild.rsp
+        "/p:OutDir=$(OutDir)" >> msbuild.rsp
+        "/p:tclDir=$(ExternalsDir)\tcl-core-$(SourceTag)" >> msbuild.rsp
+        "/p:tkDir=$(ExternalsDir)\tk-$(SourceTag)" >> msbuild.rsp
+      displayName: 'Generate msbuild.rsp'
+
+    - powershell: |
+        msbuild PCbuild\tcl.vcxproj @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        msbuild PCbuild\tk.vcxproj  @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        msbuild PCbuild\tix.vcxproj @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+      displayName: 'Build for win32'
+
+    - powershell: |
+        msbuild PCbuild\tcl.vcxproj @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        msbuild PCbuild\tk.vcxproj  @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        msbuild PCbuild\tix.vcxproj @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+      displayName: 'Build for amd64'
+
+    - publish: '$(OutDir)'
+      artifact: 'tcltk'

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -42,12 +42,12 @@ jobs:
     # forcibly override the variables we set in it.
     - powershell: |
         del -Force -EA 0 msbuild.rsp
-        "/p:IntDir=$(IntDir)" >> msbuild.rsp
-        "/p:ExternalsDir=$(ExternalsDir)" >> msbuild.rsp
-        "/p:OutDir=$(OutDir)" >> msbuild.rsp
-        "/p:tclDir=$(ExternalsDir)\$(TclSourceTag)" >> msbuild.rsp
-        "/p:tkDir=$(ExternalsDir)\$(TkSourceTag)" >> msbuild.rsp
-        "/p:tixDir=$(ExternalsDir)\$(TixSourceTag)" >> msbuild.rsp
+        "/p:IntDir=$(IntDir)\" >> msbuild.rsp
+        "/p:ExternalsDir=$(ExternalsDir)\" >> msbuild.rsp
+        "/p:OutDir=$(OutDir)\" >> msbuild.rsp
+        "/p:tclDir=$(ExternalsDir)\$(TclSourceTag)\" >> msbuild.rsp
+        "/p:tkDir=$(ExternalsDir)\$(TkSourceTag)\" >> msbuild.rsp
+        "/p:tixDir=$(ExternalsDir)\$(TixSourceTag)\" >> msbuild.rsp
       displayName: 'Generate msbuild.rsp'
 
     - powershell: |

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -7,7 +7,7 @@ variables:
   Configuration: 'Release'
   
   # MUST BE SET AT QUEUE TIME
-  # SigningCertificate: ''
+  # SigningCertificate: 'Python Software Foundation'
   # SourcesRepo: 'https://github.com/python/cpython-source-deps'
   # TclSourceTag: 'tcl-core-8.6.12.0'
   # TkSourceTag: 'tk-8.6.12.0'
@@ -17,8 +17,8 @@ jobs:
 - job: Build_TclTk
   displayName: 'Tcl/Tk'
   pool:
-    #name: 'Windows Release'
-    vmImage: windows-latest
+    name: 'Windows Release'
+    #vmImage: windows-latest
 
   workspace:
     clean: all

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -1,12 +1,5 @@
 name: TclTk_$(SourceTag)_$(Date:yyyyMMdd)$(Rev:.rr)
 
-resources:
-  repositories:
-  - repository: sources
-    type: github
-    endpoint: null
-    name: python/cpython-source-deps
-
 variables:
   IntDir: '$(Build.BinariesDirectory)\obj'
   ExternalsDir: '$(Build.BinariesDirectory)\externals'
@@ -28,13 +21,13 @@ jobs:
     clean: all
 
   steps:
-    - checkout: self
-    - checkout: sources@refs/tags/tcl-core-$(SourceTag)
-      path: "$(ExternalsDir)\tcl-core-$(SourceTag)"
-      fetchDepth: 1
-    - checkout: sources@refs/tags/tk-$(SourceTag)
-      path: "$(ExternalsDir)\tk-$(SourceTag)"
-      fetchDepth: 1
+    - powershell: |
+        git clone $(SourcesRepo) -b tcl-core-$(SourceTag) --depth 1 "$(ExternalsDir)\tcl-core-$(SourceTag)"
+      displayName: 'Check out Tcl sources'
+
+    - powershell: |
+        git clone $(SourcesRepo) -b tk-$(SourceTag) --depth 1 "$(ExternalsDir)\tk-$(SourceTag)"
+      displayName: 'Check out Tk sources'
 
     - powershell: |
         del -Force -EA 0 msbuild.rsp

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -36,6 +36,8 @@ jobs:
         git clone $(SourcesRepo) -b $(TixSourceTag) --depth 1 "$(ExternalsDir)\$(TixSourceTag)"
       displayName: 'Check out Tix sources'
 
+    # This msbuild.rsp file will be picked up automatically by the build and will
+    # forcibly override the variables we set in it.
     - powershell: |
         del -Force -EA 0 msbuild.rsp
         "/p:IntDir=$(IntDir)" >> msbuild.rsp
@@ -47,15 +49,15 @@ jobs:
       displayName: 'Generate msbuild.rsp'
 
     - powershell: |
-        & msbuild PCbuild\tcl.vcxproj @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
-        & msbuild PCbuild\tk.vcxproj  @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
-        & msbuild PCbuild\tix.vcxproj @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & msbuild PCbuild\tcl.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & msbuild PCbuild\tk.vcxproj  /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & msbuild PCbuild\tix.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
       displayName: 'Build for win32'
 
     - powershell: |
-        & msbuild PCbuild\tcl.vcxproj @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
-        & msbuild PCbuild\tk.vcxproj  @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
-        & msbuild PCbuild\tix.vcxproj @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & msbuild PCbuild\tcl.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & msbuild PCbuild\tk.vcxproj  /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & msbuild PCbuild\tix.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
       displayName: 'Build for amd64'
 
     - publish: '$(OutDir)'

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -4,6 +4,7 @@ resources:
   repositories:
   - repository: sources
     type: github
+    endpoint: ''
     name: python/cpython-source-deps
 
 variables:

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -1,4 +1,4 @@
-name: TclTk_$(SourceTag)_$(Date:yyyyMMdd)$(Rev:.rr)
+name: tcl$(TkSourceTag)_$(Date:yyyyMMdd)$(Rev:.rr)
 
 variables:
   IntDir: '$(Build.BinariesDirectory)\obj'
@@ -25,15 +25,15 @@ jobs:
 
   steps:
     - powershell: |
-        git clone $(SourcesRepo) -b $(TclSourceTag) --depth 1 "$(ExternalsDir)\$(TclSourceTag)"
+        git clone $(SourcesRepo) -b ref/tags/$(TclSourceTag) --depth 1 "$(ExternalsDir)\$(TclSourceTag)"
       displayName: 'Check out Tcl sources'
 
     - powershell: |
-        git clone $(SourcesRepo) -b $(TkSourceTag) --depth 1 "$(ExternalsDir)\$(TkSourceTag)"
+        git clone $(SourcesRepo) -b ref/tags/$(TkSourceTag) --depth 1 "$(ExternalsDir)\$(TkSourceTag)"
       displayName: 'Check out Tk sources'
 
     - powershell: |
-        git clone $(SourcesRepo) -b $(TixSourceTag) --depth 1 "$(ExternalsDir)\$(TixSourceTag)"
+        git clone $(SourcesRepo) -b ref/tags/$(TixSourceTag) --depth 1 "$(ExternalsDir)\$(TixSourceTag)"
       displayName: 'Check out Tix sources'
 
     - powershell: |

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -38,13 +38,11 @@ jobs:
         git clone $(SourcesRepo) -b $(TixSourceTag) --depth 1 "$(ExternalsDir)\$(TixSourceTag)"
       displayName: 'Check out Tix sources'
 
-    # This msbuild.rsp file will be picked up automatically by the build and will
-    # forcibly override the variables we set in it.
+    # This msbuild.rsp file will be used by the build to forcibly override these variables
     - powershell: |
         del -Force -EA 0 msbuild.rsp
         "/p:IntDir=$(IntDir)\" >> msbuild.rsp
         "/p:ExternalsDir=$(ExternalsDir)\" >> msbuild.rsp
-        "/p:OutDir=$(OutDir)\" >> msbuild.rsp
         "/p:tclDir=$(ExternalsDir)\$(TclSourceTag)\" >> msbuild.rsp
         "/p:tkDir=$(ExternalsDir)\$(TkSourceTag)\" >> msbuild.rsp
         "/p:tixDir=$(ExternalsDir)\$(TixSourceTag)\" >> msbuild.rsp

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -47,15 +47,15 @@ jobs:
       displayName: 'Generate msbuild.rsp'
 
     - powershell: |
-        msbuild PCbuild\tcl.vcxproj @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
-        msbuild PCbuild\tk.vcxproj  @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
-        msbuild PCbuild\tix.vcxproj @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & msbuild PCbuild\tcl.vcxproj @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & msbuild PCbuild\tk.vcxproj  @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & msbuild PCbuild\tix.vcxproj @msbuild.rsp /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
       displayName: 'Build for win32'
 
     - powershell: |
-        msbuild PCbuild\tcl.vcxproj @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
-        msbuild PCbuild\tk.vcxproj  @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
-        msbuild PCbuild\tix.vcxproj @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & msbuild PCbuild\tcl.vcxproj @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & msbuild PCbuild\tk.vcxproj  @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & msbuild PCbuild\tix.vcxproj @msbuild.rsp /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
       displayName: 'Build for amd64'
 
     - publish: '$(OutDir)'

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -25,15 +25,15 @@ jobs:
 
   steps:
     - powershell: |
-        git clone $(SourcesRepo) -b ref/tags/$(TclSourceTag) --depth 1 "$(ExternalsDir)\$(TclSourceTag)"
+        git clone $(SourcesRepo) -b $(TclSourceTag) --depth 1 "$(ExternalsDir)\$(TclSourceTag)"
       displayName: 'Check out Tcl sources'
 
     - powershell: |
-        git clone $(SourcesRepo) -b ref/tags/$(TkSourceTag) --depth 1 "$(ExternalsDir)\$(TkSourceTag)"
+        git clone $(SourcesRepo) -b $(TkSourceTag) --depth 1 "$(ExternalsDir)\$(TkSourceTag)"
       displayName: 'Check out Tk sources'
 
     - powershell: |
-        git clone $(SourcesRepo) -b ref/tags/$(TixSourceTag) --depth 1 "$(ExternalsDir)\$(TixSourceTag)"
+        git clone $(SourcesRepo) -b $(TixSourceTag) --depth 1 "$(ExternalsDir)\$(TixSourceTag)"
       displayName: 'Check out Tix sources'
 
     - powershell: |

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -41,7 +41,6 @@ jobs:
     # This msbuild.rsp file will be picked up automatically by the build and will
     # forcibly override the variables we set in it.
     - powershell: |
-        cd PCbuild
         del -Force -EA 0 msbuild.rsp
         "/p:IntDir=$(IntDir)" >> msbuild.rsp
         "/p:ExternalsDir=$(ExternalsDir)" >> msbuild.rsp
@@ -52,15 +51,15 @@ jobs:
       displayName: 'Generate msbuild.rsp'
 
     - powershell: |
-        & "$(msbuild)" PCbuild\tcl.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
-        & "$(msbuild)" PCbuild\tk.vcxproj  /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
-        & "$(msbuild)" PCbuild\tix.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & "$(msbuild)" PCbuild\tcl.vcxproj "@msbuild.rsp" /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & "$(msbuild)" PCbuild\tk.vcxproj  "@msbuild.rsp" /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & "$(msbuild)" PCbuild\tix.vcxproj "@msbuild.rsp" /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
       displayName: 'Build for win32'
 
     - powershell: |
-        & "$(msbuild)" PCbuild\tcl.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
-        & "$(msbuild)" PCbuild\tk.vcxproj  /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
-        & "$(msbuild)" PCbuild\tix.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & "$(msbuild)" PCbuild\tcl.vcxproj "@msbuild.rsp" /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & "$(msbuild)" PCbuild\tk.vcxproj  "@msbuild.rsp" /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & "$(msbuild)" PCbuild\tix.vcxproj "@msbuild.rsp" /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
       displayName: 'Build for amd64'
 
     - publish: '$(OutDir)'

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -4,7 +4,7 @@ resources:
   repositories:
   - repository: sources
     type: github
-    endpoint: ''
+    endpoint: null
     name: python/cpython-source-deps
 
 variables:

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -1,5 +1,11 @@
 name: TclTk_$(SourceTag)_$(Date:yyyyMMdd)$(Rev:.rr)
 
+resources:
+  repositories:
+  - repository: sources
+    type: github
+    name: python/cpython-source-deps
+
 variables:
   IntDir: '$(Build.BinariesDirectory)\obj'
   ExternalsDir: '$(Build.BinariesDirectory)\externals'
@@ -22,10 +28,10 @@ jobs:
 
   steps:
     - checkout: self
-    - checkout: $(SourcesRepo)@refs/tags/tcl-core-$(SourceTag)
+    - checkout: sources@refs/tags/tcl-core-$(SourceTag)
       path: "$(ExternalsDir)\tcl-core-$(SourceTag)"
       fetchDepth: 1
-    - checkout: $(SourcesRepo)@refs/tags/tk-$(SourceTag)
+    - checkout: sources@refs/tags/tk-$(SourceTag)
       path: "$(ExternalsDir)\tk-$(SourceTag)"
       fetchDepth: 1
 

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -9,6 +9,9 @@ variables:
   # MUST BE SET AT QUEUE TIME
   # SigningCertificate: ''
   # SourcesRepo: 'https://github.com/python/cpython-source-deps'
+  # TclSourceTag: 'tcl-core-8.6.12.0'
+  # TkSourceTag: 'tk-8.6.12.0'
+  # TixSourceTag: 'tix-8.4.3.6'
 
 jobs:
 - job: Build_TclTk
@@ -22,20 +25,25 @@ jobs:
 
   steps:
     - powershell: |
-        git clone $(SourcesRepo) -b tcl-core-$(SourceTag) --depth 1 "$(ExternalsDir)\tcl-core-$(SourceTag)"
+        git clone $(SourcesRepo) -b $(TclSourceTag) --depth 1 "$(ExternalsDir)\$(TclSourceTag)"
       displayName: 'Check out Tcl sources'
 
     - powershell: |
-        git clone $(SourcesRepo) -b tk-$(SourceTag) --depth 1 "$(ExternalsDir)\tk-$(SourceTag)"
+        git clone $(SourcesRepo) -b $(TkSourceTag) --depth 1 "$(ExternalsDir)\$(TkSourceTag)"
       displayName: 'Check out Tk sources'
+
+    - powershell: |
+        git clone $(SourcesRepo) -b $(TixSourceTag) --depth 1 "$(ExternalsDir)\$(TixSourceTag)"
+      displayName: 'Check out Tix sources'
 
     - powershell: |
         del -Force -EA 0 msbuild.rsp
         "/p:IntDir=$(IntDir)" >> msbuild.rsp
         "/p:ExternalsDir=$(ExternalsDir)" >> msbuild.rsp
         "/p:OutDir=$(OutDir)" >> msbuild.rsp
-        "/p:tclDir=$(ExternalsDir)\tcl-core-$(SourceTag)" >> msbuild.rsp
-        "/p:tkDir=$(ExternalsDir)\tk-$(SourceTag)" >> msbuild.rsp
+        "/p:tclDir=$(ExternalsDir)\$(TclSourceTag)" >> msbuild.rsp
+        "/p:tkDir=$(ExternalsDir)\$(TkSourceTag)" >> msbuild.rsp
+        "/p:tixDir=$(ExternalsDir)\$(TixSourceTag)" >> msbuild.rsp
       displayName: 'Generate msbuild.rsp'
 
     - powershell: |
@@ -52,3 +60,4 @@ jobs:
 
     - publish: '$(OutDir)'
       artifact: 'tcltk'
+      displayName: 'Publishing tcltk'

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -51,15 +51,15 @@ jobs:
       displayName: 'Generate msbuild.rsp'
 
     - powershell: |
-        & "$msbuild" PCbuild\tcl.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
-        & "$msbuild" PCbuild\tk.vcxproj  /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
-        & "$msbuild" PCbuild\tix.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & "$(msbuild)" PCbuild\tcl.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & "$(msbuild)" PCbuild\tk.vcxproj  /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & "$(msbuild)" PCbuild\tix.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
       displayName: 'Build for win32'
 
     - powershell: |
-        & "$msbuild" PCbuild\tcl.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
-        & "$msbuild" PCbuild\tk.vcxproj  /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
-        & "$msbuild" PCbuild\tix.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & "$(msbuild)" PCbuild\tcl.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & "$(msbuild)" PCbuild\tk.vcxproj  /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & "$(msbuild)" PCbuild\tix.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
       displayName: 'Build for amd64'
 
     - publish: '$(OutDir)'

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -21,13 +21,13 @@ jobs:
     clean: all
 
   steps:
-    - powershell: |
-        git clone $(SourcesRepo) -b tcl-core-$(SourceTag) --depth 1 "$(ExternalsDir)\tcl-core-$(SourceTag)"
-      displayName: 'Clone Tcl sources'
-
-    - powershell: |
-        git clone $(SourcesRepo) -b tk-$(SourceTag) --depth 1 "$(ExternalsDir)\tk-$(SourceTag)"
-      displayName: 'Clone Tcl sources'
+    - checkout: self
+    - checkout: $(SourcesRepo)@refs/tags/tcl-core-$(SourceTag)
+      path: "$(ExternalsDir)\tcl-core-$(SourceTag)"
+      fetchDepth: 1
+    - checkout: $(SourcesRepo)@refs/tags/tk-$(SourceTag)
+      path: "$(ExternalsDir)\tk-$(SourceTag)"
+      fetchDepth: 1
 
     - powershell: |
         del -Force -EA 0 msbuild.rsp

--- a/.azure-pipelines/tcltk-build.yml
+++ b/.azure-pipelines/tcltk-build.yml
@@ -24,6 +24,8 @@ jobs:
     clean: all
 
   steps:
+    - template: ./find-tools.yml
+
     - powershell: |
         git clone $(SourcesRepo) -b $(TclSourceTag) --depth 1 "$(ExternalsDir)\$(TclSourceTag)"
       displayName: 'Check out Tcl sources'
@@ -49,15 +51,15 @@ jobs:
       displayName: 'Generate msbuild.rsp'
 
     - powershell: |
-        & msbuild PCbuild\tcl.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
-        & msbuild PCbuild\tk.vcxproj  /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
-        & msbuild PCbuild\tix.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & "$msbuild" PCbuild\tcl.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & "$msbuild" PCbuild\tk.vcxproj  /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
+        & "$msbuild" PCbuild\tix.vcxproj /p:Platform=Win32 /p:tcltkDir="$(OutDir)\win32"
       displayName: 'Build for win32'
 
     - powershell: |
-        & msbuild PCbuild\tcl.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
-        & msbuild PCbuild\tk.vcxproj  /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
-        & msbuild PCbuild\tix.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & "$msbuild" PCbuild\tcl.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & "$msbuild" PCbuild\tk.vcxproj  /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
+        & "$msbuild" PCbuild\tix.vcxproj /p:Platform=x64 /p:tcltkDir="$(OutDir)\amd64"
       displayName: 'Build for amd64'
 
     - publish: '$(OutDir)'


### PR DESCRIPTION
These definition files are for OpenSSL, libffi and Tcl/Tk, which we build and sign ourselves.