### PR TITLE
bpo-45798: Move _decimal build setup into configure (GH-29541)

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -496,6 +496,45 @@ LIBRARY_OBJS=	\
 DTRACE_DEPS = \
 	Python/ceval.o Python/import.o Python/sysmodule.o Modules/gcmodule.o
 
+##########################################################################
+# decimal's libmpdec
+
+LIBMPDEC_OBJS= \
+		Modules/_decimal/libmpdec/basearith.o \
+		Modules/_decimal/libmpdec/constants.o \
+		Modules/_decimal/libmpdec/context.o \
+		Modules/_decimal/libmpdec/convolute.o \
+		Modules/_decimal/libmpdec/crt.o \
+		Modules/_decimal/libmpdec/difradix2.o \
+		Modules/_decimal/libmpdec/fnt.o \
+		Modules/_decimal/libmpdec/fourstep.o \
+		Modules/_decimal/libmpdec/io.o \
+		Modules/_decimal/libmpdec/mpalloc.o \
+		Modules/_decimal/libmpdec/mpdecimal.o \
+		Modules/_decimal/libmpdec/numbertheory.o \
+		Modules/_decimal/libmpdec/sixstep.o \
+		Modules/_decimal/libmpdec/transpose.o
+
+LIBMPDEC_HEADERS= \
+		$(srcdir)/Modules/_decimal/libmpdec/basearith.h \
+		$(srcdir)/Modules/_decimal/libmpdec/bits.h \
+		$(srcdir)/Modules/_decimal/libmpdec/constants.h \
+		$(srcdir)/Modules/_decimal/libmpdec/convolute.h \
+		$(srcdir)/Modules/_decimal/libmpdec/crt.h \
+		$(srcdir)/Modules/_decimal/libmpdec/difradix2.h \
+		$(srcdir)/Modules/_decimal/libmpdec/fnt.h \
+		$(srcdir)/Modules/_decimal/libmpdec/fourstep.h \
+		$(srcdir)/Modules/_decimal/libmpdec/io.h \
+		$(srcdir)/Modules/_decimal/libmpdec/mpalloc.h \
+		$(srcdir)/Modules/_decimal/libmpdec/mpdecimal.h \
+		$(srcdir)/Modules/_decimal/libmpdec/numbertheory.h \
+		$(srcdir)/Modules/_decimal/libmpdec/sixstep.h \
+		$(srcdir)/Modules/_decimal/libmpdec/transpose.h \
+		$(srcdir)/Modules/_decimal/libmpdec/typearith.h \
+		$(srcdir)/Modules/_decimal/libmpdec/umodarith.h
+
+LIBMPDEC_A= Modules/_decimal/libmpdec/libmpdec.a
+
 #########################################################################
 # Rules
 
@@ -647,7 +686,7 @@ $(srcdir)/Modules/_blake2/blake2s_impl.c: $(srcdir)/Modules/_blake2/blake2b_impl
 # -s, --silent or --quiet is always the first char.
 # Under BSD make, MAKEFLAGS might be " -s -v x=y".
 # Ignore macros passed by GNU make, passed after --
-sharedmods: $(BUILDPYTHON) pybuilddir.txt
+sharedmods: $(BUILDPYTHON) pybuilddir.txt @LIBMPDEC_INTERNAL@
 	@case "`echo X $$MAKEFLAGS | sed 's/^X //;s/ -- .*//'`" in \
 	    *\ -s*|s*) quiet="-q";; \
 	    *) quiet="";; \
@@ -729,6 +768,60 @@ $(DLLLIBRARY) libpython$(LDVERSION).dll.a: $(LIBRARY_OBJS)
 	else true; \
 	fi
 
