### PR TITLE
bpo-45976: Remove unhelpful locals in Random._randbelow()

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -237,11 +237,9 @@ class Random(_random.Random):
 
         if not n:
             return 0
-        getrandbits = self.getrandbits
         k = n.bit_length()  # don't use (n-1) here because n can be 1
-        r = getrandbits(k)  # 0 <= r < 2**k
-        while r >= n:
-            r = getrandbits(k)
+        while (r := self.getrandbits(k)) >= n:  # 0 <= r < 2**k
+            pass
         return r
 
     def _randbelow_without_getrandbits(self, n, maxsize=1<<BPF):
@@ -250,19 +248,17 @@ class Random(_random.Random):
         The implementation does not use getrandbits, but only random.
         """
 
-        random = self.random
         if n >= maxsize:
             _warn("Underlying random() generator does not supply \n"
                 "enough bits to choose from a population range this large.\n"
                 "To remove the range limitation, add a getrandbits() method.")
-            return _floor(random() * n)
+            return _floor(self.random() * n)
         if n == 0:
             return 0
         rem = maxsize % n
         limit = (maxsize - rem) / maxsize   # int(limit * maxsize) % n == 0
-        r = random()
-        while r >= limit:
-            r = random()
+        while (r := self.random()) >= limit:
+            pass
         return _floor(r * maxsize) % n
 
     _randbelow = _randbelow_with_getrandbits

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -238,8 +238,9 @@ class Random(_random.Random):
         if not n:
             return 0
         k = n.bit_length()  # don't use (n-1) here because n can be 1
-        while (r := self.getrandbits(k)) >= n:  # 0 <= r < 2**k
-            pass
+        r = self.getrandbits(k)  # 0 <= r < 2**k
+        while r >= n:
+            r = self.getrandbits(k)
         return r
 
     def _randbelow_without_getrandbits(self, n, maxsize=1<<BPF):
@@ -257,8 +258,9 @@ class Random(_random.Random):
             return 0
         rem = maxsize % n
         limit = (maxsize - rem) / maxsize   # int(limit * maxsize) % n == 0
-        while (r := self.random()) >= limit:
-            pass
+        r = self.random()
+        while r >= limit:
+            r = self.random()
         return _floor(r * maxsize) % n
 
     _randbelow = _randbelow_with_getrandbits


### PR DESCRIPTION
_randbelow_with_getrandbits() calls getrandbits() at most twice on average, so
the local reference never pays for itself.  Speeds up randrange(), shuffle(),
and sample().

_randbelow_without_getrandbits() gets a similar change for similar reasons.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45976](https://bugs.python.org/issue45976) -->
https://bugs.python.org/issue45976
<!-- /issue-number -->
