### PR TITLE
bpo-46530: add `"thread_time"` to `test_time.test_get_clock_info`

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -556,20 +556,26 @@ class TimeTestCase(unittest.TestCase):
         self.assertRaises(ValueError, time.ctime, float("nan"))
 
     def test_get_clock_info(self):
-        clocks = ['monotonic', 'perf_counter', 'process_time', 'time']
+        clocks = [
+            'monotonic',
+            'perf_counter',
+            'process_time',
+            'time',
+            'thread_time',
+        ]
 
         for name in clocks:
-            info = time.get_clock_info(name)
+            with self.subTest(name=name)
+                info = time.get_clock_info(name)
 
-            #self.assertIsInstance(info, dict)
-            self.assertIsInstance(info.implementation, str)
-            self.assertNotEqual(info.implementation, '')
-            self.assertIsInstance(info.monotonic, bool)
-            self.assertIsInstance(info.resolution, float)
-            # 0.0 < resolution <= 1.0
-            self.assertGreater(info.resolution, 0.0)
-            self.assertLessEqual(info.resolution, 1.0)
-            self.assertIsInstance(info.adjustable, bool)
+                self.assertIsInstance(info.implementation, str)
+                self.assertNotEqual(info.implementation, '')
+                self.assertIsInstance(info.monotonic, bool)
+                self.assertIsInstance(info.resolution, float)
+                # 0.0 < resolution <= 1.0
+                self.assertGreater(info.resolution, 0.0)
+                self.assertLessEqual(info.resolution, 1.0)
+                self.assertIsInstance(info.adjustable, bool)
 
         self.assertRaises(ValueError, time.get_clock_info, 'xxx')
 

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -565,7 +565,7 @@ class TimeTestCase(unittest.TestCase):
         ]
 
         for name in clocks:
-            with self.subTest(name=name)
+            with self.subTest(name=name):
                 info = time.get_clock_info(name)
 
                 self.assertIsInstance(info.implementation, str)


### PR DESCRIPTION
Originally discovered here: https://github.com/python/typeshed/pull/7040

<!-- issue-number: [bpo-46530](https://bugs.python.org/issue46530) -->
https://bugs.python.org/issue46530
<!-- /issue-number -->
