### PR TITLE
[3.9] bpo-46129: Fix asyncio test error about deprecation warning

### DIFF
--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -770,7 +770,8 @@ class ConditionTests(unittest.IsolatedAsyncioTestCase):
                     ValueError,
                     "loop argument must agree with lock"
                 ):
-                    asyncio.Condition(lock, loop=loop)
+                    with self.assertWarns(DeprecationWarning):
+                        asyncio.Condition(lock, loop=loop)
 
         await wrong_loop_in_lock()
         await wrong_loop_in_cond()


### PR DESCRIPTION
Introduced by https://github.com/python/cpython/pull/30204 commit
Failed run is https://github.com/python/cpython/runs/4575343334?check_suite_focus=true

<!-- issue-number: [bpo-46129](https://bugs.python.org/issue46129) -->
https://bugs.python.org/issue46129
<!-- /issue-number -->
