### PR TITLE
bpo-45745: Remove regrtest --findleaks options

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -149,7 +149,6 @@ class Namespace(argparse.Namespace):
         self.single = False
         self.randomize = False
         self.fromfile = None
-        self.findleaks = 1
         self.fail_env_changed = False
         self.use_resources = None
         self.trace = False
@@ -266,9 +265,6 @@ def _create_parser():
                             '(instead of the Python stdlib test suite)')
 
     group = parser.add_argument_group('Special runs')
-    group.add_argument('-l', '--findleaks', action='store_const', const=2,
-                       default=1,
-                       help='deprecated alias to --fail-env-changed')
     group.add_argument('-L', '--runleaks', action='store_true',
                        help='run the leaks(1) command just before exit.' +
                             more_details)
@@ -370,9 +366,6 @@ def _parse_args(args, **kwargs):
             parser.error("unrecognized arguments: %s" % arg)
             sys.exit(1)
 
-    if ns.findleaks > 1:
-        # --findleaks implies --fail-env-changed
-        ns.fail_env_changed = True
     if ns.single and ns.fromfile:
         parser.error("-s and -f don't go together!")
     if ns.use_mp is not None and ns.trace:

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -46,7 +46,7 @@ class Regrtest:
     files beginning with test_ will be used.
 
     The other default arguments (verbose, quiet, exclude,
-    single, randomize, findleaks, use_resources, trace, coverdir,
+    single, randomize, use_resources, trace, coverdir,
     print_slow, and random_seed) allow programmers calling main()
     directly to set the values that would normally be set by flags
     on the command line.

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -138,7 +138,7 @@ STDTESTS = [
 NOTTESTS = set()
 
 
-# used by --findleaks, store for gc.garbage
+# Storage of uncollectable objects
 FOUND_GARBAGE = []
 
 
@@ -279,7 +279,7 @@ def save_env(ns: Namespace, test_name: str):
 
 def _runtest_inner2(ns: Namespace, test_name: str) -> bool:
     # Load the test function, run the test function, handle huntrleaks
-    # and findleaks to detect leaks
+    # to detect leaks.
 
     abstest = get_abs_module(ns, test_name)
 

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1178,7 +1178,7 @@ class ArgsTestCase(BaseTestCase):
                                   no_test_ran=[testname])
 
     @support.cpython_only
-    def test_findleaks(self):
+    def test_uncollectable(self):
         code = textwrap.dedent(r"""
             import _testcapi
             import gc
@@ -1199,12 +1199,6 @@ class ArgsTestCase(BaseTestCase):
         testname = self.create_test(code=code)
 
         output = self.run_tests("--fail-env-changed", testname, exitcode=3)
-        self.check_executed_tests(output, [testname],
-                                  env_changed=[testname],
-                                  fail_env_changed=True)
-
-        # --findleaks is now basically an alias to --fail-env-changed
-        output = self.run_tests("--findleaks", testname, exitcode=3)
         self.check_executed_tests(output, [testname],
                                   env_changed=[testname],
                                   fail_env_changed=True)

--- a/Misc/NEWS.d/next/Tests/2021-11-10-12-01-28.bpo-45745.wX5B3K.rst
+++ b/Misc/NEWS.d/next/Tests/2021-11-10-12-01-28.bpo-45745.wX5B3K.rst
@@ -1,0 +1,3 @@
+Remove the ``--findleaks`` command line option of regrtest: use the
+``--fail-env-changed`` option instead. Since Python 3.7, it was a deprecated
+alias to the ``--fail-env-changed`` option.


### PR DESCRIPTION
Remove the --findleaks command line option of regrtest: use the
--fail-env-changed option instead. Since Python 3.7, it was a
deprecated alias to the --fail-env-changed option.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45745](https://bugs.python.org/issue45745) -->
https://bugs.python.org/issue45745
<!-- /issue-number -->
