### PR TITLE
bpo-45173: Keep configparser deprecations until Python 3.12

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -1201,6 +1201,28 @@ ConfigParser Objects
       names is stripped before :meth:`optionxform` is called.
 
 
+   .. method:: readfp(fp, filename=None)
+
+      .. deprecated:: 3.2
+         Use :meth:`read_file` instead.
+
+      .. versionchanged:: 3.2
+         :meth:`readfp` now iterates on *fp* instead of calling ``fp.readline()``.
+
+      For existing code calling :meth:`readfp` with arguments which don't
+      support iteration, the following generator may be used as a wrapper
+      around the file-like object::
+
+         def readline_generator(fp):
+             line = fp.readline()
+             while line:
+                 yield line
+                 line = fp.readline()
+
+      Instead of ``parser.readfp(fp)`` use
+      ``parser.read_file(readline_generator(fp))``.
+
+
 .. data:: MAX_INTERPOLATION_DEPTH
 
    The maximum depth for recursive interpolation for :meth:`get` when the *raw*
@@ -1337,9 +1359,6 @@ Exceptions
    .. versionchanged:: 3.2
       The ``filename`` attribute and :meth:`__init__` argument were renamed to
       ``source`` for consistency.
-
-   .. versionchanged:: 3.11
-      The deprecated ``filename`` attribute was removed.
 
 
 .. rubric:: Footnotes

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -501,13 +501,6 @@ Removed
   the ``l*gettext()`` functions.
   (Contributed by Dong-hee Na and Serhiy Storchaka in :issue:`44235`.)
 
-* Removed from the :mod:`configparser` module:
-  the :class:`SafeConfigParser` class,
-  the :attr:`filename` property of the :class:`ParsingError` class,
-  the :meth:`readfp` method of the :class:`ConfigParser` class,
-  deprecated since Python 3.2.
-  (Contributed by Hugo van Kemenade in :issue:`45173`.)
-
 * The :func:`@asyncio.coroutine <asyncio.coroutine>` :term:`decorator` enabling
   legacy generator-based coroutines to be compatible with async/await code.
   The function has been deprecated since Python 3.8 and the removal was

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -457,6 +457,16 @@ Deprecated
   as deprecated, its docstring is now corrected).
   (Contributed by Hugo van Kemenade in :issue:`45837`.)
 
+* The following have been deprecated in :mod:`configparser` since Python 3.2.
+  Their deprecation warnings have now been updated to note they will removed in
+  Python 3.12:
+
+  * the :class:`configparser.SafeConfigParser` class
+  * the :attr:`configparser.ParsingError.filename` property
+  * the :meth:`configparser.ParsingError.readfp` method
+
+  (Contributed by Hugo van Kemenade in :issue:`45173`.)
+
 Removed
 =======
 

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -316,7 +316,7 @@ class ParsingError(Error):
     def filename(self):
         """Deprecated, use `source'."""
         warnings.warn(
-            "The 'filename' attribute will be removed in future versions.  "
+            "The 'filename' attribute will be removed in Python 3.12. "
             "Use 'source' instead.",
             DeprecationWarning, stacklevel=2
         )
@@ -326,7 +326,7 @@ class ParsingError(Error):
     def filename(self, value):
         """Deprecated, user `source'."""
         warnings.warn(
-            "The 'filename' attribute will be removed in future versions.  "
+            "The 'filename' attribute will be removed in Python 3.12. "
             "Use 'source' instead.",
             DeprecationWarning, stacklevel=2
         )
@@ -757,7 +757,7 @@ class RawConfigParser(MutableMapping):
     def readfp(self, fp, filename=None):
         """Deprecated, use read_file instead."""
         warnings.warn(
-            "This method will be removed in future versions.  "
+            "This method will be removed in Python 3.12. "
             "Use 'parser.read_file()' instead.",
             DeprecationWarning, stacklevel=2
         )
@@ -1232,7 +1232,7 @@ class SafeConfigParser(ConfigParser):
         super().__init__(*args, **kwargs)
         warnings.warn(
             "The SafeConfigParser class has been renamed to ConfigParser "
-            "in Python 3.2. This alias will be removed in future versions."
+            "in Python 3.2. This alias will be removed in Python 3.12."
             " Use ConfigParser directly instead.",
             DeprecationWarning, stacklevel=2
         )

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -146,12 +146,13 @@ import itertools
 import os
 import re
 import sys
+import warnings
 
 __all__ = ["NoSectionError", "DuplicateOptionError", "DuplicateSectionError",
            "NoOptionError", "InterpolationError", "InterpolationDepthError",
            "InterpolationMissingOptionError", "InterpolationSyntaxError",
            "ParsingError", "MissingSectionHeaderError",
-           "ConfigParser", "RawConfigParser",
+           "ConfigParser", "SafeConfigParser", "RawConfigParser",
            "Interpolation", "BasicInterpolation",  "ExtendedInterpolation",
            "LegacyInterpolation", "SectionProxy", "ConverterMapping",
            "DEFAULTSECT", "MAX_INTERPOLATION_DEPTH"]
