### PR TITLE
bpo-46420: Use NOTRACE_DISPATCH() in specialized opcodes

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2303,7 +2303,7 @@ check_eval_breaker:
             Py_DECREF(sub);
             SET_TOP(res);
             Py_DECREF(dict);
-            NOTRACE_DISPATCH();
+            DISPATCH();
         }
 
         TARGET(BINARY_SUBSCR_GETITEM) {
@@ -2433,7 +2433,7 @@ check_eval_breaker:
             if (err != 0) {
                 goto error;
             }
-            NOTRACE_DISPATCH();
+            DISPATCH();
         }
 
         TARGET(DELETE_SUBSCR) {
@@ -4791,7 +4791,7 @@ check_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
-            NOTRACE_DISPATCH();
+            DISPATCH();
         }
 
         TARGET(CALL_NO_KW_BUILTIN_O) {
@@ -4822,7 +4822,7 @@ check_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
-            NOTRACE_DISPATCH();
+            DISPATCH();
         }
 
         TARGET(CALL_NO_KW_BUILTIN_FAST) {
@@ -4861,7 +4861,7 @@ check_eval_breaker:
                 */
                 goto error;
             }
-            NOTRACE_DISPATCH();
+            DISPATCH();
         }
 
         TARGET(CALL_NO_KW_LEN) {
@@ -4890,7 +4890,7 @@ check_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
-            NOTRACE_DISPATCH();
+            DISPATCH();
         }
 
         TARGET(CALL_NO_KW_ISINSTANCE) {
@@ -4920,7 +4920,7 @@ check_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
-            NOTRACE_DISPATCH();
+            DISPATCH();
         }
 
         TARGET(CALL_NO_KW_LIST_APPEND) {

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2048,6 +2048,7 @@ check_eval_breaker:
         }
 
         TARGET(BINARY_OP_MULTIPLY_INT) {
+            assert(cframe.use_tracing == 0);
             PyObject *left = SECOND();
             PyObject *right = TOP();
             DEOPT_IF(!PyLong_CheckExact(left), BINARY_OP);
@@ -2061,10 +2062,11 @@ check_eval_breaker:
             if (prod == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(BINARY_OP_MULTIPLY_FLOAT) {
+            assert(cframe.use_tracing == 0);
             PyObject *left = SECOND();
             PyObject *right = TOP();
             DEOPT_IF(!PyFloat_CheckExact(left), BINARY_OP);
@@ -2080,10 +2082,11 @@ check_eval_breaker:
             if (prod == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(BINARY_OP_SUBTRACT_INT) {
+            assert(cframe.use_tracing == 0);
             PyObject *left = SECOND();
             PyObject *right = TOP();
             DEOPT_IF(!PyLong_CheckExact(left), BINARY_OP);
@@ -2097,10 +2100,11 @@ check_eval_breaker:
             if (sub == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(BINARY_OP_SUBTRACT_FLOAT) {
+            assert(cframe.use_tracing == 0);
             PyObject *left = SECOND();
             PyObject *right = TOP();
             DEOPT_IF(!PyFloat_CheckExact(left), BINARY_OP);
@@ -2115,10 +2119,11 @@ check_eval_breaker:
             if (sub == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(BINARY_OP_ADD_UNICODE) {
+            assert(cframe.use_tracing == 0);
             PyObject *left = SECOND();
             PyObject *right = TOP();
             DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
@@ -2132,10 +2137,11 @@ check_eval_breaker:
             if (TOP() == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(BINARY_OP_INPLACE_ADD_UNICODE) {
+            assert(cframe.use_tracing == 0);
             PyObject *left = SECOND();
             PyObject *right = TOP();
             DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
@@ -2160,10 +2166,11 @@ check_eval_breaker:
             if (TOP() == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(BINARY_OP_ADD_FLOAT) {
+            assert(cframe.use_tracing == 0);
             PyObject *left = SECOND();
             PyObject *right = TOP();
             DEOPT_IF(!PyFloat_CheckExact(left), BINARY_OP);
@@ -2179,10 +2186,11 @@ check_eval_breaker:
             if (sum == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(BINARY_OP_ADD_INT) {
+            assert(cframe.use_tracing == 0);
             PyObject *left = SECOND();
             PyObject *right = TOP();
             DEOPT_IF(!PyLong_CheckExact(left), BINARY_OP);
@@ -2196,7 +2204,7 @@ check_eval_breaker:
             if (sum == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(BINARY_SUBSCR) {
@@ -2233,6 +2241,7 @@ check_eval_breaker:
         }
 
         TARGET(BINARY_SUBSCR_LIST_INT) {
+            assert(cframe.use_tracing == 0);
             PyObject *sub = TOP();
             PyObject *list = SECOND();
             DEOPT_IF(!PyLong_CheckExact(sub), BINARY_SUBSCR);
@@ -2252,10 +2261,11 @@ check_eval_breaker:
             Py_DECREF(sub);
             SET_TOP(res);
             Py_DECREF(list);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(BINARY_SUBSCR_TUPLE_INT) {
+            assert(cframe.use_tracing == 0);
             PyObject *sub = TOP();
             PyObject *tuple = SECOND();
             DEOPT_IF(!PyLong_CheckExact(sub), BINARY_SUBSCR);
@@ -2275,10 +2285,11 @@ check_eval_breaker:
             Py_DECREF(sub);
             SET_TOP(res);
             Py_DECREF(tuple);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(BINARY_SUBSCR_DICT) {
+            assert(cframe.use_tracing == 0);
             PyObject *dict = SECOND();
             DEOPT_IF(!PyDict_CheckExact(SECOND()), BINARY_SUBSCR);
             STAT_INC(BINARY_SUBSCR, hit);
@@ -2292,7 +2303,7 @@ check_eval_breaker:
             Py_DECREF(sub);
             SET_TOP(res);
             Py_DECREF(dict);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(BINARY_SUBSCR_GETITEM) {
@@ -2385,6 +2396,7 @@ check_eval_breaker:
         }
 
         TARGET(STORE_SUBSCR_LIST_INT) {
+            assert(cframe.use_tracing == 0);
             PyObject *sub = TOP();
             PyObject *list = SECOND();
             PyObject *value = THIRD();
@@ -2405,10 +2417,11 @@ check_eval_breaker:
             Py_DECREF(old_value);
             Py_DECREF(sub);
             Py_DECREF(list);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(STORE_SUBSCR_DICT) {
+            assert(cframe.use_tracing == 0);
             PyObject *sub = TOP();
             PyObject *dict = SECOND();
             PyObject *value = THIRD();
@@ -2420,7 +2433,7 @@ check_eval_breaker:
             if (err != 0) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(DELETE_SUBSCR) {
@@ -3103,7 +3116,7 @@ check_eval_breaker:
             STAT_INC(LOAD_GLOBAL, hit);
             Py_INCREF(res);
             PUSH(res);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(LOAD_GLOBAL_BUILTIN) {
@@ -3123,7 +3136,7 @@ check_eval_breaker:
             STAT_INC(LOAD_GLOBAL, hit);
             Py_INCREF(res);
             PUSH(res);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(DELETE_FAST) {
@@ -3555,7 +3568,7 @@ check_eval_breaker:
             Py_INCREF(res);
             SET_TOP(res);
             Py_DECREF(owner);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(LOAD_ATTR_MODULE) {
@@ -3566,7 +3579,7 @@ check_eval_breaker:
             LOAD_MODULE_ATTR_OR_METHOD(ATTR);
             SET_TOP(res);
             Py_DECREF(owner);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(LOAD_ATTR_WITH_HINT) {
@@ -3594,7 +3607,7 @@ check_eval_breaker:
             Py_INCREF(res);
             SET_TOP(res);
             Py_DECREF(owner);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(LOAD_ATTR_SLOT) {
@@ -3614,7 +3627,7 @@ check_eval_breaker:
             Py_INCREF(res);
             SET_TOP(res);
             Py_DECREF(owner);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(STORE_ATTR_ADAPTIVE) {
@@ -3663,7 +3676,7 @@ check_eval_breaker:
                 Py_DECREF(old_value);
             }
             Py_DECREF(owner);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(STORE_ATTR_WITH_HINT) {
@@ -3698,7 +3711,7 @@ check_eval_breaker:
             /* PEP 509 */
             dict->ma_version_tag = DICT_NEXT_VERSION();
             Py_DECREF(owner);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(STORE_ATTR_SLOT) {
@@ -3718,7 +3731,7 @@ check_eval_breaker:
             *(PyObject **)addr = value;
             Py_XDECREF(old_value);
             Py_DECREF(owner);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(COMPARE_OP) {
@@ -4506,10 +4519,11 @@ check_eval_breaker:
             Py_INCREF(res);
             SET_TOP(res);
             PUSH(self);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(LOAD_METHOD_NO_DICT) {
+            assert(cframe.use_tracing == 0);
             PyObject *self = TOP();
             PyTypeObject *self_cls = Py_TYPE(self);
             SpecializedCacheEntry *caches = GET_CACHE();
@@ -4524,7 +4538,7 @@ check_eval_breaker:
             Py_INCREF(res);
             SET_TOP(res);
             PUSH(self);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(LOAD_METHOD_MODULE) {
@@ -4536,7 +4550,7 @@ check_eval_breaker:
             SET_TOP(NULL);
             Py_DECREF(owner);
             PUSH(res);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(LOAD_METHOD_CLASS) {
@@ -4559,7 +4573,7 @@ check_eval_breaker:
             SET_TOP(NULL);
             Py_DECREF(cls);
             PUSH(res);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(PRECALL_METHOD) {
@@ -4744,6 +4758,7 @@ check_eval_breaker:
         }
 
         TARGET(CALL_NO_KW_TYPE_1) {
+            assert(cframe.use_tracing == 0);
             assert(STACK_ADJUST_IS_RESET);
             assert(GET_CACHE()->adaptive.original_oparg == 1);
             PyObject *obj = TOP();
@@ -4754,10 +4769,11 @@ check_eval_breaker:
             Py_DECREF(callable);
             Py_DECREF(obj);
             SET_TOP(res);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(CALL_NO_KW_BUILTIN_CLASS_1) {
+            assert(cframe.use_tracing == 0);
             assert(STACK_ADJUST_IS_RESET);
             SpecializedCacheEntry *caches = GET_CACHE();
             _PyAdaptiveEntry *cache0 = &caches[0].adaptive;
@@ -4775,7 +4791,7 @@ check_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(CALL_NO_KW_BUILTIN_O) {
@@ -4806,7 +4822,7 @@ check_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(CALL_NO_KW_BUILTIN_FAST) {
@@ -4845,7 +4861,7 @@ check_eval_breaker:
                 */
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(CALL_NO_KW_LEN) {
@@ -4874,7 +4890,7 @@ check_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(CALL_NO_KW_ISINSTANCE) {
@@ -4904,10 +4920,11 @@ check_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(CALL_NO_KW_LIST_APPEND) {
+            assert(cframe.use_tracing == 0);
             assert(_Py_OPCODE(next_instr[-2]) == PRECALL_METHOD);
             assert(GET_CACHE()->adaptive.original_oparg == 1);
             DEOPT_IF(extra_args == 0, CALL_NO_KW);
@@ -4929,7 +4946,7 @@ check_eval_breaker:
             STACK_SHRINK(2);
             SET_TOP(Py_None);
             Py_DECREF(callable);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(CALL_NO_KW_METHOD_DESCRIPTOR_O) {


### PR DESCRIPTION
Some benchmarks from GCC with `--enable-optimizations --with-lto` on WSL:

Slower (6):
- pickle_dict: 27.2 us +- 0.4 us -> 28.9 us +- 0.4 us: 1.06x slower
- unpickle_list: 5.01 us +- 0.11 us -> 5.12 us +- 0.10 us: 1.02x slower
- json_dumps: 12.8 ms +- 0.2 ms -> 13.1 ms +- 0.3 ms: 1.02x slower
- regex_dna: 208 ms +- 4 ms -> 212 ms +- 2 ms: 1.02x slower
- django_template: 41.2 ms +- 2.6 ms -> 42.0 ms +- 0.9 ms: 1.02x slower
- pickle_list: 4.57 us +- 0.13 us -> 4.65 us +- 0.16 us: 1.02x slower

Faster (34):
- pickle: 12.5 us +- 1.2 us -> 11.3 us +- 1.3 us: 1.10x faster
- nbody: 100 ms +- 2 ms -> 92.7 ms +- 2.5 ms: 1.08x faster
- deltablue: 4.55 ms +- 0.06 ms -> 4.29 ms +- 0.16 ms: 1.06x faster
- spectral_norm: 98.5 ms +- 2.4 ms -> 93.8 ms +- 1.1 ms: 1.05x faster
- json_loads: 27.2 us +- 1.1 us -> 26.0 us +- 1.8 us: 1.05x faster
- chaos: 80.5 ms +- 0.9 ms -> 77.1 ms +- 1.8 ms: 1.04x faster
- hexiom: 7.01 ms +- 0.07 ms -> 6.72 ms +- 0.26 ms: 1.04x faster
- nqueens: 87.3 ms +- 1.9 ms -> 83.7 ms +- 2.8 ms: 1.04x faster
- crypto_pyaes: 91.0 ms +- 2.2 ms -> 88.0 ms +- 1.3 ms: 1.03x faster
- scimark_lu: 112 ms +- 2 ms -> 108 ms +- 4 ms: 1.03x faster
- pidigits: 187 ms +- 1 ms -> 182 ms +- 1 ms: 1.03x faster
- dulwich_log: 83.8 ms +- 1.4 ms -> 81.5 ms +- 1.1 ms: 1.03x faster
- logging_format: 8.19 us +- 0.10 us -> 7.98 us +- 0.14 us: 1.03x faster
- logging_simple: 7.24 us +- 0.17 us -> 7.07 us +- 0.13 us: 1.02x faster
- go: 152 ms +- 3 ms -> 149 ms +- 2 ms: 1.02x faster
- regex_compile: 150 ms +- 3 ms -> 146 ms +- 2 ms: 1.02x faster
- scimark_sor: 123 ms +- 3 ms -> 120 ms +- 2 ms: 1.02x faster
- fannkuch: 406 ms +- 9 ms -> 398 ms +- 6 ms: 1.02x faster
- float: 81.2 ms +- 1.3 ms -> 79.7 ms +- 1.4 ms: 1.02x faster
- raytrace: 332 ms +- 8 ms -> 326 ms +- 7 ms: 1.02x faster
- tornado_http: 191 ms +- 8 ms -> 188 ms +- 7 ms: 1.02x faster
- mako: 11.7 ms +- 0.2 ms -> 11.6 ms +- 0.1 ms: 1.02x faster
- scimark_monte_carlo: 72.5 ms +- 1.8 ms -> 71.4 ms +- 0.9 ms: 1.01x faster
- unpickle_pure_python: 263 us +- 6 us -> 259 us +- 6 us: 1.01x faster
- sympy_expand: 570 ms +- 14 ms -> 562 ms +- 17 ms: 1.01x faster
- pickle_pure_python: 351 us +- 7 us -> 346 us +- 8 us: 1.01x faster
- sympy_str: 342 ms +- 8 ms -> 338 ms +- 12 ms: 1.01x faster
- regex_v8: 23.7 ms +- 0.6 ms -> 23.5 ms +- 0.3 ms: 1.01x faster
- pathlib: 20.9 ms +- 0.6 ms -> 20.6 ms +- 0.5 ms: 1.01x faster
- regex_effbot: 3.11 ms +- 0.08 ms -> 3.08 ms +- 0.03 ms: 1.01x faster
- xml_etree_generate: 79.9 ms +- 1.0 ms -> 79.1 ms +- 1.0 ms: 1.01x faster
- chameleon: 7.19 ms +- 0.13 ms -> 7.13 ms +- 0.10 ms: 1.01x faster
- 2to3: 272 ms +- 2 ms -> 269 ms +- 2 ms: 1.01x faster
- xml_etree_process: 57.1 ms +- 0.8 ms -> 56.7 ms +- 0.7 ms: 1.01x faster

Benchmark hidden because not significant (15): logging_silent, meteor_contest, pyflate, python_startup, python_startup_no_site, richards, scimark_fft, scimark_sparse_mat_mult, sympy_integrate, sympy_sum, telco, unpack_sequence, unpickle, xml_etree_parse, xml_etree_iterparse

Geometric mean: 1.01x faster



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46420](https://bugs.python.org/issue46420) -->
https://bugs.python.org/issue46420
<!-- /issue-number -->
