### PR TITLE
bpo-46616: Ensures test_importlib.test_windows cleans up registry keys after completion

### DIFF
--- a/Lib/test/test_importlib/test_windows.py
+++ b/Lib/test/test_importlib/test_windows.py
@@ -60,17 +60,26 @@ def setup_module(machinery, name, path=None):
         root = machinery.WindowsRegistryFinder.REGISTRY_KEY
     key = root.format(fullname=name,
                       sys_version='%d.%d' % sys.version_info[:2])
+    base_key = "Software\\Python\\PythonCore\\{}.{}".format(*sys.version_info[:2])
     try:
         with temp_module(name, "a = 1") as location:
+            try:
+                OpenKey(HKEY_CURRENT_USER, base_key)
+                if machinery.WindowsRegistryFinder.DEBUG_BUILD:
+                    delete_key = os.path.dirname(key)
+                else:
+                    delete_key = key
+            except OSError:
+                delete_key = base_key
             subkey = CreateKey(HKEY_CURRENT_USER, key)
             if path is None:
                 path = location + ".py"
             SetValue(subkey, "", REG_SZ, path)
             yield
     finally:
-        if machinery.WindowsRegistryFinder.DEBUG_BUILD:
-            key = os.path.dirname(key)
-        delete_registry_tree(HKEY_CURRENT_USER, key)
+        if delete_key:
+            print("DELETING", delete_key)
+            delete_registry_tree(HKEY_CURRENT_USER, delete_key)
 
 
 @unittest.skipUnless(sys.platform.startswith('win'), 'requires Windows')

--- a/Lib/test/test_importlib/test_windows.py
+++ b/Lib/test/test_importlib/test_windows.py
@@ -60,7 +60,10 @@ def setup_module(machinery, name, path=None):
         root = machinery.WindowsRegistryFinder.REGISTRY_KEY
     key = root.format(fullname=name,
                       sys_version='%d.%d' % sys.version_info[:2])
-    base_key = "Software\\Python\\PythonCore\\{}.{}".format(*sys.version_info[:2])
+    base_key = "Software\\Python\\PythonCore\\{}.{}".format(
+        sys.version_info.major, sys.version_info.minor)
+    assert key.casefold().startswith(base_key.casefold()), (
+        "expected key '{}' to start with '{}'".format(key, base_key))
     try:
         with temp_module(name, "a = 1") as location:
             try:
@@ -78,7 +81,6 @@ def setup_module(machinery, name, path=None):
             yield
     finally:
         if delete_key:
-            print("DELETING", delete_key)
             delete_registry_tree(HKEY_CURRENT_USER, delete_key)
 
 

--- a/Misc/NEWS.d/next/Tests/2022-02-02-18-14-38.bpo-46616.URvBtE.rst
+++ b/Misc/NEWS.d/next/Tests/2022-02-02-18-14-38.bpo-46616.URvBtE.rst
@@ -1,0 +1,2 @@
+Ensures ``test_importlib.test_windows`` cleans up registry keys after
+completion.


### PR DESCRIPTION


<!-- issue-number: [bpo-46616](https://bugs.python.org/issue46616) -->
https://bugs.python.org/issue46616
<!-- /issue-number -->
