### PR TITLE
bpo-40280: Disable epoll_create in Emscripten config.site (GH-30494)

### DIFF
--- a/Tools/wasm/config.site-wasm32-emscripten
+++ b/Tools/wasm/config.site-wasm32-emscripten
@@ -33,7 +33,6 @@ ac_cv_lib_bz2_BZ2_bzCompress=no
 # The rest is based on pyodide
 # https://github.com/pyodide/pyodide/blob/main/cpython/pyconfig.undefs.h
 
-ac_cv_func_epoll=no
 ac_cv_func_epoll_create=no
 ac_cv_func_epoll_create1=no
 ac_cv_header_linux_vm_sockets_h=no

--- a/Tools/wasm/config.site-wasm32-emscripten
+++ b/Tools/wasm/config.site-wasm32-emscripten
@@ -34,6 +34,7 @@ ac_cv_lib_bz2_BZ2_bzCompress=no
 # https://github.com/pyodide/pyodide/blob/main/cpython/pyconfig.undefs.h
 
 ac_cv_func_epoll=no
+ac_cv_func_epoll_create=no
 ac_cv_func_epoll_create1=no
 ac_cv_header_linux_vm_sockets_h=no
 ac_cv_func_socketpair=no


### PR DESCRIPTION
With the fix in 994f90c0772612780361e1dc5fa5223dce22f70a
building for Emscripten started failing with epoll link
errors as can be seen here:
https://github.com/ethanhs/python-wasm/runs/4745952720


I believe this shouldn't require a news entry.

<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
