### PR TITLE
bpo-46557: Log captured warnings without format string (GH-30975)

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -2246,7 +2246,7 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
         logger = getLogger("py.warnings")
         if not logger.handlers:
             logger.addHandler(NullHandler())
-        logger.warning("%s", s)
+        logger.warning(str(s))
 
 def captureWarnings(capture):
     """

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -2246,7 +2246,7 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
         logger = getLogger("py.warnings")
         if not logger.handlers:
             logger.addHandler(NullHandler())
-        # Log str(s) directly instead of with logger.warning("%s", s)
+        # bpo-46557: Log str(s) as msg instead of logger.warning("%s", s)
         # since some log aggregation tools group logs by the msg arg
         logger.warning(str(s))
 

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -2246,6 +2246,8 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
         logger = getLogger("py.warnings")
         if not logger.handlers:
             logger.addHandler(NullHandler())
+        # Log str(s) directly instead of with logger.warning("%s", s)
+        # since some log aggregation tools group logs by the msg arg
         logger.warning(str(s))
 
 def captureWarnings(capture):

--- a/Misc/NEWS.d/next/Library/2022-01-28-01-23-25.bpo-46557.XSbhyQ.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-28-01-23-25.bpo-46557.XSbhyQ.rst
@@ -1,1 +1,1 @@
-Captured warnings from the warnings module are now logged without a format string to prevent systems that group logs by the format string from grouping all warnings together
+Captured warnings from the warnings module are now logged without a format string to prevent systems that group logs by the format string from grouping all warnings together.

--- a/Misc/NEWS.d/next/Library/2022-01-28-01-23-25.bpo-46557.XSbhyQ.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-28-01-23-25.bpo-46557.XSbhyQ.rst
@@ -1,1 +1,1 @@
-Captured warnings from the warnings module are now logged without a format string to prevent systems that group logs by the format string from grouping all warnings together.
+Warnings captured by the logging module are now logged without a format string to prevent systems that group logs by the msg argument from grouping captured warnings together.

--- a/Misc/NEWS.d/next/Library/2022-01-28-01-23-25.bpo-46557.XSbhyQ.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-28-01-23-25.bpo-46557.XSbhyQ.rst
@@ -1,0 +1,1 @@
+Captured warnings from the warnings module are now logged without a format string to prevent systems that group logs by the format string from grouping all warnings together


### PR DESCRIPTION
For systems that aggregate logs like Sentry, the use of a format string causes all warnings to be grouped under the same issue.


<!-- issue-number: [bpo-46557](https://bugs.python.org/issue46557) -->
https://bugs.python.org/issue46557
<!-- /issue-number -->
