### PR TITLE
bpo-46655: allow stringized TypeAlias with get_type_hints

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4854,6 +4854,11 @@ class TypeAliasTests(BaseTestCase):
         with self.assertRaises(TypeError):
             isinstance(42, TypeAlias)
 
+    def test_stringized_usage(self):
+        class A:
+            a: "TypeAlias"
+        self.assertEqual(get_type_hints(A), {'a': TypeAlias})
+
     def test_no_issubclass(self):
         with self.assertRaises(TypeError):
             issubclass(Employee, TypeAlias)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -174,7 +174,7 @@ def _type_check(arg, msg, is_argument=True, module=None, *, allow_special_forms=
     if (isinstance(arg, _GenericAlias) and
             arg.__origin__ in invalid_generic_forms):
         raise TypeError(f"{arg} is not valid as type argument")
-    if arg in (Any, NoReturn, ClassVar, Final):
+    if arg in (Any, NoReturn, ClassVar, Final, TypeAlias):
         return arg
     if isinstance(arg, _SpecialForm) or arg in (Generic, Protocol):
         raise TypeError(f"Plain {arg} is not valid as type argument")

--- a/Misc/NEWS.d/next/Library/2022-02-06-08-54-03.bpo-46655.DiLzYv.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-06-08-54-03.bpo-46655.DiLzYv.rst
@@ -1,0 +1,1 @@
+In :func:`typing.get_type_hints`, support evaluating bare stringified ``TypeAlias`` annotations. Patch by Gregory Beauregard.


### PR DESCRIPTION
This is a bit weird; it isn't a type, after all. However, `_type_check` is called as part of stringized annotation resolution so *all* valid typeforms need a code path to get through it or we will cause errors for `get_type_hints` calls that may not even be intended to inspect the typeform of issue (e.g. called on a module or class). It also needs to be able to pass through `_type_check` if you want the typeform to be able to be contained in an `Annotated` (probably not a concern for `TypeAlias`).

The most reasonable way I currently know to reach this is if you called `get_type_hints` on a module with a globally defined `TypeAlias` (that was stringized). See bpo for additional commentary.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46655](https://bugs.python.org/issue46655) -->
https://bugs.python.org/issue46655
<!-- /issue-number -->
