### PR TITLE
[3.9] bpo-45838: Fix incorrect line numbers in Tools/gdb/libpython.py

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -955,6 +955,31 @@ id(42)
         self.assertRegex(gdb_output,
                          r"<method-wrapper u?'__init__' of MyList object at ")
 
+    @unittest.skipIf(python_is_optimized(),
+                     "Python was compiled with optimizations")
+    def test_try_finally_lineno(self):
+        cmd = textwrap.dedent('''
+            def foo(x):
+                try:
+                    raise RuntimeError("error")
+                    return x
+                except:
+                    id("break point")
+                finally:
+                    x += 2
+                return x
+            r = foo(3)
+        ''')
+        gdb_output = self.get_stack_trace(cmd,
+                                          cmds_after_breakpoint=["py-bt"])
+        self.assertMultilineMatches(gdb_output,
+                                    r'''^.*
+Traceback \(most recent call first\):
+  <built-in method id of module object .*>
+  File "<string>", line 7, in foo
+  File "<string>", line 11, in <module>
+''')
+
 
 class PyPrintTests(DebuggerTests):
     @unittest.skipIf(python_is_optimized(),

--- a/Misc/NEWS.d/next/Tools-Demos/2021-11-18-11-20-21.bpo-45838.TH6mwc.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2021-11-18-11-20-21.bpo-45838.TH6mwc.rst
@@ -1,0 +1,1 @@
+Fix line number calculation when debugging Python with GDB.

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -659,7 +659,10 @@ class PyCodeObjectPtr(PyObjectPtr):
             addr += ord(addr_incr)
             if addr > addrq:
                 return lineno
-            lineno += ord(line_incr)
+            line_delta = ord(line_incr)
+            if line_delta >= 128:
+                line_delta -= 256
+            lineno += line_delta
         return lineno
 
 


### PR DESCRIPTION
The line number calculation in libpython.py did not properly handle
negative (signed) line table deltas.

<!-- issue-number: [bpo-45838](https://bugs.python.org/issue45838) -->
https://bugs.python.org/issue45838
<!-- /issue-number -->
