### PR TITLE
bpo-44353: Correct docstring for `NewType`

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2427,7 +2427,7 @@ class NewType:
     """NewType creates simple unique types with almost zero
     runtime overhead. NewType(name, tp) is considered a subtype of tp
     by static type checkers. At runtime, NewType(name, tp) returns
-    a dummy function that simply returns its argument. Usage::
+    a dummy callable that simply returns its argument. Usage::
 
         UserId = NewType('UserId', int)
 


### PR DESCRIPTION
The docstring for `typing.NewType` is no longer strictly accurate, now that `NewType` is a class, rather than a function

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44353](https://bugs.python.org/issue44353) -->
https://bugs.python.org/issue44353
<!-- /issue-number -->
