### PR TITLE
bpo-26552: Close dangling coroutine or future if loop is closed

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -419,12 +419,18 @@ class BaseEventLoop(events.AbstractEventLoop):
         """Create a Future object attached to the loop."""
         return futures.Future(loop=self)
 
-    def create_task(self, coro, *, name=None):
+    def create_task(self, coro, used_wrap_await=False, name=None):
         """Schedule a coroutine object.
 
         Return a task object.
         """
-        self._check_closed()
+        try:
+            self._check_closed()
+        except RuntimeError:
+            if used_wrap_await:
+                coro.close()
+            raise
+
         if self._task_factory is None:
             task = tasks.Task(coro, loop=self, name=name)
             if task._source_traceback:

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -274,7 +274,7 @@ class AbstractEventLoop:
 
     # Method scheduling a coroutine object: create a task.
 
-    def create_task(self, coro, *, name=None):
+    def create_task(self, coro, used_wrap_await=False, name=None):
         raise NotImplementedError
 
     # Methods for interacting with threads.

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -612,6 +612,8 @@ def ensure_future(coro_or_future, *, loop=None):
 
     If the argument is a Future, it is returned directly.
     """
+    if loop is None:
+        coro_or_future.close()
     return _ensure_future(coro_or_future, loop=loop)
 
 

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -328,7 +328,7 @@ else:
     Task = _CTask = _asyncio.Task
 
 
-def create_task(coro, *, name=None):
+def create_task(coro, used_wrap_await=False, name=None):
     """Schedule the execution of a coroutine object in a spawn task.
 
     Return a Task object.
@@ -618,6 +618,7 @@ def ensure_future(coro_or_future, *, loop=None):
 
 
 def _ensure_future(coro_or_future, *, loop=None):
+    wrap_await = False
     if futures.isfuture(coro_or_future):
         if loop is not None and loop is not futures._get_loop(coro_or_future):
             raise ValueError('The future belongs to a different loop than '
@@ -627,13 +628,14 @@ def _ensure_future(coro_or_future, *, loop=None):
     if not coroutines.iscoroutine(coro_or_future):
         if inspect.isawaitable(coro_or_future):
             coro_or_future = _wrap_awaitable(coro_or_future)
+            wrap_await = True
         else:
             raise TypeError('An asyncio.Future, a coroutine or an awaitable '
                             'is required')
 
     if loop is None:
         loop = events._get_event_loop(stacklevel=4)
-    return loop.create_task(coro_or_future)
+    return loop.create_task(coro_or_future, used_wrap_await=wrap_await)
 
 
 @types.coroutine


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-26552](https://bugs.python.org/issue26552) -->
https://bugs.python.org/issue26552
<!-- /issue-number -->

With this small patch, the `RuntimeError` exception is raised without `RuntimeWarning` since the task is closed.