### PR TITLE
bpo-45653: Freeze parts of the encodings package

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -486,6 +486,10 @@ DEEPFREEZE_OBJS = \
 		Python/deepfreeze/zipimport.o \
 		Python/deepfreeze/abc.o \
 		Python/deepfreeze/codecs.o \
+		Python/deepfreeze/encodings.o \
+		Python/deepfreeze/encodings.aliases.o \
+		Python/deepfreeze/encodings.ascii.o \
+		Python/deepfreeze/encodings.utf_8.o \
 		Python/deepfreeze/io.o \
 		Python/deepfreeze/_collections_abc.o \
 		Python/deepfreeze/_sitebuiltins.o \
@@ -1008,6 +1012,18 @@ Python/deepfreeze/abc.c: Python/frozen_modules/abc.h $(DEEPFREEZE_DEPS)
 Python/deepfreeze/codecs.c: Python/frozen_modules/codecs.h $(DEEPFREEZE_DEPS)
 	$(PYTHON_FOR_FREEZE) $(srcdir)/Tools/scripts/deepfreeze.py Python/frozen_modules/codecs.h -m codecs -o Python/deepfreeze/codecs.c
 
+Python/deepfreeze/encodings.c: Python/frozen_modules/encodings.h $(DEEPFREEZE_DEPS)
+	$(PYTHON_FOR_FREEZE) $(srcdir)/Tools/scripts/deepfreeze.py Python/frozen_modules/encodings.h -m encodings -o Python/deepfreeze/encodings.c
+
+Python/deepfreeze/encodings.aliases.c: Python/frozen_modules/encodings.aliases.h $(DEEPFREEZE_DEPS)
+	$(PYTHON_FOR_FREEZE) $(srcdir)/Tools/scripts/deepfreeze.py Python/frozen_modules/encodings.aliases.h -m encodings.aliases -o Python/deepfreeze/encodings.aliases.c
+
+Python/deepfreeze/encodings.ascii.c: Python/frozen_modules/encodings.ascii.h $(DEEPFREEZE_DEPS)
+	$(PYTHON_FOR_FREEZE) $(srcdir)/Tools/scripts/deepfreeze.py Python/frozen_modules/encodings.ascii.h -m encodings.ascii -o Python/deepfreeze/encodings.ascii.c
+
+Python/deepfreeze/encodings.utf_8.c: Python/frozen_modules/encodings.utf_8.h $(DEEPFREEZE_DEPS)
+	$(PYTHON_FOR_FREEZE) $(srcdir)/Tools/scripts/deepfreeze.py Python/frozen_modules/encodings.utf_8.h -m encodings.utf_8 -o Python/deepfreeze/encodings.utf_8.c
+
 Python/deepfreeze/io.c: Python/frozen_modules/io.h $(DEEPFREEZE_DEPS)
 	$(PYTHON_FOR_FREEZE) $(srcdir)/Tools/scripts/deepfreeze.py Python/frozen_modules/io.h -m io -o Python/deepfreeze/io.c
 
@@ -1098,6 +1114,10 @@ FROZEN_FILES_IN = \
 		Lib/zipimport.py \
 		Lib/abc.py \
 		Lib/codecs.py \
+		Lib/encodings/__init__.py \
+		Lib/encodings/aliases.py \
+		Lib/encodings/ascii.py \
+		Lib/encodings/utf_8.py \
 		Lib/io.py \
 		Lib/_collections_abc.py \
 		Lib/_sitebuiltins.py \
@@ -1123,6 +1143,10 @@ FROZEN_FILES_OUT = \
 		Python/frozen_modules/zipimport.h \
 		Python/frozen_modules/abc.h \
 		Python/frozen_modules/codecs.h \
+		Python/frozen_modules/encodings.h \
+		Python/frozen_modules/encodings.aliases.h \
+		Python/frozen_modules/encodings.ascii.h \
+		Python/frozen_modules/encodings.utf_8.h \
 		Python/frozen_modules/io.h \
 		Python/frozen_modules/_collections_abc.h \
 		Python/frozen_modules/_sitebuiltins.h \
