### PR TITLE
bpo-45855: document that `no_block` has no use anymore in PyCapsule_Import

### DIFF
--- a/Doc/c-api/capsule.rst
+++ b/Doc/c-api/capsule.rst
@@ -103,12 +103,13 @@ Refer to :ref:`using-capsules` for more information on using these objects.
    Import a pointer to a C object from a capsule attribute in a module.  The
    *name* parameter should specify the full name to the attribute, as in
    ``module.attribute``.  The *name* stored in the capsule must match this
-   string exactly.  If *no_block* is true, import the module without blocking
-   (using :c:func:`PyImport_ImportModuleNoBlock`).  If *no_block* is false,
-   import the module conventionally (using :c:func:`PyImport_ImportModule`).
+   string exactly.
 
    Return the capsule's internal *pointer* on success.  On failure, set an
    exception and return ``NULL``.
+
+   .. versionchanged:: 3.3
+      *no_block* has no effect anymore.
 
 
 .. c:function:: int PyCapsule_IsValid(PyObject *capsule, const char *name)

--- a/Misc/NEWS.d/next/C API/2021-12-12-10-09-02.bpo-45855.MVsTDj.rst
+++ b/Misc/NEWS.d/next/C API/2021-12-12-10-09-02.bpo-45855.MVsTDj.rst
@@ -1,0 +1,2 @@
+Document that the *no_block* argument to :c:func:`PyCapsule_Import` is a
+no-op now.

--- a/Objects/capsule.c
+++ b/Objects/capsule.c
@@ -214,13 +214,9 @@ PyCapsule_Import(const char *name, int no_block)
         }
 
         if (object == NULL) {
-            if (no_block) {
-                object = PyImport_ImportModule(trace);
-            } else {
-                object = PyImport_ImportModule(trace);
-                if (!object) {
-                    PyErr_Format(PyExc_ImportError, "PyCapsule_Import could not import module \"%s\"", trace);
-                }
+            object = PyImport_ImportModule(trace);
+            if (!object) {
+                PyErr_Format(PyExc_ImportError, "PyCapsule_Import could not import module \"%s\"", trace);
             }
         } else {
             PyObject *object2 = PyObject_GetAttrString(object, trace);


### PR DESCRIPTION
and also remove the switch in the implementation.


<!-- issue-number: [bpo-45855](https://bugs.python.org/issue45855) -->
https://bugs.python.org/issue45855
<!-- /issue-number -->
