### PR TITLE
bpo-38472: setup.py uses LC_ALL=C to check the C compiler

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-01-26-22-59-12.bpo-38472.RxfLho.rst
+++ b/Misc/NEWS.d/next/Build/2022-01-26-22-59-12.bpo-38472.RxfLho.rst
@@ -1,0 +1,2 @@
+Fix GCC detection in setup.py when cross-compiling. The C compiler is now
+run with LC_ALL=C. Previously, the detection failed with a German locale.

--- a/setup.py
+++ b/setup.py
@@ -848,7 +848,9 @@ class PyBuildExt(build_ext):
         tmpfile = os.path.join(self.build_temp, 'ccpaths')
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        ret = run_command('%s -E -v - </dev/null 2>%s 1>/dev/null' % (CC, tmpfile))
+        # bpo-38472: With a German locale, GCC returns "gcc-Version 9.1.0
+        # (GCC)", whereas it returns "gcc version 9.1.0" with the C locale.
+        ret = run_command('LC_ALL=C %s -E -v - </dev/null 2>%s 1>/dev/null' % (CC, tmpfile))
         is_gcc = False
         is_clang = False
         in_incdirs = False


### PR DESCRIPTION
Fix GCC detection in setup.py when cross-compiling. The C compiler is
now run with LC_ALL=C. Previously, the detection failed with a German
locale.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-38472](https://bugs.python.org/issue38472) -->
https://bugs.python.org/issue38472
<!-- /issue-number -->
