### PR TITLE
bpo-46054: Correct non-utf8 character tests in test_exceptions

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2391,11 +2391,11 @@ class SyntaxErrorTests(unittest.TestCase):
         # Check non utf-8 characters
         try:
             with open(TESTFN, 'bw') as testfile:
-                testfile.write(b'\x7fELF\x02\x01\x01\x00\x00\x00')
+                testfile.write(b"\x89")
             rc, out, err = script_helper.assert_python_failure('-Wd', '-X', 'utf8', TESTFN)
             err = err.decode('utf-8').splitlines()
 
-            self.assertEqual(err[-1], "SyntaxError: invalid non-printable character U+007F")
+            self.assertIn("SyntaxError: Non-UTF-8 code starting with '\\x89' in file", err[-1])
         finally:
             unlink(TESTFN)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46054](https://bugs.python.org/issue46054) -->
https://bugs.python.org/issue46054
<!-- /issue-number -->
