### PR TITLE
bpo-46436: Fix command-line option -d/--directory in module http.server

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-01-23-19-37-00.bpo-46436.Biz1p9.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-23-19-37-00.bpo-46436.Biz1p9.rst
@@ -1,0 +1,3 @@
+Fix command-line option ``-d``/``--directory`` in module :mod:`http.server`
+which is ignored when combined with command-line option ``--cgi``. Patch by
+Géry Ogam.


### PR DESCRIPTION
Fix command-line option -d/--directory in http.server main
function that was ignored when combined with --cgi.

<!-- issue-number: [bpo-46436](https://bugs.python.org/issue46436) -->
https://bugs.python.org/issue46436
<!-- /issue-number -->

Automerge-Triggered-By: GH:merwok

Automerge-Triggered-By: GH:merwok