### PR TITLE
bpo-40170: Remove _Py_GetAllocatedBlocks() function

### DIFF
--- a/Include/cpython/objimpl.h
+++ b/Include/cpython/objimpl.h
@@ -52,14 +52,6 @@
    the 1st step is performed automatically for you, so in a C++ class
    constructor you would start directly with PyObject_Init/InitVar. */
 
-/* This function returns the number of allocated memory blocks, regardless of size */
-PyAPI_FUNC(Py_ssize_t) _Py_GetAllocatedBlocks(void);
-
-/* Macros */
-#ifdef WITH_PYMALLOC
-PyAPI_FUNC(int) _PyObject_DebugMallocStats(FILE *out);
-#endif
-
 
 typedef struct {
     /* user context passed as the first argument to the 2 functions */

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -227,6 +227,15 @@ extern void _PyObject_FreeInstanceAttributes(PyObject *self);
 extern int _PyObject_IsInstanceDictEmpty(PyObject *);
 extern PyObject* _PyType_GetSubclasses(PyTypeObject *);
 
+/* This function returns the number of allocated memory blocks, regardless of size */
+PyAPI_FUNC(Py_ssize_t) _Py_GetAllocatedBlocks(void);
+
+/* Macros */
+#ifdef WITH_PYMALLOC
+// Export the symbol for the 3rd party guppy3 project
+PyAPI_FUNC(int) _PyObject_DebugMallocStats(FILE *out);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/C API/2022-01-27-02-37-18.bpo-40170.XxQB0i.rst
+++ b/Misc/NEWS.d/next/C API/2022-01-27-02-37-18.bpo-40170.XxQB0i.rst
@@ -1,0 +1,2 @@
+Move _Py_GetAllocatedBlocks() and _PyObject_DebugMallocStats() private
+functions to the internal C API. Patch by Victor Stinner.

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -8,6 +8,9 @@
 /* Defined in tracemalloc.c */
 extern void _PyMem_DumpTraceback(int fd, const void *ptr);
 
+// Forward declaration
+int _PyObject_DebugMallocStats(FILE *out);
+
 
 /* Python's malloc wrappers (see pymem.h) */
 
@@ -1569,8 +1572,9 @@ new_arena(void)
         const char *opt = Py_GETENV("PYTHONMALLOCSTATS");
         debug_stats = (opt != NULL && *opt != '\0');
     }
-    if (debug_stats)
+    if (debug_stats) {
         _PyObject_DebugMallocStats(stderr);
+    }
 
     if (unused_arena_objects == NULL) {
         uint i;


### PR DESCRIPTION
Move _Py_GetAllocatedBlocks() and _PyObject_DebugMallocStats()
private functions to the internal C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40170](https://bugs.python.org/issue40170) -->
https://bugs.python.org/issue40170
<!-- /issue-number -->
