### PR TITLE
bpo-46417: Revert remove_subclass() change

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6553,10 +6553,6 @@ remove_subclass(PyTypeObject *base, PyTypeObject *type)
         PyErr_Clear();
     }
     Py_XDECREF(key);
-
-    if (PyDict_Size(dict) == 0) {
-        Py_CLEAR(base->tp_subclasses);
-    }
 }
 
 static void


### PR DESCRIPTION
remove_subclass() doesn't clear the tp_subclasses dict if the dict
becomes empty.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46417](https://bugs.python.org/issue46417) -->
https://bugs.python.org/issue46417
<!-- /issue-number -->
