### PR TITLE
Add `Makefile` and `.json` to `editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ indent_size = 4
 indent_size = 2
 
 [Makefile{,.pre.in,.pre}]
-indent_size = 4
+indent_size = 8
 indent_style = tab
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,17 @@
 root = true
 
-[*.{py,c,cpp,h,rst,md,yml}]
+[*.{py,c,cpp,h,rst,md,yml,json}]
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 
-[*.{py,c,cpp,h}]
+[*.{py,c,cpp,h,json}]
 indent_size = 4
 
 [*.yml]
 indent_size = 2
+
+[Makefile{,.pre.in,.pre}]
+indent_size = 4
+indent_style = tab
+trim_trailing_whitespace = true


### PR DESCRIPTION
There are quite a lot of `json` files that were missing from this definition.
I've also added all `Makefile`s to the spec, because it is important to use `tab`s when editing them.

Docs: https://editorconfig.org/
Refs https://github.com/python/cpython/pull/27638
Refs https://bugs.python.org/issue44854

CC @ambv 
