### PR TITLE
Delete `FUNDING.yml`, since there's an organisation default

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-custom: https://www.python.org/psf/donations/python-dev/
-github: [python]


### PR DESCRIPTION
That's how it looks like right now (without this patch):
<img width="1232" alt="Снимок экрана 2021-12-30 в 0 08 19" src="https://user-images.githubusercontent.com/4660275/147703536-c5cf4202-4b06-4910-b56a-95c97f0e278a.png">

Notice:
1. There's an organisation default `FUNDING.yml`, link: https://github.com/python/.github/blob/master/FUNDING.yml
2. They are identical
3. Organisation-wide file was created one month after this one, so this one is probably a left-over

CC @Mariatta 