### PR TITLE
Clarify that distutils.(plat)include is for CPython's headers

### DIFF
--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -94,8 +94,10 @@ identifier.  Python currently uses eight paths:
   platform-specific.
 - *platlib*: directory for site-specific, platform-specific files.
 - *purelib*: directory for site-specific, non-platform-specific files.
-- *include*: directory for non-platform-specific header files.
-- *platinclude*: directory for platform-specific header files.
+- *include*: directory for non-platform-specific header files for
+  the Python C-API.
+- *platinclude*: directory for platform-specific header files for
+  the Python C-API.
 - *scripts*: directory for script files.
 - *data*: directory for data files.
 


### PR DESCRIPTION
Change the docs to note that "include" and "platinclude" are for CPython's headers, and not necessarily for headers of third-party libraries.

See discussion in: https://discuss.python.org/t/clarification-on-a-wheels-header-data/9305/19



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
