### PR TITLE
bpo-46016: fcntl module add FreeBSD's F_DUP2FD_CLOEXEC flag support.

### DIFF
--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -44,6 +44,11 @@ descriptor.
    ``F_SETPIPE_SZ`` constants, which allow to check and modify a pipe's size
    respectively.
 
+.. versionchanged:: 3.11
+   On FreeBSD, the fcntl module exposes the ``F_DUP2FD`` and ``F_DUP2FD_CLOEXEC``
+   constants, which allow to duplicate a file descriptor, the latter setting
+   ``FD_CLOEXEC`` flag in addition.
+
 The module defines the following functions:
 
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -329,6 +329,14 @@ unicodedata
 * The Unicode database has been updated to version 14.0.0. (:issue:`45190`).
 
 
+fcntl
+-----
+
+* On FreeBSD, the `F_DUP2FD` and `F_DUP2FD_CLOEXEC` flags respectively
+  are supported, the former equals to ``dup2`` usage while the latter set
+  the ``FD_CLOEXEC`` flag in addition.
+
+
 Optimizations
 =============
 

--- a/Misc/NEWS.d/next/Library/2021-12-08-19-15-03.bpo-46016.s9PuyF.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-08-19-15-03.bpo-46016.s9PuyF.rst
@@ -1,0 +1,1 @@
+Adding `F_DUP2FD` and `F_DUP2FD_CLOEXEC` constants from FreeBSD into the fcntl module.

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -581,6 +581,11 @@ all_ins(PyObject* m)
     if (PyModule_AddIntMacro(m, F_NOCACHE)) return -1;
 #endif
 
+/* FreeBSD specifics */
+#ifdef F_DUP2FD_CLOEXEC
+    if (PyModule_AddIntMacro(m, F_DUP2FD_CLOEXEC)) return -1;
+#endif
+
 /* For F_{GET|SET}FL */
 #ifdef FD_CLOEXEC
     if (PyModule_AddIntMacro(m, FD_CLOEXEC)) return -1;

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -582,6 +582,9 @@ all_ins(PyObject* m)
 #endif
 
 /* FreeBSD specifics */
+#ifdef F_DUP2FD
+    if (PyModule_AddIntMacro(m, F_DUP2FD)) return -1;
+#endif
 #ifdef F_DUP2FD_CLOEXEC
     if (PyModule_AddIntMacro(m, F_DUP2FD_CLOEXEC)) return -1;
 #endif


### PR DESCRIPTION


<!-- issue-number: [bpo-46016](https://bugs.python.org/issue46016) -->
https://bugs.python.org/issue46016
<!-- /issue-number -->
