### PR TITLE
bpo-46425: fix direct invocation of `test_traceback`

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -18,7 +18,7 @@ import textwrap
 import traceback
 from functools import partial
 
-MODULE_PREFIX = f"{__name__}." if __name__ == '__main__' else ''
+MODULE_PREFIX = f'{__name__}.' if __name__ == '__main__' else ''
 
 test_code = namedtuple('code', ['co_filename', 'co_name'])
 test_code.co_positions = lambda _: iter([(6, 6, 0, 0)])

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -18,6 +18,7 @@ import textwrap
 import traceback
 from functools import partial
 
+MODULE_PREFIX = f"{__name__}." if __name__ == '__main__' else ''
 
 test_code = namedtuple('code', ['co_filename', 'co_name'])
 test_code.co_positions = lambda _: iter([(6, 6, 0, 0)])
@@ -1311,8 +1312,8 @@ class BaseExceptionReportingTests:
         err = self.get_report(A.B.X())
         str_value = 'I am X'
         str_name = '.'.join([A.B.X.__module__, A.B.X.__qualname__])
-        exp = "%s: %s\n" % (str_name, str_value)
-        self.assertEqual(exp, err)
+        exp = f"{str_name}: {str_value}\n"
+        self.assertEqual(exp, MODULE_PREFIX + err)
 
     def test_exception_modulename(self):
         class X(Exception):
@@ -1349,7 +1350,7 @@ class BaseExceptionReportingTests:
         err = self.get_report(X())
         str_value = '<exception str() failed>'
         str_name = '.'.join([X.__module__, X.__qualname__])
-        self.assertEqual(err, f"{str_name}: {str_value}\n")
+        self.assertEqual(MODULE_PREFIX + err, f"{str_name}: {str_value}\n")
 
 
     # #### Exception Groups ####

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1312,7 +1312,7 @@ class BaseExceptionReportingTests:
         err = self.get_report(A.B.X())
         str_value = 'I am X'
         str_name = '.'.join([A.B.X.__module__, A.B.X.__qualname__])
-        exp = f"{str_name}: {str_value}\n"
+        exp = "%s: %s\n" % (str_name, str_value)
         self.assertEqual(exp, MODULE_PREFIX + err)
 
     def test_exception_modulename(self):


### PR DESCRIPTION
Before this change when trying to run this module as `./python.exe ./Lib/test/test_traceback.py` (as it is intended via `uniitest.main()` call here: https://github.com/python/cpython/blob/595225e86dcc6ea520a584839925a878dce7a9b2/Lib/test/test_traceback.py#L2584-L2585), we had several failures:

```
» ./python.exe ./Lib/test/test_traceback.py
.....F.........F.............................F.........F.........................................................................................
======================================================================
FAIL: test_exception_bad__str__ (__main__.CExcReportingTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/./Lib/test/test_traceback.py", line 1353, in test_exception_bad__str__
    self.assertEqual(err, f"{str_name}: {str_value}\n")
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 'BaseExceptionReportingTests.test_exceptio[47 chars]d>\n' != '__main__.BaseExceptionReportingTests.test[56 chars]d>\n'
- BaseExceptionReportingTests.test_exception_bad__str__.<locals>.X: <exception str() failed>
+ __main__.BaseExceptionReportingTests.test_exception_bad__str__.<locals>.X: <exception str() failed>
? +++++++++


======================================================================
FAIL: test_exception_qualname (__main__.CExcReportingTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/./Lib/test/test_traceback.py", line 1316, in test_exception_qualname
    self.assertEqual(exp, err)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: '__main__.BaseExceptionReportingTests.test[40 chars] X\n' != 'BaseExceptionReportingTests.test_exceptio[31 chars] X\n'
- __main__.BaseExceptionReportingTests.test_exception_qualname.<locals>.A.B.X: I am X
? ---------
+ BaseExceptionReportingTests.test_exception_qualname.<locals>.A.B.X: I am X


======================================================================
FAIL: test_exception_bad__str__ (__main__.PyExcReportingTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/./Lib/test/test_traceback.py", line 1353, in test_exception_bad__str__
    self.assertEqual(err, f"{str_name}: {str_value}\n")
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 'BaseExceptionReportingTests.test_exceptio[47 chars]d>\n' != '__main__.BaseExceptionReportingTests.test[56 chars]d>\n'
- BaseExceptionReportingTests.test_exception_bad__str__.<locals>.X: <exception str() failed>
+ __main__.BaseExceptionReportingTests.test_exception_bad__str__.<locals>.X: <exception str() failed>
? +++++++++


======================================================================
FAIL: test_exception_qualname (__main__.PyExcReportingTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/./Lib/test/test_traceback.py", line 1316, in test_exception_qualname
    self.assertEqual(exp, err)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: '__main__.BaseExceptionReportingTests.test[40 chars] X\n' != 'BaseExceptionReportingTests.test_exceptio[31 chars] X\n'
- __main__.BaseExceptionReportingTests.test_exception_qualname.<locals>.A.B.X: I am X
? ---------
+ BaseExceptionReportingTests.test_exception_qualname.<locals>.A.B.X: I am X


----------------------------------------------------------------------
Ran 145 tests in 1.129s

FAILED (failures=4)
```

After this change both ways work:

<img width="752" alt="Снимок экрана 2022-01-21 в 16 14 43" src="https://user-images.githubusercontent.com/4660275/150533078-7983bd6e-fe48-4613-bdb4-fa440e1ca77b.png">


<!-- issue-number: [bpo-46425](https://bugs.python.org/issue46425) -->
https://bugs.python.org/issue46425
<!-- /issue-number -->

CC @corona10 as my mentor.