### PR TITLE
bpo-46038: Mark /configure file as generated in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -60,6 +60,7 @@ Include/token.h             linguist-generated=true
 Lib/token.py                linguist-generated=true
 Parser/token.c              linguist-generated=true
 Programs/test_frozenmain.h  linguist-generated=true
+configure                   linguist-generated=true
 
 # Language aware diff headers
 # https://tekin.co.uk/2020/10/better-git-diff-output-for-ruby-python-elixir-and-more

--- a/.gitattributes
+++ b/.gitattributes
@@ -61,6 +61,7 @@ Lib/token.py                linguist-generated=true
 Parser/token.c              linguist-generated=true
 Programs/test_frozenmain.h  linguist-generated=true
 configure                   linguist-generated=true
+aclocal.m4                  linguist-generated=true
 
 # Language aware diff headers
 # https://tekin.co.uk/2020/10/better-git-diff-output-for-ruby-python-elixir-and-more


### PR DESCRIPTION
`configure` is regenerated from configure.ac using a custom container with appropriate version of tools (quay.io/tiran/cpython_autoconf by Christian Heimes). As a result, configure falls into the same category as files generated by Argument Clinic, Freeze and Parser/asdl_c.py. Due to size and churn of these artifacts, they are marked in .gitattributes as generated so GitHub Pull Request Diff Viewer collapses them into a short notification. This pull request does the same for configure.

Actually, configure diff is so large that sometimes it crosses a threshold and GitHub collapses it by force with "Large diffs are not rendered by default" or even "xxx additions, yyy deletions not shown because the diff is too large. Please use a local Git client to view these changes". See GH-29756 as an extreme example and <https://github.com/python/cpython/commits/main/configure> for an average.

*I believe this PR does not need a NEWS entry because the change is relevant only for a GitHub-hosted copy.*

<!-- issue-number: [bpo-46038](https://bugs.python.org/issue46038) -->
https://bugs.python.org/issue46038
<!-- /issue-number -->
