### PR TITLE
bpo-26897: Clarify Popen stdin, stdout, stderr file object docs

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -483,13 +483,14 @@ functions.
    *stdin*, *stdout* and *stderr* specify the executed program's standard input,
    standard output and standard error file handles, respectively.  Valid values
    are :data:`PIPE`, :data:`DEVNULL`, an existing file descriptor (a positive
-   integer), an existing :term:`file object`, and ``None``.  :data:`PIPE`
-   indicates that a new pipe to the child should be created.  :data:`DEVNULL`
-   indicates that the special file :data:`os.devnull` will be used. With the
-   default settings of ``None``, no redirection will occur; the child's file
-   handles will be inherited from the parent.  Additionally, *stderr* can be
-   :data:`STDOUT`, which indicates that the stderr data from the applications
-   should be captured into the same file handle as for stdout.
+   integer), an existing :term:`file object` with a valid file descriptor,
+   and ``None``.  :data:`PIPE` indicates that a new pipe to the child should
+   be created.  :data:`DEVNULL` indicates that the special file 
+   :data:`os.devnull` will be used. With the default settings of ``None``,
+   no redirection will occur; the child's file handles will be inherited from 
+   the parent.  Additionally, *stderr* can be :data:`STDOUT`, which indicates 
+   that the stderr data from the applications should be captured into the same
+   file handle as for stdout.
 
    If *preexec_fn* is set to a callable object, this object will be called in the
    child process just before the child is executed.

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -485,10 +485,10 @@ functions.
    are :data:`PIPE`, :data:`DEVNULL`, an existing file descriptor (a positive
    integer), an existing :term:`file object` with a valid file descriptor,
    and ``None``.  :data:`PIPE` indicates that a new pipe to the child should
-   be created.  :data:`DEVNULL` indicates that the special file 
+   be created.  :data:`DEVNULL` indicates that the special file
    :data:`os.devnull` will be used. With the default settings of ``None``,
-   no redirection will occur; the child's file handles will be inherited from 
-   the parent.  Additionally, *stderr* can be :data:`STDOUT`, which indicates 
+   no redirection will occur; the child's file handles will be inherited from
+   the parent.  Additionally, *stderr* can be :data:`STDOUT`, which indicates
    that the stderr data from the applications should be captured into the same
    file handle as for stdout.
 

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -264,13 +264,14 @@ default values. The arguments that are most commonly needed are:
    *stdin*, *stdout* and *stderr* specify the executed program's standard input,
    standard output and standard error file handles, respectively.  Valid values
    are :data:`PIPE`, :data:`DEVNULL`, an existing file descriptor (a positive
-   integer), an existing file object, and ``None``.  :data:`PIPE` indicates
-   that a new pipe to the child should be created.  :data:`DEVNULL` indicates
-   that the special file :data:`os.devnull` will be used.  With the default
-   settings of ``None``, no redirection will occur; the child's file handles
-   will be inherited from the parent.  Additionally, *stderr* can be
-   :data:`STDOUT`, which indicates that the stderr data from the child
-   process should be captured into the same file handle as for *stdout*.
+   integer), an existing file object with a valid file descriptor, and ``None``.
+   :data:`PIPE` indicates that a new pipe to the child should be created. 
+   :data:`DEVNULL` indicates that the special file :data:`os.devnull` will 
+   be used.  With the default settings of ``None``, no redirection will occur;
+   the child's file handles will be inherited from the parent. 
+   Additionally, *stderr* can be :data:`STDOUT`, which indicates that the 
+   stderr data from the child process should be captured into the same file 
+   handle as for *stdout*.
 
    .. index::
       single: universal newlines; subprocess module

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -265,12 +265,12 @@ default values. The arguments that are most commonly needed are:
    standard output and standard error file handles, respectively.  Valid values
    are :data:`PIPE`, :data:`DEVNULL`, an existing file descriptor (a positive
    integer), an existing file object with a valid file descriptor, and ``None``.
-   :data:`PIPE` indicates that a new pipe to the child should be created. 
-   :data:`DEVNULL` indicates that the special file :data:`os.devnull` will 
+   :data:`PIPE` indicates that a new pipe to the child should be created.
+   :data:`DEVNULL` indicates that the special file :data:`os.devnull` will
    be used.  With the default settings of ``None``, no redirection will occur;
-   the child's file handles will be inherited from the parent. 
-   Additionally, *stderr* can be :data:`STDOUT`, which indicates that the 
-   stderr data from the child process should be captured into the same file 
+   the child's file handles will be inherited from the parent.
+   Additionally, *stderr* can be :data:`STDOUT`, which indicates that the
+   stderr data from the child process should be captured into the same file
    handle as for *stdout*.
 
    .. index::


### PR DESCRIPTION
https://bugs.python.org/issue26897


<!-- issue-number: [bpo-26897](https://bugs.python.org/issue26897) -->
https://bugs.python.org/issue26897
<!-- /issue-number -->
