### PR TITLE
bpo-46443: deepfreeze use preallocated small ints

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-01-20-05-27-07.bpo-46443.udCVII.rst
+++ b/Misc/NEWS.d/next/Build/2022-01-20-05-27-07.bpo-46443.udCVII.rst
@@ -1,0 +1,1 @@
+Deepfreeze now uses cached small integers as it saves some space for common small integers.

--- a/Tools/scripts/deepfreeze.py
+++ b/Tools/scripts/deepfreeze.py
@@ -149,6 +149,8 @@ class Printer:
         self.write(f".{name} = {getattr(obj, name)},")
 
     def generate_bytes(self, name: str, b: bytes) -> str:
+        if b == b"":
+            return "(PyObject *)&_Py_SINGLETON(bytes_empty)"
         self.write("static")
         with self.indent():
             with self.block("struct"):

--- a/Tools/scripts/deepfreeze.py
+++ b/Tools/scripts/deepfreeze.py
@@ -113,6 +113,7 @@ class Printer:
         self.write('#include "Python.h"')
         self.write('#include "internal/pycore_gc.h"')
         self.write('#include "internal/pycore_code.h"')
+        self.write('#include "internal/pycore_long.h"')
         self.write("")
 
     @contextlib.contextmanager
@@ -313,6 +314,8 @@ class Printer:
                 self.write(f".ob_digit = {{ {ds} }},")
 
     def generate_int(self, name: str, i: int) -> str:
+        if -5 <= i <= 256:
+            return f"(PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS + {i}]"
         if abs(i) < 2**15:
             self._generate_int_for_bits(name, i, 2**15)
         else:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46443](https://bugs.python.org/issue46443) -->
https://bugs.python.org/issue46443
<!-- /issue-number -->
