### PR TITLE
bpo-46659: Update the test on the mbcs codec alias

### DIFF
--- a/Lib/encodings/__init__.py
+++ b/Lib/encodings/__init__.py
@@ -152,9 +152,6 @@ def search_function(encoding):
     # Return the registry entry
     return entry
 
-# Register the search_function in the Python codec registry
-codecs.register(search_function)
-
 if sys.platform == 'win32':
     def _alias_mbcs(encoding):
         try:
@@ -167,4 +164,8 @@ if sys.platform == 'win32':
             # Imports may fail while we are shutting down
             pass
 
+    # It must be registered before search_function()
     codecs.register(_alias_mbcs)
+
+# Register the search_function in the Python codec registry
+codecs.register(search_function)

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1904,7 +1904,10 @@ class BasicUnicodeTest(unittest.TestCase, MixInCheckStateHandling):
                 name += "_codec"
             elif encoding == "latin_1":
                 name = "latin_1"
-            self.assertEqual(encoding.replace("_", "-"), name.replace("_", "-"))
+            # Skip the mbcs alias on Windows
+            if name != "mbcs":
+                self.assertEqual(encoding.replace("_", "-"),
+                                 name.replace("_", "-"))
 
             (b, size) = codecs.getencoder(encoding)(s)
             self.assertEqual(size, len(s), "encoding=%r" % encoding)

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3188,11 +3188,13 @@ class CodePageTest(unittest.TestCase):
         self.assertEqual(decoded, ('abc', 3))
 
     def test_mbcs_alias(self):
-        # Check that looking up our 'default' codepage will return
-        # mbcs when we don't have a more specific one available
-        with mock.patch('_winapi.GetACP', return_value=123):
-            codec = codecs.lookup('cp123')
-            self.assertEqual(codec.name, 'mbcs')
+        # On Windows, the encoding name must be the ANSI code page
+        encoding = locale.getpreferredencoding(False)
+        self.assertTrue(encoding.startswith('cp'), encoding)
+
+        # The encodings module create a "mbcs" alias to the ANSI code page
+        codec = codecs.lookup(encoding)
+        self.assertEqual(codec.name, "mbcs")
 
     @support.bigmemtest(size=2**31, memuse=7, dry_run=False)
     def test_large_input(self, size):

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -456,16 +456,6 @@ class ImportSideEffectTests(unittest.TestCase):
         # 'help' should be set in builtins
         self.assertTrue(hasattr(builtins, "help"))
 
-    def test_aliasing_mbcs(self):
-        if sys.platform == "win32":
-            import locale
-            if locale.getdefaultlocale()[1].startswith('cp'):
-                for value in encodings.aliases.aliases.values():
-                    if value == "mbcs":
-                        break
-                else:
-                    self.fail("did not alias mbcs")
-
     def test_sitecustomize_executed(self):
         # If sitecustomize is available, it should have been imported.
         if "sitecustomize" not in sys.modules:


### PR DESCRIPTION
Move the test on the "mbcs" codec alias from test_site to
test_codecs. Moreover, the test now uses
locale.getpreferredencoding(False) rather than
locale.getdefaultlocale() to get the ANSI code page.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46659](https://bugs.python.org/issue46659) -->
https://bugs.python.org/issue46659
<!-- /issue-number -->
