### PR TITLE
Doc: Add the omitted secondary prompt

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -166,7 +166,7 @@ are referred to by using the name of the argument. ::
 Positional and keyword arguments can be arbitrarily combined::
 
    >>> print('The story of {0}, {1}, and {other}.'.format('Bill', 'Manfred',
-                                                          other='Georg'))
+   ...                                                    other='Georg'))
    The story of Bill, Manfred, and Georg.
 
 If you have a really long format string that you don't want to split up, it


### PR DESCRIPTION
For the continuation lines, `...` should present as secondary prompt, or else the display will be abnormal, especially after the `>>>` in the upper-right corner is toggled, the line will disappear which make the code to copy incomplete.