### PR TITLE
bpo-46345: add a test case for implicit `Optional` class attribute

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3116,6 +3116,12 @@ class GetTypeHintTests(BaseTestCase):
                           'my_inner_a2': mod_generics_cache.B.A,
                           'my_outer_a': mod_generics_cache.A})
 
+    def test_get_type_hints_classes_no_implicit_optional(self):
+        class WithNoneDefault:
+            field: int = None  # most type-checkers won't be happy with it
+
+        self.assertEqual(gth(WithNoneDefault), {'field': int})
+
     def test_respect_no_type_check(self):
         @no_type_check
         class NoTpCheck:


### PR DESCRIPTION
Related https://github.com/python/cpython/pull/30304

CC @corona10 as my mentor

<!-- issue-number: [bpo-46345](https://bugs.python.org/issue46345) -->
https://bugs.python.org/issue46345
<!-- /issue-number -->
