### PR TITLE
bpo-46217: Revert use of Windows constant that is newer than what we support

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-01-07-22-55-11.bpo-46217.tgJEsB.rst
+++ b/Misc/NEWS.d/next/Windows/2022-01-07-22-55-11.bpo-46217.tgJEsB.rst
@@ -1,0 +1,2 @@
+Removed parameter that is unsupported on Windows 8.1 and early Windows 10
+and may have caused build or runtime failures.

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2129,7 +2129,7 @@ join_relfile(wchar_t *buffer, size_t bufsize,
 {
 #ifdef MS_WINDOWS
     if (FAILED(PathCchCombineEx(buffer, bufsize, dirname, relfile, 
-        PATHCCH_ALLOW_LONG_PATHS | PATHCCH_FORCE_ENABLE_LONG_NAME_PROCESS))) {
+        PATHCCH_ALLOW_LONG_PATHS))) {
         return -1;
     }
 #else


### PR DESCRIPTION


<!-- issue-number: [bpo-46217](https://bugs.python.org/issue46217) -->
https://bugs.python.org/issue46217
<!-- /issue-number -->
