### PR TITLE
bpo-46150: ensure `fakename` does not exist in `PosixPathTest.test_expanduser`

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2558,13 +2558,21 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
             othername = username
             otherhome = userhome
 
+        fakename = 'fakeuser'
+        # This user can theoretically exist on a test runner. Create unique name:
+        try:
+            while pwd.getpwnam(fakename):
+                fakename += '1'
+        except KeyError:
+            pass  # Non-existent name found
+
         p1 = P('~/Documents')
-        p2 = P('~' + username + '/Documents')
-        p3 = P('~' + othername + '/Documents')
-        p4 = P('../~' + username + '/Documents')
-        p5 = P('/~' + username + '/Documents')
+        p2 = P(f'~{username}/Documents')
+        p3 = P(f'~{othername}/Documents')
+        p4 = P(f'../~{username}/Documents')
+        p5 = P(f'/~{username}/Documents')
         p6 = P('')
-        p7 = P('~fakeuser/Documents')
+        p7 = P(f'~{fakename}/Documents')
 
         with os_helper.EnvironmentVarGuard() as env:
             env.pop('HOME', None)

--- a/Misc/NEWS.d/next/Tests/2021-12-23-13-42-15.bpo-46150.RhtADs.rst
+++ b/Misc/NEWS.d/next/Tests/2021-12-23-13-42-15.bpo-46150.RhtADs.rst
@@ -1,0 +1,2 @@
+Now ``fakename`` in ``test_pathlib.PosixPathTest.test_expanduser`` is check
+to be non-existent.

--- a/Misc/NEWS.d/next/Tests/2021-12-23-13-42-15.bpo-46150.RhtADs.rst
+++ b/Misc/NEWS.d/next/Tests/2021-12-23-13-42-15.bpo-46150.RhtADs.rst
@@ -1,2 +1,2 @@
-Now ``fakename`` in ``test_pathlib.PosixPathTest.test_expanduser`` is check
+Now ``fakename`` in ``test_pathlib.PosixPathTest.test_expanduser`` is checked
 to be non-existent.


### PR DESCRIPTION


<!-- issue-number: [bpo-46150](https://bugs.python.org/issue46150) -->
https://bugs.python.org/issue46150
<!-- /issue-number -->
