### PR TITLE
bpo-46425: fix direct invocation of `test_contextlib`

### DIFF
--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -1119,7 +1119,7 @@ class TestSuppress(unittest.TestCase):
 class TestChdir(unittest.TestCase):
     def make_relative_path(self, *parts):
         return os.path.join(
-            os.path.dirname(os.path.normpath(__file__)),
+            os.path.dirname(os.path.realpath(__file__)),
             *parts,
         )
 

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -1117,9 +1117,15 @@ class TestSuppress(unittest.TestCase):
 
 
 class TestChdir(unittest.TestCase):
+    def make_relative_path(self, *parts):
+        return os.path.join(
+            os.path.dirname(os.path.normpath(__file__)),
+            *parts,
+        )
+
     def test_simple(self):
         old_cwd = os.getcwd()
-        target = os.path.join(os.path.dirname(__file__), 'data')
+        target = self.make_relative_path('data')
         self.assertNotEqual(old_cwd, target)
 
         with chdir(target):
@@ -1128,8 +1134,8 @@ class TestChdir(unittest.TestCase):
 
     def test_reentrant(self):
         old_cwd = os.getcwd()
-        target1 = os.path.join(os.path.dirname(__file__), 'data')
-        target2 = os.path.join(os.path.dirname(__file__), 'ziptestdata')
+        target1 = self.make_relative_path('data')
+        target2 = self.make_relative_path('ziptestdata')
         self.assertNotIn(old_cwd, (target1, target2))
         chdir1, chdir2 = chdir(target1), chdir(target2)
 
@@ -1145,7 +1151,7 @@ class TestChdir(unittest.TestCase):
 
     def test_exception(self):
         old_cwd = os.getcwd()
-        target = os.path.join(os.path.dirname(__file__), 'data')
+        target = self.make_relative_path('data')
         self.assertNotEqual(old_cwd, target)
 
         try:


### PR DESCRIPTION
There was a problem with direct invocation of `test_contextlib`. The best way to illustrate it is:


```                                                      
» ./python.exe Lib/test/test_contextlib.py
...................................................................................
----------------------------------------------------------------------
Ran 83 tests in 0.046s

OK
```

But, when a path starts with `./`, we have a problem:

```                                                          
» ./python.exe ./Lib/test/test_contextlib.py
............................FFF....................................................
======================================================================
FAIL: test_exception (__main__.TestChdir)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/./Lib/test/test_contextlib.py", line 1159, in test_exception
    self.assertEqual(os.getcwd(), target)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: '/Users/sobolev/Desktop/cpython/Lib/test/data' != '/Users/sobolev/Desktop/cpython/./Lib/test/data'
- /Users/sobolev/Desktop/cpython/Lib/test/data
+ /Users/sobolev/Desktop/cpython/./Lib/test/data
?                                ++


======================================================================
FAIL: test_reentrant (__main__.TestChdir)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/./Lib/test/test_contextlib.py", line 1143, in test_reentrant
    self.assertEqual(os.getcwd(), target1)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: '/Users/sobolev/Desktop/cpython/Lib/test/data' != '/Users/sobolev/Desktop/cpython/./Lib/test/data'
- /Users/sobolev/Desktop/cpython/Lib/test/data
+ /Users/sobolev/Desktop/cpython/./Lib/test/data
?                                ++


======================================================================
FAIL: test_simple (__main__.TestChdir)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/./Lib/test/test_contextlib.py", line 1132, in test_simple
    self.assertEqual(os.getcwd(), target)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: '/Users/sobolev/Desktop/cpython/Lib/test/data' != '/Users/sobolev/Desktop/cpython/./Lib/test/data'
- /Users/sobolev/Desktop/cpython/Lib/test/data
+ /Users/sobolev/Desktop/cpython/./Lib/test/data
?                                ++


----------------------------------------------------------------------
Ran 83 tests in 0.050s

FAILED (failures=3)

```

When `__file__` is normalized - the error is gone. Now we can use both styles to call this module.

<!-- issue-number: [bpo-46425](https://bugs.python.org/issue46425) -->
https://bugs.python.org/issue46425
<!-- /issue-number -->

CC @corona10 as my mentor.