### PR TITLE
bpo-46126: Disable 'descriptions' when running tests internally.

### DIFF
--- a/Lib/test/support/testresult.py
+++ b/Lib/test/support/testresult.py
@@ -145,7 +145,11 @@ def get_test_runner_class(verbosity, buffer=False):
         return functools.partial(unittest.TextTestRunner,
                                  resultclass=RegressionTestResult,
                                  buffer=buffer,
-                                 verbosity=verbosity)
+                                 verbosity=verbosity,
+                                 # disable descriptions so errors are
+                                 # readily traceable. bpo-46126
+                                 descriptions=False,
+                                 )
     return functools.partial(QuietRegressionTestRunner, buffer=buffer)
 
 def get_test_runner(stream, verbosity, capture_output=False):

--- a/Misc/NEWS.d/next/Tests/2021-12-18-22-23-50.bpo-46126.0LH3Yb.rst
+++ b/Misc/NEWS.d/next/Tests/2021-12-18-22-23-50.bpo-46126.0LH3Yb.rst
@@ -1,0 +1,1 @@
+Disable 'descriptions' when running tests internally.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46126](https://bugs.python.org/issue46126) -->
https://bugs.python.org/issue46126
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco