### PR TITLE
bpo-46233: Minor speedup for bigint squaring

### DIFF
--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1507,12 +1507,12 @@ class LongTest(unittest.TestCase):
         # itself, using a special, faster algorithm. This test is mostly
         # to ensure that no asserts in the implementation trigger, in
         # cases with a maximal amount of carries.
-            for bitlen in range(1, 400):
-                n = (1 << bitlen) - 1 # solid string of 1 bits
-                with self.subTest(bitlen=bitlen, n=n):
-                    # (2**i - 1)**2 = 2**(2*i) - 2*2**i + 1
-                    self.assertEqual(n**2,
-                        (1 << (2 * bitlen)) - (1 << (bitlen + 1)) + 1)
+        for bitlen in range(1, 400):
+            n = (1 << bitlen) - 1 # solid string of 1 bits
+            with self.subTest(bitlen=bitlen, n=n):
+                # (2**i - 1)**2 = 2**(2*i) - 2*2**i + 1
+                self.assertEqual(n**2,
+                    (1 << (2 * bitlen)) - (1 << (bitlen + 1)) + 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1502,6 +1502,17 @@ class LongTest(unittest.TestCase):
             self.assertEqual(type(numerator), int)
             self.assertEqual(type(denominator), int)
 
+    def test_square(self):
+        # Multiplication makes a special case of multiplying an int with
+        # itself, using a special, faster algorithm. This test is mostly
+        # to ensure that no asserts in the implementation trigger, in
+        # cases with a maximal amount of carries.
+            for bitlen in range(1, 400):
+                n = (1 << bitlen) - 1 # solid string of 1 bits
+                with self.subTest(bitlen=bitlen, n=n):
+                    # (2**i - 1)**2 = 2**(2*i) - 2*2**i + 1
+                    self.assertEqual(n**2,
+                        (1 << (2 * bitlen)) - (1 << (bitlen + 1)) + 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3275,7 +3275,7 @@ x_mul(PyLongObject *a, PyLongObject *b)
                      * more than 2*B - 2 to a stored digit no more than B - 1.
                      * So the sum was no more than 3*B - 3, so the current
                      * carry no more than floor((3*B - 3)/B) = 2, assuming
-                     * B > 3. I believe a more demanding analysis would show
+                     * B >= 3. I believe a more demanding analysis would show
                      * the carry can be no larger than 1, but the 2 from that
                      * easy analysis is good enough for code correctness.
                      */

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3237,12 +3237,12 @@ x_mul(PyLongObject *a, PyLongObject *b)
          * via exploiting that each entry in the multiplication
          * pyramid appears twice (except for the size_a squares).
          */
+        digit *paend = a->ob_digit + size_a;
         for (i = 0; i < size_a; ++i) {
             twodigits carry;
             twodigits f = a->ob_digit[i];
             digit *pz = z->ob_digit + (i << 1);
             digit *pa = a->ob_digit + i + 1;
-            digit *paend = a->ob_digit + size_a;
 
             SIGCHECK({
                     Py_DECREF(z);
@@ -3268,10 +3268,22 @@ x_mul(PyLongObject *a, PyLongObject *b)
                 carry += *pz;
                 *pz++ = (digit)(carry & PyLong_MASK);
                 carry >>= PyLong_SHIFT;
+                if (carry) {
+                    /* If there's still a carry, it must be into a position
+                     * that still holds a 0. Where the base
+                     ^ B is 1 << PyLong_SHIFT, the last add was of a carry no
+                     * more than 2*B - 2 to a stored digit no more than B - 1.
+                     * So the sum was no more than 3*B - 3, so the current
+                     * carry no more than floor((3*B - 3)/B) = 2, assuming
+                     * B > 3. I believe a more demanding analysis would show
+                     * the carry can be no larger than 1, but the 2 from that
+                     * easy analysis is good enough for code correctness.
+                     */
+                    assert(*pz == 0);
+                    assert(carry <= 2);
+                    *pz = (digit)carry;
+                }
             }
-            if (carry)
-                *pz += (digit)(carry & PyLong_MASK);
-            assert((carry >> PyLong_SHIFT) == 0);
         }
     }
     else {      /* a is not the same as b -- gradeschool int mult */

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3281,10 +3281,9 @@ x_mul(PyLongObject *a, PyLongObject *b)
                      * So the sum was no more than 2*B - 1, so the current
                      * carry no more than floor((2*B - 1)/B) = 1.
                      */
-                    ++pz;
-                    assert(*pz == 0);
                     assert(carry == 1);
-                    *pz = (digit)carry;
+                    assert(pz[1] == 0);
+                    pz[1] = (digit)carry;
                 }
             }
         }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3265,22 +3265,25 @@ x_mul(PyLongObject *a, PyLongObject *b)
                 assert(carry <= (PyLong_MASK << 1));
             }
             if (carry) {
+                /* See comment below. pz points at the highest possible
+                 * carry position from the last outer loop iteration, so
+                 * *pz is at most 1.
+                 */
+                assert(*pz <= 1);
                 carry += *pz;
-                *pz++ = (digit)(carry & PyLong_MASK);
+                *pz = (digit)(carry & PyLong_MASK);
                 carry >>= PyLong_SHIFT;
                 if (carry) {
                     /* If there's still a carry, it must be into a position
                      * that still holds a 0. Where the base
                      ^ B is 1 << PyLong_SHIFT, the last add was of a carry no
-                     * more than 2*B - 2 to a stored digit no more than B - 1.
-                     * So the sum was no more than 3*B - 3, so the current
-                     * carry no more than floor((3*B - 3)/B) = 2, assuming
-                     * B >= 3. I believe a more demanding analysis would show
-                     * the carry can be no larger than 1, but the 2 from that
-                     * easy analysis is good enough for code correctness.
+                     * more than 2*B - 2 to a stored digit no more than 1.
+                     * So the sum was no more than 2*B - 1, so the current
+                     * carry no more than floor((2*B - 1)/B) = 1.
                      */
+                    ++pz;
                     assert(*pz == 0);
-                    assert(carry <= 2);
+                    assert(carry == 1);
                     *pz = (digit)carry;
                 }
             }


### PR DESCRIPTION
x_mul()'s special code for squaring does a bit of useless work at
the end of each digit pass. Clean it up.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46233](https://bugs.python.org/issue46233) -->
https://bugs.python.org/issue46233
<!-- /issue-number -->
