### PR TITLE
bpo-46162: make `property` generic

### DIFF
--- a/Lib/test/ann_module7.py
+++ b/Lib/test/ann_module7.py
@@ -1,0 +1,5 @@
+# Test that generic `property` works with future import.
+
+from __future__ import annotations
+
+p: property[int, str] = property()

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -83,7 +83,9 @@ class BaseTest(unittest.TestCase):
                      WeakSet, ReferenceType, ref,
                      ShareableList, MPSimpleQueue,
                      Future, _WorkItem,
-                     Morsel]
+                     Morsel,
+                     property,
+                     ]
     if ctypes is not None:
         generic_types.extend((ctypes.Array, ctypes.LibraryLoader))
 

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -216,7 +216,18 @@ class PropertyTests(unittest.TestCase):
                 p.__set_name__(*([0] * i))
 
     def test_property___class_getitem__(self):
-        self.assertIsInstance(property[int, str], GenericAlias)
+        p = property[int, str]
+        self.assertIsInstance(p, GenericAlias)
+        self.assertIs(p.__origin__, property)
+        self.assertEqual(p.__args__, (int, str))
+        self.assertEqual(p.__parameters__, ())
+
+        from typing import TypeVar
+        G = TypeVar('G')
+        S = TypeVar('S')
+        p1 = property[G, S]
+        self.assertEqual(p1.__args__, (G, S))
+        self.assertEqual(p1.__parameters__, (G, S))
 
 
 # Issue 5890: subclasses of property do not preserve method __doc__ strings

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -4,6 +4,7 @@
 import sys
 import unittest
 from test import support
+from types import GenericAlias
 
 class PropertyBase(Exception):
     pass
@@ -213,6 +214,9 @@ class PropertyTests(unittest.TestCase):
                 fr'^__set_name__\(\) takes 2 positional arguments but {i} were given$'
             ):
                 p.__set_name__(*([0] * i))
+
+    def test_property___class_getitem__(self):
+        self.assertIsInstance(property[int, str], GenericAlias)
 
 
 # Issue 5890: subclasses of property do not preserve method __doc__ strings

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -4,7 +4,6 @@
 import sys
 import unittest
 from test import support
-from types import GenericAlias
 
 class PropertyBase(Exception):
     pass
@@ -216,6 +215,7 @@ class PropertyTests(unittest.TestCase):
                 p.__set_name__(*([0] * i))
 
     def test_property___class_getitem__(self):
+        from types import GenericAlias
         p = property[int, str]
         self.assertIsInstance(p, GenericAlias)
         self.assertIs(p.__origin__, property)

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -269,6 +269,9 @@ class GenericPropertyTests(unittest.TestCase):
             with self.subTest(klass=klass):
                 self.assertEqual(get_type_hints(klass), {})
                 self.assertEqual(klass.__annotations__, {})
+                # Getting hints of `property` itself is not allowed
+                with self.assertRaises(TypeError):
+                    get_type_hints(klass.a)
 
     def test_property_inner_annotations(self):
         from inspect import getattr_static

--- a/Misc/NEWS.d/next/Library/2021-12-23-12-53-34.bpo-46162.bE3xrz.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-23-12-53-34.bpo-46162.bE3xrz.rst
@@ -1,0 +1,1 @@
+Make :class:`property` generic.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1566,6 +1566,7 @@ static PyMethodDef property_methods[] = {
     {"setter", property_setter, METH_O, setter_doc},
     {"deleter", property_deleter, METH_O, deleter_doc},
     {"__set_name__", property_set_name, METH_VARARGS, set_name_doc},
+    {"__class_getitem__", Py_GenericAlias, METH_O|METH_CLASS, PyDoc_STR("See PEP 585")},
     {0}
 };
 


### PR DESCRIPTION
Original discussion: https://github.com/python/typing/issues/985

<!-- issue-number: [bpo-46162](https://bugs.python.org/issue46162) -->
https://bugs.python.org/issue46162
<!-- /issue-number -->

Related, `cached_property` is already generic: https://github.com/python/cpython/blob/main/Lib/functools.py#L1002
