### PR TITLE
bpo-34498: Warn against using deprecated ``typing`` aliases with ``@singledispatch``

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -436,8 +436,8 @@ The :mod:`functools` module defines the following functions:
       library. All have been deprecated since Python 3.9 (see :pep:`585`).
       Annotating the first argument of a ``@singledispatch`` implementation
       with one of these aliases is not supported, and will lead to a
-      :exc:`TypeError` being raised. Use :pep:`585`-style syntax instead:
-      ``list[int]`` rather than ``typing.List[int]``,
+      :exc:`TypeError` being raised in Python 3.7 and above. Use
+      :pep:`585`-style syntax instead: ``list`` rather than ``typing.List``,
       ``collections.abc.Iterable[str]`` rather than ``typing.Iterable[str]``,
       etc.
 

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -430,6 +430,17 @@ The :mod:`functools` module defines the following functions:
      ...     for i, elem in enumerate(arg):
      ...         print(i, elem)
 
+   .. note::
+      The :mod:`typing` module provides a number of aliases to
+      builtin classes, as well as classes found elsewhere in the standard
+      library. All have been deprecated since Python 3.9 (see :pep:`585`).
+      Annotating the first argument of a ``@singledispatch`` implementation
+      with one of these aliases is not supported, and will lead to a
+      :exc:`TypeError` being raised. Use :pep:`585`-style syntax instead:
+      ``list[int]`` rather than ``typing.List[int]``,
+      ``collections.abc.Iterable[str]`` rather than ``typing.Iterable[str]``,
+      etc.
+
    For code which doesn't use type annotations, the appropriate type
    argument can be passed explicitly to the decorator itself::
 

--- a/Misc/NEWS.d/next/Documentation/2021-11-09-22-20-54.bpo-34498.oTiZ46.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-11-09-22-20-54.bpo-34498.oTiZ46.rst
@@ -1,0 +1,3 @@
+Add note to :func:`functools.singledispatch` documentation warning that
+attempting to register an implementation with a deprecated alias from the
+:mod:`typing` module is not supported.


### PR DESCRIPTION
Attempting to register a ``singledispatch`` implementation on certain aliases
from the ``typing`` module will lead to an exception being raised. Since these
aliases are all deprecated, this PR proposes simply adding a note to the
documentation steering users towards PEP 585-style syntax.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-34498](https://bugs.python.org/issue34498) -->
https://bugs.python.org/issue34498
<!-- /issue-number -->
