### PR TITLE
bpo-45865: Removed inheritance from object in unittest

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -41,7 +41,7 @@ class _UnexpectedSuccess(Exception):
     """
 
 
-class _Outcome(object):
+class _Outcome:
     def __init__(self, result=None):
         self.expecting_failure = False
         self.result = result
@@ -322,7 +322,7 @@ class _OrderedChainMap(collections.ChainMap):
                     yield k
 
 
-class TestCase(object):
+class TestCase:
     """A class whose instances are single test cases.
 
     By default, the test code itself should be placed in a method named

--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -63,7 +63,7 @@ def _jython_aware_splitext(path):
     return os.path.splitext(path)[0]
 
 
-class TestLoader(object):
+class TestLoader:
     """
     This class is responsible for loading tests according to various criteria
     and returning them wrapped in a TestSuite

--- a/Lib/unittest/main.py
+++ b/Lib/unittest/main.py
@@ -52,7 +52,7 @@ def _convert_select_pattern(pattern):
     return pattern
 
 
-class TestProgram(object):
+class TestProgram:
     """A command-line program that runs a set of tests; this is primarily
        for making test modules conveniently executable.
     """

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -278,7 +278,7 @@ def _is_magic(name):
     return '__%s__' % name[2:-2] == name
 
 
-class _SentinelObject(object):
+class _SentinelObject:
     "A unique, named, sentinel object."
     def __init__(self, name):
         self.name = name
@@ -290,7 +290,7 @@ class _SentinelObject(object):
         return 'sentinel.%s' % self.name
 
 
-class _Sentinel(object):
+class _Sentinel:
     """Access attributes to return a named object, usable as a sentinel."""
     def __init__(self):
         self._sentinels = {}
@@ -385,13 +385,13 @@ def _check_and_set_parent(parent, value, name, new_name):
     return True
 
 # Internal class to identify if we wrapped an iterator object or not.
-class _MockIter(object):
+class _MockIter:
     def __init__(self, obj):
         self.obj = iter(obj)
     def __next__(self):
         return next(self.obj)
 
-class Base(object):
+class Base:
     _mock_return_value = DEFAULT
     _mock_side_effect = None
     def __init__(self, /, *args, **kwargs):
@@ -1250,7 +1250,7 @@ def _check_spec_arg_typos(kwargs_to_check):
             )
 
 
-class _patch(object):
+class _patch:
 
     attribute_name = None
     _active_patches = []
@@ -1755,7 +1755,7 @@ def patch(
     )
 
 
-class _patch_dict(object):
+class _patch_dict:
     """
     Patch a dictionary, or dictionary like object, and restore the dictionary
     to its original state after the test.
@@ -2378,7 +2378,7 @@ class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock):
     """
 
 
-class _ANY(object):
+class _ANY:
     "A helper object that compares equal to everything."
 
     def __eq__(self, other):
@@ -2768,7 +2768,7 @@ def _must_skip(spec, entry, is_type):
     return is_type
 
 
-class _SpecState(object):
+class _SpecState:
 
     def __init__(self, spec, spec_set=False, parent=None,
                  name=None, ids=None, instance=False):

--- a/Lib/unittest/result.py
+++ b/Lib/unittest/result.py
@@ -21,7 +21,7 @@ STDOUT_LINE = '\nStdout:\n%s'
 STDERR_LINE = '\nStderr:\n%s'
 
 
-class TestResult(object):
+class TestResult:
     """Holder for test result information.
 
     Test results are automatically managed by the TestCase and TestSuite

--- a/Lib/unittest/runner.py
+++ b/Lib/unittest/runner.py
@@ -11,7 +11,7 @@ from .signals import registerResult
 __unittest = True
 
 
-class _WritelnDecorator(object):
+class _WritelnDecorator:
     """Used to decorate file-like objects with a handy 'writeln' method"""
     def __init__(self,stream):
         self.stream = stream
@@ -152,7 +152,7 @@ class TextTestResult(result.TestResult):
             self.stream.flush()
 
 
-class TextTestRunner(object):
+class TextTestRunner:
     """A test runner class that displays results in textual form.
 
     It prints out the names of tests as they are run, errors as they

--- a/Lib/unittest/signals.py
+++ b/Lib/unittest/signals.py
@@ -6,7 +6,7 @@ from functools import wraps
 __unittest = True
 
 
-class _InterruptHandler(object):
+class _InterruptHandler:
     def __init__(self, default_handler):
         self.called = False
         self.original_handler = default_handler

--- a/Lib/unittest/suite.py
+++ b/Lib/unittest/suite.py
@@ -13,7 +13,7 @@ def _call_if_exists(parent, attr):
     func()
 
 
-class BaseTestSuite(object):
+class BaseTestSuite:
     """A simple test suite that doesn't provide class or module shared fixtures.
     """
     _cleanup = True
@@ -325,7 +325,7 @@ class TestSuite(BaseTestSuite):
             _call_if_exists(result, '_restoreStdout')
 
 
-class _ErrorHolder(object):
+class _ErrorHolder:
     """
     Placeholder for a TestCase inside a result. As far as a TestResult
     is concerned, this looks exactly like a unit test. Used to insert
