### PR TITLE
[3.9] bpo-46105: Honor spec when generating requirement specs with urls and extras. (GH-30151).

### DIFF
--- a/Lib/importlib/metadata.py
+++ b/Lib/importlib/metadata.py
@@ -344,17 +344,26 @@ class Distribution:
         def make_condition(name):
             return name and 'extra == "{name}"'.format(name=name)
 
-        def parse_condition(section):
+        def quoted_marker(section):
             section = section or ''
             extra, sep, markers = section.partition(':')
             if extra and markers:
-                markers = '({markers})'.format(markers=markers)
+                markers = f'({markers})'
             conditions = list(filter(None, [markers, make_condition(extra)]))
             return '; ' + ' and '.join(conditions) if conditions else ''
 
+        def url_req_space(req):
+            """
+            PEP 508 requires a space between the url_spec and the quoted_marker.
+            Ref python/importlib_metadata#357.
+            """
+            # '@' is uniquely indicative of a url_req.
+            return ' ' * ('@' in req)
+
         for section, deps in sections.items():
             for dep in deps:
-                yield dep + parse_condition(section)
+                space = url_req_space(dep)
+                yield dep + space + quoted_marker(section)
 
 
 class DistributionFinder(MetaPathFinder):

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -121,6 +121,7 @@ class APITests(
 
             [extra1]
             dep4
+            dep6@ git+https://example.com/python/dep.git@v1.0.0
 
             [extra2:python_version < "3"]
             dep5
@@ -132,6 +133,7 @@ class APITests(
             'dep3; python_version < "3"',
             'dep4; extra == "extra1"',
             'dep5; (python_version < "3") and extra == "extra2"',
+            'dep6@ git+https://example.com/python/dep.git@v1.0.0 ; extra == "extra1"',
             ]
         # It's important that the environment marker expression be
         # wrapped in parentheses to avoid the following 'and' binding more

--- a/Misc/NEWS.d/next/Library/2021-12-16-14-30-36.bpo-46105.pprB1K.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-16-14-30-36.bpo-46105.pprB1K.rst
@@ -1,0 +1,2 @@
+Honor spec when generating requirement specs with urls and extras
+(importlib_metadata 4.8.3).


### PR DESCRIPTION


(cherry picked from commit 109d96602199a91e94eb14b8cb3720841f22ded7)

Co-authored-by: Jason R. Coombs <jaraco@jaraco.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46105](https://bugs.python.org/issue46105) -->
https://bugs.python.org/issue46105
<!-- /issue-number -->
