### PR TITLE
bpo-45874: Handle empty query string correctly in urllib.parse.parse_qsl

### DIFF
--- a/Lib/test/test_cgi.py
+++ b/Lib/test/test_cgi.py
@@ -51,7 +51,7 @@ def do_test(buf, method):
         return ComparableException(err)
 
 parse_strict_test_cases = [
-    ("", ValueError("bad query field: ''")),
+    ("", {}),
     ("&", ValueError("bad query field: ''")),
     ("&&", ValueError("bad query field: ''")),
     # Should the next few really be valid?

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -745,26 +745,27 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
             raise ValueError('Max number of fields exceeded')
 
     r = []
-    for name_value in qs.split(separator):
-        if not name_value and not strict_parsing:
-            continue
-        nv = name_value.split('=', 1)
-        if len(nv) != 2:
-            if strict_parsing:
-                raise ValueError("bad query field: %r" % (name_value,))
-            # Handle case of a control-name with no equal sign
-            if keep_blank_values:
-                nv.append('')
-            else:
+    if qs:
+        for name_value in qs.split(separator):
+            if not name_value and not strict_parsing:
                 continue
-        if len(nv[1]) or keep_blank_values:
-            name = nv[0].replace('+', ' ')
-            name = unquote(name, encoding=encoding, errors=errors)
-            name = _coerce_result(name)
-            value = nv[1].replace('+', ' ')
-            value = unquote(value, encoding=encoding, errors=errors)
-            value = _coerce_result(value)
-            r.append((name, value))
+            nv = name_value.split('=', 1)
+            if len(nv) != 2:
+                if strict_parsing:
+                    raise ValueError("bad query field: %r" % (name_value,))
+                # Handle case of a control-name with no equal sign
+                if keep_blank_values:
+                    nv.append('')
+                else:
+                    continue
+            if len(nv[1]) or keep_blank_values:
+                name = nv[0].replace('+', ' ')
+                name = unquote(name, encoding=encoding, errors=errors)
+                name = _coerce_result(name)
+                value = nv[1].replace('+', ' ')
+                value = unquote(value, encoding=encoding, errors=errors)
+                value = _coerce_result(value)
+                r.append((name, value))
     return r
 
 def unquote_plus(string, encoding='utf-8', errors='replace'):

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -740,7 +740,7 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
     # is less than max_num_fields. This prevents a memory exhaustion DOS
     # attack via post bodies with many fields.
     if max_num_fields is not None:
-        num_fields = 1 + qs.count(separator)
+        num_fields = 1 + qs.count(separator) if qs else 0
         if max_num_fields < num_fields:
             raise ValueError('Max number of fields exceeded')
 

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -745,27 +745,27 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
             raise ValueError('Max number of fields exceeded')
 
     r = []
-    if qs:
-        for name_value in qs.split(separator):
-            if not name_value and not strict_parsing:
+    query_args = qs.split(separator) if qs else []
+    for name_value in query_args:
+        if not name_value and not strict_parsing:
+            continue
+        nv = name_value.split('=', 1)
+        if len(nv) != 2:
+            if strict_parsing:
+                raise ValueError("bad query field: %r" % (name_value,))
+            # Handle case of a control-name with no equal sign
+            if keep_blank_values:
+                nv.append('')
+            else:
                 continue
-            nv = name_value.split('=', 1)
-            if len(nv) != 2:
-                if strict_parsing:
-                    raise ValueError("bad query field: %r" % (name_value,))
-                # Handle case of a control-name with no equal sign
-                if keep_blank_values:
-                    nv.append('')
-                else:
-                    continue
-            if len(nv[1]) or keep_blank_values:
-                name = nv[0].replace('+', ' ')
-                name = unquote(name, encoding=encoding, errors=errors)
-                name = _coerce_result(name)
-                value = nv[1].replace('+', ' ')
-                value = unquote(value, encoding=encoding, errors=errors)
-                value = _coerce_result(value)
-                r.append((name, value))
+        if len(nv[1]) or keep_blank_values:
+            name = nv[0].replace('+', ' ')
+            name = unquote(name, encoding=encoding, errors=errors)
+            name = _coerce_result(name)
+            value = nv[1].replace('+', ' ')
+            value = unquote(value, encoding=encoding, errors=errors)
+            value = _coerce_result(value)
+            r.append((name, value))
     return r
 
 def unquote_plus(string, encoding='utf-8', errors='replace'):

--- a/Misc/NEWS.d/next/Library/2021-12-02-11-55-45.bpo-45874.dtJIsN.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-02-11-55-45.bpo-45874.dtJIsN.rst
@@ -1,0 +1,3 @@
+The empty query string, consisting of no query arguments, is now handled
+correctly in ``urllib.parse.parse_qsl``. This caused problems before when
+strict parsing was enabled.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45874](https://bugs.python.org/issue45874) -->
https://bugs.python.org/issue45874
<!-- /issue-number -->
