### PR TITLE
[3.10] bpo-27718: Fix help for the signal module (GH-30063)

### DIFF
--- a/Lib/signal.py
+++ b/Lib/signal.py
@@ -1,6 +1,5 @@
 import _signal
 from _signal import *
-from functools import wraps as _wraps
 from enum import IntEnum as _IntEnum
 
 _globals = globals()
@@ -42,6 +41,16 @@ def _enum_to_int(value):
         return value
 
 
+# Similar to functools.wraps(), but only assign __doc__.
+# __module__ should be preserved,
+# __name__ and __qualname__ are already fine,
+# __annotations__ is not set.
+def _wraps(wrapped):
+    def decorator(wrapper):
+        wrapper.__doc__ = wrapped.__doc__
+        return wrapper
+    return decorator
+
 @_wraps(_signal.signal)
 def signal(signalnum, handler):
     handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
@@ -59,7 +68,6 @@ if 'pthread_sigmask' in _globals:
     def pthread_sigmask(how, mask):
         sigs_set = _signal.pthread_sigmask(how, mask)
         return set(_int_to_enum(x, Signals) for x in sigs_set)
-    pthread_sigmask.__doc__ = _signal.pthread_sigmask.__doc__
 
 
 if 'sigpending' in _globals:
@@ -73,7 +81,6 @@ if 'sigwait' in _globals:
     def sigwait(sigset):
         retsig = _signal.sigwait(sigset)
         return _int_to_enum(retsig, Signals)
-    sigwait.__doc__ = _signal.sigwait
 
 
 if 'valid_signals' in _globals:

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -1,4 +1,5 @@
 import errno
+import inspect
 import os
 import random
 import signal
@@ -32,6 +33,14 @@ class GenericTests(unittest.TestCase):
             elif name.startswith('CTRL_'):
                 self.assertIsInstance(sig, signal.Signals)
                 self.assertEqual(sys.platform, "win32")
+
+    def test_functions_module_attr(self):
+        # Issue #27718: If __all__ is not defined all non-builtin functions
+        # should have correct __module__ to be displayed by pydoc.
+        for name in dir(signal):
+            value = getattr(signal, name)
+            if inspect.isroutine(value) and not inspect.isbuiltin(value):
+                self.assertEqual(value.__module__, 'signal')
 
 
 @unittest.skipIf(sys.platform == "win32", "Not valid on Windows")

--- a/Misc/NEWS.d/next/Library/2021-12-11-22-51-30.bpo-27718.MgQiGl.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-11-22-51-30.bpo-27718.MgQiGl.rst
@@ -1,0 +1,2 @@
+Fix help for the :mod:`signal` module. Some functions (e.g. ``signal()`` and
+``getsignal()``) were omitted.


### PR DESCRIPTION
Functions signal(), getsignal(), pthread_sigmask(), sigpending(),
sigwait() and valid_signals() were omitted.

If __all__ is not defined all non-builtin functions should have
correct __module__.
(cherry picked from commit e08c0d8eec528f1d7a282ee19bcadb9aae9ec123)


<!-- issue-number: [bpo-27718](https://bugs.python.org/issue27718) -->
https://bugs.python.org/issue27718
<!-- /issue-number -->
