### PR TITLE
bpo-46244: Remove __slots__ from typing.TypeVar, .ParamSpec

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -730,8 +730,6 @@ class ForwardRef(_Final, _root=True):
 class _TypeVarLike:
     """Mixin for TypeVar-like types (TypeVar and ParamSpec)."""
 
-    __slots__ = ('__name__', '__bound__', '__covariant__', '__contravariant__')
-
     def __init__(self, bound, covariant, contravariant):
         """Used to setup TypeVars and ParamSpec's bound, covariant and
         contravariant attributes.
@@ -807,8 +805,6 @@ class TypeVar( _Final, _Immutable, _TypeVarLike, _root=True):
 
     Note that only type variables defined in global scope can be pickled.
     """
-
-    __slots__ = ('__constraints__', '__dict__')
 
     def __init__(self, name, *constraints, bound=None,
                  covariant=False, contravariant=False):
@@ -908,8 +904,6 @@ class ParamSpec(_Final, _Immutable, _TypeVarLike, _root=True):
     Note that only parameter specification variables defined in global scope can
     be pickled.
     """
-
-    __slots__ = ('__dict__', )
 
     @property
     def args(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -729,6 +729,9 @@ class ForwardRef(_Final, _root=True):
 
 class _TypeVarLike:
     """Mixin for TypeVar-like types (TypeVar and ParamSpec)."""
+
+    __slots__ = ('__name__', '__bound__', '__covariant__', '__contravariant__')
+
     def __init__(self, bound, covariant, contravariant):
         """Used to setup TypeVars and ParamSpec's bound, covariant and
         contravariant attributes.
@@ -805,8 +808,7 @@ class TypeVar( _Final, _Immutable, _TypeVarLike, _root=True):
     Note that only type variables defined in global scope can be pickled.
     """
 
-    __slots__ = ('__name__', '__bound__', '__constraints__',
-                 '__covariant__', '__contravariant__', '__dict__')
+    __slots__ = ('__constraints__', '__dict__')
 
     def __init__(self, name, *constraints, bound=None,
                  covariant=False, contravariant=False):
@@ -907,8 +909,7 @@ class ParamSpec(_Final, _Immutable, _TypeVarLike, _root=True):
     be pickled.
     """
 
-    __slots__ = ('__name__', '__bound__', '__covariant__', '__contravariant__',
-                 '__dict__')
+    __slots__ = ('__dict__', )
 
     @property
     def args(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -729,7 +729,6 @@ class ForwardRef(_Final, _root=True):
 
 class _TypeVarLike:
     """Mixin for TypeVar-like types (TypeVar and ParamSpec)."""
-
     def __init__(self, bound, covariant, contravariant):
         """Used to setup TypeVars and ParamSpec's bound, covariant and
         contravariant attributes.

--- a/Misc/NEWS.d/next/Library/2022-01-06-21-31-14.bpo-46244.hjyfJj.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-06-21-31-14.bpo-46244.hjyfJj.rst
@@ -1,0 +1,2 @@
+Add missing ``__slots__`` to ``typing._TypeVarLike``. Patch by Arie
+Bovenberg.

--- a/Misc/NEWS.d/next/Library/2022-01-06-21-31-14.bpo-46244.hjyfJj.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-06-21-31-14.bpo-46244.hjyfJj.rst
@@ -1,2 +1,2 @@
-Removed ``__slots__`` from :class:``typing.ParamSpec`` and :class:``typing.TypeVar``.
+Removed ``__slots__`` from :class:`typing.ParamSpec` and :class:`typing.TypeVar`.
 They served no purpose. Patch by Arie Bovenberg.

--- a/Misc/NEWS.d/next/Library/2022-01-06-21-31-14.bpo-46244.hjyfJj.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-06-21-31-14.bpo-46244.hjyfJj.rst
@@ -1,2 +1,2 @@
-Add missing ``__slots__`` to ``typing._TypeVarLike``. Patch by Arie
-Bovenberg.
+Removed ``__slots__`` from :class:``typing.ParamSpec`` and :class:``typing.TypeVar``.
+They served no purpose. Patch by Arie Bovenberg.


### PR DESCRIPTION
The mixin class "typing._TypeVarLike" has no `__slots__`. Its subclasses do define `__slots__`, so it looks like a mistake. 

This was [confirmed](https://bugs.python.org/msg409602) in the bug report

<!-- issue-number: [bpo-46244](https://bugs.python.org/issue46244) -->
https://bugs.python.org/issue46244
<!-- /issue-number -->
