### PR TITLE
bpo-45729: [doc] Add license_url for python-docs-theme 2022.1.

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -69,7 +69,8 @@ html_theme = 'python_docs_theme'
 html_theme_path = ['tools']
 html_theme_options = {
     'collapsiblesidebar': True,
-    'issues_url': 'https://docs.python.org/3/bugs.html',
+    'issues_url': '/bugs.html',
+    'license_url': '/license.html',
     'root_include_title': False   # We use the version switcher instead.
 }
 

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -9,4 +9,4 @@ blurb
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.
-python-docs-theme
+python-docs-theme>=2022.1


### PR DESCRIPTION
I also changed issues_url so it serve local pages when using `make serve` locally.

It'll also works on prod as `/license.html` redirects to `/3/license.html` (same for `/bugs.html`).


<!-- issue-number: [bpo-45729](https://bugs.python.org/issue45729) -->
https://bugs.python.org/issue45729
<!-- /issue-number -->
