### PR TITLE
bpo-46094: Add test to check that parameters explicitly exist on unittest.TestResult

### DIFF
--- a/Lib/unittest/test/test_result.py
+++ b/Lib/unittest/test/test_result.py
@@ -69,6 +69,11 @@ class Test_TestResult(unittest.TestCase):
         self.assertEqual(result.shouldStop, False)
         self.assertIsNone(result._stdout_buffer)
         self.assertIsNone(result._stderr_buffer)
+    
+    # "Called to make sure that the required parameters exist on
+    # TestResult. They are needed for multiple inheritance."
+    def test_initWithArguments(self):
+        unittest.TestResult(stream=None, descriptions=None, verbosity=None)
 
     # "This method can be called to signal that the set of tests being
     # run should be aborted by setting the TestResult's shouldStop

--- a/Misc/NEWS.d/next/Tests/2021-12-17-21-27-26.bpo-46094.TQOInR.rst
+++ b/Misc/NEWS.d/next/Tests/2021-12-17-21-27-26.bpo-46094.TQOInR.rst
@@ -1,0 +1,1 @@
+Add a test to explicitly check for TestResult parameters.


### PR DESCRIPTION
This simple test will make sure they exist even though they're not used within `__init__()`. They're required for multiple inheritance.

<!-- issue-number: [bpo-46094](https://bugs.python.org/issue46094) -->
https://bugs.python.org/issue46094
<!-- /issue-number -->
