### PR TITLE
bpo-46063: Add 'delay=True' to file handler initialization. (GH-30103)

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5451,7 +5451,8 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
             p = os.path.join(wd, '%s.log' % prefix)
             rotator = logging.handlers.TimedRotatingFileHandler(p, when='s',
                                                                 interval=5,
-                                                                backupCount=7)
+                                                                backupCount=7,
+                                                                delay=True)
             rotators.append(rotator)
             if prefix.startswith('a.b'):
                 for t in times:


### PR DESCRIPTION


<!-- issue-number: [bpo-46063](https://bugs.python.org/issue46063) -->
https://bugs.python.org/issue46063
<!-- /issue-number -->
