### PR TITLE
bpo-46072: Collect stats for UNPACK_SEQUENCE.

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2791,6 +2791,12 @@ handle_eval_breaker:
         TARGET(UNPACK_SEQUENCE) {
             PREDICTED(UNPACK_SEQUENCE);
             PyObject *seq = POP(), *item, **items;
+#ifdef Py_STATS
+            extern int _PySpecialization_ClassifySequence(PyObject *);
+            _py_stats.opcode_stats[UNPACK_SEQUENCE].specialization.failure++;
+            _py_stats.opcode_stats[UNPACK_SEQUENCE].specialization.
+                failure_kinds[_PySpecialization_ClassifySequence(seq)]++;
+#endif
             if (PyTuple_CheckExact(seq) &&
                 PyTuple_GET_SIZE(seq) == oparg) {
                 items = ((PyTupleObject *)seq)->ob_item;

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -572,6 +572,10 @@ initial_counter_value(void) {
 #define SPEC_FAIL_ITER_DICT_VALUES 22
 #define SPEC_FAIL_ITER_ENUMERATE 23
 
+/* UNPACK_SEQUENCE */
+#define SPEC_FAIL_TUPLE 10
+#define SPEC_FAIL_LIST 11
+
 
 static int
 specialize_module_load_attr(
@@ -1880,7 +1884,6 @@ success:
     adaptive->counter = initial_counter_value();
 }
 
-
 int
  _PySpecialization_ClassifyIterator(PyObject *iter)
 {
@@ -1927,6 +1930,18 @@ int
 
     if (strncmp(t->tp_name, "itertools", 8) == 0) {
         return SPEC_FAIL_ITER_ITERTOOLS;
+    }
+    return SPEC_FAIL_OTHER;
+}
+
+int
+_PySpecialization_ClassifySequence(PyObject *seq)
+{
+    if (PyTuple_CheckExact(seq)) {
+        return SPEC_FAIL_TUPLE;
+    }
+    if (PyList_CheckExact(seq)) {
+        return SPEC_FAIL_LIST;
     }
     return SPEC_FAIL_OTHER;
 }


### PR DESCRIPTION
This is more for completeness, than any expectation that the stats will be particularly useful.
On the standard benchmark suite ~77% of unpacks are tuples, ~23% are lists and ~0.02% are something else.


<!-- issue-number: [bpo-46072](https://bugs.python.org/issue46072) -->
https://bugs.python.org/issue46072
<!-- /issue-number -->
