### PR TITLE
[3.10] bpo-39026: Fix Python.h when building with Xcode (GH-29488)

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -106,6 +106,7 @@
 #include "sliceobject.h"
 #include "cellobject.h"
 #include "iterobject.h"
+#include "cpython/initconfig.h"
 #include "genobject.h"
 #include "descrobject.h"
 #include "genericaliasobject.h"
@@ -118,8 +119,6 @@
 
 #include "codecs.h"
 #include "pyerrors.h"
-
-#include "cpython/initconfig.h"
 #include "pythread.h"
 #include "pystate.h"
 #include "context.h"

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -2,8 +2,6 @@
 #  error "this header file must not be included directly"
 #endif
 
-#include "cpython/initconfig.h"
-
 PyAPI_FUNC(int) _PyInterpreterState_RequiresIDRef(PyInterpreterState *);
 PyAPI_FUNC(void) _PyInterpreterState_RequireIDRef(PyInterpreterState *, int);
 

--- a/Misc/NEWS.d/next/C API/2021-11-09-15-42-11.bpo-39026.sUnYWn.rst
+++ b/Misc/NEWS.d/next/C API/2021-11-09-15-42-11.bpo-39026.sUnYWn.rst
@@ -1,0 +1,2 @@
+Fix Python.h to build C extensions with Xcode: remove a relative include
+from ``Include/cpython/pystate.h``.


### PR DESCRIPTION
Fix Python.h to build C extensions with Xcode: remove a relative
include from Include/cpython/pystate.h.

(cherry picked from commit 4ae26b9c1d0c33e3db92c6f305293f9240dea358)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-39026](https://bugs.python.org/issue39026) -->
https://bugs.python.org/issue39026
<!-- /issue-number -->
