### PR TITLE
bpo-33125: Enables building traditional installer for Windows ARM64

### DIFF
--- a/.azure-pipelines/windows-release.yml
+++ b/.azure-pipelines/windows-release.yml
@@ -34,6 +34,10 @@ parameters:
   displayName: "Signature description"
   type: string
   default: 'Built: $(Build.BuildNumber)'
+- name: DoARM64
+  displayName: "Publish ARM64 build"
+  type: boolean
+  default: true
 - name: DoPGO
   displayName: "Run PGO"
   type: boolean
@@ -64,25 +68,26 @@ parameters:
   default: '0'
 
 variables:
-    __RealSigningCertificate: 'Python Software Foundation'
-    ${{ if ne(parameters.GitRemote, '(Other)') }}:
-      GitRemote: ${{ parameters.GitRemote }}
-    ${{ else }}:
-      GitRemote: ${{ parameters.GitRemote_Other }}
-    SourceTag: ${{ parameters.SourceTag }}
-    DoPGO: ${{ parameters.DoPGO }}
-    ${{ if ne(parameters.SigningCertificate, 'Unsigned') }}:
-      SigningCertificate: ${{ parameters.SigningCertificate }}
-    SigningDescription: ${{ parameters.SigningDescription }}
-    DoLayout: ${{ parameters.DoLayout }}
-    DoMSIX: ${{ parameters.DoMSIX }}
-    DoNuget: ${{ parameters.DoNuget }}
-    DoEmbed: ${{ parameters.DoEmbed }}
-    DoMSI: ${{ parameters.DoMSI }}
-    DoPublish: ${{ parameters.DoPublish }}
+  __RealSigningCertificate: 'Python Software Foundation'
+  ${{ if ne(parameters.GitRemote, '(Other)') }}:
+    GitRemote: ${{ parameters.GitRemote }}
+  ${{ else }}:
+    GitRemote: ${{ parameters.GitRemote_Other }}
+  SourceTag: ${{ parameters.SourceTag }}
+  DoPGO: ${{ parameters.DoPGO }}
+  ${{ if ne(parameters.SigningCertificate, 'Unsigned') }}:
+    SigningCertificate: ${{ parameters.SigningCertificate }}
+  SigningDescription: ${{ parameters.SigningDescription }}
+  DoLayout: ${{ parameters.DoLayout }}
+  DoMSIX: ${{ parameters.DoMSIX }}
+  DoNuget: ${{ parameters.DoNuget }}
+  DoEmbed: ${{ parameters.DoEmbed }}
+  DoMSI: ${{ parameters.DoMSI }}
+  DoPublish: ${{ parameters.DoPublish }}
+  PublishARM64: ${{ parameters.DoARM64 }}
 # QUEUE TIME VARIABLES
-#    PyDotOrgUsername: ''
-#    PyDotOrgServer: ''
+#  PyDotOrgUsername: ''
+#  PyDotOrgServer: ''
 
 trigger: none
 pr: none

--- a/.azure-pipelines/windows-release/msi-steps.yml
+++ b/.azure-pipelines/windows-release/msi-steps.yml
@@ -103,6 +103,7 @@ steps:
       Platform: x86
       Py_OutDir: $(Build.BinariesDirectory)
       PYTHON: $(Build.BinariesDirectory)\win32\python.exe
+      PythonForBuild: $(Build.BinariesDirectory)\win32\python.exe
       PYTHONHOME: $(Build.SourcesDirectory)
       TclTkLibraryDir: $(Build.BinariesDirectory)\tcltk_lib_win32
       BuildForRelease: true
@@ -115,6 +116,7 @@ steps:
       Platform: x64
       Py_OutDir: $(Build.BinariesDirectory)
       PYTHON: $(Build.BinariesDirectory)\amd64\python.exe
+      PythonForBuild: $(Build.BinariesDirectory)\amd64\python.exe
       PYTHONHOME: $(Build.SourcesDirectory)
       TclTkLibraryDir: $(Build.BinariesDirectory)\tcltk_lib_amd64
       BuildForRelease: true
@@ -128,6 +130,7 @@ steps:
       Platform: ARM64
       Py_OutDir: $(Build.BinariesDirectory)
       PYTHON: $(Build.BinariesDirectory)\win32\python.exe
+      PythonForBuild: $(Build.BinariesDirectory)\win32\python.exe
       PYTHONHOME: $(Build.SourcesDirectory)
       BuildForRelease: true
       SuppressMinGWLib: true

--- a/.azure-pipelines/windows-release/msi-steps.yml
+++ b/.azure-pipelines/windows-release/msi-steps.yml
@@ -46,6 +46,20 @@ steps:
       targetPath: $(Build.BinariesDirectory)\amd64
 
   - task: DownloadPipelineArtifact@1
+    displayName: 'Download artifact: bin_arm64'
+    condition: and(succeeded(), eq(variables['PublishARM64'], 'true'))
+    inputs:
+      artifactName: bin_arm64
+      targetPath: $(Build.BinariesDirectory)\arm64
+
+  - task: DownloadPipelineArtifact@1
+    displayName: 'Download artifact: bin_arm64_d'
+    condition: and(succeeded(), eq(variables['PublishARM64'], 'true'))
+    inputs:
+      artifactName: bin_arm64_d
+      targetPath: $(Build.BinariesDirectory)\arm64
+
+  - task: DownloadPipelineArtifact@1
     displayName: 'Download artifact: tcltk_lib_win32'
     inputs:
       artifactName: tcltk_lib_win32
@@ -84,7 +98,6 @@ steps:
 
   - script: |
       %MSBUILD% Tools\msi\bundle\releaselocal.wixproj /t:Rebuild /p:RebuildAll=true
-      %MSBUILD% Tools\msi\bundle\releaseweb.wixproj /t:Rebuild /p:RebuildAll=false
     displayName: 'Build win32 installer'
     env:
       Platform: x86
@@ -97,7 +110,6 @@ steps:
 
   - script: |
       %MSBUILD% Tools\msi\bundle\releaselocal.wixproj /t:Rebuild /p:RebuildAll=true
-      %MSBUILD% Tools\msi\bundle\releaseweb.wixproj /t:Rebuild /p:RebuildAll=false
     displayName: 'Build amd64 installer'
     env:
       Platform: x64
@@ -108,8 +120,20 @@ steps:
       BuildForRelease: true
       SuppressMinGWLib: true
 
+  - script: |
+      %MSBUILD% Tools\msi\bundle\releaselocal.wixproj /t:Rebuild /p:RebuildAll=true
+    displayName: 'Build arm64 installer'
+    condition: and(succeeded(), eq(variables['PublishARM64'], 'true'))
+    env:
+      Platform: ARM64
+      Py_OutDir: $(Build.BinariesDirectory)
+      PYTHON: $(Build.BinariesDirectory)\win32\python.exe
+      PYTHONHOME: $(Build.SourcesDirectory)
+      BuildForRelease: true
+      SuppressMinGWLib: true
+
   - task: CopyFiles@2
-    displayName: 'Assemble artifact: msi (1/2)'
+    displayName: 'Assemble artifact: msi (win32)'
     inputs:
       sourceFolder: $(Build.BinariesDirectory)\win32\en-us
       targetFolder: $(Build.ArtifactStagingDirectory)\msi\win32
@@ -119,10 +143,21 @@ steps:
         *.exe
 
   - task: CopyFiles@2
-    displayName: 'Assemble artifact: msi (2/2)'
+    displayName: 'Assemble artifact: msi (amd64)'
     inputs:
       sourceFolder: $(Build.BinariesDirectory)\amd64\en-us
       targetFolder: $(Build.ArtifactStagingDirectory)\msi\amd64
+      contents: |
+        *.msi
+        *.cab
+        *.exe
+
+  - task: CopyFiles@2
+    displayName: 'Assemble artifact: msi (arm64)'
+    condition: and(succeeded(), eq(variables['PublishARM64'], 'true'))
+    inputs:
+      sourceFolder: $(Build.BinariesDirectory)\arm64\en-us
+      targetFolder: $(Build.ArtifactStagingDirectory)\msi\arm64
       contents: |
         *.msi
         *.cab

--- a/.azure-pipelines/windows-release/stage-publish-nugetorg.yml
+++ b/.azure-pipelines/windows-release/stage-publish-nugetorg.yml
@@ -36,9 +36,9 @@ jobs:
 
 
   - powershell: 'gci pythonarm*.nupkg | %{ Write-Host "Not publishing: $($_.Name)"; gi $_ } | del'
-    displayName: 'Prevent publishing ARM/ARM64 packages'
+    displayName: 'Prevent publishing ARM64 packages'
     workingDirectory: '$(Build.BinariesDirectory)\nuget'
