### PR TITLE
bpo-46329: Reduce default recursion to 800 if Py_DEBUG is enabled.

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -13,7 +13,11 @@ struct pyruntimestate;
 struct _ceval_runtime_state;
 
 #ifndef Py_DEFAULT_RECURSION_LIMIT
-#  define Py_DEFAULT_RECURSION_LIMIT 1000
+#  ifdef Py_DEBUG
+#    define Py_DEFAULT_RECURSION_LIMIT 850
+#  else
+#    define Py_DEFAULT_RECURSION_LIMIT 1000
+#  endif
 #endif
 
 #include "pycore_interp.h"        // PyInterpreterState.eval_frame

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -109,7 +109,7 @@ class TestSpecifics(unittest.TestCase):
         self.assertEqual(d['z'], 12)
 
     def test_extended_arg(self):
-        longexpr = 'x = x or ' + '-x' * 2500
+        longexpr = 'x = x or ' + '-x' * 2000
         g = {}
         code = '''
 def f(x):

--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-31-13-50-05.bpo-46329.KlwVAt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-31-13-50-05.bpo-46329.KlwVAt.rst
@@ -1,0 +1,2 @@
+Temporarily reduce default recursion to 800 for debug builds. This prevents
+C stack overflows with Clang debug builds.


### PR DESCRIPTION
Prevents C stack overflow on Clang debug builds.

This is a temporary fix to get the buildbots working again.
This should be reverted in time for the 3.11 beta.

@pablogsal 
As it looks like https://github.com/python/cpython/pull/31011 has failed, would this be an acceptable, temporary fix?


<!-- issue-number: [bpo-46329](https://bugs.python.org/issue46329) -->
https://bugs.python.org/issue46329
<!-- /issue-number -->
