### PR TITLE
bpo-46129: Rewrite asyncio.locks tests with IsolatedAsyncioTestCase

### DIFF
--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -653,11 +653,11 @@ class ConditionTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(t2.done())
         self.assertTrue(t2.result())
 
-    async def test_notify_unacquired(self):
+    def test_notify_unacquired(self):
         cond = asyncio.Condition()
         self.assertRaises(RuntimeError, cond.notify)
 
-    async def test_notify_all_unacquired(self):
+    def test_notify_all_unacquired(self):
         cond = asyncio.Condition()
         self.assertRaises(RuntimeError, cond.notify_all)
 

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -1,11 +1,11 @@
 """Tests for lock.py"""
 
 import unittest
+from contextlib import suppress
 from unittest import mock
 import re
 
 import asyncio
-from test.test_asyncio import utils as test_utils
 
 STR_RGX_REPR = (
     r'^<(?P<class>.*?) object at (?P<address>.*?)'
@@ -20,36 +20,29 @@ def tearDownModule():
     asyncio.set_event_loop_policy(None)
 
 
-class LockTests(test_utils.TestCase):
+class LockTests(unittest.IsolatedAsyncioTestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.loop = self.new_test_loop()
-
-    def test_repr(self):
+    async def test_repr(self):
         lock = asyncio.Lock()
         self.assertTrue(repr(lock).endswith('[unlocked]>'))
         self.assertTrue(RGX_REPR.match(repr(lock)))
 
-        self.loop.run_until_complete(lock.acquire())
+        await lock.acquire()
         self.assertTrue(repr(lock).endswith('[locked]>'))
         self.assertTrue(RGX_REPR.match(repr(lock)))
 
-    def test_lock(self):
+    async def test_lock(self):
         lock = asyncio.Lock()
-
-        async def acquire_lock():
-            return await lock
 
         with self.assertRaisesRegex(
             TypeError,
             "object Lock can't be used in 'await' expression"
         ):
-            self.loop.run_until_complete(acquire_lock())
+            await lock
 
         self.assertFalse(lock.locked())
 
-    def test_lock_doesnt_accept_loop_parameter(self):
+    async def test_lock_doesnt_accept_loop_parameter(self):
         primitives_cls = [
             asyncio.Lock,
             asyncio.Condition,
@@ -58,17 +51,17 @@ class LockTests(test_utils.TestCase):
             asyncio.BoundedSemaphore,
         ]
 
+        loop = asyncio.new_event_loop()
+
         for cls in primitives_cls:
             with self.assertRaisesRegex(
                 TypeError,
                 rf'As of 3.10, the \*loop\* parameter was removed from '
                 rf'{cls.__name__}\(\) since it is no longer necessary'
             ):
-                cls(loop=self.loop)
+                cls(loop=loop)
 
-    def test_lock_by_with_statement(self):
-        loop = asyncio.new_event_loop()  # don't use TestLoop quirks
-        self.set_event_loop(loop)
+    async def test_lock_by_with_statement(self):
         primitives = [
             asyncio.Lock(),
             asyncio.Condition(),
@@ -76,7 +69,7 @@ class LockTests(test_utils.TestCase):
             asyncio.BoundedSemaphore(),
         ]
 
-        async def test(lock):
+        for lock in primitives:
             await asyncio.sleep(0.01)
             self.assertFalse(lock.locked())
             with self.assertRaisesRegex(
@@ -87,15 +80,11 @@ class LockTests(test_utils.TestCase):
                     pass
             self.assertFalse(lock.locked())
 
-        for primitive in primitives:
-            loop.run_until_complete(test(primitive))
-            self.assertFalse(primitive.locked())
-
-    def test_acquire(self):
+    async def test_acquire(self):
         lock = asyncio.Lock()
         result = []
 
-        self.assertTrue(self.loop.run_until_complete(lock.acquire()))
+        self.assertTrue(await lock.acquire())
 
         async def c1(result):
             if await lock.acquire():
@@ -112,27 +101,27 @@ class LockTests(test_utils.TestCase):
                 result.append(3)
             return True
 
-        t1 = self.loop.create_task(c1(result))
-        t2 = self.loop.create_task(c2(result))
+        t1 = asyncio.create_task(c1(result))
+        t2 = asyncio.create_task(c2(result))
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([], result)
 
         lock.release()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1], result)
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1], result)
 
