### PR TITLE
bpo-45881: Use CC from env first for cross building (GH-29752)

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-11-24-17-14-06.bpo-45881.GTXXLk.rst
+++ b/Misc/NEWS.d/next/Build/2021-11-24-17-14-06.bpo-45881.GTXXLk.rst
@@ -1,0 +1,2 @@
+``setup.py`` now uses ``CC`` from environment first to discover multiarch
+and cross compile paths.


### PR DESCRIPTION
``setup.py`` now uses ``CC`` from environment first to discover multiarch
and cross compile paths. The sysconfig variable contains the value for
the build host.

The patch also re-arranges ``set_compiler_executables``,
``configure_compiler``, and ``init_inc_lib_dirs`` to make the code
easier to follow.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45881](https://bugs.python.org/issue45881) -->
https://bugs.python.org/issue45881
<!-- /issue-number -->
