### PR TITLE
bpo-41498: Fix build on platforms without sigset_t (GH-29770)

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-11-25-09-15-04.bpo-41498.qAk5eo.rst
+++ b/Misc/NEWS.d/next/Build/2021-11-25-09-15-04.bpo-41498.qAk5eo.rst
@@ -1,0 +1,4 @@
+Python now compiles on platforms without ``sigset_t``. Several functions
+in :mod:`signal` are not available when ``sigset_t`` is missing.
+
+Based on patch by Roman Yurchak for pyodide.

--- a/Modules/clinic/signalmodule.c.h
+++ b/Modules/clinic/signalmodule.c.h
@@ -354,7 +354,7 @@ exit:
 
 #endif /* defined(HAVE_GETITIMER) */
 
-#if defined(PYPTHREAD_SIGMASK)
+#if defined(HAVE_SIGSET_T) && defined(PYPTHREAD_SIGMASK)
 
 PyDoc_STRVAR(signal_pthread_sigmask__doc__,
 "pthread_sigmask($module, how, mask, /)\n"
@@ -391,9 +391,9 @@ exit:
     return return_value;
 }
 
-#endif /* defined(PYPTHREAD_SIGMASK) */
+#endif /* defined(HAVE_SIGSET_T) && defined(PYPTHREAD_SIGMASK) */
 
-#if defined(HAVE_SIGPENDING)
+#if defined(HAVE_SIGSET_T) && defined(HAVE_SIGPENDING)
 
 PyDoc_STRVAR(signal_sigpending__doc__,
 "sigpending($module, /)\n"
@@ -416,9 +416,9 @@ signal_sigpending(PyObject *module, PyObject *Py_UNUSED(ignored))
     return signal_sigpending_impl(module);
 }
 
-#endif /* defined(HAVE_SIGPENDING) */
+#endif /* defined(HAVE_SIGSET_T) && defined(HAVE_SIGPENDING) */
 
-#if defined(HAVE_SIGWAIT)
+#if defined(HAVE_SIGSET_T) && defined(HAVE_SIGWAIT)
 
 PyDoc_STRVAR(signal_sigwait__doc__,
 "sigwait($module, sigset, /)\n"
@@ -451,9 +451,9 @@ exit:
     return return_value;
 }
 
-#endif /* defined(HAVE_SIGWAIT) */
+#endif /* defined(HAVE_SIGSET_T) && defined(HAVE_SIGWAIT) */
 
-#if (defined(HAVE_SIGFILLSET) || defined(MS_WINDOWS))
+#if ((defined(HAVE_SIGFILLSET) && defined(HAVE_SIGSET_T)) || defined(MS_WINDOWS))
 
 PyDoc_STRVAR(signal_valid_signals__doc__,
 "valid_signals($module, /)\n"
@@ -476,9 +476,9 @@ signal_valid_signals(PyObject *module, PyObject *Py_UNUSED(ignored))
     return signal_valid_signals_impl(module);
 }
 
-#endif /* (defined(HAVE_SIGFILLSET) || defined(MS_WINDOWS)) */
+#endif /* ((defined(HAVE_SIGFILLSET) && defined(HAVE_SIGSET_T)) || defined(MS_WINDOWS)) */
 
-#if defined(HAVE_SIGWAITINFO)
+#if defined(HAVE_SIGSET_T) && defined(HAVE_SIGWAITINFO)
 
 PyDoc_STRVAR(signal_sigwaitinfo__doc__,
 "sigwaitinfo($module, sigset, /)\n"
@@ -509,9 +509,9 @@ exit:
     return return_value;
 }
 
-#endif /* defined(HAVE_SIGWAITINFO) */
+#endif /* defined(HAVE_SIGSET_T) && defined(HAVE_SIGWAITINFO) */
 
-#if defined(HAVE_SIGTIMEDWAIT)
+#if defined(HAVE_SIGSET_T) && defined(HAVE_SIGTIMEDWAIT)
 
 PyDoc_STRVAR(signal_sigtimedwait__doc__,
 "sigtimedwait($module, sigset, timeout, /)\n"
@@ -548,7 +548,7 @@ exit:
     return return_value;
 }
 
-#endif /* defined(HAVE_SIGTIMEDWAIT) */
+#endif /* defined(HAVE_SIGSET_T) && defined(HAVE_SIGTIMEDWAIT) */
 
 #if defined(HAVE_PTHREAD_KILL)
 
@@ -698,4 +698,4 @@ exit:
 #ifndef SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF
     #define SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF
 #endif /* !defined(SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF) */
-/*[clinic end generated code: output=59c33f0af42aebb5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c353e686367bc384 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5934,6 +5934,7 @@ parse_posix_spawn_flags(PyObject *module, const char *func_name, PyObject *setpg
 
     }
 
+#ifdef HAVE_SIGSET_T
    if (setsigmask) {
         sigset_t set;
         if (!_Py_Sigset_Converter(setsigmask, &set)) {
@@ -5959,6 +5960,13 @@ parse_posix_spawn_flags(PyObject *module, const char *func_name, PyObject *setpg
         }
         all_flags |= POSIX_SPAWN_SETSIGDEF;
     }
+#else
+    if (setsigmask || setsigdef) {
+        PyErr_SetString(PyExc_NotImplementedError,
+                        "sigset is not supported on this platform");
+        goto fail;
+    }
+#endif
 
     if (scheduler) {
 #ifdef POSIX_SPAWN_SETSCHEDULER

--- a/Modules/posixmodule.h
+++ b/Modules/posixmodule.h
@@ -23,9 +23,7 @@ PyAPI_FUNC(int) _Py_Gid_Converter(PyObject *, gid_t *);
 # define HAVE_SIGSET_T
 #endif
 
-#ifdef HAVE_SIGSET_T
 PyAPI_FUNC(int) _Py_Sigset_Converter(PyObject *, void *);
-#endif /* HAVE_SIGSET_T */
 #endif /* Py_LIMITED_API */
 
 #ifdef __cplusplus

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -60,6 +60,8 @@ module signal
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=b0301a3bde5fe9d3]*/
 
+#ifdef HAVE_SETSIG_T
+
 /*[python input]
 
 class sigset_t_converter(CConverter):
@@ -68,6 +70,7 @@ class sigset_t_converter(CConverter):
 
 [python start generated code]*/
 /*[python end generated code: output=da39a3ee5e6b4b0d input=b5689d14466b6823]*/
+#endif
 
 /*
    NOTES ON THE INTERACTION BETWEEN SIGNALS AND THREADS
@@ -932,6 +935,7 @@ signal_getitimer_impl(PyObject *module, int which)
 #endif // HAVE_GETITIMER
 
 
+#ifdef HAVE_SIGSET_T
 #if defined(PYPTHREAD_SIGMASK) || defined(HAVE_SIGPENDING)
 static PyObject*
 sigset_to_set(sigset_t mask)
@@ -1063,9 +1067,9 @@ signal_sigwait_impl(PyObject *module, sigset_t sigset)
 }
 
 #endif   /* #ifdef HAVE_SIGWAIT */
+#endif   /* #ifdef HAVE_SIGSET_T */
 
-
-#if defined(HAVE_SIGFILLSET) || defined(MS_WINDOWS)
+#if (defined(HAVE_SIGFILLSET) && defined(HAVE_SIGSET_T)) || defined(MS_WINDOWS)
 
 /*[clinic input]
 signal.valid_signals
@@ -1103,7 +1107,8 @@ signal_valid_signals_impl(PyObject *module)
 #endif
 }
 
-#endif   /* #if defined(HAVE_SIGFILLSET) || defined(MS_WINDOWS) */
+#endif   /* #if (defined(HAVE_SIGFILLSET) && defined(HAVE_SIGSET_T)) || defined(MS_WINDOWS) */
+
 
 
 #if defined(HAVE_SIGWAITINFO) || defined(HAVE_SIGTIMEDWAIT)
@@ -1168,6 +1173,7 @@ fill_siginfo(siginfo_t *si)
 }
 #endif
 
+#ifdef HAVE_SIGSET_T
 #ifdef HAVE_SIGWAITINFO
 
 /*[clinic input]
@@ -1270,6 +1276,7 @@ signal_sigtimedwait_impl(PyObject *module, sigset_t sigset,
 }
 
 #endif   /* #ifdef HAVE_SIGTIMEDWAIT */
+#endif   /* #ifdef HAVE_SIGSET_T */
 
 
 #if defined(HAVE_PTHREAD_KILL)


### PR DESCRIPTION
Python now compiles on platforms without ``sigset_t``. Several functions
in :mod:`signal` are not available when ``sigset_t`` is missing.

Based on patch by Roman Yurchak for pyodide.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-41498](https://bugs.python.org/issue41498) -->
https://bugs.python.org/issue41498
<!-- /issue-number -->
