### PR TITLE
bpo-44133: Skip PyThread_get_thread_native_id() if not available

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -2,6 +2,7 @@
 # these are all functions _testcapi exports whose name begins with 'test_'.
 
 from collections import OrderedDict
+import _thread
 import importlib.machinery
 import importlib.util
 import os
@@ -648,7 +649,11 @@ class CAPITest(unittest.TestCase):
         # "PyThread_get_thread_native_id" symbols are exported by the Python
         # (directly by the binary, or via by the Python dynamic library).
         ctypes = import_helper.import_module('ctypes')
-        names = ['PyThread_get_thread_native_id']
+        names = []
+
+        # Test if the PY_HAVE_THREAD_NATIVE_ID macro is defined
+        if hasattr(_thread, 'get_native_id'):
+            names.append('PyThread_get_thread_native_id')
 
         # Python/frozenmain.c fails to build on Windows when the symbols are
         # missing:
@@ -657,6 +662,7 @@ class CAPITest(unittest.TestCase):
         # - PyInitFrozenExtensions
         if os.name != 'nt':
             names.append('Py_FrozenMain')
+
         for name in names:
             with self.subTest(name=name):
                 self.assertTrue(hasattr(ctypes.pythonapi, name))


### PR DESCRIPTION
test_capi.test_export_symbols() doesn't check if Python exports the
"PyThread_get_thread_native_id" symbol if the _thread.get_native_id()
function is not available (if the PY_HAVE_THREAD_NATIVE_ID macro is
not defined).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44133](https://bugs.python.org/issue44133) -->
https://bugs.python.org/issue44133
<!-- /issue-number -->
