### PR TITLE
bpo-45582: Fix framework path and bootstrap build

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -954,9 +954,9 @@ BOOTSTRAP_HEADERS = \
 
 Programs/_bootstrap_python.o: Programs/_bootstrap_python.c $(BOOTSTRAP_HEADERS) $(PYTHON_HEADERS)
 
-_bootstrap_python: $(LIBRARY_OBJS_OMIT_FROZEN) Programs/_bootstrap_python.o Modules/getpath_bootstrap.o Modules/Setup.local
+_bootstrap_python: $(LIBRARY_OBJS_OMIT_FROZEN) Programs/_bootstrap_python.o Modules/getpath.o Modules/Setup.local
 	$(LINKCC) $(PY_LDFLAGS_NOLTO) -o $@ $(LIBRARY_OBJS_OMIT_FROZEN) \
-		Programs/_bootstrap_python.o Modules/getpath_bootstrap.o $(LIBS) $(MODLIBS) $(SYSLIBS)
+		Programs/_bootstrap_python.o Modules/getpath.o $(LIBS) $(MODLIBS) $(SYSLIBS)
 
 ############################################################################
 # Deepfreeze targets
@@ -1204,18 +1204,6 @@ Modules/getpath.o: $(srcdir)/Modules/getpath.c Python/frozen_modules/getpath.h M
 		-DVPATH='"$(VPATH)"' \
 		-DPLATLIBDIR='"$(PLATLIBDIR)"' \
 		-o $@ $(srcdir)/Modules/getpath.c
-
-# like getpath.o with additional -DPY_BOOTSTRAP_PYTHON=1
-Modules/getpath_bootstrap.o: $(srcdir)/Modules/getpath.c Python/frozen_modules/getpath.h Makefile $(PYTHON_HEADERS)
-	$(CC) -c $(PY_CORE_CFLAGS) -DPYTHONPATH='"$(PYTHONPATH)"' \
-		-DPREFIX='"$(prefix)"' \
-		-DEXEC_PREFIX='"$(exec_prefix)"' \
-		-DVERSION='"$(VERSION)"' \
-		-DVPATH='"$(VPATH)"' \
-		-DPLATLIBDIR='"$(PLATLIBDIR)"' \
-		-DPY_BOOTSTRAP_PYTHON=1 \
-		-o $@ $(srcdir)/Modules/getpath.c
-
 
 Programs/python.o: $(srcdir)/Programs/python.c
 	$(MAINCC) -c $(PY_CORE_CFLAGS) -o $@ $(srcdir)/Programs/python.c

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -754,12 +754,10 @@ library_to_dict(PyObject *dict, const char *key)
     if (PyWin_DLLhModule) {
         return winmodule_to_dict(dict, key, PyWin_DLLhModule);
     }
-#elif defined(WITH_NEXT_FRAMEWORK) && !defined(PY_BOOTSTRAP_PYTHON)
-    // _bootstrap_python does not use framework and crashes
+#elif defined(WITH_NEXT_FRAMEWORK)
     static char modPath[MAXPATHLEN + 1];
     static int modPathInitialized = -1;
     if (modPathInitialized < 0) {
-        NSModule pythonModule;
         modPathInitialized = 0;
 
         /* On Mac OS X we have a special case if we're running from a framework.
@@ -767,12 +765,17 @@ library_to_dict(PyObject *dict, const char *key)
            which is in the framework, not relative to the executable, which may
            be outside of the framework. Except when we're in the build
            directory... */
-        pythonModule = NSModuleForSymbol(NSLookupAndBindSymbol("_Py_Initialize"));
-
-        /* Use dylib functions to find out where the framework was loaded from */
-        const char *path = NSLibraryNameForModule(pythonModule);
-        if (path) {
-            strncpy(modPath, path, MAXPATHLEN);
+        NSSymbol symbol = NSLookupAndBindSymbol("_Py_Initialize");
+        if (symbol != NULL) {
+            NSModule pythonModule = NSModuleForSymbol(symbol);
+            if (pythonModule != NULL) {
+                /* Use dylib functions to find out where the framework was loaded from */
+                const char *path = NSLibraryNameForModule(pythonModule);
+                if (path) {
+                    strncpy(modPath, path, MAXPATHLEN);
+                    modPathInitialized = 1;
+                }
+            }
         }
     }
     if (modPathInitialized > 0) {


### PR DESCRIPTION
* Check NS API return values for NULL to prevent segfault in
  ``_bootstrap_python``.
* Set modPathInitialized to 1 so the ``decode_to_dict`` path is used.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45582](https://bugs.python.org/issue45582) -->
https://bugs.python.org/issue45582
<!-- /issue-number -->
