### PR TITLE
gh-59170: Proxy `super().x = y` and `del super().x` (updated)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-06-22-56-19.bpo-14965.CcMLxs.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-06-22-56-19.bpo-14965.CcMLxs.rst
@@ -1,0 +1,3 @@
+Proxying data descriptor setters with ``super().x = y`` and deleters with ``del
+super().x`` will now follow getter use with ``super().x``. Previously, these
+would unconditionally fail. Patch by Daniel Urban.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8831,6 +8831,71 @@ super_getattro(PyObject *self, PyObject *name)
     return PyObject_GenericGetAttr(self, name);
 }
 
+static int
+super_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    superobject *su = (superobject *)self;
+    int skip = (su->obj_type == NULL);
+
+    if (!skip) {
+        /* We don't allow overwriting __class__. */
+        skip = (PyUnicode_Check(name) &&
+            PyUnicode_GET_LENGTH(name) == 9 &&
+            PyUnicode_CompareWithASCIIString(name, "__class__") == 0);
+    }
+
+    if (!skip) {
+        PyObject *mro, *descr, *tmp, *dict;
+        PyTypeObject *starttype;
+        descrsetfunc f;
+        Py_ssize_t i, n;
+        int done = 0, result = 0;
+
+        starttype = su->obj_type;
+        mro = starttype->tp_mro;
+
+        if (mro == NULL)
+            n = 0;
+        else {
+            assert(PyTuple_Check(mro));
+            n = PyTuple_GET_SIZE(mro);
+        }
+        for (i = 0; i < n; i++) {
+            if ((PyObject *)(su->type) == PyTuple_GET_ITEM(mro, i))
+                break;
+        }
+        i++;
+        descr = NULL;
+        /* keep a strong reference to mro because starttype->tp_mro can be
+           replaced during PyDict_GetItem(dict, name)  */
+        Py_INCREF(mro);
+        for (; i < n; i++) {
+            tmp = PyTuple_GET_ITEM(mro, i);
+            if (PyType_Check(tmp))
+                dict = ((PyTypeObject *)tmp)->tp_dict;
+            else
+                continue;
+            descr = PyDict_GetItem(dict, name);
+            if (descr != NULL) {
+                Py_INCREF(descr);
+                f = Py_TYPE(descr)->tp_descr_set;
+                if ((f != NULL) && PyDescr_IsData(descr)) {
+                    /* We found a data descriptor: */
+                    result = f(descr, su->obj, value);
+                    done = 1;
+                }
+                Py_DECREF(descr);
+                break;
+            }
+        }
+        Py_DECREF(mro);
+        if (done) {
+            return result;
+        }
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
 static PyTypeObject *
 supercheck(PyTypeObject *type, PyObject *obj)
 {
@@ -9082,7 +9147,7 @@ PyTypeObject PySuper_Type = {
     0,                                          /* tp_call */
     0,                                          /* tp_str */
     super_getattro,                             /* tp_getattro */
-    0,                                          /* tp_setattro */
+    super_setattro,                             /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,                    /* tp_flags */


### PR DESCRIPTION
I'm resubmitting #26194 with proper commit authorship, as the PR has gone stale and this seems to be the only thing blocking the PR from being merged.
Both the original submitter (@habnabit) and the patch author (@durban) have signed the CLA.
It is the opinion of the original submitter (@habnabit) that this PR should be backported, as it is arguably a bugfix. I do not disagree.

This patch was originally contributed by Daniel Urban, whose summary
follows:

> I'm attaching a patch implementing `super.__setattr__` (and
> `__delattr__`).

> The implementation in the patch only works, if super can find a data
> descriptor in the MRO, otherwise it throws an `AttributeError`. As it
> can be seen in the tests, in some cases this may result in
> counter-intuitive behaviour. But I wasn't able to find another
> behaviour, that is consistent with both `super.__getattr__` and normal
> `__setattr__` semantics.



<!-- issue-number: [bpo-14965](https://bugs.python.org/issue14965) -->
https://bugs.python.org/issue14965
<!-- /issue-number -->

<!-- gh-issue-number: gh-59170 -->
* Issue: gh-59170
<!-- /gh-issue-number -->
