### PR TITLE
bpo-46656: Remove Py_NO_NAN macro

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -630,10 +630,12 @@ Build Changes
   (Contributed by Victor Stinner in :issue:`45440`.)
 
 * Building Python now requires a C99 ``<math.h>`` header file providing
-  a ``NAN`` constant, or the ``__builtin_nan()`` built-in function. If a
-  platform does not support Not-a-Number (NaN), the ``Py_NO_NAN`` macro can be
-  defined in the ``pyconfig.h`` file.
+  a ``NAN`` constant, or the ``__builtin_nan()`` built-in function.
   (Contributed by Victor Stinner in :issue:`46640`.)
+
+* Building Python now requires support for floating point Not-a-Number (NaN):
+  remove the ``Py_NO_NAN`` macro.
+  (Contributed by Victor Stinner in :issue:`46656`.)
 
 * Freelists for object structs can now be disabled. A new :program:`configure`
   option :option:`!--without-freelists` can be used to disable all freelists

--- a/Include/floatobject.h
+++ b/Include/floatobject.h
@@ -16,9 +16,7 @@ PyAPI_DATA(PyTypeObject) PyFloat_Type;
 #define PyFloat_Check(op) PyObject_TypeCheck(op, &PyFloat_Type)
 #define PyFloat_CheckExact(op) Py_IS_TYPE(op, &PyFloat_Type)
 
-#ifdef Py_NAN
-#  define Py_RETURN_NAN return PyFloat_FromDouble(Py_NAN)
-#endif
+#define Py_RETURN_NAN return PyFloat_FromDouble(Py_NAN)
 
 #define Py_RETURN_INF(sign)                          \
     do {                                             \

--- a/Include/pymath.h
+++ b/Include/pymath.h
@@ -50,11 +50,8 @@
 #  define Py_HUGE_VAL HUGE_VAL
 #endif
 
-/* Py_NAN
- * A value that evaluates to a quiet Not-a-Number (NaN).
- * Define Py_NO_NAN in pyconfig.h if your platform doesn't support NaNs.
- */
-#if !defined(Py_NAN) && !defined(Py_NO_NAN)
+// Py_NAN: Value that evaluates to a quiet Not-a-Number (NaN).
+#if !defined(Py_NAN)
 #  if _Py__has_builtin(__builtin_nan)
      // Built-in implementation of the ISO C99 function nan(): quiet NaN.
 #    define Py_NAN (__builtin_nan(""))

--- a/Misc/NEWS.d/next/Build/2022-02-04-21-26-50.bpo-46640.HXUmQp.rst
+++ b/Misc/NEWS.d/next/Build/2022-02-04-21-26-50.bpo-46640.HXUmQp.rst
@@ -1,4 +1,3 @@
 Building Python now requires a C99 ``<math.h>`` header file providing a ``NAN``
-constant, or the ``__builtin_nan()`` built-in function. If a platform does not
-support Not-a-Number (NaN), the ``Py_NO_NAN`` macro can be defined in the
-``pyconfig.h`` file. Patch by Victor Stinner.
+constant, or the ``__builtin_nan()`` built-in function.
+Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Build/2022-02-06-14-04-20.bpo-46656.ajJjkh.rst
+++ b/Misc/NEWS.d/next/Build/2022-02-06-14-04-20.bpo-46656.ajJjkh.rst
@@ -1,0 +1,2 @@
+Building Python now requires support for floating point Not-a-Number (NaN):
+remove the ``Py_NO_NAN`` macro. Patch by by Victor Stinner.

--- a/Modules/cmathmodule.c
+++ b/Modules/cmathmodule.c
@@ -113,7 +113,7 @@ c_infj(void)
     return r;
 }
 
-#if _PY_SHORT_FLOAT_REPR == 1 || defined(Py_NAN)
+#if _PY_SHORT_FLOAT_REPR == 1
 
 static double
 m_nan(void)
@@ -1282,7 +1282,7 @@ cmath_exec(PyObject *mod)
                            PyComplex_FromCComplex(c_infj())) < 0) {
         return -1;
     }
-#if _PY_SHORT_FLOAT_REPR == 1 || defined(Py_NAN)
+#if _PY_SHORT_FLOAT_REPR == 1
     if (PyModule_AddObject(mod, "nan", PyFloat_FromDouble(m_nan())) < 0) {
         return -1;
     }

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -283,7 +283,7 @@ m_inf(void)
 /* Constant nan value, generated in the same way as float('nan'). */
 /* We don't currently assume that Py_NAN is defined everywhere. */
 
-#if _PY_SHORT_FLOAT_REPR == 1 || defined(Py_NAN)
+#if _PY_SHORT_FLOAT_REPR == 1
 
 static double
 m_nan(void)
@@ -3838,7 +3838,7 @@ math_exec(PyObject *module)
     if (PyModule_AddObject(module, "inf", PyFloat_FromDouble(m_inf())) < 0) {
         return -1;
     }
-#if _PY_SHORT_FLOAT_REPR == 1 || defined(Py_NAN)
+#if _PY_SHORT_FLOAT_REPR == 1
     if (PyModule_AddObject(module, "nan", PyFloat_FromDouble(m_nan())) < 0) {
         return -1;
     }

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -2486,15 +2486,7 @@ _PyFloat_Unpack2(const unsigned char *p, int le)
         }
         else {
             /* NaN */
-#ifdef Py_NAN
             return sign ? -Py_NAN : Py_NAN;
-#else
-            PyErr_SetString(
-                PyExc_ValueError,
-                "can't unpack IEEE 754 NaN "
-                "on platform that does not support NaNs");
-            return -1;
-#endif  // !defined(Py_NAN)
         }
 #else  // _PY_SHORT_FLOAT_REPR == 1
         if (f == 0) {

--- a/Python/pystrtod.c
+++ b/Python/pystrtod.c
@@ -82,12 +82,10 @@ _Py_parse_inf_or_nan(const char *p, char **endptr)
             s += 5;
         retval = negate ? -Py_HUGE_VAL : Py_HUGE_VAL;
     }
-#ifdef Py_NAN
     else if (case_insensitive_match(s, "nan")) {
         s += 3;
         retval = negate ? -Py_NAN : Py_NAN;
     }
-#endif
     else {
         s = p;
         retval = -1.0;


### PR DESCRIPTION
Building Python now requires support for floating point Not-a-Number
(NaN): remove the Py_NO_NAN macro.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46656](https://bugs.python.org/issue46656) -->
https://bugs.python.org/issue46656
<!-- /issue-number -->
