### PR TITLE
bpo-40170: Remove PyHeapType_GET_MEMBERS() macro

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -951,3 +951,8 @@ Removed
   worked since the :c:type:`PyWeakReference` structure is opaque in the
   limited C API.
   (Contributed by Victor Stinner in :issue:`35134`.)
+
+* Remove the ``PyHeapType_GET_MEMBERS()`` macro. It was exposed in the
+  public C API by mistake, it must only be used by Python internally.
+  Use the ``PyTypeObject.tp_members`` member instead.
+  (Contributed by Victor Stinner in :issue:`40170`.)

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -293,10 +293,6 @@ typedef struct _heaptypeobject {
     /* here are optional user slots, followed by the members. */
 } PyHeapTypeObject;
 
-/* access macro to the members which are floating "behind" the object */
-#define PyHeapType_GET_MEMBERS(etype) \
-    ((PyMemberDef *)(((char *)etype) + Py_TYPE(etype)->tp_basicsize))
-
 PyAPI_FUNC(const char *) _PyType_Name(PyTypeObject *);
 PyAPI_FUNC(PyObject *) _PyType_Lookup(PyTypeObject *, PyObject *);
 PyAPI_FUNC(PyObject *) _PyType_LookupId(PyTypeObject *, _Py_Identifier *);

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -227,6 +227,10 @@ extern void _PyObject_FreeInstanceAttributes(PyObject *self);
 extern int _PyObject_IsInstanceDictEmpty(PyObject *);
 extern PyObject* _PyType_GetSubclasses(PyTypeObject *);
 
+// Access macro to the members which are floating "behind" the object
+#define _PyHeapType_GET_MEMBERS(etype) \
+    ((PyMemberDef *)(((char *)etype) + Py_TYPE(etype)->tp_basicsize))
+
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/C API/2022-01-27-02-51-22.bpo-40170.uPolek.rst
+++ b/Misc/NEWS.d/next/C API/2022-01-27-02-51-22.bpo-40170.uPolek.rst
@@ -1,0 +1,4 @@
+Remove the ``PyHeapType_GET_MEMBERS()`` macro. It was exposed in the public C
+API by mistake, it must only be used by Python internally.  Use the
+``PyTypeObject.tp_members`` member instead. Patch by Victor Stinner.
+

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1209,7 +1209,7 @@ traverse_slots(PyTypeObject *type, PyObject *self, visitproc visit, void *arg)
     PyMemberDef *mp;
 
     n = Py_SIZE(type);
-    mp = PyHeapType_GET_MEMBERS((PyHeapTypeObject *)type);
+    mp = _PyHeapType_GET_MEMBERS((PyHeapTypeObject *)type);
     for (i = 0; i < n; i++, mp++) {
         if (mp->type == T_OBJECT_EX) {
             char *addr = (char *)self + mp->offset;
@@ -1281,7 +1281,7 @@ clear_slots(PyTypeObject *type, PyObject *self)
     PyMemberDef *mp;
 
     n = Py_SIZE(type);
-    mp = PyHeapType_GET_MEMBERS((PyHeapTypeObject *)type);
+    mp = _PyHeapType_GET_MEMBERS((PyHeapTypeObject *)type);
     for (i = 0; i < n; i++, mp++) {
         if (mp->type == T_OBJECT_EX && !(mp->flags & READONLY)) {
             char *addr = (char *)self + mp->offset;
@@ -2968,7 +2968,7 @@ type_new_descriptors(const type_new_ctx *ctx, PyTypeObject *type)
     PyHeapTypeObject *et = (PyHeapTypeObject *)type;
     Py_ssize_t slotoffset = ctx->base->tp_basicsize;
     if (et->ht_slots != NULL) {
-        PyMemberDef *mp = PyHeapType_GET_MEMBERS(et);
+        PyMemberDef *mp = _PyHeapType_GET_MEMBERS(et);
         Py_ssize_t nslot = PyTuple_GET_SIZE(et->ht_slots);
         for (Py_ssize_t i = 0; i < nslot; i++, mp++) {
             mp->name = PyUnicode_AsUTF8(
@@ -3005,7 +3005,7 @@ type_new_descriptors(const type_new_ctx *ctx, PyTypeObject *type)
 
     type->tp_basicsize = slotoffset;
     type->tp_itemsize = ctx->base->tp_itemsize;
-    type->tp_members = PyHeapType_GET_MEMBERS(et);
+    type->tp_members = _PyHeapType_GET_MEMBERS(et);
     return 0;
 }
 
@@ -3561,8 +3561,8 @@ PyType_FromModuleAndSpec(PyObject *module, PyType_Spec *spec, PyObject *bases)
         else if (slot->slot == Py_tp_members) {
             /* Move the slots to the heap type itself */
             size_t len = Py_TYPE(type)->tp_itemsize * nmembers;
-            memcpy(PyHeapType_GET_MEMBERS(res), slot->pfunc, len);
-            type->tp_members = PyHeapType_GET_MEMBERS(res);
+            memcpy(_PyHeapType_GET_MEMBERS(res), slot->pfunc, len);
+            type->tp_members = _PyHeapType_GET_MEMBERS(res);
         }
         else {
             /* Copy other slots directly */


### PR DESCRIPTION
Remove the PyHeapType_GET_MEMBERS() macro. It was exposed in the
public C API by mistake, it must only be used by Python internally.
Use the PyTypeObject.tp_members member instead.

Rename PyHeapType_GET_MEMBERS() to _PyHeapType_GET_MEMBERS() and move
it to the internal C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40170](https://bugs.python.org/issue40170) -->
https://bugs.python.org/issue40170
<!-- /issue-number -->
