### PR TITLE
bpo-45771: Handle OSError when reading response data in urllib.request.urlopen

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1733,7 +1733,7 @@ class HandlerTests(unittest.TestCase):
         handler = urllib.request.AbstractHTTPHandler()
         req = Request("http://dummy/")
         req.timeout = None
-        with self.assertRaises(http.client.BadStatusLine):
+        with self.assertRaises(urllib.error.URLError):
             handler.do_open(conn, req)
         self.assertTrue(conn.fakesock.closed, "Connection not closed")
 

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1347,9 +1347,9 @@ class AbstractHTTPHandler(BaseHandler):
             try:
                 h.request(req.get_method(), req.selector, req.data, headers,
                           encode_chunked=req.has_header('Transfer-encoding'))
+                r = h.getresponse()
             except OSError as err: # timeout error
                 raise URLError(err)
-            r = h.getresponse()
         except:
             h.close()
             raise

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1773,6 +1773,7 @@ Robin Thomas
 Brian Thorne
 Christopher Thorne
 Stephen Thorne
+Michael Thorpe
 Jeremy Thurgood
 Eric Tiedemann
 July Tikhonov


### PR DESCRIPTION
`HTTPConnection.getresponse` is documented to raise `ConnectionError`,
but `TimeoutError` (`socket.timeout`) may also be raised while reading.

test plan:
- Existing unit tests
- I couldn't find an easily modifiable existing test to induce this failure, if required I will create a new one

<!-- issue-number: [bpo-45771](https://bugs.python.org/issue45771) -->
https://bugs.python.org/issue45771
<!-- /issue-number -->
