### PR TITLE
bpo-46044: Fix doc typo introduced in GH-30043

### DIFF
--- a/Doc/distutils/sourcedist.rst
+++ b/Doc/distutils/sourcedist.rst
@@ -37,7 +37,7 @@ to create a gzipped tarball and a zip file.  The available formats are:
 | ``xztar`` | xz'ed tar file          | \(5)        |
 |           | (:file:`.tar.xz`)       |             |
 +-----------+-------------------------+-------------+
-| ``ztar``  | compressed tar file     | \(4),(5)    |
+| ``ztar``  | compressed tar file     | (4),(5)     |
 |           | (:file:`.tar.Z`)        |             |
 +-----------+-------------------------+-------------+
 | ``tar``   | tar file (:file:`.tar`) | \(5)        |

--- a/Doc/distutils/sourcedist.rst
+++ b/Doc/distutils/sourcedist.rst
@@ -37,7 +37,7 @@ to create a gzipped tarball and a zip file.  The available formats are:
 | ``xztar`` | xz'ed tar file          | \(5)        |
 |           | (:file:`.tar.xz`)       |             |
 +-----------+-------------------------+-------------+
-| ``ztar``  | compressed tar file     | \(5)        |
+| ``ztar``  | compressed tar file     | \(4),(5)    |
 |           | (:file:`.tar.Z`)        |             |
 +-----------+-------------------------+-------------+
 | ``tar``   | tar file (:file:`.tar`) | \(5)        |


### PR DESCRIPTION
See https://github.com/python/cpython/pull/30043/files#r770944718

My bad I likely messed up by using a repeat command in my editor


<!-- issue-number: [bpo-46044](https://bugs.python.org/issue46044) -->
https://bugs.python.org/issue46044
<!-- /issue-number -->

Automerge-Triggered-By: GH:merwok