### PR TITLE
bpo-46417: Add missing types of _PyTypes_InitTypes()

### DIFF
--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2904,7 +2904,7 @@ PyTypeObject PyBytes_Type = {
     bytes_methods,                              /* tp_methods */
     0,                                          /* tp_members */
     0,                                          /* tp_getset */
-    &PyBaseObject_Type,                         /* tp_base */
+    0,                                          /* tp_base */
     0,                                          /* tp_dict */
     0,                                          /* tp_descr_get */
     0,                                          /* tp_descr_set */

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1841,9 +1841,10 @@ _PyTypes_InitState(PyInterpreterState *interp)
 static PyTypeObject* static_types[] = {
     // base types
     &PyAsyncGen_Type,
-    &PyBool_Type,
     &PyByteArrayIter_Type,
     &PyByteArray_Type,
+    &PyBytesIter_Type,
+    &PyBytes_Type,
     &PyCFunction_Type,
     &PyCallIter_Type,
     &PyCapsule_Type,
@@ -1866,6 +1867,7 @@ static PyTypeObject* static_types[] = {
     &PyDict_Type,
     &PyEllipsis_Type,
     &PyEnum_Type,
+    &PyFloat_Type,
     &PyFrame_Type,
     &PyFrozenSet_Type,
     &PyFunction_Type,
@@ -1876,6 +1878,7 @@ static PyTypeObject* static_types[] = {
     &PyListRevIter_Type,
     &PyList_Type,
     &PyLongRangeIter_Type,
+    &PyLong_Type,
     &PyMemberDescr_Type,
     &PyMemoryView_Type,
     &PyMethodDescr_Type,
@@ -1897,6 +1900,10 @@ static PyTypeObject* static_types[] = {
     &PyStdPrinter_Type,
     &PySuper_Type,
     &PyTraceBack_Type,
+    &PyTupleIter_Type,
+    &PyTuple_Type,
+    &PyUnicodeIter_Type,
+    &PyUnicode_Type,
     &PyWrapperDescr_Type,
     &Py_GenericAliasType,
     &_PyAnextAwaitable_Type,
@@ -1917,6 +1924,7 @@ static PyTypeObject* static_types[] = {
 
     // subclasses: _PyTypes_FiniTypes() deallocates them before their base
     // class
+    &PyBool_Type,         // base=&PyLong_Type
     &PyCMethod_Type,      // base=&PyCFunction_Type
     &PyODictItems_Type,   // base=&PyDictItems_Type
     &PyODictKeys_Type,    // base=&PyDictKeys_Type

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15511,7 +15511,7 @@ PyTypeObject PyUnicode_Type = {
     unicode_methods,              /* tp_methods */
     0,                            /* tp_members */
     0,                            /* tp_getset */
-    &PyBaseObject_Type,           /* tp_base */
+    0,                            /* tp_base */
     0,                            /* tp_dict */
     0,                            /* tp_descr_get */
     0,                            /* tp_descr_set */


### PR DESCRIPTION
Add types removed by mistake by the commit adding
_PyTypes_FiniTypes().

Move also PyBool_Type at the end, since it depends on PyLong_Type.

PyBytes_Type and PyUnicode_Type no longer depend explicitly on
PyBaseObject_Type: it's the default of PyType_Ready().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46417](https://bugs.python.org/issue46417) -->
https://bugs.python.org/issue46417
<!-- /issue-number -->