@@ -372,7 +372,7 @@ def _isnotsuite(test):
     return False
 
 
-class _DebugResult(object):
+class _DebugResult:
     "Used by the TestSuite to hold previous class when running in debug."
     _previousTestClass = None
     _moduleSetUpFailed = False

--- a/Lib/unittest/test/support.py
+++ b/Lib/unittest/test/support.py
@@ -1,7 +1,7 @@
 import unittest
 
 
-class TestEquality(object):
+class TestEquality:
     """Used as a mixin for TestCase"""
 
     # Check for a valid __eq__ implementation
@@ -16,7 +16,7 @@ class TestEquality(object):
             self.assertNotEqual(obj_1, obj_2)
             self.assertNotEqual(obj_2, obj_1)
 
-class TestHashing(object):
+class TestHashing:
     """Used as a mixin for TestCase"""
 
     # Check for a valid __hash__ implementation
@@ -107,7 +107,7 @@ class LoggingResult(_BaseLoggingResult):
         super().addSubTest(test, subtest, err)
 
 
-class ResultWithNoStartTestRunStopTestRun(object):
+class ResultWithNoStartTestRunStopTestRun:
     """An object honouring TestResult before startTestRun/stopTestRun."""
 
     def __init__(self):

--- a/Lib/unittest/test/test_break.py
+++ b/Lib/unittest/test/test_break.py
@@ -191,7 +191,7 @@ class TestBreak(unittest.TestCase):
         result = object()
         default_handler = signal.getsignal(signal.SIGINT)
 
-        class FakeRunner(object):
+        class FakeRunner:
             initArgs = []
             runArgs = []
             def __init__(self, *args, **kwargs):

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -27,7 +27,7 @@ log_foobar = logging.getLogger('foo.bar')
 log_quux = logging.getLogger('quux')
 
 
-class Test(object):
+class Test:
     "Keep these TestCase classes out of the main namespace"
 
     class Foo(unittest.TestCase):
@@ -643,7 +643,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
             'Tests shortDescription() whitespace is trimmed, so that the first')
 
     def testAddTypeEqualityFunc(self):
-        class SadSnake(object):
+        class SadSnake:
             """Dummy class for test_addTypeEqualityFunc."""
         s1, s2 = SadSnake(), SadSnake()
         self.assertFalse(s1 == s2)

--- a/Lib/unittest/test/test_discovery.py
+++ b/Lib/unittest/test/test_discovery.py
@@ -156,7 +156,7 @@ class TestDiscovery(unittest.TestCase):
         os.path.isfile = lambda path: os.path.basename(path) not in directories
         self.addCleanup(restore_isfile)
 
-        class Module(object):
+        class Module:
             paths = []
             load_tests_args = []
 
@@ -230,7 +230,7 @@ class TestDiscovery(unittest.TestCase):
         os.path.isfile = lambda path: os.path.basename(path) not in directories
         self.addCleanup(restore_isfile)
 
-        class Module(object):
+        class Module:
             paths = []
             load_tests_args = []
 
@@ -315,7 +315,7 @@ class TestDiscovery(unittest.TestCase):
         os.path.isdir = lambda path: not path.endswith('.py')
         os.path.isfile = lambda path: path.endswith('.py')
 
-        class Module(object):
+        class Module:
             paths = []
             load_tests_args = []
 
@@ -432,7 +432,7 @@ class TestDiscovery(unittest.TestCase):
         os.path.isdir = lambda path: not path.endswith('.py')
         self.addCleanup(sys.path.remove, abspath('/toplevel'))
 
-        class Module(object):
+        class Module:
             paths = []
             load_tests_args = []
 
@@ -632,7 +632,7 @@ class TestDiscovery(unittest.TestCase):
         program = object.__new__(unittest.TestProgram)
         program._initArgParsers()
 
-        class Loader(object):
+        class Loader:
             args = []
             def discover(self, start_dir, pattern, top_level_dir):
                 self.args.append((start_dir, pattern, top_level_dir))
@@ -645,7 +645,7 @@ class TestDiscovery(unittest.TestCase):
     def test_command_line_handling_do_discovery_calls_loader(self):
         program = TestableTestProgram()
 
