### PR TITLE
bpo-45813: Drop redundant assertion from frame.clear()

### DIFF
--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2191,12 +2191,19 @@ class CoroutineTest(unittest.TestCase):
             return 'end'
         self.assertEqual(run_async(run_gen()), ([], 'end'))
 
-    def test_bpo_45813(self):
+    def test_bpo_45813_1(self):
         'This would crash the interpreter in 3.11a2'
         async def f():
             pass
         frame = f().cr_frame
         frame.clear()
+
+    def test_bpo_45813_2(self):
+        'This would crash the interpreter in 3.11a2'
+        async def f():
+            pass
+        gen = f()
+        gen.cr_frame.clear()
 
 
 class CoroAsyncIOCompatTest(unittest.TestCase):

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2196,14 +2196,16 @@ class CoroutineTest(unittest.TestCase):
         async def f():
             pass
         frame = f().cr_frame
-        frame.clear()
+        with self.assertWarns(RuntimeWarning):
+            frame.clear()
 
     def test_bpo_45813_2(self):
         'This would crash the interpreter in 3.11a2'
         async def f():
             pass
         gen = f()
-        gen.cr_frame.clear()
+        with self.assertWarns(RuntimeWarning):
+            gen.cr_frame.clear()
 
 
 class CoroAsyncIOCompatTest(unittest.TestCase):

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2195,9 +2195,9 @@ class CoroutineTest(unittest.TestCase):
         'This would crash the interpreter in 3.11a2'
         async def f():
             pass
-        frame = f().cr_frame
         with self.assertWarns(RuntimeWarning):
-            frame.clear()
+            frame = f().cr_frame
+        frame.clear()
 
     def test_bpo_45813_2(self):
         'This would crash the interpreter in 3.11a2'

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -686,7 +686,6 @@ frame_clear(PyFrameObject *f, PyObject *Py_UNUSED(ignored))
     }
     if (f->f_frame->generator) {
         _PyGen_Finalize(f->f_frame->generator);
-        assert(f->f_frame->generator == NULL);
     }
     (void)frame_tp_clear(f);
     Py_RETURN_NONE;

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -613,6 +613,10 @@ static PyGetSetDef frame_getsetlist[] = {
 static void
 frame_dealloc(PyFrameObject *f)
 {
+    /* It is the responsibility of the owning generator/coroutine
+     * to have cleared the generator pointer */
+    assert(f->f_frame->generator == NULL);
+
     if (_PyObject_GC_IS_TRACKED(f)) {
         _PyObject_GC_UNTRACK(f);
     }


### PR DESCRIPTION
#29700 fixes one crash scenario.

This PR fixes a case when the generator is held by external reference, not the generator's frame object.

A separate NEWs entry is not required, #29700 already provides a good enough description.

<!-- issue-number: [bpo-45813](https://bugs.python.org/issue45813) -->
https://bugs.python.org/issue45813
<!-- /issue-number -->
