### PR TITLE
bpo-45711: [asyncio] Normalize exceptions immediately after Fetch, before they are stored as StackItem, which should be normalized

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-12-02-17-22-06.bpo-45711.D6jsdv.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-02-17-22-06.bpo-45711.D6jsdv.rst
@@ -1,0 +1,1 @@
+Make :mod:`asyncio` normalize exceptions as soon as they are captured with :c:func:`PyErr_Fetch`, and before they are stored as an exc_info triplet. This brings :mod:`asyncio` in line with the rest of the codebase, where an exc_info triplet is always normalized.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2702,6 +2702,11 @@ task_step_impl(TaskObj *task, PyObject *exc)
         if (PyErr_ExceptionMatches(asyncio_CancelledError)) {
             /* CancelledError */
             PyErr_Fetch(&et, &ev, &tb);
+            assert(et);
+            PyErr_NormalizeException(&et, &ev, &tb);
+            if (tb != NULL) {
+                PyException_SetTraceback(ev, tb);
+            }
 
             FutureObj *fut = (FutureObj*)task;
             _PyErr_StackItem *exc_state = &fut->fut_cancelled_exc_state;
@@ -2714,14 +2719,12 @@ task_step_impl(TaskObj *task, PyObject *exc)
 
         /* Some other exception; pop it and call Task.set_exception() */
         PyErr_Fetch(&et, &ev, &tb);
-
         assert(et);
-        if (!ev || !PyObject_TypeCheck(ev, (PyTypeObject *) et)) {
-            PyErr_NormalizeException(&et, &ev, &tb);
-        }
+        PyErr_NormalizeException(&et, &ev, &tb);
         if (tb != NULL) {
             PyException_SetTraceback(ev, tb);
         }
+
         o = future_set_exception((FutureObj*)task, ev);
         if (!o) {
             /* An exception in Task.set_exception() */
@@ -2965,7 +2968,7 @@ task_step(TaskObj *task, PyObject *exc)
         PyObject *et, *ev, *tb;
         PyErr_Fetch(&et, &ev, &tb);
         leave_task(task->task_loop, (PyObject*)task);
-        _PyErr_ChainExceptions(et, ev, tb);
+        _PyErr_ChainExceptions(et, ev, tb); /* Normalizes (et, ev, tb) */
         return NULL;
     }
     else {
@@ -3014,8 +3017,10 @@ task_wakeup(TaskObj *task, PyObject *o)
     }
 
     PyErr_Fetch(&et, &ev, &tb);
-    if (!ev || !PyObject_TypeCheck(ev, (PyTypeObject *) et)) {
-        PyErr_NormalizeException(&et, &ev, &tb);
+    assert(et);
+    PyErr_NormalizeException(&et, &ev, &tb);
+    if (tb != NULL) {
+        PyException_SetTraceback(ev, tb);
     }
 
     result = task_step(task, ev);

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -647,26 +647,6 @@ _PyErr_ChainStackItem(_PyErr_StackItem *exc_info)
     PyObject *typ, *val, *tb;
     _PyErr_Fetch(tstate, &typ, &val, &tb);
 
-    PyObject *typ2, *val2, *tb2;
-    typ2 = exc_info->exc_type;
-    val2 = exc_info->exc_value;
-    tb2 = exc_info->exc_traceback;
-#ifdef Py_DEBUG
-    PyObject *typ2_before = typ2;
-    PyObject *val2_before = val2;
-    PyObject *tb2_before = tb2;
-#endif
-    _PyErr_NormalizeException(tstate, &typ2, &val2, &tb2);
-#ifdef Py_DEBUG
-    /* exc_info should already be normalized */
-    assert(typ2 == typ2_before);
-    assert(val2 == val2_before);
-    assert(tb2 == tb2_before);
-#endif
-    if (tb2 != NULL) {
-        PyException_SetTraceback(val2, tb2);
-    }
-
     /* _PyErr_SetObject sets the context from PyThreadState. */
     _PyErr_SetObject(tstate, typ, val);
     Py_DECREF(typ);  // since _PyErr_Occurred was true

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -647,6 +647,26 @@ _PyErr_ChainStackItem(_PyErr_StackItem *exc_info)
     PyObject *typ, *val, *tb;
     _PyErr_Fetch(tstate, &typ, &val, &tb);
 
+    PyObject *typ2, *val2, *tb2;
+    typ2 = exc_info->exc_type;
+    val2 = exc_info->exc_value;
+    tb2 = exc_info->exc_traceback;
+#ifdef Py_DEBUG
+    PyObject *typ2_before = typ2;
+    PyObject *val2_before = val2;
+    PyObject *tb2_before = tb2;
+#endif
+    _PyErr_NormalizeException(tstate, &typ2, &val2, &tb2);
+#ifdef Py_DEBUG
+    /* exc_info should already be normalized */
+    assert(typ2 == typ2_before);
+    assert(val2 == val2_before);
+    assert(tb2 == tb2_before);
+#endif
+    if (tb2 != NULL) {
+        PyException_SetTraceback(val2, tb2);
+    }
+
     /* _PyErr_SetObject sets the context from PyThreadState. */
     _PyErr_SetObject(tstate, typ, val);
     Py_DECREF(typ);  // since _PyErr_Occurred was true

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -636,6 +636,10 @@ _PyErr_ChainStackItem(_PyErr_StackItem *exc_info)
         return;
     }
 
+    if (exc_info->exc_traceback) {
+        PyException_SetTraceback(exc_info->exc_value, exc_info->exc_traceback);
+    }
+
     _PyErr_StackItem *saved_exc_info;
     if (exc_info_given) {
         /* Temporarily set the thread state's exc_info since this is what

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -636,10 +636,6 @@ _PyErr_ChainStackItem(_PyErr_StackItem *exc_info)
         return;
     }
 
-    if (exc_info->exc_traceback) {
-        PyException_SetTraceback(exc_info->exc_value, exc_info->exc_traceback);
-    }
-
     _PyErr_StackItem *saved_exc_info;
     if (exc_info_given) {
         /* Temporarily set the thread state's exc_info since this is what


### PR DESCRIPTION
The handled exception exc_info (unlike the in-flight exception currexc) is always normalized. Except in asyncio, where unnormalised exceptions are saved in a StackItem and need to be normalized when they are used.

This PR brings asyncio in line with the rest of the code, by normalising exceptions and setting the traceback when they are Fetched.



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45711](https://bugs.python.org/issue45711) -->
https://bugs.python.org/issue45711
<!-- /issue-number -->
