### PR TITLE
bpo-46104: [typing docs]: Fix example broken by PR #30148

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -432,7 +432,7 @@ value of type :data:`Any` and assign it to any variable::
    a = []          # OK
    a = 2           # OK
 
-   s = ''          # Inferred type of 's' is str
+   s: str = ''
    s = a           # OK
 
    def foo(item: Any) -> int:


### PR DESCRIPTION
This PR addresses a review by @gvanrossum, which can be found in the discussion in GH-30179.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46104](https://bugs.python.org/issue46104) -->
https://bugs.python.org/issue46104
<!-- /issue-number -->
