### PR TITLE
bpo-46008: Add _PyInterpreterState_Main().

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -24,8 +24,6 @@ _Py_IsMainThread(void)
 static inline PyInterpreterState *
 _PyInterpreterState_Main(void)
 {
-    /* Use directly _PyRuntime rather than tstate->interp->runtime, since
-       this function is used in performance critical code path (ceval) */
     return _PyRuntime.interpreters.main;
 }
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -21,19 +21,25 @@ _Py_IsMainThread(void)
 }
 
 
-static inline int
-_Py_IsMainInterpreter(PyInterpreterState *interp)
+static inline PyInterpreterState *
+_PyInterpreterState_Main(void)
 {
     /* Use directly _PyRuntime rather than tstate->interp->runtime, since
        this function is used in performance critical code path (ceval) */
-    return (interp == _PyRuntime.interpreters.main);
+    return _PyRuntime.interpreters.main;
+}
+
+static inline int
+_Py_IsMainInterpreter(PyInterpreterState *interp)
+{
+    return (interp == _PyInterpreterState_Main());
 }
 
 
 static inline const PyConfig *
 _Py_GetMainConfig(void)
 {
-    PyInterpreterState *interp = _PyRuntime.interpreters.main;
+    PyInterpreterState *interp = _PyInterpreterState_Main();
     if (interp == NULL) {
         return NULL;
     }
@@ -45,7 +51,7 @@ _Py_GetMainConfig(void)
 static inline int
 _Py_ThreadCanHandleSignals(PyInterpreterState *interp)
 {
-    return (_Py_IsMainThread() && interp == _PyRuntime.interpreters.main);
+    return (_Py_IsMainThread() && _Py_IsMainInterpreter(interp));
 }
 
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6696,7 +6696,7 @@ os_fork1_impl(PyObject *module)
 {
     pid_t pid;
 
-    if (_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
+    if (!_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
         PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
         return NULL;
     }
@@ -7348,7 +7348,7 @@ os_forkpty_impl(PyObject *module)
     int master_fd = -1;
     pid_t pid;
 
-    if (_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
+    if (!_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
         PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
         return NULL;
     }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6696,7 +6696,7 @@ os_fork1_impl(PyObject *module)
 {
     pid_t pid;
 
-    if (_PyInterpreterState_GET() != PyInterpreterState_Main()) {
+    if (_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
         PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
         return NULL;
     }
@@ -7348,7 +7348,7 @@ os_forkpty_impl(PyObject *module)
     int master_fd = -1;
     pid_t pid;
 
-    if (_PyInterpreterState_GET() != PyInterpreterState_Main()) {
+    if (_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
         PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
         return NULL;
     }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1953,7 +1953,7 @@ new_interpreter(PyThreadState **tstate_p, int isolated_subinterpreter)
 #endif
     {
         /* No current thread state, copy from the main interpreter */
-        PyInterpreterState *main_interp = PyInterpreterState_Main();
+        PyInterpreterState *main_interp = _PyInterpreterState_Main();
         config = _PyInterpreterState_GetConfig(main_interp);
     }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1204,7 +1204,7 @@ PyInterpreterState_Head(void)
 PyInterpreterState *
 PyInterpreterState_Main(void)
 {
-    return _PyRuntime.interpreters.main;
+    return _PyInterpreterState_Main();
 }
 
 PyInterpreterState *


### PR DESCRIPTION
`PyInterpreterState_Main()` is a plain function exposed in the public C-API.  For internal usage we can take the more efficient approach in this PR.

<!-- issue-number: [bpo-46008](https://bugs.python.org/issue46008) -->
https://bugs.python.org/issue46008
<!-- /issue-number -->
