### PR TITLE
[3.10] bpo-45568: Actually use @asynccontextmanager in usage example (GH-29151)

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -130,7 +130,9 @@ Functions and classes provided:
    either as decorators or with :keyword:`async with` statements::
 
      import time
+     from contextlib import asynccontextmanager
 
+     @asynccontextmanager
      async def timeit():
          now = time.monotonic()
          try:


### PR DESCRIPTION
Automerge-Triggered-By: GH:asvetlov
(cherry picked from commit 4dd82194f4a0e48a94191655e571b3aad1c4a22a)

Co-authored-by: Zbigniew Siciarz <zbigniew@siciarz.net>


<!-- issue-number: [bpo-45568](https://bugs.python.org/issue45568) -->
https://bugs.python.org/issue45568
<!-- /issue-number -->
