### PR TITLE
bpo-45917: Add math.exp2() method - return 2 raised to the power of x

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -355,6 +355,11 @@ Power and logarithmic functions
    of natural logarithms.  This is usually more accurate than ``math.e ** x``
    or ``pow(math.e, x)``.
 
+.. function:: exp2(x)
+
+   Return *2* raised to the power *x*.
+
+   .. versionadded:: 3.11
 
 .. function:: expm1(x)
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -355,11 +355,13 @@ Power and logarithmic functions
    of natural logarithms.  This is usually more accurate than ``math.e ** x``
    or ``pow(math.e, x)``.
 
+
 .. function:: exp2(x)
 
    Return *2* raised to the power *x*.
 
    .. versionadded:: 3.11
+
 
 .. function:: expm1(x)
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -203,6 +203,8 @@ fractions
 
 math
 ----
+* Add :func:`math.exp2`: return 2 raised to the power of x.
+  (Contributed by Gideon Mitchell in :issue:`45917`.)
 
 * Add :func:`math.cbrt`: return the cube root of x.
   (Contributed by Ajith Ramachandran in :issue:`44357`.)

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -501,6 +501,16 @@ class MathTests(unittest.TestCase):
         self.assertTrue(math.isnan(math.exp(NAN)))
         self.assertRaises(OverflowError, math.exp, 1000000)
 
+    def testExp2(self):
+        self.assertRaises(TypeError, math.exp2)
+        self.ftest('exp2(-1)', math.exp2(-1), 0.5)
+        self.ftest('exp2(0)', math.exp2(0), 1)
+        self.ftest('exp2(1)', math.exp2(1), 2)
+        self.assertEqual(math.exp2(INF), INF)
+        self.assertEqual(math.exp2(NINF), 0.)
+        self.assertTrue(math.isnan(math.exp2(NAN)))
+        self.assertRaises(OverflowError, math.exp2, 1000000)
+
     def testFabs(self):
         self.assertRaises(TypeError, math.fabs)
         self.ftest('fabs(-1)', math.fabs(-1), 1)

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -506,6 +506,7 @@ class MathTests(unittest.TestCase):
         self.ftest('exp2(-1)', math.exp2(-1), 0.5)
         self.ftest('exp2(0)', math.exp2(0), 1)
         self.ftest('exp2(1)', math.exp2(1), 2)
+        self.ftest('exp2(2.3)', math.exp2(2.3), 4.924577653379665)
         self.assertEqual(math.exp2(INF), INF)
         self.assertEqual(math.exp2(NINF), 0.)
         self.assertTrue(math.isnan(math.exp2(NAN)))

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1191,6 +1191,7 @@ Julien Miotte
 Andrii V. Mishkovskyi
 Dom Mitchell
 Dustin J. Mitchell
+Gideon Mitchell
 Tim Mitchell
 Zubin Mithra
 Florian Mladitsch

--- a/Misc/NEWS.d/next/Library/2021-11-28-17-24-11.bpo-45917.J5TIrd.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-28-17-24-11.bpo-45917.J5TIrd.rst
@@ -1,0 +1,1 @@
+Added :func:`math.exp2`:, which returns 2 raised to the power of x.

--- a/Misc/NEWS.d/next/Library/2021-11-28-22-44-54.bpo-45917.lNn_gz.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-28-22-44-54.bpo-45917.lNn_gz.rst
@@ -1,0 +1,1 @@
+Added a function that returns 2 raised to a given number :func:`math.exp2`

--- a/Misc/NEWS.d/next/Library/2021-11-28-22-44-54.bpo-45917.lNn_gz.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-28-22-44-54.bpo-45917.lNn_gz.rst
@@ -1,1 +1,0 @@
-Added a function that returns 2 raised to a given number :func:`math.exp2`

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1248,6 +1248,9 @@ FUNC1A(erfc, m_erfc,
 FUNC1(exp, exp, 1,
       "exp($module, x, /)\n--\n\n"
       "Return e raised to the power of x.")
+FUNC1(exp2, exp2, 1,
+      "exp2($module, x, /)\n--\n\n"
+      "Return 2 raised to the power of x.")
 FUNC1(expm1, expm1, 1,
       "expm1($module, x, /)\n--\n\n"
       "Return exp(x)-1.\n\n"
@@ -3564,6 +3567,7 @@ static PyMethodDef math_methods[] = {
     {"erf",             math_erf,       METH_O,         math_erf_doc},
     {"erfc",            math_erfc,      METH_O,         math_erfc_doc},
     {"exp",             math_exp,       METH_O,         math_exp_doc},
+    {"exp2",            math_exp2,      METH_O,         math_exp2_doc},
     {"expm1",           math_expm1,     METH_O,         math_expm1_doc},
     {"fabs",            math_fabs,      METH_O,         math_fabs_doc},
     MATH_FACTORIAL_METHODDEF


### PR DESCRIPTION
<!-- issue-number: [bpo-45917](https://bugs.python.org/issue45917) -->
https://bugs.python.org/issue45917
<!-- /issue-number -->
