### PR TITLE
bpo-46141: Fix ipaddress.ip_network TypeErrors

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -52,7 +52,7 @@ def ip_address(address):
         pass
 
     raise ValueError('%r does not appear to be an IPv4 or IPv6 address' %
-                     address)
+                     (address,))
 
 
 def ip_network(address, strict=True):
@@ -82,7 +82,7 @@ def ip_network(address, strict=True):
         pass
 
     raise ValueError('%r does not appear to be an IPv4 or IPv6 network' %
-                     address)
+                     (address,))
 
 
 def ip_interface(address):
@@ -117,7 +117,7 @@ def ip_interface(address):
         pass
 
     raise ValueError('%r does not appear to be an IPv4 or IPv6 interface' %
-                     address)
+                     (address,))
 
 
 def v4_int_to_packed(address):

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -51,8 +51,8 @@ def ip_address(address):
     except (AddressValueError, NetmaskValueError):
         pass
 
-    raise ValueError('%r does not appear to be an IPv4 or IPv6 address' %
-                     (address,))
+    raise ValueError(f'{address!r} does not appear to be an IPv4 or '
+                     f'IPv6 address')
 
 
 def ip_network(address, strict=True):
@@ -81,8 +81,8 @@ def ip_network(address, strict=True):
     except (AddressValueError, NetmaskValueError):
         pass
 
-    raise ValueError('%r does not appear to be an IPv4 or IPv6 network' %
-                     (address,))
+    raise ValueError(f'{address!r} does not appear to be an IPv4 or '
+                     f'IPv6 network')
 
 
 def ip_interface(address):
@@ -116,8 +116,8 @@ def ip_interface(address):
     except (AddressValueError, NetmaskValueError):
         pass
 
-    raise ValueError('%r does not appear to be an IPv4 or IPv6 interface' %
-                     (address,))
+    raise ValueError(f'{address!r} does not appear to be an IPv4 or '
+                     f'IPv6 interface')
 
 
 def v4_int_to_packed(address):

--- a/Misc/NEWS.d/next/Library/2021-12-21-01-22-33.bpo-46141.ilGn6L.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-21-01-22-33.bpo-46141.ilGn6L.rst
@@ -1,0 +1,3 @@
+Fix :func:`~ipaddress.ip_network`, :func:`~ipaddress.ip_address` and
+:func:`~ipaddress.ip_interface` to throw a correct error if a tuple is
+passed. Fix by Bar Harel.


### PR DESCRIPTION
Minor fix:

IPv4Network accepts a tuple.

If you send a tuple to ip_network instead, it throws a TypeError while attempting to format the ValueError message.

Fixed all 3 `%` formats.

Skip NEWS + Skip issue please.

<!-- issue-number: [bpo-46141](https://bugs.python.org/issue46141) -->
https://bugs.python.org/issue46141
<!-- /issue-number -->
