### PR TITLE
[3.9] bpo-45732: Update bundled Tcl/Tk on Windows to 8.6.12 (GH-29477)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2021-11-08-21-53-11.bpo-45732.idl5kx.rst
+++ b/Misc/NEWS.d/next/Windows/2021-11-08-21-53-11.bpo-45732.idl5kx.rst
@@ -1,0 +1,1 @@
+Updates bundled Tcl/Tk to 8.6.12.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -55,8 +55,8 @@ set libraries=%libraries%                                       bzip2-1.0.6
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.3.0
 if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1l
 set libraries=%libraries%                                       sqlite-3.35.5.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.9.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.9.0
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.12.0
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.12.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tix-8.4.3.6
 set libraries=%libraries%                                       xz-5.2.2
 set libraries=%libraries%                                       zlib-1.2.11
@@ -78,7 +78,7 @@ echo.Fetching external binaries...
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.3.0
 if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1l
-if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.9.0
+if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.12.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 
 for %%b in (%binaries%) do (

--- a/PCbuild/tcltk.props
+++ b/PCbuild/tcltk.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TclMajorVersion>8</TclMajorVersion>
     <TclMinorVersion>6</TclMinorVersion>
-    <TclPatchLevel>9</TclPatchLevel>
+    <TclPatchLevel>12</TclPatchLevel>
     <TclRevision>0</TclRevision>
     <TkMajorVersion>$(TclMajorVersion)</TkMajorVersion>
     <TkMinorVersion>$(TclMinorVersion)</TkMinorVersion>


### PR DESCRIPTION


<!-- issue-number: [bpo-45732](https://bugs.python.org/issue45732) -->
https://bugs.python.org/issue45732
<!-- /issue-number -->
