### PR TITLE
bpo-30512: add CAN Socket support for NetBSD

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -396,9 +396,12 @@ Constants
    Many constants of these forms, documented in the Linux documentation, are
    also defined in the socket module.
 
-   .. availability:: Linux >= 2.6.25.
+   .. availability:: Linux >= 2.6.25, NetBSD >= 8.
 
    .. versionadded:: 3.3
+
+   .. versionchanged:: 3.11
+      NetBSD support was added.
 
 .. data:: CAN_BCM
           CAN_BCM_*

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -251,6 +251,13 @@ os
   (Contributed by Dong-hee Na in :issue:`44611`.)
 
 
+socket
+------
+
+* Add CAN Socket support for NetBSD.
+  (Contributed by Thomas Klausner in :issue:`30512`.)
+
+
 sqlite3
 -------
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-12-00-49-19.bpo-30512.nU9E9V.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-12-00-49-19.bpo-30512.nU9E9V.rst
@@ -1,0 +1,1 @@
+Add CAN Socket support for NetBSD

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-12-00-49-19.bpo-30512.nU9E9V.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-12-00-49-19.bpo-30512.nU9E9V.rst
@@ -1,1 +1,1 @@
-Add CAN Socket support for NetBSD
+Add CAN Socket support for NetBSD.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7715,7 +7715,7 @@ PyInit__socket(void)
 #endif
 #if defined(HAVE_LINUX_CAN_RAW_H) || defined(HAVE_NETCAN_CAN_H)
     PyModule_AddIntMacro(m, CAN_RAW_FILTER);
-#if defined(CAN_RAW_ERR_FILTER)
+#ifdef CAN_RAW_ERR_FILTER
     PyModule_AddIntMacro(m, CAN_RAW_ERR_FILTER);
 #endif
     PyModule_AddIntMacro(m, CAN_RAW_LOOPBACK);

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7698,7 +7698,7 @@ PyInit__socket(void)
     PyModule_AddIntMacro(m, SOL_CAN_RAW);
     PyModule_AddIntMacro(m, CAN_RAW);
 #endif
-#ifdef HAVE_LINUX_CAN_H
+#if defined(HAVE_LINUX_CAN_H) || defined(HAVE_NETCAN_CAN_H)
     PyModule_AddIntMacro(m, CAN_EFF_FLAG);
     PyModule_AddIntMacro(m, CAN_RTR_FLAG);
     PyModule_AddIntMacro(m, CAN_ERR_FLAG);
@@ -7713,9 +7713,11 @@ PyInit__socket(void)
     PyModule_AddIntMacro(m, CAN_J1939);
 #endif
 #endif
-#ifdef HAVE_LINUX_CAN_RAW_H
+#if defined(HAVE_LINUX_CAN_RAW_H) || defined(HAVE_NETCAN_CAN_H)
     PyModule_AddIntMacro(m, CAN_RAW_FILTER);
+#if defined(CAN_RAW_ERR_FILTER)
     PyModule_AddIntMacro(m, CAN_RAW_ERR_FILTER);
+#endif
     PyModule_AddIntMacro(m, CAN_RAW_LOOPBACK);
     PyModule_AddIntMacro(m, CAN_RAW_RECV_OWN_MSGS);
 #endif
@@ -7789,20 +7791,6 @@ PyInit__socket(void)
     PyModule_AddIntMacro(m, J1939_EE_INFO_TX_ABORT);
 
     PyModule_AddIntMacro(m, J1939_FILTER_MAX);
-#endif
-#ifdef HAVE_NETCAN_CAN_H
-    PyModule_AddIntMacro(m, CAN_EFF_FLAG);
-    PyModule_AddIntMacro(m, CAN_RTR_FLAG);
-    PyModule_AddIntMacro(m, CAN_ERR_FLAG);
-
-    PyModule_AddIntMacro(m, CAN_SFF_MASK);
-    PyModule_AddIntMacro(m, CAN_EFF_MASK);
-    PyModule_AddIntMacro(m, CAN_ERR_MASK);
-
-    PyModule_AddIntMacro(m, CAN_RAW_FILTER);
-    /* PyModule_AddIntMacro(m, CAN_RAW_ERR_FILTER); */
-    PyModule_AddIntMacro(m, CAN_RAW_LOOPBACK);
-    PyModule_AddIntMacro(m, CAN_RAW_RECV_OWN_MSGS);
 #endif
 #ifdef SOL_RDS
     PyModule_AddIntMacro(m, SOL_RDS);

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7790,6 +7790,20 @@ PyInit__socket(void)
 
     PyModule_AddIntMacro(m, J1939_FILTER_MAX);
 #endif
