### PR TITLE
bpo-46417: Clear Unicode static types at exit

### DIFF
--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -17,6 +17,7 @@ extern void _PyUnicode_InitState(PyInterpreterState *);
 extern PyStatus _PyUnicode_InitGlobalObjects(PyInterpreterState *);
 extern PyStatus _PyUnicode_InitTypes(PyInterpreterState *);
 extern void _PyUnicode_Fini(PyInterpreterState *);
+extern void _PyUnicode_FiniTypes(PyInterpreterState *);
 
 
 /* other API */

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3545,12 +3545,6 @@ _PyExc_FiniTypes(PyInterpreterState *interp)
 
     for (Py_ssize_t i=Py_ARRAY_LENGTH(static_exceptions) - 1; i >= 0; i--) {
         PyTypeObject *exc = static_exceptions[i].exc;
-
-        // Cannot delete a type if it still has subclasses
-        if (exc->tp_subclasses != NULL) {
-            continue;
-        }
-
         _PyStaticType_Dealloc(exc);
     }
 }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1994,10 +1994,6 @@ _PyTypes_FiniTypes(PyInterpreterState *interp)
     // their base classes.
     for (Py_ssize_t i=Py_ARRAY_LENGTH(static_types)-1; i>=0; i--) {
         PyTypeObject *type = static_types[i];
-        // Cannot delete a type if it still has subclasses
-        if (type->tp_subclasses != NULL) {
-            continue;
-        }
         _PyStaticType_Dealloc(type);
     }
 }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4079,10 +4079,12 @@ type_dealloc_common(PyTypeObject *type)
 void
 _PyStaticType_Dealloc(PyTypeObject *type)
 {
-    // _PyStaticType_Dealloc() must not be called if a type has subtypes.
+    // If a type still has subtypes, it cannot be deallocated.
     // A subtype can inherit attributes and methods of its parent type,
     // and a type must no longer be used once it's deallocated.
-    assert(type->tp_subclasses == NULL);
+    if (type->tp_subclasses != NULL) {
+        return;
+    }
 
     type_dealloc_common(type);
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15567,23 +15567,19 @@ _PyUnicode_InitTypes(PyInterpreterState *interp)
         return _PyStatus_OK();
     }
 
-    if (PyType_Ready(&PyUnicode_Type) < 0) {
-        return _PyStatus_ERR("Can't initialize unicode type");
-    }
-    if (PyType_Ready(&PyUnicodeIter_Type) < 0) {
-        return _PyStatus_ERR("Can't initialize unicode iterator type");
-    }
-
     if (PyType_Ready(&EncodingMapType) < 0) {
-         return _PyStatus_ERR("Can't initialize encoding map type");
+        goto error;
     }
     if (PyType_Ready(&PyFieldNameIter_Type) < 0) {
-        return _PyStatus_ERR("Can't initialize field name iterator type");
+        goto error;
     }
     if (PyType_Ready(&PyFormatterIter_Type) < 0) {
-        return _PyStatus_ERR("Can't initialize formatter iter type");
+        goto error;
     }
     return _PyStatus_OK();
+
+error:
+    return _PyStatus_ERR("Can't initialize unicode types");
 }
 
 
@@ -16109,6 +16105,19 @@ unicode_is_finalizing(void)
     return (interned == NULL);
 }
 #endif
+
+
+void
+_PyUnicode_FiniTypes(PyInterpreterState *interp)
+{
+    if (!_Py_IsMainInterpreter(interp)) {
+        return;
+    }
+
+    _PyStaticType_Dealloc(&EncodingMapType);
+    _PyStaticType_Dealloc(&PyFieldNameIter_Type);
+    _PyStaticType_Dealloc(&PyFormatterIter_Type);
+}
 
 
 void

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1664,6 +1664,7 @@ flush_std_files(void)
 static void
 finalize_interp_types(PyInterpreterState *interp)
 {
+    _PyUnicode_FiniTypes(interp);
     _PySys_Fini(interp);
     _PyExc_Fini(interp);
     _PyFrame_Fini(interp);


### PR DESCRIPTION
Add _PyUnicode_FiniTypes() function, called by
finalize_interp_types(). It clears these static types:

* EncodingMapType
* PyFieldNameIter_Type
* PyFormatterIter_Type

_PyStaticType_Dealloc() now does nothing if tp_subclasses
is not NULL.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46417](https://bugs.python.org/issue46417) -->
https://bugs.python.org/issue46417
<!-- /issue-number -->
