### PR TITLE
bpo-46503: Prevent an assert from firing when parsing some invalid \N sequences in f-strings.

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -746,12 +746,16 @@ x = (
         # differently inside f-strings.
         self.assertAllRaise(SyntaxError, r"\(unicode error\) 'unicodeescape' codec can't decode bytes in position .*: malformed \\N character escape",
                             [r"f'\N'",
+                             r"f'\N '",
+                             r"f'\N  '",  # See bpo-46503.
                              r"f'\N{'",
                              r"f'\N{GREEK CAPITAL LETTER DELTA'",
 
                              # Here are the non-f-string versions,
                              #  which should give the same errors.
                              r"'\N'",
+                             r"'\N '",
+                             r"'\N  '",
                              r"'\N{'",
                              r"'\N{GREEK CAPITAL LETTER DELTA'",
                              ])

--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-24-21-24-41.bpo-46503.4UrPsE.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-24-21-24-41.bpo-46503.4UrPsE.rst
@@ -1,0 +1,1 @@
+Fix an assert when parsing some invalid \N escape sequences in f-strings.


### PR DESCRIPTION
Also, fix a nearby tiny PEP 7 nit.

<!-- issue-number: [bpo-46503](https://bugs.python.org/issue46503) -->
https://bugs.python.org/issue46503
<!-- /issue-number -->
