### PR TITLE
bpo-46668: Remove the mbcs alias

### DIFF
--- a/Lib/encodings/__init__.py
+++ b/Lib/encodings/__init__.py
@@ -152,20 +152,5 @@ def search_function(encoding):
     # Return the registry entry
     return entry
 
-if sys.platform == 'win32':
-    def _alias_mbcs(encoding):
-        try:
-            import _winapi
-            ansi_code_page = "cp%s" % _winapi.GetACP()
-            if encoding == ansi_code_page:
-                import encodings.mbcs
-                return encodings.mbcs.getregentry()
-        except ImportError:
-            # Imports may fail while we are shutting down
-            pass
-
-    # It must be registered before search_function()
-    codecs.register(_alias_mbcs)
-
 # Register the search_function in the Python codec registry
 codecs.register(search_function)

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3190,15 +3190,6 @@ class CodePageTest(unittest.TestCase):
                                           False)
         self.assertEqual(decoded, ('abc', 3))
 
-    def test_mbcs_alias(self):
-        # On Windows, the encoding name must be the ANSI code page
-        encoding = locale.getpreferredencoding(False)
-        self.assertTrue(encoding.startswith('cp'), encoding)
-
-        # The encodings module create a "mbcs" alias to the ANSI code page
-        codec = codecs.lookup(encoding)
-        self.assertEqual(codec.name, "mbcs")
-
     @support.bigmemtest(size=2**31, memuse=7, dry_run=False)
     def test_large_input(self, size):
         # Test input longer than INT_MAX.

--- a/Misc/NEWS.d/next/Library/2022-02-07-00-15-26.bpo-46668._JVAGD.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-07-00-15-26.bpo-46668._JVAGD.rst
@@ -1,0 +1,3 @@
+Python no longer creates an alias for the ANSI code page to the "mbcs"
+codec: always use the Python implementation of the code page. Patch by
+Victor Stinner.


### PR DESCRIPTION
Python no longer creates an alias for the ANSI code page to the
"mbcs" codec: always use the Python implementation of the code page.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46668](https://bugs.python.org/issue46668) -->
https://bugs.python.org/issue46668
<!-- /issue-number -->
