### PR TITLE
bpo-46583: remove unused `sys.version_info` check from `selectors`

### DIFF
--- a/Lib/selectors.py
+++ b/Lib/selectors.py
@@ -50,12 +50,11 @@ SelectorKey.__doc__ = """SelectorKey(fileobj, fd, events, data)
     Object used to associate a file object to its backing
     file descriptor, selected event mask, and attached data.
 """
-if sys.version_info >= (3, 5):
-    SelectorKey.fileobj.__doc__ = 'File object registered.'
-    SelectorKey.fd.__doc__ = 'Underlying file descriptor.'
-    SelectorKey.events.__doc__ = 'Events that must be waited for on this file object.'
-    SelectorKey.data.__doc__ = ('''Optional opaque data associated to this file object.
-    For example, this could be used to store a per-client session ID.''')
+SelectorKey.fileobj.__doc__ = 'File object registered.'
+SelectorKey.fd.__doc__ = 'Underlying file descriptor.'
+SelectorKey.events.__doc__ = 'Events that must be waited for on this file object.'
+SelectorKey.data.__doc__ = ('''Optional opaque data associated to this file object.
+For example, this could be used to store a per-client session ID.''')
 
 
 class _SelectorMapping(Mapping):


### PR DESCRIPTION
I am going to add `skip-news`, because it is not a user-facing change.

<!-- issue-number: [bpo-46583](https://bugs.python.org/issue46583) -->
https://bugs.python.org/issue46583
<!-- /issue-number -->