+#ifdef HAVE_NETCAN_CAN_H
+    PyModule_AddIntMacro(m, CAN_EFF_FLAG);
+    PyModule_AddIntMacro(m, CAN_RTR_FLAG);
+    PyModule_AddIntMacro(m, CAN_ERR_FLAG);
+
+    PyModule_AddIntMacro(m, CAN_SFF_MASK);
+    PyModule_AddIntMacro(m, CAN_EFF_MASK);
+    PyModule_AddIntMacro(m, CAN_ERR_MASK);
+
+    PyModule_AddIntMacro(m, CAN_RAW_FILTER);
+    /* PyModule_AddIntMacro(m, CAN_RAW_ERR_FILTER); */
+    PyModule_AddIntMacro(m, CAN_RAW_LOOPBACK);
+    PyModule_AddIntMacro(m, CAN_RAW_RECV_OWN_MSGS);
+#endif
 #ifdef SOL_RDS
     PyModule_AddIntMacro(m, SOL_RDS);
 #endif

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -129,6 +129,8 @@ typedef int socklen_t;
 
 #ifdef HAVE_LINUX_CAN_H
 # include <linux/can.h>
+#elif defined(HAVE_NETCAN_CAN_H)
+# include <netcan/can.h>
 #else
 # undef AF_CAN
 # undef PF_CAN
@@ -253,7 +255,7 @@ typedef union sock_addr {
 #ifdef HAVE_NETPACKET_PACKET_H
     struct sockaddr_ll ll;
 #endif
-#ifdef HAVE_LINUX_CAN_H
+#if defined(HAVE_LINUX_CAN_H) || defined(HAVE_NETCAN_CAN_H)
     struct sockaddr_can can;
 #endif
 #ifdef HAVE_SYS_KERN_CONTROL_H

--- a/configure
+++ b/configure
@@ -8782,7 +8782,8 @@ done
 
 
 # On Linux, can.h, can/bcm.h, can/j1939.h, can/raw.h require sys/socket.h
-for ac_header in linux/can.h linux/can/bcm.h linux/can/j1939.h linux/can/raw.h
+# On NetBSD, netcan/can.h requires sys/socket.h
+for ac_header in linux/can.h linux/can/bcm.h linux/can/j1939.h linux/can/raw.h netcan/can.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "

--- a/configure
+++ b/configure
@@ -10290,7 +10290,7 @@ then
 		# small for the default recursion limit. Increase the stack size
 		# to ensure that tests don't crash
     stack_size="1000000"  # 16 MB
-    if test "$with_ubsan" = "yes"
+    if test "$with_ubsan" == "yes"
     then
         # Undefined behavior sanitizer requires an even deeper stack
         stack_size="4000000"  # 64 MB

--- a/configure
+++ b/configure
@@ -10290,7 +10290,7 @@ then
 		# small for the default recursion limit. Increase the stack size
 		# to ensure that tests don't crash
     stack_size="1000000"  # 16 MB
-    if test "$with_ubsan" == "yes"
+    if test "$with_ubsan" = "yes"
     then
         # Undefined behavior sanitizer requires an even deeper stack
         stack_size="4000000"  # 64 MB

--- a/configure.ac
+++ b/configure.ac
@@ -2306,7 +2306,8 @@ AC_CHECK_HEADERS(linux/vm_sockets.h,,,[
 ])
 
 # On Linux, can.h, can/bcm.h, can/j1939.h, can/raw.h require sys/socket.h
-AC_CHECK_HEADERS(linux/can.h linux/can/bcm.h linux/can/j1939.h linux/can/raw.h,,,[
+# On NetBSD, netcan/can.h requires sys/socket.h
+AC_CHECK_HEADERS(linux/can.h linux/can/bcm.h linux/can/j1939.h linux/can/raw.h netcan/can.h,,,[
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -2847,7 +2847,7 @@ then
 		# small for the default recursion limit. Increase the stack size
 		# to ensure that tests don't crash
     stack_size="1000000"  # 16 MB
-    if test "$with_ubsan" == "yes"
+    if test "$with_ubsan" = "yes"
     then
         # Undefined behavior sanitizer requires an even deeper stack
         stack_size="4000000"  # 64 MB

--- a/configure.ac
+++ b/configure.ac
@@ -2847,7 +2847,7 @@ then
 		# small for the default recursion limit. Increase the stack size
 		# to ensure that tests don't crash
     stack_size="1000000"  # 16 MB
-    if test "$with_ubsan" = "yes"
+    if test "$with_ubsan" == "yes"
     then
         # Undefined behavior sanitizer requires an even deeper stack
         stack_size="4000000"  # 64 MB

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -769,6 +769,9 @@
 /* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
 #undef HAVE_NDIR_H
 
+/* Define to 1 if you have the <netcan/can.h> header file. */
+#undef HAVE_NETCAN_CAN_H
+
 /* Define to 1 if you have the <netinet/in.h> header file. */
 #undef HAVE_NETINET_IN_H
 


### PR DESCRIPTION
This also fixes a small unrelated bug in the configure script - test(1) only supports "=" as a comparison operator, "==" is a bash extension. If this should be a separate pull request, please let me know.

<!-- issue-number: [bpo-30512](https://bugs.python.org/issue30512) -->
https://bugs.python.org/issue30512
<!-- /issue-number -->
