### PR TITLE
bpo-39064: make ZipFile raise BadZipFile instead of ValueError when reading a corrupt file

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1366,7 +1366,10 @@ class ZipFile:
             print("given, inferred, offset", offset_cd, inferred, concat)
         # self.start_dir:  Position of start of central directory
         self.start_dir = offset_cd + concat
-        fp.seek(self.start_dir, 0)
+        try:
+            fp.seek(self.start_dir, 0)
+        except ValueError as e:
+            raise BadZipFile("Bad offset for central directory")
         data = fp.read(size_cd)
         fp = io.BytesIO(data)
         total = 0


### PR DESCRIPTION
I don't know how to write a test for this.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-39064](https://bugs.python.org/issue39064) -->
https://bugs.python.org/issue39064
<!-- /issue-number -->
