### PR TITLE
bpo-46417: Py_Finalize() clears static exceptioins

### DIFF
--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3543,7 +3543,7 @@ _PyExc_FiniTypes(PyInterpreterState *interp)
         return;
     }
 
-    for (size_t i=0; i < Py_ARRAY_LENGTH(static_exceptions); i++) {
+    for (Py_ssize_t i=Py_ARRAY_LENGTH(static_exceptions) - 1; i >= 0; i--) {
         PyTypeObject *exc = static_exceptions[i].exc;
 
         // Cannot delete a type if it still has subclasses

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3536,13 +3536,36 @@ _PyExc_InitTypes(PyInterpreterState *interp)
 }
 
 
+static void
+_PyExc_FiniTypes(PyInterpreterState *interp)
+{
+    if (!_Py_IsMainInterpreter(interp)) {
+        return;
+    }
+
+    for (size_t i=0; i < Py_ARRAY_LENGTH(static_exceptions); i++) {
+        PyTypeObject *exc = static_exceptions[i].exc;
+
+        // Cannot delete a type if it still has subclasses
+        if (exc->tp_subclasses != NULL) {
+            continue;
+        }
+
+        _PyStaticType_Dealloc(exc);
+    }
+}
+
+
 PyStatus
 _PyExc_InitGlobalObjects(PyInterpreterState *interp)
 {
+    if (!_Py_IsMainInterpreter(interp)) {
+        return _PyStatus_OK();
+    }
+
     if (preallocate_memerrors() < 0) {
         return _PyStatus_NO_MEMORY();
     }
-
     return _PyStatus_OK();
 }
 
@@ -3656,6 +3679,8 @@ _PyExc_Fini(PyInterpreterState *interp)
     struct _Py_exc_state *state = &interp->exc_state;
     free_preallocated_memerrors(state);
     Py_CLEAR(state->errnomap);
+
+    _PyExc_FiniTypes(interp);
 }
 
 /* Helper to do the equivalent of "raise X from Y" in C, but always using


### PR DESCRIPTION
The Py_Finalize() function now clears exceptions implemented as
static types.

Add _PyExc_FiniTypes() function, called by _PyExc_Fini().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46417](https://bugs.python.org/issue46417) -->
https://bugs.python.org/issue46417
<!-- /issue-number -->
