### PR TITLE
bpo-46611: add coverage to instance and class checks in `typing.py`

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -704,7 +704,7 @@ class UnionTests(unittest.TestCase):
         self.assertEqual(hash(int | str), hash(typing.Union[int, str]))
 
     def test_instancecheck_and_subclasscheck(self):
-        for x in [int | str, typing.Union[int, str]]:
+        for x in (int | str, typing.Union[int, str]):
             with self.subTest(x=x):
                 self.assertIsInstance(1, x)
                 self.assertIsInstance(True, x)
@@ -715,15 +715,15 @@ class UnionTests(unittest.TestCase):
                 self.assertTrue(issubclass(str, x))
                 self.assertFalse(issubclass(type(None), x))
 
-        for x in [int | None, typing.Union[int, None]]:
+        for x in (int | None, typing.Union[int, None]):
             with self.subTest(x=x):
                 self.assertIsInstance(None, x)
                 self.assertTrue(issubclass(type(None), x))
 
-        for x in [
+        for x in (
             int | collections.abc.Mapping,
             typing.Union[int, collections.abc.Mapping],
-        ]:
+        ):
             with self.subTest(x=x):
                 self.assertIsInstance({}, x)
                 self.assertNotIsInstance((), x)
@@ -733,19 +733,19 @@ class UnionTests(unittest.TestCase):
     def test_instancecheck_and_subclasscheck_order(self):
         T = typing.TypeVar('T')
 
-        will_resolve = [
+        will_resolve = (
             int | T,
             typing.Union[int, T],
-        ]
+        )
         for x in will_resolve:
             with self.subTest(x=x):
                 self.assertIsInstance(1, x)
                 self.assertTrue(issubclass(int, x))
 
-        wont_resolve = [
+        wont_resolve = (
             T | int,
             typing.Union[T, int],
-        ]
+        )
         for x in wont_resolve:
             with self.subTest(x=x):
                 with self.assertRaises(TypeError):
@@ -753,7 +753,7 @@ class UnionTests(unittest.TestCase):
                 with self.assertRaises(TypeError):
                     isinstance(1, x)
 
-        for x in [*will_resolve, *wont_resolve]:
+        for x in (*will_resolve, *wont_resolve):
             with self.subTest(x=x):
                 with self.assertRaises(TypeError):
                     issubclass(object, x)

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -730,6 +730,36 @@ class UnionTests(unittest.TestCase):
                 self.assertTrue(issubclass(dict, x))
                 self.assertFalse(issubclass(list, x))
 
+    def test_instancecheck_and_subclasscheck_order(self):
+        T = typing.TypeVar('T')
+
+        will_resolve = [
+            int | T,
+            typing.Union[int, T],
+        ]
+        for x in will_resolve:
+            with self.subTest(x=x):
+                self.assertIsInstance(1, x)
+                self.assertTrue(issubclass(int, x))
+
+        wont_resolve = [
+            T | int,
+            typing.Union[T, int],
+        ]
+        for x in wont_resolve:
+            with self.subTest(x=x):
+                with self.assertRaises(TypeError):
+                    issubclass(int, x)
+                with self.assertRaises(TypeError):
+                    isinstance(1, x)
+
+        for x in [*will_resolve, *wont_resolve]:
+            with self.subTest(x=x):
+                with self.assertRaises(TypeError):
+                    issubclass(object, x)
+                with self.assertRaises(TypeError):
+                    isinstance(object(), x)
+
     def test_bad_instancecheck(self):
         class BadMeta(type):
             def __instancecheck__(cls, inst):

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -703,22 +703,32 @@ class UnionTests(unittest.TestCase):
         self.assertEqual(hash(int | str), hash(str | int))
         self.assertEqual(hash(int | str), hash(typing.Union[int, str]))
 
-    def test_instancecheck(self):
-        x = int | str
-        self.assertIsInstance(1, x)
-        self.assertIsInstance(True, x)
-        self.assertIsInstance('a', x)
-        self.assertNotIsInstance(None, x)
-        self.assertTrue(issubclass(int, x))
-        self.assertTrue(issubclass(bool, x))
-        self.assertTrue(issubclass(str, x))
-        self.assertFalse(issubclass(type(None), x))
-        x = int | None
-        self.assertIsInstance(None, x)
-        self.assertTrue(issubclass(type(None), x))
-        x = int | collections.abc.Mapping
-        self.assertIsInstance({}, x)
-        self.assertTrue(issubclass(dict, x))
+    def test_instancecheck_and_subclasscheck(self):
+        for x in [int | str, typing.Union[int, str]]:
+            with self.subTest(x=x):
+                self.assertIsInstance(1, x)
+                self.assertIsInstance(True, x)
+                self.assertIsInstance('a', x)
+                self.assertNotIsInstance(None, x)
+                self.assertTrue(issubclass(int, x))
+                self.assertTrue(issubclass(bool, x))
+                self.assertTrue(issubclass(str, x))
+                self.assertFalse(issubclass(type(None), x))
+
+        for x in [int | None, typing.Union[int, None]]:
+            with self.subTest(x=x):
+                self.assertIsInstance(None, x)
+                self.assertTrue(issubclass(type(None), x))
+
+        for x in [
+            int | collections.abc.Mapping,
+            typing.Union[int, collections.abc.Mapping],
+        ]:
+            with self.subTest(x=x):
+                self.assertIsInstance({}, x)
+                self.assertNotIsInstance((), x)
+                self.assertTrue(issubclass(dict, x))
+                self.assertFalse(issubclass(list, x))
 
     def test_bad_instancecheck(self):
         class BadMeta(type):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -430,6 +430,8 @@ class TupleTests(BaseTestCase):
         class MyTuple(tuple):
             pass
         self.assertIsSubclass(MyTuple, Tuple)
+        self.assertIsSubclass(Tuple, Tuple)
+        self.assertIsSubclass(tuple, Tuple)
 
     def test_tuple_instance_type_error(self):
         with self.assertRaises(TypeError):
@@ -457,6 +459,7 @@ class BaseCallableTests:
         with self.assertRaises(TypeError):
             issubclass(types.FunctionType, Callable[[int], int])
         self.assertIsSubclass(types.FunctionType, Callable)
+        self.assertIsSubclass(Callable, Callable)
 
     def test_eq_hash(self):
         Callable = self.Callable


### PR DESCRIPTION
Some proofs that these lines were not covered:
<img width="752" alt="Снимок экрана 2022-02-02 в 16 38 20" src="https://user-images.githubusercontent.com/4660275/152168781-9a5f8acb-ab6c-4aa4-807b-ba0c8a66363c.png">
<img width="752" alt="Снимок экрана 2022-02-02 в 16 12 59" src="https://user-images.githubusercontent.com/4660275/152168796-656c878b-1dd6-4294-937a-0aa341baa8bf.png">

Now, they are! 👍 

<!-- issue-number: [bpo-46611](https://bugs.python.org/issue46611) -->
https://bugs.python.org/issue46611
<!-- /issue-number -->
