### PR TITLE
bpo-45953: Statically initialize all the non-object PyInterpreterState fields we can.

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -12,8 +12,13 @@ extern "C" {
 struct pyruntimestate;
 struct _ceval_runtime_state;
 
+#ifndef Py_DEFAULT_RECURSION_LIMIT
+#  define Py_DEFAULT_RECURSION_LIMIT 1000
+#endif
+
 #include "pycore_interp.h"        // PyInterpreterState.eval_frame
 #include "pycore_pystate.h"       // _PyThreadState_GET()
+
 
 extern void _Py_FinishPendingCalls(PyThreadState *tstate);
 extern void _PyEval_InitRuntimeState(struct _ceval_runtime_state *);

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -134,6 +134,7 @@ struct _gc_runtime_state {
     /* Current call-stack depth of tp_dealloc calls. */
     int trash_delete_nesting;
 
+    /* Is automatic collection enabled? */
     int enabled;
     int debug;
     /* linked lists of container objects */
@@ -160,6 +161,7 @@ struct _gc_runtime_state {
        the first time. */
     Py_ssize_t long_lived_pending;
 };
+
 
 extern void _PyGC_InitState(struct _gc_runtime_state *);
 

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -40,7 +40,13 @@ extern "C" {
             .recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
         }, \
         .gc = { \
-            .enabled = 1,  /* automatic collection enabled? */ \
+            .enabled = 1, \
+            .generations = { \
+                /* .head is set in _PyGC_InitState(). */ \
+                { .threshold = 700, }, \
+                { .threshold = 10, }, \
+                { .threshold = 10, }, \
+            }, \
         }, \
         ._initial_thread = _PyThreadState_INIT, \
     }

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -39,6 +39,9 @@ extern "C" {
         .ceval = { \
             .recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
         }, \
+        .gc = { \
+            .enabled = 1,  /* automatic collection enabled? */ \
+        }, \
         ._initial_thread = _PyThreadState_INIT, \
     }
 

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -39,15 +39,17 @@ extern "C" {
 #  else
 #    define _Py_DLOPEN_FLAGS RTLD_LAZY
 #  endif
+#  define DLOPENFLAGS_INIT .dlopenflags = _Py_DLOPEN_FLAGS,
 #else
 #  define _Py_DLOPEN_FLAGS 0
+#  define DLOPENFLAGS_INIT
 #endif
 
 #define _PyInterpreterState_INIT \
     { \
         ._static = 1, \
         .id_refcount = -1, \
-        .dlopenflags = _Py_DLOPEN_FLAGS, \
+        DLOPENFLAGS_INIT \
         .ceval = { \
             .recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
         }, \

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -32,10 +32,22 @@ extern "C" {
         ._main_interpreter = _PyInterpreterState_INIT, \
     }
 
+#ifdef HAVE_DLOPEN
+#  include <dlfcn.h>
+#  if HAVE_DECL_RTLD_NOW
+#    define _Py_DLOPEN_FLAGS RTLD_NOW
+#  else
+#    define _Py_DLOPEN_FLAGS RTLD_LAZY
+#  endif
+#else
+#  define _Py_DLOPEN_FLAGS 0
+#endif
+
 #define _PyInterpreterState_INIT \
     { \
         ._static = 1, \
         .id_refcount = -1, \
+        .dlopenflags = _Py_DLOPEN_FLAGS, \
         .ceval = { \
             .recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
         }, \

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -35,6 +35,7 @@ extern "C" {
 #define _PyInterpreterState_INIT \
     { \
         ._static = 1, \
+        .id_refcount = -1, \
         ._initial_thread = _PyThreadState_INIT, \
     }
 

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -36,6 +36,9 @@ extern "C" {
     { \
         ._static = 1, \
         .id_refcount = -1, \
+        .ceval = { \
+            .recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
+        }, \
         ._initial_thread = _PyThreadState_INIT, \
     }
 

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -139,22 +139,20 @@ get_gc_state(void)
 void
 _PyGC_InitState(GCState *gcstate)
 {
-#define _GEN_HEAD(n) GEN_HEAD(gcstate, n)
-    struct gc_generation generations[NUM_GENERATIONS] = {
-        /* PyGC_Head,                                    threshold,    count */
-        {{(uintptr_t)_GEN_HEAD(0), (uintptr_t)_GEN_HEAD(0)},   700,        0},
-        {{(uintptr_t)_GEN_HEAD(1), (uintptr_t)_GEN_HEAD(1)},   10,         0},
-        {{(uintptr_t)_GEN_HEAD(2), (uintptr_t)_GEN_HEAD(2)},   10,         0},
-    };
+#define INIT_HEAD(GEN) \
+    do { \
+        GEN.head._gc_next = (uintptr_t)&GEN.head; \
+        GEN.head._gc_prev = (uintptr_t)&GEN.head; \
+    } while (0)
+
     for (int i = 0; i < NUM_GENERATIONS; i++) {
-        gcstate->generations[i] = generations[i];
+        assert(gcstate->generations[i].count == 0);
+        INIT_HEAD(gcstate->generations[i]);
     };
     gcstate->generation0 = GEN_HEAD(gcstate, 0);
-    struct gc_generation permanent_generation = {
-          {(uintptr_t)&gcstate->permanent_generation.head,
-           (uintptr_t)&gcstate->permanent_generation.head}, 0, 0
-    };
-    gcstate->permanent_generation = permanent_generation;
+    INIT_HEAD(gcstate->permanent_generation);
+
+#undef INIT_HEAD
 }
 
 

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -139,8 +139,6 @@ get_gc_state(void)
 void
 _PyGC_InitState(GCState *gcstate)
 {
-    gcstate->enabled = 1; /* automatic collection enabled? */
-
 #define _GEN_HEAD(n) GEN_HEAD(gcstate, n)
     struct gc_generation generations[NUM_GENERATIONS] = {
         /* PyGC_Head,                                    threshold,    count */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -737,10 +737,6 @@ Py_MakePendingCalls(void)
 
 /* The interpreter's recursion limit */
 
-#ifndef Py_DEFAULT_RECURSION_LIMIT
-#  define Py_DEFAULT_RECURSION_LIMIT 1000
-#endif
-
 void
 _PyEval_InitRuntimeState(struct _ceval_runtime_state *ceval)
 {

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -748,8 +748,6 @@ _PyEval_InitRuntimeState(struct _ceval_runtime_state *ceval)
 void
 _PyEval_InitState(struct _ceval_state *ceval, PyThread_type_lock pending_lock)
 {
-    ceval->recursion_limit = Py_DEFAULT_RECURSION_LIMIT;
-
     struct _pending_calls *pending = &ceval->pending;
     assert(pending->lock == NULL);
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -290,14 +290,6 @@ init_interpreter(PyInterpreterState *interp,
     _PyGC_InitState(&interp->gc);
     PyConfig_InitPythonConfig(&interp->config);
     _PyType_InitCache(interp);
-    interp->eval_frame = NULL;
-#ifdef HAVE_DLOPEN
-#if HAVE_DECL_RTLD_NOW
-    interp->dlopenflags = RTLD_NOW;
-#else
-    interp->dlopenflags = RTLD_LAZY;
-#endif
-#endif
 
     interp->_initialized = 1;
 }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -281,7 +281,6 @@ init_interpreter(PyInterpreterState *interp,
 
     assert(id > 0 || (id == 0 && interp == runtime->interpreters.main));
     interp->id = id;
-    interp->id_refcount = -1;
 
     assert(runtime->interpreters.head == interp);
     assert(next != NULL || (interp == runtime->interpreters.main));


### PR DESCRIPTION


<!-- issue-number: [bpo-45953](https://bugs.python.org/issue45953) -->
https://bugs.python.org/issue45953
<!-- /issue-number -->
