### PR TITLE
bpo-46176: mmap module adding MAP_STACK constant.

### DIFF
--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -367,8 +367,12 @@ MAP_* Constants
           MAP_ANON
           MAP_ANONYMOUS
           MAP_POPULATE
+          MAP_STACK
 
     These are the various flags that can be passed to :meth:`mmap.mmap`. Note that some options might not be present on some systems.
 
     .. versionchanged:: 3.10
        Added MAP_POPULATE constant.
+
+    .. versionadded:: 3.11
+       Added MAP_STACK constant.

--- a/Misc/NEWS.d/next/Library/2021-12-25-11-11-21.bpo-46176.EOY9wd.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-25-11-11-21.bpo-46176.EOY9wd.rst
@@ -1,0 +1,1 @@
+Adding the ``MAP_STACK`` constant for the mmap module.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1638,6 +1638,11 @@ mmap_exec(PyObject *module)
 #ifdef MAP_POPULATE
     ADD_INT_MACRO(module, MAP_POPULATE);
 #endif
+#ifdef MAP_STACK
+    // Mostly a no-op on Linux and NetBSD, but useful on OpenBSD
+    // for stack usage (even on x86 arch)
+    ADD_INT_MACRO(module, MAP_STACK);
+#endif
     if (PyModule_AddIntConstant(module, "PAGESIZE", (long)my_getpagesize()) < 0 ) {
         return -1;
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-46176](https://bugs.python.org/issue46176) -->
https://bugs.python.org/issue46176
<!-- /issue-number -->
