### PR TITLE
bpo-46553: allow bare typing.ClassVar annotations

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2071,7 +2071,7 @@ class GenericTests(BaseTestCase):
         with self.assertRaises(TypeError):
             Tuple[Optional]
         with self.assertRaises(TypeError):
-            ClassVar[ClassVar]
+            ClassVar[ClassVar[int]]
         with self.assertRaises(TypeError):
             List[ClassVar[int]]
 
@@ -2896,12 +2896,16 @@ class ForwardRefTests(BaseTestCase):
         class C:
             a: Annotated['ClassVar[int]', (3, 5)] = 4
             b: Annotated['Final[int]', "const"] = 4
+            x: 'ClassVar' = 4
+            y: 'Final' = 4
 
         class CF:
             b: List['Final[int]'] = 4
 
         self.assertEqual(get_type_hints(C, globals())['a'], ClassVar[int])
         self.assertEqual(get_type_hints(C, globals())['b'], Final[int])
+        self.assertEqual(get_type_hints(C, globals())['x'], ClassVar)
+        self.assertEqual(get_type_hints(C, globals())['y'], Final)
         with self.assertRaises(TypeError):
             get_type_hints(CF, globals()),
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -173,7 +173,7 @@ def _type_check(arg, msg, is_argument=True, module=None, *, allow_special_forms=
     if (isinstance(arg, _GenericAlias) and
             arg.__origin__ in invalid_generic_forms):
         raise TypeError(f"{arg} is not valid as type argument")
-    if arg in (Any, NoReturn, Final):
+    if arg in (Any, NoReturn, ClassVar, Final):
         return arg
     if isinstance(arg, _SpecialForm) or arg in (Generic, Protocol):
         raise TypeError(f"Plain {arg} is not valid as type argument")

--- a/Misc/NEWS.d/next/Library/2022-01-28-08-47-53.bpo-46553.f7Uc96.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-28-08-47-53.bpo-46553.f7Uc96.rst
@@ -1,1 +1,1 @@
-In :func:`typing.get_type_hints`, support evaluating bare stringified ``ClassVar` annotations. Patch by Gregory Beauregard.
+In :func:`typing.get_type_hints`, support evaluating bare stringified ``ClassVar`` annotations. Patch by Gregory Beauregard.

--- a/Misc/NEWS.d/next/Library/2022-01-28-08-47-53.bpo-46553.f7Uc96.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-28-08-47-53.bpo-46553.f7Uc96.rst
@@ -1,0 +1,1 @@
+In :func:`typing.get_type_hints`, support evaluating bare stringified ``ClassVar` annotations. Patch by Gregory Beauregard.


### PR DESCRIPTION
This is a simple matter of just adding `ClassVar` to the list of types allowed to be bare before the later call that raises for bare types.

These are used in the wild and covered by dataclasses unit tests.
Several static type checkers support this pattern.

Note we adjust one test from `ClassVar[ClassVar]` to
`ClassVar[ClassVar[int]]` so that it still fails. This is surprising, but
not a result of weirdness we're doing in this patch. This is a
limitation of the current way runtime type checking works that this case
is allowed when bare special forms are allowed. For example, before this
patch `ClassVar[Final]` is a valid runtime annotation despite nesting these
forms being generally disallowed, so it's expected allowing bare `ClassVar`
makes `ClassVar[ClassVar]` valid as well.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46553](https://bugs.python.org/issue46553) -->
https://bugs.python.org/issue46553
<!-- /issue-number -->
