### PR TITLE
bpo-46623: Skip two test_zlib tests on s390x

### DIFF
--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -3,6 +3,7 @@ from test import support
 from test.support import import_helper
 import binascii
 import copy
+import os
 import pickle
 import random
 import sys
@@ -17,6 +18,35 @@ requires_Compress_copy = unittest.skipUnless(
 requires_Decompress_copy = unittest.skipUnless(
         hasattr(zlib.decompressobj(), "copy"),
         'requires Decompress.copy()')
+
+# bpo-46623: On s390x, when a hardware accelerator is used, using different
+# ways to compress data with zlib can produce different compressed data.
+# Simplified test_pair() code:
+#
+#   def func1(datasrc):
+#       return zlib.compress(datasrc)
+#
+#   def func2(datasrc)
+#       co = zlib.compressobj()
+#       x1 = co.compress(data)
+#       x2 = co.flush()
+#       return x1 + x2
+#
+# On s390x if zlib uses a hardware accelerator, func1() creates a single
+# "final" compressed block whereas func2() produces 3 compressed blocks (the
+# last one is a final block). On other platforms with no accelerator, func1()
+# and func2() produce the same compressed data made of a single (final)
+# compressed block.
+#
+# Only the compressed data is different, the decompression returns the original
+# data:
+#
+#   zlib.decompress(func1()) == zlib.decompress(func2()) == datasrc
+#
+# Make the assumption that s390x always has an accelerator to simplify the
+# skip condition.
+skip_on_s390x = unittest.skipIf(os.uname().machine == 's390x',
+                                'skipped on s390x')
 
 
 class VersionTestCase(unittest.TestCase):
@@ -182,6 +212,7 @@ class CompressTestCase(BaseCompressTestCase, unittest.TestCase):
                                          bufsize=zlib.DEF_BUF_SIZE),
                          HAMLET_SCENE)
 
+    @skip_on_s390x
     def test_speech128(self):
         # compress more data
         data = HAMLET_SCENE * 128
@@ -233,6 +264,7 @@ class CompressTestCase(BaseCompressTestCase, unittest.TestCase):
 
 class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
     # Test compression object
+    @skip_on_s390x
     def test_pair(self):
         # straightforward compress/decompress objects
         datasrc = HAMLET_SCENE * 128

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -44,8 +44,8 @@ requires_Decompress_copy = unittest.skipUnless(
 #   zlib.decompress(func1()) == zlib.decompress(func2()) == datasrc
 #
 # Make the assumption that s390x always has an accelerator to simplify the
-# skip condition.
-skip_on_s390x = unittest.skipIf(os.uname().machine == 's390x',
+# skip condition. Don't skip on Windows which doesn't have os.uname().
+skip_on_s390x = unittest.skipIf(hasattr(os, 'uname') and os.uname().machine == 's390x',
                                 'skipped on s390x')
 
 

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -23,10 +23,10 @@ requires_Decompress_copy = unittest.skipUnless(
 # ways to compress data with zlib can produce different compressed data.
 # Simplified test_pair() code:
 #
-#   def func1(datasrc):
-#       return zlib.compress(datasrc)
+#   def func1(data):
+#       return zlib.compress(data)
 #
-#   def func2(datasrc)
+#   def func2(data)
 #       co = zlib.compressobj()
 #       x1 = co.compress(data)
 #       x2 = co.flush()
@@ -41,10 +41,10 @@ requires_Decompress_copy = unittest.skipUnless(
 # Only the compressed data is different, the decompression returns the original
 # data:
 #
-#   zlib.decompress(func1()) == zlib.decompress(func2()) == datasrc
+#   zlib.decompress(func1(data)) == zlib.decompress(func2(data)) == data
 #
-# Make the assumption that s390x always has an accelerator to simplify the
-# skip condition. Don't skip on Windows which doesn't have os.uname().
+# Make the assumption that s390x always has an accelerator to simplify the skip
+# condition. Windows doesn't have os.uname() but it doesn't support s390x.
 skip_on_s390x = unittest.skipIf(hasattr(os, 'uname') and os.uname().machine == 's390x',
                                 'skipped on s390x')
 

--- a/Misc/NEWS.d/next/Tests/2022-02-03-09-45-26.bpo-46623.vxzuhV.rst
+++ b/Misc/NEWS.d/next/Tests/2022-02-03-09-45-26.bpo-46623.vxzuhV.rst
@@ -1,0 +1,2 @@
+Skip test_pair() and test_speech128() of test_zlib on s390x since they fail
+if zlib uses the s390x hardware accelerator. Patch by Victor Stinner.


### PR DESCRIPTION
Skip test_pair() and test_speech128() of test_zlib on s390x since
they fail if zlib uses the s390x hardware accelerator.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46623](https://bugs.python.org/issue46623) -->
https://bugs.python.org/issue46623
<!-- /issue-number -->
