### PR TITLE
bpo-44637: Fix DBQuote mail header refold

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2841,7 +2841,14 @@ def _refold_parse_tree(parse_tree, *, policy):
                 continue
         if not hasattr(part, 'encode'):
             # It's not a terminal, try folding the subparts.
-            newparts = list(part)
+            if part.token_type == 'bare-quoted-string':
+                newparts = [
+                    ValueTerminal('"', 'DQUOTE'),
+                    *list(part),
+                    ValueTerminal('"', 'DQUOTE'),
+                ]
+            else:
+                newparts = list(part)
             if not part.as_ew_allowed:
                 wrap_as_ew_blocked += 1
                 newparts.append(end_ew_not_allowed)

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -1431,6 +1431,13 @@ List: List-Unsubscribe:
              =?utf-8?q?_to_see_if_line_wrapping_with_encoded_words_and_embedded?=
              =?utf-8?q?_folding_white_space_works?=""")+'\n')
 
+    def test_long_quoted_string_header(self):
+        msg = Message(policy=email.policy.default)
+        msg['To'] = '"John Doe Example Inc. Houtesiplou Belgium" <john.doe@example.com>'
+        self.assertEqual(
+            msg.as_string(maxheaderlen=40),
+            'To: "John Doe Example Inc. Houtesiplou\n Belgium" <john.doe@example.com>\n\n',
+        )
 
 
 # Test mangling of "From " lines in the body of a message

--- a/Misc/NEWS.d/next/Security/2022-04-19-10-38-00.gh-issue-88803.TMtK9R.rst
+++ b/Misc/NEWS.d/next/Security/2022-04-19-10-38-00.gh-issue-88803.TMtK9R.rst
@@ -1,0 +1,1 @@
+When a mail header content is too long, the RFC demands to fold it over multiple lines, finding a sweet spot (e.g. between two words) where to split the line. When the sweet-spot was inside of a quoted-string, the quotation marks were wrongly removed which led to invalid header values.


### PR DESCRIPTION
When a header content is too long, the RFC demands to fold it over
multiple lines. Each line starting with a space to denote folded-lines
from regular ones.

Folding a line requires splitint it, there are only a few sweet spots
where it is possible to do so (e.g. between two words). Words are pretty
deep in the parse-tree thus multiple parts must be unwrap to reveal
them. One of those parts can be a quoted-string, printing a
quoted-string as a whole correctly wraps its content with double-quotes
but printing every child never quotes them.

When a quoted-string must be unwrap to find a sweet-splot to split the
line, we now inject double-quotes literals before and after its
children.

<!-- issue-number: [bpo-44637](https://bugs.python.org/issue44637) -->
https://bugs.python.org/issue44637
<!-- /issue-number -->
