### PR TITLE
bpo-45693: Document `port` parameter to `loop.create_server`

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -631,6 +631,11 @@ Creating network servers
        assumed and a list of multiple sockets will be returned (most likely
        one for IPv4 and another one for IPv6).
 
+   * The *port* parameter can be set to specify which port the server should
+     listen on. If ``0`` or ``None`` (the default), a random unused port will
+     be selected (note that if *host* resolves to multiple network interfaces,
+     a different random port will be selected for each interface).
+
    * *family* can be set to either :data:`socket.AF_INET` or
      :data:`~socket.AF_INET6` to force the socket to use IPv4 or IPv6.
      If not set, the *family* will be determined from host name


### PR DESCRIPTION
Document the `port` parameter to `loop.create_server` in `asyncio`. In
particular, note that if `host` resolves to multiple network interfaces,
passing in `port=0` will result in a different random unused port being
used for each interface.

<!-- issue-number: [bpo-45693](https://bugs.python.org/issue45693) -->
https://bugs.python.org/issue45693
<!-- /issue-number -->

Automerge-Triggered-By: GH:ericvsmith