### PR TITLE
bpo-46196: document method cmd.Cmd.columnize

### DIFF
--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -121,6 +121,13 @@ A :class:`Cmd` instance has the following methods:
    :meth:`complete_\*` method is available.  By default, it returns an empty list.
 
 
+.. method:: Cmd.columnize(list, displaywidth=80)
+
+   Method called to display a list of strings as a compact set of columns.
+   Each column is only as wide as necessary.
+   Columns are separated by two spaces (one was not legible enough).
+
+
 .. method:: Cmd.precmd(line)
 
    Hook method executed just before the command line *line* is interpreted, but

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -125,7 +125,7 @@ A :class:`Cmd` instance has the following methods:
 
    Method called to display a list of strings as a compact set of columns.
    Each column is only as wide as necessary.
-   Columns are separated by two spaces (one was not legible enough).
+   Columns are separated by two spaces for readability.
 
 
 .. method:: Cmd.precmd(line)

--- a/Misc/NEWS.d/next/Documentation/2021-12-30-19-12-24.bpo-46196.UvQ8Sq.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-12-30-19-12-24.bpo-46196.UvQ8Sq.rst
@@ -1,1 +1,1 @@
-Add docs about :method:`cmd.Cmd.columnize`.
+Add docs about :meth:`cmd.Cmd.columnize`.

--- a/Misc/NEWS.d/next/Documentation/2021-12-30-19-12-24.bpo-46196.UvQ8Sq.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-12-30-19-12-24.bpo-46196.UvQ8Sq.rst
@@ -1,0 +1,1 @@
+Add docs about :method:`cmd.Cmd.columnize`.

--- a/Misc/NEWS.d/next/Documentation/2021-12-30-19-12-24.bpo-46196.UvQ8Sq.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-12-30-19-12-24.bpo-46196.UvQ8Sq.rst
@@ -1,1 +1,1 @@
-Add docs about :meth:`cmd.Cmd.columnize`.
+Document method :meth:`cmd.Cmd.columnize`.


### PR DESCRIPTION
I've decided that just coping the existing docs from https://github.com/python/cpython/blob/8d7644fa64213207b8dc6f555cb8a02bfabeced2/Lib/cmd.py#L346-L351 is good enough.

If not, I would be happy to change it.

<!-- issue-number: [bpo-46196](https://bugs.python.org/issue46196) -->
https://bugs.python.org/issue46196
<!-- /issue-number -->
