### PR TITLE
bpo-46588: fix typo in test_calltip.py 

### DIFF
--- a/Lib/idlelib/idle_test/test_calltip.py
+++ b/Lib/idlelib/idle_test/test_calltip.py
@@ -106,7 +106,7 @@ subclasses to override in order to tweak the default behaviour.
 If you want to completely replace the main wrapping algorithm,
 you\'ll probably have to override _wrap_chunks().''')
 
-    def test_properly_formated(self):
+    def test_properly_formatted(self):
 
         def foo(s='a'*100):
             pass

--- a/Misc/NEWS.d/next/Tests/2022-01-30-17-01-02.bpo-46588.rkoatg.rst
+++ b/Misc/NEWS.d/next/Tests/2022-01-30-17-01-02.bpo-46588.rkoatg.rst
@@ -1,0 +1,5 @@
+* `Lib/idlelib/idle_test/test_calltip.py` test_properly_formated → **test_properly_formatted**
+
+<!-- issue-number: [bpo-46588](https://bugs.python.org/issue46588) -->
+https://bugs.python.org/issue46588
+<!-- /issue-number -->


### PR DESCRIPTION
* `Lib/idlelib/idle_test/test_calltip.py` test_properly_formated → **test_properly_formatted**

<!-- issue-number: [bpo-46588](https://bugs.python.org/issue46588) -->
https://bugs.python.org/issue46588
<!-- /issue-number -->
