### PR TITLE
bpo-45931: Prevent Directory.Build.props/targets from leaking from directories above the repo

### DIFF
--- a/PCbuild/Directory.Build.props
+++ b/PCbuild/Directory.Build.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- This is intentionally left blank but exists to avoid being imported from some directory above -->
+</Project>

--- a/PCbuild/Directory.Build.targets
+++ b/PCbuild/Directory.Build.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- This is intentionally left blank but exists to avoid being imported from some directory above -->
+</Project>

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -11,8 +11,8 @@
 
     We set BasePlatformToolset for ICC's benefit, it's otherwise ignored.
     -->
-    <BasePlatformToolset Condition="'$(BasePlatformToolset)' == '' and ('$(MSBuildToolsVersion)' == '17.0' or '$(VisualStudioVersion)' == '17.0')">v142</BasePlatformToolset>
-    <BasePlatformToolset Condition="'$(BasePlatformToolset)' == '' and ('$(MSBuildToolsVersion)' == '16.0' or '$(VisualStudioVersion)' == '16.0')">v142</BasePlatformToolset>
+    <BasePlatformToolset Condition="'$(BasePlatformToolset)' == '' and '$(VisualStudioVersion)' == '17.0'">v142</BasePlatformToolset>
+    <BasePlatformToolset Condition="'$(BasePlatformToolset)' == '' and '$(VisualStudioVersion)' == '16.0'">v142</BasePlatformToolset>
     <BasePlatformToolset Condition="'$(BasePlatformToolset)' == '' and ('$(MSBuildToolsVersion)' == '15.0' or '$(VisualStudioVersion)' == '15.0')">v141</BasePlatformToolset>
     <BasePlatformToolset Condition="'$(BasePlatformToolset)' == '' and '$(VCTargetsPath14)' != ''">v140</BasePlatformToolset>
     <BasePlatformToolset Condition="'$(BasePlatformToolset)' == '' and '$(VCTargetsPath12)' != ''">v120</BasePlatformToolset>


### PR DESCRIPTION
Prevent Directory.Build.props/targets from leaking from directories above the repo.

Docs on Directory.Build.props/targets: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2022

<!-- issue-number: [bpo-45931](https://bugs.python.org/issue45931) -->
https://bugs.python.org/issue45931
<!-- /issue-number -->
