### PR TITLE
bpo-46425: fix direct invokation of multiple test modules

### DIFF
--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -3,7 +3,6 @@ import contextlib
 import filecmp
 import importlib.util
 import io
-import itertools
 import os
 import pathlib
 import py_compile
@@ -29,9 +28,8 @@ except NotImplementedError:
 from test import support
 from test.support import os_helper
 from test.support import script_helper
-
-from .test_py_compile import without_source_date_epoch
-from .test_py_compile import SourceDateEpochTestMeta
+from test.test_py_compile import without_source_date_epoch
+from test.test_py_compile import SourceDateEpochTestMeta
 
 
 def get_pyc(script, opt):

--- a/Lib/test/test_distutils.py
+++ b/Lib/test/test_distutils.py
@@ -5,7 +5,7 @@ the test_suite() function there returns a test suite that's ready to
 be run.
 """
 
-import warnings
+import unittest
 from test import support
 from test.support import warnings_helper
 

--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -170,4 +170,4 @@ class SystemTapOptimizedTests(TraceTests, unittest.TestCase):
 
 
 if __name__ == '__main__':
-    test_main()
+    unittest.main()

--- a/Lib/test/test_tools/test_freeze.py
+++ b/Lib/test/test_tools/test_freeze.py
@@ -6,8 +6,8 @@ import unittest
 
 from test import support
 from test.support import os_helper
+from test.test_tools import imports_under_tool, skip_if_missing
 
-from . import imports_under_tool, skip_if_missing
 skip_if_missing('freeze')
 with imports_under_tool('freeze', 'test'):
     import freeze as helper

--- a/Lib/test/test_zipfile64.py
+++ b/Lib/test/test_zipfile64.py
@@ -18,8 +18,9 @@ import sys
 from tempfile import TemporaryFile
 
 from test.support import os_helper
-from test.support import TESTFN, requires_zlib
+from test.support import requires_zlib
 
+TESTFN = os_helper.TESTFN
 TESTFN2 = TESTFN + "2"
 
 # How much time in seconds can pass before we print a 'Still working' message.

--- a/Lib/unittest/test/test_program.py
+++ b/Lib/unittest/test/test_program.py
@@ -6,7 +6,7 @@ import subprocess
 from test import support
 import unittest
 import unittest.test
-from .test_result import BufferedWriter
+from unittest.test.test_result import BufferedWriter
 
 
 class Test_TestProgram(unittest.TestCase):


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/30641
CC @corona10 as my mentor.

<!-- issue-number: [bpo-46425](https://bugs.python.org/issue46425) -->
https://bugs.python.org/issue46425
<!-- /issue-number -->

I am going to mark this as "needs backport" to 3.9 and 3.10, because this is a bugfix.