### PR TITLE
bpo-46263: Do not ever expect "use_frozen_modules" to be -1.

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1247,8 +1247,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'stdlib_dir': stdlib,
         }
         self.default_program_name(config)
-        if not config['executable']:
-            config['use_frozen_modules'] = -1
         env = {'TESTHOME': home, 'PYTHONPATH': paths_str}
         self.check_all_configs("test_init_setpythonhome", config,
                                api=API_COMPAT, env=env)

--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-06-10-54-07.bpo-46263.60dRZb.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-06-10-54-07.bpo-46263.60dRZb.rst
@@ -1,0 +1,2 @@
+We always expect the "use_frozen_modules" config to be set, now that
+getpath.c was rewritten in pure Python and the logic improved.


### PR DESCRIPTION
The check was added in gh-28940 (https://github.com/python/cpython/pull/28940/commits/f1d38785b2b15168bcbcd25819fa9e2d66189354 specifically) as a workaround in response to some buildbot failures.  However, gh-29041 (for https://bugs.python.org/issue45582) made improvements to the "getpath" logic.  Now a default "use_frozen_modules" is always set.  So we can drop the workaround in the test.

This should resolve the buildbot failure on FreeBSD.

<!-- issue-number: [bpo-46263](https://bugs.python.org/issue46263) -->
https://bugs.python.org/issue46263
<!-- /issue-number -->
