### PR TITLE
bpo-45476: Disallow using asdl_seq_GET() as l-value

### DIFF
--- a/Include/internal/pycore_asdl.h
+++ b/Include/internal/pycore_asdl.h
@@ -78,9 +78,9 @@ asdl_ ## NAME ## _seq *_Py_asdl_ ## NAME ## _seq_new(Py_ssize_t size, PyArena *a
     return seq; \
 }
 
-#define asdl_seq_GET_UNTYPED(S, I) (S)->elements[(I)]
-#define asdl_seq_GET(S, I) (S)->typed_elements[(I)]
-#define asdl_seq_LEN(S) ((S) == NULL ? 0 : (S)->size)
+#define asdl_seq_GET_UNTYPED(S, I) _Py_RVALUE((S)->elements[(I)])
+#define asdl_seq_GET(S, I) _Py_RVALUE((S)->typed_elements[(I)])
+#define asdl_seq_LEN(S) _Py_RVALUE(((S) == NULL ? 0 : (S)->size))
 
 #ifdef Py_DEBUG
 #  define asdl_seq_SET(S, I, V) \


### PR DESCRIPTION
The following internal macros can not longer be used as l-value:

* asdl_seq_GET()
* asdl_seq_GET_UNTYPED()
* asdl_seq_LEN()

They are modified to use the _Py_RVALUE() macro.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45476](https://bugs.python.org/issue45476) -->
https://bugs.python.org/issue45476
<!-- /issue-number -->
