### PR TITLE
bpo-46110: Revert "bpo-46110: Add a recursion check to avoid stack overflow in the PEG parser"

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1729,14 +1729,6 @@ while 1:
 """
         self._check_error(source, "too many statically nested blocks")
 
-    @support.cpython_only
-    def test_error_on_parser_stack_overflow(self):
-        source = "-" * 100000 + "4"
-        for mode in ["exec", "eval", "single"]:
-            with self.subTest(mode=mode):
-                with self.assertRaises(MemoryError):
-                    compile(source, "<string>", mode)
-
 
 def load_tests(loader, tests, pattern):
     tests.addTest(doctest.DocTestSuite())

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-18-02-37-07.bpo-46110.B6hAfu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-18-02-37-07.bpo-46110.B6hAfu.rst
@@ -1,2 +1,0 @@
-Add a maximum recursion check to the PEG parser to avoid stack overflow.
-Patch by Pablo Galindo

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -6,8 +6,6 @@
 #else
 #  define D(x)
 #endif
-
-# define MAXSTACK 6000
 static const int n_keyword_lists = 9;
 static KeywordToken *reserved_keywords[] = {
     (KeywordToken[]) {{NULL, -1}},
@@ -970,19 +968,16 @@ static asdl_seq *_loop1_222_rule(Parser *p);
 static mod_ty
 file_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // statements? $
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> file[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "statements? $"));
@@ -998,7 +993,7 @@ file_rule(Parser *p)
             _res = _PyPegen_make_module ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1009,7 +1004,7 @@ file_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -1017,19 +1012,16 @@ file_rule(Parser *p)
 static mod_ty
 interactive_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // statement_newline
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> interactive[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "statement_newline"));
@@ -1042,7 +1034,7 @@ interactive_rule(Parser *p)
             _res = _PyAST_Interactive ( a , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1053,7 +1045,7 @@ interactive_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -1061,19 +1053,16 @@ interactive_rule(Parser *p)
 static mod_ty
 eval_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // expressions NEWLINE* $
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> eval[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expressions NEWLINE* $"));
@@ -1092,7 +1081,7 @@ eval_rule(Parser *p)
             _res = _PyAST_Expression ( a , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1103,7 +1092,7 @@ eval_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -1111,19 +1100,16 @@ eval_rule(Parser *p)
 static mod_ty
 func_type_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // '(' type_expressions? ')' '->' expression NEWLINE* $
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> func_type[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' type_expressions? ')' '->' expression NEWLINE* $"));
@@ -1154,7 +1140,7 @@ func_type_rule(Parser *p)
             _res = _PyAST_FunctionType ( a , b , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1165,7 +1151,7 @@ func_type_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -1173,19 +1159,16 @@ func_type_rule(Parser *p)
 static expr_ty
 fstring_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // star_expressions
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> fstring[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_expressions"));
@@ -1204,7 +1187,7 @@ fstring_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -1212,19 +1195,16 @@ fstring_rule(Parser *p)
 static asdl_stmt_seq*
 statements_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     { // statement+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> statements[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "statement+"));
@@ -1237,7 +1217,7 @@ statements_rule(Parser *p)
             _res = ( asdl_stmt_seq* ) _PyPegen_seq_flatten ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1248,7 +1228,7 @@ statements_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -1256,19 +1236,16 @@ statements_rule(Parser *p)
 static asdl_stmt_seq*
 statement_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     { // compound_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> statement[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "compound_stmt"));
@@ -1281,7 +1258,7 @@ statement_rule(Parser *p)
             _res = ( asdl_stmt_seq* ) _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1292,7 +1269,7 @@ statement_rule(Parser *p)
     }
     { // simple_stmts
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> statement[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "simple_stmts"));
@@ -1305,7 +1282,7 @@ statement_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1316,7 +1293,7 @@ statement_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -1324,19 +1301,16 @@ statement_rule(Parser *p)
 static asdl_stmt_seq*
 statement_newline_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -1345,7 +1319,7 @@ statement_newline_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // compound_stmt NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> statement_newline[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "compound_stmt NEWLINE"));
@@ -1361,7 +1335,7 @@ statement_newline_rule(Parser *p)
             _res = ( asdl_stmt_seq* ) _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1372,7 +1346,7 @@ statement_newline_rule(Parser *p)
     }
     { // simple_stmts
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> statement_newline[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "simple_stmts"));
@@ -1391,7 +1365,7 @@ statement_newline_rule(Parser *p)
     }
     { // NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> statement_newline[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE"));
@@ -1403,7 +1377,7 @@ statement_newline_rule(Parser *p)
             D(fprintf(stderr, "%*c+ statement_newline[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NEWLINE"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -1413,7 +1387,7 @@ statement_newline_rule(Parser *p)
             _res = ( asdl_stmt_seq* ) _PyPegen_singleton_seq ( p , CHECK ( stmt_ty , _PyAST_Pass ( EXTRA ) ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1424,7 +1398,7 @@ statement_newline_rule(Parser *p)
     }
     { // $
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> statement_newline[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "$"));
@@ -1437,7 +1411,7 @@ statement_newline_rule(Parser *p)
             _res = _PyPegen_interactive_exit ( p );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1448,7 +1422,7 @@ statement_newline_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -1456,19 +1430,16 @@ statement_newline_rule(Parser *p)
 static asdl_stmt_seq*
 simple_stmts_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     { // simple_stmt !';' NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmts[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "simple_stmt !';' NEWLINE"));
@@ -1486,7 +1457,7 @@ simple_stmts_rule(Parser *p)
             _res = ( asdl_stmt_seq* ) _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1497,7 +1468,7 @@ simple_stmts_rule(Parser *p)
     }
     { // ';'.simple_stmt+ ';'? NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmts[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "';'.simple_stmt+ ';'? NEWLINE"));
@@ -1517,7 +1488,7 @@ simple_stmts_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1528,7 +1499,7 @@ simple_stmts_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -1549,23 +1520,20 @@ simple_stmts_rule(Parser *p)
 static stmt_ty
 simple_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     if (_PyPegen_is_memoized(p, simple_stmt_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -1574,7 +1542,7 @@ simple_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // assignment
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assignment"));
@@ -1593,7 +1561,7 @@ simple_stmt_rule(Parser *p)
     }
     { // star_expressions
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_expressions"));
@@ -1605,7 +1573,7 @@ simple_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ simple_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "star_expressions"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -1615,7 +1583,7 @@ simple_stmt_rule(Parser *p)
             _res = _PyAST_Expr ( e , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1626,7 +1594,7 @@ simple_stmt_rule(Parser *p)
     }
     { // &'return' return_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'return' return_stmt"));
@@ -1647,7 +1615,7 @@ simple_stmt_rule(Parser *p)
     }
     { // &('import' | 'from') import_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&('import' | 'from') import_stmt"));
@@ -1668,7 +1636,7 @@ simple_stmt_rule(Parser *p)
     }
     { // &'raise' raise_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'raise' raise_stmt"));
@@ -1689,7 +1657,7 @@ simple_stmt_rule(Parser *p)
     }
     { // 'pass'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'pass'"));
@@ -1701,7 +1669,7 @@ simple_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ simple_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'pass'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -1711,7 +1679,7 @@ simple_stmt_rule(Parser *p)
             _res = _PyAST_Pass ( EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1722,7 +1690,7 @@ simple_stmt_rule(Parser *p)
     }
     { // &'del' del_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'del' del_stmt"));
@@ -1743,7 +1711,7 @@ simple_stmt_rule(Parser *p)
     }
     { // &'yield' yield_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'yield' yield_stmt"));
@@ -1764,7 +1732,7 @@ simple_stmt_rule(Parser *p)
     }
     { // &'assert' assert_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'assert' assert_stmt"));
@@ -1785,7 +1753,7 @@ simple_stmt_rule(Parser *p)
     }
     { // 'break'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'break'"));
@@ -1797,7 +1765,7 @@ simple_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ simple_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'break'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -1807,7 +1775,7 @@ simple_stmt_rule(Parser *p)
             _res = _PyAST_Break ( EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1818,7 +1786,7 @@ simple_stmt_rule(Parser *p)
     }
     { // 'continue'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'continue'"));
@@ -1830,7 +1798,7 @@ simple_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ simple_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'continue'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -1840,7 +1808,7 @@ simple_stmt_rule(Parser *p)
             _res = _PyAST_Continue ( EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -1851,7 +1819,7 @@ simple_stmt_rule(Parser *p)
     }
     { // &'global' global_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'global' global_stmt"));
@@ -1872,7 +1840,7 @@ simple_stmt_rule(Parser *p)
     }
     { // &'nonlocal' nonlocal_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'nonlocal' nonlocal_stmt"));
@@ -1894,7 +1862,7 @@ simple_stmt_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, simple_stmt_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -1910,19 +1878,16 @@ simple_stmt_rule(Parser *p)
 static stmt_ty
 compound_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // &('def' | '@' | ASYNC) function_def
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&('def' | '@' | ASYNC) function_def"));
@@ -1943,7 +1908,7 @@ compound_stmt_rule(Parser *p)
     }
     { // &'if' if_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'if' if_stmt"));
@@ -1964,7 +1929,7 @@ compound_stmt_rule(Parser *p)
     }
     { // &('class' | '@') class_def
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&('class' | '@') class_def"));
@@ -1985,7 +1950,7 @@ compound_stmt_rule(Parser *p)
     }
     { // &('with' | ASYNC) with_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&('with' | ASYNC) with_stmt"));
@@ -2006,7 +1971,7 @@ compound_stmt_rule(Parser *p)
     }
     { // &('for' | ASYNC) for_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&('for' | ASYNC) for_stmt"));
@@ -2027,7 +1992,7 @@ compound_stmt_rule(Parser *p)
     }
     { // &'try' try_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'try' try_stmt"));
@@ -2048,7 +2013,7 @@ compound_stmt_rule(Parser *p)
     }
     { // &'while' while_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'while' while_stmt"));
@@ -2069,7 +2034,7 @@ compound_stmt_rule(Parser *p)
     }
     { // match_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "match_stmt"));
@@ -2088,7 +2053,7 @@ compound_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -2101,19 +2066,16 @@ compound_stmt_rule(Parser *p)
 static stmt_ty
 assignment_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -2122,7 +2084,7 @@ assignment_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME ':' expression ['=' annotated_rhs]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME ':' expression ['=' annotated_rhs]"));
@@ -2143,7 +2105,7 @@ assignment_rule(Parser *p)
             D(fprintf(stderr, "%*c+ assignment[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME ':' expression ['=' annotated_rhs]"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -2153,7 +2115,7 @@ assignment_rule(Parser *p)
             _res = CHECK_VERSION ( stmt_ty , 6 , "Variable annotation syntax is" , _PyAST_AnnAssign ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , b , c , 1 , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2164,7 +2126,7 @@ assignment_rule(Parser *p)
     }
     { // ('(' single_target ')' | single_subscript_attribute_target) ':' expression ['=' annotated_rhs]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('(' single_target ')' | single_subscript_attribute_target) ':' expression ['=' annotated_rhs]"));
@@ -2185,7 +2147,7 @@ assignment_rule(Parser *p)
             D(fprintf(stderr, "%*c+ assignment[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "('(' single_target ')' | single_subscript_attribute_target) ':' expression ['=' annotated_rhs]"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -2195,7 +2157,7 @@ assignment_rule(Parser *p)
             _res = CHECK_VERSION ( stmt_ty , 6 , "Variable annotations syntax is" , _PyAST_AnnAssign ( a , b , c , 0 , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2206,7 +2168,7 @@ assignment_rule(Parser *p)
     }
     { // ((star_targets '='))+ (yield_expr | star_expressions) !'=' TYPE_COMMENT?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "((star_targets '='))+ (yield_expr | star_expressions) !'=' TYPE_COMMENT?"));
@@ -2226,7 +2188,7 @@ assignment_rule(Parser *p)
             D(fprintf(stderr, "%*c+ assignment[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "((star_targets '='))+ (yield_expr | star_expressions) !'=' TYPE_COMMENT?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -2236,7 +2198,7 @@ assignment_rule(Parser *p)
             _res = _PyAST_Assign ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2247,7 +2209,7 @@ assignment_rule(Parser *p)
     }
     { // single_target augassign ~ (yield_expr | star_expressions)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "single_target augassign ~ (yield_expr | star_expressions)"));
@@ -2268,7 +2230,7 @@ assignment_rule(Parser *p)
             D(fprintf(stderr, "%*c+ assignment[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "single_target augassign ~ (yield_expr | star_expressions)"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -2278,7 +2240,7 @@ assignment_rule(Parser *p)
             _res = _PyAST_AugAssign ( a , b -> kind , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2287,13 +2249,13 @@ assignment_rule(Parser *p)
         D(fprintf(stderr, "%*c%s assignment[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "single_target augassign ~ (yield_expr | star_expressions)"));
         if (_cut_var) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
     }
     if (p->call_invalid_rules) { // invalid_assignment
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_assignment"));
@@ -2312,7 +2274,7 @@ assignment_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -2320,19 +2282,16 @@ assignment_rule(Parser *p)
 static expr_ty
 annotated_rhs_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // yield_expr
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> annotated_rhs[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "yield_expr"));
@@ -2351,7 +2310,7 @@ annotated_rhs_rule(Parser *p)
     }
     { // star_expressions
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> annotated_rhs[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_expressions"));
@@ -2370,7 +2329,7 @@ annotated_rhs_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -2391,19 +2350,16 @@ annotated_rhs_rule(Parser *p)
 static AugOperator*
 augassign_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     AugOperator* _res = NULL;
     int _mark = p->mark;
     { // '+='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'+='"));
@@ -2416,7 +2372,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , Add );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2427,7 +2383,7 @@ augassign_rule(Parser *p)
     }
     { // '-='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'-='"));
@@ -2440,7 +2396,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , Sub );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2451,7 +2407,7 @@ augassign_rule(Parser *p)
     }
     { // '*='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*='"));
@@ -2464,7 +2420,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , Mult );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2475,7 +2431,7 @@ augassign_rule(Parser *p)
     }
     { // '@='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'@='"));
@@ -2488,7 +2444,7 @@ augassign_rule(Parser *p)
             _res = CHECK_VERSION ( AugOperator* , 5 , "The '@' operator is" , _PyPegen_augoperator ( p , MatMult ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2499,7 +2455,7 @@ augassign_rule(Parser *p)
     }
     { // '/='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'/='"));
@@ -2512,7 +2468,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , Div );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2523,7 +2479,7 @@ augassign_rule(Parser *p)
     }
     { // '%='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'%='"));
@@ -2536,7 +2492,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , Mod );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2547,7 +2503,7 @@ augassign_rule(Parser *p)
     }
     { // '&='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'&='"));
@@ -2560,7 +2516,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , BitAnd );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2571,7 +2527,7 @@ augassign_rule(Parser *p)
     }
     { // '|='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'|='"));
@@ -2584,7 +2540,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , BitOr );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2595,7 +2551,7 @@ augassign_rule(Parser *p)
     }
     { // '^='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'^='"));
@@ -2608,7 +2564,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , BitXor );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2619,7 +2575,7 @@ augassign_rule(Parser *p)
     }
     { // '<<='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'<<='"));
@@ -2632,7 +2588,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , LShift );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2643,7 +2599,7 @@ augassign_rule(Parser *p)
     }
     { // '>>='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'>>='"));
@@ -2656,7 +2612,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , RShift );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2667,7 +2623,7 @@ augassign_rule(Parser *p)
     }
     { // '**='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**='"));
@@ -2680,7 +2636,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , Pow );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2691,7 +2647,7 @@ augassign_rule(Parser *p)
     }
     { // '//='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> augassign[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'//='"));
@@ -2704,7 +2660,7 @@ augassign_rule(Parser *p)
             _res = _PyPegen_augoperator ( p , FloorDiv );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2715,7 +2671,7 @@ augassign_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -2723,19 +2679,16 @@ augassign_rule(Parser *p)
 static stmt_ty
 return_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -2744,7 +2697,7 @@ return_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'return' star_expressions?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> return_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'return' star_expressions?"));
@@ -2759,7 +2712,7 @@ return_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ return_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'return' star_expressions?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -2769,7 +2722,7 @@ return_stmt_rule(Parser *p)
             _res = _PyAST_Return ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2780,7 +2733,7 @@ return_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -2788,19 +2741,16 @@ return_stmt_rule(Parser *p)
 static stmt_ty
 raise_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -2809,7 +2759,7 @@ raise_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'raise' expression ['from' expression]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> raise_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'raise' expression ['from' expression]"));
@@ -2827,7 +2777,7 @@ raise_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ raise_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'raise' expression ['from' expression]"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -2837,7 +2787,7 @@ raise_stmt_rule(Parser *p)
             _res = _PyAST_Raise ( a , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2848,7 +2798,7 @@ raise_stmt_rule(Parser *p)
     }
     { // 'raise'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> raise_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'raise'"));
@@ -2860,7 +2810,7 @@ raise_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ raise_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'raise'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -2870,7 +2820,7 @@ raise_stmt_rule(Parser *p)
             _res = _PyAST_Raise ( NULL , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2881,7 +2831,7 @@ raise_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -2889,19 +2839,16 @@ raise_stmt_rule(Parser *p)
 static stmt_ty
 global_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -2910,7 +2857,7 @@ global_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'global' ','.NAME+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> global_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'global' ','.NAME+"));
@@ -2925,7 +2872,7 @@ global_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ global_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'global' ','.NAME+"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -2935,7 +2882,7 @@ global_stmt_rule(Parser *p)
             _res = _PyAST_Global ( CHECK ( asdl_identifier_seq* , _PyPegen_map_names_to_ids ( p , a ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -2946,7 +2893,7 @@ global_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -2954,19 +2901,16 @@ global_stmt_rule(Parser *p)
 static stmt_ty
 nonlocal_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -2975,7 +2919,7 @@ nonlocal_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'nonlocal' ','.NAME+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> nonlocal_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'nonlocal' ','.NAME+"));
@@ -2990,7 +2934,7 @@ nonlocal_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ nonlocal_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'nonlocal' ','.NAME+"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -3000,7 +2944,7 @@ nonlocal_stmt_rule(Parser *p)
             _res = _PyAST_Nonlocal ( CHECK ( asdl_identifier_seq* , _PyPegen_map_names_to_ids ( p , a ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3011,7 +2955,7 @@ nonlocal_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3019,19 +2963,16 @@ nonlocal_stmt_rule(Parser *p)
 static stmt_ty
 del_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -3040,7 +2981,7 @@ del_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'del' del_targets &(';' | NEWLINE)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> del_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'del' del_targets &(';' | NEWLINE)"));
@@ -3057,7 +2998,7 @@ del_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ del_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'del' del_targets &(';' | NEWLINE)"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -3067,7 +3008,7 @@ del_stmt_rule(Parser *p)
             _res = _PyAST_Delete ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3078,7 +3019,7 @@ del_stmt_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_del_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> del_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_del_stmt"));
@@ -3097,7 +3038,7 @@ del_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3105,19 +3046,16 @@ del_stmt_rule(Parser *p)
 static stmt_ty
 yield_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -3126,7 +3064,7 @@ yield_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // yield_expr
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> yield_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "yield_expr"));
@@ -3138,7 +3076,7 @@ yield_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ yield_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "yield_expr"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -3148,7 +3086,7 @@ yield_stmt_rule(Parser *p)
             _res = _PyAST_Expr ( y , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3159,7 +3097,7 @@ yield_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3167,19 +3105,16 @@ yield_stmt_rule(Parser *p)
 static stmt_ty
 assert_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -3188,7 +3123,7 @@ assert_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'assert' expression [',' expression]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> assert_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'assert' expression [',' expression]"));
@@ -3206,7 +3141,7 @@ assert_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ assert_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'assert' expression [',' expression]"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -3216,7 +3151,7 @@ assert_stmt_rule(Parser *p)
             _res = _PyAST_Assert ( a , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3227,7 +3162,7 @@ assert_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3235,19 +3170,16 @@ assert_stmt_rule(Parser *p)
 static stmt_ty
 import_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // import_name
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "import_name"));
@@ -3266,7 +3198,7 @@ import_stmt_rule(Parser *p)
     }
     { // import_from
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "import_from"));
@@ -3285,7 +3217,7 @@ import_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3293,19 +3225,16 @@ import_stmt_rule(Parser *p)
 static stmt_ty
 import_name_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -3314,7 +3243,7 @@ import_name_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'import' dotted_as_names
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_name[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'import' dotted_as_names"));
@@ -3329,7 +3258,7 @@ import_name_rule(Parser *p)
             D(fprintf(stderr, "%*c+ import_name[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'import' dotted_as_names"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -3339,7 +3268,7 @@ import_name_rule(Parser *p)
             _res = _PyAST_Import ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3350,7 +3279,7 @@ import_name_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3360,19 +3289,16 @@ import_name_rule(Parser *p)
 static stmt_ty
 import_from_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -3381,7 +3307,7 @@ import_from_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'from' (('.' | '...'))* dotted_name 'import' import_from_targets
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_from[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'from' (('.' | '...'))* dotted_name 'import' import_from_targets"));
@@ -3405,7 +3331,7 @@ import_from_rule(Parser *p)
             D(fprintf(stderr, "%*c+ import_from[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'from' (('.' | '...'))* dotted_name 'import' import_from_targets"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -3415,7 +3341,7 @@ import_from_rule(Parser *p)
             _res = _PyAST_ImportFrom ( b -> v . Name . id , c , _PyPegen_seq_count_dots ( a ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3426,7 +3352,7 @@ import_from_rule(Parser *p)
     }
     { // 'from' (('.' | '...'))+ 'import' import_from_targets
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_from[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'from' (('.' | '...'))+ 'import' import_from_targets"));
@@ -3447,7 +3373,7 @@ import_from_rule(Parser *p)
             D(fprintf(stderr, "%*c+ import_from[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'from' (('.' | '...'))+ 'import' import_from_targets"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -3457,7 +3383,7 @@ import_from_rule(Parser *p)
             _res = _PyAST_ImportFrom ( NULL , b , _PyPegen_seq_count_dots ( a ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3468,7 +3394,7 @@ import_from_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3480,19 +3406,16 @@ import_from_rule(Parser *p)
 static asdl_alias_seq*
 import_from_targets_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_alias_seq* _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -3501,7 +3424,7 @@ import_from_targets_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '(' import_from_as_names ','? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_from_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' import_from_as_names ','? ')'"));
@@ -3524,7 +3447,7 @@ import_from_targets_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3535,7 +3458,7 @@ import_from_targets_rule(Parser *p)
     }
     { // import_from_as_names !','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_from_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "import_from_as_names !','"));
@@ -3556,7 +3479,7 @@ import_from_targets_rule(Parser *p)
     }
     { // '*'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_from_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*'"));
@@ -3568,7 +3491,7 @@ import_from_targets_rule(Parser *p)
             D(fprintf(stderr, "%*c+ import_from_targets[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -3578,7 +3501,7 @@ import_from_targets_rule(Parser *p)
             _res = ( asdl_alias_seq* ) _PyPegen_singleton_seq ( p , CHECK ( alias_ty , _PyPegen_alias_for_star ( p , EXTRA ) ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3589,7 +3512,7 @@ import_from_targets_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_import_from_targets
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_from_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_import_from_targets"));
@@ -3608,7 +3531,7 @@ import_from_targets_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3616,19 +3539,16 @@ import_from_targets_rule(Parser *p)
 static asdl_alias_seq*
 import_from_as_names_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_alias_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.import_from_as_name+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_from_as_names[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.import_from_as_name+"));
@@ -3641,7 +3561,7 @@ import_from_as_names_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3652,7 +3572,7 @@ import_from_as_names_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3660,19 +3580,16 @@ import_from_as_names_rule(Parser *p)
 static alias_ty
 import_from_as_name_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     alias_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -3681,7 +3598,7 @@ import_from_as_name_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME ['as' NAME]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_from_as_name[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME ['as' NAME]"));
@@ -3696,7 +3613,7 @@ import_from_as_name_rule(Parser *p)
             D(fprintf(stderr, "%*c+ import_from_as_name[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME ['as' NAME]"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -3706,7 +3623,7 @@ import_from_as_name_rule(Parser *p)
             _res = _PyAST_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3717,7 +3634,7 @@ import_from_as_name_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3725,19 +3642,16 @@ import_from_as_name_rule(Parser *p)
 static asdl_alias_seq*
 dotted_as_names_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_alias_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.dotted_as_name+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> dotted_as_names[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.dotted_as_name+"));
@@ -3750,7 +3664,7 @@ dotted_as_names_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3761,7 +3675,7 @@ dotted_as_names_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3769,19 +3683,16 @@ dotted_as_names_rule(Parser *p)
 static alias_ty
 dotted_as_name_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     alias_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -3790,7 +3701,7 @@ dotted_as_name_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // dotted_name ['as' NAME]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> dotted_as_name[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "dotted_name ['as' NAME]"));
@@ -3805,7 +3716,7 @@ dotted_as_name_rule(Parser *p)
             D(fprintf(stderr, "%*c+ dotted_as_name[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "dotted_name ['as' NAME]"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -3815,7 +3726,7 @@ dotted_as_name_rule(Parser *p)
             _res = _PyAST_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3826,7 +3737,7 @@ dotted_as_name_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3836,13 +3747,10 @@ static expr_ty dotted_name_raw(Parser *);
 static expr_ty
 dotted_name_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, dotted_name_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
@@ -3850,42 +3758,37 @@ dotted_name_rule(Parser *p)
     while (1) {
         int tmpvar_0 = _PyPegen_update_memo(p, _mark, dotted_name_type, _res);
         if (tmpvar_0) {
-            p->level--;
+            D(p->level--);
             return _res;
         }
         p->mark = _mark;
         p->in_raw_rule++;
         void *_raw = dotted_name_raw(p);
         p->in_raw_rule--;
-        if (p->error_indicator) {
-            p->level--;
+        if (p->error_indicator)
             return NULL;
-        }
         if (_raw == NULL || p->mark <= _resmark)
             break;
         _resmark = p->mark;
         _res = _raw;
     }
     p->mark = _resmark;
-    p->level--;
+    D(p->level--);
     return _res;
 }
 static expr_ty
 dotted_name_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // dotted_name '.' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> dotted_name[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "dotted_name '.' NAME"));
@@ -3904,7 +3807,7 @@ dotted_name_raw(Parser *p)
             _res = _PyPegen_join_names_with_dot ( p , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3915,7 +3818,7 @@ dotted_name_raw(Parser *p)
     }
     { // NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> dotted_name[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME"));
@@ -3934,7 +3837,7 @@ dotted_name_raw(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -3942,23 +3845,20 @@ dotted_name_raw(Parser *p)
 static asdl_stmt_seq*
 block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_stmt_seq* _res = NULL;
     if (_PyPegen_is_memoized(p, block_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     { // NEWLINE INDENT statements DEDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE INDENT statements DEDENT"));
@@ -3980,7 +3880,7 @@ block_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -3991,7 +3891,7 @@ block_rule(Parser *p)
     }
     { // simple_stmts
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "simple_stmts"));
@@ -4010,7 +3910,7 @@ block_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_block"));
@@ -4030,7 +3930,7 @@ block_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, block_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -4038,19 +3938,16 @@ block_rule(Parser *p)
 static asdl_expr_seq*
 decorators_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // (('@' named_expression NEWLINE))+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> decorators[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(('@' named_expression NEWLINE))+"));
@@ -4063,7 +3960,7 @@ decorators_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4074,7 +3971,7 @@ decorators_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -4082,19 +3979,16 @@ decorators_rule(Parser *p)
 static stmt_ty
 class_def_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // decorators class_def_raw
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> class_def[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "decorators class_def_raw"));
@@ -4110,7 +4004,7 @@ class_def_rule(Parser *p)
             _res = _PyPegen_class_def_decorators ( p , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4121,7 +4015,7 @@ class_def_rule(Parser *p)
     }
     { // class_def_raw
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> class_def[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "class_def_raw"));
@@ -4140,7 +4034,7 @@ class_def_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -4148,19 +4042,16 @@ class_def_rule(Parser *p)
 static stmt_ty
 class_def_raw_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -4169,7 +4060,7 @@ class_def_raw_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_class_def_raw
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> class_def_raw[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_class_def_raw"));
@@ -4188,7 +4079,7 @@ class_def_raw_rule(Parser *p)
     }
     { // 'class' NAME ['(' arguments? ')'] &&':' block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> class_def_raw[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'class' NAME ['(' arguments? ')'] &&':' block"));
@@ -4212,7 +4103,7 @@ class_def_raw_rule(Parser *p)
             D(fprintf(stderr, "%*c+ class_def_raw[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'class' NAME ['(' arguments? ')'] &&':' block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -4222,7 +4113,7 @@ class_def_raw_rule(Parser *p)
             _res = _PyAST_ClassDef ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Call . args : NULL , ( b ) ? ( ( expr_ty ) b ) -> v . Call . keywords : NULL , c , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4233,7 +4124,7 @@ class_def_raw_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -4241,19 +4132,16 @@ class_def_raw_rule(Parser *p)
 static stmt_ty
 function_def_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // decorators function_def_raw
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> function_def[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "decorators function_def_raw"));
@@ -4269,7 +4157,7 @@ function_def_rule(Parser *p)
             _res = _PyPegen_function_def_decorators ( p , d , f );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4280,7 +4168,7 @@ function_def_rule(Parser *p)
     }
     { // function_def_raw
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> function_def[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "function_def_raw"));
@@ -4299,7 +4187,7 @@ function_def_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -4310,19 +4198,16 @@ function_def_rule(Parser *p)
 static stmt_ty
 function_def_raw_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -4331,7 +4216,7 @@ function_def_raw_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_def_raw
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> function_def_raw[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_def_raw"));
@@ -4350,7 +4235,7 @@ function_def_raw_rule(Parser *p)
     }
     { // 'def' NAME &&'(' params? ')' ['->' expression] &&':' func_type_comment? block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> function_def_raw[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'def' NAME &&'(' params? ')' ['->' expression] &&':' func_type_comment? block"));
@@ -4386,7 +4271,7 @@ function_def_raw_rule(Parser *p)
             D(fprintf(stderr, "%*c+ function_def_raw[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'def' NAME &&'(' params? ')' ['->' expression] &&':' func_type_comment? block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -4396,7 +4281,7 @@ function_def_raw_rule(Parser *p)
             _res = _PyAST_FunctionDef ( n -> v . Name . id , ( params ) ? params : CHECK ( arguments_ty , _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4407,7 +4292,7 @@ function_def_raw_rule(Parser *p)
     }
     { // ASYNC 'def' NAME &&'(' params? ')' ['->' expression] &&':' func_type_comment? block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> function_def_raw[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC 'def' NAME &&'(' params? ')' ['->' expression] &&':' func_type_comment? block"));
@@ -4446,7 +4331,7 @@ function_def_raw_rule(Parser *p)
             D(fprintf(stderr, "%*c+ function_def_raw[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "ASYNC 'def' NAME &&'(' params? ')' ['->' expression] &&':' func_type_comment? block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -4456,7 +4341,7 @@ function_def_raw_rule(Parser *p)
             _res = CHECK_VERSION ( stmt_ty , 5 , "Async functions are" , _PyAST_AsyncFunctionDef ( n -> v . Name . id , ( params ) ? params : CHECK ( arguments_ty , _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4467,7 +4352,7 @@ function_def_raw_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -4475,19 +4360,16 @@ function_def_raw_rule(Parser *p)
 static arguments_ty
 params_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     arguments_ty _res = NULL;
     int _mark = p->mark;
     if (p->call_invalid_rules) { // invalid_parameters
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> params[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_parameters"));
@@ -4506,7 +4388,7 @@ params_rule(Parser *p)
     }
     { // parameters
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> params[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "parameters"));
@@ -4525,7 +4407,7 @@ params_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -4538,19 +4420,16 @@ params_rule(Parser *p)
 static arguments_ty
 parameters_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     arguments_ty _res = NULL;
     int _mark = p->mark;
     { // slash_no_default param_no_default* param_with_default* star_etc?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "slash_no_default param_no_default* param_with_default* star_etc?"));
@@ -4572,7 +4451,7 @@ parameters_rule(Parser *p)
             _res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4583,7 +4462,7 @@ parameters_rule(Parser *p)
     }
     { // slash_with_default param_with_default* star_etc?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "slash_with_default param_with_default* star_etc?"));
@@ -4602,7 +4481,7 @@ parameters_rule(Parser *p)
             _res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4613,7 +4492,7 @@ parameters_rule(Parser *p)
     }
     { // param_no_default+ param_with_default* star_etc?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default+ param_with_default* star_etc?"));
@@ -4632,7 +4511,7 @@ parameters_rule(Parser *p)
             _res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4643,7 +4522,7 @@ parameters_rule(Parser *p)
     }
     { // param_with_default+ star_etc?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_with_default+ star_etc?"));
@@ -4659,7 +4538,7 @@ parameters_rule(Parser *p)
             _res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4670,7 +4549,7 @@ parameters_rule(Parser *p)
     }
     { // star_etc
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_etc"));
@@ -4683,7 +4562,7 @@ parameters_rule(Parser *p)
             _res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , NULL , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4694,7 +4573,7 @@ parameters_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -4702,19 +4581,16 @@ parameters_rule(Parser *p)
 static asdl_arg_seq*
 slash_no_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_arg_seq* _res = NULL;
     int _mark = p->mark;
     { // param_no_default+ '/' ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> slash_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default+ '/' ','"));
@@ -4733,7 +4609,7 @@ slash_no_default_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4744,7 +4620,7 @@ slash_no_default_rule(Parser *p)
     }
     { // param_no_default+ '/' &')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> slash_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default+ '/' &')'"));
@@ -4762,7 +4638,7 @@ slash_no_default_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4773,7 +4649,7 @@ slash_no_default_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -4783,19 +4659,16 @@ slash_no_default_rule(Parser *p)
 static SlashWithDefault*
 slash_with_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     SlashWithDefault* _res = NULL;
     int _mark = p->mark;
     { // param_no_default* param_with_default+ '/' ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> slash_with_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default* param_with_default+ '/' ','"));
@@ -4817,7 +4690,7 @@ slash_with_default_rule(Parser *p)
             _res = _PyPegen_slash_with_default ( p , ( asdl_arg_seq* ) a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4828,7 +4701,7 @@ slash_with_default_rule(Parser *p)
     }
     { // param_no_default* param_with_default+ '/' &')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> slash_with_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default* param_with_default+ '/' &')'"));
@@ -4849,7 +4722,7 @@ slash_with_default_rule(Parser *p)
             _res = _PyPegen_slash_with_default ( p , ( asdl_arg_seq* ) a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4860,7 +4733,7 @@ slash_with_default_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -4872,19 +4745,16 @@ slash_with_default_rule(Parser *p)
 static StarEtc*
 star_etc_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     StarEtc* _res = NULL;
     int _mark = p->mark;
     { // '*' param_no_default param_maybe_default* kwds?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_etc[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' param_no_default param_maybe_default* kwds?"));
@@ -4906,7 +4776,7 @@ star_etc_rule(Parser *p)
             _res = _PyPegen_star_etc ( p , a , b , c );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4917,7 +4787,7 @@ star_etc_rule(Parser *p)
     }
     { // '*' ',' param_maybe_default+ kwds?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_etc[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' ',' param_maybe_default+ kwds?"));
@@ -4939,7 +4809,7 @@ star_etc_rule(Parser *p)
             _res = _PyPegen_star_etc ( p , NULL , b , c );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4950,7 +4820,7 @@ star_etc_rule(Parser *p)
     }
     { // kwds
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_etc[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "kwds"));
@@ -4963,7 +4833,7 @@ star_etc_rule(Parser *p)
             _res = _PyPegen_star_etc ( p , NULL , NULL , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -4974,7 +4844,7 @@ star_etc_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_star_etc
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_etc[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_star_etc"));
@@ -4993,7 +4863,7 @@ star_etc_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5001,19 +4871,16 @@ star_etc_rule(Parser *p)
 static arg_ty
 kwds_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // '**' param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> kwds[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**' param_no_default"));
@@ -5029,7 +4896,7 @@ kwds_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5040,7 +4907,7 @@ kwds_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5048,19 +4915,16 @@ kwds_rule(Parser *p)
 static arg_ty
 param_no_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // param ',' TYPE_COMMENT?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> param_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param ',' TYPE_COMMENT?"));
@@ -5079,7 +4943,7 @@ param_no_default_rule(Parser *p)
             _res = _PyPegen_add_type_comment_to_arg ( p , a , tc );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5090,7 +4954,7 @@ param_no_default_rule(Parser *p)
     }
     { // param TYPE_COMMENT? &')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> param_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param TYPE_COMMENT? &')'"));
@@ -5108,7 +4972,7 @@ param_no_default_rule(Parser *p)
             _res = _PyPegen_add_type_comment_to_arg ( p , a , tc );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5119,7 +4983,7 @@ param_no_default_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5127,19 +4991,16 @@ param_no_default_rule(Parser *p)
 static NameDefaultPair*
 param_with_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // param default ',' TYPE_COMMENT?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> param_with_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param default ',' TYPE_COMMENT?"));
@@ -5161,7 +5022,7 @@ param_with_default_rule(Parser *p)
             _res = _PyPegen_name_default_pair ( p , a , c , tc );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5172,7 +5033,7 @@ param_with_default_rule(Parser *p)
     }
     { // param default TYPE_COMMENT? &')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> param_with_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param default TYPE_COMMENT? &')'"));
@@ -5193,7 +5054,7 @@ param_with_default_rule(Parser *p)
             _res = _PyPegen_name_default_pair ( p , a , c , tc );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5204,7 +5065,7 @@ param_with_default_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5214,19 +5075,16 @@ param_with_default_rule(Parser *p)
 static NameDefaultPair*
 param_maybe_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // param default? ',' TYPE_COMMENT?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> param_maybe_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param default? ',' TYPE_COMMENT?"));
@@ -5248,7 +5106,7 @@ param_maybe_default_rule(Parser *p)
             _res = _PyPegen_name_default_pair ( p , a , c , tc );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5259,7 +5117,7 @@ param_maybe_default_rule(Parser *p)
     }
     { // param default? TYPE_COMMENT? &')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> param_maybe_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param default? TYPE_COMMENT? &')'"));
@@ -5280,7 +5138,7 @@ param_maybe_default_rule(Parser *p)
             _res = _PyPegen_name_default_pair ( p , a , c , tc );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5291,7 +5149,7 @@ param_maybe_default_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5299,19 +5157,16 @@ param_maybe_default_rule(Parser *p)
 static arg_ty
 param_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     arg_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -5320,7 +5175,7 @@ param_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME annotation?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> param[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME annotation?"));
@@ -5335,7 +5190,7 @@ param_rule(Parser *p)
             D(fprintf(stderr, "%*c+ param[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME annotation?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -5345,7 +5200,7 @@ param_rule(Parser *p)
             _res = _PyAST_arg ( a -> v . Name . id , b , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5356,7 +5211,7 @@ param_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5364,19 +5219,16 @@ param_rule(Parser *p)
 static expr_ty
 annotation_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // ':' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> annotation[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':' expression"));
@@ -5392,7 +5244,7 @@ annotation_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5403,7 +5255,7 @@ annotation_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5411,19 +5263,16 @@ annotation_rule(Parser *p)
 static expr_ty
 default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // '=' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'=' expression"));
@@ -5439,7 +5288,7 @@ default_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5450,7 +5299,7 @@ default_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5461,19 +5310,16 @@ default_rule(Parser *p)
 static stmt_ty
 if_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -5482,7 +5328,7 @@ if_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_if_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> if_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_if_stmt"));
@@ -5501,7 +5347,7 @@ if_stmt_rule(Parser *p)
     }
     { // 'if' named_expression ':' block elif_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> if_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'if' named_expression ':' block elif_stmt"));
@@ -5525,7 +5371,7 @@ if_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ if_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'if' named_expression ':' block elif_stmt"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -5535,7 +5381,7 @@ if_stmt_rule(Parser *p)
             _res = _PyAST_If ( a , b , CHECK ( asdl_stmt_seq* , _PyPegen_singleton_seq ( p , c ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5546,7 +5392,7 @@ if_stmt_rule(Parser *p)
     }
     { // 'if' named_expression ':' block else_block?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> if_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'if' named_expression ':' block else_block?"));
@@ -5570,7 +5416,7 @@ if_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ if_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'if' named_expression ':' block else_block?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -5580,7 +5426,7 @@ if_stmt_rule(Parser *p)
             _res = _PyAST_If ( a , b , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5591,7 +5437,7 @@ if_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5602,19 +5448,16 @@ if_stmt_rule(Parser *p)
 static stmt_ty
 elif_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -5623,7 +5466,7 @@ elif_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_elif_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> elif_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_elif_stmt"));
@@ -5642,7 +5485,7 @@ elif_stmt_rule(Parser *p)
     }
     { // 'elif' named_expression ':' block elif_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> elif_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'elif' named_expression ':' block elif_stmt"));
@@ -5666,7 +5509,7 @@ elif_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ elif_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'elif' named_expression ':' block elif_stmt"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -5676,7 +5519,7 @@ elif_stmt_rule(Parser *p)
             _res = _PyAST_If ( a , b , CHECK ( asdl_stmt_seq* , _PyPegen_singleton_seq ( p , c ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5687,7 +5530,7 @@ elif_stmt_rule(Parser *p)
     }
     { // 'elif' named_expression ':' block else_block?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> elif_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'elif' named_expression ':' block else_block?"));
@@ -5711,7 +5554,7 @@ elif_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ elif_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'elif' named_expression ':' block else_block?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -5721,7 +5564,7 @@ elif_stmt_rule(Parser *p)
             _res = _PyAST_If ( a , b , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5732,7 +5575,7 @@ elif_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5740,19 +5583,16 @@ elif_stmt_rule(Parser *p)
 static asdl_stmt_seq*
 else_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     if (p->call_invalid_rules) { // invalid_else_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> else_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_else_stmt"));
@@ -5771,7 +5611,7 @@ else_block_rule(Parser *p)
     }
     { // 'else' &&':' block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> else_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'else' &&':' block"));
@@ -5790,7 +5630,7 @@ else_block_rule(Parser *p)
             _res = b;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5801,7 +5641,7 @@ else_block_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5809,19 +5649,16 @@ else_block_rule(Parser *p)
 static stmt_ty
 while_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -5830,7 +5667,7 @@ while_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_while_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> while_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_while_stmt"));
@@ -5849,7 +5686,7 @@ while_stmt_rule(Parser *p)
     }
     { // 'while' named_expression ':' block else_block?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> while_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'while' named_expression ':' block else_block?"));
@@ -5873,7 +5710,7 @@ while_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ while_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'while' named_expression ':' block else_block?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -5883,7 +5720,7 @@ while_stmt_rule(Parser *p)
             _res = _PyAST_While ( a , b , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -5894,7 +5731,7 @@ while_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -5906,19 +5743,16 @@ while_stmt_rule(Parser *p)
 static stmt_ty
 for_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -5927,7 +5761,7 @@ for_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_for_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> for_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_for_stmt"));
@@ -5946,7 +5780,7 @@ for_stmt_rule(Parser *p)
     }
     { // 'for' star_targets 'in' ~ star_expressions &&':' TYPE_COMMENT? block else_block?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> for_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'for' star_targets 'in' ~ star_expressions &&':' TYPE_COMMENT? block else_block?"));
@@ -5982,7 +5816,7 @@ for_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ for_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'for' star_targets 'in' ~ star_expressions &&':' TYPE_COMMENT? block else_block?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -5992,7 +5826,7 @@ for_stmt_rule(Parser *p)
             _res = _PyAST_For ( t , ex , b , el , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6001,13 +5835,13 @@ for_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c%s for_stmt[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'for' star_targets 'in' ~ star_expressions &&':' TYPE_COMMENT? block else_block?"));
         if (_cut_var) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
     }
     { // ASYNC 'for' star_targets 'in' ~ star_expressions &&':' TYPE_COMMENT? block else_block?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> for_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC 'for' star_targets 'in' ~ star_expressions &&':' TYPE_COMMENT? block else_block?"));
@@ -6046,7 +5880,7 @@ for_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ for_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "ASYNC 'for' star_targets 'in' ~ star_expressions &&':' TYPE_COMMENT? block else_block?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -6056,7 +5890,7 @@ for_stmt_rule(Parser *p)
             _res = CHECK_VERSION ( stmt_ty , 5 , "Async for loops are" , _PyAST_AsyncFor ( t , ex , b , el , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6065,13 +5899,13 @@ for_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c%s for_stmt[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "ASYNC 'for' star_targets 'in' ~ star_expressions &&':' TYPE_COMMENT? block else_block?"));
         if (_cut_var) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
     }
     if (p->call_invalid_rules) { // invalid_for_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> for_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_for_target"));
@@ -6090,7 +5924,7 @@ for_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -6104,19 +5938,16 @@ for_stmt_rule(Parser *p)
 static stmt_ty
 with_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -6125,7 +5956,7 @@ with_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_with_stmt_indent
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> with_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_with_stmt_indent"));
@@ -6144,7 +5975,7 @@ with_stmt_rule(Parser *p)
     }
     { // 'with' '(' ','.with_item+ ','? ')' ':' block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> with_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'with' '(' ','.with_item+ ','? ')' ':' block"));
@@ -6175,7 +6006,7 @@ with_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ with_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'with' '(' ','.with_item+ ','? ')' ':' block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -6185,7 +6016,7 @@ with_stmt_rule(Parser *p)
             _res = _PyAST_With ( a , b , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6196,7 +6027,7 @@ with_stmt_rule(Parser *p)
     }
     { // 'with' ','.with_item+ ':' TYPE_COMMENT? block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> with_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'with' ','.with_item+ ':' TYPE_COMMENT? block"));
@@ -6220,7 +6051,7 @@ with_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ with_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'with' ','.with_item+ ':' TYPE_COMMENT? block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -6230,7 +6061,7 @@ with_stmt_rule(Parser *p)
             _res = _PyAST_With ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6241,7 +6072,7 @@ with_stmt_rule(Parser *p)
     }
     { // ASYNC 'with' '(' ','.with_item+ ','? ')' ':' block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> with_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC 'with' '(' ','.with_item+ ','? ')' ':' block"));
@@ -6275,7 +6106,7 @@ with_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ with_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "ASYNC 'with' '(' ','.with_item+ ','? ')' ':' block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -6285,7 +6116,7 @@ with_stmt_rule(Parser *p)
             _res = CHECK_VERSION ( stmt_ty , 5 , "Async with statements are" , _PyAST_AsyncWith ( a , b , NULL , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6296,7 +6127,7 @@ with_stmt_rule(Parser *p)
     }
     { // ASYNC 'with' ','.with_item+ ':' TYPE_COMMENT? block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> with_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC 'with' ','.with_item+ ':' TYPE_COMMENT? block"));
@@ -6323,7 +6154,7 @@ with_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ with_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "ASYNC 'with' ','.with_item+ ':' TYPE_COMMENT? block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -6333,7 +6164,7 @@ with_stmt_rule(Parser *p)
             _res = CHECK_VERSION ( stmt_ty , 5 , "Async with statements are" , _PyAST_AsyncWith ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6344,7 +6175,7 @@ with_stmt_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_with_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> with_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_with_stmt"));
@@ -6363,7 +6194,7 @@ with_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -6374,19 +6205,16 @@ with_stmt_rule(Parser *p)
 static withitem_ty
 with_item_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     withitem_ty _res = NULL;
     int _mark = p->mark;
     { // expression 'as' star_target &(',' | ')' | ':')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> with_item[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression 'as' star_target &(',' | ')' | ':')"));
@@ -6407,7 +6235,7 @@ with_item_rule(Parser *p)
             _res = _PyAST_withitem ( e , t , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6418,7 +6246,7 @@ with_item_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_with_item
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> with_item[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_with_item"));
@@ -6437,7 +6265,7 @@ with_item_rule(Parser *p)
     }
     { // expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> with_item[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression"));
@@ -6450,7 +6278,7 @@ with_item_rule(Parser *p)
             _res = _PyAST_withitem ( e , NULL , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6461,7 +6289,7 @@ with_item_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -6473,19 +6301,16 @@ with_item_rule(Parser *p)
 static stmt_ty
 try_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -6494,7 +6319,7 @@ try_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_try_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> try_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_try_stmt"));
@@ -6513,7 +6338,7 @@ try_stmt_rule(Parser *p)
     }
     { // 'try' &&':' block finally_block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> try_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'try' &&':' block finally_block"));
@@ -6534,7 +6359,7 @@ try_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ try_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'try' &&':' block finally_block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -6544,7 +6369,7 @@ try_stmt_rule(Parser *p)
             _res = _PyAST_Try ( b , NULL , NULL , f , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6555,7 +6380,7 @@ try_stmt_rule(Parser *p)
     }
     { // 'try' &&':' block except_block+ else_block? finally_block?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> try_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'try' &&':' block except_block+ else_block? finally_block?"));
@@ -6582,7 +6407,7 @@ try_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ try_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'try' &&':' block except_block+ else_block? finally_block?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -6592,7 +6417,7 @@ try_stmt_rule(Parser *p)
             _res = _PyAST_Try ( b , ex , el , f , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6603,7 +6428,7 @@ try_stmt_rule(Parser *p)
     }
     { // 'try' &&':' block except_star_block+ else_block? finally_block?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> try_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'try' &&':' block except_star_block+ else_block? finally_block?"));
@@ -6630,7 +6455,7 @@ try_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ try_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'try' &&':' block except_star_block+ else_block? finally_block?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -6640,7 +6465,7 @@ try_stmt_rule(Parser *p)
             _res = _PyAST_TryStar ( b , ex , el , f , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6651,7 +6476,7 @@ try_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -6663,19 +6488,16 @@ try_stmt_rule(Parser *p)
 static excepthandler_ty
 except_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     excepthandler_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -6684,7 +6506,7 @@ except_block_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_except_stmt_indent
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> except_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_except_stmt_indent"));
@@ -6703,7 +6525,7 @@ except_block_rule(Parser *p)
     }
     { // 'except' expression ['as' NAME] ':' block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> except_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' expression ['as' NAME] ':' block"));
@@ -6727,7 +6549,7 @@ except_block_rule(Parser *p)
             D(fprintf(stderr, "%*c+ except_block[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except' expression ['as' NAME] ':' block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -6737,7 +6559,7 @@ except_block_rule(Parser *p)
             _res = _PyAST_ExceptHandler ( e , ( t ) ? ( ( expr_ty ) t ) -> v . Name . id : NULL , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6748,7 +6570,7 @@ except_block_rule(Parser *p)
     }
     { // 'except' ':' block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> except_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' ':' block"));
@@ -6766,7 +6588,7 @@ except_block_rule(Parser *p)
             D(fprintf(stderr, "%*c+ except_block[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except' ':' block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -6776,7 +6598,7 @@ except_block_rule(Parser *p)
             _res = _PyAST_ExceptHandler ( NULL , NULL , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6787,7 +6609,7 @@ except_block_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_except_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> except_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_except_stmt"));
@@ -6806,7 +6628,7 @@ except_block_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -6817,19 +6639,16 @@ except_block_rule(Parser *p)
 static excepthandler_ty
 except_star_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     excepthandler_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -6838,7 +6657,7 @@ except_star_block_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_except_star_stmt_indent
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> except_star_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_except_star_stmt_indent"));
@@ -6857,7 +6676,7 @@ except_star_block_rule(Parser *p)
     }
     { // 'except' '*' expression ['as' NAME] ':' block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> except_star_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' '*' expression ['as' NAME] ':' block"));
@@ -6884,7 +6703,7 @@ except_star_block_rule(Parser *p)
             D(fprintf(stderr, "%*c+ except_star_block[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except' '*' expression ['as' NAME] ':' block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -6894,7 +6713,7 @@ except_star_block_rule(Parser *p)
             _res = _PyAST_ExceptHandler ( e , ( t ) ? ( ( expr_ty ) t ) -> v . Name . id : NULL , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6905,7 +6724,7 @@ except_star_block_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_except_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> except_star_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_except_stmt"));
@@ -6924,7 +6743,7 @@ except_star_block_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -6932,19 +6751,16 @@ except_star_block_rule(Parser *p)
 static asdl_stmt_seq*
 finally_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     if (p->call_invalid_rules) { // invalid_finally_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> finally_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_finally_stmt"));
@@ -6963,7 +6779,7 @@ finally_block_rule(Parser *p)
     }
     { // 'finally' &&':' block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> finally_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'finally' &&':' block"));
@@ -6982,7 +6798,7 @@ finally_block_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -6993,7 +6809,7 @@ finally_block_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -7003,19 +6819,16 @@ finally_block_rule(Parser *p)
 static stmt_ty
 match_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -7024,7 +6837,7 @@ match_stmt_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // "match" subject_expr ':' NEWLINE INDENT case_block+ DEDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> match_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "\"match\" subject_expr ':' NEWLINE INDENT case_block+ DEDENT"));
@@ -7054,7 +6867,7 @@ match_stmt_rule(Parser *p)
             D(fprintf(stderr, "%*c+ match_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "\"match\" subject_expr ':' NEWLINE INDENT case_block+ DEDENT"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -7064,7 +6877,7 @@ match_stmt_rule(Parser *p)
             _res = CHECK_VERSION ( stmt_ty , 10 , "Pattern matching is" , _PyAST_Match ( subject , cases , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7075,7 +6888,7 @@ match_stmt_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_match_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> match_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_match_stmt"));
@@ -7094,7 +6907,7 @@ match_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -7102,19 +6915,16 @@ match_stmt_rule(Parser *p)
 static expr_ty
 subject_expr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -7123,7 +6933,7 @@ subject_expr_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // star_named_expression ',' star_named_expressions?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> subject_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_named_expression ',' star_named_expressions?"));
@@ -7141,7 +6951,7 @@ subject_expr_rule(Parser *p)
             D(fprintf(stderr, "%*c+ subject_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "star_named_expression ',' star_named_expressions?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -7151,7 +6961,7 @@ subject_expr_rule(Parser *p)
             _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq* , _PyPegen_seq_insert_in_front ( p , value , values ) ) , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7162,7 +6972,7 @@ subject_expr_rule(Parser *p)
     }
     { // named_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> subject_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "named_expression"));
@@ -7181,7 +6991,7 @@ subject_expr_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -7189,19 +6999,16 @@ subject_expr_rule(Parser *p)
 static match_case_ty
 case_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     match_case_ty _res = NULL;
     int _mark = p->mark;
     if (p->call_invalid_rules) { // invalid_case_block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> case_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_case_block"));
@@ -7220,7 +7027,7 @@ case_block_rule(Parser *p)
     }
     { // "case" patterns guard? ':' block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> case_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "\"case\" patterns guard? ':' block"));
@@ -7245,7 +7052,7 @@ case_block_rule(Parser *p)
             _res = _PyAST_match_case ( pattern , guard , body , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7256,7 +7063,7 @@ case_block_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -7264,19 +7071,16 @@ case_block_rule(Parser *p)
 static expr_ty
 guard_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // 'if' named_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> guard[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'if' named_expression"));
@@ -7292,7 +7096,7 @@ guard_rule(Parser *p)
             _res = guard;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7303,7 +7107,7 @@ guard_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -7311,19 +7115,16 @@ guard_rule(Parser *p)
 static pattern_ty
 patterns_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -7332,7 +7133,7 @@ patterns_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // open_sequence_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> patterns[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "open_sequence_pattern"));
@@ -7344,7 +7145,7 @@ patterns_rule(Parser *p)
             D(fprintf(stderr, "%*c+ patterns[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "open_sequence_pattern"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -7354,7 +7155,7 @@ patterns_rule(Parser *p)
             _res = _PyAST_MatchSequence ( patterns , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7365,7 +7166,7 @@ patterns_rule(Parser *p)
     }
     { // pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> patterns[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "pattern"));
@@ -7384,7 +7185,7 @@ patterns_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -7392,19 +7193,16 @@ patterns_rule(Parser *p)
 static pattern_ty
 pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     { // as_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "as_pattern"));
@@ -7423,7 +7221,7 @@ pattern_rule(Parser *p)
     }
     { // or_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "or_pattern"));
@@ -7442,7 +7240,7 @@ pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -7450,19 +7248,16 @@ pattern_rule(Parser *p)
 static pattern_ty
 as_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -7471,7 +7266,7 @@ as_pattern_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // or_pattern 'as' pattern_capture_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> as_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "or_pattern 'as' pattern_capture_target"));
@@ -7489,7 +7284,7 @@ as_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ as_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "or_pattern 'as' pattern_capture_target"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -7499,7 +7294,7 @@ as_pattern_rule(Parser *p)
             _res = _PyAST_MatchAs ( pattern , target -> v . Name . id , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7510,7 +7305,7 @@ as_pattern_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_as_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> as_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_as_pattern"));
@@ -7529,7 +7324,7 @@ as_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -7537,19 +7332,16 @@ as_pattern_rule(Parser *p)
 static pattern_ty
 or_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -7558,7 +7350,7 @@ or_pattern_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '|'.closed_pattern+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> or_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'|'.closed_pattern+"));
@@ -7570,7 +7362,7 @@ or_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ or_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'|'.closed_pattern+"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -7580,7 +7372,7 @@ or_pattern_rule(Parser *p)
             _res = asdl_seq_LEN ( patterns ) == 1 ? asdl_seq_GET ( patterns , 0 ) : _PyAST_MatchOr ( patterns , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7591,7 +7383,7 @@ or_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -7607,19 +7399,16 @@ or_pattern_rule(Parser *p)
 static pattern_ty
 closed_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     { // literal_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "literal_pattern"));
@@ -7638,7 +7427,7 @@ closed_pattern_rule(Parser *p)
     }
     { // capture_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "capture_pattern"));
@@ -7657,7 +7446,7 @@ closed_pattern_rule(Parser *p)
     }
     { // wildcard_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "wildcard_pattern"));
@@ -7676,7 +7465,7 @@ closed_pattern_rule(Parser *p)
     }
     { // value_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "value_pattern"));
@@ -7695,7 +7484,7 @@ closed_pattern_rule(Parser *p)
     }
     { // group_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "group_pattern"));
@@ -7714,7 +7503,7 @@ closed_pattern_rule(Parser *p)
     }
     { // sequence_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "sequence_pattern"));
@@ -7733,7 +7522,7 @@ closed_pattern_rule(Parser *p)
     }
     { // mapping_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "mapping_pattern"));
@@ -7752,7 +7541,7 @@ closed_pattern_rule(Parser *p)
     }
     { // class_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "class_pattern"));
@@ -7771,7 +7560,7 @@ closed_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -7785,19 +7574,16 @@ closed_pattern_rule(Parser *p)
 static pattern_ty
 literal_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -7806,7 +7592,7 @@ literal_pattern_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // signed_number !('+' | '-')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_number !('+' | '-')"));
@@ -7820,7 +7606,7 @@ literal_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_number !('+' | '-')"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -7830,7 +7616,7 @@ literal_pattern_rule(Parser *p)
             _res = _PyAST_MatchValue ( value , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7841,7 +7627,7 @@ literal_pattern_rule(Parser *p)
     }
     { // complex_number
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "complex_number"));
@@ -7853,7 +7639,7 @@ literal_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "complex_number"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -7863,7 +7649,7 @@ literal_pattern_rule(Parser *p)
             _res = _PyAST_MatchValue ( value , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7874,7 +7660,7 @@ literal_pattern_rule(Parser *p)
     }
     { // strings
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "strings"));
@@ -7886,7 +7672,7 @@ literal_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "strings"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -7896,7 +7682,7 @@ literal_pattern_rule(Parser *p)
             _res = _PyAST_MatchValue ( value , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7907,7 +7693,7 @@ literal_pattern_rule(Parser *p)
     }
     { // 'None'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'None'"));
@@ -7919,7 +7705,7 @@ literal_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'None'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -7929,7 +7715,7 @@ literal_pattern_rule(Parser *p)
             _res = _PyAST_MatchSingleton ( Py_None , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7940,7 +7726,7 @@ literal_pattern_rule(Parser *p)
     }
     { // 'True'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'True'"));
@@ -7952,7 +7738,7 @@ literal_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'True'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -7962,7 +7748,7 @@ literal_pattern_rule(Parser *p)
             _res = _PyAST_MatchSingleton ( Py_True , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -7973,7 +7759,7 @@ literal_pattern_rule(Parser *p)
     }
     { // 'False'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'False'"));
@@ -7985,7 +7771,7 @@ literal_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'False'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -7995,7 +7781,7 @@ literal_pattern_rule(Parser *p)
             _res = _PyAST_MatchSingleton ( Py_False , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8006,7 +7792,7 @@ literal_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8020,19 +7806,16 @@ literal_pattern_rule(Parser *p)
 static expr_ty
 literal_expr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -8041,7 +7824,7 @@ literal_expr_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // signed_number !('+' | '-')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_number !('+' | '-')"));
@@ -8062,7 +7845,7 @@ literal_expr_rule(Parser *p)
     }
     { // complex_number
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "complex_number"));
@@ -8081,7 +7864,7 @@ literal_expr_rule(Parser *p)
     }
     { // strings
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "strings"));
@@ -8100,7 +7883,7 @@ literal_expr_rule(Parser *p)
     }
     { // 'None'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'None'"));
@@ -8112,7 +7895,7 @@ literal_expr_rule(Parser *p)
             D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'None'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -8122,7 +7905,7 @@ literal_expr_rule(Parser *p)
             _res = _PyAST_Constant ( Py_None , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8133,7 +7916,7 @@ literal_expr_rule(Parser *p)
     }
     { // 'True'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'True'"));
@@ -8145,7 +7928,7 @@ literal_expr_rule(Parser *p)
             D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'True'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -8155,7 +7938,7 @@ literal_expr_rule(Parser *p)
             _res = _PyAST_Constant ( Py_True , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8166,7 +7949,7 @@ literal_expr_rule(Parser *p)
     }
     { // 'False'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'False'"));
@@ -8178,7 +7961,7 @@ literal_expr_rule(Parser *p)
             D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'False'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -8188,7 +7971,7 @@ literal_expr_rule(Parser *p)
             _res = _PyAST_Constant ( Py_False , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8199,7 +7982,7 @@ literal_expr_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8209,19 +7992,16 @@ literal_expr_rule(Parser *p)
 static expr_ty
 complex_number_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -8230,7 +8010,7 @@ complex_number_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // signed_real_number '+' imaginary_number
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> complex_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_real_number '+' imaginary_number"));
@@ -8248,7 +8028,7 @@ complex_number_rule(Parser *p)
             D(fprintf(stderr, "%*c+ complex_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_real_number '+' imaginary_number"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -8258,7 +8038,7 @@ complex_number_rule(Parser *p)
             _res = _PyAST_BinOp ( real , Add , imag , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8269,7 +8049,7 @@ complex_number_rule(Parser *p)
     }
     { // signed_real_number '-' imaginary_number
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> complex_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_real_number '-' imaginary_number"));
@@ -8287,7 +8067,7 @@ complex_number_rule(Parser *p)
             D(fprintf(stderr, "%*c+ complex_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_real_number '-' imaginary_number"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -8297,7 +8077,7 @@ complex_number_rule(Parser *p)
             _res = _PyAST_BinOp ( real , Sub , imag , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8308,7 +8088,7 @@ complex_number_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8316,19 +8096,16 @@ complex_number_rule(Parser *p)
 static expr_ty
 signed_number_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -8337,7 +8114,7 @@ signed_number_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NUMBER
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> signed_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NUMBER"));
@@ -8356,7 +8133,7 @@ signed_number_rule(Parser *p)
     }
     { // '-' NUMBER
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> signed_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'-' NUMBER"));
@@ -8371,7 +8148,7 @@ signed_number_rule(Parser *p)
             D(fprintf(stderr, "%*c+ signed_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'-' NUMBER"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -8381,7 +8158,7 @@ signed_number_rule(Parser *p)
             _res = _PyAST_UnaryOp ( USub , number , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8392,7 +8169,7 @@ signed_number_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8400,19 +8177,16 @@ signed_number_rule(Parser *p)
 static expr_ty
 signed_real_number_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -8421,7 +8195,7 @@ signed_real_number_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // real_number
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> signed_real_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "real_number"));
@@ -8440,7 +8214,7 @@ signed_real_number_rule(Parser *p)
     }
     { // '-' real_number
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> signed_real_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'-' real_number"));
@@ -8455,7 +8229,7 @@ signed_real_number_rule(Parser *p)
             D(fprintf(stderr, "%*c+ signed_real_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'-' real_number"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -8465,7 +8239,7 @@ signed_real_number_rule(Parser *p)
             _res = _PyAST_UnaryOp ( USub , real , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8476,7 +8250,7 @@ signed_real_number_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8484,19 +8258,16 @@ signed_real_number_rule(Parser *p)
 static expr_ty
 real_number_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // NUMBER
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> real_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NUMBER"));
@@ -8509,7 +8280,7 @@ real_number_rule(Parser *p)
             _res = _PyPegen_ensure_real ( p , real );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8520,7 +8291,7 @@ real_number_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8528,19 +8299,16 @@ real_number_rule(Parser *p)
 static expr_ty
 imaginary_number_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // NUMBER
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> imaginary_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NUMBER"));
@@ -8553,7 +8321,7 @@ imaginary_number_rule(Parser *p)
             _res = _PyPegen_ensure_imaginary ( p , imag );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8564,7 +8332,7 @@ imaginary_number_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8572,19 +8340,16 @@ imaginary_number_rule(Parser *p)
 static pattern_ty
 capture_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -8593,7 +8358,7 @@ capture_pattern_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // pattern_capture_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> capture_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "pattern_capture_target"));
@@ -8605,7 +8370,7 @@ capture_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ capture_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "pattern_capture_target"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -8615,7 +8380,7 @@ capture_pattern_rule(Parser *p)
             _res = _PyAST_MatchAs ( NULL , target -> v . Name . id , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8626,7 +8391,7 @@ capture_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8634,19 +8399,16 @@ capture_pattern_rule(Parser *p)
 static expr_ty
 pattern_capture_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // !"_" NAME !('.' | '(' | '=')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> pattern_capture_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "!\"_\" NAME !('.' | '(' | '=')"));
@@ -8663,7 +8425,7 @@ pattern_capture_target_rule(Parser *p)
             _res = _PyPegen_set_expr_context ( p , name , Store );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8674,7 +8436,7 @@ pattern_capture_target_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8682,19 +8444,16 @@ pattern_capture_target_rule(Parser *p)
 static pattern_ty
 wildcard_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -8703,7 +8462,7 @@ wildcard_pattern_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // "_"
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> wildcard_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "\"_\""));
@@ -8715,7 +8474,7 @@ wildcard_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ wildcard_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "\"_\""));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -8725,7 +8484,7 @@ wildcard_pattern_rule(Parser *p)
             _res = _PyAST_MatchAs ( NULL , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8736,7 +8495,7 @@ wildcard_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8744,19 +8503,16 @@ wildcard_pattern_rule(Parser *p)
 static pattern_ty
 value_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -8765,7 +8521,7 @@ value_pattern_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // attr !('.' | '(' | '=')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> value_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "attr !('.' | '(' | '=')"));
@@ -8779,7 +8535,7 @@ value_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ value_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "attr !('.' | '(' | '=')"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -8789,7 +8545,7 @@ value_pattern_rule(Parser *p)
             _res = _PyAST_MatchValue ( attr , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8800,7 +8556,7 @@ value_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8810,13 +8566,10 @@ static expr_ty attr_raw(Parser *);
 static expr_ty
 attr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, attr_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
@@ -8824,42 +8577,37 @@ attr_rule(Parser *p)
     while (1) {
         int tmpvar_1 = _PyPegen_update_memo(p, _mark, attr_type, _res);
         if (tmpvar_1) {
-            p->level--;
+            D(p->level--);
             return _res;
         }
         p->mark = _mark;
         p->in_raw_rule++;
         void *_raw = attr_raw(p);
         p->in_raw_rule--;
-        if (p->error_indicator) {
-            p->level--;
+        if (p->error_indicator)
             return NULL;
-        }
         if (_raw == NULL || p->mark <= _resmark)
             break;
         _resmark = p->mark;
         _res = _raw;
     }
     p->mark = _resmark;
-    p->level--;
+    D(p->level--);
     return _res;
 }
 static expr_ty
 attr_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -8868,7 +8616,7 @@ attr_raw(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // name_or_attr '.' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> attr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "name_or_attr '.' NAME"));
@@ -8886,7 +8634,7 @@ attr_raw(Parser *p)
             D(fprintf(stderr, "%*c+ attr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "name_or_attr '.' NAME"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -8896,7 +8644,7 @@ attr_raw(Parser *p)
             _res = _PyAST_Attribute ( value , attr -> v . Name . id , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -8907,7 +8655,7 @@ attr_raw(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8916,19 +8664,16 @@ attr_raw(Parser *p)
 static expr_ty
 name_or_attr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // attr
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> name_or_attr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "attr"));
@@ -8947,7 +8692,7 @@ name_or_attr_rule(Parser *p)
     }
     { // NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> name_or_attr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME"));
@@ -8966,7 +8711,7 @@ name_or_attr_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -8974,19 +8719,16 @@ name_or_attr_rule(Parser *p)
 static pattern_ty
 group_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     { // '(' pattern ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> group_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' pattern ')'"));
@@ -9005,7 +8747,7 @@ group_pattern_rule(Parser *p)
             _res = pattern;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9016,7 +8758,7 @@ group_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -9024,19 +8766,16 @@ group_pattern_rule(Parser *p)
 static pattern_ty
 sequence_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -9045,7 +8784,7 @@ sequence_pattern_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '[' maybe_sequence_pattern? ']'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> sequence_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'[' maybe_sequence_pattern? ']'"));
@@ -9063,7 +8802,7 @@ sequence_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ sequence_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'[' maybe_sequence_pattern? ']'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9073,7 +8812,7 @@ sequence_pattern_rule(Parser *p)
             _res = _PyAST_MatchSequence ( patterns , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9084,7 +8823,7 @@ sequence_pattern_rule(Parser *p)
     }
     { // '(' open_sequence_pattern? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> sequence_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' open_sequence_pattern? ')'"));
@@ -9102,7 +8841,7 @@ sequence_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ sequence_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' open_sequence_pattern? ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9112,7 +8851,7 @@ sequence_pattern_rule(Parser *p)
             _res = _PyAST_MatchSequence ( patterns , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9123,7 +8862,7 @@ sequence_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -9131,19 +8870,16 @@ sequence_pattern_rule(Parser *p)
 static asdl_seq*
 open_sequence_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // maybe_star_pattern ',' maybe_sequence_pattern?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> open_sequence_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "maybe_star_pattern ',' maybe_sequence_pattern?"));
@@ -9162,7 +8898,7 @@ open_sequence_pattern_rule(Parser *p)
             _res = _PyPegen_seq_insert_in_front ( p , pattern , patterns );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9173,7 +8909,7 @@ open_sequence_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -9181,19 +8917,16 @@ open_sequence_pattern_rule(Parser *p)
 static asdl_seq*
 maybe_sequence_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.maybe_star_pattern+ ','?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> maybe_sequence_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.maybe_star_pattern+ ','?"));
@@ -9210,7 +8943,7 @@ maybe_sequence_pattern_rule(Parser *p)
             _res = patterns;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9221,7 +8954,7 @@ maybe_sequence_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -9229,19 +8962,16 @@ maybe_sequence_pattern_rule(Parser *p)
 static pattern_ty
 maybe_star_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     { // star_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> maybe_star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_pattern"));
@@ -9260,7 +8990,7 @@ maybe_star_pattern_rule(Parser *p)
     }
     { // pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> maybe_star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "pattern"));
@@ -9279,7 +9009,7 @@ maybe_star_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -9287,19 +9017,16 @@ maybe_star_pattern_rule(Parser *p)
 static pattern_ty
 star_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -9308,7 +9035,7 @@ star_pattern_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '*' pattern_capture_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' pattern_capture_target"));
@@ -9323,7 +9050,7 @@ star_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ star_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' pattern_capture_target"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9333,7 +9060,7 @@ star_pattern_rule(Parser *p)
             _res = _PyAST_MatchStar ( target -> v . Name . id , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9344,7 +9071,7 @@ star_pattern_rule(Parser *p)
     }
     { // '*' wildcard_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' wildcard_pattern"));
@@ -9359,7 +9086,7 @@ star_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ star_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' wildcard_pattern"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9369,7 +9096,7 @@ star_pattern_rule(Parser *p)
             _res = _PyAST_MatchStar ( NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9380,7 +9107,7 @@ star_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -9392,19 +9119,16 @@ star_pattern_rule(Parser *p)
 static pattern_ty
 mapping_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -9413,7 +9137,7 @@ mapping_pattern_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '{' '}'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> mapping_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{' '}'"));
@@ -9428,7 +9152,7 @@ mapping_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ mapping_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'{' '}'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9438,7 +9162,7 @@ mapping_pattern_rule(Parser *p)
             _res = _PyAST_MatchMapping ( NULL , NULL , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9449,7 +9173,7 @@ mapping_pattern_rule(Parser *p)
     }
     { // '{' double_star_pattern ','? '}'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> mapping_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{' double_star_pattern ','? '}'"));
@@ -9471,7 +9195,7 @@ mapping_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ mapping_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'{' double_star_pattern ','? '}'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9481,7 +9205,7 @@ mapping_pattern_rule(Parser *p)
             _res = _PyAST_MatchMapping ( NULL , NULL , rest -> v . Name . id , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9492,7 +9216,7 @@ mapping_pattern_rule(Parser *p)
     }
     { // '{' items_pattern ',' double_star_pattern ','? '}'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> mapping_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{' items_pattern ',' double_star_pattern ','? '}'"));
@@ -9520,7 +9244,7 @@ mapping_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ mapping_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'{' items_pattern ',' double_star_pattern ','? '}'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9530,7 +9254,7 @@ mapping_pattern_rule(Parser *p)
             _res = _PyAST_MatchMapping ( CHECK ( asdl_expr_seq* , _PyPegen_get_pattern_keys ( p , items ) ) , CHECK ( asdl_pattern_seq* , _PyPegen_get_patterns ( p , items ) ) , rest -> v . Name . id , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9541,7 +9265,7 @@ mapping_pattern_rule(Parser *p)
     }
     { // '{' items_pattern ','? '}'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> mapping_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{' items_pattern ','? '}'"));
@@ -9563,7 +9287,7 @@ mapping_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ mapping_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'{' items_pattern ','? '}'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9573,7 +9297,7 @@ mapping_pattern_rule(Parser *p)
             _res = _PyAST_MatchMapping ( CHECK ( asdl_expr_seq* , _PyPegen_get_pattern_keys ( p , items ) ) , CHECK ( asdl_pattern_seq* , _PyPegen_get_patterns ( p , items ) ) , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9584,7 +9308,7 @@ mapping_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -9592,19 +9316,16 @@ mapping_pattern_rule(Parser *p)
 static asdl_seq*
 items_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.key_value_pattern+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> items_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.key_value_pattern+"));
@@ -9623,7 +9344,7 @@ items_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -9631,19 +9352,16 @@ items_pattern_rule(Parser *p)
 static KeyPatternPair*
 key_value_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     KeyPatternPair* _res = NULL;
     int _mark = p->mark;
     { // (literal_expr | attr) ':' pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> key_value_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(literal_expr | attr) ':' pattern"));
@@ -9662,7 +9380,7 @@ key_value_pattern_rule(Parser *p)
             _res = _PyPegen_key_pattern_pair ( p , key , pattern );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9673,7 +9391,7 @@ key_value_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -9681,19 +9399,16 @@ key_value_pattern_rule(Parser *p)
 static expr_ty
 double_star_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // '**' pattern_capture_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> double_star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**' pattern_capture_target"));
@@ -9709,7 +9424,7 @@ double_star_pattern_rule(Parser *p)
             _res = target;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9720,7 +9435,7 @@ double_star_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -9733,19 +9448,16 @@ double_star_pattern_rule(Parser *p)
 static pattern_ty
 class_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -9754,7 +9466,7 @@ class_pattern_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // name_or_attr '(' ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> class_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "name_or_attr '(' ')'"));
@@ -9772,7 +9484,7 @@ class_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ class_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "name_or_attr '(' ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9782,7 +9494,7 @@ class_pattern_rule(Parser *p)
             _res = _PyAST_MatchClass ( cls , NULL , NULL , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9793,7 +9505,7 @@ class_pattern_rule(Parser *p)
     }
     { // name_or_attr '(' positional_patterns ','? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> class_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "name_or_attr '(' positional_patterns ','? ')'"));
@@ -9818,7 +9530,7 @@ class_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ class_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "name_or_attr '(' positional_patterns ','? ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9828,7 +9540,7 @@ class_pattern_rule(Parser *p)
             _res = _PyAST_MatchClass ( cls , patterns , NULL , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9839,7 +9551,7 @@ class_pattern_rule(Parser *p)
     }
     { // name_or_attr '(' keyword_patterns ','? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> class_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "name_or_attr '(' keyword_patterns ','? ')'"));
@@ -9864,7 +9576,7 @@ class_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ class_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "name_or_attr '(' keyword_patterns ','? ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9874,7 +9586,7 @@ class_pattern_rule(Parser *p)
             _res = _PyAST_MatchClass ( cls , NULL , CHECK ( asdl_identifier_seq* , _PyPegen_map_names_to_ids ( p , CHECK ( asdl_expr_seq* , _PyPegen_get_pattern_keys ( p , keywords ) ) ) ) , CHECK ( asdl_pattern_seq* , _PyPegen_get_patterns ( p , keywords ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9885,7 +9597,7 @@ class_pattern_rule(Parser *p)
     }
     { // name_or_attr '(' positional_patterns ',' keyword_patterns ','? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> class_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "name_or_attr '(' positional_patterns ',' keyword_patterns ','? ')'"));
@@ -9916,7 +9628,7 @@ class_pattern_rule(Parser *p)
             D(fprintf(stderr, "%*c+ class_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "name_or_attr '(' positional_patterns ',' keyword_patterns ','? ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -9926,7 +9638,7 @@ class_pattern_rule(Parser *p)
             _res = _PyAST_MatchClass ( cls , patterns , CHECK ( asdl_identifier_seq* , _PyPegen_map_names_to_ids ( p , CHECK ( asdl_expr_seq* , _PyPegen_get_pattern_keys ( p , keywords ) ) ) ) , CHECK ( asdl_pattern_seq* , _PyPegen_get_patterns ( p , keywords ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -9937,7 +9649,7 @@ class_pattern_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_class_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> class_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_class_pattern"));
@@ -9956,7 +9668,7 @@ class_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -9964,19 +9676,16 @@ class_pattern_rule(Parser *p)
 static asdl_pattern_seq*
 positional_patterns_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_pattern_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.pattern+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> positional_patterns[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.pattern+"));
@@ -9989,7 +9698,7 @@ positional_patterns_rule(Parser *p)
             _res = args;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10000,7 +9709,7 @@ positional_patterns_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10008,19 +9717,16 @@ positional_patterns_rule(Parser *p)
 static asdl_seq*
 keyword_patterns_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.keyword_pattern+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> keyword_patterns[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.keyword_pattern+"));
@@ -10039,7 +9745,7 @@ keyword_patterns_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10047,19 +9753,16 @@ keyword_patterns_rule(Parser *p)
 static KeyPatternPair*
 keyword_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     KeyPatternPair* _res = NULL;
     int _mark = p->mark;
     { // NAME '=' pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> keyword_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME '=' pattern"));
@@ -10078,7 +9781,7 @@ keyword_pattern_rule(Parser *p)
             _res = _PyPegen_key_pattern_pair ( p , arg , value );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10089,7 +9792,7 @@ keyword_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10097,19 +9800,16 @@ keyword_pattern_rule(Parser *p)
 static expr_ty
 expressions_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -10118,7 +9818,7 @@ expressions_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // expression ((',' expression))+ ','?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ((',' expression))+ ','?"));
@@ -10137,7 +9837,7 @@ expressions_rule(Parser *p)
             D(fprintf(stderr, "%*c+ expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expression ((',' expression))+ ','?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -10147,7 +9847,7 @@ expressions_rule(Parser *p)
             _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq* , _PyPegen_seq_insert_in_front ( p , a , b ) ) , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10158,7 +9858,7 @@ expressions_rule(Parser *p)
     }
     { // expression ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ','"));
@@ -10173,7 +9873,7 @@ expressions_rule(Parser *p)
             D(fprintf(stderr, "%*c+ expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expression ','"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -10183,7 +9883,7 @@ expressions_rule(Parser *p)
             _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq* , _PyPegen_singleton_seq ( p , a ) ) , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10194,7 +9894,7 @@ expressions_rule(Parser *p)
     }
     { // expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression"));
@@ -10213,7 +9913,7 @@ expressions_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10226,23 +9926,20 @@ expressions_rule(Parser *p)
 static expr_ty
 expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, expression_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -10251,7 +9948,7 @@ expression_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_expression"));
@@ -10270,7 +9967,7 @@ expression_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_legacy_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_legacy_expression"));
@@ -10289,7 +9986,7 @@ expression_rule(Parser *p)
     }
     { // disjunction 'if' disjunction 'else' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "disjunction 'if' disjunction 'else' expression"));
@@ -10313,7 +10010,7 @@ expression_rule(Parser *p)
             D(fprintf(stderr, "%*c+ expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "disjunction 'if' disjunction 'else' expression"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -10323,7 +10020,7 @@ expression_rule(Parser *p)
             _res = _PyAST_IfExp ( b , a , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10334,7 +10031,7 @@ expression_rule(Parser *p)
     }
     { // disjunction
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "disjunction"));
@@ -10353,7 +10050,7 @@ expression_rule(Parser *p)
     }
     { // lambdef
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambdef"));
@@ -10373,7 +10070,7 @@ expression_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, expression_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10381,19 +10078,16 @@ expression_rule(Parser *p)
 static expr_ty
 yield_expr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -10402,7 +10096,7 @@ yield_expr_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'yield' 'from' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> yield_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'yield' 'from' expression"));
@@ -10420,7 +10114,7 @@ yield_expr_rule(Parser *p)
             D(fprintf(stderr, "%*c+ yield_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'yield' 'from' expression"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -10430,7 +10124,7 @@ yield_expr_rule(Parser *p)
             _res = _PyAST_YieldFrom ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10441,7 +10135,7 @@ yield_expr_rule(Parser *p)
     }
     { // 'yield' star_expressions?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> yield_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'yield' star_expressions?"));
@@ -10456,7 +10150,7 @@ yield_expr_rule(Parser *p)
             D(fprintf(stderr, "%*c+ yield_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'yield' star_expressions?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -10466,7 +10160,7 @@ yield_expr_rule(Parser *p)
             _res = _PyAST_Yield ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10477,7 +10171,7 @@ yield_expr_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10488,19 +10182,16 @@ yield_expr_rule(Parser *p)
 static expr_ty
 star_expressions_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -10509,7 +10200,7 @@ star_expressions_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // star_expression ((',' star_expression))+ ','?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_expression ((',' star_expression))+ ','?"));
@@ -10528,7 +10219,7 @@ star_expressions_rule(Parser *p)
             D(fprintf(stderr, "%*c+ star_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "star_expression ((',' star_expression))+ ','?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -10538,7 +10229,7 @@ star_expressions_rule(Parser *p)
             _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq* , _PyPegen_seq_insert_in_front ( p , a , b ) ) , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10549,7 +10240,7 @@ star_expressions_rule(Parser *p)
     }
     { // star_expression ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_expression ','"));
@@ -10564,7 +10255,7 @@ star_expressions_rule(Parser *p)
             D(fprintf(stderr, "%*c+ star_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "star_expression ','"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -10574,7 +10265,7 @@ star_expressions_rule(Parser *p)
             _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq* , _PyPegen_singleton_seq ( p , a ) ) , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10585,7 +10276,7 @@ star_expressions_rule(Parser *p)
     }
     { // star_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_expression"));
@@ -10604,7 +10295,7 @@ star_expressions_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10612,23 +10303,20 @@ star_expressions_rule(Parser *p)
 static expr_ty
 star_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, star_expression_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -10637,7 +10325,7 @@ star_expression_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '*' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' bitwise_or"));
@@ -10652,7 +10340,7 @@ star_expression_rule(Parser *p)
             D(fprintf(stderr, "%*c+ star_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' bitwise_or"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -10662,7 +10350,7 @@ star_expression_rule(Parser *p)
             _res = _PyAST_Starred ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10673,7 +10361,7 @@ star_expression_rule(Parser *p)
     }
     { // expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression"));
@@ -10693,7 +10381,7 @@ star_expression_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, star_expression_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10701,19 +10389,16 @@ star_expression_rule(Parser *p)
 static asdl_expr_seq*
 star_named_expressions_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.star_named_expression+ ','?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_named_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.star_named_expression+ ','?"));
@@ -10730,7 +10415,7 @@ star_named_expressions_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10741,7 +10426,7 @@ star_named_expressions_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10749,19 +10434,16 @@ star_named_expressions_rule(Parser *p)
 static expr_ty
 star_named_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -10770,7 +10452,7 @@ star_named_expression_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '*' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_named_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' bitwise_or"));
@@ -10785,7 +10467,7 @@ star_named_expression_rule(Parser *p)
             D(fprintf(stderr, "%*c+ star_named_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' bitwise_or"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -10795,7 +10477,7 @@ star_named_expression_rule(Parser *p)
             _res = _PyAST_Starred ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10806,7 +10488,7 @@ star_named_expression_rule(Parser *p)
     }
     { // named_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_named_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "named_expression"));
@@ -10825,7 +10507,7 @@ star_named_expression_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10833,19 +10515,16 @@ star_named_expression_rule(Parser *p)
 static expr_ty
 assignment_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -10854,7 +10533,7 @@ assignment_expression_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME ':=' ~ expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> assignment_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME ':=' ~ expression"));
@@ -10875,7 +10554,7 @@ assignment_expression_rule(Parser *p)
             D(fprintf(stderr, "%*c+ assignment_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME ':=' ~ expression"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -10885,7 +10564,7 @@ assignment_expression_rule(Parser *p)
             _res = _PyAST_NamedExpr ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -10894,13 +10573,13 @@ assignment_expression_rule(Parser *p)
         D(fprintf(stderr, "%*c%s assignment_expression[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NAME ':=' ~ expression"));
         if (_cut_var) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10908,19 +10587,16 @@ assignment_expression_rule(Parser *p)
 static expr_ty
 named_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // assignment_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> named_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
@@ -10939,7 +10615,7 @@ named_expression_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_named_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> named_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_named_expression"));
@@ -10958,7 +10634,7 @@ named_expression_rule(Parser *p)
     }
     { // expression !':='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> named_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression !':='"));
@@ -10979,7 +10655,7 @@ named_expression_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -10987,23 +10663,20 @@ named_expression_rule(Parser *p)
 static expr_ty
 disjunction_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, disjunction_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -11012,7 +10685,7 @@ disjunction_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // conjunction (('or' conjunction))+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> disjunction[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "conjunction (('or' conjunction))+"));
@@ -11027,7 +10700,7 @@ disjunction_rule(Parser *p)
             D(fprintf(stderr, "%*c+ disjunction[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "conjunction (('or' conjunction))+"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -11037,7 +10710,7 @@ disjunction_rule(Parser *p)
             _res = _PyAST_BoolOp ( Or , CHECK ( asdl_expr_seq* , _PyPegen_seq_insert_in_front ( p , a , b ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11048,7 +10721,7 @@ disjunction_rule(Parser *p)
     }
     { // conjunction
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> disjunction[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "conjunction"));
@@ -11068,7 +10741,7 @@ disjunction_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, disjunction_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11076,23 +10749,20 @@ disjunction_rule(Parser *p)
 static expr_ty
 conjunction_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, conjunction_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -11101,7 +10771,7 @@ conjunction_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // inversion (('and' inversion))+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> conjunction[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "inversion (('and' inversion))+"));
@@ -11116,7 +10786,7 @@ conjunction_rule(Parser *p)
             D(fprintf(stderr, "%*c+ conjunction[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "inversion (('and' inversion))+"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -11126,7 +10796,7 @@ conjunction_rule(Parser *p)
             _res = _PyAST_BoolOp ( And , CHECK ( asdl_expr_seq* , _PyPegen_seq_insert_in_front ( p , a , b ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11137,7 +10807,7 @@ conjunction_rule(Parser *p)
     }
     { // inversion
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> conjunction[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "inversion"));
@@ -11157,7 +10827,7 @@ conjunction_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, conjunction_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11165,23 +10835,20 @@ conjunction_rule(Parser *p)
 static expr_ty
 inversion_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, inversion_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -11190,7 +10857,7 @@ inversion_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'not' inversion
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> inversion[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'not' inversion"));
@@ -11205,7 +10872,7 @@ inversion_rule(Parser *p)
             D(fprintf(stderr, "%*c+ inversion[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'not' inversion"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -11215,7 +10882,7 @@ inversion_rule(Parser *p)
             _res = _PyAST_UnaryOp ( Not , a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11226,7 +10893,7 @@ inversion_rule(Parser *p)
     }
     { // comparison
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> inversion[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "comparison"));
@@ -11246,7 +10913,7 @@ inversion_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, inversion_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11254,19 +10921,16 @@ inversion_rule(Parser *p)
 static expr_ty
 comparison_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -11275,7 +10939,7 @@ comparison_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // bitwise_or compare_op_bitwise_or_pair+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> comparison[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_or compare_op_bitwise_or_pair+"));
@@ -11290,7 +10954,7 @@ comparison_rule(Parser *p)
             D(fprintf(stderr, "%*c+ comparison[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_or compare_op_bitwise_or_pair+"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -11300,7 +10964,7 @@ comparison_rule(Parser *p)
             _res = _PyAST_Compare ( a , CHECK ( asdl_int_seq* , _PyPegen_get_cmpops ( p , b ) ) , CHECK ( asdl_expr_seq* , _PyPegen_get_exprs ( p , b ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11311,7 +10975,7 @@ comparison_rule(Parser *p)
     }
     { // bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> comparison[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_or"));
@@ -11330,7 +10994,7 @@ comparison_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11348,19 +11012,16 @@ comparison_rule(Parser *p)
 static CmpopExprPair*
 compare_op_bitwise_or_pair_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // eq_bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compare_op_bitwise_or_pair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "eq_bitwise_or"));
@@ -11379,7 +11040,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     }
     { // noteq_bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compare_op_bitwise_or_pair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "noteq_bitwise_or"));
@@ -11398,7 +11059,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     }
     { // lte_bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compare_op_bitwise_or_pair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lte_bitwise_or"));
@@ -11417,7 +11078,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     }
     { // lt_bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compare_op_bitwise_or_pair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lt_bitwise_or"));
@@ -11436,7 +11097,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     }
     { // gte_bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compare_op_bitwise_or_pair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "gte_bitwise_or"));
@@ -11455,7 +11116,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     }
     { // gt_bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compare_op_bitwise_or_pair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "gt_bitwise_or"));
@@ -11474,7 +11135,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     }
     { // notin_bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compare_op_bitwise_or_pair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "notin_bitwise_or"));
@@ -11493,7 +11154,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     }
     { // in_bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compare_op_bitwise_or_pair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "in_bitwise_or"));
@@ -11512,7 +11173,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     }
     { // isnot_bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compare_op_bitwise_or_pair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "isnot_bitwise_or"));
@@ -11531,7 +11192,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     }
     { // is_bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> compare_op_bitwise_or_pair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "is_bitwise_or"));
@@ -11550,7 +11211,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11558,19 +11219,16 @@ compare_op_bitwise_or_pair_rule(Parser *p)
 static CmpopExprPair*
 eq_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '==' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> eq_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'==' bitwise_or"));
@@ -11586,7 +11244,7 @@ eq_bitwise_or_rule(Parser *p)
             _res = _PyPegen_cmpop_expr_pair ( p , Eq , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11597,7 +11255,7 @@ eq_bitwise_or_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11605,19 +11263,16 @@ eq_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 noteq_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // ('!=') bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> noteq_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('!=') bitwise_or"));
@@ -11633,7 +11288,7 @@ noteq_bitwise_or_rule(Parser *p)
             _res = _PyPegen_cmpop_expr_pair ( p , NotEq , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11644,7 +11299,7 @@ noteq_bitwise_or_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11652,19 +11307,16 @@ noteq_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 lte_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '<=' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lte_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'<=' bitwise_or"));
@@ -11680,7 +11332,7 @@ lte_bitwise_or_rule(Parser *p)
             _res = _PyPegen_cmpop_expr_pair ( p , LtE , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11691,7 +11343,7 @@ lte_bitwise_or_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11699,19 +11351,16 @@ lte_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 lt_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '<' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lt_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'<' bitwise_or"));
@@ -11727,7 +11376,7 @@ lt_bitwise_or_rule(Parser *p)
             _res = _PyPegen_cmpop_expr_pair ( p , Lt , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11738,7 +11387,7 @@ lt_bitwise_or_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11746,19 +11395,16 @@ lt_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 gte_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '>=' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> gte_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'>=' bitwise_or"));
@@ -11774,7 +11420,7 @@ gte_bitwise_or_rule(Parser *p)
             _res = _PyPegen_cmpop_expr_pair ( p , GtE , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11785,7 +11431,7 @@ gte_bitwise_or_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11793,19 +11439,16 @@ gte_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 gt_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '>' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> gt_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'>' bitwise_or"));
@@ -11821,7 +11464,7 @@ gt_bitwise_or_rule(Parser *p)
             _res = _PyPegen_cmpop_expr_pair ( p , Gt , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11832,7 +11475,7 @@ gt_bitwise_or_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11840,19 +11483,16 @@ gt_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 notin_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'not' 'in' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> notin_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'not' 'in' bitwise_or"));
@@ -11871,7 +11511,7 @@ notin_bitwise_or_rule(Parser *p)
             _res = _PyPegen_cmpop_expr_pair ( p , NotIn , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11882,7 +11522,7 @@ notin_bitwise_or_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11890,19 +11530,16 @@ notin_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 in_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'in' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> in_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'in' bitwise_or"));
@@ -11918,7 +11555,7 @@ in_bitwise_or_rule(Parser *p)
             _res = _PyPegen_cmpop_expr_pair ( p , In , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11929,7 +11566,7 @@ in_bitwise_or_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11937,19 +11574,16 @@ in_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 isnot_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'is' 'not' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> isnot_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'is' 'not' bitwise_or"));
@@ -11968,7 +11602,7 @@ isnot_bitwise_or_rule(Parser *p)
             _res = _PyPegen_cmpop_expr_pair ( p , IsNot , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -11979,7 +11613,7 @@ isnot_bitwise_or_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -11987,19 +11621,16 @@ isnot_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 is_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'is' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> is_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'is' bitwise_or"));
@@ -12015,7 +11646,7 @@ is_bitwise_or_rule(Parser *p)
             _res = _PyPegen_cmpop_expr_pair ( p , Is , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12026,7 +11657,7 @@ is_bitwise_or_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -12036,13 +11667,10 @@ static expr_ty bitwise_or_raw(Parser *);
 static expr_ty
 bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, bitwise_or_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
@@ -12050,42 +11678,37 @@ bitwise_or_rule(Parser *p)
     while (1) {
         int tmpvar_2 = _PyPegen_update_memo(p, _mark, bitwise_or_type, _res);
         if (tmpvar_2) {
-            p->level--;
+            D(p->level--);
             return _res;
         }
         p->mark = _mark;
         p->in_raw_rule++;
         void *_raw = bitwise_or_raw(p);
         p->in_raw_rule--;
-        if (p->error_indicator) {
-            p->level--;
+        if (p->error_indicator)
             return NULL;
-        }
         if (_raw == NULL || p->mark <= _resmark)
             break;
         _resmark = p->mark;
         _res = _raw;
     }
     p->mark = _resmark;
-    p->level--;
+    D(p->level--);
     return _res;
 }
 static expr_ty
 bitwise_or_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -12094,7 +11717,7 @@ bitwise_or_raw(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // bitwise_or '|' bitwise_xor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_or '|' bitwise_xor"));
@@ -12112,7 +11735,7 @@ bitwise_or_raw(Parser *p)
             D(fprintf(stderr, "%*c+ bitwise_or[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_or '|' bitwise_xor"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12122,7 +11745,7 @@ bitwise_or_raw(Parser *p)
             _res = _PyAST_BinOp ( a , BitOr , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12133,7 +11756,7 @@ bitwise_or_raw(Parser *p)
     }
     { // bitwise_xor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_xor"));
@@ -12152,7 +11775,7 @@ bitwise_or_raw(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -12162,13 +11785,10 @@ static expr_ty bitwise_xor_raw(Parser *);
 static expr_ty
 bitwise_xor_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, bitwise_xor_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
@@ -12176,42 +11796,37 @@ bitwise_xor_rule(Parser *p)
     while (1) {
         int tmpvar_3 = _PyPegen_update_memo(p, _mark, bitwise_xor_type, _res);
         if (tmpvar_3) {
-            p->level--;
+            D(p->level--);
             return _res;
         }
         p->mark = _mark;
         p->in_raw_rule++;
         void *_raw = bitwise_xor_raw(p);
         p->in_raw_rule--;
-        if (p->error_indicator) {
-            p->level--;
+        if (p->error_indicator)
             return NULL;
-        }
         if (_raw == NULL || p->mark <= _resmark)
             break;
         _resmark = p->mark;
         _res = _raw;
     }
     p->mark = _resmark;
-    p->level--;
+    D(p->level--);
     return _res;
 }
 static expr_ty
 bitwise_xor_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -12220,7 +11835,7 @@ bitwise_xor_raw(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // bitwise_xor '^' bitwise_and
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> bitwise_xor[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_xor '^' bitwise_and"));
@@ -12238,7 +11853,7 @@ bitwise_xor_raw(Parser *p)
             D(fprintf(stderr, "%*c+ bitwise_xor[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_xor '^' bitwise_and"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12248,7 +11863,7 @@ bitwise_xor_raw(Parser *p)
             _res = _PyAST_BinOp ( a , BitXor , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12259,7 +11874,7 @@ bitwise_xor_raw(Parser *p)
     }
     { // bitwise_and
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> bitwise_xor[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_and"));
@@ -12278,7 +11893,7 @@ bitwise_xor_raw(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -12288,13 +11903,10 @@ static expr_ty bitwise_and_raw(Parser *);
 static expr_ty
 bitwise_and_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, bitwise_and_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
@@ -12302,42 +11914,37 @@ bitwise_and_rule(Parser *p)
     while (1) {
         int tmpvar_4 = _PyPegen_update_memo(p, _mark, bitwise_and_type, _res);
         if (tmpvar_4) {
-            p->level--;
+            D(p->level--);
             return _res;
         }
         p->mark = _mark;
         p->in_raw_rule++;
         void *_raw = bitwise_and_raw(p);
         p->in_raw_rule--;
-        if (p->error_indicator) {
-            p->level--;
+        if (p->error_indicator)
             return NULL;
-        }
         if (_raw == NULL || p->mark <= _resmark)
             break;
         _resmark = p->mark;
         _res = _raw;
     }
     p->mark = _resmark;
-    p->level--;
+    D(p->level--);
     return _res;
 }
 static expr_ty
 bitwise_and_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -12346,7 +11953,7 @@ bitwise_and_raw(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // bitwise_and '&' shift_expr
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> bitwise_and[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_and '&' shift_expr"));
@@ -12364,7 +11971,7 @@ bitwise_and_raw(Parser *p)
             D(fprintf(stderr, "%*c+ bitwise_and[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_and '&' shift_expr"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12374,7 +11981,7 @@ bitwise_and_raw(Parser *p)
             _res = _PyAST_BinOp ( a , BitAnd , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12385,7 +11992,7 @@ bitwise_and_raw(Parser *p)
     }
     { // shift_expr
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> bitwise_and[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "shift_expr"));
@@ -12404,7 +12011,7 @@ bitwise_and_raw(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -12414,13 +12021,10 @@ static expr_ty shift_expr_raw(Parser *);
 static expr_ty
 shift_expr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, shift_expr_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
@@ -12428,42 +12032,37 @@ shift_expr_rule(Parser *p)
     while (1) {
         int tmpvar_5 = _PyPegen_update_memo(p, _mark, shift_expr_type, _res);
         if (tmpvar_5) {
-            p->level--;
+            D(p->level--);
             return _res;
         }
         p->mark = _mark;
         p->in_raw_rule++;
         void *_raw = shift_expr_raw(p);
         p->in_raw_rule--;
-        if (p->error_indicator) {
-            p->level--;
+        if (p->error_indicator)
             return NULL;
-        }
         if (_raw == NULL || p->mark <= _resmark)
             break;
         _resmark = p->mark;
         _res = _raw;
     }
     p->mark = _resmark;
-    p->level--;
+    D(p->level--);
     return _res;
 }
 static expr_ty
 shift_expr_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -12472,7 +12071,7 @@ shift_expr_raw(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // shift_expr '<<' sum
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> shift_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "shift_expr '<<' sum"));
@@ -12490,7 +12089,7 @@ shift_expr_raw(Parser *p)
             D(fprintf(stderr, "%*c+ shift_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "shift_expr '<<' sum"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12500,7 +12099,7 @@ shift_expr_raw(Parser *p)
             _res = _PyAST_BinOp ( a , LShift , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12511,7 +12110,7 @@ shift_expr_raw(Parser *p)
     }
     { // shift_expr '>>' sum
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> shift_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "shift_expr '>>' sum"));
@@ -12529,7 +12128,7 @@ shift_expr_raw(Parser *p)
             D(fprintf(stderr, "%*c+ shift_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "shift_expr '>>' sum"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12539,7 +12138,7 @@ shift_expr_raw(Parser *p)
             _res = _PyAST_BinOp ( a , RShift , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12550,7 +12149,7 @@ shift_expr_raw(Parser *p)
     }
     { // sum
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> shift_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "sum"));
@@ -12569,7 +12168,7 @@ shift_expr_raw(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -12579,13 +12178,10 @@ static expr_ty sum_raw(Parser *);
 static expr_ty
 sum_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, sum_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
@@ -12593,42 +12189,37 @@ sum_rule(Parser *p)
     while (1) {
         int tmpvar_6 = _PyPegen_update_memo(p, _mark, sum_type, _res);
         if (tmpvar_6) {
-            p->level--;
+            D(p->level--);
             return _res;
         }
         p->mark = _mark;
         p->in_raw_rule++;
         void *_raw = sum_raw(p);
         p->in_raw_rule--;
-        if (p->error_indicator) {
-            p->level--;
+        if (p->error_indicator)
             return NULL;
-        }
         if (_raw == NULL || p->mark <= _resmark)
             break;
         _resmark = p->mark;
         _res = _raw;
     }
     p->mark = _resmark;
-    p->level--;
+    D(p->level--);
     return _res;
 }
 static expr_ty
 sum_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -12637,7 +12228,7 @@ sum_raw(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // sum '+' term
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> sum[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "sum '+' term"));
@@ -12655,7 +12246,7 @@ sum_raw(Parser *p)
             D(fprintf(stderr, "%*c+ sum[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "sum '+' term"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12665,7 +12256,7 @@ sum_raw(Parser *p)
             _res = _PyAST_BinOp ( a , Add , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12676,7 +12267,7 @@ sum_raw(Parser *p)
     }
     { // sum '-' term
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> sum[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "sum '-' term"));
@@ -12694,7 +12285,7 @@ sum_raw(Parser *p)
             D(fprintf(stderr, "%*c+ sum[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "sum '-' term"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12704,7 +12295,7 @@ sum_raw(Parser *p)
             _res = _PyAST_BinOp ( a , Sub , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12715,7 +12306,7 @@ sum_raw(Parser *p)
     }
     { // term
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> sum[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "term"));
@@ -12734,7 +12325,7 @@ sum_raw(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -12750,13 +12341,10 @@ static expr_ty term_raw(Parser *);
 static expr_ty
 term_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, term_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
@@ -12764,42 +12352,37 @@ term_rule(Parser *p)
     while (1) {
         int tmpvar_7 = _PyPegen_update_memo(p, _mark, term_type, _res);
         if (tmpvar_7) {
-            p->level--;
+            D(p->level--);
             return _res;
         }
         p->mark = _mark;
         p->in_raw_rule++;
         void *_raw = term_raw(p);
         p->in_raw_rule--;
-        if (p->error_indicator) {
-            p->level--;
+        if (p->error_indicator)
             return NULL;
-        }
         if (_raw == NULL || p->mark <= _resmark)
             break;
         _resmark = p->mark;
         _res = _raw;
     }
     p->mark = _resmark;
-    p->level--;
+    D(p->level--);
     return _res;
 }
 static expr_ty
 term_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -12808,7 +12391,7 @@ term_raw(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // term '*' factor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> term[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "term '*' factor"));
@@ -12826,7 +12409,7 @@ term_raw(Parser *p)
             D(fprintf(stderr, "%*c+ term[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "term '*' factor"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12836,7 +12419,7 @@ term_raw(Parser *p)
             _res = _PyAST_BinOp ( a , Mult , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12847,7 +12430,7 @@ term_raw(Parser *p)
     }
     { // term '/' factor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> term[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "term '/' factor"));
@@ -12865,7 +12448,7 @@ term_raw(Parser *p)
             D(fprintf(stderr, "%*c+ term[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "term '/' factor"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12875,7 +12458,7 @@ term_raw(Parser *p)
             _res = _PyAST_BinOp ( a , Div , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12886,7 +12469,7 @@ term_raw(Parser *p)
     }
     { // term '//' factor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> term[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "term '//' factor"));
@@ -12904,7 +12487,7 @@ term_raw(Parser *p)
             D(fprintf(stderr, "%*c+ term[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "term '//' factor"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12914,7 +12497,7 @@ term_raw(Parser *p)
             _res = _PyAST_BinOp ( a , FloorDiv , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12925,7 +12508,7 @@ term_raw(Parser *p)
     }
     { // term '%' factor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> term[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "term '%' factor"));
@@ -12943,7 +12526,7 @@ term_raw(Parser *p)
             D(fprintf(stderr, "%*c+ term[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "term '%' factor"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12953,7 +12536,7 @@ term_raw(Parser *p)
             _res = _PyAST_BinOp ( a , Mod , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -12964,7 +12547,7 @@ term_raw(Parser *p)
     }
     { // term '@' factor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> term[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "term '@' factor"));
@@ -12982,7 +12565,7 @@ term_raw(Parser *p)
             D(fprintf(stderr, "%*c+ term[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "term '@' factor"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -12992,7 +12575,7 @@ term_raw(Parser *p)
             _res = CHECK_VERSION ( expr_ty , 5 , "The '@' operator is" , _PyAST_BinOp ( a , MatMult , b , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13003,7 +12586,7 @@ term_raw(Parser *p)
     }
     { // factor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> term[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "factor"));
@@ -13022,7 +12605,7 @@ term_raw(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -13030,23 +12613,20 @@ term_raw(Parser *p)
 static expr_ty
 factor_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, factor_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -13055,7 +12635,7 @@ factor_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '+' factor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> factor[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'+' factor"));
@@ -13070,7 +12650,7 @@ factor_rule(Parser *p)
             D(fprintf(stderr, "%*c+ factor[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'+' factor"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13080,7 +12660,7 @@ factor_rule(Parser *p)
             _res = _PyAST_UnaryOp ( UAdd , a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13091,7 +12671,7 @@ factor_rule(Parser *p)
     }
     { // '-' factor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> factor[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'-' factor"));
@@ -13106,7 +12686,7 @@ factor_rule(Parser *p)
             D(fprintf(stderr, "%*c+ factor[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'-' factor"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13116,7 +12696,7 @@ factor_rule(Parser *p)
             _res = _PyAST_UnaryOp ( USub , a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13127,7 +12707,7 @@ factor_rule(Parser *p)
     }
     { // '~' factor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> factor[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'~' factor"));
@@ -13142,7 +12722,7 @@ factor_rule(Parser *p)
             D(fprintf(stderr, "%*c+ factor[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'~' factor"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13152,7 +12732,7 @@ factor_rule(Parser *p)
             _res = _PyAST_UnaryOp ( Invert , a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13163,7 +12743,7 @@ factor_rule(Parser *p)
     }
     { // power
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> factor[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "power"));
@@ -13183,7 +12763,7 @@ factor_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, factor_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -13191,19 +12771,16 @@ factor_rule(Parser *p)
 static expr_ty
 power_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -13212,7 +12789,7 @@ power_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // await_primary '**' factor
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> power[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "await_primary '**' factor"));
@@ -13230,7 +12807,7 @@ power_rule(Parser *p)
             D(fprintf(stderr, "%*c+ power[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "await_primary '**' factor"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13240,7 +12817,7 @@ power_rule(Parser *p)
             _res = _PyAST_BinOp ( a , Pow , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13251,7 +12828,7 @@ power_rule(Parser *p)
     }
     { // await_primary
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> power[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "await_primary"));
@@ -13270,7 +12847,7 @@ power_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -13278,23 +12855,20 @@ power_rule(Parser *p)
 static expr_ty
 await_primary_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, await_primary_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -13303,7 +12877,7 @@ await_primary_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // AWAIT primary
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> await_primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "AWAIT primary"));
@@ -13318,7 +12892,7 @@ await_primary_rule(Parser *p)
             D(fprintf(stderr, "%*c+ await_primary[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "AWAIT primary"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13328,7 +12902,7 @@ await_primary_rule(Parser *p)
             _res = CHECK_VERSION ( expr_ty , 5 , "Await expressions are" , _PyAST_Await ( a , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13339,7 +12913,7 @@ await_primary_rule(Parser *p)
     }
     { // primary
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> await_primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "primary"));
@@ -13359,7 +12933,7 @@ await_primary_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, await_primary_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -13374,13 +12948,10 @@ static expr_ty primary_raw(Parser *);
 static expr_ty
 primary_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, primary_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
@@ -13388,42 +12959,37 @@ primary_rule(Parser *p)
     while (1) {
         int tmpvar_8 = _PyPegen_update_memo(p, _mark, primary_type, _res);
         if (tmpvar_8) {
-            p->level--;
+            D(p->level--);
             return _res;
         }
         p->mark = _mark;
         p->in_raw_rule++;
         void *_raw = primary_raw(p);
         p->in_raw_rule--;
-        if (p->error_indicator) {
-            p->level--;
+        if (p->error_indicator)
             return NULL;
-        }
         if (_raw == NULL || p->mark <= _resmark)
             break;
         _resmark = p->mark;
         _res = _raw;
     }
     p->mark = _resmark;
-    p->level--;
+    D(p->level--);
     return _res;
 }
 static expr_ty
 primary_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -13432,7 +12998,7 @@ primary_raw(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // primary '.' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "primary '.' NAME"));
@@ -13450,7 +13016,7 @@ primary_raw(Parser *p)
             D(fprintf(stderr, "%*c+ primary[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "primary '.' NAME"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13460,7 +13026,7 @@ primary_raw(Parser *p)
             _res = _PyAST_Attribute ( a , b -> v . Name . id , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13471,7 +13037,7 @@ primary_raw(Parser *p)
     }
     { // primary genexp
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "primary genexp"));
@@ -13486,7 +13052,7 @@ primary_raw(Parser *p)
             D(fprintf(stderr, "%*c+ primary[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "primary genexp"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13496,7 +13062,7 @@ primary_raw(Parser *p)
             _res = _PyAST_Call ( a , CHECK ( asdl_expr_seq* , ( asdl_expr_seq* ) _PyPegen_singleton_seq ( p , b ) ) , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13507,7 +13073,7 @@ primary_raw(Parser *p)
     }
     { // primary '(' arguments? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "primary '(' arguments? ')'"));
@@ -13528,7 +13094,7 @@ primary_raw(Parser *p)
             D(fprintf(stderr, "%*c+ primary[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "primary '(' arguments? ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13538,7 +13104,7 @@ primary_raw(Parser *p)
             _res = _PyAST_Call ( a , ( b ) ? ( ( expr_ty ) b ) -> v . Call . args : NULL , ( b ) ? ( ( expr_ty ) b ) -> v . Call . keywords : NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13549,7 +13115,7 @@ primary_raw(Parser *p)
     }
     { // primary '[' slices ']'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "primary '[' slices ']'"));
@@ -13570,7 +13136,7 @@ primary_raw(Parser *p)
             D(fprintf(stderr, "%*c+ primary[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "primary '[' slices ']'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13580,7 +13146,7 @@ primary_raw(Parser *p)
             _res = _PyAST_Subscript ( a , b , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13591,7 +13157,7 @@ primary_raw(Parser *p)
     }
     { // atom
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "atom"));
@@ -13610,7 +13176,7 @@ primary_raw(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -13618,19 +13184,16 @@ primary_raw(Parser *p)
 static expr_ty
 slices_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -13639,7 +13202,7 @@ slices_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // slice !','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> slices[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "slice !','"));
@@ -13654,7 +13217,7 @@ slices_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13665,7 +13228,7 @@ slices_rule(Parser *p)
     }
     { // ','.slice+ ','?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> slices[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.slice+ ','?"));
@@ -13681,7 +13244,7 @@ slices_rule(Parser *p)
             D(fprintf(stderr, "%*c+ slices[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.slice+ ','?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13691,7 +13254,7 @@ slices_rule(Parser *p)
             _res = _PyAST_Tuple ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13702,7 +13265,7 @@ slices_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -13710,19 +13273,16 @@ slices_rule(Parser *p)
 static expr_ty
 slice_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -13731,7 +13291,7 @@ slice_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // expression? ':' expression? [':' expression?]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> slice[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression? ':' expression? [':' expression?]"));
@@ -13752,7 +13312,7 @@ slice_rule(Parser *p)
             D(fprintf(stderr, "%*c+ slice[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expression? ':' expression? [':' expression?]"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13762,7 +13322,7 @@ slice_rule(Parser *p)
             _res = _PyAST_Slice ( a , b , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13773,7 +13333,7 @@ slice_rule(Parser *p)
     }
     { // named_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> slice[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "named_expression"));
@@ -13786,7 +13346,7 @@ slice_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13797,7 +13357,7 @@ slice_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -13815,19 +13375,16 @@ slice_rule(Parser *p)
 static expr_ty
 atom_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -13836,7 +13393,7 @@ atom_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME"));
@@ -13855,7 +13412,7 @@ atom_rule(Parser *p)
     }
     { // 'True'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'True'"));
@@ -13867,7 +13424,7 @@ atom_rule(Parser *p)
             D(fprintf(stderr, "%*c+ atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'True'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13877,7 +13434,7 @@ atom_rule(Parser *p)
             _res = _PyAST_Constant ( Py_True , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13888,7 +13445,7 @@ atom_rule(Parser *p)
     }
     { // 'False'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'False'"));
@@ -13900,7 +13457,7 @@ atom_rule(Parser *p)
             D(fprintf(stderr, "%*c+ atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'False'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13910,7 +13467,7 @@ atom_rule(Parser *p)
             _res = _PyAST_Constant ( Py_False , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13921,7 +13478,7 @@ atom_rule(Parser *p)
     }
     { // 'None'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'None'"));
@@ -13933,7 +13490,7 @@ atom_rule(Parser *p)
             D(fprintf(stderr, "%*c+ atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'None'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -13943,7 +13500,7 @@ atom_rule(Parser *p)
             _res = _PyAST_Constant ( Py_None , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -13954,7 +13511,7 @@ atom_rule(Parser *p)
     }
     { // &STRING strings
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&STRING strings"));
@@ -13975,7 +13532,7 @@ atom_rule(Parser *p)
     }
     { // NUMBER
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NUMBER"));
@@ -13994,7 +13551,7 @@ atom_rule(Parser *p)
     }
     { // &'(' (tuple | group | genexp)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'(' (tuple | group | genexp)"));
@@ -14015,7 +13572,7 @@ atom_rule(Parser *p)
     }
     { // &'[' (list | listcomp)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'[' (list | listcomp)"));
@@ -14036,7 +13593,7 @@ atom_rule(Parser *p)
     }
     { // &'{' (dict | set | dictcomp | setcomp)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'{' (dict | set | dictcomp | setcomp)"));
@@ -14057,7 +13614,7 @@ atom_rule(Parser *p)
     }
     { // '...'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'...'"));
@@ -14069,7 +13626,7 @@ atom_rule(Parser *p)
             D(fprintf(stderr, "%*c+ atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'...'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -14079,7 +13636,7 @@ atom_rule(Parser *p)
             _res = _PyAST_Constant ( Py_Ellipsis , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14090,7 +13647,7 @@ atom_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -14098,19 +13655,16 @@ atom_rule(Parser *p)
 static expr_ty
 group_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // '(' (yield_expr | named_expression) ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> group[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' (yield_expr | named_expression) ')'"));
@@ -14129,7 +13683,7 @@ group_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14140,7 +13694,7 @@ group_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_group
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> group[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_group"));
@@ -14159,7 +13713,7 @@ group_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -14167,19 +13721,16 @@ group_rule(Parser *p)
 static expr_ty
 lambdef_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -14188,7 +13739,7 @@ lambdef_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'lambda' lambda_params? ':' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambdef[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'lambda' lambda_params? ':' expression"));
@@ -14209,7 +13760,7 @@ lambdef_rule(Parser *p)
             D(fprintf(stderr, "%*c+ lambdef[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'lambda' lambda_params? ':' expression"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -14219,7 +13770,7 @@ lambdef_rule(Parser *p)
             _res = _PyAST_Lambda ( ( a ) ? a : CHECK ( arguments_ty , _PyPegen_empty_arguments ( p ) ) , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14230,7 +13781,7 @@ lambdef_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -14238,19 +13789,16 @@ lambdef_rule(Parser *p)
 static arguments_ty
 lambda_params_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     arguments_ty _res = NULL;
     int _mark = p->mark;
     if (p->call_invalid_rules) { // invalid_lambda_parameters
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_params[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_lambda_parameters"));
@@ -14269,7 +13817,7 @@ lambda_params_rule(Parser *p)
     }
     { // lambda_parameters
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_params[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_parameters"));
@@ -14288,7 +13836,7 @@ lambda_params_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -14301,19 +13849,16 @@ lambda_params_rule(Parser *p)
 static arguments_ty
 lambda_parameters_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     arguments_ty _res = NULL;
     int _mark = p->mark;
     { // lambda_slash_no_default lambda_param_no_default* lambda_param_with_default* lambda_star_etc?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_slash_no_default lambda_param_no_default* lambda_param_with_default* lambda_star_etc?"));
@@ -14335,7 +13880,7 @@ lambda_parameters_rule(Parser *p)
             _res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14346,7 +13891,7 @@ lambda_parameters_rule(Parser *p)
     }
     { // lambda_slash_with_default lambda_param_with_default* lambda_star_etc?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_slash_with_default lambda_param_with_default* lambda_star_etc?"));
@@ -14365,7 +13910,7 @@ lambda_parameters_rule(Parser *p)
             _res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14376,7 +13921,7 @@ lambda_parameters_rule(Parser *p)
     }
     { // lambda_param_no_default+ lambda_param_with_default* lambda_star_etc?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default+ lambda_param_with_default* lambda_star_etc?"));
@@ -14395,7 +13940,7 @@ lambda_parameters_rule(Parser *p)
             _res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14406,7 +13951,7 @@ lambda_parameters_rule(Parser *p)
     }
     { // lambda_param_with_default+ lambda_star_etc?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_with_default+ lambda_star_etc?"));
@@ -14422,7 +13967,7 @@ lambda_parameters_rule(Parser *p)
             _res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14433,7 +13978,7 @@ lambda_parameters_rule(Parser *p)
     }
     { // lambda_star_etc
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_star_etc"));
@@ -14446,7 +13991,7 @@ lambda_parameters_rule(Parser *p)
             _res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , NULL , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14457,7 +14002,7 @@ lambda_parameters_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -14467,19 +14012,16 @@ lambda_parameters_rule(Parser *p)
 static asdl_arg_seq*
 lambda_slash_no_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_arg_seq* _res = NULL;
     int _mark = p->mark;
     { // lambda_param_no_default+ '/' ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_slash_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default+ '/' ','"));
@@ -14498,7 +14040,7 @@ lambda_slash_no_default_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14509,7 +14051,7 @@ lambda_slash_no_default_rule(Parser *p)
     }
     { // lambda_param_no_default+ '/' &':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_slash_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default+ '/' &':'"));
@@ -14527,7 +14069,7 @@ lambda_slash_no_default_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14538,7 +14080,7 @@ lambda_slash_no_default_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -14548,19 +14090,16 @@ lambda_slash_no_default_rule(Parser *p)
 static SlashWithDefault*
 lambda_slash_with_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     SlashWithDefault* _res = NULL;
     int _mark = p->mark;
     { // lambda_param_no_default* lambda_param_with_default+ '/' ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_slash_with_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default* lambda_param_with_default+ '/' ','"));
@@ -14582,7 +14121,7 @@ lambda_slash_with_default_rule(Parser *p)
             _res = _PyPegen_slash_with_default ( p , ( asdl_arg_seq* ) a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14593,7 +14132,7 @@ lambda_slash_with_default_rule(Parser *p)
     }
     { // lambda_param_no_default* lambda_param_with_default+ '/' &':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_slash_with_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default* lambda_param_with_default+ '/' &':'"));
@@ -14614,7 +14153,7 @@ lambda_slash_with_default_rule(Parser *p)
             _res = _PyPegen_slash_with_default ( p , ( asdl_arg_seq* ) a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14625,7 +14164,7 @@ lambda_slash_with_default_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -14637,19 +14176,16 @@ lambda_slash_with_default_rule(Parser *p)
 static StarEtc*
 lambda_star_etc_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     StarEtc* _res = NULL;
     int _mark = p->mark;
     { // '*' lambda_param_no_default lambda_param_maybe_default* lambda_kwds?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_star_etc[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' lambda_param_no_default lambda_param_maybe_default* lambda_kwds?"));
@@ -14671,7 +14207,7 @@ lambda_star_etc_rule(Parser *p)
             _res = _PyPegen_star_etc ( p , a , b , c );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14682,7 +14218,7 @@ lambda_star_etc_rule(Parser *p)
     }
     { // '*' ',' lambda_param_maybe_default+ lambda_kwds?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_star_etc[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' ',' lambda_param_maybe_default+ lambda_kwds?"));
@@ -14704,7 +14240,7 @@ lambda_star_etc_rule(Parser *p)
             _res = _PyPegen_star_etc ( p , NULL , b , c );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14715,7 +14251,7 @@ lambda_star_etc_rule(Parser *p)
     }
     { // lambda_kwds
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_star_etc[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_kwds"));
@@ -14728,7 +14264,7 @@ lambda_star_etc_rule(Parser *p)
             _res = _PyPegen_star_etc ( p , NULL , NULL , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14739,7 +14275,7 @@ lambda_star_etc_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_lambda_star_etc
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_star_etc[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_lambda_star_etc"));
@@ -14758,7 +14294,7 @@ lambda_star_etc_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -14766,19 +14302,16 @@ lambda_star_etc_rule(Parser *p)
 static arg_ty
 lambda_kwds_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // '**' lambda_param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_kwds[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**' lambda_param_no_default"));
@@ -14794,7 +14327,7 @@ lambda_kwds_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14805,7 +14338,7 @@ lambda_kwds_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -14813,19 +14346,16 @@ lambda_kwds_rule(Parser *p)
 static arg_ty
 lambda_param_no_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // lambda_param ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_param_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param ','"));
@@ -14841,7 +14371,7 @@ lambda_param_no_default_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14852,7 +14382,7 @@ lambda_param_no_default_rule(Parser *p)
     }
     { // lambda_param &':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_param_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param &':'"));
@@ -14867,7 +14397,7 @@ lambda_param_no_default_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14878,7 +14408,7 @@ lambda_param_no_default_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -14886,19 +14416,16 @@ lambda_param_no_default_rule(Parser *p)
 static NameDefaultPair*
 lambda_param_with_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // lambda_param default ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_param_with_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param default ','"));
@@ -14917,7 +14444,7 @@ lambda_param_with_default_rule(Parser *p)
             _res = _PyPegen_name_default_pair ( p , a , c , NULL );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14928,7 +14455,7 @@ lambda_param_with_default_rule(Parser *p)
     }
     { // lambda_param default &':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_param_with_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param default &':'"));
@@ -14946,7 +14473,7 @@ lambda_param_with_default_rule(Parser *p)
             _res = _PyPegen_name_default_pair ( p , a , c , NULL );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -14957,7 +14484,7 @@ lambda_param_with_default_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -14965,19 +14492,16 @@ lambda_param_with_default_rule(Parser *p)
 static NameDefaultPair*
 lambda_param_maybe_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // lambda_param default? ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_param_maybe_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param default? ','"));
@@ -14996,7 +14520,7 @@ lambda_param_maybe_default_rule(Parser *p)
             _res = _PyPegen_name_default_pair ( p , a , c , NULL );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15007,7 +14531,7 @@ lambda_param_maybe_default_rule(Parser *p)
     }
     { // lambda_param default? &':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_param_maybe_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param default? &':'"));
@@ -15025,7 +14549,7 @@ lambda_param_maybe_default_rule(Parser *p)
             _res = _PyPegen_name_default_pair ( p , a , c , NULL );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15036,7 +14560,7 @@ lambda_param_maybe_default_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15044,19 +14568,16 @@ lambda_param_maybe_default_rule(Parser *p)
 static arg_ty
 lambda_param_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     arg_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -15065,7 +14586,7 @@ lambda_param_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_param[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME"));
@@ -15077,7 +14598,7 @@ lambda_param_rule(Parser *p)
             D(fprintf(stderr, "%*c+ lambda_param[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -15087,7 +14608,7 @@ lambda_param_rule(Parser *p)
             _res = _PyAST_arg ( a -> v . Name . id , NULL , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15098,7 +14619,7 @@ lambda_param_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15106,23 +14627,20 @@ lambda_param_rule(Parser *p)
 static expr_ty
 strings_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, strings_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     { // STRING+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> strings[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "STRING+"));
@@ -15135,7 +14653,7 @@ strings_rule(Parser *p)
             _res = _PyPegen_concatenate_strings ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15147,7 +14665,7 @@ strings_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, strings_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15155,19 +14673,16 @@ strings_rule(Parser *p)
 static expr_ty
 list_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -15176,7 +14691,7 @@ list_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '[' star_named_expressions? ']'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> list[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'[' star_named_expressions? ']'"));
@@ -15194,7 +14709,7 @@ list_rule(Parser *p)
             D(fprintf(stderr, "%*c+ list[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'[' star_named_expressions? ']'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -15204,7 +14719,7 @@ list_rule(Parser *p)
             _res = _PyAST_List ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15215,7 +14730,7 @@ list_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15223,19 +14738,16 @@ list_rule(Parser *p)
 static expr_ty
 tuple_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -15244,7 +14756,7 @@ tuple_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '(' [star_named_expression ',' star_named_expressions?] ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> tuple[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' [star_named_expression ',' star_named_expressions?] ')'"));
@@ -15262,7 +14774,7 @@ tuple_rule(Parser *p)
             D(fprintf(stderr, "%*c+ tuple[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' [star_named_expression ',' star_named_expressions?] ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -15272,7 +14784,7 @@ tuple_rule(Parser *p)
             _res = _PyAST_Tuple ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15283,7 +14795,7 @@ tuple_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15291,19 +14803,16 @@ tuple_rule(Parser *p)
 static expr_ty
 set_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -15312,7 +14821,7 @@ set_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '{' star_named_expressions '}'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> set[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{' star_named_expressions '}'"));
@@ -15330,7 +14839,7 @@ set_rule(Parser *p)
             D(fprintf(stderr, "%*c+ set[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'{' star_named_expressions '}'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -15340,7 +14849,7 @@ set_rule(Parser *p)
             _res = _PyAST_Set ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15351,7 +14860,7 @@ set_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15359,19 +14868,16 @@ set_rule(Parser *p)
 static expr_ty
 dict_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -15380,7 +14886,7 @@ dict_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '{' double_starred_kvpairs? '}'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> dict[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{' double_starred_kvpairs? '}'"));
@@ -15398,7 +14904,7 @@ dict_rule(Parser *p)
             D(fprintf(stderr, "%*c+ dict[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'{' double_starred_kvpairs? '}'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -15408,7 +14914,7 @@ dict_rule(Parser *p)
             _res = _PyAST_Dict ( CHECK ( asdl_expr_seq* , _PyPegen_get_keys ( p , a ) ) , CHECK ( asdl_expr_seq* , _PyPegen_get_values ( p , a ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15419,7 +14925,7 @@ dict_rule(Parser *p)
     }
     { // '{' invalid_double_starred_kvpairs '}'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> dict[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{' invalid_double_starred_kvpairs '}'"));
@@ -15444,7 +14950,7 @@ dict_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15452,19 +14958,16 @@ dict_rule(Parser *p)
 static asdl_seq*
 double_starred_kvpairs_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.double_starred_kvpair+ ','?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> double_starred_kvpairs[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.double_starred_kvpair+ ','?"));
@@ -15481,7 +14984,7 @@ double_starred_kvpairs_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15492,7 +14995,7 @@ double_starred_kvpairs_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15500,19 +15003,16 @@ double_starred_kvpairs_rule(Parser *p)
 static KeyValuePair*
 double_starred_kvpair_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     KeyValuePair* _res = NULL;
     int _mark = p->mark;
     { // '**' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> double_starred_kvpair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**' bitwise_or"));
@@ -15528,7 +15028,7 @@ double_starred_kvpair_rule(Parser *p)
             _res = _PyPegen_key_value_pair ( p , NULL , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15539,7 +15039,7 @@ double_starred_kvpair_rule(Parser *p)
     }
     { // kvpair
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> double_starred_kvpair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "kvpair"));
@@ -15558,7 +15058,7 @@ double_starred_kvpair_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15566,19 +15066,16 @@ double_starred_kvpair_rule(Parser *p)
 static KeyValuePair*
 kvpair_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     KeyValuePair* _res = NULL;
     int _mark = p->mark;
     { // expression ':' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> kvpair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ':' expression"));
@@ -15597,7 +15094,7 @@ kvpair_rule(Parser *p)
             _res = _PyPegen_key_value_pair ( p , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15608,7 +15105,7 @@ kvpair_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15616,19 +15113,16 @@ kvpair_rule(Parser *p)
 static asdl_comprehension_seq*
 for_if_clauses_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_comprehension_seq* _res = NULL;
     int _mark = p->mark;
     { // for_if_clause+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> for_if_clauses[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "for_if_clause+"));
@@ -15641,7 +15135,7 @@ for_if_clauses_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15652,7 +15146,7 @@ for_if_clauses_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15663,19 +15157,16 @@ for_if_clauses_rule(Parser *p)
 static comprehension_ty
 for_if_clause_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     comprehension_ty _res = NULL;
     int _mark = p->mark;
     { // ASYNC 'for' star_targets 'in' ~ disjunction (('if' disjunction))*
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> for_if_clause[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC 'for' star_targets 'in' ~ disjunction (('if' disjunction))*"));
@@ -15706,7 +15197,7 @@ for_if_clause_rule(Parser *p)
             _res = CHECK_VERSION ( comprehension_ty , 6 , "Async comprehensions are" , _PyAST_comprehension ( a , b , c , 1 , p -> arena ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15715,13 +15206,13 @@ for_if_clause_rule(Parser *p)
         D(fprintf(stderr, "%*c%s for_if_clause[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "ASYNC 'for' star_targets 'in' ~ disjunction (('if' disjunction))*"));
         if (_cut_var) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
     }
     { // 'for' star_targets 'in' ~ disjunction (('if' disjunction))*
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> for_if_clause[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'for' star_targets 'in' ~ disjunction (('if' disjunction))*"));
@@ -15749,7 +15240,7 @@ for_if_clause_rule(Parser *p)
             _res = _PyAST_comprehension ( a , b , c , 0 , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15758,13 +15249,13 @@ for_if_clause_rule(Parser *p)
         D(fprintf(stderr, "%*c%s for_if_clause[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'for' star_targets 'in' ~ disjunction (('if' disjunction))*"));
         if (_cut_var) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
     }
     if (p->call_invalid_rules) { // invalid_for_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> for_if_clause[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_for_target"));
@@ -15783,7 +15274,7 @@ for_if_clause_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15791,19 +15282,16 @@ for_if_clause_rule(Parser *p)
 static expr_ty
 listcomp_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -15812,7 +15300,7 @@ listcomp_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '[' named_expression for_if_clauses ']'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> listcomp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'[' named_expression for_if_clauses ']'"));
@@ -15833,7 +15321,7 @@ listcomp_rule(Parser *p)
             D(fprintf(stderr, "%*c+ listcomp[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'[' named_expression for_if_clauses ']'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -15843,7 +15331,7 @@ listcomp_rule(Parser *p)
             _res = _PyAST_ListComp ( a , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15854,7 +15342,7 @@ listcomp_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_comprehension
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> listcomp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_comprehension"));
@@ -15873,7 +15361,7 @@ listcomp_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15881,19 +15369,16 @@ listcomp_rule(Parser *p)
 static expr_ty
 setcomp_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -15902,7 +15387,7 @@ setcomp_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '{' named_expression for_if_clauses '}'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> setcomp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{' named_expression for_if_clauses '}'"));
@@ -15923,7 +15408,7 @@ setcomp_rule(Parser *p)
             D(fprintf(stderr, "%*c+ setcomp[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'{' named_expression for_if_clauses '}'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -15933,7 +15418,7 @@ setcomp_rule(Parser *p)
             _res = _PyAST_SetComp ( a , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -15944,7 +15429,7 @@ setcomp_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_comprehension
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> setcomp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_comprehension"));
@@ -15963,7 +15448,7 @@ setcomp_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -15973,19 +15458,16 @@ setcomp_rule(Parser *p)
 static expr_ty
 genexp_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -15994,7 +15476,7 @@ genexp_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '(' (assignment_expression | expression !':=') for_if_clauses ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> genexp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' (assignment_expression | expression !':=') for_if_clauses ')'"));
@@ -16015,7 +15497,7 @@ genexp_rule(Parser *p)
             D(fprintf(stderr, "%*c+ genexp[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' (assignment_expression | expression !':=') for_if_clauses ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -16025,7 +15507,7 @@ genexp_rule(Parser *p)
             _res = _PyAST_GeneratorExp ( a , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16036,7 +15518,7 @@ genexp_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_comprehension
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> genexp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_comprehension"));
@@ -16055,7 +15537,7 @@ genexp_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -16063,19 +15545,16 @@ genexp_rule(Parser *p)
 static expr_ty
 dictcomp_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -16084,7 +15563,7 @@ dictcomp_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '{' kvpair for_if_clauses '}'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> dictcomp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{' kvpair for_if_clauses '}'"));
@@ -16105,7 +15584,7 @@ dictcomp_rule(Parser *p)
             D(fprintf(stderr, "%*c+ dictcomp[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'{' kvpair for_if_clauses '}'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -16115,7 +15594,7 @@ dictcomp_rule(Parser *p)
             _res = _PyAST_DictComp ( a -> key , a -> value , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16126,7 +15605,7 @@ dictcomp_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_dict_comprehension
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> dictcomp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_dict_comprehension"));
@@ -16145,7 +15624,7 @@ dictcomp_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -16153,23 +15632,20 @@ dictcomp_rule(Parser *p)
 static expr_ty
 arguments_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, arguments_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     { // args ','? &')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> arguments[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "args ','? &')'"));
@@ -16188,7 +15664,7 @@ arguments_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16199,7 +15675,7 @@ arguments_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_arguments
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> arguments[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_arguments"));
@@ -16219,7 +15695,7 @@ arguments_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, arguments_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -16229,19 +15705,16 @@ arguments_rule(Parser *p)
 static expr_ty
 args_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -16250,7 +15723,7 @@ args_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // ','.(starred_expression | (assignment_expression | expression !':=') !'=')+ [',' kwargs]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> args[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.(starred_expression | (assignment_expression | expression !':=') !'=')+ [',' kwargs]"));
@@ -16265,7 +15738,7 @@ args_rule(Parser *p)
             D(fprintf(stderr, "%*c+ args[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.(starred_expression | (assignment_expression | expression !':=') !'=')+ [',' kwargs]"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -16275,7 +15748,7 @@ args_rule(Parser *p)
             _res = _PyPegen_collect_call_seqs ( p , a , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16286,7 +15759,7 @@ args_rule(Parser *p)
     }
     { // kwargs
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> args[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "kwargs"));
@@ -16298,7 +15771,7 @@ args_rule(Parser *p)
             D(fprintf(stderr, "%*c+ args[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "kwargs"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -16308,7 +15781,7 @@ args_rule(Parser *p)
             _res = _PyAST_Call ( _PyPegen_dummy_name ( p ) , CHECK_NULL_ALLOWED ( asdl_expr_seq* , _PyPegen_seq_extract_starred_exprs ( p , a ) ) , CHECK_NULL_ALLOWED ( asdl_keyword_seq* , _PyPegen_seq_delete_starred_exprs ( p , a ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16319,7 +15792,7 @@ args_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -16330,19 +15803,16 @@ args_rule(Parser *p)
 static asdl_seq*
 kwargs_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.kwarg_or_starred+ ',' ','.kwarg_or_double_starred+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> kwargs[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.kwarg_or_starred+ ',' ','.kwarg_or_double_starred+"));
@@ -16361,7 +15831,7 @@ kwargs_rule(Parser *p)
             _res = _PyPegen_join_sequences ( p , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16372,7 +15842,7 @@ kwargs_rule(Parser *p)
     }
     { // ','.kwarg_or_starred+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> kwargs[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.kwarg_or_starred+"));
@@ -16391,7 +15861,7 @@ kwargs_rule(Parser *p)
     }
     { // ','.kwarg_or_double_starred+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> kwargs[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.kwarg_or_double_starred+"));
@@ -16410,7 +15880,7 @@ kwargs_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -16418,19 +15888,16 @@ kwargs_rule(Parser *p)
 static expr_ty
 starred_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -16439,7 +15906,7 @@ starred_expression_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '*' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> starred_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' expression"));
@@ -16454,7 +15921,7 @@ starred_expression_rule(Parser *p)
             D(fprintf(stderr, "%*c+ starred_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' expression"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -16464,7 +15931,7 @@ starred_expression_rule(Parser *p)
             _res = _PyAST_Starred ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16475,7 +15942,7 @@ starred_expression_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -16483,19 +15950,16 @@ starred_expression_rule(Parser *p)
 static KeywordOrStarred*
 kwarg_or_starred_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     KeywordOrStarred* _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -16504,7 +15968,7 @@ kwarg_or_starred_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_kwarg
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> kwarg_or_starred[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_kwarg"));
@@ -16523,7 +15987,7 @@ kwarg_or_starred_rule(Parser *p)
     }
     { // NAME '=' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> kwarg_or_starred[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME '=' expression"));
@@ -16541,7 +16005,7 @@ kwarg_or_starred_rule(Parser *p)
             D(fprintf(stderr, "%*c+ kwarg_or_starred[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME '=' expression"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -16551,7 +16015,7 @@ kwarg_or_starred_rule(Parser *p)
             _res = _PyPegen_keyword_or_starred ( p , CHECK ( keyword_ty , _PyAST_keyword ( a -> v . Name . id , b , EXTRA ) ) , 1 );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16562,7 +16026,7 @@ kwarg_or_starred_rule(Parser *p)
     }
     { // starred_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> kwarg_or_starred[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "starred_expression"));
@@ -16575,7 +16039,7 @@ kwarg_or_starred_rule(Parser *p)
             _res = _PyPegen_keyword_or_starred ( p , a , 0 );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16586,7 +16050,7 @@ kwarg_or_starred_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -16594,19 +16058,16 @@ kwarg_or_starred_rule(Parser *p)
 static KeywordOrStarred*
 kwarg_or_double_starred_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     KeywordOrStarred* _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -16615,7 +16076,7 @@ kwarg_or_double_starred_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     if (p->call_invalid_rules) { // invalid_kwarg
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> kwarg_or_double_starred[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_kwarg"));
@@ -16634,7 +16095,7 @@ kwarg_or_double_starred_rule(Parser *p)
     }
     { // NAME '=' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> kwarg_or_double_starred[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME '=' expression"));
@@ -16652,7 +16113,7 @@ kwarg_or_double_starred_rule(Parser *p)
             D(fprintf(stderr, "%*c+ kwarg_or_double_starred[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME '=' expression"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -16662,7 +16123,7 @@ kwarg_or_double_starred_rule(Parser *p)
             _res = _PyPegen_keyword_or_starred ( p , CHECK ( keyword_ty , _PyAST_keyword ( a -> v . Name . id , b , EXTRA ) ) , 1 );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16673,7 +16134,7 @@ kwarg_or_double_starred_rule(Parser *p)
     }
     { // '**' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> kwarg_or_double_starred[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**' expression"));
@@ -16688,7 +16149,7 @@ kwarg_or_double_starred_rule(Parser *p)
             D(fprintf(stderr, "%*c+ kwarg_or_double_starred[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'**' expression"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -16698,7 +16159,7 @@ kwarg_or_double_starred_rule(Parser *p)
             _res = _PyPegen_keyword_or_starred ( p , CHECK ( keyword_ty , _PyAST_keyword ( NULL , a , EXTRA ) ) , 1 );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16709,7 +16170,7 @@ kwarg_or_double_starred_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -16717,19 +16178,16 @@ kwarg_or_double_starred_rule(Parser *p)
 static expr_ty
 star_targets_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -16738,7 +16196,7 @@ star_targets_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // star_target !','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_target !','"));
@@ -16753,7 +16211,7 @@ star_targets_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16764,7 +16222,7 @@ star_targets_rule(Parser *p)
     }
     { // star_target ((',' star_target))* ','?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_target ((',' star_target))* ','?"));
@@ -16783,7 +16241,7 @@ star_targets_rule(Parser *p)
             D(fprintf(stderr, "%*c+ star_targets[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "star_target ((',' star_target))* ','?"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -16793,7 +16251,7 @@ star_targets_rule(Parser *p)
             _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq* , _PyPegen_seq_insert_in_front ( p , a , b ) ) , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16804,7 +16262,7 @@ star_targets_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -16812,19 +16270,16 @@ star_targets_rule(Parser *p)
 static asdl_expr_seq*
 star_targets_list_seq_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.star_target+ ','?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_targets_list_seq[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.star_target+ ','?"));
@@ -16841,7 +16296,7 @@ star_targets_list_seq_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16852,7 +16307,7 @@ star_targets_list_seq_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -16860,19 +16315,16 @@ star_targets_list_seq_rule(Parser *p)
 static asdl_expr_seq*
 star_targets_tuple_seq_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // star_target ((',' star_target))+ ','?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_targets_tuple_seq[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_target ((',' star_target))+ ','?"));
@@ -16892,7 +16344,7 @@ star_targets_tuple_seq_rule(Parser *p)
             _res = ( asdl_expr_seq* ) _PyPegen_seq_insert_in_front ( p , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16903,7 +16355,7 @@ star_targets_tuple_seq_rule(Parser *p)
     }
     { // star_target ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_targets_tuple_seq[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_target ','"));
@@ -16919,7 +16371,7 @@ star_targets_tuple_seq_rule(Parser *p)
             _res = ( asdl_expr_seq* ) _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16930,7 +16382,7 @@ star_targets_tuple_seq_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -16938,23 +16390,20 @@ star_targets_tuple_seq_rule(Parser *p)
 static expr_ty
 star_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, star_target_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -16963,7 +16412,7 @@ star_target_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '*' (!'*' star_target)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' (!'*' star_target)"));
@@ -16978,7 +16427,7 @@ star_target_rule(Parser *p)
             D(fprintf(stderr, "%*c+ star_target[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' (!'*' star_target)"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -16988,7 +16437,7 @@ star_target_rule(Parser *p)
             _res = _PyAST_Starred ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -16999,7 +16448,7 @@ star_target_rule(Parser *p)
     }
     { // target_with_star_atom
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "target_with_star_atom"));
@@ -17019,7 +16468,7 @@ star_target_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, star_target_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -17030,23 +16479,20 @@ star_target_rule(Parser *p)
 static expr_ty
 target_with_star_atom_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, target_with_star_atom_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -17055,7 +16501,7 @@ target_with_star_atom_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // t_primary '.' NAME !t_lookahead
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> target_with_star_atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "t_primary '.' NAME !t_lookahead"));
@@ -17075,7 +16521,7 @@ target_with_star_atom_rule(Parser *p)
             D(fprintf(stderr, "%*c+ target_with_star_atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "t_primary '.' NAME !t_lookahead"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -17085,7 +16531,7 @@ target_with_star_atom_rule(Parser *p)
             _res = _PyAST_Attribute ( a , b -> v . Name . id , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17096,7 +16542,7 @@ target_with_star_atom_rule(Parser *p)
     }
     { // t_primary '[' slices ']' !t_lookahead
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> target_with_star_atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "t_primary '[' slices ']' !t_lookahead"));
@@ -17119,7 +16565,7 @@ target_with_star_atom_rule(Parser *p)
             D(fprintf(stderr, "%*c+ target_with_star_atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "t_primary '[' slices ']' !t_lookahead"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -17129,7 +16575,7 @@ target_with_star_atom_rule(Parser *p)
             _res = _PyAST_Subscript ( a , b , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17140,7 +16586,7 @@ target_with_star_atom_rule(Parser *p)
     }
     { // star_atom
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> target_with_star_atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_atom"));
@@ -17160,7 +16606,7 @@ target_with_star_atom_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, target_with_star_atom_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -17172,19 +16618,16 @@ target_with_star_atom_rule(Parser *p)
 static expr_ty
 star_atom_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -17193,7 +16636,7 @@ star_atom_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME"));
@@ -17206,7 +16649,7 @@ star_atom_rule(Parser *p)
             _res = _PyPegen_set_expr_context ( p , a , Store );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17217,7 +16660,7 @@ star_atom_rule(Parser *p)
     }
     { // '(' target_with_star_atom ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' target_with_star_atom ')'"));
@@ -17236,7 +16679,7 @@ star_atom_rule(Parser *p)
             _res = _PyPegen_set_expr_context ( p , a , Store );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17247,7 +16690,7 @@ star_atom_rule(Parser *p)
     }
     { // '(' star_targets_tuple_seq? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' star_targets_tuple_seq? ')'"));
@@ -17265,7 +16708,7 @@ star_atom_rule(Parser *p)
             D(fprintf(stderr, "%*c+ star_atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' star_targets_tuple_seq? ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -17275,7 +16718,7 @@ star_atom_rule(Parser *p)
             _res = _PyAST_Tuple ( a , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17286,7 +16729,7 @@ star_atom_rule(Parser *p)
     }
     { // '[' star_targets_list_seq? ']'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> star_atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'[' star_targets_list_seq? ']'"));
@@ -17304,7 +16747,7 @@ star_atom_rule(Parser *p)
             D(fprintf(stderr, "%*c+ star_atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'[' star_targets_list_seq? ']'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -17314,7 +16757,7 @@ star_atom_rule(Parser *p)
             _res = _PyAST_List ( a , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17325,7 +16768,7 @@ star_atom_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -17333,19 +16776,16 @@ star_atom_rule(Parser *p)
 static expr_ty
 single_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // single_subscript_attribute_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> single_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "single_subscript_attribute_target"));
@@ -17364,7 +16804,7 @@ single_target_rule(Parser *p)
     }
     { // NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> single_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME"));
@@ -17377,7 +16817,7 @@ single_target_rule(Parser *p)
             _res = _PyPegen_set_expr_context ( p , a , Store );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17388,7 +16828,7 @@ single_target_rule(Parser *p)
     }
     { // '(' single_target ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> single_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' single_target ')'"));
@@ -17407,7 +16847,7 @@ single_target_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17418,7 +16858,7 @@ single_target_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -17428,19 +16868,16 @@ single_target_rule(Parser *p)
 static expr_ty
 single_subscript_attribute_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -17449,7 +16886,7 @@ single_subscript_attribute_target_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // t_primary '.' NAME !t_lookahead
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> single_subscript_attribute_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "t_primary '.' NAME !t_lookahead"));
@@ -17469,7 +16906,7 @@ single_subscript_attribute_target_rule(Parser *p)
             D(fprintf(stderr, "%*c+ single_subscript_attribute_target[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "t_primary '.' NAME !t_lookahead"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -17479,7 +16916,7 @@ single_subscript_attribute_target_rule(Parser *p)
             _res = _PyAST_Attribute ( a , b -> v . Name . id , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17490,7 +16927,7 @@ single_subscript_attribute_target_rule(Parser *p)
     }
     { // t_primary '[' slices ']' !t_lookahead
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> single_subscript_attribute_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "t_primary '[' slices ']' !t_lookahead"));
@@ -17513,7 +16950,7 @@ single_subscript_attribute_target_rule(Parser *p)
             D(fprintf(stderr, "%*c+ single_subscript_attribute_target[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "t_primary '[' slices ']' !t_lookahead"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -17523,7 +16960,7 @@ single_subscript_attribute_target_rule(Parser *p)
             _res = _PyAST_Subscript ( a , b , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17534,7 +16971,7 @@ single_subscript_attribute_target_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -17549,13 +16986,10 @@ static expr_ty t_primary_raw(Parser *);
 static expr_ty
 t_primary_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, t_primary_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
@@ -17563,42 +16997,37 @@ t_primary_rule(Parser *p)
     while (1) {
         int tmpvar_9 = _PyPegen_update_memo(p, _mark, t_primary_type, _res);
         if (tmpvar_9) {
-            p->level--;
+            D(p->level--);
             return _res;
         }
         p->mark = _mark;
         p->in_raw_rule++;
         void *_raw = t_primary_raw(p);
         p->in_raw_rule--;
-        if (p->error_indicator) {
-            p->level--;
+        if (p->error_indicator)
             return NULL;
-        }
         if (_raw == NULL || p->mark <= _resmark)
             break;
         _resmark = p->mark;
         _res = _raw;
     }
     p->mark = _resmark;
-    p->level--;
+    D(p->level--);
     return _res;
 }
 static expr_ty
 t_primary_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -17607,7 +17036,7 @@ t_primary_raw(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // t_primary '.' NAME &t_lookahead
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> t_primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "t_primary '.' NAME &t_lookahead"));
@@ -17627,7 +17056,7 @@ t_primary_raw(Parser *p)
             D(fprintf(stderr, "%*c+ t_primary[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "t_primary '.' NAME &t_lookahead"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -17637,7 +17066,7 @@ t_primary_raw(Parser *p)
             _res = _PyAST_Attribute ( a , b -> v . Name . id , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17648,7 +17077,7 @@ t_primary_raw(Parser *p)
     }
     { // t_primary '[' slices ']' &t_lookahead
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> t_primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "t_primary '[' slices ']' &t_lookahead"));
@@ -17671,7 +17100,7 @@ t_primary_raw(Parser *p)
             D(fprintf(stderr, "%*c+ t_primary[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "t_primary '[' slices ']' &t_lookahead"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -17681,7 +17110,7 @@ t_primary_raw(Parser *p)
             _res = _PyAST_Subscript ( a , b , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17692,7 +17121,7 @@ t_primary_raw(Parser *p)
     }
     { // t_primary genexp &t_lookahead
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> t_primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "t_primary genexp &t_lookahead"));
@@ -17709,7 +17138,7 @@ t_primary_raw(Parser *p)
             D(fprintf(stderr, "%*c+ t_primary[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "t_primary genexp &t_lookahead"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -17719,7 +17148,7 @@ t_primary_raw(Parser *p)
             _res = _PyAST_Call ( a , CHECK ( asdl_expr_seq* , ( asdl_expr_seq* ) _PyPegen_singleton_seq ( p , b ) ) , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17730,7 +17159,7 @@ t_primary_raw(Parser *p)
     }
     { // t_primary '(' arguments? ')' &t_lookahead
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> t_primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "t_primary '(' arguments? ')' &t_lookahead"));
@@ -17753,7 +17182,7 @@ t_primary_raw(Parser *p)
             D(fprintf(stderr, "%*c+ t_primary[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "t_primary '(' arguments? ')' &t_lookahead"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -17763,7 +17192,7 @@ t_primary_raw(Parser *p)
             _res = _PyAST_Call ( a , ( b ) ? ( ( expr_ty ) b ) -> v . Call . args : NULL , ( b ) ? ( ( expr_ty ) b ) -> v . Call . keywords : NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17774,7 +17203,7 @@ t_primary_raw(Parser *p)
     }
     { // atom &t_lookahead
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> t_primary[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "atom &t_lookahead"));
@@ -17789,7 +17218,7 @@ t_primary_raw(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17800,7 +17229,7 @@ t_primary_raw(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -17808,19 +17237,16 @@ t_primary_raw(Parser *p)
 static void *
 t_lookahead_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '('
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> t_lookahead[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'('"));
@@ -17839,7 +17265,7 @@ t_lookahead_rule(Parser *p)
     }
     { // '['
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> t_lookahead[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'['"));
@@ -17858,7 +17284,7 @@ t_lookahead_rule(Parser *p)
     }
     { // '.'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> t_lookahead[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'.'"));
@@ -17877,7 +17303,7 @@ t_lookahead_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -17885,19 +17311,16 @@ t_lookahead_rule(Parser *p)
 static asdl_expr_seq*
 del_targets_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.del_target+ ','?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> del_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.del_target+ ','?"));
@@ -17914,7 +17337,7 @@ del_targets_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -17925,7 +17348,7 @@ del_targets_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -17936,23 +17359,20 @@ del_targets_rule(Parser *p)
 static expr_ty
 del_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, del_target_type, &_res)) {
-        p->level--;
+        D(p->level--);
         return _res;
     }
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -17961,7 +17381,7 @@ del_target_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // t_primary '.' NAME !t_lookahead
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> del_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "t_primary '.' NAME !t_lookahead"));
@@ -17981,7 +17401,7 @@ del_target_rule(Parser *p)
             D(fprintf(stderr, "%*c+ del_target[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "t_primary '.' NAME !t_lookahead"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -17991,7 +17411,7 @@ del_target_rule(Parser *p)
             _res = _PyAST_Attribute ( a , b -> v . Name . id , Del , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18002,7 +17422,7 @@ del_target_rule(Parser *p)
     }
     { // t_primary '[' slices ']' !t_lookahead
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> del_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "t_primary '[' slices ']' !t_lookahead"));
@@ -18025,7 +17445,7 @@ del_target_rule(Parser *p)
             D(fprintf(stderr, "%*c+ del_target[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "t_primary '[' slices ']' !t_lookahead"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -18035,7 +17455,7 @@ del_target_rule(Parser *p)
             _res = _PyAST_Subscript ( a , b , Del , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18046,7 +17466,7 @@ del_target_rule(Parser *p)
     }
     { // del_t_atom
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> del_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "del_t_atom"));
@@ -18066,7 +17486,7 @@ del_target_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, del_target_type, _res);
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -18074,19 +17494,16 @@ del_target_rule(Parser *p)
 static expr_ty
 del_t_atom_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -18095,7 +17512,7 @@ del_t_atom_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> del_t_atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME"));
@@ -18108,7 +17525,7 @@ del_t_atom_rule(Parser *p)
             _res = _PyPegen_set_expr_context ( p , a , Del );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18119,7 +17536,7 @@ del_t_atom_rule(Parser *p)
     }
     { // '(' del_target ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> del_t_atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' del_target ')'"));
@@ -18138,7 +17555,7 @@ del_t_atom_rule(Parser *p)
             _res = _PyPegen_set_expr_context ( p , a , Del );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18149,7 +17566,7 @@ del_t_atom_rule(Parser *p)
     }
     { // '(' del_targets? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> del_t_atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' del_targets? ')'"));
@@ -18167,7 +17584,7 @@ del_t_atom_rule(Parser *p)
             D(fprintf(stderr, "%*c+ del_t_atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' del_targets? ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -18177,7 +17594,7 @@ del_t_atom_rule(Parser *p)
             _res = _PyAST_Tuple ( a , Del , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18188,7 +17605,7 @@ del_t_atom_rule(Parser *p)
     }
     { // '[' del_targets? ']'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> del_t_atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'[' del_targets? ']'"));
@@ -18206,7 +17623,7 @@ del_t_atom_rule(Parser *p)
             D(fprintf(stderr, "%*c+ del_t_atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'[' del_targets? ']'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -18216,7 +17633,7 @@ del_t_atom_rule(Parser *p)
             _res = _PyAST_List ( a , Del , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18227,7 +17644,7 @@ del_t_atom_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -18242,19 +17659,16 @@ del_t_atom_rule(Parser *p)
 static asdl_expr_seq*
 type_expressions_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.expression+ ',' '*' expression ',' '**' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> type_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.expression+ ',' '*' expression ',' '**' expression"));
@@ -18285,7 +17699,7 @@ type_expressions_rule(Parser *p)
             _res = ( asdl_expr_seq* ) _PyPegen_seq_append_to_end ( p , CHECK ( asdl_seq* , _PyPegen_seq_append_to_end ( p , a , b ) ) , c );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18296,7 +17710,7 @@ type_expressions_rule(Parser *p)
     }
     { // ','.expression+ ',' '*' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> type_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.expression+ ',' '*' expression"));
@@ -18318,7 +17732,7 @@ type_expressions_rule(Parser *p)
             _res = ( asdl_expr_seq* ) _PyPegen_seq_append_to_end ( p , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18329,7 +17743,7 @@ type_expressions_rule(Parser *p)
     }
     { // ','.expression+ ',' '**' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> type_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.expression+ ',' '**' expression"));
@@ -18351,7 +17765,7 @@ type_expressions_rule(Parser *p)
             _res = ( asdl_expr_seq* ) _PyPegen_seq_append_to_end ( p , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18362,7 +17776,7 @@ type_expressions_rule(Parser *p)
     }
     { // '*' expression ',' '**' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> type_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' expression ',' '**' expression"));
@@ -18387,7 +17801,7 @@ type_expressions_rule(Parser *p)
             _res = ( asdl_expr_seq* ) _PyPegen_seq_append_to_end ( p , CHECK ( asdl_seq* , _PyPegen_singleton_seq ( p , a ) ) , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18398,7 +17812,7 @@ type_expressions_rule(Parser *p)
     }
     { // '*' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> type_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' expression"));
@@ -18414,7 +17828,7 @@ type_expressions_rule(Parser *p)
             _res = ( asdl_expr_seq* ) _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18425,7 +17839,7 @@ type_expressions_rule(Parser *p)
     }
     { // '**' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> type_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**' expression"));
@@ -18441,7 +17855,7 @@ type_expressions_rule(Parser *p)
             _res = ( asdl_expr_seq* ) _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18452,7 +17866,7 @@ type_expressions_rule(Parser *p)
     }
     { // ','.expression+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> type_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.expression+"));
@@ -18465,7 +17879,7 @@ type_expressions_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18476,7 +17890,7 @@ type_expressions_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -18487,19 +17901,16 @@ type_expressions_rule(Parser *p)
 static Token*
 func_type_comment_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Token* _res = NULL;
     int _mark = p->mark;
     { // NEWLINE TYPE_COMMENT &(NEWLINE INDENT)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> func_type_comment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE TYPE_COMMENT &(NEWLINE INDENT)"));
@@ -18517,7 +17928,7 @@ func_type_comment_rule(Parser *p)
             _res = t;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18528,7 +17939,7 @@ func_type_comment_rule(Parser *p)
     }
     if (p->call_invalid_rules) { // invalid_double_type_comments
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> func_type_comment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_double_type_comments"));
@@ -18547,7 +17958,7 @@ func_type_comment_rule(Parser *p)
     }
     { // TYPE_COMMENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> func_type_comment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "TYPE_COMMENT"));
@@ -18566,7 +17977,7 @@ func_type_comment_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -18580,19 +17991,16 @@ func_type_comment_rule(Parser *p)
 static void *
 invalid_arguments_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // args ',' '*'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_arguments[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "args ',' '*'"));
@@ -18611,7 +18019,7 @@ invalid_arguments_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "iterable argument unpacking follows keyword argument unpacking" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18622,7 +18030,7 @@ invalid_arguments_rule(Parser *p)
     }
     { // expression for_if_clauses ',' [args | expression for_if_clauses]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_arguments[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression for_if_clauses ',' [args | expression for_if_clauses]"));
@@ -18645,7 +18053,7 @@ invalid_arguments_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , PyPegen_last_item ( b , comprehension_ty ) -> target , "Generator expression must be parenthesized" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18656,7 +18064,7 @@ invalid_arguments_rule(Parser *p)
     }
     { // NAME '=' expression for_if_clauses
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_arguments[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME '=' expression for_if_clauses"));
@@ -18678,7 +18086,7 @@ invalid_arguments_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "invalid syntax. Maybe you meant '==' or ':=' instead of '='?" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18689,7 +18097,7 @@ invalid_arguments_rule(Parser *p)
     }
     { // args for_if_clauses
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_arguments[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "args for_if_clauses"));
@@ -18705,7 +18113,7 @@ invalid_arguments_rule(Parser *p)
             _res = _PyPegen_nonparen_genexp_in_call ( p , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18716,7 +18124,7 @@ invalid_arguments_rule(Parser *p)
     }
     { // args ',' expression for_if_clauses
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_arguments[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "args ',' expression for_if_clauses"));
@@ -18738,7 +18146,7 @@ invalid_arguments_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , asdl_seq_GET ( b , b -> size - 1 ) -> target , "Generator expression must be parenthesized" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18749,7 +18157,7 @@ invalid_arguments_rule(Parser *p)
     }
     { // args ',' args
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_arguments[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "args ',' args"));
@@ -18768,7 +18176,7 @@ invalid_arguments_rule(Parser *p)
             _res = _PyPegen_arguments_parsing_error ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18779,7 +18187,7 @@ invalid_arguments_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -18790,19 +18198,16 @@ invalid_arguments_rule(Parser *p)
 static void *
 invalid_kwarg_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ('True' | 'False' | 'None') '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_kwarg[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('True' | 'False' | 'None') '='"));
@@ -18818,7 +18223,7 @@ invalid_kwarg_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "cannot assign to %s" , PyBytes_AS_STRING ( a -> bytes ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18829,7 +18234,7 @@ invalid_kwarg_rule(Parser *p)
     }
     { // NAME '=' expression for_if_clauses
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_kwarg[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME '=' expression for_if_clauses"));
@@ -18851,7 +18256,7 @@ invalid_kwarg_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "invalid syntax. Maybe you meant '==' or ':=' instead of '='?" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18862,7 +18267,7 @@ invalid_kwarg_rule(Parser *p)
     }
     { // !(NAME '=') expression '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_kwarg[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "!(NAME '=') expression '='"));
@@ -18880,7 +18285,7 @@ invalid_kwarg_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "expression cannot contain assignment, perhaps you meant \"==\"?" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18891,7 +18296,7 @@ invalid_kwarg_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -18902,19 +18307,16 @@ invalid_kwarg_rule(Parser *p)
 static expr_ty
 expression_without_invalid_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     int _start_lineno = p->tokens[_mark]->lineno;
@@ -18923,7 +18325,7 @@ expression_without_invalid_rule(Parser *p)
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // disjunction 'if' disjunction 'else' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> expression_without_invalid[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "disjunction 'if' disjunction 'else' expression"));
@@ -18947,7 +18349,7 @@ expression_without_invalid_rule(Parser *p)
             D(fprintf(stderr, "%*c+ expression_without_invalid[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "disjunction 'if' disjunction 'else' expression"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             int _end_lineno = _token->end_lineno;
@@ -18957,7 +18359,7 @@ expression_without_invalid_rule(Parser *p)
             _res = _PyAST_IfExp ( b , a , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -18968,7 +18370,7 @@ expression_without_invalid_rule(Parser *p)
     }
     { // disjunction
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> expression_without_invalid[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "disjunction"));
@@ -18987,7 +18389,7 @@ expression_without_invalid_rule(Parser *p)
     }
     { // lambdef
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> expression_without_invalid[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambdef"));
@@ -19006,7 +18408,7 @@ expression_without_invalid_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19014,19 +18416,16 @@ expression_without_invalid_rule(Parser *p)
 static void *
 invalid_legacy_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // NAME !'(' star_expressions
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_legacy_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME !'(' star_expressions"));
@@ -19044,7 +18443,7 @@ invalid_legacy_expression_rule(Parser *p)
             _res = _PyPegen_check_legacy_stmt ( p , a ) ? RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "Missing parentheses in call to '%U'. Did you mean %U(...)?" , a -> v . Name . id , a -> v . Name . id ) : NULL;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19055,7 +18454,7 @@ invalid_legacy_expression_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19065,19 +18464,16 @@ invalid_legacy_expression_rule(Parser *p)
 static void *
 invalid_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // !(NAME STRING | SOFT_KEYWORD) disjunction expression_without_invalid
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "!(NAME STRING | SOFT_KEYWORD) disjunction expression_without_invalid"));
@@ -19095,7 +18491,7 @@ invalid_expression_rule(Parser *p)
             _res = _PyPegen_check_legacy_stmt ( p , a ) ? NULL : p -> tokens [p -> mark - 1] -> level == 0 ? NULL : RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "invalid syntax. Perhaps you forgot a comma?" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19106,7 +18502,7 @@ invalid_expression_rule(Parser *p)
     }
     { // disjunction 'if' disjunction !('else' | ':')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "disjunction 'if' disjunction !('else' | ':')"));
@@ -19127,7 +18523,7 @@ invalid_expression_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "expected 'else' after 'if' expression" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19138,7 +18534,7 @@ invalid_expression_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19149,19 +18545,16 @@ invalid_expression_rule(Parser *p)
 static void *
 invalid_named_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // expression ':=' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_named_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ':=' expression"));
@@ -19180,7 +18573,7 @@ invalid_named_expression_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "cannot use assignment expressions with %s" , _PyPegen_get_expr_name ( a ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19191,7 +18584,7 @@ invalid_named_expression_rule(Parser *p)
     }
     { // NAME '=' bitwise_or !('=' | ':=')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_named_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME '=' bitwise_or !('=' | ':=')"));
@@ -19212,7 +18605,7 @@ invalid_named_expression_rule(Parser *p)
             _res = p -> in_raw_rule ? NULL : RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "invalid syntax. Maybe you meant '==' or ':=' instead of '='?" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19223,7 +18616,7 @@ invalid_named_expression_rule(Parser *p)
     }
     { // !(list | tuple | genexp | 'True' | 'None' | 'False') bitwise_or '=' bitwise_or !('=' | ':=')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_named_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "!(list | tuple | genexp | 'True' | 'None' | 'False') bitwise_or '=' bitwise_or !('=' | ':=')"));
@@ -19246,7 +18639,7 @@ invalid_named_expression_rule(Parser *p)
             _res = p -> in_raw_rule ? NULL : RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "cannot assign to %s here. Maybe you meant '==' instead of '='?" , _PyPegen_get_expr_name ( a ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19257,7 +18650,7 @@ invalid_named_expression_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19271,19 +18664,16 @@ invalid_named_expression_rule(Parser *p)
 static void *
 invalid_assignment_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // invalid_ann_assign_target ':' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_ann_assign_target ':' expression"));
@@ -19302,7 +18692,7 @@ invalid_assignment_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "only single target (not %s) can be annotated" , _PyPegen_get_expr_name ( a ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19313,7 +18703,7 @@ invalid_assignment_rule(Parser *p)
     }
     { // star_named_expression ',' star_named_expressions* ':' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_named_expression ',' star_named_expressions* ':' expression"));
@@ -19338,7 +18728,7 @@ invalid_assignment_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "only single target (not tuple) can be annotated" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19349,7 +18739,7 @@ invalid_assignment_rule(Parser *p)
     }
     { // expression ':' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ':' expression"));
@@ -19368,7 +18758,7 @@ invalid_assignment_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "illegal target for annotation" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19379,7 +18769,7 @@ invalid_assignment_rule(Parser *p)
     }
     { // ((star_targets '='))* star_expressions '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "((star_targets '='))* star_expressions '='"));
@@ -19398,7 +18788,7 @@ invalid_assignment_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_INVALID_TARGET ( STAR_TARGETS , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19409,7 +18799,7 @@ invalid_assignment_rule(Parser *p)
     }
     { // ((star_targets '='))* yield_expr '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "((star_targets '='))* yield_expr '='"));
@@ -19428,7 +18818,7 @@ invalid_assignment_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "assignment to yield expression not possible" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19439,7 +18829,7 @@ invalid_assignment_rule(Parser *p)
     }
     { // star_expressions augassign (yield_expr | star_expressions)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_expressions augassign (yield_expr | star_expressions)"));
@@ -19458,7 +18848,7 @@ invalid_assignment_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "'%s' is an illegal expression for augmented assignment" , _PyPegen_get_expr_name ( a ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19469,7 +18859,7 @@ invalid_assignment_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19477,19 +18867,16 @@ invalid_assignment_rule(Parser *p)
 static expr_ty
 invalid_ann_assign_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // list
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_ann_assign_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "list"));
@@ -19508,7 +18895,7 @@ invalid_ann_assign_target_rule(Parser *p)
     }
     { // tuple
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_ann_assign_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "tuple"));
@@ -19527,7 +18914,7 @@ invalid_ann_assign_target_rule(Parser *p)
     }
     { // '(' invalid_ann_assign_target ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_ann_assign_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' invalid_ann_assign_target ')'"));
@@ -19546,7 +18933,7 @@ invalid_ann_assign_target_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19557,7 +18944,7 @@ invalid_ann_assign_target_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19565,19 +18952,16 @@ invalid_ann_assign_target_rule(Parser *p)
 static void *
 invalid_del_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'del' star_expressions
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_del_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'del' star_expressions"));
@@ -19593,7 +18977,7 @@ invalid_del_stmt_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_INVALID_TARGET ( DEL_TARGETS , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19604,7 +18988,7 @@ invalid_del_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19612,19 +18996,16 @@ invalid_del_stmt_rule(Parser *p)
 static void *
 invalid_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE !INDENT"));
@@ -19639,7 +19020,7 @@ invalid_block_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19650,7 +19031,7 @@ invalid_block_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19661,19 +19042,16 @@ invalid_block_rule(Parser *p)
 static void *
 invalid_comprehension_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ('[' | '(' | '{') starred_expression for_if_clauses
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_comprehension[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('[' | '(' | '{') starred_expression for_if_clauses"));
@@ -19692,7 +19070,7 @@ invalid_comprehension_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "iterable unpacking cannot be used in comprehension" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19703,7 +19081,7 @@ invalid_comprehension_rule(Parser *p)
     }
     { // ('[' | '{') star_named_expression ',' star_named_expressions for_if_clauses
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_comprehension[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('[' | '{') star_named_expression ',' star_named_expressions for_if_clauses"));
@@ -19728,7 +19106,7 @@ invalid_comprehension_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , PyPegen_last_item ( b , expr_ty ) , "did you forget parentheses around the comprehension target?" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19739,7 +19117,7 @@ invalid_comprehension_rule(Parser *p)
     }
     { // ('[' | '{') star_named_expression ',' for_if_clauses
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_comprehension[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('[' | '{') star_named_expression ',' for_if_clauses"));
@@ -19761,7 +19139,7 @@ invalid_comprehension_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "did you forget parentheses around the comprehension target?" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19772,7 +19150,7 @@ invalid_comprehension_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19780,19 +19158,16 @@ invalid_comprehension_rule(Parser *p)
 static void *
 invalid_dict_comprehension_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '{' '**' bitwise_or for_if_clauses '}'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_dict_comprehension[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{' '**' bitwise_or for_if_clauses '}'"));
@@ -19817,7 +19192,7 @@ invalid_dict_comprehension_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "dict unpacking cannot be used in dict comprehension" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19828,7 +19203,7 @@ invalid_dict_comprehension_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19838,19 +19213,16 @@ invalid_dict_comprehension_rule(Parser *p)
 static void *
 invalid_parameters_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // param_no_default* invalid_parameters_helper param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default* invalid_parameters_helper param_no_default"));
@@ -19869,7 +19241,7 @@ invalid_parameters_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "non-default argument follows default argument" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19880,7 +19252,7 @@ invalid_parameters_rule(Parser *p)
     }
     { // param_no_default* '(' param_no_default+ ','? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default* '(' param_no_default+ ','? ')'"));
@@ -19906,7 +19278,7 @@ invalid_parameters_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "Function parameters cannot be parenthesized" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19917,7 +19289,7 @@ invalid_parameters_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19925,19 +19297,16 @@ invalid_parameters_rule(Parser *p)
 static void *
 invalid_parameters_helper_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // slash_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_parameters_helper[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "slash_with_default"));
@@ -19950,7 +19319,7 @@ invalid_parameters_helper_rule(Parser *p)
             _res = _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -19961,7 +19330,7 @@ invalid_parameters_helper_rule(Parser *p)
     }
     { // param_with_default+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_parameters_helper[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_with_default+"));
@@ -19980,7 +19349,7 @@ invalid_parameters_helper_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -19990,19 +19359,16 @@ invalid_parameters_helper_rule(Parser *p)
 static void *
 invalid_lambda_parameters_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // lambda_param_no_default* invalid_lambda_parameters_helper lambda_param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_lambda_parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default* invalid_lambda_parameters_helper lambda_param_no_default"));
@@ -20021,7 +19387,7 @@ invalid_lambda_parameters_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "non-default argument follows default argument" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20032,7 +19398,7 @@ invalid_lambda_parameters_rule(Parser *p)
     }
     { // lambda_param_no_default* '(' ','.lambda_param+ ','? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_lambda_parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default* '(' ','.lambda_param+ ','? ')'"));
@@ -20058,7 +19424,7 @@ invalid_lambda_parameters_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "Lambda expression parameters cannot be parenthesized" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20069,7 +19435,7 @@ invalid_lambda_parameters_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20079,19 +19445,16 @@ invalid_lambda_parameters_rule(Parser *p)
 static void *
 invalid_lambda_parameters_helper_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // lambda_slash_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_lambda_parameters_helper[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_slash_with_default"));
@@ -20104,7 +19467,7 @@ invalid_lambda_parameters_helper_rule(Parser *p)
             _res = _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20115,7 +19478,7 @@ invalid_lambda_parameters_helper_rule(Parser *p)
     }
     { // lambda_param_with_default+
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_lambda_parameters_helper[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_with_default+"));
@@ -20134,7 +19497,7 @@ invalid_lambda_parameters_helper_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20142,19 +19505,16 @@ invalid_lambda_parameters_helper_rule(Parser *p)
 static void *
 invalid_star_etc_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '*' (')' | ',' (')' | '**'))
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_star_etc[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' (')' | ',' (')' | '**'))"));
@@ -20170,7 +19530,7 @@ invalid_star_etc_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "named arguments must follow bare *" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20181,7 +19541,7 @@ invalid_star_etc_rule(Parser *p)
     }
     { // '*' ',' TYPE_COMMENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_star_etc[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' ',' TYPE_COMMENT"));
@@ -20200,7 +19560,7 @@ invalid_star_etc_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "bare * has associated type comment" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20211,7 +19571,7 @@ invalid_star_etc_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20219,19 +19579,16 @@ invalid_star_etc_rule(Parser *p)
 static void *
 invalid_lambda_star_etc_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '*' (':' | ',' (':' | '**'))
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_lambda_star_etc[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' (':' | ',' (':' | '**'))"));
@@ -20247,7 +19604,7 @@ invalid_lambda_star_etc_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "named arguments must follow bare *" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20258,7 +19615,7 @@ invalid_lambda_star_etc_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20266,19 +19623,16 @@ invalid_lambda_star_etc_rule(Parser *p)
 static void *
 invalid_double_type_comments_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_double_type_comments[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT"));
@@ -20303,7 +19657,7 @@ invalid_double_type_comments_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "Cannot have two type comments on def" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20314,7 +19668,7 @@ invalid_double_type_comments_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20322,19 +19676,16 @@ invalid_double_type_comments_rule(Parser *p)
 static void *
 invalid_with_item_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // expression 'as' expression &(',' | ')' | ':')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_with_item[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression 'as' expression &(',' | ')' | ':')"));
@@ -20355,7 +19706,7 @@ invalid_with_item_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_INVALID_TARGET ( STAR_TARGETS , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20366,7 +19717,7 @@ invalid_with_item_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20374,19 +19725,16 @@ invalid_with_item_rule(Parser *p)
 static void *
 invalid_for_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ASYNC? 'for' star_expressions
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_for_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC? 'for' star_expressions"));
@@ -20406,7 +19754,7 @@ invalid_for_target_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_INVALID_TARGET ( FOR_TARGETS , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20417,7 +19765,7 @@ invalid_for_target_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20425,19 +19773,16 @@ invalid_for_target_rule(Parser *p)
 static void *
 invalid_group_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '(' starred_expression ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_group[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' starred_expression ')'"));
@@ -20456,7 +19801,7 @@ invalid_group_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "cannot use starred expression here" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20467,7 +19812,7 @@ invalid_group_rule(Parser *p)
     }
     { // '(' '**' expression ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_group[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' '**' expression ')'"));
@@ -20489,7 +19834,7 @@ invalid_group_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "cannot use double starred expression here" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20500,7 +19845,7 @@ invalid_group_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20508,19 +19853,16 @@ invalid_group_rule(Parser *p)
 static void *
 invalid_import_from_targets_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // import_from_as_names ',' NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_import_from_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "import_from_as_names ',' NEWLINE"));
@@ -20539,7 +19881,7 @@ invalid_import_from_targets_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "trailing comma not allowed without surrounding parentheses" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20550,7 +19892,7 @@ invalid_import_from_targets_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20560,19 +19902,16 @@ invalid_import_from_targets_rule(Parser *p)
 static void *
 invalid_with_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ASYNC? 'with' ','.(expression ['as' star_target])+ &&':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_with_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC? 'with' ','.(expression ['as' star_target])+ &&':'"));
@@ -20601,7 +19940,7 @@ invalid_with_stmt_rule(Parser *p)
     }
     { // ASYNC? 'with' '(' ','.(expressions ['as' star_target])+ ','? ')' &&':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_with_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC? 'with' '(' ','.(expressions ['as' star_target])+ ','? ')' &&':'"));
@@ -20640,7 +19979,7 @@ invalid_with_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20650,19 +19989,16 @@ invalid_with_stmt_rule(Parser *p)
 static void *
 invalid_with_stmt_indent_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ASYNC? 'with' ','.(expression ['as' star_target])+ ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_with_stmt_indent[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC? 'with' ','.(expression ['as' star_target])+ ':' NEWLINE !INDENT"));
@@ -20690,7 +20026,7 @@ invalid_with_stmt_indent_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'with' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20701,7 +20037,7 @@ invalid_with_stmt_indent_rule(Parser *p)
     }
     { // ASYNC? 'with' '(' ','.(expressions ['as' star_target])+ ','? ')' ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_with_stmt_indent[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC? 'with' '(' ','.(expressions ['as' star_target])+ ','? ')' ':' NEWLINE !INDENT"));
@@ -20739,7 +20075,7 @@ invalid_with_stmt_indent_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'with' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20750,7 +20086,7 @@ invalid_with_stmt_indent_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20761,19 +20097,16 @@ invalid_with_stmt_indent_rule(Parser *p)
 static void *
 invalid_try_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'try' ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_try_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'try' ':' NEWLINE !INDENT"));
@@ -20794,7 +20127,7 @@ invalid_try_stmt_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'try' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20805,7 +20138,7 @@ invalid_try_stmt_rule(Parser *p)
     }
     { // 'try' ':' block !('except' | 'finally')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_try_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'try' ':' block !('except' | 'finally')"));
@@ -20826,7 +20159,7 @@ invalid_try_stmt_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "expected 'except' or 'finally' block" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20837,7 +20170,7 @@ invalid_try_stmt_rule(Parser *p)
     }
     { // 'try' ':' block* ((except_block+ except_star_block) | (except_star_block+ except_block)) block*
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_try_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'try' ':' block* ((except_block+ except_star_block) | (except_star_block+ except_block)) block*"));
@@ -20862,7 +20195,7 @@ invalid_try_stmt_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "cannot have both 'except' and 'except*' on the same 'try'" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20873,7 +20206,7 @@ invalid_try_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -20885,19 +20218,16 @@ invalid_try_stmt_rule(Parser *p)
 static void *
 invalid_except_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'except' '*'? expression ',' expressions ['as' NAME] ':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_except_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' '*'? expression ',' expressions ['as' NAME] ':'"));
@@ -20930,7 +20260,7 @@ invalid_except_stmt_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_STARTING_FROM ( a , "multiple exception types must be parenthesized" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20941,7 +20271,7 @@ invalid_except_stmt_rule(Parser *p)
     }
     { // 'except' '*'? expression ['as' NAME] NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_except_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' '*'? expression ['as' NAME] NEWLINE"));
@@ -20968,7 +20298,7 @@ invalid_except_stmt_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "expected ':'" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -20979,7 +20309,7 @@ invalid_except_stmt_rule(Parser *p)
     }
     { // 'except' NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_except_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' NEWLINE"));
@@ -20995,7 +20325,7 @@ invalid_except_stmt_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "expected ':'" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21006,7 +20336,7 @@ invalid_except_stmt_rule(Parser *p)
     }
     { // 'except' '*' (NEWLINE | ':')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_except_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' '*' (NEWLINE | ':')"));
@@ -21025,7 +20355,7 @@ invalid_except_stmt_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "expected one or more exception types" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21036,7 +20366,7 @@ invalid_except_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21044,19 +20374,16 @@ invalid_except_stmt_rule(Parser *p)
 static void *
 invalid_finally_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'finally' ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_finally_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'finally' ':' NEWLINE !INDENT"));
@@ -21077,7 +20404,7 @@ invalid_finally_stmt_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'finally' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21088,7 +20415,7 @@ invalid_finally_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21098,19 +20425,16 @@ invalid_finally_stmt_rule(Parser *p)
 static void *
 invalid_except_stmt_indent_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'except' expression ['as' NAME] ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_except_stmt_indent[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' expression ['as' NAME] ':' NEWLINE !INDENT"));
@@ -21138,7 +20462,7 @@ invalid_except_stmt_indent_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'except' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21149,7 +20473,7 @@ invalid_except_stmt_indent_rule(Parser *p)
     }
     { // 'except' ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_except_stmt_indent[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' ':' NEWLINE !INDENT"));
@@ -21170,7 +20494,7 @@ invalid_except_stmt_indent_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "expected an indented block after except statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21181,7 +20505,7 @@ invalid_except_stmt_indent_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21190,19 +20514,16 @@ invalid_except_stmt_indent_rule(Parser *p)
 static void *
 invalid_except_star_stmt_indent_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'except' '*' expression ['as' NAME] ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_except_star_stmt_indent[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' '*' expression ['as' NAME] ':' NEWLINE !INDENT"));
@@ -21233,7 +20554,7 @@ invalid_except_star_stmt_indent_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'except*' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21244,7 +20565,7 @@ invalid_except_star_stmt_indent_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21254,19 +20575,16 @@ invalid_except_star_stmt_indent_rule(Parser *p)
 static void *
 invalid_match_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // "match" subject_expr !':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_match_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "\"match\" subject_expr !':'"));
@@ -21284,7 +20602,7 @@ invalid_match_stmt_rule(Parser *p)
             _res = CHECK_VERSION ( void* , 10 , "Pattern matching is" , RAISE_SYNTAX_ERROR ( "expected ':'" ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21295,7 +20613,7 @@ invalid_match_stmt_rule(Parser *p)
     }
     { // "match" subject_expr ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_match_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "\"match\" subject_expr ':' NEWLINE !INDENT"));
@@ -21319,7 +20637,7 @@ invalid_match_stmt_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'match' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21330,7 +20648,7 @@ invalid_match_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21340,19 +20658,16 @@ invalid_match_stmt_rule(Parser *p)
 static void *
 invalid_case_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // "case" patterns guard? !':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_case_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "\"case\" patterns guard? !':'"));
@@ -21374,7 +20689,7 @@ invalid_case_block_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "expected ':'" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21385,7 +20700,7 @@ invalid_case_block_rule(Parser *p)
     }
     { // "case" patterns guard? ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_case_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "\"case\" patterns guard? ':' NEWLINE !INDENT"));
@@ -21413,7 +20728,7 @@ invalid_case_block_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'case' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21424,7 +20739,7 @@ invalid_case_block_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21432,19 +20747,16 @@ invalid_case_block_rule(Parser *p)
 static void *
 invalid_as_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // or_pattern 'as' "_"
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_as_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "or_pattern 'as' \"_\""));
@@ -21463,7 +20775,7 @@ invalid_as_pattern_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "cannot use '_' as a target" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21474,7 +20786,7 @@ invalid_as_pattern_rule(Parser *p)
     }
     { // or_pattern 'as' !NAME expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_as_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "or_pattern 'as' !NAME expression"));
@@ -21495,7 +20807,7 @@ invalid_as_pattern_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "invalid pattern target" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21506,7 +20818,7 @@ invalid_as_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21514,19 +20826,16 @@ invalid_as_pattern_rule(Parser *p)
 static void *
 invalid_class_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // name_or_attr '(' invalid_class_argument_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_class_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "name_or_attr '(' invalid_class_argument_pattern"));
@@ -21545,7 +20854,7 @@ invalid_class_pattern_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( PyPegen_first_item ( a , pattern_ty ) , PyPegen_last_item ( a , pattern_ty ) , "positional patterns follow keyword patterns" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21556,7 +20865,7 @@ invalid_class_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21565,19 +20874,16 @@ invalid_class_pattern_rule(Parser *p)
 static asdl_pattern_seq*
 invalid_class_argument_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_pattern_seq* _res = NULL;
     int _mark = p->mark;
     { // [positional_patterns ','] keyword_patterns ',' positional_patterns
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_class_argument_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "[positional_patterns ','] keyword_patterns ',' positional_patterns"));
@@ -21600,7 +20906,7 @@ invalid_class_argument_pattern_rule(Parser *p)
             _res = a;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21611,7 +20917,7 @@ invalid_class_argument_pattern_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21621,19 +20927,16 @@ invalid_class_argument_pattern_rule(Parser *p)
 static void *
 invalid_if_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'if' named_expression NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_if_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'if' named_expression NEWLINE"));
@@ -21652,7 +20955,7 @@ invalid_if_stmt_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "expected ':'" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21663,7 +20966,7 @@ invalid_if_stmt_rule(Parser *p)
     }
     { // 'if' named_expression ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_if_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'if' named_expression ':' NEWLINE !INDENT"));
@@ -21687,7 +20990,7 @@ invalid_if_stmt_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'if' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21698,7 +21001,7 @@ invalid_if_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21708,19 +21011,16 @@ invalid_if_stmt_rule(Parser *p)
 static void *
 invalid_elif_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'elif' named_expression NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_elif_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'elif' named_expression NEWLINE"));
@@ -21739,7 +21039,7 @@ invalid_elif_stmt_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "expected ':'" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21750,7 +21050,7 @@ invalid_elif_stmt_rule(Parser *p)
     }
     { // 'elif' named_expression ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_elif_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'elif' named_expression ':' NEWLINE !INDENT"));
@@ -21774,7 +21074,7 @@ invalid_elif_stmt_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'elif' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21785,7 +21085,7 @@ invalid_elif_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21793,19 +21093,16 @@ invalid_elif_stmt_rule(Parser *p)
 static void *
 invalid_else_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'else' ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_else_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'else' ':' NEWLINE !INDENT"));
@@ -21826,7 +21123,7 @@ invalid_else_stmt_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'else' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21837,7 +21134,7 @@ invalid_else_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21847,19 +21144,16 @@ invalid_else_stmt_rule(Parser *p)
 static void *
 invalid_while_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'while' named_expression NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_while_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'while' named_expression NEWLINE"));
@@ -21878,7 +21172,7 @@ invalid_while_stmt_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR ( "expected ':'" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21889,7 +21183,7 @@ invalid_while_stmt_rule(Parser *p)
     }
     { // 'while' named_expression ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_while_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'while' named_expression ':' NEWLINE !INDENT"));
@@ -21913,7 +21207,7 @@ invalid_while_stmt_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'while' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21924,7 +21218,7 @@ invalid_while_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21932,19 +21226,16 @@ invalid_while_stmt_rule(Parser *p)
 static void *
 invalid_for_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ASYNC? 'for' star_targets 'in' star_expressions ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_for_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC? 'for' star_targets 'in' star_expressions ':' NEWLINE !INDENT"));
@@ -21978,7 +21269,7 @@ invalid_for_stmt_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'for' statement on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -21989,7 +21280,7 @@ invalid_for_stmt_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -21998,19 +21289,16 @@ invalid_for_stmt_rule(Parser *p)
 static void *
 invalid_def_raw_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ASYNC? 'def' NAME '(' params? ')' ['->' expression] ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_def_raw[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC? 'def' NAME '(' params? ')' ['->' expression] ':' NEWLINE !INDENT"));
@@ -22052,7 +21340,7 @@ invalid_def_raw_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after function definition on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -22063,7 +21351,7 @@ invalid_def_raw_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -22071,19 +21359,16 @@ invalid_def_raw_rule(Parser *p)
 static void *
 invalid_class_def_raw_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'class' NAME ['(' arguments? ')'] ':' NEWLINE !INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_class_def_raw[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'class' NAME ['(' arguments? ')'] ':' NEWLINE !INDENT"));
@@ -22111,7 +21396,7 @@ invalid_class_def_raw_rule(Parser *p)
             _res = RAISE_INDENTATION_ERROR ( "expected an indented block after class definition on line %d" , a -> lineno );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -22122,7 +21407,7 @@ invalid_class_def_raw_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -22133,19 +21418,16 @@ invalid_class_def_raw_rule(Parser *p)
 static void *
 invalid_double_starred_kvpairs_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ','.double_starred_kvpair+ ',' invalid_kvpair
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_double_starred_kvpairs[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.double_starred_kvpair+ ',' invalid_kvpair"));
@@ -22170,7 +21452,7 @@ invalid_double_starred_kvpairs_rule(Parser *p)
     }
     { // expression ':' '*' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_double_starred_kvpairs[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ':' '*' bitwise_or"));
@@ -22192,7 +21474,7 @@ invalid_double_starred_kvpairs_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_STARTING_FROM ( a , "cannot use a starred expression in a dictionary value" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -22203,7 +21485,7 @@ invalid_double_starred_kvpairs_rule(Parser *p)
     }
     { // expression ':' &('}' | ',')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_double_starred_kvpairs[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ':' &('}' | ',')"));
@@ -22221,7 +21503,7 @@ invalid_double_starred_kvpairs_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "expression expected after dictionary key and ':'" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -22232,7 +21514,7 @@ invalid_double_starred_kvpairs_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -22240,19 +21522,16 @@ invalid_double_starred_kvpairs_rule(Parser *p)
 static void *
 invalid_kvpair_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // expression !(':')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_kvpair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression !(':')"));
@@ -22267,7 +21546,7 @@ invalid_kvpair_rule(Parser *p)
             _res = RAISE_ERROR_KNOWN_LOCATION ( p , PyExc_SyntaxError , a -> lineno , a -> end_col_offset - 1 , a -> end_lineno , - 1 , "':' expected after dictionary key" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -22278,7 +21557,7 @@ invalid_kvpair_rule(Parser *p)
     }
     { // expression ':' '*' bitwise_or
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_kvpair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ':' '*' bitwise_or"));
@@ -22300,7 +21579,7 @@ invalid_kvpair_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_STARTING_FROM ( a , "cannot use a starred expression in a dictionary value" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -22311,7 +21590,7 @@ invalid_kvpair_rule(Parser *p)
     }
     { // expression ':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_kvpair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ':'"));
@@ -22327,7 +21606,7 @@ invalid_kvpair_rule(Parser *p)
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "expression expected after dictionary key and ':'" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -22338,7 +21617,7 @@ invalid_kvpair_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -22346,12 +21625,9 @@ invalid_kvpair_rule(Parser *p)
 static asdl_seq *
 _loop0_1_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -22361,14 +21637,14 @@ _loop0_1_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_1[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE"));
@@ -22384,7 +21660,7 @@ _loop0_1_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -22401,13 +21677,13 @@ _loop0_1_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_1_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -22415,12 +21691,9 @@ _loop0_1_rule(Parser *p)
 static asdl_seq *
 _loop0_2_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -22430,14 +21703,14 @@ _loop0_2_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_2[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE"));
@@ -22453,7 +21726,7 @@ _loop0_2_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -22470,13 +21743,13 @@ _loop0_2_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_2_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -22484,12 +21757,9 @@ _loop0_2_rule(Parser *p)
 static asdl_seq *
 _loop1_3_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -22499,14 +21769,14 @@ _loop1_3_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // statement
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_3[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "statement"));
@@ -22522,7 +21792,7 @@ _loop1_3_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -22536,7 +21806,7 @@ _loop1_3_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -22544,13 +21814,13 @@ _loop1_3_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_3_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -22558,12 +21828,9 @@ _loop1_3_rule(Parser *p)
 static asdl_seq *
 _loop0_5_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -22573,14 +21840,14 @@ _loop0_5_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ';' simple_stmt
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_5[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "';' simple_stmt"));
@@ -22596,7 +21863,7 @@ _loop0_5_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -22605,7 +21872,7 @@ _loop0_5_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -22622,13 +21889,13 @@ _loop0_5_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_5_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -22636,19 +21903,16 @@ _loop0_5_rule(Parser *p)
 static asdl_seq *
 _gather_4_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // simple_stmt _loop0_5
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_4[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "simple_stmt _loop0_5"));
@@ -22670,7 +21934,7 @@ _gather_4_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -22678,19 +21942,16 @@ _gather_4_rule(Parser *p)
 static void *
 _tmp_6_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'import'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_6[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'import'"));
@@ -22709,7 +21970,7 @@ _tmp_6_rule(Parser *p)
     }
     { // 'from'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_6[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'from'"));
@@ -22728,7 +21989,7 @@ _tmp_6_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -22736,19 +21997,16 @@ _tmp_6_rule(Parser *p)
 static void *
 _tmp_7_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'def'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_7[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'def'"));
@@ -22767,7 +22025,7 @@ _tmp_7_rule(Parser *p)
     }
     { // '@'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_7[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'@'"));
@@ -22786,7 +22044,7 @@ _tmp_7_rule(Parser *p)
     }
     { // ASYNC
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_7[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC"));
@@ -22805,7 +22063,7 @@ _tmp_7_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -22813,19 +22071,16 @@ _tmp_7_rule(Parser *p)
 static void *
 _tmp_8_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'class'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_8[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'class'"));
@@ -22844,7 +22099,7 @@ _tmp_8_rule(Parser *p)
     }
     { // '@'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_8[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'@'"));
@@ -22863,7 +22118,7 @@ _tmp_8_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -22871,19 +22126,16 @@ _tmp_8_rule(Parser *p)
 static void *
 _tmp_9_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'with'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_9[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'with'"));
@@ -22902,7 +22154,7 @@ _tmp_9_rule(Parser *p)
     }
     { // ASYNC
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_9[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC"));
@@ -22921,7 +22173,7 @@ _tmp_9_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -22929,19 +22181,16 @@ _tmp_9_rule(Parser *p)
 static void *
 _tmp_10_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'for'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_10[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'for'"));
@@ -22960,7 +22209,7 @@ _tmp_10_rule(Parser *p)
     }
     { // ASYNC
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_10[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC"));
@@ -22979,7 +22228,7 @@ _tmp_10_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -22987,19 +22236,16 @@ _tmp_10_rule(Parser *p)
 static void *
 _tmp_11_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '=' annotated_rhs
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_11[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'=' annotated_rhs"));
@@ -23015,7 +22261,7 @@ _tmp_11_rule(Parser *p)
             _res = d;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -23026,7 +22272,7 @@ _tmp_11_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -23034,19 +22280,16 @@ _tmp_11_rule(Parser *p)
 static void *
 _tmp_12_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '(' single_target ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_12[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' single_target ')'"));
@@ -23065,7 +22308,7 @@ _tmp_12_rule(Parser *p)
             _res = b;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -23076,7 +22319,7 @@ _tmp_12_rule(Parser *p)
     }
     { // single_subscript_attribute_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_12[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "single_subscript_attribute_target"));
@@ -23095,7 +22338,7 @@ _tmp_12_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -23103,19 +22346,16 @@ _tmp_12_rule(Parser *p)
 static void *
 _tmp_13_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '=' annotated_rhs
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_13[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'=' annotated_rhs"));
@@ -23131,7 +22371,7 @@ _tmp_13_rule(Parser *p)
             _res = d;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -23142,7 +22382,7 @@ _tmp_13_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -23150,12 +22390,9 @@ _tmp_13_rule(Parser *p)
 static asdl_seq *
 _loop1_14_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -23165,14 +22402,14 @@ _loop1_14_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // (star_targets '=')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_14[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(star_targets '=')"));
@@ -23188,7 +22425,7 @@ _loop1_14_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -23202,7 +22439,7 @@ _loop1_14_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -23210,13 +22447,13 @@ _loop1_14_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_14_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -23224,19 +22461,16 @@ _loop1_14_rule(Parser *p)
 static void *
 _tmp_15_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_15[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "yield_expr"));
@@ -23255,7 +22489,7 @@ _tmp_15_rule(Parser *p)
     }
     { // star_expressions
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_15[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_expressions"));
@@ -23274,7 +22508,7 @@ _tmp_15_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -23282,19 +22516,16 @@ _tmp_15_rule(Parser *p)
 static void *
 _tmp_16_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_16[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "yield_expr"));
@@ -23313,7 +22544,7 @@ _tmp_16_rule(Parser *p)
     }
     { // star_expressions
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_16[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_expressions"));
@@ -23332,7 +22563,7 @@ _tmp_16_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -23340,19 +22571,16 @@ _tmp_16_rule(Parser *p)
 static void *
 _tmp_17_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'from' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_17[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'from' expression"));
@@ -23368,7 +22596,7 @@ _tmp_17_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -23379,7 +22607,7 @@ _tmp_17_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -23387,12 +22615,9 @@ _tmp_17_rule(Parser *p)
 static asdl_seq *
 _loop0_19_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -23402,14 +22627,14 @@ _loop0_19_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_19[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' NAME"));
@@ -23425,7 +22650,7 @@ _loop0_19_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -23434,7 +22659,7 @@ _loop0_19_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -23451,13 +22676,13 @@ _loop0_19_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_19_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -23465,19 +22690,16 @@ _loop0_19_rule(Parser *p)
 static asdl_seq *
 _gather_18_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // NAME _loop0_19
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_18[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME _loop0_19"));
@@ -23499,7 +22721,7 @@ _gather_18_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -23507,12 +22729,9 @@ _gather_18_rule(Parser *p)
 static asdl_seq *
 _loop0_21_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -23522,14 +22741,14 @@ _loop0_21_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_21[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' NAME"));
@@ -23545,7 +22764,7 @@ _loop0_21_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -23554,7 +22773,7 @@ _loop0_21_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -23571,13 +22790,13 @@ _loop0_21_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_21_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -23585,19 +22804,16 @@ _loop0_21_rule(Parser *p)
 static asdl_seq *
 _gather_20_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // NAME _loop0_21
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_20[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME _loop0_21"));
@@ -23619,7 +22835,7 @@ _gather_20_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -23627,19 +22843,16 @@ _gather_20_rule(Parser *p)
 static void *
 _tmp_22_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ';'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_22[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "';'"));
@@ -23658,7 +22871,7 @@ _tmp_22_rule(Parser *p)
     }
     { // NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_22[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE"));
@@ -23677,7 +22890,7 @@ _tmp_22_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -23685,19 +22898,16 @@ _tmp_22_rule(Parser *p)
 static void *
 _tmp_23_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_23[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' expression"));
@@ -23713,7 +22923,7 @@ _tmp_23_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -23724,7 +22934,7 @@ _tmp_23_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -23732,12 +22942,9 @@ _tmp_23_rule(Parser *p)
 static asdl_seq *
 _loop0_24_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -23747,14 +22954,14 @@ _loop0_24_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ('.' | '...')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_24[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('.' | '...')"));
@@ -23770,7 +22977,7 @@ _loop0_24_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -23787,13 +22994,13 @@ _loop0_24_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_24_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -23801,12 +23008,9 @@ _loop0_24_rule(Parser *p)
 static asdl_seq *
 _loop1_25_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -23816,14 +23020,14 @@ _loop1_25_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ('.' | '...')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_25[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('.' | '...')"));
@@ -23839,7 +23043,7 @@ _loop1_25_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -23853,7 +23057,7 @@ _loop1_25_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -23861,13 +23065,13 @@ _loop1_25_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_25_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -23875,12 +23079,9 @@ _loop1_25_rule(Parser *p)
 static asdl_seq *
 _loop0_27_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -23890,14 +23091,14 @@ _loop0_27_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' import_from_as_name
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_27[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' import_from_as_name"));
@@ -23913,7 +23114,7 @@ _loop0_27_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -23922,7 +23123,7 @@ _loop0_27_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -23939,13 +23140,13 @@ _loop0_27_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_27_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -23953,19 +23154,16 @@ _loop0_27_rule(Parser *p)
 static asdl_seq *
 _gather_26_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // import_from_as_name _loop0_27
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_26[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "import_from_as_name _loop0_27"));
@@ -23987,7 +23185,7 @@ _gather_26_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -23995,19 +23193,16 @@ _gather_26_rule(Parser *p)
 static void *
 _tmp_28_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_28[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' NAME"));
@@ -24023,7 +23218,7 @@ _tmp_28_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -24034,7 +23229,7 @@ _tmp_28_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -24042,12 +23237,9 @@ _tmp_28_rule(Parser *p)
 static asdl_seq *
 _loop0_30_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -24057,14 +23249,14 @@ _loop0_30_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' dotted_as_name
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_30[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' dotted_as_name"));
@@ -24080,7 +23272,7 @@ _loop0_30_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -24089,7 +23281,7 @@ _loop0_30_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -24106,13 +23298,13 @@ _loop0_30_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_30_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -24120,19 +23312,16 @@ _loop0_30_rule(Parser *p)
 static asdl_seq *
 _gather_29_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // dotted_as_name _loop0_30
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_29[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "dotted_as_name _loop0_30"));
@@ -24154,7 +23343,7 @@ _gather_29_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -24162,19 +23351,16 @@ _gather_29_rule(Parser *p)
 static void *
 _tmp_31_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_31[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' NAME"));
@@ -24190,7 +23376,7 @@ _tmp_31_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -24201,7 +23387,7 @@ _tmp_31_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -24209,12 +23395,9 @@ _tmp_31_rule(Parser *p)
 static asdl_seq *
 _loop1_32_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -24224,14 +23407,14 @@ _loop1_32_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ('@' named_expression NEWLINE)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_32[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('@' named_expression NEWLINE)"));
@@ -24247,7 +23430,7 @@ _loop1_32_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -24261,7 +23444,7 @@ _loop1_32_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -24269,13 +23452,13 @@ _loop1_32_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_32_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -24283,19 +23466,16 @@ _loop1_32_rule(Parser *p)
 static void *
 _tmp_33_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '(' arguments? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_33[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' arguments? ')'"));
@@ -24314,7 +23494,7 @@ _tmp_33_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -24325,7 +23505,7 @@ _tmp_33_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -24333,19 +23513,16 @@ _tmp_33_rule(Parser *p)
 static void *
 _tmp_34_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '->' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_34[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'->' expression"));
@@ -24361,7 +23538,7 @@ _tmp_34_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -24372,7 +23549,7 @@ _tmp_34_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -24380,19 +23557,16 @@ _tmp_34_rule(Parser *p)
 static void *
 _tmp_35_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '->' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_35[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'->' expression"));
@@ -24408,7 +23582,7 @@ _tmp_35_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -24419,7 +23593,7 @@ _tmp_35_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -24427,12 +23601,9 @@ _tmp_35_rule(Parser *p)
 static asdl_seq *
 _loop0_36_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -24442,14 +23613,14 @@ _loop0_36_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_36[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default"));
@@ -24465,7 +23636,7 @@ _loop0_36_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -24482,13 +23653,13 @@ _loop0_36_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_36_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -24496,12 +23667,9 @@ _loop0_36_rule(Parser *p)
 static asdl_seq *
 _loop0_37_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -24511,14 +23679,14 @@ _loop0_37_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_37[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_with_default"));
@@ -24534,7 +23702,7 @@ _loop0_37_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -24551,13 +23719,13 @@ _loop0_37_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_37_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -24565,12 +23733,9 @@ _loop0_37_rule(Parser *p)
 static asdl_seq *
 _loop0_38_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -24580,14 +23745,14 @@ _loop0_38_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_38[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_with_default"));
@@ -24603,7 +23768,7 @@ _loop0_38_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -24620,13 +23785,13 @@ _loop0_38_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_38_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -24634,12 +23799,9 @@ _loop0_38_rule(Parser *p)
 static asdl_seq *
 _loop1_39_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -24649,14 +23811,14 @@ _loop1_39_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_39[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default"));
@@ -24672,7 +23834,7 @@ _loop1_39_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -24686,7 +23848,7 @@ _loop1_39_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -24694,13 +23856,13 @@ _loop1_39_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_39_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -24708,12 +23870,9 @@ _loop1_39_rule(Parser *p)
 static asdl_seq *
 _loop0_40_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -24723,14 +23882,14 @@ _loop0_40_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_40[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_with_default"));
@@ -24746,7 +23905,7 @@ _loop0_40_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -24763,13 +23922,13 @@ _loop0_40_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_40_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -24777,12 +23936,9 @@ _loop0_40_rule(Parser *p)
 static asdl_seq *
 _loop1_41_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -24792,14 +23948,14 @@ _loop1_41_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_41[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_with_default"));
@@ -24815,7 +23971,7 @@ _loop1_41_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -24829,7 +23985,7 @@ _loop1_41_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -24837,13 +23993,13 @@ _loop1_41_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_41_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -24851,12 +24007,9 @@ _loop1_41_rule(Parser *p)
 static asdl_seq *
 _loop1_42_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -24866,14 +24019,14 @@ _loop1_42_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_42[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default"));
@@ -24889,7 +24042,7 @@ _loop1_42_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -24903,7 +24056,7 @@ _loop1_42_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -24911,13 +24064,13 @@ _loop1_42_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_42_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -24925,12 +24078,9 @@ _loop1_42_rule(Parser *p)
 static asdl_seq *
 _loop1_43_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -24940,14 +24090,14 @@ _loop1_43_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_43[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default"));
@@ -24963,7 +24113,7 @@ _loop1_43_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -24977,7 +24127,7 @@ _loop1_43_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -24985,13 +24135,13 @@ _loop1_43_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_43_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -24999,12 +24149,9 @@ _loop1_43_rule(Parser *p)
 static asdl_seq *
 _loop0_44_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -25014,14 +24161,14 @@ _loop0_44_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_44[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default"));
@@ -25037,7 +24184,7 @@ _loop0_44_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -25054,13 +24201,13 @@ _loop0_44_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_44_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -25068,12 +24215,9 @@ _loop0_44_rule(Parser *p)
 static asdl_seq *
 _loop1_45_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -25083,14 +24227,14 @@ _loop1_45_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_45[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_with_default"));
@@ -25106,7 +24250,7 @@ _loop1_45_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -25120,7 +24264,7 @@ _loop1_45_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -25128,13 +24272,13 @@ _loop1_45_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_45_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -25142,12 +24286,9 @@ _loop1_45_rule(Parser *p)
 static asdl_seq *
 _loop0_46_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -25157,14 +24298,14 @@ _loop0_46_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_46[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default"));
@@ -25180,7 +24321,7 @@ _loop0_46_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -25197,13 +24338,13 @@ _loop0_46_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_46_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -25211,12 +24352,9 @@ _loop0_46_rule(Parser *p)
 static asdl_seq *
 _loop1_47_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -25226,14 +24364,14 @@ _loop1_47_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_47[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_with_default"));
@@ -25249,7 +24387,7 @@ _loop1_47_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -25263,7 +24401,7 @@ _loop1_47_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -25271,13 +24409,13 @@ _loop1_47_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_47_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -25285,12 +24423,9 @@ _loop1_47_rule(Parser *p)
 static asdl_seq *
 _loop0_48_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -25300,14 +24435,14 @@ _loop0_48_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_maybe_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_48[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_maybe_default"));
@@ -25323,7 +24458,7 @@ _loop0_48_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -25340,13 +24475,13 @@ _loop0_48_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_48_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -25354,12 +24489,9 @@ _loop0_48_rule(Parser *p)
 static asdl_seq *
 _loop1_49_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -25369,14 +24501,14 @@ _loop1_49_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_maybe_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_49[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_maybe_default"));
@@ -25392,7 +24524,7 @@ _loop1_49_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -25406,7 +24538,7 @@ _loop1_49_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -25414,13 +24546,13 @@ _loop1_49_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_49_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -25428,12 +24560,9 @@ _loop1_49_rule(Parser *p)
 static asdl_seq *
 _loop0_51_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -25443,14 +24572,14 @@ _loop0_51_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' with_item
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_51[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' with_item"));
@@ -25466,7 +24595,7 @@ _loop0_51_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -25475,7 +24604,7 @@ _loop0_51_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -25492,13 +24621,13 @@ _loop0_51_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_51_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -25506,19 +24635,16 @@ _loop0_51_rule(Parser *p)
 static asdl_seq *
 _gather_50_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_51
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_50[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "with_item _loop0_51"));
@@ -25540,7 +24666,7 @@ _gather_50_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -25548,12 +24674,9 @@ _gather_50_rule(Parser *p)
 static asdl_seq *
 _loop0_53_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -25563,14 +24686,14 @@ _loop0_53_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' with_item
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_53[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' with_item"));
@@ -25586,7 +24709,7 @@ _loop0_53_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -25595,7 +24718,7 @@ _loop0_53_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -25612,13 +24735,13 @@ _loop0_53_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_53_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -25626,19 +24749,16 @@ _loop0_53_rule(Parser *p)
 static asdl_seq *
 _gather_52_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_53
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_52[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "with_item _loop0_53"));
@@ -25660,7 +24780,7 @@ _gather_52_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -25668,12 +24788,9 @@ _gather_52_rule(Parser *p)
 static asdl_seq *
 _loop0_55_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -25683,14 +24800,14 @@ _loop0_55_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' with_item
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_55[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' with_item"));
@@ -25706,7 +24823,7 @@ _loop0_55_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -25715,7 +24832,7 @@ _loop0_55_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -25732,13 +24849,13 @@ _loop0_55_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_55_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -25746,19 +24863,16 @@ _loop0_55_rule(Parser *p)
 static asdl_seq *
 _gather_54_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_55
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_54[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "with_item _loop0_55"));
@@ -25780,7 +24894,7 @@ _gather_54_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -25788,12 +24902,9 @@ _gather_54_rule(Parser *p)
 static asdl_seq *
 _loop0_57_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -25803,14 +24914,14 @@ _loop0_57_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' with_item
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_57[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' with_item"));
@@ -25826,7 +24937,7 @@ _loop0_57_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -25835,7 +24946,7 @@ _loop0_57_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -25852,13 +24963,13 @@ _loop0_57_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_57_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -25866,19 +24977,16 @@ _loop0_57_rule(Parser *p)
 static asdl_seq *
 _gather_56_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_57
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_56[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "with_item _loop0_57"));
@@ -25900,7 +25008,7 @@ _gather_56_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -25908,19 +25016,16 @@ _gather_56_rule(Parser *p)
 static void *
 _tmp_58_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_58[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','"));
@@ -25939,7 +25044,7 @@ _tmp_58_rule(Parser *p)
     }
     { // ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_58[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "')'"));
@@ -25958,7 +25063,7 @@ _tmp_58_rule(Parser *p)
     }
     { // ':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_58[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':'"));
@@ -25977,7 +25082,7 @@ _tmp_58_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -25985,12 +25090,9 @@ _tmp_58_rule(Parser *p)
 static asdl_seq *
 _loop1_59_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -26000,14 +25102,14 @@ _loop1_59_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // except_block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_59[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "except_block"));
@@ -26023,7 +25125,7 @@ _loop1_59_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -26037,7 +25139,7 @@ _loop1_59_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -26045,13 +25147,13 @@ _loop1_59_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_59_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -26059,12 +25161,9 @@ _loop1_59_rule(Parser *p)
 static asdl_seq *
 _loop1_60_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -26074,14 +25173,14 @@ _loop1_60_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // except_star_block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_60[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "except_star_block"));
@@ -26097,7 +25196,7 @@ _loop1_60_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -26111,7 +25210,7 @@ _loop1_60_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -26119,13 +25218,13 @@ _loop1_60_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_60_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -26133,19 +25232,16 @@ _loop1_60_rule(Parser *p)
 static void *
 _tmp_61_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_61[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' NAME"));
@@ -26161,7 +25257,7 @@ _tmp_61_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -26172,7 +25268,7 @@ _tmp_61_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -26180,19 +25276,16 @@ _tmp_61_rule(Parser *p)
 static void *
 _tmp_62_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_62[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' NAME"));
@@ -26208,7 +25301,7 @@ _tmp_62_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -26219,7 +25312,7 @@ _tmp_62_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -26227,12 +25320,9 @@ _tmp_62_rule(Parser *p)
 static asdl_seq *
 _loop1_63_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -26242,14 +25332,14 @@ _loop1_63_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // case_block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_63[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "case_block"));
@@ -26265,7 +25355,7 @@ _loop1_63_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -26279,7 +25369,7 @@ _loop1_63_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -26287,13 +25377,13 @@ _loop1_63_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_63_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -26301,12 +25391,9 @@ _loop1_63_rule(Parser *p)
 static asdl_seq *
 _loop0_65_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -26316,14 +25403,14 @@ _loop0_65_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // '|' closed_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_65[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'|' closed_pattern"));
@@ -26339,7 +25426,7 @@ _loop0_65_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -26348,7 +25435,7 @@ _loop0_65_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -26365,13 +25452,13 @@ _loop0_65_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_65_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -26379,19 +25466,16 @@ _loop0_65_rule(Parser *p)
 static asdl_seq *
 _gather_64_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // closed_pattern _loop0_65
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_64[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "closed_pattern _loop0_65"));
@@ -26413,7 +25497,7 @@ _gather_64_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -26421,19 +25505,16 @@ _gather_64_rule(Parser *p)
 static void *
 _tmp_66_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '+'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_66[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'+'"));
@@ -26452,7 +25533,7 @@ _tmp_66_rule(Parser *p)
     }
     { // '-'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_66[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'-'"));
@@ -26471,7 +25552,7 @@ _tmp_66_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -26479,19 +25560,16 @@ _tmp_66_rule(Parser *p)
 static void *
 _tmp_67_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '+'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_67[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'+'"));
@@ -26510,7 +25588,7 @@ _tmp_67_rule(Parser *p)
     }
     { // '-'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_67[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'-'"));
@@ -26529,7 +25607,7 @@ _tmp_67_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -26537,19 +25615,16 @@ _tmp_67_rule(Parser *p)
 static void *
 _tmp_68_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '.'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_68[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'.'"));
@@ -26568,7 +25643,7 @@ _tmp_68_rule(Parser *p)
     }
     { // '('
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_68[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'('"));
@@ -26587,7 +25662,7 @@ _tmp_68_rule(Parser *p)
     }
     { // '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_68[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'='"));
@@ -26606,7 +25681,7 @@ _tmp_68_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -26614,19 +25689,16 @@ _tmp_68_rule(Parser *p)
 static void *
 _tmp_69_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '.'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_69[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'.'"));
@@ -26645,7 +25717,7 @@ _tmp_69_rule(Parser *p)
     }
     { // '('
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_69[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'('"));
@@ -26664,7 +25736,7 @@ _tmp_69_rule(Parser *p)
     }
     { // '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_69[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'='"));
@@ -26683,7 +25755,7 @@ _tmp_69_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -26691,12 +25763,9 @@ _tmp_69_rule(Parser *p)
 static asdl_seq *
 _loop0_71_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -26706,14 +25775,14 @@ _loop0_71_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' maybe_star_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_71[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' maybe_star_pattern"));
@@ -26729,7 +25798,7 @@ _loop0_71_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -26738,7 +25807,7 @@ _loop0_71_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -26755,13 +25824,13 @@ _loop0_71_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_71_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -26769,19 +25838,16 @@ _loop0_71_rule(Parser *p)
 static asdl_seq *
 _gather_70_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // maybe_star_pattern _loop0_71
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_70[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "maybe_star_pattern _loop0_71"));
@@ -26803,7 +25869,7 @@ _gather_70_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -26811,12 +25877,9 @@ _gather_70_rule(Parser *p)
 static asdl_seq *
 _loop0_73_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -26826,14 +25889,14 @@ _loop0_73_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' key_value_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_73[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' key_value_pattern"));
@@ -26849,7 +25912,7 @@ _loop0_73_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -26858,7 +25921,7 @@ _loop0_73_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -26875,13 +25938,13 @@ _loop0_73_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_73_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -26889,19 +25952,16 @@ _loop0_73_rule(Parser *p)
 static asdl_seq *
 _gather_72_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // key_value_pattern _loop0_73
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_72[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "key_value_pattern _loop0_73"));
@@ -26923,7 +25983,7 @@ _gather_72_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -26931,19 +25991,16 @@ _gather_72_rule(Parser *p)
 static void *
 _tmp_74_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // literal_expr
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_74[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "literal_expr"));
@@ -26962,7 +26019,7 @@ _tmp_74_rule(Parser *p)
     }
     { // attr
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_74[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "attr"));
@@ -26981,7 +26038,7 @@ _tmp_74_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -26989,12 +26046,9 @@ _tmp_74_rule(Parser *p)
 static asdl_seq *
 _loop0_76_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -27004,14 +26058,14 @@ _loop0_76_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_76[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' pattern"));
@@ -27027,7 +26081,7 @@ _loop0_76_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -27036,7 +26090,7 @@ _loop0_76_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -27053,13 +26107,13 @@ _loop0_76_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_76_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -27067,19 +26121,16 @@ _loop0_76_rule(Parser *p)
 static asdl_seq *
 _gather_75_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // pattern _loop0_76
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_75[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "pattern _loop0_76"));
@@ -27101,7 +26152,7 @@ _gather_75_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -27109,12 +26160,9 @@ _gather_75_rule(Parser *p)
 static asdl_seq *
 _loop0_78_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -27124,14 +26172,14 @@ _loop0_78_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' keyword_pattern
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_78[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' keyword_pattern"));
@@ -27147,7 +26195,7 @@ _loop0_78_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -27156,7 +26204,7 @@ _loop0_78_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -27173,13 +26221,13 @@ _loop0_78_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_78_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -27187,19 +26235,16 @@ _loop0_78_rule(Parser *p)
 static asdl_seq *
 _gather_77_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // keyword_pattern _loop0_78
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_77[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "keyword_pattern _loop0_78"));
@@ -27221,7 +26266,7 @@ _gather_77_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -27229,12 +26274,9 @@ _gather_77_rule(Parser *p)
 static asdl_seq *
 _loop1_79_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -27244,14 +26286,14 @@ _loop1_79_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // (',' expression)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_79[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(',' expression)"));
@@ -27267,7 +26309,7 @@ _loop1_79_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -27281,7 +26323,7 @@ _loop1_79_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -27289,13 +26331,13 @@ _loop1_79_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_79_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -27303,12 +26345,9 @@ _loop1_79_rule(Parser *p)
 static asdl_seq *
 _loop1_80_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -27318,14 +26357,14 @@ _loop1_80_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // (',' star_expression)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_80[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(',' star_expression)"));
@@ -27341,7 +26380,7 @@ _loop1_80_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -27355,7 +26394,7 @@ _loop1_80_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -27363,13 +26402,13 @@ _loop1_80_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_80_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -27377,12 +26416,9 @@ _loop1_80_rule(Parser *p)
 static asdl_seq *
 _loop0_82_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -27392,14 +26428,14 @@ _loop0_82_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' star_named_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_82[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' star_named_expression"));
@@ -27415,7 +26451,7 @@ _loop0_82_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -27424,7 +26460,7 @@ _loop0_82_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -27441,13 +26477,13 @@ _loop0_82_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_82_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -27455,19 +26491,16 @@ _loop0_82_rule(Parser *p)
 static asdl_seq *
 _gather_81_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // star_named_expression _loop0_82
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_81[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_named_expression _loop0_82"));
@@ -27489,7 +26522,7 @@ _gather_81_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -27497,12 +26530,9 @@ _gather_81_rule(Parser *p)
 static asdl_seq *
 _loop1_83_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -27512,14 +26542,14 @@ _loop1_83_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ('or' conjunction)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_83[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('or' conjunction)"));
@@ -27535,7 +26565,7 @@ _loop1_83_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -27549,7 +26579,7 @@ _loop1_83_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -27557,13 +26587,13 @@ _loop1_83_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_83_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -27571,12 +26601,9 @@ _loop1_83_rule(Parser *p)
 static asdl_seq *
 _loop1_84_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -27586,14 +26613,14 @@ _loop1_84_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ('and' inversion)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_84[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('and' inversion)"));
@@ -27609,7 +26636,7 @@ _loop1_84_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -27623,7 +26650,7 @@ _loop1_84_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -27631,13 +26658,13 @@ _loop1_84_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_84_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -27645,12 +26672,9 @@ _loop1_84_rule(Parser *p)
 static asdl_seq *
 _loop1_85_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -27660,14 +26684,14 @@ _loop1_85_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // compare_op_bitwise_or_pair
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_85[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "compare_op_bitwise_or_pair"));
@@ -27683,7 +26707,7 @@ _loop1_85_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -27697,7 +26721,7 @@ _loop1_85_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -27705,13 +26729,13 @@ _loop1_85_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_85_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -27719,19 +26743,16 @@ _loop1_85_rule(Parser *p)
 static void *
 _tmp_86_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '!='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_86[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'!='"));
@@ -27744,7 +26765,7 @@ _tmp_86_rule(Parser *p)
             _res = _PyPegen_check_barry_as_flufl ( p , tok ) ? NULL : tok;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -27755,7 +26776,7 @@ _tmp_86_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -27763,12 +26784,9 @@ _tmp_86_rule(Parser *p)
 static asdl_seq *
 _loop0_88_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -27778,14 +26796,14 @@ _loop0_88_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' slice
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_88[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' slice"));
@@ -27801,7 +26819,7 @@ _loop0_88_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -27810,7 +26828,7 @@ _loop0_88_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -27827,13 +26845,13 @@ _loop0_88_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_88_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -27841,19 +26859,16 @@ _loop0_88_rule(Parser *p)
 static asdl_seq *
 _gather_87_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // slice _loop0_88
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_87[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "slice _loop0_88"));
@@ -27875,7 +26890,7 @@ _gather_87_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -27883,19 +26898,16 @@ _gather_87_rule(Parser *p)
 static void *
 _tmp_89_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ':' expression?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_89[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':' expression?"));
@@ -27911,7 +26923,7 @@ _tmp_89_rule(Parser *p)
             _res = d;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -27922,7 +26934,7 @@ _tmp_89_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -27930,19 +26942,16 @@ _tmp_89_rule(Parser *p)
 static void *
 _tmp_90_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // tuple
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_90[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "tuple"));
@@ -27961,7 +26970,7 @@ _tmp_90_rule(Parser *p)
     }
     { // group
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_90[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "group"));
@@ -27980,7 +26989,7 @@ _tmp_90_rule(Parser *p)
     }
     { // genexp
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_90[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "genexp"));
@@ -27999,7 +27008,7 @@ _tmp_90_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -28007,19 +27016,16 @@ _tmp_90_rule(Parser *p)
 static void *
 _tmp_91_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // list
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_91[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "list"));
@@ -28038,7 +27044,7 @@ _tmp_91_rule(Parser *p)
     }
     { // listcomp
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_91[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "listcomp"));
@@ -28057,7 +27063,7 @@ _tmp_91_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -28065,19 +27071,16 @@ _tmp_91_rule(Parser *p)
 static void *
 _tmp_92_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // dict
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_92[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "dict"));
@@ -28096,7 +27099,7 @@ _tmp_92_rule(Parser *p)
     }
     { // set
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_92[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "set"));
@@ -28115,7 +27118,7 @@ _tmp_92_rule(Parser *p)
     }
     { // dictcomp
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_92[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "dictcomp"));
@@ -28134,7 +27137,7 @@ _tmp_92_rule(Parser *p)
     }
     { // setcomp
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_92[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "setcomp"));
@@ -28153,7 +27156,7 @@ _tmp_92_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -28161,19 +27164,16 @@ _tmp_92_rule(Parser *p)
 static void *
 _tmp_93_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_93[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "yield_expr"));
@@ -28192,7 +27192,7 @@ _tmp_93_rule(Parser *p)
     }
     { // named_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_93[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "named_expression"));
@@ -28211,7 +27211,7 @@ _tmp_93_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -28219,12 +27219,9 @@ _tmp_93_rule(Parser *p)
 static asdl_seq *
 _loop0_94_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -28234,14 +27231,14 @@ _loop0_94_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_94[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default"));
@@ -28257,7 +27254,7 @@ _loop0_94_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -28274,13 +27271,13 @@ _loop0_94_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_94_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -28288,12 +27285,9 @@ _loop0_94_rule(Parser *p)
 static asdl_seq *
 _loop0_95_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -28303,14 +27297,14 @@ _loop0_95_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_95[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_with_default"));
@@ -28326,7 +27320,7 @@ _loop0_95_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -28343,13 +27337,13 @@ _loop0_95_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_95_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -28357,12 +27351,9 @@ _loop0_95_rule(Parser *p)
 static asdl_seq *
 _loop0_96_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -28372,14 +27363,14 @@ _loop0_96_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_96[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_with_default"));
@@ -28395,7 +27386,7 @@ _loop0_96_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -28412,13 +27403,13 @@ _loop0_96_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_96_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -28426,12 +27417,9 @@ _loop0_96_rule(Parser *p)
 static asdl_seq *
 _loop1_97_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -28441,14 +27429,14 @@ _loop1_97_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_97[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default"));
@@ -28464,7 +27452,7 @@ _loop1_97_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -28478,7 +27466,7 @@ _loop1_97_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -28486,13 +27474,13 @@ _loop1_97_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_97_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -28500,12 +27488,9 @@ _loop1_97_rule(Parser *p)
 static asdl_seq *
 _loop0_98_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -28515,14 +27500,14 @@ _loop0_98_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_98[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_with_default"));
@@ -28538,7 +27523,7 @@ _loop0_98_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -28555,13 +27540,13 @@ _loop0_98_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_98_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -28569,12 +27554,9 @@ _loop0_98_rule(Parser *p)
 static asdl_seq *
 _loop1_99_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -28584,14 +27566,14 @@ _loop1_99_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_99[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_with_default"));
@@ -28607,7 +27589,7 @@ _loop1_99_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -28621,7 +27603,7 @@ _loop1_99_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -28629,13 +27611,13 @@ _loop1_99_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_99_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -28643,12 +27625,9 @@ _loop1_99_rule(Parser *p)
 static asdl_seq *
 _loop1_100_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -28658,14 +27637,14 @@ _loop1_100_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_100[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default"));
@@ -28681,7 +27660,7 @@ _loop1_100_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -28695,7 +27674,7 @@ _loop1_100_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -28703,13 +27682,13 @@ _loop1_100_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_100_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -28717,12 +27696,9 @@ _loop1_100_rule(Parser *p)
 static asdl_seq *
 _loop1_101_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -28732,14 +27708,14 @@ _loop1_101_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_101[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default"));
@@ -28755,7 +27731,7 @@ _loop1_101_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -28769,7 +27745,7 @@ _loop1_101_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -28777,13 +27753,13 @@ _loop1_101_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_101_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -28791,12 +27767,9 @@ _loop1_101_rule(Parser *p)
 static asdl_seq *
 _loop0_102_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -28806,14 +27779,14 @@ _loop0_102_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_102[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default"));
@@ -28829,7 +27802,7 @@ _loop0_102_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -28846,13 +27819,13 @@ _loop0_102_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_102_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -28860,12 +27833,9 @@ _loop0_102_rule(Parser *p)
 static asdl_seq *
 _loop1_103_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -28875,14 +27845,14 @@ _loop1_103_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_103[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_with_default"));
@@ -28898,7 +27868,7 @@ _loop1_103_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -28912,7 +27882,7 @@ _loop1_103_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -28920,13 +27890,13 @@ _loop1_103_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_103_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -28934,12 +27904,9 @@ _loop1_103_rule(Parser *p)
 static asdl_seq *
 _loop0_104_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -28949,14 +27916,14 @@ _loop0_104_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_104[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default"));
@@ -28972,7 +27939,7 @@ _loop0_104_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -28989,13 +27956,13 @@ _loop0_104_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_104_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -29003,12 +27970,9 @@ _loop0_104_rule(Parser *p)
 static asdl_seq *
 _loop1_105_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -29018,14 +27982,14 @@ _loop1_105_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_105[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_with_default"));
@@ -29041,7 +28005,7 @@ _loop1_105_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -29055,7 +28019,7 @@ _loop1_105_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -29063,13 +28027,13 @@ _loop1_105_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_105_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -29077,12 +28041,9 @@ _loop1_105_rule(Parser *p)
 static asdl_seq *
 _loop0_106_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -29092,14 +28053,14 @@ _loop0_106_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_maybe_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_106[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_maybe_default"));
@@ -29115,7 +28076,7 @@ _loop0_106_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -29132,13 +28093,13 @@ _loop0_106_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_106_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -29146,12 +28107,9 @@ _loop0_106_rule(Parser *p)
 static asdl_seq *
 _loop1_107_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -29161,14 +28119,14 @@ _loop1_107_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_maybe_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_107[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_maybe_default"));
@@ -29184,7 +28142,7 @@ _loop1_107_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -29198,7 +28156,7 @@ _loop1_107_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -29206,13 +28164,13 @@ _loop1_107_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_107_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -29220,12 +28178,9 @@ _loop1_107_rule(Parser *p)
 static asdl_seq *
 _loop1_108_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -29235,14 +28190,14 @@ _loop1_108_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // STRING
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_108[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "STRING"));
@@ -29258,7 +28213,7 @@ _loop1_108_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -29272,7 +28227,7 @@ _loop1_108_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -29280,13 +28235,13 @@ _loop1_108_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_108_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -29294,19 +28249,16 @@ _loop1_108_rule(Parser *p)
 static void *
 _tmp_109_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // star_named_expression ',' star_named_expressions?
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_109[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_named_expression ',' star_named_expressions?"));
@@ -29325,7 +28277,7 @@ _tmp_109_rule(Parser *p)
             _res = _PyPegen_seq_insert_in_front ( p , y , z );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -29336,7 +28288,7 @@ _tmp_109_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -29344,12 +28296,9 @@ _tmp_109_rule(Parser *p)
 static asdl_seq *
 _loop0_111_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -29359,14 +28308,14 @@ _loop0_111_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' double_starred_kvpair
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_111[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' double_starred_kvpair"));
@@ -29382,7 +28331,7 @@ _loop0_111_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -29391,7 +28340,7 @@ _loop0_111_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -29408,13 +28357,13 @@ _loop0_111_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_111_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -29422,19 +28371,16 @@ _loop0_111_rule(Parser *p)
 static asdl_seq *
 _gather_110_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // double_starred_kvpair _loop0_111
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_110[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "double_starred_kvpair _loop0_111"));
@@ -29456,7 +28402,7 @@ _gather_110_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -29464,12 +28410,9 @@ _gather_110_rule(Parser *p)
 static asdl_seq *
 _loop1_112_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -29479,14 +28422,14 @@ _loop1_112_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // for_if_clause
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_112[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "for_if_clause"));
@@ -29502,7 +28445,7 @@ _loop1_112_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -29516,7 +28459,7 @@ _loop1_112_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -29524,13 +28467,13 @@ _loop1_112_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_112_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -29538,12 +28481,9 @@ _loop1_112_rule(Parser *p)
 static asdl_seq *
 _loop0_113_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -29553,14 +28493,14 @@ _loop0_113_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ('if' disjunction)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_113[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('if' disjunction)"));
@@ -29576,7 +28516,7 @@ _loop0_113_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -29593,13 +28533,13 @@ _loop0_113_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_113_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -29607,12 +28547,9 @@ _loop0_113_rule(Parser *p)
 static asdl_seq *
 _loop0_114_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -29622,14 +28559,14 @@ _loop0_114_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ('if' disjunction)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_114[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('if' disjunction)"));
@@ -29645,7 +28582,7 @@ _loop0_114_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -29662,13 +28599,13 @@ _loop0_114_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_114_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -29676,19 +28613,16 @@ _loop0_114_rule(Parser *p)
 static void *
 _tmp_115_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // assignment_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_115[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
@@ -29707,7 +28641,7 @@ _tmp_115_rule(Parser *p)
     }
     { // expression !':='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_115[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression !':='"));
@@ -29728,7 +28662,7 @@ _tmp_115_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -29736,12 +28670,9 @@ _tmp_115_rule(Parser *p)
 static asdl_seq *
 _loop0_117_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -29751,14 +28682,14 @@ _loop0_117_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' (starred_expression | (assignment_expression | expression !':=') !'=')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_117[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' (starred_expression | (assignment_expression | expression !':=') !'=')"));
@@ -29774,7 +28705,7 @@ _loop0_117_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -29783,7 +28714,7 @@ _loop0_117_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -29800,13 +28731,13 @@ _loop0_117_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_117_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -29815,19 +28746,16 @@ _loop0_117_rule(Parser *p)
 static asdl_seq *
 _gather_116_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // (starred_expression | (assignment_expression | expression !':=') !'=') _loop0_117
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_116[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(starred_expression | (assignment_expression | expression !':=') !'=') _loop0_117"));
@@ -29849,7 +28777,7 @@ _gather_116_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -29857,19 +28785,16 @@ _gather_116_rule(Parser *p)
 static void *
 _tmp_118_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' kwargs
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_118[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' kwargs"));
@@ -29885,7 +28810,7 @@ _tmp_118_rule(Parser *p)
             _res = k;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -29896,7 +28821,7 @@ _tmp_118_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -29904,12 +28829,9 @@ _tmp_118_rule(Parser *p)
 static asdl_seq *
 _loop0_120_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -29919,14 +28841,14 @@ _loop0_120_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' kwarg_or_starred
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_120[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' kwarg_or_starred"));
@@ -29942,7 +28864,7 @@ _loop0_120_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -29951,7 +28873,7 @@ _loop0_120_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -29968,13 +28890,13 @@ _loop0_120_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_120_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -29982,19 +28904,16 @@ _loop0_120_rule(Parser *p)
 static asdl_seq *
 _gather_119_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_starred _loop0_120
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_119[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "kwarg_or_starred _loop0_120"));
@@ -30016,7 +28935,7 @@ _gather_119_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -30024,12 +28943,9 @@ _gather_119_rule(Parser *p)
 static asdl_seq *
 _loop0_122_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -30039,14 +28955,14 @@ _loop0_122_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' kwarg_or_double_starred
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_122[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' kwarg_or_double_starred"));
@@ -30062,7 +28978,7 @@ _loop0_122_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -30071,7 +28987,7 @@ _loop0_122_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -30088,13 +29004,13 @@ _loop0_122_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_122_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -30102,19 +29018,16 @@ _loop0_122_rule(Parser *p)
 static asdl_seq *
 _gather_121_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_double_starred _loop0_122
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_121[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "kwarg_or_double_starred _loop0_122"));
@@ -30136,7 +29049,7 @@ _gather_121_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -30144,12 +29057,9 @@ _gather_121_rule(Parser *p)
 static asdl_seq *
 _loop0_124_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -30159,14 +29069,14 @@ _loop0_124_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' kwarg_or_starred
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_124[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' kwarg_or_starred"));
@@ -30182,7 +29092,7 @@ _loop0_124_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -30191,7 +29101,7 @@ _loop0_124_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -30208,13 +29118,13 @@ _loop0_124_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_124_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -30222,19 +29132,16 @@ _loop0_124_rule(Parser *p)
 static asdl_seq *
 _gather_123_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_starred _loop0_124
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_123[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "kwarg_or_starred _loop0_124"));
@@ -30256,7 +29163,7 @@ _gather_123_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -30264,12 +29171,9 @@ _gather_123_rule(Parser *p)
 static asdl_seq *
 _loop0_126_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -30279,14 +29183,14 @@ _loop0_126_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' kwarg_or_double_starred
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_126[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' kwarg_or_double_starred"));
@@ -30302,7 +29206,7 @@ _loop0_126_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -30311,7 +29215,7 @@ _loop0_126_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -30328,13 +29232,13 @@ _loop0_126_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_126_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -30342,19 +29246,16 @@ _loop0_126_rule(Parser *p)
 static asdl_seq *
 _gather_125_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_double_starred _loop0_126
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_125[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "kwarg_or_double_starred _loop0_126"));
@@ -30376,7 +29277,7 @@ _gather_125_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -30384,12 +29285,9 @@ _gather_125_rule(Parser *p)
 static asdl_seq *
 _loop0_127_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -30399,14 +29297,14 @@ _loop0_127_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // (',' star_target)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_127[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(',' star_target)"));
@@ -30422,7 +29320,7 @@ _loop0_127_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -30439,13 +29337,13 @@ _loop0_127_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_127_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -30453,12 +29351,9 @@ _loop0_127_rule(Parser *p)
 static asdl_seq *
 _loop0_129_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -30468,14 +29363,14 @@ _loop0_129_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' star_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_129[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' star_target"));
@@ -30491,7 +29386,7 @@ _loop0_129_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -30500,7 +29395,7 @@ _loop0_129_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -30517,13 +29412,13 @@ _loop0_129_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_129_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -30531,19 +29426,16 @@ _loop0_129_rule(Parser *p)
 static asdl_seq *
 _gather_128_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // star_target _loop0_129
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_128[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_target _loop0_129"));
@@ -30565,7 +29457,7 @@ _gather_128_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -30573,12 +29465,9 @@ _gather_128_rule(Parser *p)
 static asdl_seq *
 _loop1_130_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -30588,14 +29477,14 @@ _loop1_130_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // (',' star_target)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_130[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(',' star_target)"));
@@ -30611,7 +29500,7 @@ _loop1_130_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -30625,7 +29514,7 @@ _loop1_130_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -30633,13 +29522,13 @@ _loop1_130_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_130_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -30647,19 +29536,16 @@ _loop1_130_rule(Parser *p)
 static void *
 _tmp_131_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // !'*' star_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_131[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "!'*' star_target"));
@@ -30680,7 +29566,7 @@ _tmp_131_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -30688,12 +29574,9 @@ _tmp_131_rule(Parser *p)
 static asdl_seq *
 _loop0_133_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -30703,14 +29586,14 @@ _loop0_133_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' del_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_133[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' del_target"));
@@ -30726,7 +29609,7 @@ _loop0_133_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -30735,7 +29618,7 @@ _loop0_133_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -30752,13 +29635,13 @@ _loop0_133_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_133_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -30766,19 +29649,16 @@ _loop0_133_rule(Parser *p)
 static asdl_seq *
 _gather_132_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // del_target _loop0_133
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_132[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "del_target _loop0_133"));
@@ -30800,7 +29680,7 @@ _gather_132_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -30808,12 +29688,9 @@ _gather_132_rule(Parser *p)
 static asdl_seq *
 _loop0_135_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -30823,14 +29700,14 @@ _loop0_135_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_135[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' expression"));
@@ -30846,7 +29723,7 @@ _loop0_135_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -30855,7 +29732,7 @@ _loop0_135_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -30872,13 +29749,13 @@ _loop0_135_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_135_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -30886,19 +29763,16 @@ _loop0_135_rule(Parser *p)
 static asdl_seq *
 _gather_134_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_135
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_134[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression _loop0_135"));
@@ -30920,7 +29794,7 @@ _gather_134_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -30928,12 +29802,9 @@ _gather_134_rule(Parser *p)
 static asdl_seq *
 _loop0_137_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -30943,14 +29814,14 @@ _loop0_137_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_137[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' expression"));
@@ -30966,7 +29837,7 @@ _loop0_137_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -30975,7 +29846,7 @@ _loop0_137_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -30992,13 +29863,13 @@ _loop0_137_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_137_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -31006,19 +29877,16 @@ _loop0_137_rule(Parser *p)
 static asdl_seq *
 _gather_136_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_137
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_136[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression _loop0_137"));
@@ -31040,7 +29908,7 @@ _gather_136_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31048,12 +29916,9 @@ _gather_136_rule(Parser *p)
 static asdl_seq *
 _loop0_139_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -31063,14 +29928,14 @@ _loop0_139_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_139[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' expression"));
@@ -31086,7 +29951,7 @@ _loop0_139_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -31095,7 +29960,7 @@ _loop0_139_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -31112,13 +29977,13 @@ _loop0_139_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_139_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -31126,19 +29991,16 @@ _loop0_139_rule(Parser *p)
 static asdl_seq *
 _gather_138_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_139
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_138[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression _loop0_139"));
@@ -31160,7 +30022,7 @@ _gather_138_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31168,12 +30030,9 @@ _gather_138_rule(Parser *p)
 static asdl_seq *
 _loop0_141_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -31183,14 +30042,14 @@ _loop0_141_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_141[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' expression"));
@@ -31206,7 +30065,7 @@ _loop0_141_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -31215,7 +30074,7 @@ _loop0_141_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -31232,13 +30091,13 @@ _loop0_141_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_141_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -31246,19 +30105,16 @@ _loop0_141_rule(Parser *p)
 static asdl_seq *
 _gather_140_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_141
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_140[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression _loop0_141"));
@@ -31280,7 +30136,7 @@ _gather_140_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31288,19 +30144,16 @@ _gather_140_rule(Parser *p)
 static void *
 _tmp_142_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // NEWLINE INDENT
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_142[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE INDENT"));
@@ -31322,7 +30175,7 @@ _tmp_142_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31330,19 +30183,16 @@ _tmp_142_rule(Parser *p)
 static void *
 _tmp_143_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // args
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_143[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "args"));
@@ -31361,7 +30211,7 @@ _tmp_143_rule(Parser *p)
     }
     { // expression for_if_clauses
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_143[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression for_if_clauses"));
@@ -31383,7 +30233,7 @@ _tmp_143_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31391,19 +30241,16 @@ _tmp_143_rule(Parser *p)
 static void *
 _tmp_144_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'True'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_144[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'True'"));
@@ -31422,7 +30269,7 @@ _tmp_144_rule(Parser *p)
     }
     { // 'False'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_144[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'False'"));
@@ -31441,7 +30288,7 @@ _tmp_144_rule(Parser *p)
     }
     { // 'None'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_144[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'None'"));
@@ -31460,7 +30307,7 @@ _tmp_144_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31468,19 +30315,16 @@ _tmp_144_rule(Parser *p)
 static void *
 _tmp_145_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // NAME '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_145[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME '='"));
@@ -31502,7 +30346,7 @@ _tmp_145_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31510,19 +30354,16 @@ _tmp_145_rule(Parser *p)
 static void *
 _tmp_146_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // NAME STRING
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_146[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME STRING"));
@@ -31544,7 +30385,7 @@ _tmp_146_rule(Parser *p)
     }
     { // SOFT_KEYWORD
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_146[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "SOFT_KEYWORD"));
@@ -31563,7 +30404,7 @@ _tmp_146_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31571,19 +30412,16 @@ _tmp_146_rule(Parser *p)
 static void *
 _tmp_147_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'else'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_147[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'else'"));
@@ -31602,7 +30440,7 @@ _tmp_147_rule(Parser *p)
     }
     { // ':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_147[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':'"));
@@ -31621,7 +30459,7 @@ _tmp_147_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31629,19 +30467,16 @@ _tmp_147_rule(Parser *p)
 static void *
 _tmp_148_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_148[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'='"));
@@ -31660,7 +30495,7 @@ _tmp_148_rule(Parser *p)
     }
     { // ':='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_148[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':='"));
@@ -31679,7 +30514,7 @@ _tmp_148_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31687,19 +30522,16 @@ _tmp_148_rule(Parser *p)
 static void *
 _tmp_149_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // list
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_149[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "list"));
@@ -31718,7 +30550,7 @@ _tmp_149_rule(Parser *p)
     }
     { // tuple
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_149[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "tuple"));
@@ -31737,7 +30569,7 @@ _tmp_149_rule(Parser *p)
     }
     { // genexp
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_149[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "genexp"));
@@ -31756,7 +30588,7 @@ _tmp_149_rule(Parser *p)
     }
     { // 'True'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_149[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'True'"));
@@ -31775,7 +30607,7 @@ _tmp_149_rule(Parser *p)
     }
     { // 'None'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_149[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'None'"));
@@ -31794,7 +30626,7 @@ _tmp_149_rule(Parser *p)
     }
     { // 'False'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_149[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'False'"));
@@ -31813,7 +30645,7 @@ _tmp_149_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31821,19 +30653,16 @@ _tmp_149_rule(Parser *p)
 static void *
 _tmp_150_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_150[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'='"));
@@ -31852,7 +30681,7 @@ _tmp_150_rule(Parser *p)
     }
     { // ':='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_150[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':='"));
@@ -31871,7 +30700,7 @@ _tmp_150_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -31879,12 +30708,9 @@ _tmp_150_rule(Parser *p)
 static asdl_seq *
 _loop0_151_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -31894,14 +30720,14 @@ _loop0_151_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // star_named_expressions
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_151[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_named_expressions"));
@@ -31917,7 +30743,7 @@ _loop0_151_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -31934,13 +30760,13 @@ _loop0_151_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_151_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -31948,12 +30774,9 @@ _loop0_151_rule(Parser *p)
 static asdl_seq *
 _loop0_152_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -31963,14 +30786,14 @@ _loop0_152_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // (star_targets '=')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_152[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(star_targets '=')"));
@@ -31986,7 +30809,7 @@ _loop0_152_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -32003,13 +30826,13 @@ _loop0_152_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_152_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -32017,12 +30840,9 @@ _loop0_152_rule(Parser *p)
 static asdl_seq *
 _loop0_153_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -32032,14 +30852,14 @@ _loop0_153_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // (star_targets '=')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_153[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(star_targets '=')"));
@@ -32055,7 +30875,7 @@ _loop0_153_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -32072,13 +30892,13 @@ _loop0_153_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_153_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -32086,19 +30906,16 @@ _loop0_153_rule(Parser *p)
 static void *
 _tmp_154_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_154[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "yield_expr"));
@@ -32117,7 +30934,7 @@ _tmp_154_rule(Parser *p)
     }
     { // star_expressions
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_154[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_expressions"));
@@ -32136,7 +30953,7 @@ _tmp_154_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -32144,19 +30961,16 @@ _tmp_154_rule(Parser *p)
 static void *
 _tmp_155_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '['
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_155[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'['"));
@@ -32175,7 +30989,7 @@ _tmp_155_rule(Parser *p)
     }
     { // '('
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_155[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'('"));
@@ -32194,7 +31008,7 @@ _tmp_155_rule(Parser *p)
     }
     { // '{'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_155[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{'"));
@@ -32213,7 +31027,7 @@ _tmp_155_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -32221,19 +31035,16 @@ _tmp_155_rule(Parser *p)
 static void *
 _tmp_156_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '['
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_156[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'['"));
@@ -32252,7 +31063,7 @@ _tmp_156_rule(Parser *p)
     }
     { // '{'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_156[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{'"));
@@ -32271,7 +31082,7 @@ _tmp_156_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -32279,19 +31090,16 @@ _tmp_156_rule(Parser *p)
 static void *
 _tmp_157_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '['
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_157[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'['"));
@@ -32310,7 +31118,7 @@ _tmp_157_rule(Parser *p)
     }
     { // '{'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_157[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{'"));
@@ -32329,7 +31137,7 @@ _tmp_157_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -32337,12 +31145,9 @@ _tmp_157_rule(Parser *p)
 static asdl_seq *
 _loop0_158_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -32352,14 +31157,14 @@ _loop0_158_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_158[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default"));
@@ -32375,7 +31180,7 @@ _loop0_158_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -32392,13 +31197,13 @@ _loop0_158_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_158_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -32406,12 +31211,9 @@ _loop0_158_rule(Parser *p)
 static asdl_seq *
 _loop0_159_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -32421,14 +31223,14 @@ _loop0_159_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_159[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default"));
@@ -32444,7 +31246,7 @@ _loop0_159_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -32461,13 +31263,13 @@ _loop0_159_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_159_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -32475,12 +31277,9 @@ _loop0_159_rule(Parser *p)
 static asdl_seq *
 _loop1_160_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -32490,14 +31289,14 @@ _loop1_160_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_160[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default"));
@@ -32513,7 +31312,7 @@ _loop1_160_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -32527,7 +31326,7 @@ _loop1_160_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -32535,13 +31334,13 @@ _loop1_160_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_160_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -32549,12 +31348,9 @@ _loop1_160_rule(Parser *p)
 static asdl_seq *
 _loop1_161_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -32564,14 +31360,14 @@ _loop1_161_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_161[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_with_default"));
@@ -32587,7 +31383,7 @@ _loop1_161_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -32601,7 +31397,7 @@ _loop1_161_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -32609,13 +31405,13 @@ _loop1_161_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_161_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -32623,12 +31419,9 @@ _loop1_161_rule(Parser *p)
 static asdl_seq *
 _loop0_162_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -32638,14 +31431,14 @@ _loop0_162_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_162[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default"));
@@ -32661,7 +31454,7 @@ _loop0_162_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -32678,13 +31471,13 @@ _loop0_162_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_162_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -32692,12 +31485,9 @@ _loop0_162_rule(Parser *p)
 static asdl_seq *
 _loop0_163_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -32707,14 +31497,14 @@ _loop0_163_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_no_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_163[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default"));
@@ -32730,7 +31520,7 @@ _loop0_163_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -32747,13 +31537,13 @@ _loop0_163_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_163_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -32761,12 +31551,9 @@ _loop0_163_rule(Parser *p)
 static asdl_seq *
 _loop0_165_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -32776,14 +31563,14 @@ _loop0_165_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' lambda_param
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_165[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' lambda_param"));
@@ -32799,7 +31586,7 @@ _loop0_165_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -32808,7 +31595,7 @@ _loop0_165_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -32825,13 +31612,13 @@ _loop0_165_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_165_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -32839,19 +31626,16 @@ _loop0_165_rule(Parser *p)
 static asdl_seq *
 _gather_164_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // lambda_param _loop0_165
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_164[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param _loop0_165"));
@@ -32873,7 +31657,7 @@ _gather_164_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -32881,12 +31665,9 @@ _gather_164_rule(Parser *p)
 static asdl_seq *
 _loop1_166_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -32896,14 +31677,14 @@ _loop1_166_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // lambda_param_with_default
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_166[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_with_default"));
@@ -32919,7 +31700,7 @@ _loop1_166_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -32933,7 +31714,7 @@ _loop1_166_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -32941,13 +31722,13 @@ _loop1_166_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_166_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -32955,19 +31736,16 @@ _loop1_166_rule(Parser *p)
 static void *
 _tmp_167_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_167[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "')'"));
@@ -32986,7 +31764,7 @@ _tmp_167_rule(Parser *p)
     }
     { // ',' (')' | '**')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_167[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' (')' | '**')"));
@@ -33008,7 +31786,7 @@ _tmp_167_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -33016,19 +31794,16 @@ _tmp_167_rule(Parser *p)
 static void *
 _tmp_168_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_168[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':'"));
@@ -33047,7 +31822,7 @@ _tmp_168_rule(Parser *p)
     }
     { // ',' (':' | '**')
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_168[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' (':' | '**')"));
@@ -33069,7 +31844,7 @@ _tmp_168_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -33077,19 +31852,16 @@ _tmp_168_rule(Parser *p)
 static void *
 _tmp_169_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_169[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','"));
@@ -33108,7 +31880,7 @@ _tmp_169_rule(Parser *p)
     }
     { // ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_169[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "')'"));
@@ -33127,7 +31899,7 @@ _tmp_169_rule(Parser *p)
     }
     { // ':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_169[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':'"));
@@ -33146,7 +31918,7 @@ _tmp_169_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -33154,12 +31926,9 @@ _tmp_169_rule(Parser *p)
 static asdl_seq *
 _loop0_171_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -33169,14 +31938,14 @@ _loop0_171_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' (expression ['as' star_target])
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_171[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' (expression ['as' star_target])"));
@@ -33192,7 +31961,7 @@ _loop0_171_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -33201,7 +31970,7 @@ _loop0_171_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -33218,13 +31987,13 @@ _loop0_171_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_171_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -33232,19 +32001,16 @@ _loop0_171_rule(Parser *p)
 static asdl_seq *
 _gather_170_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // (expression ['as' star_target]) _loop0_171
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_170[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(expression ['as' star_target]) _loop0_171"));
@@ -33266,7 +32032,7 @@ _gather_170_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -33274,12 +32040,9 @@ _gather_170_rule(Parser *p)
 static asdl_seq *
 _loop0_173_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -33289,14 +32052,14 @@ _loop0_173_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' (expressions ['as' star_target])
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_173[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' (expressions ['as' star_target])"));
@@ -33312,7 +32075,7 @@ _loop0_173_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -33321,7 +32084,7 @@ _loop0_173_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -33338,13 +32101,13 @@ _loop0_173_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_173_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -33352,19 +32115,16 @@ _loop0_173_rule(Parser *p)
 static asdl_seq *
 _gather_172_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // (expressions ['as' star_target]) _loop0_173
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_172[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(expressions ['as' star_target]) _loop0_173"));
@@ -33386,7 +32146,7 @@ _gather_172_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -33394,12 +32154,9 @@ _gather_172_rule(Parser *p)
 static asdl_seq *
 _loop0_175_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -33409,14 +32166,14 @@ _loop0_175_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' (expression ['as' star_target])
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_175[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' (expression ['as' star_target])"));
@@ -33432,7 +32189,7 @@ _loop0_175_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -33441,7 +32198,7 @@ _loop0_175_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -33458,13 +32215,13 @@ _loop0_175_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_175_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -33472,19 +32229,16 @@ _loop0_175_rule(Parser *p)
 static asdl_seq *
 _gather_174_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // (expression ['as' star_target]) _loop0_175
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_174[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(expression ['as' star_target]) _loop0_175"));
@@ -33506,7 +32260,7 @@ _gather_174_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -33514,12 +32268,9 @@ _gather_174_rule(Parser *p)
 static asdl_seq *
 _loop0_177_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -33529,14 +32280,14 @@ _loop0_177_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' (expressions ['as' star_target])
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_177[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' (expressions ['as' star_target])"));
@@ -33552,7 +32303,7 @@ _loop0_177_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -33561,7 +32312,7 @@ _loop0_177_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -33578,13 +32329,13 @@ _loop0_177_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_177_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -33592,19 +32343,16 @@ _loop0_177_rule(Parser *p)
 static asdl_seq *
 _gather_176_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // (expressions ['as' star_target]) _loop0_177
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_176[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(expressions ['as' star_target]) _loop0_177"));
@@ -33626,7 +32374,7 @@ _gather_176_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -33634,19 +32382,16 @@ _gather_176_rule(Parser *p)
 static void *
 _tmp_178_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'except'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_178[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except'"));
@@ -33665,7 +32410,7 @@ _tmp_178_rule(Parser *p)
     }
     { // 'finally'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_178[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'finally'"));
@@ -33684,7 +32429,7 @@ _tmp_178_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -33692,12 +32437,9 @@ _tmp_178_rule(Parser *p)
 static asdl_seq *
 _loop0_179_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -33707,14 +32449,14 @@ _loop0_179_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_179[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "block"));
@@ -33730,7 +32472,7 @@ _loop0_179_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -33747,13 +32489,13 @@ _loop0_179_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_179_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -33761,19 +32503,16 @@ _loop0_179_rule(Parser *p)
 static void *
 _tmp_180_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // (except_block+ except_star_block)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_180[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(except_block+ except_star_block)"));
@@ -33792,7 +32531,7 @@ _tmp_180_rule(Parser *p)
     }
     { // (except_star_block+ except_block)
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_180[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(except_star_block+ except_block)"));
@@ -33811,7 +32550,7 @@ _tmp_180_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -33819,12 +32558,9 @@ _tmp_180_rule(Parser *p)
 static asdl_seq *
 _loop0_181_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -33834,14 +32570,14 @@ _loop0_181_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_181[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "block"));
@@ -33857,7 +32593,7 @@ _loop0_181_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -33874,13 +32610,13 @@ _loop0_181_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_181_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -33888,19 +32624,16 @@ _loop0_181_rule(Parser *p)
 static void *
 _tmp_182_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_182[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' NAME"));
@@ -33922,7 +32655,7 @@ _tmp_182_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -33930,19 +32663,16 @@ _tmp_182_rule(Parser *p)
 static void *
 _tmp_183_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_183[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' NAME"));
@@ -33964,7 +32694,7 @@ _tmp_183_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -33972,19 +32702,16 @@ _tmp_183_rule(Parser *p)
 static void *
 _tmp_184_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_184[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE"));
@@ -34003,7 +32730,7 @@ _tmp_184_rule(Parser *p)
     }
     { // ':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_184[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':'"));
@@ -34022,7 +32749,7 @@ _tmp_184_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34030,19 +32757,16 @@ _tmp_184_rule(Parser *p)
 static void *
 _tmp_185_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_185[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' NAME"));
@@ -34064,7 +32788,7 @@ _tmp_185_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34072,19 +32796,16 @@ _tmp_185_rule(Parser *p)
 static void *
 _tmp_186_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_186[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' NAME"));
@@ -34106,7 +32827,7 @@ _tmp_186_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34114,19 +32835,16 @@ _tmp_186_rule(Parser *p)
 static void *
 _tmp_187_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // positional_patterns ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_187[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "positional_patterns ','"));
@@ -34148,7 +32866,7 @@ _tmp_187_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34156,19 +32874,16 @@ _tmp_187_rule(Parser *p)
 static void *
 _tmp_188_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '->' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_188[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'->' expression"));
@@ -34190,7 +32905,7 @@ _tmp_188_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34198,19 +32913,16 @@ _tmp_188_rule(Parser *p)
 static void *
 _tmp_189_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '(' arguments? ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_189[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' arguments? ')'"));
@@ -34236,7 +32948,7 @@ _tmp_189_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34244,12 +32956,9 @@ _tmp_189_rule(Parser *p)
 static asdl_seq *
 _loop0_191_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -34259,14 +32968,14 @@ _loop0_191_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // ',' double_starred_kvpair
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_191[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' double_starred_kvpair"));
@@ -34282,7 +32991,7 @@ _loop0_191_rule(Parser *p)
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 PyMem_Free(_children);
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             if (_n == _children_capacity) {
@@ -34291,7 +33000,7 @@ _loop0_191_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -34308,13 +33017,13 @@ _loop0_191_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_191_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -34322,19 +33031,16 @@ _loop0_191_rule(Parser *p)
 static asdl_seq *
 _gather_190_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // double_starred_kvpair _loop0_191
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_190[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "double_starred_kvpair _loop0_191"));
@@ -34356,7 +33062,7 @@ _gather_190_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34364,19 +33070,16 @@ _gather_190_rule(Parser *p)
 static void *
 _tmp_192_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '}'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_192[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'}'"));
@@ -34395,7 +33098,7 @@ _tmp_192_rule(Parser *p)
     }
     { // ','
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_192[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','"));
@@ -34414,7 +33117,7 @@ _tmp_192_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34422,19 +33125,16 @@ _tmp_192_rule(Parser *p)
 static void *
 _tmp_193_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // star_targets '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_193[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_targets '='"));
@@ -34450,7 +33150,7 @@ _tmp_193_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -34461,7 +33161,7 @@ _tmp_193_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34469,19 +33169,16 @@ _tmp_193_rule(Parser *p)
 static void *
 _tmp_194_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '.'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_194[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'.'"));
@@ -34500,7 +33197,7 @@ _tmp_194_rule(Parser *p)
     }
     { // '...'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_194[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'...'"));
@@ -34519,7 +33216,7 @@ _tmp_194_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34527,19 +33224,16 @@ _tmp_194_rule(Parser *p)
 static void *
 _tmp_195_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '.'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_195[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'.'"));
@@ -34558,7 +33252,7 @@ _tmp_195_rule(Parser *p)
     }
     { // '...'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_195[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'...'"));
@@ -34577,7 +33271,7 @@ _tmp_195_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34585,19 +33279,16 @@ _tmp_195_rule(Parser *p)
 static void *
 _tmp_196_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // '@' named_expression NEWLINE
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_196[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'@' named_expression NEWLINE"));
@@ -34616,7 +33307,7 @@ _tmp_196_rule(Parser *p)
             _res = f;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -34627,7 +33318,7 @@ _tmp_196_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34635,19 +33326,16 @@ _tmp_196_rule(Parser *p)
 static void *
 _tmp_197_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_197[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' expression"));
@@ -34663,7 +33351,7 @@ _tmp_197_rule(Parser *p)
             _res = c;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -34674,7 +33362,7 @@ _tmp_197_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34682,19 +33370,16 @@ _tmp_197_rule(Parser *p)
 static void *
 _tmp_198_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' star_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_198[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' star_expression"));
@@ -34710,7 +33395,7 @@ _tmp_198_rule(Parser *p)
             _res = c;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -34721,7 +33406,7 @@ _tmp_198_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34729,19 +33414,16 @@ _tmp_198_rule(Parser *p)
 static void *
 _tmp_199_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'or' conjunction
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_199[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'or' conjunction"));
@@ -34757,7 +33439,7 @@ _tmp_199_rule(Parser *p)
             _res = c;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -34768,7 +33450,7 @@ _tmp_199_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34776,19 +33458,16 @@ _tmp_199_rule(Parser *p)
 static void *
 _tmp_200_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'and' inversion
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_200[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'and' inversion"));
@@ -34804,7 +33483,7 @@ _tmp_200_rule(Parser *p)
             _res = c;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -34815,7 +33494,7 @@ _tmp_200_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34823,19 +33502,16 @@ _tmp_200_rule(Parser *p)
 static void *
 _tmp_201_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'if' disjunction
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_201[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'if' disjunction"));
@@ -34851,7 +33527,7 @@ _tmp_201_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -34862,7 +33538,7 @@ _tmp_201_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34870,19 +33546,16 @@ _tmp_201_rule(Parser *p)
 static void *
 _tmp_202_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'if' disjunction
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_202[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'if' disjunction"));
@@ -34898,7 +33571,7 @@ _tmp_202_rule(Parser *p)
             _res = z;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -34909,7 +33582,7 @@ _tmp_202_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34917,19 +33590,16 @@ _tmp_202_rule(Parser *p)
 static void *
 _tmp_203_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // starred_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_203[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "starred_expression"));
@@ -34948,7 +33618,7 @@ _tmp_203_rule(Parser *p)
     }
     { // (assignment_expression | expression !':=') !'='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_203[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(assignment_expression | expression !':=') !'='"));
@@ -34969,7 +33639,7 @@ _tmp_203_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -34977,19 +33647,16 @@ _tmp_203_rule(Parser *p)
 static void *
 _tmp_204_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' star_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_204[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' star_target"));
@@ -35005,7 +33672,7 @@ _tmp_204_rule(Parser *p)
             _res = c;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -35016,7 +33683,7 @@ _tmp_204_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35024,19 +33691,16 @@ _tmp_204_rule(Parser *p)
 static void *
 _tmp_205_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' star_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_205[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' star_target"));
@@ -35052,7 +33716,7 @@ _tmp_205_rule(Parser *p)
             _res = c;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
-                p->level--;
+                D(p->level--);
                 return NULL;
             }
             goto done;
@@ -35063,7 +33727,7 @@ _tmp_205_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35071,19 +33735,16 @@ _tmp_205_rule(Parser *p)
 static void *
 _tmp_206_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // star_targets '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_206[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_targets '='"));
@@ -35105,7 +33766,7 @@ _tmp_206_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35113,19 +33774,16 @@ _tmp_206_rule(Parser *p)
 static void *
 _tmp_207_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // star_targets '='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_207[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_targets '='"));
@@ -35147,7 +33805,7 @@ _tmp_207_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35155,19 +33813,16 @@ _tmp_207_rule(Parser *p)
 static void *
 _tmp_208_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ')'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_208[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "')'"));
@@ -35186,7 +33841,7 @@ _tmp_208_rule(Parser *p)
     }
     { // '**'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_208[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**'"));
@@ -35205,7 +33860,7 @@ _tmp_208_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35213,19 +33868,16 @@ _tmp_208_rule(Parser *p)
 static void *
 _tmp_209_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // ':'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_209[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':'"));
@@ -35244,7 +33896,7 @@ _tmp_209_rule(Parser *p)
     }
     { // '**'
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_209[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**'"));
@@ -35263,7 +33915,7 @@ _tmp_209_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35271,19 +33923,16 @@ _tmp_209_rule(Parser *p)
 static void *
 _tmp_210_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // expression ['as' star_target]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_210[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ['as' star_target]"));
@@ -35306,7 +33955,7 @@ _tmp_210_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35314,19 +33963,16 @@ _tmp_210_rule(Parser *p)
 static void *
 _tmp_211_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // expressions ['as' star_target]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_211[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expressions ['as' star_target]"));
@@ -35349,7 +33995,7 @@ _tmp_211_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35357,19 +34003,16 @@ _tmp_211_rule(Parser *p)
 static void *
 _tmp_212_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // expression ['as' star_target]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_212[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ['as' star_target]"));
@@ -35392,7 +34035,7 @@ _tmp_212_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35400,19 +34043,16 @@ _tmp_212_rule(Parser *p)
 static void *
 _tmp_213_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // expressions ['as' star_target]
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_213[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expressions ['as' star_target]"));
@@ -35435,7 +34075,7 @@ _tmp_213_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35443,19 +34083,16 @@ _tmp_213_rule(Parser *p)
 static void *
 _tmp_214_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // except_block+ except_star_block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_214[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "except_block+ except_star_block"));
@@ -35477,7 +34114,7 @@ _tmp_214_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35485,19 +34122,16 @@ _tmp_214_rule(Parser *p)
 static void *
 _tmp_215_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // except_star_block+ except_block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_215[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "except_star_block+ except_block"));
@@ -35519,7 +34153,7 @@ _tmp_215_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35527,19 +34161,16 @@ _tmp_215_rule(Parser *p)
 static void *
 _tmp_216_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // assignment_expression
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_216[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
@@ -35558,7 +34189,7 @@ _tmp_216_rule(Parser *p)
     }
     { // expression !':='
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_216[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression !':='"));
@@ -35579,7 +34210,7 @@ _tmp_216_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35587,19 +34218,16 @@ _tmp_216_rule(Parser *p)
 static void *
 _tmp_217_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' star_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_217[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' star_target"));
@@ -35621,7 +34249,7 @@ _tmp_217_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35629,19 +34257,16 @@ _tmp_217_rule(Parser *p)
 static void *
 _tmp_218_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' star_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_218[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' star_target"));
@@ -35663,7 +34288,7 @@ _tmp_218_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35671,19 +34296,16 @@ _tmp_218_rule(Parser *p)
 static void *
 _tmp_219_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' star_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_219[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' star_target"));
@@ -35705,7 +34327,7 @@ _tmp_219_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35713,19 +34335,16 @@ _tmp_219_rule(Parser *p)
 static void *
 _tmp_220_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' star_target
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_220[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' star_target"));
@@ -35747,7 +34366,7 @@ _tmp_220_rule(Parser *p)
     }
     _res = NULL;
   done:
-    p->level--;
+    D(p->level--);
     return _res;
 }
 
@@ -35755,12 +34374,9 @@ _tmp_220_rule(Parser *p)
 static asdl_seq *
 _loop1_221_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -35770,14 +34386,14 @@ _loop1_221_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // except_block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_221[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "except_block"));
@@ -35793,7 +34409,7 @@ _loop1_221_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -35807,7 +34423,7 @@ _loop1_221_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -35815,13 +34431,13 @@ _loop1_221_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_221_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 
@@ -35829,12 +34445,9 @@ _loop1_221_rule(Parser *p)
 static asdl_seq *
 _loop1_222_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK) {
-        p->error_indicator = 1;
-        PyErr_NoMemory();
-    }
+    D(p->level++);
     if (p->error_indicator) {
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     void *_res = NULL;
@@ -35844,14 +34457,14 @@ _loop1_222_rule(Parser *p)
     if (!_children) {
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     Py_ssize_t _children_capacity = 1;
     Py_ssize_t _n = 0;
     { // except_star_block
         if (p->error_indicator) {
-            p->level--;
+            D(p->level--);
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_222[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "except_star_block"));
@@ -35867,7 +34480,7 @@ _loop1_222_rule(Parser *p)
                 if (!_new_children) {
                     p->error_indicator = 1;
                     PyErr_NoMemory();
-                    p->level--;
+                    D(p->level--);
                     return NULL;
                 }
                 _children = _new_children;
@@ -35881,7 +34494,7 @@ _loop1_222_rule(Parser *p)
     }
     if (_n == 0 || p->error_indicator) {
         PyMem_Free(_children);
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -35889,13 +34502,13 @@ _loop1_222_rule(Parser *p)
         PyMem_Free(_children);
         p->error_indicator = 1;
         PyErr_NoMemory();
-        p->level--;
+        D(p->level--);
         return NULL;
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_222_type, _seq);
-    p->level--;
+    D(p->level--);
     return _seq;
 }
 

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -815,7 +815,6 @@ void *
 _PyPegen_run_parser(Parser *p)
 {
     void *res = _PyPegen_parse(p);
-    assert(p->level == 0);
     if (res == NULL) {
         if (PyErr_Occurred() && !PyErr_ExceptionMatches(PyExc_SyntaxError)) {
             return NULL;

--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -37,8 +37,6 @@ EXTENSION_PREFIX = """\
 #  define D(x)
 #endif
 
