### PR TITLE
bpo-44359: Fix test_ftplib unhandled thread exceptions

### DIFF
--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -56,6 +56,13 @@ MLSD_DATA = ("type=cdir;perm=el;unique==keVO1+ZF4; test\r\n"
              "type=file;perm=r;unique==SGP2; file \xAE non-ascii char\r\n")
 
 
+def default_error_handler():
+    # bpo-44359: Silently ignore socket errors. Such errors occur when a client
+    # socket is closed, in TestFTPClass.tearDown() and makepasv() tests, and
+    # the server gets an error on its side.
+    pass
+
+
 class DummyDTPHandler(asynchat.async_chat):
     dtp_conn_closed = False
 
@@ -87,7 +94,7 @@ class DummyDTPHandler(asynchat.async_chat):
         super(DummyDTPHandler, self).push(what.encode(self.encoding))
 
     def handle_error(self):
-        raise Exception
+        default_error_handler()
 
 
 class DummyFTPHandler(asynchat.async_chat):
@@ -137,7 +144,7 @@ class DummyFTPHandler(asynchat.async_chat):
             self.push('550 command "%s" not understood.' %cmd)
 
     def handle_error(self):
-        raise Exception
+        default_error_handler()
 
     def push(self, data):
         asynchat.async_chat.push(self, data.encode(self.encoding) + b'\r\n')
@@ -315,7 +322,7 @@ class DummyFTPServer(asyncore.dispatcher, threading.Thread):
         return 0
 
     def handle_error(self):
-        raise Exception
+        default_error_handler()
 
 
 if ssl is not None:
@@ -418,7 +425,7 @@ if ssl is not None:
                 raise
 
         def handle_error(self):
-            raise Exception
+            default_error_handler()
 
         def close(self):
             if (isinstance(self.socket, ssl.SSLSocket) and

--- a/Misc/NEWS.d/next/Tests/2022-02-02-02-24-04.bpo-44359.kPPSmN.rst
+++ b/Misc/NEWS.d/next/Tests/2022-02-02-02-24-04.bpo-44359.kPPSmN.rst
@@ -1,0 +1,2 @@
+test_ftplib now silently ignores socket errors to prevent logging unhandled
+threading exceptions. Patch by Victor Stinner.


### PR DESCRIPTION
test_ftplib now silently ignores socket errors to prevent logging
unhandled threading exceptions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44359](https://bugs.python.org/issue44359) -->
https://bugs.python.org/issue44359
<!-- /issue-number -->
