### PR TITLE
bpo-45940: Only add system multiarch paths when not compiling for WASM

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-11-30-17-18-39.bpo-45940.mEg6Gm.rst
+++ b/Misc/NEWS.d/next/Build/2021-11-30-17-18-39.bpo-45940.mEg6Gm.rst
@@ -1,0 +1,1 @@
+Multiarch flags are not used on WASM targets.

--- a/setup.py
+++ b/setup.py
@@ -919,7 +919,9 @@ class PyBuildExt(build_ext):
         # only change this for cross builds for 3.3, issues on Mageia
         if CROSS_COMPILING:
             self.add_cross_compiling_paths()
-        self.add_multiarch_paths()
+        # Only include multiarch if not targeting the web
+        if not sysconfig.get_config_var('HOST_GNU_TYPE').startswith('wasm'):
+            self.add_multiarch_paths()
         self.add_ldflags_cppflags()
 
     def init_inc_lib_dirs(self):
@@ -1243,7 +1245,7 @@ class PyBuildExt(build_ext):
             self.missing.append('_curses_panel')
 
     def detect_crypt(self):
-         self.addext(Extension('_crypt', ['_cryptmodule.c']))
+        self.addext(Extension('_crypt', ['_cryptmodule.c']))
 
     def detect_dbm_gdbm(self):
         # Modules that provide persistent dictionary-like semantics.  You will


### PR DESCRIPTION
This was discovered while working on https://github.com/ethanhs/python-wasm

It seems @tiran when you fixed sysconfig it caused this method to work, which also broke my build :)


I believe we can't just disable this outright when cross compiling (for e.g. cross compiling to ARM Debian based distros) so hopefully this seems reasonable.

<!-- issue-number: [bpo-45940](https://bugs.python.org/issue45940) -->
https://bugs.python.org/issue45940
<!-- /issue-number -->
