### PR TITLE
bpo-40477: macOS Python Launcher app fixes for recent macOS releases

### DIFF
--- a/Mac/PythonLauncher/Info.plist.in
+++ b/Mac/PythonLauncher/Info.plist.in
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
+	<string>en</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
@@ -39,6 +39,8 @@
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>Python Launcher</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2001-2022 Python Software Foundation</string>
 	<key>CFBundleGetInfoString</key>
 	<string>%VERSION%, © 2001-2022 Python Software Foundation</string>
 	<key>CFBundleIconFile</key>
@@ -61,5 +63,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Python Launcher uses Apple events to launch your Python script in a Terminal window.</string>
 </dict>
 </plist>

--- a/Mac/PythonLauncher/doscript.m
+++ b/Mac/PythonLauncher/doscript.m
@@ -19,7 +19,7 @@ doscript(const char *command)
     AEDesc desc;
     OSStatus err;
 
-    [[NSWorkspace sharedWorkspace] launchApplication:@"/Applications/Utilities/Terminal.app/"];
+    [[NSWorkspace sharedWorkspace] launchApplication:@"Terminal.app"];
 
     // Build event
     err = AEBuildAppleEvent(kAECoreSuite, kAEDoScript,

--- a/Misc/NEWS.d/next/macOS/2022-01-02-21-56-53.bpo-40477.W3nnM6.rst
+++ b/Misc/NEWS.d/next/macOS/2022-01-02-21-56-53.bpo-40477.W3nnM6.rst
@@ -1,0 +1,2 @@
+The Python Launcher app for macOS now properly launches scripts and, if
+necessary, the Terminal app when running on recent macOS releases.


### PR DESCRIPTION
The PR here solves two problems encountered by users of the macOS `Python Launcher` app on recent macOS releases (10.14+):

1.  The launcher app was no longer able to launch the macOS Terminal.app to run a script.
2. Even if Terminal.app was already launched, the launcher app was unable to send an Apple Event to Terminal.app to open and run  Python with the desired .py file.

The solution to  item 1 was to no longer specify an absolute path to `Terminal.app` but rather let LaunchServices figure out the path.

Item 2 was fixed by adding the `NSAppleEventsUsageDescription` key to the launcher app's property list. The first time the launcher runs, macOS displays a message to the user requesting permission to use Apple events; if granted by the user, the launcher will now be able to send open events to `Terminal.app` and all is well.

Tested on the most recent releases of macOS 12, 11, 10.16, 10.15, 10.14, and 10.9 and on both Intel and Apple Silicon Macs.

Thanks to @ronaldoussoren for tracking down the `NSAppleEventsUsageDescription` requirement!

<!-- issue-number: [bpo-40477](https://bugs.python.org/issue40477) -->
https://bugs.python.org/issue40477
<!-- /issue-number -->