-    condition: and(succeeded(), not(variables['PublishArmPackages']))
+    condition: and(succeeded(), eq(variables['PublishARM64'], 'true'))
 
   - task: NuGetCommand@2
     displayName: Push packages

--- a/.azure-pipelines/windows-release/stage-publish-pythonorg.yml
+++ b/.azure-pipelines/windows-release/stage-publish-pythonorg.yml
@@ -77,10 +77,11 @@ jobs:
         downloadPath: $(Build.BinariesDirectory)
 
 
+  # Note that ARM64 MSIs are skipped at build when this option is specified
   - powershell: 'gci *embed-arm*.zip | %{ Write-Host "Not publishing: $($_.Name)"; gi $_ } | del'
-    displayName: 'Prevent publishing ARM/ARM64 packages'
+    displayName: 'Prevent publishing ARM64 packages'
     workingDirectory: '$(Build.BinariesDirectory)\embed'
-    condition: and(succeeded(), not(variables['PublishArmPackages']))
+    condition: and(succeeded(), eq(variables['PublishARM64'], 'true'))
 
 
   - template: ./gpg-sign.yml

--- a/.azure-pipelines/windows-release/stage-test-msi.yml
+++ b/.azure-pipelines/windows-release/stage-test-msi.yml
@@ -11,19 +11,19 @@ jobs:
   strategy:
     matrix:
       win32_User:
-        ExeMatch: 'python-[\dabrc.]+-webinstall\.exe'
+        ExeMatch: 'python-[\dabrc.]+\.exe'
         Logs: $(Build.ArtifactStagingDirectory)\logs\win32_User
         InstallAllUsers: 0
       win32_Machine:
-        ExeMatch: 'python-[\dabrc.]+-webinstall\.exe'
+        ExeMatch: 'python-[\dabrc.]+\.exe'
         Logs: $(Build.ArtifactStagingDirectory)\logs\win32_Machine
         InstallAllUsers: 1
       amd64_User:
-        ExeMatch: 'python-[\dabrc.]+-amd64-webinstall\.exe'
+        ExeMatch: 'python-[\dabrc.]+-amd64\.exe'
         Logs: $(Build.ArtifactStagingDirectory)\logs\amd64_User
         InstallAllUsers: 0
       amd64_Machine:
-        ExeMatch: 'python-[\dabrc.]+-amd64-webinstall\.exe'
+        ExeMatch: 'python-[\dabrc.]+-amd64\.exe'
         Logs: $(Build.ArtifactStagingDirectory)\logs\amd64_Machine
         InstallAllUsers: 1
 

--- a/.github/workflows/build_msi.yml
+++ b/.github/workflows/build_msi.yml
@@ -37,3 +37,11 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build CPython installer
       run: .\Tools\msi\build.bat -x64
+
+  build_win_arm64:
+    name: 'Windows (ARM64) Installer'
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build CPython installer
+      run: .\Tools\msi\build.bat -arm64

--- a/Misc/NEWS.d/next/Windows/2022-01-25-14-48-39.bpo-33125.5WyY_J.rst
+++ b/Misc/NEWS.d/next/Windows/2022-01-25-14-48-39.bpo-33125.5WyY_J.rst
@@ -1,0 +1,2 @@
+The traditional EXE/MSI based installer for Windows is now available for
+ARM64

--- a/PCbuild/openssl.props
+++ b/PCbuild/openssl.props
@@ -13,6 +13,7 @@
     <_DLLSuffix>-1_1</_DLLSuffix>
     <_DLLSuffix Condition="$(Platform) == 'ARM'">$(_DLLSuffix)-arm</_DLLSuffix>
     <_DLLSuffix Condition="$(Platform) == 'ARM64'">$(_DLLSuffix)-arm64</_DLLSuffix>
+    <OpenSSLDLLSuffix>$(_DLLSuffix)</OpenSSLDLLSuffix>
   </PropertyGroup>
   <ItemGroup>
     <_SSLDLL Include="$(opensslOutDir)\libcrypto$(_DLLSuffix).dll" />
@@ -20,10 +21,14 @@
     <_SSLDLL Include="$(opensslOutDir)\libssl$(_DLLSuffix).dll" />
     <_SSLDLL Include="$(opensslOutDir)\libssl$(_DLLSuffix).pdb" />
   </ItemGroup>
-  <Target Name="_CopySSLDLL" Inputs="@(_SSLDLL)" Outputs="@(_SSLDLL->'$(OutDir)%(Filename)%(Extension)')" AfterTargets="Build">
+  <Target Name="_CopySSLDLL"
+          Inputs="@(_SSLDLL)"
+          Outputs="@(_SSLDLL->'$(OutDir)%(Filename)%(Extension)')"
+          Condition="$(SkipCopySSLDLL) == ''"
+          AfterTargets="Build">
     <Copy SourceFiles="@(_SSLDLL)" DestinationFolder="$(OutDir)" />
   </Target>
-  <Target Name="_CleanSSLDLL" BeforeTargets="Clean">
+  <Target Name="_CleanSSLDLL" Condition="$(SkipCopySSLDLL) == ''" BeforeTargets="Clean">
     <Delete Files="@(_SSLDLL->'$(OutDir)%(Filename)%(Extension)')" TreatErrorsAsWarnings="true" />
   </Target>
 </Project>

--- a/PCbuild/tcltk.props
+++ b/PCbuild/tcltk.props
@@ -29,6 +29,7 @@
     <tcltkLib>$(tcltkDir)lib\tcl$(TclMajorVersion)$(TclMinorVersion)t$(TclDebugExt).lib;$(tcltkDir)lib\tk$(TkMajorVersion)$(TkMinorVersion)t$(TclDebugExt).lib</tcltkLib>
     <TclMachine>IX86</TclMachine>
     <TclMachine Condition="'$(Platform)' == 'x64'">AMD64</TclMachine>
+    <TclMachine Condition="'$(Platform)' == 'ARM64'">ARM64</TclMachine>
     <TclVersions>TCL_MAJOR_VERSION=$(TclMajorVersion) TCL_MINOR_VERSION=$(TclMinorVersion) TCL_PATCH_LEVEL=$(TclPatchLevel)</TclVersions>
     <TclShortVersions>TCL_MAJOR=$(TclMajorVersion) TCL_MINOR=$(TclMinorVersion) TCL_PATCH=$(TclPatchLevel)</TclShortVersions>
     <TkVersions>TK_MAJOR_VERSION=$(TkMajorVersion) TK_MINOR_VERSION=$(TkMinorVersion) TK_PATCH_LEVEL=$(TkPatchLevel)</TkVersions>

--- a/Tools/msi/appendpath/appendpath.wxs
+++ b/Tools/msi/appendpath/appendpath.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         
         <PropertyRef Id="UpgradeTable" />
         <PropertyRef Id="REGISTRYKEY" />

