### PR TITLE
bpo-46659: Deprecate locale.getdefaultlocale()

### DIFF
--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -301,6 +301,8 @@ The :mod:`locale` module defines the following exception and functions:
    *language code* and *encoding* may be ``None`` if their values cannot be
    determined.
 
+   .. deprecated:: 3.11 3.13
+
 
 .. function:: getlocale(category=LC_CTYPE)
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -475,6 +475,12 @@ Deprecated
 
   (Contributed by Hugo van Kemenade in :issue:`45173`.)
 
+* The :func:`locale.getdefaultlocale` function is deprecated and will be
+  removed in Python 3.13. Use :func:`locale.setlocale`,
+  :func:`locale.getpreferredencoding(False) <locale.getpreferredencoding>` and
+  :func:`locale.getlocale` functions instead.
+  (Contributed by Victor Stinner in :issue:`46659`.)
+
 
 Removed
 =======

--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -555,6 +555,12 @@ def getdefaultlocale(envvars=('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE')):
 
     """
 
+    import warnings
+    warnings.warn(
+        "Use setlocale(), getpreferredencoding(False) and getlocale() instead",
+        DeprecationWarning, stacklevel=2
+    )
+
     try:
         # check if it's supported by the _locale module
         import _locale

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -518,7 +518,8 @@ class TestMiscellaneous(unittest.TestCase):
 
             os.environ['LC_CTYPE'] = 'UTF-8'
 
-            self.assertEqual(locale.getdefaultlocale(), (None, 'UTF-8'))
+            with check_warnings(('', DeprecationWarning)):
+                self.assertEqual(locale.getdefaultlocale(), (None, 'UTF-8'))
 
         finally:
             for k in orig_env:

--- a/Misc/NEWS.d/next/Library/2022-02-06-17-57-45.bpo-46659.zTmkoQ.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-06-17-57-45.bpo-46659.zTmkoQ.rst
@@ -1,0 +1,4 @@
+The :func:`locale.getdefaultlocale` function is deprecated and will be removed
+in Python 3.13. Use :func:`locale.setlocale`,
+:func:`locale.getpreferredencoding(False) <locale.getpreferredencoding>` and
+:func:`locale.getlocale` functions instead.  Patch by Victor Stinner.


### PR DESCRIPTION
The locale.getdefaultlocale() function is deprecated and will be removed in
Python 3.13. Use locale.setlocale(),
locale.getpreferredencoding(False) and locale.getlocale() functions
instead.

<!-- issue-number: [bpo-46659](https://bugs.python.org/issue46659) -->
https://bugs.python.org/issue46659
<!-- /issue-number -->