### PR TITLE
Restore MSIX signing and ensure expired certificates are not selected

### DIFF
--- a/.azure-pipelines/windows-release/stage-pack-msix.yml
+++ b/.azure-pipelines/windows-release/stage-pack-msix.yml
@@ -121,6 +121,10 @@ jobs:
       downloadPath: $(Build.BinariesDirectory)
 
   # MSIX must be signed and timestamped simultaneously
+  #
+  # Getting "Error: SignerSign() failed." (-2147024885/0x8007000b)"?
+  # It may be that the certificate info collected in stage-sign.yml is wrong. Check that
+  # you do not have multiple matches for the certificate name you have specified.
   - powershell: |
       $failed = $true
       foreach ($retry in 1..3) {

--- a/.azure-pipelines/windows-release/stage-pack-msix.yml
+++ b/.azure-pipelines/windows-release/stage-pack-msix.yml
@@ -96,9 +96,7 @@ jobs:
   displayName: Sign side-loadable MSIX bundles
   dependsOn:
   - Pack_MSIX
-  # Our current certificate does not support MSIX signing, so we unconditionally skip this step
-  #condition: and(succeeded(), variables['SigningCertificate'])
-  condition: false
+  condition: and(succeeded(), variables['SigningCertificate'])
 
   pool:
     name: 'Windows Release'

--- a/.azure-pipelines/windows-release/stage-sign.yml
+++ b/.azure-pipelines/windows-release/stage-sign.yml
@@ -91,7 +91,7 @@ jobs:
   - powershell: |
       $m = 'CN=$(SigningCertificate)'
       $c = ((gci Cert:\CurrentUser\My), (gci Cert:\LocalMachine\My)) | %{ $_ } | `
-         ?{ $_.Subject -match $m } | `
+         ?{ $_.Subject -match $m -and $_.NotBefore -lt (Get-Date) -and $_.NotAfter -gt (Get-Date) } | `
          select -First 1
       if (-not $c) {
           Write-Host "Failed to find certificate for $(SigningCertificate)"


### PR DESCRIPTION
Reverts the change in d6c6e6b and applies a better fix.