### PR TITLE
bpo-45382: test.pythoninfo logs more Windows versions

### DIFF
--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -744,11 +744,13 @@ def collect_windows(info_add):
         for line in output.splitlines():
             line = line.strip()
             if line.startswith('Caption='):
-                line = line.removeprefix('Caption=')
-                info_add('windows.version_caption', line.strip())
+                line = line.removeprefix('Caption=').strip()
+                if line:
+                    info_add('windows.version_caption', line)
             elif line.startswith('Version='):
-                line = line.removeprefix('Version=')
-                info_add('windows.version', line.strip())
+                line = line.removeprefix('Version=').strip()
+                if line:
+                    info_add('windows.version', line)
 
     try:
         proc = subprocess.Popen(["ver"], shell=True,
@@ -763,7 +765,8 @@ def collect_windows(info_add):
     else:
         output = output.strip()
         line = output.splitlines()[0]
-        info_add('windows.ver', line)
+        if line:
+            info_add('windows.ver', line)
 
 
 def collect_fips(info_add):

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -729,6 +729,42 @@ def collect_windows(info_add):
     except (ImportError, AttributeError):
         pass
 
+    import subprocess
+    try:
+        proc = subprocess.Popen(["wmic", "os", "get", "Caption,Version", "/value"],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                text=True)
+        output, stderr = proc.communicate()
+        if proc.returncode:
+            output = ""
+    except OSError:
+        pass
+    else:
+        for line in output.splitlines():
+            line = line.strip()
+            if line.startswith('Caption='):
+                line = line.removeprefix('Caption=')
+                info_add('windows.version_caption', line.strip())
+            elif line.startswith('Version='):
+                line = line.removeprefix('Version=')
+                info_add('windows.version', line.strip())
+
+    try:
+        proc = subprocess.Popen(["ver"], shell=True,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                text=True)
+        output = proc.communicate()[0]
+        if proc.returncode:
+            output = ""
+    except OSError:
+        return
+    else:
+        output = output.strip()
+        line = output.splitlines()[0]
+        info_add('windows.ver', line)
+
 
 def collect_fips(info_add):
     try:


### PR DESCRIPTION
Add the following info to test.pythoninfo:

* windows.ver: output of the shell "ver" command
* windows.version and windows.version_caption: output of the
  "wmic os get Caption,Version /value" command.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45382](https://bugs.python.org/issue45382) -->
https://bugs.python.org/issue45382
<!-- /issue-number -->
