### PR TITLE
bpo-40170: PyType_SUPPORTS_WEAKREFS() becomes a regular function

### DIFF
--- a/Include/cpython/objimpl.h
+++ b/Include/cpython/objimpl.h
@@ -91,7 +91,7 @@ PyAPI_FUNC(int) PyObject_IS_GC(PyObject *obj);
 #endif
 
 
-/* Test if a type supports weak references */
-#define PyType_SUPPORTS_WEAKREFS(t) ((t)->tp_weaklistoffset > 0)
+// Test if a type supports weak references
+PyAPI_FUNC(int) PyType_SUPPORTS_WEAKREFS(PyTypeObject *type);
 
 PyAPI_FUNC(PyObject **) PyObject_GET_WEAKREFS_LISTPTR(PyObject *op);

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -200,6 +200,11 @@ extern int _Py_CheckSlotResult(
 // See also the Py_TPFLAGS_READY flag.
 #define _PyType_IsReady(type) ((type)->tp_dict != NULL)
 
+// Test if a type supports weak references
+static inline int _PyType_SUPPORTS_WEAKREFS(PyTypeObject *type) {
+    return (type->tp_weaklistoffset > 0);
+}
+
 extern PyObject* _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems);
 
 extern int _PyObject_InitializeDict(PyObject *obj);

--- a/Modules/_weakref.c
+++ b/Modules/_weakref.c
@@ -28,7 +28,7 @@ _weakref_getweakrefcount_impl(PyObject *module, PyObject *object)
 {
     PyWeakReference **list;
 
-    if (!PyType_SUPPORTS_WEAKREFS(Py_TYPE(object)))
+    if (!_PyType_SUPPORTS_WEAKREFS(Py_TYPE(object)))
         return 0;
 
     list = GET_WEAKREFS_LISTPTR(object);
@@ -85,7 +85,7 @@ weakref_getweakrefs(PyObject *self, PyObject *object)
 {
     PyObject *result = NULL;
 
-    if (PyType_SUPPORTS_WEAKREFS(Py_TYPE(object))) {
+    if (_PyType_SUPPORTS_WEAKREFS(Py_TYPE(object))) {
         PyWeakReference **list = GET_WEAKREFS_LISTPTR(object);
         Py_ssize_t count = _PyWeakref_GetWeakrefCount(*list);
 

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -791,7 +791,7 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
             _PyWeakref_ClearRef((PyWeakReference *)op);
         }
 
-        if (! PyType_SUPPORTS_WEAKREFS(Py_TYPE(op)))
+        if (! _PyType_SUPPORTS_WEAKREFS(Py_TYPE(op)))
             continue;
 
         /* It supports weakrefs.  Does it have any? */

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3729,7 +3729,7 @@ _PyErr_TrySetFromCause(const char *format, ...)
     base_exc_size = _PyExc_BaseException.tp_basicsize;
     same_basic_size = (
         caught_type_size == base_exc_size ||
-        (PyType_SUPPORTS_WEAKREFS(caught_type) &&
+        (_PyType_SUPPORTS_WEAKREFS(caught_type) &&
             (caught_type_size == base_exc_size + (Py_ssize_t)sizeof(PyObject *))
         )
     );

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2473,11 +2473,20 @@ type_init(PyObject *cls, PyObject *args, PyObject *kwds)
     return 0;
 }
 
+
 unsigned long
 PyType_GetFlags(PyTypeObject *type)
 {
     return type->tp_flags;
 }
+
+
+int
+PyType_SUPPORTS_WEAKREFS(PyTypeObject *type)
+{
+    return _PyType_SUPPORTS_WEAKREFS(type);
+}
+
 
 /* Determine the most derived metatype. */
 PyTypeObject *

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -299,7 +299,7 @@ weakref___new__(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         PyWeakReference *ref, *proxy;
         PyWeakReference **list;
 
-        if (!PyType_SUPPORTS_WEAKREFS(Py_TYPE(ob))) {
+        if (!_PyType_SUPPORTS_WEAKREFS(Py_TYPE(ob))) {
             PyErr_Format(PyExc_TypeError,
                          "cannot create weak reference to '%s' object",
                          Py_TYPE(ob)->tp_name);
@@ -794,7 +794,7 @@ PyWeakref_NewRef(PyObject *ob, PyObject *callback)
     PyWeakReference **list;
     PyWeakReference *ref, *proxy;
 
-    if (!PyType_SUPPORTS_WEAKREFS(Py_TYPE(ob))) {
+    if (!_PyType_SUPPORTS_WEAKREFS(Py_TYPE(ob))) {
         PyErr_Format(PyExc_TypeError,
                      "cannot create weak reference to '%s' object",
                      Py_TYPE(ob)->tp_name);
@@ -853,7 +853,7 @@ PyWeakref_NewProxy(PyObject *ob, PyObject *callback)
     PyWeakReference **list;
     PyWeakReference *ref, *proxy;
 
-    if (!PyType_SUPPORTS_WEAKREFS(Py_TYPE(ob))) {
+    if (!_PyType_SUPPORTS_WEAKREFS(Py_TYPE(ob))) {
         PyErr_Format(PyExc_TypeError,
                      "cannot create weak reference to '%s' object",
                      Py_TYPE(ob)->tp_name);
@@ -949,7 +949,7 @@ PyObject_ClearWeakRefs(PyObject *object)
     PyWeakReference **list;
 
     if (object == NULL
-        || !PyType_SUPPORTS_WEAKREFS(Py_TYPE(object))
+        || !_PyType_SUPPORTS_WEAKREFS(Py_TYPE(object))
         || Py_REFCNT(object) != 0)
     {
         PyErr_BadInternalCall();


### PR DESCRIPTION
Convert the PyType_SUPPORTS_WEAKREFS() macro to a regular function.
It no longer access the PyTypeObject.tp_weaklistoffset member
directly.

Add _PyType_SUPPORTS_WEAKREFS() static inline functions, used
internally by Python for best performances.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40170](https://bugs.python.org/issue40170) -->
https://bugs.python.org/issue40170
<!-- /issue-number -->