-        t3 = self.loop.create_task(c3(result))
+        t3 = asyncio.create_task(c3(result))
 
         lock.release()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1, 2], result)
 
         lock.release()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1, 2, 3], result)
 
         self.assertTrue(t1.done())
@@ -142,18 +131,17 @@ class LockTests(test_utils.TestCase):
         self.assertTrue(t3.done())
         self.assertTrue(t3.result())
 
-    def test_acquire_cancel(self):
+    async def test_acquire_cancel(self):
         lock = asyncio.Lock()
-        self.assertTrue(self.loop.run_until_complete(lock.acquire()))
+        self.assertTrue(await lock.acquire())
 
-        task = self.loop.create_task(lock.acquire())
-        self.loop.call_soon(task.cancel)
-        self.assertRaises(
-            asyncio.CancelledError,
-            self.loop.run_until_complete, task)
+        task = asyncio.create_task(lock.acquire())
+        asyncio.get_running_loop().call_soon(task.cancel)
+        with self.assertRaises(asyncio.CancelledError):
+            await task
         self.assertFalse(lock._waiters)
 
-    def test_cancel_race(self):
+    async def test_cancel_race(self):
         # Several tasks:
         # - A acquires the lock
         # - B is blocked in acquire()
@@ -178,15 +166,15 @@ class LockTests(test_utils.TestCase):
             finally:
                 lock.release()
 
-        fa = self.loop.create_future()
-        ta = self.loop.create_task(lockit('A', fa))
-        test_utils.run_briefly(self.loop)
+        fa = asyncio.get_running_loop().create_future()
+        ta = asyncio.create_task(lockit('A', fa))
+        await asyncio.sleep(0)
         self.assertTrue(lock.locked())
-        tb = self.loop.create_task(lockit('B', None))
-        test_utils.run_briefly(self.loop)
+        tb = asyncio.create_task(lockit('B', None))
+        await asyncio.sleep(0)
         self.assertEqual(len(lock._waiters), 1)
-        tc = self.loop.create_task(lockit('C', None))
-        test_utils.run_briefly(self.loop)
+        tc = asyncio.create_task(lockit('C', None))
+        await asyncio.sleep(0)
         self.assertEqual(len(lock._waiters), 2)
 
         # Create the race and check.
@@ -194,16 +182,17 @@ class LockTests(test_utils.TestCase):
         fa.set_result(None)
         tb.cancel()
         self.assertTrue(lock._waiters[0].cancelled())
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertFalse(lock.locked())
         self.assertTrue(ta.done())
         self.assertTrue(tb.cancelled())
-        self.assertTrue(tc.done())
+        await tc
 
-    def test_cancel_release_race(self):
+    async def test_cancel_release_race(self):
         # Issue 32734
         # Acquire 4 locks, cancel second, release first
         # and 2 locks are taken at once.
+        loop = asyncio.get_running_loop()
         lock = asyncio.Lock()
         lock_count = 0
         call_count = 0
@@ -215,27 +204,23 @@ class LockTests(test_utils.TestCase):
             await lock.acquire()
             lock_count += 1
 
-        async def lockandtrigger():
-            await lock.acquire()
-            self.loop.call_soon(trigger)
-
         def trigger():
             t1.cancel()
             lock.release()
 
-        t0 = self.loop.create_task(lockandtrigger())
-        t1 = self.loop.create_task(lockit())
-        t2 = self.loop.create_task(lockit())
-        t3 = self.loop.create_task(lockit())
+        await lock.acquire()
 
-        # First loop acquires all
-        test_utils.run_briefly(self.loop)
-        self.assertTrue(t0.done())
+        t1 = asyncio.create_task(lockit())
+        t2 = asyncio.create_task(lockit())
+        t3 = asyncio.create_task(lockit())
 
-        # Second loop calls trigger
-        test_utils.run_briefly(self.loop)
-        # Third loop calls cancellation
-        test_utils.run_briefly(self.loop)
+        # Start scheduled tasks
+        await asyncio.sleep(0)
+
+        loop.call_soon(trigger)
+        with suppress(asyncio.CancelledError):
+            # Wait for cancellation
+            await t1
 
         # Make sure only one lock was taken
         self.assertEqual(lock_count, 1)
@@ -245,62 +230,59 @@ class LockTests(test_utils.TestCase):
 
         # Cleanup the task that is stuck on acquire.
         t3.cancel()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertTrue(t3.cancelled())
 
