### PR TITLE
bpo-46107: ExceptionGroup.subgroup()/split() should copy __note__ to the parts

### DIFF
--- a/Lib/test/test_exception_group.py
+++ b/Lib/test/test_exception_group.py
@@ -495,13 +495,14 @@ class ExceptionGroupSplitTestBase(ExceptionGroupTestBase):
                 match and e in match_leaves,
                 rest and e in rest_leaves)
 
-        # message, cause and context equal to eg
+        # message, cause and context, traceback and note equal to eg
         for part in [match, rest, sg]:
             if part is not None:
                 self.assertEqual(eg.message, part.message)
                 self.assertIs(eg.__cause__, part.__cause__)
                 self.assertIs(eg.__context__, part.__context__)
                 self.assertIs(eg.__traceback__, part.__traceback__)
+                self.assertIs(eg.__note__, part.__note__)
 
         def tbs_for_leaf(leaf, eg):
             for e, tbs in leaf_generator(eg):
@@ -566,6 +567,7 @@ class NestedExceptionGroupSplitTest(ExceptionGroupSplitTestBase):
         try:
             nested_group()
         except ExceptionGroup as e:
+            e.__note__ = f"the note: {id(e)}"
             eg = e
 
         eg_template = [

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-16-23-27-05.bpo-46107.7q5an0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-16-23-27-05.bpo-46107.7q5an0.rst
@@ -1,1 +1,1 @@
-Fix bug where :meth:`ExceptionGroup.split` and :meth:`ExceptionGroup.split` do not copy the exception group's ``__note__`` field to the parts.
+Fix bug where :meth:`ExceptionGroup.split` and :meth:`ExceptionGroup.subgroup` do not copy the exception group's ``__note__`` field to the parts.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-16-23-27-05.bpo-46107.7q5an0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-16-23-27-05.bpo-46107.7q5an0.rst
@@ -1,0 +1,1 @@
+Fix bug where :meth:`ExceptionGroup.split` and :meth:`ExceptionGroup.split` do not copy the exception group's ``__note__`` field to the parts.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-16-23-27-05.bpo-46107.7q5an0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-16-23-27-05.bpo-46107.7q5an0.rst
@@ -1,1 +1,1 @@
-Fix bug where :meth:`ExceptionGroup.split` and :meth:`ExceptionGroup.subgroup` do not copy the exception group's ``__note__`` field to the parts.
+Fix bug where :meth:`ExceptionGroup.split` and :meth:`ExceptionGroup.subgroup` did not copy the exception group's ``__note__`` field to the parts.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -901,6 +901,11 @@ exceptiongroup_subset(
     }
     PyException_SetContext(eg, PyException_GetContext(orig));
     PyException_SetCause(eg, PyException_GetCause(orig));
+
+    PyObject *note = _PyBaseExceptionObject_cast(orig)->note;
+    Py_XINCREF(note);
+    _PyBaseExceptionObject_cast(eg)->note = note;
+
     *result = eg;
     return 0;
 error:


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46107](https://bugs.python.org/issue46107) -->
https://bugs.python.org/issue46107
<!-- /issue-number -->
