### PR TITLE
gh-90678: Handle identifiers that look like keywords in `ast.unparse`

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -28,7 +28,7 @@ import sys
 from _ast import *
 from contextlib import contextmanager, nullcontext
 from enum import IntEnum, auto, _simple_enum
-import keyword
+from keyword import iskeyword
 
 
 def parse(source, filename='<unknown>', mode='exec', *,
@@ -677,7 +677,7 @@ def _mangle_keyword(x):
     won't be parsed as a keyword, as desired."""
     return (
         x if x in ('True', 'False', 'None') else
-        chr(ord(x[0]) + _MANGLE_INCR) + x[1:] if keyword.iskeyword(x) else
+        chr(ord(x[0]) + _MANGLE_INCR) + x[1:] if iskeyword(x) else
         x)
 
 

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1699,7 +1699,7 @@ class _Unparser(NodeVisitor):
             with self.require_parens(_Precedence.TEST, node):
                 self.set_precedence(_Precedence.BOR, node.pattern)
                 self.traverse(node.pattern)
-                self.write(f" as {node.name}")
+                self.write(f" as {_mangle_keyword(node.name)}")
 
     def visit_MatchOr(self, node):
         with self.require_parens(_Precedence.BOR, node):

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -910,13 +910,12 @@ class _Unparser(NodeVisitor):
             self.write(", ")
             self.traverse(node.msg)
 
-    def visit_Global(self, node):
-        self.fill("global ")
+    def visit_Global(self, node, kw="global "):
+        self.fill(kw)
         self.interleave(lambda: self.write(", "), self.write, node.names)
 
     def visit_Nonlocal(self, node):
-        self.fill("nonlocal ")
-        self.interleave(lambda: self.write(", "), self.write, node.names)
+        self.visit_Global(node, kw="nonlocal ")
 
     def visit_Await(self, node):
         with self.require_parens(_Precedence.AWAIT, node):

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -867,7 +867,7 @@ class _Unparser(NodeVisitor):
         self.fill("from ")
         self.write("." * node.level)
         if node.module:
-            self.write(node.module)
+            self.write(_mangle_keyword(node.module))
         self.write(" import ")
         self.interleave(lambda: self.write(", "), self.traverse, node.names)
 
@@ -925,7 +925,7 @@ class _Unparser(NodeVisitor):
 
     def visit_Global(self, node, kw="global "):
         self.fill(kw)
-        self.interleave(lambda: self.write(", "), self.write, node.names)
+        self.interleave(lambda: self.write(", "), self.write, map(_mangle_keyword, node.names))
 
     def visit_Nonlocal(self, node):
         self.visit_Global(node, kw="nonlocal ")
@@ -1004,7 +1004,7 @@ class _Unparser(NodeVisitor):
             self.traverse(node.type)
         if node.name:
             self.write(" as ")
-            self.write(node.name)
+            self.write(_mangle_keyword(node.name))
         with self.block():
             self.traverse(node.body)
 
@@ -1013,7 +1013,7 @@ class _Unparser(NodeVisitor):
         for deco in node.decorator_list:
             self.fill("@")
             self.traverse(deco)
-        self.fill("class " + node.name)
+        self.fill("class " + _mangle_keyword(node.name))
         with self.delimit_if("(", ")", condition = node.bases or node.keywords):
             comma = False
             for e in node.bases:
@@ -1043,7 +1043,7 @@ class _Unparser(NodeVisitor):
         for deco in node.decorator_list:
             self.fill("@")
             self.traverse(deco)
-        def_str = fill_suffix + " " + node.name
+        def_str = fill_suffix + " " + _mangle_keyword(node.name)
         self.fill(def_str)
         with self.delimit("(", ")"):
             self.traverse(node.args)
@@ -1467,7 +1467,7 @@ class _Unparser(NodeVisitor):
         if isinstance(node.value, Constant) and isinstance(node.value.value, int):
             self.write(" ")
         self.write(".")
-        self.write(node.attr)
+        self.write(_mangle_keyword(node.attr))
 
     def visit_Call(self, node):
         self.set_precedence(_Precedence.ATOM, node.func)
@@ -1532,7 +1532,7 @@ class _Unparser(NodeVisitor):
                 self.traverse(case)
 
     def visit_arg(self, node):
-        self.write(node.arg)
+        self.write(_mangle_keyword(node.arg))
         if node.annotation:
             self.write(": ")
             self.traverse(node.annotation)
@@ -1563,7 +1563,7 @@ class _Unparser(NodeVisitor):
                 self.write(", ")
             self.write("*")
             if node.vararg:
-                self.write(node.vararg.arg)
+                self.write(_mangle_keyword(node.vararg.arg))
                 if node.vararg.annotation:
                     self.write(": ")
                     self.traverse(node.vararg.annotation)
@@ -1583,7 +1583,7 @@ class _Unparser(NodeVisitor):
                 first = False
             else:
                 self.write(", ")
-            self.write("**" + node.kwarg.arg)
+            self.write("**" + _mangle_keyword(node.kwarg.arg))
             if node.kwarg.annotation:
                 self.write(": ")
                 self.traverse(node.kwarg.annotation)
@@ -1592,7 +1592,7 @@ class _Unparser(NodeVisitor):
         if node.arg is None:
             self.write("**")
         else:
-            self.write(node.arg)
+            self.write(_mangle_keyword(node.arg))
             self.write("=")
         self.traverse(node.value)
 
@@ -1608,9 +1608,9 @@ class _Unparser(NodeVisitor):
             self.traverse(node.body)
 
     def visit_alias(self, node):
-        self.write(node.name)
+        self.write(_mangle_keyword(node.name))
         if node.asname:
-            self.write(" as " + node.asname)
+            self.write(" as " + _mangle_keyword(node.asname))
 
     def visit_withitem(self, node):
         self.traverse(node.context_expr)

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -282,6 +282,19 @@ class UnparseTestCase(ASTTestCase):
     def test_unicode_mangled_keywords(self):
         # See issue 46520
         self.check_ast_roundtrip('𝕕𝕖𝕗 = 1')
+        self.check_ast_roundtrip('del 𝕕𝕖𝕝')
+        self.check_ast_roundtrip('f(𝕕𝕖𝕗, 𝕕𝕖𝕗 = 2, *𝕕𝕖𝕗, **𝕕𝕖𝕗)')
+        self.check_ast_roundtrip('def 𝕕𝕖𝕗(𝕕𝕖𝕗, 𝕕𝕖𝕗 = 2, *𝕕𝕖𝕗, **𝕕𝕖𝕗): pass')
+        self.check_ast_roundtrip('class 𝕔𝕝𝕒𝕤𝕤: pass')
+        self.check_ast_roundtrip('with 𝕨𝕚𝕥𝕙 as 𝕒𝕤: pass')
+        self.check_ast_roundtrip('try: pass\nexcept 𝕖𝕩𝕔𝕖𝕡𝕥 as 𝕒𝕤: pass')
+        self.check_ast_roundtrip('import 𝕚𝕞𝕡𝕠𝕣𝕥 as 𝕒𝕤')
+        self.check_ast_roundtrip('from 𝕗𝕣𝕠𝕞 import 𝕚𝕞𝕡𝕠𝕣𝕥 as 𝕒𝕤')
+        self.check_ast_roundtrip('global 𝕘𝕝𝕠𝕓𝕒𝕝')
+        self.check_ast_roundtrip('nonlocal 𝕟𝕠𝕟𝕝𝕠𝕔𝕒𝕝')
+        self.check_ast_roundtrip('foo.𝕝𝕒𝕞𝕓𝕕𝕒')
+        self.check_ast_roundtrip('lambda 𝕝𝕒𝕞𝕓𝕕𝕒: 1')
+        self.check_ast_roundtrip('(𝕕𝕖𝕗 := 1)')
 
     def test_bytes(self):
         self.check_ast_roundtrip("b'123'")

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -279,6 +279,10 @@ class UnparseTestCase(ASTTestCase):
     def test_raise_from(self):
         self.check_ast_roundtrip(raise_from)
 
+    def test_unicode_mangled_keywords(self):
+        # See issue 46520
+        self.check_ast_roundtrip('𝕕𝕖𝕗 = 1')
+
     def test_bytes(self):
         self.check_ast_roundtrip("b'123'")
 

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -295,6 +295,14 @@ class UnparseTestCase(ASTTestCase):
         self.check_ast_roundtrip('foo.𝕝𝕒𝕞𝕓𝕕𝕒')
         self.check_ast_roundtrip('lambda 𝕝𝕒𝕞𝕓𝕕𝕒: 1')
         self.check_ast_roundtrip('(𝕕𝕖𝕗 := 1)')
+        # `match` is parsed unusually, allowing ASCII keywords in many
+        # places.
+        self.check_ast_roundtrip('''match match:
+            case [*case]: 1
+            case {**case}: 1
+            case 𝕔𝕝𝕒𝕤𝕤(case = 1): 1
+            case case as 𝕒𝕤: 1'''
+        )
 
     def test_bytes(self):
         self.check_ast_roundtrip("b'123'")

--- a/Misc/NEWS.d/next/Library/2022-01-29-12-57-50.bpo-46520.38HC5x.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-29-12-57-50.bpo-46520.38HC5x.rst
@@ -1,0 +1,2 @@
+``ast.unparse`` can now handle the result of parsing code that uses
+not-quite-Python-keywords like "𝕕𝕖𝕗".


### PR DESCRIPTION
Handle identifiers that look like keywords in `ast.unparse`

<!-- issue-number: [bpo-46520](https://bugs.python.org/issue46520) -->
https://bugs.python.org/issue46520
<!-- /issue-number -->

<!-- gh-issue-number: gh-90678 -->
* Issue: gh-90678
<!-- /gh-issue-number -->
