### PR TITLE
bpo-46323: Use PyObject_Vectorcall while calling ctypes callback function

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-05-14-46-21.bpo-46323.FC1OJg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-05-14-46-21.bpo-46323.FC1OJg.rst
@@ -1,2 +1,2 @@
-Use :c:func:`PyObject_Vectorcall` while calling ctypes callback funtion.
+Use :c:func:`PyObject_Vectorcall` while calling ctypes callback function.
 Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-05-14-46-21.bpo-46323.FC1OJg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-05-14-46-21.bpo-46323.FC1OJg.rst
@@ -1,0 +1,2 @@
+Use :c:func:`PyObject_Vectorcall` while calling ctypes callback funtion.
+Patch by Dong-hee Na.

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -180,14 +180,12 @@ static void _CallPythonObject(void *mem,
         PyObject *cnv = cnvs[i];
         StgDictObject *dict;
 
-        Py_INCREF(cnv);
         dict = PyType_stgdict(cnv);
 
         if (dict && dict->getfunc && !_ctypes_simple_instance(cnv)) {
             PyObject *v = dict->getfunc(*pArgs, dict->size);
             if (!v) {
                 PrintError("create argument %zd:\n", i);
-                Py_DECREF(cnv);
                 goto Done;
             }
             args[i] = v;
@@ -206,7 +204,6 @@ static void _CallPythonObject(void *mem,
             }
             if (!CDataObject_Check(obj)) {
                 Py_DECREF(obj);
-                Py_DECREF(cnv);
                 PrintError("unexpected result of create argument %zd:\n", i);
                 goto Done;
             }
@@ -219,10 +216,8 @@ static void _CallPythonObject(void *mem,
             PyErr_SetString(PyExc_TypeError,
                             "cannot build parameter");
             PrintError("Parsing argument %zd\n", i);
-            Py_DECREF(cnv);
             goto Done;
         }
-        Py_DECREF(cnv);
         /* XXX error handling! */
         pArgs++;
     }
@@ -391,11 +386,7 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
     PyObject **cnvs = PySequence_Fast_ITEMS(converters);
     for (i = 0; i < nArgs; ++i) {
         PyObject *cnv = cnvs[i];
-        if (cnv == NULL)
-            goto error;
-        Py_INCREF(cnv);
         p->atypes[i] = _ctypes_get_ffi_type(cnv);
-        Py_DECREF(cnv);
     }
     p->atypes[i] = NULL;
 

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -173,12 +173,15 @@ static void _CallPythonObject(void *mem,
             goto Done;
         }
     }
+
+    PyObject **cnvs = PySequence_Fast_ITEMS(converters);
     for (i = 0; i < n_args; i++) {
-        /* Note: new reference! */
-        PyObject *cnv = PySequence_GetItem(converters, i);
+        PyObject *cnv = cnvs[i];
         StgDictObject *dict;
-        if (cnv)
+        if (cnv) {
+            Py_INCREF(cnv);
             dict = PyType_stgdict(cnv);
+        }
         else {
             PrintError("Getting argument converter %zd\n", i);
             goto Done;
@@ -388,10 +391,12 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
     }
 
     p->flags = flags;
+    PyObject **cnvs = PySequence_Fast_ITEMS(converters);
     for (i = 0; i < nArgs; ++i) {
-        PyObject *cnv = PySequence_GetItem(converters, i);
+        PyObject *cnv = cnvs[i];
         if (cnv == NULL)
             goto error;
+        Py_INCREF(cnv);
         p->atypes[i] = _ctypes_get_ffi_type(cnv);
         Py_DECREF(cnv);
     }

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -178,14 +178,14 @@ static void _CallPythonObject(void *mem,
     for (i = 0; i < n_args; i++) {
         PyObject *cnv = cnvs[i];
         StgDictObject *dict;
-        if (cnv) {
-            Py_INCREF(cnv);
-            dict = PyType_stgdict(cnv);
-        }
-        else {
+
+        if (cnv == NULL) {
             PrintError("Getting argument converter %zd\n", i);
             goto Done;
         }
+
+        Py_INCREF(cnv);
+        dict = PyType_stgdict(cnv);
 
         if (dict && dict->getfunc && !_ctypes_simple_instance(cnv)) {
             PyObject *v = dict->getfunc(*pArgs, dict->size);

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -147,6 +147,7 @@ static void _CallPythonObject(void *mem,
                               void **pArgs)
 {
     PyObject *result;
+    PyObject **args = NULL;
     Py_ssize_t nArgs;
     PyObject *error_object = NULL;
     int *space;
@@ -162,7 +163,6 @@ static void _CallPythonObject(void *mem,
     }
 
     PyObject *args_stack[_PY_FASTCALL_SMALL_STACK];
-    PyObject **args;
     if (nArgs <= (Py_ssize_t)Py_ARRAY_LENGTH(args_stack)) {
         args = args_stack;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46323](https://bugs.python.org/issue46323) -->
https://bugs.python.org/issue46323
<!-- /issue-number -->

`````

With v3 benchmark

Mean +- std dev: [base] 1.32 us +- 0.02 us -> [opt] 1.18 us +- 0.02 us: 1.13x faster
`````