### PR TITLE
bpo-46630: Fix initial focus of IDLE query dialogs

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -4,6 +4,9 @@ Released on 2022-10-03
 =========================
 
 
+bpo-46630: Make query dialogs on Windows start with a cursor in the
+entry box.
+
 bpo-46591: Make the IDLE doc URL on the About IDLE dialog clickable.
 
 bpo-45296: Clarify close, quit, and exit in IDLE.  In the File menu,

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -83,6 +83,7 @@ class Query(Toplevel):
 
         if not _utest:
             self.deiconify()  # Unhide now that geometry set.
+            self.entry.focus_set()
             self.wait_window()
 
     def create_widgets(self, ok_text='OK'):  # Do not replace.
@@ -100,7 +101,6 @@ class Query(Toplevel):
                            text=self.message)
         self.entryvar = StringVar(self, self.text0)
         self.entry = Entry(frame, width=30, textvariable=self.entryvar)
-        self.entry.focus_set()
         self.error_font = Font(name='TkCaptionFont',
                                exists=True, root=self.parent)
         self.entry_error = Label(frame, text=' ', foreground='red',

--- a/Misc/NEWS.d/next/IDLE/2022-02-03-15-47-53.bpo-46630.tREOjo.rst
+++ b/Misc/NEWS.d/next/IDLE/2022-02-03-15-47-53.bpo-46630.tREOjo.rst
@@ -1,0 +1,1 @@
+Make query dialogs on Windows start with a cursor in the entry box.


### PR DESCRIPTION
On Windows, one had to Tab or click on the entry box
to get a cursor and be able to enter anything.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46630](https://bugs.python.org/issue46630) -->
https://bugs.python.org/issue46630
<!-- /issue-number -->
