### PR TITLE
bpo-43424: Deprecate `webbrowser.MacOSXOSAScript._name` attribute

### DIFF
--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -197,6 +197,11 @@ Browser controllers provide these methods which parallel three of the
 module-level convenience functions:
 
 
+.. attribute:: name
+
+   System-dependent name for the browser.
+
+
 .. method:: controller.open(url, new=0, autoraise=True)
 
    Display *url* using the browser handled by this controller. If *new* is 1, a new

--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -304,7 +304,7 @@ class ImportTest(unittest.TestCase):
         webbrowser = import_helper.import_fresh_module('webbrowser')
         try:
             browser = webbrowser.get().name
-        except (webbrowser.Error, AttributeError) as err:
+        except webbrowser.Error as err:
             self.skipTest(str(err))
         with os_helper.EnvironmentVarGuard() as env:
             env["BROWSER"] = browser
@@ -316,7 +316,7 @@ class ImportTest(unittest.TestCase):
         try:
             webbrowser.get()
             least_preferred_browser = webbrowser.get(webbrowser._tryorder[-1]).name
-        except (webbrowser.Error, AttributeError, IndexError) as err:
+        except (webbrowser.Error, IndexError) as err:
             self.skipTest(str(err))
 
         with os_helper.EnvironmentVarGuard() as env:

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -667,18 +667,25 @@ if sys.platform == 'darwin':
 
     class MacOSXOSAScript(BaseBrowser):
         def __init__(self, name):
-            self._name = name
+            super().__init__(name)
+
+        @property
+        def _name(self):
+            warnings.warn(f'{self.__class__.__name__}._name is deprecated in 3.11'
+                          f' use {self.__class__.__name__}.name instead.',
+                          DeprecationWarning, stacklevel=2)
+            return self.name
 
         def open(self, url, new=0, autoraise=True):
-            if self._name == 'default':
+            if self.name == 'default':
                 script = 'open location "%s"' % url.replace('"', '%22') # opens in default browser
             else:
-                script = '''
+                script = f'''
                    tell application "%s"
                        activate
                        open location "%s"
                    end
-                   '''%(self._name, url.replace('"', '%22'))
+                   '''%(self.name, url.replace('"', '%22'))
 
             osapipe = os.popen("osascript", "w")
             if osapipe is None:

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -666,7 +666,7 @@ if sys.platform == 'darwin':
             return not rc
 
     class MacOSXOSAScript(BaseBrowser):
-        def __init__(self, name):
+        def __init__(self, name='default'):
             super().__init__(name)
 
         @property

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -676,6 +676,13 @@ if sys.platform == 'darwin':
                           DeprecationWarning, stacklevel=2)
             return self.name
 
+        @_name.setter
+        def _name(self, val):
+            warnings.warn(f'{self.__class__.__name__}._name is deprecated in 3.11'
+                          f' use {self.__class__.__name__}.name instead.',
+                          DeprecationWarning, stacklevel=2)
+            self.name = val
+
         def open(self, url, new=0, autoraise=True):
             if self.name == 'default':
                 script = 'open location "%s"' % url.replace('"', '%22') # opens in default browser

--- a/Misc/NEWS.d/next/Library/2021-12-23-14-36-58.bpo-43424.d9x2JZ.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-23-14-36-58.bpo-43424.d9x2JZ.rst
@@ -1,0 +1,1 @@
+Deprecate :attr:`webbrowser.MacOSXOSAScript._name` and use ``name`` instead.


### PR DESCRIPTION
Changes:
- Now all `BaseBrowser` subtypes have the same interface
- I've also covered `name` in the docs, since original issue was about it

Looks like `MacOSXOSAScript` is not tested, so I didn't add any tests except local manual check:

```python
Python 3.11.0a3+ (heads/main-dirty:71ef0b4c2b, Dec 23 2021, 12:38:09) [Clang 11.0.0 (clang-1100.0.33.16)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import webbrowser
>>> a = webbrowser.get()
>>> a.name
'default'
>>> a._name
<stdin>:1: DeprecationWarning: MacOSXOSAScript._name is deprecated in 3.11 use MacOSXOSAScript.name instead.
'default'
>>> a.open('https://python.org')
True
```


<!-- issue-number: [bpo-43424](https://bugs.python.org/issue43424) -->
https://bugs.python.org/issue43424
<!-- /issue-number -->

Related https://github.com/python/typeshed/pull/6673