-    def test_finished_waiter_cancelled(self):
+    async def test_finished_waiter_cancelled(self):
         lock = asyncio.Lock()
 
-        ta = self.loop.create_task(lock.acquire())
-        test_utils.run_briefly(self.loop)
+        ta = asyncio.create_task(lock.acquire())
+        await asyncio.sleep(0)
         self.assertTrue(lock.locked())
 
-        tb = self.loop.create_task(lock.acquire())
-        test_utils.run_briefly(self.loop)
+        tb = asyncio.create_task(lock.acquire())
+        await asyncio.sleep(0)
         self.assertEqual(len(lock._waiters), 1)
 
         # Create a second waiter, wake up the first, and cancel it.
         # Without the fix, the second was not woken up.
-        tc = self.loop.create_task(lock.acquire())
+        tc = asyncio.create_task(lock.acquire())
         lock.release()
         tb.cancel()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
 
         self.assertTrue(lock.locked())
         self.assertTrue(ta.done())
         self.assertTrue(tb.cancelled())
 
-    def test_release_not_acquired(self):
+        # Cleanup
+        tc.cancel()
+        await asyncio.sleep(0)
+
+    async def test_release_not_acquired(self):
         lock = asyncio.Lock()
 
         self.assertRaises(RuntimeError, lock.release)
 
-    def test_release_no_waiters(self):
+    async def test_release_no_waiters(self):
         lock = asyncio.Lock()
-        self.loop.run_until_complete(lock.acquire())
+        await lock.acquire()
         self.assertTrue(lock.locked())
 
         lock.release()
         self.assertFalse(lock.locked())
 
-    def test_context_manager(self):
-        async def f():
-            lock = asyncio.Lock()
-            self.assertFalse(lock.locked())
+    async def test_context_manager(self):
+        lock = asyncio.Lock()
+        self.assertFalse(lock.locked())
 
-            async with lock:
-                self.assertTrue(lock.locked())
+        async with lock:
+            self.assertTrue(lock.locked())
 
-            self.assertFalse(lock.locked())
-
-        self.loop.run_until_complete(f())
+        self.assertFalse(lock.locked())
 
 
-class EventTests(test_utils.TestCase):
-
-    def setUp(self):
-        super().setUp()
-        self.loop = self.new_test_loop()
+class EventTests(unittest.IsolatedAsyncioTestCase):
 
     def test_repr(self):
         ev = asyncio.Event()
@@ -316,7 +298,7 @@ class EventTests(test_utils.TestCase):
         self.assertTrue('waiters:1' in repr(ev))
         self.assertTrue(RGX_REPR.match(repr(ev)))
 
-    def test_wait(self):
+    async def test_wait(self):
         ev = asyncio.Event()
         self.assertFalse(ev.is_set())
 
@@ -334,16 +316,16 @@ class EventTests(test_utils.TestCase):
             if await ev.wait():
                 result.append(3)
 
-        t1 = self.loop.create_task(c1(result))
-        t2 = self.loop.create_task(c2(result))
+        t1 = asyncio.create_task(c1(result))
+        t2 = asyncio.create_task(c2(result))
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([], result)
 
-        t3 = self.loop.create_task(c3(result))
+        t3 = asyncio.create_task(c3(result))
 
         ev.set()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([3, 1, 2], result)
 
         self.assertTrue(t1.done())
@@ -353,24 +335,23 @@ class EventTests(test_utils.TestCase):
         self.assertTrue(t3.done())
         self.assertIsNone(t3.result())
 
-    def test_wait_on_set(self):
+    async def test_wait_on_set(self):
         ev = asyncio.Event()
         ev.set()
 
-        res = self.loop.run_until_complete(ev.wait())
+        res = await ev.wait()
         self.assertTrue(res)
 
-    def test_wait_cancel(self):
+    async def test_wait_cancel(self):
         ev = asyncio.Event()
 
-        wait = self.loop.create_task(ev.wait())
-        self.loop.call_soon(wait.cancel)
-        self.assertRaises(
-            asyncio.CancelledError,
-            self.loop.run_until_complete, wait)
+        wait = asyncio.create_task(ev.wait())
+        asyncio.get_running_loop().call_soon(wait.cancel)
+        with self.assertRaises(asyncio.CancelledError):
+            await wait
         self.assertFalse(ev._waiters)
 
-    def test_clear(self):
+    async def test_clear(self):
         ev = asyncio.Event()
         self.assertFalse(ev.is_set())
 
@@ -380,7 +361,7 @@ class EventTests(test_utils.TestCase):
         ev.clear()
         self.assertFalse(ev.is_set())
 
-    def test_clear_with_waiters(self):
+    async def test_clear_with_waiters(self):
         ev = asyncio.Event()
         result = []
 
@@ -389,8 +370,8 @@ class EventTests(test_utils.TestCase):
                 result.append(1)
             return True
 
-        t = self.loop.create_task(c1(result))
-        test_utils.run_briefly(self.loop)
+        t = asyncio.create_task(c1(result))
+        await asyncio.sleep(0)
         self.assertEqual([], result)
 
         ev.set()
@@ -401,7 +382,7 @@ class EventTests(test_utils.TestCase):
         ev.set()
         self.assertEqual(1, len(ev._waiters))
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1], result)
         self.assertEqual(0, len(ev._waiters))
 
@@ -409,13 +390,9 @@ class EventTests(test_utils.TestCase):
         self.assertTrue(t.result())
 
 
-class ConditionTests(test_utils.TestCase):
+class ConditionTests(unittest.IsolatedAsyncioTestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.loop = self.new_test_loop()
-
-    def test_wait(self):
+    async def test_wait(self):
         cond = asyncio.Condition()
         result = []
 
@@ -437,37 +414,37 @@ class ConditionTests(test_utils.TestCase):
                 result.append(3)
             return True
 
-        t1 = self.loop.create_task(c1(result))
-        t2 = self.loop.create_task(c2(result))
-        t3 = self.loop.create_task(c3(result))
+        t1 = asyncio.create_task(c1(result))
+        t2 = asyncio.create_task(c2(result))
+        t3 = asyncio.create_task(c3(result))
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([], result)
         self.assertFalse(cond.locked())
 
-        self.assertTrue(self.loop.run_until_complete(cond.acquire()))
+        self.assertTrue(await cond.acquire())
         cond.notify()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([], result)
         self.assertTrue(cond.locked())
 
         cond.release()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1], result)
         self.assertTrue(cond.locked())
 
         cond.notify(2)
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1], result)
         self.assertTrue(cond.locked())
 
         cond.release()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1, 2], result)
         self.assertTrue(cond.locked())
 
         cond.release()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1, 2, 3], result)
         self.assertTrue(cond.locked())
 
@@ -478,49 +455,47 @@ class ConditionTests(test_utils.TestCase):
         self.assertTrue(t3.done())
         self.assertTrue(t3.result())
 
-    def test_wait_cancel(self):
+    async def test_wait_cancel(self):
         cond = asyncio.Condition()
-        self.loop.run_until_complete(cond.acquire())
+        await cond.acquire()
 
-        wait = self.loop.create_task(cond.wait())
-        self.loop.call_soon(wait.cancel)
-        self.assertRaises(
-            asyncio.CancelledError,
-            self.loop.run_until_complete, wait)
+        wait = asyncio.create_task(cond.wait())
+        asyncio.get_running_loop().call_soon(wait.cancel)
+        with self.assertRaises(asyncio.CancelledError):
+            await wait
         self.assertFalse(cond._waiters)
         self.assertTrue(cond.locked())
 
-    def test_wait_cancel_contested(self):
+    async def test_wait_cancel_contested(self):
         cond = asyncio.Condition()
 
-        self.loop.run_until_complete(cond.acquire())
+        await cond.acquire()
         self.assertTrue(cond.locked())
 
-        wait_task = self.loop.create_task(cond.wait())
-        test_utils.run_briefly(self.loop)
+        wait_task = asyncio.create_task(cond.wait())
+        await asyncio.sleep(0)
         self.assertFalse(cond.locked())
 
         # Notify, but contest the lock before cancelling
-        self.loop.run_until_complete(cond.acquire())
+        await cond.acquire()
         self.assertTrue(cond.locked())
         cond.notify()
-        self.loop.call_soon(wait_task.cancel)
-        self.loop.call_soon(cond.release)
+        asyncio.get_running_loop().call_soon(wait_task.cancel)
+        asyncio.get_running_loop().call_soon(cond.release)
 
         try:
-            self.loop.run_until_complete(wait_task)
+            await wait_task
         except asyncio.CancelledError:
             # Should not happen, since no cancellation points
             pass
 
         self.assertTrue(cond.locked())
 
-    def test_wait_cancel_after_notify(self):
+    async def test_wait_cancel_after_notify(self):
         # See bpo-32841
         waited = False
 
         cond = asyncio.Condition()
-        cond._loop = self.loop
 
         async def wait_on_cond():
             nonlocal waited
@@ -528,27 +503,26 @@ class ConditionTests(test_utils.TestCase):
                 waited = True  # Make sure this area was reached
                 await cond.wait()
 
-        waiter = asyncio.ensure_future(wait_on_cond(), loop=self.loop)
-        test_utils.run_briefly(self.loop)  # Start waiting
+        waiter = asyncio.create_task(wait_on_cond())
+        await asyncio.sleep(0)  # Start waiting
 
-        self.loop.run_until_complete(cond.acquire())
+        await cond.acquire()
         cond.notify()
-        test_utils.run_briefly(self.loop)  # Get to acquire()
+        await asyncio.sleep(0)  # Get to acquire()
         waiter.cancel()
-        test_utils.run_briefly(self.loop)  # Activate cancellation
+        await asyncio.sleep(0)  # Activate cancellation
         cond.release()
-        test_utils.run_briefly(self.loop)  # Cancellation should occur
+        await asyncio.sleep(0)  # Cancellation should occur
 
         self.assertTrue(waiter.cancelled())
         self.assertTrue(waited)
 
-    def test_wait_unacquired(self):
+    async def test_wait_unacquired(self):
         cond = asyncio.Condition()
-        self.assertRaises(
-            RuntimeError,
-            self.loop.run_until_complete, cond.wait())
+        with self.assertRaises(RuntimeError):
+            await cond.wait()
 
-    def test_wait_for(self):
+    async def test_wait_for(self):
         cond = asyncio.Condition()
         presult = False
 
@@ -564,40 +538,38 @@ class ConditionTests(test_utils.TestCase):
                 cond.release()
             return True
 
-        t = self.loop.create_task(c1(result))
+        t = asyncio.create_task(c1(result))
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([], result)
 
-        self.loop.run_until_complete(cond.acquire())
+        await cond.acquire()
         cond.notify()
         cond.release()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([], result)
 
         presult = True
-        self.loop.run_until_complete(cond.acquire())
+        await cond.acquire()
         cond.notify()
         cond.release()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1], result)
 
         self.assertTrue(t.done())
         self.assertTrue(t.result())
 
-    def test_wait_for_unacquired(self):
+    async def test_wait_for_unacquired(self):
         cond = asyncio.Condition()
 
         # predicate can return true immediately
-        res = self.loop.run_until_complete(cond.wait_for(lambda: [1, 2, 3]))
+        res = await cond.wait_for(lambda: [1, 2, 3])
         self.assertEqual([1, 2, 3], res)
 
-        self.assertRaises(
-            RuntimeError,
-            self.loop.run_until_complete,
-            cond.wait_for(lambda: False))
+        with self.assertRaises(RuntimeError):
+            await cond.wait_for(lambda: False)
 
-    def test_notify(self):
+    async def test_notify(self):
         cond = asyncio.Condition()
         result = []
 
@@ -622,24 +594,24 @@ class ConditionTests(test_utils.TestCase):
                 cond.release()
             return True
 
-        t1 = self.loop.create_task(c1(result))
-        t2 = self.loop.create_task(c2(result))
-        t3 = self.loop.create_task(c3(result))
+        t1 = asyncio.create_task(c1(result))
+        t2 = asyncio.create_task(c2(result))
+        t3 = asyncio.create_task(c3(result))
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([], result)
 
-        self.loop.run_until_complete(cond.acquire())
+        await cond.acquire()
         cond.notify(1)
         cond.release()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1], result)
 
-        self.loop.run_until_complete(cond.acquire())
+        await cond.acquire()
         cond.notify(1)
         cond.notify(2048)
         cond.release()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1, 2, 3], result)
 
         self.assertTrue(t1.done())
@@ -649,7 +621,7 @@ class ConditionTests(test_utils.TestCase):
         self.assertTrue(t3.done())
         self.assertTrue(t3.result())
 
-    def test_notify_all(self):
+    async def test_notify_all(self):
         cond = asyncio.Condition()
 
         result = []
@@ -668,16 +640,16 @@ class ConditionTests(test_utils.TestCase):
                 cond.release()
             return True
 
