### PR TITLE
bpo-46272: Fix two heading comments in python.gram

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -676,8 +676,8 @@ inversion[expr_ty] (memo):
     | 'not' a=inversion { _PyAST_UnaryOp(Not, a, EXTRA) }
     | comparison
 
-# Comparisons operators
-# ---------------------
+# Comparison operators
+# --------------------
 
 comparison[expr_ty]:
     | a=bitwise_or b=compare_op_bitwise_or_pair+ {
@@ -712,7 +712,7 @@ in_bitwise_or[CmpopExprPair*]: 'in' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, I
 isnot_bitwise_or[CmpopExprPair*]: 'is' 'not' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, IsNot, a) }
 is_bitwise_or[CmpopExprPair*]: 'is' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, Is, a) }
 
-# Logical operators
+# Bitwise operators
 # -----------------
 
 bitwise_or[expr_ty]:


### PR DESCRIPTION
One typo fix and one heading change, both in comments. No functional changes.

<!-- issue-number: [bpo-46272](https://bugs.python.org/issue46272) -->
https://bugs.python.org/issue46272
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal