### PR TITLE
bpo-45886: Fix OOT build when srcdir has frozen module headers (GH-29793)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ Lib/distutils/command/*.pdb
 Lib/lib2to3/*.pickle
 Lib/test/data/*
 !Lib/test/data/README
-/_bootstrap_python
 /Makefile
 /Makefile.pre
 Mac/Makefile

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -587,7 +587,10 @@ build_all:	check-clean-src $(BUILDPYTHON) oldsharedmods sharedmods gdbhooks \
 
 # Check that the source is clean when building out of source.
 check-clean-src:
-	@if test -n "$(VPATH)" -a -f "$(srcdir)/Programs/python.o"; then \
+	@if test -n "$(VPATH)" -a \( \
+	    -f "$(srcdir)/Programs/python.o" \
+	    -o -f "$(srcdir)\Python/frozen_modules/importlib._bootstrap.h" \
+	\); then \
 		echo "Error: The source directory ($(srcdir)) is not clean" ; \
 		echo "Building Python out of the source tree (in $(abs_builddir)) requires a clean source tree ($(abs_srcdir))" ; \
 		echo "Try to run: make -C \"$(srcdir)\" clean" ; \
@@ -2292,6 +2295,8 @@ clean-retain-profile: pycremoval
 	-rm -f Lib/lib2to3/*Grammar*.pickle
 	-rm -f Programs/_testembed Programs/_freeze_module
 	-rm -f Python/deepfreeze/*.[co]
+	-rm -f Python/frozen_modules/*.h
+	-rm -f Python/frozen_modules/MANIFEST
 	-find build -type f -a ! -name '*.gc??' -exec rm -f {} ';'
 	-rm -f Include/pydtrace_probes.h
 	-rm -f profile-gen-stamp
@@ -2329,8 +2334,6 @@ distclean: clobber
 		Modules/Setup.stdlib Modules/ld_so_aix Modules/python.exp Misc/python.pc \
 		Misc/python-embed.pc Misc/python-config.sh
 	-rm -f python*-gdb.py
-	-rm -f Python/frozen_modules/*.h
-	-rm -f Python/frozen_modules/MANIFEST
 	# Issue #28258: set LC_ALL to avoid issues with Estonian locale.
 	# Expansion is performed here by shell (spawned by make) itself before
 	# arguments are passed to find. So LC_ALL=C must be set as a separate


### PR DESCRIPTION
The presence of frozen module headers in srcdir interfers with OOT
build. Make considers headers in srcdir up to date, but later builds do
not use VPATH to locate files. make clean now removes the headers, too.

Also remove stale ``_bootstrap_python`` from .gitignore.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45886](https://bugs.python.org/issue45886) -->
https://bugs.python.org/issue45886
<!-- /issue-number -->
