### PR TITLE
bpo-45723: Improve and simplify more configure.ac checks (GH-29485)

### DIFF
--- a/configure
+++ b/configure
@@ -7091,7 +7091,7 @@ if ${ac_cv_enable_extra_warning+:} false; then :
 else
 
     py_cflags=$CFLAGS
-    CFLAGS="$CFLAGS -Wextra -Werror"
+    as_fn_append CFLAGS "-Wextra -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -7202,7 +7202,7 @@ if ${ac_cv_disable_unused_result_warning+:} false; then :
 else
 
     py_cflags=$CFLAGS
-    CFLAGS="$CFLAGS -Wunused-result -Werror"
+    as_fn_append CFLAGS "-Wunused-result -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -7244,7 +7244,7 @@ if ${ac_cv_disable_unused_parameter_warning+:} false; then :
 else
 
     py_cflags=$CFLAGS
-    CFLAGS="$CFLAGS -Wunused-parameter -Werror"
+    as_fn_append CFLAGS "-Wunused-parameter -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -7282,7 +7282,7 @@ if ${ac_cv_disable_missing_field_initializers_warning+:} false; then :
 else
 
     py_cflags=$CFLAGS
-    CFLAGS="$CFLAGS -Wmissing-field-initializers -Werror"
+    as_fn_append CFLAGS "-Wmissing-field-initializers -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -7320,7 +7320,7 @@ if ${ac_cv_enable_sign_compare_warning+:} false; then :
 else
 
     py_cflags=$CFLAGS
-    CFLAGS="$CFLAGS -Wsign-compare -Werror"
+    as_fn_append CFLAGS "-Wsign-compare -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -7358,7 +7358,7 @@ if ${ac_cv_enable_unreachable_code_warning+:} false; then :
 else
 
     py_cflags=$CFLAGS
-    CFLAGS="$CFLAGS -Wunreachable-code -Werror"
+    as_fn_append CFLAGS "-Wunreachable-code -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -7408,7 +7408,7 @@ if ${ac_cv_enable_strict_prototypes_warning+:} false; then :
 else
 
     py_cflags=$CFLAGS
-    CFLAGS="$CFLAGS -Wstrict-prototypes -Werror"
+    as_fn_append CFLAGS "-Wstrict-prototypes -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/configure
+++ b/configure
@@ -7084,15 +7084,16 @@ yes)
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
 
 
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can add -Wextra" >&5
 $as_echo_n "checking if we can add -Wextra... " >&6; }
-
-  py_cflags=$CFLAGS
-  CFLAGS="$CFLAGS -Wextra -Werror"
-  if ${ac_cv_enable_extra_warning+:} false; then :
+if ${ac_cv_enable_extra_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+    py_cflags=$CFLAGS
+    CFLAGS="$CFLAGS -Wextra -Werror"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
@@ -7109,10 +7110,11 @@ else
   ac_cv_enable_extra_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CFLAGS=$py_cflags
 
 fi
-
-  CFLAGS=$py_cflags
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_extra_warning" >&5
+$as_echo "$ac_cv_enable_extra_warning" >&6; }
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_extra_warning" >&5
 $as_echo "$ac_cv_enable_extra_warning" >&6; }
 
@@ -7196,15 +7198,16 @@ fi
   *icc*) :
     ac_cv_disable_unused_result_warning=no
 
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC unused-result warning" >&5
 $as_echo_n "checking if we can disable $CC unused-result warning... " >&6; }
-
-  py_cflags=$CFLAGS
-  CFLAGS="$CFLAGS -Wunused-result -Werror"
-  if ${ac_cv_disable_unused_result_warning+:} false; then :
+if ${ac_cv_disable_unused_result_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+    py_cflags=$CFLAGS
+    CFLAGS="$CFLAGS -Wunused-result -Werror"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
@@ -7221,10 +7224,11 @@ else
   ac_cv_disable_unused_result_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CFLAGS=$py_cflags
 
 fi
-
-  CFLAGS=$py_cflags
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_result_warning" >&5
+$as_echo "$ac_cv_disable_unused_result_warning" >&6; }
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_result_warning" >&5
 $as_echo "$ac_cv_disable_unused_result_warning" >&6; }
 
@@ -7238,15 +7242,16 @@ esac
 fi
 
 
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC unused-parameter warning" >&5
 $as_echo_n "checking if we can disable $CC unused-parameter warning... " >&6; }
-
-  py_cflags=$CFLAGS
-  CFLAGS="$CFLAGS -Wunused-parameter -Werror"
-  if ${ac_cv_disable_unused_parameter_warning+:} false; then :
+if ${ac_cv_disable_unused_parameter_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+    py_cflags=$CFLAGS
+    CFLAGS="$CFLAGS -Wunused-parameter -Werror"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
@@ -7263,10 +7268,11 @@ else
   ac_cv_disable_unused_parameter_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CFLAGS=$py_cflags
 
 fi
-
-  CFLAGS=$py_cflags
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_parameter_warning" >&5
+$as_echo "$ac_cv_disable_unused_parameter_warning" >&6; }
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_parameter_warning" >&5
 $as_echo "$ac_cv_disable_unused_parameter_warning" >&6; }
 
@@ -7276,15 +7282,16 @@ $as_echo "$ac_cv_disable_unused_parameter_warning" >&6; }
 fi
 
 
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC missing-field-initializers warning" >&5
 $as_echo_n "checking if we can disable $CC missing-field-initializers warning... " >&6; }
-
-  py_cflags=$CFLAGS
-  CFLAGS="$CFLAGS -Wmissing-field-initializers -Werror"
-  if ${ac_cv_disable_missing_field_initializers_warning+:} false; then :
+if ${ac_cv_disable_missing_field_initializers_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+    py_cflags=$CFLAGS
+    CFLAGS="$CFLAGS -Wmissing-field-initializers -Werror"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
@@ -7301,10 +7308,11 @@ else
   ac_cv_disable_missing_field_initializers_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CFLAGS=$py_cflags
 
 fi
-
-  CFLAGS=$py_cflags
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_missing_field_initializers_warning" >&5
+$as_echo "$ac_cv_disable_missing_field_initializers_warning" >&6; }
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_missing_field_initializers_warning" >&5
 $as_echo "$ac_cv_disable_missing_field_initializers_warning" >&6; }
 
@@ -7314,15 +7322,16 @@ $as_echo "$ac_cv_disable_missing_field_initializers_warning" >&6; }
 fi
 
 
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can enable $CC sign-compare warning" >&5
 $as_echo_n "checking if we can enable $CC sign-compare warning... " >&6; }
