### PR TITLE
bpo-13886: Skip PTY non-ASCII tests if readline is loaded

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -2090,12 +2090,24 @@ class PtyTests(unittest.TestCase):
         # is different and invokes GNU readline if available).
         self.check_input_tty("prompt", b"quux")
 
+    def skip_if_readline(self):
+        # bpo-13886: When the readline module is loaded, PyOS_Readline() uses
+        # the readline implementation. In some cases, the Python readline
+        # callback rlhandler() is called by readline with a string without
+        # non-ASCII characters. Skip tests on non-ASCII characters if the
+        # readline module is loaded, since test_builtin is not intented to test
+        # the readline module, but the builtins module.
+        if 'readline' in sys.modules:
+            self.skipTest("the readline module is loaded")
+
     def test_input_tty_non_ascii(self):
-        # Check stdin/stdout encoding is used when invoking GNU readline
+        self.skip_if_readline()
+        # Check stdin/stdout encoding is used when invoking PyOS_Readline()
         self.check_input_tty("prompté", b"quux\xe9", "utf-8")
 
     def test_input_tty_non_ascii_unicode_errors(self):
-        # Check stdin/stdout error handler is used when invoking GNU readline
+        self.skip_if_readline()
+        # Check stdin/stdout error handler is used when invoking PyOS_Readline()
         self.check_input_tty("prompté", b"quux\xe9", "ascii")
 
     def test_input_no_stdout_fileno(self):

--- a/Misc/NEWS.d/next/Tests/2022-01-17-13-10-04.bpo-13886.5mZH4b.rst
+++ b/Misc/NEWS.d/next/Tests/2022-01-17-13-10-04.bpo-13886.5mZH4b.rst
@@ -1,0 +1,3 @@
+Skip test_builtin PTY tests on non-ASCII characters if the readline module
+is loaded. The readline module changes input() behavior, but test_builtin is
+not intented to test the readline module. Patch by Victor Stinner.


### PR DESCRIPTION
Skip test_builtin PTY tests on non-ASCII characters if the readline
module is loaded. The readline module changes input() behavior, but
test_builtin is not intented to test the readline module.

When the readline module is loaded, PyOS_Readline() uses the readline
implementation. In some cases, the Python readline callback
rlhandler() is called by readline with a string without non-ASCII
characters.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-13886](https://bugs.python.org/issue13886) -->
https://bugs.python.org/issue13886
<!-- /issue-number -->
