### PR TITLE
bpo-45709: Fix tracing when exception is handled.

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -1137,6 +1137,38 @@ class TraceTestCase(unittest.TestCase):
             (7, 'line'),
             (7, 'return')])
 
+    def test_tracing_exception_raised_in_with(self):
+
+        class NullCtx:
+            def __enter__(self):
+                return self
+            def __exit__(self, *excinfo):
+                pass
+
+        def func():
+            try:
+                with NullCtx():
+                    1/0
+            except ZeroDivisionError:
+                pass
+
+        self.run_and_compare(func,
+            [(0, 'call'),
+             (1, 'line'),
+             (2, 'line'),
+             (-5, 'call'),
+             (-4, 'line'),
+             (-4, 'return'),
+             (3, 'line'),
+             (3, 'exception'),
+             (2, 'line'),
+             (-3, 'call'),
+             (-2, 'line'),
+             (-2, 'return'),
+             (4, 'line'),
+             (5, 'line'),
+             (5, 'return')])
+
 
 class SkipLineEventsTraceTestCase(TraceTestCase):
     """Repeat the trace tests, but with per-line events skipped"""

--- a/Misc/NEWS.d/next/Core and Builtins/2021-11-19-13-17-47.bpo-45709.H_t7ut.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-11-19-13-17-47.bpo-45709.H_t7ut.rst
@@ -1,0 +1,2 @@
+Restore behavior from 3.10 when tracing an exception raised within a with
+statement.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5093,10 +5093,7 @@ exception_unwind:
         JUMPTO(handler);
         /* Resume normal execution */
         frame->f_state = FRAME_EXECUTING;
-        frame->f_lasti = handler;
-        NEXTOPARG();
-        PRE_DISPATCH_GOTO();
-        DISPATCH_GOTO();
+        DISPATCH();
     }
 
 exiting:


### PR DESCRIPTION
Use the normal dispatching sequence when jumping to an exception handler.

<!-- issue-number: [bpo-45709](https://bugs.python.org/issue45709) -->
https://bugs.python.org/issue45709
<!-- /issue-number -->
