### PR TITLE
bpo-46103: Fix inspect.getmembers call the instance __bases__ attribute which ma…

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -446,7 +446,7 @@ def _getmembers(object, predicate, getter):
     names = dir(object)
     if isclass(object):
         mro = (object,) + getmro(object)
-        # :dd any DynamicClassAttributes to the list of names if object is a class;
+        # add any DynamicClassAttributes to the list of names if object is a class;
         # this may result in duplicate entries if, for example, a virtual
         # attribute with the same name as a DynamicClassAttribute exists
         try:

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -441,23 +441,23 @@ def isabstract(object):
     return False
 
 def _getmembers(object, predicate, getter):
-    if isclass(object):
-        mro = (object,) + getmro(object)
-    else:
-        mro = ()
     results = []
     processed = set()
     names = dir(object)
-    # :dd any DynamicClassAttributes to the list of names if object is a class;
-    # this may result in duplicate entries if, for example, a virtual
-    # attribute with the same name as a DynamicClassAttribute exists
-    try:
-        for base in object.__bases__:
-            for k, v in base.__dict__.items():
-                if isinstance(v, types.DynamicClassAttribute):
-                    names.append(k)
-    except AttributeError:
-        pass
+    if isclass(object):
+        mro = (object,) + getmro(object)
+        # :dd any DynamicClassAttributes to the list of names if object is a class;
+        # this may result in duplicate entries if, for example, a virtual
+        # attribute with the same name as a DynamicClassAttribute exists
+        try:
+            for base in object.__bases__:
+                for k, v in base.__dict__.items():
+                    if isinstance(v, types.DynamicClassAttribute):
+                        names.append(k)
+        except AttributeError:
+            pass
+    else:
+        mro = ()
     for key in names:
         # First try to get the value via getattr.  Some descriptors don't
         # like calling their __get__ (see bug #1785), so fall back to

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -1212,8 +1212,13 @@ class TestClassesAndFunctions(unittest.TestCase):
             @types.DynamicClassAttribute
             def eggs(self):
                 return 'spam'
+        class B:
+            def __getattr__(self, attribute):
+                return None
         self.assertIn(('eggs', 'scrambled'), inspect.getmembers(A))
         self.assertIn(('eggs', 'spam'), inspect.getmembers(A()))
+        b = B()
+        self.assertIn(('__getattr__', b.__getattr__), inspect.getmembers(b))
 
     def test_getmembers_static(self):
         class A:

--- a/Misc/NEWS.d/next/Library/2021-12-16-23-42-54.bpo-46103.LMnZAN.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-16-23-42-54.bpo-46103.LMnZAN.rst
@@ -1,0 +1,2 @@
+Fix :func:`inspect.getmembers` will call the instance __bases__ attribute
+which may cause exception. Patch by Weipeng Hong.

--- a/Misc/NEWS.d/next/Library/2021-12-16-23-42-54.bpo-46103.LMnZAN.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-16-23-42-54.bpo-46103.LMnZAN.rst
@@ -1,2 +1,2 @@
-Fix :func:`inspect.getmembers` will call the instance ``__bases__`` attribute
-which may cause exception. Patch by Weipeng Hong.
+Now :func:`inspect.getmembers` only gets :attr:`__bases__` attribute from
+class type. Patch by Weipeng Hong.

--- a/Misc/NEWS.d/next/Library/2021-12-16-23-42-54.bpo-46103.LMnZAN.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-16-23-42-54.bpo-46103.LMnZAN.rst
@@ -1,2 +1,2 @@
-Fix :func:`inspect.getmembers` will call the instance __bases__ attribute
+Fix :func:`inspect.getmembers` will call the instance ``__bases__`` attribute
 which may cause exception. Patch by Weipeng Hong.


### PR DESCRIPTION
…y cause exception

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46103](https://bugs.python.org/issue46103) -->
https://bugs.python.org/issue46103
<!-- /issue-number -->
