### PR TITLE
bpo-44674: Use unhashability as a proxy for mutability for default dataclass __init__ arguments.

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -712,9 +712,9 @@ Mutable default values
    creation they also share this behavior.  There is no general way
    for Data Classes to detect this condition.  Instead, the
    :func:`dataclass` decorator will raise a :exc:`TypeError` if it
-   detects a default parameter of type ``list``, ``dict``, or ``set``.
-   This is a partial solution, but it does protect against many common
-   errors.
+   detects an unhashable default parameter.  The assumption is that if
+   an parameter is unhashable, it is mutable.  This is a partial
+   solution, but it does protect against many common errors.
 
    Using default factory functions is a way to create new instances of
    mutable types as default values for fields::
@@ -724,3 +724,9 @@ Mutable default values
          x: list = field(default_factory=list)
 
      assert D().x is not D().x
+
+   .. versionchanged:: 3.11
+      Instead of looking for and disallowing objects of type ``list``,
+      ``dict``, or ``set``, unhashable objects are now not allowed as
+      default values.  Unhashability is used to approximate
+      mutability.

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -713,8 +713,8 @@ Mutable default values
    for Data Classes to detect this condition.  Instead, the
    :func:`dataclass` decorator will raise a :exc:`TypeError` if it
    detects an unhashable default parameter.  The assumption is that if
-   an parameter is unhashable, it is mutable.  This is a partial
-   solution, but it does protect against many common errors.
+   a value is unhashable, it is mutable.  This is a partial solution,
+   but it does protect against many common errors.
 
    Using default factory functions is a way to create new instances of
    mutable types as default values for fields::

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -811,10 +811,9 @@ def _get_field(cls, a_name, a_type, default_kw_only):
     # For real fields, disallow mutable defaults.  Use unhashable as a proxy
     # indicator for mutability.  Read the __hash__ attribute from the class,
     # not the instance.
-    if f._field_type is _FIELD:
-        if f.default.__class__.__hash__ is None:
-            raise ValueError(f'mutable default {type(f.default)} for field '
-                             f'{f.name} is not allowed: use default_factory')
+    if f._field_type is _FIELD and f.default.__class__.__hash__ is None:
+        raise ValueError(f'mutable default {type(f.default)} for field '
+                         f'{f.name} is not allowed: use default_factory')
 
     return f
 

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -808,8 +808,9 @@ def _get_field(cls, a_name, a_type, default_kw_only):
             raise TypeError(f'field {f.name} is a ClassVar but specifies '
                             'kw_only')
 
-    # For real fields, disallow mutable defaults for known types.
-    if f._field_type is _FIELD and isinstance(f.default, (list, dict, set)):
+    # For real fields, disallow mutable defaults.  Use unhashable as a proxy
+    # indicator for mutability.
+    if f._field_type is _FIELD and f.default.__hash__ is None:
         raise ValueError(f'mutable default {type(f.default)} for field '
                          f'{f.name} is not allowed: use default_factory')
 

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -811,7 +811,7 @@ def _get_field(cls, a_name, a_type, default_kw_only):
     # For real fields, disallow mutable defaults.  Use unhashable as a proxy
     # indicator for mutability.  Read the __hash__ attribute from the class,
     # not the instance.
-    defaults_hash_fn = getattr(f.default.__class__, '__hash__')
+    defaults_hash_fn = f.default.__class__.__hash__
     if f._field_type is _FIELD and defaults_hash_fn is None:
         raise ValueError(f'mutable default {type(f.default)} for field '
                          f'{f.name} is not allowed: use default_factory')

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -811,10 +811,10 @@ def _get_field(cls, a_name, a_type, default_kw_only):
     # For real fields, disallow mutable defaults.  Use unhashable as a proxy
     # indicator for mutability.  Read the __hash__ attribute from the class,
     # not the instance.
-    defaults_hash_fn = f.default.__class__.__hash__
-    if f._field_type is _FIELD and defaults_hash_fn is None:
-        raise ValueError(f'mutable default {type(f.default)} for field '
-                         f'{f.name} is not allowed: use default_factory')
+    if f._field_type is _FIELD:
+        if f.default.__class__.__hash__ is None:
+            raise ValueError(f'mutable default {type(f.default)} for field '
+                             f'{f.name} is not allowed: use default_factory')
 
     return f
 

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -809,8 +809,10 @@ def _get_field(cls, a_name, a_type, default_kw_only):
                             'kw_only')
 
     # For real fields, disallow mutable defaults.  Use unhashable as a proxy
-    # indicator for mutability.
-    if f._field_type is _FIELD and f.default.__hash__ is None:
+    # indicator for mutability.  Read the __hash__ attribute from the class,
+    # not the instance.
+    defaults_hash_fn = getattr(f.default.__class__, '__hash__')
+    if f._field_type is _FIELD and defaults_hash_fn is None:
         raise ValueError(f'mutable default {type(f.default)} for field '
                          f'{f.name} is not allowed: use default_factory')
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -500,6 +500,29 @@ class TestCase(unittest.TestCase):
         self.assertNotEqual(C(3), C(4, 10))
         self.assertNotEqual(C(3, 10), C(4, 10))
 
+    def test_no_unhashable_default(self):
+        # See bpo-44674.
+        class Unhashable:
+            __hash__ = None
+
+        class Hashable:
+            def __hash__(self):
+                return 0
+
+        with self.assertRaisesRegex(ValueError,
+                                    f'mutable default .* for field '
+                                    'a is not allowed'):
+            @dataclass
+            class A:
+                a: dict = {}
+
+        with self.assertRaisesRegex(ValueError,
+                                    f'mutable default .* for field '
+                                    'a is not allowed'):
+            @dataclass
+            class A:
+                a: Any = Unhashable()
+
     def test_hash_field_rules(self):
         # Test all 6 cases of:
         #  hash=True/False/None

--- a/Misc/NEWS.d/next/Library/2021-11-29-19-37-20.bpo-44674.NijWLt.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-29-19-37-20.bpo-44674.NijWLt.rst
@@ -1,0 +1,3 @@
+Change how dataclasses disallows mutable default values.  It used to use a
+list of known types (list, dict, set).  Now it disallows unhashable objects
+to be defaults.  It's using unhashability as a proxy for mutability.

--- a/Misc/NEWS.d/next/Library/2021-11-29-19-37-20.bpo-44674.NijWLt.rst
+++ b/Misc/NEWS.d/next/Library/2021-11-29-19-37-20.bpo-44674.NijWLt.rst
@@ -1,3 +1,6 @@
-Change how dataclasses disallows mutable default values.  It used to use a
-list of known types (list, dict, set).  Now it disallows unhashable objects
-to be defaults.  It's using unhashability as a proxy for mutability.
+Change how dataclasses disallows mutable default values.  It used to
+use a list of known types (list, dict, set).  Now it disallows
+unhashable objects to be defaults.  It's using unhashability as a
+proxy for mutability.  Patch by Eric V. Smith, idea by Raymond
+Hettinger.
+


### PR DESCRIPTION


<!-- issue-number: [bpo-44674](https://bugs.python.org/issue44674) -->
https://bugs.python.org/issue44674
<!-- /issue-number -->
