### PR TITLE
gh-90437: Fix __main__.py documentation wording

### DIFF
--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -253,7 +253,7 @@ attribute will include the package's path if imported::
 
 This won't work for ``__main__.py`` files in the root directory of a .zip file
 though.  Hence, for consistency, minimal ``__main__.py`` like the :mod:`venv`
-one mentioned above are preferred.
+one mentioned below are preferred.
 
 .. seealso::
 

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -251,7 +251,7 @@ attribute will include the package's path if imported::
     >>> asyncio.__main__.__name__
     'asyncio.__main__'
 
-This won’t work for ``__main__.py`` files in the root directory of a
+This won't work for ``__main__.py`` files in the root directory of a
 ``.zip`` file though.  Hence, for consistency, minimal ``__main__.py``
 without a ``__name__`` check is preferred.
 

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -252,7 +252,7 @@ attribute will include the package's path if imported::
     'asyncio.__main__'
 
 This won't work for ``__main__.py`` files in the root directory of a
-``.zip`` file though.  Hence, for consistency, minimal ``__main__.py``
+``.zip`` file though.  Hence, for consistency, a minimal ``__main__.py``
 without a ``__name__`` check is preferred.
 
 .. seealso::

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -251,8 +251,9 @@ attribute will include the package's path if imported::
     >>> asyncio.__main__.__name__
     'asyncio.__main__'
 
-This won’t work for __main__.py files in the root directory of a .zip file though.
-Hence, for consistency, minimal __main__.py without a __name__ check is preferred.
+This won’t work for ``__main__.py`` files in the root directory of a
+``.zip`` file though.  Hence, for consistency, minimal ``__main__.py``
+without a ``__name__`` check is preferred.
 
 .. seealso::
 

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -251,9 +251,8 @@ attribute will include the package's path if imported::
     >>> asyncio.__main__.__name__
     'asyncio.__main__'
 
-This won't work for ``__main__.py`` files in the root directory of a .zip file
-though.  Hence, for consistency, minimal ``__main__.py`` like the :mod:`venv`
-one mentioned below are preferred.
+This won’t work for __main__.py files in the root directory of a .zip file though.
+Hence, for consistency, minimal __main__.py without a __name__ check is preferred.
 
 .. seealso::
 

--- a/Misc/NEWS.d/next/Documentation/2022-01-08-09-44-45.bpo-46279.YZx4i8.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-01-08-09-44-45.bpo-46279.YZx4i8.rst
@@ -1,0 +1,1 @@
+Corrected trivial clarification error in __main__.py documentation

--- a/Misc/NEWS.d/next/Documentation/2022-01-08-09-44-45.bpo-46279.YZx4i8.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-01-08-09-44-45.bpo-46279.YZx4i8.rst
@@ -1,1 +1,0 @@
-Corrected trivial clarification error in __main__.py documentation


### PR DESCRIPTION
<!-- gh-issue-number: gh-90437 -->
gh-90437
<!-- /gh-issue-number -->
