### PR TITLE
bpo-46638: Makes registry virtualisation setting stable when building MSIX packages

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-02-04-18-02-33.bpo-46638.mSJOSX.rst
+++ b/Misc/NEWS.d/next/Windows/2022-02-04-18-02-33.bpo-46638.mSJOSX.rst
@@ -1,0 +1,4 @@
+Ensures registry virtualization is consistently disabled. For 3.10 and
+earlier, it remains enabled (some registry writes are protected), while for
+3.11 and later it is disabled (registry modifications affect all
+applications).

--- a/PC/layout/support/appxmanifest.py
+++ b/PC/layout/support/appxmanifest.py
@@ -413,17 +413,17 @@ def get_appxmanifest(ns):
             node.text = value
 
     try:
-        winver = [int(i) for i in os.getenv("APPX_DATA_WINVER", "").split(".", maxsplit=3)]
+        winver = tuple(int(i) for i in os.getenv("APPX_DATA_WINVER", "").split(".", maxsplit=3))
     except (TypeError, ValueError):
-        winver = []
+        winver = ()
 
     # Default "known good" version is 10.0.22000, first Windows 11 release
-    winver = ((tuple(winver) + (0, 0, 0))[:3]) if winver else (10, 0, 22000)
+    winver = winver or (10, 0, 22000)
 
     if winver < (10, 0, 17763):
         winver = 10, 0, 17763
     find_or_add(xml, "m:Dependencies/m:TargetDeviceFamily").set(
-        "MaxVersionTested", "{}.{}.{}.0".format(*winver)
+        "MaxVersionTested", "{}.{}.{}.{}".format(*(winver + (0, 0, 0, 0)[:4]))
     )
 
     # Only for Python 3.11 and later. Older versions do not disable virtualization

--- a/PC/layout/support/appxmanifest.py
+++ b/PC/layout/support/appxmanifest.py
@@ -412,14 +412,22 @@ def get_appxmanifest(ns):
         if value:
             node.text = value
 
-    winver = sys.getwindowsversion()[:3]
+    try:
+        winver = [int(i) for i in os.getenv("APPX_DATA_WINVER", "").split(".", maxsplit=3)]
+    except (TypeError, ValueError):
+        winver = []
+
+    # Default "known good" version is 10.0.22000, first Windows 11 release
+    winver = ((tuple(winver) + (0, 0, 0))[:3]) if winver else (10, 0, 22000)
+
     if winver < (10, 0, 17763):
         winver = 10, 0, 17763
     find_or_add(xml, "m:Dependencies/m:TargetDeviceFamily").set(
         "MaxVersionTested", "{}.{}.{}.0".format(*winver)
     )
 
-    if winver > (10, 0, 17763):
+    # Only for Python 3.11 and later. Older versions do not disable virtualization
+    if (VER_MAJOR, VER_MINOR) >= (3, 11) and winver > (10, 0, 17763):
         disable_registry_virtualization(xml)
 
     app = add_application(

--- a/PC/layout/support/constants.py
+++ b/PC/layout/support/constants.py
@@ -16,7 +16,7 @@ def _unpack_hexversion():
         hexversion = int(os.getenv("PYTHON_HEXVERSION"), 16)
     except (TypeError, ValueError):
         hexversion = sys.hexversion
-    return struct.pack(">i", sys.hexversion)
+    return struct.pack(">i", hexversion)
 
 
 def _get_suffix(field4):


### PR DESCRIPTION


<!-- issue-number: [bpo-46638](https://bugs.python.org/issue46638) -->
https://bugs.python.org/issue46638
<!-- /issue-number -->