-        class Loader(object):
+        class Loader:
             args = []
             def discover(self, start_dir, pattern, top_level_dir):
                 self.args.append((start_dir, pattern, top_level_dir))
@@ -717,7 +717,7 @@ class TestDiscovery(unittest.TestCase):
         self.assertTrue(program.catchbreak)
 
     def setup_module_clash(self):
-        class Module(object):
+        class Module:
             __file__ = 'bar/foo.py'
         sys.modules['foo'] = Module
         full_path = os.path.abspath('foo')

--- a/Lib/unittest/test/test_loader.py
+++ b/Lib/unittest/test/test_loader.py
@@ -145,7 +145,7 @@ class Test_TestLoader(unittest.TestCase):
             def test(self):
                 pass
 
-        class NotAModule(object):
+        class NotAModule:
             test_2 = MyTestCase
 
         loader = unittest.TestLoader()
@@ -391,7 +391,7 @@ class Test_TestLoader(unittest.TestCase):
             def test(self):
                 pass
 
-        class NotAModule(object):
+        class NotAModule:
             test_2 = MyTestCase
 
         loader = unittest.TestLoader()
@@ -815,7 +815,7 @@ class Test_TestLoader(unittest.TestCase):
             def test(self):
                 pass
 
-        class NotAModule(object):
+        class NotAModule:
             test_2 = MyTestCase
 
         loader = unittest.TestLoader()

--- a/Lib/unittest/test/test_program.py
+++ b/Lib/unittest/test/test_program.py
@@ -32,7 +32,7 @@ class Test_TestProgram(unittest.TestCase):
         result = object()
         test = object()
 
-        class FakeRunner(object):
+        class FakeRunner:
             def run(self, test):
                 self.test = test
                 return result
@@ -73,7 +73,7 @@ class Test_TestProgram(unittest.TestCase):
                 [self.loadTestsFromTestCase(Test_TestProgram.FooBar)])
 
     def test_defaultTest_with_string(self):
-        class FakeRunner(object):
+        class FakeRunner:
             def run(self, test):
                 self.test = test
                 return True
@@ -88,7 +88,7 @@ class Test_TestProgram(unittest.TestCase):
         self.assertEqual(('unittest.test',), program.testNames)
 
     def test_defaultTest_with_iterable(self):
-        class FakeRunner(object):
+        class FakeRunner:
             def run(self, test):
                 self.test = test
                 return True
@@ -156,7 +156,7 @@ class InitialisableProgram(unittest.TestProgram):
 
 RESULT = object()
 
-class FakeRunner(object):
+class FakeRunner:
     initArgs = None
     test = None
     raiseError = 0

--- a/Lib/unittest/test/test_result.py
+++ b/Lib/unittest/test/test_result.py
@@ -9,7 +9,7 @@ import unittest
 from unittest.util import strclass
 
 
-class MockTraceback(object):
+class MockTraceback:
     class TracebackException:
         def __init__(self, *args, **kwargs):
             self.capture_locals = kwargs.get('capture_locals', False)
@@ -322,8 +322,8 @@ class Test_TestResult(unittest.TestCase):
         self.assertIn("some recognizable failure", formatted_exc)
 
     def testStackFrameTrimming(self):
-        class Frame(object):
-            class tb_frame(object):
+        class Frame:
+            class tb_frame:
                 f_globals = {}
         result = unittest.TestResult()
         self.assertFalse(result._is_relevant_tb_level(Frame))
@@ -1107,7 +1107,7 @@ class TestOutputBuffering(unittest.TestCase):
         class Foo(unittest.TestCase):
             def test_foo(self):
                 pass
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 print('set up module')
@@ -1135,7 +1135,7 @@ class TestOutputBuffering(unittest.TestCase):
         class Foo(unittest.TestCase):
             def test_foo(self):
                 pass
-        class Module(object):
+        class Module:
             @staticmethod
             def tearDownModule():
                 print('tear down module')
@@ -1163,7 +1163,7 @@ class TestOutputBuffering(unittest.TestCase):
         class Foo(unittest.TestCase):
             def test_foo(self):
                 pass
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 print('set up module')
@@ -1193,7 +1193,7 @@ class TestOutputBuffering(unittest.TestCase):
         class Foo(unittest.TestCase):
             def test_foo(self):
                 pass
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 print('set up module')
@@ -1232,7 +1232,7 @@ class TestOutputBuffering(unittest.TestCase):
         class Foo(unittest.TestCase):
             def test_foo(self):
                 pass
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 print('set up module')

--- a/Lib/unittest/test/test_runner.py
+++ b/Lib/unittest/test/test_runner.py
@@ -461,7 +461,7 @@ class TestModuleCleanUp(unittest.TestCase):
         def module_cleanup2(*args, **kwargs):
             module_cleanups.append((4, args, kwargs))
 
