### PR TITLE
bpo-45616: Let py.exe distinguish between v3.1 and v3.10

### DIFF
--- a/Misc/NEWS.d/next/Windows/2021-11-23-11-44-42.bpo-45616.K52PLZ.rst
+++ b/Misc/NEWS.d/next/Windows/2021-11-23-11-44-42.bpo-45616.K52PLZ.rst
@@ -1,0 +1,4 @@
+Fix Python Launcher's ability to distinguish between versions 3.1 and 3.10
+when either one is explicitly requested.  Previously, 3.1 would be used if
+3.10 was requested but not installed, and 3.10 would be used if 3.1 was
+requested but 3.10 was installed.

--- a/PC/launcher.c
+++ b/PC/launcher.c
@@ -542,8 +542,17 @@ find_python_by_version(wchar_t const * wanted_ver)
     }
     for (i = 0; i < num_installed_pythons; i++, ip++) {
         n = wcslen(ip->version);
-        if (n > wlen)
+        /*
+         * If wlen is greater than 1, we're probably trying to find a specific
+         * version and thus want an exact match: 3.1 != 3.10.  Otherwise, we
+         * just want a prefix match.
+         */
+        if ((wlen > 1) && (n != wlen)) {
+            continue;
+        }
+        if (n > wlen) {
             n = wlen;
+        }
         if ((wcsncmp(ip->version, wanted_ver, n) == 0) &&
             /* bits == 0 => don't care */
             ((bits == 0) || (ip->bits == bits))) {


### PR DESCRIPTION


<!-- issue-number: [bpo-45616](https://bugs.python.org/issue45616) -->
https://bugs.python.org/issue45616
<!-- /issue-number -->
