### PR TITLE
bpo-29882:  _Py_popcount32() doesn't need 64x64 multiply

### DIFF
--- a/Include/internal/pycore_bitutils.h
+++ b/Include/internal/pycore_bitutils.h
@@ -125,7 +125,7 @@ _Py_popcount32(uint32_t x)
     // Put count of each 8 bits into those 8 bits
     x = (x + (x >> 4)) & M4;
     // Sum of the 4 byte counts
-    return (uint32_t)((uint64_t)x * (uint64_t)SUM) >> 24;
+    return (x * SUM) >> 24;
 #endif
 }
 


### PR DESCRIPTION
32x32 bits multiply is enough for _Py_popcount32().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-29882](https://bugs.python.org/issue29882) -->
https://bugs.python.org/issue29882
<!-- /issue-number -->
