### PR TITLE
bpo-41682: skip `test_sendfile_close_peer_in_the_middle_of_receiving` in `test_asyncio`

### DIFF
--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -456,6 +456,7 @@ class SendfileMixin(SendfileBase):
     # themselves).
     @unittest.skipIf(sys.platform.startswith('sunos'),
                      "Doesn't work on Solaris")
+    @unittest.skip("It is flaky and needs to be fixed")  # TODO: bpo-41682
     def test_sendfile_close_peer_in_the_middle_of_receiving(self):
         srv_proto, cli_proto = self.prepare_sendfile(close_after=1024)
         with self.assertRaises(ConnectionError):

--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -457,7 +457,7 @@ class SendfileMixin(SendfileBase):
     @unittest.skipIf(sys.platform.startswith('sunos'),
                      "Doesn't work on Solaris")
     @unittest.skipIf(sys.platform == "win32",
-                     "It is flaky on win and needs to be fixed")  # TODO: bpo-41682
+                     "It is flaky on Windows and needs to be fixed")  # TODO: bpo-41682
     def test_sendfile_close_peer_in_the_middle_of_receiving(self):
         srv_proto, cli_proto = self.prepare_sendfile(close_after=1024)
         with self.assertRaises(ConnectionError):

--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -456,7 +456,8 @@ class SendfileMixin(SendfileBase):
     # themselves).
     @unittest.skipIf(sys.platform.startswith('sunos'),
                      "Doesn't work on Solaris")
-    @unittest.skip("It is flaky and needs to be fixed")  # TODO: bpo-41682
+    @unittest.skipIf(sys.platform == "win32",
+                     "It is flaky on win and needs to be fixed")  # TODO: bpo-41682
     def test_sendfile_close_peer_in_the_middle_of_receiving(self):
         srv_proto, cli_proto = self.prepare_sendfile(close_after=1024)
         with self.assertRaises(ConnectionError):


### PR DESCRIPTION
It is failing way too often:
<img width="553" alt="Снимок экрана 2022-01-22 в 22 26 45" src="https://user-images.githubusercontent.com/4660275/150652868-a66b400b-fec9-415a-a7c4-f5e4e1eb6606.png">

Most of the commits above failed due to this single test.
I don't know how to fix it, but at least we can decrease the noise.

<!-- issue-number: [bpo-41682](https://bugs.python.org/issue41682) -->
https://bugs.python.org/issue41682
<!-- /issue-number -->
