### PR TITLE
bpo-40479: Fix undefined behavior in Modules/_hashopenssl.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-06-23-08-30.bpo-40479.zED3Zu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-06-23-08-30.bpo-40479.zED3Zu.rst
@@ -1,0 +1,1 @@
+Add a missing call to ``va_end()`` in ``Modules/_hashopenssl.c``.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -266,6 +266,7 @@ _setException(PyObject *exc, const char* altmsg, ...)
         } else {
             PyErr_FormatV(exc, altmsg, vargs);
         }
+        va_end(vargs);
         return NULL;
     }
     va_end(vargs);


### PR DESCRIPTION
va_end() must be called before returning.

<!-- issue-number: [bpo-40479](https://bugs.python.org/issue40479) -->
https://bugs.python.org/issue40479
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran