### PR TITLE
bpo-46235: Do all ref-counting at once during list/tuple multiplication

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-02-23-55-13.bpo-46235.gUjp2v.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-02-23-55-13.bpo-46235.gUjp2v.rst
@@ -1,0 +1,1 @@
+Certain sequence multiplication operations like ``[0] * 1_000`` are now faster due to reference-counting optimizations. Patch by Dennis Sweeney.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -571,6 +571,9 @@ list_repeat(PyListObject *a, Py_ssize_t n)
     if (Py_SIZE(a) == 1) {
         PyObject *elem = a->ob_item[0];
         Py_SET_REFCNT(elem, Py_REFCNT(elem) + n);
+#ifdef Py_REF_DEBUG
+        _Py_RefTotal += n;
+#endif
         while (dest < dest_end) {
             *dest++ = elem;
         }
@@ -581,6 +584,9 @@ list_repeat(PyListObject *a, Py_ssize_t n)
         PyObject **src;
         for (src = src0; src < src_end; src++) {
             Py_SET_REFCNT(*src, Py_REFCNT(*src) + n);
+#ifdef Py_REF_DEBUG
+            _Py_RefTotal += n;
+#endif
         }
         while (dest < dest_end) {
             src = src0;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -565,7 +565,6 @@ list_repeat(PyListObject *a, Py_ssize_t n)
     np = (PyListObject *) list_new_prealloc(size);
     if (np == NULL)
         return NULL;
-
     PyObject **dest = np->ob_item;
     PyObject **dest_end = dest + size;
     if (Py_SIZE(a) == 1) {
@@ -579,22 +578,20 @@ list_repeat(PyListObject *a, Py_ssize_t n)
         }
     }
     else {
-        PyObject **src0 = a->ob_item;
-        PyObject **src_end = src0 + Py_SIZE(a);
-        PyObject **src;
-        for (src = src0; src < src_end; src++) {
+        PyObject **src = a->ob_item;
+        PyObject **src_end = src + Py_SIZE(a);
+        while (src < src_end) {
             Py_SET_REFCNT(*src, Py_REFCNT(*src) + n);
 #ifdef Py_REF_DEBUG
             _Py_RefTotal += n;
 #endif
+            *dest++ = *src++;
         }
+        // Now src chases after dest in the same buffer
+        src = np->ob_item;
         while (dest < dest_end) {
-            src = src0;
-            while (src < src_end) {
-                *dest++ = *src++;
-            }
+            *dest++ = *src++;
         }
-        assert(src == src_end && dest == dest_end);
     }
     Py_SET_SIZE(np, size);
     return (PyObject *) np;

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -589,10 +589,8 @@ tupleconcat(PyTupleObject *a, PyObject *bb)
 static PyObject *
 tuplerepeat(PyTupleObject *a, Py_ssize_t n)
 {
-    Py_ssize_t i, j;
     Py_ssize_t size;
     PyTupleObject *np;
-    PyObject **p, **items;
     if (Py_SIZE(a) == 0 || n == 1) {
         if (PyTuple_CheckExact(a)) {
             /* Since tuples are immutable, we can return a shared
@@ -610,15 +608,22 @@ tuplerepeat(PyTupleObject *a, Py_ssize_t n)
     np = tuple_alloc(size);
     if (np == NULL)
         return NULL;
-    p = np->ob_item;
-    items = a->ob_item;
-    for (i = 0; i < n; i++) {
-        for (j = 0; j < Py_SIZE(a); j++) {
-            *p = items[j];
-            Py_INCREF(*p);
-            p++;
+
+    PyObject **src0 = a->ob_item;
+    PyObject **src_end = src0 + Py_SIZE(a);
+    PyObject **src;
+    for (src = src0; src < src_end; src++) {
+        Py_SET_REFCNT(*src, Py_REFCNT(*src) + n);
+    }
+    PyObject **dest = np->ob_item;
+    PyObject **dest_end = dest + size;
+    while (dest < dest_end) {
+        src = src0;
+        while (src < src_end) {
+            *dest++ = *src++;
         }
     }
+    assert(src == src_end && dest == dest_end);
     _PyObject_GC_TRACK(np);
     return (PyObject *) np;
 }

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -614,6 +614,9 @@ tuplerepeat(PyTupleObject *a, Py_ssize_t n)
     PyObject **src;
     for (src = src0; src < src_end; src++) {
         Py_SET_REFCNT(*src, Py_REFCNT(*src) + n);
+#ifdef Py_REF_DEBUG
+        _Py_RefTotal += n;
+#endif
     }
     PyObject **dest = np->ob_item;
     PyObject **dest_end = dest + size;


### PR DESCRIPTION
See the bpo issue for benchmarks.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46235](https://bugs.python.org/issue46235) -->
https://bugs.python.org/issue46235
<!-- /issue-number -->
