### PR TITLE
bpo-46130: docs: Make link text translatable in whatsnew/3.10

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -704,6 +704,7 @@ are added to enable the warning.
 
 See :ref:`io-text-encoding` for more information.
 
+.. _new-feat-related-type-hints:
 
 New Features Related to Type Hints
 ==================================
@@ -1429,7 +1430,7 @@ of types readily interpretable by type checkers.
 typing
 ------
 
-For major changes, see `New Features Related to Type Hints`_.
+For major changes, see :ref:`new-feat-related-type-hints`.
 
 The behavior of :class:`typing.Literal` was changed to conform with :pep:`586`
 and to match the behavior of static type checkers specified in the PEP.


### PR DESCRIPTION
Use `:ref:` to a created anchor so that the title gets automatically obtained and avoiding the need for translating (and allowing it at the same).

Note that the HTML version of the docs create an anchor for the section but I'm unable to use it with `:ref:`, hence I'm unable to get title text automatically.

p.s.: Please ask the bot to backport it to branch 3.10 as well.

<!-- issue-number: [bpo-46130](https://bugs.python.org/issue46130) -->
https://bugs.python.org/issue46130
<!-- /issue-number -->
