### PR TITLE
bpo-40280: Emscripten systems use .wasm suffix by default (GH-29842)

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -53,7 +53,11 @@ General Options
    Set the Python executable suffix to *SUFFIX*.
 
    The default suffix is ``.exe`` on Windows and macOS (``python.exe``
-   executable), and an empty string on other platforms (``python`` executable).
+   executable), ``.wasm`` on Emscripten (``python.wasm`` executable), and
+   an empty string on other platforms (``python`` executable).
+
+   .. versionchanged:: 3.11
+      The default suffix on Emscripten platform is ``.wasm``.
 
 .. cmdoption:: --with-tzpath=<list of absolute paths separated by pathsep>
 

--- a/Misc/NEWS.d/next/Build/2021-11-29-14-37-29.bpo-40280.UlTMR8.rst
+++ b/Misc/NEWS.d/next/Build/2021-11-29-14-37-29.bpo-40280.UlTMR8.rst
@@ -1,0 +1,1 @@
+Emscripten platform now uses ``.wasm`` suffix by default.

--- a/configure
+++ b/configure
@@ -1738,7 +1738,8 @@ Optional Packages:
   --with-cxx-main[=COMPILER]
                           compile main() and link Python executable with C++
                           compiler specified in COMPILER (default is $CXX)
-  --with-suffix=SUFFIX    set executable suffix to SUFFIX (default is '.exe')
+  --with-suffix=SUFFIX    set executable suffix to SUFFIX (default is empty,
+                          yes is mapped to '.exe')
   --with-pydebug          build with Py_DEBUG defined (default is no)
   --with-trace-refs       enable tracing references for debugging purpose
                           (default is no)
@@ -6136,11 +6137,26 @@ $as_echo_n "checking for --with-suffix... " >&6; }
 # Check whether --with-suffix was given.
 if test "${with_suffix+set}" = set; then :
   withval=$with_suffix;
-	case $withval in
-	no)	EXEEXT=;;
-	yes)	EXEEXT=.exe;;
-	*)	EXEEXT=$withval;;
-	esac
+	case $with_suffix in #(
+  no) :
+    EXEEXT= ;; #(
+  yes) :
+    EXEEXT=.exe ;; #(
+  *) :
+    EXEEXT=$with_suffix
+   ;;
+esac
+
+else
+
+  case $ac_sys_system in #(
+  Emscripten) :
+    EXEEXT=.wasm ;; #(
+  *) :
+    EXEEXT=
+   ;;
+esac
+
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $EXEEXT" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -1018,16 +1018,22 @@ atheos*|Linux*/1*)
    exit 1;;
 esac
 
-AC_MSG_CHECKING(for --with-suffix)
-AC_ARG_WITH(suffix,
-            AS_HELP_STRING([--with-suffix=SUFFIX], [set executable suffix to SUFFIX (default is '.exe')]),
+AC_MSG_CHECKING([for --with-suffix])
+AC_ARG_WITH([suffix],
+            [AS_HELP_STRING([--with-suffix=SUFFIX], [set executable suffix to SUFFIX (default is empty, yes is mapped to '.exe')])],
 [
-	case $withval in
-	no)	EXEEXT=;;
-	yes)	EXEEXT=.exe;;
-	*)	EXEEXT=$withval;;
-	esac])
-AC_MSG_RESULT($EXEEXT)
+	AS_CASE([$with_suffix],
+    [no], [EXEEXT=],
+    [yes], [EXEEXT=.exe],
+    [EXEEXT=$with_suffix]
+  )
+], [
+  AS_CASE([$ac_sys_system],
+    [Emscripten], [EXEEXT=.wasm],
+    [EXEEXT=]
+  )
+])
+AC_MSG_RESULT([$EXEEXT])
 
 # Test whether we're running on a non-case-sensitive system, in which
 # case we give a warning if no ext is given


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
