### PR TITLE
bpo-46678: Fix Invalid cross device link in Lib/test/support/import_helper.py

### DIFF
--- a/Lib/test/support/import_helper.py
+++ b/Lib/test/support/import_helper.py
@@ -3,6 +3,7 @@ import _imp
 import importlib
 import importlib.util
 import os
+import shutil
 import sys
 import unittest
 import warnings
@@ -59,7 +60,7 @@ def make_legacy_pyc(source):
     pyc_file = importlib.util.cache_from_source(source)
     up_one = os.path.dirname(os.path.abspath(source))
     legacy_pyc = os.path.join(up_one, source + 'c')
-    os.rename(pyc_file, legacy_pyc)
+    shutil.move(pyc_file, legacy_pyc)
     return legacy_pyc
 
 

--- a/Misc/NEWS.d/next/Tests/2022-02-07-12-40-45.bpo-46678.zfOrgL.rst
+++ b/Misc/NEWS.d/next/Tests/2022-02-07-12-40-45.bpo-46678.zfOrgL.rst
@@ -1,0 +1,3 @@
+The function ``make_legacy_pyc`` in ``Lib/test/support/import_helper.py`` no
+longer fails when ``PYTHONPYCACHEPREFIX`` is set to a directory on a
+different device from where tempfiles are stored.


### PR DESCRIPTION
In [Lib/test/support/import_helper.py](https://github.com/python/cpython/blob/master/Lib/test/support/import_helper.py), the function `make_legacy_pyc` makes a call to `os.rename` which can fail when the source and target live on different devices. This happens (for example) when `PYTHONPYCACHEPREFIX` is set to a directory anywhere on disk, while a ramdisk is mounted on `/tmp` (the latter of which is the default on various Linux distros). Replacing `os.rename` with `shutil.move` fixes this.

<!-- issue-number: [bpo-46678](https://bugs.python.org/issue46678) -->
https://bugs.python.org/issue46678
<!-- /issue-number -->

Automerge-Triggered-By: GH:brettcannon