### PR TITLE
bpo-45903: Fix typo in What's New: Signature.from_builtin is removed

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -470,7 +470,7 @@ Removed
     use the :func:`inspect.signature` function and :class:`Signature` object
     directly.
 
-  * the undocumented ``Signature.from_callable`` and ``Signature.from_function``
+  * the undocumented ``Signature.from_builtin`` and ``Signature.from_function``
     functions, deprecated since Python 3.5; use the
     :meth:`Signature.from_callable() <inspect.Signature.from_callable>` method
     instead.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Fix typo in "What's New In Python 3.11":

It's really `Signature.from_builtin` that is removed; `Signature.from_callable` is what should be called instead.

Typo originates from my https://github.com/python/cpython/pull/28618 / [bpo-45320](https://bugs.python.org/issue45320).

Does this typo fix need a news entry?

<!-- issue-number: [bpo-45903](https://bugs.python.org/issue45903) -->
https://bugs.python.org/issue45903
<!-- /issue-number -->
