### PR TITLE
bpo-46008: Move Py*State init into distinct functions.

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -77,6 +77,12 @@ struct _ts {
     struct _ts *next;
     PyInterpreterState *interp;
 
+    /* Has been initialized to a safe state.
+
+       In order to be effective, this must be set to 0 during or right
+       after allocation. */
+    int _initialized;
+
     int recursion_remaining;
     int recursion_limit;
     int recursion_headroom; /* Allow 50 more calls to handle any errors. */

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -262,6 +262,11 @@ struct _is {
     int requires_idref;
     PyThread_type_lock id_mutex;
 
+    /* Has been initialized to a safe state.
+
+       In order to be effective, this must be set to 0 during or right
+       after allocation. */
+    int _initialized;
     int finalizing;
 
     struct _ceval_state ceval;

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -240,7 +240,6 @@ struct _is {
     struct _is *next;
 
     struct pythreads {
-        int _preallocated_used;
         uint64_t next_unique_id;
         struct _ts *head;
         /* Used in Modules/_threadmodule.c. */

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -67,6 +67,12 @@ struct _Py_unicode_runtime_ids {
 /* Full Python runtime state */
 
 typedef struct pyruntimestate {
+    /* Has been initialized to a safe state.
+
+       In order to be effective, this must be set to 0 during or right
+       after allocation. */
+    int _initialized;
+
     /* Is running Py_PreInitialize()? */
     int preinitializing;
 
@@ -136,7 +142,9 @@ typedef struct pyruntimestate {
 } _PyRuntimeState;
 
 #define _PyRuntimeState_INIT \
-    {.preinitialized = 0, .core_initialized = 0, .initialized = 0}
+    { \
+        ._initialized = 0, \
+    }
 /* Note: _PyRuntimeState_INIT sets other fields to 0/NULL */
 
 

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -147,6 +147,13 @@ typedef struct pyruntimestate {
     }
 /* Note: _PyRuntimeState_INIT sets other fields to 0/NULL */
 
+static inline void
+_PyRuntimeState_reset(_PyRuntimeState *runtime)
+{
+    /* Make it match _PyRuntimeState_INIT. */
+    memset(runtime, 0, sizeof(*runtime));
+}
+
 
 PyAPI_DATA(_PyRuntimeState) _PyRuntime;
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -90,6 +90,11 @@ init_runtime(_PyRuntimeState *runtime,
              PyThread_type_lock interpreters_mutex,
              PyThread_type_lock xidregistry_mutex)
 {
+    if (runtime->_initialized) {
+        _PyRuntimeState_reset(runtime);
+        assert(!runtime->initialized);
+    }
+
     runtime->open_code_hook = open_code_hook;
     runtime->open_code_userdata = open_code_userdata;
     runtime->audit_hook_head = audit_hook_head;
@@ -133,8 +138,6 @@ _PyRuntimeState_Init(_PyRuntimeState *runtime)
     // bpo-42882: Preserve next_index value if Py_Initialize()/Py_Finalize()
     // is called multiple times.
     Py_ssize_t unicode_next_index = runtime->unicode_ids.next_index;
-
-    memset(runtime, 0, sizeof(*runtime));
 
     PyThread_type_lock lock1, lock2, lock3;
     if (alloc_for_runtime(&lock1, &lock2, &lock3) != 0) {


### PR DESCRIPTION
Currently basic initialization of `PyInterprterState` happens in `PyInterpreterState_New()` (along with allocation and adding the new interpreter to the runtime state).  This prevents us from initializing interpreter states that were allocated separately (e.g. statically or in a free list).  We address that here by factoring out a separate function just for initialization.  We do the same for `PyThreadState`.  `_PyRuntimeState` was sorted out when we added it since `_PyRuntime` is statically allocated.  However, in this PR we update the existing init code to line up with the functions for `PyInterpreterState` and `PyThreadState`.

(There should be zero change in behavior.)

<!-- issue-number: [bpo-46008](https://bugs.python.org/issue46008) -->
https://bugs.python.org/issue46008
<!-- /issue-number -->
