### PR TITLE
[3.10] bpo-46676: Make ParamSpec args and kwargs equal to themselves …

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4743,12 +4743,20 @@ class ParamSpecTests(BaseTestCase):
 
     def test_args_kwargs(self):
         P = ParamSpec('P')
+        P_2 = ParamSpec('P_2')
         self.assertIn('args', dir(P))
         self.assertIn('kwargs', dir(P))
         self.assertIsInstance(P.args, ParamSpecArgs)
         self.assertIsInstance(P.kwargs, ParamSpecKwargs)
         self.assertIs(P.args.__origin__, P)
         self.assertIs(P.kwargs.__origin__, P)
+        self.assertEqual(P.args, P.args)
+        self.assertEqual(P.kwargs, P.kwargs)
+        self.assertNotEqual(P.args, P_2.args)
+        self.assertNotEqual(P.kwargs, P_2.kwargs)
+        self.assertNotEqual(P.args, P.kwargs)
+        self.assertNotEqual(P.kwargs, P.args)
+        self.assertNotEqual(P.args, P_2.kwargs)
         self.assertEqual(repr(P.args), "P.args")
         self.assertEqual(repr(P.kwargs), "P.kwargs")
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -830,6 +830,11 @@ class ParamSpecArgs(_Final, _Immutable, _root=True):
     def __repr__(self):
         return f"{self.__origin__.__name__}.args"
 
+    def __eq__(self, other):
+        if not isinstance(other, ParamSpecArgs):
+            return NotImplemented
+        return self.__origin__ == other.__origin__
+
 
 class ParamSpecKwargs(_Final, _Immutable, _root=True):
     """The kwargs for a ParamSpec object.
@@ -848,6 +853,11 @@ class ParamSpecKwargs(_Final, _Immutable, _root=True):
 
     def __repr__(self):
         return f"{self.__origin__.__name__}.kwargs"
+
+    def __eq__(self, other):
+        if not isinstance(other, ParamSpecKwargs):
+            return NotImplemented
+        return self.__origin__ == other.__origin__
 
 
 class ParamSpec(_Final, _Immutable, _TypeVarLike, _root=True):

--- a/Misc/NEWS.d/next/Library/2022-02-07-19-20-42.bpo-46676.3Aws1o.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-07-19-20-42.bpo-46676.3Aws1o.rst
@@ -1,0 +1,1 @@
+Make :data:`typing.ParamSpec` args and kwargs equal to themselves. Patch by Gregory Beauregard.


### PR DESCRIPTION
…(GH-31203)

(cherry picked from commit c8b62bbe46e20d4b6dd556f2fa85960d1269aa45)
There was no merge conflict; just a different problem with the bot I guess.

Co-authored-by: Gregory Beauregard <greg@greg.red>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46676](https://bugs.python.org/issue46676) -->
https://bugs.python.org/issue46676
<!-- /issue-number -->
