### PR TITLE
bpo-46431: use raw string for regex in test

### DIFF
--- a/Lib/test/test_exception_group.py
+++ b/Lib/test/test_exception_group.py
@@ -22,7 +22,7 @@ class TestExceptionGroupTypeHierarchy(unittest.TestCase):
 
 class BadConstructorArgs(unittest.TestCase):
     def test_bad_EG_construction__too_many_args(self):
-        MSG = 'BaseExceptionGroup.__new__\(\) takes exactly 2 arguments'
+        MSG = r'BaseExceptionGroup.__new__\(\) takes exactly 2 arguments'
         with self.assertRaisesRegex(TypeError, MSG):
             ExceptionGroup('no errors')
         with self.assertRaisesRegex(TypeError, MSG):


### PR DESCRIPTION
Fixes:

DeprecationWarning: invalid escape sequence '\('
  MSG = 'BaseExceptionGroup.__new__\(\) takes exactly 2 arguments'

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46431](https://bugs.python.org/issue46431) -->
https://bugs.python.org/issue46431
<!-- /issue-number -->
