### PR TITLE
bpo-46425: fix direct invocation of `asyncio` tests

### DIFF
--- a/Lib/test/test_asyncio/test_context.py
+++ b/Lib/test/test_asyncio/test_context.py
@@ -32,3 +32,7 @@ class DecimalContextTest(unittest.TestCase):
 
         self.assertEqual(str(r2[0]), '0.333333')
         self.assertEqual(str(r2[1]), '0.111111')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Lib/test/test_asyncio/test_futures2.py
+++ b/Lib/test/test_asyncio/test_futures2.py
@@ -16,3 +16,7 @@ class FutureTests(unittest.IsolatedAsyncioTestCase):
         # The check for returned string is not very reliable but
         # exact comparison for the whole string is even weaker.
         self.assertIn('...', repr(await asyncio.wait_for(func(), timeout=10)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Lib/test/test_asyncio/test_protocols.py
+++ b/Lib/test/test_asyncio/test_protocols.py
@@ -55,3 +55,7 @@ class ProtocolsAbsTests(unittest.TestCase):
         self.assertIsNone(sp.pipe_connection_lost(1, f))
         self.assertIsNone(sp.process_exited())
         self.assertFalse(hasattr(sp, '__dict__'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Lib/test/test_asyncio/test_runners.py
+++ b/Lib/test/test_asyncio/test_runners.py
@@ -2,7 +2,7 @@ import asyncio
 import unittest
 
 from unittest import mock
-from . import utils as test_utils
+from test.test_asyncio import utils as test_utils
 
 
 class TestPolicy(asyncio.AbstractEventLoopPolicy):
@@ -180,3 +180,7 @@ class RunTests(BaseTest):
 
         self.assertIsNone(spinner.ag_frame)
         self.assertFalse(spinner.ag_running)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -565,3 +565,7 @@ else:
 
         def create_event_loop(self):
             return asyncio.SelectorEventLoop(selectors.SelectSelector())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Lib/test/test_asyncio/test_sock_lowlevel.py
+++ b/Lib/test/test_asyncio/test_sock_lowlevel.py
@@ -1,5 +1,4 @@
 import socket
-import time
 import asyncio
 import sys
 import unittest
@@ -512,3 +511,7 @@ else:
 
         def create_event_loop(self):
             return asyncio.SelectorEventLoop(selectors.SelectSelector())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Right now some tests in `test_asyncio` are suitable to be executed directly as `python Lib/test/test_asyncio/test_X.py` and some are only executable with `-m test` or `-m Lib/test/test_asyncio`.

- Supports all styles: https://github.com/python/cpython/blob/c02e860ee79f29905be6fca997c96bb1a404bb32/Lib/test/test_asyncio/test_asyncio_waitfor.py#L60-L61
- Does not support direct invocation: https://github.com/python/cpython/blob/c02e860ee79f29905be6fca997c96bb1a404bb32/Lib/test/test_asyncio/test_context.py#L33-L34

This does not look good to me.

So, I've fixed several tests modules in `test_asyncio` when invoked directly as `python module_name.py`

There were two major problems:
- relative imports
- missing `unittest.main()` call

The best way to illustrate this problem is to show `Lib/test/test_asyncio/test_runners.py`:

Step 1. No changes.

```
» ./python.exe Lib/test/test_asyncio/test_runners.py
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/Lib/test/test_asyncio/test_runners.py", line 5, in <module>
    from . import utils as test_utils
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: attempted relative import with no known parent package
```

Step 2. Fixed relative import.

```
» ./python.exe Lib/test/test_asyncio/test_runners.py

```

(nothing happens)

Step 3. With `unottest.main()`:

```
» ./python.exe Lib/test/test_asyncio/test_runners.py
........
----------------------------------------------------------------------
Ran 8 tests in 0.018s

OK

```

CC @corona10 as my mentor.

<!-- issue-number: [bpo-46425](https://bugs.python.org/issue46425) -->
https://bugs.python.org/issue46425
<!-- /issue-number -->
