### PR TITLE
bpo-34602: Fix unportable test(1) operator in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -10289,7 +10289,7 @@ then
 		# small for the default recursion limit. Increase the stack size
 		# to ensure that tests don't crash
     stack_size="1000000"  # 16 MB
-    if test "$with_ubsan" == "yes"
+    if test "$with_ubsan" = "yes"
     then
         # Undefined behavior sanitizer requires an even deeper stack
         stack_size="4000000"  # 64 MB

--- a/configure.ac
+++ b/configure.ac
@@ -2846,7 +2846,7 @@ then
 		# small for the default recursion limit. Increase the stack size
 		# to ensure that tests don't crash
     stack_size="1000000"  # 16 MB
-    if test "$with_ubsan" == "yes"
+    if test "$with_ubsan" = "yes"
     then
         # Undefined behavior sanitizer requires an even deeper stack
         stack_size="4000000"  # 64 MB


### PR DESCRIPTION
Split off from https://github.com/python/cpython/pull/30066 as requested by @taleinat

<!-- issue-number: [bpo-34602](https://bugs.python.org/issue34602) -->
https://bugs.python.org/issue34602
<!-- /issue-number -->
