### PR TITLE
bpo-46474: Avoid REDoS in EntryPoint.pattern (sync with importlib_metadata 4.10.1)

### DIFF
--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -156,8 +156,8 @@ class EntryPoint(DeprecatedTuple):
 
     pattern = re.compile(
         r'(?P<module>[\w.]+)\s*'
-        r'(:\s*(?P<attr>[\w.]+))?\s*'
-        r'(?P<extras>\[.*\])?\s*$'
+        r'(:\s*(?P<attr>[\w.]+)\s*)?'
+        r'((?P<extras>\[.*\])\s*)?$'
     )
     """
     A regular expression describing the syntax for an entry point,

--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -571,18 +571,6 @@ class Distribution:
         )
         return filter(None, declared)
 
-    @classmethod
-    def _local(cls, root='.'):
-        from pep517 import build, meta
-
-        system = build.compat_system(root)
-        builder = functools.partial(
-            meta.build,
-            source_dir=root,
-            system=system,
-        )
-        return PathDistribution(zipfile.Path(meta.build_as_zip(builder)))
-
     @property
     def metadata(self) -> _meta.PackageMetadata:
         """Return the parsed metadata for this Distribution.

--- a/Lib/test/test_importlib/fixtures.py
+++ b/Lib/test/test_importlib/fixtures.py
@@ -12,7 +12,7 @@ from test.support import requires_zlib
 from typing import Dict, Union
 
 try:
-    from importlib import resources
+    from importlib import resources  # type: ignore
 
     getattr(resources, 'files')
     getattr(resources, 'as_file')
@@ -230,21 +230,6 @@ class EggInfoFile(OnSysPath, SiteDir):
     def setUp(self):
         super().setUp()
         build_files(EggInfoFile.files, prefix=self.site_dir)
-
-
-class LocalPackage:
-    files: FilesDef = {
-        "setup.py": """
-            import setuptools
-            setuptools.setup(name="local-pkg", version="2.0.1")
-            """,
-    }
-
-    def setUp(self):
-        self.fixtures = contextlib.ExitStack()
-        self.addCleanup(self.fixtures.close)
-        self.fixtures.enter_context(tempdir_as_cwd())
-        build_files(self.files)
 
 
 def build_files(file_defs, prefix=pathlib.Path()):

--- a/Misc/NEWS.d/next/Library/2022-01-22-14-45-46.bpo-46474.2DUC62.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-22-14-45-46.bpo-46474.2DUC62.rst
@@ -1,0 +1,2 @@
+Removed private method from ``importlib.metadata.Path``. Sync with
+importlib_metadata 4.10.0.

--- a/Misc/NEWS.d/next/Library/2022-01-22-14-49-10.bpo-46474.eKQhvx.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-22-14-49-10.bpo-46474.eKQhvx.rst
@@ -1,0 +1,2 @@
+In ``importlib.metadata.EntryPoint.pattern``, avoid potential REDoS by
+limiting ambiguity in consecutive whitespace.


### PR DESCRIPTION
- [bpo-46474](https://bugs.python.org/issue46474): Fix for REDoS in EntryPoint.pattern (importlib_metadata 4.10.1).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46474](https://bugs.python.org/issue46474) -->
https://bugs.python.org/issue46474
<!-- /issue-number -->
