### PR TITLE
bpo-45756: do not execute `@property` descrs while creating mock autospecs

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -494,6 +494,10 @@ class NonCallableMock(Base):
         _spec_asyncs = []
 
         for attr in dir(spec):
+            if isinstance(inspect.getattr_static(spec, attr, None), property):
+                # We don't want to execute `@property` decorators with `getattr`.
+                # It might affect user's code in unknown way.
+                continue
             if iscoroutinefunction(getattr(spec, attr, None)):
                 _spec_asyncs.append(attr)
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -495,7 +495,7 @@ class NonCallableMock(Base):
 
         for attr in dir(spec):
             if isinstance(inspect.getattr_static(spec, attr, None), property):
-                # We don't want to execute `@property` decorators with `getattr`.
+                # Don't execute `property` decorators with `getattr`.
                 # It might affect user's code in unknown way.
                 continue
             if iscoroutinefunction(getattr(spec, attr, None)):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -896,6 +896,36 @@ class MockTest(unittest.TestCase):
         self.assertRaises(AttributeError, set_attr)
 
 
+    def test_class_with_property(self):
+        class X:
+            @property
+            def some(self):
+                raise ValueError('Should not be raised')
+
+        mock = Mock(spec=X)
+        self.assertIsInstance(mock, X)
+
+        mock = Mock(spec=X())
+        self.assertIsInstance(mock, X)
+
+
+    def test_class_with_settable_property(self):
+        class X:
+            @property
+            def some(self):
+                raise ValueError('Should not be raised')
+
+            @some.setter
+            def some(self, value):
+                raise TypeError('Should not be raised')
+
+        mock = Mock(spec=X)
+        self.assertIsInstance(mock, X)
+
+        mock = Mock(spec=X())
+        self.assertIsInstance(mock, X)
+
+
     def test_copy(self):
         current = sys.getrecursionlimit()
         self.addCleanup(sys.setrecursionlimit, current)

--- a/Misc/NEWS.d/next/Library/2021-12-03-11-19-44.bpo-45756.nSDJWj.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-03-11-19-44.bpo-45756.nSDJWj.rst
@@ -1,2 +1,2 @@
-We no longer execute ``@property`` descriptors while creating autospecs in
-``mock.py``. This was not safe and could affect user's code in unknown way.
+Do not execute ``@property`` descriptors while creating autospecs in :mod:`unittest.mock`. 
+This was not safe and could affect users' code in unknown way.

--- a/Misc/NEWS.d/next/Library/2021-12-03-11-19-44.bpo-45756.nSDJWj.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-03-11-19-44.bpo-45756.nSDJWj.rst
@@ -1,0 +1,2 @@
+We no longer execute ``@property`` descriptors while creating autospecs in
+``mock.py``. This was not safe and could affect user's code in unknown way.

--- a/Misc/NEWS.d/next/Library/2021-12-03-11-19-44.bpo-45756.nSDJWj.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-03-11-19-44.bpo-45756.nSDJWj.rst
@@ -1,2 +1,2 @@
-Do not execute ``@property`` descriptors while creating autospecs in :mod:`unittest.mock`. 
+Do not execute ``@property`` descriptors while creating autospecs in :mod:`unittest.mock`.
 This was not safe and could affect users' code in unknown way.


### PR DESCRIPTION
In this PR I am trying to solve this corner case with `inspect.getattr_static`, so atrtibutes won't be actually resolved.

I guess `@property` is special enough to skip it there.
Any other similar cases, that we would need to fix (probably in the upcoming PRs)?

<!-- issue-number: [bpo-45756](https://bugs.python.org/issue45756) -->
https://bugs.python.org/issue45756
<!-- /issue-number -->

Related: https://bugs.python.org/issue41768
