### PR TITLE
[3.9]bpo-41857: Document timeout arguments in select module (GH-22406)

### DIFF
--- a/Modules/clinic/selectmodule.c.h
+++ b/Modules/clinic/selectmodule.c.h
@@ -193,6 +193,10 @@ PyDoc_STRVAR(select_poll_poll__doc__,
 "\n"
 "Polls the set of registered file descriptors.\n"
 "\n"
+"  timeout\n"
+"    The maximum time to wait in milliseconds, or else None (or a negative\n"
+"    value) to wait indefinitely.\n"
+"\n"
 "Returns a list containing any descriptors that have events or errors to\n"
 "report, as a list of (fd, event) 2-tuples.");
 
@@ -362,6 +366,10 @@ PyDoc_STRVAR(select_devpoll_poll__doc__,
 "--\n"
 "\n"
 "Polls the set of registered file descriptors.\n"
+"\n"
+"  timeout\n"
+"    The maximum time to wait in milliseconds, or else None (or a negative\n"
+"    value) to wait indefinitely.\n"
 "\n"
 "Returns a list containing any descriptors that have events or errors to\n"
 "report, as a list of (fd, event) 2-tuples.");
@@ -1219,4 +1227,4 @@ exit:
 #ifndef SELECT_KQUEUE_CONTROL_METHODDEF
     #define SELECT_KQUEUE_CONTROL_METHODDEF
 #endif /* !defined(SELECT_KQUEUE_CONTROL_METHODDEF) */
-/*[clinic end generated code: output=ef42c3485a8fe3a0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d78e30f231a926d6 input=a9049054013a1b77]*/

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -580,6 +580,8 @@ select_poll_unregister_impl(pollObject *self, int fd)
 select.poll.poll
 
     timeout as timeout_obj: object = None
+      The maximum time to wait in milliseconds, or else None (or a negative
+      value) to wait indefinitely.
     /
 
 Polls the set of registered file descriptors.
@@ -590,7 +592,7 @@ report, as a list of (fd, event) 2-tuples.
 
 static PyObject *
 select_poll_poll_impl(pollObject *self, PyObject *timeout_obj)
-/*[clinic end generated code: output=876e837d193ed7e4 input=7a446ed45189e894]*/
+/*[clinic end generated code: output=876e837d193ed7e4 input=c2f6953ec45e5622]*/
 {
     PyObject *result_list = NULL;
     int poll_result, i, j;
@@ -911,6 +913,8 @@ select_devpoll_unregister_impl(devpollObject *self, int fd)
 /*[clinic input]
 select.devpoll.poll
     timeout as timeout_obj: object = None
+      The maximum time to wait in milliseconds, or else None (or a negative
+      value) to wait indefinitely.
     /
 
 Polls the set of registered file descriptors.
@@ -921,7 +925,7 @@ report, as a list of (fd, event) 2-tuples.
 
 static PyObject *
 select_devpoll_poll_impl(devpollObject *self, PyObject *timeout_obj)
-/*[clinic end generated code: output=2654e5457cca0b3c input=fd0db698d84f0333]*/
+/*[clinic end generated code: output=2654e5457cca0b3c input=3c3f0a355ec2bedb]*/
 {
     struct dvpoll dvp;
     PyObject *result_list = NULL;


### PR DESCRIPTION
The docstring for the poll() methods of the [select.poll](https://docs.python.org/3/library/select.html#select.poll.poll) and [select.devpoll](https://docs.python.org/3/library/select.html#select.devpoll.poll) classes did not describe the expected units of the timeout argument (milliseconds). Previously this information was only available from the online documentation.

This is a potential source of confusion, because other poll() methods in the select module, such as epoll and kqueue Polling objects, use units of seconds (and were documented).

Include the units in the docstring description so that this information is at least available from interactive help.

Co-authored-by: Zane Bitter <zbitter@redhat.com>

<!-- issue-number: [bpo-41857](https://bugs.python.org/issue41857) -->
https://bugs.python.org/issue41857
<!-- /issue-number -->