-        class Module(object):
+        class Module:
             unittest.addModuleCleanup(module_cleanup1, 1, 2, 3,
                                       four='hello', five='goodbye')
             unittest.addModuleCleanup(module_cleanup2)
@@ -485,7 +485,7 @@ class TestModuleCleanUp(unittest.TestCase):
         def module_cleanup_bad(*args, **kwargs):
             raise Exception('CleanUpExc')
 
-        class Module(object):
+        class Module:
             unittest.addModuleCleanup(module_cleanup_good, 1, 2, 3,
                                       four='hello', five='goodbye')
             unittest.addModuleCleanup(module_cleanup_bad)
@@ -503,7 +503,7 @@ class TestModuleCleanUp(unittest.TestCase):
         def cleanup(*args, **kwargs):
             cleanups.append((args, kwargs))
 
-        class Module(object):
+        class Module:
             unittest.addModuleCleanup(cleanup, 1, 2, function='hello')
             with self.assertRaises(TypeError):
                 unittest.addModuleCleanup(function=cleanup, arg='hello')
@@ -516,7 +516,7 @@ class TestModuleCleanUp(unittest.TestCase):
     def test_run_module_cleanUp(self):
         blowUp = True
         ordering = []
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -556,7 +556,7 @@ class TestModuleCleanUp(unittest.TestCase):
         blowUp = True
         blowUp2 = False
         ordering = []
-        class Module1(object):
+        class Module1:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -567,7 +567,7 @@ class TestModuleCleanUp(unittest.TestCase):
             def tearDownModule():
                 ordering.append('tearDownModule')
 
-        class Module2(object):
+        class Module2:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule2')
@@ -629,7 +629,7 @@ class TestModuleCleanUp(unittest.TestCase):
 
     def test_run_module_cleanUp_without_teardown(self):
         ordering = []
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -654,7 +654,7 @@ class TestModuleCleanUp(unittest.TestCase):
 
     def test_run_module_cleanUp_when_teardown_exception(self):
         ordering = []
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -685,7 +685,7 @@ class TestModuleCleanUp(unittest.TestCase):
     def test_debug_module_executes_cleanUp(self):
         ordering = []
         blowUp = False
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -726,7 +726,7 @@ class TestModuleCleanUp(unittest.TestCase):
     def test_debug_module_cleanUp_when_teardown_exception(self):
         ordering = []
         blowUp = False
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -813,7 +813,7 @@ class TestModuleCleanUp(unittest.TestCase):
     def test_with_errors_in_addClassCleanup(self):
         ordering = []
 
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -845,7 +845,7 @@ class TestModuleCleanUp(unittest.TestCase):
 
     def test_with_errors_in_addCleanup(self):
         ordering = []
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -878,7 +878,7 @@ class TestModuleCleanUp(unittest.TestCase):
         module_blow_up = False
         class_blow_up = False
         method_blow_up = False
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -963,7 +963,7 @@ class TestModuleCleanUp(unittest.TestCase):
         def cleanup3():
             ordering.append('cleanup3')
 
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')

--- a/Lib/unittest/test/test_setups.py
+++ b/Lib/unittest/test/test_setups.py
@@ -183,7 +183,7 @@ class TestSetups(unittest.TestCase):
     def test_setup_teardown_order_with_pathological_suite(self):
         results = []
 
-        class Module1(object):
+        class Module1:
             @staticmethod
             def setUpModule():
                 results.append('Module1.setUpModule')
@@ -191,7 +191,7 @@ class TestSetups(unittest.TestCase):
             def tearDownModule():
                 results.append('Module1.tearDownModule')
 
-        class Module2(object):
+        class Module2:
             @staticmethod
             def setUpModule():
                 results.append('Module2.setUpModule')
@@ -263,7 +263,7 @@ class TestSetups(unittest.TestCase):
                           'teardown 3', 'Module2.tearDownModule'])
 
     def test_setup_module(self):
-        class Module(object):
+        class Module:
             moduleSetup = 0
             @staticmethod
             def setUpModule():
@@ -283,7 +283,7 @@ class TestSetups(unittest.TestCase):
         self.assertEqual(len(result.errors), 0)
 
     def test_error_in_setup_module(self):
-        class Module(object):
+        class Module:
             moduleSetup = 0
             moduleTornDown = 0
             @staticmethod
@@ -340,7 +340,7 @@ class TestSetups(unittest.TestCase):
         self.assertEqual(result.testsRun, 2)
 
     def test_teardown_module(self):
-        class Module(object):
+        class Module:
             moduleTornDown = 0
             @staticmethod
             def tearDownModule():
