### PR TITLE
bpo-46218: Change long_pow() to sliding window algorithm

### DIFF
--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -21,8 +21,6 @@ extern "C" {
    PyLong_SHIFT.  The majority of the code doesn't care about the precise
    value of PyLong_SHIFT, but there are some notable exceptions:
 
-   - long_pow() requires that PyLong_SHIFT be divisible by 5
-
    - PyLong_{As,From}ByteArray require that PyLong_SHIFT be at least 8
 
    - long_hash() requires that PyLong_SHIFT is *strictly* less than the number
@@ -62,10 +60,6 @@ typedef long stwodigits; /* signed variant of twodigits */
 #endif
 #define PyLong_BASE     ((digit)1 << PyLong_SHIFT)
 #define PyLong_MASK     ((digit)(PyLong_BASE - 1))
-
-#if PyLong_SHIFT % 5 != 0
-#error "longobject.c requires that PyLong_SHIFT be divisible by 5"
-#endif
 
 /* Long integer representation.
    The absolute value of a number is equal to

--- a/Lib/test/test_pow.py
+++ b/Lib/test/test_pow.py
@@ -102,11 +102,11 @@ class PowTest(unittest.TestCase):
         prime = 1000000000039 # for speed, relatively small prime modulus
         for i in range(10):
             a = random.randrange(1000, 1000000)
-            bpower = random.randrange(1000, 5000)
+            bpower = random.randrange(1000, 50000)
             b = random.randrange(1 << (bpower - 1), 1 << bpower)
             b1 = random.randrange(1, b)
             b2 = b - b1
-            got1 = pow(a, b1 + b2, prime)
+            got1 = pow(a, b, prime)
             got2 = pow(a, b1, prime) * pow(a, b2, prime) % prime
             if got1 != got2:
                 self.fail(f"{a=:x} {b1=:x} {b2=:x} {got1=:x} {got2=:x}")

--- a/Lib/test/test_pow.py
+++ b/Lib/test/test_pow.py
@@ -93,6 +93,28 @@ class PowTest(unittest.TestCase):
                             pow(int(i),j,k)
                         )
 
+    def test_big_exp(self):
+        import random
+        self.assertEqual(pow(2, 50000), 1 << 50000)
+        # Randomized modular tests, checking the identities
+        #  a**(b1 + b2) == a**b1 * a**b2
+        #  a**(b1 * b2) == (a**b1)**b2
+        prime = 1000000000039 # for speed, relatively small prime modulus
+        for i in range(10):
+            a = random.randrange(1000, 1000000)
+            bpower = random.randrange(1000, 5000)
+            b = random.randrange(1 << (bpower - 1), 1 << bpower)
+            b1 = random.randrange(1, b)
+            b2 = b - b1
+            got1 = pow(a, b1 + b2, prime)
+            got2 = pow(a, b1, prime) * pow(a, b2, prime) % prime
+            if got1 != got2:
+                self.fail(f"{a=:x} {b1=:x} {b2=:x} {got1=:x} {got2=:x}")
+            got3 = pow(a, b1 * b2, prime)
+            got4 = pow(pow(a, b1, prime), b2, prime)
+            if got3 != got4:
+                self.fail(f"{a=:x} {b1=:x} {b2=:x} {got3=:x} {got4=:x}")
+
     def test_bug643260(self):
         class TestRpow:
             def __rpow__(self, other):

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -80,7 +80,7 @@ maybe_small_long(PyLongObject *v)
  * that a table of 2**(EXP_WINDOW_SIZE - 1) intermediate results is
  * precomputed.
  */
-#define EXP_WINDOW_SIZE 6
+#define EXP_WINDOW_SIZE 5
 #define EXP_TABLE_LEN (1 << (EXP_WINDOW_SIZE - 1))
 #define HUGE_EXP_CUTOFF 120
 
@@ -4183,8 +4183,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
      * precomputed so that table[i] == a**(2*i+1) % c for i in
      * range(EXP_TABLE_LEN).
      */
-    PyLongObject *table[EXP_TABLE_LEN] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-                                           0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+    PyLongObject *table[EXP_TABLE_LEN] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 
     /* a, b, c = v, w, x */
     CHECK_BINOP(v, w);

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -77,7 +77,7 @@ maybe_small_long(PyLongObject *v)
 /* For exponentiation, use the binary left-to-right algorithm unless the
  ^ exponent contains more than HUGE_EXP_CUTOFF bits.  In that case, do
  * (no more than) EXP_WINDOW_SIZE bits at a time.  The potential drawback is
- * hat a table of 2**(EXP_WINDOW_SIZE - 1) intermediate results is
+ * that a table of 2**(EXP_WINDOW_SIZE - 1) intermediate results is
  * precomputed.
  */
 #define EXP_WINDOW_SIZE 6

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -82,7 +82,26 @@ maybe_small_long(PyLongObject *v)
  */
 #define EXP_WINDOW_SIZE 5
 #define EXP_TABLE_LEN (1 << (EXP_WINDOW_SIZE - 1))
-#define HUGE_EXP_CUTOFF 120
+/* Suppose the exponent has bit length e. All ways of doing this
+ * need e squarings. The binary method also needs a multiply for
+ * each bit set. In a k-ary method with window width w, a multiply
+ * for each non-zero window, so at worst (and likely!)
+ * ceiling(e/w). The k-ary sliding window method has the same
+ * worst case, but the window slides so it can sometimes skip
+ * over an all-zero window that the fixed-window method can't
+ * exploit. In addition, the windowing methods need multiplies
+ * to precompute a table of small powers.
+ *
+ * For the sliding window method with width 5, 16 precomputation
+ * multiplies are needed. Assuming about half the exponent bits
+ * are set, then, the binary method needs about e/2 extra mults
+ * and the window method about 16 + e/5.
+ *
+ * The latter is smaller for e > 53 1/3. We don't have direct
+ * access to the bit length, though, so call it 60, which is a
+ * multiple of a long digit's max bit length (15 or 30 so far).
+ */
+#define HUGE_EXP_CUTOFF 60
 
 #define SIGCHECK(PyTryBlock)                    \
     do {                                        \

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4337,7 +4337,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
         }
         /* else bi is 0, and z==1 is correct */
     }
