### PR TITLE
bpo-46417: Debug tp_subclasses crash

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4138,7 +4138,7 @@ _PyType_GetSubclasses(PyTypeObject *self)
     }
 
     // Hold a strong reference to tp_subclasses while iterating on it
-    PyObject *dict = Py_XNewRef(self->tp_subclasses);
+    PyObject *dict = self->tp_subclasses;
     if (dict == NULL) {
         return list;
     }
@@ -4159,7 +4159,6 @@ _PyType_GetSubclasses(PyTypeObject *self)
         }
     }
 done:
-    Py_DECREF(dict);
     return list;
 }
 
@@ -6568,6 +6567,10 @@ remove_subclass(PyTypeObject *base, PyTypeObject *type)
         PyErr_Clear();
     }
     Py_XDECREF(key);
+
+    if (PyDict_Size(dict) == 0) {
+        Py_CLEAR(base->tp_subclasses);
+    }
 }
 
 static void


### PR DESCRIPTION
* _PyType_GetSubclasses() no longer holds a reference to
  tp_subclasses: its loop cannot modify tp_subclasses.
* remove_subclass() now sets tp_subclasses to NULL if the dictionary
  becomes empty.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46417](https://bugs.python.org/issue46417) -->
https://bugs.python.org/issue46417
<!-- /issue-number -->