@@ -360,7 +360,7 @@ class TestSetups(unittest.TestCase):
         self.assertEqual(len(result.errors), 0)
 
     def test_error_in_teardown_module(self):
-        class Module(object):
+        class Module:
             moduleTornDown = 0
             @staticmethod
             def tearDownModule():
@@ -424,7 +424,7 @@ class TestSetups(unittest.TestCase):
             def test_two(self):
                 pass
 
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 raise unittest.SkipTest('foo')
@@ -442,7 +442,7 @@ class TestSetups(unittest.TestCase):
     def test_suite_debug_executes_setups_and_teardowns(self):
         ordering = []
 
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -469,7 +469,7 @@ class TestSetups(unittest.TestCase):
         self.assertEqual(ordering, expectedOrder)
 
     def test_suite_debug_propagates_exceptions(self):
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 if phase == 0:

--- a/Lib/unittest/test/test_suite.py
+++ b/Lib/unittest/test/test_suite.py
@@ -9,7 +9,7 @@ from unittest.test.support import LoggingResult, TestEquality
 ### Support code for Test_TestSuite
 ################################################################
 
-class Test(object):
+class Test:
     class Foo(unittest.TestCase):
         def test_1(self): pass
         def test_2(self): pass
@@ -395,7 +395,7 @@ class Test_TestSuite(unittest.TestCase, TestEquality):
                 pass
             def testFail(self):
                 fail
-        class Module(object):
+        class Module:
             wasSetUp = False
             wasTornDown = False
             @staticmethod

--- a/Lib/unittest/test/testmock/support.py
+++ b/Lib/unittest/test/testmock/support.py
@@ -6,11 +6,11 @@ def is_instance(obj, klass):
     return issubclass(type(obj), klass)
 
 
-class SomeClass(object):
+class SomeClass:
     class_attribute = None
 
     def wibble(self): pass
 
 
-class X(object):
+class X:
     pass

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -36,7 +36,7 @@ async def async_func_args(a, b, *, c): pass
 
 def normal_func(): pass
 
-class NormalClass(object):
+class NormalClass:
     def a(self): pass
 
 
@@ -663,7 +663,7 @@ class AsyncContextManagerTest(unittest.TestCase):
 
 
 class AsyncIteratorTest(unittest.TestCase):
