### PR TITLE
bpo-45956: Add common scanf regular expressions

### DIFF
--- a/Lib/re.py
+++ b/Lib/re.py
@@ -309,6 +309,21 @@ def _subx(pattern, template):
         return sre_parse.expand_template(template, match)
     return filter
 
+# From https://docs.python.org/3/library/re.html#simulating-scanf
+
+def chars(n):
+    return compile(f".{{n}}")
+
+
+char = compile(".")
+int = compile(r"[-+]?\d+")
+float = compile(r"[-+]?(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?")
+hexfloat = compile(r"[-+]?(0[xX][\dA-Fa-f]+|0[0-7]*|\d+)")
+octal = compile("[-+]?[0-7]+")
+whitespace = compile(r"\S+")
+unsigned = compile(r"\d+")
+hex = compile(r"[-+]?(0[xX])?[\dA-Fa-f]+")
+
 # register myself for pickling
 
 import copyreg

--- a/Misc/NEWS.d/next/Library/2021-12-01-21-46-45.bpo-45956.Pocly6.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-01-21-46-45.bpo-45956.Pocly6.rst
@@ -1,0 +1,1 @@
+Add officially suggested regular expressions for scanf equivalents from https://docs.python.org/3/library/re.html#simulating-scanf to re module


### PR DESCRIPTION
While Python continues to not have an equivalent to `scanf()`, it can
provide commonly-used (and documented) regular expressions as part of
the `re` module.

See https://docs.python.org/3/library/re.html#simulating-scanf

<!-- issue-number: [bpo-45956](https://bugs.python.org/issue45956) -->
https://bugs.python.org/issue45956
<!-- /issue-number -->