--- a/Tools/msi/buildrelease.bat
+++ b/Tools/msi/buildrelease.bat
@@ -195,8 +195,6 @@ set BUILDOPTS=/p:Platform=%1 /p:BuildForRelease=true /p:DownloadUrl=%DOWNLOAD_UR
 if defined BUILDMSI (
     %MSBUILD% "%D%bundle\releaselocal.wixproj" /t:Rebuild %BUILDOPTS% %CERTOPTS% /p:RebuildAll=true
     if errorlevel 1 exit /B
-    %MSBUILD% "%D%bundle\releaseweb.wixproj" /t:Rebuild %BUILDOPTS% %CERTOPTS% /p:RebuildAll=false
-    if errorlevel 1 exit /B
 )
 
 if defined BUILDZIP (

--- a/Tools/msi/buildrelease.bat
+++ b/Tools/msi/buildrelease.bat
@@ -85,14 +85,6 @@ call "%D%..\..\doc\make.bat" htmlhelp
 if errorlevel 1 goto :eof
 :skipdoc
 
-rem where dlltool /q && goto skipdlltoolsearch
-rem set _DLLTOOL_PATH=
-rem where /R "%EXTERNALS%\" dlltool > "%TEMP%\dlltool.loc" 2> nul && set /P _DLLTOOL_PATH= < "%TEMP%\dlltool.loc" & del "%TEMP%\dlltool.loc"
-rem if not exist "%_DLLTOOL_PATH%" echo Cannot find binutils on PATH or in external && exit /B 1
-rem for %%f in (%_DLLTOOL_PATH%) do set PATH=%PATH%;%%~dpf
-rem set _DLLTOOL_PATH=
-:skipdlltoolsearch
-
 if defined BUILDX86 (
     call :build x86
     if errorlevel 1 exit /B

--- a/Tools/msi/buildrelease.bat
+++ b/Tools/msi/buildrelease.bat
@@ -34,6 +34,7 @@ set EXTERNALS=%D%..\..\externals\windows-installer\
 
 set BUILDX86=
 set BUILDX64=
+set BUILDARM64=
 set TARGET=Rebuild
 set TESTTARGETDIR=
 set PGO=-m test -q --pgo
@@ -58,6 +59,7 @@ if "%1" EQU "-b" (set TARGET=Build) && shift && goto CheckOpts
 if "%1" EQU "--build" (set TARGET=Build) && shift && goto CheckOpts
 if "%1" EQU "-x86" (set BUILDX86=1) && shift && goto CheckOpts
 if "%1" EQU "-x64" (set BUILDX64=1) && shift && goto CheckOpts
+if "%1" EQU "-arm64" (set BUILDARM64=1) && shift && goto CheckOpts
 if "%1" EQU "--pgo" (set PGO=%~2) && shift && shift && goto CheckOpts
 if "%1" EQU "--skip-pgo" (set PGO=) && shift && goto CheckOpts
 if "%1" EQU "--skip-nuget" (set BUILDNUGET=) && shift && goto CheckOpts
@@ -66,7 +68,7 @@ if "%1" EQU "--skip-msi" (set BUILDMSI=) && shift && goto CheckOpts
 
 if "%1" NEQ "" echo Invalid option: "%1" && exit /B 1
 
-if not defined BUILDX86 if not defined BUILDX64 (set BUILDX86=1) && (set BUILDX64=1)
+if not defined BUILDX86 if not defined BUILDX64 if not defined BUILDARM64 (set BUILDX86=1) && (set BUILDX64=1)
 
 if not exist "%GIT%" where git > "%TEMP%\git.loc" 2> nul && set /P GIT= < "%TEMP%\git.loc" & del "%TEMP%\git.loc"
 if not exist "%GIT%" echo Cannot find Git on PATH && exit /B 1
@@ -83,12 +85,12 @@ call "%D%..\..\doc\make.bat" htmlhelp
 if errorlevel 1 goto :eof
 :skipdoc
 
-where dlltool /q && goto skipdlltoolsearch
-set _DLLTOOL_PATH=
-where /R "%EXTERNALS%\" dlltool > "%TEMP%\dlltool.loc" 2> nul && set /P _DLLTOOL_PATH= < "%TEMP%\dlltool.loc" & del "%TEMP%\dlltool.loc"
-if not exist "%_DLLTOOL_PATH%" echo Cannot find binutils on PATH or in external && exit /B 1
-for %%f in (%_DLLTOOL_PATH%) do set PATH=%PATH%;%%~dpf
-set _DLLTOOL_PATH=
+rem where dlltool /q && goto skipdlltoolsearch
+rem set _DLLTOOL_PATH=
+rem where /R "%EXTERNALS%\" dlltool > "%TEMP%\dlltool.loc" 2> nul && set /P _DLLTOOL_PATH= < "%TEMP%\dlltool.loc" & del "%TEMP%\dlltool.loc"
+rem if not exist "%_DLLTOOL_PATH%" echo Cannot find binutils on PATH or in external && exit /B 1
+rem for %%f in (%_DLLTOOL_PATH%) do set PATH=%PATH%;%%~dpf
+rem set _DLLTOOL_PATH=
 :skipdlltoolsearch
 
 if defined BUILDX86 (
@@ -98,6 +100,11 @@ if defined BUILDX86 (
 
 if defined BUILDX64 (
     call :build x64 "%PGO%"
+    if errorlevel 1 exit /B
+)
+
+if defined BUILDARM64 (
+    call :build ARM64
     if errorlevel 1 exit /B
 )
 
@@ -117,12 +124,21 @@ if "%1" EQU "x86" (
     set BUILD_PLAT=Win32
     set OUTDIR_PLAT=win32
     set OBJDIR_PLAT=x86
-) else (
+) else if "%1" EQU "x64" (
     set BUILD=%Py_OutDir%amd64\
     set PGO=%~2
     set BUILD_PLAT=x64
     set OUTDIR_PLAT=amd64
     set OBJDIR_PLAT=x64
+) else if "%1" EQU "ARM64" (
+    set BUILD=%Py_OutDir%amd64\
+    set PGO=%~2
+    set BUILD_PLAT=ARM64
+    set OUTDIR_PLAT=arm64
+    set OBJDIR_PLAT=arm64
+) else (
+    echo Unknown platform %1
+    exit /B 1
 )
 
 if exist "%BUILD%en-us" (
@@ -184,13 +200,21 @@ if defined BUILDMSI (
 )
 
 if defined BUILDZIP (
-    %MSBUILD% "%D%make_zip.proj" /t:Build %BUILDOPTS% %CERTOPTS% /p:OutputPath="%BUILD%en-us"
-    if errorlevel 1 exit /B
+    if "%BUILD_PLAT%" EQU "ARM64" (
+        echo Skipping embeddable ZIP generation for ARM64 platform
+    ) else (
+        %MSBUILD% "%D%make_zip.proj" /t:Build %BUILDOPTS% %CERTOPTS% /p:OutputPath="%BUILD%en-us"
+        if errorlevel 1 exit /B
+    )
 )
 
 if defined BUILDNUGET (
-    %MSBUILD% "%D%..\nuget\make_pkg.proj" /t:Build /p:Configuration=Release /p:Platform=%1 /p:OutputPath="%BUILD%en-us"
-    if errorlevel 1 exit /B
+    if "%BUILD_PLAT%" EQU "ARM64" (
+        echo Skipping Nuget package generation for ARM64 platform
+    ) else (
+        %MSBUILD% "%D%..\nuget\make_pkg.proj" /t:Build /p:Configuration=Release /p:Platform=%1 /p:OutputPath="%BUILD%en-us"
+        if errorlevel 1 exit /B
+    )
 )
 
 if not "%OUTDIR%" EQU "" (
@@ -205,7 +229,7 @@ if not "%OUTDIR%" EQU "" (
 exit /B 0
 
 :Help
-echo buildrelease.bat [--out DIR] [-x86] [-x64] [--certificate CERTNAME] [--build] [--pgo COMMAND]
+echo buildrelease.bat [--out DIR] [-x86] [-x64] [-arm64] [--certificate CERTNAME] [--build] [--pgo COMMAND]
 echo                  [--skip-build] [--skip-doc] [--skip-nuget] [--skip-zip] [--skip-pgo]
 echo                  [--download DOWNLOAD URL] [--test TARGETDIR]
 echo                  [-h]
@@ -213,6 +237,7 @@ echo.
 echo    --out (-o)          Specify an additional output directory for installers
 echo    -x86                Build x86 installers
 echo    -x64                Build x64 installers
+echo    -arm64              Build ARM64 installers
 echo    --build (-b)        Incrementally build Python rather than rebuilding
 echo    --skip-build (-B)   Do not build Python (just do the installers)
 echo    --skip-doc (-D)     Do not build documentation
@@ -230,6 +255,9 @@ echo If --test is not specified, the installer tests are not run.
 echo.
 echo For the --pgo option, any Python command line can be used, or 'default' to
 echo use the default task (-m test --pgo).
+echo.
+echo x86 and ARM64 builds will never use PGO. ARM64 builds will never generate
+echo embeddable or Nuget packages.
 echo.
 echo The following substitutions will be applied to the download URL:
 echo     Variable        Description         Example

--- a/Tools/msi/bundle/Default.ARM64.xsl
+++ b/Tools/msi/bundle/Default.ARM64.xsl
@@ -1,0 +1,26 @@
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://schemas.microsoft.com/wix/2006/localization">
+    <xsl:output indent="yes"/>
+    <xsl:strip-space elements="*"/>
+
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="*[local-name()='String' and @Id='InstallButtonNote']">
+        <String Id="InstallButtonNote">[TargetDir]
+
+Includes pip and documentation
+Creates shortcuts but no file associations</String>
+    </xsl:template>
+
+    <xsl:template match="*[local-name()='String' and @Id='Include_launcherHelp']">
+        <String Id="Include_launcherHelp">(The 'py' launcher is currently unavailable on ARM64.)</String>
+    </xsl:template>
+    <xsl:template match="*[local-name()='String' and @Id='Include_tcltkHelpLabel']">
+        <String Id="Include_tcltkHelpLabel">(tcl/tk and IDLE are currently unavailable on ARM64.)</String>
+    </xsl:template>
+</xsl:stylesheet>

--- a/Tools/msi/bundle/Default.thm
+++ b/Tools/msi/bundle/Default.thm
@@ -59,7 +59,7 @@
         <Text X="205" Y="126" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_pipHelpLabel)</Text>
         
         <Checkbox Name="Include_tcltk" X="185" Y="151" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="no">#(loc.Include_tcltkLabel)</Checkbox>
-        <Text X="205" Y="176" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_tcltkHelpLabel)</Text>
+        <Text Name="Include_tcltkLabel" X="205" Y="176" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_tcltkHelpLabel)</Text>
         
         <Checkbox Name="Include_test" X="185" Y="201" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="no">#(loc.Include_testLabel)</Checkbox>
         <Text X="205" Y="226" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_testHelpLabel)</Text>

--- a/Tools/msi/bundle/Default.thm
+++ b/Tools/msi/bundle/Default.thm
@@ -52,16 +52,16 @@
         <Text X="185" Y="11" Width="-11" Height="36" FontId="1" DisablePrefix="yes">#(loc.Custom1Header)</Text>
         <Image X="0" Y="0" Width="178" Height="382" ImageFile="SideBar.png"/>
         
-        <Checkbox Name="Include_doc" X="185" Y="51" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.Include_docLabel)</Checkbox>
+        <Checkbox Name="Include_doc" X="185" Y="51" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="no">#(loc.Include_docLabel)</Checkbox>
         <Text X="205" Y="76" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_docHelpLabel)</Text>
         
-        <Checkbox Name="Include_pip" X="185" Y="101" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.Include_pipLabel)</Checkbox>
+        <Checkbox Name="Include_pip" X="185" Y="101" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="no">#(loc.Include_pipLabel)</Checkbox>
         <Text X="205" Y="126" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_pipHelpLabel)</Text>
         
