### PR TITLE
bpo-46417: Finalize structseq types at exit

### DIFF
--- a/Include/internal/pycore_floatobject.h
+++ b/Include/internal/pycore_floatobject.h
@@ -14,6 +14,7 @@ extern "C" {
 extern void _PyFloat_InitState(PyInterpreterState *);
 extern PyStatus _PyFloat_InitTypes(PyInterpreterState *);
 extern void _PyFloat_Fini(PyInterpreterState *);
+extern void _PyFloat_FiniType(PyInterpreterState *);
 
 
 /* other API */

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -15,6 +15,7 @@ extern "C" {
 /* runtime lifecycle */
 
 extern PyStatus _PyLong_InitTypes(PyInterpreterState *);
+extern void _PyLong_FiniTypes(PyInterpreterState *interp);
 
 
 /* other API */

--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -12,6 +12,7 @@ extern "C" {
 /* runtime lifecycle */
 
 extern PyStatus _PyErr_InitTypes(PyInterpreterState *);
+extern void _PyErr_FiniTypes(PyInterpreterState *);
 
 
 /* other API */

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -58,6 +58,7 @@ extern PyStatus _PySys_Create(
 extern PyStatus _PySys_ReadPreinitWarnOptions(PyWideStringList *options);
 extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
 extern int _PySys_UpdateConfig(PyThreadState *tstate);
+extern void _PySys_Fini(PyInterpreterState *interp);
 extern PyStatus _PyBuiltins_AddExceptions(PyObject * bltinmod);
 extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 
@@ -81,6 +82,7 @@ extern void _PyTraceMalloc_Fini(void);
 extern void _PyWarnings_Fini(PyInterpreterState *interp);
 extern void _PyAST_Fini(PyInterpreterState *interp);
 extern void _PyAtExit_Fini(PyInterpreterState *interp);
+extern void _PyThread_FiniType(PyInterpreterState *interp);
 
 extern PyStatus _PyGILState_Init(_PyRuntimeState *runtime);
 extern PyStatus _PyGILState_SetTstate(PyThreadState *tstate);

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -40,6 +40,8 @@ struct type_cache {
 
 extern PyStatus _PyTypes_InitSlotDefs(void);
 
+extern void _PyStaticType_Dealloc(PyTypeObject *type);
+
 
 #ifdef __cplusplus
 }

--- a/Include/structseq.h
+++ b/Include/structseq.h
@@ -27,6 +27,9 @@ PyAPI_FUNC(void) PyStructSequence_InitType(PyTypeObject *type,
 PyAPI_FUNC(int) PyStructSequence_InitType2(PyTypeObject *type,
                                            PyStructSequence_Desc *desc);
 #endif
+#ifdef Py_BUILD_CORE
+PyAPI_FUNC(void) _PyStructSequence_FiniType(PyTypeObject *type);
+#endif
 PyAPI_FUNC(PyTypeObject*) PyStructSequence_NewType(PyStructSequence_Desc *desc);
 
 PyAPI_FUNC(PyObject *) PyStructSequence_New(PyTypeObject* type);

--- a/Lib/test/_test_embed_structseq.py
+++ b/Lib/test/_test_embed_structseq.py
@@ -3,14 +3,24 @@ import types
 import unittest
 
 
-class TestStructseq(unittest.TestCase):
+# bpo-46417: Test that structseq types used by the sys module are still
+# valid when Py_Finalize()/Py_Initialize() are called multiple times.
+class TestStructSeq(unittest.TestCase):
+    # test PyTypeObject members
     def check_structseq(self, obj_type):
+        # ob_refcnt
         self.assertGreaterEqual(sys.getrefcount(obj_type), 1)
-        self.assertIsInstance(type.__name__, str)
+        # tp_base
         self.assertTrue(issubclass(obj_type, tuple))
+        # tp_bases
         self.assertEqual(obj_type.__bases__, (tuple,))
-        self.assertEqual(obj_type.__mro__, (obj_type, tuple, object))
+        # tp_dict
         self.assertIsInstance(obj_type.__dict__, types.MappingProxyType)
+        # tp_mro
+        self.assertEqual(obj_type.__mro__, (obj_type, tuple, object))
+        # tp_name
+        self.assertIsInstance(type.__name__, str)
+        # tp_subclasses
         self.assertEqual(obj_type.__subclasses__(), [])
 
     def test_sys_attrs(self):

--- a/Lib/test/_test_embed_structseq.py
+++ b/Lib/test/_test_embed_structseq.py
@@ -1,0 +1,45 @@
+import sys
+import types
+import unittest
+
+
+class TestStructseq(unittest.TestCase):
+    def check_structseq(self, obj_type):
+        self.assertGreaterEqual(sys.getrefcount(obj_type), 1)
+        self.assertIsInstance(type.__name__, str)
+        self.assertTrue(issubclass(obj_type, tuple))
+        self.assertEqual(obj_type.__bases__, (tuple,))
+        self.assertEqual(obj_type.__mro__, (obj_type, tuple, object))
+        self.assertIsInstance(obj_type.__dict__, types.MappingProxyType)
+        self.assertEqual(obj_type.__subclasses__(), [])
+
+    def test_sys_attrs(self):
+        for attr_name in (
+            'flags',          # FlagsType
+            'float_info',     # FloatInfoType
+            'hash_info',      # Hash_InfoType
+            'int_info',       # Int_InfoType
+            'thread_info',    # ThreadInfoType
+            'version_info',   # VersionInfoType
+        ):
+            with self.subTest(attr=attr_name):
+                attr = getattr(sys, attr_name)
+                self.check_structseq(type(attr))
+
+    def test_sys_funcs(self):
+        func_names = ['get_asyncgen_hooks']  # AsyncGenHooksType
+        if hasattr(sys, 'getwindowsversion'):
+            func_names.append('getwindowsversion')  # WindowsVersionType
+        for func_name in func_names:
+            with self.subTest(func=func_name):
+                func = getattr(sys, func_name)
+                obj = func()
+                self.check_structseq(type(obj))
+
+
+try:
+    unittest.main()
+except SystemExit as exc:
+    if exc.args[0] != 0:
+        raise
+print("Tests passed")

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -329,6 +329,34 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
         self.assertEqual(out, "Py_RunMain(): sys.argv=['-c', 'arg2']\n" * nloop)
         self.assertEqual(err, '')
 
+    def test_finalize_structseq(self):
+        # bpo-46417: Py_Finalize() clears structseq static types. Check that
+        # sys attributes using struct types still work when
+        # Py_Finalize()/Py_Initialize() is called multiple times.
+        code = textwrap.dedent(r'''
+            import sys
+            print(sys.get_asyncgen_hooks())
+            print(sys.flags)
+            print(sys.float_info)
+            print(sys.hash_info)
+            print(sys.int_info)
+            print(sys.thread_info)
+            print(f"{sys.version=!r}", flush=True)
+        ''')
+        if hasattr(sys, 'getwindowsversion'):
+            code += '\n' + 'print(sys.getwindowsversion())'
+        expected = textwrap.dedent(r'''
+            asyncgen_hooks(.*)
+            sys.flags(.*)
+            sys.float_info(.*)
+            sys.hash_info(.*)
+            sys.int_info(.*)
+            sys.thread_info(.*)
+            sys.version='.*'
+        ''')
+        out, err = self.run_embedded_interpreter("test_repeated_init_exec", code)
+        self.assertRegex(out, expected)
+
 
 class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
     maxDiff = 4096

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -333,29 +333,13 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
         # bpo-46417: Py_Finalize() clears structseq static types. Check that
         # sys attributes using struct types still work when
         # Py_Finalize()/Py_Initialize() is called multiple times.
-        code = textwrap.dedent(r'''
-            import sys
-            print(sys.get_asyncgen_hooks())
-            print(sys.flags)
-            print(sys.float_info)
-            print(sys.hash_info)
-            print(sys.int_info)
-            print(sys.thread_info)
-            print(f"{sys.version=!r}", flush=True)
-        ''')
-        if hasattr(sys, 'getwindowsversion'):
-            code += '\n' + 'print(sys.getwindowsversion())'
-        expected = textwrap.dedent(r'''
-            asyncgen_hooks(.*)
-            sys.flags(.*)
-            sys.float_info(.*)
-            sys.hash_info(.*)
-            sys.int_info(.*)
-            sys.thread_info(.*)
-            sys.version='.*'
-        ''')
+        # print() calls type->tp_repr(instance) and so checks that the types
+        # are still working properly.
+        script = support.findfile('_test_embed_structseq.py')
+        with open(script, encoding="utf-8") as fp:
+            code = fp.read()
         out, err = self.run_embedded_interpreter("test_repeated_init_exec", code)
-        self.assertRegex(out, expected)
+        self.assertEqual(out, 'Tests passed\n' * INIT_LOOPS)
 
 
 class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -2082,6 +2082,14 @@ _PyFloat_Fini(PyInterpreterState *interp)
 #endif
 }
 
+void
+_PyFloat_FiniType(PyInterpreterState *interp)
+{
+    if (_Py_IsMainInterpreter(interp)) {
+        _PyStructSequence_FiniType(&FloatInfoType);
+    }
+}
+
 /* Print summary info about the state of the optimized allocator */
 void
 _PyFloat_DebugMallocStats(FILE *out)

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5949,3 +5949,14 @@ _PyLong_InitTypes(PyInterpreterState *interp)
 
     return _PyStatus_OK();
 }
+
+
+void
+_PyLong_FiniTypes(PyInterpreterState *interp)
+{
+    if (!_Py_IsMainInterpreter(interp)) {
+        return;
+    }
+
+    _PyStructSequence_FiniType(&Int_InfoType);
+}

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -540,7 +540,7 @@ _PyStructSequence_FiniType(PyTypeObject *type)
     assert(type->tp_name != NULL);
     assert(type->tp_base == &PyTuple_Type);
 
-    // Cannot delete a type if it still has alive subclasses
+    // Cannot delete a type if it still has subclasses
     if (type->tp_subclasses != NULL) {
         return;
     }
@@ -551,12 +551,12 @@ _PyStructSequence_FiniType(PyTypeObject *type)
 
     _PyStaticType_Dealloc(type);
     assert(Py_REFCNT(type) == 1);
-    // Undo _PyStructSequence_InitType() Py_INCREF(type).
-    // Don't use Py_DECREF(): static type must be deallocated
+    // Undo Py_INCREF(type) of _PyStructSequence_InitType().
+    // Don't use Py_DECREF(): static type must not be deallocated
     Py_SET_REFCNT(type, 0);
 
-    // Make sure that _PyStructSequence_InitType() will initialize the type
-    // again
+    // Make sure that _PyStructSequence_InitType() will initialize
+    // the type again
     assert(Py_REFCNT(type) == 0);
     assert(type->tp_name == NULL);
 }

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -532,6 +532,36 @@ PyStructSequence_InitType(PyTypeObject *type, PyStructSequence_Desc *desc)
     (void)PyStructSequence_InitType2(type, desc);
 }
 
+
+void
+_PyStructSequence_FiniType(PyTypeObject *type)
+{
+    // Ensure that the type is initialized
+    assert(type->tp_name != NULL);
+    assert(type->tp_base == &PyTuple_Type);
+
+    // Cannot delete a type if it still has alive subclasses
+    if (type->tp_subclasses != NULL) {
+        return;
+    }
+
+    // Undo PyStructSequence_NewType()
+    type->tp_name = NULL;
+    PyMem_Free(type->tp_members);
+
+    _PyStaticType_Dealloc(type);
+    assert(Py_REFCNT(type) == 1);
+    // Undo _PyStructSequence_InitType() Py_INCREF(type).
+    // Don't use Py_DECREF(): static type must be deallocated
+    Py_SET_REFCNT(type, 0);
+
+    // Make sure that _PyStructSequence_InitType() will initialize the type
+    // again
+    assert(Py_REFCNT(type) == 0);
+    assert(type->tp_name == NULL);
+}
+
+
 PyTypeObject *
 PyStructSequence_NewType(PyStructSequence_Desc *desc)
 {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4074,7 +4074,11 @@ _PyDictKeys_DecRef(PyDictKeysObject *keys);
 void
 _PyStaticType_Dealloc(PyTypeObject *type)
 {
+    // _PyStaticType_Dealloc() must not be called if a type has subtypes.
+    // A subtype can inherit attributes and methods of its parent type,
+    // and a type must no longer be used once it's deallocated.
     assert(type->tp_subclasses == NULL);
+
     Py_CLEAR(type->tp_dict);
     Py_CLEAR(type->tp_bases);
     Py_CLEAR(type->tp_mro);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4070,10 +4070,23 @@ type_setattro(PyTypeObject *type, PyObject *name, PyObject *value)
 extern void
 _PyDictKeys_DecRef(PyDictKeysObject *keys);
 
+
+void
+_PyStaticType_Dealloc(PyTypeObject *type)
+{
+    assert(type->tp_subclasses == NULL);
+    Py_CLEAR(type->tp_dict);
+    Py_CLEAR(type->tp_bases);
+    Py_CLEAR(type->tp_mro);
+    Py_CLEAR(type->tp_cache);
+    Py_CLEAR(type->tp_subclasses);
+    type->tp_flags &= ~Py_TPFLAGS_READY;
+}
+
+
 static void
 type_dealloc(PyTypeObject *type)
 {
-    PyHeapTypeObject *et;
     PyObject *tp, *val, *tb;
 
     /* Assert this is a heap-allocated type object */
@@ -4082,8 +4095,8 @@ type_dealloc(PyTypeObject *type)
     PyErr_Fetch(&tp, &val, &tb);
     remove_all_subclasses(type, type->tp_bases);
     PyErr_Restore(tp, val, tb);
+
     PyObject_ClearWeakRefs((PyObject *)type);
-    et = (PyHeapTypeObject *)type;
     Py_XDECREF(type->tp_base);
     Py_XDECREF(type->tp_dict);
     Py_XDECREF(type->tp_bases);
@@ -4094,6 +4107,8 @@ type_dealloc(PyTypeObject *type)
      * of most other objects.  It's okay to cast it to char *.
      */
     PyObject_Free((char *)type->tp_doc);
+
+    PyHeapTypeObject *et = (PyHeapTypeObject *)type;
     Py_XDECREF(et->ht_name);
     Py_XDECREF(et->ht_qualname);
     Py_XDECREF(et->ht_slots);

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -1241,6 +1241,17 @@ _PyErr_InitTypes(PyInterpreterState *interp)
 }
 
 
+void
+_PyErr_FiniTypes(PyInterpreterState *interp)
+{
+    if (!_Py_IsMainInterpreter(interp)) {
+        return;
+    }
+
+    _PyStructSequence_FiniType(&UnraisableHookArgsType);
+}
+
+
 static PyObject *
 make_unraisable_hook_args(PyThreadState *tstate, PyObject *exc_type,
                           PyObject *exc_value, PyObject *exc_tb,

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1666,11 +1666,17 @@ flush_std_files(void)
 static void
 finalize_interp_types(PyInterpreterState *interp)
 {
+    _PySys_Fini(interp);
     _PyExc_Fini(interp);
     _PyFrame_Fini(interp);
     _PyAsyncGen_Fini(interp);
     _PyContext_Fini(interp);
+    _PyFloat_FiniType(interp);
+    _PyLong_FiniTypes(interp);
+    _PyThread_FiniType(interp);
+    _PyErr_FiniTypes(interp);
     _PyTypes_Fini(interp);
+
     // Call _PyUnicode_ClearInterned() before _PyDict_Fini() since it uses
     // a dict internally.
     _PyUnicode_ClearInterned(interp);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3102,6 +3102,21 @@ error:
 }
 
 
+void
+_PySys_Fini(PyInterpreterState *interp)
+{
+    if (_Py_IsMainInterpreter(interp)) {
+        _PyStructSequence_FiniType(&VersionInfoType);
+        _PyStructSequence_FiniType(&FlagsType);
+#if defined(MS_WINDOWS)
+        _PyStructSequence_FiniType(&WindowsVersionType);
+#endif
+        _PyStructSequence_FiniType(&Hash_InfoType);
+        _PyStructSequence_FiniType(&AsyncGenHooksType);
+    }
+}
+
+
 static PyObject *
 makepathobject(const wchar_t *path, wchar_t delim)
 {

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -243,3 +243,14 @@ PyThread_GetInfo(void)
     PyStructSequence_SET_ITEM(threadinfo, pos++, value);
     return threadinfo;
 }
+
+
+void
+_PyThread_FiniType(PyInterpreterState *interp)
+{
+    if (!_Py_IsMainInterpreter(interp)) {
+        return;
+    }
+
+    _PyStructSequence_FiniType(&ThreadInfoType);
+}


### PR DESCRIPTION
Add _PyStructSequence_FiniType() and _PyStaticType_Dealloc()
functions to finalize a structseq static type in Py_Finalize().
Currrently, these functions do nothing if Python is built in release
mode.

Clear static types:

* AsyncGenHooksType: sys.set_asyncgen_hooks()
* FlagsType: sys.flags
* FloatInfoType: sys.float_info
* Hash_InfoType: sys.hash_info
* Int_InfoType: sys.int_info
* ThreadInfoType: sys.thread_info
* UnraisableHookArgsType: sys.unraisablehook
* VersionInfoType: sys.version
* WindowsVersionType: sys.getwindowsversion()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46417](https://bugs.python.org/issue46417) -->
https://bugs.python.org/issue46417
<!-- /issue-number -->
