### PR TITLE
bpo-45826: Fix a crash in suggestions.c by checking for `traceback is None`

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1885,6 +1885,37 @@ class NameErrorTests(unittest.TestCase):
 
         self.assertNotIn("something", err.getvalue())
 
+    def test_issue45826(self):
+        # regression test for bpo-45826
+        def f():
+            with self.assertRaisesRegex(NameError, 'aaa'):
+                aab
+
+        try:
+            f()
+        except self.failureException:
+            with support.captured_stderr() as err:
+                sys.__excepthook__(*sys.exc_info())
+
+        self.assertIn("aab", err.getvalue())
+
+    def test_issue45826_focused(self):
+        def f():
+            try:
+                nonsense
+            except BaseException as E:
+                E.with_traceback(None)
+                raise ZeroDivisionError()
+
+        try:
+            f()
+        except ZeroDivisionError:
+            with support.captured_stderr() as err:
+                sys.__excepthook__(*sys.exc_info())
+
+        self.assertIn("nonsense", err.getvalue())
+        self.assertIn("ZeroDivisionError", err.getvalue())
+
 
 class AttributeErrorTests(unittest.TestCase):
     def test_attributes(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-11-17-08-05-27.bpo-45826.OERoTm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-11-17-08-05-27.bpo-45826.OERoTm.rst
@@ -1,0 +1,1 @@
+Fixed a crash when calling ``.with_traceback(None)`` on ``NameError``. This occurs internally in ``unittest.TestCase.assertRaises()``.

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -203,16 +203,15 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
     // Abort if we don't have a variable name or we have an invalid one
     // or if we don't have a traceback to work with
     if (name == NULL || !PyUnicode_CheckExact(name) ||
-        traceback == NULL || Py_IsNone((PyObject *)traceback)
+        traceback == NULL || !Py_IS_TYPE(traceback, &PyTraceBack_Type)
     ) {
         return NULL;
     }
 
     // Move to the traceback of the exception
     while (1) {
-        assert(Py_IS_TYPE(traceback, &PyTraceBack_Type));
         PyTracebackObject *next = traceback->tb_next;
-        if (next == NULL || Py_IsNone((PyObject *)traceback)) {
+        if (next == NULL || !Py_IS_TYPE(next, &PyTraceBack_Type)) {
             break;
         }
         else {

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -202,13 +202,22 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
     PyTracebackObject *traceback = (PyTracebackObject *) exc->traceback; // borrowed reference
     // Abort if we don't have a variable name or we have an invalid one
     // or if we don't have a traceback to work with
-    if (name == NULL || traceback == NULL || !PyUnicode_CheckExact(name)) {
+    if (name == NULL || !PyUnicode_CheckExact(name) ||
+        traceback == NULL || Py_IsNone((PyObject *)traceback)
+    ) {
         return NULL;
     }
 
     // Move to the traceback of the exception
-    while (traceback->tb_next != NULL) {
-        traceback = traceback->tb_next;
+    while (1) {
+        assert(Py_IS_TYPE(traceback, &PyTraceBack_Type));
+        PyTracebackObject *next = traceback->tb_next;
+        if (next == NULL || Py_IsNone((PyObject *)traceback)) {
+            break;
+        }
+        else {
+            traceback = next;
+        }
     }
 
     PyFrameObject *frame = traceback->tb_frame;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45826](https://bugs.python.org/issue45826) -->
https://bugs.python.org/issue45826
<!-- /issue-number -->
