### PR TITLE
[3.10] Remove a NEWS entry for bpo-45878.

### DIFF
--- a/Misc/NEWS.d/next/Tests/2021-11-23-12-36-21.bpo-45878.eOs_Mp.rst
+++ b/Misc/NEWS.d/next/Tests/2021-11-23-12-36-21.bpo-45878.eOs_Mp.rst
@@ -1,2 +1,0 @@
-Test ``Lib/ctypes/test/test_functions.py::test_mro`` now uses
-``self.assertRaises`` instead of ``try/except``.


### PR DESCRIPTION
The docs linter complains about it, and in general news entries for such changes are not required.


<!-- issue-number: [bpo-45878](https://bugs.python.org/issue45878) -->
https://bugs.python.org/issue45878
<!-- /issue-number -->
