### PR TITLE
bpo-45953: Preserve backward compatibility on some PyThreadState field names.

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -187,16 +187,19 @@ struct _ts {
     /* The following fields are here to avoid allocation during init.
        The data is exposed through PyThreadState pointer fields.
        These fields should not be accessed directly outside of init.
+       This is indicated by an underscore prefix on the field names.
 
        All other PyInterpreterState pointer fields are populated when
        needed and default to NULL.
        */
+       // Note some fields do not have a leading underscore for backward
+       // compatibility.  See https://bugs.python.org/issue45953#msg412046.
 
     /* The thread's exception stack entry.  (Always the last entry.) */
-    _PyErr_StackItem _exc_state;
+    _PyErr_StackItem exc_state;
 
     /* The bottom-most frame on the stack. */
-    CFrame _root_cframe;
+    CFrame root_cframe;
 };
 
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -776,9 +776,9 @@ init_threadstate(PyThreadState *tstate,
     tstate->recursion_limit = interp->ceval.recursion_limit,
     tstate->recursion_remaining = interp->ceval.recursion_limit,
 
-    tstate->exc_info = &tstate->_exc_state;
+    tstate->exc_info = &tstate->exc_state;
 
-    tstate->cframe = &tstate->_root_cframe;
+    tstate->cframe = &tstate->root_cframe;
     tstate->datastack_chunk = NULL;
     tstate->datastack_top = NULL;
     tstate->datastack_limit = NULL;
@@ -1016,10 +1016,10 @@ PyThreadState_Clear(PyThreadState *tstate)
     Py_CLEAR(tstate->curexc_value);
     Py_CLEAR(tstate->curexc_traceback);
 
-    Py_CLEAR(tstate->_exc_state.exc_value);
+    Py_CLEAR(tstate->exc_state.exc_value);
 
     /* The stack of exception states should contain just this thread. */
-    if (verbose && tstate->exc_info != &tstate->_exc_state) {
+    if (verbose && tstate->exc_info != &tstate->exc_state) {
         fprintf(stderr,
           "PyThreadState_Clear: warning: thread still has a generator\n");
     }


### PR DESCRIPTION
The gevent project is using the two `PyThreadState` fields I renamed in gh-30590.  This PR fixes the names.  See https://bugs.python.org/issue45953#msg412046.

<!-- issue-number: [bpo-45953](https://bugs.python.org/issue45953) -->
https://bugs.python.org/issue45953
<!-- /issue-number -->

Automerge-Triggered-By: GH:ericsnowcurrently