### PR TITLE
bpo-45799: [Doc] improve confusing sentence in __main__.rst

### DIFF
--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -116,8 +116,8 @@ Idiomatic Usage
 ^^^^^^^^^^^^^^^
 
 Some modules contain code that is intended for script use only, like parsing
-command-line arguments or fetching data from standard input.  When a module
-like this were to be imported from a different module, for example to unit test
+command-line arguments or fetching data from standard input.  If a module
+like this is imported from a different module, for example to unit test
 it, the script code would unintentionally execute as well.
 
 This is where using the ``if __name__ == '__main__'`` code block comes in

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -117,7 +117,7 @@ Idiomatic Usage
 
 Some modules contain code that is intended for script use only, like parsing
 command-line arguments or fetching data from standard input.  If a module
-like this is imported from a different module, for example to unit test
+like this was imported from a different module, for example to unit test
 it, the script code would unintentionally execute as well.
 
 This is where using the ``if __name__ == '__main__'`` code block comes in


### PR DESCRIPTION
I was reading this bit last night and thought it was a typo. In the light of day, I realized it wasn't *technically* a typo, but definitely confusing wording. This PR fixes the confusing sentence.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45799](https://bugs.python.org/issue45799) -->
https://bugs.python.org/issue45799
<!-- /issue-number -->

Automerge-Triggered-By: GH:ericvsmith