### PR TITLE
bpo-46310: simplify `for` loop in `asyncio/windows_events`

### DIFF
--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -834,7 +834,7 @@ class IocpProactor:
             return
 
         # Cancel remaining registered operations.
-        for fut, ov, obj, callback in self._cache.values():
+        for fut, ov, obj, callback in list(self._cache.values()):
             if fut.cancelled():
                 # Nothing to do with cancelled futures
                 pass

--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -834,7 +834,7 @@ class IocpProactor:
             return
 
         # Cancel remaining registered operations.
-        for address, (fut, ov, obj, callback) in list(self._cache.items()):
+        for fut, ov, obj, callback in self._cache.values():
             if fut.cancelled():
                 # Nothing to do with cancelled futures
                 pass

--- a/Misc/NEWS.d/next/Library/2022-01-09-09-13-37.bpo-46310.o_97gT.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-09-09-13-37.bpo-46310.o_97gT.rst
@@ -1,1 +1,0 @@
-Use :meth:`dict.values` over :meth:`dict.items` with unused key variable in asyncio.windows_events.

--- a/Misc/NEWS.d/next/Library/2022-01-09-09-13-37.bpo-46310.o_97gT.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-09-09-13-37.bpo-46310.o_97gT.rst
@@ -1,1 +1,1 @@
-Use ``.values()`` over ``.items()`` with unused key variable in :mod:`asyncio.windows_events`.
+Use :meth:`dict.values` over :meth:`dict.items` with unused key variable in asyncio.windows_events.

--- a/Misc/NEWS.d/next/Library/2022-01-09-09-13-37.bpo-46310.o_97gT.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-09-09-13-37.bpo-46310.o_97gT.rst
@@ -1,0 +1,1 @@
+Use ``.values()`` over ``.items()`` with unused key variable in :mod:`asyncio.windows_events`.


### PR DESCRIPTION
It used to have two problems:
1. Extra `list()` call on results, not sure why it was needed
2. `.items()` with unused key, `.values()` simplifies that

I don't think we need NEWS or issue for that.

<!-- issue-number: [bpo-46310](https://bugs.python.org/issue46310) -->
https://bugs.python.org/issue46310
<!-- /issue-number -->
