### PR TITLE
bpo-43137: Revert "webbrowser: Don't run gvfs-open on GNOME"

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -467,6 +467,10 @@ def register_X_browsers():
     if shutil.which("gio"):
         register("gio", None, BackgroundBrowser(["gio", "open", "--", "%s"]))
 
+    # Equivalent of gio open before 2015
+    if "GNOME_DESKTOP_SESSION_ID" in os.environ and shutil.which("gvfs-open"):
+        register("gvfs-open", None, BackgroundBrowser("gvfs-open"))
+
     # The default KDE browser
     if "KDE_FULL_SESSION" in os.environ and shutil.which("kfmclient"):
         register("kfmclient", Konqueror, Konqueror("kfmclient"))


### PR DESCRIPTION
gvfs-open was deprecated in 2015 and removed in 2018, but its replacement,
gio(1), is not available in Ubuntu 16.04, which is apparently still
supported by CPython upstream even though it is considered to be EOL by
Ubuntu developers.

<!-- issue-number: [bpo-43137](https://bugs.python.org/issue43137) -->
https://bugs.python.org/issue43137
<!-- /issue-number -->
