### PR TITLE
bpo-46262: cover error path in `enum.Flag._missing_`

### DIFF
--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -3414,6 +3414,19 @@ class TestFlag(unittest.TestCase):
         self.assertFalse(NeverEnum.__dict__.get('_test1', False))
         self.assertFalse(NeverEnum.__dict__.get('_test2', False))
 
+    def test_default_missing(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "'RED' is not a valid TestFlag.Color",
+        ) as ctx:
+            self.Color('RED')
+        self.assertIs(ctx.exception.__context__, None)
+
+        P = Flag('P', 'X Y')
+        with self.assertRaisesRegex(ValueError, "'X' is not a valid P") as ctx:
+            P('X')
+        self.assertIs(ctx.exception.__context__, None)
+
 
 class TestIntFlag(unittest.TestCase):
     """Tests of the IntFlags."""
@@ -3974,6 +3987,19 @@ class TestIntFlag(unittest.TestCase):
                 failed,
                 'at least one thread failed while creating composite members')
         self.assertEqual(256, len(seen), 'too many composite members created')
+
+    def test_default_missing(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "'RED' is not a valid TestIntFlag.Color",
+        ) as ctx:
+            self.Color('RED')
+        self.assertIs(ctx.exception.__context__, None)
+
+        P = IntFlag('P', 'X Y')
+        with self.assertRaisesRegex(ValueError, "'X' is not a valid P") as ctx:
+            P('X')
+        self.assertIs(ctx.exception.__context__, None)
 
 
 class TestEmptyAndNonLatinStrings(unittest.TestCase):

--- a/Misc/NEWS.d/next/Tests/2022-01-05-01-38-45.bpo-46262.MhiLWP.rst
+++ b/Misc/NEWS.d/next/Tests/2022-01-05-01-38-45.bpo-46262.MhiLWP.rst
@@ -1,1 +1,1 @@
-Cover `ValueError` path in :meth:`enum.Flag._missing_`.
+Cover ``ValueError`` path in :meth:`enum.Flag._missing_`.

--- a/Misc/NEWS.d/next/Tests/2022-01-05-01-38-45.bpo-46262.MhiLWP.rst
+++ b/Misc/NEWS.d/next/Tests/2022-01-05-01-38-45.bpo-46262.MhiLWP.rst
@@ -1,0 +1,1 @@
+Cover `ValueError` path in :meth:`enum.Flag._missing_`.

--- a/Misc/NEWS.d/next/Tests/2022-01-05-01-38-45.bpo-46262.MhiLWP.rst
+++ b/Misc/NEWS.d/next/Tests/2022-01-05-01-38-45.bpo-46262.MhiLWP.rst
@@ -1,1 +1,1 @@
-Cover ``ValueError`` path in :meth:`enum.Flag._missing_`.
+Cover ``ValueError`` path in tests for :meth:`enum.Flag._missing_`.


### PR DESCRIPTION
This path is now covered: https://github.com/python/cpython/blob/31e43cbe5f01cdd5b5ab330ec3040920e8b61a91/Lib/enum.py#L1222-L1225

<!-- issue-number: [bpo-46262](https://bugs.python.org/issue46262) -->
https://bugs.python.org/issue46262
<!-- /issue-number -->
