### PR TITLE
bpo-46266: Improve day constants (`MONDAY` ... `SUNDAY`) in `calendar`

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -28,7 +28,7 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
 2 BC, and so on.
 
 
-.. class:: Calendar(firstweekday=MONDAY)
+.. class:: Calendar(firstweekday=0)
 
    Creates a :class:`Calendar` object. *firstweekday* is an integer specifying the
    first day of the week. :const:`MONDAY` is ``0`` (the default), :const:`SUNDAY` is ``6``.
@@ -275,13 +275,13 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
            cssclass_year = "text-italic lead"
 
 
-.. class:: LocaleTextCalendar(firstweekday=MONDAY, locale=None)
+.. class:: LocaleTextCalendar(firstweekday=0, locale=None)
 
    This subclass of :class:`TextCalendar` can be passed a locale name in the
    constructor and will return month and weekday names in the specified locale.
 
 
-.. class:: LocaleHTMLCalendar(firstweekday=MONDAY, locale=None)
+.. class:: LocaleHTMLCalendar(firstweekday=0, locale=None)
 
    This subclass of :class:`HTMLCalendar` can be passed a locale name in the
    constructor and will return month and weekday names in the specified

--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -28,10 +28,10 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
 2 BC, and so on.
 
 
-.. class:: Calendar(firstweekday=0)
+.. class:: Calendar(firstweekday=MONDAY)
 
    Creates a :class:`Calendar` object. *firstweekday* is an integer specifying the
-   first day of the week. ``0`` is Monday (the default), ``6`` is Sunday.
+   first day of the week. :const:`MONDAY` is ``0`` (the default), :const:`SUNDAY` is ``6``.
 
    A :class:`Calendar` object provides several methods that can be used for
    preparing the calendar data for formatting. This class doesn't do any formatting
@@ -275,13 +275,13 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
            cssclass_year = "text-italic lead"
 
 
-.. class:: LocaleTextCalendar(firstweekday=0, locale=None)
+.. class:: LocaleTextCalendar(firstweekday=MONDAY, locale=None)
 
    This subclass of :class:`TextCalendar` can be passed a locale name in the
    constructor and will return month and weekday names in the specified locale.
 
 
-.. class:: LocaleHTMLCalendar(firstweekday=0, locale=None)
+.. class:: LocaleHTMLCalendar(firstweekday=MONDAY, locale=None)
 
    This subclass of :class:`HTMLCalendar` can be passed a locale name in the
    constructor and will return month and weekday names in the specified
@@ -406,6 +406,15 @@ The :mod:`calendar` module exports the following data attributes:
    locale.  This follows normal convention of January being month number 1, so it
    has a length of 13 and  ``month_abbr[0]`` is the empty string.
 
+.. data:: MONDAY
+          TUESDAY
+          WEDNESDAY
+          THURSDAY
+          FRIDAY
+          SATURDAY
+          SUNDAY
+
+   Aliases for day numbers, where ``MONDAY`` is ``0`` and ``SUNDAY`` is ``6``.
 
 .. seealso::
 

--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -15,7 +15,9 @@ __all__ = ["IllegalMonthError", "IllegalWeekdayError", "setfirstweekday",
            "monthcalendar", "prmonth", "month", "prcal", "calendar",
            "timegm", "month_name", "month_abbr", "day_name", "day_abbr",
            "Calendar", "TextCalendar", "HTMLCalendar", "LocaleTextCalendar",
-           "LocaleHTMLCalendar", "weekheader"]
+           "LocaleHTMLCalendar", "weekheader",
+           "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY",
+           "SATURDAY", "SUNDAY"]
 
 # Exception raised for bad input (with string parameter for details)
 error = ValueError
@@ -151,7 +153,7 @@ class Calendar(object):
     provides data to subclasses.
     """
 
-    def __init__(self, firstweekday=0):
+    def __init__(self, firstweekday=MONDAY):
         self.firstweekday = firstweekday # 0 = Monday, 6 = Sunday
 
     def getfirstweekday(self):
@@ -561,7 +563,7 @@ class LocaleTextCalendar(TextCalendar):
     month and weekday names in the specified locale.
     """
 
-    def __init__(self, firstweekday=0, locale=None):
+    def __init__(self, firstweekday=MONDAY, locale=None):
         TextCalendar.__init__(self, firstweekday)
         if locale is None:
             locale = _locale.getdefaultlocale()
@@ -581,7 +583,7 @@ class LocaleHTMLCalendar(HTMLCalendar):
     This class can be passed a locale name in the constructor and will return
     month and weekday names in the specified locale.
     """
-    def __init__(self, firstweekday=0, locale=None):
+    def __init__(self, firstweekday=MONDAY, locale=None):
         HTMLCalendar.__init__(self, firstweekday)
         if locale is None:
             locale = _locale.getdefaultlocale()

--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -153,7 +153,7 @@ class Calendar(object):
     provides data to subclasses.
     """
 
-    def __init__(self, firstweekday=MONDAY):
+    def __init__(self, firstweekday=0):
         self.firstweekday = firstweekday # 0 = Monday, 6 = Sunday
 
     def getfirstweekday(self):
@@ -563,7 +563,7 @@ class LocaleTextCalendar(TextCalendar):
     month and weekday names in the specified locale.
     """
 
-    def __init__(self, firstweekday=MONDAY, locale=None):
+    def __init__(self, firstweekday=0, locale=None):
         TextCalendar.__init__(self, firstweekday)
         if locale is None:
             locale = _locale.getdefaultlocale()
@@ -583,7 +583,7 @@ class LocaleHTMLCalendar(HTMLCalendar):
     This class can be passed a locale name in the constructor and will return
     month and weekday names in the specified locale.
     """
-    def __init__(self, firstweekday=MONDAY, locale=None):
+    def __init__(self, firstweekday=0, locale=None):
         HTMLCalendar.__init__(self, firstweekday)
         if locale is None:
             locale = _locale.getdefaultlocale()

--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -935,8 +935,7 @@ class CommandLineTestCase(unittest.TestCase):
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
         not_exported = {
-            'mdays', 'January', 'February', 'EPOCH', 'MONDAY', 'TUESDAY',
-            'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY',
+            'mdays', 'January', 'February', 'EPOCH',
             'different_locale', 'c', 'prweek', 'week', 'format',
             'formatstring', 'main', 'monthlen', 'prevmonth', 'nextmonth'}
         support.check__all__(self, calendar, not_exported=not_exported)

--- a/Misc/NEWS.d/next/Library/2022-01-05-12-48-18.bpo-46266.ACQCgX.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-05-12-48-18.bpo-46266.ACQCgX.rst
@@ -1,0 +1,4 @@
+Improve day constants in :mod:`calendar`.
+
+Now all constants (`MONDAY` ... `SUNDAY`) are documented, tested, and added
+to ``__all__``.


### PR DESCRIPTION
Things I've changed:
1. Used `MONDAY` constant everywhere `0` was used as a default day. It is way more readable, you don't have to guess what `0` is in this context.
2. I've added all day constants to `__all__`, this is the only thing I doubt. I don't know what policy is about `__all__`, so this can be reverted if I am not correct. But, initially I though that it is useful to have them when `from calendar import *` and this way they are automatically tested by `test__all__`
3. Since they are now in `__all__`, I've updated the test case. Now we check that they are still present
4. Docs are updated, now `:const:MONDAY` is clickable

<!-- issue-number: [bpo-46266](https://bugs.python.org/issue46266) -->
https://bugs.python.org/issue46266
<!-- /issue-number -->
