### PR TITLE
bpo-45220: Ensure RT_MANIFEST is defined when compiling Windows resource files

### DIFF
--- a/PC/pylauncher.rc
+++ b/PC/pylauncher.rc
@@ -2,6 +2,11 @@
 
 #include "python_ver_rc.h"
 
+#ifndef RT_MANIFEST
+// bpo-45220: Cannot reliably #include RT_MANIFEST from
+// anywhere, so we hardcode it
+#define RT_MANIFEST 24
+#endif
 // Include the manifest file that indicates we support all
 // current versions of Windows.
 1 RT_MANIFEST "python.manifest"

--- a/PC/pyshellext.rc
+++ b/PC/pyshellext.rc
@@ -2,6 +2,12 @@
 
 #include "python_ver_rc.h"
 
+#ifndef RT_MANIFEST
+// bpo-45220: Cannot reliably #include RT_MANIFEST from
+// anywhere, so we hardcode it
+#define RT_MANIFEST 24
+#endif
+
 // Include the manifest file that indicates we support all
 // current versions of Windows.
 1 RT_MANIFEST "python.manifest"

--- a/PC/python_exe.rc
+++ b/PC/python_exe.rc
@@ -2,6 +2,12 @@
 
 #include "python_ver_rc.h"
 
+#ifndef RT_MANIFEST
+// bpo-45220: Cannot reliably #include RT_MANIFEST from
+// anywhere, so we hardcode it
+#define RT_MANIFEST 24
+#endif
+
 // Include the manifest file that indicates we support all
 // current versions of Windows.
 1 RT_MANIFEST "python.manifest"

--- a/PC/python_nt.rc
+++ b/PC/python_nt.rc
@@ -2,6 +2,12 @@
 
 #include "python_ver_rc.h"
 
+#ifndef RT_MANIFEST
+// bpo-45220: Cannot reliably #include RT_MANIFEST from
+// anywhere, so we hardcode it
+#define RT_MANIFEST 24
+#endif
+
 // Include the manifest file that indicates we support all
 // current versions of Windows.
 2 RT_MANIFEST "python.manifest"

--- a/PC/pythonw_exe.rc
+++ b/PC/pythonw_exe.rc
@@ -2,6 +2,12 @@
 
 #include "python_ver_rc.h"
 
+#ifndef RT_MANIFEST
+// bpo-45220: Cannot reliably #include RT_MANIFEST from
+// anywhere, so we hardcode it
+#define RT_MANIFEST 24
+#endif
+
 // Include the manifest file that indicates we support all
 // current versions of Windows.
 1 RT_MANIFEST "python.manifest"

--- a/PC/sqlite3.rc
+++ b/PC/sqlite3.rc
@@ -2,6 +2,12 @@
 
 #include <winver.h>
 
+#ifndef RT_MANIFEST
+// bpo-45220: Cannot reliably #include RT_MANIFEST from
+// anywhere, so we hardcode it
+#define RT_MANIFEST 24
+#endif
+
 // Include the manifest file that indicates we support all
 // current versions of Windows.
 2 RT_MANIFEST "python.manifest"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45220](https://bugs.python.org/issue45220) -->
https://bugs.python.org/issue45220
<!-- /issue-number -->
