### PR TITLE
bpo-46649: Propagate Python thread name to PyThreadState

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -200,6 +200,16 @@ struct _ts {
 
     /* The bottom-most frame on the stack. */
     CFrame root_cframe;
+
+    PyTStateRef *ref;
+    PyObject *thread_name;
+};
+
+
+// The PyTStateRef typedef is in Include/pystate.h.
+struct _tsr {
+    PyObject_HEAD
+    PyThreadState *tstate;
 };
 
 

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -14,12 +14,19 @@ removed (with effort). */
 /* Forward declarations for PyFrameObject, PyThreadState
    and PyInterpreterState */
 struct _ts;
+struct _tsr;
 struct _is;
 
 /* struct _ts is defined in cpython/pystate.h */
 typedef struct _ts PyThreadState;
+/* struct _tsr is defined in cpython/pystate.h */
+typedef struct _tsr PyTStateRef;
 /* struct _is is defined in internal/pycore_interp.h */
 typedef struct _is PyInterpreterState;
+
+PyAPI_DATA(PyTypeObject) PyTStateRef_Type;
+
+#define PyTStateRef_Check(op) Py_IS_TYPE(op, &PyTStateRef_Type)
 
 PyAPI_FUNC(PyInterpreterState *) PyInterpreterState_New(void);
 PyAPI_FUNC(void) PyInterpreterState_Clear(PyInterpreterState *);

--- a/Misc/NEWS.d/next/C API/2022-02-05-13-09-58.bpo-46649.e0XRkS.rst
+++ b/Misc/NEWS.d/next/C API/2022-02-05-13-09-58.bpo-46649.e0XRkS.rst
@@ -1,0 +1,4 @@
+The name of Python threads is now propagated to the PyThreadState structure to
+make it easier for tools that rely on the ABI to retrieve such information.
+
+Patch by Gabriele N. Tornetta

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -5770,6 +5770,21 @@ test_tstate_capi(PyObject *self, PyObject *Py_UNUSED(args))
     Py_RETURN_NONE;
 }
 
+static PyObject *
+get_thread_name(PyObject *self, PyObject *arg)
+{
+    if (!PyTStateRef_Check(arg)) {
+        PyErr_SetString(PyExc_TypeError, "argument must be a thread state reference");
+        return NULL;
+    }
+    
+    PyTStateRef * tsr = (PyTStateRef *)arg;
+    if (tsr->tstate == NULL)
+        return Py_NewRef(Py_None);
+    
+    return Py_NewRef(tsr->tstate->thread_name);
+}
+
 
 static PyObject *negative_dictoffset(PyObject *, PyObject *);
 static PyObject *test_buildvalue_issue38913(PyObject *, PyObject *);
@@ -6057,6 +6072,7 @@ static PyMethodDef TestMethods[] = {
      PyDoc_STR("fatal_error(message, release_gil=False): call Py_FatalError(message)")},
     {"type_get_version", type_get_version, METH_O, PyDoc_STR("type->tp_version_tag")},
     {"test_tstate_capi", test_tstate_capi, METH_NOARGS, NULL},
+    {"get_thread_name", get_thread_name, METH_O},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -783,7 +783,7 @@ init_threadstate(PyThreadState *tstate,
     tstate->datastack_chunk = NULL;
     tstate->datastack_top = NULL;
     tstate->datastack_limit = NULL;
-
+    
     tstate->_initialized = 1;
 }
 
@@ -1034,6 +1034,11 @@ PyThreadState_Clear(PyThreadState *tstate)
     Py_CLEAR(tstate->async_gen_finalizer);
 
     Py_CLEAR(tstate->context);
+    
+    if (tstate->ref != NULL)
+        tstate->ref->tstate = NULL;
+    Py_CLEAR(tstate->ref);
+    Py_CLEAR(tstate->thread_name);
 
     if (tstate->on_delete != NULL) {
         tstate->on_delete(tstate->on_delete_data);


### PR DESCRIPTION
This change allows Python thread objects to propagate their name to the underlying PyThreadState structure to make it easier for tools that rely on the ABI, like sampling profilers, to retrieve this information and provide richer profiling data.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46649](https://bugs.python.org/issue46649) -->
https://bugs.python.org/issue46649
<!-- /issue-number -->
