### PR TITLE
bpo-45235: Fix argparse namespace overridden by subparsers default

### DIFF
--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2449,7 +2449,7 @@ class TestAddSubparsers(TestCase):
 
         # return the main parser
         return parser
-    
+
     def _get_parser_with_shared_option(self):
         parser = ErrorRaisingArgumentParser(prog='PROG', description='main description')
         parser.add_argument('-f', '--foo', default='0')

--- a/Misc/NEWS.d/next/Library/2021-11-16-08-55-25.bpo-45235.OV9_9i.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-16-08-55-25.bpo-45235.OV9_9i.rst
@@ -1,0 +1,1 @@
+Fix an issue that subparsers defaults override the existing values in the argparse Namespace.


### PR DESCRIPTION
This PR is another attempt to fix [bpo-45235](https://bugs.python.org/issue45235). 
In this patch, setting the default values is postponed until parsing is done and if the value is absent in the namespace. Also added a test case to cover the regression issue.

As a side-effect, the default values of other arguments won't be seen during parsing(such as inside an action). But IMO it is an invalid use case since the value may be later overridden by a passed-in value.


<!-- issue-number: [bpo-45235](https://bugs.python.org/issue45235) -->
https://bugs.python.org/issue45235
<!-- /issue-number -->
