### PR TITLE
bpo-46624: Revert "Remove deprecated support for non-integer values"

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -135,10 +135,15 @@ Functions for integers
       values.  Formerly it used a style like ``int(random()*n)`` which could produce
       slightly uneven distributions.
 
-   .. versionchanged:: 3.11
-      Automatic conversion of non-integer types is no longer supported.
-      Calls such as ``randrange(10.0)`` and ``randrange(Fraction(10, 1))``
-      now raise a :exc:`TypeError`.
+   .. deprecated:: 3.10
+      The automatic conversion of non-integer types to equivalent integers is
+      deprecated.  Currently ``randrange(10.0)`` is losslessly converted to
+      ``randrange(10)``.  In the future, this will raise a :exc:`TypeError`.
+
+   .. deprecated:: 3.10
+      The exception raised for non-integral values such as ``randrange(10.5)``
+      or ``randrange('10')`` will be changed from :exc:`ValueError` to
+      :exc:`TypeError`.
 
 .. function:: randint(a, b)
 

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -282,17 +282,27 @@ class Random(_random.Random):
     ## -------------------- integer methods  -------------------
 
     def randrange(self, start, stop=None, step=_ONE):
-        """Choose a random item from range(stop) or range(start, stop[, step]).
+        """Choose a random item from range(start, stop[, step]).
 
