### PR TITLE
bpo-45644: json.tool: Use staged write for outfile.

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -28,7 +28,7 @@ def _staged_outfile(path):
     try:
         with file:
             yield file
-    except BaseException as e:
+    except:
         os.remove(tempname)
         raise
     else:

--- a/Misc/NEWS.d/next/Library/2022-01-18-18-32-49.bpo-33927.2dO0-u.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-18-18-32-49.bpo-33927.2dO0-u.rst
@@ -1,0 +1,3 @@
+``python -m json.tool infile outfile`` uses staged write idiom for
+``outfile``. This allows that outfile is same to infile even when
+``--json-lines`` option is used.


### PR DESCRIPTION
To support `python -m json.tool --json-lines infile infile`.

<!-- issue-number: [bpo-45644](https://bugs.python.org/issue45644) -->
https://bugs.python.org/issue45644
<!-- /issue-number -->
