### PR TITLE
bpo-46417: Clear _io module static objects at exit

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -29,6 +29,8 @@
 #include "pycore_typeobject.h"    // _PyTypes_InitTypes()
 #include "pycore_unicodeobject.h" // _PyUnicode_InitTypes()
 
+extern void _PyIO_Fini(void);
+
 #include <locale.h>               // setlocale()
 #include <stdlib.h>               // getenv()
 
@@ -1701,6 +1703,10 @@ finalize_interp_clear(PyThreadState *tstate)
 
     /* Clear interpreter state and all thread states */
     _PyInterpreterState_Clear(tstate);
+
+    if (is_main_interp) {
+        _PyIO_Fini();
+    }
 
     /* Clear all loghooks */
     /* Both _PySys_Audit function and users still need PyObject, such as tuple.


### PR DESCRIPTION
Add _PyIO_Fini() function, called by finalize_interp_clear(). It
clears static objects used by the _io extension module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46417](https://bugs.python.org/issue46417) -->
https://bugs.python.org/issue46417
<!-- /issue-number -->
