### PR TITLE
doc: Add empty line for print() in fib

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -484,7 +484,9 @@ normally suppressed by the interpreter if it would be the only value written.
 You can see it if you really want to using :func:`print`::
 
    >>> fib(0)
+   
    >>> print(fib(0))
+   
    None
 
 It is simple to write a function that returns a list of the numbers of the


### PR DESCRIPTION
There's `print()` statement after the `while` loop in the function `fib`, which would generate an empty line in the output, if there's not any number to print in the above loop.