### PR TITLE
bpo-40280: Add build target for Emscripten/node.js

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -855,7 +855,7 @@ python-rawfs.js: Programs/python.o $(LIBRARY_DEPS) pybuilddir.txt
 	    $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) \
 	    -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 \
 	    -s NODERAWFS=1 -s EXIT_RUNTIME=1 -s USE_PTHREADS \
-		-s PROXY_TO_PTHREAD
+	    -s PROXY_TO_PTHREAD
 
 ##########################################################################
 # Build static libmpdec.a

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -833,6 +833,7 @@ $(DLLLIBRARY) libpython$(LDVERSION).dll.a: $(LIBRARY_OBJS)
 # wasm32-emscripten build
 # wasm assets directory is relative to current build dir, e.g. "./usr/local".
 # --preload-file turns a relative asset path into an absolute path.
+# With node.js, we use the rawfs which is much easier for tests
 WASM_ASSETS_DIR=".$(prefix)"
 WASM_STDLIB="$(WASM_ASSETS_DIR)/local/lib/python$(VERSION)/os.py"
 
@@ -844,7 +845,14 @@ $(WASM_STDLIB): $(srcdir)/Lib/*.py $(srcdir)/Lib/*/*.py \
 python.html: Programs/python.o $(LIBRARY_DEPS) $(WASM_STDLIB)
 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o \
 	    $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) \
-	    -s ASSERTIONS=1 --preload-file $(WASM_ASSETS_DIR)
+	    -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 \
+		--preload-file $(WASM_ASSETS_DIR)
+
+python.js: Programs/python.o $(LIBRARY_DEPS) $(WASM_STDLIB)
+	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o \
+	    $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) \
+	    -s ASSERTIONS=1 -s NODERAWFS=1 -s ALLOW_MEMORY_GROWTH=1 \
+		-s EXIT_RUNTIME=1
 
 ##########################################################################
 # Build static libmpdec.a

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -848,11 +848,11 @@ python.html: Programs/python.o $(LIBRARY_DEPS) $(WASM_STDLIB)
 	    -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 \
 		--preload-file $(WASM_ASSETS_DIR)
 
-python.js: Programs/python.o $(LIBRARY_DEPS) $(WASM_STDLIB)
+python.js: Programs/python.o $(LIBRARY_DEPS)
 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o \
 	    $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) \
-	    -s ASSERTIONS=1 -s NODERAWFS=1 -s ALLOW_MEMORY_GROWTH=1 \
-		-s EXIT_RUNTIME=1
+	    -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 \
+	    -s NODERAWFS=1 -s EXIT_RUNTIME=1
 
 ##########################################################################
 # Build static libmpdec.a

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -848,7 +848,7 @@ python.html: Programs/python.o $(LIBRARY_DEPS) $(WASM_STDLIB)
 	    -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 \
 		--preload-file $(WASM_ASSETS_DIR)
 
-python.js: Programs/python.o $(LIBRARY_DEPS)
+python-rawfs.js: Programs/python.o $(LIBRARY_DEPS)
 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o \
 	    $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) \
 	    -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -38,6 +38,7 @@ CC=		@CC@
 CXX=		@CXX@
 MAINCC=		@MAINCC@
 LINKCC=		@LINKCC@
+LINKCC_BUILDPYTHON =	@LINKCC_BUILDPYTHON@
 AR=		@AR@
 READELF=	@READELF@
 SOABI=		@SOABI@
@@ -317,6 +318,7 @@ COVERAGE_REPORT_OPTIONS=--no-branch-coverage --title "CPython lcov report"
 
 
 ##########################################################################
+
 # Modules
 MODULE_OBJS=	\
 		Modules/config.o \
@@ -717,7 +719,7 @@ clinic: check-clean-src $(srcdir)/Modules/_blake2/blake2s_impl.c
 
 # Build the interpreter
 $(BUILDPYTHON):	Programs/python.o $(LIBRARY_DEPS)
-	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
+	$(LINKCC_BUILDPYTHON) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
 
 platform: $(BUILDPYTHON) pybuilddir.txt
 	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
