### PR TITLE
bpo-46603: improve coverage of `typing._strip_annotations`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3355,6 +3355,15 @@ class GetTypeHintTests(BaseTestCase):
             {"x": typing.Annotated[int | float, "const"]}
         )
 
+    def test_get_type_hints_annotated_in_union(self):  # bpo-46603
+        def with_union(x: int | list[Annotated[str, 'meta']]): ...
+
+        self.assertEqual(get_type_hints(with_union), {'x': int | list[str]})
+        self.assertEqual(
+            get_type_hints(with_union, include_extras=True),
+            {'x': int | list[Annotated[str, 'meta']]},
+        )
+
     def test_get_type_hints_annotated_refs(self):
 
         Const = Annotated[T, "Const"]


### PR DESCRIPTION
It was not covered at all, proof:

<img width="752" alt="Снимок экрана 2022-02-02 в 0 05 19" src="https://user-images.githubusercontent.com/4660275/152053176-d7f56977-ede0-4c6b-9d73-2e89c1696c69.png">

It took me some time to understand how can I possibly reach it. After adding this test, we now cover this path. Proof:

<img width="752" alt="Снимок экрана 2022-02-02 в 0 11 25" src="https://user-images.githubusercontent.com/4660275/152053240-85936437-9641-41f1-a77d-47c2d1438c0f.png">


<!-- issue-number: [bpo-46603](https://bugs.python.org/issue46603) -->
https://bugs.python.org/issue46603
<!-- /issue-number -->
