### PR TITLE
bpo-45997: Fix asyncio.Semaphore waiters order

### DIFF
--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -965,6 +965,45 @@ class SemaphoreTests(test_utils.TestCase):
         sem.release()
         self.assertFalse(sem.locked())
 
+    def test_acquire_fifo_order(self):
+        sem = asyncio.Semaphore(1)
+        result = []
+
+        async def c1():
+            await sem.acquire()
+            result.append('c1_1')
+            sem.release()
+
+            await sem.acquire()
+            result.append('c1_2')
+            sem.release()
+
+        async def c2():
+            await sem.acquire()
+            result.append('c2_1')
+            sem.release()
+
+            await sem.acquire()
+            result.append('c2_2')
+            sem.release()
+
+        async def c3():
+            await sem.acquire()
+            result.append('c3_1')
+            sem.release()
+
+            await sem.acquire()
+            result.append('c3_2')
+            sem.release()
+
+        t1 = self.loop.create_task(c1())
+        t2 = self.loop.create_task(c2())
+        t3 = self.loop.create_task(c3())
+
+        race_tasks = [t1, t2, t3]
+        self.loop.run_until_complete(asyncio.gather(*race_tasks))
+        self.assertEqual(['c1_1', 'c2_1', 'c3_1', 'c1_2', 'c2_2', 'c3_2'], result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Allow other Semaphore waiters to acquire lock after releasing by current coroutine by skipping one event loop iteration. If everything is OK for Semaphore, I can add the same logic to other asyncio synchronization primitives 


<!-- issue-number: [bpo-45997](https://bugs.python.org/issue45997) -->
https://bugs.python.org/issue45997
<!-- /issue-number -->
