### PR TITLE
bpo-46672: fix `NameError` in `asyncio.gather` if type check fails

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -634,7 +634,7 @@ def _ensure_future(coro_or_future, *, loop=None):
         loop = events._get_event_loop(stacklevel=4)
     try:
         return loop.create_task(coro_or_future)
-    except RuntimeError: 
+    except RuntimeError:
         if not called_wrap_awaitable:
             coro_or_future.close()
         raise
@@ -721,7 +721,7 @@ def gather(*coros_or_futures, return_exceptions=False):
         nonlocal nfinished
         nfinished += 1
 
-        if outer.done():
+        if outer is None or outer.done():
             if not fut.cancelled():
                 # Mark exception retrieved.
                 fut.exception()
@@ -777,6 +777,7 @@ def gather(*coros_or_futures, return_exceptions=False):
     nfuts = 0
     nfinished = 0
     loop = None
+    outer = None  # bpo-46672
     for arg in coros_or_futures:
         if arg not in arg_to_fut:
             fut = _ensure_future(arg, loop=loop)

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3190,6 +3190,20 @@ class CoroutineGatherTests(GatherTestsBase, test_utils.TestCase):
         test_utils.run_briefly(self.one_loop)
         self.assertIsInstance(f.exception(), RuntimeError)
 
+    def test_issue46672(self):
+        with mock.patch(
+            'asyncio.base_events.BaseEventLoop.call_exception_handler',
+        ):
+            async def coro(s):
+                return s
+            c = coro('abc')
+
+            with self.assertRaises(TypeError):
+                self._gather(c, {})
+            self._run_loop(self.one_loop)
+            # NameError should not happen:
+            self.one_loop.call_exception_handler.assert_not_called()
+
 
 class RunCoroutineThreadsafeTests(test_utils.TestCase):
     """Test case for asyncio.run_coroutine_threadsafe."""

--- a/Misc/NEWS.d/next/Library/2022-02-07-13-15-16.bpo-46672.4swIjx.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-07-13-15-16.bpo-46672.4swIjx.rst
@@ -1,0 +1,1 @@
+Fixes ``NameError`` in :func:`asyncio.gather` when initial type check fails.

--- a/Misc/NEWS.d/next/Library/2022-02-07-13-15-16.bpo-46672.4swIjx.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-07-13-15-16.bpo-46672.4swIjx.rst
@@ -1,1 +1,1 @@
-Fixes ``NameError`` in :func:`asyncio.gather` when initial type check fails.
+Fix ``NameError`` in :func:`asyncio.gather` when initial type check fails.


### PR DESCRIPTION
I am a bit unsure about the full coverage of `if outer is None or outer.done():` condition. Does it cover all corner cases?

<!-- issue-number: [bpo-46672](https://bugs.python.org/issue46672) -->
https://bugs.python.org/issue46672
<!-- /issue-number -->
