### PR TITLE
bpo-46483: change `PurePath.__class_getitem__` to return `GenericAlias`

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -12,6 +12,7 @@ from errno import ENOENT, ENOTDIR, EBADF, ELOOP
 from operator import attrgetter
 from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO
 from urllib.parse import quote_from_bytes as urlquote_from_bytes
+from types import GenericAlias
 
 
 __all__ = [
@@ -690,8 +691,7 @@ class PurePath(object):
             return NotImplemented
         return self._cparts >= other._cparts
 
-    def __class_getitem__(cls, type):
-        return cls
+    __class_getitem__ = classmethod(GenericAlias)
 
     drive = property(attrgetter('_drv'),
                      doc="""The drive prefix (letter or UNC path), if any.""")

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2429,12 +2429,18 @@ class _BasePathTest(object):
     def test_complex_symlinks_relative_dot_dot(self):
         self._check_complex_symlinks(os.path.join('dirA', '..'))
 
+    def test_class_getitem(self):
+        from types import GenericAlias
+
+        alias = self.cls[str]
+        self.assertIsInstance(alias, GenericAlias)
+        self.assertIs(alias.__origin__, self.cls)
+        self.assertEqual(alias.__args__, (str,))
+        self.assertEqual(alias.__parameters__, ())
+
 
 class PathTest(_BasePathTest, unittest.TestCase):
     cls = pathlib.Path
-
-    def test_class_getitem(self):
-        self.assertIs(self.cls[str], self.cls)
 
     def test_concrete_class(self):
         p = self.cls('a')

--- a/Misc/NEWS.d/next/Library/2022-01-23-11-17-48.bpo-46483.j7qwWb.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-23-11-17-48.bpo-46483.j7qwWb.rst
@@ -1,0 +1,2 @@
+Change :meth:`pathlib.PurePath.__class_getitem__` to return
+:class:`types.GenericAlias`.


### PR DESCRIPTION
Refs:
- https://github.com/python/cpython/pull/17498
- https://github.com/python/cpython/pull/30777

CC @corona10 as my mentor.

<!-- issue-number: [bpo-46483](https://bugs.python.org/issue46483) -->
https://bugs.python.org/issue46483
<!-- /issue-number -->
