### PR TITLE
[3.10] bpo-37602: Clarify that the lib2to3 nonzero fixer changes only…

### DIFF
--- a/Doc/library/2to3.rst
+++ b/Doc/library/2to3.rst
@@ -333,7 +333,8 @@ and off individually.  They are described here in more detail.
 
 .. 2to3fixer:: nonzero
 
-   Renames :meth:`__nonzero__` to :meth:`~object.__bool__`.
+   Renames definitions of methods called :meth:`__nonzero__`
+   to :meth:`~object.__bool__`.
 
 .. 2to3fixer:: numliterals
 


### PR DESCRIPTION
… definitions (GH-30075)

(cherry picked from commit 481f3ffdbe40bd19677a1ba0ac2e7cece8949b47)

Co-authored-by: Irit Katriel <1055913+iritkatriel@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-37602](https://bugs.python.org/issue37602) -->
https://bugs.python.org/issue37602
<!-- /issue-number -->