-
-  py_cflags=$CFLAGS
-  CFLAGS="$CFLAGS -Wsign-compare -Werror"
-  if ${ac_cv_enable_sign_compare_warning+:} false; then :
+if ${ac_cv_enable_sign_compare_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+    py_cflags=$CFLAGS
+    CFLAGS="$CFLAGS -Wsign-compare -Werror"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
@@ -7339,10 +7348,11 @@ else
   ac_cv_enable_sign_compare_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CFLAGS=$py_cflags
 
 fi
-
-  CFLAGS=$py_cflags
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_sign_compare_warning" >&5
+$as_echo "$ac_cv_enable_sign_compare_warning" >&6; }
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_sign_compare_warning" >&5
 $as_echo "$ac_cv_enable_sign_compare_warning" >&6; }
 
@@ -7352,15 +7362,16 @@ $as_echo "$ac_cv_enable_sign_compare_warning" >&6; }
 fi
 
 
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can enable $CC unreachable-code warning" >&5
 $as_echo_n "checking if we can enable $CC unreachable-code warning... " >&6; }
-
-  py_cflags=$CFLAGS
-  CFLAGS="$CFLAGS -Wunreachable-code -Werror"
-  if ${ac_cv_enable_unreachable_code_warning+:} false; then :
+if ${ac_cv_enable_unreachable_code_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+    py_cflags=$CFLAGS
+    CFLAGS="$CFLAGS -Wunreachable-code -Werror"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
@@ -7377,10 +7388,11 @@ else
   ac_cv_enable_unreachable_code_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CFLAGS=$py_cflags
 
 fi
-
-  CFLAGS=$py_cflags
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_unreachable_code_warning" >&5
+$as_echo "$ac_cv_enable_unreachable_code_warning" >&6; }
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_unreachable_code_warning" >&5
 $as_echo "$ac_cv_enable_unreachable_code_warning" >&6; }
 
@@ -7402,15 +7414,16 @@ $as_echo "$ac_cv_enable_unreachable_code_warning" >&6; }
     fi
 
 
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can enable $CC strict-prototypes warning" >&5
 $as_echo_n "checking if we can enable $CC strict-prototypes warning... " >&6; }
-
-  py_cflags=$CFLAGS
-  CFLAGS="$CFLAGS -Wstrict-prototypes -Werror"
-  if ${ac_cv_enable_strict_prototypes_warning+:} false; then :
+if ${ac_cv_enable_strict_prototypes_warning+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+    py_cflags=$CFLAGS
+    CFLAGS="$CFLAGS -Wstrict-prototypes -Werror"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
@@ -7427,10 +7440,11 @@ else
   ac_cv_enable_strict_prototypes_warning=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CFLAGS=$py_cflags
 
 fi
-
-  CFLAGS=$py_cflags
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_strict_prototypes_warning" >&5
+$as_echo "$ac_cv_enable_strict_prototypes_warning" >&6; }
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_strict_prototypes_warning" >&5
 $as_echo "$ac_cv_enable_strict_prototypes_warning" >&6; }
 

--- a/configure
+++ b/configure
@@ -5668,7 +5668,7 @@ if ${ac_cv_wl_no_as_needed+:} false; then :
 else
 
   save_LDFLAGS="$LDFLAGS"
-  LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
+  as_fn_append LDFLAGS -Wl,--no-as-needed
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/configure
+++ b/configure
@@ -5692,7 +5692,6 @@ rm -f core conftest.err conftest.$ac_objext \
   LDFLAGS="$save_LDFLAGS"
 
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_wl_no_as_needed" >&5
 $as_echo "$ac_cv_wl_no_as_needed" >&6; }
 
@@ -7115,8 +7114,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_extra_warning" >&5
 $as_echo "$ac_cv_enable_extra_warning" >&6; }
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_extra_warning" >&5
-$as_echo "$ac_cv_enable_extra_warning" >&6; }
 
 
     if test "x$ac_cv_enable_extra_warning" = xyes; then :
@@ -7127,12 +7124,12 @@ fi
     # GCC produce warnings for legal Python code.  Enable
     # -fno-strict-aliasing on versions of GCC that support but produce
     # warnings.  See Issue3326
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts and needs -fno-strict-aliasing" >&5
-$as_echo_n "checking whether $CC accepts and needs -fno-strict-aliasing... " >&6; }
      ac_save_cc="$CC"
      CC="$CC -fno-strict-aliasing"
      save_CFLAGS="$CFLAGS"
-     if ${ac_cv_no_strict_aliasing+:} false; then :
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts and needs -fno-strict-aliasing" >&5
+$as_echo_n "checking whether $CC accepts and needs -fno-strict-aliasing... " >&6; }
+if ${ac_cv_no_strict_aliasing+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -7183,11 +7180,10 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_no_strict_aliasing" >&5
+$as_echo "$ac_cv_no_strict_aliasing" >&6; }
      CFLAGS="$save_CFLAGS"
      CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_no_strict_aliasing" >&5
-$as_echo "$ac_cv_no_strict_aliasing" >&6; }
     if test "x$ac_cv_no_strict_aliasing" = xyes; then :
   BASECFLAGS="$BASECFLAGS -fno-strict-aliasing"
 fi
@@ -7228,8 +7224,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_result_warning" >&5
-$as_echo "$ac_cv_disable_unused_result_warning" >&6; }
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_result_warning" >&5
 $as_echo "$ac_cv_disable_unused_result_warning" >&6; }
 
  ;; #(
@@ -7273,8 +7267,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_parameter_warning" >&5
 $as_echo "$ac_cv_disable_unused_parameter_warning" >&6; }
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_parameter_warning" >&5
-$as_echo "$ac_cv_disable_unused_parameter_warning" >&6; }
 
 
     if test "x$ac_cv_disable_unused_parameter_warning" = xyes; then :
@@ -7312,8 +7304,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_missing_field_initializers_warning" >&5
-$as_echo "$ac_cv_disable_missing_field_initializers_warning" >&6; }
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_missing_field_initializers_warning" >&5
 $as_echo "$ac_cv_disable_missing_field_initializers_warning" >&6; }
 
 
@@ -7353,8 +7343,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_sign_compare_warning" >&5
 $as_echo "$ac_cv_enable_sign_compare_warning" >&6; }
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_sign_compare_warning" >&5
-$as_echo "$ac_cv_enable_sign_compare_warning" >&6; }
 
 
     if test "x$ac_cv_enable_sign_compare_warning" = xyes; then :
@@ -7392,8 +7380,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_unreachable_code_warning" >&5
-$as_echo "$ac_cv_enable_unreachable_code_warning" >&6; }
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_unreachable_code_warning" >&5
 $as_echo "$ac_cv_enable_unreachable_code_warning" >&6; }
 
 
