### PR TITLE
bpo-46471: use global singletons for single byte bytes objects

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-01-22-11-06-23.bpo-46471.03snrE.rst
+++ b/Misc/NEWS.d/next/Build/2022-01-22-11-06-23.bpo-46471.03snrE.rst
@@ -1,0 +1,1 @@
+Use global singletons for single byte bytes objects in deepfreeze.

--- a/Tools/scripts/deepfreeze.py
+++ b/Tools/scripts/deepfreeze.py
@@ -150,6 +150,8 @@ class Printer:
     def generate_bytes(self, name: str, b: bytes) -> str:
         if b == b"":
             return "(PyObject *)&_Py_SINGLETON(bytes_empty)"
+        if len(b) == 1:
+            return f"(PyObject *)&_Py_SINGLETON(bytes_characters[{b[0]}])"
         self.write("static")
         with self.indent():
             with self.block("struct"):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

By using global singletons for single byte bytes objects in deepfreeze, there is no need to generate c code for it so it reduces the size of generated c file and reduces memory use of the objects when they are allocated on the heap as now they are statically allocated and they are already immortal.
<!-- issue-number: [bpo-46471](https://bugs.python.org/issue46471) -->
https://bugs.python.org/issue46471
<!-- /issue-number -->
