### PR TITLE
bpo-40280: Emscripten with_ensurepip=no, second attempt (GH-29884)

### DIFF
--- a/configure
+++ b/configure
@@ -20271,7 +20271,7 @@ else
 
       case $ac_sys_system in #(
   Emscripten) :
-    $with_ensurepip=no ;; #(
+    with_ensurepip=no ;; #(
   *) :
     with_ensurepip=upgrade
        ;;

--- a/configure.ac
+++ b/configure.ac
@@ -5873,7 +5873,7 @@ AC_ARG_WITH(ensurepip,
     [],
     [
       AS_CASE([$ac_sys_system],
-        [Emscripten], [$with_ensurepip=no],
+        [Emscripten], [with_ensurepip=no],
         [with_ensurepip=upgrade]
       )
     ])


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
