### PR TITLE
bpo-46041: Add identity comparison micro-optimizations to listobject.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-10-18-35-50.bpo-46041.Fz9Dyo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-10-18-35-50.bpo-46041.Fz9Dyo.rst
@@ -1,0 +1,1 @@
+Add two reference counting micro-optimizations to listobject.c.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -437,6 +437,10 @@ list_contains(PyListObject *a, PyObject *el)
 
     for (i = 0, cmp = 0 ; cmp == 0 && i < Py_SIZE(a); ++i) {
         item = PyList_GET_ITEM(a, i);
+        // Fast-path: avoid reference counting item
+        if (item == el) {
+            return 1;
+        }
         Py_INCREF(item);
         cmp = PyObject_RichCompareBool(item, el, Py_EQ);
         Py_DECREF(item);
@@ -2647,6 +2651,10 @@ list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
     }
     for (i = start; i < stop && i < Py_SIZE(self); i++) {
         PyObject *obj = self->ob_item[i];
+        // Fast-path: avoid reference counting obj
+        if (obj == value) {
+            return PyLong_FromSsize_t(i);
+        }
         Py_INCREF(obj);
         int cmp = PyObject_RichCompareBool(obj, value, Py_EQ);
         Py_DECREF(obj);


### PR DESCRIPTION
Add two micro-optimizations similar to
[bpo-39425](https://bugs.python.org/issue39425) that avoid reference
counting in the fast path.

<!-- issue-number: [bpo-46041](https://bugs.python.org/issue46041) -->
https://bugs.python.org/issue46041
<!-- /issue-number -->
