### PR TITLE
bpo-45792: Fix contextvar.Token's intersphinx FQN

### DIFF
--- a/Doc/library/contextvars.rst
+++ b/Doc/library/contextvars.rst
@@ -94,7 +94,7 @@ Context Variables
           # var.get() would raise a LookupError.
 
 
-.. class:: contextvars.Token
+.. class:: Token
 
    *Token* objects are returned by the :meth:`ContextVar.set` method.
    They can be passed to the :meth:`ContextVar.reset` method to revert


### PR DESCRIPTION
Since `.. module:: contextvars` sets the module using `.. class:: contextvars.Token`, intersphinx records it as `contextvars.contextvars.Token`.

<!-- issue-number: [bpo-45792](https://bugs.python.org/issue45792) -->
https://bugs.python.org/issue45792
<!-- /issue-number -->
