### PR TITLE
bpo-46120: State that `|` is preferred over `Union`

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -625,7 +625,7 @@ These can be used as types in annotations using ``[]``, each having a unique syn
 
    Union type; ``Union[X, Y]`` is equivalent to ``X | Y`` and means either X or Y.
 
-   To define a union, use e.g. ``Union[int, str]`` or the shorthand ``int | str``.  Details:
+   To define a union, use e.g. ``Union[int, str]`` or the shorthand ``int | str``. Using that shorthand is recommended. Details:
 
    * The arguments must be types and there must be at least one.
 

--- a/Misc/NEWS.d/next/Documentation/2021-12-21-12-45-57.bpo-46120.PE0DmJ.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-12-21-12-45-57.bpo-46120.PE0DmJ.rst
@@ -1,1 +1,1 @@
-State that ``|`` is preferred for readability over ``Union`` in the docs.
+State that ``|`` is preferred for readability over ``Union`` in the :mod:`typing` docs.

--- a/Misc/NEWS.d/next/Documentation/2021-12-21-12-45-57.bpo-46120.PE0DmJ.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-12-21-12-45-57.bpo-46120.PE0DmJ.rst
@@ -1,0 +1,1 @@
+State that ``|`` is preferred for readability over ``Union`` in the docs.


### PR DESCRIPTION
Originally discussed in https://mail.python.org/archives/list/typing-sig@python.org/thread/TW5M6XDN7DO346RXMADKBAAGNSZPC4ZQ/

CC @Fidget-Spinner 

<!-- issue-number: [bpo-46120](https://bugs.python.org/issue46120) -->
https://bugs.python.org/issue46120
<!-- /issue-number -->
