### PR TITLE
bpo-45582: framework build: modPath must not be const (GH-29944)

### DIFF
--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -756,7 +756,7 @@ library_to_dict(PyObject *dict, const char *key)
     }
 #elif defined(WITH_NEXT_FRAMEWORK) && !defined(PY_BOOTSTRAP_PYTHON)
     // _bootstrap_python does not use framework and crashes
-    static const char modPath[MAXPATHLEN + 1];
+    static char modPath[MAXPATHLEN + 1];
     static int modPathInitialized = -1;
     if (modPathInitialized < 0) {
         NSModule pythonModule;


### PR DESCRIPTION
modPath was marked as static const although the char array is modified
later in the function. Fixes a crash when building with
--enable-framework. Issue was found by Ronald.

Co-authored-by: Ronald Oussoren <ronaldoussoren@mac.com>
Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45582](https://bugs.python.org/issue45582) -->
https://bugs.python.org/issue45582
<!-- /issue-number -->
