### PR TITLE
bpo-45569: Discover which buildbots are using 15-bit PyLong digits

### DIFF
--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -50,6 +50,7 @@ typedef int64_t stwodigits; /* signed variant of twodigits */
 #define _PyLong_DECIMAL_SHIFT   9 /* max(e such that 10**e fits in a digit) */
 #define _PyLong_DECIMAL_BASE    ((digit)1000000000) /* 10 ** DECIMAL_SHIFT */
 #elif PYLONG_BITS_IN_DIGIT == 15
+#error "15-bit digits not supported"
 typedef unsigned short digit;
 typedef short sdigit; /* signed variant of digit */
 typedef unsigned long twodigits;

--- a/PCbuild/pcbuild.proj
+++ b/PCbuild/pcbuild.proj
@@ -18,7 +18,7 @@
 
   <ItemDefinitionGroup>
     <FreezeProjects>
-      <Platform>$(PreferredToolArchitecture)</Platform>
+      <Platform>$(Platform)</Platform>
       <Configuration>$(Configuration)</Configuration>
       <Configuration Condition="$(Configuration) == 'PGInstrument'">Release</Configuration>
       <Properties></Properties>


### PR DESCRIPTION
THIS PR SHOULD NOT BE MERGED!

This PR is simply an attempt to discover which buildbots (if any) are using 15-bit PyLong digits for their build. Once the buildbots have reported back, this PR can be closed.

<!-- issue-number: [bpo-45569](https://bugs.python.org/issue45569) -->
https://bugs.python.org/issue45569
<!-- /issue-number -->
