### PR TITLE
bpo-46203: Add a (conservative) timeout for Windows builds on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build CPython
       run: .\PCbuild\build.bat -e -p Win32
+      timeout-minutes: 30
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests
@@ -130,6 +131,7 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
       run: .\PCbuild\build.bat -e -p x64
+      timeout-minutes: 30
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests


### PR DESCRIPTION
Following a recent GitHub Actions incident that caused builds to give no output until the step timed out after 6 hours, this PR adds timeouts of 30 minutes to the x64 and x86 Windows build steps on GitHub Actions.

<!-- issue-number: [bpo-46203](https://bugs.python.org/issue46203) -->
https://bugs.python.org/issue46203
<!-- /issue-number -->
