### PR TITLE
bpo-46439: Clarify urllib.request.add_header documentation

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -547,7 +547,8 @@ request.
    name, and later calls will overwrite previous calls in case the *key* collides.
    Currently, this is no loss of HTTP functionality, since all headers which have
    meaning when used more than once have a (header-specific) way of gaining the
-   same functionality using only one header.
+   same functionality using only one header.  Note that headers added using
+   this method are also added to redirected requests.
 
 
 .. method:: Request.add_unredirected_header(key, header)


### PR DESCRIPTION
Add note that headers added via urllib.request.add_header are added to redirected requests.

<!-- issue-number: [bpo-46439](https://bugs.python.org/issue46439) -->
https://bugs.python.org/issue46439
<!-- /issue-number -->
