### PR TITLE
bpo-45695: Test out-of-tree builds on GHA (GH-29904)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,13 +179,28 @@ jobs:
         echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
     - name: Configure ccache action
       uses: hendrikmuhs/ccache-action@v1
-    - name: Configure CPython
-      run: ./configure --with-pydebug --with-openssl=$OPENSSL_DIR
-    - name: Build CPython
+    - name: Setup directory envs for out-of-tree builds
+      run: |
+        echo "CPYTHON_RO_SRCDIR=$(realpath -m ${GITHUB_WORKSPACE}/../cpython-ro-srcdir)" >> $GITHUB_ENV
+        echo "CPYTHON_BUILDDIR=$(realpath -m ${GITHUB_WORKSPACE}/../cpython-builddir)" >> $GITHUB_ENV
+    - name: Create directories for read-only out-of-tree builds
+      run: mkdir -p $CPYTHON_RO_SRCDIR $CPYTHON_BUILDDIR
+    - name: Bind mount sources read-only
+      run: sudo mount --bind -o ro $GITHUB_WORKSPACE $CPYTHON_RO_SRCDIR
+    - name: Configure CPython out-of-tree
+      working-directory: ${{ env.CPYTHON_BUILDDIR }}
+      run: ../cpython-ro-srcdir/configure --with-pydebug --with-openssl=$OPENSSL_DIR
+    - name: Build CPython out-of-tree
+      working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: make -j4
     - name: Display build info
+      working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: make pythoninfo
+    - name: Remount sources writable for tests
+      # some tests write to srcdir, lack of pyc files slows down testing
+      run: sudo mount $CPYTHON_RO_SRCDIR -oremount,rw
     - name: Tests
+      working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: xvfb-run make buildbottest TESTOPTS="-j4 -uall,-cpu"
 
   build_ubuntu_ssltests:

--- a/Misc/NEWS.d/next/Tests/2021-12-03-14-19-16.bpo-45695.QKBn2E.rst
+++ b/Misc/NEWS.d/next/Tests/2021-12-03-14-19-16.bpo-45695.QKBn2E.rst
@@ -1,3 +1,1 @@
-The Ubuntu test runner now configures and compiles CPython out of tree. The
-source directory is a read-only bind mount to ensure that the build cannot
-create or modify any files in the source tree.
+Out-of-tree builds with a read-only source directory are now tested by CI.

--- a/Misc/NEWS.d/next/Tests/2021-12-03-14-19-16.bpo-45695.QKBn2E.rst
+++ b/Misc/NEWS.d/next/Tests/2021-12-03-14-19-16.bpo-45695.QKBn2E.rst
@@ -1,0 +1,3 @@
+The Ubuntu test runner now configures and compiles CPython out of tree. The
+source directory is a read-only bind mount to ensure that the build cannot
+create or modify any files in the source tree.


### PR DESCRIPTION
The Ubuntu test runner now configures and compiles CPython out of tree.
The source directory is a read-only bind mount to ensure that the build
cannot create or modify any files in the source tree.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45695](https://bugs.python.org/issue45695) -->
https://bugs.python.org/issue45695
<!-- /issue-number -->
