### PR TITLE
bpo-35821: Fix restructuredtext code formatting in logging.rst

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -81,12 +81,12 @@ is the module's name in the Python package namespace.
       of ancestor loggers.
 
       Spelling it out with an example: If the propagate attribute of the logger named
-      `A.B.C` evaluates to true, any event logged to `A.B.C` via a method call such as
-      `logging.getLogger('A.B.C').error(...)` will [subject to passing that logger's
+      ``A.B.C`` evaluates to true, any event logged to ``A.B.C`` via a method call such as
+      ``logging.getLogger('A.B.C').error(...)`` will [subject to passing that logger's
       level and filter settings] be passed in turn to any handlers attached to loggers
-      named `A.B`, `A` and the root logger, after first being passed to any handlers
-      attached to `A.B.C`. If any logger in the chain `A.B.C`, `A.B`, `A` has its
-      `propagate` attribute set to false, then that is the last logger whose handlers
+      named ``A.B``, ``A`` and the root logger, after first being passed to any handlers
+      attached to ``A.B.C``. If any logger in the chain ``A.B.C``, ``A.B``, ``A`` has its
+      ``propagate`` attribute set to false, then that is the last logger whose handlers
       are offered the event to handle, and propagation stops at that point.
 
       The constructor sets this attribute to ``True``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-35821](https://bugs.python.org/issue35821) -->
https://bugs.python.org/issue35821
<!-- /issue-number -->