-        Roughly equivalent to ``choice(range(start, stop, step))``
-        but supports arbitrarily large ranges and is optimized
-        for common cases.
+        This fixes the problem with randint() which includes the
+        endpoint; in Python this is usually not what you want.
 
         """
 
         # This code is a bit messy to make it fast for the
         # common case while still doing adequate error checking.
-        istart = _index(start)
+        try:
+            istart = _index(start)
+        except TypeError:
+            istart = int(start)
+            if istart != start:
+                _warn('randrange() will raise TypeError in the future',
+                      DeprecationWarning, 2)
+                raise ValueError("non-integer arg 1 for randrange()")
+            _warn('non-integer arguments to randrange() have been deprecated '
+                  'since Python 3.10 and will be removed in a subsequent '
+                  'version',
+                  DeprecationWarning, 2)
         if stop is None:
             # We don't check for "step != 1" because it hasn't been
             # type checked and converted to an integer yet.
@@ -302,15 +312,37 @@ class Random(_random.Random):
                 return self._randbelow(istart)
             raise ValueError("empty range for randrange()")
 
-        # Stop argument supplied.
-        istop = _index(stop)
+        # stop argument supplied.
+        try:
+            istop = _index(stop)
+        except TypeError:
+            istop = int(stop)
+            if istop != stop:
+                _warn('randrange() will raise TypeError in the future',
+                      DeprecationWarning, 2)
+                raise ValueError("non-integer stop for randrange()")
+            _warn('non-integer arguments to randrange() have been deprecated '
+                  'since Python 3.10 and will be removed in a subsequent '
+                  'version',
+                  DeprecationWarning, 2)
         width = istop - istart
-        istep = _index(step)
+        try:
+            istep = _index(step)
+        except TypeError:
+            istep = int(step)
+            if istep != step:
+                _warn('randrange() will raise TypeError in the future',
+                      DeprecationWarning, 2)
+                raise ValueError("non-integer step for randrange()")
+            _warn('non-integer arguments to randrange() have been deprecated '
+                  'since Python 3.10 and will be removed in a subsequent '
+                  'version',
+                  DeprecationWarning, 2)
         # Fast path.
         if istep == 1:
             if width > 0:
                 return istart + self._randbelow(width)
-            raise ValueError(f"empty range in randrange({start}, {stop}, {step})")
+            raise ValueError("empty range for randrange() (%d, %d, %d)" % (istart, istop, width))
 
         # Non-unit step argument supplied.
         if istep > 0:
@@ -320,7 +352,7 @@ class Random(_random.Random):
         else:
             raise ValueError("zero step for randrange()")
         if n <= 0:
-            raise ValueError(f"empty range in randrange({start}, {stop}, {step})")
+            raise ValueError("empty range for randrange()")
         return istart + istep * self._randbelow(n)
 
     def randint(self, a, b):

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -481,44 +481,50 @@ class SystemRandom_TestBasicOps(TestBasicOps, unittest.TestCase):
         self.assertEqual(rint, 0)
 
     def test_randrange_errors(self):
-        raises_value_error = partial(self.assertRaises, ValueError, self.gen.randrange)
-        raises_type_error = partial(self.assertRaises, TypeError, self.gen.randrange)
-
+        raises = partial(self.assertRaises, ValueError, self.gen.randrange)
         # Empty range
-        raises_value_error(3, 3)
-        raises_value_error(-721)
-        raises_value_error(0, 100, -12)
+        raises(3, 3)
+        raises(-721)
+        raises(0, 100, -12)
+        # Non-integer start/stop
+        self.assertWarns(DeprecationWarning, raises, 3.14159)
+        self.assertWarns(DeprecationWarning, self.gen.randrange, 3.0)
+        self.assertWarns(DeprecationWarning, self.gen.randrange, Fraction(3, 1))
+        self.assertWarns(DeprecationWarning, raises, '3')
+        self.assertWarns(DeprecationWarning, raises, 0, 2.71828)
+        self.assertWarns(DeprecationWarning, self.gen.randrange, 0, 2.0)
+        self.assertWarns(DeprecationWarning, self.gen.randrange, 0, Fraction(2, 1))
+        self.assertWarns(DeprecationWarning, raises, 0, '2')
+        # Zero and non-integer step
+        raises(0, 42, 0)
+        self.assertWarns(DeprecationWarning, raises, 0, 42, 0.0)
+        self.assertWarns(DeprecationWarning, raises, 0, 0, 0.0)
+        self.assertWarns(DeprecationWarning, raises, 0, 42, 3.14159)
+        self.assertWarns(DeprecationWarning, self.gen.randrange, 0, 42, 3.0)
+        self.assertWarns(DeprecationWarning, self.gen.randrange, 0, 42, Fraction(3, 1))
+        self.assertWarns(DeprecationWarning, raises, 0, 42, '3')
+        self.assertWarns(DeprecationWarning, self.gen.randrange, 0, 42, 1.0)
+        self.assertWarns(DeprecationWarning, raises, 0, 0, 1.0)
 
-        # Zero step
-        raises_value_error(0, 42, 0)
-        raises_type_error(0, 42, 0.0)
-        raises_type_error(0, 0, 0.0)
-
-        # Non-integer stop
-        raises_type_error(3.14159)
-        raises_type_error(3.0)
-        raises_type_error(Fraction(3, 1))
-        raises_type_error('3')
-        raises_type_error(0, 2.71827)
-        raises_type_error(0, 2.0)
-        raises_type_error(0, Fraction(2, 1))
-        raises_type_error(0, '2')
-        raises_type_error(0, 2.71827, 2)
-
-        # Non-integer start
-        raises_type_error(2.71827, 5)
-        raises_type_error(2.0, 5)
-        raises_type_error(Fraction(2, 1), 5)
-        raises_type_error('2', 5)
-        raises_type_error(2.71827, 5, 2)
-
-        # Non-integer step
-        raises_type_error(0, 42, 3.14159)
-        raises_type_error(0, 42, 3.0)
-        raises_type_error(0, 42, Fraction(3, 1))
-        raises_type_error(0, 42, '3')
-        raises_type_error(0, 42, 1.0)
-        raises_type_error(0, 0, 1.0)
+    def test_randrange_argument_handling(self):
+        randrange = self.gen.randrange
+        with self.assertWarns(DeprecationWarning):
+            randrange(10.0, 20, 2)
+        with self.assertWarns(DeprecationWarning):
+            randrange(10, 20.0, 2)
+        with self.assertWarns(DeprecationWarning):
+            randrange(10, 20, 1.0)
+        with self.assertWarns(DeprecationWarning):
+            randrange(10, 20, 2.0)
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(ValueError):
+                randrange(10.5)
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(ValueError):
+                randrange(10, 20.5)
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(ValueError):
+                randrange(10, 20, 1.5)
 
     def test_randrange_step(self):
         # bpo-42772: When stop is None, the step argument was being ignored.

--- a/Misc/NEWS.d/next/Library/2022-02-03-12-07-41.bpo-46624.f_Qqh0.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-03-12-07-41.bpo-46624.f_Qqh0.rst
@@ -1,0 +1,1 @@
+Restore support for non-integer arguments of :func:`random.randrange` and :func:`random.randint`.


### PR DESCRIPTION
The removal happened after only one release where it was deprecated.

https://www.python.org/dev/peps/pep-0387/#making-incompatible-changes

This reverts commit 5afa0a411243210a30526c7459a0ccff5cb88494.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46624](https://bugs.python.org/issue46624) -->
https://bugs.python.org/issue46624
<!-- /issue-number -->
