### PR TITLE
[3.10] bpo-45727: Only trigger the 'did you forgot a comma' error suggestion if inside parentheses.

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -859,8 +859,8 @@ invalid_expression:
     # !(NAME STRING) is not matched so we don't show this error with some invalid string prefixes like: kf"dsfsdf"
     # Soft keywords need to also be ignored because they can be parsed as NAME NAME
    | !(NAME STRING | SOFT_KEYWORD) a=disjunction b=expression_without_invalid {
-        _PyPegen_check_legacy_stmt(p, a) ? NULL : RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b,
-        "invalid syntax. Perhaps you forgot a comma?") }
+        _PyPegen_check_legacy_stmt(p, a) ? NULL : p->tokens[p->mark-1]->level == 0 ? NULL :
+        RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "invalid syntax. Perhaps you forgot a comma?") }
    | a=disjunction 'if' b=disjunction !('else'|':') { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "expected 'else' after 'if' expression") }
 
 invalid_named_expression:

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -226,14 +226,14 @@ class ExceptionTests(unittest.TestCase):
         check(b'Python = "\xcf\xb3\xf2\xee\xed" +', 1, 18)
         check('x = "a', 1, 5)
         check('lambda x: x = 2', 1, 1)
-        check('f{a + b + c}', 1, 1)
+        check('f{a + b + c}', 1, 2)
         check('[file for str(file) in []\n])', 1, 11)
         check('a = « hello » « world »', 1, 5)
         check('[\nfile\nfor str(file)\nin\n[]\n]', 3, 5)
         check('[file for\n str(file) in []]', 2, 2)
         check("ages = {'Alice'=22, 'Bob'=23}", 1, 16)
         check('match ...:\n    case {**rest, "key": value}:\n        ...', 2, 19)
-        check("a b c d e f", 1, 1)
+        check("[a b c d e f]", 1, 2)
 
         # Errors thrown by compile.c
         check('class foo:return 1', 1, 11)

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -944,7 +944,7 @@ x = (
                              "Bf''",
                              "BF''",]
         double_quote_cases = [case.replace("'", '"') for case in single_quote_cases]
-        self.assertAllRaise(SyntaxError, 'unexpected EOF while parsing',
+        self.assertAllRaise(SyntaxError, 'invalid syntax',
                             single_quote_cases + double_quote_cases)
 
     def test_leading_trailing_spaces(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-11-24-18-24-49.bpo-45727._xVbbo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-11-24-18-24-49.bpo-45727._xVbbo.rst
@@ -1,0 +1,3 @@
+Refine the custom syntax error that suggests that a comma may be missing to
+trigger only when the expressions are detected between parentheses or
+brackets. Patch by Pablo Galindo

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -18288,7 +18288,7 @@ invalid_expression_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ invalid_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "!(NAME STRING | SOFT_KEYWORD) disjunction expression_without_invalid"));
-            _res = _PyPegen_check_legacy_stmt ( p , a ) ? NULL : RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "invalid syntax. Perhaps you forgot a comma?" );
+            _res = _PyPegen_check_legacy_stmt ( p , a ) ? NULL : p -> tokens [ p -> mark - 1 ] -> level == 0 ? NULL : RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "invalid syntax. Perhaps you forgot a comma?" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -692,6 +692,8 @@ initialize_token(Parser *p, Token *token, const char *start, const char *end, in
         return -1;
     }
 
+    token->level = p->tok->level;
+
     const char *line_start = token_type == STRING ? p->tok->multi_line_start : p->tok->line_start;
     int lineno = token_type == STRING ? p->tok->first_lineno : p->tok->lineno;
     int end_lineno = p->tok->lineno;
@@ -1357,7 +1359,7 @@ _PyPegen_run_parser(Parser *p)
         if (p->fill == 0) {
             RAISE_SYNTAX_ERROR("error at start before reading any input");
         }
-        else if (p->tok->done == E_EOF) {
+        else if (last_token->type == ERRORTOKEN && p->tok->done == E_EOF) {
             if (p->tok->level) {
                 raise_unclosed_parentheses_error(p);
             } else {

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -33,6 +33,7 @@ typedef struct _memo {
 typedef struct {
     int type;
     PyObject *bytes;
+    int level;
     int lineno, col_offset, end_lineno, end_col_offset;
     Memo *memo;
 } Token;

--- a/Parser/pegen_errors.c
+++ b/Parser/pegen_errors.c
@@ -399,7 +399,7 @@ _Pypegen_set_syntax_error(Parser* p, Token* last_token) {
         RAISE_SYNTAX_ERROR("error at start before reading any input");
     }
     // Parser encountered EOF (End of File) unexpectedtly
-    if (p->tok->done == E_EOF) {
+    if (last_token->type == ERRORTOKEN && p->tok->done == E_EOF) {
         if (p->tok->level) {
             raise_unclosed_parentheses_error(p);
         } else {


### PR DESCRIPTION
Backport of GH-29757

Co-authored-by: Pablo Galindo <pablogsal@gmail.com>

<!-- issue-number: [bpo-45727](https://bugs.python.org/issue45727) -->
https://bugs.python.org/issue45727
<!-- /issue-number -->
