### PR TITLE
bpo-45970: Fix fatal error along the failure path of Py_NewIntperter

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1987,10 +1987,10 @@ error:
 
     /* Oops, it didn't work.  Undo it all. */
     PyErr_PrintEx(0);
+    PyThreadState_Swap(save_tstate);
     PyThreadState_Clear(tstate);
     PyThreadState_Delete(tstate);
     PyInterpreterState_Delete(interp);
-    PyThreadState_Swap(save_tstate);
 
     return status;
 }


### PR DESCRIPTION
The saved thread state has to be swapped back in *before* deleting the new
thread state. Otherwise, it causes a fatal error about deleting the current
thread state.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45970](https://bugs.python.org/issue45970) -->
https://bugs.python.org/issue45970
<!-- /issue-number -->
