### PR TITLE
bpo-46361: Fix "small" `int` caching

### DIFF
--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -2551,6 +2551,14 @@ class PythonAPItests(unittest.TestCase):
         self.assertRaises(ValueError, int, Decimal('snan'))
         self.assertRaises(OverflowError, int, Decimal('inf'))
         self.assertRaises(OverflowError, int, Decimal('-inf'))
+    
+    @cpython_only
+    def test_small_ints(self):
+        # bpo-46361
+        Decimal = self.decimal.Decimal
+
+        for x in range(-5, 257):
+            self.assertIs(int(Decimal(x)), x)
 
     def test_trunc(self):
         Decimal = self.decimal.Decimal

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -2551,12 +2551,11 @@ class PythonAPItests(unittest.TestCase):
         self.assertRaises(ValueError, int, Decimal('snan'))
         self.assertRaises(OverflowError, int, Decimal('inf'))
         self.assertRaises(OverflowError, int, Decimal('-inf'))
-    
+
     @cpython_only
     def test_small_ints(self):
-        # bpo-46361
         Decimal = self.decimal.Decimal
-
+        # bpo-46361
         for x in range(-5, 257):
             self.assertIs(int(Decimal(x)), x)
 

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1471,6 +1471,14 @@ class LongTest(unittest.TestCase):
         self.assertEqual(i, 1)
         self.assertEqual(getattr(i, 'foo', 'none'), 'bar')
 
+    @support.cpython_only
+    def test_from_bytes_small(self):
+        # bpo-46361
+        for i in range(-5, 257):
+            b = i.to_bytes(2, signed=True)
+            self.assertIs(int.from_bytes(b, signed=True), i)
+        
+
     def test_access_to_nonexistent_digit_0(self):
         # http://bugs.python.org/issue14630: A bug in _PyLong_Copy meant that
         # ob_digit[0] was being incorrectly accessed for instances of a

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1477,7 +1477,6 @@ class LongTest(unittest.TestCase):
         for i in range(-5, 257):
             b = i.to_bytes(2, signed=True)
             self.assertIs(int.from_bytes(b, signed=True), i)
-        
 
     def test_access_to_nonexistent_digit_0(self):
         # http://bugs.python.org/issue14630: A bug in _PyLong_Copy meant that

--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-12-17-15-17.bpo-46361.mgI_j_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-12-17-15-17.bpo-46361.mgI_j_.rst
@@ -1,0 +1,2 @@
+Ensure that "small" integers created by :meth:`int.from_bytes` and
+:class:`decimal.Decimal` are properly cached.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3348,7 +3348,6 @@ dec_as_long(PyObject *dec, PyObject *context, int round)
     PyLongObject *pylong;
     digit *ob_digit;
     size_t n;
-    Py_ssize_t i;
     mpd_t *x;
     mpd_context_t workctx;
     uint32_t status = 0;
@@ -3388,34 +3387,36 @@ dec_as_long(PyObject *dec, PyObject *context, int round)
     #error "PYLONG_BITS_IN_DIGIT should be 15 or 30"
 #endif
 
+    Py_ssize_t sign = mpd_isnegative(x) && !mpd_iszero(x) ? -1 : 1;
+    mpd_del(x);
+
     if (n == SIZE_MAX) {
         PyErr_NoMemory();
-        mpd_del(x);
         return NULL;
     }
 
     assert(n > 0);
+    while ((n > 0) && (ob_digit[n - 1] == 0)) {
+        n--;
+    }
+
+    if (n < 2) {
+        pylong = (PyLongObject *)PyLong_FromLong(sign * ob_digit[0]);
+        mpd_free(ob_digit);
+        return (PyObject *)pylong;
+    }
+
     pylong = _PyLong_New(n);
     if (pylong == NULL) {
         mpd_free(ob_digit);
-        mpd_del(x);
         return NULL;
     }
 
     memcpy(pylong->ob_digit, ob_digit, n * sizeof(digit));
     mpd_free(ob_digit);
 
-    i = n;
-    while ((i > 0) && (pylong->ob_digit[i-1] == 0)) {
-        i--;
-    }
+    Py_SET_SIZE(pylong, sign * n);
 
-    Py_SET_SIZE(pylong, i);
-    if (mpd_isnegative(x) && !mpd_iszero(x)) {
-        Py_SET_SIZE(pylong, -i);
-    }
-
-    mpd_del(x);
     return (PyObject *) pylong;
 }
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -31,7 +31,6 @@
 
 #include <Python.h>
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "pycore_long.h"          // _PyLong_SMALL_INTS
 #include "complexobject.h"
 #include "mpdecimal.h"
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3396,6 +3396,7 @@ dec_as_long(PyObject *dec, PyObject *context, int round)
     }
 
     Py_ssize_t sign = mpd_isnegative(x) && !mpd_iszero(x) ? -1 : 1;
+    mpd_del(x);
 
     if (n == 1) {
         sdigit value = sign * ob_digit[0];
@@ -3410,7 +3411,6 @@ dec_as_long(PyObject *dec, PyObject *context, int round)
     pylong = _PyLong_New(n);
     if (pylong == NULL) {
         mpd_free(ob_digit);
-        mpd_del(x);
         return NULL;
     }
 
@@ -3424,7 +3424,6 @@ dec_as_long(PyObject *dec, PyObject *context, int round)
 
     Py_SET_SIZE(pylong, sign * i);
 
-    mpd_del(x);
     return (PyObject *) pylong;
 }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -911,7 +911,7 @@ _PyLong_FromByteArray(const unsigned char* bytes, size_t n,
     }
 
     Py_SET_SIZE(v, is_signed ? -idigit : idigit);
-    return (PyObject *)long_normalize(v);
+    return (PyObject *)maybe_small_long(long_normalize(v));
 }
 
 int


### PR DESCRIPTION


<!-- issue-number: [bpo-46361](https://bugs.python.org/issue46361) -->
https://bugs.python.org/issue46361
<!-- /issue-number -->