@@ -7445,19 +7431,17 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_strict_prototypes_warning" >&5
 $as_echo "$ac_cv_enable_strict_prototypes_warning" >&6; }
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_strict_prototypes_warning" >&5
-$as_echo "$ac_cv_enable_strict_prototypes_warning" >&6; }
 
 
     if test "x$ac_cv_enable_strict_prototypes_warning" = xyes; then :
   CFLAGS_NODIST="$CFLAGS_NODIST -Wstrict-prototypes"
 fi
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can make implicit function declaration an error in $CC" >&5
-$as_echo_n "checking if we can make implicit function declaration an error in $CC... " >&6; }
      ac_save_cc="$CC"
      CC="$CC -Werror=implicit-function-declaration"
-     if ${ac_cv_enable_implicit_function_declaration_error+:} false; then :
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can make implicit function declaration an error in $CC" >&5
+$as_echo_n "checking if we can make implicit function declaration an error in $CC... " >&6; }
+if ${ac_cv_enable_implicit_function_declaration_error+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -7484,20 +7468,19 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_implicit_function_declaration_error" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_implicit_function_declaration_error" >&5
 $as_echo "$ac_cv_enable_implicit_function_declaration_error" >&6; }
+     CC="$ac_save_cc"
 
     if test "x$ac_cv_enable_implicit_function_declaration_error" = xyes; then :
   CFLAGS_NODIST="$CFLAGS_NODIST -Werror=implicit-function-declaration"
 fi
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can use visibility in $CC" >&5
-$as_echo_n "checking if we can use visibility in $CC... " >&6; }
      ac_save_cc="$CC"
      CC="$CC -fvisibility=hidden"
-     if ${ac_cv_enable_visibility+:} false; then :
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can use visibility in $CC" >&5
+$as_echo_n "checking if we can use visibility in $CC... " >&6; }
+if ${ac_cv_enable_visibility+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -7524,10 +7507,9 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_visibility" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_visibility" >&5
 $as_echo "$ac_cv_enable_visibility" >&6; }
+     CC="$ac_save_cc"
 
     if test "x$ac_cv_enable_visibility" = xyes; then :
   CFLAGS_NODIST="$CFLAGS_NODIST -fvisibility=hidden"
@@ -7790,7 +7772,6 @@ fi
 
 
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_pthread_is_default" >&5
 $as_echo "$ac_cv_pthread_is_default" >&6; }
 
@@ -7842,7 +7823,6 @@ fi
 
 CC="$ac_save_cc"
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_kpthread" >&5
 $as_echo "$ac_cv_kpthread" >&6; }
 fi
@@ -7892,7 +7872,6 @@ fi
 
 CC="$ac_save_cc"
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_kthread" >&5
 $as_echo "$ac_cv_kthread" >&6; }
 fi
@@ -7942,7 +7921,6 @@ fi
 
 CC="$ac_save_cc"
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_pthread" >&5
 $as_echo "$ac_cv_pthread" >&6; }
 fi
@@ -10341,7 +10319,8 @@ fi
 
 
 fi
-
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_aligned_required" >&5
+$as_echo "$ac_cv_aligned_required" >&6; }
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_aligned_required" >&5
 $as_echo "$ac_cv_aligned_required" >&6; }
 if test "$ac_cv_aligned_required" = yes ; then
@@ -11237,7 +11216,7 @@ $as_echo "#define HAVE_BROKEN_POSIX_SEMAPHORES 1" >>confdefs.h
 
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking if PTHREAD_SCOPE_SYSTEM is supported" >&5
 $as_echo_n "checking if PTHREAD_SCOPE_SYSTEM is supported... " >&6; }
-      if ${ac_cv_pthread_system_supported+:} false; then :
+if ${ac_cv_pthread_system_supported+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   if test "$cross_compiling" = yes; then :
@@ -11271,8 +11250,7 @@ fi
 
 
 fi
-
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_pthread_system_supported" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_pthread_system_supported" >&5
 $as_echo "$ac_cv_pthread_system_supported" >&6; }
       if test "$ac_cv_pthread_system_supported" = "yes"; then
 
@@ -13927,7 +13905,7 @@ if test "x$ac_cv_func_getaddrinfo" = xyes; then :
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking getaddrinfo bug" >&5
 $as_echo_n "checking getaddrinfo bug... " >&6; }
-  if ${ac_cv_buggy_getaddrinfo+:} false; then :
+if ${ac_cv_buggy_getaddrinfo+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   if test "$cross_compiling" = yes; then :
@@ -14041,13 +14019,11 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 fi
-
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_buggy_getaddrinfo" >&5
+$as_echo "$ac_cv_buggy_getaddrinfo" >&6; }
 
 
 fi
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_buggy_getaddrinfo" >&5
-$as_echo "$ac_cv_buggy_getaddrinfo" >&6; }
 
 if test "$ac_cv_func_getaddrinfo" = no -o "$ac_cv_buggy_getaddrinfo" = yes
 then
@@ -14311,7 +14287,6 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_header_time_altzone" >&5
 $as_echo "$ac_cv_header_time_altzone" >&6; }
 if test $ac_cv_header_time_altzone = yes; then
@@ -14343,7 +14318,6 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_struct_addrinfo" >&5
 $as_echo "$ac_cv_struct_addrinfo" >&6; }
 if test $ac_cv_struct_addrinfo = yes; then
@@ -14377,7 +14351,6 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_struct_sockaddr_storage" >&5
 $as_echo "$ac_cv_struct_sockaddr_storage" >&6; }
 if test $ac_cv_struct_sockaddr_storage = yes; then
@@ -14412,7 +14385,6 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_struct_sockaddr_alg" >&5
 $as_echo "$ac_cv_struct_sockaddr_alg" >&6; }
 if test $ac_cv_struct_sockaddr_alg = yes; then
@@ -15341,7 +15313,6 @@ fi
 
 
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_posix_semaphores_enabled" >&5
 $as_echo "$ac_cv_posix_semaphores_enabled" >&6; }
 if test $ac_cv_posix_semaphores_enabled = no
@@ -15396,7 +15367,6 @@ fi
 
 
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_broken_sem_getvalue" >&5
 $as_echo "$ac_cv_broken_sem_getvalue" >&6; }
 if test $ac_cv_broken_sem_getvalue = yes
@@ -15616,7 +15586,7 @@ then
   # check whether wchar_t is signed or not
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether wchar_t is signed" >&5
 $as_echo_n "checking whether wchar_t is signed... " >&6; }
-  if ${ac_cv_wchar_t_signed+:} false; then :
+if ${ac_cv_wchar_t_signed+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
@@ -15644,8 +15614,7 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 fi
-
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_wchar_t_signed" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_wchar_t_signed" >&5
 $as_echo "$ac_cv_wchar_t_signed" >&6; }
 fi
 
