### PR TITLE
bpo-46123: Disable optimizations for _freeze_module.exe on MSVC for faster building

### DIFF
--- a/Misc/NEWS.d/next/Windows/2021-12-18-11-59-10.bpo-46123.7nJjXc.rst
+++ b/Misc/NEWS.d/next/Windows/2021-12-18-11-59-10.bpo-46123.7nJjXc.rst
@@ -1,0 +1,1 @@
+_freeze_module.exe on Windows is now not optimized by MSVC for faster building.

--- a/Misc/NEWS.d/next/Windows/2021-12-18-11-59-10.bpo-46123.7nJjXc.rst
+++ b/Misc/NEWS.d/next/Windows/2021-12-18-11-59-10.bpo-46123.7nJjXc.rst
@@ -1,1 +1,0 @@
-_freeze_module.exe on Windows is now not optimized by MSVC for faster building.

--- a/PCbuild/_freeze_module.vcxproj
+++ b/PCbuild/_freeze_module.vcxproj
@@ -89,10 +89,13 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>Py_NO_ENABLE_SHARED;Py_BUILD_CORE;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>Disabled</Optimization>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalDependencies>version.lib;ws2_32.lib;pathcch.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
**EDIT**: This does not disable the existing `InlineFunctionExpansion`(`/Ob`) option. 
<!-- issue-number: [bpo-46123](https://bugs.python.org/issue46123) -->
https://bugs.python.org/issue46123
<!-- /issue-number -->
