### PR TITLE
Fix broken OMG link

### DIFF
--- a/Doc/library/xml.dom.rst
+++ b/Doc/library/xml.dom.rst
@@ -73,7 +73,7 @@ implementations are free to support the strict mapping from IDL).  See section
    `Document Object Model (DOM) Level 1 Specification <https://www.w3.org/TR/REC-DOM-Level-1/>`_
       The W3C recommendation for the DOM supported by :mod:`xml.dom.minidom`.
 
-   `Python Language Mapping Specification <http://www.omg.org/cgi-bin/doc?formal/02-11-05.pdf>`_
+   `Python Language Mapping Specification <https://www.omg.org/spec/PYTH/1.2/PDF>`_
       This specifies the mapping from OMG IDL to Python.
 
 


### PR DESCRIPTION
I got the new link from this page: https://www.omg.org/spec/PYTH

I'm not certain that it's the right doc, but the dates and title match.