### PR TITLE
bpo-46104: Reduce use of pre-PEP 526 syntax in typing docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1782,7 +1782,7 @@ Asynchronous programming
       c: Coroutine[list[str], str, int]  # Some coroutine defined elsewhere
       x = c.send('hi')                   # Inferred type of 'x' is list[str]
       async def bar() -> None:
-          y = await c                    # Inferred type of y is int
+          y = await c                    # Inferred type of 'y' is int
 
    .. versionadded:: 3.5.3
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -428,12 +428,12 @@ value of type :data:`Any` and assign it to any variable::
 
    from typing import Any
 
-   a = None    # type: Any
-   a = []      # OK
-   a = 2       # OK
+   a: Any = None
+   a = []          # OK
+   a = 2           # OK
 
-   s = ''      # type: str
-   s = a       # OK
+   s: str = ''
+   s = a           # OK
 
    def foo(item: Any) -> int:
        # Typechecks; 'item' could be any type,
@@ -1779,11 +1779,10 @@ Asynchronous programming
    correspond to those of :class:`Generator`, for example::
 
       from collections.abc import Coroutine
-      c = None # type: Coroutine[list[str], str, int]
-      ...
-      x = c.send('hi') # type: list[str]
+      c: Coroutine[list[str], str, int]  # Some coroutine defined elsewhere
+      x: list[str] = c.send('hi')
       async def bar() -> None:
-          x = await c # type: int
+          x: int = await c
 
    .. versionadded:: 3.5.3
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1780,7 +1780,7 @@ Asynchronous programming
 
       from collections.abc import Coroutine
       c: Coroutine[list[str], str, int]  # Some coroutine defined elsewhere
-      x = c.send('hi')                   # Inferred type of x is list[str]
+      x = c.send('hi')                   # Inferred type of 'x' is list[str]
       async def bar() -> None:
           y = await c                    # Inferred type of y is int
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -432,7 +432,7 @@ value of type :data:`Any` and assign it to any variable::
    a = []          # OK
    a = 2           # OK
 
-   s: str = ''
+   s = ''          # the type-checker infers the type of s is str
    s = a           # OK
 
    def foo(item: Any) -> int:
@@ -1780,9 +1780,9 @@ Asynchronous programming
 
       from collections.abc import Coroutine
       c: Coroutine[list[str], str, int]  # Some coroutine defined elsewhere
-      x: list[str] = c.send('hi')
+      x = c.send('hi')                   # the type-checker infers the type of x is list[str]
       async def bar() -> None:
-          x: int = await c
+          y = await c                    # the type-checker infers the type of y is int
 
    .. versionadded:: 3.5.3
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -432,7 +432,7 @@ value of type :data:`Any` and assign it to any variable::
    a = []          # OK
    a = 2           # OK
 
-   s = ''          # Inferred type of s is str
+   s = ''          # Inferred type of 's' is str
    s = a           # OK
 
    def foo(item: Any) -> int:

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -432,7 +432,7 @@ value of type :data:`Any` and assign it to any variable::
    a = []          # OK
    a = 2           # OK
 
-   s = ''          # the type-checker infers the type of s is str
+   s = ''          # Inferred type of s is str
    s = a           # OK
 
    def foo(item: Any) -> int:
@@ -1780,9 +1780,9 @@ Asynchronous programming
 
       from collections.abc import Coroutine
       c: Coroutine[list[str], str, int]  # Some coroutine defined elsewhere
-      x = c.send('hi')                   # the type-checker infers the type of x is list[str]
+      x = c.send('hi')                   # Inferred type of x is list[str]
       async def bar() -> None:
-          y = await c                    # the type-checker infers the type of y is int
+          y = await c                    # Inferred type of y is int
 
    .. versionadded:: 3.5.3
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46104](https://bugs.python.org/issue46104) -->
https://bugs.python.org/issue46104
<!-- /issue-number -->