@@ -16059,7 +16028,6 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_rshift_extends_sign" >&5
 $as_echo "$ac_cv_rshift_extends_sign" >&6; }
 if test "$ac_cv_rshift_extends_sign" = no
@@ -16100,7 +16068,6 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_have_getc_unlocked" >&5
 $as_echo "$ac_cv_have_getc_unlocked" >&6; }
 if test "$ac_cv_have_getc_unlocked" = yes
@@ -16510,7 +16477,6 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_broken_nice" >&5
 $as_echo "$ac_cv_broken_nice" >&6; }
 if test "$ac_cv_broken_nice" = yes
@@ -16561,7 +16527,6 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_broken_poll" >&5
 $as_echo "$ac_cv_broken_poll" >&6; }
 if test "$ac_cv_broken_poll" = yes
@@ -16658,7 +16623,6 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_working_tzset" >&5
 $as_echo "$ac_cv_working_tzset" >&6; }
 if test "$ac_cv_working_tzset" = yes
@@ -16695,7 +16659,6 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_stat_tv_nsec" >&5
 $as_echo "$ac_cv_stat_tv_nsec" >&6; }
 if test "$ac_cv_stat_tv_nsec" = yes
@@ -16732,7 +16695,6 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_stat_tv_nsec2" >&5
 $as_echo "$ac_cv_stat_tv_nsec2" >&6; }
 if test "$ac_cv_stat_tv_nsec2" = yes
@@ -16808,7 +16770,6 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_mvwdelch_is_expression" >&5
 $as_echo "$ac_cv_mvwdelch_is_expression" >&6; }
 
@@ -16852,7 +16813,6 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_window_has_flags" >&5
 $as_echo "$ac_cv_window_has_flags" >&6; }
 
@@ -17497,7 +17457,6 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_broken_mbstowcs" >&5
 $as_echo "$ac_cv_broken_mbstowcs" >&6; }
 if test "$ac_cv_broken_mbstowcs" = yes
@@ -17574,7 +17533,6 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_computed_gotos" >&5
 $as_echo "$ac_cv_computed_gotos" >&6; }
 case "$ac_cv_computed_gotos" in yes*)

--- a/configure
+++ b/configure
@@ -10321,8 +10321,6 @@ fi
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_aligned_required" >&5
 $as_echo "$ac_cv_aligned_required" >&6; }
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_aligned_required" >&5
-$as_echo "$ac_cv_aligned_required" >&6; }
 if test "$ac_cv_aligned_required" = yes ; then
 
 $as_echo "#define HAVE_ALIGNED_REQUIRED 1" >>confdefs.h

--- a/configure
+++ b/configure
@@ -5663,9 +5663,13 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for -Wl,--no-as-needed" >&5
 $as_echo_n "checking for -Wl,--no-as-needed... " >&6; }
-save_LDFLAGS="$LDFLAGS"
-LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${ac_cv_wl_no_as_needed+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  save_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
@@ -5678,16 +5682,19 @@ main ()
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
   NO_AS_NEEDED="-Wl,--no-as-needed"
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
+     ac_cv_wl_no_as_needed=yes
 else
   NO_AS_NEEDED=""
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
+     ac_cv_wl_no_as_needed=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-LDFLAGS="$save_LDFLAGS"
+  LDFLAGS="$save_LDFLAGS"
+
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_wl_no_as_needed" >&5
+$as_echo "$ac_cv_wl_no_as_needed" >&6; }
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the Android API level" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -897,8 +897,7 @@ if test x$MULTIARCH != x; then
 fi
 AC_SUBST(MULTIARCH_CPPFLAGS)
 
-AC_MSG_CHECKING([for -Wl,--no-as-needed])
-AC_CACHE_VAL([ac_cv_wl_no_as_needed], [
+AC_CACHE_CHECK([for -Wl,--no-as-needed], [ac_cv_wl_no_as_needed], [
   save_LDFLAGS="$LDFLAGS"
   LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
@@ -908,7 +907,6 @@ AC_CACHE_VAL([ac_cv_wl_no_as_needed], [
      AS_VAR_SET([ac_cv_wl_no_as_needed], [no])])
   LDFLAGS="$save_LDFLAGS"
 ])
-AC_MSG_RESULT([$ac_cv_wl_no_as_needed])
 AC_SUBST(NO_AS_NEEDED)
 
 AC_MSG_CHECKING([for the Android API level])
@@ -1652,7 +1650,6 @@ AC_DEFUN([PY_CHECK_CC_WARNING], [
                       [AS_VAR_SET([py_var], [no])])
     AS_VAR_COPY([CFLAGS], [py_cflags])
   ])
-  AC_MSG_RESULT([$py_var])
   AS_VAR_POPDEF([py_var])
 ])
 
@@ -1669,11 +1666,11 @@ yes)
     # GCC produce warnings for legal Python code.  Enable
     # -fno-strict-aliasing on versions of GCC that support but produce
     # warnings.  See Issue3326
-    AC_MSG_CHECKING(whether $CC accepts and needs -fno-strict-aliasing)
      ac_save_cc="$CC"
      CC="$CC -fno-strict-aliasing"
      save_CFLAGS="$CFLAGS"
-     AC_CACHE_VAL(ac_cv_no_strict_aliasing,
+     AC_CACHE_CHECK([whether $CC accepts and needs -fno-strict-aliasing],
+                    [ac_cv_no_strict_aliasing],
        AC_COMPILE_IFELSE(
          [
 	   AC_LANG_PROGRAM([[]], [[]])
@@ -1694,7 +1691,6 @@ yes)
 	 ]))
      CFLAGS="$save_CFLAGS"
      CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_no_strict_aliasing)
     AS_VAR_IF([ac_cv_no_strict_aliasing], [yes],
               [BASECFLAGS="$BASECFLAGS -fno-strict-aliasing"])
 
@@ -1740,10 +1736,10 @@ yes)
     AS_VAR_IF([ac_cv_enable_strict_prototypes_warning], [yes],
               [CFLAGS_NODIST="$CFLAGS_NODIST -Wstrict-prototypes"])
 
-    AC_MSG_CHECKING(if we can make implicit function declaration an error in $CC)
      ac_save_cc="$CC"
      CC="$CC -Werror=implicit-function-declaration"
-     AC_CACHE_VAL(ac_cv_enable_implicit_function_declaration_error,
+     AC_CACHE_CHECK([if we can make implicit function declaration an error in $CC],
+                    [ac_cv_enable_implicit_function_declaration_error],
        AC_COMPILE_IFELSE(
          [
 	   AC_LANG_PROGRAM([[]], [[]])
@@ -1753,15 +1749,13 @@ yes)
            ac_cv_enable_implicit_function_declaration_error=no
 	 ]))
      CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_enable_implicit_function_declaration_error)
 
     AS_VAR_IF([ac_cv_enable_implicit_function_declaration_error], [yes],
               [CFLAGS_NODIST="$CFLAGS_NODIST -Werror=implicit-function-declaration"])
 
