### PR TITLE
bpo-46353: Fix "pydoc -k" when a module fails to load

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2230,6 +2230,8 @@ class ModuleScanner:
                 except SyntaxError:
                     # raised by tests for bad coding cookies or BOM
                     continue
+                if spec is None:
+                    continue
                 loader = spec.loader
                 if hasattr(loader, 'get_source'):
                     try:

--- a/Misc/NEWS.d/next/Library/2022-01-12-14-10-42.bpo-46353.wSHF5T.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-12-14-10-42.bpo-46353.wSHF5T.rst
@@ -1,0 +1,2 @@
+Skip scan of modules that fail to load during keyword search in
+:mod:`pydoc`.


### PR DESCRIPTION
The 'spec' value, here coming from pkgutil._get_spec(), may be None
because <importer>.find_module() may return None. We account for this in
pydoc's ModuleScanner and skip such modules scan.


<!-- issue-number: [bpo-46353](https://bugs.python.org/issue46353) -->
https://bugs.python.org/issue46353
<!-- /issue-number -->
