### PR TITLE
Doc: enhance readability by avoiding big blocks for small numbers.

### DIFF
--- a/Doc/tutorial/floatingpoint.rst
+++ b/Doc/tutorial/floatingpoint.rst
@@ -12,8 +12,8 @@ Floating Point Arithmetic:  Issues and Limitations
 
 
 Floating-point numbers are represented in computer hardware as base 2 (binary)
-fractions.  For example, the decimal fraction ``0.125``
-has value 1/10 + 2/100 + 5/1000, and in the same way the binary fraction ``0.001``
+fractions.  For example, the **decimal** fraction ``0.125``
+has value 1/10 + 2/100 + 5/1000, and in the same way the **binary** fraction ``0.001``
 has value 0/2 + 0/4 + 1/8. These two fractions have identical values, the only
 real difference being that the first is written in base 10 fractional notation,
 and the second in base 2.

--- a/Doc/tutorial/floatingpoint.rst
+++ b/Doc/tutorial/floatingpoint.rst
@@ -12,15 +12,9 @@ Floating Point Arithmetic:  Issues and Limitations
 
 
 Floating-point numbers are represented in computer hardware as base 2 (binary)
-fractions.  For example, the decimal fraction ::
-
-   0.125
-
-has value 1/10 + 2/100 + 5/1000, and in the same way the binary fraction ::
-
-   0.001
-
-has value 0/2 + 0/4 + 1/8.  These two fractions have identical values, the only
+fractions.  For example, the decimal fraction ``0.125``
+has value 1/10 + 2/100 + 5/1000, and in the same way the binary fraction ``0.001``
+has value 0/2 + 0/4 + 1/8. These two fractions have identical values, the only
 real difference being that the first is written in base 10 fractional notation,
 and the second in base 2.
 


### PR DESCRIPTION
Initially reported by Gregory Jacob on the docs@ mailing list:

https://mail.python.org/archives/list/docs@python.org/thread/VPSFGLOZOHSPF7TGPOI65AOH25TCPSVR/

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

It goes from:

![image](https://user-images.githubusercontent.com/239510/152676989-3e6d205c-4a9c-4f44-a1f1-cef975b03524.png)

to:

![Screenshot 2022-02-06 at 13-22-23 15 Floating Point Arithmetic Issues and Limitations — Python 3 11 0a5 documentation](https://user-images.githubusercontent.com/239510/152680543-df6a9d90-233b-446c-92c7-cc38de030e7f.png)


is that more readable for everyone? I'm not fully convinced, please tell me.
