### PR TITLE
Clarify docs on IntEnum comparability

### DIFF
--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -596,7 +596,7 @@ to each other::
     >>> Shape.CIRCLE == Request.POST
     True
 
-However, they still can't be compared to standard :class:`Enum` enumerations::
+However, they still compare not equal to standard :class:`Enum` enumerations::
 
     >>> class Shape(IntEnum):
     ...     CIRCLE = 1


### PR DESCRIPTION
Update documention to specify that IntEnum values *can* be compared to standard Enum values,
but will always compare non-equal.
