### PR TITLE
bpo-46600: Fix test_gdb.test_pycfunction() for clang -Og

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -897,15 +897,19 @@ id(42)
     # to suppress these. See also the comment in DebuggerTests.get_stack_trace
     def test_pycfunction(self):
         'Verify that "py-bt" displays invocations of PyCFunction instances'
+        # bpo-46600: If the compiler inlines _null_to_none() in meth_varargs()
+        # (ex: clang -Og), _null_to_none() is the frame #1. Otherwise,
+        # meth_varargs() is the frame #1.
+        expected_frame = r'#(1|2)'
         # Various optimizations multiply the code paths by which these are
         # called, so test a variety of calling conventions.
-        for func_name, args, expected_frame in (
-            ('meth_varargs', '', 1),
-            ('meth_varargs_keywords', '', 1),
-            ('meth_o', '[]', 1),
-            ('meth_noargs', '', 1),
-            ('meth_fastcall', '', 1),
-            ('meth_fastcall_keywords', '', 1),
+        for func_name, args in (
+            ('meth_varargs', ''),
+            ('meth_varargs_keywords', ''),
+            ('meth_o', '[]'),
+            ('meth_noargs', ''),
+            ('meth_fastcall', ''),
+            ('meth_fastcall_keywords', ''),
         ):
             for obj in (
                 '_testcapi',
@@ -945,10 +949,9 @@ id(42)
                         # defined.' message in stderr.
                         ignore_stderr=True,
                     )
-                    self.assertIn(
-                        f'#{expected_frame} <built-in method {func_name}',
-                        gdb_output,
-                    )
+                    regex = expected_frame
+                    regex += re.escape(f' <built-in method {func_name}')
+                    self.assertRegex(gdb_output, regex)
 
     @unittest.skipIf(python_is_optimized(),
                      "Python was compiled with optimizations")

--- a/Misc/NEWS.d/next/Tests/2022-02-01-17-13-53.bpo-46600.FMCk8Z.rst
+++ b/Misc/NEWS.d/next/Tests/2022-02-01-17-13-53.bpo-46600.FMCk8Z.rst
@@ -1,0 +1,2 @@
+Fix test_gdb.test_pycfunction() for Python built with ``clang -Og``.
+Tolerate inlined functions in the gdb traceback. Patch by Victor Stinner.


### PR DESCRIPTION
Fix test_gdb.test_pycfunction() for Python built with clang -Og.
Tolerate inlined functions in the gdb traceback.

When _testcapimodule.c is built by clang -Og, _null_to_none() is
inlined in meth_varargs() and so gdb returns _null_to_none() as
the frame #1. If it's not inlined, meth_varargs() is the frame #1.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46600](https://bugs.python.org/issue46600) -->
https://bugs.python.org/issue46600
<!-- /issue-number -->
