### PR TITLE
bpo-46679: Don't ignore timeout argument in test.support.wait_process.

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1999,7 +1999,7 @@ def wait_process(pid, *, exitcode, timeout=None):
             # process is still running
 
             dt = time.monotonic() - t0
-            if dt > SHORT_TIMEOUT:
+            if dt > timeout:
                 try:
                     os.kill(pid, signal.SIGKILL)
                     os.waitpid(pid, 0)

--- a/Misc/NEWS.d/next/Tests/2022-02-07-13-24-28.bpo-46679.S-HI_R.rst
+++ b/Misc/NEWS.d/next/Tests/2022-02-07-13-24-28.bpo-46679.S-HI_R.rst
@@ -1,0 +1,2 @@
+The function ``wait_process`` in ``Lib/test/support/__init__.py`` no longer
+ignores its ``timeout`` argument.

--- a/Misc/NEWS.d/next/Tests/2022-02-07-13-24-28.bpo-46679.S-HI_R.rst
+++ b/Misc/NEWS.d/next/Tests/2022-02-07-13-24-28.bpo-46679.S-HI_R.rst
@@ -1,2 +1,0 @@
-The function ``wait_process`` in ``Lib/test/support/__init__.py`` no longer
-ignores its ``timeout`` argument.


### PR DESCRIPTION
The function `wait_process` in `Lib/test/support/__init__.py` ignores its `timeout` argument. This argument is useful, for example, in tests that need to determine whether a deadlock has been fixed (e.g., the test added in #30310).

<!-- issue-number: [bpo-46679](https://bugs.python.org/issue46679) -->
https://bugs.python.org/issue46679
<!-- /issue-number -->
