### PR TITLE
bpo-46362: Make abspath() test available for Windows PGO

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1419,7 +1419,8 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         ]
         out, err = self.run_embedded_interpreter(
             "test_init_initialize_config",
-            env=dict(PYTHONPATH=os.path.pathsep.join(c[0] for c in CASES))
+            env={**remove_python_envvars(),
+                 "PYTHONPATH": os.path.pathsep.join(c[0] for c in CASES)}
         )
         self.assertEqual(err, "")
         try:


### PR DESCRIPTION
PGO instrumented build doesn't pass `test_embed` without `os.environ['PATH']` to MSVC binaries, and I missed the setting for `test_getpath_abspath_win32()`.


<!-- issue-number: [bpo-46362](https://bugs.python.org/issue46362) -->
https://bugs.python.org/issue46362
<!-- /issue-number -->
