### PR TITLE
bpo-37705: Remove orphaned PC/errmap.mak

### DIFF
--- a/PC/errmap.mak
+++ b/PC/errmap.mak
@@ -1,5 +1,0 @@
-errmap.h:	generrmap.exe
-	.\generrmap.exe > errmap.h
-
-genermap.exe:	generrmap.c
-	cl generrmap.c


### PR DESCRIPTION
After GH-15623 deleted `generrmap.c`, a related mak-file stopped working. The mak contains generrmap-related rules only so it should be removed altogether.

Further search for `errmap\.mak|generrmap` regex through content of CPython files shows no dangling reference left.

Since generrmap is already effectively removed, this pull request contains no blurp.

<!-- issue-number: [bpo-37705](https://bugs.python.org/issue37705) -->
https://bugs.python.org/issue37705
<!-- /issue-number -->

Automerge-Triggered-By: GH:zware