### PR TITLE
bpo-46090: Allow `PyThreadState.datastack_*` members to be `NULL`

### DIFF
--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -173,11 +173,15 @@ _PyThreadState_BumpFramePointerSlow(PyThreadState *tstate, size_t size);
 static inline InterpreterFrame *
 _PyThreadState_BumpFramePointer(PyThreadState *tstate, size_t size)
 {
+    assert(!!tstate->datastack_top == !!tstate->datastack_limit);
+    assert(!!tstate->datastack_top == !!tstate->datastack_chunk);
     PyObject **base = tstate->datastack_top;
-    PyObject **top = base + size;
-    if (top < tstate->datastack_limit) {
-        tstate->datastack_top = top;
-        return (InterpreterFrame *)base;
+    if (base) {
+        PyObject **top = base + size;
+        if (top < tstate->datastack_limit) {
+            tstate->datastack_top = top;
+            return (InterpreterFrame *)base;
+        }
     }
     return _PyThreadState_BumpFramePointerSlow(tstate, size);
 }

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -173,11 +173,10 @@ _PyThreadState_BumpFramePointerSlow(PyThreadState *tstate, size_t size);
 static inline InterpreterFrame *
 _PyThreadState_BumpFramePointer(PyThreadState *tstate, size_t size)
 {
-    assert(!!tstate->datastack_top == !!tstate->datastack_limit);
-    assert(!!tstate->datastack_top == !!tstate->datastack_chunk);
     PyObject **base = tstate->datastack_top;
     if (base) {
         PyObject **top = base + size;
+        assert(tstate->datastack_limit);
         if (top < tstate->datastack_limit) {
             tstate->datastack_top = top;
             return (InterpreterFrame *)base;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2199,7 +2199,7 @@ push_chunk(PyThreadState *tstate, int size)
     }
     tstate->datastack_chunk = new;
     tstate->datastack_limit = (PyObject **)(((char *)new) + allocate_size);
-    PyObject **res = &new->data[0];
+    PyObject **res = &new->data[new->previous == NULL];
     tstate->datastack_top = res + size;
     return res;
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-46090](https://bugs.python.org/issue46090) -->
https://bugs.python.org/issue46090
<!-- /issue-number -->
