### PR TITLE
bpo-46238: reuse `_winapi` constants in `asyncio.windows_events`

### DIFF
--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -28,8 +28,8 @@ __all__ = (
 )
 
 
-NULL = 0
-INFINITE = 0xffffffff
+NULL = _winapi.NULL
+INFINITE = _winapi.INFINITE
 ERROR_CONNECTION_REFUSED = 1225
 ERROR_CONNECTION_ABORTED = 1236
 
@@ -405,7 +405,7 @@ class ProactorEventLoop(proactor_events.BaseProactorEventLoop):
 class IocpProactor:
     """Proactor implementation using IOCP."""
 
-    def __init__(self, concurrency=0xffffffff):
+    def __init__(self, concurrency=INFINITE):
         self._loop = None
         self._results = []
         self._iocp = _overlapped.CreateIoCompletionPort(

--- a/Misc/NEWS.d/next/Library/2022-01-03-12-19-10.bpo-46238.lANhCi.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-03-12-19-10.bpo-46238.lANhCi.rst
@@ -1,0 +1,1 @@
+Reuse ``_winapi`` constants in ``asyncio.windows_events``.


### PR DESCRIPTION


<!-- issue-number: [bpo-46238](https://bugs.python.org/issue46238) -->
https://bugs.python.org/issue46238
<!-- /issue-number -->
