### PR TITLE
docs: Fix typos and use anchor for internal link

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1437,7 +1437,7 @@ and to match the behavior of static type checkers specified in the PEP.
 
 1. ``Literal`` now de-duplicates parameters.
 2. Equality comparisons between ``Literal`` objects are now order independent.
-3. ``Literal`` comparisons now respects types.  For example,
+3. ``Literal`` comparisons now respect types.  For example,
    ``Literal[0] == Literal[False]`` previously evaluated to ``True``.  It is
    now ``False``.  To support this change, the internally used type cache now
    supports differentiating types.
@@ -1647,13 +1647,12 @@ Deprecated
   :meth:`importlib.machinery.FrozenImporter.find_module`,
   :meth:`importlib.machinery.WindowsRegistryFinder.find_module`,
   :meth:`importlib.machinery.PathFinder.find_module`,
-  :meth:`importlib.abc.MetaPathFinder.find_module`),
+  :meth:`importlib.abc.MetaPathFinder.find_module` ),
   :meth:`importlib.abc.PathEntryFinder.find_module` (
-  :meth:`importlib.machinery.FileFinder.find_module`,
-  ), and
+  :meth:`importlib.machinery.FileFinder.find_module` ), and
   :meth:`importlib.abc.PathEntryFinder.find_loader` (
-  :meth:`importlib.machinery.FileFinder.find_loader`
-  ) now raise :exc:`DeprecationWarning` and are slated for removal in
+  :meth:`importlib.machinery.FileFinder.find_loader` )
+  now raise :exc:`DeprecationWarning` and are slated for removal in
   Python 3.12 (previously they were documented as deprecated in Python 3.4).
   (Contributed by Brett Cannon in :issue:`42135`.)
 
@@ -1694,7 +1693,7 @@ Deprecated
 * :func:`asyncio.get_event_loop` now emits a deprecation warning if there is
   no running event loop. In the future it will be an alias of
   :func:`~asyncio.get_running_loop`.
-  :mod:`asyncio` functions which implicitly create a :class:`~asyncio.Future`
+  :mod:`asyncio` functions which implicitly create :class:`~asyncio.Future`
   or :class:`~asyncio.Task` objects now emit
   a deprecation warning if there is no running event loop and no explicit
   *loop* argument is passed: :func:`~asyncio.ensure_future`,
@@ -1834,7 +1833,7 @@ Removed
      running in different threads.
 
   Note that the low-level API will still accept ``loop``.
-  See `Changes in the Python API`_ for examples of how to replace existing code.
+  See :ref:`changes-python-api` for examples of how to replace existing code.
 
   (Contributed by Yurii Karabas, Andrew Svetlov, Yury Selivanov and Kyle Stanley
   in :issue:`42392`.)
@@ -1858,6 +1857,7 @@ Changes in the Python syntax
   following keyword.
   (Contributed by Serhiy Storchaka in :issue:`43833`).
 
+.. _changes-python-api:
 
 Changes in the Python API
 -------------------------
@@ -1979,7 +1979,7 @@ Build Changes
   (Contributed by Victor Stinner in :issue:`36020`.)
 
 * :mod:`sqlite3` requires SQLite 3.7.15 or higher. (Contributed by Sergey Fedoseev
-  and Erlend E. Aasland :issue:`40744` and :issue:`40810`.)
+  and Erlend E. Aasland in :issue:`40744` and :issue:`40810`.)
 
 * The :mod:`atexit` module must now always be built as a built-in module.
   (Contributed by Victor Stinner in :issue:`42639`.)


### PR DESCRIPTION
This fixes typos ("respect" for plural "comparisons", trailing comma inside parentheses, article "a" for plural "objects", "in" before issue number), and use internal link with `:ref:` to allow better link text translation (similar scenario of  [bpo-46130](https://bugs.python.org/issue46130)).

p.s.: Please ask the bot to backport it to branch 3.10 as well.