### PR TITLE
bpo-45723: Remove dead code for obsolete `--with-dyld` option

### DIFF
--- a/configure
+++ b/configure
@@ -3315,10 +3315,6 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
-##AC_ARG_WITH(dyld,
-##            AS_HELP_STRING([--with-dyld],
-##                           [use (OpenStep|Rhapsody) dynamic linker]))
-##
 # Set name for machine-dependent library files
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking MACHDEP" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -377,10 +377,6 @@ AC_SUBST(FRAMEWORKINSTALLAPPSPREFIX)
 
 AC_DEFINE_UNQUOTED(_PYTHONFRAMEWORK, "${PYTHONFRAMEWORK}", [framework name])
 
-##AC_ARG_WITH(dyld,
-##            AS_HELP_STRING([--with-dyld],
-##                           [use (OpenStep|Rhapsody) dynamic linker]))
-##
 # Set name for machine-dependent library files
 AC_ARG_VAR([MACHDEP], [name for machine-dependent library files])
 AC_MSG_CHECKING(MACHDEP)


### PR DESCRIPTION
Was commented out by Jack Jansen in 2001-08-15 by commit
b6e9cad34ce46a6a733d8aa5bf5b9d389fa1316f:

"Ripped out Next/OpenStep support, which was broken anyway"

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45723](https://bugs.python.org/issue45723) -->
https://bugs.python.org/issue45723
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran