### PR TITLE
bpo-46072: Add per-instruction miss stats.

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5399,6 +5399,7 @@ handle_eval_breaker:
 #define MISS_WITH_CACHE(opname) \
 opname ## _miss: \
     { \
+        STAT_INC(opcode, miss); \
         STAT_INC(opname, miss); \
         _PyAdaptiveEntry *cache = &GET_CACHE()->adaptive; \
         cache->counter--; \

--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -22,11 +22,10 @@ for name in opcode.opname[1:]:
             pass
     opname.append(name)
 
-
 TOTAL = "specialization.deferred", "specialization.hit", "specialization.miss", "execution_count"
 
 def print_specialization_stats(name, family_stats):
-    if "specialization.failure" not in family_stats:
+    if "specializable" not in family_stats:
         return
     total = sum(family_stats.get(kind, 0) for kind in TOTAL)
     if total == 0:
@@ -87,13 +86,18 @@ def main():
     for i, opcode_stat in enumerate(opcode_stats):
         if "execution_count" in opcode_stat:
             count = opcode_stat['execution_count']
-            counts.append((count, opname[i]))
+            miss = 0
+            if "specializable" not in opcode_stat:
+                miss = opcode_stat.get("specialization.miss")
+            counts.append((count, opname[i], miss))
             total += count
     counts.sort(reverse=True)
     cummulative = 0
-    for (count, name) in counts:
+    for (count, name, miss) in counts:
         cummulative += count
         print(f"{name}: {count} {100*count/total:0.1f}% {100*cummulative/total:0.1f}%")
+        if miss:
+            print(f"    Misses: {miss} {100*miss/count:0.1f}%")
     print("Specialization stats:")
     for i, opcode_stat in enumerate(opcode_stats):
         name = opname[i]


### PR DESCRIPTION
Also explictly mark which instructions are specializable in stats. It is not the job of the summary script to guess which instructions are specializable.

Per instruction stats now look like:
```
LOAD_METHOD_NO_DICT: 488505073 0.7% 84.8%
    Misses: 5702208 1.2%
STORE_ATTR_INSTANCE_VALUE: 485786899 0.7% 85.5%
    Misses: 6904720 1.4%
BINARY_OP_SUBTRACT_INT: 460413189 0.7% 86.2%
    Misses: 2710155 0.6%
...
```

<!-- issue-number: [bpo-46072](https://bugs.python.org/issue46072) -->
https://bugs.python.org/issue46072
<!-- /issue-number -->
