### PR TITLE
[3.9] bpo-45614: Fix traceback display for exceptions with invalid module n…

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -740,6 +740,17 @@ class BaseExceptionReportingTests:
         err = self.get_report(Exception(''))
         self.assertIn('Exception\n', err)
 
+    def test_exception_modulename_not_unicode(self):
+        class X(Exception):
+            def __str__(self):
+                return "I am X"
+
+        X.__module__ = 42
+
+        err = self.get_report(X())
+        exp = f'<unknown>.{X.__qualname__}: I am X\n'
+        self.assertEqual(exp, err)
+
     def test_syntax_error_various_offsets(self):
         for offset in range(-5, 10):
             for add in [0, 2]:

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -574,6 +574,8 @@ class TracebackException:
         stype = self.exc_type.__qualname__
         smod = self.exc_type.__module__
         if smod not in ("__main__", "builtins"):
+            if not isinstance(smod, str):
+                smod = "<unknown>"
             stype = smod + '.' + stype
 
         if not issubclass(self.exc_type, SyntaxError):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-11-23-12-06-41.bpo-45614.fIekgI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-11-23-12-06-41.bpo-45614.fIekgI.rst
@@ -1,0 +1,1 @@
+Fix :mod:`traceback` display for exceptions with invalid module name.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -903,7 +903,7 @@ print_exception(PyObject *f, PyObject *value)
         {
             Py_XDECREF(modulename);
             PyErr_Clear();
-            err = PyFile_WriteString("<unknown>", f);
+            err = PyFile_WriteString("<unknown>.", f);
         }
         else {
             if (!_PyUnicode_EqualToASCIIId(modulename, &PyId_builtins))


### PR DESCRIPTION
…ame (GH-29726)

(cherry picked from commit 4dfae6f38e1720ddafcdd68043e476ecb41cb4d5)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45614](https://bugs.python.org/issue45614) -->
https://bugs.python.org/issue45614
<!-- /issue-number -->
