### PR TITLE
bpo-46670: Fix #ifdef in sha3module.c

### DIFF
--- a/Modules/_sha3/sha3module.c
+++ b/Modules/_sha3/sha3module.c
@@ -57,6 +57,8 @@
   typedef uint64_t UINT64;
   typedef unsigned char UINT8;
 #endif
+// kcp/KeccakP-1600-opt64.c doesn't need to define UINT8
+#define NOT_PYTHON 0
 
 /* replacement for brg_endian.h */
 #define IS_LITTLE_ENDIAN 1234
@@ -69,7 +71,7 @@
 #endif
 
 /* Prevent bus errors on platforms requiring aligned accesses such ARM. */
-#if HAVE_ALIGNED_REQUIRED && !defined(NO_MISALIGNED_ACCESSES)
+#if defined(HAVE_ALIGNED_REQUIRED) && !defined(NO_MISALIGNED_ACCESSES)
 #define NO_MISALIGNED_ACCESSES
 #endif
 


### PR DESCRIPTION
* Test if HAVE_ALIGNED_REQUIRED is defined, not its value.
* Define explicitly NOT_PYTHON macro to 0.

Fix "gcc -Wundef" warnings.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46670](https://bugs.python.org/issue46670) -->
https://bugs.python.org/issue46670
<!-- /issue-number -->
