### PR TITLE
bpo-46080: Fix crash when argparse.BooleanOptionalAction is used with default=argparse.SUPPRESS and help specified

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -876,7 +876,7 @@ class BooleanOptionalAction(Action):
                 option_string = '--no-' + option_string[2:]
                 _option_strings.append(option_string)
 
-        if help is not None and default is not None:
+        if help is not None and default is not None and default is not SUPPRESS:
             help += " (default: %(default)s)"
 
         super().__init__(

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -3611,6 +3611,8 @@ class TestHelpUsage(HelpTestCase):
         Sig('--bar', help='Whether to bar', default=True,
                      action=argparse.BooleanOptionalAction),
         Sig('-f', '--foobar', '--barfoo', action=argparse.BooleanOptionalAction),
+        Sig('--bazz', action=argparse.BooleanOptionalAction,
+                      default=argparse.SUPPRESS, help='Bazz!'),
     ]
     argument_group_signatures = [
         (Sig('group'), [
@@ -3623,8 +3625,8 @@ class TestHelpUsage(HelpTestCase):
     usage = '''\
         usage: PROG [-h] [-w W [W ...]] [-x [X ...]] [--foo | --no-foo]
                     [--bar | --no-bar]
-                    [-f | --foobar | --no-foobar | --barfoo | --no-barfoo] [-y [Y]]
-                    [-z Z Z Z]
+                    [-f | --foobar | --no-foobar | --barfoo | --no-barfoo]
+                    [--bazz | --no-bazz] [-y [Y]] [-z Z Z Z]
                     a b b [c] [d ...] e [e ...]
         '''
     help = usage + '''\
@@ -3641,6 +3643,7 @@ class TestHelpUsage(HelpTestCase):
           --foo, --no-foo       Whether to foo
           --bar, --no-bar       Whether to bar (default: True)
           -f, --foobar, --no-foobar, --barfoo, --no-barfoo
+          --bazz, --no-bazz     Bazz!
 
         group:
           -y [Y]                y

--- a/Misc/NEWS.d/next/Library/2021-12-15-06-29-00.bpo-46080.AuQpLt.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-15-06-29-00.bpo-46080.AuQpLt.rst
@@ -1,1 +1,3 @@
-No longer crashes on help text composition if :class:`argparse.BooleanOptionalAction`'s default is ``argparse.SUPPRESS`` and ``help`` is specified.
+Fix exception in argparse help text generation if a
+:class:`argparse.BooleanOptionalAction` argument's default is
+``argparse.SUPPRESS`` and it has ``help`` specified.  Patch by Felix Fontain.

--- a/Misc/NEWS.d/next/Library/2021-12-15-06-29-00.bpo-46080.AuQpLt.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-15-06-29-00.bpo-46080.AuQpLt.rst
@@ -1,3 +1,3 @@
 Fix exception in argparse help text generation if a
 :class:`argparse.BooleanOptionalAction` argument's default is
-``argparse.SUPPRESS`` and it has ``help`` specified.  Patch by Felix Fontain.
+``argparse.SUPPRESS`` and it has ``help`` specified.  Patch by Felix Fontein.

--- a/Misc/NEWS.d/next/Library/2021-12-15-06-29-00.bpo-46080.AuQpLt.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-15-06-29-00.bpo-46080.AuQpLt.rst
@@ -1,0 +1,1 @@
+No longer crashes on help text composition if :class:`argparse.BooleanOptionalAction`'s default is ``argparse.SUPPRESS`` and ``help`` is specified.


### PR DESCRIPTION
When `argparse.BooleanOptionalAction` is used with `default=argparse.SUPPRESS` and `help` specified, help text composition currently crashes. This PR fixes that by also checking whether `default is not SUPPRESS` before appending `%(default)s` to `help`.

<!-- issue-number: [bpo-46080](https://bugs.python.org/issue46080) -->
https://bugs.python.org/issue46080
<!-- /issue-number -->
