### PR TITLE
bpo-46648: test_urllib2.test_issue16464() uses httpbin.org

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1791,9 +1791,10 @@ class MiscTests(unittest.TestCase):
     @unittest.skipUnless(support.is_resource_enabled('network'),
                          'test requires network access')
     def test_issue16464(self):
-        with socket_helper.transient_internet("http://www.example.com/"):
+        url = "http://httpbin.org/post"
+        with socket_helper.transient_internet(url):
             opener = urllib.request.build_opener()
-            request = urllib.request.Request("http://www.example.com/")
+            request = urllib.request.Request(url)
             self.assertEqual(None, request.data)
 
             opener.open(request, "1".encode("us-ascii"))

--- a/Misc/NEWS.d/next/Tests/2022-02-05-18-58-37.bpo-46648.EJUGbT.rst
+++ b/Misc/NEWS.d/next/Tests/2022-02-05-18-58-37.bpo-46648.EJUGbT.rst
@@ -1,0 +1,3 @@
+The test_issue16464() test of test_urllib2 now uses
+``http://httpbin.org/post`` URL instead of ``http://www.example.com/``.
+Patch by Victor Stinner.


### PR DESCRIPTION
The test_issue16464() test of test_urllib2 now uses
"http://httpbin.org/post" URL instead of "http://www.example.com/".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46648](https://bugs.python.org/issue46648) -->
https://bugs.python.org/issue46648
<!-- /issue-number -->