@@ -845,14 +847,15 @@ $(WASM_STDLIB): $(srcdir)/Lib/*.py $(srcdir)/Lib/*/*.py \
 python.html: Programs/python.o $(LIBRARY_DEPS) $(WASM_STDLIB)
 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o \
 	    $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) \
-	    -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 \
-		--preload-file $(WASM_ASSETS_DIR)
+	    -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 -s USE_PTHREADS \
+		-s PROXY_TO_PTHREAD --preload-file $(WASM_ASSETS_DIR)
 
-python-rawfs.js: Programs/python.o $(LIBRARY_DEPS)
+python-rawfs.js: Programs/python.o $(LIBRARY_DEPS) pybuilddir.txt
 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o \
 	    $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) \
 	    -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 \
-	    -s NODERAWFS=1 -s EXIT_RUNTIME=1
+	    -s NODERAWFS=1 -s EXIT_RUNTIME=1 -s USE_PTHREADS \
+		-s PROXY_TO_PTHREAD
 
 ##########################################################################
 # Build static libmpdec.a

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -318,7 +318,6 @@ COVERAGE_REPORT_OPTIONS=--no-branch-coverage --title "CPython lcov report"
 
 
 ##########################################################################
-
 # Modules
 MODULE_OBJS=	\
 		Modules/config.o \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -848,7 +848,7 @@ python.html: Programs/python.o $(LIBRARY_DEPS) $(WASM_STDLIB)
 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o \
 	    $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) \
 	    -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 -s USE_PTHREADS \
-		-s PROXY_TO_PTHREAD --preload-file $(WASM_ASSETS_DIR)
+	    -s PROXY_TO_PTHREAD --preload-file $(WASM_ASSETS_DIR)
 
 python-rawfs.js: Programs/python.o $(LIBRARY_DEPS) pybuilddir.txt
 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o \

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -5114,6 +5114,7 @@ sock_initobj(PyObject *self, PyObject *args, PyObject *kwds)
                                      &family, &type, &proto, &fdobj))
         return -1;
 
+
 #ifdef MS_WINDOWS
     /* In this case, we don't use the family, type and proto args */
     if (fdobj == NULL || fdobj == Py_None)
@@ -7926,7 +7927,7 @@ PyInit__socket(void)
 #ifdef  IPPROTO_VRRP
     PyModule_AddIntMacro(m, IPPROTO_VRRP);
 #endif
-#ifdef  IPPROTO_SCTP
+#if defined(IPPROTO_SCTP) && !defined(__EMSCRIPTEN__)
     PyModule_AddIntMacro(m, IPPROTO_SCTP);
 #endif
 #ifdef  IPPROTO_BIP

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -5114,7 +5114,6 @@ sock_initobj(PyObject *self, PyObject *args, PyObject *kwds)
                                      &family, &type, &proto, &fdobj))
         return -1;
 
-
 #ifdef MS_WINDOWS
     /* In this case, we don't use the family, type and proto args */
     if (fdobj == NULL || fdobj == Py_None)

--- a/Tools/wasm/config.site-wasm32-emscripten
+++ b/Tools/wasm/config.site-wasm32-emscripten
@@ -7,6 +7,13 @@
 # Partly based on pyodide's pyconfig.undefs.h file.
 #
 
+ac_exeext=.wasm
+
+# Emscripten will build code that includes pthreads without the flag, but fail to run...
+ac_cv_pthread_is_default=no
+ac_cv_kthread=no
+ac_cv_pthread=yes
+
 # cannot be detected in cross builds
 ac_cv_buggy_getaddrinfo=no
 

--- a/Tools/wasm/wasm_assets.py
+++ b/Tools/wasm/wasm_assets.py
@@ -100,6 +100,21 @@ OMIT_SUBDIRS = (
     "unittest/test/",
 )
 
+SKIP_COMPILE = (
+    "test/bad_coding.py",
+    "test/bad_coding2.py",
+    "test/badsyntax_3131.py",
+    "test/badsyntax_future3.py",
+    "test/badsyntax_future4.py",
+    "test/badsyntax_future5.py",
+    "test/badsyntax_future6.py",
+    "test/badsyntax_future7.py",
+    "test/badsyntax_future8.py",
+    "test/badsyntax_future9.py",
+    "test/badsyntax_future10.py",
+    "test/badsyntax_pep3120.py",
+)
+
 
 OMIT_ABSOLUTE = {SRCDIR_LIB / name for name in OMIT_FILES}
 OMIT_SUBDIRS_ABSOLUTE = tuple(str(SRCDIR_LIB / name) for name in OMIT_SUBDIRS)
@@ -124,7 +139,9 @@ def create_stdlib_zip(
                 continue
             if entry in OMIT_ABSOLUTE:
                 continue
-            if entry.name.endswith(".py") or entry.is_dir():
+            if entry in SKIP_COMPILE:
+                pzf.write(entry)
+            elif entry.name.endswith(".py") or entry.is_dir():
                 # writepy() writes .pyc files (bytecode).
                 pzf.writepy(entry, filterfunc=filterfunc)
         for entry in sysconfig_data:

--- a/Tools/wasm/wasm_assets.py
+++ b/Tools/wasm/wasm_assets.py
@@ -100,21 +100,6 @@ OMIT_SUBDIRS = (
     "unittest/test/",
 )
 
-SKIP_COMPILE = (
-    "test/bad_coding.py",
-    "test/bad_coding2.py",
-    "test/badsyntax_3131.py",
-    "test/badsyntax_future3.py",
-    "test/badsyntax_future4.py",
-    "test/badsyntax_future5.py",
-    "test/badsyntax_future6.py",
-    "test/badsyntax_future7.py",
-    "test/badsyntax_future8.py",
-    "test/badsyntax_future9.py",
-    "test/badsyntax_future10.py",
-    "test/badsyntax_pep3120.py",
-)
-
 
 OMIT_ABSOLUTE = {SRCDIR_LIB / name for name in OMIT_FILES}
 OMIT_SUBDIRS_ABSOLUTE = tuple(str(SRCDIR_LIB / name) for name in OMIT_SUBDIRS)
@@ -139,9 +124,7 @@ def create_stdlib_zip(
                 continue
             if entry in OMIT_ABSOLUTE:
                 continue
-            if entry in SKIP_COMPILE:
-                pzf.write(entry)
-            elif entry.name.endswith(".py") or entry.is_dir():
+            if entry.name.endswith(".py") or entry.is_dir():
                 # writepy() writes .pyc files (bytecode).
                 pzf.writepy(entry, filterfunc=filterfunc)
         for entry in sysconfig_data:

--- a/configure
+++ b/configure
@@ -878,6 +878,7 @@ AR
 GNULD
 EXPORTSFROM
 EXPORTSYMS
+LINKCC_BUILDPYTHON
 LINKCC
 LDVERSION
 RUNSHARED
@@ -6326,6 +6327,25 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LINKCC" >&5
 $as_echo "$LINKCC" >&6; }
 
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking LINKCC_BUILDPYTHON" >&5
+$as_echo_n "checking LINKCC_BUILDPYTHON... " >&6; }
+if test -z "$LINKCC_BUILDPYTHON"
+then
+  # the .wasm executable doesn't support building with pthreads,
+  # so we hack around the symbol errors as they will be provided by
+  # Emscripten
+  case $ac_sys_system in #(
+  Emscripten) :
+    LINKCC_BUILDPYTHON="emcc -s ERROR_ON_UNDEFINED_SYMBOLS=0" ;; #(
+  *) :
+    LINKCC_BUILDPYTHON='$(LINKCC)'
+   ;;
+esac
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $LINKCC_BUILDPYTHON" >&5
+$as_echo "$LINKCC_BUILDPYTHON" >&6; }
+
 # EXPORTSYMS holds the list of exported symbols for AIX.
 # EXPORTSFROM holds the module name exporting symbols on AIX.
 EXPORTSYMS=
@@ -8276,7 +8296,6 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_pthread_is_default" >&5
 $as_echo "$ac_cv_pthread_is_default" >&6; }
 
-
 if test $ac_cv_pthread_is_default = yes
 then
   ac_cv_kpthread=no
@@ -8451,16 +8470,21 @@ fi
 
 if test $ac_cv_cxx_thread = yes
 then
