### PR TITLE
bpo-40915: Fix a 32bit compiler warning in mmapmodule.c on Windows

### DIFF
--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -536,7 +536,8 @@ mmap_resize_method(mmap_object *self,
                 !SetEndOfFile(self->file_handle)) {
                 /* resizing failed. try to remap the file */
                 file_resize_error = GetLastError();
-                new_size = max_size.QuadPart = self->size;
+                max_size.QuadPart = self->size;
+                new_size = self->size;
             }
         }
 


### PR DESCRIPTION
MSVC(x86) shows the following warning at `mmap_resize_method()` when building 3.11.
```
mmapmodule.c(539,58): warning C4244: '=':
conversion from 'LONGLONG' to 'Py_ssize_t', possible loss of data
```

<!-- issue-number: [bpo-40915](https://bugs.python.org/issue40915) -->
https://bugs.python.org/issue40915
<!-- /issue-number -->
