### PR TITLE
[3.9] [bpo-45765] Fix distribution discovery on empty path. (GH-29487).

### DIFF
--- a/Lib/importlib/metadata.py
+++ b/Lib/importlib/metadata.py
@@ -419,7 +419,7 @@ class FastPath:
 
     def children(self):
         with suppress(Exception):
-            return os.listdir(self.root or '')
+            return os.listdir(self.root or '.')
         with suppress(Exception):
             return self.zip_children()
         return []

--- a/Misc/NEWS.d/next/Library/2021-11-09-09-04-19.bpo-45765.JVobxK.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-09-09-04-19.bpo-45765.JVobxK.rst
@@ -1,0 +1,1 @@
+In importlib.metadata, fix distribution discovery for an empty path.


### PR DESCRIPTION
(cherry picked from commit 6ec0dec7b7b50d4fee5b2b66cf38e4291bcdf44c)

Co-authored-by: Jason R. Coombs <jaraco@jaraco.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45765](https://bugs.python.org/issue45765) -->
https://bugs.python.org/issue45765
<!-- /issue-number -->