-        t1 = self.loop.create_task(c1(result))
-        t2 = self.loop.create_task(c2(result))
+        t1 = asyncio.create_task(c1(result))
+        t2 = asyncio.create_task(c2(result))
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([], result)
 
-        self.loop.run_until_complete(cond.acquire())
+        await cond.acquire()
         cond.notify_all()
         cond.release()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1, 2], result)
 
         self.assertTrue(t1.done())
@@ -685,20 +657,20 @@ class ConditionTests(test_utils.TestCase):
         self.assertTrue(t2.done())
         self.assertTrue(t2.result())
 
-    def test_notify_unacquired(self):
+    async def test_notify_unacquired(self):
         cond = asyncio.Condition()
         self.assertRaises(RuntimeError, cond.notify)
 
-    def test_notify_all_unacquired(self):
+    async def test_notify_all_unacquired(self):
         cond = asyncio.Condition()
         self.assertRaises(RuntimeError, cond.notify_all)
 
-    def test_repr(self):
+    async def test_repr(self):
         cond = asyncio.Condition()
         self.assertTrue('unlocked' in repr(cond))
         self.assertTrue(RGX_REPR.match(repr(cond)))
 
-        self.loop.run_until_complete(cond.acquire())
+        await cond.acquire()
         self.assertTrue('locked' in repr(cond))
 
         cond._waiters.append(mock.Mock())
@@ -709,17 +681,14 @@ class ConditionTests(test_utils.TestCase):
         self.assertTrue('waiters:2' in repr(cond))
         self.assertTrue(RGX_REPR.match(repr(cond)))
 
-    def test_context_manager(self):
-        async def f():
-            cond = asyncio.Condition()
-            self.assertFalse(cond.locked())
-            async with cond:
-                self.assertTrue(cond.locked())
-            self.assertFalse(cond.locked())
+    async def test_context_manager(self):
+        cond = asyncio.Condition()
+        self.assertFalse(cond.locked())
+        async with cond:
+            self.assertTrue(cond.locked())
+        self.assertFalse(cond.locked())
 
-        self.loop.run_until_complete(f())
-
-    def test_explicit_lock(self):
+    async def test_explicit_lock(self):
         async def f(lock=None, cond=None):
             if lock is None:
                 lock = asyncio.Lock()
@@ -740,12 +709,12 @@ class ConditionTests(test_utils.TestCase):
             self.assertFalse(cond.locked())
 
         # All should work in the same way.
-        self.loop.run_until_complete(f())
-        self.loop.run_until_complete(f(asyncio.Lock()))
+        await f()
+        await f(asyncio.Lock())
         lock = asyncio.Lock()
-        self.loop.run_until_complete(f(lock, asyncio.Condition(lock)))
+        await f(lock, asyncio.Condition(lock))
 
-    def test_ambiguous_loops(self):
+    async def test_ambiguous_loops(self):
         loop = asyncio.new_event_loop()
         self.addCleanup(loop.close)
 
@@ -780,38 +749,28 @@ class ConditionTests(test_utils.TestCase):
                 ):
                     await cond.wait()
 
-        self.loop.run_until_complete(wrong_loop_in_lock())
-        self.loop.run_until_complete(wrong_loop_in_cond())
+        await wrong_loop_in_lock()
+        await wrong_loop_in_cond()
 
-    def test_timeout_in_block(self):
-        loop = asyncio.new_event_loop()
-        self.addCleanup(loop.close)
-
-        async def task_timeout():
-            condition = asyncio.Condition()
-            async with condition:
-                with self.assertRaises(asyncio.TimeoutError):
-                    await asyncio.wait_for(condition.wait(), timeout=0.5)
-
-        loop.run_until_complete(task_timeout())
+    async def test_timeout_in_block(self):
+        condition = asyncio.Condition()
+        async with condition:
+            with self.assertRaises(asyncio.TimeoutError):
+                await asyncio.wait_for(condition.wait(), timeout=0.5)
 
 
-class SemaphoreTests(test_utils.TestCase):
-
-    def setUp(self):
-        super().setUp()
-        self.loop = self.new_test_loop()
+class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
 
     def test_initial_value_zero(self):
         sem = asyncio.Semaphore(0)
         self.assertTrue(sem.locked())
 
-    def test_repr(self):
+    async def test_repr(self):
         sem = asyncio.Semaphore()
         self.assertTrue(repr(sem).endswith('[unlocked, value:1]>'))
         self.assertTrue(RGX_REPR.match(repr(sem)))
 
