### PR TITLE
bpo-40280: Emscripten defaults to --with-ensurepip=no (GH-29873)

### DIFF
--- a/configure
+++ b/configure
@@ -20268,7 +20268,15 @@ $as_echo_n "checking for ensurepip... " >&6; }
 if test "${with_ensurepip+set}" = set; then :
   withval=$with_ensurepip;
 else
-  with_ensurepip=upgrade
+
+      case $ac_sys_system in #(
+  Emscripten) :
+    $with_ensurepip=no ;; #(
+  *) :
+    with_ensurepip=upgrade
+       ;;
+esac
+
 fi
 
 case $with_ensurepip in #(

--- a/configure.ac
+++ b/configure.ac
@@ -5871,7 +5871,12 @@ AC_ARG_WITH(ensurepip,
     [AS_HELP_STRING([--with-ensurepip@<:@=install|upgrade|no@:>@],
         ["install" or "upgrade" using bundled pip (default is upgrade)])],
     [],
-    [with_ensurepip=upgrade])
+    [
+      AS_CASE([$ac_sys_system],
+        [Emscripten], [$with_ensurepip=no],
+        [with_ensurepip=upgrade]
+      )
+    ])
 AS_CASE($with_ensurepip,
     [yes|upgrade],[ENSUREPIP=upgrade],
     [install],[ENSUREPIP=install],


### PR DESCRIPTION
Reduces installation size of browser bundle

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
