### PR TITLE
bpo-46417: Clear symtable identifiers at exit

### DIFF
--- a/Include/internal/pycore_symtable.h
+++ b/Include/internal/pycore_symtable.h
@@ -128,6 +128,8 @@ extern struct symtable* _Py_SymtableStringObjectFlags(
     int start,
     PyCompilerFlags *flags);
 
+extern void _PySymtable_Fini(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -119,7 +119,10 @@ class CmdLineTest(unittest.TestCase):
         rc, out, err = run_python('-X', 'showrefcount', '-c', code)
         self.assertEqual(out.rstrip(), b"{'showrefcount': True}")
         if Py_DEBUG:
-            self.assertRegex(err, br'^\[\d+ refs, \d+ blocks\]')
+            # bpo-46417: Tolerate negative reference count which can occur
+            # because of bugs in C extensions. This test is only about checking
+            # the showrefcount feature.
+            self.assertRegex(err, br'^\[-?\d+ refs, \d+ blocks\]')
         else:
             self.assertEqual(err, b'')
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -23,6 +23,7 @@
 #include "pycore_runtime_init.h"  // _PyRuntimeState_INIT
 #include "pycore_sliceobject.h"   // _PySlice_Fini()
 #include "pycore_structseq.h"     // _PyStructSequence_InitState()
+#include "pycore_symtable.h"      // _PySymtable_Fini()
 #include "pycore_sysmodule.h"     // _PySys_ClearAuditHooks()
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads()
 #include "pycore_tuple.h"         // _PyTuple_InitTypes()
@@ -1700,6 +1701,9 @@ finalize_interp_clear(PyThreadState *tstate)
     int is_main_interp = _Py_IsMainInterpreter(tstate->interp);
 
     _PyExc_ClearExceptionGroupType(tstate->interp);
+    if (is_main_interp) {
+        _PySymtable_Fini();
+    }
 
     /* Clear interpreter state and all thread states */
     _PyInterpreterState_Clear(tstate);

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1121,7 +1121,7 @@ static int
 symtable_add_def(struct symtable *st, PyObject *name, int flag,
                  int lineno, int col_offset, int end_lineno, int end_col_offset)
 {
-    return symtable_add_def_helper(st, name, flag, st->st_cur, 
+    return symtable_add_def_helper(st, name, flag, st->st_cur,
                         lineno, col_offset, end_lineno, end_col_offset);
 }
 
@@ -2134,7 +2134,7 @@ symtable_raise_if_annotation_block(struct symtable *st, const char *name, expr_t
 static int
 symtable_raise_if_comprehension_block(struct symtable *st, expr_ty e) {
     _Py_comprehension_ty type = st->st_cur->ste_comprehension;
-    PyErr_SetString(PyExc_SyntaxError, 
+    PyErr_SetString(PyExc_SyntaxError,
             (type == ListComprehension) ? "'yield' inside list comprehension" :
             (type == SetComprehension) ? "'yield' inside set comprehension" :
             (type == DictComprehension) ? "'yield' inside dict comprehension" :
@@ -2172,4 +2172,17 @@ _Py_SymtableStringObjectFlags(const char *str, PyObject *filename,
     PyObject_Free((void *)future);
     _PyArena_Free(arena);
     return st;
+}
+
+void
+_PySymtable_Fini(void)
+{
+    Py_CLEAR(top);
+    Py_CLEAR(lambda);
+    Py_CLEAR(genexpr);
+    Py_CLEAR(listcomp);
+    Py_CLEAR(setcomp);
+    Py_CLEAR(dictcomp);
+    Py_CLEAR(__class__);
+    Py_CLEAR(_annotation);
 }


### PR DESCRIPTION
Add _PySymtable_Fini() function, called by finalize_interp_clear().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46417](https://bugs.python.org/issue46417) -->
https://bugs.python.org/issue46417
<!-- /issue-number -->
