### PR TITLE
bpo-46569: fix typo in `StrEnum` docs

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -420,7 +420,7 @@ Data Types
 
    .. note:: :meth:`__str__` is :func:`str.__str__` to better support the
       *replacement of existing constants* use-case.  :meth:`__format__` is likewise
-      :func:`int.__format__` for that same reason.
+      :func:`str.__format__` for that same reason.
 
    .. versionadded:: 3.11
 


### PR DESCRIPTION
Thanks to `Dutcho` for finding this!

<!-- issue-number: [bpo-46569](https://bugs.python.org/issue46569) -->
https://bugs.python.org/issue46569
<!-- /issue-number -->
