### PR TITLE
bpo-46427: Use MSBuild's properties correctly when building _freeze_module

### DIFF
--- a/PCbuild/pcbuild.proj
+++ b/PCbuild/pcbuild.proj
@@ -18,7 +18,9 @@
 
   <ItemDefinitionGroup>
     <FreezeProjects>
-      <Platform>$(PreferredToolArchitecture)</Platform>
+      <Platform>$(Platform)</Platform>
+      <Platform Condition="$(Platform) == 'ARM'">Win32</Platform>
+      <Platform Condition="$(Platform) == 'ARM64'">x64</Platform>
       <Configuration>$(Configuration)</Configuration>
       <Configuration Condition="$(Configuration) == 'PGInstrument'">Release</Configuration>
       <Properties></Properties>


### PR DESCRIPTION


<!-- issue-number: [bpo-46427](https://bugs.python.org/issue46427) -->
https://bugs.python.org/issue46427
<!-- /issue-number -->
