### PR TITLE
[3.9] bpo-46425: Fix direct invocation of multiple test modules (GH-30666)

### DIFF
--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -3,7 +3,6 @@ import contextlib
 import filecmp
 import importlib.util
 import io
-import itertools
 import os
 import pathlib
 import py_compile
@@ -24,9 +23,8 @@ except ImportError:
 
 from test import support
 from test.support import script_helper
-
-from .test_py_compile import without_source_date_epoch
-from .test_py_compile import SourceDateEpochTestMeta
+from test.test_py_compile import without_source_date_epoch
+from test.test_py_compile import SourceDateEpochTestMeta
 
 
 def get_pyc(script, opt):

--- a/Lib/test/test_distutils.py
+++ b/Lib/test/test_distutils.py
@@ -7,7 +7,7 @@ be run.
 
 import distutils.tests
 import test.support
-
+import unittest
 
 def load_tests(*_):
     # used by unittest

--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -170,4 +170,4 @@ class SystemTapOptimizedTests(TraceTests, unittest.TestCase):
 
 
 if __name__ == '__main__':
-    test_main()
+    unittest.main()

--- a/Lib/test/test_zipfile64.py
+++ b/Lib/test/test_zipfile64.py
@@ -16,7 +16,6 @@ import time
 import sys
 
 from tempfile import TemporaryFile
-
 from test.support import TESTFN, requires_zlib
 
 TESTFN2 = TESTFN + "2"

--- a/Lib/test/test_zipfile64.py
+++ b/Lib/test/test_zipfile64.py
@@ -16,6 +16,7 @@ import time
 import sys
 
 from tempfile import TemporaryFile
+
 from test.support import TESTFN, requires_zlib
 
 TESTFN2 = TESTFN + "2"

--- a/Lib/unittest/test/test_program.py
+++ b/Lib/unittest/test/test_program.py
@@ -6,7 +6,7 @@ import subprocess
 from test import support
 import unittest
 import unittest.test
-from .test_result import BufferedWriter
+from unittest.test.test_result import BufferedWriter
 
 
 class Test_TestProgram(unittest.TestCase):


### PR DESCRIPTION
(cherry picked from commit 1292aa6db5bed889a3c87df443754fcae0177801)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>


<!-- issue-number: [bpo-46425](https://bugs.python.org/issue46425) -->
https://bugs.python.org/issue46425
<!-- /issue-number -->