@@ -1170,6 +1194,18 @@ Python/frozen_modules/abc.h: Lib/abc.py $(FREEZE_MODULE_DEPS)
 
 Python/frozen_modules/codecs.h: Lib/codecs.py $(FREEZE_MODULE_DEPS)
 	$(FREEZE_MODULE) codecs $(srcdir)/Lib/codecs.py Python/frozen_modules/codecs.h
+
+Python/frozen_modules/encodings.h: Lib/encodings/__init__.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings $(srcdir)/Lib/encodings/__init__.py Python/frozen_modules/encodings.h
+
+Python/frozen_modules/encodings.aliases.h: Lib/encodings/aliases.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.aliases $(srcdir)/Lib/encodings/aliases.py Python/frozen_modules/encodings.aliases.h
+
+Python/frozen_modules/encodings.ascii.h: Lib/encodings/ascii.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.ascii $(srcdir)/Lib/encodings/ascii.py Python/frozen_modules/encodings.ascii.h
+
+Python/frozen_modules/encodings.utf_8.h: Lib/encodings/utf_8.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.utf_8 $(srcdir)/Lib/encodings/utf_8.py Python/frozen_modules/encodings.utf_8.h
 
 Python/frozen_modules/io.h: Lib/io.py $(FREEZE_MODULE_DEPS)
 	$(FREEZE_MODULE) io $(srcdir)/Lib/io.py Python/frozen_modules/io.h

--- a/Misc/NEWS.d/next/Build/2021-12-10-16-06-13.bpo-45653.FQo2rA.rst
+++ b/Misc/NEWS.d/next/Build/2021-12-10-16-06-13.bpo-45653.FQo2rA.rst
@@ -1,0 +1,1 @@
+Parts of the :mod:`encodings` package is now frozen.

--- a/PCbuild/_freeze_module.vcxproj
+++ b/PCbuild/_freeze_module.vcxproj
@@ -272,6 +272,34 @@
       <DeepIntFile>$(IntDir)codecs.g.c</DeepIntFile>
       <DeepOutFile>$(PySourcePath)Python\deepfreeze\df.codecs.c</DeepOutFile>
     </None>
+    <None Include="..\Lib\encodings\__init__.py">
+      <ModName>encodings</ModName>
+      <IntFile>$(IntDir)encodings.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.h</OutFile>
+      <DeepIntFile>$(IntDir)encodings.g.c</DeepIntFile>
+      <DeepOutFile>$(PySourcePath)Python\deepfreeze\df.encodings.c</DeepOutFile>
+    </None>
+    <None Include="..\Lib\encodings\aliases.py">
+      <ModName>encodings.aliases</ModName>
+      <IntFile>$(IntDir)encodings.aliases.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.aliases.h</OutFile>
+      <DeepIntFile>$(IntDir)encodings.aliases.g.c</DeepIntFile>
+      <DeepOutFile>$(PySourcePath)Python\deepfreeze\df.encodings.aliases.c</DeepOutFile>
+    </None>
+    <None Include="..\Lib\encodings\ascii.py">
+      <ModName>encodings.ascii</ModName>
+      <IntFile>$(IntDir)encodings.ascii.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.ascii.h</OutFile>
+      <DeepIntFile>$(IntDir)encodings.ascii.g.c</DeepIntFile>
+      <DeepOutFile>$(PySourcePath)Python\deepfreeze\df.encodings.ascii.c</DeepOutFile>
+    </None>
+    <None Include="..\Lib\encodings\utf_8.py">
+      <ModName>encodings.utf_8</ModName>
+      <IntFile>$(IntDir)encodings.utf_8.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.utf_8.h</OutFile>
+      <DeepIntFile>$(IntDir)encodings.utf_8.g.c</DeepIntFile>
+      <DeepOutFile>$(PySourcePath)Python\deepfreeze\df.encodings.utf_8.c</DeepOutFile>
+    </None>
     <None Include="..\Lib\io.py">
       <ModName>io</ModName>
       <IntFile>$(IntDir)io.g.h</IntFile>

