### PR TITLE
Add escape characters code block to whitespace constant doc section.

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -69,7 +69,7 @@ The constants defined in this module are:
 
    A string containing all ASCII characters that are considered whitespace.
    This includes the characters space, tab, linefeed, return, formfeed, and
-   vertical tab.
+   vertical tab (``' \t\n\r\x0b\x0c'``).
 
 
 .. _string-formatting:


### PR DESCRIPTION
All other sections of String constants have a code block with example characters, except whitespace, adding ' \t\n\r\x0b\x0c' to this section will bring it in line with the standard.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
