### PR TITLE
bpo-46306: simplify `CodeType` attribute access in `doctest.py`

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1113,7 +1113,7 @@ class DocTestFinder:
         if inspect.istraceback(obj): obj = obj.tb_frame
         if inspect.isframe(obj): obj = obj.f_code
         if inspect.iscode(obj):
-            lineno = getattr(obj, 'co_firstlineno', None)-1
+            lineno = obj.co_firstlineno - 1
 
         # Find the line number where the docstring starts.  Assume
         # that it's the first line that begins with a quote mark.

--- a/Misc/NEWS.d/next/Library/2022-01-08-13-53-25.bpo-46306.1_es8z.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-08-13-53-25.bpo-46306.1_es8z.rst
@@ -1,2 +1,2 @@
-Assume that :class:`types.CodeType` always has ``co_firstlineno`` prop in
+Assume that :class:`types.CodeType` always has :attr:`types.CodeType.co_firstlineno` in
 :mod:`doctest`.

--- a/Misc/NEWS.d/next/Library/2022-01-08-13-53-25.bpo-46306.1_es8z.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-08-13-53-25.bpo-46306.1_es8z.rst
@@ -1,0 +1,2 @@
+Assume that :class:`types.CodeType` always has ``co_firstlineno`` prop in
+:mod:`doctest`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46306](https://bugs.python.org/issue46306) -->
https://bugs.python.org/issue46306
<!-- /issue-number -->
