### PR TITLE
bpo-46018: Ensure that math.expm1 does not raise on underflow

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-12-09-00-44-42.bpo-46018.hkTI7v.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-09-00-44-42.bpo-46018.hkTI7v.rst
@@ -1,0 +1,1 @@
+Ensure that :func:`math.expm1` does not raise on underflow.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46018](https://bugs.python.org/issue46018) -->
https://bugs.python.org/issue46018
<!-- /issue-number -->
