### PR TITLE
feature: remove unused argument in Lib.asyncio.queue

### DIFF
--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -41,11 +41,11 @@ class Queue(mixins._LoopBoundMixin):
         self._unfinished_tasks = 0
         self._finished = locks.Event()
         self._finished.set()
-        self._init(maxsize)
+        self._init()
 
     # These three are overridable in subclasses.
 
-    def _init(self, maxsize):
+    def _init(self):
         self._queue = collections.deque()
 
     def _get(self):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