-    else if (i * PyLong_SHIFT <= HUGE_EXP_CUTOFF) {
+    else if (i <= HUGE_EXP_CUTOFF / PyLong_SHIFT ) {
         /* Left-to-right binary exponentiation (HAC Algorithm 14.79) */
         /* http://www.cacr.math.uwaterloo.ca/hac/about/chap14.pdf    */
 
@@ -4446,7 +4446,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
     Py_CLEAR(z);
     /* fall through */
   Done:
-    if (Py_SIZE(b) * PyLong_SHIFT > HUGE_EXP_CUTOFF) {
+    if (Py_SIZE(b) > HUGE_EXP_CUTOFF / PyLong_SHIFT) {
         for (i = 0; i < EXP_TABLE_LEN; ++i)
             Py_XDECREF(table[i]);
     }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4390,7 +4390,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
     }
     else {
         /* Left-to-right k-ary sliding window exponentiation
-         * (Handbookd of Applied Cryptography (HAC) Algorithm 14.85)
+         * (Handbook of Applied Cryptography (HAC) Algorithm 14.85)
          */
         Py_INCREF(a);
         table[0] = a;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4372,7 +4372,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
     }
     else {
         /* Left-to-right k-ary sliding window exponentiation
-         * (HAC Algorithm 14.85)
+         * (Handbookd of Applied Cryptography (HAC) Algorithm 14.85)
          */
         Py_INCREF(a);
         table[0] = a;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4202,7 +4202,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
      * precomputed so that table[i] == a**(2*i+1) % c for i in
      * range(EXP_TABLE_LEN).
      */
-    PyLongObject *table[EXP_TABLE_LEN] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+    PyLongObject *table[EXP_TABLE_LEN] = {0};
 
     /* a, b, c = v, w, x */
     CHECK_BINOP(v, w);


### PR DESCRIPTION
For large exponents in long_pow(), use the sliding window algorithm instead.

Also boost the window size from 5 bits to 6, which should yield a modest but significant speedup for long exponents. The precomputed table remains the same size, though, because the sliding window algorithm only stores results for odd exponents.

long_pow() no longer requires that the number of bits in a CPython long digit be a multiple of 5. It no longer cares at all what the digit width is.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46218](https://bugs.python.org/issue46218) -->
https://bugs.python.org/issue46218
<!-- /issue-number -->
