### PR TITLE
bpo-46425: Partially revert GH-30682

### DIFF
--- a/Lib/test/test_importlib/test_compatibilty_files.py
+++ b/Lib/test/test_importlib/test_compatibilty_files.py
@@ -8,7 +8,7 @@ from importlib.resources._adapters import (
     wrap_spec,
 )
 
-from test.test_importlib.resources import util
+from .resources import util
 
 
 class CompatibilityFilesTests(unittest.TestCase):
@@ -100,7 +100,3 @@ class CompatibilityFilesNoReaderTests(unittest.TestCase):
 
     def test_spec_path_joinpath(self):
         self.assertIsInstance(self.files / 'a', CompatibilityFiles.OrphanPath)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Lib/test/test_importlib/test_contents.py
+++ b/Lib/test/test_importlib/test_contents.py
@@ -1,8 +1,8 @@
 import unittest
 from importlib import resources
 
-from test.test_importlib import data01
-from test.test_importlib.resources import util
+from . import data01
+from .resources import util
 
 
 class ContentsTests:
@@ -38,10 +38,6 @@ class ContentsNamespaceTests(ContentsTests, unittest.TestCase):
     }
 
     def setUp(self):
-        from test.test_importlib import namespacedata01
+        from . import namespacedata01
 
         self.data = namespacedata01
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Lib/test/test_importlib/test_files.py
+++ b/Lib/test/test_importlib/test_files.py
@@ -3,8 +3,8 @@ import unittest
 
 from importlib import resources
 from importlib.abc import Traversable
-from test.test_importlib import data01
-from test.test_importlib.resources import util
+from . import data01
+from .resources import util
 
 
 class FilesTests:
@@ -37,7 +37,7 @@ class OpenZipTests(FilesTests, util.ZipSetup, unittest.TestCase):
 
 class OpenNamespaceTests(FilesTests, unittest.TestCase):
     def setUp(self):
-        from test.test_importlib import namespacedata01
+        from . import namespacedata01
 
         self.data = namespacedata01
 

--- a/Lib/test/test_importlib/test_main.py
+++ b/Lib/test/test_importlib/test_main.py
@@ -9,9 +9,9 @@ import importlib.metadata
 try:
     import pyfakefs.fake_filesystem_unittest as ffs
 except ImportError:
-    from test.test_importlib.stubs import fake_filesystem_unittest as ffs
+    from .stubs import fake_filesystem_unittest as ffs
 
-from test.test_importlib import fixtures
+from . import fixtures
 from importlib.metadata import (
     Distribution,
     EntryPoint,
@@ -315,7 +315,3 @@ class PackagesDistributionsTest(
             prefix=self.site_dir,
         )
         packages_distributions()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -5,7 +5,7 @@ import warnings
 import importlib
 import contextlib
 
-from test.test_importlib import fixtures
+from . import fixtures
 from importlib.metadata import (
     Distribution,
     PackageNotFoundError,
@@ -313,7 +313,3 @@ class InvalidateCache(unittest.TestCase):
     def test_invalidate_cache(self):
         # No externally observable behavior, but ensures test coverage...
         importlib.invalidate_caches()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Lib/test/test_importlib/test_open.py
+++ b/Lib/test/test_importlib/test_open.py
@@ -1,8 +1,8 @@
 import unittest
 
 from importlib import resources
-from test.test_importlib import data01
-from test.test_importlib.resources import util
+from . import data01
+from .resources import util
 
 
 class CommonBinaryTests(util.CommonTests, unittest.TestCase):
@@ -68,7 +68,7 @@ class OpenDiskTests(OpenTests, unittest.TestCase):
 
 class OpenDiskNamespaceTests(OpenTests, unittest.TestCase):
     def setUp(self):
-        from test.test_importlib import namespacedata01
+        from . import namespacedata01
 
         self.data = namespacedata01
 

--- a/Lib/test/test_importlib/test_path.py
+++ b/Lib/test/test_importlib/test_path.py
@@ -2,8 +2,8 @@ import io
 import unittest
 
 from importlib import resources
-from test.test_importlib import data01
-from test.test_importlib.resources import util
+from . import data01
+from .resources import util
 
 
 class CommonTests(util.CommonTests, unittest.TestCase):

--- a/Lib/test/test_importlib/test_read.py
+++ b/Lib/test/test_importlib/test_read.py
@@ -1,8 +1,8 @@
 import unittest
 
 from importlib import import_module, resources
-from test.test_importlib import data01
-from test.test_importlib.resources import util
+from . import data01
+from .resources import util
 
 
 class CommonBinaryTests(util.CommonTests, unittest.TestCase):
@@ -66,7 +66,7 @@ class ReadZipTests(ReadTests, util.ZipSetup, unittest.TestCase):
 
 class ReadNamespaceTests(ReadTests, unittest.TestCase):
     def setUp(self):
-        from test.test_importlib import namespacedata01
+        from . import namespacedata01
 
         self.data = namespacedata01
 

--- a/Lib/test/test_importlib/test_resource.py
+++ b/Lib/test/test_importlib/test_resource.py
@@ -3,8 +3,9 @@ import unittest
 import uuid
 import pathlib
 
-from test.test_importlib import data01, zipdata01, zipdata02
-from test.test_importlib.resources import util
+from . import data01
+from . import zipdata01, zipdata02
+from .resources import util
 from importlib import resources, import_module
 from test.support import import_helper
 from test.support.os_helper import unlink

--- a/Lib/test/test_importlib/test_zip.py
+++ b/Lib/test/test_importlib/test_zip.py
@@ -1,7 +1,7 @@
 import sys
 import unittest
 
-from test.test_importlib import fixtures
+from . import fixtures
 from importlib.metadata import (
     PackageNotFoundError,
     distribution,
@@ -60,6 +60,3 @@ class TestEgg(TestZip):
     def test_normalized_name(self):
         dist = distribution('example')
         assert dist._normalized_name == 'example'
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
This reverts commit 57316c52bae5d6420f5067f3891ec328deb97305 for files pertaining to importlib.metadata and importlib.resources ([rationale](https://github.com/python/cpython/pull/30682#issuecomment-1019330414)).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46425](https://bugs.python.org/issue46425) -->
https://bugs.python.org/issue46425
<!-- /issue-number -->
