### PR TITLE
bpo-40280: Misc fixes for wasm32-emscripten (GH-30722)

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -26,6 +26,10 @@ try:
     import _posixsubprocess
 except ImportError:
     _posixsubprocess = None
+try:
+    import _testmultiphase
+except ImportError:
+    _testmultiphase = None
 
 # Skip this test if the _testcapi module isn't available.
 _testcapi = import_helper.import_module('_testcapi')
@@ -798,6 +802,7 @@ class SubinterpreterTest(unittest.TestCase):
 
         self.assertFalse(hasattr(binascii.Error, "foobar"))
 
+    @unittest.skipIf(_testmultiphase is None, "test requires _testmultiphase module")
     def test_module_state_shared_in_global(self):
         """
         bpo-44050: Extension module state should be shared between interpreters
@@ -991,6 +996,7 @@ class PyMemDefaultTests(PyMemDebugTests):
     PYTHONMALLOC = ''
 
 
+@unittest.skipIf(_testmultiphase is None, "test requires _testmultiphase module")
 class Test_ModuleStateAccess(unittest.TestCase):
     """Test access to module start (PEP 573)"""
 

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -15,14 +15,14 @@ import time
 import unittest
 
 from unittest import mock, skipUnless
-from concurrent.futures import ProcessPoolExecutor
 try:
     # compileall relies on ProcessPoolExecutor if ProcessPoolExecutor exists
     # and it can function.
+    from concurrent.futures import ProcessPoolExecutor
     from concurrent.futures.process import _check_system_limits
     _check_system_limits()
     _have_multiprocessing = True
-except NotImplementedError:
+except (NotImplementedError, ModuleNotFoundError):
     _have_multiprocessing = False
 
 from test import support

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -23,7 +23,7 @@ def requires_load_dynamic(meth):
     """Decorator to skip a test if not running under CPython or lacking
     imp.load_dynamic()."""
     meth = support.cpython_only(meth)
-    return unittest.skipIf(not hasattr(imp, 'load_dynamic'),
+    return unittest.skipIf(getattr(imp, 'load_dynamic', None) is None,
                            'imp.load_dynamic() required')(meth)
 
 

--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -1,8 +1,9 @@
 from test.support import verbose, reap_children
 from test.support.import_helper import import_module
 
-# Skip these tests if termios is not available
+# Skip these tests if termios or fcntl are not available
 import_module('termios')
+import_module("fcntl")
 
 import errno
 import os

--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -346,7 +346,7 @@ class TestTracemallocEnabled(unittest.TestCase):
         # everything is fine
         return 0
 
-    @unittest.skipUnless(hasattr(os, 'fork'), 'need os.fork()')
+    @support.requires_fork()
     def test_fork(self):
         # check that tracemalloc is still working after fork
         pid = os.fork()

--- a/Tools/wasm/config.site-wasm32-emscripten
+++ b/Tools/wasm/config.site-wasm32-emscripten
@@ -58,12 +58,14 @@ ac_cv_func_fchmodat=no
 ac_cv_func_dup3=no
 
 # Syscalls not implemented in emscripten
+# [Errno 52] Function not implemented
 ac_cv_func_preadv2=no
 ac_cv_func_preadv=no
 ac_cv_func_pwritev2=no
 ac_cv_func_pwritev=no
 ac_cv_func_pipe2=no
 ac_cv_func_nice=no
+ac_cv_func_setitimer=no
 
 # Syscalls that resulted in a segfault
 ac_cv_func_utimensat=no

--- a/configure
+++ b/configure
@@ -21323,7 +21323,7 @@ case $ac_sys_system/$ac_sys_emscripten_target in #(
    ;; #(
       Emscripten/node) :
 
-    py_stdlib_not_available="_ctypes _curses _curses_panel _dbm _gdbm _scproxy _tkinter nis ossaudiodev spwd syslog"
+    py_stdlib_not_available="_ctypes _curses _curses_panel _dbm _gdbm _scproxy _tkinter _xxsubinterpreters grp nis ossaudiodev spwd syslog"
    ;; #(
   *) :
     py_stdlib_not_available="_scproxy"

--- a/configure.ac
+++ b/configure.ac
@@ -6384,6 +6384,8 @@ AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
       _gdbm
       _scproxy
       _tkinter
+      _xxsubinterpreters
+      grp
       nis
       ossaudiodev
       spwd


### PR DESCRIPTION
- skip tests when modules like fcntl or _multiprocessing are not available
- add missing check for fork
- grp and subinterpreter don't work on wasm32-emscripten node builds

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
