### PR TITLE
bpo-46059: Clarify pattern-matching example in "control flow" docs

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -393,14 +393,13 @@ Several other key features of this statement:
 - Patterns may use named constants.  These must be dotted names
   to prevent them from being interpreted as capture variable::
 
-      import random
       from enum import Enum
       class Color(Enum):
           RED = 0
           GREEN = 1
           BLUE = 2
 
-      color = random.choice(list(Color))
+      color = Color(int(input("Pick a number between 1 to 2: ")))
 
       match color:
           case Color.RED:

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -393,11 +393,14 @@ Several other key features of this statement:
 - Patterns may use named constants.  These must be dotted names
   to prevent them from being interpreted as capture variable::
 
+      import random
       from enum import Enum
       class Color(Enum):
           RED = 0
           GREEN = 1
           BLUE = 2
+
+      color = random.choice(list(Color))
 
       match color:
           case Color.RED:

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -395,11 +395,11 @@ Several other key features of this statement:
 
       from enum import Enum
       class Color(Enum):
-          RED = 0
-          GREEN = 1
-          BLUE = 2
+          RED = 'red'
+          GREEN = 'green'
+          BLUE = 'blue'
 
-      color = Color(int(input("Pick a number between 1 to 2: ")))
+      color = Color(input("Enter your choice of 'red', 'blue' or 'green': "))
 
       match color:
           case Color.RED:


### PR DESCRIPTION
The "Color" example in the pattern-matching section of the "control flow" documentation is not immediately runnable, leading to confusion.

I've chosen here to avoid putting this example in a function, simply because there are a lot of other pattern-matching examples that are already inside functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46059](https://bugs.python.org/issue46059) -->
https://bugs.python.org/issue46059
<!-- /issue-number -->