+##########################################################################
+# Build static libmpdec.a
+LIBMPDEC_CFLAGS=$(PY_STDMODULE_CFLAGS) $(CCSHARED) @LIBMPDEC_CFLAGS@
+
+# for setup.py
+DECIMAL_CFLAGS=@LIBMPDEC_CFLAGS@
+DECIMAL_LDFLAGS=@LIBMPDEC_LDFLAGS@
+
+# "%.o: %c" is not portable
+Modules/_decimal/libmpdec/basearith.o: $(srcdir)/Modules/_decimal/libmpdec/basearith.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/basearith.c
+
+Modules/_decimal/libmpdec/constants.o: $(srcdir)/Modules/_decimal/libmpdec/constants.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/constants.c
+
+Modules/_decimal/libmpdec/context.o: $(srcdir)/Modules/_decimal/libmpdec/context.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/context.c
+
+Modules/_decimal/libmpdec/convolute.o: $(srcdir)/Modules/_decimal/libmpdec/convolute.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/convolute.c
+
+Modules/_decimal/libmpdec/crt.o: $(srcdir)/Modules/_decimal/libmpdec/crt.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/crt.c
+
+Modules/_decimal/libmpdec/difradix2.o: $(srcdir)/Modules/_decimal/libmpdec/difradix2.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/difradix2.c
+
+Modules/_decimal/libmpdec/fnt.o: $(srcdir)/Modules/_decimal/libmpdec/fnt.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/fnt.c
+
+Modules/_decimal/libmpdec/fourstep.o: $(srcdir)/Modules/_decimal/libmpdec/fourstep.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/fourstep.c
+
+Modules/_decimal/libmpdec/io.o: $(srcdir)/Modules/_decimal/libmpdec/io.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/io.c
+
+Modules/_decimal/libmpdec/mpalloc.o: $(srcdir)/Modules/_decimal/libmpdec/mpalloc.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/mpalloc.c
+
+Modules/_decimal/libmpdec/mpdecimal.o: $(srcdir)/Modules/_decimal/libmpdec/mpdecimal.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/mpdecimal.c
+
+Modules/_decimal/libmpdec/numbertheory.o: $(srcdir)/Modules/_decimal/libmpdec/numbertheory.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/numbertheory.c
+
+Modules/_decimal/libmpdec/sixstep.o: $(srcdir)/Modules/_decimal/libmpdec/sixstep.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/sixstep.c
+
+Modules/_decimal/libmpdec/transpose.o: $(srcdir)/Modules/_decimal/libmpdec/transpose.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/transpose.c
+
+$(LIBMPDEC_A): $(LIBMPDEC_OBJS)
+	-rm -f $@
+	$(AR) $(ARFLAGS) $@ $(LIBMPDEC_OBJS)
 
 # create relative links from build/lib.platform/egg.so to Modules/egg.so
 # pybuilddir.txt is created too late. We cannot use it in Makefile
@@ -2313,7 +2406,7 @@ MODULE_PYEXPAT_DEPS=$(srcdir)/Modules/expat/ascii.h $(srcdir)/Modules/expat/asci
 MODULE_UNICODEDATA_DEPS=$(srcdir)/Modules/unicodedata_db.h $(srcdir)/Modules/unicodename_db.h
 MODULE__BLAKE2_DEPS=$(srcdir)/Modules/_blake2/impl/blake2-config.h $(srcdir)/Modules/_blake2/impl/blake2-dispatch.c $(srcdir)/Modules/_blake2/impl/blake2-impl.h $(srcdir)/Modules/_blake2/impl/blake2-kat.h $(srcdir)/Modules/_blake2/impl/blake2.h $(srcdir)/Modules/_blake2/impl/blake2b-load-sse2.h $(srcdir)/Modules/_blake2/impl/blake2b-load-sse41.h $(srcdir)/Modules/_blake2/impl/blake2b-ref.c $(srcdir)/Modules/_blake2/impl/blake2b-round.h $(srcdir)/Modules/_blake2/impl/blake2b-test.c $(srcdir)/Modules/_blake2/impl/blake2b.c $(srcdir)/Modules/_blake2/impl/blake2bp-test.c $(srcdir)/Modules/_blake2/impl/blake2bp.c $(srcdir)/Modules/_blake2/impl/blake2s-load-sse2.h $(srcdir)/Modules/_blake2/impl/blake2s-load-sse41.h $(srcdir)/Modules/_blake2/impl/blake2s-load-xop.h $(srcdir)/Modules/_blake2/impl/blake2s-ref.c $(srcdir)/Modules/_blake2/impl/blake2s-round.h $(srcdir)/Modules/_blake2/impl/blake2s-test.c $(srcdir)/Modules/_blake2/impl/blake2s.c $(srcdir)/Modules/_blake2/impl/blake2sp-test.c $(srcdir)/Modules/_blake2/impl/blake2sp.c $(srcdir)/Modules/hashlib.h
 MODULE__CTYPES_DEPS=$(srcdir)/Modules/_ctypes/ctypes.h
