### PR TITLE
Set meaningful job name for LibFFI

### DIFF
--- a/.azure-pipelines/libffi-build.yml
+++ b/.azure-pipelines/libffi-build.yml
@@ -11,7 +11,7 @@ variables:
 
 jobs:
 - job: Build_LibFFI
-  displayName: LibFFI
+  displayName: Build LibFFI
   pool:
     vmImage: windows-latest
 


### PR DESCRIPTION
Just a simple & trivial change related to the pipeline to make transparent what is being done when the job "LibFFI" is executed/running.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
