### PR TITLE
Fix a `UnboundLocalError` bug in `test_sysconfig`

### DIFF
--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -436,8 +436,8 @@ class TestSysConfig(unittest.TestCase):
                 expected_suffixes = 'i386-linux-gnu.so', 'x86_64-linux-gnux32.so', 'i386-linux-musl.so'
             else: # 8 byte pointer size
                 expected_suffixes = 'x86_64-linux-gnu.so', 'x86_64-linux-musl.so'
-        self.assertTrue(suffix.endswith(expected_suffixes),
-                        f'unexpected suffix {suffix!r}')
+            self.assertTrue(suffix.endswith(expected_suffixes),
+                            f'unexpected suffix {suffix!r}')
 
     @unittest.skipUnless(sys.platform == 'darwin', 'OS X-specific test')
     def test_osx_ext_suffix(self):


### PR DESCRIPTION
Accidentally introduced by GH-24502

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:brettcannon