### PR TITLE
bpo-46414: Add typing.reveal_type

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1955,7 +1955,7 @@ Functions and decorators
    ``typing`` allows your code to run without runtime errors and
    communicates intent more clearly.
 
-   At runtime, this function prints the runtime type of its argument
+   At runtime, this function prints the runtime type of its argument to stderr
    and returns it unchanged::
 
       x = reveal_type(1)  # prints "Runtime type is int"

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1956,7 +1956,10 @@ Functions and decorators
    communicates intent more clearly.
 
    At runtime, this function prints the runtime type of its argument
-   and returns it unchanged.
+   and returns it unchanged::
+
+      x = reveal_type(1)  # prints "Runtime type is int"
+      print(x)  # prints "1"
 
    .. versionadded:: 3.11
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1932,6 +1932,34 @@ Functions and decorators
    runtime we intentionally don't check anything (we want this
    to be as fast as possible).
 
+.. function:: reveal_type(obj)
+
+   Reveal the inferred static type of an expression.
+
+   When a static type checker encounters a call to this function,
+   it emits a diagnostic with the type of the argument. For example::
+
+      x: int = 1
+      reveal_type(x)  # Revealed type is "builtins.int"
+
+   This can be useful when you want to debug how your type checker
+   handles a particular piece of code.
+
+   The function returns its argument unchanged, which allows using
+   it within an expression::
+
+      x = reveal_type(1)  # Revealed type is "builtins.int"
+
+   Most type checkers support ``reveal_type()`` anywhere, even if the
+   name is not imported from ``typing``. Importing the name from
+   ``typing`` allows your code to run without runtime errors and
+   communicates intent more clearly.
+
+   At runtime, this function prints the runtime type of its argument
+   and returns it unchanged.
+
+   .. versionadded:: 3.11
+
 .. decorator:: overload
 
    The ``@overload`` decorator allows describing functions and methods

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -36,7 +36,7 @@ import typing
 import weakref
 import types
 
-from test.support import import_helper
+from test.support import import_helper, captured_stdout
 from test import mod_generics_cache
 from test import _typed_dict_helper
 
@@ -5112,7 +5112,9 @@ class SpecialAttrsTests(BaseTestCase):
 class RevealTypeTests(BaseTestCase):
     def test_reveal_type(self):
         obj = object()
-        self.assertIs(obj, reveal_type(obj))
+        with captured_stdout() as stdout:
+            self.assertIs(obj, reveal_type(obj))
+        self.assertEqual(stdout.getvalue(), "Runtime type is 'object'\n")
 
 
 class AllTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -36,7 +36,7 @@ import typing
 import weakref
 import types
 
-from test.support import import_helper, captured_stdout
+from test.support import import_helper, captured_stderr
 from test import mod_generics_cache
 from test import _typed_dict_helper
 
@@ -5112,9 +5112,9 @@ class SpecialAttrsTests(BaseTestCase):
 class RevealTypeTests(BaseTestCase):
     def test_reveal_type(self):
         obj = object()
-        with captured_stdout() as stdout:
+        with captured_stderr() as stderr:
             self.assertIs(obj, reveal_type(obj))
-        self.assertEqual(stdout.getvalue(), "Runtime type is 'object'\n")
+        self.assertEqual(stderr.getvalue(), "Runtime type is 'object'\n")
 
 
 class AllTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -20,6 +20,7 @@ from typing import cast, runtime_checkable
 from typing import get_type_hints
 from typing import get_origin, get_args
 from typing import is_typeddict
+from typing import reveal_type
 from typing import no_type_check, no_type_check_decorator
 from typing import Type
 from typing import NewType
@@ -5106,6 +5107,12 @@ class SpecialAttrsTests(BaseTestCase):
         # in dir() of the GenericAlias. See bpo-45755.
         self.assertIn('bar', dir(Foo[int]))
         self.assertIn('baz', dir(Foo[int]))
+
+
+class RevealTypeTests(BaseTestCase):
+    def test_reveal_type(self):
+        obj = object()
+        self.assertIs(obj, reveal_type(obj))
 
 
 class AllTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2686,5 +2686,5 @@ def reveal_type(obj: T, /) -> T:
     argument and returns it unchanged.
 
     """
-    print("Runtime type is", type(obj))
+    print(f"Runtime type is {type(obj).__name__!r}")
     return obj

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2686,5 +2686,5 @@ def reveal_type(obj: T, /) -> T:
     argument and returns it unchanged.
 
     """
-    print(f"Runtime type is {type(obj).__name__!r}")
+    print(f"Runtime type is {type(obj).__name__!r}", file=sys.stderr)
     return obj

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -130,6 +130,7 @@ __all__ = [
     'overload',
     'ParamSpecArgs',
     'ParamSpecKwargs',
+    'reveal_type',
     'runtime_checkable',
     'Text',
     'TYPE_CHECKING',
@@ -2667,3 +2668,23 @@ class re(metaclass=_DeprecatedType):
 
 re.__name__ = __name__ + '.re'
 sys.modules[re.__name__] = re
+
+
+def reveal_type(obj: T, /) -> T:
+    """Reveal the inferred type of a variable.
+
+    When a static type checker encounters a call to ``reveal_type()``,
+    it will emit the inferred type of the argument::
+
+        x: int = 1
+        reveal_type(x)
+
+    Running a static type checker (e.g., ``mypy``) on this example
+    will produce output similar to 'Revealed type is "builtins.int"'.
+
+    At runtime, the function prints the runtime type of the
+    argument and returns it unchanged.
+
+    """
+    print("Runtime type is", type(obj))
+    return obj

--- a/Misc/NEWS.d/next/Library/2022-01-17-10-00-02.bpo-46414.Ld0b_y.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-17-10-00-02.bpo-46414.Ld0b_y.rst
@@ -1,0 +1,1 @@
+Add ``typing.reveal_type()``. Patch by Jelle Zijlstra.

--- a/Misc/NEWS.d/next/Library/2022-01-17-10-00-02.bpo-46414.Ld0b_y.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-17-10-00-02.bpo-46414.Ld0b_y.rst
@@ -1,1 +1,1 @@
-Add ``typing.reveal_type()``. Patch by Jelle Zijlstra.
+Add :func:`typing.reveal_type`. Patch by Jelle Zijlstra.


### PR DESCRIPTION
Part of the documentation was taken from mypy:
https://mypy.readthedocs.io/en/stable/common_issues.html#reveal-type


<!-- issue-number: [bpo-46414](https://bugs.python.org/issue46414) -->
https://bugs.python.org/issue46414
<!-- /issue-number -->
