### PR TITLE
bpo-45296: Clarify close, quit, and exit in IDLE

### DIFF
--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -96,11 +96,13 @@ Save Copy As...
 Print Window
    Print the current window to the default printer.
 
-Close
-   Close the current window (ask to save if unsaved).
+Close Window
+   Close the current window (if an unsaved editor, ask to save; if an unsaved
+   Shell, ask to quit execution).  Calling ``exit()`` or ``close()`` in the Shell
+   window also closes Shell.  If this is the only window, also exit IDLE.
 
-Exit
-   Close all windows and quit IDLE (ask to save unsaved windows).
+Exit IDLE
+   Close all windows and quit IDLE (ask to save unsaved edit windows).
 
 Edit menu (Shell and Editor)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Lib/idlelib/help.html
+++ b/Lib/idlelib/help.html
@@ -5,7 +5,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>IDLE &#8212; Python 3.11.0a0 documentation</title>
+    <title>IDLE &#8212; Python 3.11.0a4 documentation</title>
     <link rel="stylesheet" href="../_static/pydoctheme.css" type="text/css" />
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
 
@@ -18,7 +18,7 @@
     <script src="../_static/sidebar.js"></script>
 
     <link rel="search" type="application/opensearchdescription+xml"
-          title="Search within Python 3.11.0a0 documentation"
+          title="Search within Python 3.11.0a4 documentation"
           href="../_static/opensearch.xml"/>
     <link rel="author" title="About these documents" href="../about.html" />
     <link rel="index" title="Index" href="../genindex.html" />
@@ -71,7 +71,7 @@
 
 
     <li id="cpython-language-and-version">
-      <a href="../index.html">3.11.0a0 Documentation</a> &#187;
+      <a href="../index.html">3.11.0a4 Documentation</a> &#187;
     </li>
 
           <li class="nav-item nav-item-1"><a href="index.html" >The Python Standard Library</a> &#187;</li>
@@ -163,9 +163,11 @@ file.</p>
 </dd>
 <dt>Print Window</dt><dd><p>Print the current window to the default printer.</p>
 </dd>
-<dt>Close</dt><dd><p>Close the current window (ask to save if unsaved).</p>
+<dt>Close Window</dt><dd><p>Close the current window (if an unsaved editor, ask to save; if an unsaved
+Shell, ask to quit execution).  Calling <code class="docutils literal notranslate"><span class="pre">exit()</span></code> or <code class="docutils literal notranslate"><span class="pre">close()</span></code> in the Shell
+window also closes Shell.  If this is the only window, also exit IDLE.</p>
 </dd>
-<dt>Exit</dt><dd><p>Close all windows and quit IDLE (ask to save unsaved windows).</p>
+<dt>Exit IDLE</dt><dd><p>Close all windows and quit IDLE (ask to save unsaved edit windows).</p>
 </dd>
 </dl>
 </div>
@@ -976,7 +978,7 @@ also used for testing.</p>
 
 
     <li id="cpython-language-and-version">
-      <a href="../index.html">3.11.0a0 Documentation</a> &#187;
+      <a href="../index.html">3.11.0a4 Documentation</a> &#187;
     </li>
 
           <li class="nav-item nav-item-1"><a href="index.html" >The Python Standard Library</a> &#187;</li>
@@ -1000,7 +1002,7 @@ also used for testing.</p>
       </ul>
     </div>
     <div class="footer">
-    &copy; <a href="../copyright.html">Copyright</a> 2001-2021, Python Software Foundation.
+    &copy; <a href="../copyright.html">Copyright</a> 2001-2022, Python Software Foundation.
     <br />
 
     The Python Software Foundation is a non-profit corporation.
@@ -1008,8 +1010,8 @@ also used for testing.</p>
 <br />
     <br />
 
-    Last updated on Sep 06, 2021.
-    <a href="https://docs.python.org/3/bugs.html">Found a bug</a>?
+    Last updated on Jan 26, 2022.
+    <a href="/bugs.html">Found a bug</a>?
     <br />
 
     Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 3.2.1.

--- a/Lib/idlelib/mainmenu.py
+++ b/Lib/idlelib/mainmenu.py
@@ -34,8 +34,8 @@ menudefs = [
    None,
    ('Prin_t Window', '<<print-window>>'),
    None,
-   ('_Close', '<<close-window>>'),
-   ('E_xit', '<<close-all-windows>>'),
+   ('_Close Window', '<<close-window>>'),
+   ('E_xit IDLE', '<<close-all-windows>>'),
    ]),
 
  ('edit', [

--- a/Misc/NEWS.d/next/IDLE/2022-01-26-19-33-55.bpo-45296.LzZKdU.rst
+++ b/Misc/NEWS.d/next/IDLE/2022-01-26-19-33-55.bpo-45296.LzZKdU.rst
@@ -1,0 +1,4 @@
+Clarify close, quit, and exit in IDLE.  In the File menu, 'Close' and 'Exit'
+are now 'Close Window' (the current one) and 'Exit' is now 'Exit IDLE'
+(by closing all windows).  In Shell, 'quit()' and 'exit()' mean 'close Shell'.
+If there are no other windows, this also exits IDLE.


### PR DESCRIPTION
In the File menu, 'Close' and 'Exit' are now 'Close Window' (the current
one) and 'Exit' is now 'Exit IDLE' (by closing all windows).
In Shell, 'quit()' and 'exit()' mean 'close Shell'.
If there are no other windows, this also exits IDLE.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45296](https://bugs.python.org/issue45296) -->
https://bugs.python.org/issue45296
<!-- /issue-number -->
