### PR TITLE
bpo-46670: Test if a macro is defined, not its value

### DIFF
--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -418,7 +418,7 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
         goto error;
     }
 #if HAVE_FFI_PREP_CLOSURE_LOC
-#   if USING_APPLE_OS_LIBFFI
+#   ifdef USING_APPLE_OS_LIBFFI
 #      define HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
 #   else
 #      define HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME 1
@@ -430,7 +430,7 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
     } else
 #endif
     {
-#if USING_APPLE_OS_LIBFFI && defined(__arm64__)
+#if defined(USING_APPLE_OS_LIBFFI) && defined(__arm64__)
         PyErr_Format(PyExc_NotImplementedError, "ffi_prep_closure_loc() is missing");
         goto error;
 #else

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -826,7 +826,7 @@ static int _call_function_pointer(int flags,
         cc = FFI_STDCALL;
 #endif
 
-#   if USING_APPLE_OS_LIBFFI
+#   ifdef USING_APPLE_OS_LIBFFI
 #      define HAVE_FFI_PREP_CIF_VAR_RUNTIME __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
 #   elif HAVE_FFI_PREP_CIF_VAR
 #      define HAVE_FFI_PREP_CIF_VAR_RUNTIME true

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -362,7 +362,7 @@ PyObject *_ctypes_get_errobj(int **pspace);
 extern PyObject *ComError;
 #endif
 
-#if USING_MALLOC_CLOSURE_DOT_C
+#ifdef USING_MALLOC_CLOSURE_DOT_C
 void Py_ffi_closure_free(void *p);
 void *Py_ffi_closure_alloc(size_t size, void** codeloc);
 #else

--- a/Modules/_ctypes/malloc_closure.c
+++ b/Modules/_ctypes/malloc_closure.c
@@ -91,13 +91,13 @@ static void more_core(void)
 /* put the item back into the free list */
 void Py_ffi_closure_free(void *p)
 {
-#if HAVE_FFI_CLOSURE_ALLOC
-#if USING_APPLE_OS_LIBFFI
+#ifdef HAVE_FFI_CLOSURE_ALLOC
+#ifdef USING_APPLE_OS_LIBFFI
     if (__builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)) {
 #endif
         ffi_closure_free(p);
         return;
-#if USING_APPLE_OS_LIBFFI
+#ifdef USING_APPLE_OS_LIBFFI
     }
 #endif
 #endif
@@ -109,12 +109,12 @@ void Py_ffi_closure_free(void *p)
 /* return one item from the free list, allocating more if needed */
 void *Py_ffi_closure_alloc(size_t size, void** codeloc)
 {
-#if HAVE_FFI_CLOSURE_ALLOC
-#if USING_APPLE_OS_LIBFFI
+#ifdef HAVE_FFI_CLOSURE_ALLOC
+#ifdef USING_APPLE_OS_LIBFFI
     if (__builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)) {
 #endif
         return ffi_closure_alloc(size, codeloc);
-#if USING_APPLE_OS_LIBFFI
+#ifdef USING_APPLE_OS_LIBFFI
     }
 #endif
 #endif

--- a/Modules/audioop.c
+++ b/Modules/audioop.c
@@ -297,7 +297,7 @@ static const int stepsizeTable[89] = {
 #define GETINT16(cp, i)         GETINTX(int16_t, (cp), (i))
 #define GETINT32(cp, i)         GETINTX(int32_t, (cp), (i))
 
-#if WORDS_BIGENDIAN
+#ifdef WORDS_BIGENDIAN
 #define GETINT24(cp, i)  (                              \
         ((unsigned char *)(cp) + (i))[2] +              \
         (((unsigned char *)(cp) + (i))[1] << 8) +       \
@@ -314,7 +314,7 @@ static const int stepsizeTable[89] = {
 #define SETINT16(cp, i, val)    SETINTX(int16_t, (cp), (i), (val))
 #define SETINT32(cp, i, val)    SETINTX(int32_t, (cp), (i), (val))
 
-#if WORDS_BIGENDIAN
+#ifdef WORDS_BIGENDIAN
 #define SETINT24(cp, i, val)  do {                              \
         ((unsigned char *)(cp) + (i))[2] = (int)(val);          \
         ((unsigned char *)(cp) + (i))[1] = (int)(val) >> 8;     \

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -61,7 +61,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #endif
 
 #ifdef HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION
-#include "pycore_fileutils.h"     // _Py_LocaleUsesNonUnicodeWchar()
+#  include "pycore_fileutils.h"   // _Py_LocaleUsesNonUnicodeWchar()
 #endif
 
 /* Uncomment to display statistics on interned strings at exit
@@ -3344,7 +3344,7 @@ PyUnicode_AsWideChar(PyObject *unicode,
     }
     unicode_copy_as_widechar(unicode, w, size);
 
-#if HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION
+#ifdef HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION
     /* Oracle Solaris uses non-Unicode internal wchar_t form for
        non-Unicode locales and hence needs conversion first. */
     if (_Py_LocaleUsesNonUnicodeWchar()) {
@@ -3381,7 +3381,7 @@ PyUnicode_AsWideCharString(PyObject *unicode,
     }
     unicode_copy_as_widechar(unicode, buffer, buflen + 1);
 
-#if HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION
+#ifdef HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION
     /* Oracle Solaris uses non-Unicode internal wchar_t form for
        non-Unicode locales and hence needs conversion first. */
     if (_Py_LocaleUsesNonUnicodeWchar()) {

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -962,7 +962,7 @@ _PyTime_GetSystemClockWithInfo(_PyTime_t *t, _Py_clock_info_t *info)
 }
 
 
-#if __APPLE__
+#ifdef __APPLE__
 static int
 py_mach_timebase_info(_PyTime_t *pnumer, _PyTime_t *pdenom, int raise)
 {


### PR DESCRIPTION
* audioop.c: #ifdef WORDS_BIGENDIAN
* ctypes.h: #ifdef USING_MALLOC_CLOSURE_DOT_C
* pytime.c: #ifdef __APPLE__
* unicodeobject.c: #ifdef HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46670](https://bugs.python.org/issue46670) -->
https://bugs.python.org/issue46670
<!-- /issue-number -->
