### PR TITLE
bpo-46232: Fix parsing of certs with bit string in DN (GH-30351)

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-01-03-09-46-44.bpo-46232.s0KlyI.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-03-09-46-44.bpo-46232.s0KlyI.rst
@@ -1,0 +1,2 @@
+The :mod:`ssl` module now handles certificates with bit strings in DN
+correctly.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46232](https://bugs.python.org/issue46232) -->
https://bugs.python.org/issue46232
<!-- /issue-number -->
