### PR TITLE
bpo-45614: Fix traceback display for exceptions with invalid module name

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1254,6 +1254,17 @@ class BaseExceptionReportingTests:
                 exp = "%s: %s\n" % (str_name, str_value)
                 self.assertEqual(exp, err)
 
+    def test_exception_modulename_not_unicode(self):
+        class X(Exception):
+            def __str__(self):
+                return "I am X"
+
+        X.__module__ = 42
+
+        err = self.get_report(X())
+        exp = f'<unknown>.{X.__qualname__}: I am X\n'
+        self.assertEqual(exp, err)
+
     def test_exception_bad__str__(self):
         class X(Exception):
             def __str__(self):

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -808,6 +808,8 @@ class TracebackException:
         stype = self.exc_type.__qualname__
         smod = self.exc_type.__module__
         if smod not in ("__main__", "builtins"):
+            if not isinstance(smod, str):
+                smod = "<unknown>"
             stype = smod + '.' + stype
 
         if not issubclass(self.exc_type, SyntaxError):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-11-23-12-06-41.bpo-45614.fIekgI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-11-23-12-06-41.bpo-45614.fIekgI.rst
@@ -1,0 +1,1 @@
+Fix :mod:`traceback` display for exceptions with invalid module name.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1022,7 +1022,7 @@ print_exception(struct exception_print_context *ctx, PyObject *value)
             {
                 Py_XDECREF(modulename);
                 PyErr_Clear();
-                err = PyFile_WriteString("<unknown>", f);
+                err = PyFile_WriteString("<unknown>.", f);
             }
             else {
                 if (!_PyUnicode_EqualToASCIIId(modulename, &PyId_builtins) &&


### PR DESCRIPTION
This was found via missing test coverage.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45614](https://bugs.python.org/issue45614) -->
https://bugs.python.org/issue45614
<!-- /issue-number -->