-    AC_MSG_CHECKING(if we can use visibility in $CC)
      ac_save_cc="$CC"
      CC="$CC -fvisibility=hidden"
-     AC_CACHE_VAL(ac_cv_enable_visibility,
+     AC_CACHE_CHECK([if we can use visibility in $CC], [ac_cv_enable_visibility],
        AC_COMPILE_IFELSE(
          [
 	   AC_LANG_PROGRAM([[]], [[]])
@@ -1771,7 +1765,6 @@ yes)
            ac_cv_enable_visibility=no
 	 ]))
      CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_enable_visibility)
 
     AS_VAR_IF([ac_cv_enable_visibility], [yes],
               [CFLAGS_NODIST="$CFLAGS_NODIST -fvisibility=hidden"])
@@ -1971,8 +1964,8 @@ fi
 # complain if unaccepted options are passed (e.g. gcc on Mac OS X).
 # So we have to see first whether pthreads are available without
 # options before we can check whether -Kpthread improves anything.
-AC_MSG_CHECKING(whether pthreads are available without options)
-AC_CACHE_VAL(ac_cv_pthread_is_default,
+AC_CACHE_CHECK([whether pthreads are available without options],
+               [ac_cv_pthread_is_default],
 [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <pthread.h>
@@ -1992,7 +1985,6 @@ int main(){
   ac_cv_pthread=no
 ],[ac_cv_pthread_is_default=no],[ac_cv_pthread_is_default=no])
 ])
-AC_MSG_RESULT($ac_cv_pthread_is_default)
 
 
 if test $ac_cv_pthread_is_default = yes
@@ -2004,8 +1996,7 @@ else
 # Some compilers won't report that they do not support -Kpthread,
 # so we need to run a program to see whether it really made the
 # function available.
-AC_MSG_CHECKING(whether $CC accepts -Kpthread)
-AC_CACHE_VAL(ac_cv_kpthread,
+AC_CACHE_CHECK([whether $CC accepts -Kpthread], [ac_cv_kpthread],
 [ac_save_cc="$CC"
 CC="$CC -Kpthread"
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
@@ -2023,7 +2014,6 @@ int main(){
 }
 ]])],[ac_cv_kpthread=yes],[ac_cv_kpthread=no],[ac_cv_kpthread=no])
 CC="$ac_save_cc"])
-AC_MSG_RESULT($ac_cv_kpthread)
 fi
 
 if test $ac_cv_kpthread = no -a $ac_cv_pthread_is_default = no
@@ -2033,8 +2023,7 @@ then
 # Some compilers won't report that they do not support -Kthread,
 # so we need to run a program to see whether it really made the
 # function available.
-AC_MSG_CHECKING(whether $CC accepts -Kthread)
-AC_CACHE_VAL(ac_cv_kthread,
+AC_CACHE_CHECK([whether $CC accepts -Kthread], [ac_cv_kthread],
 [ac_save_cc="$CC"
 CC="$CC -Kthread"
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
@@ -2052,7 +2041,6 @@ int main(){
 }
 ]])],[ac_cv_kthread=yes],[ac_cv_kthread=no],[ac_cv_kthread=no])
 CC="$ac_save_cc"])
-AC_MSG_RESULT($ac_cv_kthread)
 fi
 
 if test $ac_cv_kthread = no -a $ac_cv_pthread_is_default = no
@@ -2062,8 +2050,7 @@ then
 # Some compilers won't report that they do not support -pthread,
 # so we need to run a program to see whether it really made the
 # function available.
-AC_MSG_CHECKING(whether $CC accepts -pthread)
-AC_CACHE_VAL(ac_cv_pthread,
+AC_CACHE_CHECK([whether $CC accepts -pthread], [ac_cv_pthread],
 [ac_save_cc="$CC"
 CC="$CC -pthread"
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
@@ -2081,7 +2068,6 @@ int main(){
 }
 ]])],[ac_cv_pthread=yes],[ac_cv_pthread=no],[ac_cv_pthread=no])
 CC="$ac_save_cc"])
-AC_MSG_RESULT($ac_cv_pthread)
 fi
 
 # If we have set a CC compiler flag for thread support then
@@ -2890,8 +2876,7 @@ dnl The AIX_BUILDDATE is obtained from the kernel fileset - bos.mp64
 esac
 
 # check for systems that require aligned memory access
