### PR TITLE
bpo-46258: Streamline isqrt fast path

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-01-04-18-05-25.bpo-46258.DYgwRo.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-04-18-05-25.bpo-46258.DYgwRo.rst
@@ -1,0 +1,2 @@
+Speed up :func:`math.isqrt` for positive integers smaller than ``2**64`` by
+approximately 10%.

--- a/Misc/NEWS.d/next/Library/2022-01-04-18-05-25.bpo-46258.DYgwRo.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-04-18-05-25.bpo-46258.DYgwRo.rst
@@ -1,2 +1,2 @@
-Speed up :func:`math.isqrt` for positive integers smaller than ``2**64`` by
-approximately 10%.
+Speed up :func:`math.isqrt` for small positive integers by replacing two
+division steps with a lookup table.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1807,7 +1807,7 @@ math_isqrt(PyObject *module, PyObject *n)
     /* Fast path: if c <= 31 then n < 2**64 and we can compute directly with a
        fast, almost branch-free algorithm. */
     if (c <= 31U) {
-        int shift = 31 - c;
+        int shift = 31 - (int)c;
         m = (uint64_t)PyLong_AsUnsignedLongLong(n);
         Py_DECREF(n);
         if (m == (uint64_t)(-1) && PyErr_Occurred()) {

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1720,10 +1720,11 @@ completes the proof sketch.
 
 /*
     The _approximate_isqrt_tab table provides approximate square roots for
-    16-bit integers. It can be verified by direct computation that for each n
-    in the range 2**14 <= n < 2**16, the value a =
-    _approximate_isqrt_tab[(n >> 8) - 64] is an 8-bit approximate square root
-    of n, satisfying (a - 1)**2 < n < (a + 1)**2.
+    16-bit integers. For any n in the range 2**14 <= n < 2**16, the value
+
+        a = _approximate_isqrt_tab[(n >> 8) - 64]
+
+    is an approximate square root of n, satisfying (a - 1)**2 < n < (a + 1)**2.
 
     The table was computed in Python using the expression:
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1718,23 +1718,46 @@ completes the proof sketch.
 
 */
 
+/*
+    The _approximate_isqrt_tab table provides approximate square roots for
+    16-bit integers. It can be verified by direct computation that for each n
+    in the range 2**14 <= n < 2**16, the value a =
+    _approximate_isqrt_tab[(n >> 8) - 64] is an 8-bit approximate square root
+    of n, satisfying (a - 1)**2 < n < (a + 1)**2.
+
+    The table was computed in Python using the expression:
+
+        [min(round(sqrt(256*n + 128)), 255) for n in range(64, 256)]
+*/
+
+static const uint8_t _approximate_isqrt_tab[192] = {
+    128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
+    140, 141, 142, 143, 144, 144, 145, 146, 147, 148, 149, 150,
+    151, 151, 152, 153, 154, 155, 156, 156, 157, 158, 159, 160,
+    160, 161, 162, 163, 164, 164, 165, 166, 167, 167, 168, 169,
+    170, 170, 171, 172, 173, 173, 174, 175, 176, 176, 177, 178,
+    179, 179, 180, 181, 181, 182, 183, 183, 184, 185, 186, 186,
+    187, 188, 188, 189, 190, 190, 191, 192, 192, 193, 194, 194,
+    195, 196, 196, 197, 198, 198, 199, 200, 200, 201, 201, 202,
+    203, 203, 204, 205, 205, 206, 206, 207, 208, 208, 209, 210,
+    210, 211, 211, 212, 213, 213, 214, 214, 215, 216, 216, 217,
+    217, 218, 219, 219, 220, 220, 221, 221, 222, 223, 223, 224,
+    224, 225, 225, 226, 227, 227, 228, 228, 229, 229, 230, 230,
+    231, 232, 232, 233, 233, 234, 234, 235, 235, 236, 237, 237,
+    238, 238, 239, 239, 240, 240, 241, 241, 242, 242, 243, 243,
+    244, 244, 245, 246, 246, 247, 247, 248, 248, 249, 249, 250,
+    250, 251, 251, 252, 252, 253, 253, 254, 254, 255, 255, 255,
+};
 
 /* Approximate square root of a large 64-bit integer.
 
    Given `n` satisfying `2**62 <= n < 2**64`, return `a`
    satisfying `(a - 1)**2 < n < (a + 1)**2`. */
 
-/* Lookup table to short-circuit the first division step in _approximate_isqrt.
-   [8*round(sqrt(72+16*n)) for n in range(12)].  */
-static const uint8_t isqrt_tab[12] = {
-    64, 72, 80, 88, 88, 96, 104, 104, 112, 112, 120, 128,
-};
-
 static inline uint32_t
 _approximate_isqrt(uint64_t n)
 {
-    uint32_t u = isqrt_tab[(n >> 60) - 4];
-    u = u + (uint32_t)(n >> 50) / u;
+    uint32_t u = _approximate_isqrt_tab[(n >> 56) - 64];
     u = (u << 7) + (uint32_t)(n >> 41) / u;
     return (u << 15) + (uint32_t)((n >> 17) / u);
 }


### PR DESCRIPTION
This PR makes some minor simplifications to the implementation of `math.isqrt`. Those simplifications improve the speed of `math.isqrt` for inputs smaller than `2**64` by around 20% on my machine.

In detail:
- In `_approximate_sqrt`, use a lookup table based on the topmost 8 bits to replace the first two Newton iterations. This reduces the total number of divisions needed from 4 to 2.
- Change the return type of `_approximate_sqrt` from `uint64_t` to `uint32_t`.
- Replace the `u * u - 1U >= m` test with the simpler but equivalent test `u * u > m`.
- Add casts to make it clear to the compiler that a 32-bit-by-32-bit division is enough for the first of the two divisions in `_approximate_sqrt` (though I'd expect most compilers not to need this).
- Suggest to the compiler that `_approximate_sqrt` be inlined.
- Simplify the shift computation.

On my Intel x64 machine, the assembly produced by Clang involves one `divl` instruction and one `divq` instruction.

There's one subtle but important change here: in the previous implementation of `_approximate_sqrt`, it was possible for the returned value to be exactly `2**32` (but no larger), so we couldn't assume that it would fit in a `uint32_t`. With the new code, the returned value is always `< 2**32`. It's this fact that makes it possible to change the return type, and to replace the `u*u - 1 >= m` test with `u*u > m`. To prove this bound: if we ignore overflow for the moment, since the result of `_approximate_sqrt` is always within `1` of the true square root (following the proof already outlined in the comments), the only way that the result of the final addition can be `2**32` (overflowing to `0`) is if the input `n` exceeds `(2**32 - 1)**2`. But in that case we know most of the top bits of `n`: the top 32 bits are either `0xfffffffe` or `0xffffffff`, and so we can trace through the first steps of `_approximate_sqrt` - the value of `u` retrieved from the lookup table is `255`, then the value assigned to `u` in the following line is `65536`. Then it's easy to see that if `u = 65536`, `(n >> 17 / u) < 2**31` and `u << 15 = 2**31`, so the result of the addition fits in a `uint32_t`.




<!-- issue-number: [bpo-46258](https://bugs.python.org/issue46258) -->
https://bugs.python.org/issue46258
<!-- /issue-number -->
