### PR TITLE
bpo-45753: Make recursion checks more efficient.

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -80,6 +80,7 @@ struct _ts {
     PyInterpreterState *interp;
 
     int recursion_remaining;
+    int recursion_limit;
     int recursion_headroom; /* Allow 50 more calls to handle any errors. */
 
     /* 'tracing' keeps track of the execution depth when tracing/profiling.

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -79,9 +79,8 @@ struct _ts {
     struct _ts *next;
     PyInterpreterState *interp;
 
-    int recursion_depth;
+    int recursion_spare;
     int recursion_headroom; /* Allow 50 more calls to handle any errors. */
-    int stackcheck_counter;
 
     /* 'tracing' keeps track of the execution depth when tracing/profiling.
        This is to prevent the actual trace/profile code from being recorded in

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -79,7 +79,7 @@ struct _ts {
     struct _ts *next;
     PyInterpreterState *interp;
 
-    int recursion_spare;
+    int recursion_remaining;
     int recursion_headroom; /* Allow 50 more calls to handle any errors. */
 
     /* 'tracing' keeps track of the execution depth when tracing/profiling.

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -75,12 +75,12 @@ extern void _PyEval_DeactivateOpCache(void);
 /* With USE_STACKCHECK macro defined, trigger stack checks in
    _Py_CheckRecursiveCall() on every 64th call to Py_EnterRecursiveCall. */
 static inline int _Py_MakeRecCheck(PyThreadState *tstate)  {
-    return (tstate->recursion_spare-- <= 0
-            || (tstate->recursion_spare & 63) == 0);
+    return (tstate->recursion_remaining-- <= 0
+            || (tstate->recursion_remaining & 63) == 0);
 }
 #else
 static inline int _Py_MakeRecCheck(PyThreadState *tstate) {
-    return tstate->recursion_spare-- <= 0;
+    return tstate->recursion_remaining-- <= 0;
 }
 #endif
 
@@ -101,7 +101,7 @@ static inline int _Py_EnterRecursiveCall_inline(const char *where) {
 #define Py_EnterRecursiveCall(where) _Py_EnterRecursiveCall_inline(where)
 
 static inline void _Py_LeaveRecursiveCall(PyThreadState *tstate)  {
-    tstate->recursion_spare++;
+    tstate->recursion_remaining++;
 }
 
 static inline void _Py_LeaveRecursiveCall_inline(void)  {

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -75,12 +75,12 @@ extern void _PyEval_DeactivateOpCache(void);
 /* With USE_STACKCHECK macro defined, trigger stack checks in
    _Py_CheckRecursiveCall() on every 64th call to Py_EnterRecursiveCall. */
 static inline int _Py_MakeRecCheck(PyThreadState *tstate)  {
-    return (++tstate->recursion_depth > tstate->interp->ceval.recursion_limit
-            || ++tstate->stackcheck_counter > 64);
+    return (tstate->recursion_spare-- <= 0
+            || (tstate->recursion_spare & 63) == 0);
 }
 #else
 static inline int _Py_MakeRecCheck(PyThreadState *tstate) {
-    return (++tstate->recursion_depth > tstate->interp->ceval.recursion_limit);
+    return tstate->recursion_spare-- <= 0;
 }
 #endif
 
@@ -101,7 +101,7 @@ static inline int _Py_EnterRecursiveCall_inline(const char *where) {
 #define Py_EnterRecursiveCall(where) _Py_EnterRecursiveCall_inline(where)
 
 static inline void _Py_LeaveRecursiveCall(PyThreadState *tstate)  {
-    tstate->recursion_depth--;
+    tstate->recursion_spare++;
 }
 
 static inline void _Py_LeaveRecursiveCall_inline(void)  {

--- a/Misc/NEWS.d/next/Core and Builtins/2021-11-11-17-14-21.bpo-45753.nEBFcC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-11-11-17-14-21.bpo-45753.nEBFcC.rst
@@ -1,0 +1,2 @@
+Make recursion checks a bit more efficient by tracking amount of calls left
+before overflow.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -38,7 +38,7 @@ get_recursion_depth(PyObject *self, PyObject *Py_UNUSED(args))
 
     /* subtract one to ignore the frame of the get_recursion_depth() call */
 
-    return PyLong_FromLong(tstate->interp->ceval.recursion_limit - tstate->recursion_remaining - 1);
+    return PyLong_FromLong(tstate->recursion_limit - tstate->recursion_remaining - 1);
 }
 
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -37,7 +37,8 @@ get_recursion_depth(PyObject *self, PyObject *Py_UNUSED(args))
     PyThreadState *tstate = _PyThreadState_GET();
 
     /* subtract one to ignore the frame of the get_recursion_depth() call */
-    return PyLong_FromLong(tstate->recursion_depth - 1);
+
+    return PyLong_FromLong(tstate->interp->ceval.recursion_limit - tstate->recursion_spare - 1);
 }
 
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -38,7 +38,7 @@ get_recursion_depth(PyObject *self, PyObject *Py_UNUSED(args))
 
     /* subtract one to ignore the frame of the get_recursion_depth() call */
 
-    return PyLong_FromLong(tstate->interp->ceval.recursion_limit - tstate->recursion_spare - 1);
+    return PyLong_FromLong(tstate->interp->ceval.recursion_limit - tstate->recursion_remaining - 1);
 }
 
 

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4,7 +4,6 @@
  */
 #include "Python.h"
 #include "pycore_ast.h"           // asdl_stmt_seq
-#include "pycore_interp.h"        // recursion limit
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 
 #include <assert.h>
@@ -934,7 +933,7 @@ _PyAST_Validate(mod_ty mod)
         return 0;
     }
     /* Be careful here to prevent overflow. */
-    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_remaining;
+    int recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;
     starting_recursion_depth = (recursion_depth< INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
         recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
     state.recursion_depth = starting_recursion_depth;

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -934,7 +934,7 @@ _PyAST_Validate(mod_ty mod)
         return 0;
     }
     /* Be careful here to prevent overflow. */
-    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_spare;
+    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_remaining;
     starting_recursion_depth = (recursion_depth< INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
         recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
     state.recursion_depth = starting_recursion_depth;

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4,6 +4,7 @@
  */
 #include "Python.h"
 #include "pycore_ast.h"           // asdl_stmt_seq
+#include "pycore_interp.h"        // recursion limit
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 
 #include <assert.h>
@@ -933,8 +934,9 @@ _PyAST_Validate(mod_ty mod)
         return 0;
     }
     /* Be careful here to prevent overflow. */
-    starting_recursion_depth = (tstate->recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        tstate->recursion_depth * COMPILER_STACK_FRAME_SCALE : tstate->recursion_depth;
+    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_spare;
+    starting_recursion_depth = (recursion_depth< INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
+        recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
     state.recursion_depth = starting_recursion_depth;
     state.recursion_limit = (recursion_limit < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
         recursion_limit * COMPILER_STACK_FRAME_SCALE : recursion_limit;

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -2,7 +2,6 @@
 #include "Python.h"
 #include "pycore_ast.h"           // _PyAST_GetDocString()
 #include "pycore_compile.h"       // _PyASTOptimizeState
-#include "pycore_interp.h"        // recursion limit
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_format.h"        // F_LJUST
 
@@ -1099,7 +1098,7 @@ _PyAST_Optimize(mod_ty mod, PyArena *arena, _PyASTOptimizeState *state)
         return 0;
     }
     /* Be careful here to prevent overflow. */
-    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_remaining;
+    int recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;
     starting_recursion_depth = (recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
         recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
     state->recursion_depth = starting_recursion_depth;

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -2,6 +2,7 @@
 #include "Python.h"
 #include "pycore_ast.h"           // _PyAST_GetDocString()
 #include "pycore_compile.h"       // _PyASTOptimizeState
+#include "pycore_interp.h"        // recursion limit
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_format.h"        // F_LJUST
 
@@ -1098,8 +1099,9 @@ _PyAST_Optimize(mod_ty mod, PyArena *arena, _PyASTOptimizeState *state)
         return 0;
     }
     /* Be careful here to prevent overflow. */
-    starting_recursion_depth = (tstate->recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        tstate->recursion_depth * COMPILER_STACK_FRAME_SCALE : tstate->recursion_depth;
+    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_spare;
+    starting_recursion_depth = (recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
+        recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
     state->recursion_depth = starting_recursion_depth;
     state->recursion_limit = (recursion_limit < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
         recursion_limit * COMPILER_STACK_FRAME_SCALE : recursion_limit;

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -1099,7 +1099,7 @@ _PyAST_Optimize(mod_ty mod, PyArena *arena, _PyASTOptimizeState *state)
         return 0;
     }
     /* Be careful here to prevent overflow. */
-    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_spare;
+    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_remaining;
     starting_recursion_depth = (recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
         recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
     state->recursion_depth = starting_recursion_depth;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -636,7 +636,8 @@ new_threadstate(PyInterpreterState *interp, int init)
 
     tstate->interp = interp;
 
-    tstate->recursion_remaining = INT_MIN/2;
+    tstate->recursion_limit = interp->ceval.recursion_limit;
+    tstate->recursion_remaining = interp->ceval.recursion_limit;
     tstate->recursion_headroom = 0;
     tstate->tracing = 0;
     tstate->root_cframe.use_tracing = 0;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -636,7 +636,7 @@ new_threadstate(PyInterpreterState *interp, int init)
 
     tstate->interp = interp;
 
-    tstate->recursion_remaining = interp->ceval.recursion_limit;
+    tstate->recursion_remaining = INT_MIN/2;
     tstate->recursion_headroom = 0;
     tstate->tracing = 0;
     tstate->root_cframe.use_tracing = 0;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -636,7 +636,7 @@ new_threadstate(PyInterpreterState *interp, int init)
 
     tstate->interp = interp;
 
-    tstate->recursion_spare = interp->ceval.recursion_limit;
+    tstate->recursion_remaining = interp->ceval.recursion_limit;
     tstate->recursion_headroom = 0;
     tstate->tracing = 0;
     tstate->root_cframe.use_tracing = 0;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -636,9 +636,8 @@ new_threadstate(PyInterpreterState *interp, int init)
 
     tstate->interp = interp;
 
-    tstate->recursion_depth = 0;
+    tstate->recursion_spare = interp->ceval.recursion_limit;
     tstate->recursion_headroom = 0;
-    tstate->stackcheck_counter = 0;
     tstate->tracing = 0;
     tstate->root_cframe.use_tracing = 0;
     tstate->root_cframe.current_frame = NULL;

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1,7 +1,6 @@
 #include "Python.h"
 #include "pycore_ast.h"           // identifier, stmt_ty
 #include "pycore_compile.h"       // _Py_Mangle(), _PyFuture_FromAST()
-#include "pycore_interp.h"        // recursion limit
 #include "pycore_parser.h"        // _PyParser_ASTFromString()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_symtable.h"      // PySTEntryObject
@@ -299,7 +298,7 @@ _PySymtable_Build(mod_ty mod, PyObject *filename, PyFutureFeatures *future)
         return NULL;
     }
     /* Be careful here to prevent overflow. */
-    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_remaining;
+    int recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;
     starting_recursion_depth = (recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
         recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
     st->recursion_depth = starting_recursion_depth;

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1,6 +1,7 @@
 #include "Python.h"
 #include "pycore_ast.h"           // identifier, stmt_ty
 #include "pycore_compile.h"       // _Py_Mangle(), _PyFuture_FromAST()
+#include "pycore_interp.h"        // recursion limit
 #include "pycore_parser.h"        // _PyParser_ASTFromString()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_symtable.h"      // PySTEntryObject
@@ -298,8 +299,9 @@ _PySymtable_Build(mod_ty mod, PyObject *filename, PyFutureFeatures *future)
         return NULL;
     }
     /* Be careful here to prevent overflow. */
-    starting_recursion_depth = (tstate->recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        tstate->recursion_depth * COMPILER_STACK_FRAME_SCALE : tstate->recursion_depth;
+    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_spare;
+    starting_recursion_depth = (recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
+        recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
     st->recursion_depth = starting_recursion_depth;
     st->recursion_limit = (recursion_limit < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
         recursion_limit * COMPILER_STACK_FRAME_SCALE : recursion_limit;

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -299,7 +299,7 @@ _PySymtable_Build(mod_ty mod, PyObject *filename, PyFutureFeatures *future)
         return NULL;
     }
     /* Be careful here to prevent overflow. */
-    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_spare;
+    int recursion_depth = tstate->interp->ceval.recursion_limit - tstate->recursion_remaining;
     starting_recursion_depth = (recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
         recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
     st->recursion_depth = starting_recursion_depth;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1187,20 +1187,14 @@ sys_setrecursionlimit_impl(PyObject *module, int new_limit)
         return NULL;
     }
 
-    /* Issue #25274: When the recursion depth hits the recursion limit in
-       _Py_CheckRecursiveCall(), the overflowed flag of the thread state is
-       set to 1 and a RecursionError is raised. The overflowed flag is reset
-       to 0 when the recursion depth goes below the low-water mark: see
-       Py_LeaveRecursiveCall().
-
-       Reject too low new limit if the current recursion depth is higher than
-       the new low-water mark. Otherwise it may not be possible anymore to
-       reset the overflowed flag to 0. */
-    if (tstate->interp->ceval.recursion_limit - tstate->recursion_remaining > new_limit) {
+    /* Reject too low new limit if the current recursion depth is higher than
+       the new low-water mark. */
+    int depth = tstate->recursion_limit - tstate->recursion_remaining;
+    if (depth > new_limit) {
         _PyErr_Format(tstate, PyExc_RecursionError,
                       "cannot set the recursion limit to %i at "
                       "the recursion depth %i: the limit is too low",
-                      new_limit, tstate->interp->ceval.recursion_limit - tstate->recursion_remaining);
+                      new_limit, depth);
         return NULL;
     }
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1190,7 +1190,7 @@ sys_setrecursionlimit_impl(PyObject *module, int new_limit)
     /* Reject too low new limit if the current recursion depth is higher than
        the new low-water mark. */
     int depth = tstate->recursion_limit - tstate->recursion_remaining;
-    if (depth > new_limit) {
+    if (depth >= new_limit) {
         _PyErr_Format(tstate, PyExc_RecursionError,
                       "cannot set the recursion limit to %i at "
                       "the recursion depth %i: the limit is too low",

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1196,11 +1196,11 @@ sys_setrecursionlimit_impl(PyObject *module, int new_limit)
        Reject too low new limit if the current recursion depth is higher than
        the new low-water mark. Otherwise it may not be possible anymore to
        reset the overflowed flag to 0. */
-    if (tstate->interp->ceval.recursion_limit - tstate->recursion_spare > new_limit) {
+    if (tstate->interp->ceval.recursion_limit - tstate->recursion_remaining > new_limit) {
         _PyErr_Format(tstate, PyExc_RecursionError,
                       "cannot set the recursion limit to %i at "
                       "the recursion depth %i: the limit is too low",
-                      new_limit, tstate->interp->ceval.recursion_limit - tstate->recursion_spare);
+                      new_limit, tstate->interp->ceval.recursion_limit - tstate->recursion_remaining);
         return NULL;
     }
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1196,11 +1196,11 @@ sys_setrecursionlimit_impl(PyObject *module, int new_limit)
        Reject too low new limit if the current recursion depth is higher than
        the new low-water mark. Otherwise it may not be possible anymore to
        reset the overflowed flag to 0. */
-    if (tstate->recursion_depth >= new_limit) {
+    if (tstate->interp->ceval.recursion_limit - tstate->recursion_spare > new_limit) {
         _PyErr_Format(tstate, PyExc_RecursionError,
                       "cannot set the recursion limit to %i at "
                       "the recursion depth %i: the limit is too low",
-                      new_limit, tstate->recursion_depth);
+                      new_limit, tstate->interp->ceval.recursion_limit - tstate->recursion_spare);
         return NULL;
     }
 


### PR DESCRIPTION
Should, in theory, be faster.
Seems to provide a [small speedup](https://gist.github.com/markshannon/cfd9bf5107f188312c338876971d44d0) when tested.

<!-- issue-number: [bpo-45753](https://bugs.python.org/issue45753) -->
https://bugs.python.org/issue45753
<!-- /issue-number -->
