### PR TITLE
bpo-46339: Fix crash in the parser when computing error text for multi-line f-strings

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -280,6 +280,12 @@ class ExceptionTests(unittest.TestCase):
             }
             \"\"\"
             }'''""", 5, 17)
+        check('''f"""
+
+
+            {
+            6
+            0="""''', 5, 13)
 
         # Errors thrown by symtable.c
         check('x = [(yield i) for i in range(3)]', 1, 7)

--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-11-11-50-19.bpo-46339.OVumDZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-11-11-50-19.bpo-46339.OVumDZ.rst
@@ -1,0 +1,3 @@
+Fix a crash in the parser when retrieving the error text for multi-line
+f-strings expressions that do not start in the first line of the string.
+Patch by Pablo Galindo

--- a/Parser/pegen_errors.c
+++ b/Parser/pegen_errors.c
@@ -254,6 +254,7 @@ get_error_line_from_tokenizer_buffers(Parser *p, Py_ssize_t lineno)
 
     for (int i = 0; i < relative_lineno - 1; i++) {
         char *new_line = strchr(cur_line, '\n') + 1;
+        assert(new_line != NULL && new_line < p->tok->inp);
         if (new_line == NULL || new_line >= p->tok->inp) {
             break;
         }

--- a/Parser/pegen_errors.c
+++ b/Parser/pegen_errors.c
@@ -250,8 +250,14 @@ get_error_line_from_tokenizer_buffers(Parser *p, Py_ssize_t lineno)
     char *cur_line = p->tok->fp_interactive ? p->tok->interactive_src_start : p->tok->str;
     assert(cur_line != NULL);
 
-    for (int i = 0; i < lineno - 1; i++) {
-        cur_line = strchr(cur_line, '\n') + 1;
+    Py_ssize_t relative_lineno = p->starting_lineno ? lineno - p->starting_lineno + 1 : lineno;
+
+    for (int i = 0; i < relative_lineno - 1; i++) {
+        char *new_line = strchr(cur_line, '\n') + 1;
+        if (new_line == NULL || new_line >= p->tok->inp) {
+            break;
+        }
+        cur_line = new_line;
     }
 
     char *next_newline;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46339](https://bugs.python.org/issue46339) -->
https://bugs.python.org/issue46339
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal