### PR TITLE
bpo-46008: Return void from _PyEval_InitState().

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -17,7 +17,7 @@ struct _ceval_runtime_state;
 
 extern void _Py_FinishPendingCalls(PyThreadState *tstate);
 extern void _PyEval_InitRuntimeState(struct _ceval_runtime_state *);
-extern int _PyEval_InitState(struct _ceval_state *ceval);
+extern void _PyEval_InitState(struct _ceval_state *, PyThread_type_lock);
 extern void _PyEval_FiniState(struct _ceval_state *ceval);
 PyAPI_FUNC(void) _PyEval_SignalReceived(PyInterpreterState *interp);
 PyAPI_FUNC(int) _PyEval_AddPendingCall(

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -747,24 +747,19 @@ _PyEval_InitRuntimeState(struct _ceval_runtime_state *ceval)
 #endif
 }
 
-int
-_PyEval_InitState(struct _ceval_state *ceval)
+void
+_PyEval_InitState(struct _ceval_state *ceval, PyThread_type_lock pending_lock)
 {
     ceval->recursion_limit = Py_DEFAULT_RECURSION_LIMIT;
 
     struct _pending_calls *pending = &ceval->pending;
     assert(pending->lock == NULL);
 
-    pending->lock = PyThread_allocate_lock();
-    if (pending->lock == NULL) {
-        return -1;
-    }
+    pending->lock = pending_lock;
 
 #ifdef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
     _gil_initialize(&ceval->gil);
 #endif
-
-    return 0;
 }
 
 void

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -225,10 +225,12 @@ PyInterpreterState_New(void)
     _PyRuntimeState *runtime = &_PyRuntime;
     interp->runtime = runtime;
 
-    if (_PyEval_InitState(&interp->ceval) < 0) {
+    PyThread_type_lock pending_lock = PyThread_allocate_lock();
+    if (pending_lock == NULL) {
         goto out_of_memory;
     }
 
+    _PyEval_InitState(&interp->ceval, pending_lock);
     _PyGC_InitState(&interp->gc);
     PyConfig_InitPythonConfig(&interp->config);
     _PyType_InitCache(interp);


### PR DESCRIPTION
This falls into the category of keep-allocation-and-initialization separate.  It also allows us to use `_PyEval_InitState()` in functions that also return `void`.

<!-- issue-number: [bpo-46008](https://bugs.python.org/issue46008) -->
https://bugs.python.org/issue46008
<!-- /issue-number -->
