### PR TITLE
bpo-46644: No longer accept arbitrary callables as type arguments in generics

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -261,6 +261,12 @@ class UnionTests(BaseTestCase):
     def test_basics(self):
         u = Union[int, float]
         self.assertNotEqual(u, Union)
+        with self.assertRaises(TypeError):
+            Union[int, 42]
+        with self.assertRaises(TypeError):
+            Union[int, chr]
+        with self.assertRaises(TypeError):
+            Union[int, ...]
 
     def test_subclass_error(self):
         with self.assertRaises(TypeError):
@@ -386,10 +392,6 @@ class UnionTests(BaseTestCase):
         def f(x: u): ...
         self.assertIs(get_type_hints(f)['x'], u)
 
-    def test_function_repr_union(self):
-        def fun() -> int: ...
-        self.assertEqual(repr(Union[fun, int]), 'typing.Union[fun, int]')
-
     def test_union_str_pattern(self):
         # Shouldn't crash; see http://bugs.python.org/issue25390
         A = Union[str, Pattern]
@@ -401,11 +403,6 @@ class UnionTests(BaseTestCase):
         from xml.etree.ElementTree import Element
 
         Union[Element, str]  # Shouldn't crash
-
-        def Elem(*args):
-            return Element(*args)
-
-        Union[Elem, str]  # Nor should this
 
 
 class TupleTests(BaseTestCase):
@@ -2500,6 +2497,8 @@ class ClassVarTests(BaseTestCase):
         with self.assertRaises(TypeError):
             ClassVar[1]
         with self.assertRaises(TypeError):
+            ClassVar[chr]
+        with self.assertRaises(TypeError):
             ClassVar[int, str]
         with self.assertRaises(TypeError):
             ClassVar[int][str]
@@ -2539,6 +2538,8 @@ class FinalTests(BaseTestCase):
         Final[int]  # OK
         with self.assertRaises(TypeError):
             Final[1]
+        with self.assertRaises(TypeError):
+            Final[chr]
         with self.assertRaises(TypeError):
             Final[int, str]
         with self.assertRaises(TypeError):

--- a/Misc/NEWS.d/next/Library/2022-02-06-13-56-58.bpo-46644.rWSd0I.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-06-13-56-58.bpo-46644.rWSd0I.rst
@@ -1,0 +1,2 @@
+No longer accept arbitrary callables as type arguments in generics. E.g.
+``List[chr]`` is now an error.


### PR DESCRIPTION


<!-- issue-number: [bpo-46644](https://bugs.python.org/issue46644) -->
https://bugs.python.org/issue46644
<!-- /issue-number -->
