### PR TITLE
bpo-46425: fix direct invocation of `test_sqlite3`

### DIFF
--- a/Lib/test/test_sqlite3/test_hooks.py
+++ b/Lib/test/test_sqlite3/test_hooks.py
@@ -24,7 +24,7 @@ import unittest
 import sqlite3 as sqlite
 
 from test.support.os_helper import TESTFN, unlink
-from .test_userfunctions import with_tracebacks
+from test.test_sqlite3.test_userfunctions import with_tracebacks
 
 class CollationTests(unittest.TestCase):
     def test_create_collation_not_string(self):

--- a/Lib/test/test_sqlite3/test_regression.py
+++ b/Lib/test/test_sqlite3/test_regression.py
@@ -21,14 +21,13 @@
 # 3. This notice may not be removed or altered from any source distribution.
 
 import datetime
-import sys
 import unittest
 import sqlite3 as sqlite
 import weakref
 import functools
-from test import support
 
-from .test_dbapi import memory_database, managed_connect, cx_limit
+from test import support
+from test.test_sqlite3.test_dbapi import memory_database, managed_connect, cx_limit
 
 
 class RegressionTests(unittest.TestCase):

--- a/Lib/test/test_sqlite3/test_transactions.py
+++ b/Lib/test/test_sqlite3/test_transactions.py
@@ -23,7 +23,7 @@
 import os, unittest
 import sqlite3 as sqlite
 
-from .test_dbapi import memory_database
+from test.test_sqlite3.test_dbapi import memory_database
 
 def get_db_path():
     return "sqlite_testdb"

--- a/Lib/test/test_sqlite3/test_userfunctions.py
+++ b/Lib/test/test_sqlite3/test_userfunctions.py
@@ -32,7 +32,7 @@ import unittest.mock
 import sqlite3 as sqlite
 
 from test.support import bigmemtest, catch_unraisable_exception
-from .test_dbapi import cx_limit
+from test.test_sqlite3.test_dbapi import cx_limit
 
 
 def with_tracebacks(exc, regex="", name=""):


### PR DESCRIPTION
This fixes `./python.exe Lib/test/test_sqlite3/...` tests.
Without this change it fails:

```
» ./python.exe Lib/test/test_sqlite3/test_transactions.py 
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/Lib/test/test_sqlite3/test_transactions.py", line 26, in <module>
    from .test_dbapi import memory_database
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: attempted relative import with no known parent package
```

Refs https://github.com/python/cpython/pull/30666
CC @corona10 as my mentor. 

<!-- issue-number: [bpo-46425](https://bugs.python.org/issue46425) -->
https://bugs.python.org/issue46425
<!-- /issue-number -->
