### PR TITLE
bpo-46231: Remove invalid_* rules preceded by more tokens from the grammar docs

### DIFF
--- a/Doc/tools/extensions/peg_highlight.py
+++ b/Doc/tools/extensions/peg_highlight.py
@@ -56,8 +56,8 @@ class PEGLexer(RegexLexer):
             (_name + _text_ws + r"(\[[\w\d_\*]+?\])" + _text_ws + "(=)", bygroups(None, None, None, None, None),),
         ],
         "invalids": [
-            (r"^(\s+\|\s+invalid_\w+\s*\n)", bygroups(None)),
-            (r"^(\s+\|\s+incorrect_\w+\s*\n)", bygroups(None)),
+            (r"^(\s+\|\s+.*invalid_\w+.*\n)", bygroups(None)),
+            (r"^(\s+\|\s+.*incorrect_\w+.*\n)", bygroups(None)),
             (r"^(#.*invalid syntax.*(?:.|\n)*)", bygroups(None),),
         ],
         "root": [


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46231](https://bugs.python.org/issue46231) -->
https://bugs.python.org/issue46231
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal