### PR TITLE
bpo-40280: Emscripten has no support for subprocesses

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -607,7 +607,10 @@ def _syscmd_file(target, default=''):
         # XXX Others too ?
         return default
 
-    import subprocess
+    try:
+        import subprocess
+    except ImportError:
+        return default
     target = _follow_symlinks(target)
     # "file" output is locale dependent: force the usage of the C locale
     # to get deterministic behavior.
@@ -746,7 +749,10 @@ class _Processor:
         """
         Fall back to `uname -p`
         """
-        import subprocess
+        try:
+            import subprocess
+        except ImportError:
+            return
         try:
             return subprocess.check_output(
                 ['uname', '-p'],

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -752,7 +752,7 @@ class _Processor:
         try:
             import subprocess
         except ImportError:
-            return
+            return None
         try:
             return subprocess.check_output(
                 ['uname', '-p'],

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1556,6 +1556,8 @@ def getpager():
         return plainpager
     if not sys.stdin.isatty() or not sys.stdout.isatty():
         return plainpager
+    if sys.platform == "emscripten":
+        return plainpager
     use_pager = os.environ.get('MANPAGER') or os.environ.get('PAGER')
     if use_pager:
         if sys.platform == 'win32': # pipes completely broken in Windows


### PR DESCRIPTION
Fixes ``platform`` and ``help()`` on emscripten.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran