### PR TITLE
bpo-46574: Allow non-numeric arguments to itertools.count

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -308,24 +308,25 @@ loops that truncate the stream.
 
 .. function:: count(start=0, step=1)
 
-   Make an iterator that returns evenly spaced values starting with number *start*. Often
+   Make an iterator returning *step* repeatedly added to *start*. Often
    used as an argument to :func:`map` to generate consecutive data points.
    Also, used with :func:`zip` to add sequence numbers.  Roughly equivalent to::
 
       def count(start=0, step=1):
-          # count(10) --> 10 11 12 13 14 ...
+          # count(10) -> 10 11 12 13 14 ...
           # count(2.5, 0.5) -> 2.5 3.0 3.5 ...
+          # count('', 'a') -> '' 'a' 'aa' ...
           n = start
           while True:
               yield n
-              n += step
+              n = n + step
 
    When counting with floating point numbers, better accuracy can sometimes be
    achieved by substituting multiplicative code such as: ``(start + step * i
    for i in count())``.
 
    .. versionchanged:: 3.1
-      Added *step* argument and allowed non-integer arguments.
+      Added *step* argument and allowed non-integer numeric arguments.
 
 .. function:: cycle(iterable)
 

--- a/Misc/NEWS.d/next/Library/2022-01-29-19-49-57.bpo-46574.aj0OBE.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-29-19-49-57.bpo-46574.aj0OBE.rst
@@ -1,0 +1,1 @@
+``itertools.count`` now accepts non-numeric arguments

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -624,11 +624,11 @@ PyDoc_STRVAR(itertools_count__doc__,
 "Return a count object whose .__next__() method returns consecutive values.\n"
 "\n"
 "Equivalent to:\n"
-"    def count(firstval=0, step=1):\n"
-"        x = firstval\n"
+"    def count(start=0, step=1):\n"
+"        x = start\n"
 "        while 1:\n"
 "            yield x\n"
-"            x += step");
+"            x = x + step");
 
 static PyObject *
 itertools_count_impl(PyTypeObject *type, PyObject *long_cnt,

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -4140,15 +4140,15 @@ fast_mode:  when cnt an integer < PY_SSIZE_T_MAX and no step is specified.
 
     assert(cnt != PY_SSIZE_T_MAX && long_cnt == NULL && long_step==PyLong(1));
     Advances with:  cnt += 1
-    When count hits Y_SSIZE_T_MAX, switch to slow_mode.
+    When count hits PY_SSIZE_T_MAX, switch to slow_mode.
 
-slow_mode:  when cnt == PY_SSIZE_T_MAX, step is not int(1), or cnt is a float.
+slow_mode:  when cnt == PY_SSIZE_T_MAX, step is not int(1), or cnt is not an int.
 
     assert(cnt == PY_SSIZE_T_MAX && long_cnt != NULL && long_step != NULL);
     All counting is done with python objects (no overflows or underflows).
-    Advances with:  long_cnt += long_step
+    Advances with:  long_cnt = long_cnt + long_step
     Step may be zero -- effectively a slow version of repeat(cnt).
-    Either long_cnt or long_step may be a float, Fraction, or Decimal.
+    Either long_cnt or long_step may be non-integers (like float, Fraction, Decimal, str, or list).
 */
 
 /*[clinic input]
@@ -4159,11 +4159,11 @@ itertools.count.__new__
 Return a count object whose .__next__() method returns consecutive values.
 
 Equivalent to:
-    def count(firstval=0, step=1):
-        x = firstval
+    def count(start=0, step=1):
+        x = start
         while 1:
             yield x
-            x += step
+            x = x + step
 [clinic start generated code]*/
 
 static PyObject *
@@ -4175,12 +4175,6 @@ itertools_count_impl(PyTypeObject *type, PyObject *long_cnt,
     int fast_mode;
     Py_ssize_t cnt = 0;
     long step;
-
-    if ((long_cnt != NULL && !PyNumber_Check(long_cnt)) ||
-        (long_step != NULL && !PyNumber_Check(long_step))) {
-                    PyErr_SetString(PyExc_TypeError, "a number is required");
-                    return NULL;
-    }
 
     fast_mode = (long_cnt == NULL || PyLong_Check(long_cnt)) &&
                 (long_step == NULL || PyLong_Check(long_step));


### PR DESCRIPTION
https://bugs.python.org/issue46574

<!-- issue-number: [bpo-46574](https://bugs.python.org/issue46574) -->
https://bugs.python.org/issue46574
<!-- /issue-number -->
