### PR TITLE
bpo-46016: GHA Doc job now also runs "make check"

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -38,8 +38,15 @@ jobs:
       run: make -j4
     - name: 'Install build dependencies'
       run: make -C Doc/ PYTHON=../python venv
-    - name: 'Build documentation'
-      run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going -j4" doctest html
+    # Run "check doctest html" as 3 steps to get a more readable output
+    # in the web UI
+    - name: 'Check documentation'
+      run: make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going -j4" check
+    # Use "xvfb-run" since some doctest tests open GUI windows
+    - name: 'Run documentation doctest'
+      run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going -j4" doctest
+    - name: 'Build HTML documentation'
+      run: make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going -j4" html
     - name: 'Upload'
       uses: actions/upload-artifact@v2.2.4
       with:


### PR DESCRIPTION
The GitHub Action documentation job now also runs "make check" to
check the documentation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46016](https://bugs.python.org/issue46016) -->
https://bugs.python.org/issue46016
<!-- /issue-number -->