-        <Checkbox Name="Include_tcltk" X="185" Y="151" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.Include_tcltkLabel)</Checkbox>
+        <Checkbox Name="Include_tcltk" X="185" Y="151" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="no">#(loc.Include_tcltkLabel)</Checkbox>
         <Text X="205" Y="176" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_tcltkHelpLabel)</Text>
         
-        <Checkbox Name="Include_test" X="185" Y="201" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.Include_testLabel)</Checkbox>
+        <Checkbox Name="Include_test" X="185" Y="201" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="no">#(loc.Include_testLabel)</Checkbox>
         <Text X="205" Y="226" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_testHelpLabel)</Text>
 
         <Checkbox Name="Include_launcher" X="185" Y="251" Width="100" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="no">#(loc.Include_launcherLabel)</Checkbox>

--- a/Tools/msi/bundle/Default.wxl
+++ b/Tools/msi/bundle/Default.wxl
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">[WixBundleName] Setup</String>
-  <String Id="Title">[WixBundleName]</String>
   <String Id="Installing">Installing</String>
   <String Id="Installation">Setup</String>
   <String Id="Modifying">Updating</String>

--- a/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
+++ b/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
@@ -1501,6 +1501,9 @@ private:
         hr = UpdateUIStrings(_command.action);
         BalExitOnFailure(hr, "Failed to load UI strings.");
 
+        hr = FindProgramFilesArm();
+        BalExitOnFailure(hr, "Fatal error locating Program Files (Arm)");
+
         GetBundleFileVersion();
         // don't fail if we couldn't get the version info; best-effort only
     LExit:
@@ -2179,6 +2182,37 @@ private:
             );
         }
         return hr;
+    }
+
+    HRESULT FindProgramFilesArm() {
+        wchar_t buffer[MAX_PATH + 1];
+        DWORD bufferLen = MAX_PATH;
+        LSTATUS res = RegGetValueW(
+            HKEY_LOCAL_MACHINE,
+            L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion",
+            L"ProgramFilesDir (Arm)",
+            RRF_RT_REG_SZ | RRF_RT_REG_EXPAND_SZ | RRF_SUBKEY_WOW6464KEY,
+            NULL,
+            buffer,
+            &bufferLen
+        );
+        if (res != ERROR_SUCCESS) {
+            // ProgramFilesArmFolder will default to ProgramFilesFolder. We only report
+            // an error if the value existed, as it will simply just be absent on non-ARM
+            // devices.
+            if (res != ERROR_FILE_NOT_FOUND) {
+                BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Failed to query 'ProgramFilesDir (Arm)': error code %d", res);
+            }
+            return S_OK;
+        }
+        if (buffer[0]) {
+            wchar_t *p = &buffer[bufferLen / sizeof(wchar_t)];
+            while (*p == L'\\' || *p == L'\0') { p -= 1; }
+            *++p = L'\\';
+            *++p = L'\0';
+            _engine->SetVariableString(L"ProgramFilesArmFolder", buffer);
+        }
+        return S_OK;
     }
 
     //

