### PR TITLE
bpo-45582: Write empty pybuilddir.txt on Windows to allow relocatable build directories

### DIFF
--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -449,6 +449,10 @@ if not home_was_set and real_executable_dir and not py_setpath:
             readlines(joinpath(real_executable_dir, BUILDDIR_TXT))[0],
         )
         build_prefix = joinpath(real_executable_dir, VPATH)
+    except IndexError:
+        # File exists but is empty
+        platstdlib_dir = real_executable_dir
+        build_prefix = joinpath(real_executable_dir, VPATH)
     except FileNotFoundError:
         if isfile(joinpath(real_executable_dir, BUILD_LANDMARK)):
             build_prefix = joinpath(real_executable_dir, VPATH)

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -73,7 +73,7 @@
       <LinkTimeCodeGeneration Condition="$(SupportPGO) and $(Configuration) == 'PGInstrument'">PGInstrument</LinkTimeCodeGeneration>
       <LinkTimeCodeGeneration Condition="$(SupportPGO) and $(Configuration) == 'PGUpdate'">PGUpdate</LinkTimeCodeGeneration>
       <AdditionalDependencies>advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalOptions Condition="$(Configuration) != 'Debug'">/OPT:REF,NOICF /CGTHREADS:1 /PDBTHREADS:1 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="$(Configuration) != 'Debug'">/OPT:REF,NOICF %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Lib>
       <LinkTimeCodeGeneration Condition="$(Configuration) == 'Release'">true</LinkTimeCodeGeneration>

--- a/PCbuild/python.vcxproj
+++ b/PCbuild/python.vcxproj
@@ -148,10 +148,6 @@ $(_PGOPath)
     <WriteLinesToFile File="$(PySourcePath)python.bat" Lines="$(_Content)" Overwrite="true" Condition="'$(_Content)' != '$(_ExistingContent)'" />
   </Target>
   <Target Name="GeneratePyBuildDirTxt" BeforeTargets="AfterBuild">
-    <PropertyGroup>
-      <_Content>$(OutDir)</_Content>
-      <_ExistingContent Condition="Exists('$(OutDir)pybuilddir.txt')">$([System.IO.File]::ReadAllText('$(OutDir)pybuilddir.txt'))</_ExistingContent>
-    </PropertyGroup>
-    <WriteLinesToFile File="$(OutDir)pybuilddir.txt" Lines="$(_Content)" Overwrite="true" Condition="'$(_Content)' != '$(_ExistingContent)'" />
+    <WriteLinesToFile File="$(OutDir)pybuilddir.txt" Lines="" Overwrite="true" />
   </Target>
 </Project>


### PR DESCRIPTION


<!-- issue-number: [bpo-45582](https://bugs.python.org/issue45582) -->
https://bugs.python.org/issue45582
<!-- /issue-number -->
