### PR TITLE
bpo-46584: remove check for `py2.3` from `ctypes/test_python_api`

### DIFF
--- a/Lib/ctypes/test/test_python_api.py
+++ b/Lib/ctypes/test/test_python_api.py
@@ -1,5 +1,5 @@
 from ctypes import *
-import unittest, sys
+import unittest
 from test import support
 
 ################################################################
@@ -10,10 +10,8 @@ from _ctypes import PyObj_FromPtr
 ################################################################
 
 from sys import getrefcount as grc
-if sys.version_info > (2, 4):
-    c_py_ssize_t = c_size_t
-else:
-    c_py_ssize_t = c_int
+
+c_py_ssize_t = c_size_t
 
 class PythonAPITestCase(unittest.TestCase):
 

--- a/Lib/ctypes/test/test_python_api.py
+++ b/Lib/ctypes/test/test_python_api.py
@@ -11,15 +11,13 @@ from _ctypes import PyObj_FromPtr
 
 from sys import getrefcount as grc
 
-c_py_ssize_t = c_size_t
-
 class PythonAPITestCase(unittest.TestCase):
 
     def test_PyBytes_FromStringAndSize(self):
         PyBytes_FromStringAndSize = pythonapi.PyBytes_FromStringAndSize
 
         PyBytes_FromStringAndSize.restype = py_object
-        PyBytes_FromStringAndSize.argtypes = c_char_p, c_py_ssize_t
+        PyBytes_FromStringAndSize.argtypes = c_char_p, c_size_t
 
         self.assertEqual(PyBytes_FromStringAndSize(b"abcdefghi", 3), b"abc")
 


### PR DESCRIPTION


<!-- issue-number: [bpo-46584](https://bugs.python.org/issue46584) -->
https://bugs.python.org/issue46584
<!-- /issue-number -->

Automerge-Triggered-By: GH:zware