### PR TITLE
bpo-46004: Fix error location for loops with invalid targets

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -234,6 +234,7 @@ class ExceptionTests(unittest.TestCase):
         check("ages = {'Alice'=22, 'Bob'=23}", 1, 16)
         check('match ...:\n    case {**rest, "key": value}:\n        ...', 2, 19)
         check("[a b c d e f]", 1, 2)
+        check("for x yfff:", 1, 7)
 
         # Errors thrown by compile.c
         check('class foo:return 1', 1, 11)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-07-11-24-24.bpo-46004.TTEU1p.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-07-11-24-24.bpo-46004.TTEU1p.rst
@@ -1,0 +1,2 @@
+Fix the :exc:`SyntaxError` location for errors involving for loops with
+invalid targets. Patch by Pablo Galindo

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -381,6 +381,7 @@ _PyPegen_expect_token(Parser *p, int type)
     }
     Token *t = p->tokens[p->mark];
     if (t->type != type) {
+        if (Py_DebugFlag) printf("Token = %s - Expected %d\n", PyBytes_AsString(t->bytes), type);
         return NULL;
     }
     p->mark += 1;

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -381,7 +381,6 @@ _PyPegen_expect_token(Parser *p, int type)
     }
     Token *t = p->tokens[p->mark];
     if (t->type != type) {
-        if (Py_DebugFlag) printf("Token = %s - Expected %d\n", PyBytes_AsString(t->bytes), type);
         return NULL;
     }
     p->mark += 1;

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -227,8 +227,9 @@ _RAISE_SYNTAX_ERROR_INVALID_TARGET(Parser *p, TARGETS_TYPE type, void *e)
             msg,
             _PyPegen_get_expr_name(invalid_target)
         );
+        return RAISE_SYNTAX_ERROR_KNOWN_LOCATION(invalid_target, "invalid syntax");
     }
-    return RAISE_SYNTAX_ERROR("invalid syntax");
+    return NULL;
 }
 
 // Action utility functions


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46004](https://bugs.python.org/issue46004) -->
https://bugs.python.org/issue46004
<!-- /issue-number -->
