### PR TITLE
bpo-46556: emit `DeprecationWarning` from `pathlib.Path.__enter__()`

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -968,17 +968,21 @@ class Path(PurePath):
         return self._from_parsed_parts(self._drv, self._root, parts)
 
     def __enter__(self):
+        # In previous versions of pathlib, __exit__() marked this path as
+        # closed; subsequent attempts to perform I/O would raise an IOError.
+        # This functionality was never documented, and had the effect of
+        # making Path objects mutable, contrary to PEP 428.
+        # In Python 3.9 the _closed attribute was removed, and __exit__()
+        # was made a no-op.
+        # In Python 3.11 this method began emitting DeprecationWarning
+        # In Python 3.13 this method and __exit__() should be removed.
+        warnings.warn("pathlib.Path.__enter__() is deprecated and scheduled "
+                      "for removal in Python 3.13. Path objects should not "
+                      "be used as context managers.",
+                      DeprecationWarning, stacklevel=2)
         return self
 
     def __exit__(self, t, v, tb):
-        # https://bugs.python.org/issue39682
-        # In previous versions of pathlib, this method marked this path as
-        # closed; subsequent attempts to perform I/O would raise an IOError.
-        # This functionality was never documented, and had the effect of
-        # making Path objects mutable, contrary to PEP 428. In Python 3.9 the
-        # _closed attribute was removed, and this method made a no-op.
-        # This method and __enter__()/__exit__() should be deprecated and
-        # removed in the future.
         pass
 
     # Public API

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -976,8 +976,8 @@ class Path(PurePath):
         # In Python 3.11 __enter__() began emitting DeprecationWarning.
         # In Python 3.13 __enter__() and __exit__() should be removed.
         warnings.warn("pathlib.Path.__enter__() is deprecated and scheduled "
-                      "for removal in Python 3.13. Path objects should not "
-                      "be used as context managers.",
+                      "for removal in Python 3.13; Path objects as context "
+                      "managers is a no-op",
                       DeprecationWarning, stacklevel=2)
         return self
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -972,10 +972,9 @@ class Path(PurePath):
         # closed; subsequent attempts to perform I/O would raise an IOError.
         # This functionality was never documented, and had the effect of
         # making Path objects mutable, contrary to PEP 428.
-        # In Python 3.9 the _closed attribute was removed, and __exit__()
-        # was made a no-op.
-        # In Python 3.11 this method began emitting DeprecationWarning
-        # In Python 3.13 this method and __exit__() should be removed.
+        # In Python 3.9 __exit__() was made a no-op.
+        # In Python 3.11 __enter__() began emitting DeprecationWarning.
+        # In Python 3.13 __enter__() and __exit__() should be removed.
         warnings.warn("pathlib.Path.__enter__() is deprecated and scheduled "
                       "for removal in Python 3.13. Path objects should not "
                       "be used as context managers.",

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -976,8 +976,8 @@ class Path(PurePath):
         # In Python 3.11 __enter__() began emitting DeprecationWarning.
         # In Python 3.13 __enter__() and __exit__() should be removed.
         warnings.warn("pathlib.Path.__enter__() is deprecated and scheduled "
-                      "for removal in Python 3.13; Path objects as context "
-                      "managers is a no-op",
+                      "for removal in Python 3.13; Path objects as a context "
+                      "manager is a no-op",
                       DeprecationWarning, stacklevel=2)
         return self
 

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1445,12 +1445,6 @@ class _BasePathTest(object):
     def assertEqualNormCase(self, path_a, path_b):
         self.assertEqual(os.path.normcase(path_a), os.path.normcase(path_b))
 
-    def test_context_manager(self):
-        # bpo-46556: path context managers are deprecated in Python 3.11.
-        with self.assertWarns(DeprecationWarning):
-            with self.cls():
-                pass
-
     def _test_cwd(self, p):
         q = self.cls(os.getcwd())
         self.assertEqual(p, q)
@@ -1836,8 +1830,10 @@ class _BasePathTest(object):
         it = p.iterdir()
         it2 = p.iterdir()
         next(it2)
-        with p:
-            pass
+        # bpo-46556: path context managers are deprecated in Python 3.11.
+        with self.assertWarns(DeprecationWarning):
+            with p:
+                pass
         # Using a path as a context manager is a no-op, thus the following
         # operations should still succeed after the context manage exits.
         next(it)
@@ -1845,8 +1841,9 @@ class _BasePathTest(object):
         p.exists()
         p.resolve()
         p.absolute()
-        with p:
-            pass
+        with self.assertWarns(DeprecationWarning):
+            with p:
+                pass
 
     def test_chmod(self):
         p = self.cls(BASE) / 'fileA'

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1445,6 +1445,12 @@ class _BasePathTest(object):
     def assertEqualNormCase(self, path_a, path_b):
         self.assertEqual(os.path.normcase(path_a), os.path.normcase(path_b))
 
+    def test_context_manager(self):
+        # bpo-46556: path context managers are deprecated in Python 3.11.
+        with self.assertWarns(DeprecationWarning):
+            with self.cls():
+                pass
+
     def _test_cwd(self, p):
         q = self.cls(os.getcwd())
         self.assertEqual(p, q)

--- a/Misc/NEWS.d/next/Library/2022-01-27-23-20-30.bpo-46556.tlpAgS.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-27-23-20-30.bpo-46556.tlpAgS.rst
@@ -1,0 +1,2 @@
+Deprecate undocumented support for using a :class:`pathlib.Path` object as a
+context manager.


### PR DESCRIPTION
In Python 3.9, `Path.__exit__()` was made a no-op.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46556](https://bugs.python.org/issue46556) -->
https://bugs.python.org/issue46556
<!-- /issue-number -->

Automerge-Triggered-By: GH:brettcannon