### PR TITLE
bpo-46242: better error message for extending `Enum` with members

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -852,8 +852,8 @@ class EnumType(type):
                             % (class_name, base.__name__)
                             )
 
-    @staticmethod
-    def _get_mixins_(class_name, bases):
+    @classmethod
+    def _get_mixins_(cls, class_name, bases):
         """
         Returns the type for creating enum members, and the first inherited
         enum class.
@@ -894,12 +894,8 @@ class EnumType(type):
         if not issubclass(first_enum, Enum):
             raise TypeError("new enumerations should be created as "
                     "`EnumName([mixin_type, ...] [data_type,] enum_type)`")
+        cls._check_for_existing_members(class_name, bases)
         member_type = _find_data_type(bases) or object
-        if first_enum._member_names_:
-            raise TypeError(
-                "%s: cannot extend enumeration %r"
-                % (class_name, first_enum.__name__)
-                )
         return member_type, first_enum
 
     @staticmethod

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -767,7 +767,7 @@ class EnumType(type):
         """
         metacls = cls.__class__
         bases = (cls, ) if type is None else (type, cls)
-        _, first_enum = cls._get_mixins_(cls, bases)
+        _, first_enum = cls._get_mixins_(class_name, bases)
         classdict = metacls.__prepare__(class_name, bases)
 
         # special processing needed for names?
@@ -896,7 +896,10 @@ class EnumType(type):
                     "`EnumName([mixin_type, ...] [data_type,] enum_type)`")
         member_type = _find_data_type(bases) or object
         if first_enum._member_names_:
-            raise TypeError("Cannot extend enumerations")
+            raise TypeError(
+                "%s: cannot extend enumeration %r"
+                % (class_name, first_enum.__name__)
+                )
         return member_type, first_enum
 
     @staticmethod

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1423,6 +1423,8 @@ class TestEnum(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "EvenMoreColor: cannot extend enumeration 'Color'"):
             class EvenMoreColor(Color, IntEnum):
                 chartruese = 7
+        with self.assertRaisesRegex(TypeError, "Foo: cannot extend enumeration 'Color'"):
+            Color('Foo', ('pink', 'black'))
 
     def test_exclude_methods(self):
         class whatever(Enum):

--- a/Misc/NEWS.d/next/Library/2022-01-03-16-25-06.bpo-46242.f4l_CL.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-03-16-25-06.bpo-46242.f4l_CL.rst
@@ -1,0 +1,1 @@
+Improve error message when creating a new :class:`enum.Enum` type subclassing an existing ``Enum`` with ``_member_names_`` using :method:`enum.Enum.__call__`.

--- a/Misc/NEWS.d/next/Library/2022-01-03-16-25-06.bpo-46242.f4l_CL.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-03-16-25-06.bpo-46242.f4l_CL.rst
@@ -1,1 +1,1 @@
-Improve error message when creating a new :class:`enum.Enum` type subclassing an existing ``Enum`` with ``_member_names_`` using :method:`enum.Enum.__call__`.
+Improve error message when creating a new :class:`enum.Enum` type subclassing an existing ``Enum`` with ``_member_names_`` using :meth:`enum.Enum.__call__`.


### PR DESCRIPTION
Three major changes:
1. Better error message, which is more informative and is in sync with https://github.com/python/cpython/blob/549e62827262264cda30455e10e315602129da72/Lib/enum.py#L850-L853 Another idea is too call `_check_for_existing_members` on `first_enum` in `_get_mixins_`. But, since `_get_mixins_` is `@staticmethod`, I've decided not to use explicit `EnumType._check_for_existing_members()` or not to convert it to `@classmethod`
2. For some reason in `_create_` wrong type was passed to `_get_mixins_`, instead of `str`, `Enum` was passed
3. I've also covered this feature with a test case

<!-- issue-number: [bpo-46242](https://bugs.python.org/issue46242) -->
https://bugs.python.org/issue46242
<!-- /issue-number -->
