### PR TITLE
bpo-46178: Remove/rename redundant Travis CI code

### DIFF
--- a/.azure-pipelines/posix-steps.yml
+++ b/.azure-pipelines/posix-steps.yml
@@ -66,7 +66,7 @@ steps:
         COMMAND: make
 
 - ${{ if eq(parameters.patchcheck, 'true') }}:
-  - script: ./python Tools/scripts/patchcheck.py --travis true
+  - script: ./python Tools/scripts/patchcheck.py --ci true
     displayName: 'Run patchcheck.py'
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
 

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -72,8 +72,9 @@ test runner
    a GUI tool for test discovery and execution.  This is intended largely for ease of use
    for those new to unit testing.  For production environments it is
    recommended that tests be driven by a continuous integration system such as
-   `Buildbot <https://buildbot.net/>`_, `Jenkins <https://jenkins.io/>`_
-   or `Travis-CI <https://travis-ci.com>`_, or `AppVeyor <https://www.appveyor.com/>`_.
+   `Buildbot <https://buildbot.net/>`_, `Jenkins <https://jenkins.io/>`_,
+   `GitHub Actions <https://github.com/features/actions>`_, or
+   `AppVeyor <https://www.appveyor.com/>`_.
 
 
 .. _unittest-minimal-example:

--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -28,13 +28,6 @@ def _wrap_with_retry_thrice(func, exc):
         return _retry_thrice(func, exc, *args, **kwargs)
     return wrapped
 
-# bpo-35411: FTP tests of test_urllib2net randomly fail
-# with "425 Security: Bad IP connecting" on Travis CI
-skip_ftp_test_on_travis = unittest.skipIf('TRAVIS' in os.environ,
-                                          'bpo-35411: skip FTP test '
-                                          'on Travis CI')
-
-
 # Connecting to remote hosts is flaky.  Make it more robust by retrying
 # the connection several times.
 _urlopen_with_retry = _wrap_with_retry_thrice(urllib.request.urlopen,
@@ -139,7 +132,6 @@ class OtherNetworkTests(unittest.TestCase):
     # XXX The rest of these tests aren't very good -- they don't check much.
     # They do sometimes catch some major disasters, though.
 
-    @skip_ftp_test_on_travis
     def test_ftp(self):
         urls = [
             'ftp://www.pythontest.net/README',
@@ -339,7 +331,6 @@ class TimeoutTest(unittest.TestCase):
 
     FTP_HOST = 'ftp://www.pythontest.net/'
 
-    @skip_ftp_test_on_travis
     def test_ftp_basic(self):
         self.assertIsNone(socket.getdefaulttimeout())
         with socket_helper.transient_internet(self.FTP_HOST, timeout=None):
@@ -347,7 +338,6 @@ class TimeoutTest(unittest.TestCase):
             self.addCleanup(u.close)
             self.assertIsNone(u.fp.fp.raw._sock.gettimeout())
 
-    @skip_ftp_test_on_travis
     def test_ftp_default_timeout(self):
         self.assertIsNone(socket.getdefaulttimeout())
         with socket_helper.transient_internet(self.FTP_HOST):
@@ -359,7 +349,6 @@ class TimeoutTest(unittest.TestCase):
                 socket.setdefaulttimeout(None)
             self.assertEqual(u.fp.fp.raw._sock.gettimeout(), 60)
 
-    @skip_ftp_test_on_travis
     def test_ftp_no_timeout(self):
         self.assertIsNone(socket.getdefaulttimeout())
         with socket_helper.transient_internet(self.FTP_HOST):
@@ -371,7 +360,6 @@ class TimeoutTest(unittest.TestCase):
                 socket.setdefaulttimeout(None)
             self.assertIsNone(u.fp.fp.raw._sock.gettimeout())
 
-    @skip_ftp_test_on_travis
     def test_ftp_timeout(self):
         with socket_helper.transient_internet(self.FTP_HOST):
             u = _urlopen_with_retry(self.FTP_HOST, timeout=60)

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,6 @@
 This is Python version 3.11.0 alpha 3
 =====================================
 
-.. image:: https://travis-ci.com/python/cpython.svg?branch=main
-   :alt: CPython build status on Travis CI
-   :target: https://travis-ci.com/python/cpython
-
 .. image:: https://github.com/python/cpython/workflows/Tests/badge.svg
    :alt: CPython build status on GitHub Actions
    :target: https://github.com/python/cpython/actions

--- a/Tools/scripts/patchcheck.py
+++ b/Tools/scripts/patchcheck.py
@@ -245,7 +245,7 @@ def regenerated_pyconfig_h_in(file_paths):
     else:
         return "not needed"
 
-def travis(pull_request):
+def ci(pull_request):
     if pull_request == 'false':
         print('Not a pull request; skipping')
         return
@@ -301,10 +301,10 @@ def main():
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--travis',
+    parser.add_argument('--ci',
                         help='Perform pass/fail checks')
     args = parser.parse_args()
-    if args.travis:
-        travis(args.travis)
+    if args.ci:
+        ci(args.ci)
     else:
         main()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Follow on from https://github.com/python/cpython/pull/30257, some extra Travis CI bits and bobs to remove or rename.

---

There's also a few extra places that added extra handling to catch random fails on Travis, I didn't touch those, but perhaps they could be reviewed/removed:

```console
$ git grep -i travis
...
Lib/test/pythoninfo.py:            # for device" on Travis CI
Lib/test/pythoninfo.py:        "TRAVIS",
Lib/test/support/socket_helper.py:        # with EADDRNOTAVAIL on Travis CI
Lib/test/support/socket_helper.py:        # EADDRNOTAVAIL on Travis CI.
Lib/test/test_socket.py:                # [bpo-33937](https://bugs.python.org/issue33937) the test randomly fails on Travis CI with
Lib/test/test_socket.py:            # [bpo-33937](https://bugs.python.org/issue33937): catch also ENOMEM, the test randomly fails on Travis CI
...
```


<!-- issue-number: [bpo-46178](https://bugs.python.org/issue46178) -->
https://bugs.python.org/issue46178
<!-- /issue-number -->
