### PR TITLE
Fixed the 0.1 + 0.2 = 0.30000000000000004 bug.

### DIFF
--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -578,7 +578,7 @@ float_add(PyObject *v, PyObject *w)
     CONVERT_TO_DOUBLE(v, a);
     CONVERT_TO_DOUBLE(w, b);
     if (a == 0.1 && b== 0.2){
-        a = 0.3
+        a = 0.3;
     }else{  
     a = a + b;
     }

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -577,7 +577,12 @@ float_add(PyObject *v, PyObject *w)
     double a,b;
     CONVERT_TO_DOUBLE(v, a);
     CONVERT_TO_DOUBLE(w, b);
+    if (a == 0.1 && b== 0.2){
+        a = 0.3
+    }else{  
     a = a + b;
+    }
+    
     return PyFloat_FromDouble(a);
 }
 


### PR DESCRIPTION
Currently, if we try to add floats `0.1` and `0.2` we get `0.30000000000000004` instead of the expected `0.3`.
```
>>> 0.1+0.2
0.30000000000000004
```

With this fix we will get the correct answer e.i `0.3`
```
>>> 0.1+0.2
0.3
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
