### PR TITLE
bpo-37971: fix the position of decorator application

### DIFF
--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -205,9 +205,9 @@ class TestLineCounts(unittest.TestCase):
             (self.my_py_filename, firstlineno + 4): 1,
             (self.my_py_filename, firstlineno + 5): 1,
             (self.my_py_filename, firstlineno + 6): 1,
-            (self.my_py_filename, firstlineno + 7): 1,
-            (self.my_py_filename, firstlineno + 8): 1,
-            (self.my_py_filename, firstlineno + 9): 1,
+            (self.my_py_filename, firstlineno + 7): 2,
+            (self.my_py_filename, firstlineno + 8): 2,
+            (self.my_py_filename, firstlineno + 9): 2,
             (self.my_py_filename, firstlineno + 10): 1,
             (self.my_py_filename, firstlineno + 11): 1,
         }

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-10-13-42-17.bpo-37971.6BC1Tx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-10-13-42-17.bpo-37971.6BC1Tx.rst
@@ -1,10 +1,3 @@
 Fix a bug where the line numbers given in a traceback when a decorator
 application raised an exception were wrong.
 
-#.. section: Library #.. section: Documentation #.. section: Tests #..
-section: Build #.. section: Windows #.. section: macOS #.. section: IDLE #..
-section: Tools/Demos #.. section: C API
-
-# Write your Misc/NEWS entry below.  It should be a simple ReST paragraph. #
-Don't start with "- Issue #<n>: " or "- bpo-<n>: " or that sort of stuff.
-###########################################################################

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-10-13-42-17.bpo-37971.6BC1Tx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-10-13-42-17.bpo-37971.6BC1Tx.rst
@@ -1,0 +1,10 @@
+Fix a bug where the line numbers given in a traceback when a decorator
+application raised an exception were wrong.
+
+#.. section: Library #.. section: Documentation #.. section: Tests #..
+section: Build #.. section: Windows #.. section: macOS #.. section: IDLE #..
+section: Tools/Demos #.. section: C API
+
+# Write your Misc/NEWS entry below.  It should be a simple ReST paragraph. #
+Don't start with "- Issue #<n>: " or "- bpo-<n>: " or that sort of stuff.
+###########################################################################

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2133,6 +2133,27 @@ compiler_decorators(struct compiler *c, asdl_expr_seq* decos)
 }
 
 static int
+compiler_apply_decorators(struct compiler *c, asdl_expr_seq* decos)
+{
+    if (!decos)
+        return 1;
+
+    int old_lineno = c->u->u_lineno;
+    int old_end_lineno = c->u->u_end_lineno;
+    int old_col_offset = c->u->u_col_offset;
+    int old_end_col_offset = c->u->u_end_col_offset;
+    for (int i = asdl_seq_LEN(decos) - 1; i > -1; i--) {
+        SET_LOC(c, (expr_ty)asdl_seq_GET(decos, i));
+        ADDOP_I(c, CALL_FUNCTION, 1);
+    }
+    c->u->u_lineno = old_lineno;
+    c->u->u_end_lineno = old_end_lineno;
+    c->u->u_col_offset = old_col_offset;
+    c->u->u_end_col_offset = old_end_col_offset;
+    return 1;
+}
+
+static int
 compiler_visit_kwonlydefaults(struct compiler *c, asdl_arg_seq *kwonlyargs,
                               asdl_expr_seq *kw_defaults)
 {
@@ -2462,11 +2483,8 @@ compiler_function(struct compiler *c, stmt_ty s, int is_async)
     Py_DECREF(qualname);
     Py_DECREF(co);
 
-    /* decorators */
-    for (i = 0; i < asdl_seq_LEN(decos); i++) {
-        ADDOP_I(c, CALL_FUNCTION, 1);
-    }
-
+    if (!compiler_apply_decorators(c, decos))
+        return 0;
     return compiler_nameop(c, name, Store);
 }
 
@@ -2597,9 +2615,8 @@ compiler_class(struct compiler *c, stmt_ty s)
         return 0;
 
     /* 6. apply decorators */
-    for (i = 0; i < asdl_seq_LEN(decos); i++) {
-        ADDOP_I(c, CALL_FUNCTION, 1);
-    }
+    if (!compiler_apply_decorators(c, decos))
+        return 0;
 
     /* 7. store into <name> */
     if (!compiler_nameop(c, s->v.ClassDef.name, Store))

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2142,7 +2142,7 @@ compiler_apply_decorators(struct compiler *c, asdl_expr_seq* decos)
     int old_end_lineno = c->u->u_end_lineno;
     int old_col_offset = c->u->u_col_offset;
     int old_end_col_offset = c->u->u_end_col_offset;
-    for (int i = asdl_seq_LEN(decos) - 1; i > -1; i--) {
+    for (Py_ssize_t i = asdl_seq_LEN(decos) - 1; i > -1; i--) {
         SET_LOC(c, (expr_ty)asdl_seq_GET(decos, i));
         ADDOP_I(c, CALL_FUNCTION, 1);
     }


### PR DESCRIPTION
the line numbers of actually calling the decorator functions of
functions and classes was wrong (as opposed to loading them, were they
have been correct previously too).

I am unsure whether this would require a magic change or not. In theory it changes the pyc files, but I don't know what CPython's policy is when to change magic (it doesn't break any behavior, only position info is fixed).

<!-- issue-number: [bpo-37971](https://bugs.python.org/issue37971) -->
https://bugs.python.org/issue37971
<!-- /issue-number -->
