### PR TITLE
bpo-33927: Handle pyton -m json.tool --json-lines infile infile

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -69,6 +69,10 @@ def main():
             if options.outfile is None:
                 out = sys.stdout
             else:
+                if (options.outfile.exists() and
+                    options.outfile.expanduser().samefile(infile.name)):
+                    # exhaust the generator before opening for writing
+                    objs = list(objs)
                 out = options.outfile.open('w', encoding='utf-8')
             with out as outfile:
                 for obj in objs:

--- a/Lib/test/support/script_helper.py
+++ b/Lib/test/support/script_helper.py
@@ -197,6 +197,7 @@ def spawn_python(*args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kw):
 
 def kill_python(p):
     """Run the given Popen process until completion and return stdout."""
+    data = None
     if p.stdin:
         p.stdin.close()
     if p.stdout:

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -7,7 +7,7 @@ import subprocess
 
 from test import support
 from test.support import os_helper
-from test.support.script_helper import assert_python_ok
+from test.support.script_helper import assert_python_ok, killing
 
 
 class TestTool(unittest.TestCase):
@@ -168,14 +168,11 @@ class TestTool(unittest.TestCase):
                                   bufsize=0,
                                   )
         args = sys.executable, '-u', '-m', 'json.tool', '--json-lines'
-        with self.assertRaises(subprocess.TimeoutExpired) as timeout:
+        with killing(stream), \
+                self.assertRaises(subprocess.TimeoutExpired) as timeout:
             subprocess.run(args, stdin=stream.stdout,
                            capture_output=True, timeout=1,
                            bufsize=0)
-        stream.kill()
-        stream.stdout.read()
-        stream.stdout.close()
-        stream.wait()
 
         self.assertIsNotNone(timeout.exception.stdout)
         self.assertTrue(timeout.exception.stdout.startswith(b'0\n1\n2\n'))

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -175,7 +175,10 @@ class TestTool(unittest.TestCase):
                            bufsize=0)
 
         self.assertIsNotNone(timeout.exception.stdout)
-        self.assertTrue(timeout.exception.stdout.startswith(b'0\n1\n2\n'))
+        self.assertEqual(
+            timeout.exception.stdout.splitlines()[:3],
+            [b'0', b'1', b'2']
+        )
 
     def test_help_flag(self):
         rc, out, err = assert_python_ok('-m', 'json.tool', '-h')


### PR DESCRIPTION
Handles the remaining case that [bpo-45644](https://bugs.python.org/issue45644) left open of [bpo-33927](https://bugs.python.org/issue33927).
https://bugs.python.org/issue45644#msg405913

Thanks @remilapeyre for pointing that out.

As far as I can see this should be enough to close [bpo-33927](https://bugs.python.org/issue33927)

<!-- issue-number: [bpo-33927](https://bugs.python.org/issue33927) -->
https://bugs.python.org/issue33927
<!-- /issue-number -->
