### PR TITLE
bpo-40280: Use Setup.stdlib static for wasm builds (GH-29784)

### DIFF
--- a/Modules/Setup.stdlib.in
+++ b/Modules/Setup.stdlib.in
@@ -22,8 +22,8 @@
 
 
 # Build modules statically or as shared extensions
-*shared*
-# *static*
+# *shared* / *static*
+*@MODULE_BUILDTYPE@*
 
 
 ############################################################################

--- a/configure
+++ b/configure
@@ -770,6 +770,7 @@ MODULE_TIME_FALSE
 MODULE_TIME_TRUE
 MODULE__IO_FALSE
 MODULE__IO_TRUE
+MODULE_BUILDTYPE
 TEST_MODULES
 LIBRARY_DEPS
 STATIC_LIBPYTHON
@@ -21011,6 +21012,15 @@ case $ac_sys_system in #(
     py_stdlib_not_available="_scproxy"
  ;;
 esac
+
+case $host_cpu in #(
+  wasm32|wasm64) :
+    MODULE_BUILDTYPE=static ;; #(
+  *) :
+    MODULE_BUILDTYPE=${MODULE_BUILDTYPE:-shared}
+ ;;
+esac
+
 
 
 MODULE_BLOCK=

--- a/configure.ac
+++ b/configure.ac
@@ -6185,6 +6185,13 @@ AS_CASE([$ac_sys_system],
   [py_stdlib_not_available="_scproxy"]
 )
 
+dnl Default value for Modules/Setup.stdlib build type
+AS_CASE([$host_cpu],
+  [wasm32|wasm64], [MODULE_BUILDTYPE=static],
+  [MODULE_BUILDTYPE=${MODULE_BUILDTYPE:-shared}]
+)
+AC_SUBST([MODULE_BUILDTYPE])
+
 dnl _MODULE_BLOCK_ADD([VAR], [VALUE])
 dnl internal: adds $1=quote($2) to MODULE_BLOCK
 AC_DEFUN([_MODULE_BLOCK_ADD], [AS_VAR_APPEND([MODULE_BLOCK], ["$1=_AS_QUOTE([$2])$as_nl"])])


### PR DESCRIPTION
``Modules/Setup.stdlib`` contains ``Setup`` lines for all stdlib extension modules for which ``configure`` has detected their dependencies. The file is not used yet and still under development. To use the file, do ``ln -sfr Modules/Setup.stdlib Modules/Setup.local``.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
