### PR TITLE
bpo-46076: Improve documentation for per-attribute docstrings with `__slots__`

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1963,8 +1963,9 @@ Notes on using *__slots__*
 Per-attribute docstrings with *__slots__*
 """""""""""""""""""""""""""""""""""""""""
 
-If a :term:`mapping` is used to specify *__slots__*, the values of the mapping
-can be used to specify docstrings for each attribute. For example::
+If a :class:`dictionary <dict>` is used to specify *__slots__*, the values of
+the dictionary can be used to specify docstrings for each attribute. For
+example::
 
   class Card:
       """A card from a standard French deck"""

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1944,9 +1944,7 @@ Notes on using *__slots__*
 * Nonempty *__slots__* does not work for classes derived from "variable-length"
   built-in types such as :class:`int`, :class:`bytes` and :class:`tuple`.
 
-* Any non-string iterable may be assigned to *__slots__*. Mappings may also be
-  used; however, in the future, special meaning may be assigned to the values
-  corresponding to each key.
+* Any non-string :term:`iterable` may be assigned to *__slots__*.
 
 * :attr:`~instance.__class__` assignment works only if both classes have the
   same *__slots__*.
@@ -1961,6 +1959,52 @@ Notes on using *__slots__*
   created for each
   of the iterator's values. However, the *__slots__* attribute will be an empty
   iterator.
+
+Per-attribute docstrings with *__slots__*
+"""""""""""""""""""""""""""""""""""""""""
+
+If a :term:`mapping` is used to specify *__slots__*, the values of the mapping
+can be used to specify docstrings for each attribute. For example::
+
+  class Card:
+      """A card from a standard French deck"""
+
+      __slots__ = {
+          'suit': 'Either "Spades", "Hearts", "Clubs" or "Diamonds"',
+          'rank': 'A positive integer in the range 2 <= x <= 14'
+      }
+
+      def __init__(self, suit, rank):
+          self.suit = suit
+          self.rank = rank
+
+Calling :func:`help` on this class will yield the following output::
+
+  >>> help(Card)
+  Help on class Card in module __main__:
+
+  class Card(builtins.object)
+   |  Card(suit, rank)
+   |
+   |  A card from a standard French deck
+   |
+   |  Methods defined here:
+   |
+   |  __init__(self, suit, rank)
+   |      Initialize self.  See help(type(self)) for accurate signature.
+   |
+   |  ----------------------------------------------------------------------
+   |  Data descriptors defined here:
+   |
+   |  rank
+   |      A positive integer in the range 2 <= x <= 14
+   |
+   |  suit
+   |      Either "Spades", "Hearts", "Clubs" or "Diamonds"
+
+
+.. versionadded:: 3.8
+
 
 .. _class-customization:
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2004,7 +2004,9 @@ Calling :func:`help` on this class will yield the following output::
    |      Either "Spades", "Hearts", "Clubs" or "Diamonds"
 
 
-.. versionadded:: 3.8
+.. versionchanged:: 3.8
+   Docstrings in the values of a *__slots__* dictionary are now recognised by
+   :func:`help`.
 
 
 .. _class-customization:

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1946,6 +1946,11 @@ Notes on using *__slots__*
 
 * Any non-string :term:`iterable` may be assigned to *__slots__*.
 
+* If a :class:`dictionary <dict>` is used to assign *__slots__*, the dictionary
+  keys will be used as the slot names. The values of the dictionary can be used
+  to provide per-attribute docstrings that will be recognised by
+  :func:`inspect.getdoc` and displayed in the output of :func:`help`.
+
 * :attr:`~instance.__class__` assignment works only if both classes have the
   same *__slots__*.
 
@@ -1959,55 +1964,6 @@ Notes on using *__slots__*
   created for each
   of the iterator's values. However, the *__slots__* attribute will be an empty
   iterator.
-
-Per-attribute docstrings with *__slots__*
-"""""""""""""""""""""""""""""""""""""""""
-
-If a :class:`dictionary <dict>` is used to specify *__slots__*, the values of
-the dictionary can be used to specify docstrings for each attribute. For
-example::
-
-  class Card:
-      """A card from a standard French deck"""
-
-      __slots__ = {
-          'suit': 'Either "Spades", "Hearts", "Clubs" or "Diamonds"',
-          'rank': 'A positive integer in the range 2 <= x <= 14'
-      }
-
-      def __init__(self, suit, rank):
-          self.suit = suit
-          self.rank = rank
-
-Calling :func:`help` on this class will yield the following output::
-
-  >>> help(Card)
-  Help on class Card in module __main__:
-
-  class Card(builtins.object)
-   |  Card(suit, rank)
-   |
-   |  A card from a standard French deck
-   |
-   |  Methods defined here:
-   |
-   |  __init__(self, suit, rank)
-   |      Initialize self.  See help(type(self)) for accurate signature.
-   |
-   |  ----------------------------------------------------------------------
-   |  Data descriptors defined here:
-   |
-   |  rank
-   |      A positive integer in the range 2 <= x <= 14
-   |
-   |  suit
-   |      Either "Spades", "Hearts", "Clubs" or "Diamonds"
-
-
-.. versionchanged:: 3.8
-   Docstrings in the values of a *__slots__* dictionary are now recognised by
-   :func:`help`.
-
 
 .. _class-customization:
 

--- a/Misc/NEWS.d/next/Documentation/2021-12-14-22-27-49.bpo-46076.nYQ9a8.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-12-14-22-27-49.bpo-46076.nYQ9a8.rst
@@ -1,2 +1,0 @@
-Improve documentation for the ability to use a ``__slots__`` dictionary to
-assign per-attribute docstrings. Patch by Alex Waygood.

--- a/Misc/NEWS.d/next/Documentation/2021-12-14-22-27-49.bpo-46076.nYQ9a8.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-12-14-22-27-49.bpo-46076.nYQ9a8.rst
@@ -1,0 +1,2 @@
+Improve documentation for the ability to use a ``__slots__`` dictionary to
+assign per-attribute docstrings. Patch by Alex Waygood.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46076](https://bugs.python.org/issue46076) -->
https://bugs.python.org/issue46076
<!-- /issue-number -->
