### PR TITLE
bpo-46542: test_lib2to3 uses support.infinite_recursion()

### DIFF
--- a/Lib/lib2to3/pytree.py
+++ b/Lib/lib2to3/pytree.py
@@ -720,8 +720,8 @@ class WildcardPattern(BasePattern):
                         r[self.name] = nodes[:count]
                     yield count, r
             except RuntimeError:
-                # We fall back to the iterative pattern matching scheme if the recursive
-                # scheme hits the recursion limit.
+                # Fall back to the iterative pattern matching scheme if the
+                # recursive scheme hits the recursion limit (RecursionError).
                 for count, r in self._iterative_matches(nodes):
                     if self.name:
                         r[self.name] = nodes[:count]

--- a/Lib/lib2to3/tests/data/infinite_recursion.py
+++ b/Lib/lib2to3/tests/data/infinite_recursion.py
@@ -1,5 +1,5 @@
-# This file is used to verify that 2to3 falls back to a slower, iterative pattern matching
-# scheme in the event that the faster recursive system fails due to infinite recursion.
+# Verify that 2to3 falls back from the recursive pattern matching scheme to a
+# slower, iterative scheme in the event on RecursionError.
 from ctypes import *
 STRING = c_char_p
 

--- a/Lib/lib2to3/tests/data/infinite_recursion.py
+++ b/Lib/lib2to3/tests/data/infinite_recursion.py
@@ -1,5 +1,5 @@
 # Verify that 2to3 falls back from the recursive pattern matching scheme to a
-# slower, iterative scheme in the event on RecursionError.
+# slower, iterative scheme in the event of a RecursionError.
 from ctypes import *
 STRING = c_char_p
 

--- a/Lib/lib2to3/tests/test_all_fixers.py
+++ b/Lib/lib2to3/tests/test_all_fixers.py
@@ -6,8 +6,10 @@ running time.
 # Author: Collin Winter
 
 # Python imports
-import unittest
+import os.path
+import sys
 import test.support
+import unittest
 
 # Local imports
 from . import support
@@ -19,9 +21,22 @@ class Test_all(support.TestCase):
     def setUp(self):
         self.refactor = support.get_refactorer()
 
+    def refactor_file(self, filepath):
+        if test.support.verbose:
+            print(f"Refactor file: {filepath}")
+        if os.path.basename(filepath) == 'infinite_recursion.py':
+            # bpo-46542: Processing infinite_recursion.py can crash Python
+            # if Python is built in debug mode: lower the recursion limit
+            # to prevent a crash.
+            with test.support.infinite_recursion(150):
+                self.refactor.refactor_file(filepath)
+        else:
+            self.refactor.refactor_file(filepath)
+
     def test_all_project_files(self):
         for filepath in support.all_project_files():
-            self.refactor.refactor_file(filepath)
+            with self.subTest(filepath=filepath):
+                self.refactor_file(filepath)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Tests/2022-01-31-17-34-13.bpo-46542.RTMm1T.rst
+++ b/Misc/NEWS.d/next/Tests/2022-01-31-17-34-13.bpo-46542.RTMm1T.rst
@@ -1,0 +1,2 @@
+Fix a Python crash in test_lib2to3 when using Python built in debug mode:
+limit the recursion limit. Patch by Victor Stinner.


### PR DESCRIPTION
Fix a Python crash in test_lib2to3 when using Python built in debug
mode: limit the recursion limit.

The test_all_project_files() test of test_lib2to3 now uses the
test.support.infinite_recursion() context manager when processing the
infinite_recursion.py file to prevent a crash when Python is built in
debug mode.

The two test_all_project_files() tests now use subTest() and log the
refactored/parsed filename (if test_lib2to3 is run in verbose mode).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46542](https://bugs.python.org/issue46542) -->
https://bugs.python.org/issue46542
<!-- /issue-number -->
