### PR TITLE
bpo-45711: Remove unnecessary normalization of exc_info

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-05-17-36-08.bpo-45711.3TmTSw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-05-17-36-08.bpo-45711.3TmTSw.rst
@@ -1,1 +1,1 @@
-:c:func:`_PyErr_ChainStackItem` no longer normalized ``exc_info`` (including setting the traceback on the exception instance) because ``exc_info`` is always normalized.
+:c:func:`_PyErr_ChainStackItem` no longer normalizes ``exc_info`` (including setting the traceback on the exception instance) because ``exc_info`` is always normalized.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-05-17-36-08.bpo-45711.3TmTSw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-05-17-36-08.bpo-45711.3TmTSw.rst
@@ -1,0 +1,1 @@
+:c:func:`_PyErr_ChainStackItem` no longer normalized ``exc_info`` (including setting the traceback on the exception instance) because ``exc_info`` is always normalized.

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -647,26 +647,6 @@ _PyErr_ChainStackItem(_PyErr_StackItem *exc_info)
     PyObject *typ, *val, *tb;
     _PyErr_Fetch(tstate, &typ, &val, &tb);
 
-    PyObject *typ2, *val2, *tb2;
-    typ2 = exc_info->exc_type;
-    val2 = exc_info->exc_value;
-    tb2 = exc_info->exc_traceback;
-#ifdef Py_DEBUG
-    PyObject *typ2_before = typ2;
-    PyObject *val2_before = val2;
-    PyObject *tb2_before = tb2;
-#endif
-    _PyErr_NormalizeException(tstate, &typ2, &val2, &tb2);
-#ifdef Py_DEBUG
-    /* exc_info should already be normalized */
-    assert(typ2 == typ2_before);
-    assert(val2 == val2_before);
-    assert(tb2 == tb2_before);
-#endif
-    if (tb2 != NULL) {
-        PyException_SetTraceback(val2, tb2);
-    }
-
     /* _PyErr_SetObject sets the context from PyThreadState. */
     _PyErr_SetObject(tstate, typ, val);
     Py_DECREF(typ);  // since _PyErr_Occurred was true


### PR DESCRIPTION
exc_info should always be normalized, so it is not necessary to normalize it here. 

It is also not necessary to copy the traceback to the exception instance. I added an assertion that the traceback does not change, and it broke only one test: test_exception_chaining_after_await_with_context_cycle

This is a test that raises the same exception twice, and makes sure that no context cycle is created.   The test is not concerned with the traceback at all. We discussed the issue of the traceback change in this test in PR29780.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45711](https://bugs.python.org/issue45711) -->
https://bugs.python.org/issue45711
<!-- /issue-number -->
