### PR TITLE
[3.10] bpo-46303: Fix build error on "struct stat" on Windows

### DIFF
--- a/Include/cpython/fileutils.h
+++ b/Include/cpython/fileutils.h
@@ -2,6 +2,10 @@
 #  error "this header file must not be included directly"
 #endif
 
+// bpo-46303: On Windows, 'struct stat' may not be defined. Forward declaration
+// to avoid compiler warning on 'struct stat*' in this header file.
+struct stat;
+
 typedef enum {
     _Py_ERROR_UNKNOWN=0,
     _Py_ERROR_STRICT,

--- a/Misc/NEWS.d/next/C API/2022-01-11-12-11-59.bpo-46303.XsI0Ne.rst
+++ b/Misc/NEWS.d/next/C API/2022-01-11-12-11-59.bpo-46303.XsI0Ne.rst
@@ -1,0 +1,3 @@
+Fix build error when including the main Python.h header file if ``struct
+stat`` is not defined. This structure is used by ``fileutils.h``. Patch by
+Victor Stinner.


### PR DESCRIPTION
Fix build error when including the main Python.h header file
if "struct stat" is not defined. This structure is used by
fileutils.h.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46303](https://bugs.python.org/issue46303) -->
https://bugs.python.org/issue46303
<!-- /issue-number -->
