### PR TITLE
bpo-44649: Fix dataclasses(slots=True) with a field with a default, but init=False

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2880,6 +2880,17 @@ class TestSlots(unittest.TestCase):
                 self.assertIsNot(obj, p)
                 self.assertEqual(obj, p)
 
+    def test_slots_with_default_no_init(self):
+        # Originally reported in bpo-44649.
+        @dataclass(slots=True)
+        class A:
+            a: str
+            b: str = field(default='b', init=False)
+
+        obj = A("a")
+        self.assertEqual(obj.a, 'a')
+        self.assertEqual(obj.b, 'b')
+
 class TestDescriptors(unittest.TestCase):
     def test_set_name(self):
         # See bpo-33141.

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2891,6 +2891,17 @@ class TestSlots(unittest.TestCase):
         self.assertEqual(obj.a, 'a')
         self.assertEqual(obj.b, 'b')
 
+    def test_slots_with_default_factory_no_init(self):
+        # Originally reported in bpo-44649.
+        @dataclass(slots=True)
+        class A:
+            a: str
+            b: str = field(default_factory=lambda:'b', init=False)
+
+        obj = A("a")
+        self.assertEqual(obj.a, 'a')
+        self.assertEqual(obj.b, 'b')
+
 class TestDescriptors(unittest.TestCase):
     def test_set_name(self):
         # See bpo-33141.

--- a/Misc/NEWS.d/next/Library/2021-11-21-20-50-42.bpo-44649.E8M936.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-21-20-50-42.bpo-44649.E8M936.rst
@@ -1,0 +1,2 @@
+Handle dataclass(slots=True) with a field that has default a default value,
+but for which init=False.


### PR DESCRIPTION


<!-- issue-number: [bpo-44649](https://bugs.python.org/issue44649) -->
https://bugs.python.org/issue44649
<!-- /issue-number -->