-MODULE__DECIMAL_DEPS=$(srcdir)/Modules/_decimal/docstrings.h $(srcdir)/Modules/_decimal/libmpdec/basearith.h $(srcdir)/Modules/_decimal/libmpdec/bits.h $(srcdir)/Modules/_decimal/libmpdec/constants.h $(srcdir)/Modules/_decimal/libmpdec/convolute.h $(srcdir)/Modules/_decimal/libmpdec/crt.h $(srcdir)/Modules/_decimal/libmpdec/difradix2.h $(srcdir)/Modules/_decimal/libmpdec/fnt.h $(srcdir)/Modules/_decimal/libmpdec/fourstep.h $(srcdir)/Modules/_decimal/libmpdec/io.h $(srcdir)/Modules/_decimal/libmpdec/mpalloc.h $(srcdir)/Modules/_decimal/libmpdec/mpdecimal.h $(srcdir)/Modules/_decimal/libmpdec/numbertheory.h $(srcdir)/Modules/_decimal/libmpdec/sixstep.h $(srcdir)/Modules/_decimal/libmpdec/transpose.h $(srcdir)/Modules/_decimal/libmpdec/typearith.h $(srcdir)/Modules/_decimal/libmpdec/umodarith.h
+MODULE__DECIMAL_DEPS=$(srcdir)/Modules/_decimal/docstrings.h $(LIBMPDEC_HEADERS) @LIBMPDEC_INTERNAL@
 MODULE__ELEMENTTREE_DEPS=$(srcdir)/Modules/expat/ascii.h $(srcdir)/Modules/expat/asciitab.h $(srcdir)/Modules/expat/expat.h $(srcdir)/Modules/expat/expat_config.h $(srcdir)/Modules/expat/expat_external.h $(srcdir)/Modules/expat/internal.h $(srcdir)/Modules/expat/latin1tab.h $(srcdir)/Modules/expat/utf8tab.h $(srcdir)/Modules/expat/xmlparse.c $(srcdir)/Modules/expat/xmlrole.c $(srcdir)/Modules/expat/xmlrole.h $(srcdir)/Modules/expat/xmltok.c $(srcdir)/Modules/expat/xmltok.h $(srcdir)/Modules/expat/xmltok_impl.h $(srcdir)/Modules/pyexpat.c
 MODULE__HASHLIB_DEPS=$(srcdir)/Modules/hashlib.h
 MODULE__IO_DEPS=$(srcdir)/Modules/_io/_iomodule.h

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -514,6 +514,8 @@ LIBMPDEC_OBJS= \
 		Modules/_decimal/libmpdec/numbertheory.o \
 		Modules/_decimal/libmpdec/sixstep.o \
 		Modules/_decimal/libmpdec/transpose.o
+		# _decimal does not use signaling API
+		# Modules/_decimal/libmpdec/mpsignal.o
 
 LIBMPDEC_HEADERS= \
 		$(srcdir)/Modules/_decimal/libmpdec/basearith.h \
@@ -809,6 +811,9 @@ Modules/_decimal/libmpdec/mpalloc.o: $(srcdir)/Modules/_decimal/libmpdec/mpalloc
 
 Modules/_decimal/libmpdec/mpdecimal.o: $(srcdir)/Modules/_decimal/libmpdec/mpdecimal.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
 	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/mpdecimal.c
+
+Modules/_decimal/libmpdec/mpsignal.o: $(srcdir)/Modules/_decimal/libmpdec/mpsignal.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
+	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/mpsignal.c
 
 Modules/_decimal/libmpdec/numbertheory.o: $(srcdir)/Modules/_decimal/libmpdec/numbertheory.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)
 	$(CC) -c $(LIBMPDEC_CFLAGS) -o $@ $(srcdir)/Modules/_decimal/libmpdec/numbertheory.c

--- a/Misc/NEWS.d/next/Build/2021-11-13-10-18-22.bpo-45798.IraaTs.rst
+++ b/Misc/NEWS.d/next/Build/2021-11-13-10-18-22.bpo-45798.IraaTs.rst
@@ -1,0 +1,2 @@
+Settings for :mod:`decimal` internal C extension are now detected by
+``configure``. The bundled ``libmpdec`` library is built in ``Makefile``.

