### PR TITLE
bpo-45773: Remove invalid peephole optimizations

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-01-14-30-56.bpo-45773.Up77LD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-01-14-30-56.bpo-45773.Up77LD.rst
@@ -1,0 +1,1 @@
+Remove two invalid "peephole" optimizations from the bytecode compiler.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -8753,7 +8753,6 @@ optimize_basic_block(struct compiler *c, basicblock *bb, PyObject *consts)
                 switch (target->i_opcode) {
                     case JUMP_ABSOLUTE:
                     case JUMP_FORWARD:
-                    case JUMP_IF_FALSE_OR_POP:
                         i -= jump_thread(inst, target, POP_JUMP_IF_FALSE);
                 }
                 break;
@@ -8761,7 +8760,6 @@ optimize_basic_block(struct compiler *c, basicblock *bb, PyObject *consts)
                 switch (target->i_opcode) {
                     case JUMP_ABSOLUTE:
                     case JUMP_FORWARD:
-                    case JUMP_IF_TRUE_OR_POP:
                         i -= jump_thread(inst, target, POP_JUMP_IF_TRUE);
                 }
                 break;


### PR DESCRIPTION
The good news is that I can't get the compiler to actually emit these particular jump sequences.

<!-- issue-number: [bpo-45773](https://bugs.python.org/issue45773) -->
https://bugs.python.org/issue45773
<!-- /issue-number -->
