### PR TITLE
bpo-46600: ./configure --with-pydebug uses -Og with clang

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-02-01-14-07-37.bpo-46600.NNLnfj.rst
+++ b/Misc/NEWS.d/next/Build/2022-02-01-14-07-37.bpo-46600.NNLnfj.rst
@@ -1,0 +1,3 @@
+Fix the test checking if the C compiler supports ``-Og`` option in the
+``./configure`` script to also use ``-Og`` on clang which supports it. Patch
+by Victor Stinner.

--- a/configure
+++ b/configure
@@ -7624,7 +7624,7 @@ case $CC in
 esac
 
 # Check if CC supports -Og optimization level
-save_CFLAGS="$CFLAGS"
+save_CFLAGS=$CFLAGS
 CFLAGS="-Og"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Og optimization level" >&5
 $as_echo_n "checking if $CC supports -Og optimization level... " >&6; }
@@ -7658,7 +7658,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cc_supports_og" >&5
 $as_echo "$ac_cv_cc_supports_og" >&6; }
-CFLAGS="$save_CFLAGS"
+CFLAGS=$save_CFLAGS
 
 # Optimization messes up debuggers, so turn it off for
 # debug builds.

--- a/configure
+++ b/configure
@@ -7623,6 +7623,50 @@ case $CC in
         fi
 esac
 
+# Check if CC supports -Og optimization level
+save_CFLAGS="$CFLAGS"
+CFLAGS="-Og"
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Og optimization level" >&5
+$as_echo_n "checking if $CC supports -Og optimization level... " >&6; }
+if ${ac_cv_cc_supports_og+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+      ac_cv_cc_supports_og=yes
+
+else
+
+      ac_cv_cc_supports_og=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cc_supports_og" >&5
+$as_echo "$ac_cv_cc_supports_og" >&6; }
+CFLAGS="$save_CFLAGS"
+
+# Optimization messes up debuggers, so turn it off for
+# debug builds.
+PYDEBUG_CFLAGS="-O0"
+if test "x$ac_cv_cc_supports_og" = xyes; then :
+  PYDEBUG_CFLAGS="-Og"
+fi
+
 # tweak OPT based on compiler and platform, only if the user didn't set
 # it on the command line
 
@@ -7648,13 +7692,7 @@ then
 	case $ac_cv_prog_cc_g in
 	yes)
 	    if test "$Py_DEBUG" = 'true' ; then
-		# Optimization messes up debuggers, so turn it off for
-		# debug builds.
-                if "$CC" -v --help 2>/dev/null |grep -- -Og > /dev/null; then
-                    OPT="-g -Og -Wall"
-                else
-                    OPT="-g -O0 -Wall"
-                fi
+		OPT="-g $PYDEBUG_CFLAGS -Wall"
 	    else
 		OPT="-g $WRAP -O3 -Wall"
 	    fi

--- a/configure.ac
+++ b/configure.ac
@@ -1791,6 +1791,28 @@ case $CC in
         fi
 esac
 
+# Check if CC supports -Og optimization level
+save_CFLAGS="$CFLAGS"
+CFLAGS="-Og"
+AC_CACHE_CHECK([if $CC supports -Og optimization level],
+               [ac_cv_cc_supports_og],
+  AC_COMPILE_IFELSE(
+    [
+      AC_LANG_PROGRAM([[]], [[]])
+    ],[
+      ac_cv_cc_supports_og=yes
+    ],[
+      ac_cv_cc_supports_og=no
+    ])
+)
+CFLAGS="$save_CFLAGS"
+
+# Optimization messes up debuggers, so turn it off for
+# debug builds.
+PYDEBUG_CFLAGS="-O0"
+AS_VAR_IF([ac_cv_cc_supports_og], [yes],
+          [PYDEBUG_CFLAGS="-Og"])
+
 # tweak OPT based on compiler and platform, only if the user didn't set
 # it on the command line
 AC_SUBST(OPT)
@@ -1816,13 +1838,7 @@ then
 	case $ac_cv_prog_cc_g in
 	yes)
 	    if test "$Py_DEBUG" = 'true' ; then
-		# Optimization messes up debuggers, so turn it off for
-		# debug builds.
-                if "$CC" -v --help 2>/dev/null |grep -- -Og > /dev/null; then
-                    OPT="-g -Og -Wall"
-                else
-                    OPT="-g -O0 -Wall"
-                fi
+		OPT="-g $PYDEBUG_CFLAGS -Wall"
 	    else
 		OPT="-g $WRAP -O3 -Wall"
 	    fi

--- a/configure.ac
+++ b/configure.ac
@@ -1792,7 +1792,7 @@ case $CC in
 esac
 
 # Check if CC supports -Og optimization level
-save_CFLAGS="$CFLAGS"
+_SAVE_VAR([CFLAGS])
 CFLAGS="-Og"
 AC_CACHE_CHECK([if $CC supports -Og optimization level],
                [ac_cv_cc_supports_og],
@@ -1805,7 +1805,7 @@ AC_CACHE_CHECK([if $CC supports -Og optimization level],
       ac_cv_cc_supports_og=no
     ])
 )
-CFLAGS="$save_CFLAGS"
+_RESTORE_VAR([CFLAGS])
 
 # Optimization messes up debuggers, so turn it off for
 # debug builds.


### PR DESCRIPTION
Fix the test checking if the C compiler supports -Og option in the
./configure script to also use -Og on clang which supports it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46600](https://bugs.python.org/issue46600) -->
https://bugs.python.org/issue46600
<!-- /issue-number -->
