### PR TITLE
bpo-46527: allow calling enumerate(iterable=...) again

### DIFF
--- a/Lib/test/test_enumerate.py
+++ b/Lib/test/test_enumerate.py
@@ -128,6 +128,18 @@ class EnumerateTestCase(unittest.TestCase, PickleTest):
         self.assertRaises(TypeError, self.enum, 'abc', 'a') # wrong type
         self.assertRaises(TypeError, self.enum, 'abc', 2, 3) # too many arguments
 
+    def test_kwargs(self):
+        self.assertEqual(list(self.enum(iterable=Ig(self.seq))), self.res)
+        expected = list(self.enum(Ig(self.seq), 0))
+        self.assertEqual(list(self.enum(iterable=Ig(self.seq), start=0)),
+                         expected)
+        self.assertEqual(list(self.enum(start=0, iterable=Ig(self.seq))),
+                         expected)
+        self.assertRaises(TypeError, self.enum, iterable=[], x=3)
+        self.assertRaises(TypeError, self.enum, start=0, x=3)
+        self.assertRaises(TypeError, self.enum, x=0, y=3)
+        self.assertRaises(TypeError, self.enum, x=0)
+
     @support.cpython_only
     def test_tuple_reuse(self):
         # Tests an implementation detail where tuple is reused
@@ -266,14 +278,16 @@ class EnumerateStartTestCase(EnumerateTestCase):
 
 
 class TestStart(EnumerateStartTestCase):
+    def enum(self, iterable, start=11):
+        return enumerate(iterable, start=start)
 
-    enum = lambda self, i: enumerate(i, start=11)
     seq, res = 'abc', [(11, 'a'), (12, 'b'), (13, 'c')]
 
 
 class TestLongStart(EnumerateStartTestCase):
+    def enum(self, iterable, start=sys.maxsize + 1):
+        return enumerate(iterable, start=start)
 
-    enum = lambda self, i: enumerate(i, start=sys.maxsize+1)
     seq, res = 'abc', [(sys.maxsize+1,'a'), (sys.maxsize+2,'b'),
                        (sys.maxsize+3,'c')]
 

--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-25-19-34-55.bpo-46527.mQLNPk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-25-19-34-55.bpo-46527.mQLNPk.rst
@@ -1,0 +1,2 @@
+Allow passing ``iterable`` as a keyword argument to :func:`enumerate` again.
+Patch by Jelle Zijlstra.

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -95,7 +95,7 @@ enumerate_vectorcall(PyObject *type, PyObject *const *args,
         nkwargs = PyTuple_GET_SIZE(kwnames);
     }
 
-    // Manually implement enumerable(iterable, start=...)
+    // Manually implement enumerate(iterable, start=...)
     if (nargs + nkwargs == 2) {
         if (nkwargs == 1) {
             PyObject *kw = PyTuple_GET_ITEM(kwnames, 0);


### PR DESCRIPTION
As mentioned in the issue, this fixes a regression in 3.11.

The regression was introduced in GH-25154 ([bpo-43706](https://bugs.python.org/issue43706)). There were already
comments there about how this was too much code for a simple change. This
makes it even worse. I'd be open to removing the vectorcall support instead.

<!-- issue-number: [bpo-46527](https://bugs.python.org/issue46527) -->
https://bugs.python.org/issue46527
<!-- /issue-number -->
