### PR TITLE
[3.10] bpo-45757: Fix bug where dis produced an incorrect oparg on EXTENDED_ARG before a no-arg opcode (GH-29480)

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -428,6 +428,7 @@ def _unpack_opargs(code):
             extended_arg = (arg << 8) if op == EXTENDED_ARG else 0
         else:
             arg = None
+            extended_arg = 0
         yield (i, op, arg)
 
 def findlabels(code):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -180,6 +180,23 @@ dis_bug42562 = """\
           2 RETURN_VALUE
 """
 
+# Extended arg followed by NOP
+code_bug_45757 = bytes([
+        0x90, 0x01,  # EXTENDED_ARG 0x01
+        0x09, 0xFF,  # NOP 0xFF
+        0x90, 0x01,  # EXTENDED_ARG 0x01
+        0x64, 0x29,  # LOAD_CONST 0x29
+        0x53, 0x00,  # RETURN_VALUE 0x00
+    ])
+
+dis_bug_45757 = """\
+          0 EXTENDED_ARG             1
+          2 NOP
+          4 EXTENDED_ARG             1
+          6 LOAD_CONST             297
+          8 RETURN_VALUE
+"""
+
 _BIG_LINENO_FORMAT = """\
 %3d           0 LOAD_GLOBAL              0 (spam)
               2 POP_TOP
@@ -533,6 +550,10 @@ class DisTests(unittest.TestCase):
 
     def test_bug_42562(self):
         self.do_disassembly_test(bug42562, dis_bug42562)
+
+    def test_bug_45757(self):
+        # Extended arg followed by NOP
+        self.do_disassembly_test(code_bug_45757, dis_bug_45757)
 
     def test_big_linenos(self):
         def func(count):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -193,7 +193,7 @@ dis_bug_45757 = """\
           0 EXTENDED_ARG             1
           2 NOP
           4 EXTENDED_ARG             1
-          6 LOAD_CONST             297
+          6 LOAD_CONST             297 (297)
           8 RETURN_VALUE
 """
 

--- a/Misc/NEWS.d/next/Library/2021-11-08-23-22-14.bpo-45757.MHZHt3.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-08-23-22-14.bpo-45757.MHZHt3.rst
@@ -1,0 +1,1 @@
+Fix bug where :mod:`dis` produced an incorrect oparg when :opcode:`EXTENDED_ARG` is followed by an opcode that does not use its argument.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45757](https://bugs.python.org/issue45757) -->
https://bugs.python.org/issue45757
<!-- /issue-number -->