--- a/PCbuild/_freeze_module.vcxproj.filters
+++ b/PCbuild/_freeze_module.vcxproj.filters
@@ -420,6 +420,18 @@
     <None Include="..\Lib\codecs.py">
       <Filter>Python Files</Filter>
     </None>
+    <None Include="..\Lib\encodings\__init__.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\aliases.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\ascii.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\utf_8.py">
+      <Filter>Python Files</Filter>
+    </None>
     <None Include="..\Lib\io.py">
       <Filter>Python Files</Filter>
     </None>

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -532,6 +532,10 @@
     <ClCompile Include="..\Python\deepfreeze\df.zipimport.c" />
     <ClCompile Include="..\Python\deepfreeze\df.abc.c" />
     <ClCompile Include="..\Python\deepfreeze\df.codecs.c" />
+    <ClCompile Include="..\Python\deepfreeze\df.encodings.c" />
+    <ClCompile Include="..\Python\deepfreeze\df.encodings.aliases.c" />
+    <ClCompile Include="..\Python\deepfreeze\df.encodings.ascii.c" />
+    <ClCompile Include="..\Python\deepfreeze\df.encodings.utf_8.c" />
     <ClCompile Include="..\Python\deepfreeze\df.io.c" />
     <ClCompile Include="..\Python\deepfreeze\df._collections_abc.c" />
     <ClCompile Include="..\Python\deepfreeze\df._sitebuiltins.c" />

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -1421,8 +1421,9 @@ _set_encodings_path(PyObject *mod) {
         goto exit;
     }
     const PyConfig *config = _Py_GetConfig();