-    class WithAsyncIterator(object):
+    class WithAsyncIterator:
         def __init__(self):
             self.items = ["foo", "NormalFoo", "baz"]
 

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -11,7 +11,7 @@ from unittest.mock import (
 from datetime import datetime
 from functools import partial
 
-class SomeClass(object):
+class SomeClass:
     def one(self, a, b): pass
     def two(self): pass
     def three(self, a=None): pass
@@ -45,7 +45,7 @@ class AnyTest(unittest.TestCase):
 
     def test_any_mock_calls_comparison_order(self):
         mock = Mock()
-        class Foo(object):
+        class Foo:
             def __eq__(self, other): pass
             def __ne__(self, other): pass
 
@@ -417,7 +417,7 @@ class SpecSignatureTest(unittest.TestCase):
         mock = create_autospec(f, return_value='foo')
         self.assertEqual(mock(), 'foo')
 
-        class Foo(object):
+        class Foo:
             pass
 
         mock = create_autospec(Foo, return_value='foo')
@@ -432,7 +432,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_mocking_unbound_methods(self):
-        class Foo(object):
+        class Foo:
             def foo(self, foo): pass
         p = patch.object(Foo, 'foo')
         mock_foo = p.start()
@@ -442,7 +442,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_create_autospec_keyword_arguments(self):
-        class Foo(object):
+        class Foo:
             a = 3
         m = create_autospec(Foo, a='3')
         self.assertEqual(m.a, '3')
@@ -479,7 +479,7 @@ class SpecSignatureTest(unittest.TestCase):
 
         self.assertRaises(AttributeError, getattr, mock, 'foo')
 
-        class Foo(object):
+        class Foo:
             foo = []
 
         mock = create_autospec(Foo)
@@ -500,13 +500,13 @@ class SpecSignatureTest(unittest.TestCase):
 
     def test_spec_has_descriptor_returning_function(self):
 
-        class CrazyDescriptor(object):
+        class CrazyDescriptor:
 
             def __get__(self, obj, type_):
                 if obj is None:
                     return lambda x: None
 
-        class MyClass(object):
+        class MyClass:
 
             some_attr = CrazyDescriptor()
 
@@ -520,7 +520,7 @@ class SpecSignatureTest(unittest.TestCase):
 
     def test_spec_has_function_not_in_bases(self):
 
-        class CrazyClass(object):
+        class CrazyClass:
 
             def __dir__(self):
                 return super(CrazyClass, self).__dir__()+['crazy']
@@ -620,7 +620,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_descriptors(self):
-        class Foo(object):
+        class Foo:
             @classmethod
             def f(cls, a, b): pass
             @staticmethod
@@ -640,7 +640,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_recursive(self):
-        class A(object):
+        class A:
             def a(self): pass
             foo = 'foo bar baz'
             bar = foo
@@ -662,9 +662,9 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_spec_inheritance_for_classes(self):
-        class Foo(object):
+        class Foo:
             def a(self, x): pass
-            class Bar(object):
+            class Bar:
                 def f(self, y): pass
 
         class_mock = create_autospec(Foo)
@@ -700,7 +700,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_inherit(self):
-        class Foo(object):
+        class Foo:
             a = 3
 
         Foo.Foo = Foo
@@ -763,12 +763,12 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_skip_attributeerrors(self):
-        class Raiser(object):
+        class Raiser:
             def __get__(self, obj, type=None):
                 if obj is None:
                     raise AttributeError('Can only be accessed via an instance')
 
-        class RaiserClass(object):
+        class RaiserClass:
             raiser = Raiser()
 
             @staticmethod
@@ -787,7 +787,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_signature_class(self):
-        class Foo(object):
+        class Foo:
             def __init__(self, a, b=3): pass
 
         mock = create_autospec(Foo)
@@ -807,13 +807,13 @@ class SpecSignatureTest(unittest.TestCase):
     def test_class_with_no_init(self):
         # this used to raise an exception
         # due to trying to get a signature from object.__init__
-        class Foo(object):
+        class Foo:
             pass
         create_autospec(Foo)
 
 
     def test_signature_callable(self):
-        class Callable(object):
+        class Callable:
             def __init__(self, x, y): pass
             def __call__(self, a): pass
 
@@ -841,7 +841,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_signature_noncallable(self):
-        class NonCallable(object):
+        class NonCallable:
             def __init__(self):
                 pass
 
@@ -858,7 +858,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_create_autospec_none(self):
-        class Foo(object):
+        class Foo:
             bar = None
 
         mock = create_autospec(Foo)
@@ -870,7 +870,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_autospec_functions_with_self_in_odd_place(self):
-        class Foo(object):
+        class Foo:
             def f(a, self): pass
 
         a = create_autospec(Foo)
@@ -883,7 +883,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_autospec_data_descriptor(self):
-        class Descriptor(object):
+        class Descriptor:
             def __init__(self, value):
                 self.value = value
 
@@ -895,7 +895,7 @@ class SpecSignatureTest(unittest.TestCase):
         class MyProperty(property):
             pass
 
-        class Foo(object):
+        class Foo:
             __slots__ = ['slot']
 
             @property

--- a/Lib/unittest/test/testmock/testmagicmethods.py
+++ b/Lib/unittest/test/testmock/testmagicmethods.py
@@ -333,7 +333,7 @@ class TestMockingMagicMethods(unittest.TestCase):
 
 
     def test_magic_methods_and_spec(self):
-        class Iterable(object):
+        class Iterable:
             def __iter__(self): pass
 
         mock = Mock(spec=Iterable)
@@ -342,7 +342,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock.__iter__ = Mock(return_value=iter([]))
         self.assertEqual(list(mock), [])
 
-        class NonIterable(object):
+        class NonIterable:
             pass
         mock = Mock(spec=NonIterable)
         self.assertRaises(AttributeError, lambda: mock.__iter__)
@@ -357,7 +357,7 @@ class TestMockingMagicMethods(unittest.TestCase):
 
 
     def test_magic_methods_and_spec_set(self):
-        class Iterable(object):
+        class Iterable:
             def __iter__(self): pass
 
         mock = Mock(spec_set=Iterable)
@@ -366,7 +366,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock.__iter__ = Mock(return_value=iter([]))
         self.assertEqual(list(mock), [])
 
-        class NonIterable(object):
+        class NonIterable:
             pass
         mock = Mock(spec_set=NonIterable)
         self.assertRaises(AttributeError, lambda: mock.__iter__)

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -15,7 +15,7 @@ from unittest.mock import (
 )
 
 
-class Iter(object):
+class Iter:
     def __init__(self):
         self.thing = iter(['this', 'is', 'an', 'iter'])
 
@@ -28,7 +28,7 @@ class Iter(object):
     __next__ = next
 
 
-class Something(object):
+class Something:
     def meth(self, a, b, c, d=None): pass
 
     @classmethod
@@ -122,7 +122,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_repr_with_spec(self):
-        class X(object):
+        class X:
             pass
 
         mock = Mock(spec=X)
@@ -206,8 +206,8 @@ class MockTest(unittest.TestCase):
 
 
     def test_autospec_mock(self):
-        class A(object):
-            class B(object):
+        class A:
+            class B:
                 C = None
 
         with mock.patch.object(A, 'B'):
@@ -566,7 +566,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_from_spec(self):
-        class Something(object):
+        class Something:
             x = 3
             __something__ = None
             def y(self): pass
@@ -604,7 +604,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_wraps_prevents_automatic_creation_of_mocks(self):
-        class Real(object):
+        class Real:
             pass
 
         real = Real()
@@ -624,7 +624,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_wraps_attributes(self):
-        class Real(object):
+        class Real:
             attribute = Mock()
 
         real = Real()
@@ -640,7 +640,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_side_effect_iterable_with_default(self):
-        class Real(object):
+        class Real:
             def method(self):
                 return sentinel.ORIGINAL_VALUE
 
@@ -654,7 +654,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_side_effect_iterable(self):
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -667,7 +667,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_side_effect_exception(self):
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -678,7 +678,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_side_effect_function(self):
-        class Real(object):
+        class Real:
             def method(self): pass
         def side_effect():
             return sentinel.VALUE
@@ -691,7 +691,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_return_value(self):
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -703,7 +703,7 @@ class MockTest(unittest.TestCase):
 
     def test_customize_wrapped_object_with_return_value_and_side_effect(self):
         # side_effect should always take precedence over return_value.
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -718,7 +718,7 @@ class MockTest(unittest.TestCase):
 
     def test_customize_wrapped_object_with_return_value_and_side_effect2(self):
         # side_effect can return DEFAULT to default to return_value
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -730,7 +730,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_return_value_and_side_effect_default(self):
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -842,7 +842,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_spec_class(self):
-        class X(object):
+        class X:
             pass
 
         mock = Mock(spec=X)
@@ -882,7 +882,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_setting_attribute_with_spec_set(self):
-        class X(object):
+        class X:
             y = 3
 
         mock = Mock(spec=X)
@@ -1304,7 +1304,7 @@ class MockTest(unittest.TestCase):
         self.assertEqual([mock(), mock(), mock()], ['g', 'h', 'i'])
         self.assertRaises(StopIteration, mock)
 
-        class Foo(object):
+        class Foo:
             pass
         mock = MagicMock(side_effect=Foo)
         self.assertIsInstance(mock(), Foo)
@@ -1742,11 +1742,11 @@ class MockTest(unittest.TestCase):
         self.assertEqual(m.f.side_effect, None)
 
     def test_mock_add_spec(self):
-        class _One(object):
+        class _One:
             one = 1
-        class _Two(object):
+        class _Two:
             two = 2
-        class Anything(object):
+        class Anything:
             one = two = three = 'four'
 
         klasses = [
@@ -1846,7 +1846,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_manager_mock(self):
-        class Foo(object):
+        class Foo:
             one = 'one'
             two = 'two'
         manager = Mock()

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -25,7 +25,7 @@ MODNAME = '%s.PTModule' % __name__
 
 
 def _get_proxy(obj, get_only=True):
-    class Proxy(object):
+    class Proxy:
         def __getattr__(self, name):
             return getattr(obj, name)
     if not get_only:
@@ -43,7 +43,7 @@ something  = sentinel.Something
 something_else  = sentinel.SomethingElse
 
 
-class Foo(object):
+class Foo:
     def __init__(self, a): pass
     def f(self, a): pass
     def g(self): pass
@@ -55,7 +55,7 @@ class Foo(object):
     @classmethod
     def class_method(cls): pass
 
-    class Bar(object):
+    class Bar:
         def a(self): pass
 
 foo_name = '%s.Foo' % __name__
@@ -64,7 +64,7 @@ foo_name = '%s.Foo' % __name__
 def function(a, b=Foo): pass
 
 
-class Container(object):
+class Container:
     def __init__(self):
         self.values = {}
 
@@ -95,7 +95,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_single_patchobject(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
 
         @patch.object(Something, 'attribute', sentinel.Patched)
@@ -112,7 +112,7 @@ class PatchTest(unittest.TestCase):
             patch.object('Something', 'do_something')
 
     def test_patchobject_with_none(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
 
         @patch.object(Something, 'attribute', None)
@@ -125,7 +125,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_multiple_patchobject(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
             next_attribute = sentinel.Original2
 
@@ -215,7 +215,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patchobject_with_default_mock(self):
-        class Test(object):
+        class Test:
             something = sentinel.Original
             something2 = sentinel.Original2
 
@@ -405,7 +405,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patch_with_static_methods(self):
-        class Foo(object):
+        class Foo:
             @staticmethod
             def woot():
                 return sentinel.Static
@@ -429,7 +429,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patch_slots(self):
-        class Foo(object):
+        class Foo:
             __slots__ = ('Foo',)
 
         foo = Foo()
@@ -444,10 +444,10 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patchobject_class_decorator(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
 
-        class Foo(object):
+        class Foo:
             def test_method(other_self):
                 self.assertEqual(Something.attribute, sentinel.Patched,
                                  "unpatched")
@@ -466,10 +466,10 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patch_class_decorator(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
 
-        class Foo(object):
+        class Foo:
 
             test_class_attr = 'whatever'
 
@@ -492,7 +492,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patchobject_twice(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
             next_attribute = sentinel.Original2
 
@@ -783,7 +783,7 @@ class PatchTest(unittest.TestCase):
         d = {'spam': 'eggs'}
         original = d.copy()
 
-        class Test(object):
+        class Test:
             def test_first(self):
                 this.assertEqual(d, {'foo': 'bar'})
             def test_second(self):
@@ -810,7 +810,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_get_only_proxy(self):
-        class Something(object):
+        class Something:
             foo = 'foo'
         class SomethingElse:
             foo = 'foo'
@@ -828,7 +828,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_get_set_delete_proxy(self):
-        class Something(object):
+        class Something:
             foo = 'foo'
         class SomethingElse:
             foo = 'foo'
@@ -887,13 +887,13 @@ class PatchTest(unittest.TestCase):
 
 
     def test_autospec(self):
-        class Boo(object):
+        class Boo:
             def __init__(self, a): pass
             def f(self, a): pass
             def g(self): pass
             foo = 'bar'
 
-            class Bar(object):
+            class Bar:
                 def a(self): pass
 
         def _test(mock):
@@ -1083,7 +1083,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_new_callable_keyword_arguments(self):
-        class Bar(object):
+        class Bar:
             kwargs = None
             def __init__(self, **kwargs):
                 Bar.kwargs = kwargs
@@ -1098,7 +1098,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_new_callable_spec(self):
-        class Bar(object):
+        class Bar:
             kwargs = None
             def __init__(self, **kwargs):
                 Bar.kwargs = kwargs
@@ -1173,7 +1173,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_new_callable_inherit_non_mock(self):
-        class NotAMock(object):
+        class NotAMock:
             def __init__(self, spec):
                 self.spec = spec
 
@@ -1191,7 +1191,7 @@ class PatchTest(unittest.TestCase):
     def test_new_callable_class_decorating(self):
         test = self
         original = Foo
-        class SomeTest(object):
+        class SomeTest:
 
             def _test(self, mock_foo):
                 test.assertIsNot(Foo, original)
@@ -1359,7 +1359,7 @@ class PatchTest(unittest.TestCase):
         original_f = Foo.f
         original_g = Foo.g
 
-        class SomeTest(object):
+        class SomeTest:
 
             def _test(self, f, foo):
                 test.assertIs(Foo, original_foo)
@@ -1417,7 +1417,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patch_multiple_new_callable(self):
-        class Thing(object):
+        class Thing:
             pass
 
         patcher = patch.multiple(
@@ -1555,7 +1555,7 @@ class PatchTest(unittest.TestCase):
 
     @patch('unittest.mock.patch.TEST_PREFIX', 'foo')
     def test_patch_test_prefix(self):
-        class Foo(object):
+        class Foo:
             thing = 'original'
 
             def foo_one(self):
@@ -1578,7 +1578,7 @@ class PatchTest(unittest.TestCase):
 
     @patch('unittest.mock.patch.TEST_PREFIX', 'bar')
     def test_patch_dict_test_prefix(self):
-        class Foo(object):
+        class Foo:
             def bar_one(self):
                 return dict(the_dict)
             def bar_two(self):
@@ -1801,7 +1801,7 @@ class PatchTest(unittest.TestCase):
 
     def test_stopall_lifo(self):
         stopped = []
-        class thing(object):
+        class thing:
             one = two = three = None
 
         def get_patch(attribute):

--- a/Lib/unittest/test/testmock/testwith.py
+++ b/Lib/unittest/test/testmock/testwith.py
@@ -38,7 +38,7 @@ class WithTest(unittest.TestCase):
 
 
     def test_patch_object_with_statement(self):
-        class Foo(object):
+        class Foo:
             something = 'foo'
         original = Foo.something
         with patch.object(Foo, 'something'):


### PR DESCRIPTION
Removed all inheritance from `object` in unitest, as unnecessary since Python 3, thanks to [pyupgrade](https://github.com/asottile/pyupgrade/).


<!-- issue-number: [bpo-45865](https://bugs.python.org/issue45865) -->
https://bugs.python.org/issue45865
<!-- /issue-number -->
