### PR TITLE
bpo-46048: Fix parsing of single character lines in getpath readlines()

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -594,6 +594,26 @@ class _pthFileTests(unittest.TestCase):
             sys_path.append(abs_path)
         return sys_path
 
+    def test_underpth_basic(self):
+        libpath = test.support.STDLIB_DIR
+        exe_prefix = os.path.dirname(sys.executable)
+        pth_lines = ['#.', '# ..', *sys.path, '.', '..']
+        exe_file = self._create_underpth_exe(pth_lines)
+        sys_path = self._calc_sys_path_for_underpth_nosite(
+            os.path.dirname(exe_file),
+            pth_lines)
+
+        output = subprocess.check_output([exe_file, '-c',
+            'import sys; print("\\n".join(sys.path) if sys.flags.no_site else "")'
+        ], encoding='ansi')
+        actual_sys_path = output.rstrip().split('\n')
+        self.assertTrue(actual_sys_path, "sys.flags.no_site was False")
+        self.assertEqual(
+            actual_sys_path,
+            sys_path,
+            "sys.path is incorrect"
+        )
+
     def test_underpth_nosite_file(self):
         libpath = test.support.STDLIB_DIR
         exe_prefix = os.path.dirname(sys.executable)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-11-13-14-42.bpo-46048._-OGD9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-11-13-14-42.bpo-46048._-OGD9.rst
@@ -1,0 +1,2 @@
+Fixes parsing of :file:`._pth` files on startup so that single-character
+paths are correctly read.

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -386,11 +386,11 @@ getpath_readlines(PyObject *Py_UNUSED(self), PyObject *args)
     wchar_t *p1 = wbuffer;
     wchar_t *p2 = p1;
     while ((p2 = wcschr(p1, L'\n')) != NULL) {
-        size_t cb = p2 - p1;
-        while (cb && (p1[cb] == L'\n' || p1[cb] == L'\r')) {
+        Py_ssize_t cb = p2 - p1;
+        while (cb >= 0 && (p1[cb] == L'\n' || p1[cb] == L'\r')) {
             --cb;
         }
-        PyObject *u = PyUnicode_FromWideChar(p1, cb ? cb + 1 : 0);
+        PyObject *u = PyUnicode_FromWideChar(p1, cb >= 0 ? cb + 1 : 0);
         if (!u || PyList_Append(r, u) < 0) {
             Py_XDECREF(u);
             Py_CLEAR(r);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46048](https://bugs.python.org/issue46048) -->
https://bugs.python.org/issue46048
<!-- /issue-number -->
