### PR TITLE
bpo-46161: fix the bug of starunpack_helper in compile.c

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -666,5 +666,23 @@ class ClassTests(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, error_msg):
             object.__init__(E(), 42)
 
+    def testClassWithExtCall(self):
+        class Meta(int):
+            def __init__(*args, **kwargs):
+                pass
+
+            def __new__(cls, name, bases, attrs, **kwargs):
+                return bases, kwargs
+
+        d = {'metaclass': Meta}
+
+        class A(**d): pass
+        self.assertEqual(A, ((), {}))
+        class A(0, 1, 2, 3, 4, 5, 6, 7, **d): pass
+        self.assertEqual(A, (tuple(range(8)), {}))
+        class A(0, *range(1, 8), **d, foo='bar'): pass
+        self.assertEqual(A, (tuple(range(8)), {'foo': 'bar'}))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-23-12-32-45.bpo-46161.EljBmu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-23-12-32-45.bpo-46161.EljBmu.rst
@@ -1,0 +1,1 @@
+Fix the class building error when the arguments are constants and CALL_FUNCTION_EX is used.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4206,7 +4206,7 @@ starunpack_helper(struct compiler *c, asdl_expr_seq *elts, int pushed,
             Py_INCREF(val);
             PyTuple_SET_ITEM(folded, i, val);
         }
-        if (tuple) {
+        if (tuple && !pushed) {
             ADDOP_LOAD_CONST_NEW(c, folded);
         } else {
             if (add == SET_ADD) {
@@ -4218,6 +4218,9 @@ starunpack_helper(struct compiler *c, asdl_expr_seq *elts, int pushed,
             ADDOP_I(c, build, pushed);
             ADDOP_LOAD_CONST_NEW(c, folded);
             ADDOP_I(c, extend, 1);
+            if (tuple) {
+                ADDOP(c, LIST_TO_TUPLE);
+            }
         }
         return 1;
     }


### PR DESCRIPTION
`pushed` should also be considered when building tuples. Otherwise, when the remaining arguments are constant, it will ignore the pushed ones.

Consider this code,
```py
class MyMetaclass(type): pass
use_metaclass = {'metaclass': MyMetaclass}
class MyClass(1, 2, 3, **use_metaclass): pass
```
and its bytecode,
```
  1           0 LOAD_BUILD_CLASS
              2 LOAD_CONST               0 (<code object MyMetaclass at 0x7f4dfea6db40, file "bug.py", line 1>)
              4 MAKE_FUNCTION            0
              6 LOAD_CONST               1 ('MyMetaclass')
              8 LOAD_NAME                0 (type)
             10 CALL_NO_KW               3
             12 STORE_NAME               1 (MyMetaclass)

  2          14 LOAD_CONST               2 ('metaclass')
             16 LOAD_NAME                1 (MyMetaclass)
             18 BUILD_MAP                1
             20 STORE_NAME               2 (use_metaclass)

  3          22 LOAD_BUILD_CLASS
             24 LOAD_CONST               3 (<code object MyClass at 0x7f4dfea6d540, file "bug.py", line 3>)
             26 MAKE_FUNCTION            0
             28 LOAD_CONST               4 ('MyClass')
             30 LOAD_CONST               5 ((1, 2, 3))
             32 BUILD_MAP                0
             34 LOAD_NAME                2 (use_metaclass)
             36 DICT_MERGE               1
             38 CALL_FUNCTION_EX         1
             40 STORE_NAME               3 (MyClass)
             42 LOAD_CONST               6 (None)
             44 RETURN_VALUE
```

Obviously, the arguments were incorrectly constructed, and the string `MyClass` was called instead of the class builder.
```
Traceback (most recent call last):
  File "xxxx/bug.py", line 3, in <module>
    class MyClass(1, 2, 3, **use_metaclass): pass
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'str' object is not callable
```

The more serious problem is that it makes the stack unbalanced.

<!-- issue-number: [bpo-46161](https://bugs.python.org/issue46161) -->
https://bugs.python.org/issue46161
<!-- /issue-number -->