-        self.loop.run_until_complete(sem.acquire())
+        await sem.acquire()
         self.assertTrue(repr(sem).endswith('[locked]>'))
         self.assertTrue('waiters' not in repr(sem))
         self.assertTrue(RGX_REPR.match(repr(sem)))
@@ -824,18 +783,15 @@ class SemaphoreTests(test_utils.TestCase):
         self.assertTrue('waiters:2' in repr(sem))
         self.assertTrue(RGX_REPR.match(repr(sem)))
 
-    def test_semaphore(self):
+    async def test_semaphore(self):
         sem = asyncio.Semaphore()
         self.assertEqual(1, sem._value)
-
-        async def acquire_lock():
-            return await sem
 
         with self.assertRaisesRegex(
             TypeError,
             "object Semaphore can't be used in 'await' expression",
         ):
-            self.loop.run_until_complete(acquire_lock())
+            await sem
 
         self.assertFalse(sem.locked())
         self.assertEqual(1, sem._value)
@@ -843,12 +799,12 @@ class SemaphoreTests(test_utils.TestCase):
     def test_semaphore_value(self):
         self.assertRaises(ValueError, asyncio.Semaphore, -1)
 
-    def test_acquire(self):
+    async def test_acquire(self):
         sem = asyncio.Semaphore(3)
         result = []
 
-        self.assertTrue(self.loop.run_until_complete(sem.acquire()))
-        self.assertTrue(self.loop.run_until_complete(sem.acquire()))
+        self.assertTrue(await sem.acquire())
+        self.assertTrue(await sem.acquire())
         self.assertFalse(sem.locked())
 
         async def c1(result):
@@ -871,23 +827,23 @@ class SemaphoreTests(test_utils.TestCase):
             result.append(4)
             return True
 
-        t1 = self.loop.create_task(c1(result))
-        t2 = self.loop.create_task(c2(result))
-        t3 = self.loop.create_task(c3(result))
+        t1 = asyncio.create_task(c1(result))
+        t2 = asyncio.create_task(c2(result))
+        t3 = asyncio.create_task(c3(result))
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual([1], result)
         self.assertTrue(sem.locked())
         self.assertEqual(2, len(sem._waiters))
         self.assertEqual(0, sem._value)
 
-        t4 = self.loop.create_task(c4(result))
+        t4 = asyncio.create_task(c4(result))
 
         sem.release()
         sem.release()
         self.assertEqual(2, sem._value)
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertEqual(0, sem._value)
         self.assertEqual(3, len(result))
         self.assertTrue(sem.locked())
@@ -902,54 +858,53 @@ class SemaphoreTests(test_utils.TestCase):
 
         # cleanup locked semaphore
         sem.release()
-        self.loop.run_until_complete(asyncio.gather(*race_tasks))
+        await asyncio.gather(*race_tasks)
 
-    def test_acquire_cancel(self):
+    async def test_acquire_cancel(self):
         sem = asyncio.Semaphore()
-        self.loop.run_until_complete(sem.acquire())
+        await sem.acquire()
 
-        acquire = self.loop.create_task(sem.acquire())
-        self.loop.call_soon(acquire.cancel)
-        self.assertRaises(
-            asyncio.CancelledError,
-            self.loop.run_until_complete, acquire)
+        acquire = asyncio.create_task(sem.acquire())
+        asyncio.get_running_loop().call_soon(acquire.cancel)
+        with self.assertRaises(asyncio.CancelledError):
+            await acquire
         self.assertTrue((not sem._waiters) or
                         all(waiter.done() for waiter in sem._waiters))
 
-    def test_acquire_cancel_before_awoken(self):
+    async def test_acquire_cancel_before_awoken(self):
         sem = asyncio.Semaphore(value=0)
 
-        t1 = self.loop.create_task(sem.acquire())
-        t2 = self.loop.create_task(sem.acquire())
-        t3 = self.loop.create_task(sem.acquire())
-        t4 = self.loop.create_task(sem.acquire())
+        t1 = asyncio.create_task(sem.acquire())
+        t2 = asyncio.create_task(sem.acquire())
+        t3 = asyncio.create_task(sem.acquire())
+        t4 = asyncio.create_task(sem.acquire())
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
 
         sem.release()
         t1.cancel()
         t2.cancel()
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         num_done = sum(t.done() for t in [t3, t4])
         self.assertEqual(num_done, 1)
 
         t3.cancel()
         t4.cancel()
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
 
