### PR TITLE
bpo-46006: Move the interned strings and identifiers to _PyRuntimeState.

### DIFF
--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -45,6 +45,8 @@ extern "C" {
     _PyRuntime.global_objects.NAME
 #define _Py_SINGLETON(NAME) \
     _Py_GLOBAL_OBJECT(singletons.NAME)
+#define _Py_CACHED_OBJECT(NAME) \
+    _Py_GLOBAL_OBJECT(cached.NAME)
 
 struct _Py_global_objects {
     struct {
@@ -66,6 +68,17 @@ struct _Py_global_objects {
             PyObject **array;
         } unicode_ids;
     } singletons;
+    struct {
+        /* This dictionary holds all interned unicode strings.  Note that references
+           to strings in this dictionary are *not* counted in the string's ob_refcnt.
+           When the interned string reaches a refcnt of 0 the string deallocation
+           function will delete the reference from this dictionary.
+
+           Another way to look at this is that to say that the actual reference
+           count of a string is:  s->ob_refcnt + (s->state ? 2 : 0)
+        */
+        PyObject *unicode_interned;
+    } cached;
 };
 
 #define _Py_global_objects_INIT { \

--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -54,6 +54,17 @@ struct _Py_global_objects {
          * -_PY_NSMALLNEGINTS (inclusive) to _PY_NSMALLPOSINTS (exclusive).
          */
         PyLongObject small_ints[_PY_NSMALLNEGINTS + _PY_NSMALLPOSINTS];
+
+        /* Unicode identifiers (_Py_Identifier): see _PyUnicode_FromId() */
+        struct _Py_unicode_ids {
+            PyThread_type_lock lock;
+            // next_index value must be preserved when Py_Initialize()/Py_Finalize()
+            // is called multiple times: see _PyUnicode_FromId() implementation.
+            Py_ssize_t next_index;
+
+            Py_ssize_t size;
+            PyObject **array;
+        } unicode_ids;
     } singletons;
 };
 

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -116,8 +116,6 @@ typedef struct pyruntimestate {
     void *open_code_userdata;
     _Py_AuditHookEntry *audit_hook_head;
 
-    struct _Py_unicode_runtime_ids unicode_ids;
-
     struct _Py_global_objects global_objects;
     // If anything gets added after global_objects then
     // _PyRuntimeState_reset() needs to get updated to clear it.

--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -35,16 +35,6 @@ struct _Py_unicode_state {
        shared as well. */
     PyObject *latin1[256];
     struct _Py_unicode_fs_codec fs_codec;
-
-    /* This dictionary holds all interned unicode strings.  Note that references
-       to strings in this dictionary are *not* counted in the string's ob_refcnt.
-       When the interned string reaches a refcnt of 0 the string deallocation
-       function will delete the reference from this dictionary.
-
-       Another way to look at this is that to say that the actual reference
-       count of a string is:  s->ob_refcnt + (s->state ? 2 : 0)
-    */
-    PyObject *interned;
 };
 
 extern void _PyUnicode_ClearInterned(PyInterpreterState *);

--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -19,13 +19,6 @@ extern void _PyUnicode_Fini(PyInterpreterState *);
 
 /* other API */
 
-struct _Py_unicode_runtime_ids {
-    PyThread_type_lock lock;
-    // next_index value must be preserved when Py_Initialize()/Py_Finalize()
-    // is called multiple times: see _PyUnicode_FromId() implementation.
-    Py_ssize_t next_index;
-};
-
 /* fs_codec.encoding is initialized to NULL.
    Later, it is set to a non-NULL string by _PyUnicode_InitEncodings(). */
 struct _Py_unicode_fs_codec {
@@ -33,11 +26,6 @@ struct _Py_unicode_fs_codec {
     int utf8;         // encoding=="utf-8"?
     char *errors;     // Filesystem errors (encoded to UTF-8)
     _Py_error_handler error_handler;
-};
-
-struct _Py_unicode_ids {
-    Py_ssize_t size;
-    PyObject **array;
 };
 
 struct _Py_unicode_state {
@@ -57,9 +45,6 @@ struct _Py_unicode_state {
        count of a string is:  s->ob_refcnt + (s->state ? 2 : 0)
     */
     PyObject *interned;
-
-    // Unicode identifiers (_Py_Identifier): see _PyUnicode_FromId()
-    struct _Py_unicode_ids ids;
 };
 
 extern void _PyUnicode_ClearInterned(PyInterpreterState *);

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-16-17-26-17.bpo-46006.vAP3Et.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-16-17-26-17.bpo-46006.vAP3Et.rst
@@ -1,0 +1,3 @@
+Move the interned strings and Py_IDENTIFIER strings back to the
+process-global runtime state instead of the per-interpreter state (at least
+for now).

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -2388,8 +2388,11 @@ _PyUnicode_FromId(_Py_Identifier *id)
 
 
 static void
-unicode_clear_identifiers(void)
+unicode_clear_identifiers(PyInterpreterState *interp)
 {
+    if (!_Py_IsMainInterpreter(interp)) {
+        return;
+    }
     for (Py_ssize_t i=0; i < IDENTIFIERS.size; i++) {
         Py_XDECREF(IDENTIFIERS.array[i]);
     }
@@ -15653,6 +15656,9 @@ PyUnicode_InternFromString(const char *cp)
 void
 _PyUnicode_ClearInterned(PyInterpreterState *interp)
 {
+    if (!_Py_IsMainInterpreter(interp)) {
+        return;
+    }
     if (INTERNED == NULL) {
         return;
     }
@@ -16088,7 +16094,7 @@ _PyUnicode_Fini(PyInterpreterState *interp)
 
     _PyUnicode_FiniEncodings(&state->fs_codec);
 
-    unicode_clear_identifiers();
+    unicode_clear_identifiers(interp);
 
     for (Py_ssize_t i = 0; i < 256; i++) {
         Py_CLEAR(state->latin1[i]);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -16090,7 +16090,7 @@ _PyUnicode_Fini(PyInterpreterState *interp)
     struct _Py_unicode_state *state = &interp->unicode;
 
     // _PyUnicode_ClearInterned() must be called before
-    assert(INTERNED == NULL);
+    assert(INTERNED == NULL || !_Py_IsMainInterpreter(interp));
 
     _PyUnicode_FiniEncodings(&state->fs_codec);
 


### PR DESCRIPTION
Currently the interned strings (and strings created for `_Py_IDENTIFIER()`) are per-interpreter.  This is causing some bugs because other objects which may hold a reference to the string are still global.  So until we are closer to moving the bulk of the global objects to per-interpreter, the simplest thing is to move the interned strings (and identifiers) to `_PyRuntimeState`.

<!-- issue-number: [bpo-46006](https://bugs.python.org/issue46006) -->
https://bugs.python.org/issue46006
<!-- /issue-number -->
