### PR TITLE
Removing inconsistent slash at README url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ General Information
 - Source code: https://github.com/python/cpython
 - Issue tracker: https://bugs.python.org
 - Documentation: https://docs.python.org
-- Developer's Guide: https://devguide.python.org/
+- Developer's Guide: https://devguide.python.org
 
 Contributing to CPython
 -----------------------


### PR DESCRIPTION
At the README.rst at the general information list there is a inconsistent slash at the Developer's Guide url.
This removes the slash:
```diff
- - Developer's Guide: https://devguide.python.org/
+ - Developer's Guide: https://devguide.python.org
```

