### PR TITLE
bpo-46544: do not leak `x` and `uspace` in `textwrap`

### DIFF
--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -63,11 +63,7 @@ class TextWrapper:
         Append to the last line of truncated text.
     """
 
-    unicode_whitespace_trans = {}
-    uspace = ord(' ')
-    for x in _whitespace:
-        unicode_whitespace_trans[ord(x)] = uspace
-    del x, uspace
+    unicode_whitespace_trans = dict.fromkeys(map(ord, _whitespace), ord(' '))
 
     # This funky little regex is just the trick for splitting
     # text up into word-wrappable chunks.  E.g.

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -67,6 +67,7 @@ class TextWrapper:
     uspace = ord(' ')
     for x in _whitespace:
         unicode_whitespace_trans[ord(x)] = uspace
+    del x, uspace
 
     # This funky little regex is just the trick for splitting
     # text up into word-wrappable chunks.  E.g.

--- a/Misc/NEWS.d/next/Library/2022-01-27-13-30-02.bpo-46544.oFDVWj.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-27-13-30-02.bpo-46544.oFDVWj.rst
@@ -1,0 +1,2 @@
+Don't leak ``x`` & ``uspace`` intermediate vars in
+:class:`textwrap.TextWrapper`.


### PR DESCRIPTION

<!-- issue-number: [bpo-46544](https://bugs.python.org/issue46544) -->
https://bugs.python.org/issue46544
<!-- /issue-number -->
