### PR TITLE
bpo-45510: Check both types when specializing subtraction

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1490,6 +1490,10 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
             break;
         case NB_SUBTRACT:
         case NB_INPLACE_SUBTRACT:
+            if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
+                SPECIALIZATION_FAIL(BINARY_OP, SPEC_FAIL_DIFFERENT_TYPES);
+                goto failure;
+            }
             if (PyLong_CheckExact(lhs)) {
                 *instr = _Py_MAKECODEUNIT(BINARY_OP_SUBTRACT_INT,
                                           _Py_OPARG(*instr));


### PR DESCRIPTION
The current specialization code for `-` and `-=` is missing a type check for the RHS. This causes the VM to waste time repeatedly optimizing and deoptimizing things like `42 + 42.0` and `42.0 + 42`, for instance.

<!-- issue-number: [bpo-45510](https://bugs.python.org/issue45510) -->
https://bugs.python.org/issue45510
<!-- /issue-number -->
