### PR TITLE
bpo-23183: Document the timeit output

### DIFF
--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -282,6 +282,13 @@ It is possible to provide a setup statement that is executed only once at the be
    $ python -m timeit -s 'text = "sample string"; char = "g"'  'text.find(char)'
    1000000 loops, best of 5: 0.342 usec per loop
 
+In the output, there are three fields. The loop count, which tells you how many
+times the statement body was run per timing loop repetition. The repetition
+count ('best of 5') which tells you how many times the timing loop was
+repeated, and finally the time the statement body took on average within the
+best repetition of the timing loop. That is, the time the fastest repetition
+took divided by the loop count.
+
 ::
 
    >>> import timeit


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Converted the 2015 patch at https://bugs.python.org/issue23183 to a GitHub PR.

Kept the text the same, except changed "best of 3" to "best of 5" to match the actual current output.

Added the original patch author @rbtcollins as commit co-author.

I think we can skip a NEWS entry for this docs PR.

<!-- issue-number: [bpo-23183](https://bugs.python.org/issue23183) -->
https://bugs.python.org/issue23183
<!-- /issue-number -->
