### PR TITLE
bpo-46590: I suggests to modify Include/object.h in 98 line

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -95,7 +95,7 @@ typedef struct _typeobject PyTypeObject;
  * not necessarily a byte count.
  */
 #define PyObject_VAR_HEAD      PyVarObject ob_base;
-#define Py_INVALID_SIZE (Py_ssize_t)-1
+#define Py_INVALID_SIZE ((Py_ssize_t)-1)
 
 /* Nothing is actually declared to be a PyObject, but every pointer to
  * a Python object can be cast to a PyObject*.  This is inheritance built


### PR DESCRIPTION
before version
#define Py_INVALID_SIZE (Py_ssize_t)-1

after version
#define Py_INVALID_SIZE ((Py_ssize_t)-1)

I think that the after version is more safety.
thanks to read this request.

<!-- issue-number: [bpo-46590](https://bugs.python.org/issue46590) -->
https://bugs.python.org/issue46590
<!-- /issue-number -->
