### PR TITLE
bpo-45615: Add missing test for printing traceback for non-exception. Fix…

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1060,6 +1060,21 @@ class TracebackFormatTests(unittest.TestCase):
         self.assertIn('ExceptionGroup', output)
         self.assertLessEqual(output.count('ExceptionGroup'), LIMIT)
 
+    @cpython_only
+    def test_print_exception_bad_type_capi(self):
+        from _testcapi import exception_print
+        with captured_output("stderr") as stderr:
+            exception_print(42)
+        self.assertEqual(
+            stderr.getvalue(),
+            ('TypeError: print_exception(): '
+             'Exception expected for value, int found\n')
+        )
+
+    def test_print_exception_bad_type_python(self):
+        with self.assertRaises(TypeError):
+            traceback.print_exception(42)
+
 
 cause_message = (
     "\nThe above exception was the direct cause "

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1072,7 +1072,8 @@ class TracebackFormatTests(unittest.TestCase):
         )
 
     def test_print_exception_bad_type_python(self):
-        with self.assertRaises(TypeError):
+        msg = "Exception expected for value, int found"
+        with self.assertRaisesRegex(TypeError, msg):
             traceback.print_exception(42)
 
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -98,7 +98,11 @@ def _parse_value_tb(exc, value, tb):
         raise ValueError("Both or neither of value and tb must be given")
     if value is tb is _sentinel:
         if exc is not None:
-            return exc, exc.__traceback__
+            if isinstance(exc, BaseException):
+                return exc, exc.__traceback__
+
+            raise TypeError(f'Exception expected for value, '
+                            f'{type(exc).__name__} found')
         else:
             return None, None
     return value, tb

--- a/Misc/NEWS.d/next/Library/2021-12-13-15-51-16.bpo-45615.hVx83Q.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-13-15-51-16.bpo-45615.hVx83Q.rst
@@ -1,1 +1,1 @@
-Functions in the :mod:`traceback` module raise :exc:`TypeError` rather than :exc:`AttributeError` when an exception arg is not of type :exc:`BaseException`.
+Functions in the :mod:`traceback` module raise :exc:`TypeError` rather than :exc:`AttributeError` when an exception argument is not of type :exc:`BaseException`.

--- a/Misc/NEWS.d/next/Library/2021-12-13-15-51-16.bpo-45615.hVx83Q.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-13-15-51-16.bpo-45615.hVx83Q.rst
@@ -1,0 +1,1 @@
+Functions in the :mod:`traceback` module raise :exc:`TypeError` rather than :exc:`AttributeError` when an exception arg is not of type :exc:`BaseException`.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3513,17 +3513,17 @@ static PyObject *
 exception_print(PyObject *self, PyObject *args)
 {
     PyObject *value;
-    PyObject *tb;
+    PyObject *tb = NULL;
 
     if (!PyArg_ParseTuple(args, "O:exception_print",
-                            &value))
-        return NULL;
-    if (!PyExceptionInstance_Check(value)) {
-        PyErr_Format(PyExc_TypeError, "an exception instance is required");
+                            &value)) {
         return NULL;
     }
 
-    tb = PyException_GetTraceback(value);
+    if (PyExceptionInstance_Check(value)) {
+        tb = PyException_GetTraceback(value);
+    }
+
     PyErr_Display((PyObject *) Py_TYPE(value), value, tb);
     Py_XDECREF(tb);
 


### PR DESCRIPTION
… traceback.py to raise TypeError instead of AttributeError


This gap was discovered via code coverage. The testcapi function checked the type, so it didn't give the C traceback a chance to see the error. I removed that so the C code is now covered. 

The python traceback wasn't handling this error well, that's fixed here.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45615](https://bugs.python.org/issue45615) -->
https://bugs.python.org/issue45615
<!-- /issue-number -->
