### PR TITLE
bpo-46417: Clear more static types

### DIFF
--- a/Include/internal/pycore_context.h
+++ b/Include/internal/pycore_context.h
@@ -8,9 +8,11 @@
 #include "pycore_hamt.h"   /* PyHamtObject */
 
 
+extern PyTypeObject _PyContextTokenMissing_Type;
+
 /* runtime lifecycle */
 
-PyStatus _PyContext_InitTypes(PyInterpreterState *);
+PyStatus _PyContext_Init(PyInterpreterState *);
 void _PyContext_Fini(PyInterpreterState *);
 
 

--- a/Include/internal/pycore_hamt.h
+++ b/Include/internal/pycore_hamt.h
@@ -8,9 +8,16 @@
 #define _Py_HAMT_MAX_TREE_DEPTH 7
 
 
+extern PyTypeObject _PyHamt_Type;
+extern PyTypeObject _PyHamt_ArrayNode_Type;
+extern PyTypeObject _PyHamt_BitmapNode_Type;
+extern PyTypeObject _PyHamt_CollisionNode_Type;
+extern PyTypeObject _PyHamtKeys_Type;
+extern PyTypeObject _PyHamtValues_Type;
+extern PyTypeObject _PyHamtItems_Type;
+
 /* runtime lifecycle */
 
-PyStatus _PyHamt_InitTypes(PyInterpreterState *);
 void _PyHamt_Fini(PyInterpreterState *);
 
 
@@ -67,15 +74,6 @@ typedef struct {
     PyHamtIteratorState hi_iter;
     binaryfunc hi_yield;
 } PyHamtIterator;
-
-
-PyAPI_DATA(PyTypeObject) _PyHamt_Type;
-PyAPI_DATA(PyTypeObject) _PyHamt_ArrayNode_Type;
-PyAPI_DATA(PyTypeObject) _PyHamt_BitmapNode_Type;
-PyAPI_DATA(PyTypeObject) _PyHamt_CollisionNode_Type;
-PyAPI_DATA(PyTypeObject) _PyHamtKeys_Type;
-PyAPI_DATA(PyTypeObject) _PyHamtValues_Type;
-PyAPI_DATA(PyTypeObject) _PyHamtItems_Type;
 
 
 /* Create a new HAMT immutable mapping. */

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -4,6 +4,7 @@
 #include "Python.h"
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
+#include "pycore_context.h"       // _PyContextTokenMissing_Type
 #include "pycore_dict.h"          // _PyObject_MakeDictFromInstanceAttributes()
 #include "pycore_floatobject.h"   // _PyFloat_DebugMallocStats()
 #include "pycore_initconfig.h"    // _PyStatus_EXCEPTION()
