### PR TITLE
bpo-45496: Allow flexibility in winfo_rgb tests

### DIFF
--- a/Lib/tkinter/test/test_tkinter/test_misc.py
+++ b/Lib/tkinter/test/test_tkinter/test_misc.py
@@ -205,9 +205,8 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         def assertApprox(col1, col2):
             # A small amount of flexibility is required (bpo-45496)
             # 33 is ~0.05% of 65535, which is a reasonable margin
-            self.assertTrue(all(
-                abs(i - j) < 33 for i, j in zip(col1, col2)
-            ))
+            for col1_channel, col2_channel in zip(col1, col2):
+                self.assertAlmostEqual(col1_channel, col2_channel, delta=33)
 
         root = self.root
         rgb = root.winfo_rgb

--- a/Lib/tkinter/test/test_tkinter/test_misc.py
+++ b/Lib/tkinter/test/test_tkinter/test_misc.py
@@ -201,6 +201,14 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
             root.clipboard_get()
 
     def test_winfo_rgb(self):
+
+        def assertApprox(col1, col2):
+            # A small amount of flexibility is required (bpo-45496)
+            # 33 is ~0.05% of 65535, which is a reasonable margin
+            self.assertTrue(all(
+                abs(i - j) < 33 for i, j in zip(col1, col2)
+            ))
+
         root = self.root
         rgb = root.winfo_rgb
 
@@ -210,9 +218,9 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         # #RGB - extends each 4-bit hex value to be 16-bit.
         self.assertEqual(rgb('#F0F'), (0xFFFF, 0x0000, 0xFFFF))
         # #RRGGBB - extends each 8-bit hex value to be 16-bit.
-        self.assertEqual(rgb('#4a3c8c'), (0x4a4a, 0x3c3c, 0x8c8c))
+        assertApprox(rgb('#4a3c8c'), (0x4a4a, 0x3c3c, 0x8c8c))
         # #RRRRGGGGBBBB
-        self.assertEqual(rgb('#dede14143939'), (0xdede, 0x1414, 0x3939))
+        assertApprox(rgb('#dede14143939'), (0xdede, 0x1414, 0x3939))
         # Invalid string.
         with self.assertRaises(tkinter.TclError):
             rgb('#123456789a')

--- a/Misc/NEWS.d/next/Tests/2021-12-18-13-31-29.bpo-45496.lQsPOW.rst
+++ b/Misc/NEWS.d/next/Tests/2021-12-18-13-31-29.bpo-45496.lQsPOW.rst
@@ -1,0 +1,1 @@
+Allow a small margin to avoid failing the tkinter `winfo_rgb` test when on different hardware.

--- a/Misc/NEWS.d/next/Tests/2021-12-18-13-31-29.bpo-45496.lQsPOW.rst
+++ b/Misc/NEWS.d/next/Tests/2021-12-18-13-31-29.bpo-45496.lQsPOW.rst
@@ -1,1 +1,0 @@
-Allow a small margin to avoid failing the tkinter ``winfo_rgb`` test when on different hardware.

--- a/Misc/NEWS.d/next/Tests/2021-12-18-13-31-29.bpo-45496.lQsPOW.rst
+++ b/Misc/NEWS.d/next/Tests/2021-12-18-13-31-29.bpo-45496.lQsPOW.rst
@@ -1,1 +1,1 @@
-Allow a small margin to avoid failing the tkinter `winfo_rgb` test when on different hardware.
+Allow a small margin to avoid failing the tkinter ``winfo_rgb`` test when on different hardware.


### PR DESCRIPTION
Allow a margin of 0.05% per colour channel to avoid tests failing on different hardware.

<!-- issue-number: [bpo-45496](https://bugs.python.org/issue45496) -->
https://bugs.python.org/issue45496
<!-- /issue-number -->
