### PR TITLE
bpo-40280: Enable assertions in Emscripten debug builds

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-12-02-13-17-57.bpo-40280.H4YNr5.rst
+++ b/Misc/NEWS.d/next/Build/2021-12-02-13-17-57.bpo-40280.H4YNr5.rst
@@ -1,0 +1,1 @@
+Emscripten now builds with assertions enabled in debug builds.

--- a/configure
+++ b/configure
@@ -7521,6 +7521,12 @@ then
 	case $ac_sys_system in
 	    SCO_SV*) OPT="$OPT -m486 -DSCO5"
 	    ;;
+      Emscripten)
+        if test "$Py_DEBUG" = 'true' ; then
+          # Compile with assertions in debug mode
+          OPT="$OPT -s ASSERTIONS=1"
+        fi
+      ;;
         esac
 	;;
 

--- a/configure.ac
+++ b/configure.ac
@@ -1734,6 +1734,12 @@ then
 	case $ac_sys_system in
 	    SCO_SV*) OPT="$OPT -m486 -DSCO5"
 	    ;;
+      Emscripten)
+        if test "$Py_DEBUG" = 'true' ; then
+          # Compile with assertions in debug mode
+          OPT="$OPT -s ASSERTIONS=1"
+        fi
+      ;;
         esac
 	;;
 


### PR DESCRIPTION
Setting is documented here: https://emscripten.org/docs/porting/Debugging.html#compiler-settings

> ASSERTIONS=1 is used to enable runtime checks for common memory allocation errors (e.g. writing more memory than was allocated). It also defines how Emscripten should handle errors in program flow. The value can be set to ASSERTIONS=2 in order to run additional tests.
> ASSERTIONS=1 is enabled by default. Assertions are turned off for optimized code (-O1 and above).

These are useful for catching things like OOMs and such.

<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
