### PR TITLE
bpo-45837: Properly deprecate turtle.RawTurtle.settiltangle

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -369,6 +369,11 @@ Deprecated
 
   (Contributed by Erlend E. Aasland in :issue:`5846`.)
 
+* The :meth:`turtle.RawTurtle.settiltangle` is deprecated since Python 3.1,
+  it now emits a deprecation warning and will be removed in Python 3.13. Use
+  :meth:`turtle.RawTurtle.tiltangle` instead (it was earlier incorrectly marked
+  as deprecated, its docstring is now corrected).
+  (Contributed by Hugo van Kemenade in :issue:`45837`.)
 
 Removed
 =======

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -110,6 +110,7 @@ import math
 import time
 import inspect
 import sys
+import warnings
 
 from os.path import isfile, split, join
 from copy import deepcopy
@@ -2850,20 +2851,23 @@ class RawTurtle(TPen, TNavigator):
         regardless of its current tilt-angle. DO NOT change the turtle's
         heading (direction of movement).
 
+        Deprecated since Python 3.1
 
         Examples (for a Turtle instance named turtle):
         >>> turtle.shape("circle")
         >>> turtle.shapesize(5,2)
         >>> turtle.settiltangle(45)
-        >>> stamp()
+        >>> turtle.stamp()
         >>> turtle.fd(50)
         >>> turtle.settiltangle(-45)
-        >>> stamp()
+        >>> turtle.stamp()
         >>> turtle.fd(50)
         """
-        tilt = -angle * self._degreesPerAU * self._angleOrient
-        tilt = math.radians(tilt) % math.tau
-        self.pen(resizemode="user", tilt=tilt)
+        warnings.warn("turtle.RawTurtle.settiltangle() is deprecated since "
+                      "Python 3.1 and scheduled for removal in Python 3.13."
+                      "Use tiltangle() instead.",
+                       DeprecationWarning)
+        self.tiltangle(angle)
 
     def tiltangle(self, angle=None):
         """Set or return the current tilt-angle.
@@ -2877,19 +2881,32 @@ class RawTurtle(TPen, TNavigator):
         between the orientation of the turtleshape and the heading of the
         turtle (its direction of movement).
 
-        Deprecated since Python 3.1
+        (Incorrectly marked as deprecated since Python 3.1, it is really
+        settiltangle that is deprecated.)
 
         Examples (for a Turtle instance named turtle):
         >>> turtle.shape("circle")
-        >>> turtle.shapesize(5,2)
-        >>> turtle.tilt(45)
+        >>> turtle.shapesize(5, 2)
         >>> turtle.tiltangle()
+        0.0
+        >>> turtle.tiltangle(45)
+        >>> turtle.tiltangle()
+        45.0
+        >>> turtle.stamp()
+        >>> turtle.fd(50)
+        >>> turtle.tiltangle(-45)
+        >>> turtle.tiltangle()
+        315.0
+        >>> turtle.stamp()
+        >>> turtle.fd(50)
         """
         if angle is None:
             tilt = -math.degrees(self._tilt) * self._angleOrient
             return (tilt / self._degreesPerAU) % self._fullcircle
         else:
-            self.settiltangle(angle)
+            tilt = -angle * self._degreesPerAU * self._angleOrient
+            tilt = math.radians(tilt) % math.tau
+            self.pen(resizemode="user", tilt=tilt)
 
     def tilt(self, angle):
         """Rotate the turtleshape by angle.
@@ -2908,7 +2925,7 @@ class RawTurtle(TPen, TNavigator):
         >>> turtle.tilt(30)
         >>> turtle.fd(50)
         """
-        self.settiltangle(angle + self.tiltangle())
+        self.tiltangle(angle + self.tiltangle())
 
     def shapetransform(self, t11=None, t12=None, t21=None, t22=None):
         """Set or return the current transformation matrix of the turtle shape.

--- a/Misc/NEWS.d/next/Library/2021-11-18-13-13-19.bpo-45837.aGyr1I.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-18-13-13-19.bpo-45837.aGyr1I.rst
@@ -1,0 +1,9 @@
+The :meth:`turtle.RawTurtle.settiltangle` is deprecated since Python 3.1,
+it now emits a deprecation warning and will be removed in Python 3.13.
+
+Use :meth:`turtle.RawTurtle.tiltangle` instead.
+
+:meth:`turtle.RawTurtle.tiltangle` was earlier incorrectly marked as deprecated,
+its docstring has been corrected.
+
+Patch by Hugo van Kemenade.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
turtle's `settiltangle` was deprecated in Python 3.1, according to [docs](https://docs.python.org/3.10/library/turtle.html#turtle.settiltangle):

> Deprecated since version 3.1.

And the [reason](https://docs.python.org/3.10/library/turtle.html#changes-since-python-3-0):

> `Turtle.tiltangle()` has been enhanced in functionality: it now can be used to get or set the tiltangle. `Turtle.settiltangle()` has been deprecated.


However, in [docstrings](https://github.com/python/cpython/blob/v3.10.0/Lib/turtle.py#L2880), `tiltangle` was accidentally commented as deprecated:

> Deprecated since Python 3.1

Neither `tiltangle` nor `settiltangle` raise `DeprecationWarning`s.

So let's:

* Correct `tiltangle`'s docstring to say it's not really deprecated
* Update `settiltangle`'s docstring to say it's deprecated
* Add a `DeprecationWarning` to `settiltangle`
* Internally call `self.tiltangle` instead of `self.settiltangle`


BPO references:

* 2009 https://bugs.python.org/issue5923 - when `settiltangle` was originally deprecated, with rationale.

* 2010 https://bugs.python.org/issue7888 - the deprecation mixup was discovered and apparently corrected in py3k and release31-maint. I've not done the SCM archaeology to discover why this didn't make it through!

* 2020 https://bugs.python.org/issue41165 - both mentioned as deprecated, discrepancy not noted.

<!-- issue-number: [bpo-45837](https://bugs.python.org/issue45837) -->
https://bugs.python.org/issue45837
<!-- /issue-number -->
