### PR TITLE
bpo-46044: Annotate deprecated sdists formats

### DIFF
--- a/Doc/distutils/sourcedist.rst
+++ b/Doc/distutils/sourcedist.rst
@@ -62,8 +62,8 @@ Notes:
    requires the :program:`compress` program. Notice that this format is now
    pending for deprecation and will be removed in the future versions of Python.
 (5)
-  Those have been deprecated by `Pep 527 <https://www.python.org/dev/peps/pep-0527/>`_,
-  and PyPI only accepts ``.zip`` and ``.tar.gz`` file.
+  deprecated by `PEP 527 <https://www.python.org/dev/peps/pep-0527/>`_;
+  `PyPI <https://pypi.org>`_ only accepts ``.zip`` and ``.tar.gz`` files.
 
 When using any ``tar`` format (``gztar``, ``bztar``, ``xztar``, ``ztar`` or
 ``tar``), under Unix you can specify the ``owner`` and ``group`` names

--- a/Doc/distutils/sourcedist.rst
+++ b/Doc/distutils/sourcedist.rst
@@ -23,25 +23,25 @@ option, for example::
 
 to create a gzipped tarball and a zip file.  The available formats are:
 
-+-----------+-------------------------+---------+
-| Format    | Description             | Notes   |
-+===========+=========================+=========+
-| ``zip``   | zip file (:file:`.zip`) | (1),(3) |
-+-----------+-------------------------+---------+
-| ``gztar`` | gzip'ed tar file        | \(2)    |
-|           | (:file:`.tar.gz`)       |         |
-+-----------+-------------------------+---------+
-| ``bztar`` | bzip2'ed tar file       |         |
-|           | (:file:`.tar.bz2`)      |         |
-+-----------+-------------------------+---------+
-| ``xztar`` | xz'ed tar file          |         |
-|           | (:file:`.tar.xz`)       |         |
-+-----------+-------------------------+---------+
-| ``ztar``  | compressed tar file     | \(4)    |
-|           | (:file:`.tar.Z`)        |         |
-+-----------+-------------------------+---------+
-| ``tar``   | tar file (:file:`.tar`) |         |
-+-----------+-------------------------+---------+
++-----------+-------------------------+-------------+
+| Format    | Description             | Notes       |
++===========+=========================+=============+
+| ``zip``   | zip file (:file:`.zip`) | (1),(3)     |
++-----------+-------------------------+-------------+
+| ``gztar`` | gzip'ed tar file        | \(2)        |
+|           | (:file:`.tar.gz`)       |             |
++-----------+-------------------------+-------------+
+| ``bztar`` | bzip2'ed tar file       | \(5)        |
+|           | (:file:`.tar.bz2`)      |             |
++-----------+-------------------------+-------------+
+| ``xztar`` | xz'ed tar file          | \(5)        |
+|           | (:file:`.tar.xz`)       |             |
++-----------+-------------------------+-------------+
+| ``ztar``  | compressed tar file     | \(5)        |
+|           | (:file:`.tar.Z`)        |             |
++-----------+-------------------------+-------------+
+| ``tar``   | tar file (:file:`.tar`) | \(5)        |
++-----------+-------------------------+-------------+
 
 .. versionchanged:: 3.5
    Added support for the ``xztar`` format.
@@ -61,6 +61,9 @@ Notes:
 (4)
    requires the :program:`compress` program. Notice that this format is now
    pending for deprecation and will be removed in the future versions of Python.
+(5)
+  Those have been deprecated by `Pep 527 <https://www.python.org/dev/peps/pep-0527/>`_,
+  and PyPI only accepts ``.zip`` and ``.tar.gz`` file.
 
 When using any ``tar`` format (``gztar``, ``bztar``, ``xztar``, ``ztar`` or
 ``tar``), under Unix you can specify the ``owner`` and ``group`` names


### PR DESCRIPTION
While this page have deprecated informations it is still heavily index
by Google.

Discussed on twitter: https://twitter.com/brettsky/status/1469465729082662916

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46044](https://bugs.python.org/issue46044) -->
https://bugs.python.org/issue46044
<!-- /issue-number -->

Automerge-Triggered-By: GH:brettcannon