### PR TITLE
bpo-45554: Document multiprocessing.Process.exitcode values

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -569,8 +569,15 @@ The :mod:`multiprocessing` package mostly replicates the API of the
    .. attribute:: exitcode
 
       The child's exit code.  This will be ``None`` if the process has not yet
-      terminated.  A negative value *-N* indicates that the child was terminated
-      by signal *N*.
+      terminated.
+
+      If the child's :meth:`run` method returned normally, the exit code
+      will be 0.  If it terminated via :func:`sys.exit` with an integer
+      argument *N*, the exit code will be *N*.
+
+      If the child terminated due to an exception not caught within
+      :meth:`run`, the exit code will be 1.  If it was terminated by
+      signal *N*, the exit code will be the negative value *-N*.
 
    .. attribute:: authkey
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1118,6 +1118,7 @@ Vincent Marchetti
 David Marek
 Doug Marien
 Sven Marnach
+John Marshall
 Alex Martelli
 Dennis Mårtensson
 Anthony Martin

--- a/Misc/NEWS.d/next/Documentation/2021-12-16-11-44-21.bpo-45554.RhPt2B.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-12-16-11-44-21.bpo-45554.RhPt2B.rst
@@ -1,1 +1,0 @@
-Expand the :attr:`multiprocessing.Process.exitcode` documentation.

--- a/Misc/NEWS.d/next/Documentation/2021-12-16-11-44-21.bpo-45554.RhPt2B.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-12-16-11-44-21.bpo-45554.RhPt2B.rst
@@ -1,0 +1,1 @@
+Expand the :attr:`multiprocessing.Process.exitcode` documentation.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This addresses [bpo-45554](https://bugs.python.org/issue45554) by expanding the `exitcode` documentation to also describe what `exitcode` will be in cases of normal termination, `sys.exit()` called, and on uncaught exceptions.

<!-- issue-number: [bpo-45554](https://bugs.python.org/issue45554) -->
https://bugs.python.org/issue45554
<!-- /issue-number -->

Automerge-Triggered-By: GH:pitrou