### PR TITLE
bpo-44031: fix test_tabnanny failure in non-ascii CWD

### DIFF
--- a/Lib/test/test_tabnanny.py
+++ b/Lib/test/test_tabnanny.py
@@ -293,8 +293,8 @@ class TestCommandLine(TestCase):
         _, out, err = script_helper.assert_python_ok('-m', 'tabnanny', *args)
         # Note: The `splitlines()` will solve the problem of CRLF(\r) added
         # by OS Windows.
-        out = out.decode('ascii')
-        err = err.decode('ascii')
+        out = out.decode('utf-8')
+        err = err.decode('utf-8')
         if partial:
             for std, output in ((stdout, out), (stderr, err)):
                 _output = output.splitlines()

--- a/Lib/test/test_tabnanny.py
+++ b/Lib/test/test_tabnanny.py
@@ -293,8 +293,8 @@ class TestCommandLine(TestCase):
         _, out, err = script_helper.assert_python_ok('-m', 'tabnanny', *args)
         # Note: The `splitlines()` will solve the problem of CRLF(\r) added
         # by OS Windows.
-        out = out.decode('utf-8')
-        err = err.decode('utf-8')
+        out = os.fsdecode(out)
+        err = os.fsdecode(err)
         if partial:
             for std, output in ((stdout, out), (stderr, err)):
                 _output = output.splitlines()


### PR DESCRIPTION
I was able to reproduce the failure on a Mac, and this change fixes it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44031](https://bugs.python.org/issue44031) -->
https://bugs.python.org/issue44031
<!-- /issue-number -->
