### PR TITLE
bpo-46659: calendar uses locale.getlocale()

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -290,7 +290,7 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
 .. note::
 
    The :meth:`formatweekday` and :meth:`formatmonthname` methods of these two
-   classes temporarily change the current locale to the given *locale*.  Because
+   classes temporarily change the ``LC_TIME`` locale to the given *locale*.  Because
    the current locale is a process-wide setting, they are not thread-safe.
 
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -589,6 +589,12 @@ Changes in the Python API
   of sorting simply isn't well-defined in the absence of a total ordering
   on list elements.
 
+* :mod:`calendar`: The :class:`calendar.LocaleTextCalendar` and
+  :class:`calendar.LocaleHTMLCalendar` classes now use
+  :func:`locale.getlocale`, instead of using :func:`locale.getdefaultlocale`,
+  if no locale is specified.
+  (Contributed by Victor Stinner in :issue:`46659`.)
+
 
 Build Changes
 =============

--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -566,7 +566,7 @@ class LocaleTextCalendar(TextCalendar):
     def __init__(self, firstweekday=0, locale=None):
         TextCalendar.__init__(self, firstweekday)
         if locale is None:
-            locale = _locale.getlocale()
+            locale = _locale.getlocale(_locale.LC_TIME)
         self.locale = locale
 
     def formatweekday(self, day, width):
@@ -586,7 +586,7 @@ class LocaleHTMLCalendar(HTMLCalendar):
     def __init__(self, firstweekday=0, locale=None):
         HTMLCalendar.__init__(self, firstweekday)
         if locale is None:
-            locale = _locale.getlocale()
+            locale = _locale.getlocale(_locale.LC_TIME)
         self.locale = locale
 
     def formatweekday(self, day):

--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -566,7 +566,7 @@ class LocaleTextCalendar(TextCalendar):
     def __init__(self, firstweekday=0, locale=None):
         TextCalendar.__init__(self, firstweekday)
         if locale is None:
-            locale = _locale.getdefaultlocale()
+            locale = _locale.getlocale()
         self.locale = locale
 
     def formatweekday(self, day, width):
@@ -586,7 +586,7 @@ class LocaleHTMLCalendar(HTMLCalendar):
     def __init__(self, firstweekday=0, locale=None):
         HTMLCalendar.__init__(self, firstweekday)
         if locale is None:
-            locale = _locale.getdefaultlocale()
+            locale = _locale.getlocale()
         self.locale = locale
 
     def formatweekday(self, day):

--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -859,7 +859,8 @@ class CommandLineTestCase(unittest.TestCase):
         self.assertFailure('-L')
         self.assertFailure('--locale')
         self.assertFailure('-L', 'en')
-        lang, enc = locale.getdefaultlocale()
+
+        lang, enc = locale.getlocale()
         lang = lang or 'C'
         enc = enc or 'UTF-8'
         try:

--- a/Misc/NEWS.d/next/Library/2022-02-06-19-13-02.bpo-46659.q-vNL9.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-06-19-13-02.bpo-46659.q-vNL9.rst
@@ -1,0 +1,4 @@
+The :class:`calendar.LocaleTextCalendar` and
+:class:`calendar.LocaleHTMLCalendar` classes now use :func:`locale.getlocale`,
+instead of using :func:`locale.getdefaultlocale`, if no locale is specified.
+Patch by Victor Stinner.


### PR DESCRIPTION
The calendar.LocaleTextCalendar and calendar.LocaleHTMLCalendar
classes module now use locale.getlocale(), instead of using
locale.getdefaultlocale(), if no locale is specified.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46659](https://bugs.python.org/issue46659) -->
https://bugs.python.org/issue46659
<!-- /issue-number -->
