### PR TITLE
bpo-46025: Fix a crash in the atexit module for auto-unregistering functions

### DIFF
--- a/Lib/test/_test_atexit.py
+++ b/Lib/test/_test_atexit.py
@@ -123,7 +123,11 @@ class GeneralTest(unittest.TestCase):
             1/0
         atexit.register(func)
         try:
-            atexit._run_exitfuncs()
+            with support.catch_unraisable_exception() as cm:
+                atexit._run_exitfuncs()
+                self.assertEqual(cm.unraisable.object, func)
+                self.assertEqual(cm.unraisable.exc_type, ZeroDivisionError)
+                self.assertEqual(type(cm.unraisable.exc_value), ZeroDivisionError)
         finally:
             atexit.unregister(func)
 

--- a/Lib/test/_test_atexit.py
+++ b/Lib/test/_test_atexit.py
@@ -116,6 +116,17 @@ class GeneralTest(unittest.TestCase):
         atexit._run_exitfuncs()
         self.assertEqual(l, [5])
 
+    def test_atexit_with_unregistered_function(self):
+        # See bpo-46025 for more info
+        def func():
+            atexit.unregister(func)
+            1/0
+        atexit.register(func)
+        try:
+            atexit._run_exitfuncs()
+        finally:
+            atexit.unregister(func)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-09-11-41-35.bpo-46025.pkEvW9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-09-11-41-35.bpo-46025.pkEvW9.rst
@@ -1,0 +1,2 @@
+Fix a crash in the :mod:`atexit` module involving functions that unregister
+themselves before raising exceptions. Patch by Pablo Galindo.

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -94,8 +94,7 @@ atexit_callfuncs(struct atexit_state *state)
         }
 
         // bpo-46025: Increment the refcount of cb->func as the call itself may unregister it
-        PyObject* the_func = cb->func;
-        Py_INCREF(the_func);
+        PyObject* the_func = Py_NewRef(cb->func);
         PyObject *res = PyObject_Call(cb->func, cb->args, cb->kwargs);
         if (res == NULL) {
             _PyErr_WriteUnraisableMsg("in atexit callback", the_func);

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -93,13 +93,17 @@ atexit_callfuncs(struct atexit_state *state)
             continue;
         }
 
+        // Increment the refcount of cb->func as the call itself may unregister it
+        PyObject* the_func = cb->func;
+        Py_INCREF(the_func);
         PyObject *res = PyObject_Call(cb->func, cb->args, cb->kwargs);
         if (res == NULL) {
-            _PyErr_WriteUnraisableMsg("in atexit callback", cb->func);
+            _PyErr_WriteUnraisableMsg("in atexit callback", the_func);
         }
         else {
             Py_DECREF(res);
         }
+        Py_DECREF(the_func);
     }
 
     atexit_cleanup(state);

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -93,7 +93,7 @@ atexit_callfuncs(struct atexit_state *state)
             continue;
         }
 
-        // Increment the refcount of cb->func as the call itself may unregister it
+        // bpo-46025: Increment the refcount of cb->func as the call itself may unregister it
         PyObject* the_func = cb->func;
         Py_INCREF(the_func);
         PyObject *res = PyObject_Call(cb->func, cb->args, cb->kwargs);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46025](https://bugs.python.org/issue46025) -->
https://bugs.python.org/issue46025
<!-- /issue-number -->
