### PR TITLE
[3.10] [Enum] update member.member removal to 3.11

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -1152,7 +1152,7 @@ all-uppercase names for members)::
 
 .. note::
 
-   This behavior is deprecated and will be removed in 3.12.
+   This behavior is deprecated and will be removed in 3.11.
 
 .. versionchanged:: 3.5
 


### PR DESCRIPTION
In 3.11, Color.RED.BLUE will again raise an AttributeError as it did in 3.4.