### PR TITLE
bpo-46208: Fix the relative path normalization of _Py_normpath() in fileutils.c

### DIFF
--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -235,6 +235,10 @@ class TestNtpath(NtpathTestCase):
 
         tester("ntpath.normpath('\\\\.\\NUL')", r'\\.\NUL')
         tester("ntpath.normpath('\\\\?\\D:/XY\\Z')", r'\\?\D:/XY\Z')
+        tester("ntpath.normpath('handbook/../../Tests/image.png')", r'..\Tests\image.png')
+        tester("ntpath.normpath('handbook/../../../Tests/image.png')", r'..\..\Tests\image.png')
+        tester("ntpath.normpath('handbook///../a/.././../b/c')", r'..\b\c')
+        tester("ntpath.normpath('handbook/a/../..///../../b/c')", r'..\..\b\c')
 
     def test_realpath_curdir(self):
         expected = ntpath.normpath(os.getcwd())

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -240,6 +240,11 @@ class TestNtpath(NtpathTestCase):
         tester("ntpath.normpath('handbook///../a/.././../b/c')", r'..\b\c')
         tester("ntpath.normpath('handbook/a/../..///../../b/c')", r'..\..\b\c')
 
+        tester("ntpath.normpath('//server/share/..')" ,    '\\\\server\\share\\')
+        tester("ntpath.normpath('//server/share/../')" ,   '\\\\server\\share\\')
+        tester("ntpath.normpath('//server/share/../..')",  '\\\\server\\share\\')
+        tester("ntpath.normpath('//server/share/../../')", '\\\\server\\share\\')
+
     def test_realpath_curdir(self):
         expected = ntpath.normpath(os.getcwd())
         tester("ntpath.realpath('.')", expected)

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -329,13 +329,22 @@ class PosixPathTest(unittest.TestCase):
         ("/..", "/"),
         ("/../", "/"),
         ("/..//", "/"),
+        ("//.", "//"),
         ("//..", "//"),
+        ("//...", "//..."),
+        ("//../foo", "//foo"),
+        ("//../../foo", "//foo"),
         ("/../foo", "/foo"),
         ("/../../foo", "/foo"),
         ("/../foo/../", "/"),
         ("/../foo/../bar", "/bar"),
         ("/../../foo/../bar/./baz/boom/..", "/bar/baz"),
         ("/../../foo/../bar/./baz/boom/.", "/bar/baz/boom"),
+        ("handbook/../Tests/image.png", "Tests/image.png"),
+        ("handbook/../../Tests/image.png", "../Tests/image.png"),
+        ("handbook/../../../Tests/image.png", "../../Tests/image.png"),
+        ("handbook///../a/.././../b/c", "../b/c"),
+        ("handbook/a/../..///../../b/c", "../../b/c"),
     ]
 
     def test_normpath(self):
@@ -348,31 +357,6 @@ class PosixPathTest(unittest.TestCase):
             expected = expected.encode('utf-8')
             with self.subTest(path, type=bytes):
                 result = posixpath.normpath(path)
-                self.assertEqual(result, expected)
-
-    NORMPATH_CASES_DUMMY = [
-        ("handbook/../../Tests/image.png", "Tests/image.png"),
-        ("handbook/../../../Tests/image.png", "Tests/image.png"),
-        ("handbook///../a/.././../b/c", "b/c"),
-        ("handbook/a/../..///../../b/c", "b/c"),
-    ]
-
-    def test_normpath_dummy(self):
-        for path, expected in self.NORMPATH_CASES_DUMMY:
-            with self.subTest(path):
-                print(path)
-                result = posixpath.normpath(path)
-                print(result)
-                print()
-                self.assertEqual(result, expected)
-
-            path = path.encode('utf-8')
-            expected = expected.encode('utf-8')
-            with self.subTest(path, type=bytes):
-                print(path)
-                result = posixpath.normpath(path)
-                print(result)
-                print()
                 self.assertEqual(result, expected)
 
     @skip_if_ABSTFN_contains_backslash

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -336,8 +336,6 @@ class PosixPathTest(unittest.TestCase):
         ("/../foo/../bar", "/bar"),
         ("/../../foo/../bar/./baz/boom/..", "/bar/baz"),
         ("/../../foo/../bar/./baz/boom/.", "/bar/baz/boom"),
-        ("handbook/../../Tests/image.png", "../Tests/image.png"),
-        ("handbook/../../../Tests/image.png", "../../Tests/image.png"),
     ]
 
     def test_normpath(self):
@@ -350,6 +348,31 @@ class PosixPathTest(unittest.TestCase):
             expected = expected.encode('utf-8')
             with self.subTest(path, type=bytes):
                 result = posixpath.normpath(path)
+                self.assertEqual(result, expected)
+
+    NORMPATH_CASES_DUMMY = [
+        ("handbook/../../Tests/image.png", "Tests/image.png"),
+        ("handbook/../../../Tests/image.png", "Tests/image.png"),
+        ("handbook///../a/.././../b/c", "b/c"),
+        ("handbook/a/../..///../../b/c", "b/c"),
+    ]
+
+    def test_normpath_dummy(self):
+        for path, expected in self.NORMPATH_CASES_DUMMY:
+            with self.subTest(path):
+                print(path)
+                result = posixpath.normpath(path)
+                print(result)
+                print()
+                self.assertEqual(result, expected)
+
+            path = path.encode('utf-8')
+            expected = expected.encode('utf-8')
+            with self.subTest(path, type=bytes):
+                print(path)
+                result = posixpath.normpath(path)
+                print(result)
+                print()
                 self.assertEqual(result, expected)
 
     @skip_if_ABSTFN_contains_backslash

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -351,6 +351,8 @@ class PosixPathTest(unittest.TestCase):
         ("//foo/../..", "//"),
         ("///foo/..", "/"),
         ("///foo/../..", "/"),
