### PR TITLE
bpo-21987: fix TarFile.getmember getting a dir with a trailing slash

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1610,8 +1610,6 @@ class TarFile(object):
                 if fileobj is not None:
                     saved_pos = fileobj.tell()
                 try:
-                    if fileobj is not None and saved_pos==BLOCKSIZE:
-                        fileobj.seek(0)
                     return func(name, "r", fileobj, **kwargs)
                 except (ReadError, CompressionError) as e:
                     error_msgs.append(f'- method {comptype}: {e!r}')

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1610,6 +1610,8 @@ class TarFile(object):
                 if fileobj is not None:
                     saved_pos = fileobj.tell()
                 try:
+                    if fileobj is not None and saved_pos==BLOCKSIZE:
+                        fileobj.seek(0)
                     return func(name, "r", fileobj, **kwargs)
                 except (ReadError, CompressionError) as e:
                     error_msgs.append(f'- method {comptype}: {e!r}')
@@ -1789,7 +1791,7 @@ class TarFile(object):
            than once in the archive, its last occurrence is assumed to be the
            most up-to-date version.
         """
-        tarinfo = self._getmember(name)
+        tarinfo = self._getmember(name.rstrip('/'))
         if tarinfo is None:
             raise KeyError("filename %r not found" % name)
         return tarinfo

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -234,8 +234,10 @@ class UstarReadTest(ReadTest, unittest.TestCase):
                 finally:
                     os.rmdir(name)
             with tarfile.open(tmpname) as tar:
-                tar.getmember(name)
-                tar.getmember(name + '/')
+                self.assertEqual(
+                    tar.getmember(name),
+                    tar.getmember(name + '/')
+                )
 
 class GzipUstarReadTest(GzipTest, UstarReadTest):
     pass

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -220,6 +220,29 @@ class UstarReadTest(ReadTest, unittest.TestCase):
     def test_issue14160(self):
         self._test_fileobj_link("symtype2", "ustar/regtype")
 
+    def test_add_dir_getmember(self):
+        # bpo-21987
+        self.add_dir_and_getmember('bar')
+        self.add_dir_and_getmember('a'*101)
+
+    def add_dir_and_getmember(self, name):
+        tar = tarfile.open(tmpname, 'w')
+        cwd = os.getcwd()
+        try:
+            os.chdir(TEMPDIR)
+            os.mkdir(name)
+            tar.add(name)
+        finally:
+            os.rmdir(name)
+            os.chdir(cwd)
+            tar.close()
+        tar = tarfile.open(tmpname)
+        try:
+            tar.getmember(name)
+            tar.getmember(name + '/')
+        finally:
+            tar.close()
+
 class GzipUstarReadTest(GzipTest, UstarReadTest):
     pass
 

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -226,22 +226,16 @@ class UstarReadTest(ReadTest, unittest.TestCase):
         self.add_dir_and_getmember('a'*101)
 
     def add_dir_and_getmember(self, name):
-        tar = tarfile.open(tmpname, 'w')
-        cwd = os.getcwd()
-        try:
-            os.chdir(TEMPDIR)
-            os.mkdir(name)
-            tar.add(name)
-        finally:
-            os.rmdir(name)
-            os.chdir(cwd)
-            tar.close()
-        tar = tarfile.open(tmpname)
-        try:
-            tar.getmember(name)
-            tar.getmember(name + '/')
-        finally:
-            tar.close()
+        with os_helper.temp_cwd():
+            with tarfile.open(tmpname, 'w') as tar:
+                try:
+                    os.mkdir(name)
+                    tar.add(name)
+                finally:
+                    os.rmdir(name)
+            with tarfile.open(tmpname) as tar:
+                tar.getmember(name)
+                tar.getmember(name + '/')
 
 class GzipUstarReadTest(GzipTest, UstarReadTest):
     pass

--- a/Misc/NEWS.d/next/Library/2021-12-28-11-55-10.bpo-21987.avBK-p.rst
+++ b/Misc/NEWS.d/next/Library/2021-12-28-11-55-10.bpo-21987.avBK-p.rst
@@ -1,0 +1,2 @@
+Fix an issue with :meth:`tarfile.TarFile.getmember` getting a directory name
+with a trailing slash.


### PR DESCRIPTION

<!-- issue-number: [bpo-21987](https://bugs.python.org/issue21987) -->
https://bugs.python.org/issue21987
<!-- /issue-number -->

Co-authored with Matt Behrens