### PR TITLE
bpo-46101: argparse bug fix when using parents & subcommands

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1213,9 +1213,12 @@ class _SubParsersAction(Action):
         # In case this subparser defines new defaults, we parse them
         # in a new namespace object and then update the original
         # namespace for the relevant parts.
+        defaults = {action.dest: action.default for action in parser._actions}
         subnamespace, arg_strings = parser.parse_known_args(arg_strings, None)
         for key, value in vars(subnamespace).items():
-            setattr(namespace, key, value)
+            current_value = getattr(namespace, key, None)
+            if current_value is None or value != defaults.get(key):
+                setattr(namespace, key, value)
 
         if arg_strings:
             vars(namespace).setdefault(_UNRECOGNIZED_ARGS_ATTR, [])

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2560,6 +2560,29 @@ class TestParentParsers(TestCase):
               -x X
         '''.format(progname, ' ' if progname else '' )))
 
+    def test_common_opts_with_defaults(self):
+        common_opts_parser = ErrorRaisingArgumentParser(add_help=False)
+        common_opts_parser.add_argument("--endpoint", choices=("prod", "dev"), default="prod")
+        common_opts_parser.add_argument("--comment")
+
+        parser = ErrorRaisingArgumentParser(parents=[common_opts_parser])
+        subparsers = parser.add_subparsers(required=True)
+        subcmd_cmd = subparsers.add_parser("subcmd", parents=[common_opts_parser])
+        subcmd_cmd.add_argument("--debug", action="store_true")
+
+        self.assertEqual(
+            parser.parse_known_args("--endpoint=dev subcmd".split()),
+            (NS(endpoint="dev", comment=None, debug=False), []),
+        )
+        self.assertEqual(
+            parser.parse_known_args("--comment=Hello subcmd --debug".split()),
+            (NS(endpoint="prod", comment="Hello", debug=True), []),
+        )
+        self.assertEqual(
+            parser.parse_known_args("--comment=Hello subcmd --comment=World".split()),
+            (NS(endpoint="prod", comment="World", debug=False), []),
+        )
+
 # ==============================
 # Mutually exclusive group tests
 # ==============================

--- a/Misc/NEWS.d/next/Library/2021-12-16-15-53-23.bpo-46101.Ur9YhV.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-16-15-53-23.bpo-46101.Ur9YhV.rst
@@ -1,0 +1,1 @@
+argparse bug fix when using parents & subcommands: options are no more ignored when provided before a subcommand


### PR DESCRIPTION
Here is some minimal code reproducing the issue:
```python
import argparse

common_opts_parser = argparse.ArgumentParser(add_help=False)
common_opts_parser.add_argument("--endpoint", choices=("prod", "dev"), default="dev")

parser = argparse.ArgumentParser(parents=[common_opts_parser])
subparsers = parser.add_subparsers(required=True)

subcmd_cmd = subparsers.add_parser("subcmd", parents=[common_opts_parser])
subcmd_cmd.add_argument("--debug", action="store_true")

print(parser.parse_args())
```
Everything works fine / as expected when specifying the common optional arg last:

    $ ./bug_repro.py subcmd --endpoint=dev
    Namespace(endpoint='dev', debug=False)

However when specifying the --endpoint between the program and the subcommand, the value provided is ignored:

    $ ./bug_repro.py --endpoint=dev subcmd
    Namespace(endpoint=None, debug=False)

Tested under Windows / Python 3.11.0a0 with:
```
python -m test -v -m test_common_opts test_argparse
```

<!-- issue-number: [bpo-46101](https://bugs.python.org/issue46101) -->
https://bugs.python.org/issue46101
<!-- /issue-number -->
