### PR TITLE
bpo-46150: Allow test_pathlib to pass on systems where fakeuser exists.

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2564,7 +2564,7 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
         p4 = P('../~' + username + '/Documents')
         p5 = P('/~' + username + '/Documents')
         p6 = P('')
-        p7 = P('~fakeuser/Documents')
+        p7 = P('~fake800813user/Documents')
 
         with os_helper.EnvironmentVarGuard() as env:
             env.pop('HOME', None)


### PR DESCRIPTION
By providing a more likely to be unique username not used for testing of other infrastructure. ;)


<!-- issue-number: [bpo-46150](https://bugs.python.org/issue46150) -->
https://bugs.python.org/issue46150
<!-- /issue-number -->
