### PR TITLE
bpo-46417: PyWeakref_GET_OBJECT() uses PyWeakref_CheckRef()

### DIFF
--- a/Doc/c-api/weakref.rst
+++ b/Doc/c-api/weakref.rst
@@ -66,5 +66,5 @@ as much as it can.
 
 .. c:function:: PyObject* PyWeakref_GET_OBJECT(PyObject *ref)
 
-   Similar to :c:func:`PyWeakref_GetObject`, but implemented as a macro that does no
-   error checking.
+   Similar to :c:func:`PyWeakref_GetObject`, but implemented as a static inline
+   function which only check errors with assertions.

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -155,8 +155,7 @@ _in_weak_set(PyObject *set, PyObject *obj)
 static PyObject *
 _destroy(PyObject *setweakref, PyObject *objweakref)
 {
-    PyObject *set;
-    set = PyWeakref_GET_OBJECT(setweakref);
+    PyObject *set = PyWeakref_GET_OBJECT(setweakref);
     if (set == Py_None) {
         Py_RETURN_NONE;
     }
@@ -502,7 +501,6 @@ set_collection_flag_recursive(PyTypeObject *child, unsigned long flag)
     assert(PyDict_CheckExact(grandchildren));
     Py_ssize_t i = 0;
     while (PyDict_Next(grandchildren, &i, NULL, &grandchildren)) {
-        assert(PyWeakref_CheckRef(grandchildren));
         PyObject *grandchild = PyWeakref_GET_OBJECT(grandchildren);
         if (PyType_Check(grandchild)) {
             set_collection_flag_recursive((PyTypeObject *)grandchild, flag);

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -246,7 +246,7 @@ PyDict_SetItemProxy(PyObject *dict, PyObject *key, PyObject *item)
     return result;
 }
 
-PyObject *
+static PyObject *
 PyDict_GetItemProxy(PyObject *dict, PyObject *key)
 {
     PyObject *result;
@@ -256,7 +256,7 @@ PyDict_GetItemProxy(PyObject *dict, PyObject *key)
         return NULL;
     if (!PyWeakref_CheckProxy(item))
         return item;
-    result = PyWeakref_GET_OBJECT(item);
+    result = _PyWeakref_GET_OBJECT((PyWeakReference*)item);
     if (result == Py_None)
         return NULL;
     return result;

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1031,7 +1031,6 @@ local_getattro(localobject *self, PyObject *name)
 static PyObject *
 _localdummy_destroyed(PyObject *localweakref, PyObject *dummyweakref)
 {
-    assert(PyWeakref_CheckRef(localweakref));
     PyObject *obj = PyWeakref_GET_OBJECT(localweakref);
     if (obj == Py_None) {
         Py_RETURN_NONE;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -339,7 +339,6 @@ PyType_Modified(PyTypeObject *type)
         assert(PyDict_CheckExact(raw));
         i = 0;
         while (PyDict_Next(raw, &i, NULL, &ref)) {
-            assert(PyWeakref_CheckRef(ref));
             ref = PyWeakref_GET_OBJECT(ref);
             if (ref != Py_None) {
                 PyType_Modified(_PyType_CAST(ref));
@@ -4146,7 +4145,6 @@ type___subclasses___impl(PyTypeObject *self)
     assert(PyDict_CheckExact(raw));
     i = 0;
     while (PyDict_Next(raw, &i, NULL, &ref)) {
-        assert(PyWeakref_CheckRef(ref));
         ref = PyWeakref_GET_OBJECT(ref);
         if (ref != Py_None) {
             if (PyList_Append(list, ref) < 0) {
@@ -8647,9 +8645,7 @@ recurse_down_subclasses(PyTypeObject *type, PyObject *name,
     assert(PyDict_CheckExact(subclasses));
     i = 0;
     while (PyDict_Next(subclasses, &i, NULL, &ref)) {
-        assert(PyWeakref_CheckRef(ref));
         PyObject *obj = PyWeakref_GET_OBJECT(ref);
-        assert(obj != NULL);
         if (obj == Py_None) {
             continue;
         }


### PR DESCRIPTION
PyWeakref_GET_OBJECT() now ensures that the its argument is valid
using PyWeakref_CheckRef().

* Convert PyWeakref_GET_OBJECT() macro to a static inline function.
* Remove now redundant assert(PyWeakref_CheckRef(ref)) before
  PyWeakref_GET_OBJECT(ref) calls.
* Add proxy_get_object() to proxy functions.
* _ctypes PyDict_GetItemProxy() uses the private
  _PyWeakref_GET_OBJECT() function.
* Cleanup weakrefobject.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46417](https://bugs.python.org/issue46417) -->
https://bugs.python.org/issue46417
<!-- /issue-number -->