--- a/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
+++ b/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
@@ -89,7 +89,6 @@ enum CONTROL_ID {
     ID_TARGETDIR_EDITBOX,
     ID_CUSTOM_ASSOCIATE_FILES_CHECKBOX,
     ID_CUSTOM_INSTALL_ALL_USERS_CHECKBOX,
-    ID_CUSTOM_INCLUDE_TCLTK_HELP_LABEL,
     ID_CUSTOM_INSTALL_LAUNCHER_ALL_USERS_CHECKBOX,
     ID_CUSTOM_INCLUDE_LAUNCHER_HELP_LABEL,
     ID_CUSTOM_COMPILE_ALL_CHECKBOX,
@@ -157,7 +156,6 @@ static THEME_ASSIGN_CONTROL_ID CONTROL_ID_NAMES[] = {
     { ID_CUSTOM_INSTALL_ALL_USERS_CHECKBOX, L"InstallAllUsers" },
     { ID_CUSTOM_INSTALL_LAUNCHER_ALL_USERS_CHECKBOX, L"CustomInstallLauncherAllUsers" },
     { ID_CUSTOM_INCLUDE_LAUNCHER_HELP_LABEL, L"Include_launcherHelp" },
-    { ID_CUSTOM_INCLUDE_TCLTK_HELP_LABEL, L"Include_tcltkHelpLabel" },
     { ID_CUSTOM_COMPILE_ALL_CHECKBOX, L"CompileAll" },
     { ID_CUSTOM_BROWSE_BUTTON, L"CustomBrowseButton" },
     { ID_CUSTOM_BROWSE_BUTTON_LABEL, L"CustomBrowseButtonLabel" },
@@ -444,11 +442,6 @@ class PythonBootstrapperApplication : public CBalBaseBootstrapperApplication {
         ThemeControlElevates(_theme, ID_INSTALL_BUTTON, elevated);
         ThemeControlElevates(_theme, ID_INSTALL_SIMPLE_BUTTON, elevated);
         ThemeControlElevates(_theme, ID_INSTALL_UPGRADE_BUTTON, elevated);
-
-#ifdef ARM64
-        // Currently we do not support the launcher on ARM64, so hide its checkbox
-        ThemeShowControl(_theme, ID_INSTALL_LAUNCHER_ALL_USERS_CHECKBOX, SW_HIDE);
-#endif
     }
 
     void Custom1Page_Show() {

--- a/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
+++ b/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
@@ -2206,7 +2206,7 @@ private:
             return S_OK;
         }
         if (buffer[0]) {
-            wchar_t *p = &buffer[bufferLen / sizeof(wchar_t)];
+            wchar_t *p = &buffer[bufferLen / sizeof(wchar_t) - 1];
             while (*p == L'\\' || *p == L'\0') { p -= 1; }
             *++p = L'\\';
             *++p = L'\0';

--- a/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
+++ b/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
@@ -89,6 +89,7 @@ enum CONTROL_ID {
     ID_TARGETDIR_EDITBOX,
     ID_CUSTOM_ASSOCIATE_FILES_CHECKBOX,
     ID_CUSTOM_INSTALL_ALL_USERS_CHECKBOX,
+    ID_CUSTOM_INCLUDE_TCLTK_HELP_LABEL,
     ID_CUSTOM_INSTALL_LAUNCHER_ALL_USERS_CHECKBOX,
     ID_CUSTOM_INCLUDE_LAUNCHER_HELP_LABEL,
     ID_CUSTOM_COMPILE_ALL_CHECKBOX,
@@ -156,6 +157,7 @@ static THEME_ASSIGN_CONTROL_ID CONTROL_ID_NAMES[] = {
     { ID_CUSTOM_INSTALL_ALL_USERS_CHECKBOX, L"InstallAllUsers" },
     { ID_CUSTOM_INSTALL_LAUNCHER_ALL_USERS_CHECKBOX, L"CustomInstallLauncherAllUsers" },
     { ID_CUSTOM_INCLUDE_LAUNCHER_HELP_LABEL, L"Include_launcherHelp" },
+    { ID_CUSTOM_INCLUDE_TCLTK_HELP_LABEL, L"Include_tcltkHelpLabel" },
     { ID_CUSTOM_COMPILE_ALL_CHECKBOX, L"CompileAll" },
     { ID_CUSTOM_BROWSE_BUTTON, L"CustomBrowseButton" },
     { ID_CUSTOM_BROWSE_BUTTON_LABEL, L"CustomBrowseButtonLabel" },
@@ -442,6 +444,11 @@ class PythonBootstrapperApplication : public CBalBaseBootstrapperApplication {
         ThemeControlElevates(_theme, ID_INSTALL_BUTTON, elevated);
         ThemeControlElevates(_theme, ID_INSTALL_SIMPLE_BUTTON, elevated);
         ThemeControlElevates(_theme, ID_INSTALL_UPGRADE_BUTTON, elevated);
+
+#ifdef ARM64
+        // Currently we do not support the launcher on ARM64, so hide its checkbox
+        ThemeShowControl(_theme, ID_INSTALL_LAUNCHER_ALL_USERS_CHECKBOX, SW_HIDE);
+#endif
     }
 
     void Custom1Page_Show() {

--- a/Tools/msi/bundle/bootstrap/pythonba.vcxproj
+++ b/Tools/msi/bundle/bootstrap/pythonba.vcxproj
@@ -41,6 +41,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemDefinitionGroup>
     <ClCompile>
+      <PreprocessorDefinitions Condition="$(BuildForPlatform) == 'ARM64'">ARM64=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>_CRT_STDIO_LEGACY_WIDE_SPECIFIERS=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(WixInstallPath)sdk\inc</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/Tools/msi/bundle/bootstrap/pythonba.vcxproj
+++ b/Tools/msi/bundle/bootstrap/pythonba.vcxproj
@@ -21,11 +21,10 @@
   <PropertyGroup Label="Globals">
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
-    <PlatformToolset Condition="'$(PlatformToolset)' == '' and ('$(MSBuildToolsVersion)' == '16.0' or '$(VisualStudioVersion)' == '16.0')">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' and '$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' and '$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <PlatformToolset Condition="'$(PlatformToolset)' == '' and ('$(MSBuildToolsVersion)' == '15.0' or '$(VisualStudioVersion)' == '15.0')">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(PlatformToolset)' == '' and '$(VCTargetsPath14)' != ''">v140</PlatformToolset>
-    <PlatformToolset Condition="'$(PlatformToolset)' == '' and '$(VCTargetsPath14)' != ''">v140</PlatformToolset>
-    <PlatformToolset Condition="'$(PlatformToolset)' == '' and '$(VCTargetsPath12)' != ''">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == ''">v140</PlatformToolset>
     <ProjectGuid>{7A09B132-B3EE-499B-A700-A4B2157FEA3D}</ProjectGuid>
     <TargetName>PythonBA</TargetName>
   </PropertyGroup>
@@ -50,8 +49,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;gdiplus.lib;msimg32.lib;shlwapi.lib;wininet.lib;dutil.lib;balutil.lib;version.lib;uxtheme.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories Condition="'$(PlatformToolset)' == 'v142'">$(WixInstallPath)sdk\vs2017\lib\x86</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(PlatformToolset)' == 'v141'">$(WixInstallPath)sdk\vs2017\lib\x86</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="$(PlatformToolset.StartsWith(`v14`))">$(WixInstallPath)sdk\vs2017\lib\x86</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(PlatformToolset)' == 'v140'">$(WixInstallPath)sdk\vs2015\lib\x86</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(PlatformToolset)' == 'v120'">$(WixInstallPath)sdk\vs2013\lib\x86</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>pythonba.def</ModuleDefinitionFile>

--- a/Tools/msi/bundle/bundle.targets
+++ b/Tools/msi/bundle/bundle.targets
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <SchemaVersion>2.0</SchemaVersion>
         <OutputType>Bundle</OutputType>
-        
+
         <BootstrapConfiguration Condition="'$(BootstrapConfiguration)' == ''">Release</BootstrapConfiguration>
         <LinkerSuppressSpecificWarnings>1132;1135;1140</LinkerSuppressSpecificWarnings>
         <OutputName Condition="$(BuildForRelease)">$(OutputName)-$(PythonVersion)</OutputName>
@@ -16,13 +16,13 @@
 
         <OutputPath>$(OutputPath)en-us\</OutputPath>
         <OutDir>$(OutputPath)</OutDir>
-        
+
         <!-- See Tools/msi/buildrelease.bat for help on configuring the download URL -->
         <DownloadUrl Condition="'$(DownloadUrl)' == '' and '$(DownloadUrlBase)' != ''">$(DownloadUrlBase.TrimEnd(`/`))/{version}/{arch}{releasename}/{msi}</DownloadUrl>
         <DefineConstants Condition="'$(DownloadUrl)' != ''">$(DefineConstants);DownloadUrl=$(DownloadUrl.Replace(`{version}`, `$(MajorVersionNumber).$(MinorVersionNumber).$(MicroVersionNumber)`).Replace(`{arch}`, `$(ArchName)`).Replace(`{releasename}`, `$(ReleaseLevelName)`).Replace(`{msi}`, `{2}`))</DefineConstants>
         <DefineConstants Condition="'$(DownloadUrl)' == ''">$(DefineConstants);DownloadUrl={2}</DefineConstants>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <WixExtension Include="WixUtilExtension">
             <HintPath>WixUtilExtension</HintPath>
@@ -43,7 +43,6 @@
     </ItemGroup>
     <ItemGroup>
         <Content Include="Default.thm" />
-        <Content Include="Default.wxl" />
         <Content Include="SideBar.png" />
     </ItemGroup>
     <ItemGroup>
@@ -55,7 +54,7 @@
             <BindName></BindName>
         </LinkerBindInputPaths>
     </ItemGroup>
-    
+
     <ItemDefinitionGroup>
         <Package>
             <Properties>BuildForRelease=$(BuildForRelease)</Properties>
@@ -75,35 +74,56 @@
         <Package Include="..\tools\tools*.wixproj" />
         <Package Include="..\ucrt\ucrt*.wixproj" Condition="$(Platform) != 'ARM64'" />
     </ItemGroup>
-    
+
     <PropertyGroup>
         <BuildPackagesTargets>Build</BuildPackagesTargets>
     </PropertyGroup>
-    
+
     <Target Name="_SetRebuildTarget" BeforeTargets="BeforeRebuild">
         <PropertyGroup>
             <BuildPackagesTargets>Rebuild</BuildPackagesTargets>
         </PropertyGroup>
     </Target>
-    
+
     <Target Name="BuildPackages" BeforeTargets="BeforeBuild" Condition="'$(RebuildAll)' != 'false'">
         <MSBuild Projects="@(Package)" Targets="$(BuildPackagesTargets)" BuildInParallel="true" />
     </Target>
-    
+
     <Target Name="BuildBootstrapApplication" BeforeTargets="BeforeBuild">
         <Message Text="Building bootstrap app" Importance="high" />
-        
+
         <MSBuild Projects="bootstrap\pythonba.vcxproj"
                  Targets="Build;GetNativeTargetPath"
                  UseResultsCache="true"
-                 Properties="Configuration=$(BootstrapConfiguration);Platform=Win32">
+                 Properties="Configuration=$(BootstrapConfiguration);Platform=Win32;BuildForPlatform=$(Platform)">
             <Output TaskParameter="TargetOutputs" PropertyName="BootstrapAppPath" />
         </MSBuild>
-        
+
         <PropertyGroup>
             <DefineConstants>$(DefineConstants);BootstrapApp=$(BootstrapAppPath)</DefineConstants>
         </PropertyGroup>
     </Target>
-    
+
+    <Target Name="AddDefaultWxl" BeforeTargets="BeforeBuild" Condition="!Exists('Default.$(Platform).xsl')">
+        <ItemGroup>
+            <EmbeddedResource Include="Default.wxl" />
+        </ItemGroup>
+        <PropertyGroup>
+            <DefineConstants>$(DefineConstants);DefaultWxl=Default.wxl</DefineConstants>
+        </PropertyGroup>
+    </Target>
+    <Target Name="AddUpdatedDefaultWxl" BeforeTargets="BeforeBuild" Condition="Exists('Default.$(Platform).xsl')">
+        <XslTransformation XmlInputPaths="Default.wxl"
+                           OutputPaths="$(IntermediateOutputPath)Default.wxl"
+                           XslInputPath="Default.$(Platform).xsl"
+                           UseTrustedSettings="true" />
+        <ItemGroup>
+          <EmbeddedResource Include="$(IntermediateOutputPath)Default.wxl" />
+        </ItemGroup>
+        <PropertyGroup>
+            <DefineConstants>$(DefineConstants);DefaultWxl=$(IntermediateOutputPath)Default.wxl</DefineConstants>
+        </PropertyGroup>
+    </Target>
+
     <Import Project="..\msi.targets" />
 </Project>

--- a/Tools/msi/bundle/bundle.targets
+++ b/Tools/msi/bundle/bundle.targets
@@ -9,6 +9,7 @@
         <OutputName Condition="$(BuildForRelease)">$(OutputName)-$(PythonVersion)</OutputName>
         <OutputName Condition="!$(BuildForRelease)">$(OutputName)-$(MajorVersionNumber).$(MinorVersionNumber).$(MicroVersionNumber).$(RevisionNumber)</OutputName>
         <OutputName Condition="$(Platform) == 'x64'">$(OutputName)-amd64</OutputName>
+        <OutputName Condition="$(Platform) == 'ARM64'">$(OutputName)-arm64</OutputName>
         <OutputName Condition="'$(OutputSuffix)' != ''">$(OutputName)-$(OutputSuffix)</OutputName>
         <OutputName Condition="'$(Configuration)' == 'Debug'">$(OutputName)-d</OutputName>
         <TargetName>$(OutputName)</TargetName>
@@ -69,10 +70,10 @@
         <Package Include="..\path\path*.wixproj" />
         <Package Include="..\appendpath\appendpath*.wixproj" />
         <Package Include="..\pip\pip*.wixproj" />
-        <Package Include="..\tcltk\tcltk*.wixproj" />
+        <Package Include="..\tcltk\tcltk*.wixproj" Condition="$(Platform) != 'ARM64'" />
         <Package Include="..\test\test*.wixproj" />
         <Package Include="..\tools\tools*.wixproj" />
-        <Package Include="..\ucrt\ucrt*.wixproj" />
+        <Package Include="..\ucrt\ucrt*.wixproj" Condition="$(Platform) != 'ARM64'" />
     </ItemGroup>
     
     <PropertyGroup>

--- a/Tools/msi/bundle/bundle.targets
+++ b/Tools/msi/bundle/bundle.targets
@@ -104,7 +104,7 @@
         </PropertyGroup>
     </Target>
 
-    <Target Name="AddDefaultWxl" BeforeTargets="BeforeBuild" Condition="!Exists('Default.$(Platform).xsl')">
+    <Target Name="AddDefaultWxl" AfterTargets="PrepareForBuild" Condition="!Exists('Default.$(Platform).xsl')">
         <ItemGroup>
             <EmbeddedResource Include="Default.wxl" />
         </ItemGroup>
@@ -112,7 +112,7 @@
             <DefineConstants>$(DefineConstants);DefaultWxl=Default.wxl</DefineConstants>
         </PropertyGroup>
     </Target>
-    <Target Name="AddUpdatedDefaultWxl" BeforeTargets="BeforeBuild" Condition="Exists('Default.$(Platform).xsl')">
+    <Target Name="AddUpdatedDefaultWxl" AfterTargets="PrepareForBuild" Condition="Exists('Default.$(Platform).xsl')">
         <XslTransformation XmlInputPaths="Default.wxl"
                            OutputPaths="$(IntermediateOutputPath)Default.wxl"
                            XslInputPath="Default.$(Platform).xsl"

--- a/Tools/msi/bundle/bundle.wxs
+++ b/Tools/msi/bundle/bundle.wxs
@@ -49,7 +49,7 @@
     <Variable Name="DefaultJustForMeTargetDir" Value="[LocalAppDataFolder]Programs\Python\Python[WinVerNoDot]" bal:Overridable="yes" />
     <Variable Name="OptionalFeaturesRegistryKey" Value="Software\Python\PythonCore\[WinVer]\InstalledFeatures" />
     <Variable Name="TargetDirRegistryKey" Value="Software\Python\PythonCore\[WinVer]\InstallPath" />
-    
+
     <!--
     An empty string will use the other defaults based on InstallAllUsers
     (and switch dynamically in the UI). To get the old default, pass
@@ -59,7 +59,7 @@
     <Variable Name="DefaultCustomTargetDir" Value="" bal:Overridable="yes" />
 
     <Variable Name="InstallAllUsersState" Value="enabled" bal:Overridable="yes" />
-    <?if "$(var.PyTestExt)"="" ?>
+    <?if "$(var.PyTestExt)"="" and $(var.Platform)!="ARM64" ?>
     <Variable Name="InstallLauncherAllUsersState" Value="enabled" bal:Overridable="yes" />
     <?else ?>
     <Variable Name="InstallLauncherAllUsersState" Value="disable" bal:Overridable="yes" />
@@ -82,28 +82,33 @@
     <Variable Name="Include_tcltk" Value="1" bal:Overridable="yes" />
     <?endif ?>
     <Variable Name="Include_pip" Value="1" bal:Overridable="yes" />
+    <?if $(var.Platform)~="ARM64" ?>
+    <Variable Name="Include_launcher" Value="0" bal:Overridable="yes" />
+    <Variable Name="Include_launcherState" Value="disable" />
+    <?else ?>
     <Variable Name="Include_launcher" Value="-1" bal:Overridable="yes" />
     <?if "$(var.PyTestExt)"="" ?>
     <Variable Name="Include_launcherState" Value="enabled" bal:Overridable="yes" />
     <?else ?>
     <Variable Name="Include_launcherState" Value="disable" />
     <?endif ?>
+    <?endif ?>
     <Variable Name="Include_symbols" Value="0" bal:Overridable="yes" />
     <Variable Name="Include_debug" Value="0" bal:Overridable="yes" />
-    
+
     <Variable Name="LauncherOnly" Value="0" bal:Overridable="yes" />
     <Variable Name="DetectedLauncher" Value="0" />
     <Variable Name="DetectedOldLauncher" Value="0" />
-    
+
     <Variable Name="AssociateFiles" Value="1" bal:Overridable="yes" />
     <Variable Name="Shortcuts" Value="1" bal:Overridable="yes" />
     <Variable Name="PrependPath" Value="0" bal:Overridable="yes" />
     <Variable Name="AppendPath" Value="0" bal:Overridable="yes" />
     <Variable Name="CompileAll" Value="0" bal:Overridable="yes" />
-    
+
     <Variable Name="SimpleInstall" Value="0" bal:Overridable="yes" />
     <Variable Name="SimpleInstallDescription" Value="" bal:Overridable="yes" />
-    
+
     <Chain ParallelCache="yes">
       <?if $(var.Platform)!="ARM64" ?>
       <PackageGroupRef Id="crt" />
@@ -117,8 +122,8 @@
       <PackageGroupRef Id="tools" />
       <?if $(var.Platform)!="ARM64" ?>
       <PackageGroupRef Id="tcltk" />
-      <?endif ?>
       <PackageGroupRef Id="launcher" />
+      <?endif ?>
       <PackageGroupRef Id="pip" />
       <PackageGroupRef Id="packageinstall" />
       <PackageGroupRef Id="postinstall" />

--- a/Tools/msi/bundle/bundle.wxs
+++ b/Tools/msi/bundle/bundle.wxs
@@ -12,7 +12,7 @@
           dep:ProviderKey="CPython-$(var.MajorVersionNumber).$(var.MinorVersionNumber)$(var.PyArchExt)$(var.PyTestExt)">
     <BootstrapperApplication Id="PythonBA" SourceFile="$(var.BootstrapApp)">
         <Payload Compressed='yes' SourceFile='Default.thm' />
-        <Payload Compressed='yes' SourceFile='Default.wxl' />
+        <Payload Compressed='yes' SourceFile='$(var.DefaultWxl)' />
         <Payload Compressed='yes' SourceFile='SideBar.png' />
     </BootstrapperApplication>
 

--- a/Tools/msi/bundle/bundle.wxs
+++ b/Tools/msi/bundle/bundle.wxs
@@ -36,6 +36,10 @@
     <?if $(var.Platform)~="x64" ?>
     <Variable Name="DefaultAllUsersTargetDir" Value="[ProgramFiles64Folder]Python[WinVerNoDot]" bal:Overridable="yes" />
     <Variable Name="TargetPlatform" Value="x64" />
+    <?elseif $(var.Platform)~="ARM64" ?>
+    <!-- TODO: Determine correct ProgramFilesArmFolder -->
+    <Variable Name="DefaultAllUsersTargetDir" Value="[ProgramFilesFolder]Python[WinVerNoDot]" bal:Overridable="yes" />
+    <Variable Name="TargetPlatform" Value="ARM64" />
     <?else ?>
     <Variable Name="DefaultAllUsersTargetDir" Value="[ProgramFilesFolder]Python[WinVerNoDot]" bal:Overridable="yes" />
     <Variable Name="TargetPlatform" Value="x86" />
@@ -69,7 +73,12 @@
     <Variable Name="Include_test" Value="1" bal:Overridable="yes" />
     <Variable Name="Include_doc" Value="1" bal:Overridable="yes" />
     <Variable Name="Include_tools" Value="1" bal:Overridable="yes" />
+    <?if $(var.Platform)~="ARM64" ?>
+    <Variable Name="Include_tcltk" Value="0" />
+    <Variable Name="Include_tcltkState" Value="disable" />
+    <?else ?>
     <Variable Name="Include_tcltk" Value="1" bal:Overridable="yes" />
+    <?endif ?>
     <Variable Name="Include_pip" Value="1" bal:Overridable="yes" />
     <Variable Name="Include_launcher" Value="-1" bal:Overridable="yes" />
     <?if "$(var.PyTestExt)"="" ?>
@@ -94,7 +103,9 @@
     <Variable Name="SimpleInstallDescription" Value="" bal:Overridable="yes" />
     
     <Chain ParallelCache="yes">
+      <?if $(var.Platform)!="ARM64" ?>
       <PackageGroupRef Id="crt" />
+      <?endif ?>
       <PackageGroupRef Id="core" />
       <PackageGroupRef Id="dev" />
       <PackageGroupRef Id="exe" />
@@ -102,7 +113,9 @@
       <PackageGroupRef Id="test" />
       <PackageGroupRef Id="doc" />
       <PackageGroupRef Id="tools" />
+      <?if $(var.Platform)!="ARM64" ?>
       <PackageGroupRef Id="tcltk" />
+      <?endif ?>
       <PackageGroupRef Id="launcher" />
       <PackageGroupRef Id="pip" />
       <PackageGroupRef Id="packageinstall" />

--- a/Tools/msi/bundle/bundle.wxs
+++ b/Tools/msi/bundle/bundle.wxs
@@ -26,6 +26,9 @@
     <Variable Name="WinVer" Value="$(var.MajorVersionNumber).$(var.MinorVersionNumber)$(var.PyArchExt)$(var.PyTestExt)" />
     <Variable Name="WinVerNoDot" Value="$(var.MajorVersionNumber)$(var.MinorVersionNumber)$(var.PyArchExt)$(var.PyTestExt)" />
 
+    <!-- A more accurate value may be calculated by the bootstrapper -->
+    <Variable Name="ProgramFilesArmFolder" Value="[ProgramFilesFolder]" bal:Overridable="yes" />
+
     <Variable Name="InstallAllUsers" Value="0" bal:Overridable="yes" />
     <?if "$(var.PyTestExt)"="" ?>
     <Variable Name="InstallLauncherAllUsers" Value="1" bal:Overridable="yes" />
@@ -37,8 +40,7 @@
     <Variable Name="DefaultAllUsersTargetDir" Value="[ProgramFiles64Folder]Python[WinVerNoDot]" bal:Overridable="yes" />
     <Variable Name="TargetPlatform" Value="x64" />
     <?elseif $(var.Platform)~="ARM64" ?>
-    <!-- TODO: Determine correct ProgramFilesArmFolder -->
-    <Variable Name="DefaultAllUsersTargetDir" Value="[ProgramFilesFolder]Python[WinVerNoDot]" bal:Overridable="yes" />
+    <Variable Name="DefaultAllUsersTargetDir" Value="[ProgramFilesArmFolder]Python[WinVerNoDot]" bal:Overridable="yes" />
     <Variable Name="TargetPlatform" Value="ARM64" />
     <?else ?>
     <Variable Name="DefaultAllUsersTargetDir" Value="[ProgramFilesFolder]Python[WinVerNoDot]" bal:Overridable="yes" />

--- a/Tools/msi/bundle/bundle.wxs
+++ b/Tools/msi/bundle/bundle.wxs
@@ -59,7 +59,9 @@
     <Variable Name="DefaultCustomTargetDir" Value="" bal:Overridable="yes" />
 
     <Variable Name="InstallAllUsersState" Value="enabled" bal:Overridable="yes" />
-    <?if "$(var.PyTestExt)"="" and $(var.Platform)!="ARM64" ?>
+    <?if "$(var.Platform)"~="ARM64" ?>
+    <Variable Name="InstallLauncherAllUsersState" Value="hide" bal:Overridable="yes" />
+    <?elseif "$(var.PyTestExt)"="" ?>
     <Variable Name="InstallLauncherAllUsersState" Value="enabled" bal:Overridable="yes" />
     <?else ?>
     <Variable Name="InstallLauncherAllUsersState" Value="disable" bal:Overridable="yes" />

--- a/Tools/msi/core/core.wxs
+++ b/Tools/msi/core/core.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/core/core_d.wxs
+++ b/Tools/msi/core/core_d.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title_d)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/core/core_pdb.wxs
+++ b/Tools/msi/core/core_pdb.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.TitlePdb)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/dev/dev.wxs
+++ b/Tools/msi/dev/dev.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/dev/dev_d.wxs
+++ b/Tools/msi/dev/dev_d.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title_d)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/doc/doc.wxs
+++ b/Tools/msi/doc/doc.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/exe/exe.wxs
+++ b/Tools/msi/exe/exe.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
 
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/exe/exe_d.wxs
+++ b/Tools/msi/exe/exe_d.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title_d)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/exe/exe_pdb.wxs
+++ b/Tools/msi/exe/exe_pdb.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.TitlePdb)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/get_externals.bat
+++ b/Tools/msi/get_externals.bat
@@ -56,7 +56,7 @@ set binaries=%binaries%     gpg
 set binaries=%binaries%     htmlhelp
 set binaries=%binaries%     nuget
 set binaries=%binaries%     redist-1
-set binaries=%binaries%     wix
+set binaries=%binaries%     wix-314
 
 for %%b in (%binaries%) do (
     if exist "%EXTERNALS_DIR%\%%b" (

--- a/Tools/msi/launcher/launcher.wxs
+++ b/Tools/msi/launcher/launcher.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <Property Id="Suppress_TARGETDIR_Check" Value="1" />

--- a/Tools/msi/lib/lib.wxs
+++ b/Tools/msi/lib/lib.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/lib/lib_d.wxs
+++ b/Tools/msi/lib/lib_d.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title_d)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/lib/lib_pdb.wxs
+++ b/Tools/msi/lib/lib_pdb.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.TitlePdb)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/msi.props
+++ b/Tools/msi/msi.props
@@ -178,7 +178,7 @@
             <_GenerateCommand>import uuid; print('\n'.join('{}={}'.format(i, uuid.uuid5(uuid.UUID('c8d9733e-a70c-43ff-ab0c-e26456f11083'), '$(ReleaseUri.Replace(`{arch}`, `$(ArchName)`))' + j)) for i,j in [$(_Uuids.Replace(`"`,`'`))]))</_GenerateCommand>
         </PropertyGroup>
         
-        <Exec Command='"$(PythonForBuild)" -c "$(_GenerateCommand)" &gt; "$(IntermediateOutputPath)$(OutputName)guids.txt"'
+        <Exec Command='$(PythonForBuild) -c "$(_GenerateCommand)" &gt; "$(IntermediateOutputPath)$(OutputName)guids.txt"'
               WorkingDirectory="$(MSBuildThisFileDirectory)"
               IgnoreExitCode="false" />
         

--- a/Tools/msi/msi.props
+++ b/Tools/msi/msi.props
@@ -12,9 +12,11 @@
         <Platform Condition="'$(Platform)' == ''">x86</Platform>
         <InstallScope Condition="'$(InstallScope)' != 'perMachine'">perUser</InstallScope>
         <_MakeCatCommand Condition="'$(_MakeCatCommand)' == ''">makecat</_MakeCatCommand>
+        <SkipCopySSLDLL>true</SkipCopySSLDLL>
     </PropertyGroup>
 
     <Import Project="wix.props" />
+    <Import Project="..\..\PCbuild\openssl.props" />
     <Import Project="..\..\PCbuild\tcltk.props" />
 
     <PropertyGroup>
@@ -71,8 +73,10 @@
     <PropertyGroup>
         <Bitness>32-bit</Bitness>
         <Bitness Condition="$(Platform) == 'x64'">64-bit</Bitness>
+        <Bitness Condition="$(Platform) == 'ARM64'">ARM64</Bitness>
         <PlatformArchitecture>32bit</PlatformArchitecture>
         <PlatformArchitecture Condition="$(Platform) == 'x64'">64bit</PlatformArchitecture>
+        <PlatformArchitecture Condition="$(Platform) == 'ARM64'">ARM64</PlatformArchitecture>
         <DefineConstants>
             $(DefineConstants);
             Version=$(InstallerVersion);
@@ -88,16 +92,11 @@
             PyArchExt=$(PyArchExt);
             PyTestExt=$(PyTestExt);
             OptionalFeatureName=$(OutputName);
-            ssltag=-1_1;
+            ssltag=$(OpenSSLDLLSuffix);
+            Suffix32=$(PyArchExt);
         </DefineConstants>
         <DefineConstants Condition="'$(CRTRedist)' != ''">
             $(DefineConstants);CRTRedist=$(CRTRedist);
-        </DefineConstants>
-        <DefineConstants Condition="$(Platform) != 'x64'">
-            $(DefineConstants);Suffix32=-32;
-        </DefineConstants>
-        <DefineConstants Condition="$(Platform) == 'x64'">
-            $(DefineConstants);Suffix32=;
         </DefineConstants>
     </PropertyGroup>
 
@@ -134,10 +133,14 @@
         <LinkerBindInputPaths Include="$(BuildPath64)">
             <BindName>build64</BindName>
         </LinkerBindInputPaths>
+        <LinkerBindInputPaths Include="$(BuildPathARM64)">
+            <BindName>buildarm64</BindName>
+        </LinkerBindInputPaths>
     </ItemGroup>
 
     <Target Name="_ValidateMsiProps" BeforeTargets="PrepareForBuild">
-        <Error Text="Platform '$(Platform)' is not supported. Use 'x86' or 'x64'." Condition="$(Platform) != 'x86' and $(Platform) != 'x64'" />
+        <Error Text="Platform '$(Platform)' is not supported. Use 'x86', 'x64' or 'ARM64'."
+               Condition="$(Platform) != 'x86' and $(Platform) != 'x64' and $(Platform) != 'ARM64'" />
     </Target>
     
     <ItemGroup>
@@ -166,13 +169,16 @@
             <Uri>registry/$(OutputName)</Uri>
         </_Uuid>
     </ItemGroup>
-    <Target Name="_GenerateGuids" AfterTargets="PrepareForBuild" Condition="$(TargetName) != 'launcher'">
+    <Target Name="_GenerateGuids"
+            AfterTargets="PrepareForBuild"
+            DependsOnTargets="FindPythonForBuild"
+            Condition="$(TargetName) != 'launcher'">
         <PropertyGroup>
             <_Uuids>@(_Uuid->'("%(Identity)", "$(MajorVersionNumber).$(MinorVersionNumber)/%(Uri)")',',')</_Uuids>
             <_GenerateCommand>import uuid; print('\n'.join('{}={}'.format(i, uuid.uuid5(uuid.UUID('c8d9733e-a70c-43ff-ab0c-e26456f11083'), '$(ReleaseUri.Replace(`{arch}`, `$(ArchName)`))' + j)) for i,j in [$(_Uuids.Replace(`"`,`'`))]))</_GenerateCommand>
         </PropertyGroup>
         
-        <Exec Command='"$(PythonExe)" -c "$(_GenerateCommand)" &gt; "$(IntermediateOutputPath)$(OutputName)guids.txt"'
+        <Exec Command='"$(PythonForBuild)" -c "$(_GenerateCommand)" &gt; "$(IntermediateOutputPath)$(OutputName)guids.txt"'
               WorkingDirectory="$(MSBuildThisFileDirectory)"
               IgnoreExitCode="false" />
         

--- a/Tools/msi/msi.targets
+++ b/Tools/msi/msi.targets
@@ -20,7 +20,7 @@
         </ItemGroup>
 
         <WriteLinesToFile File="$(_FileListTarget)" Lines="@(InstallFiles->'&quot;%(_Source)&quot;,&quot;%(_Target)&quot;,&quot;%(Group)&quot;,&quot;%(DiskId)&quot;,&quot;%(Condition)&quot;')" Overwrite="true" />
-        <Exec Command='"$(PythonForBuild)" csv_to_wxs.py "$(_FileListTarget)" "$(_InstallFilesTarget)"'
+        <Exec Command='$(PythonForBuild) csv_to_wxs.py "$(_FileListTarget)" "$(_InstallFilesTarget)"'
               WorkingDirectory="$(MSBuildThisFileDirectory)" />
 
         <ItemGroup>

--- a/Tools/msi/msi.targets
+++ b/Tools/msi/msi.targets
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <Target Name="ProcessInstallFiles" AfterTargets="PrepareForBuild" Condition="@(InstallFiles) != ''">
+    <Target Name="ProcessInstallFiles"
+            AfterTargets="PrepareForBuild"
+            DependsOnTargets="FindPythonForBuild"
+            Condition="@(InstallFiles) != ''">
         <PropertyGroup>
             <_FileListTarget>$(IntermediateOutputPath)$(MSBuildProjectName).g.csv</_FileListTarget>
             <_InstallFilesTarget>$(IntermediateOutputPath)$(MSBuildProjectName).g.wxs</_InstallFilesTarget>
@@ -17,7 +20,7 @@
         </ItemGroup>
 
         <WriteLinesToFile File="$(_FileListTarget)" Lines="@(InstallFiles->'&quot;%(_Source)&quot;,&quot;%(_Target)&quot;,&quot;%(Group)&quot;,&quot;%(DiskId)&quot;,&quot;%(Condition)&quot;')" Overwrite="true" />
-        <Exec Command='"$(PythonExe)" csv_to_wxs.py "$(_FileListTarget)" "$(_InstallFilesTarget)"'
+        <Exec Command='"$(PythonForBuild)" csv_to_wxs.py "$(_FileListTarget)" "$(_InstallFilesTarget)"'
               WorkingDirectory="$(MSBuildThisFileDirectory)" />
 
         <ItemGroup>

--- a/Tools/msi/path/path.wxs
+++ b/Tools/msi/path/path.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         
         <PropertyRef Id="UpgradeTable" />
         <PropertyRef Id="REGISTRYKEY" />

--- a/Tools/msi/pip/pip.wxs
+++ b/Tools/msi/pip/pip.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         
         <PropertyRef Id="UpgradeTable" />
         <PropertyRef Id="REGISTRYKEY" />

--- a/Tools/msi/purge.py
+++ b/Tools/msi/purge.py
@@ -65,9 +65,15 @@ PATHS = [
     "python-{}-webinstall.exe".format(m.group(0)),
     "python-{}-amd64.exe".format(m.group(0)),
     "python-{}-amd64-webinstall.exe".format(m.group(0)),
+    "python-{}-arm64.exe".format(m.group(0)),
+    "python-{}-arm64-webinstall.exe".format(m.group(0)),
     "python-{}-embed-amd64.zip".format(m.group(0)),
     "python-{}-embed-win32.zip".format(m.group(0)),
-] + ["win32{}/{}".format(REL, f) for f in FILES] + ["amd64{}/{}".format(REL, f) for f in FILES]
+    "python-{}-embed-arm64.zip".format(m.group(0)),
+    *["win32{}/{}".format(REL, f) for f in FILES],
+    *["amd64{}/{}".format(REL, f) for f in FILES],
+    *["arm64{}/{}".format(REL, f) for f in FILES],
+]
 PATHS = PATHS + [p + ".asc" for p in PATHS]
 
 print('Purged:')

