### PR TITLE
bpo-46425: revert changes to `importlib.metadata` and `importlib.resources` tests

### DIFF
--- a/Lib/test/test_importlib/test_compatibilty_files.py
+++ b/Lib/test/test_importlib/test_compatibilty_files.py
@@ -8,7 +8,7 @@ from importlib.resources._adapters import (
     wrap_spec,
 )
 
-from test.test_importlib.resources import util
+from . import util
 
 
 class CompatibilityFilesTests(unittest.TestCase):
@@ -102,5 +102,5 @@ class CompatibilityFilesNoReaderTests(unittest.TestCase):
         self.assertIsInstance(self.files / 'a', CompatibilityFiles.OrphanPath)
 
 
-if __name__ == '__main__':
-    unittest.main()
+# This module is not suitable to be executed directly.
+# Use appropriate test tool.

--- a/Lib/test/test_importlib/test_contents.py
+++ b/Lib/test/test_importlib/test_contents.py
@@ -1,8 +1,8 @@
 import unittest
 from importlib import resources
 
-from test.test_importlib import data01
-from test.test_importlib.resources import util
+from . import data01
+from .resources import util
 
 
 class ContentsTests:
@@ -38,10 +38,10 @@ class ContentsNamespaceTests(ContentsTests, unittest.TestCase):
     }
 
     def setUp(self):
-        from test.test_importlib import namespacedata01
+        from . import namespacedata01
 
         self.data = namespacedata01
 
 
-if __name__ == '__main__':
-    unittest.main()
+# This module is not suitable to be executed directly.
+# Use appropriate test tool.

--- a/Lib/test/test_importlib/test_files.py
+++ b/Lib/test/test_importlib/test_files.py
@@ -3,8 +3,8 @@ import unittest
 
 from importlib import resources
 from importlib.abc import Traversable
-from test.test_importlib import data01
-from test.test_importlib.resources import util
+from . import data01
+from .resources import util
 
 
 class FilesTests:
@@ -37,10 +37,10 @@ class OpenZipTests(FilesTests, util.ZipSetup, unittest.TestCase):
 
 class OpenNamespaceTests(FilesTests, unittest.TestCase):
     def setUp(self):
-        from test.test_importlib import namespacedata01
+        from . import namespacedata01
 
         self.data = namespacedata01
 
 
-if __name__ == '__main__':
-    unittest.main()
+# This module is not suitable to be executed directly.
+# Use appropriate test tool.

--- a/Lib/test/test_importlib/test_main.py
+++ b/Lib/test/test_importlib/test_main.py
@@ -9,9 +9,9 @@ import importlib.metadata
 try:
     import pyfakefs.fake_filesystem_unittest as ffs
 except ImportError:
-    from test.test_importlib.stubs import fake_filesystem_unittest as ffs
+    from .stubs import fake_filesystem_unittest as ffs
 
