### PR TITLE
bpo-45723: Remove obsolete AC_EXEEXT from configure.ac

### DIFF
--- a/configure
+++ b/configure
@@ -5738,7 +5738,6 @@ atheos*|Linux*/1*)
    exit 1;;
 esac
 
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-suffix" >&5
 $as_echo_n "checking for --with-suffix... " >&6; }
 

--- a/configure.ac
+++ b/configure.ac
@@ -947,7 +947,6 @@ atheos*|Linux*/1*)
    exit 1;;
 esac
 
-AC_EXEEXT
 AC_MSG_CHECKING(for --with-suffix)
 AC_ARG_WITH(suffix,
             AS_HELP_STRING([--with-suffix=SUFFIX], [set executable suffix to SUFFIX (default is '.exe')]),


### PR DESCRIPTION
From the autoconf docs *Obsolete Macros* section:

    Defined the output variable EXEEXT based on the output of the 
    compiler, which is now done automatically. Typically set to empty
    string if Posix and ‘.exe’ if a DOS variant.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45723](https://bugs.python.org/issue45723) -->
https://bugs.python.org/issue45723
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran