### PR TITLE
bpo-46434: Handle missing docstring in pdb help

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1577,6 +1577,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 self.error('No help for %r; please do not run Python with -OO '
                            'if you need command help' % arg)
                 return
+            if command.__doc__ is None:
+                self.error('No help for %r; __doc__ string missing' % arg)
+                return
             self.message(command.__doc__.rstrip())
 
     do_h = do_help

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1474,6 +1474,27 @@ def bœr():
         self.assertNotIn(b'SyntaxError', stdout,
                          "Got a syntax error running test script under PDB")
 
+    def test_issue46434(self):
+        # Temporarily patch in an extra help command which doesn't have a
+        # docstring to emulate what happens in an embeddable distribution
+        script = """
+            def do_testcmdwithnodocs(self, arg):
+                pass
+
+            import pdb
+            pdb.Pdb.do_testcmdwithnodocs = do_testcmdwithnodocs
+        """
+        commands = """
+            continue
+            help testcmdwithnodocs
+        """
+        stdout, stderr = self.run_pdb_script(script, commands)
+        output = (stdout or '') + (stderr or '')
+        self.assertNotIn('AttributeError', output,
+                     'Calling help on a command with no docs should be handled gracefully')
+        self.assertIn("*** No help for 'testcmdwithnodocs'; __doc__ string missing", output,
+                      'Calling help on a command with no docs should print an error')
+
     def test_issue13183(self):
         script = """
             from bar import bar

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1491,7 +1491,7 @@ def bœr():
         stdout, stderr = self.run_pdb_script(script, commands)
         output = (stdout or '') + (stderr or '')
         self.assertNotIn('AttributeError', output,
-                     'Calling help on a command with no docs should be handled gracefully')
+                         'Calling help on a command with no docs should be handled gracefully')
         self.assertIn("*** No help for 'testcmdwithnodocs'; __doc__ string missing", output,
                       'Calling help on a command with no docs should print an error')
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1675,6 +1675,7 @@ Evgeny Sologubov
 Cody Somerville
 Anthony Sottile
 Edoardo Spadolini
+Tom Sparrow
 Geoffrey Spear
 Clay Spence
 Stefan Sperling

--- a/Misc/NEWS.d/next/Library/2022-01-20-10-35-10.bpo-46434.geS-aP.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-20-10-35-10.bpo-46434.geS-aP.rst
@@ -1,0 +1,2 @@
+pdb help now gracefully handles any case where __doc__ is missing, for
+example when run from a windows embeddable package

--- a/Misc/NEWS.d/next/Library/2022-01-20-10-35-10.bpo-46434.geS-aP.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-20-10-35-10.bpo-46434.geS-aP.rst
@@ -1,2 +1,2 @@
-pdb help now gracefully handles any case where __doc__ is missing, for
-example when run from a windows embeddable package
+:mod:`pdb` now gracefully handles ``help`` when :attr:`__doc__` is missing,
+for example when run with pregenerated optimized ``.pyc`` files.


### PR DESCRIPTION
Proposed fix for https://bugs.python.org/issue46434

When using embeddable windows distribution of python, `__doc__` strings are missing so `help CMD` in pdb explodes without this patch.

This is my first contribution, apologies I wasn't sure whether I should update Docs, Misc/ACKS or Misc/NEWS.d

<!-- issue-number: [bpo-46434](https://bugs.python.org/issue46434) -->
https://bugs.python.org/issue46434
<!-- /issue-number -->