-    /* standard stdlib dir */
     if (config->stdlib_dir != NULL) {
+        // standard library directory
+
         // os.path.join(stdlib_dir, "encodings")
         wchar_t *encodings_dirw = _Py_join_relfile(
             config->stdlib_dir, L"encodings");
@@ -1438,9 +1439,8 @@ _set_encodings_path(PyObject *mod) {
         if (PyList_Append(path, encodings_dir) < 0) {
             goto exit;
         }
-    }
-    // Additional search paths, required for embedding
-    if (config->module_search_paths_set) {
+    } else if (config->module_search_paths_set) {
+        // No stdlib_dir, search module_search paths
         for (Py_ssize_t i = 0; i < config->module_search_paths.length; ++i) {
             wchar_t *encodings_dirw = _Py_join_relfile(
                 config->module_search_paths.items[i], L"encodings");
@@ -1470,14 +1470,15 @@ _set_encodings_path(PyObject *mod) {
             }
         }
     }
-    // set and override __path__
-    if (PyObject_SetAttrString(mod, "__path__", path) < 0) {
-        goto exit;
+    if (PyObject_IsTrue(path)) {
+        // set and override __path__
+        if (PyObject_SetAttrString(mod, "__path__", path) < 0) {
+            goto exit;
+        }
     }
     rc = 0;
   exit:
     Py_XDECREF(path);
-
     return rc;
 }
 

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -1449,12 +1449,12 @@ _set_encodings_path(PyObject *mod) {
                 goto exit;
             }
 #ifdef MS_WINDOWS
-            DWORD attr = GetFileAttributesW(path);
+            DWORD attr = GetFileAttributesW(encodings_dirw);
             int isdir = (attr != INVALID_FILE_ATTRIBUTES) &&
                          (attr & FILE_ATTRIBUTE_DIRECTORY);
 #else
             struct stat st;
-            int isdir = (_Py_wstat(path, &st) == 0) && S_ISDIR(st.st_mode);
+            int isdir = (_Py_wstat(encodings_dirw, &st) == 0) && S_ISDIR(st.st_mode);
 #endif
             if (!isdir) {
                 PyMem_RawFree(encodings_dirw);

--- a/Python/frozen.c
+++ b/Python/frozen.c
@@ -44,6 +44,10 @@
 #include "frozen_modules/zipimport.h"
 #include "frozen_modules/abc.h"
 #include "frozen_modules/codecs.h"
+#include "frozen_modules/encodings.h"
+#include "frozen_modules/encodings.aliases.h"
+#include "frozen_modules/encodings.ascii.h"
+#include "frozen_modules/encodings.utf_8.h"
 #include "frozen_modules/io.h"
 #include "frozen_modules/_collections_abc.h"
 #include "frozen_modules/_sitebuiltins.h"
@@ -72,6 +76,10 @@ extern PyObject *_Py_get_importlib__bootstrap_external_toplevel(void);
 extern PyObject *_Py_get_zipimport_toplevel(void);
 extern PyObject *_Py_get_abc_toplevel(void);
 extern PyObject *_Py_get_codecs_toplevel(void);
+extern PyObject *_Py_get_encodings_toplevel(void);
+extern PyObject *_Py_get_encodings_aliases_toplevel(void);
+extern PyObject *_Py_get_encodings_ascii_toplevel(void);
+extern PyObject *_Py_get_encodings_utf_8_toplevel(void);
 extern PyObject *_Py_get_io_toplevel(void);
 extern PyObject *_Py_get__collections_abc_toplevel(void);
 extern PyObject *_Py_get__sitebuiltins_toplevel(void);
@@ -110,6 +118,10 @@ static const struct _frozen stdlib_modules[] = {
     /* stdlib - startup, without site (python -S) */
     {"abc", _Py_M__abc, (int)sizeof(_Py_M__abc), GET_CODE(abc)},
     {"codecs", _Py_M__codecs, (int)sizeof(_Py_M__codecs), GET_CODE(codecs)},
+    {"encodings", _Py_M__encodings, -(int)sizeof(_Py_M__encodings), GET_CODE(encodings)},
+    {"encodings.aliases", _Py_M__encodings_aliases, (int)sizeof(_Py_M__encodings_aliases), GET_CODE(encodings_aliases)},
+    {"encodings.ascii", _Py_M__encodings_ascii, (int)sizeof(_Py_M__encodings_ascii), GET_CODE(encodings_ascii)},
+    {"encodings.utf_8", _Py_M__encodings_utf_8, (int)sizeof(_Py_M__encodings_utf_8), GET_CODE(encodings_utf_8)},
     {"io", _Py_M__io, (int)sizeof(_Py_M__io), GET_CODE(io)},
 
     /* stdlib - startup, with site */

--- a/Tools/scripts/freeze_modules.py
+++ b/Tools/scripts/freeze_modules.py
@@ -49,10 +49,10 @@ FROZEN = [
     ('stdlib - startup, without site (python -S)', [
         'abc',
         'codecs',
-        # For now we do not freeze the encodings, due # to the noise all
-        # those extra modules add to the text printed during the build.
-        # (See https://github.com/python/cpython/pull/28398#pullrequestreview-756856469.)
-        #'<encodings.*>',
+        '<encodings>', # encodings.__init__
+        'encodings.aliases',
+        'encodings.ascii',
+        'encodings.utf_8',
         'io',
         ]),
     ('stdlib - startup, with site', [


### PR DESCRIPTION
The PR is inspired by Kumar's PR GH-29788. I extended ``_PyCodecRegistry_Init`` to set the ``encodings.__path__`` to ``[os.path.join(config->stdlib_dir, "encodings)]``.

Signed-off-by: Christian Heimes <christian@python.org>
Co-authored-by: Kumar Aditya <59607654+kumaraditya303@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45653](https://bugs.python.org/issue45653) -->
https://bugs.python.org/issue45653
<!-- /issue-number -->
