### PR TITLE
bpo-46379: remove temporaries from itertools.product reference implementation.

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -569,18 +569,19 @@ loops that truncate the stream.
    repetitions with the optional *repeat* keyword argument.  For example,
    ``product(A, repeat=4)`` means the same as ``product(A, A, A, A)``.
 
-   This function is roughly equivalent to the following code, except that the
-   actual implementation does not build up intermediate results in memory::
+   Roughly equivalent to::
 
        def product(*args, repeat=1):
            # product('ABCD', 'xy') --> Ax Ay Bx By Cx Cy Dx Dy
            # product(range(2), repeat=3) --> 000 001 010 011 100 101 110 111
-           pools = [tuple(pool) for pool in args] * repeat
-           result = [[]]
-           for pool in pools:
-               result = [x+[y] for x in result for y in pool]
-           for prod in result:
-               yield tuple(prod)
+           args = tuple(map(tuple, args)) * repeat
+           if args:
+               *head, tail = args
+               for prefix in product(*head):
+                   for value in tail:
+                       yield *prefix, value
+           else:
+               yield ()
 
    Before :func:`product` runs, it completely consumes the input iterables,
    keeping pools of values in memory to generate the products.  Accordingly,


### PR DESCRIPTION
Modify the reference implementation of itertools.product so that it does not need to create large temporaries.  Instead, to compute `product(*seq)`, we iterate over a generator of `product(*seq[:-1])`, and extend each of the values by every value in `seq[-1]`.

This allows us to remove the note at the top of the reference implementation warning of "creation of temporaries" and also yields a much more performant implementation.  I would argue that it is also a cleaner and more pythonic approach and a fun use of generators, but that is debatable.

I posted this code a while ago under the following [stackoverflow question].

[stackoverflow question]: https://stackoverflow.com/questions/1681269/


<!-- issue-number: [bpo-46379](https://bugs.python.org/issue46379) -->
https://bugs.python.org/issue46379
<!-- /issue-number -->
