### PR TITLE
bpo-46581: Propagate private vars via _GenericAlias.copy_with

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -305,6 +305,14 @@ class BaseTest(unittest.TestCase):
             self.assertEqual(copied.__args__, alias.__args__)
             self.assertEqual(copied.__parameters__, alias.__parameters__)
 
+    def test_copy_with(self):
+        # bpo-46581
+        from typing import Callable, ParamSpec
+        P = ParamSpec('P')
+        original = Callable[P, int]
+        copied = original.copy_with((P, int))
+        self.assertEqual(original.__parameters__, copied.__parameters__)
+
     def test_union(self):
         a = typing.Union[list[int], list[str]]
         self.assertEqual(a.__args__, (list[int], list[str]))

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -305,14 +305,6 @@ class BaseTest(unittest.TestCase):
             self.assertEqual(copied.__args__, alias.__args__)
             self.assertEqual(copied.__parameters__, alias.__parameters__)
 
-    def test_copy_with(self):
-        # bpo-46581
-        from typing import Callable, ParamSpec
-        P = ParamSpec('P')
-        original = Callable[P, int]
-        copied = original.copy_with((P, int))
-        self.assertEqual(original.__parameters__, copied.__parameters__)
-
     def test_union(self):
         a = typing.Union[list[int], list[str]]
         self.assertEqual(a.__args__, (list[int], list[str]))

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5796,10 +5796,23 @@ class ParamSpecTests(BaseTestCase):
     def test_paramspec_gets_copied(self):
         # bpo-46581
         P = ParamSpec('P')
-        original = Callable[P, int]
-        self.assertEqual(original.__parameters__, (P,))
-        copied = original[P]
-        self.assertEqual(original.__parameters__, copied.__parameters__)
+        P2 = ParamSpec('P2')
+        C1 = Callable[P, int]
+        self.assertEqual(C1.__parameters__, (P,))
+        self.assertEqual(C1[P2].__parameters__, (P2,))
+        self.assertEqual(C1[str].__parameters__, ())
+        self.assertEqual(C1[str, T].__parameters__, (T,))
+        self.assertEqual(C1[Concatenate[str, P2]].__parameters__, (P2,))
+        self.assertEqual(C1[Concatenate[T, P2]].__parameters__, (T, P2))
+        self.assertEqual(C1[...].__parameters__, ())
+
+        C2 = Callable[Concatenate[str, P], int]
+        self.assertEqual(C2.__parameters__, (P,))
+        self.assertEqual(C2[P2].__parameters__, (P2,))
+        self.assertEqual(C2[str].__parameters__, ())
+        self.assertEqual(C2[str, T].__parameters__, (T,))
+        self.assertEqual(C2[Concatenate[str, P2]].__parameters__, (P2,))
+        self.assertEqual(C2[Concatenate[T, P2]].__parameters__, (T, P2))
 
 
 class ConcatenateTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2804,7 +2804,6 @@ class GenericTests(BaseTestCase):
 
     def test_copy_with(self):
         # bpo-46581
-        from typing import Callable, ParamSpec
         P = ParamSpec('P')
         original = Callable[P, int]
         copied = original.copy_with((P, int))

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2802,6 +2802,14 @@ class GenericTests(BaseTestCase):
         self.assertEqual(deepcopy(ci).attr, 1)
         self.assertEqual(ci.__orig_class__, C[int])
 
