### PR TITLE
bpo-46542: test_json uses support.infinite_recursion()

### DIFF
--- a/Lib/test/test_json/test_recursion.py
+++ b/Lib/test/test_json/test_recursion.py
@@ -1,3 +1,4 @@
+from test import support
 from test.test_json import PyTest, CTest
 
 
@@ -69,11 +70,14 @@ class TestRecursion:
         # test that loading highly-nested objects doesn't segfault when C
         # accelerations are used. See #12017
         with self.assertRaises(RecursionError):
-            self.loads('{"a":' * 100000 + '1' + '}' * 100000)
+            with support.infinite_recursion():
+                self.loads('{"a":' * 100000 + '1' + '}' * 100000)
         with self.assertRaises(RecursionError):
-            self.loads('{"a":' * 100000 + '[1]' + '}' * 100000)
+            with support.infinite_recursion():
+                self.loads('{"a":' * 100000 + '[1]' + '}' * 100000)
         with self.assertRaises(RecursionError):
-            self.loads('[' * 100000 + '1' + ']' * 100000)
+            with support.infinite_recursion():
+                self.loads('[' * 100000 + '1' + ']' * 100000)
 
     def test_highly_nested_objects_encoding(self):
         # See #12051
@@ -81,9 +85,11 @@ class TestRecursion:
         for x in range(100000):
             l, d = [l], {'k':d}
         with self.assertRaises(RecursionError):
-            self.dumps(l)
+            with support.infinite_recursion():
+                self.dumps(l)
         with self.assertRaises(RecursionError):
-            self.dumps(d)
+            with support.infinite_recursion():
+                self.dumps(d)
 
     def test_endless_recursion(self):
         # See #12051
@@ -93,7 +99,8 @@ class TestRecursion:
                 return [o]
 
         with self.assertRaises(RecursionError):
-            EndlessJSONEncoder(check_circular=False).encode(5j)
+            with support.infinite_recursion():
+                EndlessJSONEncoder(check_circular=False).encode(5j)
 
 
 class TestPyRecursion(TestRecursion, PyTest): pass

--- a/Misc/NEWS.d/next/Tests/2022-01-28-01-17-10.bpo-46542.xRLTdj.rst
+++ b/Misc/NEWS.d/next/Tests/2022-01-28-01-17-10.bpo-46542.xRLTdj.rst
@@ -1,0 +1,2 @@
+Fix ``test_json`` tests checking for :exc:`RecursionError`: modify these tests
+to use ``support.infinite_recursion()``. Patch by Victor Stinner.


### PR DESCRIPTION
Fix test_json tests checking for RecursionError: modify these tests
to use support.infinite_recursion().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46542](https://bugs.python.org/issue46542) -->
https://bugs.python.org/issue46542
<!-- /issue-number -->
