### PR TITLE
bpo-46246: add missing __slots__ to importlib.metadata.DeprecatedList

### DIFF
--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -278,6 +278,8 @@ class DeprecatedList(list):
     1
     """
 
+    __slots__ = ()
+
     _warn = functools.partial(
         warnings.warn,
         "EntryPoints list interface is deprecated. Cast to list if needed.",

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -173,8 +173,9 @@ class APITests(
             entry_points().get('missing', ()) == ()
 
     def test_entry_points_allows_no_attributes(self):
+        ep = entry_points().select(group='entries', name='main')
         with self.assertRaises(AttributeError):
-            entry_points()['entries'][0].foo = 4
+            ep.foo = 4
 
     def test_metadata_for_this_package(self):
         md = metadata('egginfo-pkg')

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -172,6 +172,11 @@ class APITests(
             entry_points().get('entries', 'default') == entry_points()['entries']
             entry_points().get('missing', ()) == ()
 
+    def test_entry_points_allows_no_attributes(self):
+        self.assertRaises(
+            AttributeError, setattr, entry_points()['entries'][0], 'foo', 4
+        )
+
     def test_metadata_for_this_package(self):
         md = metadata('egginfo-pkg')
         assert md['author'] == 'Steven Ma'

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -173,9 +173,8 @@ class APITests(
             entry_points().get('missing', ()) == ()
 
     def test_entry_points_allows_no_attributes(self):
-        self.assertRaises(
-            AttributeError, setattr, entry_points()['entries'][0], 'foo', 4
-        )
+        with self.assertRaises(AttributeError):
+            entry_points()['entries'][0].foo = 4
 
     def test_metadata_for_this_package(self):
         md = metadata('egginfo-pkg')

--- a/Misc/NEWS.d/next/Library/2022-01-07-13-27-53.bpo-46246.CTLx32.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-07-13-27-53.bpo-46246.CTLx32.rst
@@ -1,0 +1,2 @@
+Add missing ``__slots__`` to ``importlib.metadata.DeprecatedList``. Patch by
+Arie Bovenberg.


### PR DESCRIPTION
Confirmed with @jaraco that this indeed needs a fix.

A question that came up while I was digging into the code: I think `SelectableGroups` could similarly use `__slots__ = ()`, since its purpose seems only for convenience around `dict`, not to have attributes of its own.

<!-- issue-number: [bpo-46246](https://bugs.python.org/issue46246) -->
https://bugs.python.org/issue46246
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco