### PR TITLE
bpo-14916: use specified tokenizer fd for file input

### DIFF
--- a/Misc/NEWS.d/next/C API/2020-09-11-02-50-41.bpo-14916.QN1Y03.rst
+++ b/Misc/NEWS.d/next/C API/2020-09-11-02-50-41.bpo-14916.QN1Y03.rst
@@ -1,0 +1,2 @@
+fixed bug in "The Very High Level Layer" of c-api that prevented
+PyRun_InteractiveOne\*() parsing from the provided FD.

--- a/Misc/NEWS.d/next/C API/2020-09-11-02-50-41.bpo-14916.QN1Y03.rst
+++ b/Misc/NEWS.d/next/C API/2020-09-11-02-50-41.bpo-14916.QN1Y03.rst
@@ -1,2 +1,1 @@
-fixed bug in "The Very High Level Layer" of c-api that prevented
-PyRun_InteractiveOne\*() parsing from the provided FD.
+Fixed bug in the tokenizer that prevented ``PyRun_InteractiveOne`` from parsing from the provided FD.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -855,7 +855,7 @@ tok_underflow_interactive(struct tok_state *tok) {
         tok->done = E_INTERACT_STOP;
         return 1;
     }
-    char *newtok = PyOS_Readline(stdin, stdout, tok->prompt);
+    char *newtok = PyOS_Readline(tok->fp ? tok->fp : stdin, stdout, tok->prompt);
     if (newtok != NULL) {
         char *translated = translate_newlines(newtok, 0, tok);
         PyMem_Free(newtok);


### PR DESCRIPTION
@pablogsal, sorry i failed to rebase to main, so i recreated https://github.com/python/cpython/pull/22190#issuecomment-1024633392

> PyRun_InteractiveOne\*() functions allow to explicitily set fd instead of stdin.
but stdin was hardcoded in readline call.

> This patch does not fix target file for prompt unlike original bpo one : prompt fd is unrelated to tokenizer source which could be read only. It is more of a bugfix regarding the docs :  actual documentation say "prompt the user" so one would expect prompt to go on stdout not a file for both PyRun_InteractiveOne\*() and PyRun_InteractiveLoop\*().

<!-- issue-number: [bpo-14916](https://bugs.python.org/issue14916) -->
https://bugs.python.org/issue14916
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal