### PR TITLE
bpo-45783: Preserve file moves and deletions in the tests for the freeze tool.

### DIFF
--- a/Lib/test/test_tools/test_freeze.py
+++ b/Lib/test/test_tools/test_freeze.py
@@ -5,6 +5,7 @@ import textwrap
 import unittest
 
 from test import support
+from test.support import os_helper
 
 from . import imports_under_tool, skip_if_missing
 skip_if_missing('freeze')
@@ -22,8 +23,8 @@ class TestFreeze(unittest.TestCase):
             print('running...')
             sys.exit(0)
             """)
-        outdir, scriptfile, python = helper.prepare(script)
-
-        executable = helper.freeze(python, scriptfile, outdir)
-        text = helper.run(executable)
+        with os_helper.temp_dir() as outdir:
+            outdir, scriptfile, python = helper.prepare(script, outdir)
+            executable = helper.freeze(python, scriptfile, outdir)
+            text = helper.run(executable)
         self.assertEqual(text, 'running...')

--- a/Misc/NEWS.d/next/Tests/2021-11-11-13-56-00.bpo-45783.8k1Rng.rst
+++ b/Misc/NEWS.d/next/Tests/2021-11-11-13-56-00.bpo-45783.8k1Rng.rst
@@ -1,0 +1,1 @@
+The test for the freeze tool now handles file moves and deletions.

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -157,7 +157,8 @@ def prepare(script=None, outdir=None):
         with open(scriptfile, 'w') as outfile:
             outfile.write(script)
 
-    # Make a copy of the repo to avoid affecting the current build.
+    # Make a copy of the repo to avoid affecting the current build
+    # (e.g. changing PREFIX).
     srcdir = os.path.join(outdir, 'cpython')
     git_copy_repo(srcdir, SRCDIR)
 

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -75,6 +75,16 @@ def ensure_opt(args, name, value):
             args[pos] = f'{opt}={value}'
 
 
+def copy_source_tree(newroot, oldroot):
+    print(f'copying the source tree into {newroot}...')
+    if os.path.exists(newroot):
+        if newroot == SRCDIR:
+            raise Exception('this probably isn\'t what you wanted')
+        shutil.rmtree(newroot)
+    shutil.copytree(oldroot, newroot)
+    _run_quiet([MAKE, 'clean'], newroot)
+
+
 def git_copy_repo(newroot, oldroot):
     if not GIT:
         raise UnsupportedError('git')
@@ -160,7 +170,10 @@ def prepare(script=None, outdir=None):
     # Make a copy of the repo to avoid affecting the current build
     # (e.g. changing PREFIX).
     srcdir = os.path.join(outdir, 'cpython')
-    git_copy_repo(srcdir, SRCDIR)
+    if os.path.exists(os.path.join(SRCDIR, '.git')):
+        git_copy_repo(srcdir, SRCDIR)
+    else:
+        copy_source_tree(srcdir, SRCDIR)
 
     # We use an out-of-tree build (instead of srcdir).
     builddir = os.path.join(outdir, 'python-build')

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -81,7 +81,8 @@ def copy_source_tree(newroot, oldroot):
             raise Exception('this probably isn\'t what you wanted')
         shutil.rmtree(newroot)
     shutil.copytree(oldroot, newroot)
-    _run_quiet([MAKE, 'clean'], newroot)
+    if os.path.exists(os.path.join(newroot, 'Makefile')):
+        _run_quiet([MAKE, 'clean'], newroot)
 
 
 def get_makefile_var(builddir, name):

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -94,7 +94,8 @@ def git_copy_repo(newroot, oldroot):
     # Copy over any uncommited files.
     text = _run_stdout([GIT, 'status', '--porcelain=1'], oldroot)
     for line in text.splitlines():
-        _, _, relfile = line.strip().partition(' ')
+        _, _, loc = line.strip().partition(' ')
+        _, _, relfile = loc.rpartition(' -> ')
         relfile = relfile.strip()
         isdir = relfile.endswith(os.path.sep)
         relfile = relfile.rstrip(os.path.sep)

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -83,7 +83,7 @@ def git_copy_repo(newroot, oldroot):
         print(f'updating copied repo {newroot}...')
         if newroot == SRCDIR:
             raise Exception('this probably isn\'t what you wanted')
-        _run_quiet([GIT, 'clean', '-d', '-f'], newroot)
+        _run_quiet([GIT, 'clean', '-d', '-x', '--force'], newroot)
         _run_quiet([GIT, 'reset'], newroot)
         _run_quiet([GIT, 'checkout', '.'], newroot)
         _run_quiet([GIT, 'pull', '-f', oldroot], newroot)

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -151,6 +151,7 @@ def prepare(script=None, outdir=None):
     # Write the script to disk.
     if script:
         scriptfile = os.path.join(outdir, 'app.py')
+        print(f'creating the script to be frozen at {scriptfile}')
         with open(scriptfile, 'w') as outfile:
             outfile.write(script)
 
@@ -177,7 +178,7 @@ def prepare(script=None, outdir=None):
         raise UnsupportedError('make')
 
     # Build python.
-    print('building python...')
+    print(f'building python in {builddir}...')
     if os.path.exists(os.path.join(srcdir, 'Makefile')):
         # Out-of-tree builds require a clean srcdir.
         _run_quiet([MAKE, '-C', srcdir, 'clean'])

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -83,10 +83,10 @@ def git_copy_repo(newroot, oldroot):
         print(f'updating copied repo {newroot}...')
         if newroot == SRCDIR:
             raise Exception('this probably isn\'t what you wanted')
+        rev = _run_stdout([GIT, 'rev-parse', 'HEAD'], newroot)
         _run_quiet([GIT, 'clean', '-d', '-x', '--force'], newroot)
-        _run_quiet([GIT, 'reset'], newroot)
-        _run_quiet([GIT, 'checkout', '.'], newroot)
-        _run_quiet([GIT, 'pull', '-f', oldroot], newroot)
+        _run_quiet([GIT, 'fetch', oldroot], newroot)
+        _run_quiet([GIT, 'reset', '--hard', rev], newroot)
     else:
         print(f'copying repo into {newroot}...')
         _run_quiet([GIT, 'clone', oldroot, newroot])

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -101,11 +101,15 @@ def git_copy_repo(newroot, oldroot):
         relfile = relfile.rstrip(os.path.sep)
         srcfile = os.path.join(oldroot, relfile)
         dstfile = os.path.join(newroot, relfile)
-        os.makedirs(os.path.dirname(dstfile), exist_ok=True)
-        if isdir:
-            shutil.copytree(srcfile, dstfile, dirs_exist_ok=True)
+        if os.path.exists(srcfile):
+            os.makedirs(os.path.dirname(dstfile), exist_ok=True)
+            if isdir:
+                shutil.copytree(srcfile, dstfile, dirs_exist_ok=True)
+            else:
+                shutil.copy2(srcfile, dstfile)
         else:
-            shutil.copy2(srcfile, dstfile)
+            # Only single files will show up here.
+            os.unlink(dstfile)
 
 
 def get_makefile_var(builddir, name):

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -108,8 +108,10 @@ def git_copy_repo(newroot, oldroot):
             else:
                 shutil.copy2(srcfile, dstfile)
         else:
-            # Only single files will show up here.
-            os.unlink(dstfile)
+            if isdir:
+                shutil.rmtree(dstfile)
+            else:
+                os.unlink(dstfile)
 
 
 def get_makefile_var(builddir, name):

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -92,7 +92,7 @@ def git_copy_repo(newroot, oldroot):
         _run_quiet([GIT, 'clone', oldroot, newroot])
 
     # Copy over any uncommited files.
-    text = _run_stdout([GIT, 'status', '-s'], oldroot)
+    text = _run_stdout([GIT, 'status', '--porcelain=1'], oldroot)
     for line in text.splitlines():
         _, _, relfile = line.strip().partition(' ')
         relfile = relfile.strip()


### PR DESCRIPTION
The prep code for the test wasn't handling the case where uncommitted files were deleted or moved.  This change takes care of that.  We also ensure more consistent results by using `git status --porcelain` instead of `git status -s`, as well as `git clean -x` and `git reset --hard`.

<!-- issue-number: [bpo-45783](https://bugs.python.org/issue45783) -->
https://bugs.python.org/issue45783
<!-- /issue-number -->