### PR TITLE
[3.10] bpo-45752: Fix no-support examples in 'copy' docs (GH-29548)

### DIFF
--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -60,7 +60,7 @@ The :func:`deepcopy` function avoids these problems by:
   components copied.
 
 This module does not copy types like module, method, stack trace, stack frame,
-file, socket, window, array, or any similar types.  It does "copy" functions and
+file, socket, window, or any similar types.  It does "copy" functions and
 classes (shallow and deeply), by returning the original object unchanged; this
 is compatible with the way these are treated by the :mod:`pickle` module.
 


### PR DESCRIPTION
(cherry picked from commit b7360ae395e9e633d384d16064c5dc04a9841e19)

Co-authored-by: M. Mostafa Farzan <m2_farzan@yahoo.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45752](https://bugs.python.org/issue45752) -->
https://bugs.python.org/issue45752
<!-- /issue-number -->

Automerge-Triggered-By: GH:asvetlov