### PR TITLE
bpo-46396: `Concatenate` does not raise semantic errors anymore

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4868,27 +4868,17 @@ class ConcatenateTests(BaseTestCase):
         self.assertEqual(C4.__args__, (Concatenate[int, T, P], T))
         self.assertEqual(C4.__parameters__, (T, P))
 
-    def test_invalid_uses(self):
+    def test_semantically_invalid_uses_have_no_errors(self):
         P = ParamSpec('P')
         T = TypeVar('T')
 
-        with self.assertRaisesRegex(
-            TypeError,
-            'Cannot take a Concatenate of no types',
-        ):
-            Concatenate[()]
+        self.assertEqual(Concatenate[()].__args__, ())
+        self.assertEqual(Concatenate[int].__args__, (int,))
+        self.assertEqual(Concatenate[P, T].__args__, (P, T))
 
-        with self.assertRaisesRegex(
-            TypeError,
-            'The last parameter to Concatenate should be a ParamSpec variable',
-        ):
-            Concatenate[P, T]
-
-        with self.assertRaisesRegex(
-            TypeError,
-            'each arg must be a type',
-        ):
-            Concatenate[1, P]
+    def test_invalid_uses_that_generate_errors(self):
+        with self.assertRaises(TypeError):
+            Concatenate[1, 2]
 
 
 class TypeGuardTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4868,7 +4868,7 @@ class ConcatenateTests(BaseTestCase):
         self.assertEqual(C4.__args__, (Concatenate[int, T, P], T))
         self.assertEqual(C4.__parameters__, (T, P))
 
-    def test_invalud_uses(self):
+    def test_invalid_uses(self):
         P = ParamSpec('P')
         T = TypeVar('T')
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4868,6 +4868,28 @@ class ConcatenateTests(BaseTestCase):
         self.assertEqual(C4.__args__, (Concatenate[int, T, P], T))
         self.assertEqual(C4.__parameters__, (T, P))
 
+    def test_invalud_uses(self):
+        P = ParamSpec('P')
+        T = TypeVar('T')
+
+        with self.assertRaisesRegex(
+            TypeError,
+            'Cannot take a Concatenate of no types',
+        ):
+            Concatenate[()]
+
+        with self.assertRaisesRegex(
+            TypeError,
+            'The last parameter to Concatenate should be a ParamSpec variable',
+        ):
+            Concatenate[P, T]
+
+        with self.assertRaisesRegex(
+            TypeError,
+            'each arg must be a type',
+        ):
+            Concatenate[1, P]
+
 
 class TypeGuardTests(BaseTestCase):
     def test_basics(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -598,13 +598,8 @@ def Concatenate(self, parameters):
 
     See PEP 612 for detailed information.
     """
-    if parameters == ():
-        raise TypeError("Cannot take a Concatenate of no types.")
     if not isinstance(parameters, tuple):
         parameters = (parameters,)
-    if not isinstance(parameters[-1], ParamSpec):
-        raise TypeError("The last parameter to Concatenate should be a "
-                        "ParamSpec variable.")
     msg = "Concatenate[arg, ...]: each arg must be a type."
     parameters = tuple(_type_check(p, msg) for p in parameters)
     return _ConcatenateGenericAlias(self, parameters)

--- a/Misc/NEWS.d/next/Library/2022-01-24-16-19-54.bpo-46396.qQYnUk.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-24-16-19-54.bpo-46396.qQYnUk.rst
@@ -1,0 +1,3 @@
+:class:`typing.Concatenate` does not raise semantic errors anymore.
+
+We leave type validation to type-checkers.


### PR DESCRIPTION
CC @corona10 as my mentor

<!-- issue-number: [bpo-46396](https://bugs.python.org/issue46396) -->
https://bugs.python.org/issue46396
<!-- /issue-number -->
