### PR TITLE
bpo-46249: Always compute `sqlite3.Cursor.lastrowid`, and do it lazily

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -846,17 +846,19 @@ Cursor Objects
    .. attribute:: lastrowid
 
       This read-only attribute provides the row id of the last inserted row. It
-      is only updated after successful ``INSERT`` or ``REPLACE`` statements
-      using the :meth:`execute` method.  For other statements, after
-      :meth:`executemany` or :meth:`executescript`, or if the insertion failed,
-      the value of ``lastrowid`` is left unchanged.  The initial value of
-      ``lastrowid`` is :const:`None`.
+      is only updated after successful ``INSERT`` or ``REPLACE`` statements.
+      For other statements, or if the insertion failed, the value of
+      ``lastrowid`` is left unchanged.  The initial value of ``lastrowid`` is
+      `0`.
 
       .. note::
          Inserts into ``WITHOUT ROWID`` tables are not recorded.
 
       .. versionchanged:: 3.6
          Added support for the ``REPLACE`` statement.
+
+      .. versionchanged:: 3.11
+         Added support for :meth:`executemany` and :meth:`executescript`.
 
    .. attribute:: arraysize
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -295,6 +295,12 @@ sqlite3
   Instead we leave it to the SQLite library to handle these cases.
   (Contributed by Erlend E. Aasland in :issue:`44092`.)
 
+* :attr:`~sqlite3.Cursor.lastrowid` is now available for
+  :meth:`~sqlite3.Cursor.executemany` and :meth:`~sqlite3.Cursor.executescript`.
+  As with :meth:`~sqlite3.Cursor.execute`, it holds the value of the actual last
+  inserted row id in the connected database.
+  (Contributed by Erlend E. Aasland in :issue:`46249`.)
+
 
 sys
 ---

--- a/Misc/NEWS.d/next/Library/2022-01-04-21-40-51.bpo-46249.P48Mgy.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-04-21-40-51.bpo-46249.P48Mgy.rst
@@ -1,0 +1,4 @@
+In :mod:`sqlite3`, :attr:`~sqlite3.Cursor.lastrowid` is now available for
+:meth:`~sqlite3.Cursor.executemany` and :meth:`~sqlite3.Cursor.executescript`.
+As with :meth:`~sqlite3.Cursor.execute`, it holds the value of the actual last
+inserted row id in the connected database. Patch by Erlend E. Aasland.

--- a/Modules/_sqlite/cursor.h
+++ b/Modules/_sqlite/cursor.h
@@ -26,6 +26,8 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
+#include "stdbool.h"
+
 #include "statement.h"
 #include "connection.h"
 #include "module.h"
@@ -37,7 +39,7 @@ typedef struct
     PyObject* description;
     PyObject* row_cast_map;
     int arraysize;
-    PyObject* lastrowid;
+    sqlite3_int64 lastrowid;
     long rowcount;
     PyObject* row_factory;
     pysqlite_Statement* statement;


### PR DESCRIPTION
This PR has four effects, two of them user visible:

1. Simplify the `execute()`/`executemany()` query loop
2. Create the lastrowid PyObject on demand, simplifying cursor GC
3. `lastrowid` is now available for all `execute*()` methods
4. The default value of `lastrowid` is now `0`

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46249](https://bugs.python.org/issue46249) -->
https://bugs.python.org/issue46249
<!-- /issue-number -->
