### PR TITLE
bpo-45607: Make it possible to enrich exception displays via setting their __note__ field

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -129,8 +129,8 @@ The following exceptions are used mostly as base classes for other exceptions.
 
    .. attribute:: __note__
 
-      A mutable field which is None by default and can be set to a string.
-      If it is not None, it is included in the traceback. This field can
+      A mutable field which is ``None`` by default and can be set to a string.
+      If it is not ``None``, it is included in the traceback. This field can
       be used to enrich exceptions after they have been caught.
 
    .. versionadded:: 3.11

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -127,6 +127,14 @@ The following exceptions are used mostly as base classes for other exceptions.
              tb = sys.exc_info()[2]
              raise OtherException(...).with_traceback(tb)
 
+   .. attribute:: __note__
+
+      A mutable field which is None by default and can be set to a string.
+      If it is not None, it is included in the traceback. This field can
+      be used to enrich exceptions after they have been caught.
+
+   .. versionadded:: 3.11
+
 
 .. exception:: Exception
 

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -129,8 +129,8 @@ The following exceptions are used mostly as base classes for other exceptions.
 
    .. attribute:: __note__
 
-      A mutable field which is ``None`` by default and can be set to a string.
-      If it is not ``None``, it is included in the traceback. This field can
+      A mutable field which is :const:`None` by default and can be set to a string.
+      If it is not :const:`None`, it is included in the traceback. This field can
       be used to enrich exceptions after they have been caught.
 
    .. versionadded:: 3.11

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -146,6 +146,12 @@ The :option:`-X` ``no_debug_ranges`` option and the environment variable
 See :pep:`657` for more details. (Contributed by Pablo Galindo, Batuhan Taskaya
 and Ammar Askar in :issue:`43950`.)
 
+Exceptions can be enriched with a string ``__note__``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``__note__`` field was added to :exc:`BaseException`. It is ``None``
+by default but can be set to a string which is added to the exception's
+traceback. (Contributed by Irit Katriel in :issue:`45607`.)
 
 Other Language Changes
 ======================

--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -6,7 +6,7 @@
 
 /* PyException_HEAD defines the initial segment of every exception class. */
 #define PyException_HEAD PyObject_HEAD PyObject *dict;\
-             PyObject *args; PyObject *traceback;\
+             PyObject *args; PyObject *note; PyObject *traceback;\
              PyObject *context; PyObject *cause;\
              char suppress_context;
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -525,6 +525,14 @@ class ExceptionTests(unittest.TestCase):
 
                 with self.assertRaises(TypeError):
                     e.__note__ = 42
+                self.assertEqual(e.__note__, "My Note")
+
+                e.__note__ = "Your Note"
+                self.assertEqual(e.__note__, "Your Note")
+
+                with self.assertRaises(TypeError):
+                    del e.__note__
+                self.assertEqual(e.__note__, "Your Note")
 
                 e.__note__ = None
                 self.assertIsNone(e.__note__)

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -516,6 +516,19 @@ class ExceptionTests(unittest.TestCase):
                                              'pickled "%r", attribute "%s' %
                                              (e, checkArgName))
 
+    def test_note(self):
+        for e in [BaseException(1), Exception(2), ValueError(3)]:
+            with self.subTest(e=e):
+                self.assertIsNone(e.__note__)
+                e.__note__ = "My Note"
+                self.assertEqual(e.__note__, "My Note")
+
+                with self.assertRaises(TypeError):
+                    e.__note__ = 42
+
+                e.__note__ = None
+                self.assertIsNone(e.__note__)
+
     def testWithTraceback(self):
         try:
             raise IndexError(4)

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1298,13 +1298,13 @@ class SizeofTest(unittest.TestCase):
         class C(object): pass
         check(C.__dict__, size('P'))
         # BaseException
-        check(BaseException(), size('5Pb'))
+        check(BaseException(), size('6Pb'))
         # UnicodeEncodeError