@@ -310,6 +311,26 @@ class ParsingError(Error):
         self.source = source
         self.errors = []
         self.args = (source, )
+
+    @property
+    def filename(self):
+        """Deprecated, use `source'."""
+        warnings.warn(
+            "The 'filename' attribute will be removed in future versions.  "
+            "Use 'source' instead.",
+            DeprecationWarning, stacklevel=2
+        )
+        return self.source
+
+    @filename.setter
+    def filename(self, value):
+        """Deprecated, user `source'."""
+        warnings.warn(
+            "The 'filename' attribute will be removed in future versions.  "
+            "Use 'source' instead.",
+            DeprecationWarning, stacklevel=2
+        )
+        self.source = value
 
     def append(self, lineno, line):
         self.errors.append((lineno, line))
@@ -732,6 +753,15 @@ class RawConfigParser(MutableMapping):
                     raise DuplicateOptionError(section, key, source)
                 elements_added.add((section, key))
                 self.set(section, key, value)
+
+    def readfp(self, fp, filename=None):
+        """Deprecated, use read_file instead."""
+        warnings.warn(
+            "This method will be removed in future versions.  "
+            "Use 'parser.read_file()' instead.",
+            DeprecationWarning, stacklevel=2
+        )
+        self.read_file(fp, source=filename)
 
     def get(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
         """Get an option value for a given section.
@@ -1193,6 +1223,19 @@ class ConfigParser(RawConfigParser):
             self.read_dict({self.default_section: defaults})
         finally:
             self._interpolation = hold_interpolation
+
+
+class SafeConfigParser(ConfigParser):
+    """ConfigParser alias for backwards compatibility purposes."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            "The SafeConfigParser class has been renamed to ConfigParser "
+            "in Python 3.2. This alias will be removed in future versions."
+            " Use ConfigParser directly instead.",
+            DeprecationWarning, stacklevel=2
+        )
 
 
 class SectionProxy(MutableMapping):

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -1612,6 +1612,13 @@ class CoverageOneHundredTestCase(unittest.TestCase):
                                             "and `source'. Use `source'.")
         error = configparser.ParsingError(filename='source')
         self.assertEqual(error.source, 'source')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", DeprecationWarning)
+            self.assertEqual(error.filename, 'source')
+            error.filename = 'filename'
+            self.assertEqual(error.source, 'filename')
+        for warning in w:
+            self.assertTrue(warning.category is DeprecationWarning)
 
     def test_interpolation_validation(self):
         parser = configparser.ConfigParser()
@@ -1629,6 +1636,27 @@ class CoverageOneHundredTestCase(unittest.TestCase):
             parser['section']['invalid_reference']
         self.assertEqual(str(cm.exception), "bad interpolation variable "
                                             "reference '%(()'")
+
+    def test_readfp_deprecation(self):
+        sio = io.StringIO("""
+        [section]
+        option = value
+        """)
+        parser = configparser.ConfigParser()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", DeprecationWarning)
+            parser.readfp(sio, filename='StringIO')
+        for warning in w:
+            self.assertTrue(warning.category is DeprecationWarning)
+        self.assertEqual(len(parser), 2)
+        self.assertEqual(parser['section']['option'], 'value')
+
+    def test_safeconfigparser_deprecation(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", DeprecationWarning)
+            parser = configparser.SafeConfigParser()
+        for warning in w:
+            self.assertTrue(warning.category is DeprecationWarning)
 
     def test_sectionproxy_repr(self):
         parser = configparser.ConfigParser()

--- a/Misc/NEWS.d/next/Library/2022-01-27-11-16-59.bpo-45173.wreRF2.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-27-11-16-59.bpo-45173.wreRF2.rst
@@ -1,0 +1,1 @@
+Note the configparser deprecations will be removed in Python 3.12.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


First commit:

Revert https://github.com/python/cpython/pull/28292 / https://github.com/python/cpython/commit/1fc41ae8709e20d741bd86c2345173688a5e84b0 to give projects another year to update before removal of configparser deprecations.

Second commit:

Update the deprecation warnings to explicitly call out that they will be removed in Python 3.12, and mention in What's New and a NEWS file.

Re:

* https://bugs.python.org/issue45173#msg411810
* https://mail.python.org/archives/list/python-dev@python.org/thread/GJTREADEXYAETECE5JDTPYWK4WMTKYGR/
* https://discuss.python.org/t/experience-with-python-3-11-in-fedora/12911



<!-- issue-number: [bpo-45173](https://bugs.python.org/issue45173) -->
https://bugs.python.org/issue45173
<!-- /issue-number -->