-AC_MSG_CHECKING(aligned memory access is required)
-AC_CACHE_VAL(ac_cv_aligned_required,
+AC_CACHE_CHECK([aligned memory access is required], [ac_cv_aligned_required],
 [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 int main()
 {
@@ -3251,8 +3236,7 @@ if test "$posix_threads" = "yes"; then
 		       ;;
       esac
 
-      AC_MSG_CHECKING(if PTHREAD_SCOPE_SYSTEM is supported)
-      AC_CACHE_VAL(ac_cv_pthread_system_supported,
+      AC_CACHE_CHECK([if PTHREAD_SCOPE_SYSTEM is supported], [ac_cv_pthread_system_supported],
       [AC_RUN_IFELSE([AC_LANG_SOURCE([[
       #include <stdio.h>
       #include <pthread.h>
@@ -3271,7 +3255,6 @@ if test "$posix_threads" = "yes"; then
       [ac_cv_pthread_system_supported=no],
       [ac_cv_pthread_system_supported=no])
       ])
-      AC_MSG_RESULT($ac_cv_pthread_system_supported)
       if test "$ac_cv_pthread_system_supported" = "yes"; then
         AC_DEFINE(PTHREAD_SYSTEM_SCHED_SUPPORTED, 1, [Defined if PTHREAD_SCOPE_SYSTEM supported.])
       fi
@@ -3978,8 +3961,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 ])
 
 AS_VAR_IF([ac_cv_func_getaddrinfo], [yes], [
-  AC_MSG_CHECKING(getaddrinfo bug)
-  AC_CACHE_VAL(ac_cv_buggy_getaddrinfo,
+  AC_CACHE_CHECK([getaddrinfo bug], [ac_cv_buggy_getaddrinfo],
   AC_RUN_IFELSE([AC_LANG_SOURCE([[[
 #include <stdio.h>
 #include <sys/types.h>
@@ -4082,8 +4064,6 @@ fi]))
 dnl if ac_cv_func_getaddrinfo
 ])
 
-AC_MSG_RESULT($ac_cv_buggy_getaddrinfo)
-
 if test "$ac_cv_func_getaddrinfo" = no -o "$ac_cv_buggy_getaddrinfo" = yes
 then
 	if test $ipv6 = yes
@@ -4120,48 +4100,40 @@ AC_CHECK_MEMBERS([struct passwd.pw_gecos, struct passwd.pw_passwd], [], [], [[
 # Issue #21085: In Cygwin, siginfo_t does not have si_band field.
 AC_CHECK_MEMBERS([siginfo_t.si_band], [], [], [[#include <signal.h>]])
 
-AC_MSG_CHECKING(for time.h that defines altzone)
-AC_CACHE_VAL(ac_cv_header_time_altzone,[
+AC_CACHE_CHECK([for time.h that defines altzone], [ac_cv_header_time_altzone], [
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <time.h>]], [[return altzone;]])],
     [ac_cv_header_time_altzone=yes],
     [ac_cv_header_time_altzone=no])
   ])
-AC_MSG_RESULT($ac_cv_header_time_altzone)
 if test $ac_cv_header_time_altzone = yes; then
   AC_DEFINE(HAVE_ALTZONE, 1, [Define this if your time.h defines altzone.])
 fi
 
-AC_MSG_CHECKING(for addrinfo)
-AC_CACHE_VAL(ac_cv_struct_addrinfo,
+AC_CACHE_CHECK([for addrinfo], [ac_cv_struct_addrinfo],
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <netdb.h>]], [[struct addrinfo a]])],
   [ac_cv_struct_addrinfo=yes],
   [ac_cv_struct_addrinfo=no]))
-AC_MSG_RESULT($ac_cv_struct_addrinfo)
 if test $ac_cv_struct_addrinfo = yes; then
 	AC_DEFINE(HAVE_ADDRINFO, 1, [struct addrinfo (netdb.h)])
 fi
 
-AC_MSG_CHECKING(for sockaddr_storage)
-AC_CACHE_VAL(ac_cv_struct_sockaddr_storage,
+AC_CACHE_CHECK([for sockaddr_storage], [ac_cv_struct_sockaddr_storage],
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #		include <sys/types.h>
 #		include <sys/socket.h>]], [[struct sockaddr_storage s]])],
   [ac_cv_struct_sockaddr_storage=yes],
   [ac_cv_struct_sockaddr_storage=no]))
-AC_MSG_RESULT($ac_cv_struct_sockaddr_storage)
 if test $ac_cv_struct_sockaddr_storage = yes; then
 	AC_DEFINE(HAVE_SOCKADDR_STORAGE, 1, [struct sockaddr_storage (sys/socket.h)])
 fi
 
-AC_MSG_CHECKING(for sockaddr_alg)
-AC_CACHE_VAL(ac_cv_struct_sockaddr_alg,
+AC_CACHE_CHECK([for sockaddr_alg], [ac_cv_struct_sockaddr_alg],
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #		include <sys/types.h>
 #		include <sys/socket.h>
 #		include <linux/if_alg.h>]], [[struct sockaddr_alg s]])],
   [ac_cv_struct_sockaddr_alg=yes],
   [ac_cv_struct_sockaddr_alg=no]))
-AC_MSG_RESULT($ac_cv_struct_sockaddr_alg)
 if test $ac_cv_struct_sockaddr_alg = yes; then
 	AC_DEFINE(HAVE_SOCKADDR_ALG, 1, [struct sockaddr_alg (linux/if_alg.h)])
 fi
@@ -4483,8 +4455,7 @@ LIBS=$LIBS_SAVE
 # the kernel module that provides POSIX semaphores
 # isn't loaded by default, so an attempt to call
 # sem_open results in a 'Signal 12' error.
-AC_MSG_CHECKING(whether POSIX semaphores are enabled)
-AC_CACHE_VAL(ac_cv_posix_semaphores_enabled,
+AC_CACHE_CHECK([whether POSIX semaphores are enabled], [ac_cv_posix_semaphores_enabled],
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <unistd.h>
 #include <fcntl.h>
@@ -4507,7 +4478,6 @@ int main(void) {
 [ac_cv_posix_semaphores_enabled=no],
 [ac_cv_posix_semaphores_enabled=yes])
 )
-AC_MSG_RESULT($ac_cv_posix_semaphores_enabled)
 if test $ac_cv_posix_semaphores_enabled = no
 then
   AC_DEFINE(POSIX_SEMAPHORES_NOT_ENABLED, 1,
@@ -4515,8 +4485,7 @@ then
 fi
 
 # Multiprocessing check for broken sem_getvalue
-AC_MSG_CHECKING(for broken sem_getvalue)
-AC_CACHE_VAL(ac_cv_broken_sem_getvalue,
+AC_CACHE_CHECK([for broken sem_getvalue], [ac_cv_broken_sem_getvalue],
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <unistd.h>
 #include <fcntl.h>
@@ -4543,7 +4512,6 @@ int main(void){
 [ac_cv_broken_sem_getvalue=yes],
 [ac_cv_broken_sem_getvalue=yes])
 )
-AC_MSG_RESULT($ac_cv_broken_sem_getvalue)
 if test $ac_cv_broken_sem_getvalue = yes
 then
   AC_DEFINE(HAVE_BROKEN_SEM_GETVALUE, 1,
@@ -4602,8 +4570,7 @@ AC_MSG_RESULT($have_ucs4_tcl)
 if test "$wchar_h" = yes
 then
   # check whether wchar_t is signed or not
-  AC_MSG_CHECKING(whether wchar_t is signed)
-  AC_CACHE_VAL(ac_cv_wchar_t_signed, [
+  AC_CACHE_CHECK([whether wchar_t is signed], [ac_cv_wchar_t_signed], [
   AC_RUN_IFELSE([AC_LANG_SOURCE([[
   #include <wchar.h>
   int main()
@@ -4615,7 +4582,6 @@ then
   [ac_cv_wchar_t_signed=yes],
   [ac_cv_wchar_t_signed=no],
   [ac_cv_wchar_t_signed=yes])])
-  AC_MSG_RESULT($ac_cv_wchar_t_signed)
 fi
 
 AC_MSG_CHECKING(whether wchar_t is usable)
@@ -4753,8 +4719,7 @@ fi],
 
 # Check whether right shifting a negative integer extends the sign bit
 # or fills with zeros (like the Cray J90, according to Tim Peters).
-AC_MSG_CHECKING(whether right shift extends the sign bit)
-AC_CACHE_VAL(ac_cv_rshift_extends_sign, [
+AC_CACHE_CHECK([whether right shift extends the sign bit], [ac_cv_rshift_extends_sign], [
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 int main()
 {
@@ -4764,7 +4729,6 @@ int main()
 [ac_cv_rshift_extends_sign=yes],
 [ac_cv_rshift_extends_sign=no],
 [ac_cv_rshift_extends_sign=yes])])
-AC_MSG_RESULT($ac_cv_rshift_extends_sign)
 if test "$ac_cv_rshift_extends_sign" = no
 then
   AC_DEFINE(SIGNED_RIGHT_SHIFT_ZERO_FILLS, 1,
@@ -4773,15 +4737,13 @@ then
 fi
 
 # check for getc_unlocked and related locking functions
-AC_MSG_CHECKING(for getc_unlocked() and friends)
-AC_CACHE_VAL(ac_cv_have_getc_unlocked, [
+AC_CACHE_CHECK([for getc_unlocked() and friends], [ac_cv_have_getc_unlocked], [
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]], [[
 	FILE *f = fopen("/dev/null", "r");
 	flockfile(f);
 	getc_unlocked(f);
 	funlockfile(f);
 ]])],[ac_cv_have_getc_unlocked=yes],[ac_cv_have_getc_unlocked=no])])
-AC_MSG_RESULT($ac_cv_have_getc_unlocked)
 if test "$ac_cv_have_getc_unlocked" = yes
 then
   AC_DEFINE(HAVE_GETC_UNLOCKED, 1,
@@ -4910,8 +4872,7 @@ fi
 # End of readline checks: restore LIBS
 LIBS=$LIBS_no_readline
 
-AC_MSG_CHECKING(for broken nice())
-AC_CACHE_VAL(ac_cv_broken_nice, [
+AC_CACHE_CHECK([for broken nice()], [ac_cv_broken_nice], [
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 #include <unistd.h>
@@ -4926,15 +4887,13 @@ int main()
 [ac_cv_broken_nice=yes],
 [ac_cv_broken_nice=no],
 [ac_cv_broken_nice=no])])
-AC_MSG_RESULT($ac_cv_broken_nice)
 if test "$ac_cv_broken_nice" = yes
 then
   AC_DEFINE(HAVE_BROKEN_NICE, 1,
   [Define if nice() returns success/failure instead of the new priority.])
 fi
 
-AC_MSG_CHECKING(for broken poll())
-AC_CACHE_VAL(ac_cv_broken_poll,
+AC_CACHE_CHECK([for broken poll()], [ac_cv_broken_poll],
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <poll.h>
 #include <unistd.h>
@@ -4958,7 +4917,6 @@ int main()
 [ac_cv_broken_poll=yes],
 [ac_cv_broken_poll=no],
 [ac_cv_broken_poll=no]))
-AC_MSG_RESULT($ac_cv_broken_poll)
 if test "$ac_cv_broken_poll" = yes
 then
   AC_DEFINE(HAVE_BROKEN_POLL, 1,
@@ -4966,8 +4924,7 @@ then
 fi
 
 # check tzset(3) exists and works like we expect it to
-AC_MSG_CHECKING(for working tzset())
-AC_CACHE_VAL(ac_cv_working_tzset, [
+AC_CACHE_CHECK([for working tzset()], [ac_cv_working_tzset], [
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 #include <time.h>
@@ -5035,7 +4992,6 @@ int main()
 [ac_cv_working_tzset=yes],
 [ac_cv_working_tzset=no],
 [ac_cv_working_tzset=no])])
-AC_MSG_RESULT($ac_cv_working_tzset)
 if test "$ac_cv_working_tzset" = yes
 then
   AC_DEFINE(HAVE_WORKING_TZSET, 1,
@@ -5043,15 +4999,13 @@ then
 fi
 
 # Look for subsecond timestamps in struct stat
-AC_MSG_CHECKING(for tv_nsec in struct stat)
-AC_CACHE_VAL(ac_cv_stat_tv_nsec,
+AC_CACHE_CHECK([for tv_nsec in struct stat], [ac_cv_stat_tv_nsec],
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/stat.h>]], [[
 struct stat st;
 st.st_mtim.tv_nsec = 1;
 ]])],
 [ac_cv_stat_tv_nsec=yes],
 [ac_cv_stat_tv_nsec=no]))
-AC_MSG_RESULT($ac_cv_stat_tv_nsec)
 if test "$ac_cv_stat_tv_nsec" = yes
 then
   AC_DEFINE(HAVE_STAT_TV_NSEC, 1,
@@ -5059,15 +5013,13 @@ then
 fi
 
 # Look for BSD style subsecond timestamps in struct stat
-AC_MSG_CHECKING(for tv_nsec2 in struct stat)
-AC_CACHE_VAL(ac_cv_stat_tv_nsec2,
+AC_CACHE_CHECK([for tv_nsec2 in struct stat], [ac_cv_stat_tv_nsec2],
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/stat.h>]], [[
 struct stat st;
 st.st_mtimespec.tv_nsec = 1;
 ]])],
 [ac_cv_stat_tv_nsec2=yes],
 [ac_cv_stat_tv_nsec2=no]))
-AC_MSG_RESULT($ac_cv_stat_tv_nsec2)
 if test "$ac_cv_stat_tv_nsec2" = yes
 then
   AC_DEFINE(HAVE_STAT_TV_NSEC2, 1,
@@ -5090,15 +5042,13 @@ AC_CHECK_HEADERS(term.h,,,[
 ])
 
 # On HP/UX 11.0, mvwdelch is a block with a return statement
-AC_MSG_CHECKING(whether mvwdelch is an expression)
-AC_CACHE_VAL(ac_cv_mvwdelch_is_expression,
+AC_CACHE_CHECK([whether mvwdelch is an expression], [ac_cv_mvwdelch_is_expression],
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
   int rtn;
   rtn = mvwdelch(0,0,0);
 ]])],
 [ac_cv_mvwdelch_is_expression=yes],
 [ac_cv_mvwdelch_is_expression=no]))
-AC_MSG_RESULT($ac_cv_mvwdelch_is_expression)
 
 if test "$ac_cv_mvwdelch_is_expression" = yes
 then
@@ -5110,8 +5060,7 @@ fi
 # structs since version 5.7.  If the macro is defined as zero before including
 # [n]curses.h, ncurses will expose fields of the structs regardless of the
 # configuration.
-AC_MSG_CHECKING(whether WINDOW has _flags)
-AC_CACHE_VAL(ac_cv_window_has_flags,
+AC_CACHE_CHECK([whether WINDOW has _flags], [ac_cv_window_has_flags],
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   #define NCURSES_OPAQUE 0
   #include <curses.h>
@@ -5121,7 +5070,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 ]])],
 [ac_cv_window_has_flags=yes],
 [ac_cv_window_has_flags=no]))
-AC_MSG_RESULT($ac_cv_window_has_flags)
 
 
 if test "$ac_cv_window_has_flags" = yes
@@ -5257,8 +5205,7 @@ AC_CHECK_TYPE(socklen_t,,
 #endif
 ])
 
-AC_MSG_CHECKING(for broken mbstowcs)
-AC_CACHE_VAL(ac_cv_broken_mbstowcs,
+AC_CACHE_CHECK([for broken mbstowcs], [ac_cv_broken_mbstowcs],
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include<stdlib.h>
@@ -5272,7 +5219,6 @@ int main() {
 [ac_cv_broken_mbstowcs=no],
 [ac_cv_broken_mbstowcs=yes],
 [ac_cv_broken_mbstowcs=no]))
-AC_MSG_RESULT($ac_cv_broken_mbstowcs)
 if test "$ac_cv_broken_mbstowcs" = yes
 then
   AC_DEFINE(HAVE_BROKEN_MBSTOWCS, 1,
@@ -5301,8 +5247,7 @@ fi
 ],
 [AC_MSG_RESULT(no value specified)])
 
-AC_MSG_CHECKING(whether $CC supports computed gotos)
-AC_CACHE_VAL(ac_cv_computed_gotos,
+AC_CACHE_CHECK([whether $CC supports computed gotos], [ac_cv_computed_gotos],
 AC_RUN_IFELSE([AC_LANG_SOURCE([[[
 int main(int argc, char **argv)
 {
@@ -5322,7 +5267,6 @@ LABEL2:
  else
    ac_cv_computed_gotos=no
  fi]))
-AC_MSG_RESULT($ac_cv_computed_gotos)
 case "$ac_cv_computed_gotos" in yes*)
   AC_DEFINE(HAVE_COMPUTED_GOTOS, 1,
   [Define if the C compiler supports computed gotos.])

--- a/configure.ac
+++ b/configure.ac
@@ -1643,19 +1643,15 @@ AC_SUBST(UNIVERSAL_ARCH_FLAGS)
 
 dnl PY_CHECK_CC_WARNING(ENABLE, WARNING, [MSG])
 AC_DEFUN([PY_CHECK_CC_WARNING], [
-  AC_MSG_CHECKING(m4_ifblank([$3], [if we can $1 $CC $2 warning], [$3]))
   AS_VAR_PUSHDEF([py_var], [ac_cv_$1_]m4_normalize($2)[_warning])
-  AS_VAR_COPY([py_cflags], [CFLAGS])
-  AS_VAR_SET([CFLAGS], ["$CFLAGS -W$2 -Werror"])
-  AC_CACHE_VAL(
-    [py_var],
-    [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[]], [[]])],
-      [AS_VAR_SET([py_var], [yes])],
-      [AS_VAR_SET([py_var], [no])],
-    )]
-  )
-  AS_VAR_COPY([CFLAGS], [py_cflags])
+  AC_CACHE_CHECK(m4_ifblank([$3], [if we can $1 $CC $2 warning], [$3]), [py_var], [
+    AS_VAR_COPY([py_cflags], [CFLAGS])
+    AS_VAR_SET([CFLAGS], ["$CFLAGS -W$2 -Werror"])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
+                      [AS_VAR_SET([py_var], [yes])],
+                      [AS_VAR_SET([py_var], [no])])
+    AS_VAR_COPY([CFLAGS], [py_cflags])
+  ])
   AC_MSG_RESULT([$py_var])
   AS_VAR_POPDEF([py_var])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -1644,7 +1644,7 @@ AC_DEFUN([PY_CHECK_CC_WARNING], [
   AS_VAR_PUSHDEF([py_var], [ac_cv_$1_]m4_normalize($2)[_warning])
   AC_CACHE_CHECK(m4_ifblank([$3], [if we can $1 $CC $2 warning], [$3]), [py_var], [
     AS_VAR_COPY([py_cflags], [CFLAGS])
-    AS_VAR_SET([CFLAGS], ["$CFLAGS -W$2 -Werror"])
+    AS_VAR_APPEND([CFLAGS], ["-W$2 -Werror"])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
                       [AS_VAR_SET([py_var], [yes])],
                       [AS_VAR_SET([py_var], [no])])

--- a/configure.ac
+++ b/configure.ac
@@ -2894,7 +2894,6 @@ int main()
 [ac_cv_aligned_required=yes],
 [ac_cv_aligned_required=yes])
 ])
-AC_MSG_RESULT($ac_cv_aligned_required)
 if test "$ac_cv_aligned_required" = yes ; then
   AC_DEFINE([HAVE_ALIGNED_REQUIRED], [1],
     [Define if aligned memory access is required])

--- a/configure.ac
+++ b/configure.ac
@@ -898,14 +898,17 @@ fi
 AC_SUBST(MULTIARCH_CPPFLAGS)
 
 AC_MSG_CHECKING([for -Wl,--no-as-needed])
-save_LDFLAGS="$LDFLAGS"
-LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
-  [NO_AS_NEEDED="-Wl,--no-as-needed"
-   AC_MSG_RESULT([yes])],
-  [NO_AS_NEEDED=""
-   AC_MSG_RESULT([no])])
-LDFLAGS="$save_LDFLAGS"
+AC_CACHE_VAL([ac_cv_wl_no_as_needed], [
+  save_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
+    [NO_AS_NEEDED="-Wl,--no-as-needed"
+     AS_VAR_SET([ac_cv_wl_no_as_needed], [yes])],
+    [NO_AS_NEEDED=""
+     AS_VAR_SET([ac_cv_wl_no_as_needed], [no])])
+  LDFLAGS="$save_LDFLAGS"
+])
+AC_MSG_RESULT([$ac_cv_wl_no_as_needed])
 AC_SUBST(NO_AS_NEEDED)
 
 AC_MSG_CHECKING([for the Android API level])

--- a/configure.ac
+++ b/configure.ac
@@ -899,12 +899,12 @@ AC_SUBST(MULTIARCH_CPPFLAGS)
 
 AC_CACHE_CHECK([for -Wl,--no-as-needed], [ac_cv_wl_no_as_needed], [
   save_LDFLAGS="$LDFLAGS"
-  LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
+  AS_VAR_APPEND([LDFLAGS], [-Wl,--no-as-needed])
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
     [NO_AS_NEEDED="-Wl,--no-as-needed"
-     AS_VAR_SET([ac_cv_wl_no_as_needed], [yes])],
+     ac_cv_wl_no_as_needed=yes],
     [NO_AS_NEEDED=""
-     AS_VAR_SET([ac_cv_wl_no_as_needed], [no])])
+     ac_cv_wl_no_as_needed=no])
   LDFLAGS="$save_LDFLAGS"
 ])
 AC_SUBST(NO_AS_NEEDED)


### PR DESCRIPTION
- Cache checking of `-Wl,--no-as-needed`
- Make PY_CHECK_CC_WARNING more efficient
- Consolidate AC_MSG_CHECKING and AC_CACHE_VAL

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45723](https://bugs.python.org/issue45723) -->
https://bugs.python.org/issue45723
<!-- /issue-number -->
