### PR TITLE
bpo-45476: Add _Py_RVALUE() macro

### DIFF
--- a/Include/cpython/cellobject.h
+++ b/Include/cpython/cellobject.h
@@ -22,7 +22,7 @@ PyAPI_FUNC(PyObject *) PyCell_Get(PyObject *);
 PyAPI_FUNC(int) PyCell_Set(PyObject *, PyObject *);
 
 #define PyCell_GET(op) (((PyCellObject *)(op))->ob_ref)
-#define PyCell_SET(op, v) ((void)(((PyCellObject *)(op))->ob_ref = v))
+#define PyCell_SET(op, v) _Py_RVALUE(((PyCellObject *)(op))->ob_ref = (v))
 
 #ifdef __cplusplus
 }

--- a/Include/cpython/listobject.h
+++ b/Include/cpython/listobject.h
@@ -30,5 +30,5 @@ PyAPI_FUNC(void) _PyList_DebugMallocStats(FILE *out);
 #define _PyList_CAST(op) (assert(PyList_Check(op)), (PyListObject *)(op))
 
 #define PyList_GET_ITEM(op, i) (_PyList_CAST(op)->ob_item[i])
-#define PyList_SET_ITEM(op, i, v) ((void)(_PyList_CAST(op)->ob_item[i] = (v)))
+#define PyList_SET_ITEM(op, i, v) _Py_RVALUE(_PyList_CAST(op)->ob_item[i] = (v))
 #define PyList_GET_SIZE(op)    Py_SIZE(_PyList_CAST(op))

--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -23,6 +23,6 @@ PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 #define PyTuple_GET_ITEM(op, i) (_PyTuple_CAST(op)->ob_item[i])
 
 /* Macro, *only* to be used to fill in brand new tuples */
-#define PyTuple_SET_ITEM(op, i, v) ((void)(_PyTuple_CAST(op)->ob_item[i] = v))
+#define PyTuple_SET_ITEM(op, i, v) _Py_RVALUE(_PyTuple_CAST(op)->ob_item[i] = (v))
 
 PyAPI_FUNC(void) _PyTuple_DebugMallocStats(FILE *out);

--- a/Include/internal/pycore_asdl.h
+++ b/Include/internal/pycore_asdl.h
@@ -91,7 +91,7 @@ asdl_ ## NAME ## _seq *_Py_asdl_ ## NAME ## _seq_new(Py_ssize_t size, PyArena *a
         (S)->typed_elements[_asdl_i] = (V); \
     } while (0)
 #else
-#  define asdl_seq_SET(S, I, V) ((void)((S)->typed_elements[I] = (V)))
+#  define asdl_seq_SET(S, I, V) _Py_RVALUE((S)->typed_elements[I] = (V))
 #endif
 
 #ifdef Py_DEBUG
@@ -103,7 +103,7 @@ asdl_ ## NAME ## _seq *_Py_asdl_ ## NAME ## _seq_new(Py_ssize_t size, PyArena *a
         (S)->elements[_asdl_i] = (V); \
     } while (0)
 #else
-#  define asdl_seq_SET_UNTYPED(S, I, V) ((void)((S)->elements[I] = (V)))
+#  define asdl_seq_SET_UNTYPED(S, I, V) _Py_RVALUE((S)->elements[I] = (V))
 #endif
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -43,7 +43,7 @@ typedef struct {
 // Lowest bit of _gc_next is used for flags only in GC.
 // But it is always 0 for normal code.
 #define _PyGCHead_NEXT(g)        ((PyGC_Head*)(g)->_gc_next)
-#define _PyGCHead_SET_NEXT(g, p) ((void)((g)->_gc_next = (uintptr_t)(p)))
+#define _PyGCHead_SET_NEXT(g, p) _Py_RVALUE((g)->_gc_next = (uintptr_t)(p))
 
 // Lowest two bits of _gc_prev is used for _PyGC_PREV_MASK_* flags.
 #define _PyGCHead_PREV(g) ((PyGC_Head*)((g)->_gc_prev & _PyGC_PREV_MASK))
@@ -56,7 +56,7 @@ typedef struct {
 #define _PyGCHead_FINALIZED(g) \
     (((g)->_gc_prev & _PyGC_PREV_MASK_FINALIZED) != 0)
 #define _PyGCHead_SET_FINALIZED(g) \
-    ((void)((g)->_gc_prev |= _PyGC_PREV_MASK_FINALIZED))
+    _Py_RVALUE((g)->_gc_prev |= _PyGC_PREV_MASK_FINALIZED)
 
 #define _PyGC_FINALIZED(o) \
     _PyGCHead_FINALIZED(_Py_AS_GC(o))

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -129,4 +129,8 @@
     Py_FatalError("Unreachable C code path reached")
 #endif
 
+// Prevent using an expression as a l-value.
+// For example, "int x; _Py_RVALUE(x) = 1;" fails with a compiler error.
+#define _Py_RVALUE(EXPR) ((void)0, (EXPR))
+
 #endif /* Py_PYMACRO_H */


### PR DESCRIPTION
Add a new _Py_RVALUE() macro to prevent using an expression as an
l-value.

Replace a "(void)" cast with the _Py_RVALUE() macro in the following
macros:

* PyCell_SET()
* PyList_SET_ITEM()
* PyTuple_SET_ITEM()
* _PyGCHead_SET_FINALIZED()
* _PyGCHead_SET_NEXT()
* asdl_seq_SET()
* asdl_seq_SET_UNTYPED()

Add also parentheses around macro arguments in PyCell_SET() and
PyTuple_SET_ITEM().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45476](https://bugs.python.org/issue45476) -->
https://bugs.python.org/issue45476
<!-- /issue-number -->
