### PR TITLE
bpo-46539: Pass status of special typeforms to forward references

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2870,6 +2870,13 @@ class ForwardRefTests(BaseTestCase):
         self.assertEqual(get_type_hints(foo, globals(), locals()),
                          {'a': Callable[..., T]})
 
+    def test_special_forms_forward(self):
+
+        class C:
+            a: Annotated['ClassVar[int]', (3, 5)] = 4
+
+        self.assertEqual(get_type_hints(C, globals())['a'], ClassVar[int])
+
     def test_syntax_error(self):
 
         with self.assertRaises(SyntaxError):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2874,8 +2874,15 @@ class ForwardRefTests(BaseTestCase):
 
         class C:
             a: Annotated['ClassVar[int]', (3, 5)] = 4
+            b: Annotated['Final[int]', "const"] = 4
+
+        class CF:
+            b: List['Final[int]'] = 4
 
         self.assertEqual(get_type_hints(C, globals())['a'], ClassVar[int])
+        self.assertEqual(get_type_hints(C, globals())['b'], Final[int])
+        with self.assertRaises(TypeError):
+            get_type_hints(CF, globals()),
 
     def test_syntax_error(self):
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -147,7 +147,7 @@ def _type_convert(arg, module=None, *, allow_special_forms=False):
     if arg is None:
         return type(None)
     if isinstance(arg, str):
-        return ForwardRef(arg, module=module, allow_special_forms=allow_special_forms)
+        return ForwardRef(arg, module=module, is_class=allow_special_forms)
     return arg
 
 
@@ -664,7 +664,7 @@ class ForwardRef(_Final, _root=True):
                  '__forward_is_argument__', '__forward_allow_special_forms__',
                  '__forward_module__')
 
-    def __init__(self, arg, is_argument=True, module=None, *, allow_special_forms=False):
+    def __init__(self, arg, is_argument=True, module=None, *, is_class=False):
         if not isinstance(arg, str):
             raise TypeError(f"Forward reference must be a string -- got {arg!r}")
         try:
@@ -676,7 +676,7 @@ class ForwardRef(_Final, _root=True):
         self.__forward_evaluated__ = False
         self.__forward_value__ = None
         self.__forward_is_argument__ = is_argument
-        self.__forward_allow_special_forms__ = allow_special_forms
+        self.__forward_allow_special_forms__ = is_class
         self.__forward_module__ = module
 
     def _evaluate(self, globalns, localns, recursive_guard):
@@ -1804,7 +1804,7 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False):
                 if value is None:
                     value = type(None)
                 if isinstance(value, str):
-                    value = ForwardRef(value, is_argument=False, allow_special_forms=True)
+                    value = ForwardRef(value, is_argument=False, is_class=True)
                 value = _eval_type(value, base_globals, base_locals)
                 hints[name] = value
         return hints if include_extras else {k: _strip_annotations(t) for k, t in hints.items()}
@@ -1841,7 +1841,7 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False):
             value = ForwardRef(
                 value,
                 is_argument=not isinstance(obj, types.ModuleType),
-                allow_special_forms=False,
+                is_class=False,
             )
         value = _eval_type(value, globalns, localns)
         if name in defaults and defaults[name] is None:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -661,7 +661,7 @@ class ForwardRef(_Final, _root=True):
 
     __slots__ = ('__forward_arg__', '__forward_code__',
                  '__forward_evaluated__', '__forward_value__',
-                 '__forward_is_argument__', '__forward_allow_special_forms__',
+                 '__forward_is_argument__', '__forward_is_class__',
                  '__forward_module__')
 
     def __init__(self, arg, is_argument=True, module=None, *, is_class=False):
@@ -676,7 +676,7 @@ class ForwardRef(_Final, _root=True):
         self.__forward_evaluated__ = False
         self.__forward_value__ = None
         self.__forward_is_argument__ = is_argument
-        self.__forward_allow_special_forms__ = is_class
+        self.__forward_is_class__ = is_class
         self.__forward_module__ = module
 
     def _evaluate(self, globalns, localns, recursive_guard):
@@ -697,7 +697,7 @@ class ForwardRef(_Final, _root=True):
                 eval(self.__forward_code__, globalns, localns),
                 "Forward references must evaluate to types.",
                 is_argument=self.__forward_is_argument__,
-                allow_special_forms=self.__forward_allow_special_forms__,
+                allow_special_forms=self.__forward_is_class__,
             )
             self.__forward_value__ = _eval_type(
                 type_, globalns, localns, recursive_guard | {self.__forward_arg__}

--- a/Misc/NEWS.d/next/Library/2022-01-26-20-36-30.bpo-46539.23iW1d.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-26-20-36-30.bpo-46539.23iW1d.rst
@@ -1,1 +1,1 @@
-In :func:`typing.get_type_hints`, support evaluating stringified `ClassVar` and `Final` annotations inside `Annotated`. Patch by Gregory Beauregard.
+In :func:`typing.get_type_hints`, support evaluating stringified ``ClassVar`` and ``Final`` annotations inside ``Annotated``. Patch by Gregory Beauregard.

--- a/Misc/NEWS.d/next/Library/2022-01-26-20-36-30.bpo-46539.23iW1d.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-26-20-36-30.bpo-46539.23iW1d.rst
@@ -1,0 +1,1 @@
+typing: Pass on status of special forms to forward references. Patch by Gregory Beauregard.

--- a/Misc/NEWS.d/next/Library/2022-01-26-20-36-30.bpo-46539.23iW1d.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-26-20-36-30.bpo-46539.23iW1d.rst
@@ -1,1 +1,1 @@
-typing: Pass on status of special forms to forward references. Patch by Gregory Beauregard.
+In :func:`typing.get_type_hints`, support evaluating stringified `ClassVar` and `Final` annotations inside `Annotated`. Patch by Gregory Beauregard.


### PR DESCRIPTION
Previously this didn't matter because there weren't any valid code paths
that could trigger a type conversion with a special form, but after the bug
fix for `Annotated` wrapping special forms it's now possible to annotate
something like `Annotated['ClassVar[int]', (3, 4)]`. This change would
also be needed for proposed future changes, such as allowing `ClassVar`
and `Final` to nest each other in dataclasses.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46539](https://bugs.python.org/issue46539) -->
https://bugs.python.org/issue46539
<!-- /issue-number -->
