### PR TITLE
[3.10] bpo-46576: bpo-46524: Disable compiler optimization within test_peg_generator

### DIFF
--- a/Misc/NEWS.d/next/Tests/2022-01-29-12-37-53.bpo-46576.-prRaV.rst
+++ b/Misc/NEWS.d/next/Tests/2022-01-29-12-37-53.bpo-46576.-prRaV.rst
@@ -1,0 +1,3 @@
+test_peg_generator now disables compiler optimization when testing
+compilation of its own C extensions to significantly speed up the
+testing on non-debug builds of CPython.

--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -1,6 +1,7 @@
 import pathlib
 import shutil
 import tokenize
+import sys
 import sysconfig
 import tempfile
 import itertools
@@ -33,6 +34,7 @@ def compile_c_extension(
     build_dir: Optional[str] = None,
     verbose: bool = False,
     keep_asserts: bool = True,
+    disable_optimization: bool = True,  # Significant test_peg_generator speedup.
 ) -> str:
     """Compile the generated source for a parser generator into an extension module.
 
@@ -62,6 +64,14 @@ def compile_c_extension(
     extra_link_args = get_extra_flags("LDFLAGS", "PY_LDFLAGS_NODIST")
     if keep_asserts:
         extra_compile_args.append("-UNDEBUG")
+    if disable_optimization:
+        if sys.platform == 'win32':
+            extra_compile_args.append("/Od")
+            extra_link_args.append("/LTCG:OFF")
+        else:
+            extra_compile_args.append("-O0")
+            if sysconfig.get_config_var("GNULD") == "yes":
+                extra_link_args.append("-fno-lto")
     extension = [
         Extension(
             extension_name,


### PR DESCRIPTION
backport of (GH-31015)

Disable compiler optimization within test_peg_generator.

This speed up test_peg_generator by always disabling compiler
optimizations by using -O0 or equivalent when the test is building its
own C extensions.

A build not using --with-pydebug in order to speed up test execution
winds up with this test taking a very long time as it would do
repeated compilation of parser C code using the same optimization
flags as CPython was built with.

This speeds the test up 6-8x on gps-raspbian.

Also incorporate's GH-31017's win32 conditional and flags.

Co-authored-by: Kumar Aditya kumaraditya303.
(cherry picked from commit 164a017e13ee96bd1ea1ae79f5ac9e25fe83994e)

Co-authored-by: Gregory P. Smith <greg@krypto.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46576](https://bugs.python.org/issue46576) -->
https://bugs.python.org/issue46576
<!-- /issue-number -->