-# define MAXSTACK 6000
-
 """
 
 
@@ -366,14 +364,10 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         self.skip_actions = skip_actions
 
     def add_level(self) -> None:
-        self.print("if (p->level++ == MAXSTACK) {")
-        with self.indent():
-            self.print("p->error_indicator = 1;")
-            self.print("PyErr_NoMemory();")
-        self.print("}")
+        self.print("D(p->level++);")
 
     def remove_level(self) -> None:
-        self.print("p->level--;")
+        self.print("D(p->level--);")
 
     def add_return(self, ret_val: str) -> None:
         self.remove_level()
@@ -550,10 +544,9 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
                 self.print("p->in_raw_rule++;")
                 self.print(f"void *_raw = {node.name}_raw(p);")
                 self.print("p->in_raw_rule--;")
-                self.print("if (p->error_indicator) {")
+                self.print("if (p->error_indicator)")
                 with self.indent():
-                    self.add_return("NULL")
-                self.print("}")
+                    self.print("return NULL;")
                 self.print("if (_raw == NULL || p->mark <= _resmark)")
                 with self.indent():
                     self.print("break;")


### PR DESCRIPTION
Reverts temporarily python/cpython#30177

<!-- issue-number: [bpo-46110](https://bugs.python.org/issue46110) -->
https://bugs.python.org/issue46110
<!-- /issue-number -->
