### PR TITLE
bpo-46425: fix direct invocation of `test_fileutils` and `test_zoneinfo`

### DIFF
--- a/Lib/test/test_fileutils.py
+++ b/Lib/test/test_fileutils.py
@@ -15,7 +15,7 @@ class PathTests(unittest.TestCase):
         if os.name == 'nt':
             raise unittest.SkipTest('Windows has its own helper for this')
         else:
-            from .test_posixpath import PosixPathTest as posixdata
+            from test.test_posixpath import PosixPathTest as posixdata
             tests = posixdata.NORMPATH_CASES
         for filename, expected in tests:
             if not os.path.isabs(filename):

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -17,8 +17,8 @@ import unittest
 from datetime import date, datetime, time, timedelta, timezone
 from functools import cached_property
 
-from . import _support as test_support
-from ._support import OS_ENV_LOCK, TZPATH_TEST_LOCK, ZoneInfoTestBase
+from test.test_zoneinfo import _support as test_support
+from test.test_zoneinfo._support import OS_ENV_LOCK, TZPATH_TEST_LOCK, ZoneInfoTestBase
 from test.support.import_helper import import_module
 
 lzma = import_module('lzma')
@@ -2107,3 +2107,7 @@ class ZoneDumpData:
 
     _ZONEDUMP_DATA = None
     _FIXED_OFFSET_ZONES = None
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
See https://github.com/python/cpython/pull/30725 for more context on this change.

Looks like this one of the last PRs in this series, only `idle` and `lib2to3` are left 🎉 

<!-- issue-number: [bpo-46425](https://bugs.python.org/issue46425) -->
https://bugs.python.org/issue46425
<!-- /issue-number -->
