### PR TITLE
bpo-44035: Show git diff after autoreconf and regen (GH-30117)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,8 +90,10 @@ jobs:
           if test -n "$changes"; then
             echo "Generated files not up to date."
             echo "Perhaps you forgot to run make regen-all or build.bat --regen. ;)"
-            echo "configure files must be regenerated with a specific, unpatched version of autoconf."
+            echo "configure files must be regenerated with a specific version of autoconf."
             echo "$changes"
+            echo ""
+            git diff --staged || true
             exit 1
           fi
       - name: Check exported libpython symbols


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44035](https://bugs.python.org/issue44035) -->
https://bugs.python.org/issue44035
<!-- /issue-number -->