-        check(UnicodeEncodeError("", "", 0, 0, ""), size('5Pb 2P2nP'))
+        check(UnicodeEncodeError("", "", 0, 0, ""), size('6Pb 2P2nP'))
         # UnicodeDecodeError
-        check(UnicodeDecodeError("", b"", 0, 0, ""), size('5Pb 2P2nP'))
+        check(UnicodeDecodeError("", b"", 0, 0, ""), size('6Pb 2P2nP'))
         # UnicodeTranslateError
-        check(UnicodeTranslateError("", 0, 1, ""), size('5Pb 2P2nP'))
+        check(UnicodeTranslateError("", 0, 1, ""), size('6Pb 2P2nP'))
         # ellipses
         check(Ellipsis, size(''))
         # EncodingMap

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1231,6 +1231,9 @@ class BaseExceptionReportingTests:
         e.__note__ = 'My Note'
         self.assertEqual(self.get_report(e), vanilla + 'My Note\n')
 
+        e.__note__ = ''
+        self.assertEqual(self.get_report(e), vanilla + '\n')
+
         e.__note__ = 'Your Note'
         self.assertEqual(self.get_report(e), vanilla + 'Your Note\n')
 
@@ -1591,7 +1594,12 @@ class BaseExceptionReportingTests:
                         excs.append(e)
                 raise ExceptionGroup("nested", excs)
             except ExceptionGroup as e:
-                e.__note__ = 'A lot of problems'
+                e.__note__ = ('>> Multi line note\n'
+                              '>> Because I am such\n'
+                              '>> an important exception.\n'
+                              '>> empty lines work too\n'
+                              '\n'
+                              '(that was an empty line)\n')
                 raise
 
         expected = (f'  + Exception Group Traceback (most recent call last):\n'
@@ -1602,7 +1610,12 @@ class BaseExceptionReportingTests:
                     f'  |     raise ExceptionGroup("nested", excs)\n'
                     f'  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n'
                     f'  | ExceptionGroup: nested\n'
-                    f'  | A lot of problems\n'
+                    f'  | >> Multi line note\n'
+                    f'  | >> Because I am such\n'
+                    f'  | >> an important exception.\n'
+                    f'  | >> empty lines work too\n'
+                    f'  | \n'
+                    f'  | (that was an empty line)\n'
                     f'  +-+---------------- 1 ----------------\n'
                     f'    | Traceback (most recent call last):\n'
                     f'    |   File "{__file__}", line {exc.__code__.co_firstlineno + 5}, in exc\n'

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1599,7 +1599,7 @@ class BaseExceptionReportingTests:
                               '>> an important exception.\n'
                               '>> empty lines work too\n'
                               '\n'
-                              '(that was an empty line)\n')
+                              '(that was an empty line)')
                 raise
 
         expected = (f'  + Exception Group Traceback (most recent call last):\n'

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1224,6 +1224,19 @@ class BaseExceptionReportingTests:
                 exp = "\n".join(expected)
                 self.assertEqual(exp, err)
 
+    def test_exception_with_note(self):
+        e = ValueError(42)
+        vanilla = self.get_report(e)
+
+        e.__note__ = 'My Note'
+        self.assertEqual(self.get_report(e), vanilla + 'My Note\n')
+
+        e.__note__ = 'Your Note'
+        self.assertEqual(self.get_report(e), vanilla + 'Your Note\n')
+
+        e.__note__ = None
+        self.assertEqual(self.get_report(e), vanilla)
+
     def test_exception_qualname(self):
         class A:
             class B:

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -819,7 +819,7 @@ class TracebackException:
         else:
             yield from self._format_syntax_error(stype)
         if self.__note__ is not None:
-            yield from [l + '\n' for l in self.__note__.split("\n")]
+            yield from [l + '\n' for l in self.__note__.split('\n')]
 
     def _format_syntax_error(self, stype):
         """Format SyntaxError exceptions (internal helper)."""

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -819,7 +819,7 @@ class TracebackException:
         else:
             yield from self._format_syntax_error(stype)
         if self.__note__ is not None:
-            yield self.__note__ + "\n"
+            yield from [l + '\n' for l in self.__note__.split("\n")]
 
     def _format_syntax_error(self, stype):
         """Format SyntaxError exceptions (internal helper)."""

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -685,11 +685,7 @@ class TracebackException:
         # Capture now to permit freeing resources: only complication is in the
         # unofficial API _format_final_exc_line
         self._str = _some_str(exc_value)
-        if exc_value is not None:
-            self.__note__ = exc_value.__note__
-            assert self.__note__ is None or isinstance(self.__note__, str)
-        else:
-            self.__note__ = None
+        self.__note__ = exc_value.__note__ if exc_value else None
 
         if exc_type and issubclass(exc_type, SyntaxError):
             # Handle SyntaxError's specially

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -685,6 +685,12 @@ class TracebackException:
         # Capture now to permit freeing resources: only complication is in the
         # unofficial API _format_final_exc_line
         self._str = _some_str(exc_value)
+        if exc_value is not None:
+            self.__note__ = exc_value.__note__
+            assert self.__note__ is None or isinstance(self.__note__, str)
+        else:
+            self.__note__ = None
+
         if exc_type and issubclass(exc_type, SyntaxError):
             # Handle SyntaxError's specially
             self.filename = exc_value.filename
@@ -816,6 +822,8 @@ class TracebackException:
             yield _format_final_exc_line(stype, self._str)
         else:
             yield from self._format_syntax_error(stype)
+        if self.__note__ is not None:
+            yield self.__note__ + "\n"
 
     def _format_syntax_error(self, stype):
         """Format SyntaxError exceptions (internal helper)."""

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-01-15-38-04.bpo-45607.JhuF8b.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-01-15-38-04.bpo-45607.JhuF8b.rst
@@ -1,0 +1,1 @@
+Add a ``__note__`` field to :exc:`BaseException` which can be set to a string, and if exists it is included in the traceback of the exception.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-01-15-38-04.bpo-45607.JhuF8b.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-01-15-38-04.bpo-45607.JhuF8b.rst
@@ -1,1 +1,4 @@
-Add a ``__note__`` field to :exc:`BaseException` which can be set to a string, and if exists it is included in the traceback of the exception.
+The ``__note__`` field was added to :exc:`BaseException`. It is ``None``
+by default but can be set to a string which is added to the exception's
+traceback.
+

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -225,8 +225,7 @@ BaseException_get_note(PyBaseExceptionObject *self, void *Py_UNUSED(ignored))
     if (self->note == NULL) {
         Py_RETURN_NONE;
     }
-    Py_INCREF(self->note);
-    return self->note;
+    return Py_NewRef(self->note);
 }
 
 static int

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -236,8 +236,8 @@ BaseException_set_note(PyBaseExceptionObject *self, PyObject *note,
         PyErr_SetString(PyExc_TypeError, "__note__ may not be deleted");
         return -1;
     }
-    else if (note != Py_None && !PyUnicode_Check(note)) {
-        PyErr_SetString(PyExc_TypeError, "__note__ must be an str or None");
+    else if (note != Py_None && !PyUnicode_CheckExact(note)) {
+        PyErr_SetString(PyExc_TypeError, "__note__ must be a string or None");
         return -1;
     }
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -46,6 +46,7 @@ BaseException_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     /* the dict is created on the fly in PyObject_GenericSetAttr */
     self->dict = NULL;
+    self->note = NULL;
     self->traceback = self->cause = self->context = NULL;
     self->suppress_context = 0;
 
@@ -81,6 +82,7 @@ BaseException_clear(PyBaseExceptionObject *self)
 {
     Py_CLEAR(self->dict);
     Py_CLEAR(self->args);
+    Py_CLEAR(self->note);
     Py_CLEAR(self->traceback);
     Py_CLEAR(self->cause);
     Py_CLEAR(self->context);
@@ -105,6 +107,7 @@ BaseException_traverse(PyBaseExceptionObject *self, visitproc visit, void *arg)
 {
     Py_VISIT(self->dict);
     Py_VISIT(self->args);
+    Py_VISIT(self->note);
     Py_VISIT(self->traceback);
     Py_VISIT(self->cause);
     Py_VISIT(self->context);
@@ -217,6 +220,34 @@ BaseException_set_args(PyBaseExceptionObject *self, PyObject *val, void *Py_UNUS
 }
 
 static PyObject *
+BaseException_get_note(PyBaseExceptionObject *self, void *Py_UNUSED(ignored))
+{
+    if (self->note == NULL) {
+        Py_RETURN_NONE;
+    }
+    Py_INCREF(self->note);
+    return self->note;
+}
+
+static int
+BaseException_set_note(PyBaseExceptionObject *self, PyObject *note, void *Py_UNUSED(ignored))
+{
+    if (note == NULL) {
+        PyErr_SetString(PyExc_TypeError, "__note__ may not be deleted");
+        return -1;
+    }
+    else if (note != Py_None && !PyUnicode_Check(note)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "__note__ must be an str or None");
+        return -1;
+    }
+
+    Py_INCREF(note);
+    Py_XSETREF(self->note, note);
+    return 0;
+}
+
+static PyObject *
 BaseException_get_tb(PyBaseExceptionObject *self, void *Py_UNUSED(ignored))
 {
     if (self->traceback == NULL) {
@@ -306,6 +337,7 @@ BaseException_set_cause(PyObject *self, PyObject *arg, void *Py_UNUSED(ignored))
 static PyGetSetDef BaseException_getset[] = {
     {"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict},
     {"args", (getter)BaseException_get_args, (setter)BaseException_set_args},
+    {"__note__", (getter)BaseException_get_note, (setter)BaseException_set_note},
     {"__traceback__", (getter)BaseException_get_tb, (setter)BaseException_set_tb},
     {"__context__", BaseException_get_context,
      BaseException_set_context, PyDoc_STR("exception context")},

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -229,7 +229,8 @@ BaseException_get_note(PyBaseExceptionObject *self, void *Py_UNUSED(ignored))
 }
 
 static int
-BaseException_set_note(PyBaseExceptionObject *self, PyObject *note, void *Py_UNUSED(ignored))
+BaseException_set_note(PyBaseExceptionObject *self, PyObject *note,
+                       void *Py_UNUSED(ignored))
 {
     if (note == NULL) {
         PyErr_SetString(PyExc_TypeError, "__note__ may not be deleted");

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -237,8 +237,7 @@ BaseException_set_note(PyBaseExceptionObject *self, PyObject *note, void *Py_UNU
         return -1;
     }
     else if (note != Py_None && !PyUnicode_Check(note)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "__note__ must be an str or None");
+        PyErr_SetString(PyExc_TypeError, "__note__ must be an str or None");
         return -1;
     }
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1083,6 +1083,25 @@ print_exception(struct exception_print_context *ctx, PyObject *value)
         PyErr_Clear();
     }
     err += PyFile_WriteString("\n", f);
+
+    if (err == 0 && PyExceptionInstance_Check(value)) {
+        _Py_IDENTIFIER(__note__);
+
+        PyObject *note = _PyObject_GetAttrId(value, &PyId___note__);
+        if (note == NULL) {
+            err = -1;
+        }
+        if (err == 0 && PyUnicode_Check(note)) {
+            err = write_indented_margin(ctx, f);
+            if (err == 0) {
+                err = PyFile_WriteObject(note, f, Py_PRINT_RAW);
+            }
+            if (err == 0) {
+                err = PyFile_WriteString("\n", f);
+            }
+        }
+        Py_XDECREF(note);
+    }
     Py_XDECREF(tb);
     Py_DECREF(value);
     /* If an error happened here, don't show it.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45607](https://bugs.python.org/issue45607) -->
https://bugs.python.org/issue45607
<!-- /issue-number -->