--- a/Tools/msi/tcltk/tcltk.wxs
+++ b/Tools/msi/tcltk/tcltk.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/tcltk/tcltk_d.wxs
+++ b/Tools/msi/tcltk/tcltk_d.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title_d)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/tcltk/tcltk_pdb.wxs
+++ b/Tools/msi/tcltk/tcltk_pdb.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.TitlePdb)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/test/test.wxs
+++ b/Tools/msi/test/test.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/test/test_d.wxs
+++ b/Tools/msi/test/test_d.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title_d)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/test/test_pdb.wxs
+++ b/Tools/msi/test/test_pdb.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.TitlePdb)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/tools/tools.wxs
+++ b/Tools/msi/tools/tools.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/ucrt/ucrt.wxs
+++ b/Tools/msi/ucrt/ucrt.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
         <PropertyRef Id="UpgradeTable" />

--- a/Tools/msi/wix.props
+++ b/Tools/msi/wix.props
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <WixInstallPath Condition="'$(WixInstallPath)' == '' and Exists('$(MSBuildThisFileDirectory)\Wix')">$(MSBuildThisFileDirectory)\Wix\</WixInstallPath>
-    <WixInstallPath Condition="'$(WixInstallPath)' == '' and Exists('$(ExternalsDir)\windows-installer\wix')">$(ExternalsDir)\windows-installer\wix\</WixInstallPath>
+    <WixInstallPath Condition="'$(WixInstallPath)' == '' and Exists('$(ExternalsDir)\windows-installer\wix-314')">$(ExternalsDir)\windows-installer\wix-314\</WixInstallPath>
     <WixInstallPath Condition="'$(WixInstallPath)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Installer XML\3.10@InstallRoot)</WixInstallPath>
     <WixInstallPath Condition="'$(WixInstallPath)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Windows Installer XML\3.10@InstallRoot)</WixInstallPath>
     <WixTargetsPath>$(WixInstallPath)\Wix.targets</WixTargetsPath>


### PR DESCRIPTION
Also skips building web-based installers completely

<!-- issue-number: [bpo-33125](https://bugs.python.org/issue33125) -->
https://bugs.python.org/issue33125
<!-- /issue-number -->
