### PR TITLE
bpo-45846: Fix capitalisation of Van Rossum in Doc/faq/programming.rst

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -2092,7 +2092,7 @@ Jim Roskind suggests performing steps in the following order in each module:
 * ``import`` statements
 * active code (including globals that are initialized from imported values).
 
-van Rossum doesn't like this approach much because the imports appear in a
+Van Rossum doesn't like this approach much because the imports appear in a
 strange place, but it does work.
 
 Matthias Urlichs recommends restructuring your code so that the recursive import


### PR DESCRIPTION
References:
- https://gvanrossum.github.io/
- https://en.wikipedia.org/wiki/Guido_van_Rossum#Life_and_education

Issue:    
https://bugs.python.org/issue45846

I know this is a trivial typo fix but I made an issue for it because I was making two other issues and because I'm a first time contributor.

<!-- issue-number: [bpo-45846](https://bugs.python.org/issue45846) -->
https://bugs.python.org/issue45846
<!-- /issue-number -->
