### PR TITLE
bpo-46072: Improve LOAD_METHOD stats

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -979,6 +979,7 @@ specialize_class_load_method(PyObject *owner, _Py_CODEUNIT *instr, PyObject *nam
             cache2->obj = descr;
             *instr = _Py_MAKECODEUNIT(LOAD_METHOD_CLASS, _Py_OPARG(*instr));
             return 0;
+#ifdef Py_STATS
         case ABSENT:
             if (_PyType_Lookup(Py_TYPE(owner), name) != NULL) {
                 SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_METACLASS_ATTRIBUTE);
@@ -987,6 +988,7 @@ specialize_class_load_method(PyObject *owner, _Py_CODEUNIT *instr, PyObject *nam
                 SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_EXPECTED_ERROR);
             }
             return -1;
+#endif
         default:
             SPECIALIZATION_FAIL(LOAD_METHOD, load_method_fail_kind(kind));
             return -1;

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -496,6 +496,10 @@ initial_counter_value(void) {
 #define SPEC_FAIL_BUILTIN_CLASS_METHOD 17
 #define SPEC_FAIL_CLASS_METHOD_OBJ 18
 #define SPEC_FAIL_OBJECT_SLOT 19
+#define SPEC_FAIL_HAS_DICT 20
+#define SPEC_FAIL_HAS_MANAGED_DICT 21
+#define SPEC_FAIL_INSTANCE_ATTRIBUTE 22
+#define SPEC_FAIL_METACLASS_ATTRIBUTE 23
 
 /* Binary subscr */
 
@@ -954,7 +958,7 @@ load_method_fail_kind(DescriptorClassification kind)
         case NON_DESCRIPTOR:
             return SPEC_FAIL_NOT_DESCRIPTOR;
         case ABSENT:
-            return SPEC_FAIL_EXPECTED_ERROR;
+            return SPEC_FAIL_INSTANCE_ATTRIBUTE;
     }
     Py_UNREACHABLE();
 }
@@ -975,6 +979,14 @@ specialize_class_load_method(PyObject *owner, _Py_CODEUNIT *instr, PyObject *nam
             cache2->obj = descr;
             *instr = _Py_MAKECODEUNIT(LOAD_METHOD_CLASS, _Py_OPARG(*instr));
             return 0;
+        case ABSENT:
+            if (_PyType_Lookup(Py_TYPE(owner), name) != NULL) {
+                SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_METACLASS_ATTRIBUTE);
+            }
+            else {
+                SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_EXPECTED_ERROR);
+            }
+            return -1;
         default:
             SPECIALIZATION_FAIL(LOAD_METHOD, load_method_fail_kind(kind));
             return -1;
@@ -1024,7 +1036,7 @@ _Py_Specialize_LoadMethod(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, 
     if (owner_cls->tp_flags & Py_TPFLAGS_MANAGED_DICT) {
         PyObject **owner_dictptr = _PyObject_ManagedDictPointer(owner);
         if (*owner_dictptr) {
-            SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_IS_ATTR);
+            SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_HAS_MANAGED_DICT);
             goto fail;
         }
         PyDictKeysObject *keys = ((PyHeapTypeObject *)owner_cls)->ht_cached_keys;
@@ -1046,7 +1058,7 @@ _Py_Specialize_LoadMethod(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, 
             *instr = _Py_MAKECODEUNIT(LOAD_METHOD_NO_DICT, _Py_OPARG(*instr));
         }
         else {
-            SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_IS_ATTR);
+            SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_HAS_DICT);
             goto fail;
         }
     }


### PR DESCRIPTION
We were falsely attributing a lot of specialization failure to `SPEC_FAIL_EXPECTED_ERROR`.

With this PR that number drops to 0.

Stats from the standard benchmark suite:
```
LOAD_METHOD:
 unquickened:    35297570 1.8%
    deferred:   309896720 15.7%
       deopt:      613976 0.0%
         hit:  1600750204 80.9%
        miss:    32841119 1.7%
  success:     1499820
  failure:     4371143
    kind  0:     8556 0.2%
    kind  2:   311220 7.1%
    kind  7:      420 0.0%
    kind  8:     1635 0.0%
    kind  9:    51709 1.2%
    kind 10:    13908 0.3%
    kind 12:    14375 0.3%
    kind 13:     7182 0.2%
    kind 14:       63 0.0%
    kind 15:     4529 0.1%
    kind 17:    24864 0.6%
    kind 18:   329370 7.5%
    kind 19:      147 0.0%
    kind 20:  1125766 25.8%
    kind 21:  1507036 34.5%
    kind 22:   760037 17.4%
    kind 23:   210326 4.8%
```
Collectively kinds 20-23 represent 82% of failures, which provides us a much better insight into how to specialize `LOAD_METHOD`.





<!-- issue-number: [bpo-46072](https://bugs.python.org/issue46072) -->
https://bugs.python.org/issue46072
<!-- /issue-number -->
