### PR TITLE
bpo-40280: Disable unusable core extension modules on emscripten (GH-29834)

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-11-29-11-24-45.bpo-40280.Knx7d7.rst
+++ b/Misc/NEWS.d/next/Build/2021-11-29-11-24-45.bpo-40280.Knx7d7.rst
@@ -1,0 +1,1 @@
+Disable unusable core extension modules on WASM/Emscripten targets.

--- a/configure
+++ b/configure
@@ -21047,6 +21047,10 @@ case $ac_sys_system in #(
     py_stdlib_not_available="_scproxy nis" ;; #(
   FreeBSD*) :
     py_stdlib_not_available="_scproxy spwd" ;; #(
+  Emscripten) :
+
+    py_stdlib_not_available="_curses _curses_panel _dbm _gdbm _multiprocessing _posixshmem _posixsubprocess _scproxy _xxsubinterpreters grp nis ossaudiodev resource spwd syslog termios"
+   ;; #(
   *) :
     py_stdlib_not_available="_scproxy"
  ;;

--- a/configure.ac
+++ b/configure.ac
@@ -6191,6 +6191,26 @@ AS_CASE([$ac_sys_system],
   [CYGWIN*], [py_stdlib_not_available="_scproxy nis"],
   [QNX*], [py_stdlib_not_available="_scproxy nis"],
   [FreeBSD*], [py_stdlib_not_available="_scproxy spwd"],
+  [Emscripten], [
+    py_stdlib_not_available="m4_normalize([
+      _curses
+      _curses_panel
+      _dbm
+      _gdbm
+      _multiprocessing
+      _posixshmem
+      _posixsubprocess
+      _scproxy
+      _xxsubinterpreters
+      grp
+      nis
+      ossaudiodev
+      resource
+      spwd
+      syslog
+      termios
+    ])"
+  ],
   [py_stdlib_not_available="_scproxy"]
 )
 


### PR DESCRIPTION
Based on https://github.com/ethanhs/python-wasm/issues/10#issue-1065408622

Fixes https://github.com/ethanhs/python-wasm/issues/10

Co-authored-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
