### PR TITLE
bpo-41354: Add .ratio_min() function with minimum substring length option for matching score

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -618,7 +618,33 @@ class SequenceMatcher:
 
         matches = sum(triple[-1] for triple in self.get_matching_blocks())
         return _calculate_ratio(matches, len(self.a) + len(self.b))
+ 
 
+    # NEW FUNCTION: ratio_min 
+    def ratio_min(self,m):
+        """Return a measure of the sequences' similarity (float in [0,1]).
+        Where T is the total number of elements in both sequences, and
+        M_min is the number of matches with every single match has length at least m, this is 2.0*M_min / T.
+        Note that this is 1 if the sequences are identical, and 0 if
+        they have no substring of length m or more in common.
+        .ratio_min() is similar to .ratio(). 
+        .ratio_min(1) is equivalent to .ratio().
+        
+        >>> s = SequenceMatcher(None, "abcd", "bcde")
+        >>> s.ratio_min(1)
+        0.75
+        >>> s.ratio_min(2)
+        0.75
+        >>> s.ratio_min(3)
+        0.75
+        >>> s.ratio_min(4)
+        0.0
+        """
+
+        matches = sum(triple[-1] for triple in self.get_matching_blocks() if triple[-1] >=m)
+        return _calculate_ratio(matches, len(self.a) + len(self.b))
+    
+    
     def quick_ratio(self):
         """Return an upper bound on ratio() relatively quickly.
 


### PR DESCRIPTION
.ratio_min(self,m) is an extension of the difflib's function .ratio(self). Equivalently to .ratio(self), .ratio_min(self,m) returns a measure of two sequences' similarity (float in [0,1]). In addition to .ratio(), it can ignore matched substrings of length less than a given threshold m.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-41354](https://bugs.python.org/issue41354) -->
https://bugs.python.org/issue41354
<!-- /issue-number -->
