### PR TITLE
bpo-46347: Fix memory leak in PyEval_EvalCodeEx.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-11-13-57-00.bpo-46347.Gd8M-S.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-11-13-57-00.bpo-46347.Gd8M-S.rst
@@ -1,0 +1,1 @@
+Fix memory leak in PyEval_EvalCodeEx.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -6128,16 +6128,9 @@ PyEval_EvalCodeEx(PyObject *_co, PyObject *globals, PyObject *locals,
         }
         allargs = newargs;
     }
-    PyObject **kwargs = PyMem_Malloc(sizeof(PyObject *)*kwcount);
-    if (kwargs == NULL) {
-        res = NULL;
-        Py_DECREF(kwnames);
-        goto fail;
-    }
     for (int i = 0; i < kwcount; i++) {
         Py_INCREF(kws[2*i]);
         PyTuple_SET_ITEM(kwnames, i, kws[2*i]);
-        kwargs[i] = kws[2*i+1];
     }
     PyFrameConstructor constr = {
         .fc_globals = globals,


### PR DESCRIPTION
First introduced in 0332e569c12d3dc97171546c6dc10e42c27de34b


<!-- issue-number: [bpo-46347](https://bugs.python.org/issue46347) -->
https://bugs.python.org/issue46347
<!-- /issue-number -->
