### PR TITLE
Clarify os.urandom return type in docs

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4870,7 +4870,7 @@ Random numbers
 
 .. function:: urandom(size)
 
-   Return a string of *size* random bytes suitable for cryptographic use.
+   Return a bytestring of *size* random bytes suitable for cryptographic use.
 
    This function returns random bytes from an OS-specific randomness source.  The
    returned data should be unpredictable enough for cryptographic applications,


### PR DESCRIPTION
Other descriptions in the same file also use 'bytestring' to refer to bytes objects.

I didn't open an issue for this as it seems like a trivial change.