### PR TITLE
[3.10] bpo-46445, bpo-46519: Re-import typing.NewType

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -19,6 +19,7 @@ from typing import get_origin, get_args
 from typing import is_typeddict
 from typing import no_type_check, no_type_check_decorator
 from typing import Type
+from typing import NewType
 from typing import NamedTuple, TypedDict
 from typing import IO, TextIO, BinaryIO
 from typing import Pattern, Match


### PR DESCRIPTION
Partially reverts 65b88d5e01c845c0cfa3ff61bc8b2faec8f67a57.

<!-- issue-number: [bpo-46445](https://bugs.python.org/issue46445) -->
https://bugs.python.org/issue46445
<!-- /issue-number -->

Automerge-Triggered-By: GH:Fidget-Spinner