### PR TITLE
bpo-26952: [argparse] clearer error when formatting an empty mutually…

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -393,7 +393,7 @@ class HelpFormatter(object):
         inserts = {}
         for group in groups:
             if not group._group_actions:
-                raise ValueError("empty mutually exclusive group")
+                raise ValueError(f'empty group {group}')
 
             try:
                 start = actions.index(group._group_actions[0])

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -392,6 +392,9 @@ class HelpFormatter(object):
         group_actions = set()
         inserts = {}
         for group in groups:
+            if not group._group_actions:
+                raise ValueError("empty mutually exclusive group")
+
             try:
                 start = actions.index(group._group_actions[0])
             except ValueError:

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2601,6 +2601,13 @@ class TestMutuallyExclusiveGroupErrors(TestCase):
               '''
         self.assertEqual(parser.format_help(), textwrap.dedent(expected))
 
+    def test_empty_group(self):
+        # See issue 26952
+        parser = argparse.ArgumentParser()
+        group = parser.add_mutually_exclusive_group()
+        with self.assertRaises(ValueError):
+            parser.parse_args(['-h'])
+
 class MEMixin(object):
 
     def test_failures_when_not_required(self):

--- a/Misc/NEWS.d/next/Library/2021-12-14-13-18-45.bpo-26952.hjhISq.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-14-13-18-45.bpo-26952.hjhISq.rst
@@ -1,0 +1,1 @@
+:mod:`argparse` raises :exc:`ValueError` with clear message when trying to render usage for an empty mutually-exclusive group. Previously it raised a cryptic :exc:`IndexError`.


### PR DESCRIPTION
… exclusive group

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-26952](https://bugs.python.org/issue26952) -->
https://bugs.python.org/issue26952
<!-- /issue-number -->
