### PR TITLE
bpo-46297: Fix interpreter crash on bootup with multiple PythonPaths set in registry

### DIFF
--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -734,12 +734,15 @@ class MockWinreg:
                 return n.removeprefix(prefix)
         raise OSError("end of enumeration")
 
-    def QueryValue(self, hkey):
+    def QueryValue(self, hkey, subkey):
         if verbose:
-            print(f"QueryValue({hkey})")
+            print(f"QueryValue({hkey}, {subkey})")
         hkey = hkey.casefold()
         if hkey not in self.open:
             raise RuntimeError("key is not open")
+        if subkey:
+            subkey = subkey.casefold()
+            hkey = f'{hkey}\\{subkey}'
         try:
             return self.keys[hkey]
         except KeyError:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -400,6 +400,7 @@ Lars Damerow
 Evan Dandrea
 Eric Daniel
 Scott David Daniels
+Derzsi Dániel
 Lawrence D'Anna
 Ben Darnell
 Kushal Das

--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-07-22-13-59.bpo-46297.83ThTl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-07-22-13-59.bpo-46297.83ThTl.rst
@@ -1,0 +1,2 @@
+Fixed an interpreter crash on bootup with multiple PythonPaths set in
+the Windows registry. Patch by Derzsi Dániel.

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -127,7 +127,7 @@
 # checked by looking for the BUILDDIR_TXT file, which contains the
 # relative path to the platlib dir. The executable_dir value is
 # derived from joining the VPATH preprocessor variable to the
-# directory containing pybuilddir.txt. If it is not found, the 
+# directory containing pybuilddir.txt. If it is not found, the
 # BUILD_LANDMARK file is found, which is part of the source tree.
 # prefix is then found by searching up for a file that should only
 # exist in the source tree, and the stdlib dir is set to prefix/Lib.
@@ -642,19 +642,12 @@ elif not pythonpath:
                     i = 0
                     while True:
                         try:
-                            keyname = winreg.EnumKey(key, i)
-                            subkey = winreg.OpenKeyEx(key, keyname)
-                            if not subkey:
-                                continue
-                            try:
-                                v = winreg.QueryValue(subkey)
-                            finally:
-                                winreg.CloseKey(subkey)
-                            if isinstance(v, str):
-                                pythonpath.append(v)
-                            i += 1
+                            v = winreg.QueryValue(key, winreg.EnumKey(key, i))
                         except OSError:
                             break
+                        if isinstance(v, str):
+                            pythonpath.append(v)
+                        i += 1
                 finally:
                     winreg.CloseKey(key)
             except OSError:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This fixes the issue https://bugs.python.org/issue46297. Regression introduced in the 3.11 branch with commit 99fcf1505218464c489d419d4500f126b6d6dc28 on Dec 3, 2021.

<!-- issue-number: [bpo-46297](https://bugs.python.org/issue46297) -->
https://bugs.python.org/issue46297
<!-- /issue-number -->
