### PR TITLE
Make creation year more explicit in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 A. HISTORY OF THE SOFTWARE
 ==========================
 
-Python was created in the early 1990s by Guido van Rossum at Stichting
+Python was created in 1991 by Guido van Rossum at Stichting
 Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
 as a successor of a language called ABC.  Guido remains Python's
 principal author, although it includes many contributions from others.


### PR DESCRIPTION
# Make creation year more explicit in license

As the zen of Python says “Explicit is better than inexplicit.”

no issue
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
