### PR TITLE
bpo-46576: bpo-46524: Disable compiler optimization within test_peg_generator.

### DIFF
--- a/Misc/NEWS.d/next/Tests/2022-01-29-12-37-53.bpo-46576.-prRaV.rst
+++ b/Misc/NEWS.d/next/Tests/2022-01-29-12-37-53.bpo-46576.-prRaV.rst
@@ -1,3 +1,3 @@
-test_peg_generator now uses -O0 when testing compilation of its own C
-extensions to significantly speed up the compilation phase when testing
-non-debug builds of CPython.
+test_peg_generator now disables compiler optimization when testing
+compilation of its own C extensions to significantly speed up the
+testing on non-debug builds of CPython.

--- a/Misc/NEWS.d/next/Tests/2022-01-29-12-37-53.bpo-46576.-prRaV.rst
+++ b/Misc/NEWS.d/next/Tests/2022-01-29-12-37-53.bpo-46576.-prRaV.rst
@@ -1,0 +1,3 @@
+test_peg_generator now uses -O0 when testing compilation of its own C
+extensions to significantly speed up the compilation phase when testing
+non-debug builds of CPython.

--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -69,6 +69,8 @@ def compile_c_extension(
             extra_link_args.append("/LTCG:OFF")
         else:
             extra_compile_args.append("-O0")
+            if sysconfig.get_config_var("GNULD") == "yes":
+                extra_link_args.append("-fno-lto")
     extension = [
         Extension(
             extension_name,

--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -32,6 +32,7 @@ def compile_c_extension(
     build_dir: Optional[str] = None,
     verbose: bool = False,
     keep_asserts: bool = True,
+    disable_optimization: bool = True,  # Significant test_peg_generator speedup.
 ) -> str:
     """Compile the generated source for a parser generator into an extension module.
 
@@ -61,6 +62,8 @@ def compile_c_extension(
     extra_link_args = get_extra_flags("LDFLAGS", "PY_LDFLAGS_NODIST")
     if keep_asserts:
         extra_compile_args.append("-UNDEBUG")
+    if disable_optimization:
+        extra_compile_args.append("-O0")
     extension = [
         Extension(
             extension_name,

--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -1,6 +1,7 @@
 import itertools
 import pathlib
 import shutil
+import sys
 import sysconfig
 import tempfile
 import tokenize
@@ -63,7 +64,11 @@ def compile_c_extension(
     if keep_asserts:
         extra_compile_args.append("-UNDEBUG")
     if disable_optimization:
-        extra_compile_args.append("-O0")
+        if sys.platform == 'win32':
+            extra_compile_args.append("/Od")
+            extra_link_args.append("/LTCG:OFF")
+        else:
+            extra_compile_args.append("-O0")
     extension = [
         Extension(
             extension_name,


### PR DESCRIPTION
This speed up test_peg_generator by always disabling compiler
optimizations by using -O0 by default when the test is building its
own C extensions.

A build not using --with-pydebug in order to speed up test execution
winds up with this test taking a very long time as it would do
repeated compilation of parser C code using the same optimization
flags as CPython was built with.

This speeds the test up 6-8x on gps-raspbian.

Includes the win32 changes from https://github.com/python/cpython/pull/31017 by Kumar Aditya

<!-- issue-number: [bpo-46576](https://bugs.python.org/issue46576) -->
https://bugs.python.org/issue46576
<!-- /issue-number -->
