### PR TITLE
bpo-46417: Call _PyDebug_PrintTotalRefs() later

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-21-12-24-14.bpo-46417.i3IqMf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-21-12-24-14.bpo-46417.i3IqMf.rst
@@ -1,0 +1,3 @@
+``python -X showrefcount`` now shows the total reference count after clearing
+and destroyed the main Python interpreter. Previously, it was shown before.
+Patch by Victor Stinner.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1862,12 +1862,6 @@ Py_FinalizeEx(void)
     /* dump hash stats */
     _PyHash_Fini();
 
-#ifdef Py_REF_DEBUG
-    if (show_ref_count) {
-        _PyDebug_PrintTotalRefs();
-    }
-#endif
-
 #ifdef Py_TRACE_REFS
     /* Display all objects still alive -- this can invoke arbitrary
      * __repr__ overrides, so requires a mostly-intact interpreter.
@@ -1894,6 +1888,12 @@ Py_FinalizeEx(void)
 
     finalize_interp_clear(tstate);
     finalize_interp_delete(tstate->interp);
+
+#ifdef Py_REF_DEBUG
+    if (show_ref_count) {
+        _PyDebug_PrintTotalRefs();
+    }
+#endif
 
 #ifdef Py_TRACE_REFS
     /* Display addresses (& refcnts) of all objects still alive.


### PR DESCRIPTION
"python -X showrefcount" now shows the total reference count after
clearing and destroyed the main Python interpreter. Previously, it
was shown before.

Py_FinalizeEx() now calls _PyDebug_PrintTotalRefs() after
finalize_interp_delete().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46417](https://bugs.python.org/issue46417) -->
https://bugs.python.org/issue46417
<!-- /issue-number -->
