### PR TITLE
bpo-46166: Fix compiler warnings in What's New in Python 3.11

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -816,13 +816,13 @@ Porting to Python 3.11
     :c:func:`Py_DECREF`.
   * ``f_back``: changed (see below), use :c:func:`PyFrame_GetBack`.
   * ``f_builtins``: removed,
-    use ``PyObject_GetAttrString(frame, "f_builtins")``.
+    use ``PyObject_GetAttrString((PyObject*)frame, "f_builtins")``.
   * ``f_globals``: removed,
-    use ``PyObject_GetAttrString(frame, "f_globals")``.
+    use ``PyObject_GetAttrString((PyObject*)frame, "f_globals")``.
   * ``f_locals``: removed,
-    use ``PyObject_GetAttrString(frame, "f_locals")``.
+    use ``PyObject_GetAttrString((PyObject*)frame, "f_locals")``.
   * ``f_lasti``: removed,
-    use ``PyObject_GetAttrString(frame, "f_lasti")``.
+    use ``PyObject_GetAttrString((PyObject*)frame, "f_lasti")``.
 
   The following fields were removed entirely, as they were details
   of the old implementation:


### PR DESCRIPTION
Fix compiler warnings on PyObject_GetAttrString() calls in the What's
New in Python 3.11 doc of PyFrameObject changes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46166](https://bugs.python.org/issue46166) -->
https://bugs.python.org/issue46166
<!-- /issue-number -->
