### PR TITLE
bpo-46278: Reflect 'context' arg in 'AbstractEventLoop.call_*()' methods

### DIFF
--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -257,13 +257,13 @@ class AbstractEventLoop:
         """Notification that a TimerHandle has been cancelled."""
         raise NotImplementedError
 
-    def call_soon(self, callback, *args):
+    def call_soon(self, callback, *args, context=None):
         return self.call_later(0, callback, *args)
 
-    def call_later(self, delay, callback, *args):
+    def call_later(self, delay, callback, *args, context=None):
         raise NotImplementedError
 
-    def call_at(self, when, callback, *args):
+    def call_at(self, when, callback, *args, cotext=None):
         raise NotImplementedError
 
     def time(self):
@@ -279,7 +279,7 @@ class AbstractEventLoop:
 
     # Methods for interacting with threads.
 
-    def call_soon_threadsafe(self, callback, *args):
+    def call_soon_threadsafe(self, callback, *args, context=None):
         raise NotImplementedError
 
     def run_in_executor(self, executor, func, *args):

--- a/Misc/NEWS.d/next/Library/2022-01-06-13-38-00.bpo-46278.wILA80.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-06-13-38-00.bpo-46278.wILA80.rst
@@ -1,0 +1,2 @@
+Reflect ``context`` argument in ``AbstractEventLoop.call_*()`` methods. Loop
+implementations already support it.


### PR DESCRIPTION


<!-- issue-number: [bpo-46278](https://bugs.python.org/issue46278) -->
https://bugs.python.org/issue46278
<!-- /issue-number -->
