### PR TITLE
bpo-38415: Remove redundant AsyncContextDecorator.__call__ override from _AsyncG…

### DIFF
--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -193,14 +193,6 @@ class _AsyncGeneratorContextManager(
 ):
     """Helper for @asynccontextmanager decorator."""
 
-    def __call__(self, func):
-        @wraps(func)
-        async def inner(*args, **kwds):
-            async with self.__class__(self.func, self.args, self.kwds):
-                return await func(*args, **kwds)
-
-        return inner
-
     async def __aenter__(self):
         # do not keep args and kwds alive unnecessarily
         # they are only needed for recreation, which is not possible anymore

--- a/Misc/NEWS.d/next/Library/2021-12-23-00-58-31.bpo-38415.NY5sUF.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-23-00-58-31.bpo-38415.NY5sUF.rst
@@ -1,1 +1,0 @@
-remove redundant AsyncContextDecorator override from _AsyncGeneratorContextManager

--- a/Misc/NEWS.d/next/Library/2021-12-23-00-58-31.bpo-38415.NY5sUF.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-23-00-58-31.bpo-38415.NY5sUF.rst
@@ -1,1 +1,1 @@
-remove redundant ``AsyncContextDecorator.__call__`` override from ``_AsyncGeneratorContextManager``
+remove redundant AsyncContextDecorator override from _AsyncGeneratorContextManager

--- a/Misc/NEWS.d/next/Library/2021-12-23-00-58-31.bpo-38415.NY5sUF.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-23-00-58-31.bpo-38415.NY5sUF.rst
@@ -1,1 +1,1 @@
-remove redundant ``AsyncContextDecorator.__call__` override from ``_AsyncGeneratorContextManager``
+remove redundant ``AsyncContextDecorator.__call__`` override from ``_AsyncGeneratorContextManager``

--- a/Misc/NEWS.d/next/Library/2021-12-23-00-58-31.bpo-38415.NY5sUF.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-23-00-58-31.bpo-38415.NY5sUF.rst
@@ -1,0 +1,1 @@
+remove redundant ``AsyncContextDecorator.__call__` override from ``_AsyncGeneratorContextManager``


### PR DESCRIPTION
…eneratorContextManager

#16667 was opened however was allowed to go stale while #20516 was created and then merged first.

This PR currently shows that the tests added in #16667 pass without the associated code change - but it might be cleaner to just do a plain revert and rely on the tests added in #20516

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-38415](https://bugs.python.org/issue38415) -->
https://bugs.python.org/issue38415
<!-- /issue-number -->


