### PR TITLE
bpo-46571: improve `typing.no_type_check` to skip foreign objects

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1999,8 +1999,8 @@ Functions and decorators
    Decorator to indicate that annotations are not type hints.
 
    This works as class or function :term:`decorator`.  With a class, it
-   applies recursively to all methods defined in that class (but not
-   to methods defined in its superclasses or subclasses).
+   applies recursively to all methods and classes defined in that class
+   (but not to methods defined in its superclasses or subclasses).
 
    This mutates the function(s) in place.
 

--- a/Lib/test/ann_module8.py
+++ b/Lib/test/ann_module8.py
@@ -1,0 +1,10 @@
+# Test `@no_type_check`,
+# see https://bugs.python.org/issue46571
+
+class NoTypeCheck_Outer:
+    class Inner:
+        x: int
+
+
+def NoTypeCheck_function(arg: int) -> int:
+    ...

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1959,11 +1959,13 @@ def no_type_check(arg):
     This mutates the function(s) or class(es) in place.
     """
     if isinstance(arg, type):
-        arg_attrs = arg.__dict__.copy()
-        for attr, val in arg.__dict__.items():
-            if val in arg.__bases__ + (arg,):
-                arg_attrs.pop(attr)
-        for obj in arg_attrs.values():
+        for obj in arg.__dict__.values():
+            if (hasattr(obj, '__qualname__')
+                    and obj.__qualname__ != f'{arg.__qualname__}.{obj.__name__}'):
+                # We only modify objects that are defined in this type directly.
+                # If classes / methods are nested in multiple layers,
+                # we will modify them when processing their direct holders.
+                continue
             if isinstance(obj, types.FunctionType):
                 obj.__no_type_check__ = True
             if isinstance(obj, type):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1959,15 +1959,23 @@ def no_type_check(arg):
     This mutates the function(s) or class(es) in place.
     """
     if isinstance(arg, type):
-        for obj in arg.__dict__.values():
-            if (hasattr(obj, '__qualname__')
-                    and obj.__qualname__ != f'{arg.__qualname__}.{obj.__name__}'):
+        for key in dir(arg):
+            obj = getattr(arg, key)
+            if (
+                not hasattr(obj, '__qualname__')
+                or obj.__qualname__ != f'{arg.__qualname__}.{obj.__name__}'
+                or getattr(obj, '__module__', None) != arg.__module__
+            ):
                 # We only modify objects that are defined in this type directly.
                 # If classes / methods are nested in multiple layers,
                 # we will modify them when processing their direct holders.
                 continue
+            # Instance, class, and static methods:
             if isinstance(obj, types.FunctionType):
                 obj.__no_type_check__ = True
+            if isinstance(obj, types.MethodType):
+                obj.__func__.__no_type_check__ = True
+            # Nested types:
             if isinstance(obj, type):
                 no_type_check(obj)
     try:

--- a/Misc/NEWS.d/next/Library/2022-02-01-11-21-34.bpo-46571.L40xUJ.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-01-11-21-34.bpo-46571.L40xUJ.rst
@@ -1,2 +1,4 @@
-Improve :func:`typing.no_type_check` to not modify foreign functions and
-types.
+Improve :func:`typing.no_type_check`.
+
+Now it does not modify external classes and functions.
+We also now correctly mark classmethods as not to be type checked.

--- a/Misc/NEWS.d/next/Library/2022-02-01-11-21-34.bpo-46571.L40xUJ.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-01-11-21-34.bpo-46571.L40xUJ.rst
@@ -1,0 +1,2 @@
+Improve :func:`typing.no_type_check` to not modify foreign functions and
+types.


### PR DESCRIPTION
There are several changes:
1. We now don't explicitly check for any base / sub types, because new name check covers it
2. I've also checked that `no_type_check` do not modify foreign functions. It was the same as with `type`s
3. I've also covered `except TypeError` in `no_type_check` with a simple test case, it was not covered at all
4. I also felt like adding `lambda` test is a good idea: because `lambda` is a bit of both in class bodies: a function and an assignment

Are there any other cases we want to cover?

<!-- issue-number: [bpo-46571](https://bugs.python.org/issue46571) -->
https://bugs.python.org/issue46571
<!-- /issue-number -->
