### PR TITLE
bpo-40280: Add wasm cross build targets (GH-29771)

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-11-25-10-55-03.bpo-40280.E9-gsQ.rst
+++ b/Misc/NEWS.d/next/Build/2021-11-25-10-55-03.bpo-40280.E9-gsQ.rst
@@ -1,0 +1,3 @@
+``configure`` now accepts machine ``wasm32`` or ``wasm64`` and OS ``wasi``
+or ``emscripten`` for cross building, e.g. ``wasm32-unknown-emscripten``
+and ``wasm32-wasi``.

--- a/Misc/NEWS.d/next/Build/2021-11-25-10-55-03.bpo-40280.E9-gsQ.rst
+++ b/Misc/NEWS.d/next/Build/2021-11-25-10-55-03.bpo-40280.E9-gsQ.rst
@@ -1,3 +1,3 @@
 ``configure`` now accepts machine ``wasm32`` or ``wasm64`` and OS ``wasi``
-or ``emscripten`` for cross building, e.g. ``wasm32-unknown-emscripten``
-and ``wasm32-wasi``.
+or ``emscripten`` for cross building, e.g. ``wasm32-unknown-emscripten``,
+``wasm32-wasi``, or ``wasm32-unknown-wasi``.

--- a/configure
+++ b/configure
@@ -3717,6 +3717,12 @@ then
 	*-*-vxworks*)
 	    ac_sys_system=VxWorks
 	    ;;
+	*-*-emscripten)
+	    ac_sys_system=Emscripten
+	    ;;
+	*-*-wasi)
+	    	    ac_sys_system=wasi
+	    ;;
 	*)
 		# for now, limit cross builds to known configurations
 		MACHDEP="unknown"
@@ -3765,6 +3771,9 @@ if test "$cross_compiling" = yes; then
 		_host_cpu=
 		;;
 	*-*-vxworks*)
+		_host_cpu=$host_cpu
+		;;
+	wasm32-*-* | wasm64-*-*)
 		_host_cpu=$host_cpu
 		;;
 	*)
@@ -10382,6 +10391,9 @@ fi
 	# Dynamic linking for HP-UX
 
 
+
+
+
 have_uuid=missing
 
 for ac_header in uuid.h
@@ -10412,10 +10424,6 @@ done
 fi
 
 done
-
-
-
-
 
 
 if test "x$have_uuid" = xmissing; then :

--- a/configure
+++ b/configure
@@ -3721,7 +3721,7 @@ then
 	    ac_sys_system=Emscripten
 	    ;;
 	*-*-wasi)
-	    	    ac_sys_system=wasi
+	    ac_sys_system=WASI
 	    ;;
 	*)
 		# for now, limit cross builds to known configurations

--- a/configure.ac
+++ b/configure.ac
@@ -465,6 +465,13 @@ then
 	*-*-vxworks*)
 	    ac_sys_system=VxWorks
 	    ;;
+	*-*-emscripten)
+	    ac_sys_system=Emscripten
+	    ;;
+	*-*-wasi)
+	    dnl wasm32-wasi, wasm32-unknown-wasi
+	    ac_sys_system=wasi
+	    ;;
 	*)
 		# for now, limit cross builds to known configurations
 		MACHDEP="unknown"
@@ -512,6 +519,9 @@ if test "$cross_compiling" = yes; then
 		_host_cpu=
 		;;
 	*-*-vxworks*)
+		_host_cpu=$host_cpu
+		;;
+	wasm32-*-* | wasm64-*-*)
 		_host_cpu=$host_cpu
 		;;
 	*)

--- a/configure.ac
+++ b/configure.ac
@@ -469,8 +469,7 @@ then
 	    ac_sys_system=Emscripten
 	    ;;
 	*-*-wasi)
-	    dnl wasm32-wasi, wasm32-unknown-wasi
-	    ac_sys_system=wasi
+	    ac_sys_system=WASI
 	    ;;
 	*)
 		# for now, limit cross builds to known configurations


### PR DESCRIPTION
CPython uses the same target triplet convention as Rust:

```
$ rustc --print target-list | grep wasm
wasm32-unknown-emscripten
wasm32-unknown-unknown
wasm32-wasi
wasm64-unknown-unknown
```

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
