### PR TITLE
bpo-45893: Add missing extern C to initconfig.h (GH-29761)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,8 @@ jobs:
     runs-on: windows-latest
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
+    env:
+       IncludeUwp: 'true'
     steps:
     - uses: actions/checkout@v2
     - name: Build CPython
@@ -109,6 +111,8 @@ jobs:
     runs-on: windows-latest
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
+    env:
+       IncludeUwp: 'true'
     steps:
     - uses: actions/checkout@v2
     - name: Register MSVC problem matcher

--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -1,6 +1,9 @@
 #ifndef Py_PYCORECONFIG_H
 #define Py_PYCORECONFIG_H
 #ifndef Py_LIMITED_API
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* --- PyStatus ----------------------------------------------- */
 
@@ -243,5 +246,8 @@ PyAPI_FUNC(PyStatus) PyConfig_SetWideStringList(PyConfig *config,
    See also PyConfig.orig_argv. */
 PyAPI_FUNC(void) Py_GetArgcArgv(int *argc, wchar_t ***argv);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* !Py_LIMITED_API */
 #endif /* !Py_PYCORECONFIG_H */


### PR DESCRIPTION
Co-authored-by: Steve Dower <steve.dower@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45893](https://bugs.python.org/issue45893) -->
https://bugs.python.org/issue45893
<!-- /issue-number -->
