### PR TITLE
bpo-45887: Re-orient type-related init/fini around per-interpreter types.

### DIFF
--- a/Include/internal/pycore_bltinmodule.h
+++ b/Include/internal/pycore_bltinmodule.h
@@ -1,0 +1,18 @@
+#ifndef Py_INTERNAL_BLTINMODULE_H
+#define Py_INTERNAL_BLTINMODULE_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+extern PyObject * _PyBuiltin_Init(PyInterpreterState *interp);
+extern PyStatus _PyBuiltins_AddExceptions(PyObject * bltinmod,
+                                           PyInterpreterState *interp);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_BLTINMODULE_H */

--- a/Include/internal/pycore_bytesobject.h
+++ b/Include/internal/pycore_bytesobject.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 extern PyStatus _PyBytes_InitCoreObjects(PyInterpreterState *interp);
-extern void _PyBytes_Fini(PyInterpreterState *interp);
+extern void _PyBytes_FiniCoreObjects(PyInterpreterState *interp);
 
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_bytesobject.h
+++ b/Include/internal/pycore_bytesobject.h
@@ -1,0 +1,18 @@
+#ifndef Py_INTERNAL_BYTESOBJECT_H
+#define Py_INTERNAL_BYTESOBJECT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+extern PyStatus _PyBytes_InitCoreObjects(PyInterpreterState *interp);
+extern void _PyBytes_Fini(PyInterpreterState *interp);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_BYTESOBJECT_H */

--- a/Include/internal/pycore_context.h
+++ b/Include/internal/pycore_context.h
@@ -36,7 +36,7 @@ struct _pycontexttokenobject {
 };
 
 
-int _PyContext_Init(void);
-void _PyContext_Fini(PyInterpreterState *interp);
+extern PyStatus _PyContext_InitTypes(PyInterpreterState *interp);
+extern void _PyContext_Fini(PyInterpreterState *interp);
 
 #endif /* !Py_INTERNAL_CONTEXT_H */

