### PR TITLE
bpo-42259: clarify pprint saferepr docs

### DIFF
--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -179,7 +179,8 @@ One more support function is also defined:
 .. function:: saferepr(object)
 
    Return a string representation of *object*, protected against recursive data
-   structures.  If the representation of *object* exposes a recursive entry, the
+   structures (recursive protection is limited to structures subclassed from :class:`~object.dict`,
+   :class:`~object.list` and :class:`~object.tuple`).  If the representation of *object* exposes a recursive entry, the
    recursive reference will be represented as ``<Recursion on typename with
    id=number>``.  The representation is not otherwise formatted.
 

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -181,7 +181,7 @@ One more support function is also defined:
 
    Return a string representation of *object*, protected against recursion in
    some common data structures, namely :class:`~object.dict`, :class:`~object.list`
-   and :class:~`object.tuple` whose ``__repr__`` has not been overridden.  If the
+   and :class:`~object.tuple` whose ``__repr__`` has not been overridden.  If the
    representation of object exposes a recursive entry, the recursive reference
    will be represented as ``<Recursion on typename with id=number>``.  The
    representation is not otherwise formatted.

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -180,8 +180,8 @@ One more support function is also defined:
 .. function:: saferepr(object)
 
    Return a string representation of *object*, protected against recursion in
-   some common data structures, namely :class:~object.dict, :class:~object.list
-   and :class:~object.tuple whose ``__repr__`` has not been overridden.  If the
+   some common data structures, namely :class:`~object.dict`, :class:`~object.list`
+   and :class:~`object.tuple` whose ``__repr__`` has not been overridden.  If the
    representation of object exposes a recursive entry, the recursive reference
    will be represented as ``<Recursion on typename with id=number>``.  The
    representation is not otherwise formatted.

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -172,7 +172,8 @@ The :mod:`pprint` module defines one class:
 .. function:: isrecursive(object)
 
    Determine if *object* requires a recursive representation.  This function is
-   subject to the same limitations as noted in :func:`saferepr` below.
+   subject to the same limitations as noted in :func:`saferepr` below and may raise an
+   :exc:`RecursionError` if it fails to detect a recursive object.
 
 
 One more support function is also defined:

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -179,10 +179,13 @@ One more support function is also defined:
 .. function:: saferepr(object)
 
    Return a string representation of *object*, protected against recursive data
-   structures (recursive protection is limited to structures subclassed from :class:`~object.dict`,
-   :class:`~object.list` and :class:`~object.tuple`).  If the representation of *object* exposes a recursive entry, the
+   structures.  If the representation of *object* exposes a recursive entry, the
    recursive reference will be represented as ``<Recursion on typename with
    id=number>``.  The representation is not otherwise formatted.
+
+   Note that for recursive protection to apply, data structures have to be
+   subclassed from :class:`~object.dict`, :class:`~object.list` or
+   :class:`~object.tuple` and the ``__repr__`` method must not be overriden.
 
    >>> pprint.saferepr(stuff)
    "[<Recursion on list with id=...>, 'spam', 'eggs', 'lumberjack', 'knights', 'ni']"

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -185,7 +185,7 @@ One more support function is also defined:
 
    Note that for recursive protection to apply, data structures have to be
    subclassed from :class:`~object.dict`, :class:`~object.list` or
-   :class:`~object.tuple` and the ``__repr__`` method must not be overriden.
+   :class:`~object.tuple` and the ``__repr__`` method must not be overridden.
 
    >>> pprint.saferepr(stuff)
    "[<Recursion on list with id=...>, 'spam', 'eggs', 'lumberjack', 'knights', 'ni']"

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -171,21 +171,20 @@ The :mod:`pprint` module defines one class:
 
 .. function:: isrecursive(object)
 
-   Determine if *object* requires a recursive representation.
+   Determine if *object* requires a recursive representation.  This function is
+   subject to the same limitations as noted in :func:`saferepr` below.
 
 
 One more support function is also defined:
 
 .. function:: saferepr(object)
 
-   Return a string representation of *object*, protected against recursive data
-   structures.  If the representation of *object* exposes a recursive entry, the
-   recursive reference will be represented as ``<Recursion on typename with
-   id=number>``.  The representation is not otherwise formatted.
-
-   Note that for recursive protection to apply, data structures have to be
-   subclassed from :class:`~object.dict`, :class:`~object.list` or
-   :class:`~object.tuple` and the ``__repr__`` method must not be overridden.
+   Return a string representation of *object*, protected against recursion in
+   some common data structures, namely :class:~object.dict, :class:~object.list
+   and :class:~object.tuple whose ``__repr__`` has not been overridden.  If the
+   representation of object exposes a recursive entry, the recursive reference
+   will be represented as ``<Recursion on typename with id=number>``.  The
+   representation is not otherwise formatted.
 
    >>> pprint.saferepr(stuff)
    "[<Recursion on list with id=...>, 'spam', 'eggs', 'lumberjack', 'knights', 'ni']"

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -181,8 +181,8 @@ One more support function is also defined:
 .. function:: saferepr(object)
 
    Return a string representation of *object*, protected against recursion in
-   some common data structures, namely :class:`~object.dict`, :class:`~object.list`
-   and :class:`~object.tuple` whose ``__repr__`` has not been overridden.  If the
+   some common data structures, namely instances of :class:`dict`, :class:`list`
+   and :class:`tuple` or subclasses whose ``__repr__`` has not been overridden.  If the
    representation of object exposes a recursive entry, the recursive reference
    will be represented as ``<Recursion on typename with id=number>``.  The
    representation is not otherwise formatted.


### PR DESCRIPTION
Clarify limitations to recursion protection in `pprint.saferepr`

<!-- issue-number: [bpo-42259](https://bugs.python.org/issue42259) -->
https://bugs.python.org/issue42259
<!-- /issue-number -->
