### PR TITLE
bpo-28249: fix `lineno` location for empty `DocTest` instances

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1087,7 +1087,7 @@ class DocTestFinder:
         """
         Return a line number of the given object's docstring.
 
-        This method returns `None` if an object does not have a docstring.
+        Returns `None` if the given object does not have a docstring.
         """
         lineno = None
         docstring = getattr(obj, '__doc__', None)

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1085,19 +1085,21 @@ class DocTestFinder:
 
     def _find_lineno(self, obj, source_lines):
         """
-        Return a line number of the given object's docstring.  Note:
-        this method assumes that the object has a docstring.
+        Return a line number of the given object's docstring.
+
+        This method returns `None` if an object does not have a docstring.
         """
         lineno = None
+        docstring = getattr(obj, '__doc__', None)
 
         # Find the line number for modules.
-        if inspect.ismodule(obj):
+        if inspect.ismodule(obj) and docstring is not None:
             lineno = 0
 
         # Find the line number for classes.
         # Note: this could be fooled if a class is defined multiple
         # times in a single file.
-        if inspect.isclass(obj):
+        if inspect.isclass(obj) and docstring is not None:
             if source_lines is None:
                 return None
             pat = re.compile(r'^\s*class\s*%s\b' %
@@ -1109,7 +1111,9 @@ class DocTestFinder:
 
         # Find the line number for functions & methods.
         if inspect.ismethod(obj): obj = obj.__func__
-        if inspect.isfunction(obj): obj = obj.__code__
+        if inspect.isfunction(obj) and getattr(obj, '__doc__', None):
+            # We don't use `docstring` var here, because `obj` can be changed.
+            obj = obj.__code__
         if inspect.istraceback(obj): obj = obj.tb_frame
         if inspect.isframe(obj): obj = obj.f_code
         if inspect.iscode(obj):

--- a/Lib/test/doctest_lineno.py
+++ b/Lib/test/doctest_lineno.py
@@ -1,0 +1,50 @@
+# This module is used in `test_doctest`.
+# It must not have a docstring.
+
+def func_with_docstring():
+    """Some unrelated info."""
+
+
+def func_without_docstring():
+    pass
+
+
+def func_with_doctest():
+    """
+    This function really contains a test case.
+
+    >>> func_with_doctest.__name__
+    'func_with_doctest'
+    """
+    return 3
+
+
+class ClassWithDocstring:
+    """Some unrelated class information."""
+
+
+class ClassWithoutDocstring:
+    pass
+
+
+class ClassWithDoctest:
+    """This class really has a test case in it.
+
+    >>> ClassWithDoctest.__name__
+    'ClassWithDoctest'
+    """
+
+
+class MethodWrapper:
+    def method_with_docstring(self):
+        """Method with a docstring."""
+
+    def method_without_docstring(self):
+        pass
+
+    def method_with_doctest(self):
+        """
+        This has a doctest!
+        >>> MethodWrapper.method_with_doctest.__name__
+        'method_with_doctest'
+        """

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -25,6 +25,7 @@ if not support.has_subprocess_support:
 
 # NOTE: There are some additional tests relating to interaction with
 #       zipimport in the test_zipimport_support test module.
+# There are also related tests in `test_doctest2` module.
 
 ######################################################################
 ## Sample Objects (used by test cases)
@@ -460,7 +461,7 @@ We'll simulate a __file__ attr that ends in pyc:
     >>> tests = finder.find(sample_func)
 
     >>> print(tests)  # doctest: +ELLIPSIS
-    [<DocTest sample_func from test_doctest.py:33 (1 example)>]
+    [<DocTest sample_func from test_doctest.py:34 (1 example)>]
 
 The exact name depends on how test_doctest was invoked, so allow for
 leading path components.
@@ -641,6 +642,26 @@ displays.
      1  SampleClass.a_staticmethod
      1  SampleClass.double
      1  SampleClass.get
+
+When used with `exclude_empty=False` we are also interested in line numbers
+of doctests that are empty.
+It used to be broken for quite some time until `bpo-28249`.
+
+    >>> from test import doctest_lineno
+    >>> tests = doctest.DocTestFinder(exclude_empty=False).find(doctest_lineno)
+    >>> for t in tests:
+    ...     print('%5s  %s' % (t.lineno, t.name))
+     None  test.doctest_lineno
+       22  test.doctest_lineno.ClassWithDocstring
+       30  test.doctest_lineno.ClassWithDoctest
+     None  test.doctest_lineno.ClassWithoutDocstring
+     None  test.doctest_lineno.MethodWrapper
+       39  test.doctest_lineno.MethodWrapper.method_with_docstring
+       45  test.doctest_lineno.MethodWrapper.method_with_doctest
+     None  test.doctest_lineno.MethodWrapper.method_without_docstring
+        4  test.doctest_lineno.func_with_docstring
+       12  test.doctest_lineno.func_with_doctest
+     None  test.doctest_lineno.func_without_docstring
 
 Turning off Recursion
 ~~~~~~~~~~~~~~~~~~~~~

--- a/Misc/NEWS.d/next/Library/2022-01-09-14-23-00.bpo-28249.4dzB80.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-09-14-23-00.bpo-28249.4dzB80.rst
@@ -1,2 +1,2 @@
 Set :attr:`doctest.DocTest.lineno` to ``None`` when object does not have
-``__doc__``.
+:attr:`__doc__`.

--- a/Misc/NEWS.d/next/Library/2022-01-09-14-23-00.bpo-28249.4dzB80.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-09-14-23-00.bpo-28249.4dzB80.rst
@@ -1,0 +1,2 @@
+Set :attr:`doctest.DocTest.lineno` to `None` when object does not have
+``__doc__``.

--- a/Misc/NEWS.d/next/Library/2022-01-09-14-23-00.bpo-28249.4dzB80.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-09-14-23-00.bpo-28249.4dzB80.rst
@@ -1,2 +1,2 @@
-Set :attr:`doctest.DocTest.lineno` to `None` when object does not have
+Set :attr:`doctest.DocTest.lineno` to ``None`` when object does not have
 ``__doc__``.


### PR DESCRIPTION
This patch fixes `lineno` for `DocTest` instances for objects that don't have `__doc__` attribute.

In the original issue this was used as an example:

```python
def a():
    # """A"""
    pass

def b():  # line 5
    """B"""
    pass

def c():
    # """C"""
    pass
```

Before this patch, `doctest.DocTestFinder(exclude_empty=False).find(example_module)` was showing:

```python
[
  <DocTest example from example.py:5 (no examples)>,
  <DocTest example.a from example.py:5 (no examples)>,
  <DocTest example.b from example.py:5 (no examples)>,
  <DocTest example.c from example.py:None (no examples)>,
]
```

Notice that `lineno` was `5` for `example` and `example.a`. Which is clearly wrong, because `example.b` is on the 5th line. But, `example.c` had `lineno=None`.

[`DocTest` docs](https://github.com/python/cpython/blob/5c66414b5561c54e7a0f4bde8cc3271908ea525e/Lib/doctest.py#L521-L524) clearly state:

> - lineno: The line number within filename where this DocTest
> begins, or `None` if the line number is unavailable.  This
> line number is zero-based, with respect to the beginning of
> the file.

So, now `lineno` is set to `None` when `__doc__` cannot be found. Now, the result for our `example` module will be:

```
[
  <DocTest example from example.py:None (no examples)>, 
  <DocTest example.a from example.py:None (no examples)>,
  <DocTest example.b from example.py:5 (no examples)>, 
  <DocTest example.c from example.py:None (no examples)>, 
]
```

Now, everything looks correct.

<!-- issue-number: [bpo-28249](https://bugs.python.org/issue28249) -->
https://bugs.python.org/issue28249
<!-- /issue-number -->

CC @corona10 as my mentor 🙂 