--- a/Include/internal/pycore_context.h
+++ b/Include/internal/pycore_context.h
@@ -37,6 +37,6 @@ struct _pycontexttokenobject {
 
 
 extern PyStatus _PyContext_InitTypes(PyInterpreterState *interp);
-extern void _PyContext_Fini(PyInterpreterState *interp);
+extern void _PyContext_FiniObjects(PyInterpreterState *interp);
 
 #endif /* !Py_INTERNAL_CONTEXT_H */

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -103,6 +103,8 @@ extern uint64_t _pydict_global_version;
 
 PyObject *_PyObject_MakeDictFromInstanceAttributes(PyObject *obj, PyDictValues *values);
 
+extern void _PyDict_Fini(PyInterpreterState *interp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -103,7 +103,7 @@ extern uint64_t _pydict_global_version;
 
 PyObject *_PyObject_MakeDictFromInstanceAttributes(PyObject *obj, PyDictValues *values);
 
-extern void _PyDict_Fini(PyInterpreterState *interp);
+extern void _PyDict_FiniCoreObjects(PyInterpreterState *interp);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_exceptions.h
+++ b/Include/internal/pycore_exceptions.h
@@ -8,7 +8,92 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+
+/**************************************
+ * lifecycle
+ **************************************/
+
 extern PyStatus _PyExc_Init(PyInterpreterState *interp);
+
+
+/**************************************
+ * exception and warning types
+ **************************************/
+
+// base excptions (in alphabetical order):
+extern PyTypeObject _PyExc_BaseException;
+extern PyTypeObject _PyExc_BaseExceptionGroup;
+extern PyTypeObject _PyExc_Exception;
+extern PyTypeObject _PyExc_GeneratorExit;
+extern PyTypeObject _PyExc_KeyboardInterrupt;
+extern PyTypeObject _PyExc_SystemExit;
+
+// Subclasses of Exception (in alphabetical order):
+extern PyTypeObject _PyExc_ArithmeticError;
+extern PyTypeObject _PyExc_AssertionError;
+extern PyTypeObject _PyExc_AttributeError;
+extern PyTypeObject _PyExc_BufferError;
+extern PyTypeObject _PyExc_EOFError;
+extern PyTypeObject _PyExc_FloatingPointError;
+extern PyTypeObject _PyExc_ImportError;
+extern PyTypeObject _PyExc_IndentationError;
+extern PyTypeObject _PyExc_IndexError;
+extern PyTypeObject _PyExc_KeyError;
+extern PyTypeObject _PyExc_LookupError;
+extern PyTypeObject _PyExc_MemoryError;
+extern PyTypeObject _PyExc_ModuleNotFoundError;
+extern PyTypeObject _PyExc_NameError;
+extern PyTypeObject _PyExc_NotImplementedError;
+extern PyTypeObject _PyExc_OSError;
+extern PyTypeObject _PyExc_OverflowError;
+extern PyTypeObject _PyExc_RecursionError;
+extern PyTypeObject _PyExc_ReferenceError;
+extern PyTypeObject _PyExc_RuntimeError;
+extern PyTypeObject _PyExc_StopAsyncIteration;
+extern PyTypeObject _PyExc_StopIteration;
+extern PyTypeObject _PyExc_SyntaxError;
+extern PyTypeObject _PyExc_SystemError;
+extern PyTypeObject _PyExc_TabError;
+extern PyTypeObject _PyExc_TypeError;
+extern PyTypeObject _PyExc_UnboundLocalError;
+extern PyTypeObject _PyExc_UnicodeDecodeError;
+extern PyTypeObject _PyExc_UnicodeEncodeError;
+extern PyTypeObject _PyExc_UnicodeError;
+extern PyTypeObject _PyExc_UnicodeTranslateError;
+extern PyTypeObject _PyExc_ValueError;
+extern PyTypeObject _PyExc_ZeroDivisionError;
+
+// subclasses of OSError (in alphabetical order):
+extern PyTypeObject _PyExc_BlockingIOError;
+extern PyTypeObject _PyExc_BrokenPipeError;
+extern PyTypeObject _PyExc_ChildProcessError;
+extern PyTypeObject _PyExc_ConnectionAbortedError;
+extern PyTypeObject _PyExc_ConnectionError;
+extern PyTypeObject _PyExc_ConnectionRefusedError;
+extern PyTypeObject _PyExc_ConnectionResetError;
+extern PyTypeObject _PyExc_FileExistsError;
+extern PyTypeObject _PyExc_FileNotFoundError;
+extern PyTypeObject _PyExc_InterruptedError;
+extern PyTypeObject _PyExc_IsADirectoryError;
+extern PyTypeObject _PyExc_NotADirectoryError;
+extern PyTypeObject _PyExc_PermissionError;
+extern PyTypeObject _PyExc_ProcessLookupError;
+extern PyTypeObject _PyExc_TimeoutError;
+
+// warning categories (in alphabetical order):
+extern PyTypeObject _PyExc_Warning;  // subclass of Exception
+extern PyTypeObject _PyExc_BytesWarning;
+extern PyTypeObject _PyExc_DeprecationWarning;
+extern PyTypeObject _PyExc_EncodingWarning;
+extern PyTypeObject _PyExc_FutureWarning;
+extern PyTypeObject _PyExc_ImportWarning;
+extern PyTypeObject _PyExc_PendingDeprecationWarning;
+extern PyTypeObject _PyExc_ResourceWarning;
+extern PyTypeObject _PyExc_RuntimeWarning;
+extern PyTypeObject _PyExc_SyntaxWarning;
+extern PyTypeObject _PyExc_UnicodeWarning;
+extern PyTypeObject _PyExc_UserWarning;
+
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_exceptions.h
+++ b/Include/internal/pycore_exceptions.h
@@ -1,0 +1,16 @@
+#ifndef Py_INTERNAL_EXCEPTIONS_H
+#define Py_INTERNAL_EXCEPTIONS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+extern PyStatus _PyExc_Init(PyInterpreterState *interp);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_EXCEPTIONS_H */

--- a/Include/internal/pycore_exceptions.h
+++ b/Include/internal/pycore_exceptions.h
@@ -13,7 +13,13 @@ extern "C" {
  * lifecycle
  **************************************/
 
-extern PyStatus _PyExc_Init(PyInterpreterState *interp);
+extern PyStatus _PyExc_InitCoreObjects(PyInterpreterState *interp);
+extern PyStatus _PyExc_InitCoreTypes(PyInterpreterState *interp);
+extern void _PyExc_FiniCoreObjects(PyInterpreterState *interp);
+
+extern PyStatus _PyExc_InitTypes(PyInterpreterState *interp);
+extern PyStatus _PyExc_InitTypeStateLast(PyInterpreterState *interp);
+extern void _PyExc_FiniObjects(PyInterpreterState *interp);
 
 
 /**************************************

--- a/Include/internal/pycore_floatobject.h
+++ b/Include/internal/pycore_floatobject.h
@@ -8,6 +8,9 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+#include "pycore_runtime.h"     // _PyRuntimeState
+#include "pycore_initconfig.h"  // PyStatus
+
 /* _PyFloat_{Pack,Unpack}{4,8}
  *
  * The struct and pickle (at least) modules need an efficient platform-
@@ -68,6 +71,12 @@ PyAPI_FUNC(int) _PyFloat_FormatAdvancedWriter(
     PyObject *format_spec,
     Py_ssize_t start,
     Py_ssize_t end);
+
+
+extern PyStatus _PyFloat_InitRuntimeState(_PyRuntimeState *runtime);
+extern PyStatus _PyFloat_InitTypes(PyInterpreterState *interp);
+extern void _PyFloat_Fini(PyInterpreterState *interp);
+
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_floatobject.h
+++ b/Include/internal/pycore_floatobject.h
@@ -75,7 +75,7 @@ PyAPI_FUNC(int) _PyFloat_FormatAdvancedWriter(
 
 extern PyStatus _PyFloat_InitRuntimeState(_PyRuntimeState *runtime);
 extern PyStatus _PyFloat_InitTypes(PyInterpreterState *interp);
-extern void _PyFloat_Fini(PyInterpreterState *interp);
+extern void _PyFloat_FiniObjects(PyInterpreterState *interp);
 
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -169,6 +169,10 @@ _PyThreadState_BumpFramePointer(PyThreadState *tstate, size_t size)
 
 void _PyThreadState_PopFrame(PyThreadState *tstate, InterpreterFrame *frame);
 
+
+extern void _PyFrame_Fini(PyInterpreterState *interp);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -170,7 +170,7 @@ _PyThreadState_BumpFramePointer(PyThreadState *tstate, size_t size)
 void _PyThreadState_PopFrame(PyThreadState *tstate, InterpreterFrame *frame);
 
 
-extern void _PyFrame_Fini(PyInterpreterState *interp);
+extern void _PyFrame_FiniObjects(PyInterpreterState *interp);
 
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_genobject.h
+++ b/Include/internal/pycore_genobject.h
@@ -1,0 +1,17 @@
+#ifndef Py_INTERNAL_GENOBJECT_H
+#define Py_INTERNAL_GENOBJECT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+extern void _PyAsyncGen_Fini(PyInterpreterState *interp);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_GENOBJECT_H */

--- a/Include/internal/pycore_genobject.h
+++ b/Include/internal/pycore_genobject.h
@@ -8,7 +8,7 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-extern void _PyAsyncGen_Fini(PyInterpreterState *interp);
+extern void _PyAsyncGen_FiniObjects(PyInterpreterState *interp);
 
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -24,8 +24,6 @@ extern void _PyInterpreterState_CoreObjectsFini(PyInterpreterState *interp);
 extern PyStatus _PyInterpreterState_ObjectsInit(PyInterpreterState *interp);
 extern void _PyInterpreterState_ObjectsFini(PyInterpreterState *interp);
 
-extern PyStatus _PyExc_Init(PyInterpreterState *interp);
-
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -1,0 +1,33 @@
+#ifndef Py_INTERNAL_GLOBAL_OBJECTS_H
+#define Py_INTERNAL_GLOBAL_OBJECTS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+#include "pycore_runtime.h"       // _PyRuntimeState
+
+
+/**************************************
+ * lifecycle
+ **************************************/
+
+extern PyStatus _PyRuntimeState_TypesInit(_PyRuntimeState *runtime);
+extern void _PyRuntimeState_TypesFini(_PyRuntimeState *runtime);
+
+extern PyStatus _PyInterpreterState_CoreObjectsInit(PyInterpreterState *interp);
+extern void _PyInterpreterState_CoreObjectsFini(PyInterpreterState *interp);
+
+extern PyStatus _PyInterpreterState_ObjectsInit(PyInterpreterState *interp);
+extern void _PyInterpreterState_ObjectsFini(PyInterpreterState *interp);
+
+extern PyStatus _PyExc_Init(PyInterpreterState *interp);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_GLOBAL_OBJECTS_H */

--- a/Include/internal/pycore_hamt.h
+++ b/Include/internal/pycore_hamt.h
@@ -111,6 +111,6 @@ PyObject * _PyHamt_NewIterValues(PyHamtObject *o);
 PyObject * _PyHamt_NewIterItems(PyHamtObject *o);
 
 PyStatus _PyHamt_InitTypes(PyInterpreterState *interp);
-void _PyHamt_Fini(PyInterpreterState *interp);
+void _PyHamt_FiniObjects(PyInterpreterState *interp);
 
 #endif /* !Py_INTERNAL_HAMT_H */

--- a/Include/internal/pycore_hamt.h
+++ b/Include/internal/pycore_hamt.h
@@ -110,7 +110,7 @@ PyObject * _PyHamt_NewIterValues(PyHamtObject *o);
 /* Return a Items iterator over "o". */
 PyObject * _PyHamt_NewIterItems(PyHamtObject *o);
 
-int _PyHamt_Init(void);
-void _PyHamt_Fini(void);
+PyStatus _PyHamt_InitTypes(PyInterpreterState *interp);
+void _PyHamt_Fini(PyInterpreterState *interp);
 
 #endif /* !Py_INTERNAL_HAMT_H */

--- a/Include/internal/pycore_list.h
+++ b/Include/internal/pycore_list.h
@@ -14,6 +14,9 @@ extern "C" {
 #define _PyList_ITEMS(op) (_PyList_CAST(op)->ob_item)
 
 
+extern void _PyList_Fini(PyInterpreterState *interp);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_list.h
+++ b/Include/internal/pycore_list.h
@@ -14,7 +14,7 @@ extern "C" {
 #define _PyList_ITEMS(op) (_PyList_CAST(op)->ob_item)
 
 
-extern void _PyList_Fini(PyInterpreterState *interp);
+extern void _PyList_FiniCoreObjects(PyInterpreterState *interp);
 
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -11,6 +11,11 @@ extern "C" {
 #include "pycore_interp.h"        // PyInterpreterState.small_ints
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 
+
+extern PyStatus _PyLong_InitCoreObjects(PyInterpreterState *interp);
+extern PyStatus _PyLong_InitTypes(PyInterpreterState *interp);
+
+
 // Return a borrowed reference to the zero singleton.
 // The function cannot return NULL.
 static inline PyObject* _PyLong_GetZero(void)

--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -8,6 +8,9 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+extern PyStatus _PyErr_InitTypes(PyInterpreterState *interp);
+
+
 static inline PyObject* _PyErr_Occurred(PyThreadState *tstate)
 {
     assert(tstate != NULL);

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -48,20 +48,6 @@ PyAPI_FUNC(void) _Py_ClearStandardStreamEncoding(void);
 PyAPI_FUNC(int) _Py_IsLocaleCoercionTarget(const char *ctype_loc);
 
 
-/* types and objects */
-
-extern PyStatus _PyRuntimeState_TypesInit(_PyRuntimeState *runtime);
-extern void _PyRuntimeState_TypesFini(_PyRuntimeState *runtime);
-
-extern PyStatus _PyInterpreterState_CoreObjectsInit(PyInterpreterState *interp);
-extern void _PyInterpreterState_CoreObjectsFini(PyInterpreterState *interp);
-
-extern PyStatus _PyInterpreterState_ObjectsInit(PyInterpreterState *interp);
-extern void _PyInterpreterState_ObjectsFini(PyInterpreterState *interp);
-
-extern PyStatus _PyExc_Init(PyInterpreterState *interp);
-
-
 /* Various one-time initializers */
 
 extern PyStatus _PyFaulthandler_Init(int enable);

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -47,15 +47,62 @@ PyAPI_FUNC(void) _Py_ClearStandardStreamEncoding(void);
 
 PyAPI_FUNC(int) _Py_IsLocaleCoercionTarget(const char *ctype_loc);
 
-/* Various one-time initializers */
+
+/* runtime-global type-related state */
+
+extern PyStatus _Py_RuntimeTypesStateInit(_PyRuntimeState *runtime);
+extern void _Py_RuntimeTypesStateFini(_PyRuntimeState *runtime);
+
+
+/* core types and objects */
+
+extern PyStatus _Py_CoreObjectsInit(PyInterpreterState *interp);
+extern void _Py_CoreObjectsFini(PyInterpreterState *interp);
+
+extern void _PyLong_Init(PyInterpreterState *interp);
+extern int _PyLong_InitTypes(void);
+extern void _PyLong_Fini(PyInterpreterState *interp);
 
 extern PyStatus _PyUnicode_Init(PyInterpreterState *interp);
 extern PyStatus _PyUnicode_InitTypes(void);
+extern void _PyUnicode_Fini(PyInterpreterState *interp);
+extern void _PyUnicode_ClearInterned(PyInterpreterState *interp);
+
 extern PyStatus _PyBytes_Init(PyInterpreterState *interp);
-extern int _PyStructSequence_Init(void);
-extern void _PyLong_Init(PyInterpreterState *interp);
-extern int _PyLong_InitTypes(void);
+extern void _PyBytes_Fini(PyInterpreterState *interp);
+
 extern PyStatus _PyTuple_Init(PyInterpreterState *interp);
+extern void _PyTuple_Fini(PyInterpreterState *interp);
+
+extern void _PyDict_Fini(PyInterpreterState *interp);
+
+extern void _PyList_Fini(PyInterpreterState *interp);
+
+
+/* global types and objects */
+
+extern PyStatus _Py_GlobalObjectsInit(PyInterpreterState *interp);
+extern void _Py_GlobalObjectsFini(PyInterpreterState *interp);
+
+extern int _PyStructSequence_Init(void);
+
+extern PyStatus _PyTypes_Init(void);
+
+extern PyStatus _PyErr_InitTypes(void);
+
+extern void _PyFloat_Init(void);
+extern int _PyFloat_InitTypes(void);
+extern void _PyFloat_Fini(PyInterpreterState *interp);
+
+extern void _PyFrame_Fini(PyInterpreterState *interp);
+
+extern void _PySlice_Fini(PyInterpreterState *interp);
+
+extern void _PyAsyncGen_Fini(PyInterpreterState *interp);
+
+
+/* Various one-time initializers */
+
 extern PyStatus _PyFaulthandler_Init(int enable);
 extern int _PyTraceMalloc_Init(int enable);
 extern PyObject * _PyBuiltin_Init(PyInterpreterState *interp);
@@ -66,28 +113,14 @@ extern PyStatus _PySys_ReadPreinitWarnOptions(PyWideStringList *options);
 extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
 extern int _PySys_UpdateConfig(PyThreadState *tstate);
 extern PyStatus _PyExc_Init(PyInterpreterState *interp);
-extern PyStatus _PyErr_InitTypes(void);
 extern PyStatus _PyBuiltins_AddExceptions(PyObject * bltinmod);
-extern void _PyFloat_Init(void);
-extern int _PyFloat_InitTypes(void);
 extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
-
-extern PyStatus _PyTypes_Init(void);
 extern PyStatus _PyImportZip_Init(PyThreadState *tstate);
 extern PyStatus _PyGC_Init(PyInterpreterState *interp);
 extern PyStatus _PyAtExit_Init(PyInterpreterState *interp);
 
 
 /* Various internal finalizers */
-
-extern void _PyFrame_Fini(PyInterpreterState *interp);
-extern void _PyDict_Fini(PyInterpreterState *interp);
-extern void _PyTuple_Fini(PyInterpreterState *interp);
-extern void _PyList_Fini(PyInterpreterState *interp);
-extern void _PyBytes_Fini(PyInterpreterState *interp);
-extern void _PyFloat_Fini(PyInterpreterState *interp);
-extern void _PySlice_Fini(PyInterpreterState *interp);
-extern void _PyAsyncGen_Fini(PyInterpreterState *interp);
 
 extern int _PySignal_Init(int install_signal_handlers);
 extern void _PySignal_Fini(void);
@@ -98,9 +131,6 @@ extern void _PyImport_Fini(void);
 extern void _PyImport_Fini2(void);
 extern void _PyGC_Fini(PyInterpreterState *interp);
 extern void _Py_HashRandomization_Fini(void);
-extern void _PyUnicode_Fini(PyInterpreterState *interp);
-extern void _PyUnicode_ClearInterned(PyInterpreterState *interp);
-extern void _PyLong_Fini(PyInterpreterState *interp);
 extern void _PyFaulthandler_Fini(void);
 extern void _PyHash_Fini(void);
 extern void _PyTraceMalloc_Fini(void);

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -71,8 +71,6 @@ extern PyStatus _PyAtExit_Init(PyInterpreterState *interp);
 extern int _PySignal_Init(int install_signal_handlers);
 extern void _PySignal_Fini(void);
 
-extern void _PyExc_ClearExceptionGroupType(PyInterpreterState *interp);
-extern void _PyExc_Fini(PyInterpreterState *interp);
 extern void _PyImport_Fini(void);
 extern void _PyImport_Fini2(void);
 extern void _PyGC_Fini(PyInterpreterState *interp);

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -48,57 +48,18 @@ PyAPI_FUNC(void) _Py_ClearStandardStreamEncoding(void);
 PyAPI_FUNC(int) _Py_IsLocaleCoercionTarget(const char *ctype_loc);
 
 
-/* runtime-global type-related state */
+/* types and objects */
 
 extern PyStatus _Py_RuntimeTypesStateInit(_PyRuntimeState *runtime);
 extern void _Py_RuntimeTypesStateFini(_PyRuntimeState *runtime);
 
-
-/* core types and objects */
-
 extern PyStatus _Py_CoreObjectsInit(PyInterpreterState *interp);
 extern void _Py_CoreObjectsFini(PyInterpreterState *interp);
-
-extern void _PyLong_Init(PyInterpreterState *interp);
-extern int _PyLong_InitTypes(void);
-extern void _PyLong_Fini(PyInterpreterState *interp);
-
-extern PyStatus _PyUnicode_Init(PyInterpreterState *interp);
-extern PyStatus _PyUnicode_InitTypes(void);
-extern void _PyUnicode_Fini(PyInterpreterState *interp);
-extern void _PyUnicode_ClearInterned(PyInterpreterState *interp);
-
-extern PyStatus _PyBytes_Init(PyInterpreterState *interp);
-extern void _PyBytes_Fini(PyInterpreterState *interp);
-
-extern PyStatus _PyTuple_Init(PyInterpreterState *interp);
-extern void _PyTuple_Fini(PyInterpreterState *interp);
-
-extern void _PyDict_Fini(PyInterpreterState *interp);
-
-extern void _PyList_Fini(PyInterpreterState *interp);
-
-
-/* global types and objects */
 
 extern PyStatus _Py_GlobalObjectsInit(PyInterpreterState *interp);
 extern void _Py_GlobalObjectsFini(PyInterpreterState *interp);
 
-extern int _PyStructSequence_Init(void);
-
-extern PyStatus _PyTypes_Init(void);
-
-extern PyStatus _PyErr_InitTypes(void);
-
-extern void _PyFloat_Init(void);
-extern int _PyFloat_InitTypes(void);
-extern void _PyFloat_Fini(PyInterpreterState *interp);
-
-extern void _PyFrame_Fini(PyInterpreterState *interp);
-
-extern void _PySlice_Fini(PyInterpreterState *interp);
-
-extern void _PyAsyncGen_Fini(PyInterpreterState *interp);
+extern PyStatus _PyExc_Init(PyInterpreterState *interp);
 
 
 /* Various one-time initializers */
@@ -112,7 +73,6 @@ extern PyStatus _PySys_Create(
 extern PyStatus _PySys_ReadPreinitWarnOptions(PyWideStringList *options);
 extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
 extern int _PySys_UpdateConfig(PyThreadState *tstate);
-extern PyStatus _PyExc_Init(PyInterpreterState *interp);
 extern PyStatus _PyBuiltins_AddExceptions(PyObject * bltinmod);
 extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 extern PyStatus _PyImportZip_Init(PyThreadState *tstate);

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -50,14 +50,14 @@ PyAPI_FUNC(int) _Py_IsLocaleCoercionTarget(const char *ctype_loc);
 
 /* types and objects */
 
-extern PyStatus _Py_RuntimeTypesStateInit(_PyRuntimeState *runtime);
-extern void _Py_RuntimeTypesStateFini(_PyRuntimeState *runtime);
+extern PyStatus _PyRuntimeState_TypesInit(_PyRuntimeState *runtime);
+extern void _PyRuntimeState_TypesFini(_PyRuntimeState *runtime);
 
-extern PyStatus _Py_CoreObjectsInit(PyInterpreterState *interp);
-extern void _Py_CoreObjectsFini(PyInterpreterState *interp);
+extern PyStatus _PyInterpreterState_CoreObjectsInit(PyInterpreterState *interp);
+extern void _PyInterpreterState_CoreObjectsFini(PyInterpreterState *interp);
 
-extern PyStatus _Py_GlobalObjectsInit(PyInterpreterState *interp);
-extern void _Py_GlobalObjectsFini(PyInterpreterState *interp);
+extern PyStatus _PyInterpreterState_ObjectsInit(PyInterpreterState *interp);
+extern void _PyInterpreterState_ObjectsFini(PyInterpreterState *interp);
 
 extern PyStatus _PyExc_Init(PyInterpreterState *interp);
 

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -52,14 +52,12 @@ PyAPI_FUNC(int) _Py_IsLocaleCoercionTarget(const char *ctype_loc);
 
 extern PyStatus _PyFaulthandler_Init(int enable);
 extern int _PyTraceMalloc_Init(int enable);
-extern PyObject * _PyBuiltin_Init(PyInterpreterState *interp);
 extern PyStatus _PySys_Create(
     PyThreadState *tstate,
     PyObject **sysmod_p);
 extern PyStatus _PySys_ReadPreinitWarnOptions(PyWideStringList *options);
 extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
 extern int _PySys_UpdateConfig(PyThreadState *tstate);
-extern PyStatus _PyBuiltins_AddExceptions(PyObject * bltinmod);
 extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 extern PyStatus _PyImportZip_Init(PyThreadState *tstate);
 extern PyStatus _PyGC_Init(PyInterpreterState *interp);

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -73,7 +73,6 @@ extern int _PyFloat_InitTypes(void);
 extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 
 extern PyStatus _PyTypes_Init(void);
-extern PyStatus _PyTypes_InitSlotDefs(void);
 extern PyStatus _PyImportZip_Init(PyThreadState *tstate);
 extern PyStatus _PyGC_Init(PyInterpreterState *interp);
 extern PyStatus _PyAtExit_Init(PyInterpreterState *interp);
@@ -98,7 +97,6 @@ extern void _PyExc_Fini(PyInterpreterState *interp);
 extern void _PyImport_Fini(void);
 extern void _PyImport_Fini2(void);
 extern void _PyGC_Fini(PyInterpreterState *interp);
-extern void _PyType_Fini(PyInterpreterState *interp);
 extern void _Py_HashRandomization_Fini(void);
 extern void _PyUnicode_Fini(PyInterpreterState *interp);
 extern void _PyUnicode_ClearInterned(PyInterpreterState *interp);

--- a/Include/internal/pycore_sliceobject.h
+++ b/Include/internal/pycore_sliceobject.h
@@ -8,7 +8,7 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-extern void _PySlice_Fini(PyInterpreterState *interp);
+extern void _PySlice_FiniObjects(PyInterpreterState *interp);
 
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_sliceobject.h
+++ b/Include/internal/pycore_sliceobject.h
@@ -1,0 +1,17 @@
+#ifndef Py_INTERNAL_SLICEOBJECT_H
+#define Py_INTERNAL_SLICEOBJECT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+extern void _PySlice_Fini(PyInterpreterState *interp);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_SLICEOBJECT_H */

--- a/Include/internal/pycore_structseq.h
+++ b/Include/internal/pycore_structseq.h
@@ -9,6 +9,9 @@ extern "C" {
 #endif
 
 
+extern PyStatus _PyStructSequence_Init(PyInterpreterState *interp);
+
+
 PyAPI_FUNC(int) _PyStructSequence_InitType(
     PyTypeObject *type,
     PyStructSequence_Desc *desc,

--- a/Include/internal/pycore_tuple.h
+++ b/Include/internal/pycore_tuple.h
@@ -16,7 +16,7 @@ extern PyObject *_PyTuple_FromArray(PyObject *const *, Py_ssize_t);
 extern PyObject *_PyTuple_FromArraySteal(PyObject *const *, Py_ssize_t);
 
 extern PyStatus _PyTuple_InitCoreObjects(PyInterpreterState *interp);
-extern void _PyTuple_Fini(PyInterpreterState *interp);
+extern void _PyTuple_FiniCoreObjects(PyInterpreterState *interp);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_tuple.h
+++ b/Include/internal/pycore_tuple.h
@@ -15,6 +15,9 @@ extern "C" {
 extern PyObject *_PyTuple_FromArray(PyObject *const *, Py_ssize_t);
 extern PyObject *_PyTuple_FromArraySteal(PyObject *const *, Py_ssize_t);
 
+extern PyStatus _PyTuple_InitCoreObjects(PyInterpreterState *interp);
+extern void _PyTuple_Fini(PyInterpreterState *interp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -1,0 +1,17 @@
+#ifndef Py_INTERNAL_TYPEOBJECT_H
+#define Py_INTERNAL_TYPEOBJECT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+extern PyStatus _PyType_Init(PyInterpreterState *interp);
+extern void _PyType_Fini(PyInterpreterState *interp);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_TYPEOBJECT_H */

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -8,8 +8,8 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-extern PyStatus _PyType_Init(PyInterpreterState *interp);
-extern void _PyType_Fini(PyInterpreterState *interp);
+extern PyStatus _PyType_InitState(PyInterpreterState *interp);
+extern void _PyType_FiniState(PyInterpreterState *interp);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -12,9 +12,13 @@ extern "C" {
 #include "pycore_initconfig.h"  // PyStatus
 
 extern PyStatus _PyUnicode_InitRuntimeState(_PyRuntimeState *runtime);
+
 extern PyStatus _PyUnicode_InitCoreObjects(PyInterpreterState *interp);
+extern void _PyUnicode_FiniCoreObjects(PyInterpreterState *interp);
+
 extern PyStatus _PyUnicode_InitTypes(PyInterpreterState *interp);
-extern void _PyUnicode_Fini(PyInterpreterState *interp);
+extern void _PyUnicode_FiniObjects(PyInterpreterState *interp);
+extern void _PyUnicode_FiniState(PyInterpreterState *interp);
 
 extern void _PyUnicode_ClearInterned(PyInterpreterState *interp);
 

--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -1,0 +1,25 @@
+#ifndef Py_INTERNAL_UNICODEOBJECT_H
+#define Py_INTERNAL_UNICODEOBJECT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+#include "pycore_runtime.h"     // _PyRuntimeState
+#include "pycore_initconfig.h"  // PyStatus
+
+extern PyStatus _PyUnicode_InitRuntimeState(_PyRuntimeState *runtime);
+extern PyStatus _PyUnicode_InitCoreObjects(PyInterpreterState *interp);
+extern PyStatus _PyUnicode_InitTypes(PyInterpreterState *interp);
+extern void _PyUnicode_Fini(PyInterpreterState *interp);
+
+extern void _PyUnicode_ClearInterned(PyInterpreterState *interp);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_UNICODEOBJECT_H */

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1424,6 +1424,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_atomic.h \
 		$(srcdir)/Include/internal/pycore_atomic_funcs.h \
 		$(srcdir)/Include/internal/pycore_bitutils.h \
+		$(srcdir)/Include/internal/pycore_bltinmodule.h \
 		$(srcdir)/Include/internal/pycore_bytes_methods.h \
 		$(srcdir)/Include/internal/pycore_bytesobject.h \
 		$(srcdir)/Include/internal/pycore_call.h \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1425,6 +1425,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_atomic_funcs.h \
 		$(srcdir)/Include/internal/pycore_bitutils.h \
 		$(srcdir)/Include/internal/pycore_bytes_methods.h \
+		$(srcdir)/Include/internal/pycore_bytesobject.h \
 		$(srcdir)/Include/internal/pycore_call.h \
 		$(srcdir)/Include/internal/pycore_ceval.h \
 		$(srcdir)/Include/internal/pycore_code.h \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -425,6 +425,7 @@ OBJECT_OBJS=	\
 		Objects/floatobject.o \
 		Objects/frameobject.o \
 		Objects/funcobject.o \
+		Objects/global_objects.o \
 		Objects/interpreteridobject.o \
 		Objects/iterobject.o \
 		Objects/listobject.o \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1439,6 +1439,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_format.h \
 		$(srcdir)/Include/internal/pycore_getopt.h \
 		$(srcdir)/Include/internal/pycore_gil.h \
+		$(srcdir)/Include/internal/pycore_global_objects.h \
 		$(srcdir)/Include/internal/pycore_hamt.h \
 		$(srcdir)/Include/internal/pycore_hashtable.h \
 		$(srcdir)/Include/internal/pycore_import.h \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1434,6 +1434,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_context.h \
 		$(srcdir)/Include/internal/pycore_dict.h \
 		$(srcdir)/Include/internal/pycore_dtoa.h \
+		$(srcdir)/Include/internal/pycore_exceptions.h \
 		$(srcdir)/Include/internal/pycore_fileutils.h \
 		$(srcdir)/Include/internal/pycore_floatobject.h \
 		$(srcdir)/Include/internal/pycore_format.h \

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3086,7 +3086,7 @@ error:
 
 
 PyStatus
-_PyBytes_Init(PyInterpreterState *interp)
+_PyBytes_InitCoreObjects(PyInterpreterState *interp)
 {
     struct _Py_bytes_state *state = &interp->bytes;
     if (bytes_create_empty_string_singleton(state) < 0) {

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3097,7 +3097,7 @@ _PyBytes_InitCoreObjects(PyInterpreterState *interp)
 
 
 void
-_PyBytes_Fini(PyInterpreterState *interp)
+_PyBytes_FiniCoreObjects(PyInterpreterState *interp)
 {
     struct _Py_bytes_state* state = &interp->bytes;
     for (int i = 0; i < UCHAR_MAX + 1; i++) {

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -268,7 +268,7 @@ _PyDict_ClearFreeList(PyInterpreterState *interp)
 
 
 void
-_PyDict_Fini(PyInterpreterState *interp)
+_PyDict_FiniCoreObjects(PyInterpreterState *interp)
 {
     _PyDict_ClearFreeList(interp);
 #if defined(Py_DEBUG) && PyDict_MAXFREELIST > 0

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3360,114 +3360,6 @@ _PyExc_InitTypeStateLast(PyInterpreterState *interp)
     return _PyStatus_OK();
 }
 
-/* Add exception types to the builtins module */
-PyStatus
-_PyBuiltins_AddExceptions(PyObject *bltinmod)
-{
-    PyObject *bdict = PyModule_GetDict(bltinmod);
-    if (bdict == NULL) {
-        return _PyStatus_ERR("exceptions bootstrapping error.");
-    }
-
-    struct _Py_exc_state *state = get_exc_state();
-    PyObject *PyExc_ExceptionGroup = state->PyExc_ExceptionGroup;
-    assert(PyExc_ExceptionGroup != NULL);
-
-#define SETBUILTIN(TYPE) \
-    if (PyDict_SetItemString(bdict, # TYPE, PyExc_ ## TYPE)) { \
-        return _PyStatus_ERR("Module dictionary insertion problem."); \
-    }
-
-    SETBUILTIN(ArithmeticError);
-    SETBUILTIN(AssertionError);
-    SETBUILTIN(AttributeError);
-    SETBUILTIN(BaseException);
-    SETBUILTIN(BaseExceptionGroup);
-    SETBUILTIN(BlockingIOError);
-    SETBUILTIN(BrokenPipeError);
-    SETBUILTIN(BufferError);
-    SETBUILTIN(ChildProcessError);
-    SETBUILTIN(ConnectionAbortedError);
-    SETBUILTIN(ConnectionError);
-    SETBUILTIN(ConnectionRefusedError);
-    SETBUILTIN(ConnectionResetError);
-    SETBUILTIN(EOFError);
-    SETBUILTIN(Exception);
-    SETBUILTIN(ExceptionGroup);
-    SETBUILTIN(FileExistsError);
-    SETBUILTIN(FileNotFoundError);
-    SETBUILTIN(FloatingPointError);
-    SETBUILTIN(GeneratorExit);
-    SETBUILTIN(ImportError);
-    SETBUILTIN(IndentationError);
-    SETBUILTIN(IndexError);
-    SETBUILTIN(InterruptedError);
-    SETBUILTIN(IsADirectoryError);
-    SETBUILTIN(KeyError);
-    SETBUILTIN(KeyboardInterrupt);
-    SETBUILTIN(LookupError);
-    SETBUILTIN(MemoryError);
-    SETBUILTIN(ModuleNotFoundError);
-    SETBUILTIN(NameError);
-    SETBUILTIN(NotADirectoryError);
-    SETBUILTIN(NotImplementedError);
-    SETBUILTIN(OSError);
-    SETBUILTIN(OverflowError);
-    SETBUILTIN(PermissionError);
-    SETBUILTIN(ProcessLookupError);
-    SETBUILTIN(RecursionError);
-    SETBUILTIN(ReferenceError);
-    SETBUILTIN(RuntimeError);
-    SETBUILTIN(StopAsyncIteration);
-    SETBUILTIN(StopIteration);
-    SETBUILTIN(SyntaxError);
-    SETBUILTIN(SystemError);
-    SETBUILTIN(SystemExit);
-    SETBUILTIN(TabError);
-    SETBUILTIN(TimeoutError);
-    SETBUILTIN(TypeError);
-    SETBUILTIN(UnboundLocalError);
-    SETBUILTIN(UnicodeDecodeError);
-    SETBUILTIN(UnicodeEncodeError);
-    SETBUILTIN(UnicodeError);
-    SETBUILTIN(UnicodeTranslateError);
-    SETBUILTIN(ValueError);
-    SETBUILTIN(ZeroDivisionError);
-
-    SETBUILTIN(BytesWarning);
-    SETBUILTIN(DeprecationWarning);
-    SETBUILTIN(EncodingWarning);
-    SETBUILTIN(FutureWarning);
-    SETBUILTIN(ImportWarning);
-    SETBUILTIN(PendingDeprecationWarning);
-    SETBUILTIN(ResourceWarning);
-    SETBUILTIN(RuntimeWarning);
-    SETBUILTIN(SyntaxWarning);
-    SETBUILTIN(UnicodeWarning);
-    SETBUILTIN(UserWarning);
-    SETBUILTIN(Warning);
-#undef SETBUILTIN
-
-#define INIT_ALIAS(NAME, TYPE) \
-    do { \
-        Py_INCREF(PyExc_ ## TYPE); \
-        Py_XDECREF(PyExc_ ## NAME); \
-        PyExc_ ## NAME = PyExc_ ## TYPE; \
-        if (PyDict_SetItemString(bdict, # NAME, PyExc_ ## NAME)) { \
-            return _PyStatus_ERR("Module dictionary insertion problem."); \
-        } \
-    } while (0)
-
-    INIT_ALIAS(EnvironmentError, OSError);
-    INIT_ALIAS(IOError, OSError);
-#ifdef MS_WINDOWS
-    INIT_ALIAS(WindowsError, OSError);
-#endif
-#undef INIT_ALIAS
-
-    return _PyStatus_OK();
-}
-
 void
 _PyExc_FiniCoreObjects(PyInterpreterState *interp)
 {
@@ -3475,7 +3367,6 @@ _PyExc_FiniCoreObjects(PyInterpreterState *interp)
     free_preallocated_memerrors(state);
     Py_CLEAR(state->errnomap);
 }
-
 
 void
 _PyExc_FiniObjects(PyInterpreterState *interp)

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -384,7 +384,7 @@ static struct PyMemberDef BaseException_members[] = {
 };
 
 
-static PyTypeObject _PyExc_BaseException = {
+PyTypeObject _PyExc_BaseException = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "BaseException", /*tp_name*/
     sizeof(PyBaseExceptionObject), /*tp_basicsize*/
@@ -434,7 +434,7 @@ PyObject *PyExc_BaseException = (PyObject *)&_PyExc_BaseException;
  * include it and not look strange.
  */
 #define SimpleExtendsException(EXCBASE, EXCNAME, EXCDOC) \
-static PyTypeObject _PyExc_ ## EXCNAME = { \
+PyTypeObject _PyExc_ ## EXCNAME = { \
     PyVarObject_HEAD_INIT(NULL, 0) \
     # EXCNAME, \
     sizeof(PyBaseExceptionObject), \
@@ -449,7 +449,7 @@ static PyTypeObject _PyExc_ ## EXCNAME = { \
 PyObject *PyExc_ ## EXCNAME = (PyObject *)&_PyExc_ ## EXCNAME
 
 #define MiddlingExtendsException(EXCBASE, EXCNAME, EXCSTORE, EXCDOC) \
-static PyTypeObject _PyExc_ ## EXCNAME = { \
+PyTypeObject _PyExc_ ## EXCNAME = { \
     PyVarObject_HEAD_INIT(NULL, 0) \
     # EXCNAME, \
     sizeof(Py ## EXCSTORE ## Object), \
@@ -466,7 +466,7 @@ PyObject *PyExc_ ## EXCNAME = (PyObject *)&_PyExc_ ## EXCNAME
 #define ComplexExtendsException(EXCBASE, EXCNAME, EXCSTORE, EXCNEW, \
                                 EXCMETHODS, EXCMEMBERS, EXCGETSET, \
                                 EXCSTR, EXCDOC) \
-static PyTypeObject _PyExc_ ## EXCNAME = { \
+PyTypeObject _PyExc_ ## EXCNAME = { \
     PyVarObject_HEAD_INIT(NULL, 0) \
     # EXCNAME, \
     sizeof(Py ## EXCSTORE ## Object), 0, \
@@ -2616,7 +2616,7 @@ done:
     return result;
 }
 
-static PyTypeObject _PyExc_UnicodeEncodeError = {
+PyTypeObject _PyExc_UnicodeEncodeError = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "UnicodeEncodeError",
     sizeof(PyUnicodeErrorObject), 0,
@@ -2723,7 +2723,7 @@ done:
     return result;
 }
 
-static PyTypeObject _PyExc_UnicodeDecodeError = {
+PyTypeObject _PyExc_UnicodeDecodeError = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "UnicodeDecodeError",
     sizeof(PyUnicodeErrorObject), 0,
@@ -2820,7 +2820,7 @@ done:
     return result;
 }
 
-static PyTypeObject _PyExc_UnicodeTranslateError = {
+PyTypeObject _PyExc_UnicodeTranslateError = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "UnicodeTranslateError",
     sizeof(PyUnicodeErrorObject), 0,
@@ -2989,7 +2989,7 @@ free_preallocated_memerrors(struct _Py_exc_state *state)
 }
 
 
-static PyTypeObject _PyExc_MemoryError = {
+PyTypeObject _PyExc_MemoryError = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "MemoryError",
     sizeof(PyBaseExceptionObject),

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -2067,7 +2067,7 @@ _PyFloat_ClearFreeList(PyInterpreterState *interp)
 }
 
 void
-_PyFloat_Fini(PyInterpreterState *interp)
+_PyFloat_FiniObjects(PyInterpreterState *interp)
 {
     _PyFloat_ClearFreeList(interp);
 #if defined(Py_DEBUG) && PyFloat_MAXFREELIST > 0

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1980,8 +1980,8 @@ PyTypeObject PyFloat_Type = {
     .tp_vectorcall = (vectorcallfunc)float_vectorcall,
 };
 
-void
-_PyFloat_Init(void)
+PyStatus
+_PyFloat_InitRuntimeState(_PyRuntimeState *runtime)
 {
     /* We attempt to determine if this machine is using IEEE
        floating point formats by peering at the bits of some
@@ -2028,18 +2028,26 @@ _PyFloat_Init(void)
 
     double_format = detected_double_format;
     float_format = detected_float_format;
+
+    return _PyStatus_OK();
 }
 
-int
-_PyFloat_InitTypes(void)
+PyStatus
+_PyFloat_InitTypes(PyInterpreterState *interp)
 {
+    // XXX Init per-interpreter.
+    if (!_Py_IsMainInterpreter(interp)) {
+        return _PyStatus_OK();
+    }
+
     /* Init float info */
     if (FloatInfoType.tp_name == NULL) {
         if (PyStructSequence_InitType2(&FloatInfoType, &floatinfo_desc) < 0) {
-            return -1;
+            return _PyStatus_ERR("can't init float");
         }
     }
-    return 0;
+
+    return _PyStatus_OK();
 }
 
 void

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1088,7 +1088,7 @@ _PyFrame_ClearFreeList(PyInterpreterState *interp)
 }
 
 void
-_PyFrame_Fini(PyInterpreterState *interp)
+_PyFrame_FiniObjects(PyInterpreterState *interp)
 {
     _PyFrame_ClearFreeList(interp);
 #if defined(Py_DEBUG) && PyFrame_MAXFREELIST > 0

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1617,7 +1617,7 @@ _PyAsyncGen_ClearFreeLists(PyInterpreterState *interp)
 }
 
 void
-_PyAsyncGen_Fini(PyInterpreterState *interp)
+_PyAsyncGen_FiniObjects(PyInterpreterState *interp)
 {
     _PyAsyncGen_ClearFreeLists(interp);
 #if defined(Py_DEBUG) && _PyAsyncGen_MAXFREELIST > 0

--- a/Objects/global_objects.c
+++ b/Objects/global_objects.c
@@ -7,6 +7,7 @@
 #include "pycore_runtime.h"       // _PyRuntimeState
 #include "pycore_pystate.h"       // _Py_IsMainInterpreter()
 #include "pycore_typeobject.h"    // _PyType_Init()
+#include "pycore_exceptions.h"    // _PyExc_Init()
 #include "pycore_long.h"          // _PyLong_InitCoreObjects()
 #include "pycore_bytesobject.h"   // _PyBytes_InitCoreObjects()
 #include "pycore_unicodeobject.h" // _PyUnicode_InitCoreObjects()

--- a/Objects/global_objects.c
+++ b/Objects/global_objects.c
@@ -175,13 +175,13 @@ init_types(PyInterpreterState *interp)
         return _PyStatus_ERR("Can't initialize " #TYPE " type"); \
     }
 
-    // Base types
+    // Base types:
     INIT_TYPE(PyBaseObject_Type);
     INIT_TYPE(PyType_Type);
     assert(PyBaseObject_Type.tp_base == NULL);
     assert(PyType_Type.tp_base == &PyBaseObject_Type);
 
-    // All other static types
+    // All other static types (in alphabetical order):
     INIT_TYPE(PyAsyncGen_Type);
     INIT_TYPE(PyBool_Type);
     INIT_TYPE(PyByteArrayIter_Type);
@@ -265,10 +265,10 @@ init_types(PyInterpreterState *interp)
     INIT_TYPE(_PyNamespace_Type);
     INIT_TYPE(_PyNone_Type);
     INIT_TYPE(_PyNotImplemented_Type);
+    INIT_TYPE(_PyUnion_Type);
     INIT_TYPE(_PyWeakref_CallableProxyType);
     INIT_TYPE(_PyWeakref_ProxyType);
     INIT_TYPE(_PyWeakref_RefType);
-    INIT_TYPE(_PyUnion_Type);
 #undef INIT_TYPE
 
     status = _PyLong_InitTypes(interp);

--- a/Objects/global_objects.c
+++ b/Objects/global_objects.c
@@ -31,7 +31,7 @@
  **************************************/
 
 PyStatus
-_Py_RuntimeTypesStateInit(_PyRuntimeState *runtime)
+_PyRuntimeState_TypesInit(_PyRuntimeState *runtime)
 {
     PyStatus status;
 
@@ -49,7 +49,7 @@ _Py_RuntimeTypesStateInit(_PyRuntimeState *runtime)
 }
 
 void
-_Py_RuntimeTypesStateFini(_PyRuntimeState *runtime)
+_PyRuntimeState_TypesFini(_PyRuntimeState *runtime)
 {
     // ...
 }
@@ -102,7 +102,7 @@ init_core_objects(PyInterpreterState *interp)
 }
 
 PyStatus
-_Py_CoreObjectsInit(PyInterpreterState *interp)
+_PyInterpreterState_CoreObjectsInit(PyInterpreterState *interp)
 {
     PyStatus status;
 
@@ -126,7 +126,7 @@ _Py_CoreObjectsInit(PyInterpreterState *interp)
 }
 
 void
-_Py_CoreObjectsFini(PyInterpreterState *interp)
+_PyInterpreterState_CoreObjectsFini(PyInterpreterState *interp)
 {
     // Call _PyUnicode_ClearInterned() before _PyDict_Fini() since it uses
     // a dict internally.
@@ -314,7 +314,7 @@ init_objects(PyInterpreterState *interp)
 }
 
 PyStatus
-_Py_GlobalObjectsInit(PyInterpreterState *interp)
+_PyInterpreterState_ObjectsInit(PyInterpreterState *interp)
 {
     PyStatus status;
 
@@ -337,7 +337,7 @@ _Py_GlobalObjectsInit(PyInterpreterState *interp)
 }
 
 void
-_Py_GlobalObjectsFini(PyInterpreterState *interp)
+_PyInterpreterState_ObjectsFini(PyInterpreterState *interp)
 {
     _PyExc_Fini(interp);
     _PyFrame_Fini(interp);

--- a/Objects/global_objects.c
+++ b/Objects/global_objects.c
@@ -148,11 +148,11 @@ _PyInterpreterState_CoreObjectsFini(PyInterpreterState *interp)
     // a dict internally.
     _PyUnicode_ClearInterned(interp);
 
-    _PyDict_Fini(interp);
-    _PyList_Fini(interp);
-    _PyTuple_Fini(interp);
-    _PyBytes_Fini(interp);
-    _PyUnicode_Fini(interp);
+    _PyDict_FiniCoreObjects(interp);
+    _PyList_FiniCoreObjects(interp);
+    _PyTuple_FiniCoreObjects(interp);
+    _PyBytes_FiniCoreObjects(interp);
+    _PyUnicode_FiniCoreObjects(interp);
     _PyExc_FiniCoreObjects(interp);
 }
 
@@ -169,6 +169,11 @@ init_state_first(PyInterpreterState *interp)
     /* Type state init goes here if it does not rely on ready types,
        and relies only on core objects (at most). */
 
+    status = _PyType_InitState(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     status = _PyStructSequence_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
@@ -181,11 +186,6 @@ static PyStatus
 init_types(PyInterpreterState *interp)
 {
     PyStatus status;
-
-    status = _PyType_Init(interp);
-    if (_PyStatus_EXCEPTION(status)) {
-        return status;
-    }
 
     /* At this point PyType_Ready() may be called. */
 
@@ -383,11 +383,18 @@ void
 _PyInterpreterState_ObjectsFini(PyInterpreterState *interp)
 {
     _PyExc_FiniObjects(interp);
-    _PyFrame_Fini(interp);
-    _PyAsyncGen_Fini(interp);
-    _PyContext_Fini(interp);
-    _PyHamt_Fini(interp);
-    _PyType_Fini(interp);
-    _PySlice_Fini(interp);
-    _PyFloat_Fini(interp);
+    _PyFrame_FiniObjects(interp);
+    _PyAsyncGen_FiniObjects(interp);
+    _PyContext_FiniObjects(interp);
+    _PyHamt_FiniObjects(interp);
+    _PyType_FiniState(interp);
+    _PySlice_FiniObjects(interp);
+    _PyFloat_FiniObjects(interp);
+
+    // Call _PyUnicode_ClearInterned() before _PyDict_Fini() since it uses
+    // a dict internally.
+    _PyUnicode_ClearInterned(interp);
+
+    _PyUnicode_FiniObjects(interp);
+    _PyUnicode_FiniState(interp);
 }

--- a/Objects/global_objects.c
+++ b/Objects/global_objects.c
@@ -1,0 +1,220 @@
+
+#include "Python.h"
+
+#include "pycore_initconfig.h"    // PyStatus()
+#include "pycore_pylifecycle.h"   // _Py_InitCoreObjects()
+#include "pycore_runtime.h"       // _PyRuntimeState
+#include "pycore_pystate.h"       // _Py_IsMainInterpreter()
+#include "pycore_typeobject.h"    // _PyType_Init()
+#include "pycore_context.h"       // _PyContext_Init()
+
+/**************************************
+ * runtime-global type-related state
+ **************************************/
+
+PyStatus
+_Py_RuntimeTypesStateInit(_PyRuntimeState *runtime)
+{
+    return _PyStatus_OK();
+}
+
+void
+_Py_RuntimeTypesStateFini(_PyRuntimeState *runtime)
+{
+    // ...
+}
+
+
+/**************************************
+ * per-interpreter "core" types
+ **************************************/
+
+// int, str, bytes, tuple, list, dict
+
+static PyStatus
+init_core_state(PyInterpreterState *interp)
+{
+    return _PyStatus_OK();
+}
+
+static PyStatus
+init_core_types(PyInterpreterState *interp)
+{
+    return _PyStatus_OK();
+}
+
+static PyStatus
+init_core_objects(PyInterpreterState *interp)
+{
+    PyStatus status;
+
+    _PyLong_Init(interp);
+
+    status = _PyBytes_Init(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    status = _PyUnicode_Init(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    status = _PyTuple_Init(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    return _PyStatus_OK();
+}
+
+PyStatus
+_Py_CoreObjectsInit(PyInterpreterState *interp)
+{
+    PyStatus status;
+
+    status = init_core_state(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    /* Initializing these cannot rely on any of the core objects. */
+    status = init_core_types(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    status = init_core_objects(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    return _PyStatus_OK();
+}
+
+void
+_Py_CoreObjectsFini(PyInterpreterState *interp)
+{
+    // Call _PyUnicode_ClearInterned() before _PyDict_Fini() since it uses
+    // a dict internally.
+    _PyUnicode_ClearInterned(interp);
+
+    _PyDict_Fini(interp);
+    _PyList_Fini(interp);
+    _PyTuple_Fini(interp);
+    _PyBytes_Fini(interp);
+    _PyUnicode_Fini(interp);
+}
+
+
+/**************************************
+ * full per-interpreter types
+ **************************************/
+
+static PyStatus
+init_state(PyInterpreterState *interp)
+{
+    return _PyStatus_OK();
+}
+
+static PyStatus
+init_types(PyInterpreterState *interp)
+{
+    PyStatus status;
+
+    status = _PyType_Init(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    int is_main_interp = _Py_IsMainInterpreter(interp);
+    if (is_main_interp) {
+        if (_PyStructSequence_Init() < 0) {
+            return _PyStatus_ERR("can't initialize structseq");
+        }
+
+        status = _PyTypes_Init();
+        if (_PyStatus_EXCEPTION(status)) {
+            return status;
+        }
+
+        if (_PyLong_InitTypes() < 0) {
+            return _PyStatus_ERR("can't init int type");
+        }
+
+        status = _PyUnicode_InitTypes();
+        if (_PyStatus_EXCEPTION(status)) {
+            return status;
+        }
+    }
+
+    if (is_main_interp) {
+        if (_PyFloat_InitTypes() < 0) {
+            return _PyStatus_ERR("can't init float");
+        }
+    }
+
+    status = _PyExc_Init(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    status = _PyErr_InitTypes();
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    if (is_main_interp) {
+        if (!_PyContext_Init()) {
+            return _PyStatus_ERR("can't init context");
+        }
+    }
+    return _PyStatus_OK();
+}
+
+static PyStatus
+init_objects(PyInterpreterState *interp)
+{
+    PyStatus status;
+
+    if (_Py_IsMainInterpreter(interp)) {
+        _PyFloat_Init();
+    }
+
+    return _PyStatus_OK();
+}
+
+PyStatus
+_Py_GlobalObjectsInit(PyInterpreterState *interp)
+{
+    PyStatus status;
+
+    status = init_state(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    status = init_types(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    status = init_objects(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    return _PyStatus_OK();
+}
+
+void
+_Py_GlobalObjectsFini(PyInterpreterState *interp)
+{
+    _PyExc_Fini(interp);
+    _PyFrame_Fini(interp);
+    _PyAsyncGen_Fini(interp);
+    _PyContext_Fini(interp);
+    _PyType_Fini(interp);
+    _PySlice_Fini(interp);
+    _PyFloat_Fini(interp);
+}

--- a/Objects/global_objects.c
+++ b/Objects/global_objects.c
@@ -1,12 +1,30 @@
 
 #include "Python.h"
 
-#include "pycore_initconfig.h"    // PyStatus()
+#include "pycore_initconfig.h"    // PyStatus
 #include "pycore_pylifecycle.h"   // _Py_InitCoreObjects()
 #include "pycore_runtime.h"       // _PyRuntimeState
 #include "pycore_pystate.h"       // _Py_IsMainInterpreter()
 #include "pycore_typeobject.h"    // _PyType_Init()
+#include "pycore_long.h"          // _PyLong_InitCoreObjects()
+#include "pycore_bytesobject.h"   // _PyBytes_InitCoreObjects()
+#include "pycore_unicodeobject.h" // _PyUnicode_InitCoreObjects()
+#include "pycore_tuple.h"         // _PyTuple_InitCoreObjects()
+#include "pycore_dict.h"          // _PyDict_Fini()
+#include "pycore_list.h"          // _PyList_Fini()
+#include "pycore_structseq.h"     // _PyStructSequence_Init()
+#include "pycore_floatobject.h"   // _PyFloat_InitTypes()
+#include "pycore_frame.h"         // _PyFrame_Fini()
+#include "pycore_sliceobject.h"   // _PySlice_Fini()
+#include "pycore_genobject.h"     // _PyAsyncGen_Fini()
 #include "pycore_context.h"       // _PyContext_Init()
+#include "pycore_hamt.h"          // _PyHamt_Init()
+#include "pycore_namespace.h"     // _PyNamespace_Type
+#include "pycore_symtable.h"      // PySTEntry_Type
+#include "pycore_unionobject.h"   // _PyUnion_Type
+#include "frameobject.h"          // PyFrame_Type
+#include "pycore_pyerrors.h"      // _PyErr_InitTypes()
+#include "pycore_interpreteridobject.h"  // _PyInterpreterID_Type
 
 /**************************************
  * runtime-global type-related state
@@ -15,6 +33,18 @@
 PyStatus
 _Py_RuntimeTypesStateInit(_PyRuntimeState *runtime)
 {
+    PyStatus status;
+
+    status = _PyUnicode_InitRuntimeState(runtime);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    status = _PyFloat_InitRuntimeState(runtime);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     return _PyStatus_OK();
 }
 
@@ -48,19 +78,22 @@ init_core_objects(PyInterpreterState *interp)
 {
     PyStatus status;
 
-    _PyLong_Init(interp);
-
-    status = _PyBytes_Init(interp);
+    status = _PyLong_InitCoreObjects(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
 
-    status = _PyUnicode_Init(interp);
+    status = _PyBytes_InitCoreObjects(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
 
-    status = _PyTuple_Init(interp);
+    status = _PyUnicode_InitCoreObjects(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    status = _PyTuple_InitCoreObjects(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
@@ -114,6 +147,13 @@ _Py_CoreObjectsFini(PyInterpreterState *interp)
 static PyStatus
 init_state(PyInterpreterState *interp)
 {
+    PyStatus status;
+
+    status = _PyStructSequence_Init(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     return _PyStatus_OK();
 }
 
@@ -127,31 +167,121 @@ init_types(PyInterpreterState *interp)
         return status;
     }
 
-    int is_main_interp = _Py_IsMainInterpreter(interp);
-    if (is_main_interp) {
-        if (_PyStructSequence_Init() < 0) {
-            return _PyStatus_ERR("can't initialize structseq");
-        }
-
-        status = _PyTypes_Init();
-        if (_PyStatus_EXCEPTION(status)) {
-            return status;
-        }
-
-        if (_PyLong_InitTypes() < 0) {
-            return _PyStatus_ERR("can't init int type");
-        }
-
-        status = _PyUnicode_InitTypes();
-        if (_PyStatus_EXCEPTION(status)) {
-            return status;
-        }
+    // XXX Init per-interpreter.
+#define INIT_TYPE(TYPE) \
+    if (PyType_Ready(&(TYPE)) < 0) { \
+        return _PyStatus_ERR("Can't initialize " #TYPE " type"); \
     }
 
-    if (is_main_interp) {
-        if (_PyFloat_InitTypes() < 0) {
-            return _PyStatus_ERR("can't init float");
-        }
+    // Base types
+    INIT_TYPE(PyBaseObject_Type);
+    INIT_TYPE(PyType_Type);
+    assert(PyBaseObject_Type.tp_base == NULL);
+    assert(PyType_Type.tp_base == &PyBaseObject_Type);
+
+    // All other static types
+    INIT_TYPE(PyAsyncGen_Type);
+    INIT_TYPE(PyBool_Type);
+    INIT_TYPE(PyByteArrayIter_Type);
+    INIT_TYPE(PyByteArray_Type);
+    INIT_TYPE(PyBytesIter_Type);
+    INIT_TYPE(PyBytes_Type);
+    INIT_TYPE(PyCFunction_Type);
+    INIT_TYPE(PyCMethod_Type);
+    INIT_TYPE(PyCallIter_Type);
+    INIT_TYPE(PyCapsule_Type);
+    INIT_TYPE(PyCell_Type);
+    INIT_TYPE(PyClassMethodDescr_Type);
+    INIT_TYPE(PyClassMethod_Type);
+    INIT_TYPE(PyCode_Type);
+    INIT_TYPE(PyComplex_Type);
+    INIT_TYPE(PyCoro_Type);
+    INIT_TYPE(PyDictItems_Type);
+    INIT_TYPE(PyDictIterItem_Type);
+    INIT_TYPE(PyDictIterKey_Type);
+    INIT_TYPE(PyDictIterValue_Type);
+    INIT_TYPE(PyDictKeys_Type);
+    INIT_TYPE(PyDictProxy_Type);
+    INIT_TYPE(PyDictRevIterItem_Type);
+    INIT_TYPE(PyDictRevIterKey_Type);
+    INIT_TYPE(PyDictRevIterValue_Type);
+    INIT_TYPE(PyDictValues_Type);
+    INIT_TYPE(PyDict_Type);
+    INIT_TYPE(PyEllipsis_Type);
+    INIT_TYPE(PyEnum_Type);
+    INIT_TYPE(PyFloat_Type);
+    INIT_TYPE(PyFrame_Type);
+    INIT_TYPE(PyFrozenSet_Type);
+    INIT_TYPE(PyFunction_Type);
+    INIT_TYPE(PyGen_Type);
+    INIT_TYPE(PyGetSetDescr_Type);
+    INIT_TYPE(PyInstanceMethod_Type);
+    INIT_TYPE(PyListIter_Type);
+    INIT_TYPE(PyListRevIter_Type);
+    INIT_TYPE(PyList_Type);
+    INIT_TYPE(PyLongRangeIter_Type);
+    INIT_TYPE(PyLong_Type);
+    INIT_TYPE(PyMemberDescr_Type);
+    INIT_TYPE(PyMemoryView_Type);
+    INIT_TYPE(PyMethodDescr_Type);
+    INIT_TYPE(PyMethod_Type);
+    INIT_TYPE(PyModuleDef_Type);
+    INIT_TYPE(PyModule_Type);
+    INIT_TYPE(PyODictItems_Type);
+    INIT_TYPE(PyODictIter_Type);
+    INIT_TYPE(PyODictKeys_Type);
+    INIT_TYPE(PyODictValues_Type);
+    INIT_TYPE(PyODict_Type);
+    INIT_TYPE(PyPickleBuffer_Type);
+    INIT_TYPE(PyProperty_Type);
+    INIT_TYPE(PyRangeIter_Type);
+    INIT_TYPE(PyRange_Type);
+    INIT_TYPE(PyReversed_Type);
+    INIT_TYPE(PySTEntry_Type);
+    INIT_TYPE(PySeqIter_Type);
+    INIT_TYPE(PySetIter_Type);
+    INIT_TYPE(PySet_Type);
+    INIT_TYPE(PySlice_Type);
+    INIT_TYPE(PyStaticMethod_Type);
+    INIT_TYPE(PyStdPrinter_Type);
+    INIT_TYPE(PySuper_Type);
+    INIT_TYPE(PyTraceBack_Type);
+    INIT_TYPE(PyTupleIter_Type);
+    INIT_TYPE(PyTuple_Type);
+    INIT_TYPE(PyUnicodeIter_Type);
+    INIT_TYPE(PyUnicode_Type);
+    INIT_TYPE(PyWrapperDescr_Type);
+    INIT_TYPE(Py_GenericAliasType);
+    INIT_TYPE(_PyAnextAwaitable_Type);
+    INIT_TYPE(_PyAsyncGenASend_Type);
+    INIT_TYPE(_PyAsyncGenAThrow_Type);
+    INIT_TYPE(_PyAsyncGenWrappedValue_Type);
+    INIT_TYPE(_PyCoroWrapper_Type);
+    INIT_TYPE(_PyInterpreterID_Type);
+    INIT_TYPE(_PyManagedBuffer_Type);
+    INIT_TYPE(_PyMethodWrapper_Type);
+    INIT_TYPE(_PyNamespace_Type);
+    INIT_TYPE(_PyNone_Type);
+    INIT_TYPE(_PyNotImplemented_Type);
+    INIT_TYPE(_PyWeakref_CallableProxyType);
+    INIT_TYPE(_PyWeakref_ProxyType);
+    INIT_TYPE(_PyWeakref_RefType);
+    INIT_TYPE(_PyUnion_Type);
+#undef INIT_TYPE
+
+    status = _PyLong_InitTypes(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    status = _PyUnicode_InitTypes(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    status = _PyFloat_InitTypes(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
     }
 
     status = _PyExc_Init(interp);
@@ -159,28 +289,27 @@ init_types(PyInterpreterState *interp)
         return status;
     }
 
-    status = _PyErr_InitTypes();
+    status = _PyErr_InitTypes(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
 
-    if (is_main_interp) {
-        if (!_PyContext_Init()) {
-            return _PyStatus_ERR("can't init context");
-        }
+    status = _PyHamt_InitTypes(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
     }
+
+    status = _PyContext_InitTypes(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     return _PyStatus_OK();
 }
 
 static PyStatus
 init_objects(PyInterpreterState *interp)
 {
-    PyStatus status;
-
-    if (_Py_IsMainInterpreter(interp)) {
-        _PyFloat_Init();
-    }
-
     return _PyStatus_OK();
 }
 
@@ -214,6 +343,7 @@ _Py_GlobalObjectsFini(PyInterpreterState *interp)
     _PyFrame_Fini(interp);
     _PyAsyncGen_Fini(interp);
     _PyContext_Fini(interp);
+    _PyHamt_Fini(interp);
     _PyType_Fini(interp);
     _PySlice_Fini(interp);
     _PyFloat_Fini(interp);

--- a/Objects/global_objects.c
+++ b/Objects/global_objects.c
@@ -1,6 +1,7 @@
 
 #include "Python.h"
 
+#include "pycore_global_objects.h"  // PyStatus
 #include "pycore_initconfig.h"    // PyStatus
 #include "pycore_pylifecycle.h"   // _Py_InitCoreObjects()
 #include "pycore_runtime.h"       // _PyRuntimeState
@@ -25,6 +26,7 @@
 #include "frameobject.h"          // PyFrame_Type
 #include "pycore_pyerrors.h"      // _PyErr_InitTypes()
 #include "pycore_interpreteridobject.h"  // _PyInterpreterID_Type
+
 
 /**************************************
  * runtime-global type-related state

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -115,7 +115,7 @@ _PyList_ClearFreeList(PyInterpreterState *interp)
 }
 
 void
-_PyList_Fini(PyInterpreterState *interp)
+_PyList_FiniCoreObjects(PyInterpreterState *interp)
 {
     _PyList_ClearFreeList(interp);
 #if defined(Py_DEBUG) && PyList_MAXFREELIST > 0

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -8,6 +8,7 @@
 #include "pycore_long.h"          // _Py_SmallInts
 #include "pycore_object.h"        // _PyObject_InitVar()
 #include "pycore_pystate.h"       // _Py_IsMainInterpreter()
+#include "pycore_initconfig.h"    // _PyStatus_OK()
 
 #include <ctype.h>
 #include <float.h>
@@ -5824,8 +5825,8 @@ PyLong_GetInfo(void)
     return int_info;
 }
 
-void
-_PyLong_Init(PyInterpreterState *interp)
+PyStatus
+_PyLong_InitCoreObjects(PyInterpreterState *interp)
 {
     if (_PyRuntime.small_ints[0].ob_base.ob_base.ob_refcnt == 0) {
         for (Py_ssize_t i=0; i < _PY_NSMALLNEGINTS + _PY_NSMALLPOSINTS; i++) {
@@ -5837,22 +5838,22 @@ _PyLong_Init(PyInterpreterState *interp)
             _PyRuntime.small_ints[i].ob_digit[0] = (digit)abs(ival);
         }
     }
+    return _PyStatus_OK();
 }
 
-int
-_PyLong_InitTypes(void)
+PyStatus
+_PyLong_InitTypes(PyInterpreterState *interp)
 {
+    // XXX Init per-interpreter.
+    if (!_Py_IsMainInterpreter(interp)) {
+        return _PyStatus_OK();
+    }
+
     /* initialize int_info */
     if (Int_InfoType.tp_name == NULL) {
         if (PyStructSequence_InitType2(&Int_InfoType, &int_info_desc) < 0) {
-            return -1;
+            return _PyStatus_ERR("can't init int type");
         }
     }
-    return 0;
-}
-
-void
-_PyLong_Fini(PyInterpreterState *interp)
-{
-    (void)interp;
+    return _PyStatus_OK();
 }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -7,16 +7,12 @@
 #include "pycore_dict.h"          // _PyObject_MakeDictFromInstanceAttributes()
 #include "pycore_floatobject.h"   // _PyFloat_DebugMallocStats()
 #include "pycore_initconfig.h"    // _PyStatus_EXCEPTION()
-#include "pycore_namespace.h"     // _PyNamespace_Type
 #include "pycore_object.h"        // _PyType_CheckConsistency()
 #include "pycore_pyerrors.h"      // _PyErr_Occurred()
 #include "pycore_pylifecycle.h"   // _PyTypes_InitSlotDefs()
 #include "pycore_pymem.h"         // _PyMem_IsPtrFreed()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "pycore_symtable.h"      // PySTEntry_Type
-#include "pycore_unionobject.h"   // _PyUnion_Type
-#include "frameobject.h"          // PyFrame_Type
-#include "pycore_interpreteridobject.h"  // _PyInterpreterID_Type
+#include "frameobject.h"          // _PyFrame_DebugMallocStats()
 
 #ifdef Py_LIMITED_API
    // Prevent recursive call _Py_IncRef() <=> Py_INCREF()
@@ -1844,115 +1840,6 @@ PyObject _Py_NotImplementedStruct = {
     _PyObject_EXTRA_INIT
     1, &_PyNotImplemented_Type
 };
-
-PyStatus
-_PyTypes_Init(void)
-{
-#define INIT_TYPE(TYPE) \
-    do { \
-        if (PyType_Ready(&(TYPE)) < 0) { \
-            return _PyStatus_ERR("Can't initialize " #TYPE " type"); \
-        } \
-    } while (0)
-
-    // Base types
-    INIT_TYPE(PyBaseObject_Type);
-    INIT_TYPE(PyType_Type);
-    assert(PyBaseObject_Type.tp_base == NULL);
-    assert(PyType_Type.tp_base == &PyBaseObject_Type);
-
-    // All other static types
-    INIT_TYPE(PyAsyncGen_Type);
-    INIT_TYPE(PyBool_Type);
-    INIT_TYPE(PyByteArrayIter_Type);
-    INIT_TYPE(PyByteArray_Type);
-    INIT_TYPE(PyBytesIter_Type);
-    INIT_TYPE(PyBytes_Type);
-    INIT_TYPE(PyCFunction_Type);
-    INIT_TYPE(PyCMethod_Type);
-    INIT_TYPE(PyCallIter_Type);
-    INIT_TYPE(PyCapsule_Type);
-    INIT_TYPE(PyCell_Type);
-    INIT_TYPE(PyClassMethodDescr_Type);
-    INIT_TYPE(PyClassMethod_Type);
-    INIT_TYPE(PyCode_Type);
-    INIT_TYPE(PyComplex_Type);
-    INIT_TYPE(PyCoro_Type);
-    INIT_TYPE(PyDictItems_Type);
-    INIT_TYPE(PyDictIterItem_Type);
-    INIT_TYPE(PyDictIterKey_Type);
-    INIT_TYPE(PyDictIterValue_Type);
-    INIT_TYPE(PyDictKeys_Type);
-    INIT_TYPE(PyDictProxy_Type);
-    INIT_TYPE(PyDictRevIterItem_Type);
-    INIT_TYPE(PyDictRevIterKey_Type);
-    INIT_TYPE(PyDictRevIterValue_Type);
-    INIT_TYPE(PyDictValues_Type);
-    INIT_TYPE(PyDict_Type);
-    INIT_TYPE(PyEllipsis_Type);
-    INIT_TYPE(PyEnum_Type);
-    INIT_TYPE(PyFloat_Type);
-    INIT_TYPE(PyFrame_Type);
-    INIT_TYPE(PyFrozenSet_Type);
-    INIT_TYPE(PyFunction_Type);
-    INIT_TYPE(PyGen_Type);
-    INIT_TYPE(PyGetSetDescr_Type);
-    INIT_TYPE(PyInstanceMethod_Type);
-    INIT_TYPE(PyListIter_Type);
-    INIT_TYPE(PyListRevIter_Type);
-    INIT_TYPE(PyList_Type);
-    INIT_TYPE(PyLongRangeIter_Type);
-    INIT_TYPE(PyLong_Type);
-    INIT_TYPE(PyMemberDescr_Type);
-    INIT_TYPE(PyMemoryView_Type);
-    INIT_TYPE(PyMethodDescr_Type);
-    INIT_TYPE(PyMethod_Type);
-    INIT_TYPE(PyModuleDef_Type);
-    INIT_TYPE(PyModule_Type);
-    INIT_TYPE(PyODictItems_Type);
-    INIT_TYPE(PyODictIter_Type);
-    INIT_TYPE(PyODictKeys_Type);
-    INIT_TYPE(PyODictValues_Type);
-    INIT_TYPE(PyODict_Type);
-    INIT_TYPE(PyPickleBuffer_Type);
-    INIT_TYPE(PyProperty_Type);
-    INIT_TYPE(PyRangeIter_Type);
-    INIT_TYPE(PyRange_Type);
-    INIT_TYPE(PyReversed_Type);
-    INIT_TYPE(PySTEntry_Type);
-    INIT_TYPE(PySeqIter_Type);
-    INIT_TYPE(PySetIter_Type);
-    INIT_TYPE(PySet_Type);
-    INIT_TYPE(PySlice_Type);
-    INIT_TYPE(PyStaticMethod_Type);
-    INIT_TYPE(PyStdPrinter_Type);
-    INIT_TYPE(PySuper_Type);
-    INIT_TYPE(PyTraceBack_Type);
-    INIT_TYPE(PyTupleIter_Type);
-    INIT_TYPE(PyTuple_Type);
-    INIT_TYPE(PyUnicodeIter_Type);
-    INIT_TYPE(PyUnicode_Type);
-    INIT_TYPE(PyWrapperDescr_Type);
-    INIT_TYPE(Py_GenericAliasType);
-    INIT_TYPE(_PyAnextAwaitable_Type);
-    INIT_TYPE(_PyAsyncGenASend_Type);
-    INIT_TYPE(_PyAsyncGenAThrow_Type);
-    INIT_TYPE(_PyAsyncGenWrappedValue_Type);
-    INIT_TYPE(_PyCoroWrapper_Type);
-    INIT_TYPE(_PyInterpreterID_Type);
-    INIT_TYPE(_PyManagedBuffer_Type);
-    INIT_TYPE(_PyMethodWrapper_Type);
-    INIT_TYPE(_PyNamespace_Type);
-    INIT_TYPE(_PyNone_Type);
-    INIT_TYPE(_PyNotImplemented_Type);
-    INIT_TYPE(_PyWeakref_CallableProxyType);
-    INIT_TYPE(_PyWeakref_ProxyType);
-    INIT_TYPE(_PyWeakref_RefType);
-    INIT_TYPE(_PyUnion_Type);
-
-    return _PyStatus_OK();
-#undef INIT_TYPE
-}
 
 
 void

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1848,11 +1848,6 @@ PyObject _Py_NotImplementedStruct = {
 PyStatus
 _PyTypes_Init(void)
 {
-    PyStatus status = _PyTypes_InitSlotDefs();
-    if (_PyStatus_EXCEPTION(status)) {
-        return status;
-    }
-
 #define INIT_TYPE(TYPE) \
     do { \
         if (PyType_Ready(&(TYPE)) < 0) { \

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -97,7 +97,7 @@ PyObject _Py_EllipsisObject = {
 /* Slice object implementation */
 
 
-void _PySlice_Fini(PyInterpreterState *interp)
+void _PySlice_FiniObjects(PyInterpreterState *interp)
 {
     PySliceObject *obj = interp->slice_cache;
     if (obj != NULL) {

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -12,6 +12,7 @@
 #include "pycore_object.h"        // _PyObject_GC_TRACK()
 #include "structmember.h"         // PyMemberDef
 #include "pycore_structseq.h"     // PyStructSequence_InitType()
+#include "pycore_initconfig.h"    // _PyStatus_OK()
 
 static const char visible_length_key[] = "n_sequence_fields";
 static const char real_length_key[] = "n_fields";
@@ -583,13 +584,18 @@ PyStructSequence_NewType(PyStructSequence_Desc *desc)
     return type;
 }
 
-int _PyStructSequence_Init(void)
+PyStatus _PyStructSequence_Init(PyInterpreterState *interp)
 {
+    // XXX Init per-interpreter.
+    if (!_Py_IsMainInterpreter(interp)) {
+        return _PyStatus_OK();
+    }
+
     if (_PyUnicode_FromId(&PyId_n_sequence_fields) == NULL
         || _PyUnicode_FromId(&PyId_n_fields) == NULL
         || _PyUnicode_FromId(&PyId_n_unnamed_fields) == NULL)
     {
-        return -1;
+        return _PyStatus_ERR("can't initialize structseq");
     }
-    return 0;
+    return _PyStatus_OK();
 }

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -1066,7 +1066,7 @@ _PyTuple_ClearFreeList(PyInterpreterState *interp)
 
 
 PyStatus
-_PyTuple_Init(PyInterpreterState *interp)
+_PyTuple_InitCoreObjects(PyInterpreterState *interp)
 {
     struct _Py_tuple_state *state = &interp->tuple;
     if (tuple_create_empty_tuple_singleton(state) < 0) {

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -1077,7 +1077,7 @@ _PyTuple_InitCoreObjects(PyInterpreterState *interp)
 
 
 void
-_PyTuple_Fini(PyInterpreterState *interp)
+_PyTuple_FiniCoreObjects(PyInterpreterState *interp)
 {
 #if PyTuple_MAXSAVESIZE > 0
     struct _Py_tuple_state *state = &interp->tuple;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -296,13 +296,16 @@ PyType_ClearCache(void)
 PyStatus
 _PyType_Init(PyInterpreterState *interp)
 {
+    // XXX Init per-interpreter.
+    if (!_Py_IsMainInterpreter(interp)) {
+        return _PyStatus_OK();
+    }
+
     PyStatus status;
 
-    if (_Py_IsMainInterpreter(interp)) {
-        status = init_slotdefs();
-        if (_PyStatus_EXCEPTION(status)) {
-            return status;
-        }
+    status = init_slotdefs();
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
     }
 
     return _PyStatus_OK();

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -294,7 +294,7 @@ PyType_ClearCache(void)
 
 
 PyStatus
-_PyType_Init(PyInterpreterState *interp)
+_PyType_InitState(PyInterpreterState *interp)
 {
     // XXX Init per-interpreter.
     if (!_Py_IsMainInterpreter(interp)) {
@@ -312,7 +312,7 @@ _PyType_Init(PyInterpreterState *interp)
 }
 
 void
-_PyType_Fini(PyInterpreterState *interp)
+_PyType_FiniState(PyInterpreterState *interp)
 {
     struct type_cache *cache = &interp->type_cache;
     type_cache_clear(cache, NULL);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -299,7 +299,7 @@ _PyType_Init(PyInterpreterState *interp)
     PyStatus status;
 
     if (_Py_IsMainInterpreter(interp)) {
-        status = init_slotdefs(interp);
+        status = init_slotdefs();
         if (_PyStatus_EXCEPTION(status)) {
             return status;
         }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15491,40 +15491,46 @@ PyTypeObject PyUnicode_Type = {
 /* Initialize the Unicode implementation */
 
 PyStatus
-_PyUnicode_Init(PyInterpreterState *interp)
+_PyUnicode_InitRuntimeState(_PyRuntimeState *runtime)
 {
-    struct _Py_unicode_state *state = &interp->unicode;
-    if (unicode_create_empty_string_singleton(state) < 0) {
-        return _PyStatus_NO_MEMORY();
-    }
-
-    if (_Py_IsMainInterpreter(interp)) {
-        /* initialize the linebreak bloom filter */
-        const Py_UCS2 linebreak[] = {
-            0x000A, /* LINE FEED */
-            0x000D, /* CARRIAGE RETURN */
-            0x001C, /* FILE SEPARATOR */
-            0x001D, /* GROUP SEPARATOR */
-            0x001E, /* RECORD SEPARATOR */
-            0x0085, /* NEXT LINE */
-            0x2028, /* LINE SEPARATOR */
-            0x2029, /* PARAGRAPH SEPARATOR */
-        };
-        bloom_linebreak = make_bloom_mask(
-            PyUnicode_2BYTE_KIND, linebreak,
-            Py_ARRAY_LENGTH(linebreak));
-    }
+    /* initialize the linebreak bloom filter */
+    const Py_UCS2 linebreak[] = {
+        0x000A, /* LINE FEED */
+        0x000D, /* CARRIAGE RETURN */
+        0x001C, /* FILE SEPARATOR */
+        0x001D, /* GROUP SEPARATOR */
+        0x001E, /* RECORD SEPARATOR */
+        0x0085, /* NEXT LINE */
+        0x2028, /* LINE SEPARATOR */
+        0x2029, /* PARAGRAPH SEPARATOR */
+    };
+    bloom_linebreak = make_bloom_mask(
+        PyUnicode_2BYTE_KIND, linebreak,
+        Py_ARRAY_LENGTH(linebreak));
 
     return _PyStatus_OK();
 }
 
 
 PyStatus
-_PyUnicode_InitTypes(void)
+_PyUnicode_InitCoreObjects(PyInterpreterState *interp)
 {
-    if (PyType_Ready(&PyUnicode_Type) < 0) {
-        return _PyStatus_ERR("Can't initialize unicode type");
+    struct _Py_unicode_state *state = &interp->unicode;
+    if (unicode_create_empty_string_singleton(state) < 0) {
+        return _PyStatus_NO_MEMORY();
     }
+    return _PyStatus_OK();
+}
+
+
+PyStatus
+_PyUnicode_InitTypes(PyInterpreterState *interp)
+{
+    // XXX Init per-interpreter.
+    if (!_Py_IsMainInterpreter(interp)) {
+        return _PyStatus_OK();
+    }
+
     if (PyType_Ready(&EncodingMapType) < 0) {
          return _PyStatus_ERR("Can't initialize encoding map type");
     }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -16062,16 +16062,12 @@ unicode_is_finalizing(void)
 
 
 void
-_PyUnicode_Fini(PyInterpreterState *interp)
+_PyUnicode_FiniCoreObjects(PyInterpreterState *interp)
 {
     struct _Py_unicode_state *state = &interp->unicode;
 
     // _PyUnicode_ClearInterned() must be called before
     assert(state->interned == NULL);
-
-    _PyUnicode_FiniEncodings(&state->fs_codec);
-
-    unicode_clear_identifiers(state);
 
     for (Py_ssize_t i = 0; i < 256; i++) {
         Py_CLEAR(state->latin1[i]);
@@ -16079,6 +16075,27 @@ _PyUnicode_Fini(PyInterpreterState *interp)
     Py_CLEAR(state->empty_string);
 }
 
+void
+_PyUnicode_FiniObjects(PyInterpreterState *interp)
+{
+    struct _Py_unicode_state *state = &interp->unicode;
+
+    // _PyUnicode_ClearInterned() must be called before
+    assert(state->interned == NULL);
+
+    unicode_clear_identifiers(state);
+}
+
+void
+_PyUnicode_FiniState(PyInterpreterState *interp)
+{
+    struct _Py_unicode_state *state = &interp->unicode;
+
+    // _PyUnicode_ClearInterned() must be called before
+    assert(state->interned == NULL);
+
+    _PyUnicode_FiniEncodings(&state->fs_codec);
+}
 
 /* A _string module, to export formatter_parser and formatter_field_name_split
    to the string.Formatter class implemented in Python. */

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -197,6 +197,7 @@
     <ClInclude Include="..\Include\internal\pycore_gc.h" />
     <ClInclude Include="..\Include\internal\pycore_getopt.h" />
     <ClInclude Include="..\Include\internal\pycore_gil.h" />
+    <ClInclude Include="..\Include\internal\pycore_global_objects.h" />
     <ClInclude Include="..\Include\internal\pycore_hamt.h" />
     <ClInclude Include="..\Include\internal\pycore_hashtable.h" />
     <ClInclude Include="..\Include\internal\pycore_import.h" />

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -191,6 +191,7 @@
     <ClInclude Include="..\Include\internal\pycore_condvar.h" />
     <ClInclude Include="..\Include\internal\pycore_context.h" />
     <ClInclude Include="..\Include\internal\pycore_dtoa.h" />
+    <ClInclude Include="..\Include\internal\pycore_exceptions.h" />
     <ClInclude Include="..\Include\internal\pycore_fileutils.h" />
     <ClInclude Include="..\Include\internal\pycore_floatobject.h" />
     <ClInclude Include="..\Include\internal\pycore_format.h" />

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -407,6 +407,7 @@
     <ClCompile Include="..\Objects\funcobject.c" />
     <ClCompile Include="..\Objects\genericaliasobject.c" />
     <ClCompile Include="..\Objects\genobject.c" />
+    <ClCompile Include="..\Objects\global_objects.c" />
     <ClCompile Include="..\Objects\interpreteridobject.c" />
     <ClCompile Include="..\Objects\iterobject.c" />
     <ClCompile Include="..\Objects\listobject.c" />

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -183,6 +183,7 @@
     <ClInclude Include="..\Include\internal\pycore_atomic_funcs.h" />
     <ClInclude Include="..\Include\internal\pycore_bitutils.h" />
     <ClInclude Include="..\Include\internal\pycore_bytes_methods.h" />
+    <ClInclude Include="..\Include\internal\pycore_bytesobject.h" />
     <ClInclude Include="..\Include\internal\pycore_call.h" />
     <ClInclude Include="..\Include\internal\pycore_ceval.h" />
     <ClInclude Include="..\Include\internal\pycore_code.h" />

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -182,6 +182,7 @@
     <ClInclude Include="..\Include\internal\pycore_atomic.h" />
     <ClInclude Include="..\Include\internal\pycore_atomic_funcs.h" />
     <ClInclude Include="..\Include\internal\pycore_bitutils.h" />
+    <ClInclude Include="..\Include\internal\pycore_bltinmodule.h" />
     <ClInclude Include="..\Include\internal\pycore_bytes_methods.h" />
     <ClInclude Include="..\Include\internal\pycore_bytesobject.h" />
     <ClInclude Include="..\Include\internal\pycore_call.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -540,6 +540,9 @@
     <ClInclude Include="..\Include\internal\pycore_gil.h">
       <Filter>Include\internal</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_global_objects.h">
+      <Filter>Include\internal</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_hamt.h">
       <Filter>Include\internal</Filter>
     </ClInclude>

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -498,6 +498,9 @@
     <ClInclude Include="..\Include\internal\pycore_bytes_methods.h">
       <Filter>Include\internal</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_bytesobject.h">
+      <Filter>Include\internal</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_call.h">
       <Filter>Include\internal</Filter>
     </ClInclude>

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -495,6 +495,9 @@
     <ClInclude Include="..\Include\internal\pycore_bitutils.h">
       <Filter>Include\internal</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_bltinmodule.h">
+      <Filter>Include\internal</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_bytes_methods.h">
       <Filter>Include\internal</Filter>
     </ClInclude>

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -899,6 +899,9 @@
     <ClCompile Include="..\Objects\genobject.c">
       <Filter>Objects</Filter>
     </ClCompile>
+    <ClCompile Include="..\Objects\global_objects.c">
+      <Filter>Objects</Filter>
+    </ClCompile>
     <ClCompile Include="..\Objects\iterobject.c">
       <Filter>Objects</Filter>
     </ClCompile>

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -522,6 +522,9 @@
     <ClInclude Include="..\Include\internal\pycore_dtoa.h">
       <Filter>Include\internal</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_exceptions.h">
+      <Filter>Include\internal</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_fileutils.h">
       <Filter>Include\internal</Filter>
     </ClInclude>

--- a/Python/context.c
+++ b/Python/context.c
@@ -1308,7 +1308,7 @@ _PyContext_ClearFreeList(PyInterpreterState *interp)
 
 
 void
-_PyContext_Fini(PyInterpreterState *interp)
+_PyContext_FiniObjects(PyInterpreterState *interp)
 {
     if (_Py_IsMainInterpreter(interp)) {
         Py_CLEAR(_token_missing);

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -1185,8 +1185,13 @@ static PyStructSequence_Desc UnraisableHookArgs_desc = {
 
 
 PyStatus
-_PyErr_InitTypes(void)
+_PyErr_InitTypes(PyInterpreterState *interp)
 {
+    // XXX Init per-interpreter.
+    if (!_Py_IsMainInterpreter(interp)) {
+        return _PyStatus_OK();
+    }
+
     if (UnraisableHookArgsType.tp_name == NULL) {
         if (PyStructSequence_InitType2(&UnraisableHookArgsType,
                                        &UnraisableHookArgs_desc) < 0) {

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -2976,7 +2976,7 @@ _PyHamt_InitTypes(PyInterpreterState *interp)
 }
 
 void
-_PyHamt_Fini(PyInterpreterState *interp)
+_PyHamt_FiniObjects(PyInterpreterState *interp)
 {
     // XXX Init per-interpreter.
     if (!_Py_IsMainInterpreter(interp)) {

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -3,6 +3,7 @@
 #include "pycore_bitutils.h"      // _Py_popcount32
 #include "pycore_hamt.h"
 #include "pycore_object.h"        // _PyObject_GC_TRACK()
+#include "pycore_initconfig.h"    // _PyStatus_OK()
 #include <stddef.h>               // offsetof()
 
 /*
@@ -2952,9 +2953,14 @@ PyTypeObject _PyHamt_CollisionNode_Type = {
 };
 
 
-int
-_PyHamt_Init(void)
+PyStatus
+_PyHamt_InitTypes(PyInterpreterState *interp)
 {
+    // XXX Init per-interpreter.
+    if (!_Py_IsMainInterpreter(interp)) {
+        return _PyStatus_OK();
+    }
+
     if ((PyType_Ready(&_PyHamt_Type) < 0) ||
         (PyType_Ready(&_PyHamt_ArrayNode_Type) < 0) ||
         (PyType_Ready(&_PyHamt_BitmapNode_Type) < 0) ||
@@ -2963,15 +2969,20 @@ _PyHamt_Init(void)
         (PyType_Ready(&_PyHamtValues_Type) < 0) ||
         (PyType_Ready(&_PyHamtItems_Type) < 0))
     {
-        return 0;
+        return _PyStatus_ERR("can't init hamt");
     }
 
-    return 1;
+    return _PyStatus_OK();
 }
 
 void
-_PyHamt_Fini(void)
+_PyHamt_Fini(PyInterpreterState *interp)
 {
+    // XXX Init per-interpreter.
+    if (!_Py_IsMainInterpreter(interp)) {
+        return;
+    }
+
     Py_CLEAR(_empty_hamt);
     Py_CLEAR(_empty_bitmap_node);
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -14,6 +14,7 @@
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_sysmodule.h"     // _PySys_ClearAuditHooks()
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads()
+#include "pycore_typeobject.h"    // _PyType_Init()
 
 #include <locale.h>               // setlocale()
 #include <stdlib.h>               // getenv()
@@ -688,8 +689,13 @@ static PyStatus
 pycore_init_types(PyInterpreterState *interp)
 {
     PyStatus status;
-    int is_main_interp = _Py_IsMainInterpreter(interp);
 
+    status = _PyType_Init(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
+    int is_main_interp = _Py_IsMainInterpreter(interp);
     if (is_main_interp) {
         if (_PyStructSequence_Init() < 0) {
             return _PyStatus_ERR("can't initialize structseq");

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -13,7 +13,8 @@
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_sysmodule.h"     // _PySys_ClearAuditHooks()
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads()
-#include "pycore_global_objects.h"  // __PyRuntimeState_TypesInit()
+#include "pycore_global_objects.h"  // _PyRuntimeState_TypesInit()
+#include "pycore_bltinmodule.h"   // _PyBuiltin_Init()
 
 #include <locale.h>               // setlocale()
 #include <stdlib.h>               // getenv()
@@ -688,7 +689,7 @@ pycore_init_builtins(PyThreadState *tstate)
     Py_INCREF(builtins_dict);
     interp->builtins = builtins_dict;
 
-    PyStatus status = _PyBuiltins_AddExceptions(bimod);
+    PyStatus status = _PyBuiltins_AddExceptions(bimod, interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -109,7 +109,7 @@ _PyRuntime_Initialize(void)
         return status;
     }
 
-    status = _Py_RuntimeTypesStateInit(&_PyRuntime);
+    status = _PyRuntimeState_TypesInit(&_PyRuntime);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
@@ -120,7 +120,7 @@ _PyRuntime_Initialize(void)
 void
 _PyRuntime_Finalize(void)
 {
-    _Py_RuntimeTypesStateFini(&_PyRuntime);
+    _PyRuntimeState_TypesFini(&_PyRuntime);
     _PyRuntimeState_Fini(&_PyRuntime);
     runtime_initialized = 0;
 }
@@ -722,7 +722,7 @@ pycore_interp_init(PyThreadState *tstate)
     PyStatus status;
     PyObject *sysmod = NULL;
 
-    status = _Py_CoreObjectsInit(interp);
+    status = _PyInterpreterState_CoreObjectsInit(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
@@ -733,7 +733,7 @@ pycore_interp_init(PyThreadState *tstate)
         return status;
     }
 
-    status = _Py_GlobalObjectsInit(interp);
+    status = _PyInterpreterState_ObjectsInit(interp);
     if (_PyStatus_EXCEPTION(status)) {
         goto done;
     }
@@ -1580,8 +1580,8 @@ finalize_interp_clear(PyThreadState *tstate)
         _Py_ClearFileSystemEncoding();
     }
 
-    _Py_GlobalObjectsFini(tstate->interp);
-    _Py_CoreObjectsFini(tstate->interp);
+    _PyInterpreterState_ObjectsFini(tstate->interp);
+    _PyInterpreterState_CoreObjectsFini(tstate->interp);
 }
 
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -13,6 +13,7 @@
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_sysmodule.h"     // _PySys_ClearAuditHooks()
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads()
+#include "pycore_global_objects.h"  // __PyRuntimeState_TypesInit()
 
 #include <locale.h>               // setlocale()
 #include <stdlib.h>               // getenv()

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1563,8 +1563,6 @@ finalize_interp_clear(PyThreadState *tstate)
 {
     int is_main_interp = _Py_IsMainInterpreter(tstate->interp);
 
-    _PyExc_ClearExceptionGroupType(tstate->interp);
-
     /* Clear interpreter state and all thread states */
     _PyInterpreterState_Clear(tstate);
 


### PR DESCRIPTION
This PR is preparing the code for per-interpreter global types.  For the most part this involves:

* breaking init/fini for global types into different phases
* renaming functions to match those phases consistently
* adding a `PyInterpreterState *` parameter, where missing
* grouping code along the lines of the init/fini phases
* moving some of the code around to align with the relevant contexts

Note that in a couple of cases I shifted the order of events in runtime/interpreter initialization/finalization around a little.  Otherwise this change is meant to change zero behavior.

<!-- issue-number: [bpo-45887](https://bugs.python.org/issue45887) -->
https://bugs.python.org/issue45887
<!-- /issue-number -->
