### PR TITLE
bpo-45582: Fix out-of-tree build issues with new getpath (GH-29902)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,6 @@ Mac/pythonw
 Misc/python.pc
 Misc/python-embed.pc
 Misc/python-config.sh
-Modules/getpath.h
 Modules/Setup.config
 Modules/Setup.local
 Modules/Setup.stdlib

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1062,10 +1062,9 @@ FROZEN_FILES_OUT = \
 Programs/_freeze_module.o: Programs/_freeze_module.c Makefile
 
 Modules/getpath_noop.o: $(srcdir)/Modules/getpath_noop.c Makefile
-	$(CC) -c $(PY_CORE_CFLAGS) -o $@ $(srcdir)/Modules/getpath_noop.c
 
-Programs/_freeze_module: Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN) Modules/getpath_noop.o
-	$(LINKCC) $(PY_CORE_LDFLAGS) -o $@ Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN) Modules/getpath_noop.o $(LIBS) $(MODLIBS) $(SYSLIBS)
+Programs/_freeze_module: Programs/_freeze_module.o Modules/getpath_noop.o $(LIBRARY_OBJS_OMIT_FROZEN)
+	$(LINKCC) $(PY_CORE_LDFLAGS) -o $@ Programs/_freeze_module.o Modules/getpath_noop.o $(LIBRARY_OBJS_OMIT_FROZEN) $(LIBS) $(MODLIBS) $(SYSLIBS)
 
 # BEGIN: freezing modules
 
@@ -1131,11 +1130,11 @@ Python/frozen_modules/frozen_only.h: $(FREEZE_MODULE) Tools/freeze/flag.py
 
 # END: freezing modules
 
-Tools/scripts/freeze_modules.py: $(FREEZE_MODULE)
-
 # We manually freeze getpath.py rather than through freeze_modules
-Modules/getpath.h: Programs/_freeze_module Modules/getpath.py
-	Programs/_freeze_module getpath $(srcdir)/Modules/getpath.py $(srcdir)/Modules/getpath.h
+Python/frozen_modules/getpath.h: $(FREEZE_MODULE) Modules/getpath.py
+	$(FREEZE_MODULE) getpath $(srcdir)/Modules/getpath.py Python/frozen_modules/getpath.h
+
+Tools/scripts/freeze_modules.py: $(FREEZE_MODULE)
 
 .PHONY: regen-frozen
 regen-frozen: Tools/scripts/freeze_modules.py $(FROZEN_FILES_IN)
@@ -1177,7 +1176,7 @@ Modules/getbuildinfo.o: $(PARSER_OBJS) \
 	      -DGITBRANCH="\"`LC_ALL=C $(GITBRANCH)`\"" \
 	      -o $@ $(srcdir)/Modules/getbuildinfo.c
 
-Modules/getpath.o: $(srcdir)/Modules/getpath.c Modules/getpath.h Makefile
+Modules/getpath.o: $(srcdir)/Modules/getpath.c Python/frozen_modules/getpath.h Makefile $(PYTHON_HEADERS)
 	$(CC) -c $(PY_CORE_CFLAGS) -DPYTHONPATH='"$(PYTHONPATH)"' \
 		-DPREFIX='"$(prefix)"' \
 		-DEXEC_PREFIX='"$(exec_prefix)"' \

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -19,7 +19,7 @@
 #endif
 
 /* Reference the precompiled getpath.py */
-#include "getpath.h"
+#include "../Python/frozen_modules/getpath.h"
 
 #if (!defined(PREFIX) || !defined(EXEC_PREFIX) \
         || !defined(VERSION) || !defined(VPATH) \

--- a/PCbuild/_freeze_module.vcxproj
+++ b/PCbuild/_freeze_module.vcxproj
@@ -379,7 +379,7 @@
     <GetPath Include="..\Modules\getpath.py">
       <ModName>getpath</ModName>
       <IntFile>$(IntDir)getpath.g.h</IntFile>
-      <OutFile>$(PySourcePath)Modules\getpath.h</OutFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\getpath.h</OutFile>
     </GetPath>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
* Create getpath.h in builddir tree instead of srcdir tree
* Move getpath.h to Python/frozen_modules so it gets removed on
 ``make clean`` and to make it more obvious that it is a frozen file.
* Add dependency on header files
* Remove target body from getpath_noop.o so it uses the ``.c.o:``
  template

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45582](https://bugs.python.org/issue45582) -->
https://bugs.python.org/issue45582
<!-- /issue-number -->
