### PR TITLE
bpo-23952: Document cgi module's maxlen variable

### DIFF
--- a/Doc/library/cgi.rst
+++ b/Doc/library/cgi.rst
@@ -21,6 +21,11 @@ Support module for Common Gateway Interface (CGI) scripts.
 This module defines a number of utilities for use by CGI scripts written in
 Python.
 
+The ``maxlen`` variable can be set to an integer indicating the maximum size
+of a POST request. POST requests larger than this size will result in a
+:exc:`ValueError` being raised during parsing. The default value of this
+variable is ``0``, meaning the request size is unlimited.
+
 
 Introduction
 ------------

--- a/Doc/library/cgi.rst
+++ b/Doc/library/cgi.rst
@@ -21,8 +21,8 @@ Support module for Common Gateway Interface (CGI) scripts.
 This module defines a number of utilities for use by CGI scripts written in
 Python.
 
-The ``maxlen`` variable can be set to an integer indicating the maximum size
-of a POST request. POST requests larger than this size will result in a
+The global variable ``maxlen`` can be set to an integer indicating the maximum
+size of a POST request. POST requests larger than this size will result in a
 :exc:`ValueError` being raised during parsing. The default value of this
 variable is ``0``, meaning the request size is unlimited.
 

--- a/Lib/cgi.py
+++ b/Lib/cgi.py
@@ -13,6 +13,11 @@
 
 This module defines a number of utilities for use by CGI scripts
 written in Python.
+
+The maxlen variable can be set to an integer indicating the maximum size of a
+POST request. POST requests larger than this size will result in a ValueError
+being raised during parsing. The default value of this variable is 0, meaning
+the request size is unlimited.
 """
 
 # History

--- a/Lib/cgi.py
+++ b/Lib/cgi.py
@@ -14,10 +14,10 @@
 This module defines a number of utilities for use by CGI scripts
 written in Python.
 
-The maxlen variable can be set to an integer indicating the maximum size of a
-POST request. POST requests larger than this size will result in a ValueError
-being raised during parsing. The default value of this variable is 0, meaning
-the request size is unlimited.
+The global variable maxlen can be set to an integer indicating the maximum size
+of a POST request. POST requests larger than this size will result in a
+ValueError being raised during parsing. The default value of this variable is 0,
+meaning the request size is unlimited.
 """
 
 # History


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Using the text suggested in https://bugs.python.org/issue23952.

I think this documentation-only change can skip a NEWS file.

<!-- issue-number: [bpo-23952](https://bugs.python.org/issue23952) -->
https://bugs.python.org/issue23952
<!-- /issue-number -->
