### PR TITLE
bpo-46610: Fix assertCountEqual for dictionary elements.

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1180,7 +1180,8 @@ class TestCase(object):
             - [0, 0, 1] and [0, 1] compare unequal.
 
         """
-        first_seq, second_seq = list(first), list(second)
+        first_seq = first.items() if isinstance(first, dict) else list(first)
+        second_seq = second.items() if isinstance(second, dict) else list(second)
         try:
             first = collections.Counter(first_seq)
             second = collections.Counter(second_seq)

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -988,6 +988,8 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
                           [], [divmod, 'x', 1, 5j, 2j, frozenset()])
         # comparing dicts
         self.assertCountEqual([{'a': 1}, {'b': 2}], [{'b': 2}, {'a': 1}])
+        self.assertRaises(self.failureException, self.assertCountEqual,
+                          {'a': 1}, {'a': 2})
         # comparing heterogeneous non-hashable sequences
         self.assertCountEqual([1, 'x', divmod, []], [divmod, [], 'x', 1])
         self.assertRaises(self.failureException, self.assertCountEqual,

--- a/Misc/NEWS.d/next/Tests/2022-02-02-14-59-17.bpo-46610.n_6gqk.rst
+++ b/Misc/NEWS.d/next/Tests/2022-02-02-14-59-17.bpo-46610.n_6gqk.rst
@@ -1,0 +1,1 @@
+For the dict value, the assertCountEqual doesn't work as expected.


### PR DESCRIPTION
For the `dict` value, the assertCountEqual doesn't work as expected.

Please see the following test:
```
self.assertCountEqual({"key":"value1"}, {"key":"value2"})
```

https://bugs.python.org/issue46610