-    def test_acquire_hang(self):
+    async def test_acquire_hang(self):
         sem = asyncio.Semaphore(value=0)
 
-        t1 = self.loop.create_task(sem.acquire())
-        t2 = self.loop.create_task(sem.acquire())
+        t1 = asyncio.create_task(sem.acquire())
+        t2 = asyncio.create_task(sem.acquire())
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
 
         sem.release()
         t1.cancel()
 
-        test_utils.run_briefly(self.loop)
+        await asyncio.sleep(0)
         self.assertTrue(sem.locked())
 
     def test_release_not_acquired(self):
@@ -957,9 +912,9 @@ class SemaphoreTests(test_utils.TestCase):
 
         self.assertRaises(ValueError, sem.release)
 
-    def test_release_no_waiters(self):
+    async def test_release_no_waiters(self):
         sem = asyncio.Semaphore()
-        self.loop.run_until_complete(sem.acquire())
+        await sem.acquire()
         self.assertTrue(sem.locked())
 
         sem.release()

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -51,7 +51,7 @@ class LockTests(unittest.IsolatedAsyncioTestCase):
             asyncio.BoundedSemaphore,
         ]
 
-        loop = asyncio.new_event_loop()
+        loop = asyncio.get_running_loop()
 
         for cls in primitives_cls:
             with self.assertRaisesRegex(

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -1,7 +1,6 @@
 """Tests for lock.py"""
 
 import unittest
-from contextlib import suppress
 from unittest import mock
 import re
 
@@ -218,7 +217,7 @@ class LockTests(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
 
         loop.call_soon(trigger)
-        with suppress(asyncio.CancelledError):
+        with self.assertRaises(asyncio.CancelledError):
             # Wait for cancellation
             await t1
 

--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -4,8 +4,6 @@ import warnings
 
 from .case import TestCase
 
-__unittest = True
-
 
 class IsolatedAsyncioTestCase(TestCase):
     # Names intentionally have a long prefix

--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -4,6 +4,7 @@ import warnings
 
 from .case import TestCase
 
+__unittest = True
 
 
 class IsolatedAsyncioTestCase(TestCase):

--- a/Misc/NEWS.d/next/Library/2021-12-19-10-47-24.bpo-46128.Qv3EK1.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-19-10-47-24.bpo-46128.Qv3EK1.rst
@@ -1,2 +1,0 @@
-Strip :class:`unittest.IsolatedAsyncioTestCase` stack frames from reported
-stacktraces.

--- a/Misc/NEWS.d/next/Library/2021-12-19-10-47-24.bpo-46128.Qv3EK1.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-19-10-47-24.bpo-46128.Qv3EK1.rst
@@ -1,0 +1,2 @@
+Strip :class:`unittest.IsolatedAsyncioTestCase` frames from reported
+stacktraces.

--- a/Misc/NEWS.d/next/Library/2021-12-19-10-47-24.bpo-46128.Qv3EK1.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-19-10-47-24.bpo-46128.Qv3EK1.rst
@@ -1,2 +1,2 @@
-Strip :class:`unittest.IsolatedAsyncioTestCase` frames from reported
+Strip :class:`unittest.IsolatedAsyncioTestCase` stack frames from reported
 stacktraces.

--- a/Misc/NEWS.d/next/Tests/2021-12-19-12-20-57.bpo-46129.I3MunH.rst
+++ b/Misc/NEWS.d/next/Tests/2021-12-19-12-20-57.bpo-46129.I3MunH.rst
@@ -1,0 +1,2 @@
+Rewrite ``asyncio.locks`` tests with
+:class:``unittest.IsolatedAsyncioTestCase` usage.

--- a/Misc/NEWS.d/next/Tests/2021-12-19-12-20-57.bpo-46129.I3MunH.rst
+++ b/Misc/NEWS.d/next/Tests/2021-12-19-12-20-57.bpo-46129.I3MunH.rst
@@ -1,2 +1,2 @@
 Rewrite ``asyncio.locks`` tests with
-:class:``unittest.IsolatedAsyncioTestCase` usage.
+:class:`unittest.IsolatedAsyncioTestCase` usage.


### PR DESCRIPTION


<!-- issue-number: [bpo-46129](https://bugs.python.org/issue46129) -->
https://bugs.python.org/issue46129
<!-- /issue-number -->
