### PR TITLE
gh-90804: mention that `bytes` are accepted in `ipaddress` docs

### DIFF
--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -40,7 +40,9 @@ IP addresses, networks and interfaces:
 .. function:: ip_address(address)
 
    Return an :class:`IPv4Address` or :class:`IPv6Address` object depending on
-   the IP address passed as argument.  Either IPv4 or IPv6 addresses may be
+   the IP address passed as argument.
+   *address* is a string or integer or bytes representing the IP address.
+   Either IPv4 or IPv6 addresses may be
    supplied; integers less than ``2**32`` will be considered to be IPv4 by default.
    A :exc:`ValueError` is raised if *address* does not represent a valid IPv4
    or IPv6 address.
@@ -54,8 +56,9 @@ IP addresses, networks and interfaces:
 .. function:: ip_network(address, strict=True)
 
    Return an :class:`IPv4Network` or :class:`IPv6Network` object depending on
-   the IP address passed as argument.  *address* is a string or integer
-   representing the IP network.  Either IPv4 or IPv6 networks may be supplied;
+   the IP address passed as argument.
+   *address* is a string or integer or bytes representing the IP network.
+   Either IPv4 or IPv6 networks may be supplied;
    integers less than ``2**32`` will be considered to be IPv4 by default.  *strict*
    is passed to :class:`IPv4Network` or :class:`IPv6Network` constructor.  A
    :exc:`ValueError` is raised if *address* does not represent a valid IPv4 or
@@ -68,11 +71,15 @@ IP addresses, networks and interfaces:
 .. function:: ip_interface(address)
 
    Return an :class:`IPv4Interface` or :class:`IPv6Interface` object depending
-   on the IP address passed as argument.  *address* is a string or integer
-   representing the IP address.  Either IPv4 or IPv6 addresses may be supplied;
+   on the IP address passed as argument.
+   *address* is a string or integer or bytes representing the IP address.
+   Either IPv4 or IPv6 addresses may be supplied;
    integers less than ``2**32`` will be considered to be IPv4 by default.  A
    :exc:`ValueError` is raised if *address* does not represent a valid IPv4 or
    IPv6 address.
+
+   >>> ipaddress.ip_interface('192.168.0.0/28')
+   IPv4Interface('192.168.0.0/28')
 
 One downside of these convenience functions is that the need to handle both
 IPv4 and IPv6 formats means that error messages provide minimal

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -26,10 +26,10 @@ class NetmaskValueError(ValueError):
 
 
 def ip_address(address):
-    """Take an IP string/int and return an object of the correct type.
+    """Take an IP string/int/bytes and return an object of the correct type.
 
     Args:
-        address: A string or integer, the IP address.  Either IPv4 or
+        address: A string or integer or bytes, the IP address.  Either IPv4 or
           IPv6 addresses may be supplied; integers less than 2**32 will
           be considered to be IPv4 by default.
 
@@ -56,10 +56,10 @@ def ip_address(address):
 
 
 def ip_network(address, strict=True):
-    """Take an IP string/int and return an object of the correct type.
+    """Take an IP string/int/bytes and return an object of the correct type.
 
     Args:
-        address: A string or integer, the IP network.  Either IPv4 or
+        address: A string or integer or bytes, the IP network.  Either IPv4 or
           IPv6 networks may be supplied; integers less than 2**32 will
           be considered to be IPv4 by default.
 
@@ -67,7 +67,7 @@ def ip_network(address, strict=True):
         An IPv4Network or IPv6Network object.
 
     Raises:
-        ValueError: if the string passed isn't either a v4 or a v6
+        ValueError: if the *address* passed isn't either a v4 or a v6
           address. Or if the network has host bits set.
 
     """
@@ -86,10 +86,10 @@ def ip_network(address, strict=True):
 
 
 def ip_interface(address):
-    """Take an IP string/int and return an object of the correct type.
+    """Take an IP string/int/bytes and return an object of the correct type.
 
     Args:
-        address: A string or integer, the IP address.  Either IPv4 or
+        address: A string or integer or bytes, the IP address.  Either IPv4 or
           IPv6 addresses may be supplied; integers less than 2**32 will
           be considered to be IPv4 by default.
 
@@ -97,7 +97,7 @@ def ip_interface(address):
         An IPv4Interface or IPv6Interface object.
 
     Raises:
-        ValueError: if the string passed isn't either a v4 or a v6
+        ValueError: if the *address* passed isn't either a v4 or a v6
           address.
 
     Notes:


### PR DESCRIPTION
I've also added a simple doctest case for `ip_interface`, because it was the only one without it 🙂 

<!-- issue-number: [bpo-46646](https://bugs.python.org/issue46646) -->
https://bugs.python.org/issue46646
<!-- /issue-number -->

<!-- gh-issue-number: gh-90804 -->
* Issue: gh-90804
<!-- /gh-issue-number -->
