### PR TITLE
bpo-45413: Define "posix_venv", "nt_venv" and "venv" sysconfig installation schemes

### DIFF
--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -73,7 +73,7 @@ Every new component that is installed using :mod:`distutils` or a
 Distutils-based system will follow the same scheme to copy its file in the right
 places.
 
-Python currently supports eight schemes:
+Python currently supports nine schemes:
 
 - *posix_prefix*: scheme for POSIX platforms like Linux or macOS.  This is
   the default scheme used when Python or a component is installed.
@@ -89,6 +89,8 @@ Python currently supports eight schemes:
 - *nt_user*: scheme for NT platforms, when the *user* option is used.
 - *nt_venv*: scheme for :mod:`Python virtual environments <venv>` on NT
   platforms; by default it is the same as *nt* .
+- *venv*: a scheme with values from ether *posix_venv* or *nt_venv* depending
+  on the platform Python runs on
 - *osx_framework_user*: scheme for macOS, when the *user* option is used.
 
 Each scheme is itself composed of a series of paths and each path has a unique
@@ -142,16 +144,6 @@ identifier.  Python currently uses eight paths:
    .. versionchanged:: 3.11
       When Python runs from a virtual environment and ``key="prefix"``,
       the *posix_venv*/*nt_venv* scheme is returned.
-
-.. function:: get_venv_scheme()
-
-   Return a preferred scheme name for an installation layout used inside
-   :mod:`Python virtual environments <venv>`.
-
-   The return value is either ``"posix_venv"``, or ``"nt_venv"``,
-   depending on the platform.
-
-   .. versionadded:: 3.11
 
 
 .. function:: _get_preferred_schemes()

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -127,7 +127,7 @@ identifier.  Python currently uses eight paths:
 
    .. versionchanged:: 3.11
       When Python runs from a virtual environment,
-      the *posix_venv*/*nt_venv* scheme is returned.
+      the *venv* scheme is returned.
 
 .. function:: get_preferred_scheme(key)
 
@@ -143,7 +143,7 @@ identifier.  Python currently uses eight paths:
 
    .. versionchanged:: 3.11
       When Python runs from a virtual environment and ``key="prefix"``,
-      the *posix_venv*/*nt_venv* scheme is returned.
+      the *venv* scheme is returned.
 
 
 .. function:: _get_preferred_schemes()

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -86,7 +86,7 @@ Python currently supports seven schemes:
 - *nt*: scheme for NT platforms like Windows.
 - *nt_user*: scheme for NT platforms, when the *user* option is used.
 - *osx_framework_user*: scheme for macOS, when the *user* option is used.
-- *venv*: scheme for creating :mod:`Python virtual environments <venv>`;
+- *venv*: scheme for :mod:`Python virtual environments <venv>`;
   by default, this is a copy of *posix_prefix* on POSIX
   or a copy of *nt* for NT platforms.
 

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -124,7 +124,7 @@ identifier.  Python currently uses eight paths:
       considered an implementation detail.
 
    .. versionchanged:: 3.11
-      When Python runs form a virtual environment,
+      When Python runs from a virtual environment,
       the *posix_venv*/*nt_venv* scheme is returned.
 
 .. function:: get_preferred_scheme(key)
@@ -140,7 +140,7 @@ identifier.  Python currently uses eight paths:
    .. versionadded:: 3.10
 
    .. versionchanged:: 3.11
-      When Python runs form a virtual environment and ``key="prefix"``,
+      When Python runs from a virtual environment and ``key="prefix"``,
       the *posix_venv*/*nt_venv* scheme is returned.
 
 .. function:: get_venv_scheme()

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -88,7 +88,7 @@ Python currently supports seven schemes:
 - *osx_framework_user*: scheme for macOS, when the *user* option is used.
 - *venv*: scheme for :mod:`Python virtual environments <venv>`;
   by default, this is a copy of *posix_prefix* on POSIX
-  or a copy of *nt* for NT platforms.
+  or a copy of *nt* on NT platforms.
 
 Each scheme is itself composed of a series of paths and each path has a unique
 identifier.  Python currently uses eight paths:

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -73,7 +73,7 @@ Every new component that is installed using :mod:`distutils` or a
 Distutils-based system will follow the same scheme to copy its file in the right
 places.
 
-Python currently supports six schemes:
+Python currently supports seven schemes:
 
 - *posix_prefix*: scheme for POSIX platforms like Linux or macOS.  This is
   the default scheme used when Python or a component is installed.
@@ -86,6 +86,9 @@ Python currently supports six schemes:
 - *nt*: scheme for NT platforms like Windows.
 - *nt_user*: scheme for NT platforms, when the *user* option is used.
 - *osx_framework_user*: scheme for macOS, when the *user* option is used.
+- *venv*: scheme for creating :mod:`Python virtual environments <venv>`;
+  by default, this is a copy of *posix_prefix* on POSIX
+  or a copy of *nt* for NT platforms.
 
 Each scheme is itself composed of a series of paths and each path has a unique
 identifier.  Python currently uses eight paths:
@@ -119,6 +122,9 @@ identifier.  Python currently uses eight paths:
       This function was previously named ``_get_default_scheme()`` and
       considered an implementation detail.
 
+   .. versionchanged:: 3.11
+      When Python runs form a virtual environment,
+      the *venv* scheme is returned.
 
 .. function:: get_preferred_scheme(key)
 
@@ -131,6 +137,10 @@ identifier.  Python currently uses eight paths:
    such as :func:`get_paths`.
 
    .. versionadded:: 3.10
+
+   .. versionchanged:: 3.11
+      When Python runs form a virtual environment and ``key="prefix"``,
+      the *venv* scheme is returned.
 
 
 .. function:: _get_preferred_schemes()

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -73,7 +73,7 @@ Every new component that is installed using :mod:`distutils` or a
 Distutils-based system will follow the same scheme to copy its file in the right
 places.
 
-Python currently supports seven schemes:
+Python currently supports eight schemes:
 
 - *posix_prefix*: scheme for POSIX platforms like Linux or macOS.  This is
   the default scheme used when Python or a component is installed.
@@ -83,12 +83,13 @@ Python currently supports seven schemes:
 - *posix_user*: scheme for POSIX platforms used when a component is installed
   through Distutils and the *user* option is used.  This scheme defines paths
   located under the user home directory.
+- *posix_venv*: scheme for :mod:`Python virtual environments <venv>` on POSIX
+  platforms; by default it is the same as *posix_prefix* .
 - *nt*: scheme for NT platforms like Windows.
 - *nt_user*: scheme for NT platforms, when the *user* option is used.
+- *nt_venv*: scheme for :mod:`Python virtual environments <venv>` on NT
+  platforms; by default it is the same as *nt* .
 - *osx_framework_user*: scheme for macOS, when the *user* option is used.
-- *venv*: scheme for :mod:`Python virtual environments <venv>`;
-  by default, this is a copy of *posix_prefix* on POSIX
-  or a copy of *nt* on NT platforms.
 
 Each scheme is itself composed of a series of paths and each path has a unique
 identifier.  Python currently uses eight paths:
@@ -124,7 +125,7 @@ identifier.  Python currently uses eight paths:
 
    .. versionchanged:: 3.11
       When Python runs form a virtual environment,
-      the *venv* scheme is returned.
+      the *posix_venv*/*nt_venv* scheme is returned.
 
 .. function:: get_preferred_scheme(key)
 
@@ -140,7 +141,17 @@ identifier.  Python currently uses eight paths:
 
    .. versionchanged:: 3.11
       When Python runs form a virtual environment and ``key="prefix"``,
-      the *venv* scheme is returned.
+      the *posix_venv*/*nt_venv* scheme is returned.
+
+.. function:: get_venv_scheme()
+
+   Return a preferred scheme name for an installation layout used inside
+   :mod:`Python virtual environments <venv>`.
+
+   The return value is either ``"posix_venv"``, or ``"nt_venv"``,
+   depending on the platform.
+
+   .. versionadded:: 3.11
 
 
 .. function:: _get_preferred_schemes()

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -178,7 +178,7 @@ creation according to their needs, the :class:`EnvBuilder` class.
         and then all necessary subdirectories will be recreated.
 
         .. versionchanged:: 3.11
-           The *posix_venv*/*nt_venv*
+           The *venv*
            :ref:`sysconfig installation scheme <installation_paths>`
            is used to construct the paths of the created directories.
 

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -177,6 +177,10 @@ creation according to their needs, the :class:`EnvBuilder` class.
         ``clear=True``, contents of the environment directory will be cleared
         and then all necessary subdirectories will be recreated.
 
+        .. versionchanged:: 3.11
+           The *venv* :ref:`sysconfig installation scheme <installation_paths>`
+           is used to construct the paths of the created directories.
+
     .. method:: create_configuration(context)
 
         Creates the ``pyvenv.cfg`` configuration file in the environment.

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -178,7 +178,8 @@ creation according to their needs, the :class:`EnvBuilder` class.
         and then all necessary subdirectories will be recreated.
 
         .. versionchanged:: 3.11
-           The *venv* :ref:`sysconfig installation scheme <installation_paths>`
+           The *posix_venv*/*nt_venv*
+           :ref:`sysconfig installation scheme <installation_paths>`
            is used to construct the paths of the created directories.
 
     .. method:: create_configuration(context)

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -331,7 +331,7 @@ sysconfig
   creates new virtual environments or when it is running from a virtual
   environment.
   The first two schemes (*posix_venv* and *nt_venv*) are OS-specific
-  for non-Windoes and Windows, the *venv* is essentially an alias to one of
+  for non-Windows and Windows, the *venv* is essentially an alias to one of
   them according to the OS Python runs on.
   This is useful for downstream distributors who modify
   :func:`sysconfig.get_preferred_scheme`.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -327,15 +327,16 @@ sysconfig
 ---------
 
 * Two new :ref:`installation schemes <installation_paths>`
-  (*posix_venv* and *nt_venv*) were added and are used when Python creates
-  new virtual environments or when it
-  is running from a virtual environment.
-  To determine what installation scheme is suitable for the platform Python
-  currently runs on, :func:`sysconfig.get_venv_scheme` was added.
+  (*posix_venv*, *nt_venv* and *venv*) were added and are used when Python
+  creates   new virtual environments or when it is running from a virtual
+  environment.
+  The first two schemes (*posix_venv* and *nt_venv*) are OS-specific
+  for non-Windoes and Windows, the *venv* is essentially an alias to one of
+  them according to the OS Python runs on.
   This is useful for downstream distributors who modify
   :func:`sysconfig.get_preferred_scheme`.
   Third party code that creates new virtual environments should use the new
-  installation scheme to determine the paths, as does :mod:`venv`.
+  *venv* installation scheme to determine the paths, as does :mod:`venv`.
   (Contributed by Miro Hrončok in :issue:`45413`.)
 
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -328,7 +328,7 @@ sysconfig
 
 * Two new :ref:`installation schemes <installation_paths>`
   (*posix_venv*, *nt_venv* and *venv*) were added and are used when Python
-  creates   new virtual environments or when it is running from a virtual
+  creates new virtual environments or when it is running from a virtual
   environment.
   The first two schemes (*posix_venv* and *nt_venv*) are OS-specific
   for non-Windoes and Windows, the *venv* is essentially an alias to one of
@@ -377,7 +377,7 @@ unicodedata
 venv
 ----
 
-* When new Python virtual environments are created, the *posix_venv*/*nt_venv*
+* When new Python virtual environments are created, the *venv*
   :ref:`sysconfig installation scheme <installation_paths>` is used
   to determine the paths inside the environment.
   When Python runs in a virtual environment, the same installation scheme

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -381,7 +381,7 @@ venv
   to determine the paths inside the environment.
   When Python runs in a virtual environment, the same installation scheme
   is the default.
-  That means, downstream distributors can change the default sysconfig install
+  That means that downstream distributors can change the default sysconfig install
   scheme without changing behavior of virtual environments.
   Third party code that also creates new virtual environments should do the same.
   (Contributed by Miro Hrončok in :issue:`45413`.)

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -370,6 +370,20 @@ unicodedata
 * The Unicode database has been updated to version 14.0.0. (:issue:`45190`).
 
 
+venv
+----
+
+* When new Python virtual environments are created,
+  the *venv* :ref:`sysconfig installation scheme <installation_paths>` is used
+  to determine the paths inside the environment.
+  When Python runs in a virtual environment, the same installation scheme
+  is the default.
+  That means, downstream distributors can change the default sysconfig install
+  scheme without changing behavior of virtual environments.
+  Third party code that also creates new virtual environments should do the same.
+  (Contributed by Miro Hrončok in :issue:`45413`.)
+
+
 fcntl
 -----
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -326,13 +326,16 @@ sys
 sysconfig
 ---------
 
-* A new *venv* :ref:`installation scheme <installation_paths>` was added
-  and is used when Python creates new virtual environments or when it
+* Two new :ref:`installation schemes <installation_paths>`
+  (*posix_venv* and *nt_venv*) were added and are used when Python creates
+  new virtual environments or when it
   is running from a virtual environment.
+  To determine what installation scheme is suitable for the platform Python
+  currently runs on, :func:`sysconfig.get_venv_scheme` was added.
   This is useful for downstream distributors who modify
   :func:`sysconfig.get_preferred_scheme`.
-  Third party code that creates new virtual environments should use this new
-  *venv* installation scheme to determine the paths, as does :mod:`venv`.
+  Third party code that creates new virtual environments should use the new
+  installation scheme to determine the paths, as does :mod:`venv`.
   (Contributed by Miro Hrončok in :issue:`45413`.)
 
 
@@ -373,8 +376,8 @@ unicodedata
 venv
 ----
 
-* When new Python virtual environments are created,
-  the *venv* :ref:`sysconfig installation scheme <installation_paths>` is used
+* When new Python virtual environments are created, the *posix_venv*/*nt_venv*
+  :ref:`sysconfig installation scheme <installation_paths>` is used
   to determine the paths inside the environment.
   When Python runs in a virtual environment, the same installation scheme
   is the default.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -322,6 +322,20 @@ sys
   (equivalent to ``sys.exc_info()[1]``).
   (Contributed by Irit Katriel in :issue:`46328`.)
 
+
+sysconfig
+---------
+
+* A new *venv* :ref:`installation scheme <installation_paths>` was added
+  and is used when Python creates new virtual environments or when it
+  is running from a virtual environment.
+  This is useful for downstream distributors who modify
+  :func:`sysconfig.get_preferred_scheme`.
+  Third party code that creates new virtual environments should use this new
+  *venv* installation scheme to determine the paths, as does :mod:`venv`.
+  (Contributed by Miro Hrončok in :issue:`45413`.)
+
+
 threading
 ---------
 

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -97,6 +97,12 @@ _INSTALL_SCHEMES = {
         },
     }
 
+# For the OS-native venv scheme, we essentially provide an alias:
+if os.name == 'nt':
+    _INSTALL_SCHEMES['venv'] = _INSTALL_SCHEMES['nt_venv']
+else:
+    _INSTALL_SCHEMES['venv'] = _INSTALL_SCHEMES['posix_venv']
+
 
 # NOTE: site.py has copy of this function.
 # Sync it when modify this function.
@@ -288,15 +294,9 @@ def _get_preferred_schemes():
     }
 
 
-def get_venv_scheme():
-    if os.name == 'nt':
-        return 'nt_venv'
-    return 'posix_venv'
-
-
 def get_preferred_scheme(key):
     if key == 'prefix' and sys.prefix != sys.base_prefix:
-        return get_venv_scheme()
+        return 'venv'
     scheme = _get_preferred_schemes()[key]
     if scheme not in _INSTALL_SCHEMES:
         raise ValueError(

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -58,6 +58,28 @@ _INSTALL_SCHEMES = {
         },
     }
 
+# Downstream distributors can overwrite the default install scheme.
+# This is done to support downstream modifications where distributors change
+# the installation layout (eg. different site-packages directory).
+# So, distributors will change the default scheme to one that correctly
+# represents their layout.
+# This presents an issue for projects/people that need to bootstrap virtual
+# environments, like virtualenv. As distributors might now be customizing
+# the default install scheme, there is no guarantee that the information
+# returned by sysconfig.get_default_scheme/get_paths is correct for
+# a virtual environment, the only guarantee we have is that it correct
+# for the *current* environment. When bootstrapping a virtual environment,
+# we need to know its layout, so that we can place the files in the
+# correct locations.
+# The "venv" install scheme is a scheme to bootstrap virtual environments,
+# essentially identical to the default posix_prefix/nt schemes.
+# Downstream distributors will need to change this,
+# if their posix_prefix/nt scheme is not venv-compatible.
+if os.name == 'nt':
+    _INSTALL_SCHEMES['venv'] = dict(_INSTALL_SCHEMES['nt'])
+else:
+    _INSTALL_SCHEMES['venv'] = dict(_INSTALL_SCHEMES['posix_prefix'])
+
 
 # NOTE: site.py has copy of this function.
 # Sync it when modify this function.

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -282,6 +282,8 @@ def get_preferred_scheme(key):
 
 
 def get_default_scheme():
+    if sys.prefix != sys.base_prefix:
+        return 'venv'
     return get_preferred_scheme('prefix')
 
 

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -75,7 +75,7 @@ _INSTALL_SCHEMES = {
 # essentially identical to the default posix_prefix/nt schemes.
 # Downstream distributors will need to change this,
 # if their posix_prefix/nt scheme is not venv-compatible.
-if os.name == 'nt':
+if sys.platform == 'win32':
     _INSTALL_SCHEMES['venv'] = dict(_INSTALL_SCHEMES['nt'])
 else:
     _INSTALL_SCHEMES['venv'] = dict(_INSTALL_SCHEMES['posix_prefix'])

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -75,7 +75,7 @@ _INSTALL_SCHEMES = {
 # essentially identical to the default posix_prefix/nt schemes.
 # Downstream distributors who patch posix_prefix/nt scheme are encouraged to do
 # it after this copy is made:
-if sys.platform == 'win32':
+if os.name == 'nt':
     _INSTALL_SCHEMES['venv'] = dict(_INSTALL_SCHEMES['nt'])
 else:
     _INSTALL_SCHEMES['venv'] = dict(_INSTALL_SCHEMES['posix_prefix'])

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -272,6 +272,8 @@ def _get_preferred_schemes():
 
 
 def get_preferred_scheme(key):
+    if key == 'prefix' and sys.prefix != sys.base_prefix:
+        return 'venv'
     scheme = _get_preferred_schemes()[key]
     if scheme not in _INSTALL_SCHEMES:
         raise ValueError(
@@ -282,8 +284,6 @@ def get_preferred_scheme(key):
 
 
 def get_default_scheme():
-    if sys.prefix != sys.base_prefix:
-        return 'venv'
     return get_preferred_scheme('prefix')
 
 

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -73,8 +73,8 @@ _INSTALL_SCHEMES = {
 # correct locations.
 # The "venv" install scheme is a scheme to bootstrap virtual environments,
 # essentially identical to the default posix_prefix/nt schemes.
-# Downstream distributors will need to change this,
-# if their posix_prefix/nt scheme is not venv-compatible.
+# Downstream distributors who patch posix_prefix/nt scheme are encouraged to do
+# it after this copy is made:
 if sys.platform == 'win32':
     _INSTALL_SCHEMES['venv'] = dict(_INSTALL_SCHEMES['nt'])
 else:

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -65,14 +65,14 @@ _INSTALL_SCHEMES = {
     # environments, like virtualenv. As distributors might now be customizing
     # the default install scheme, there is no guarantee that the information
     # returned by sysconfig.get_default_scheme/get_paths is correct for
-    # a virtual environment, the only guarantee we have is that it correct
+    # a virtual environment, the only guarantee we have is that it is correct
     # for the *current* environment. When bootstrapping a virtual environment,
     # we need to know its layout, so that we can place the files in the
     # correct locations.
     # The "*_venv" install scheme is a scheme to bootstrap virtual environments,
     # essentially identical to the default posix_prefix/nt schemes.
     # Downstream distributors who patch posix_prefix/nt scheme are encouraged to
-    # Leave the following schemes unchanged
+    # leave the following schemes unchanged
     'posix_venv': {
         'stdlib': '{installed_base}/{platlibdir}/python{py_version_short}',
         'platstdlib': '{platbase}/{platlibdir}/python{py_version_short}',

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -177,11 +177,33 @@ class TestSysConfig(unittest.TestCase):
         self.assertEqual(incpath, sysconfig.get_path('include', scheme='nt_venv'))
         self.assertEqual(libpath, sysconfig.get_path('purelib', scheme='nt_venv'))
 
-    def test_get_venv_scheme(self):
+    def test_venv_scheme(self):
         if sys.platform == 'win32':
-            self.assertEqual(sysconfig.get_venv_scheme(), 'nt_venv')
+            self.assertEqual(
+                sysconfig.get_path('scripts', scheme='venv'),
+                sysconfig.get_path('scripts', scheme='nt_venv')
+            )
+            self.assertEqual(
+                sysconfig.get_path('include', scheme='venv'),
+                sysconfig.get_path('include', scheme='nt_venv')
+            )
+            self.assertEqual(
+                sysconfig.get_path('purelib', scheme='venv'),
+                sysconfig.get_path('purelib', scheme='nt_venv')
+            )
         else:
-            self.assertEqual(sysconfig.get_venv_scheme(), 'posix_venv')
+            self.assertEqual(
+                sysconfig.get_path('scripts', scheme='venv'),
+                sysconfig.get_path('scripts', scheme='posix_venv')
+            )
+            self.assertEqual(
+                sysconfig.get_path('include', scheme='venv'),
+                sysconfig.get_path('include', scheme='posix_venv')
+            )
+            self.assertEqual(
+                sysconfig.get_path('purelib', scheme='venv'),
+                sysconfig.get_path('purelib', scheme='posix_venv')
+            )
 
     def test_get_config_vars(self):
         cvars = get_config_vars()
@@ -311,7 +333,7 @@ class TestSysConfig(unittest.TestCase):
         self.assertTrue(os.path.isfile(config_h), config_h)
 
     def test_get_scheme_names(self):
-        wanted = ['nt', 'posix_home', 'posix_prefix', 'posix_venv', 'nt_venv']
+        wanted = ['nt', 'posix_home', 'posix_prefix', 'posix_venv', 'nt_venv', 'venv']
         if HAS_USER_BASE:
             wanted.extend(['nt_user', 'osx_framework_user', 'posix_user'])
         self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -267,7 +267,7 @@ class TestSysConfig(unittest.TestCase):
         self.assertTrue(os.path.isfile(config_h), config_h)
 
     def test_get_scheme_names(self):
-        wanted = ['nt', 'posix_home', 'posix_prefix']
+        wanted = ['nt', 'posix_home', 'posix_prefix', 'venv']
         if HAS_USER_BASE:
             wanted.extend(['nt_user', 'osx_framework_user', 'posix_user'])
         self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -139,36 +139,49 @@ class TestSysConfig(unittest.TestCase):
         self.assertIsInstance(schemes, dict)
         self.assertEqual(set(schemes), expected_schemes)
 
-    def test_venv_scheme(self):
+    def test_posix_venv_scheme(self):
         # The following directories were hardcoded in the venv module
-        # before bpo-45413, here we assert the venv scheme does not regress
-        if sys.platform == 'win32':
-            binpath = 'Scripts'
-            incpath = 'Include'
-            libpath = os.path.join('Lib', 'site-packages')
-        else:
-            binpath = 'bin'
-            incpath = 'include'
-            libpath = os.path.join('lib',
-                                   'python%d.%d' % sys.version_info[:2],
-                                   'site-packages')
+        # before bpo-45413, here we assert the posix_venv scheme does not regress
+        binpath = 'bin'
+        incpath = 'include'
+        libpath = os.path.join('lib',
+                               'python%d.%d' % sys.version_info[:2],
+                               'site-packages')
 
         # Resolve the paths in prefix
         binpath = os.path.join(sys.prefix, binpath)
         incpath = os.path.join(sys.prefix, incpath)
         libpath = os.path.join(sys.prefix, libpath)
 
-        self.assertEqual(binpath, sysconfig.get_path('scripts', scheme='venv'))
-        self.assertEqual(libpath, sysconfig.get_path('purelib', scheme='venv'))
+        self.assertEqual(binpath, sysconfig.get_path('scripts', scheme='posix_venv'))
+        self.assertEqual(libpath, sysconfig.get_path('purelib', scheme='posix_venv'))
 
         # The include directory on POSIX isn't exactly the same as before,
         # but it is "within"
-        sysconfig_includedir = sysconfig.get_path('include', scheme='venv')
-        if sys.platform == 'win32':
-            self.assertEqual(incpath, sysconfig.get_path('include', scheme='venv'))
-        else:
-            self.assertTrue(sysconfig_includedir.startswith(incpath + os.sep))
+        sysconfig_includedir = sysconfig.get_path('include', scheme='posix_venv')
+        self.assertTrue(sysconfig_includedir.startswith(incpath + os.sep))
 
+    def test_nt_venv_scheme(self):
+        # The following directories were hardcoded in the venv module
+        # before bpo-45413, here we assert the posix_venv scheme does not regress
+        binpath = 'Scripts'
+        incpath = 'Include'
+        libpath = os.path.join('Lib', 'site-packages')
+
+        # Resolve the paths in prefix
+        binpath = os.path.join(sys.prefix, binpath)
+        incpath = os.path.join(sys.prefix, incpath)
+        libpath = os.path.join(sys.prefix, libpath)
+
+        self.assertEqual(binpath, sysconfig.get_path('scripts', scheme='nt_venv'))
+        self.assertEqual(incpath, sysconfig.get_path('include', scheme='nt_venv'))
+        self.assertEqual(libpath, sysconfig.get_path('purelib', scheme='nt_venv'))
+
+    def test_get_venv_scheme(self):
+        if sys.platform == 'win32':
+            self.assertEqual(sysconfig.get_venv_scheme(), 'nt_venv')
+        else:
+            self.assertEqual(sysconfig.get_venv_scheme(), 'posix_venv')
 
     def test_get_config_vars(self):
         cvars = get_config_vars()
@@ -298,7 +311,7 @@ class TestSysConfig(unittest.TestCase):
         self.assertTrue(os.path.isfile(config_h), config_h)
 
     def test_get_scheme_names(self):
-        wanted = ['nt', 'posix_home', 'posix_prefix', 'venv']
+        wanted = ['nt', 'posix_home', 'posix_prefix', 'posix_venv', 'nt_venv']
         if HAS_USER_BASE:
             wanted.extend(['nt_user', 'osx_framework_user', 'posix_user'])
         self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -143,22 +143,22 @@ class TestSysConfig(unittest.TestCase):
         # The following directories were hardcoded in the venv module
         # before bpo-45413, here we assert the venv scheme does not regress
         if sys.platform == 'win32':
-            binname = 'Scripts'
+            binpath = 'Scripts'
             incpath = 'Include'
             libpath = os.path.join('Lib', 'site-packages')
         else:
-            binname = 'bin'
+            binpath = 'bin'
             incpath = 'include'
             libpath = os.path.join('lib',
                                    'python%d.%d' % sys.version_info[:2],
                                    'site-packages')
 
         # Resolve the paths in prefix
-        binname = os.path.join(sys.prefix, binname)
+        binpath = os.path.join(sys.prefix, binpath)
         incpath = os.path.join(sys.prefix, incpath)
         libpath = os.path.join(sys.prefix, libpath)
 
-        self.assertEqual(binname, sysconfig.get_path('scripts', scheme='venv'))
+        self.assertEqual(binpath, sysconfig.get_path('scripts', scheme='venv'))
         self.assertEqual(libpath, sysconfig.get_path('purelib', scheme='venv'))
 
         # The include directory on POSIX isn't exactly the same as before,

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -139,6 +139,37 @@ class TestSysConfig(unittest.TestCase):
         self.assertIsInstance(schemes, dict)
         self.assertEqual(set(schemes), expected_schemes)
 
+    def test_venv_scheme(self):
+        # The following directories were hardcoded in the venv module
+        # before bpo-45413, here we assert the venv scheme does not regress
+        if sys.platform == 'win32':
+            binname = 'Scripts'
+            incpath = 'Include'
+            libpath = os.path.join('Lib', 'site-packages')
+        else:
+            binname = 'bin'
+            incpath = 'include'
+            libpath = os.path.join('lib',
+                                   'python%d.%d' % sys.version_info[:2],
+                                   'site-packages')
+
+        # Resolve the paths in prefix
+        binname = os.path.join(sys.prefix, binname)
+        incpath = os.path.join(sys.prefix, incpath)
+        libpath = os.path.join(sys.prefix, libpath)
+
+        self.assertEqual(binname, sysconfig.get_path('scripts', scheme='venv'))
+        self.assertEqual(libpath, sysconfig.get_path('purelib', scheme='venv'))
+
+        # The include directory on POSIX isn't exactly the same as before,
+        # but it is "within"
+        sysconfig_includedir = sysconfig.get_path('include', scheme='venv')
+        if sys.platform == 'win32':
+            self.assertEqual(incpath, sysconfig.get_path('include', scheme='venv'))
+        else:
+            self.assertTrue(sysconfig_includedir.startswith(incpath + os.sep))
+
+
     def test_get_config_vars(self):
         cvars = get_config_vars()
         self.assertIsInstance(cvars, dict)

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -236,6 +236,20 @@ class BasicTest(BaseTest):
             out, err = check_output(cmd)
             self.assertEqual(out.strip(), expected.encode(), prefix)
 
+    @requireVenvCreate
+    def test_sysconfig_preferred_and_default_scheme(self):
+        """
+        Test that the sysconfig preferred(prefix) and default scheme is venv.
+        """
+        rmtree(self.env_dir)
+        self.run_with_capture(venv.create, self.env_dir)
+        envpy = os.path.join(self.env_dir, self.bindir, self.exe)
+        cmd = [envpy, '-c', None]
+        for call in ('get_preferred_scheme("prefix")', 'get_default_scheme()'):
+            cmd[2] = 'import sysconfig; print(sysconfig.%s)' % call
+            out, err = check_output(cmd)
+            self.assertEqual(out.strip(), b'venv', err)
+
     if sys.platform == 'win32':
         ENV_SUBDIRS = (
             ('Scripts',),

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -239,8 +239,7 @@ class BasicTest(BaseTest):
     @requireVenvCreate
     def test_sysconfig_preferred_and_default_scheme(self):
         """
-        Test that the sysconfig preferred(prefix) and default scheme is
-        posix_venv/nt_venv.
+        Test that the sysconfig preferred(prefix) and default scheme is venv.
         """
         rmtree(self.env_dir)
         self.run_with_capture(venv.create, self.env_dir)
@@ -249,10 +248,7 @@ class BasicTest(BaseTest):
         for call in ('get_preferred_scheme("prefix")', 'get_default_scheme()'):
             cmd[2] = 'import sysconfig; print(sysconfig.%s)' % call
             out, err = check_output(cmd)
-            if sys.platform == 'win32':
-                self.assertEqual(out.strip(), b'nt_venv', err)
-            else:
-                self.assertEqual(out.strip(), b'posix_venv', err)
+            self.assertEqual(out.strip(), b'venv', err)
 
     if sys.platform == 'win32':
         ENV_SUBDIRS = (

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -239,7 +239,8 @@ class BasicTest(BaseTest):
     @requireVenvCreate
     def test_sysconfig_preferred_and_default_scheme(self):
         """
-        Test that the sysconfig preferred(prefix) and default scheme is venv.
+        Test that the sysconfig preferred(prefix) and default scheme is
+        posix_venv/nt_venv.
         """
         rmtree(self.env_dir)
         self.run_with_capture(venv.create, self.env_dir)
@@ -248,7 +249,10 @@ class BasicTest(BaseTest):
         for call in ('get_preferred_scheme("prefix")', 'get_default_scheme()'):
             cmd[2] = 'import sysconfig; print(sysconfig.%s)' % call
             out, err = check_output(cmd)
-            self.assertEqual(out.strip(), b'venv', err)
+            if sys.platform == 'win32':
+                self.assertEqual(out.strip(), b'nt_venv', err)
+            else:
+                self.assertEqual(out.strip(), b'posix_venv', err)
 
     if sys.platform == 'win32':
         ENV_SUBDIRS = (

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -100,8 +100,7 @@ class EnvBuilder:
             'installed_base': env_dir,
             'installed_platbase': env_dir,
         }
-        venv_scheme = sysconfig.get_venv_scheme()
-        return sysconfig.get_path(name, scheme=venv_scheme, vars=vars)
+        return sysconfig.get_path(name, scheme='venv', vars=vars)
 
     def ensure_directories(self, env_dir):
         """

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -100,7 +100,8 @@ class EnvBuilder:
             'installed_base': env_dir,
             'installed_platbase': env_dir,
         }
-        return sysconfig.get_path(name, scheme='venv', vars=vars)
+        venv_scheme = sysconfig.get_venv_scheme()
+        return sysconfig.get_path(name, scheme=venv_scheme, vars=vars)
 
     def ensure_directories(self, env_dir):
         """

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -16,6 +16,9 @@ import types
 CORE_VENV_DEPS = ('pip', 'setuptools')
 logger = logging.getLogger(__name__)
 
+def _venv_path(name):
+    return sysconfig.get_path(name, scheme='venv').removeprefix(f'{sys.prefix}/')
+
 
 class EnvBuilder:
     """
@@ -120,16 +123,10 @@ class EnvBuilder:
         context.executable = executable
         context.python_dir = dirname
         context.python_exe = exename
-        if sys.platform == 'win32':
-            binname = 'Scripts'
-            incpath = 'Include'
-            libpath = os.path.join(env_dir, 'Lib', 'site-packages')
-        else:
-            binname = 'bin'
-            incpath = 'include'
-            libpath = os.path.join(env_dir, 'lib',
-                                   'python%d.%d' % sys.version_info[:2],
-                                   'site-packages')
+        binname = _venv_path('scripts')
+        incpath = _venv_path('include')
+        libpath = os.path.join(env_dir, _venv_path('purelib'))
+
         context.inc_path = path = os.path.join(env_dir, incpath)
         create_if_needed(path)
         create_if_needed(libpath)

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -16,9 +16,6 @@ import types
 CORE_VENV_DEPS = ('pip', 'setuptools')
 logger = logging.getLogger(__name__)
 
-def _venv_path(name):
-    return sysconfig.get_path(name, scheme='venv').removeprefix(sys.prefix + os.sep)
-
 
 class EnvBuilder:
     """
@@ -96,6 +93,15 @@ class EnvBuilder:
             elif os.path.isdir(fn):
                 shutil.rmtree(fn)
 
+    def _venv_path(self, env_dir, name):
+        vars = {
+            'base': env_dir,
+            'platbase': env_dir,
+            'installed_base': env_dir,
+            'installed_platbase': env_dir,
+        }
+        return sysconfig.get_path(name, scheme='venv', vars=vars)
+
     def ensure_directories(self, env_dir):
         """
         Create the directories for the environment.
@@ -123,12 +129,12 @@ class EnvBuilder:
         context.executable = executable
         context.python_dir = dirname
         context.python_exe = exename
-        binname = _venv_path('scripts')
-        incpath = _venv_path('include')
-        libpath = os.path.join(env_dir, _venv_path('purelib'))
+        binpath = self._venv_path(env_dir, 'scripts')
+        incpath = self._venv_path(env_dir, 'include')
+        libpath = self._venv_path(env_dir, 'purelib')
 
-        context.inc_path = path = os.path.join(env_dir, incpath)
-        create_if_needed(path)
+        context.inc_path = incpath
+        create_if_needed(incpath)
         create_if_needed(libpath)
         # Issue 21197: create lib64 as a symlink to lib on 64-bit non-OS X POSIX
         if ((sys.maxsize > 2**32) and (os.name == 'posix') and
@@ -136,8 +142,8 @@ class EnvBuilder:
             link_path = os.path.join(env_dir, 'lib64')
             if not os.path.exists(link_path):   # Issue #21643
                 os.symlink('lib', link_path)
-        context.bin_path = binpath = os.path.join(env_dir, binname)
-        context.bin_name = binname
+        context.bin_path = binpath
+        context.bin_name = os.path.relpath(binpath, env_dir)
         context.env_exe = os.path.join(binpath, exename)
         create_if_needed(binpath)
         # Assign and update the command to use when launching the newly created

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -17,7 +17,7 @@ CORE_VENV_DEPS = ('pip', 'setuptools')
 logger = logging.getLogger(__name__)
 
 def _venv_path(name):
-    return sysconfig.get_path(name, scheme='venv').removeprefix(f'{sys.prefix}/')
+    return sysconfig.get_path(name, scheme='venv').removeprefix(sys.prefix + os.sep)
 
 
 class EnvBuilder:

--- a/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
@@ -1,10 +1,10 @@
 Define *posix_venv* and *nt_venv*
 :ref:`sysconfig installation schemes <installation_paths>`
 to be used for bootstrapping new virtual environments.
-Add :func:`sysconfig.get_venv_scheme` function to get the appropriate one of them.
+Add *venv* sysconfig installation scheme to get the appropriate one of the above.
 The schemes are identical to the pre-existing
 *posix_prefix* and *nt* install schemes.
-The :mod:`venv` module now uses the schemes to create new virtual environments
+The :mod:`venv` module now uses the *venv* scheme to create new virtual environments
 instead of hardcoding the paths depending only on the platform. Downstream
 Python distributors customizing the *posix_prefix* or *nt* install
 scheme in a way that is not compatible with the install scheme used in
@@ -12,4 +12,4 @@ virtual environments are encouraged not to customize the *venv* schemes.
 When Python itself runs in a virtual environment,
 :func:`sysconfig.get_default_scheme` and
 :func:`sysconfig.get_preferred_scheme` with ``key="prefix"`` returns
-*posix_venv* or *nt_venv*.
+*venv*.

--- a/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
@@ -8,4 +8,5 @@ scheme in a way that is not compatible with the install scheme used in
 virtual environments are encouraged to do it after the ``"venv"`` scheme
 is created or to supply a modified working ``"venv"`` scheme.
 When Python itself runs in a virtual environment,
-:func:`sysconfig.get_default_scheme` returns ``"venv"``.
+:func:`sysconfig.get_default_scheme` and
+:func:`sysconfig.get_preferred_scheme` with ``key="prefix"`` returns ``"venv"``.

--- a/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
@@ -7,3 +7,5 @@ Python distributors customizing the ``"posix_prefix"`` or ``"nt"`` install
 scheme in a way that is not compatible with the install scheme used in
 virtual environments are encouraged to do it after the ``"venv"`` scheme
 is created or to supply a modified working ``"venv"`` scheme.
+When Python itself runs in a virtual environment,
+:func:`sysconfig.get_default_scheme` returns ``"venv"``.

--- a/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
@@ -1,0 +1,9 @@
+Define a ``"venv"`` :mod:`sysconfig` installation scheme to be used for
+bootstrapping new virtual environments. It is a copy of the
+``"posix_prefix"`` or ``"nt"`` install scheme depending on the platform. The
+:mod:`venv` module now uses that scheme to create new virtual environments
+instead of hardcoding the paths depending only on the platform. Downstream
+Python distributors customizing the ``"posix_prefix"`` or ``"nt"`` install
+scheme in a way that is not compatible with the install scheme used in
+virtual environments are encouraged to supply a modified working ``"venv"``
+scheme.

--- a/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
@@ -5,5 +5,5 @@ bootstrapping new virtual environments. It is a copy of the
 instead of hardcoding the paths depending only on the platform. Downstream
 Python distributors customizing the ``"posix_prefix"`` or ``"nt"`` install
 scheme in a way that is not compatible with the install scheme used in
-virtual environments are encouraged to supply a modified working ``"venv"``
-scheme.
+virtual environments are encouraged to do it after the ``"venv"`` scheme
+is created or to supply a modified working ``"venv"`` scheme.

--- a/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
@@ -1,12 +1,12 @@
-Define a ``"venv"`` :mod:`sysconfig` installation scheme to be used for
-bootstrapping new virtual environments. It is a copy of the
-``"posix_prefix"`` or ``"nt"`` install scheme depending on the platform. The
+Define a *venv* :ref:`sysconfig installation scheme <installation_paths>`
+to be used for bootstrapping new virtual environments. It is a copy of the
+*posix_prefix* or *nt* install scheme depending on the platform. The
 :mod:`venv` module now uses that scheme to create new virtual environments
 instead of hardcoding the paths depending only on the platform. Downstream
-Python distributors customizing the ``"posix_prefix"`` or ``"nt"`` install
+Python distributors customizing the *posix_prefix* or *nt* install
 scheme in a way that is not compatible with the install scheme used in
-virtual environments are encouraged to do it after the ``"venv"`` scheme
-is created or to supply a modified working ``"venv"`` scheme.
+virtual environments are encouraged to do it after the *venv* scheme
+is created or to supply a modified working *venv* scheme.
 When Python itself runs in a virtual environment,
 :func:`sysconfig.get_default_scheme` and
-:func:`sysconfig.get_preferred_scheme` with ``key="prefix"`` returns ``"venv"``.
+:func:`sysconfig.get_preferred_scheme` with ``key="prefix"`` returns *venv*.

--- a/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-31-15-19-38.bpo-45413.1vaS0V.rst
@@ -1,12 +1,15 @@
-Define a *venv* :ref:`sysconfig installation scheme <installation_paths>`
-to be used for bootstrapping new virtual environments. It is a copy of the
-*posix_prefix* or *nt* install scheme depending on the platform. The
-:mod:`venv` module now uses that scheme to create new virtual environments
+Define *posix_venv* and *nt_venv*
+:ref:`sysconfig installation schemes <installation_paths>`
+to be used for bootstrapping new virtual environments.
+Add :func:`sysconfig.get_venv_scheme` function to get the appropriate one of them.
+The schemes are identical to the pre-existing
+*posix_prefix* and *nt* install schemes.
+The :mod:`venv` module now uses the schemes to create new virtual environments
 instead of hardcoding the paths depending only on the platform. Downstream
 Python distributors customizing the *posix_prefix* or *nt* install
 scheme in a way that is not compatible with the install scheme used in
-virtual environments are encouraged to do it after the *venv* scheme
-is created or to supply a modified working *venv* scheme.
+virtual environments are encouraged not to customize the *venv* schemes.
 When Python itself runs in a virtual environment,
 :func:`sysconfig.get_default_scheme` and
-:func:`sysconfig.get_preferred_scheme` with ``key="prefix"`` returns *venv*.
+:func:`sysconfig.get_preferred_scheme` with ``key="prefix"`` returns
+*posix_venv* or *nt_venv*.


### PR DESCRIPTION
Define *posix_venv* and *nt_venv* sysconfig installation schemes
to be used for bootstrapping new virtual environments.
Add *venv* sysconfig installation scheme to get the appropriate one of the above.
The schemes are identical to the pre-existing
*posix_prefix* and *nt* install schemes.
The venv module now uses the *venv* scheme to create new virtual environments
instead of hardcoding the paths depending only on the platform. Downstream
Python distributors customizing the *posix_prefix* or *nt* install
scheme in a way that is not compatible with the install scheme used in
virtual environments are encouraged not to customize the *venv* schemes.
When Python itself runs in a virtual environment,
sysconfig.get_default_scheme and
sysconfig.get_preferred_scheme with `key="prefix"` returns
*venv*.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45413](https://bugs.python.org/issue45413) -->
https://bugs.python.org/issue45413
<!-- /issue-number -->