+        ("////foo/..", "/"),
+        ("/////foo/..", "/"),
     ]
 
     def test_normpath(self):

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -336,6 +336,10 @@ class PosixPathTest(unittest.TestCase):
         ("/../foo/../bar", "/bar"),
         ("/../../foo/../bar/./baz/boom/..", "/bar/baz"),
         ("/../../foo/../bar/./baz/boom/.", "/bar/baz/boom"),
+        ("handbook/../../Tests/image.png", "../Tests/image.png"),
+        ("handbook/../../../Tests/image.png", "../../Tests/image.png"),
+        ("handbook///../a/.././../b/c", "../b/c"),
+        ("handbook/a/../..///../../b/c", "../../b/c"),
     ]
 
     def test_normpath(self):

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -338,8 +338,6 @@ class PosixPathTest(unittest.TestCase):
         ("/../../foo/../bar/./baz/boom/.", "/bar/baz/boom"),
         ("handbook/../../Tests/image.png", "../Tests/image.png"),
         ("handbook/../../../Tests/image.png", "../../Tests/image.png"),
-        ("handbook///../a/.././../b/c", "../b/c"),
-        ("handbook/a/../..///../../b/c", "../../b/c"),
     ]
 
     def test_normpath(self):

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -340,11 +340,17 @@ class PosixPathTest(unittest.TestCase):
         ("/../foo/../bar", "/bar"),
         ("/../../foo/../bar/./baz/boom/..", "/bar/baz"),
         ("/../../foo/../bar/./baz/boom/.", "/bar/baz/boom"),
-        ("handbook/../Tests/image.png", "Tests/image.png"),
-        ("handbook/../../Tests/image.png", "../Tests/image.png"),
-        ("handbook/../../../Tests/image.png", "../../Tests/image.png"),
-        ("handbook///../a/.././../b/c", "../b/c"),
-        ("handbook/a/../..///../../b/c", "../../b/c"),
+        ("foo/../bar/baz", "bar/baz"),
+        ("foo/../../bar/baz", "../bar/baz"),
+        ("foo/../../../bar/baz", "../../bar/baz"),
+        ("foo///../bar/.././../baz/boom", "../baz/boom"),
+        ("foo/bar/../..///../../baz/boom", "../../baz/boom"),
+        ("/foo/..", "/"),
+        ("/foo/../..", "/"),
+        ("//foo/..", "//"),
+        ("//foo/../..", "//"),
+        ("///foo/..", "/"),
+        ("///foo/../..", "/"),
     ]
 
     def test_normpath(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-04-01-53-35.bpo-46208.i00Vz5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-04-01-53-35.bpo-46208.i00Vz5.rst
@@ -1,0 +1,1 @@
+Fix the regression of os.path.normpath("A/../../B") not returning expected "../B" but "B".

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2301,7 +2301,14 @@ _Py_normpath(wchar_t *path, Py_ssize_t size)
                         // Absolute path, so absorb segment
                         p2 = p3 + 1;
                     } else {
-                        p2 = p3;
+                        if (p2 == minP2) {
+                            *p2++ = '.';
+                            *p2++ = '.';
+                            lastC = '.';
+                        }
+                        else {
+                            p2 = p3;
+                        }
                     }
                     p1 += 1;
                 } else if (sep_at_1) {
@@ -2314,7 +2321,7 @@ _Py_normpath(wchar_t *path, Py_ssize_t size)
             }
         } else {
             *p2++ = lastC = c;
-        } 
+        }
     }
     *p2 = L'\0';
     if (p2 != minP2) {

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2223,7 +2223,7 @@ _Py_normpath(wchar_t *path, Py_ssize_t size)
     wchar_t *pEnd = size >= 0 ? &path[size] : NULL;
     wchar_t *p2 = path;
     wchar_t *minP2 = path;
-    int do_appendleft_dotdot = 1;
+    int minP2_dotdot_joinable = 1;
 
 #define IS_END(x) (pEnd ? (x) == pEnd : !*(x))
 #ifdef ALTSEP
@@ -2274,7 +2274,7 @@ _Py_normpath(wchar_t *path, Py_ssize_t size)
         *p2++ = *p1++;
         minP2 = p2;
         lastC = SEP;
-        do_appendleft_dotdot = 0;  // follow pure python's caluculation
+        minP2_dotdot_joinable = 0;  // follow pure python's caluculation
     }
 #endif /* MS_WINDOWS */
 
@@ -2292,7 +2292,7 @@ _Py_normpath(wchar_t *path, Py_ssize_t size)
                 int sep_at_2 = !sep_at_1 && SEP_OR_END(&p1[2]);
                 if (sep_at_2 && p1[1] == L'.') {
                     if (p2 == minP2) {
-                        if (do_appendleft_dotdot) {
+                        if (minP2_dotdot_joinable) {
                             *p2++ = L'.';
                             *p2++ = L'.';
                             lastC = L'.';

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2223,7 +2223,6 @@ _Py_normpath(wchar_t *path, Py_ssize_t size)
     wchar_t *p2 = path;     // destination of a scanned character to be ljusted
     wchar_t *minP2 = path;  // the beginning of the destination range
     wchar_t lastC = L'\0';  // the last ljusted character, p2[-1] in most cases
-    int is_absolute = 0;    // whether the path is confirmed to be absolute
 
 #define IS_END(x) (pEnd ? (x) == pEnd : !*(x))
 #ifdef ALTSEP


### PR DESCRIPTION


<!-- issue-number: [bpo-46208](https://bugs.python.org/issue46208) -->
https://bugs.python.org/issue46208
<!-- /issue-number -->
