### PR TITLE
bpo-45636: Un-switch `BINARY_OP`

### DIFF
--- a/Include/internal/pycore_abstract.h
+++ b/Include/internal/pycore_abstract.h
@@ -16,6 +16,9 @@ _PyIndex_Check(PyObject *obj)
     return (tp_as_number != NULL && tp_as_number->nb_index != NULL);
 }
 
+PyObject *_PyNumber_PowerNoMod(PyObject *lhs, PyObject *rhs);
+PyObject *_PyNumber_InPlacePowerNoMod(PyObject *lhs, PyObject *rhs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/Core and Builtins/2021-11-15-13-32-54.bpo-45636.RDlTdL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-11-15-13-32-54.bpo-45636.RDlTdL.rst
@@ -1,0 +1,2 @@
+Simplify the implementation of :opcode:`BINARY_OP` by indexing into an array
+of function pointers (rather than switching on the oparg).

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -1152,6 +1152,12 @@ PyNumber_Power(PyObject *v, PyObject *w, PyObject *z)
     return ternary_op(v, w, z, NB_SLOT(nb_power), "** or pow()");
 }
 
+PyObject *
+_PyNumber_PowerNoMod(PyObject *lhs, PyObject *rhs)
+{
+    return PyNumber_Power(lhs, rhs, Py_None);
+}
+
 /* Binary in-place operators */
 
 /* The in-place operators are defined to fall back to the 'normal',
@@ -1329,6 +1335,12 @@ PyNumber_InPlacePower(PyObject *v, PyObject *w, PyObject *z)
 {
     return ternary_iop(v, w, z, NB_SLOT(nb_inplace_power),
                                 NB_SLOT(nb_power), "**=");
+}
+
+PyObject *
+_PyNumber_InPlacePowerNoMod(PyObject *lhs, PyObject *rhs)
+{
+    return PyNumber_InPlacePower(lhs, rhs, Py_None);
 }
 
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -828,6 +828,36 @@ _Py_CheckRecursiveCall(PyThreadState *tstate, const char *where)
 }
 
 
+static const binaryfunc binary_ops[] = {
+    [NB_ADD] = PyNumber_Add,
+    [NB_AND] = PyNumber_And,
+    [NB_FLOOR_DIVIDE] = PyNumber_FloorDivide,
+    [NB_LSHIFT] = PyNumber_Lshift,
+    [NB_MATRIX_MULTIPLY] = PyNumber_MatrixMultiply,
+    [NB_MULTIPLY] = PyNumber_Multiply,
+    [NB_REMAINDER] = PyNumber_Remainder,
+    [NB_OR] = PyNumber_Or,
+    [NB_POWER] = _PyNumber_PowerNoMod,
+    [NB_RSHIFT] = PyNumber_Rshift,
+    [NB_SUBTRACT] = PyNumber_Subtract,
+    [NB_TRUE_DIVIDE] = PyNumber_TrueDivide,
+    [NB_XOR] = PyNumber_Xor,
+    [NB_INPLACE_ADD] = PyNumber_InPlaceAdd,
+    [NB_INPLACE_AND] = PyNumber_InPlaceAnd,
+    [NB_INPLACE_FLOOR_DIVIDE] = PyNumber_InPlaceFloorDivide,
+    [NB_INPLACE_LSHIFT] = PyNumber_InPlaceLshift,
+    [NB_INPLACE_MATRIX_MULTIPLY] = PyNumber_InPlaceMatrixMultiply,
+    [NB_INPLACE_MULTIPLY] = PyNumber_InPlaceMultiply,
+    [NB_INPLACE_REMAINDER] = PyNumber_InPlaceRemainder,
+    [NB_INPLACE_OR] = PyNumber_InPlaceOr,
+    [NB_INPLACE_POWER] = _PyNumber_InPlacePowerNoMod,
+    [NB_INPLACE_RSHIFT] = PyNumber_InPlaceRshift,
+    [NB_INPLACE_SUBTRACT] = PyNumber_InPlaceSubtract,
+    [NB_INPLACE_TRUE_DIVIDE] = PyNumber_InPlaceTrueDivide,
+    [NB_INPLACE_XOR] = PyNumber_InPlaceXor,
+};
+
+
 // PEP 634: Structural Pattern Matching
 
 
@@ -4690,89 +4720,10 @@ check_eval_breaker:
             STAT_INC(BINARY_OP, unquickened);
             PyObject *rhs = POP();
             PyObject *lhs = TOP();
-            PyObject *res;
-            switch (oparg) {
-                case NB_ADD:
-                    res = PyNumber_Add(lhs, rhs);
-                    break;
-                case NB_AND:
-                    res = PyNumber_And(lhs, rhs);
-                    break;
-                case NB_FLOOR_DIVIDE:
-                    res = PyNumber_FloorDivide(lhs, rhs);
-                    break;
-                case NB_LSHIFT:
-                    res = PyNumber_Lshift(lhs, rhs);
-                    break;
-                case NB_MATRIX_MULTIPLY:
-                    res = PyNumber_MatrixMultiply(lhs, rhs);
-                    break;
-                case NB_MULTIPLY:
-                    res = PyNumber_Multiply(lhs, rhs);
-                    break;
-                case NB_REMAINDER:
-                    res = PyNumber_Remainder(lhs, rhs);
-                    break;
-                case NB_OR:
-                    res = PyNumber_Or(lhs, rhs);
-                    break;
-                case NB_POWER:
-                    res = PyNumber_Power(lhs, rhs, Py_None);
-                    break;
-                case NB_RSHIFT:
-                    res = PyNumber_Rshift(lhs, rhs);
-                    break;
-                case NB_SUBTRACT:
-                    res = PyNumber_Subtract(lhs, rhs);
-                    break;
-                case NB_TRUE_DIVIDE:
-                    res = PyNumber_TrueDivide(lhs, rhs);
-                    break;
-                case NB_XOR:
-                    res = PyNumber_Xor(lhs, rhs);
-                    break;
-                case NB_INPLACE_ADD:
-                    res = PyNumber_InPlaceAdd(lhs, rhs);
-                    break;
-                case NB_INPLACE_AND:
-                    res = PyNumber_InPlaceAnd(lhs, rhs);
-                    break;
-                case NB_INPLACE_FLOOR_DIVIDE:
-                    res = PyNumber_InPlaceFloorDivide(lhs, rhs);
-                    break;
-                case NB_INPLACE_LSHIFT:
-                    res = PyNumber_InPlaceLshift(lhs, rhs);
-                    break;
-                case NB_INPLACE_MATRIX_MULTIPLY:
-                    res = PyNumber_InPlaceMatrixMultiply(lhs, rhs);
-                    break;
-                case NB_INPLACE_MULTIPLY:
-                    res = PyNumber_InPlaceMultiply(lhs, rhs);
-                    break;
-                case NB_INPLACE_REMAINDER:
-                    res = PyNumber_InPlaceRemainder(lhs, rhs);
-                    break;
-                case NB_INPLACE_OR:
-                    res = PyNumber_InPlaceOr(lhs, rhs);
-                    break;
-                case NB_INPLACE_POWER:
-                    res = PyNumber_InPlacePower(lhs, rhs, Py_None);
-                    break;
-                case NB_INPLACE_RSHIFT:
-                    res = PyNumber_InPlaceRshift(lhs, rhs);
-                    break;
-                case NB_INPLACE_SUBTRACT:
-                    res = PyNumber_InPlaceSubtract(lhs, rhs);
-                    break;
-                case NB_INPLACE_TRUE_DIVIDE:
-                    res = PyNumber_InPlaceTrueDivide(lhs, rhs);
-                    break;
-                case NB_INPLACE_XOR:
-                    res = PyNumber_InPlaceXor(lhs, rhs);
-                    break;
-                default:
-                    Py_UNREACHABLE();
-            }
+            assert(0 <= oparg);
+            assert(oparg < Py_ARRAY_LENGTH(binary_ops));
+            assert(binary_ops[oparg]);
+            PyObject *res = binary_ops[oparg](lhs, rhs);
             Py_DECREF(lhs);
             Py_DECREF(rhs);
             SET_TOP(res);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4721,7 +4721,7 @@ check_eval_breaker:
             PyObject *rhs = POP();
             PyObject *lhs = TOP();
             assert(0 <= oparg);
-            assert(oparg < Py_ARRAY_LENGTH(binary_ops));
+            assert((unsigned)oparg < Py_ARRAY_LENGTH(binary_ops));
             assert(binary_ops[oparg]);
             PyObject *res = binary_ops[oparg](lhs, rhs);
             Py_DECREF(lhs);


### PR DESCRIPTION
In addition to cleaning things up considerably, this also appears to have a tiny positive perf impact:

<details>

```
Slower (12):- logging_format: 6.54 us +- 0.10 us -> 6.75 us +- 0.09 us: 1.03x slower- logging_simple: 5.98 us +- 0.08 us -> 6.17 us +- 0.10 us: 1.03x slower- logging_silent: 113 ns +- 3 ns -> 117 ns +- 3 ns: 1.03x slower
- pathlib: 18.7 ms +- 0.2 ms -> 19.1 ms +- 0.3 ms: 1.02x slower
- pickle_list: 4.35 us +- 0.05 us -> 4.45 us +- 0.05 us: 1.02x slower
- unpack_sequence: 46.6 ns +- 1.5 ns -> 47.3 ns +- 2.0 ns: 1.01x slower
- scimark_monte_carlo: 77.9 ms +- 0.8 ms -> 79.0 ms +- 1.5 ms: 1.01x slower
- float: 81.7 ms +- 0.8 ms -> 82.7 ms +- 1.0 ms: 1.01x slower
- scimark_fft: 335 ms +- 4 ms -> 338 ms +- 2 ms: 1.01x slower
- pickle_dict: 27.7 us +- 0.1 us -> 28.0 us +- 0.1 us: 1.01x slower
- sympy_integrate: 22.0 ms +- 0.1 ms -> 22.1 ms +- 0.1 ms: 1.01x slower
- deltablue: 4.74 ms +- 0.05 ms -> 4.76 ms +- 0.04 ms: 1.00x slower

Faster (24):
- pidigits: 195 ms +- 0 ms -> 188 ms +- 0 ms: 1.04x faster
- regex_dna: 218 ms +- 1 ms -> 210 ms +- 1 ms: 1.04x faster
- crypto_pyaes: 88.7 ms +- 1.1 ms -> 85.9 ms +- 0.6 ms: 1.03x faster
- pyflate: 523 ms +- 5 ms -> 512 ms +- 3 ms: 1.02x faster
- regex_v8: 23.4 ms +- 0.4 ms -> 23.0 ms +- 0.1 ms: 1.02x faster
- unpickle: 14.4 us +- 0.5 us -> 14.1 us +- 0.6 us: 1.02x faster
- nbody: 108 ms +- 1 ms -> 106 ms +- 2 ms: 1.02x faster
- fannkuch: 411 ms +- 4 ms -> 405 ms +- 3 ms: 1.02x faster
- chameleon: 7.54 ms +- 0.07 ms -> 7.43 ms +- 0.07 ms: 1.01x faster
- regex_effbot: 3.23 ms +- 0.07 ms -> 3.19 ms +- 0.11 ms: 1.01x faster
- python_startup_no_site: 5.63 ms +- 0.00 ms -> 5.58 ms +- 0.00 ms: 1.01x faster
- python_startup: 7.65 ms +- 0.01 ms -> 7.58 ms +- 0.01 ms: 1.01x faster
- sqlite_synth: 2.77 us +- 0.06 us -> 2.74 us +- 0.05 us: 1.01x faster
- pickle_pure_python: 365 us +- 3 us -> 361 us +- 2 us: 1.01x faster
- scimark_sor: 152 ms +- 3 ms -> 151 ms +- 3 ms: 1.01x faster
- go: 169 ms +- 2 ms -> 168 ms +- 3 ms: 1.01x faster
- regex_compile: 143 ms +- 1 ms -> 142 ms +- 1 ms: 1.01x faster
- unpickle_list: 5.18 us +- 0.04 us -> 5.14 us +- 0.13 us: 1.01x faster
- pickle: 9.94 us +- 0.10 us -> 9.87 us +- 0.06 us: 1.01x faster
- chaos: 77.9 ms +- 0.8 ms -> 77.5 ms +- 0.7 ms: 1.01x faster
- xml_etree_iterparse: 106 ms +- 1 ms -> 105 ms +- 1 ms: 1.00x faster
- dulwich_log: 66.5 ms +- 0.4 ms -> 66.3 ms +- 0.4 ms: 1.00x faster
- mako: 12.0 ms +- 0.1 ms -> 12.0 ms +- 0.1 ms: 1.00x faster
- 2to3: 270 ms +- 1 ms -> 269 ms +- 1 ms: 1.00x faster

Benchmark hidden because not significant (22): django_template, hexiom, json_dumps, json_loads, meteor_contest, nqueens, raytrace, richards, scimark_lu, scimark_sparse_mat_mult, spectral_norm, sqlalchemy_declarative, sqlalchemy_imperative, sympy_expand, sympy_sum, sympy_str, telco, tornado_http, unpickle_pure_python, xml_etree_parse, xml_etree_generate, xml_etree_process

Geometric mean: 1.00x faster
```

</details>

<!-- issue-number: [bpo-45636](https://bugs.python.org/issue45636) -->
https://bugs.python.org/issue45636
<!-- /issue-number -->
