### PR TITLE
gh-87109: singledispatchmethod exposes registry and dispatch

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -213,6 +213,13 @@ fractions
   (Contributed by Mark Dickinson in :issue:`44547`.)
 
 
+functools
+---------
+
+* :class:`functools.singledispatchmethod` exposes members 'registry' and
+  'dispatch'. (Contributed by Weipeng Hong in :issue:`42943`.)
+
+
 inspect
 -------
 * Add :func:`inspect.getmembers_static`: return all members without

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -916,6 +916,8 @@ class singledispatchmethod:
 
         _method.__isabstractmethod__ = self.__isabstractmethod__
         _method.register = self.register
+        _method.dispatch = self.dispatcher.dispatch
+        _method.registry = self.dispatcher.registry
         update_wrapper(_method, self.func)
         return _method
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2371,6 +2371,13 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(a.arg, "base")
         aa = A()
         self.assertFalse(hasattr(aa, 'arg'))
+        def fun(self, arg):
+            pass
+        A.t.register(list, fun)
+        self.assertIs(fun, A.t.dispatch(list))
+        self.assertIs(fun, A().t.dispatch(list))
+        self.assertIs(fun, A.t.registry[list])
+        self.assertIs(fun, A().t.registry[list])
 
     def test_staticmethod_register(self):
         class A:

--- a/Misc/NEWS.d/next/Library/2021-12-09-23-00-06.bpo-42943.fVg5Bz.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-09-23-00-06.bpo-42943.fVg5Bz.rst
@@ -1,0 +1,2 @@
+The :class:`functools.singledispatchmethod` exposes members 'registry' and
+'dispatch'. Patch by Weipeng Hong.


### PR DESCRIPTION
Because `singledispatch` exposes members `registry` and `dispatch` , `singledispatchmethod` can also do the same.

<!-- issue-number: [bpo-42943](https://bugs.python.org/issue42943) -->
https://bugs.python.org/issue42943
<!-- /issue-number -->

<!-- gh-issue-number: gh-87109 -->
* Issue: gh-87109
<!-- /gh-issue-number -->
