### PR TITLE
bpo-45813: Make sure that frame->generator is NULLed when generator is deallocated.

### DIFF
--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2191,6 +2191,13 @@ class CoroutineTest(unittest.TestCase):
             return 'end'
         self.assertEqual(run_async(run_gen()), ([], 'end'))
 
+    def test_bpo_45813(self):
+        'This would crash the interpreter in 3.11a2'
+        async def f():
+            pass
+        frame = f().cr_frame
+        frame.clear()
+
 
 class CoroAsyncIOCompatTest(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-11-22-11-28-13.bpo-45813.ZMaWE2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-11-22-11-28-13.bpo-45813.ZMaWE2.rst
@@ -1,0 +1,1 @@
+Fix crash when calling coro.cr_frame.clear() after coroutine has been freed.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -134,6 +134,7 @@ gen_dealloc(PyGenObject *gen)
     InterpreterFrame *frame = gen->gi_xframe;
     if (frame != NULL) {
         gen->gi_xframe = NULL;
+        frame->generator = NULL;
         frame->previous = NULL;
         _PyFrame_Clear(frame, 1);
     }

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -99,6 +99,9 @@ take_ownership(PyFrameObject *f, InterpreterFrame *frame)
 int
 _PyFrame_Clear(InterpreterFrame * frame, int take)
 {
+    /* It is the responsibility of the owning generator/coroutine
+     * to have cleared the generator pointer */
+    assert(frame->generator == NULL);
     if (frame->frame_obj) {
         PyFrameObject *f = frame->frame_obj;
         frame->frame_obj = NULL;


### PR DESCRIPTION


<!-- issue-number: [bpo-45813](https://bugs.python.org/issue45813) -->
https://bugs.python.org/issue45813
<!-- /issue-number -->
