### PR TITLE
bpo-45582: Fix getpath_isxfile() and test_embed on Windows

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -575,7 +575,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         return configs
 
     def get_expected_config(self, expected_preconfig, expected,
-                            env, api, modify_path_cb=None):
+                            env, api, modify_path_cb=None, cwd=None):
         configs = self._get_expected_config()
 
         pre_config = configs['pre_config']
@@ -618,6 +618,14 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             expected['base_executable'] = default_executable
         if expected['program_name'] is self.GET_DEFAULT_CONFIG:
             expected['program_name'] = './_testembed'
+            if MS_WINDOWS:
+                # follow the calculation in getpath.py
+                tmpname = expected['program_name'] + '.exe'
+                if cwd:
+                    tmpname = os.path.join(cwd, tmpname)
+                if os.path.isfile(tmpname):
+                    expected['program_name'] += '.exe'
+                del tmpname
 
         config = configs['config']
         for key, value in expected.items():
@@ -711,7 +719,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         self.get_expected_config(expected_preconfig,
                                  expected_config,
                                  env,
-                                 api, modify_path_cb)
+                                 api, modify_path_cb, cwd)
 
         out, err = self.run_embedded_interpreter(testname,
                                                  env=env, cwd=cwd)

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -230,7 +230,7 @@ getpath_isxfile(PyObject *Py_UNUSED(self), PyObject *args)
         DWORD attr = GetFileAttributesW(path);
         r = (attr != INVALID_FILE_ATTRIBUTES) &&
             !(attr & FILE_ATTRIBUTE_DIRECTORY) &&
-            SUCCEEDED(PathCchFindExtension(path, cchPath, &ext)) &&
+            SUCCEEDED(PathCchFindExtension(path, cchPath + 1, &ext)) &&
             (CompareStringOrdinal(ext, -1, L".exe", -1, 1 /* ignore case */) == CSTR_EQUAL)
             ? Py_True : Py_False;
 #else


### PR DESCRIPTION
Current `getpath_isxfile()` in getpath.c always returns false.
After the function is fixed, `test_embed.py` needs a workaround to pass the following tests that have the same error in the release build. 
- test_init_pybuilddir_win32
- test_init_pyvenv_cfg
```
FAIL: test_init_pybuilddir_win32 (test.test_embed.InitConfigTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\cp\Lib\test\test_embed.py", line 1322, in test_init_pybuilddir_win32
    self.check_all_configs("test_init_compat_config", config,
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\cp\Lib\test\test_embed.py", line 728, in check_all_configs
    self.check_config(configs, expected_config)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\cp\Lib\test\test_embed.py", line 654, in check_config
    self.assertEqual(config, expected)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: {'_co[316 chars]embed.exe', ...
    ...
-  'program_name': './_testembed.exe',
?                               ----
+  'program_name': './_testembed',
    ...
```
The debug build passes them using the default `program_name`, and the PGO build does not due to another issue.

<!-- issue-number: [bpo-45582](https://bugs.python.org/issue45582) -->
https://bugs.python.org/issue45582
<!-- /issue-number -->
