### PR TITLE
[WIP] bpo-45490: Convert static inline to macros

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -52,11 +52,7 @@ PyAPI_FUNC(PyObject *) _PyObject_MakeTpCall(
 
 #define PY_VECTORCALL_ARGUMENTS_OFFSET ((size_t)1 << (8 * sizeof(size_t) - 1))
 
-static inline Py_ssize_t
-PyVectorcall_NARGS(size_t n)
-{
-    return n & ~PY_VECTORCALL_ARGUMENTS_OFFSET;
-}
+#define PyVectorcall_NARGS(n) (Py_ssize_t)((size_t)n & ~PY_VECTORCALL_ARGUMENTS_OFFSET)
 
 PyAPI_FUNC(vectorcallfunc) PyVectorcall_Function(PyObject *callable);
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2336,13 +2336,15 @@ PyObject_GET_WEAKREFS_LISTPTR(PyObject *op)
 PyObject*
 Py_NewRef(PyObject *obj)
 {
-    return _Py_NewRef(obj);
+    Py_INCREF(obj);
+    return obj;
 }
 
 PyObject*
 Py_XNewRef(PyObject *obj)
 {
-    return _Py_XNewRef(obj);
+    Py_XINCREF(obj);
+    return obj;
 }
 
 #undef Py_Is


### PR DESCRIPTION
Convert static inline functions to macros to run a benchmark:

* PyObject_TypeCheck()
* PyType_Check()
* PyType_CheckExact()
* PyType_HasFeature()
* PyVectorcall_NARGS()
* Py_DECREF()
* Py_INCREF()
* Py_IS_TYPE()
* Py_NewRef()
* Py_REFCNT()
* Py_SIZE()
* Py_TYPE()
* Py_XDECREF()
* Py_XINCREF()

Note: Py_XNewRef() remains a static inline function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45490](https://bugs.python.org/issue45490) -->
https://bugs.python.org/issue45490
<!-- /issue-number -->
