### PR TITLE
bpo-46008: Stop calling _PyThreadState_Init() in new_threadstate().

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -128,6 +128,9 @@ static inline PyInterpreterState* _PyInterpreterState_GET(void) {
 // PyThreadState functions
 
 PyAPI_FUNC(void) _PyThreadState_SetCurrent(PyThreadState *tstate);
+// We keep this around exclusively for stable ABI compatibility.
+PyAPI_FUNC(void) _PyThreadState_Init(
+    PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_DeleteExcept(
     _PyRuntimeState *runtime,
     PyThreadState *tstate);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -127,8 +127,7 @@ static inline PyInterpreterState* _PyInterpreterState_GET(void) {
 
 // PyThreadState functions
 
-PyAPI_FUNC(void) _PyThreadState_Init(
-    PyThreadState *tstate);
+PyAPI_FUNC(void) _PyThreadState_SetCurrent(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_DeleteExcept(
     _PyRuntimeState *runtime,
     PyThreadState *tstate);

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -6,7 +6,7 @@
 #include "pycore_interp.h"        // _PyInterpreterState.threads.count
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "pycore_pylifecycle.h"
-#include "pycore_pystate.h"       // _PyThreadState_Init()
+#include "pycore_pystate.h"       // _PyThreadState_SetCurrent()
 #include <stddef.h>               // offsetof()
 #include "structmember.h"         // PyMemberDef
 
@@ -1087,7 +1087,7 @@ thread_run(void *boot_raw)
 #else
     tstate->native_thread_id = 0;
 #endif
-    _PyThreadState_Init(tstate);
+    _PyThreadState_SetCurrent(tstate);
     PyEval_AcquireThread(tstate);
     tstate->interp->threads.count++;
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -631,7 +631,7 @@ allocate_chunk(int size_in_bytes, _PyStackChunk* previous)
 }
 
 static PyThreadState *
-new_threadstate(PyInterpreterState *interp, int init)
+new_threadstate(PyInterpreterState *interp)
 {
     _PyRuntimeState *runtime = interp->runtime;
     PyThreadState *tstate = (PyThreadState *)PyMem_RawCalloc(1, sizeof(PyThreadState));
@@ -662,10 +662,6 @@ new_threadstate(PyInterpreterState *interp, int init)
     tstate->datastack_top = &tstate->datastack_chunk->data[1];
     tstate->datastack_limit = (PyObject **)(((char *)tstate->datastack_chunk) + DATA_STACK_CHUNK_SIZE);
 
-    if (init) {
-        _PyThreadState_Init(tstate);
-    }
-
     HEAD_LOCK(runtime);
     tstate->id = ++interp->threads.next_unique_id;
     tstate->next = interp->threads.head;
@@ -680,17 +676,19 @@ new_threadstate(PyInterpreterState *interp, int init)
 PyThreadState *
 PyThreadState_New(PyInterpreterState *interp)
 {
-    return new_threadstate(interp, 1);
+    PyThreadState *tstate = new_threadstate(interp);
+    _PyThreadState_SetCurrent(tstate);
+    return tstate;
 }
 
 PyThreadState *
 _PyThreadState_Prealloc(PyInterpreterState *interp)
 {
-    return new_threadstate(interp, 0);
+    return new_threadstate(interp);
 }
 
 void
-_PyThreadState_Init(PyThreadState *tstate)
+_PyThreadState_SetCurrent(PyThreadState *tstate)
 {
     _PyGILState_NoteThreadState(&tstate->interp->runtime->gilstate, tstate);
 }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -687,6 +687,14 @@ _PyThreadState_Prealloc(PyInterpreterState *interp)
     return new_threadstate(interp);
 }
 
+// We keep this around for (accidental) stable ABI compatibility.
+// Realisically, no extensions are using it.
+void
+_PyThreadState_Init(PyThreadState *tstate)
+{
+    Py_FatalError("_PyThreadState_Init() is for internal use only");
+}
+
 void
 _PyThreadState_SetCurrent(PyThreadState *tstate)
 {


### PR DESCRIPTION
This simplifies `new_threadstate()`.

We also rename `_PyThreadState_Init()` to `_PyThreadState_SetCurrent()` to reflect what it actually does.

<!-- issue-number: [bpo-46008](https://bugs.python.org/issue46008) -->
https://bugs.python.org/issue46008
<!-- /issue-number -->
