### PR TITLE
bpo-45953: Statically initialize all the _PyRuntimeState fields we can.

### DIFF
--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -17,6 +17,17 @@ extern "C" {
 
 #define _PyRuntimeState_INIT \
     { \
+        .gilstate = { \
+            .check_enabled = 1, \
+            /* A TSS key must be initialized with Py_tss_NEEDS_INIT \
+               in accordance with the specification. */ \
+            .autoTSSkey = Py_tss_NEEDS_INIT, \
+        }, \
+        .interpreters = { \
+            /* This prevents interpreters from getting created \
+              until _PyInterpreterState_Enable() is called. */ \
+            .next_id = -1, \
+        }, \
         .global_objects = _Py_global_objects_INIT, \
         ._main_interpreter = _PyInterpreterState_INIT, \
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -111,17 +111,7 @@ init_runtime(_PyRuntimeState *runtime,
 
     PyPreConfig_InitPythonConfig(&runtime->preconfig);
 
-    runtime->gilstate.check_enabled = 1;
-
-    /* A TSS key must be initialized with Py_tss_NEEDS_INIT
-       in accordance with the specification. */
-    Py_tss_t initial = Py_tss_NEEDS_INIT;
-    runtime->gilstate.autoTSSkey = initial;
-
     runtime->interpreters.mutex = interpreters_mutex;
-    // This prevents interpreters from getting created
-    // until _PyInterpreterState_Enable() is called.
-    runtime->interpreters.next_id = -1;
 
     runtime->xidregistry.mutex = xidregistry_mutex;
 


### PR DESCRIPTION


<!-- issue-number: [bpo-45953](https://bugs.python.org/issue45953) -->
https://bugs.python.org/issue45953
<!-- /issue-number -->
