### PR TITLE
[3.8] bpo-46474: Avoid REDoS in EntryPoint.pattern (GH-30803).

### DIFF
--- a/Lib/importlib/metadata.py
+++ b/Lib/importlib/metadata.py
@@ -49,8 +49,8 @@ class EntryPoint(
 
     pattern = re.compile(
         r'(?P<module>[\w.]+)\s*'
-        r'(:\s*(?P<attr>[\w.]+))?\s*'
-        r'(?P<extras>\[.*\])?\s*$'
+        r'(:\s*(?P<attr>[\w.]+)\s*)?'
+        r'((?P<extras>\[.*\])\s*)?$'
         )
     """
     A regular expression describing the syntax for an entry point,

--- a/Misc/NEWS.d/next/Library/2022-01-22-14-49-10.bpo-46474.eKQhvx.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-22-14-49-10.bpo-46474.eKQhvx.rst
@@ -1,0 +1,2 @@
+In ``importlib.metadata.EntryPoint.pattern``, avoid potential REDoS by
+limiting ambiguity in consecutive whitespace.


### PR DESCRIPTION

(cherry picked from commit 51c3e28c8a163e58dc753765e3cc51d5a717e70d)

Co-authored-by: Jason R. Coombs <jaraco@jaraco.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46474](https://bugs.python.org/issue46474) -->
https://bugs.python.org/issue46474
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco