### PR TITLE
bpo-42540: reallocation of id_mutex should not force default allocator

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4516,7 +4516,8 @@ class ForkTests(unittest.TestCase):
                 assert exitcode == 0
         """
         assert_python_ok("-c", code)
-        assert_python_ok("-c", code, PYTHONMALLOC="pymalloc_debug")
+        if support.with_pymalloc():
+            assert_python_ok("-c", code, PYTHONMALLOC="pymalloc_debug")
 
 
 # Only test if the C version is provided, otherwise TestPEP519 already tested

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4504,20 +4504,19 @@ class TimesTests(unittest.TestCase):
 
 
 @requires_os_func('fork')
-@requires_os_func('waitpid')
 class ForkTests(unittest.TestCase):
     def test_fork(self):
-        # bpo-42540: ensure os.fork() with non-default allocator
+        # bpo-42540: ensure os.fork() with non-default memory allocator does
+        # not crash on exit.
         code = """if 1:
             import os
+            from test import support
             pid = os.fork()
             if pid != 0:
-                _, exitcode = os.waitpid(pid, 0)
-                assert exitcode == 0
+                support.wait_process(pid, exitcode=0)
         """
         assert_python_ok("-c", code)
-        if support.with_pymalloc():
-            assert_python_ok("-c", code, PYTHONMALLOC="pymalloc_debug")
+        assert_python_ok("-c", code, PYTHONMALLOC="malloc_debug")
 
 
 # Only test if the C version is provided, otherwise TestPEP519 already tested

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4503,6 +4503,22 @@ class TimesTests(unittest.TestCase):
             self.assertEqual(times.elapsed, 0)
 
 
+@requires_os_func('fork')
+@requires_os_func('waitpid')
+class ForkTests(unittest.TestCase):
+    def test_fork(self):
+        # bpo-42540: ensure os.fork() with non-default allocator
+        code = """if 1:
+            import os
+            pid = os.fork()
+            if pid != 0:
+                _, exitcode = os.waitpid(pid, 0)
+                assert exitcode == 0
+        """
+        assert_python_ok("-c", code)
+        assert_python_ok("-c", code, PYTHONMALLOC="pymalloc_debug")
+
+
 # Only test if the C version is provided, otherwise TestPEP519 already tested
 # the pure Python implementation.
 if hasattr(os, "_fspath"):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-11-15-12-08-27.bpo-42540.V2w107.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-11-15-12-08-27.bpo-42540.V2w107.rst
@@ -1,2 +1,2 @@
 Fix crash when :func:`os.fork` is called with an active non-default
-allocator.
+memory allocator.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-11-15-12-08-27.bpo-42540.V2w107.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-11-15-12-08-27.bpo-42540.V2w107.rst
@@ -1,0 +1,2 @@
+Fix crash when :func:`os.fork` is called with an active non-default
+allocator.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -148,11 +148,14 @@ _PyRuntimeState_ReInitThreads(_PyRuntimeState *runtime)
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     int reinit_interp = _PyThread_at_fork_reinit(&runtime->interpreters.mutex);
-    int reinit_main_id = _PyThread_at_fork_reinit(&runtime->interpreters.main->id_mutex);
     int reinit_xidregistry = _PyThread_at_fork_reinit(&runtime->xidregistry.mutex);
     int reinit_unicode_ids = _PyThread_at_fork_reinit(&runtime->unicode_ids.lock);
 
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+
+    /* bpo-42540: id_mutex is freed by _PyInterpreterState_Delete, which does
+     * not force the default allocator. */
+    int reinit_main_id = _PyThread_at_fork_reinit(&runtime->interpreters.main->id_mutex);
 
     if (reinit_interp < 0
         || reinit_main_id < 0


### PR DESCRIPTION
Unlike the other locks reinitialized by _PyRuntimeState_ReInitThreads,
the "interpreters.main->id_mutex" is not freed by _PyRuntimeState_Fini
and should not force the default raw allocator.

<!-- issue-number: [bpo-42540](https://bugs.python.org/issue42540) -->
https://bugs.python.org/issue42540
<!-- /issue-number -->
