### PR TITLE
bpo-46303: Fix _Py_stat and _Py_wstat status argument type

### DIFF
--- a/Include/cpython/fileutils.h
+++ b/Include/cpython/fileutils.h
@@ -84,7 +84,7 @@ PyAPI_FUNC(int) _Py_fstat_noraise(
 
 PyAPI_FUNC(int) _Py_stat(
     PyObject *path,
-    struct stat *status);
+    struct _Py_stat_struct *status);
 
 PyAPI_FUNC(int) _Py_open(
     const char *pathname,

--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -40,7 +40,7 @@ PyAPI_FUNC(wchar_t*) _Py_DecodeUTF8_surrogateescape(
     size_t *wlen);
 
 extern int
-_Py_wstat(const wchar_t *, struct stat *);
+_Py_wstat(const wchar_t *, struct _Py_stat_struct *);
 
 PyAPI_FUNC(int) _Py_GetForceASCII(void);
 

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1209,7 +1209,7 @@ _Py_fstat(int fd, struct _Py_stat_struct *status)
 
 /* Like _Py_stat() but with a raw filename. */
 int
-_Py_wstat(const wchar_t* path, struct stat *buf)
+_Py_wstat(const wchar_t* path, struct _Py_stat_struct *buf)
 {
     int err;
 #ifdef MS_WINDOWS
@@ -1239,7 +1239,7 @@ _Py_wstat(const wchar_t* path, struct stat *buf)
    raised. */
 
 int
-_Py_stat(PyObject *path, struct stat *statbuf)
+_Py_stat(PyObject *path, struct _Py_stat_struct *statbuf)
 {
 #ifdef MS_WINDOWS
     int err;


### PR DESCRIPTION
Fixed an issue where the argument for _Py_stat and
_Py_wstat are incorrect for Windows by updating the
type from struct stat to struct _Py_stat_struct.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46303](https://bugs.python.org/issue46303) -->
https://bugs.python.org/issue46303
<!-- /issue-number -->
