### PR TITLE
bpo-46376: Change `PySequence_Check` and `PyMapping_Check` to use tpflags

### DIFF
--- a/Doc/c-api/mapping.rst
+++ b/Doc/c-api/mapping.rst
@@ -11,11 +11,13 @@ See also :c:func:`PyObject_GetItem`, :c:func:`PyObject_SetItem` and
 
 .. c:function:: int PyMapping_Check(PyObject *o)
 
-   Return ``1`` if the object provides mapping protocol or supports slicing,
-   and ``0`` otherwise.  Note that it returns ``1`` for Python classes with
-   a :meth:`__getitem__` method since in general case it is impossible to
-   determine what type of keys it supports. This function always succeeds.
-
+   Return ``1`` if the object provides mapping protocol
+   and ``0`` otherwise. This checks if :const:`Py_TPFLAGS_MAPPING` flag
+   set in its :c:member:`~PyTypeObject.tp_flags`). This function always succeeds.
+   
+   .. versionchanged:: 3.11
+      Previously, the function only checked for the existence of :meth:`__getitem__`
+      leading to uncertainity between sequences and mappings.
 
 .. c:function:: Py_ssize_t PyMapping_Size(PyObject *o)
                Py_ssize_t PyMapping_Length(PyObject *o)

--- a/Doc/c-api/sequence.rst
+++ b/Doc/c-api/sequence.rst
@@ -8,11 +8,13 @@ Sequence Protocol
 
 .. c:function:: int PySequence_Check(PyObject *o)
 
-   Return ``1`` if the object provides sequence protocol, and ``0`` otherwise.
-   Note that it returns ``1`` for Python classes with a :meth:`__getitem__`
-   method unless they are :class:`dict` subclasses since in general case it
-   is impossible to determine what the type of keys it supports.  This
-   function always succeeds.
+   Return ``1`` if the object provides sequence protocol
+   and ``0`` otherwise. This checks if :const:`Py_TPFLAGS_SEQUENCE` flag
+   set in its :c:member:`~PyTypeObject.tp_flags`). This function always succeeds.
+   
+   .. versionchanged:: 3.11
+      Previously, the function only checked for the existence of :meth:`__getitem__`
+      leading to uncertainity between sequences and mappings.
 
 
 .. c:function:: Py_ssize_t PySequence_Size(PyObject *o)

--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -11,7 +11,7 @@
 """Internal support module for sre"""
 
 # XXX: show string offset and offending character for all errors
-
+import collections.abc
 from sre_constants import *
 
 SPECIAL_CHARS = ".\\[{()*+?^$|"
@@ -106,7 +106,7 @@ class State:
                 raise source.error('cannot refer to group defined in the same '
                                    'lookbehind subpattern')
 
-class SubPattern:
+class SubPattern(collections.abc.Sequence):
     # a subpattern, in intermediate form
     def __init__(self, state, data=None):
         self.state = state

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -686,6 +686,7 @@ Stephen Hansen
 Barry Hantman
 Lynda Hardman
 Bar Harel
+Aviram Hassan
 Derek Harland
 Jason Harper
 David Harrigan

--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-14-15-35-52.bpo-46376.b3Joyz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-14-15-35-52.bpo-46376.b3Joyz.rst
@@ -1,0 +1,3 @@
+Changed `PySequence_Check` and `PyMapping_Check` to use `Py_TPFLAGS_SEQUENCE` and `Py_TPFLAGS_MAPPING`.
+This fixes possible scenarios where an object is both sequence and mapping at the same time when checked using those functions.
+It changes behavior for objects not being iterable/sequences if not inheriting from `abc.collections.Sequence`.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -1708,10 +1708,7 @@ PyNumber_ToBase(PyObject *n, int base)
 int
 PySequence_Check(PyObject *s)
 {
-    if (PyDict_Check(s))
-        return 0;
-    return Py_TYPE(s)->tp_as_sequence &&
-        Py_TYPE(s)->tp_as_sequence->sq_item != NULL;
+    return s && (Py_TYPE(s)->tp_flags & Py_TPFLAGS_SEQUENCE);
 }
 
 Py_ssize_t
@@ -2297,8 +2294,7 @@ PySequence_Index(PyObject *s, PyObject *o)
 int
 PyMapping_Check(PyObject *o)
 {
-    return o && Py_TYPE(o)->tp_as_mapping &&
-        Py_TYPE(o)->tp_as_mapping->mp_subscript;
+    return o && (Py_TYPE(o)->tp_flags & Py_TPFLAGS_MAPPING);
 }
 
 Py_ssize_t


### PR DESCRIPTION


<!-- issue-number: [bpo-46376](https://bugs.python.org/issue46376) -->
https://bugs.python.org/issue46376
<!-- /issue-number -->
