### PR TITLE
bpo-46007: Exclude PyUnicode_CHECK_INTERNED() from limited C API

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -715,6 +715,12 @@ Porting to Python 3.11
   been included directly, consider including ``Python.h`` instead.
   (Contributed by Victor Stinner in :issue:`35134`.)
 
+* The :c:func:`PyUnicode_CHECK_INTERNED` macro has been excluded from the
+  limited C API. It was never usable there, because it used internal structures
+  which are not available in the limited C API.
+  (Contributed by Victor Stinner in :issue:`46007`.)
+
+
 Deprecated
 ----------
 

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -279,6 +279,10 @@ PyAPI_FUNC(int) _PyUnicode_CheckConsistency(
 #define SSTATE_INTERNED_MORTAL 1
 #define SSTATE_INTERNED_IMMORTAL 2
 
+/* Use only if you know it's a string */
+#define PyUnicode_CHECK_INTERNED(op) \
+    (((PyASCIIObject *)(op))->state.interned)
+
 /* Return true if the string contains only ASCII characters, or 0 if not. The
    string may be compact (PyUnicode_IS_COMPACT_ASCII) or not, but must be
    ready. */

--- a/Include/unicodeobject.h
+++ b/Include/unicodeobject.h
@@ -269,10 +269,6 @@ PyAPI_FUNC(PyObject *) PyUnicode_InternFromString(
 // and will be removed in Python 3.12. Use PyUnicode_InternInPlace() instead.
 Py_DEPRECATED(3.10) PyAPI_FUNC(void) PyUnicode_InternImmortal(PyObject **);
 
-/* Use only if you know it's a string */
-#define PyUnicode_CHECK_INTERNED(op) \
-    (((PyASCIIObject *)(op))->state.interned)
-
 /* --- wchar_t support for platforms which support it --------------------- */
 
 #ifdef HAVE_WCHAR_H

--- a/Misc/NEWS.d/next/C API/2021-12-08-12-41-51.bpo-46007.sMgDLz.rst
+++ b/Misc/NEWS.d/next/C API/2021-12-08-12-41-51.bpo-46007.sMgDLz.rst
@@ -1,0 +1,3 @@
+The :c:func:`PyUnicode_CHECK_INTERNED` macro has been excluded from the limited
+C API. It was never usable there, because it used internal structures which are
+not available in the limited C API. Patch by Victor Stinner.


### PR DESCRIPTION
Exclude the PyUnicode_CHECK_INTERNED() macro from the limited C API,
because it uses the PyASCIIObject structure which is excluded from
the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46007](https://bugs.python.org/issue46007) -->
https://bugs.python.org/issue46007
<!-- /issue-number -->

Automerge-Triggered-By: GH:encukou