### PR TITLE
bpo-46303: Fix _Py_stat() compiler warning in _tkinter.c

### DIFF
--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -22,9 +22,15 @@ Copyright (C) 1994 Steen Lumholt.
 */
 
 #define PY_SSIZE_T_CLEAN
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
 
 #include "Python.h"
 #include <ctype.h>
+#ifdef MS_WINDOWS
+#  include "pycore_fileutils.h"   // _Py_stat()
+#endif
 
 #ifdef MS_WINDOWS
 #include <windows.h>

--- a/PC/_testconsole.c
+++ b/PC/_testconsole.c
@@ -1,11 +1,15 @@
-
 /* Testing module for multi-phase initialization of extension modules (PEP 489)
  */
+
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
 
 #include "Python.h"
 
 #ifdef MS_WINDOWS
 
+#include "pycore_fileutils.h"     // _Py_get_osfhandle()
 #include "..\modules\_io\_iomodule.h"
 
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Add missing pycore_fileutils.h include.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46303](https://bugs.python.org/issue46303) -->
https://bugs.python.org/issue46303
<!-- /issue-number -->