--- a/Modules/Setup
+++ b/Modules/Setup
@@ -149,8 +149,7 @@ time timemodule.c
 #_contextvars _contextvarsmodule.c
 #_csv _csv.c
 #_datetime _datetimemodule.c
-# UNIVERSAL: let mpdecimal.h detect settings
-#_decimal -DUNIVERSAL -I$(srcdir)/Modules/_decimal/libmpdec _decimal/_decimal.c _decimal/libmpdec/basearith.c _decimal/libmpdec/constants.c _decimal/libmpdec/context.c _decimal/libmpdec/convolute.c _decimal/libmpdec/crt.c _decimal/libmpdec/difradix2.c _decimal/libmpdec/fnt.c _decimal/libmpdec/fourstep.c _decimal/libmpdec/io.c _decimal/libmpdec/mpalloc.c _decimal/libmpdec/mpdecimal.c _decimal/libmpdec/numbertheory.c _decimal/libmpdec/sixstep.c _decimal/libmpdec/transpose.c
+#_decimal _decimal/_decimal.c $(DECIMAL_CFLAGS) $(DECIMAL_LDFLAGS)
 #_heapq _heapqmodule.c
 #_json _json.c
 #_lsprof _lsprof.c rotatingtree.c

--- a/Modules/makesetup
+++ b/Modules/makesetup
@@ -184,6 +184,11 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 			*.c++)		srcs="$srcs $arg";;
 			*.cxx)		srcs="$srcs $arg";;
 			*.cpp)		srcs="$srcs $arg";;
+			\$\(*_CFLAGS\))		cpps="$cpps $arg";;
+			\$\(*_INCLUDES\))	cpps="$cpps $arg";;
+			\$\(*_LIBS\))		libs="$libs $arg";;
+			\$\(*_LDFLAGS\))	libs="$libs $arg";;
+			\$\(*_RPATH\))		libs="$libs $arg";;
 			\$*)		libs="$libs $arg"
 					cpps="$cpps $arg";;
 			*.*)		echo 1>&2 "bad word $arg in $line"

--- a/configure
+++ b/configure
@@ -660,6 +660,9 @@ DFLAGS
 DTRACE
 TCLTK_LIBS
 TCLTK_INCLUDES
+LIBMPDEC_INTERNAL
+LIBMPDEC_LDFLAGS
+LIBMPDEC_CFLAGS
 LIBFFI_INCLUDEDIR
 TZPATH
 SHLIBS
@@ -1533,7 +1536,8 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-pkg-config       use pkg-config to detect build options (default is
+  --with-pkg-config=[yes|no|check]
+                          use pkg-config to detect build options (default is
                           check)
   --with-universal-archs=ARCH
                           specify the kind of macOS universal binary that
@@ -10764,9 +10768,26 @@ else
   with_system_libmpdec="no"
 fi
 
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_system_libmpdec" >&5
 $as_echo "$with_system_libmpdec" >&6; }
+
+if test "x$with_system_libmpdec" = xyes; then :
+
+  LIBMPDEC_CFLAGS=""
+  LIBMPDEC_LDFLAGS="-lmpdec"
+  LIBMPDEC_INTERNAL=
+
+else
+
+  LIBMPDEC_CFLAGS="-I\$(srcdir)/Modules/_decimal/libmpdec"
+  LIBMPDEC_LDFLAGS="-lm \$(LIBMPDEC_A)"
+  LIBMPDEC_INTERNAL="\$(LIBMPDEC_A)"
+
+fi
+
+
+
+
 
 # Check whether _decimal should use a coroutine-local or thread-local context
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-decimal-contextvar" >&5
@@ -10789,6 +10810,95 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_decimal_contextvar" >&5
 $as_echo "$with_decimal_contextvar" >&6; }
+
+# Check for libmpdec machine flavor
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for decimal libmpdec machine" >&5
+$as_echo_n "checking for decimal libmpdec machine... " >&6; }
+case $ac_sys_system in #(
+  Darwin*) :
+    libmpdec_system=Darwin ;; #(
+  SunOS*) :
+    libmpdec_system=sunos ;; #(
+  *) :
+    libmpdec_system=other
+ ;;
+esac
+
+libmpdec_machine=unknown
+if test "$libmpdec_system" = Darwin; then
+    case $MACOSX_DEFAULT_ARCH in #(
+  i386) :
+    libmpdec_machine=ansi32 ;; #(
+  ppc) :
+    libmpdec_machine=ansi32 ;; #(
+  x86_64) :
+    libmpdec_machine=x64 ;; #(
+  ppc64) :
+    libmpdec_machine=ansi64 ;; #(
+  arm64) :
+    libmpdec_machine=ansi64 ;; #(
+  *) :
+    libmpdec_machine=universal
+     ;;
+esac
+elif test $ac_cv_sizeof_size_t -eq 8; then
+    if test "$ac_cv_gcc_asm_for_x64" = yes; then
+        libmpdec_machine=x64
+    elif test "$ac_cv_type___uint128_t" = yes; then
+        libmpdec_machine=uint128
+    else
+        libmpdec_machine=ansi64
+    fi
+elif test $ac_cv_sizeof_size_t -eq 4; then
+    if test "$ac_cv_gcc_asm_for_x87" = yes -a "$libmpdec_system" != sunos; then
+        case $CC in #(
+  *gcc*) :
+    libmpdec_machine=ppro ;; #(
+  *clang*) :
+    libmpdec_machine=ppro ;; #(
+  *) :
+    libmpdec_machine=ansi32
+         ;;
+esac
+    else
+        libmpdec_machine=ansi32
+    fi
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libmpdec_machine" >&5
+$as_echo "$libmpdec_machine" >&6; }
+
+case $libmpdec_machine in #(
+  x64) :
+    as_fn_append LIBMPDEC_CFLAGS " -DCONFIG_64=1 -DASM=1" ;; #(
+  uint128) :
+    as_fn_append LIBMPDEC_CFLAGS " -DCONFIG_64=1 -DANSI=1 -DHAVE_UINT128_T=1" ;; #(
+  ansi64) :
+    as_fn_append LIBMPDEC_CFLAGS " -DCONFIG_64=1 -DANSI=1" ;; #(
+  ppro) :
+    as_fn_append LIBMPDEC_CFLAGS " -DCONFIG_32=1 -DANSI=1 -DASM=1 -Wno-unknown-pragmas" ;; #(
+  ansi32) :
+    as_fn_append LIBMPDEC_CFLAGS " -DCONFIG_32=1 -DANSI=1" ;; #(
+  ansi-legacy) :
+    as_fn_append LIBMPDEC_CFLAGS " -DCONFIG_32=1 -DANSI=1 -DLEGACY_COMPILER=1" ;; #(
+  universal) :
+    as_fn_append LIBMPDEC_CFLAGS " -DUNIVERSAL=1" ;; #(
+  *) :
+    as_fn_error $? "_decimal: unsupported architecture" "$LINENO" 5
+ ;;
+esac
+
+if test "$have_ipa_pure_const_bug" = yes; then
+    # Some versions of gcc miscompile inline asm:
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46491
+    # https://gcc.gnu.org/ml/gcc/2010-11/msg00366.html
+    as_fn_append LIBMPDEC_CFLAGS " -fno-ipa-pure-const"
+fi
+
+if test "$have_glibc_memmove_bug" = yes; then
+    # _FORTIFY_SOURCE wrappers for memmove and bcopy are incorrect:
+    # https://sourceware.org/ml/libc-alpha/2010-12/msg00009.html
+    as_fn_append LIBMPDEC_CFLAGS " -U_FORTIFY_SOURCE"
+fi
 
 # Check for support for loadable sqlite extensions
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for --enable-loadable-sqlite-extensions" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -3057,8 +3057,21 @@ AC_ARG_WITH(system_libmpdec,
             AS_HELP_STRING([--with-system-libmpdec], [build _decimal module using an installed libmpdec library, see Doc/library/decimal.rst (default is no)]),
             [],
             [with_system_libmpdec="no"])
-
 AC_MSG_RESULT($with_system_libmpdec)
+
+AS_VAR_IF([with_system_libmpdec], [yes], [
+  LIBMPDEC_CFLAGS=""
+  LIBMPDEC_LDFLAGS="-lmpdec"
+  LIBMPDEC_INTERNAL=
+], [
+  LIBMPDEC_CFLAGS="-I\$(srcdir)/Modules/_decimal/libmpdec"
+  LIBMPDEC_LDFLAGS="-lm \$(LIBMPDEC_A)"
+  LIBMPDEC_INTERNAL="\$(LIBMPDEC_A)"
+])
+
+AC_SUBST([LIBMPDEC_CFLAGS])
+AC_SUBST([LIBMPDEC_LDFLAGS])
+AC_SUBST([LIBMPDEC_INTERNAL])
 
 # Check whether _decimal should use a coroutine-local or thread-local context
 AC_MSG_CHECKING(for --with-decimal-contextvar)
@@ -3074,6 +3087,69 @@ then
 fi
 
 AC_MSG_RESULT($with_decimal_contextvar)
+
+# Check for libmpdec machine flavor
+AC_MSG_CHECKING(for decimal libmpdec machine)
+AS_CASE([$ac_sys_system],
+  [Darwin*], [libmpdec_system=Darwin],
+  [SunOS*], [libmpdec_system=sunos],
+  [libmpdec_system=other]
+)
+
+libmpdec_machine=unknown
+if test "$libmpdec_system" = Darwin; then
+    AS_CASE([$MACOSX_DEFAULT_ARCH],
+      [i386],   [libmpdec_machine=ansi32],
+      [ppc],    [libmpdec_machine=ansi32],
+      [x86_64], [libmpdec_machine=x64],
+      [ppc64],  [libmpdec_machine=ansi64],
+      [arm64],  [libmpdec_machine=ansi64],
+      [libmpdec_machine=universal]
+    )
+elif test $ac_cv_sizeof_size_t -eq 8; then
+    if test "$ac_cv_gcc_asm_for_x64" = yes; then
+        libmpdec_machine=x64
+    elif test "$ac_cv_type___uint128_t" = yes; then
+        libmpdec_machine=uint128
+    else
+        libmpdec_machine=ansi64
+    fi
+elif test $ac_cv_sizeof_size_t -eq 4; then
+    if test "$ac_cv_gcc_asm_for_x87" = yes -a "$libmpdec_system" != sunos; then
+        AS_CASE([$CC],
+            [*gcc*],   [libmpdec_machine=ppro],
+            [*clang*], [libmpdec_machine=ppro],
+            [libmpdec_machine=ansi32]
+        )
+    else
+        libmpdec_machine=ansi32
+    fi
+fi
+AC_MSG_RESULT([$libmpdec_machine])
+
+AS_CASE([$libmpdec_machine],
+  [x64],         [AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -DCONFIG_64=1 -DASM=1"])],
+  [uint128],     [AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -DCONFIG_64=1 -DANSI=1 -DHAVE_UINT128_T=1"])],
+  [ansi64],      [AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -DCONFIG_64=1 -DANSI=1"])],
+  [ppro],        [AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -DCONFIG_32=1 -DANSI=1 -DASM=1 -Wno-unknown-pragmas"])],
+  [ansi32],      [AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -DCONFIG_32=1 -DANSI=1"])],
+  [ansi-legacy], [AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -DCONFIG_32=1 -DANSI=1 -DLEGACY_COMPILER=1"])],
+  [universal],   [AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -DUNIVERSAL=1"])],
+  [AC_MSG_ERROR([_decimal: unsupported architecture])]
+)
+
+if test "$have_ipa_pure_const_bug" = yes; then
+    # Some versions of gcc miscompile inline asm:
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46491
+    # https://gcc.gnu.org/ml/gcc/2010-11/msg00366.html
+    AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -fno-ipa-pure-const"])
+fi
+
+if test "$have_glibc_memmove_bug" = yes; then
+    # _FORTIFY_SOURCE wrappers for memmove and bcopy are incorrect:
+    # https://sourceware.org/ml/libc-alpha/2010-12/msg00009.html
+    AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -U_FORTIFY_SOURCE"])
+fi
 
 # Check for support for loadable sqlite extensions
 AC_MSG_CHECKING(for --enable-loadable-sqlite-extensions)


### PR DESCRIPTION
Settings for :mod:`decimal` internal C extension are now detected by
:program:`configure`. The bundled `libmpdec` library is built in
``Makefile``.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45798](https://bugs.python.org/issue45798) -->
https://bugs.python.org/issue45798
<!-- /issue-number -->
