### PR TITLE
bpo-46463: Fixes escape4chm.py script used when building the CHM documentation file

### DIFF
--- a/Doc/tools/extensions/escape4chm.py
+++ b/Doc/tools/extensions/escape4chm.py
@@ -5,6 +5,7 @@ effect on some MBCS Windows systems.
 https://bugs.python.org/issue32174
 """
 
+import pathlib
 import re
 from html.entities import codepoint2name
 
@@ -39,12 +40,12 @@ def fixup_keywords(app, exception):
         return
 
     getLogger(__name__).info('fixing HTML escapes in keywords file...')
-    outdir = app.builder.outdir
+    outdir = pathlib.Path(app.builder.outdir)
     outname = app.builder.config.htmlhelp_basename
-    with app.builder.open_file(outdir, outname + '.hhk', 'r') as f:
+    with open(outdir / (outname + '.hhk'), 'rb') as f:
         index = f.read()
-    with app.builder.open_file(outdir, outname + '.hhk', 'w') as f:
-        f.write(index.replace('&#x27;', '&#39;'))
+    with open(outdir / (outname + '.hhk'), 'wb') as f:
+        f.write(index.replace(b'&#x27;', b'&#39;'))
 
 def setup(app):
     # `html-page-context` event emitted when the HTML builder has

--- a/Misc/NEWS.d/next/Documentation/2022-01-21-21-33-48.bpo-46463.fBbdTG.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-01-21-21-33-48.bpo-46463.fBbdTG.rst
@@ -1,0 +1,2 @@
+Fixes :file:`escape4chm.py` script used when building the CHM documentation
+file


### PR DESCRIPTION


<!-- issue-number: [bpo-46463](https://bugs.python.org/issue46463) -->
https://bugs.python.org/issue46463
<!-- /issue-number -->