-from test.test_importlib import fixtures
+from . import fixtures
 from importlib.metadata import (
     Distribution,
     EntryPoint,
@@ -317,5 +317,5 @@ class PackagesDistributionsTest(
         packages_distributions()
 
 
-if __name__ == '__main__':
-    unittest.main()
+# This module is not suitable to be executed directly.
+# Use appropriate test tool.

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -5,7 +5,7 @@ import warnings
 import importlib
 import contextlib
 
-from test.test_importlib import fixtures
+from . import fixtures
 from importlib.metadata import (
     Distribution,
     PackageNotFoundError,
@@ -315,5 +315,5 @@ class InvalidateCache(unittest.TestCase):
         importlib.invalidate_caches()
 
 
-if __name__ == '__main__':
-    unittest.main()
+# This module is not suitable to be executed directly.
+# Use appropriate test tool.

--- a/Lib/test/test_importlib/test_open.py
+++ b/Lib/test/test_importlib/test_open.py
@@ -1,8 +1,8 @@
 import unittest
 
 from importlib import resources
-from test.test_importlib import data01
-from test.test_importlib.resources import util
+from . import data01
+from .resources import util
 
 
 class CommonBinaryTests(util.CommonTests, unittest.TestCase):
@@ -68,7 +68,7 @@ class OpenDiskTests(OpenTests, unittest.TestCase):
 
 class OpenDiskNamespaceTests(OpenTests, unittest.TestCase):
     def setUp(self):
-        from test.test_importlib import namespacedata01
+        from . import namespacedata01
 
         self.data = namespacedata01
 
@@ -77,5 +77,5 @@ class OpenZipTests(OpenTests, util.ZipSetup, unittest.TestCase):
     pass
 
 
-if __name__ == '__main__':
-    unittest.main()
+# This module is not suitable to be executed directly.
+# Use appropriate test tool.

--- a/Lib/test/test_importlib/test_path.py
+++ b/Lib/test/test_importlib/test_path.py
@@ -2,8 +2,8 @@ import io
 import unittest
 
 from importlib import resources
-from test.test_importlib import data01
-from test.test_importlib.resources import util
+from . import data01
+from .resources import util
 
 
 class CommonTests(util.CommonTests, unittest.TestCase):
@@ -58,5 +58,5 @@ class PathZipTests(PathTests, util.ZipSetup, unittest.TestCase):
             path.unlink()
 
 
-if __name__ == '__main__':
-    unittest.main()
+# This module is not suitable to be executed directly.
+# Use appropriate test tool.

--- a/Lib/test/test_importlib/test_read.py
+++ b/Lib/test/test_importlib/test_read.py
@@ -1,8 +1,8 @@
 import unittest
 
 from importlib import import_module, resources
-from test.test_importlib import data01
-from test.test_importlib.resources import util
+from . import data01
+from .resources import util
 
 
 class CommonBinaryTests(util.CommonTests, unittest.TestCase):
@@ -66,10 +66,10 @@ class ReadZipTests(ReadTests, util.ZipSetup, unittest.TestCase):
 
 class ReadNamespaceTests(ReadTests, unittest.TestCase):
     def setUp(self):
-        from test.test_importlib import namespacedata01
+        from . import namespacedata01
 
         self.data = namespacedata01
 
 
-if __name__ == '__main__':
-    unittest.main()
+# This module is not suitable to be executed directly.
+# Use appropriate test tool.

--- a/Lib/test/test_importlib/test_resource.py
+++ b/Lib/test/test_importlib/test_resource.py
@@ -3,8 +3,9 @@ import unittest
 import uuid
 import pathlib
 
-from test.test_importlib import data01, zipdata01, zipdata02
-from test.test_importlib.resources import util
+from . import data01
+from . import zipdata01, zipdata02
+from .resources import util
 from importlib import resources, import_module
 from test.support import import_helper
 from test.support.os_helper import unlink
@@ -247,5 +248,5 @@ class ResourceFromNamespaceTest01(unittest.TestCase):
         self.assertEqual(contents, {'binary.file', 'utf-8.file', 'utf-16.file'})
 
 
-if __name__ == '__main__':
-    unittest.main()
+# This module is not suitable to be executed directly.
+# Use appropriate test tool.

--- a/Lib/test/test_importlib/test_zip.py
+++ b/Lib/test/test_importlib/test_zip.py
@@ -1,7 +1,7 @@
 import sys
 import unittest
 
-from test.test_importlib import fixtures
+from . import fixtures
 from importlib.metadata import (
     PackageNotFoundError,
     distribution,
@@ -61,5 +61,5 @@ class TestEgg(TestZip):
         dist = distribution('example')
         assert dist._normalized_name == 'example'
 
-if __name__ == '__main__':
-    unittest.main()
+# This module is not suitable to be executed directly.
+# Use appropriate test tool.


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/30682

CC @jaraco 

<!-- issue-number: [bpo-46425](https://bugs.python.org/issue46425) -->
https://bugs.python.org/issue46425
<!-- /issue-number -->
