### PR TITLE
bpo-45859: fix test_field_descriptor in test_collections for pypy

### DIFF
--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -668,6 +668,7 @@ class TestNamedTuple(unittest.TestCase):
         a.w = 5
         self.assertEqual(a.__dict__, {'w': 5})
 
+    @support.cpython_only
     def test_field_descriptor(self):
         Point = namedtuple('Point', 'x y')
         p = Point(11, 22)
@@ -676,17 +677,14 @@ class TestNamedTuple(unittest.TestCase):
         self.assertRaises(AttributeError, Point.x.__set__, p, 33)
         self.assertRaises(AttributeError, Point.x.__delete__, p)
 
-        # if there is no _itemgetter eg on PyPy, the rest doesn't make sense,
-        # because property isn't pickable
-        if type(Point.x) is not property:
-            class NewPoint(tuple):
-                x = pickle.loads(pickle.dumps(Point.x))
-                y = pickle.loads(pickle.dumps(Point.y))
+        class NewPoint(tuple):
+            x = pickle.loads(pickle.dumps(Point.x))
+            y = pickle.loads(pickle.dumps(Point.y))
 
-            np = NewPoint([1, 2])
+        np = NewPoint([1, 2])
 
-            self.assertEqual(np.x, 1)
-            self.assertEqual(np.y, 2)
+        self.assertEqual(np.x, 1)
+        self.assertEqual(np.y, 2)
 
     def test_new_builtins_issue_43102(self):
         obj = namedtuple('C', ())

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -676,14 +676,17 @@ class TestNamedTuple(unittest.TestCase):
         self.assertRaises(AttributeError, Point.x.__set__, p, 33)
         self.assertRaises(AttributeError, Point.x.__delete__, p)
 
-        class NewPoint(tuple):
-            x = pickle.loads(pickle.dumps(Point.x))
-            y = pickle.loads(pickle.dumps(Point.y))
+        # if there is no _itemgetter eg on PyPy, the rest doesn't make sense,
+        # because property isn't pickable
+        if type(Point.x) is not property:
+            class NewPoint(tuple):
+                x = pickle.loads(pickle.dumps(Point.x))
+                y = pickle.loads(pickle.dumps(Point.y))
 
-        np = NewPoint([1, 2])
+            np = NewPoint([1, 2])
 
-        self.assertEqual(np.x, 1)
-        self.assertEqual(np.y, 2)
+            self.assertEqual(np.x, 1)
+            self.assertEqual(np.y, 2)
 
     def test_new_builtins_issue_43102(self):
         obj = namedtuple('C', ())


### PR DESCRIPTION
that test tries to pickle the descriptors of a namedtuple's fields,
which is _collections._itemgetter on CPython. However, on PyPy that
class doesn't exist. The code in collections deals fine with that fact,
but the above-mentioned test does not make sense in that situation,
since you can't pickle properties.

<!-- issue-number: [bpo-45859](https://bugs.python.org/issue45859) -->
https://bugs.python.org/issue45859
<!-- /issue-number -->
