### PR TITLE
bpo-46055: Streamline inner loop for right shifts

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4491,6 +4491,7 @@ long_rshift1(PyLongObject *a, Py_ssize_t wordshift, digit remshift)
 {
     PyLongObject *z = NULL;
     Py_ssize_t newsize, hishift, i, j;
+    digit lobits, next;
 
     if (Py_SIZE(a) < 0) {
         /* Right shifting negative numbers is harder */
@@ -4514,13 +4515,13 @@ long_rshift1(PyLongObject *a, Py_ssize_t wordshift, digit remshift)
         if (z == NULL)
             return NULL;
         j = wordshift;
-        digit next = a->ob_digit[j++];
+        lobits = a->ob_digit[j++] >> remshift;
         for (i = 0; j < Py_SIZE(a); i++, j++) {
-            digit high = next >> remshift;
             next = a->ob_digit[j];
-            z->ob_digit[i] = (high | next << hishift) & PyLong_MASK;
+            z->ob_digit[i] = (lobits | next << hishift) & PyLong_MASK;
+            lobits = next >> remshift;
         }
-        z->ob_digit[i] = next >> remshift;
+        z->ob_digit[i] = lobits;
         z = maybe_small_long(long_normalize(z));
     }
     return (PyObject *)z;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4491,6 +4491,7 @@ long_rshift1(PyLongObject *a, Py_ssize_t wordshift, digit remshift)
 {
     PyLongObject *z = NULL;
     Py_ssize_t newsize, hishift, i, j;
+    twodigits accum;
 
     if (Py_SIZE(a) < 0) {
         /* Right shifting negative numbers is harder */
@@ -4514,13 +4515,13 @@ long_rshift1(PyLongObject *a, Py_ssize_t wordshift, digit remshift)
         if (z == NULL)
             return NULL;
         j = wordshift;
-        twodigits acc = a->ob_digit[j++] >> remshift;
+        accum = a->ob_digit[j++] >> remshift;
         for (i = 0; j < Py_SIZE(a); i++, j++) {
-            acc |= (twodigits)(a->ob_digit[j]) << hishift;
-            z->ob_digit[i] = acc & PyLong_MASK;
-            acc >>= PyLong_SHIFT;
+            accum |= (twodigits)a->ob_digit[j] << hishift;
+            z->ob_digit[i] = (digit)(accum & PyLong_MASK);
+            accum >>= PyLong_SHIFT;
         }
-        z->ob_digit[i] = acc;
+        z->ob_digit[i] = (digit)accum;
         z = maybe_small_long(long_normalize(z));
     }
     return (PyObject *)z;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4516,7 +4516,7 @@ long_rshift1(PyLongObject *a, Py_ssize_t wordshift, digit remshift)
         j = wordshift;
         twodigits acc = a->ob_digit[j++] >> remshift;
         for (i = 0; j < Py_SIZE(a); i++, j++) {
-            acc |= ((twodigits)(a->ob_digit[j]) << hishift);
+            acc |= (twodigits)(a->ob_digit[j]) << hishift;
             z->ob_digit[i] = acc & PyLong_MASK;
             acc >>= PyLong_SHIFT;
         }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4491,7 +4491,6 @@ long_rshift1(PyLongObject *a, Py_ssize_t wordshift, digit remshift)
 {
     PyLongObject *z = NULL;
     Py_ssize_t newsize, hishift, i, j;
-    digit lobits, next;
 
     if (Py_SIZE(a) < 0) {
         /* Right shifting negative numbers is harder */
@@ -4515,13 +4514,13 @@ long_rshift1(PyLongObject *a, Py_ssize_t wordshift, digit remshift)
         if (z == NULL)
             return NULL;
         j = wordshift;
-        lobits = a->ob_digit[j++] >> remshift;
+        twodigits acc = a->ob_digit[j++] >> remshift;
         for (i = 0; j < Py_SIZE(a); i++, j++) {
-            next = a->ob_digit[j];
-            z->ob_digit[i] = (lobits | next << hishift) & PyLong_MASK;
-            lobits = next >> remshift;
+            acc |= ((twodigits)(a->ob_digit[j]) << hishift);
+            z->ob_digit[i] = acc & PyLong_MASK;
+            acc >>= PyLong_SHIFT;
         }
-        z->ob_digit[i] = lobits;
+        z->ob_digit[i] = acc;
         z = maybe_small_long(long_normalize(z));
     }
     return (PyObject *)z;


### PR DESCRIPTION
While reviewing #30044, I noticed that the inner loop for the right shift operation could be more efficient. Here's a PR that streamlines that loop. The main changes are:

- remove an unnecessary extra masking operation (`& lomask`), and replace `& himask` with `& PyLong_MASK`
- rewrite the loop to remove multiple accesses to the digits of `a` and `z`
- remove an inner branch

On my machine (macOS 10.14.6 / Intel MacBook Pro), in informal timings I get approximately a 35% speedup for a shift of the form `huge >> small`. Some sample timings:

On main (commit cf15419a99962b3503ff7123e148d71f7f01bc15):
```
lovelace:cpython mdickinson$ ./python.exe -m timeit -s "a, b = 7**100000, 53" "a >> b"
20000 loops, best of 5: 11.5 usec per loop
```

On this branch (commit 056495d5cde239ab19920a11c07400bdcfe1ec85):
```
lovelace:cpython mdickinson$ ./python.exe -m timeit -s "a, b = 7**100000, 53" "a >> b"
50000 loops, best of 5: 8.51 usec per loop
```

Small shift operations are not significantly affected. More sample timings - on master:

```
lovelace:cpython mdickinson$ ./python.exe -m timeit -s "a, b = 7**10, 53" "a >> b"
10000000 loops, best of 5: 23.3 nsec per loop
```

On this branch:

```
lovelace:cpython mdickinson$ ./python.exe -m timeit -s "a, b = 7**10, 53" "a >> b"
10000000 loops, best of 5: 24 nsec per loop
```

(but a second run on this branch gave 22.9 nsec per loop, so any difference is being lost in the variation between runs)

<!-- issue-number: [bpo-46055](https://bugs.python.org/issue46055) -->
https://bugs.python.org/issue46055
<!-- /issue-number -->