@@ -1853,6 +1854,9 @@ static PyTypeObject* static_types[] = {
     &PyClassMethod_Type,
     &PyCode_Type,
     &PyComplex_Type,
+    &PyContextToken_Type,
+    &PyContextVar_Type,
+    &PyContext_Type,
     &PyCoro_Type,
     &PyDictItems_Type,
     &PyDictIterItem_Type,
@@ -1867,6 +1871,7 @@ static PyTypeObject* static_types[] = {
     &PyDict_Type,
     &PyEllipsis_Type,
     &PyEnum_Type,
+    &PyFilter_Type,
     &PyFloat_Type,
     &PyFrame_Type,
     &PyFrozenSet_Type,
@@ -1879,6 +1884,7 @@ static PyTypeObject* static_types[] = {
     &PyList_Type,
     &PyLongRangeIter_Type,
     &PyLong_Type,
+    &PyMap_Type,
     &PyMemberDescr_Type,
     &PyMemoryView_Type,
     &PyMethodDescr_Type,
@@ -1905,12 +1911,21 @@ static PyTypeObject* static_types[] = {
     &PyUnicodeIter_Type,
     &PyUnicode_Type,
     &PyWrapperDescr_Type,
+    &PyZip_Type,
     &Py_GenericAliasType,
     &_PyAnextAwaitable_Type,
     &_PyAsyncGenASend_Type,
     &_PyAsyncGenAThrow_Type,
     &_PyAsyncGenWrappedValue_Type,
+    &_PyContextTokenMissing_Type,
     &_PyCoroWrapper_Type,
+    &_PyHamtItems_Type,
+    &_PyHamtKeys_Type,
+    &_PyHamtValues_Type,
+    &_PyHamt_ArrayNode_Type,
+    &_PyHamt_BitmapNode_Type,
+    &_PyHamt_CollisionNode_Type,
+    &_PyHamt_Type,
     &_PyInterpreterID_Type,
     &_PyManagedBuffer_Type,
     &_PyMethodWrapper_Type,

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2986,11 +2986,6 @@ _PyBuiltin_Init(PyInterpreterState *interp)
 
     const PyConfig *config = _PyInterpreterState_GetConfig(interp);
 
-    if (PyType_Ready(&PyFilter_Type) < 0 ||
-        PyType_Ready(&PyMap_Type) < 0 ||
-        PyType_Ready(&PyZip_Type) < 0)
-        return NULL;
-
     mod = _PyModule_CreateInitialized(&builtinsmodule, PYTHON_API_VERSION);
     if (mod == NULL)
         return NULL;

--- a/Python/context.c
+++ b/Python/context.c
@@ -1260,7 +1260,7 @@ context_token_missing_tp_repr(PyObject *self)
 }
 
 
-PyTypeObject PyContextTokenMissing_Type = {
+PyTypeObject _PyContextTokenMissing_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "Token.MISSING",
     sizeof(PyContextTokenMissing),
@@ -1279,7 +1279,7 @@ get_token_missing(void)
     }
 
     _token_missing = (PyObject *)PyObject_New(
-        PyContextTokenMissing, &PyContextTokenMissing_Type);
+        PyContextTokenMissing, &_PyContextTokenMissing_Type);
     if (_token_missing == NULL) {
         return NULL;
     }
@@ -1323,23 +1323,10 @@ _PyContext_Fini(PyInterpreterState *interp)
 
 
 PyStatus
-_PyContext_InitTypes(PyInterpreterState *interp)
+_PyContext_Init(PyInterpreterState *interp)
 {
     if (!_Py_IsMainInterpreter(interp)) {
         return _PyStatus_OK();
-    }
-
-    PyStatus status = _PyHamt_InitTypes(interp);
-    if (_PyStatus_EXCEPTION(status)) {
-        return status;
-    }
-
-    if ((PyType_Ready(&PyContext_Type) < 0) ||
-        (PyType_Ready(&PyContextVar_Type) < 0) ||
-        (PyType_Ready(&PyContextToken_Type) < 0) ||
-        (PyType_Ready(&PyContextTokenMissing_Type) < 0))
-    {
-        return _PyStatus_ERR("can't init context types");
     }
 
     PyObject *missing = get_token_missing();

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -2953,27 +2953,6 @@ PyTypeObject _PyHamt_CollisionNode_Type = {
 };
 
 
-PyStatus
-_PyHamt_InitTypes(PyInterpreterState *interp)
-{
-    if (!_Py_IsMainInterpreter(interp)) {
-        return _PyStatus_OK();
-    }
-
-    if ((PyType_Ready(&_PyHamt_Type) < 0) ||
-        (PyType_Ready(&_PyHamt_ArrayNode_Type) < 0) ||
-        (PyType_Ready(&_PyHamt_BitmapNode_Type) < 0) ||
-        (PyType_Ready(&_PyHamt_CollisionNode_Type) < 0) ||
-        (PyType_Ready(&_PyHamtKeys_Type) < 0) ||
-        (PyType_Ready(&_PyHamtValues_Type) < 0) ||
-        (PyType_Ready(&_PyHamtItems_Type) < 0))
-    {
-        return _PyStatus_ERR("can't init hamt types");
-    }
-
-    return _PyStatus_OK();
-}
-
 void
 _PyHamt_Fini(PyInterpreterState *interp)
 {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -760,7 +760,7 @@ pycore_init_types(PyInterpreterState *interp)
         return status;
     }
 
-    status = _PyContext_InitTypes(interp);
+    status = _PyContext_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }


### PR DESCRIPTION
* Move PyContext static types into object.c static_types list.
* Rename PyContextTokenMissing_Type to _PyContextTokenMissing_Type
  and declare it in pycore_context.h.
* _PyHamtItems types are no long exported: replace PyAPI_DATA() with
  extern.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46417](https://bugs.python.org/issue46417) -->
https://bugs.python.org/issue46417
<!-- /issue-number -->
