### PR TITLE
Allows to specify the port on which serve documentation

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -12,6 +12,7 @@ PAPER        =
 SOURCES      =
 DISTVERSION  = $(shell $(PYTHON) tools/extensions/patchlevel.py)
 SPHINXERRORHANDLING = -W
+SERVE_PORT   =
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_elements.papersize=a4paper
@@ -217,7 +218,7 @@ check:
 	$(PYTHON) tools/rstlint.py ../Misc/NEWS.d/next/
 
 serve:
-	$(PYTHON) ../Tools/scripts/serve.py build/html
+	$(PYTHON) ../Tools/scripts/serve.py build/html $(SERVE_PORT)
 
 # Targets for daily automated doc build
 # By default, Sphinx only rebuilds pages where the page content has changed.


### PR DESCRIPTION
[user@localhost]$ make serve      # default configuration, no change
python3 ../Tools/scripts/serve.py build/html
Serving build/html on port 8000, control-C to stop
^CShutting down.

[user@localhost]$ make serve SERVE_PORT=8080 # new option
python3 ../Tools/scripts/serve.py build/html 8080
Serving build/html on port 8080, control-C to stop
