### PR TITLE
bpo-46640: Py_NAN now uses the C99 NAN constant

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -604,6 +604,12 @@ Build Changes
   ``isinf()``, ``isnan()``, ``round()``.
   (Contributed by Victor Stinner in :issue:`45440`.)
 
+* Building Python now requires a C99 ``<math.h>`` header file providing
+  a ``NAN`` constant, or the ``__builtin_nan()`` built-in function. If a
+  platform does not support Not-a-Number (NaN), the ``Py_NO_NAN`` macro can be
+  defined in the ``pyconfig.h`` file.
+  (Contributed by Victor Stinner in :issue:`46640`.)
+
 * Freelists for object structs can now be disabled. A new :program:`configure`
   option :option:`!--without-freelists` can be used to disable all freelists
   except empty tuple singleton.

--- a/Include/pymath.h
+++ b/Include/pymath.h
@@ -51,16 +51,15 @@
 #endif
 
 /* Py_NAN
- * A value that evaluates to a NaN. On IEEE 754 platforms INF*0 or
- * INF/INF works. Define Py_NO_NAN in pyconfig.h if your platform
- * doesn't support NaNs.
+ * A value that evaluates to a quiet Not-a-Number (NaN).
+ * Define Py_NO_NAN in pyconfig.h if your platform doesn't support NaNs.
  */
 #if !defined(Py_NAN) && !defined(Py_NO_NAN)
 #  if _Py__has_builtin(__builtin_nan)
      // Built-in implementation of the ISO C99 function nan(): quiet NaN.
 #    define Py_NAN (__builtin_nan(""))
 #else
-     // Use C99 NAN constant: quiet Not-A-Number (when supported).
+     // Use C99 NAN constant: quiet Not-A-Number.
      // NAN is a float, Py_NAN is a double: cast to double.
 #    define Py_NAN ((double)NAN)
 #  endif

--- a/Include/pymath.h
+++ b/Include/pymath.h
@@ -56,24 +56,14 @@
  * doesn't support NaNs.
  */
 #if !defined(Py_NAN) && !defined(Py_NO_NAN)
-#  if !defined(__INTEL_COMPILER)
-#    define Py_NAN (Py_HUGE_VAL * 0.)
-#  else /* __INTEL_COMPILER */
-#    if defined(ICC_NAN_STRICT)
-        #pragma float_control(push)
-        #pragma float_control(precise, on)
-        #pragma float_control(except,  on)
-        Py_NO_INLINE static double __icc_nan()
-        {
-            return sqrt(-1.0);
-        }
-        #pragma float_control (pop)
-#       define Py_NAN __icc_nan()
-#    else /* ICC_NAN_RELAXED as default for Intel Compiler */
-        static const union { unsigned char buf[8]; double __icc_nan; } __nan_store = {0,0,0,0,0,0,0xf8,0x7f};
-#       define Py_NAN (__nan_store.__icc_nan)
-#    endif /* ICC_NAN_STRICT */
-#  endif /* __INTEL_COMPILER */
+#  if _Py__has_builtin(__builtin_nan)
+     // Built-in implementation of the ISO C99 function nan(): quiet NaN.
+#    define Py_NAN (__builtin_nan(""))
+#else
+     // Use C99 NAN constant: quiet Not-A-Number (when supported).
+     // NAN is a float, Py_NAN is a double: cast to double.
+#    define Py_NAN ((double)NAN)
+#  endif
 #endif
 
 #endif /* Py_PYMATH_H */

--- a/Misc/NEWS.d/next/Build/2022-02-04-21-26-50.bpo-46640.HXUmQp.rst
+++ b/Misc/NEWS.d/next/Build/2022-02-04-21-26-50.bpo-46640.HXUmQp.rst
@@ -1,0 +1,4 @@
+Building Python now requires a C99 ``<math.h>`` header file providing a ``NAN``
+constant, or the ``__builtin_nan()`` built-in function. If a platform does not
+support Not-a-Number (NaN), the ``Py_NO_NAN`` macro can be defined in the
+``pyconfig.h`` file. Patch by Victor Stinner.


### PR DESCRIPTION
Building Python now requires a C99 <math.h> header file providing the
NAN constant.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46640](https://bugs.python.org/issue46640) -->
https://bugs.python.org/issue46640
<!-- /issue-number -->
