### PR TITLE
bpo-46483: remove `__class_getitem__` from `pathlib.PurePath`

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -562,6 +562,9 @@ Removed
   Python 3.4 but has been broken since Python 3.7.
   (Contributed by Inada Naoki in :issue:`23882`.)
 
+* Remove ``__class_getitem__`` method from :class:`pathlib.PurePath`,
+  because it was not used and added by mistake in previous versions.
+  (Contributed by Nikita Sobolev in :issue:`46483`.)
 
 Porting to Python 3.11
 ======================

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -12,7 +12,6 @@ from errno import ENOENT, ENOTDIR, EBADF, ELOOP
 from operator import attrgetter
 from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO
 from urllib.parse import quote_from_bytes as urlquote_from_bytes
-from types import GenericAlias
 
 
 __all__ = [
@@ -690,8 +689,6 @@ class PurePath(object):
         if not isinstance(other, PurePath) or self._flavour is not other._flavour:
             return NotImplemented
         return self._cparts >= other._cparts
-
-    __class_getitem__ = classmethod(GenericAlias)
 
     drive = property(attrgetter('_drv'),
                      doc="""The drive prefix (letter or UNC path), if any.""")

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2429,15 +2429,6 @@ class _BasePathTest(object):
     def test_complex_symlinks_relative_dot_dot(self):
         self._check_complex_symlinks(os.path.join('dirA', '..'))
 
-    def test_class_getitem(self):
-        from types import GenericAlias
-
-        alias = self.cls[str]
-        self.assertIsInstance(alias, GenericAlias)
-        self.assertIs(alias.__origin__, self.cls)
-        self.assertEqual(alias.__args__, (str,))
-        self.assertEqual(alias.__parameters__, ())
-
 
 class PathTest(_BasePathTest, unittest.TestCase):
     cls = pathlib.Path

--- a/Misc/NEWS.d/next/Library/2022-01-23-11-17-48.bpo-46483.j7qwWb.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-23-11-17-48.bpo-46483.j7qwWb.rst
@@ -1,2 +1,0 @@
-Change :meth:`pathlib.PurePath.__class_getitem__` to return
-:class:`types.GenericAlias`.

--- a/Misc/NEWS.d/next/Library/2022-01-24-13-00-09.bpo-46483.9XnmKp.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-24-13-00-09.bpo-46483.9XnmKp.rst
@@ -1,4 +1,1 @@
-Remove ``__class_getitem__`` from :class:`pathlib.PurePath`.
-
-Why? Because this class was not really generic:
-``PurePath`` only works with ``str``.
+Remove :meth:`~object.__class_getitem__` from :class:`pathlib.PurePath` as this class was not supposed to be generic.

--- a/Misc/NEWS.d/next/Library/2022-01-24-13-00-09.bpo-46483.9XnmKp.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-24-13-00-09.bpo-46483.9XnmKp.rst
@@ -1,4 +1,4 @@
 Remove ``__class_getitem__`` from :class:`pathlib.PurePath`.
 
 Why? Because this class was not really generic: 
-`PurePath` only works with `str`. 
+``PurePath`` only works with ``str``. 

--- a/Misc/NEWS.d/next/Library/2022-01-24-13-00-09.bpo-46483.9XnmKp.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-24-13-00-09.bpo-46483.9XnmKp.rst
@@ -1,0 +1,1 @@
+Remove ``__class_getitem__`` from :class:`pathlib.PurePath`

--- a/Misc/NEWS.d/next/Library/2022-01-24-13-00-09.bpo-46483.9XnmKp.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-24-13-00-09.bpo-46483.9XnmKp.rst
@@ -1,4 +1,4 @@
 Remove ``__class_getitem__`` from :class:`pathlib.PurePath`.
 
-Why? Because this class was not really generic: 
-``PurePath`` only works with ``str``. 
+Why? Because this class was not really generic:
+``PurePath`` only works with ``str``.

--- a/Misc/NEWS.d/next/Library/2022-01-24-13-00-09.bpo-46483.9XnmKp.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-24-13-00-09.bpo-46483.9XnmKp.rst
@@ -1,1 +1,4 @@
-Remove ``__class_getitem__`` from :class:`pathlib.PurePath`
+Remove ``__class_getitem__`` from :class:`pathlib.PurePath`.
+
+Why? Because this class was not really generic: 
+`PurePath` only works with `str`. 


### PR DESCRIPTION
@serhiy-storchaka proposed removing `__class_getitem__` from `PurePath`.
CC @asvetlov and @isidentical as original PR authors: https://github.com/python/cpython/pull/17498

Why?
1. It is not used anywhere in our code (obviously)
2. It is not really generic, because `PurePath` always works with `str` (unlike `os.PathLike[bytes | str]`
3. In typeshed `PurePath` is not generic: https://github.com/python/typeshed/blob/35064a7f759facd7c3787ab6095964008f97d873/stdlib/pathlib.pyi#L20

Related https://github.com/python/cpython/pull/30822

CC @corona10 as my mentor

<!-- issue-number: [bpo-46483](https://bugs.python.org/issue46483) -->
https://bugs.python.org/issue46483
<!-- /issue-number -->