-  echo 'void foo();int main(){foo();}void foo(){}' > conftest.$ac_ext
-  $CXX -c conftest.$ac_ext 2>&5
-  if $CXX -o conftest$ac_exeext conftest.$ac_objext 2>&5 \
-     && test -s conftest$ac_exeext && ./conftest$ac_exeext
-  then
+  if test "$cross_compiling" = yes; then
+    # assume that it works
     ac_cv_cxx_thread=yes
   else
-    ac_cv_cxx_thread=no
+    echo 'void foo();int main(){foo();}void foo(){}' > conftest.$ac_ext
+    $CXX -c conftest.$ac_ext 2>&5
+    if $CXX -o conftest$ac_exeext conftest.$ac_objext 2>&5 \
+      && test -s conftest$ac_exeext && ./conftest$ac_exeext
+    then
+      ac_cv_cxx_thread=yes
+    else
+      ac_cv_cxx_thread=no
+    fi
+    rm -fr conftest*
   fi
-  rm -fr conftest*
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_thread" >&5
 $as_echo "$ac_cv_cxx_thread" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -1162,6 +1162,20 @@ then
 fi
 AC_MSG_RESULT($LINKCC)
 
+AC_SUBST(LINKCC_BUILDPYTHON)
+AC_MSG_CHECKING(LINKCC_BUILDPYTHON)
+if test -z "$LINKCC_BUILDPYTHON"
+then
+  # the .wasm executable doesn't support building with pthreads,
+  # so we hack around the symbol errors as they will be provided by
+  # Emscripten
+  AS_CASE([$ac_sys_system],
+    [Emscripten], [LINKCC_BUILDPYTHON="emcc -s ERROR_ON_UNDEFINED_SYMBOLS=0"],
+    [LINKCC_BUILDPYTHON='$(LINKCC)']
+  )
+fi
+AC_MSG_RESULT($LINKCC_BUILDPYTHON)
+
 # EXPORTSYMS holds the list of exported symbols for AIX.
 # EXPORTSFROM holds the module name exporting symbols on AIX.
 EXPORTSYMS=
@@ -2125,7 +2139,6 @@ int main(){
 ],[ac_cv_pthread_is_default=no],[ac_cv_pthread_is_default=no])
 ])
 
-
 if test $ac_cv_pthread_is_default = yes
 then
   ac_cv_kpthread=no
@@ -2233,16 +2246,21 @@ fi
 
 if test $ac_cv_cxx_thread = yes
 then
-  echo 'void foo();int main(){foo();}void foo(){}' > conftest.$ac_ext
-  $CXX -c conftest.$ac_ext 2>&5
-  if $CXX -o conftest$ac_exeext conftest.$ac_objext 2>&5 \
-     && test -s conftest$ac_exeext && ./conftest$ac_exeext
-  then
+  if test "$cross_compiling" = yes; then
+    # assume that it works
     ac_cv_cxx_thread=yes
   else
-    ac_cv_cxx_thread=no
+    echo 'void foo();int main(){foo();}void foo(){}' > conftest.$ac_ext
+    $CXX -c conftest.$ac_ext 2>&5
+    if $CXX -o conftest$ac_exeext conftest.$ac_objext 2>&5 \
+      && test -s conftest$ac_exeext && ./conftest$ac_exeext
+    then
+      ac_cv_cxx_thread=yes
+    else
+      ac_cv_cxx_thread=no
+    fi
+    rm -fr conftest*
   fi
-  rm -fr conftest*
 fi
 AC_MSG_RESULT($ac_cv_cxx_thread)
 fi


### PR DESCRIPTION
This adds a "python.js" target to the Makefile. We enable the raw
node.js filesystem mode as suggested by @thomasballinger as it will make running
the test suite under node easier, c.f.
https://github.com/ethanhs/python-wasm/issues/36.

The `wasm_asset.py` script is updated to include the `test` module. Care is
taken to skip compiling the Python files that are examples of bad syntax
or encoding.

This also turns on memory growth as early into the test suite I was
running into OOMs.

cc @tiran 

~~This requires my other PR to work of course https://github.com/python/cpython/pull/30494~~ (This is now merged)


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
