### PR TITLE
bpo-45680: Minor formatting fix in stdtypes.rst

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5063,7 +5063,7 @@ All parameterized generics implement special read-only attributes.
    :pep:`484` - Type Hints
       Introducing Python's framework for type annotations.
 
-   :pep:`585` - "Type Hinting Generics In Standard Collections"
+   :pep:`585` - Type Hinting Generics In Standard Collections
       Introducing the ability to natively parameterize standard-library
       classes, provided they implement the special class method
       :meth:`~object.__class_getitem__`.


### PR DESCRIPTION
Makes quotation consistent with rest of docs in commit 0eae9a2a2db6cc5a72535f61bb988cc417011640.

<!-- issue-number: [bpo-45680](https://bugs.python.org/issue45680) -->
https://bugs.python.org/issue45680
<!-- /issue-number -->

Automerge-Triggered-By: GH:Fidget-Spinner