### PR TITLE
bpo-45582: Change the folder location of PGO-instrumented builds on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2021-12-06-14-25-05.bpo-45582.sCqL7u.rst
+++ b/Misc/NEWS.d/next/Windows/2021-12-06-14-25-05.bpo-45582.sCqL7u.rst
@@ -1,0 +1,1 @@
+When PGO building on Windows, the folder of the instrumented binaries is now located directly under the PCbuild folder.

--- a/Misc/NEWS.d/next/Windows/2021-12-06-14-25-05.bpo-45582.sCqL7u.rst
+++ b/Misc/NEWS.d/next/Windows/2021-12-06-14-25-05.bpo-45582.sCqL7u.rst
@@ -1,1 +1,3 @@
-When PGO building on Windows, the folder of the instrumented binaries is now located directly under the PCbuild folder.
+When PGO building on Windows, the folder for the instrumented binaries is
+now located at the same level as that for the production builds.
+(e.g. `PCbuild/amd64/instrumented` to `PCbuild/amd64_instrumented`)

--- a/Misc/NEWS.d/next/Windows/2021-12-06-14-25-05.bpo-45582.sCqL7u.rst
+++ b/Misc/NEWS.d/next/Windows/2021-12-06-14-25-05.bpo-45582.sCqL7u.rst
@@ -1,3 +1,3 @@
 When PGO building on Windows, the folder for the instrumented binaries is
 now located at the same level as that for the production builds.
-(e.g. `PCbuild/amd64/instrumented` to `PCbuild/amd64_instrumented`)
+(e.g. ``PCbuild/amd64/instrumented`` to ``PCbuild/amd64_instrumented``)

--- a/Misc/NEWS.d/next/Windows/2021-12-06-14-25-05.bpo-45582.sCqL7u.rst
+++ b/Misc/NEWS.d/next/Windows/2021-12-06-14-25-05.bpo-45582.sCqL7u.rst
@@ -1,3 +1,5 @@
 When PGO building on Windows, the folder for the instrumented binaries is
 now located at the same level as that for the production builds.
 (e.g. ``PCbuild/amd64/instrumented`` to ``PCbuild/amd64_instrumented``)
+We need to follow ``VPATH``, which is used in new ``getpath.py`` and defined as
+``"..\\.."`` in ``pythoncore.vcxproj``, to calculate the correct prefix folder.

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -158,8 +158,8 @@ public override bool Execute() {
 
   <Target Name="CopyPGCFiles" BeforeTargets="PrepareForBuild" Condition="$(Configuration) == 'PGUpdate'">
     <ItemGroup>
-      <_PGCFiles Include="$(OutDir)instrumented\$(TargetName)!*.pgc" />
-      <_PGDFile Include="$(OutDir)instrumented\$(TargetName).pgd" />
+      <_PGCFiles Include="$(OutDir.TrimEnd('\'))_instrumented\$(TargetName)!*.pgc" />
+      <_PGDFile Include="$(OutDir.TrimEnd('\'))_instrumented\$(TargetName).pgd" />
       <_CopyFiles Include="@(_PGCFiles);@(_PGDFile)" Condition="Exists(%(FullPath))" />
     </ItemGroup>
     <Delete Files="@(_CopyFiles->'$(OutDir)%(Filename)%(Extension)')" />

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -51,7 +51,7 @@
     <BuildPath Condition="'$(ArchName)' == 'arm64'">$(BuildPathArm64)</BuildPath>
     <BuildPath Condition="'$(BuildPath)' == ''">$(PySourcePath)PCbuild\$(ArchName)\</BuildPath>
     <BuildPath Condition="!HasTrailingSlash($(BuildPath))">$(BuildPath)\</BuildPath>
-    <BuildPath Condition="$(Configuration) == 'PGInstrument'">$(BuildPath)instrumented\</BuildPath>
+    <BuildPath Condition="$(Configuration) == 'PGInstrument'">$(BuildPath.TrimEnd('\'))_instrumented\</BuildPath>
     
     <!-- Directories of external projects. tcltk is handled in tcltk.props -->
     <ExternalsDir>$(EXTERNALS_DIR)</ExternalsDir>


### PR DESCRIPTION
Current Python cannot find paths correctly at the PGO profiling time.
Even if envvars are set, test_embed fails.

This issue does not exist when the PGO-instrumented build is located as high as the product build in directory level.

<!-- issue-number: [bpo-45582](https://bugs.python.org/issue45582) -->
https://bugs.python.org/issue45582
<!-- /issue-number -->
