### PR TITLE
bpo-46357: socket module fix warning build on FreeBSD.

### DIFF
--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -111,6 +111,9 @@ typedef int socklen_t;
 #endif
 
 #ifdef HAVE_BLUETOOTH_H
+# ifdef __FreeBSD__
+#  define L2CAP_SOCKET_CHECKED
+# endif
 #include <bluetooth.h>
 #endif
 


### PR DESCRIPTION


<!-- issue-number: [bpo-46357](https://bugs.python.org/issue46357) -->
https://bugs.python.org/issue46357
<!-- /issue-number -->
