### PR TITLE
bpo-46546: remove `method_name` var leak from `importlib.DeprecatedList`

### DIFF
--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -305,6 +305,7 @@ class DeprecatedList(list):
         'sort',
     ]:
         locals()[method_name] = _wrap_deprecated_method(method_name)
+    del method_name
 
     def __add__(self, other):
         if not isinstance(other, tuple):

--- a/Misc/NEWS.d/next/Library/2022-01-27-14-25-42.bpo-46546.rpSN2y.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-27-14-25-42.bpo-46546.rpSN2y.rst
@@ -1,0 +1,2 @@
+Remove ``method_name`` var leak from
+:class:`importlib.metadata.DeprecatedList`.


### PR DESCRIPTION
Related https://github.com/python/cpython/pull/30955

<!-- issue-number: [bpo-46546](https://bugs.python.org/issue46546) -->
https://bugs.python.org/issue46546
<!-- /issue-number -->
