### PR TITLE
bpo-45200: GHA Address Sanitizer skips 3 slowest tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,4 +306,9 @@ jobs:
     - name: Display build info
       run: make pythoninfo
     - name: Tests
-      run: xvfb-run make buildbottest TESTOPTS="-j4 -uall,-cpu -x test_ctypes test_crypt test_decimal test_faulthandler test_interpreters test___all__ test_idle test_tix test_tk test_ttk_guionly test_ttk_textonly test_multiprocessing_fork test_multiprocessing_forkserver test_multiprocessing_spawn"
+      # Skip test_tools test_peg_generator test_concurrent_futures because
+      # there are too slow: between 5 and 20 minutes on this CI.
+      #
+      # Skip multiprocessing and concurrent.futures tests which are affected by
+      # bpo-45200 bug: libasan dead lock in pthread_create().
+      run: xvfb-run make buildbottest TESTOPTS="-j4 -uall,-cpu -x test_ctypes test_crypt test_decimal test_faulthandler test_interpreters test___all__ test_idle test_tix test_tk test_ttk_guionly test_ttk_textonly test_multiprocessing_fork test_multiprocessing_forkserver test_multiprocessing_spawn test_tools test_peg_generator test_concurrent_futures"


### PR DESCRIPTION
Skip the 3 slowest tests of the Address Sanitizer CI of GitHub
Actions:

* test_tools
* test_peg_generator
* test_concurrent_futures

These tests take between 5 and 20 minutes on this CI which makes this
CI job the slowest. Making this CI job faster makes the whole Python
workflow faster. These tests are run on all others CIs.

Example of Address Sanitizer output:

    10 slowest tests:
    - test_peg_generator: 17 min 33 sec
    - test_tools: 8 min 27 sec
    - test_concurrent_futures: 5 min 24 sec
    - test_zipfile: 2 min 41 sec
    - test_compileall: 2 min 21 sec
    - test_asyncio: 2 min 17 sec
    - test_gdb: 1 min 43 sec
    - test_weakref: 1 min 35 sec
    - test_pickle: 1 min 18 sec
    - test_subprocess: 1 min 12 sec

Moreover, test_concurrent_futures also seems to be affected by
[bpo-45200](https://bugs.python.org/issue45200) bug: libasan dead lock in pthread_create().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45200](https://bugs.python.org/issue45200) -->
https://bugs.python.org/issue45200
<!-- /issue-number -->
