### PR TITLE
bpo-46504: faster code for trial quotient in x_divrem()

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -2767,8 +2767,15 @@ x_divrem(PyLongObject *v1, PyLongObject *w1, PyLongObject **prem)
         vtop = vk[size_w];
         assert(vtop <= wm1);
         vv = ((twodigits)vtop << PyLong_SHIFT) | vk[size_w-1];
+        /* The code used to compute the remainder via
+         *     r = (digit)(vv - (twodigits)wm1 * q);
+         * and compilers generally generated code to do the * and -.
+         * But modern p;ocessors generally compute q and r with a single
+         * instruction, and modern optimizing compilers exploit that if we
+         * _don't_ try to optimize it.
+         */
         q = (digit)(vv / wm1);
-        r = (digit)(vv - (twodigits)wm1 * q); /* r = vv % wm1 */
+        r = (digit)(vv % wm1);
         while ((twodigits)wm2 * q > (((twodigits)r << PyLong_SHIFT)
                                      | vk[size_w-2])) {
             --q;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -2770,7 +2770,7 @@ x_divrem(PyLongObject *v1, PyLongObject *w1, PyLongObject **prem)
         /* The code used to compute the remainder via
          *     r = (digit)(vv - (twodigits)wm1 * q);
          * and compilers generally generated code to do the * and -.
-         * But modern p;ocessors generally compute q and r with a single
+         * But modern processors generally compute q and r with a single
          * instruction, and modern optimizing compilers exploit that if we
          * _don't_ try to optimize it.
          */


### PR DESCRIPTION
This brings x_divrem() back into synch with x_divrem1(), which was changed
in [bpo-46406](https://bugs.python.org/issue46406) to generate faster code to find machine-word division
quotients and remainders. Modern processors compute both with a single
machine instruction, but convincing C to exploit that requires writing
_less_ "clever" C code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46504](https://bugs.python.org/issue46504) -->
https://bugs.python.org/issue46504
<!-- /issue-number -->
