### PR TITLE
bpo-1284670: Allow to restrict ModuleFinder to get direct dependencies 

### DIFF
--- a/Lib/modulefinder.py
+++ b/Lib/modulefinder.py
@@ -89,7 +89,7 @@ def _find_module(name, path=None):
 
 class Module:
 
-    def __init__(self, name, file=None, path=None):
+    def __init__(self, name, file=None, path=None, recurse=True):
         self.__name__ = name
         self.__file__ = file
         self.__path__ = path
@@ -113,13 +113,14 @@ class Module:
 
 class ModuleFinder:
 
-    def __init__(self, path=None, debug=0, excludes=None, replace_paths=None):
+    def __init__(self, path=None, debug=0, excludes=None, replace_paths=None, recurse=1):
         if path is None:
             path = sys.path
         self.path = path
         self.modules = {}
         self.badmodules = {}
         self.debug = debug
+        self.recurse = recurse
         self.indent = 0
         self.excludes = excludes if excludes is not None else []
         self.replace_paths = replace_paths if replace_paths is not None else []
@@ -439,9 +440,10 @@ class ModuleFinder:
                 # We don't expect anything else from the generator.
                 raise RuntimeError(what)
 
-        for c in co.co_consts:
-            if isinstance(c, type(co)):
-                self.scan_code(c, m)
+        if self.recurse:
+            for c in co.co_consts:
+                if isinstance(c, type(co)):
+                    self.scan_code(c, m)
 
     def load_package(self, fqname, pathname):
         self.msgin(2, "load_package", fqname, pathname)

--- a/Lib/test/test_modulefinder.py
+++ b/Lib/test/test_modulefinder.py
@@ -199,6 +199,21 @@ a/module.py
                                 from . import bar
 """]
 
+non_recursive_import_test_1 = [
+    "a",
+    ["a", "b", "c", "sys"],
+    [],
+    [],
+    """\
+a.py
+                                import b
+b.py
+                                import c
+c.py
+                                import sys
+"""]
+
+
 relative_import_test_4 = [
     "a.module",
     ["a", "a.module"],
@@ -319,12 +334,13 @@ def create_package(source):
             ofi.close()
 
 class ModuleFinderTest(unittest.TestCase):
-    def _do_test(self, info, report=False, debug=0, replace_paths=[], modulefinder_class=modulefinder.ModuleFinder):
+    def _do_test(self, info, report=False, debug=0, replace_paths=[], modulefinder_class=modulefinder.ModuleFinder,
+                    **kwargs):
         import_this, modules, missing, maybe_missing, source = info
         create_package(source)
         try:
             mf = modulefinder_class(path=TEST_PATH, debug=debug,
-                                           replace_paths=replace_paths)
+                                           replace_paths=replace_paths, **kwargs)
             mf.import_hook(import_this)
             if report:
                 mf.report()
@@ -432,6 +448,9 @@ b.py
                 return super().load_module(fqname, fp, pathname, file_info)
 
         self._do_test(absolute_import_test, modulefinder_class=CheckLoadModuleApi)
+
+    def test_non_recursive_1(self):
+        self._do_test(non_recursive_import_test_1, recurse=False, debug=0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-1284670](https://bugs.python.org/issue1284670) -->
https://bugs.python.org/issue1284670
<!-- /issue-number -->
