### PR TITLE
bpo-46316: optimize `pathlib.Path.iterdir()`

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1013,9 +1013,6 @@ class Path(PurePath):
         result for the special paths '.' and '..'.
         """
         for name in self._accessor.listdir(self):
-            if name in {'.', '..'}:
-                # Yielding a path object for these makes little sense
-                continue
             yield self._make_child_relpath(name)
 
     def glob(self, pattern):

--- a/Misc/NEWS.d/next/Library/2022-01-09-15-04-56.bpo-46316.AMTyd0.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-09-15-04-56.bpo-46316.AMTyd0.rst
@@ -1,0 +1,1 @@
+Optimize :meth:`pathlib.Path.iterdir` by removing an unnecessary check for special entries.


### PR DESCRIPTION
`os.listdir()` doesn't return entries for `.` or `..`, so we don't need to check for them here.

See https://docs.python.org/3/library/os.html#os.listdir

> Return a list containing the names of the entries in the directory given by path. The list is in arbitrary order, and **does not include the special entries '.' and '..' even if they are present in the directory**.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46316](https://bugs.python.org/issue46316) -->
https://bugs.python.org/issue46316
<!-- /issue-number -->
