### PR TITLE
bpo-46239: improve error message when importing `asyncio.windows_events`

### DIFF
--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -1,5 +1,10 @@
 """Selector and proactor event loops for Windows."""
 
+import sys
+
+if sys.platform != 'win32':  # pragma: no cover
+    raise ImportError('win32 only')
+
 import _overlapped
 import _winapi
 import errno

--- a/Misc/NEWS.d/next/Library/2022-01-03-12-59-20.bpo-46239.ySVSEy.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-03-12-59-20.bpo-46239.ySVSEy.rst
@@ -1,0 +1,2 @@
+Improve error message when importing :mod:`asyncio.windows_events` on
+non-Windows.


### PR DESCRIPTION
This module is Win-only, importing it on non-Win platform used to raise quite cryptic error message.

Used to be:

```python
>>> import asyncio.windows_events
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sobolev/Desktop/cpython/Lib/asyncio/windows_events.py", line 3, in <module>
    import _overlapped
    ^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named '_overlapped'
```

Now:

```
>>> import asyncio.windows_events
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sobolev/Desktop/cpython/Lib/asyncio/windows_events.py", line 6, in <module>
    raise ImportError('win32 only')
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: win32 only
```

It is now in sync with https://github.com/python/cpython/blob/549e62827262264cda30455e10e315602129da72/Lib/asyncio/windows_utils.py#L5-L6

<!-- issue-number: [bpo-46239](https://bugs.python.org/issue46239) -->
https://bugs.python.org/issue46239
<!-- /issue-number -->