+    def test_copy_with(self):
+        # bpo-46581
+        from typing import Callable, ParamSpec
+        P = ParamSpec('P')
+        original = Callable[P, int]
+        copied = original.copy_with((P, int))
+        self.assertEqual(original.__parameters__, copied.__parameters__)
+
     def test_weakref_all(self):
         T = TypeVar('T')
         things = [Any, Union[T, int], Callable[..., T], Tuple[Any, Any],

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2802,11 +2802,12 @@ class GenericTests(BaseTestCase):
         self.assertEqual(deepcopy(ci).attr, 1)
         self.assertEqual(ci.__orig_class__, C[int])
 
-    def test_copy_with(self):
+    def test_parameter_propagation(self):
         # bpo-46581
         P = ParamSpec('P')
         original = Callable[P, int]
-        copied = original.copy_with((P, int))
+        self.assertEqual(original.__parameters__, (P,))
+        copied = original[P]
         self.assertEqual(original.__parameters__, copied.__parameters__)
 
     def test_weakref_all(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2802,14 +2802,6 @@ class GenericTests(BaseTestCase):
         self.assertEqual(deepcopy(ci).attr, 1)
         self.assertEqual(ci.__orig_class__, C[int])
 
-    def test_parameter_propagation(self):
-        # bpo-46581
-        P = ParamSpec('P')
-        original = Callable[P, int]
-        self.assertEqual(original.__parameters__, (P,))
-        copied = original[P]
-        self.assertEqual(original.__parameters__, copied.__parameters__)
-
     def test_weakref_all(self):
         T = TypeVar('T')
         things = [Any, Union[T, int], Callable[..., T], Tuple[Any, Any],
@@ -5800,6 +5792,14 @@ class ParamSpecTests(BaseTestCase):
         self.assertEqual(G1[[int, str], float], List[C])
         self.assertEqual(G2[[int, str], float], list[C])
         self.assertEqual(G3[[int, str], float], list[C] | int)
+
+    def test_paramspec_gets_copied(self):
+        # bpo-46581
+        P = ParamSpec('P')
+        original = Callable[P, int]
+        self.assertEqual(original.__parameters__, (P,))
+        copied = original[P]
+        self.assertEqual(original.__parameters__, copied.__parameters__)
 
 
 class ConcatenateTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1339,6 +1339,8 @@ class _GenericAlias(_BaseGenericAlias, _root=True):
         return tuple(new_args)
 
     def copy_with(self, args):
+        if isinstance(self, _ConcatenateGenericAlias):
+            return self.__class__(self.__origin__, args)
         return self.__class__(self.__origin__, args, name=self._name, inst=self._inst,
                               _typevar_types=self._typevar_types,
                               _paramspec_tvars=self._paramspec_tvars)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1339,7 +1339,9 @@ class _GenericAlias(_BaseGenericAlias, _root=True):
         return tuple(new_args)
 
     def copy_with(self, args):
-        return self.__class__(self.__origin__, args, name=self._name, inst=self._inst)
+        return self.__class__(self.__origin__, args, name=self._name, inst=self._inst,
+                              _typevar_types=self._typevar_types,
+                              _paramspec_tvars=self._paramspec_tvars)
 
     def __repr__(self):
         if self._name:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -332,8 +332,8 @@ def _tp_cache(func=None, /, *, typed=False):
 def _eval_type(t, globalns, localns, recursive_guard=frozenset()):
     """Evaluate all forward references in the given type t.
     For use of globalns and localns see the docstring for get_type_hints().
-    recursive_guard is used to prevent infinite recursion with a recursive
-    ForwardRef.
+    recursive_guard is used to prevent prevent infinite recursion
+    with recursive ForwardRef.
     """
     if isinstance(t, ForwardRef):
         return t._evaluate(globalns, localns, recursive_guard)
@@ -1097,7 +1097,7 @@ class _BaseGenericAlias(_Final, _root=True):
             return self._name or self.__origin__.__name__
 
         # We are careful for copy and pickle.
-        # Also for simplicity we don't relay any dunder names
+        # Also for simplicity we just don't relay all dunder names
         if '__origin__' in self.__dict__ and not _is_dunder(attr):
             return getattr(self.__origin__, attr)
         raise AttributeError(attr)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -190,6 +190,7 @@ Paul Boddie
 Matthew Boedicker
 Robin Boerdijk
 Andra Bogildea
+Matt Bogosian
 Nikolay Bogoychev
 David Bolen
 Wouter Bolsterlee

--- a/Misc/NEWS.d/next/Library/2022-02-01-11-32-47.bpo-46581.t7Zw65.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-01-11-32-47.bpo-46581.t7Zw65.rst
@@ -1,3 +1,2 @@
-Propagates :attribute:`~typing._GenericAlias._typevar_types` and
-:attribute:`~typing._GenericAlias._paramspec_tvars` via
-:method:`~typing._GenericAlias.copy_with`.
+Brings :class:`ParamSpec` propagation for :class:`GenericAlias` in line with
+:class:`Concatenate` (and others).

--- a/Misc/NEWS.d/next/Library/2022-02-01-11-32-47.bpo-46581.t7Zw65.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-01-11-32-47.bpo-46581.t7Zw65.rst
@@ -1,0 +1,3 @@
+Propagates :attribute:`~typing._GenericAlias._typevar_types` and
+:attribute:`~typing._GenericAlias._paramspec_tvars` via
+:method:`~typing._GenericAlias.copy_with`.


### PR DESCRIPTION
GH-26091 added the `_typevar_types` and `_paramspec_tvars` instance variables to `_GenericAlias`. However, they were not propagated consistently. This commit addresses the most prominent deficiency identified in [bpo-46581](https://bugs.python.org/issue46581) (namely their absence from `_GenericAlias.copy_with`), but there could be others.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46581](https://bugs.python.org/issue46581) -->
https://bugs.python.org/issue46581
<!-- /issue-number -->
