### PR TITLE
bpo-44734: Fix floating point precision in test_turtle

### DIFF
--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -235,7 +235,7 @@ class TestVec2D(VectorComparisonMixin, unittest.TestCase):
         self.assertVectorsAlmostEqual(-vec, expected)
 
     def test_distance(self):
-        self.assertEqual(abs(Vec2D(6, 8)), 10)
+        self.assertAlmostEqual(abs(Vec2D(6, 8)), 10)
         self.assertEqual(abs(Vec2D(0, 0)), 0)
         self.assertAlmostEqual(abs(Vec2D(2.5, 6)), 6.5)
 


### PR DESCRIPTION
Hello,
for context, we ran across the problematic test in Fedora, when older Pythons stopped building on 32-bit because of the strict assert. The patch made it build again. We haven't spotted the failure from Python 3.7 above.

The test failure is known: [here](https://bugs.python.org/issue44728) and [here](https://bugs.python.org/issue44734). The changes in the turtle module code prevent the test from failing but it was [pointed out](https://bugs.python.org/issue44728#msg398167) that still the test is unnecessarily strict and it's better to have it relaxed.
The referred issue was already fixed for one of the two problematic asserts.


<!-- issue-number: [bpo-44734](https://bugs.python.org/issue44734) -->
https://bugs.python.org/issue44734
<!-- /issue-number -->
