### PR TITLE
bpo-46449: Fix refcount of deepfrozen code

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -1296,7 +1296,7 @@ find_frozen(PyObject *nameobj, struct frozen_info *info)
     if (info != NULL) {
         info->nameobj = nameobj;  // borrowed
         info->data = (const char *)p->code;
-        info->get_code = p->get_code;
+        info->get_code = p->get_code; // function returns borrowed ref
         info->size = p->size < 0 ? -(p->size) : p->size;
         info->is_package = p->size < 0 ? true : false;
         info->origname = name;
@@ -1321,7 +1321,7 @@ unmarshal_frozen_code(struct frozen_info *info)
     if (info->get_code) {
         PyObject *code = info->get_code();
         assert(code != NULL);
-        return code;
+        return Py_NewRef(code);
     }
     PyObject *co = PyMarshal_ReadObjectFromString(info->data, info->size);
     if (co == NULL) {


### PR DESCRIPTION
get_code() returns a borrowed reference. unmarshal_frozen_code is
expected to return a strong reference.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46449](https://bugs.python.org/issue46449) -->
https://bugs.python.org/issue46449
<!-- /issue-number -->
