### PR TITLE
[doc] Clarify MRO precedence in descriptor super binding section

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1820,7 +1820,7 @@ Class Binding
 Super Binding
    If ``a`` is an instance of :class:`super`, then the binding ``super(B, obj).m()``
    searches ``obj.__class__.__mro__`` for the base class ``A``
-   immediately preceding ``B`` and then invokes the descriptor with the call:
+   immediately following ``B`` and then invokes the descriptor with the call:
    ``A.__dict__['m'].__get__(obj, obj.__class__)``.
 
 For instance bindings, the precedence of descriptor invocation depends on


### PR DESCRIPTION
A similar sentence is present in the 'Invocation from super' section of
the descriptor howto, where it is already correct.

---
This is a trivial change.