### PR TITLE
bpo-45829: Check `__getitem__`'s version for overflow before specializing

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1187,12 +1187,8 @@ _Py_Specialize_BinarySubscr(
         assert(cls->tp_version_tag != 0);
         cache0->version = cls->tp_version_tag;
         int version = _PyFunction_GetVersionForCurrentState(func);
-        if (version == 0) {
+        if (version == 0 || version != (uint16_t)version) {
             SPECIALIZATION_FAIL(BINARY_SUBSCR, SPEC_FAIL_OUT_OF_VERSIONS);
-            goto fail;
-        }
-        if (version != (uint16_t)version) {
-            SPECIALIZATION_FAIL(BINARY_SUBSCR, SPEC_FAIL_OUT_OF_RANGE);
             goto fail;
         }
         cache0->index = version;

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1191,6 +1191,10 @@ _Py_Specialize_BinarySubscr(
             SPECIALIZATION_FAIL(BINARY_SUBSCR, SPEC_FAIL_OUT_OF_VERSIONS);
             goto fail;
         }
+        if (version != (uint16_t)version) {
+            SPECIALIZATION_FAIL(BINARY_SUBSCR, SPEC_FAIL_OUT_OF_RANGE);
+            goto fail;
+        }
         cache0->index = version;
         cache[-1].obj.obj = descriptor;
         *instr = _Py_MAKECODEUNIT(BINARY_SUBSCR_GETITEM, _Py_OPARG(*instr));


### PR DESCRIPTION


<!-- issue-number: [bpo-45829](https://bugs.python.org/issue45829) -->
https://bugs.python.org/issue45829
<!-- /issue-number -->
