### PR TITLE
bpo-46449: Adjust refcnt for Py_INCREF/Py_DECREF on immortal code-objects

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1923,4 +1923,8 @@ _PyStaticCode_Dealloc(PyCodeObject *co)
         PyObject_ClearWeakRefs((PyObject *)co);
         co->co_weakreflist = NULL;
     }
+#ifdef Py_REF_DEBUG
+    /* Adjust _Py_RefTotal for Py_INCREF/Py_DECREF on immortal codeobjects */
+    _Py_RefTotal += 999999999 - Py_REFCNT((PyObject *)co);
+#endif
 }

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1924,7 +1924,9 @@ _PyStaticCode_Dealloc(PyCodeObject *co)
         co->co_weakreflist = NULL;
     }
 #ifdef Py_REF_DEBUG
-    /* Adjust _Py_RefTotal for Py_INCREF/Py_DECREF on immortal codeobjects */
+    /* Adjust _Py_RefTotal and refcnt for Py_INCREF/Py_DECREF 
+     * on immortal codeobjects */
     _Py_RefTotal += 999999999 - Py_REFCNT((PyObject *)co);
+    Py_SET_REFCNT((PyObject*)co, 999999999);
 #endif
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-46449](https://bugs.python.org/issue46449) -->
https://bugs.python.org/issue46449
<!-- /issue-number -->
