### PR TITLE
[3.9] bpo-46416: Allow direct invocation of `Lib/test/test_typing.py` (GH-30641)

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4310,6 +4310,11 @@ class AnnotatedTests(BaseTestCase):
         X = List[Annotated[T, 5]]
         self.assertEqual(X[int], List[Annotated[int, 5]])
 
+    def test_annotated_mro(self):
+        class X(Annotated[int, (1, 10)]): ...
+        self.assertEqual(X.__mro__, (X, int, object),
+                         "Annotated should be transparent.")
+
 
 class AllTests(BaseTestCase):
     """Tests for __all__."""


### PR DESCRIPTION
(cherry picked from commit 2792d6d18eab3efeb71e6397f88db86e610541f1)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>


<!-- issue-number: [bpo-46416](https://bugs.python.org/issue46416) -->
https://bugs.python.org/issue46416
<!-- /issue-number -->
