### PR TITLE
bpo-41370: Evaluate strings as forward refs in PEP 585 generics

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2006,6 +2006,23 @@ class GenericTests(BaseTestCase):
         def barfoo2(x: CT): ...
         self.assertIs(get_type_hints(barfoo2, globals(), locals())['x'], CT)
 
+    def test_generic_pep585_forward_ref(self):
+        # See https://bugs.python.org/issue41370
+
+        class N:
+            a: list['N']
+        self.assertEqual(
+            get_type_hints(N, globals(), locals()),
+            {'a': list[N]}
+        )
+
+        class M:
+            a: dict['N', list[List[list['M']]]]
+        self.assertEqual(
+            get_type_hints(M, globals(), locals()),
+            {'a': dict[N, list[List[list[M]]]]}
+        )
+
     def test_extended_generic_rules_subclassing(self):
         class T1(Tuple[T, KT]): ...
         class T2(Tuple[T, ...]): ...

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3310,7 +3310,7 @@ class GetTypeHintTests(BaseTestCase):
         BA = Tuple[Annotated[T, (1, 0)], ...]
         def barfoo(x: BA): ...
         self.assertEqual(get_type_hints(barfoo, globals(), locals())['x'], Tuple[T, ...])
-        self.assertIs(
+        self.assertEqual(
             get_type_hints(barfoo, globals(), locals(), include_extras=True)['x'],
             BA
         )
@@ -3318,7 +3318,7 @@ class GetTypeHintTests(BaseTestCase):
         BA = tuple[Annotated[T, (1, 0)], ...]
         def barfoo(x: BA): ...
         self.assertEqual(get_type_hints(barfoo, globals(), locals())['x'], tuple[T, ...])
-        self.assertIs(
+        self.assertEqual(
             get_type_hints(barfoo, globals(), locals(), include_extras=True)['x'],
             BA
         )

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2024,6 +2024,7 @@ class GenericTests(BaseTestCase):
             {'a': dict[C1, list[List[list[C2]]]]}
         )
 
+        # Test stringified annotations
         scope = {}
         exec(textwrap.dedent('''
         from __future__ import annotations
@@ -2031,11 +2032,18 @@ class GenericTests(BaseTestCase):
             a: List[list["C2"]]
         '''), scope)
         C3 = scope['C3']
-
         self.assertEqual(C3.__annotations__['a'], "List[list['C2']]")
         self.assertEqual(
             get_type_hints(C3, globals(), locals()),
             {'a': List[list[C2]]}
+        )
+
+        # Test recursive types
+        X = list["X"]
+        def f(x: X): ...
+        self.assertEqual(
+            get_type_hints(f, globals(), locals()),
+            {'x': list[list[ForwardRef('X')]]}
         )
 
     def test_extended_generic_rules_subclassing(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -331,6 +331,12 @@ def _eval_type(t, globalns, localns, recursive_guard=frozenset()):
     if isinstance(t, ForwardRef):
         return t._evaluate(globalns, localns, recursive_guard)
     if isinstance(t, (_GenericAlias, GenericAlias, types.UnionType)):
+        if isinstance(t, GenericAlias):
+            args = tuple(
+                ForwardRef(arg) if isinstance(arg, str) else arg
+                for arg in t.__args__
+            )
+            t = t.__origin__[(*args,)]
         ev_args = tuple(_eval_type(a, globalns, localns, recursive_guard) for a in t.__args__)
         if ev_args == t.__args__:
             return t

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -336,7 +336,7 @@ def _eval_type(t, globalns, localns, recursive_guard=frozenset()):
                 ForwardRef(arg) if isinstance(arg, str) else arg
                 for arg in t.__args__
             )
-            t = t.__origin__[(*args,)]
+            t = t.__origin__[args]
         ev_args = tuple(_eval_type(a, globalns, localns, recursive_guard) for a in t.__args__)
         if ev_args == t.__args__:
             return t

--- a/Misc/NEWS.d/next/Library/2022-01-27-11-54-16.bpo-41370.gYxCPE.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-27-11-54-16.bpo-41370.gYxCPE.rst
@@ -1,0 +1,1 @@
+`typing.get_type_hints()` now supports evaluating strings as forward references in PEP 585 generic aliases.

--- a/Misc/NEWS.d/next/Library/2022-01-27-11-54-16.bpo-41370.gYxCPE.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-27-11-54-16.bpo-41370.gYxCPE.rst
@@ -1,1 +1,1 @@
-``typing.get_type_hints()`` now supports evaluating strings as forward references in PEP 585 generic aliases.
+:func:`typing.get_type_hints` now supports evaluating strings as forward references in :ref:`PEP 585 generic aliases <types-genericalias>`.

--- a/Misc/NEWS.d/next/Library/2022-01-27-11-54-16.bpo-41370.gYxCPE.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-27-11-54-16.bpo-41370.gYxCPE.rst
@@ -1,1 +1,1 @@
-`typing.get_type_hints()` now supports evaluating strings as forward references in PEP 585 generic aliases.
+``typing.get_type_hints()`` now supports evaluating strings as forward references in PEP 585 generic aliases.


### PR DESCRIPTION
This Pull Requests suggests a change to `typing._eval_type()` that considers strings in PEP 585 generics (ie. instances of `types.GenericAlias`) as forward references. This is necessary because `ForwardRef` is not and likely will not be implemented in C, and thus strings used as forward references in PEP 585 are not currently evaluated by `typing.get_type_hints()`.

https://bugs.python.org/issue41370

A test case that uses `assertIs()` currently fails because in the current state `_eval_type()` creates a copy of the same generic alias with transformed arguments, thus for any PEP 585 generic alias `x`, the comparison `x is typing.get_type_hints(func)['X']` will evaluate to `False`, assuming `func` has a field/argument annotation `X: x`. I think that this can be worked around, and happy to propose an updated implementation.

I created this PR as a proof of concept until a there is consent that in spirit this change to `get_type_hints()` is something that should happen. So for now I'll keep it as it is.

```
======================================================================
FAIL: test_get_type_hints_annotated (__main__.GetTypeHintTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/niklas/git/cpython/Lib/test/test_typing.py", line 3298, in test_get_type_hints_annotated
    self.assertIs(
    ^^^^^^^^^^^^^^
AssertionError: tuple[typing.Annotated[~T, (1, 0)], ...] is not tuple[typing.Annotated[~T, (1, 0)], ...]
```

__Open todos/questions__

* [ ] Fix `test_get_type_hints_annotated` in `test_typing.py`
* [ ] Do we actually need to treat `types.GenericAlias` separately or is it safe to assume that a string  argument is always a forward reference?
* [ ] Backport to 3.10 as a bugfix?

Co-Authored-By: Guido van Rossum <guido@python.org>

<!-- issue-number: [bpo-41370](https://bugs.python.org/issue41370) -->
https://bugs.python.org/issue41370
<!-- /issue-number -->
