### PR TITLE
bpo-46060: Clarify new_event_loop return value.

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -64,7 +64,7 @@ an event loop:
 
 .. function:: new_event_loop()
 
-   Create a new event loop object.
+   Create and return a new event loop object.
 
 Note that the behaviour of :func:`get_event_loop`, :func:`set_event_loop`,
 and :func:`new_event_loop` functions can be altered by


### PR DESCRIPTION
Minor clarifying change to documentation.

<!-- issue-number: [bpo-46060](https://bugs.python.org/issue46060) -->
https://bugs.python.org/issue46060
<!-- /issue-number -->
