### PR TITLE
bpo-46045: Do not use POSIX semaphores on NetBSD

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-11-11-36-48.bpo-46045.sfThay.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-11-11-36-48.bpo-46045.sfThay.rst
@@ -1,0 +1,1 @@
+Do not use POSIX semaphores on NetBSD

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -81,6 +81,8 @@
    we need to add 0 to make it work there as well. */
 #if (_POSIX_SEMAPHORES+0) == -1
 #define HAVE_BROKEN_POSIX_SEMAPHORES
+#elif defined(__NetBSD__)
+#define HAVE_BROKEN_POSIX_SEMAPHORES
 #else
 #include <semaphore.h>
 #include <errno.h>

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -81,8 +81,6 @@
    we need to add 0 to make it work there as well. */
 #if (_POSIX_SEMAPHORES+0) == -1
 #define HAVE_BROKEN_POSIX_SEMAPHORES
-#elif defined(__NetBSD__)
-#define HAVE_BROKEN_POSIX_SEMAPHORES
 #else
 #include <semaphore.h>
 #include <errno.h>

--- a/configure
+++ b/configure
@@ -12849,6 +12849,10 @@ $as_echo "#define HAVE_BROKEN_POSIX_SEMAPHORES 1" >>confdefs.h
 $as_echo "#define HAVE_BROKEN_POSIX_SEMAPHORES 1" >>confdefs.h
 
 		       ;;
+      NetBSD/*)
+$as_echo "#define HAVE_BROKEN_POSIX_SEMAPHORES 1" >>confdefs.h
+
+		       ;;
       esac
 
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking if PTHREAD_SCOPE_SYSTEM is supported" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -3611,6 +3611,9 @@ if test "$posix_threads" = "yes"; then
       AIX/*) AC_DEFINE(HAVE_BROKEN_POSIX_SEMAPHORES, 1,
 		       [Define if the Posix semaphores do not work on your system])
 		       ;;
+      NetBSD/*) AC_DEFINE(HAVE_BROKEN_POSIX_SEMAPHORES, 1,
+		       [Define if the Posix semaphores do not work on your system])
+		       ;;
       esac
 
       AC_CACHE_CHECK([if PTHREAD_SCOPE_SYSTEM is supported], [ac_cv_pthread_system_supported],


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46045](https://bugs.python.org/issue46045) -->
https://bugs.python.org/issue46045
<!-- /issue-number -->
