### PR TITLE
bpo-43721: Fix docstrings for property.getter/setter/deleter

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-01-10-05-27.bpo-43721.-1XAIo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-01-10-05-27.bpo-43721.-1XAIo.rst
@@ -1,0 +1,1 @@
+Fix docstrings of :attr:`~property.getter`, :attr:`~property.setter`, and :attr:`~property.deleter` to clarify that they create a new copy of the property.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1510,7 +1510,7 @@ static PyMemberDef property_members[] = {
 
 
 PyDoc_STRVAR(getter_doc,
-             "Descriptor to change the getter on a property.");
+             "Descriptor to obtain a copy of the property with a different getter.");
 
 static PyObject *
 property_getter(PyObject *self, PyObject *getter)
@@ -1520,7 +1520,7 @@ property_getter(PyObject *self, PyObject *getter)
 
 
 PyDoc_STRVAR(setter_doc,
-             "Descriptor to change the setter on a property.");
+             "Descriptor to obtain a copy of the property with a different setter.");
 
 static PyObject *
 property_setter(PyObject *self, PyObject *setter)
@@ -1530,7 +1530,7 @@ property_setter(PyObject *self, PyObject *setter)
 
 
 PyDoc_STRVAR(deleter_doc,
-             "Descriptor to change the deleter on a property.");
+             "Descriptor to obtain a copy of the property with a different deleter.");
 
 static PyObject *
 property_deleter(PyObject *self, PyObject *deleter)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-43721](https://bugs.python.org/issue43721) -->
https://bugs.python.org/issue43721
<!-- /issue-number -->
