### PR TITLE
Fix assertCountEqual for dictionary elements  

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1180,7 +1180,10 @@ class TestCase(object):
             - [0, 0, 1] and [0, 1] compare unequal.
 
         """
-        first_seq, second_seq = list(first), list(second)
+        from typing import Dict
+
+        first_seq = first.items() if isinstance(first, Dict) else list(first)
+        second_seq = second.items() if isinstance(second, Dict) else list(second)
         try:
             first = collections.Counter(first_seq)
             second = collections.Counter(second_seq)

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1180,10 +1180,8 @@ class TestCase(object):
             - [0, 0, 1] and [0, 1] compare unequal.
 
         """
-        from typing import Dict
-
-        first_seq = first.items() if isinstance(first, Dict) else list(first)
-        second_seq = second.items() if isinstance(second, Dict) else list(second)
+        first_seq = first.items() if isinstance(first, dict) else list(first)
+        second_seq = second.items() if isinstance(second, dict) else list(second)
         try:
             first = collections.Counter(first_seq)
             second = collections.Counter(second_seq)


### PR DESCRIPTION
For the `dict` value of the assertCountEqual doesn't work as expected.

Please see the following test:
```
def test_dict(self):
    self.assertCountEqual({"key":"value1"}, {"key":"value2"})
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
