### PR TITLE
bpo-46087: add a missing print() in documentation

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -689,11 +689,11 @@ Using type-specific formatting::
 Nesting arguments and more complex examples::
 
    >>> for align, text in zip('<^>', ['left', 'center', 'right']):
-   ...     '{0:{fill}{align}16}'.format(text, fill=align, align=align)
+   ...     print('{0:{fill}{align}16}'.format(text, fill=align, align=align))
    ...
-   'left<<<<<<<<<<<<'
-   '^^^^^center^^^^^'
-   '>>>>>>>>>>>right'
+   left<<<<<<<<<<<<
+   ^^^^^center^^^^^
+   >>>>>>>>>>>right
    >>>
    >>> octets = [192, 168, 0, 1]
    >>> '{:02X}{:02X}{:02X}{:02X}'.format(*octets)


### PR DESCRIPTION
Indeed, this code was not an expression, it was returning no value, so printing
it as value returned is not realistic. Adding `print` is easier than
transforming it into an actual value.

Problem is present in all version of documentation, even 2.7. So make sens to backport it anywhere python still want to backport.

<!-- issue-number: [bpo-46087](https://bugs.python.org/issue46087) -->
https://bugs.python.org/issue46087
<!-- /issue-number -->
