### PR TITLE
bpo-46329: Fix refleak in specialized `isinstance` error path

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4946,6 +4946,7 @@ handle_eval_breaker:
             PyObject *inst = TOP();
             int retval = PyObject_IsInstance(inst, cls);
             if (retval < 0) {
+                Py_DECREF(cls);
                 goto error;
             }
             PyObject *res = PyBool_FromLong(retval);


### PR DESCRIPTION
Since `cls` is `POP`-ed, `error` doesn't decref it since it decrefs from `TOS` down.

<!-- issue-number: [bpo-46329](https://bugs.python.org/issue46329) -->
https://bugs.python.org/issue46329
<!-- /issue-number -->
