### PR TITLE
bpo-46604: fix function name in ssl module docstring

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -18,9 +18,10 @@ Functions:
                           seconds past the Epoch (the time values
                           returned from time.time())
 
-  fetch_server_certificate (HOST, PORT) -- fetch the certificate provided
-                          by the server running on HOST at port PORT.  No
-                          validation of the certificate is performed.
+  get_server_certificate (addr, ssl_version, ca_certs) -- Retrieve the
+                          certificate from the server at the specified
+                          address and return it as a PEM-encoded string
+                          
 
 Integer constants:
 

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -21,7 +21,7 @@ Functions:
   get_server_certificate (addr, ssl_version, ca_certs, timeout) -- Retrieve the
                           certificate from the server at the specified
                           address and return it as a PEM-encoded string
-                          
+
 
 Integer constants:
 

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -18,7 +18,7 @@ Functions:
                           seconds past the Epoch (the time values
                           returned from time.time())
 
-  get_server_certificate (addr, ssl_version, ca_certs) -- Retrieve the
+  get_server_certificate (addr, ssl_version, ca_certs, timeout) -- Retrieve the
                           certificate from the server at the specified
                           address and return it as a PEM-encoded string
                           


### PR DESCRIPTION
[bpo-46604](https://bugs.python.org/issue46604): FIx documentation in ssl module
Replaced function `fetch_server_certificate` by `get_server_certificate` in ssl module docstrings

<!-- issue-number: [bpo-46604](https://bugs.python.org/issue46604) -->
https://bugs.python.org/issue46604
<!-- /issue-number -->
