### PR TITLE
gh-58174: Add enable/disable_interspersed_args to ArgumentParser

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1614,6 +1614,34 @@ be achieved by specifying the ``namespace=`` keyword argument::
 Other utilities
 ---------------
 
+Handling interspersed arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. method:: ArgumentParser.disable_interspersed_args()
+
+   Set parsing to stop on the first non-option.  For example, if ``-a`` and
+   ``-b`` are both simple options that take no arguments, :mod:`optparse`
+   normally accepts this syntax::
+
+      prog -a arg1 -b arg2
+
+   and treats it as equivalent to  ::
+
+      prog -a -b arg1 arg2
+
+   To disable this feature, call :meth:`disable_interspersed_args`.  This
+   restores traditional Unix syntax, where option parsing stops with the first
+   non-option argument.
+
+   Use this if you have a command processor which runs another command which has
+   options of its own and you want to make sure these options don't get
+   confused.  For example, each command might have a different set of options.
+
+.. method:: ArgumentParser.enable_interspersed_args()
+
+   Set parsing to not stop on the first non-option, allowing interspersing
+   switches with command arguments.  This is the default behavior.
+
 Sub-commands
 ^^^^^^^^^^^^
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1725,6 +1725,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         self._positionals = add_group(_('positional arguments'))
         self._optionals = add_group(_('options'))
         self._subparsers = None
+        self._disabled_interspersed_args = False
 
         # register types
         def identity(string):
@@ -1749,6 +1750,12 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 pass
             else:
                 self._defaults.update(defaults)
+
+    def disable_interspersed_args(self):
+        self._disabled_interspersed_args = True
+
+    def enable_interspersed_args(self):
+        self._disabled_interspersed_args = False
 
     # =======================
     # Pretty __repr__ methods
@@ -2035,6 +2042,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
             max_option_string_index = max(option_string_indices)
         else:
             max_option_string_index = -1
+
         while start_index <= max_option_string_index:
 
             # consume any Positionals preceding the next option
@@ -2042,6 +2050,11 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 index
                 for index in option_string_indices
                 if index >= start_index])
+
+            if self._disabled_interspersed_args and next_option_string_index != start_index:
+                arg_strings_pattern = arg_strings_pattern[:start_index] + "A" *  (len(arg_strings_pattern) - start_index)
+                break
+
             if start_index != next_option_string_index:
                 positionals_end_index = consume_positionals(start_index)
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1824,6 +1824,59 @@ class TestTypeRegistration(TestCase):
                          NS(x='my_type{1}', y='my_type{42}'))
 
 
+# ===============================
+# Test Interspersed args and '--'
+# ===============================
+
+class TestInterspersedArgs(TestCase):
+    def setUp(self):
+        self.parser = ErrorRaisingArgumentParser()
+        self.parser.add_argument('-a', action='store_true')
+        self.parser.add_argument('foo')
+        self.parser.add_argument('rem', nargs='*')
+
+    def test_simple(self):
+        self.assertEqual(self.parser.parse_args('-a 3 5 6 9'.split()),
+                         NS(a=True, foo='3', rem=['5', '6', '9']))
+        self.assertEqual(self.parser.parse_args('3 -a'.split()),
+                         NS(a=True, foo='3', rem=[]))
+        self.assertEqual(self.parser.parse_args('3 4 5 -a'.split()),
+                         NS(a=True, foo='3', rem=['4', '5']))
+
+    def test_hyphens(self):
+        self.assertEqual(self.parser.parse_args('-a -- 3 5 6 9'.split()),
+                         NS(a=True, foo='3', rem=['5', '6', '9']))
+        self.assertEqual(self.parser.parse_args('-- 3 -a'.split()),
+                         NS(a=False, foo='3', rem=['-a']))
+        self.assertEqual(self.parser.parse_args('-- 3 4 5 -a'.split()),
+                         NS(a=False, foo='3', rem=['4', '5', '-a']))
+
+    def test_interspersed_args(self):
+        self.parser.disable_interspersed_args()
+        self.assertEqual(self.parser.parse_args('-a 3 5 6 9'.split()),
+                         NS(a=True, foo='3', rem=['5', '6', '9']))
+        self.assertEqual(self.parser.parse_args('3 -a'.split()),
+                         NS(a=False, foo='3', rem=['-a']))
+        self.assertEqual(self.parser.parse_args('3 4 5 -a'.split()),
+                         NS(a=False, foo='3', rem=['4', '5', '-a']))
+
+        self.parser.enable_interspersed_args()
+        self.assertEqual(self.parser.parse_args('3 4 5 -a'.split()),
+                         NS(a=True, foo='3', rem=['4', '5']))
+
+    def test_with_remainder(self):
+        self.parser = ErrorRaisingArgumentParser()
+        self.parser.add_argument('-a', action='store_true')
+        self.parser.add_argument('-b')
+        self.parser.add_argument('rem', nargs=argparse.REMAINDER)
+        self.assertEqual(self.parser.parse_args('-b 4 -a c -b 5'.split()),
+                         NS(a=True, b='4', rem=['c', '-b', '5']))
+
+        self.parser.disable_interspersed_args()
+        self.assertEqual(self.parser.parse_args('-b 4 -a c -b 5'.split()),
+                         NS(a=True, b='4', rem=['c', '-b', '5']))
+
+
 # ============
 # Action tests
 # ============

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1793,6 +1793,7 @@ Erik Tollerud
 Stephen Tonkin
 Matias Torchinsky
 Sandro Tosi
+Laszlo Attila Toth
 Richard Townsend
 David Townshend
 Nathan Trapuzzano

--- a/Misc/NEWS.d/next/Library/2021-12-12-11-33-42.bpo-13966.Z_7qpB.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-12-11-33-42.bpo-13966.Z_7qpB.rst
@@ -1,0 +1,2 @@
+Add argparse.ArgumentParser.disable_interspersed_args() and
+enable_interspersed_args() based on optparse.OptionParser's similar methods.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-13966](https://bugs.python.org/issue13966) -->
https://bugs.python.org/issue13966
<!-- /issue-number -->

<!-- gh-issue-number: gh-58174 -->
* Issue: gh-58174
<!-- /gh-issue-number -->
