### PR TITLE
bpo-46205: exit if no workers are alive in runtest_mp

### DIFF
--- a/Lib/test/libregrtest/runtest_mp.py
+++ b/Lib/test/libregrtest/runtest_mp.py
@@ -392,16 +392,12 @@ class MultiprocessTestRunner:
             worker.wait_stopped(start_time)
 
     def _get_result(self) -> QueueOutput | None:
-        if not any(worker.is_alive() for worker in self.workers):
-            # all worker threads are done: consume pending results
-            try:
-                return self.output.get(timeout=0)
-            except queue.Empty:
-                return None
-
         use_faulthandler = (self.ns.timeout is not None)
         timeout = PROGRESS_UPDATE
-        while True:
+
+        # bpo-46205: check the status of workers every iteration to avoid
+        # waiting forever on an empty queue.
+        while any(worker.is_alive() for worker in self.workers):
             if use_faulthandler:
                 faulthandler.dump_traceback_later(MAIN_PROCESS_TIMEOUT,
                                                   exit=True)
@@ -416,8 +412,12 @@ class MultiprocessTestRunner:
             running = get_running(self.workers)
             if running and not self.ns.pgo:
                 self.log('running: %s' % ', '.join(running))
-            elif not any(worker.is_alive() for worker in self.workers):
-                return None
+
+        # all worker threads are done: consume pending results
+        try:
+            return self.output.get(timeout=0)
+        except queue.Empty:
+            return None
 
     def display_result(self, mp_result: MultiprocessResult) -> None:
         result = mp_result.result

--- a/Lib/test/libregrtest/runtest_mp.py
+++ b/Lib/test/libregrtest/runtest_mp.py
@@ -416,6 +416,8 @@ class MultiprocessTestRunner:
             running = get_running(self.workers)
             if running and not self.ns.pgo:
                 self.log('running: %s' % ', '.join(running))
+            elif not any(worker.is_alive() for worker in self.workers):
+                return None
 
     def display_result(self, mp_result: MultiprocessResult) -> None:
         result = mp_result.result

--- a/Misc/NEWS.d/next/Tests/2022-01-07-14-06-12.bpo-46205.dnc2OC.rst
+++ b/Misc/NEWS.d/next/Tests/2022-01-07-14-06-12.bpo-46205.dnc2OC.rst
@@ -1,0 +1,1 @@
+Fix hang in runtest_mp due to race condition


### PR DESCRIPTION
There is a race condition in runtest_mp where if a worker already
pushed its final output to the queue, but is still alive, then the
the main thread waits forever on the the now-empty queue.

This re-checks the status of the workers after output.get() call times
out (after 30 seconds).

<!-- issue-number: [bpo-46205](https://bugs.python.org/issue46205) -->
https://bugs.python.org/issue46205
<!-- /issue-number -->
