### PR TITLE
bpo-45292: Use raw strings for regex in tests

### DIFF
--- a/Lib/test/test_exception_group.py
+++ b/Lib/test/test_exception_group.py
@@ -38,18 +38,18 @@ class BadConstructorArgs(unittest.TestCase):
             ExceptionGroup(None, [ValueError(12)])
 
     def test_bad_EG_construction__bad_excs_sequence(self):
-        MSG = 'second argument \(exceptions\) must be a sequence'
+        MSG = r'second argument \(exceptions\) must be a sequence'
         with self.assertRaisesRegex(TypeError, MSG):
             ExceptionGroup('errors not sequence', {ValueError(42)})
         with self.assertRaisesRegex(TypeError, MSG):
             ExceptionGroup("eg", None)
 
-        MSG = 'second argument \(exceptions\) must be a non-empty sequence'
+        MSG = r'second argument \(exceptions\) must be a non-empty sequence'
         with self.assertRaisesRegex(ValueError, MSG):
             ExceptionGroup("eg", [])
 
     def test_bad_EG_construction__nested_non_exceptions(self):
-        MSG = ('Item [0-9]+ of second argument \(exceptions\)'
+        MSG = (r'Item [0-9]+ of second argument \(exceptions\)'
               ' is not an exception')
         with self.assertRaisesRegex(ValueError, MSG):
             ExceptionGroup('expect instance, not type', [OSError]);


### PR DESCRIPTION
This removes these warnings:

0:00:00 load avg: 0.39 [1/1] test_exception_group
/home/karthikeyan/stuff/python/cpython/Lib/test/test_exception_group.py:41: DeprecationWarning: invalid escape sequence '\('
  MSG = 'second argument \(exceptions\) must be a sequence'
/home/karthikeyan/stuff/python/cpython/Lib/test/test_exception_group.py:47: DeprecationWarning: invalid escape sequence '\('
  MSG = 'second argument \(exceptions\) must be a non-empty sequence'
/home/karthikeyan/stuff/python/cpython/Lib/test/test_exception_group.py:52: DeprecationWarning: invalid escape sequence '\('
  MSG = ('Item [0-9]+ of second argument \(exceptions\)'


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45292](https://bugs.python.org/issue45292) -->
https://bugs.python.org/issue45292
<!-- /issue-number -->
