### PR TITLE
gh-64978: Add `chown()` to `pathlib.Path`

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -755,6 +755,30 @@ call fails (for example because the path doesn't exist).
    .. versionchanged:: 3.10
       The *follow_symlinks* parameter was added.
 
+.. method:: Path.chown(uid, gid, *, dir_fd=None, follow_symlinks=True)
+
+   Change the file ownership, like :func:`os.chown`.
+
+   This method normally follows symlinks. Some Unix flavours support changing
+   permissions on the symlink itself; on these platforms you may add the
+   argument ``follow_symlinks=False``, or use :meth:`~Path.lchown`.
+
+   ::
+
+      >>> p = Path('setup.py')
+      >>> p.stat().st_uid
+      1000
+      >>> p.stat().st_gid
+      1000
+      >>> p.chown(1, 20)
+      >>> p.stat().st_uid
+      1
+      >>> p.stat().st_gid
+      20
+
+   .. availability:: Unix.
+
+
 .. method:: Path.exists()
 
    Whether the path points to an existing file or directory::
@@ -923,9 +947,17 @@ call fails (for example because the path doesn't exist).
    symbolic link's mode is changed rather than its target's.
 
 
+.. method:: Path.lchown(uid, gid, *, dir_fd=None)
+
+   Like :meth:`Path.chown`, but if the path points to a symbolic link, the
+   symbolic link's mode is changed rather than its target's.
+
+   .. availability:: Unix.
+
+
 .. method:: Path.lstat()
 
-   Like :meth:`Path.stat` but, if the path points to a symbolic link, return
+   Like :meth:`Path.stat`, but if the path points to a symbolic link, return
    the symbolic link's information rather than its target's.
 
 
@@ -1260,6 +1292,7 @@ Below is a table mapping various :mod:`os` functions to their corresponding
 :func:`os.path.abspath`                :meth:`Path.absolute` [#]_
 :func:`os.path.realpath`               :meth:`Path.resolve`
 :func:`os.chmod`                       :meth:`Path.chmod`
+:func:`os.chown`                       :meth:`Path.chown`
 :func:`os.mkdir`                       :meth:`Path.mkdir`
 :func:`os.makedirs`                    :meth:`Path.mkdir`
 :func:`os.rename`                      :meth:`Path.rename`

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -755,13 +755,13 @@ call fails (for example because the path doesn't exist).
    .. versionchanged:: 3.10
       The *follow_symlinks* parameter was added.
 
-.. method:: Path.chown(uid, gid, *, dir_fd=None, follow_symlinks=True)
+.. method:: Path.chown(uid, gid, *, follow_symlinks=True)
 
    Change the file ownership, like :func:`os.chown`.
 
    This method normally follows symlinks. Some Unix flavours support changing
    permissions on the symlink itself; on these platforms you may add the
-   argument ``follow_symlinks=False``, or use :meth:`~Path.lchown`.
+   argument ``follow_symlinks=False``.
 
    ::
 
@@ -945,14 +945,6 @@ call fails (for example because the path doesn't exist).
 
    Like :meth:`Path.chmod` but, if the path points to a symbolic link, the
    symbolic link's mode is changed rather than its target's.
-
-
-.. method:: Path.lchown(uid, gid, *, dir_fd=None)
-
-   Like :meth:`Path.chown`, but if the path points to a symbolic link, the
-   symbolic link's mode is changed rather than its target's.
-
-   .. availability:: Unix.
 
 
 .. method:: Path.lstat()

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -778,6 +778,8 @@ call fails (for example because the path doesn't exist).
 
    .. availability:: Unix.
 
+   .. versionadded:: 3.12
+
 
 .. method:: Path.exists()
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1127,6 +1127,19 @@ class Path(PurePath):
         """
         self.chmod(mode, follow_symlinks=False)
 
+    def chown(self, uid, gid, *, dir_fd=None, follow_symlinks=True):
+        """
+        Change the owner and group id of path to the numeric uid and gid, like os.chown().
+        """
+        os.chown(self, uid, gid, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+
+    def lchown(self, uid, gid, *, dir_fd=None):
+        """
+        Like chown(), except if the path points to a symlink, the symlink's
+        permissions are changed, rather than its target's.
+        """
+        self.chown(uid, gid, dir_fd=dir_fd, follow_symlinks=False)
+
     def unlink(self, missing_ok=False):
         """
         Remove this file or link.
@@ -1393,3 +1406,9 @@ class WindowsPath(Path, PureWindowsPath):
 
     def is_mount(self):
         raise NotImplementedError("Path.is_mount() is unsupported on this system")
+
+    def chown(self, uid, gid, *, dir_fd=None, follow_symlinks=True):
+        raise NotImplementedError("Path.chown() is unsupported on this system")
+
+    def lchown(self, uid, gid, *, dir_fd=None):
+        raise NotImplementedError("Path.lchown() is unsupported on this system")

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1127,18 +1127,11 @@ class Path(PurePath):
         """
         self.chmod(mode, follow_symlinks=False)
 
-    def chown(self, uid, gid, *, dir_fd=None, follow_symlinks=True):
+    def chown(self, uid, gid, *, follow_symlinks=True):
         """
         Change the owner and group id of path to the numeric uid and gid, like os.chown().
         """
-        os.chown(self, uid, gid, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
-
-    def lchown(self, uid, gid, *, dir_fd=None):
-        """
-        Like chown(), except if the path points to a symlink, the symlink's
-        permissions are changed, rather than its target's.
-        """
-        self.chown(uid, gid, dir_fd=dir_fd, follow_symlinks=False)
+        os.chown(self, uid, gid, follow_symlinks=follow_symlinks)
 
     def unlink(self, missing_ok=False):
         """
@@ -1407,8 +1400,5 @@ class WindowsPath(Path, PureWindowsPath):
     def is_mount(self):
         raise NotImplementedError("Path.is_mount() is unsupported on this system")
 
-    def chown(self, uid, gid, *, dir_fd=None, follow_symlinks=True):
+    def chown(self, uid, gid, *, follow_symlinks=True):
         raise NotImplementedError("Path.chown() is unsupported on this system")
-
-    def lchown(self, uid, gid, *, dir_fd=None):
-        raise NotImplementedError("Path.lchown() is unsupported on this system")

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1874,6 +1874,34 @@ class _BasePathTest(object):
         p.chmod(new_mode)
         self.assertEqual(p.stat().st_mode, new_mode)
 
+    def test_chown(self):
+        p = self.cls(BASE) / 'fileA'
+        uid = p.stat().st_uid
+        gid = p.stat().st_gid
+        new_uid = 2000
+        new_gid = 2000
+        p.chown(uid=new_uid, gid=new_gid)
+        self.assertEqual(p.stat().st_uid, new_uid)
+        self.assertEqual(p.stat().st_gid, new_gid)
+        # Set back
+        p.chown(uid=uid, gid=gid)
+        self.assertEqual(p.stat().st_uid, uid)
+        self.assertEqual(p.stat().st_gid, gid)
+
+    def test_lchown(self):
+        p = self.cls(BASE) / 'fileA'
+        uid = p.stat().st_uid
+        gid = p.stat().st_gid
+        new_uid = 2000
+        new_gid = 2000
+        p.lchown(uid=new_uid, gid=new_gid)
+        self.assertEqual(p.stat().st_uid, new_uid)
+        self.assertEqual(p.stat().st_gid, new_gid)
+        # Set back
+        p.lchown(uid=uid, gid=gid)
+        self.assertEqual(p.stat().st_uid, uid)
+        self.assertEqual(p.stat().st_gid, gid)
+
     # On Windows, os.chmod does not follow symlinks (issue #15411)
     @only_posix
     def test_chmod_follow_symlinks_true(self):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1926,26 +1926,6 @@ class _BasePathTest(object):
         new_gid = 503
         with self.assertRaises(NotImplementedError):
             p.chown(uid=new_uid, gid=new_gid)
-    
-    @only_posix
-    @mock.patch('pathlib.Path.chown')
-    def test_lchown(self, chown_mock):
-        new_uid = 503
-        new_gid = 503
-
-        p = self.cls(BASE) / 'fileA'
-
-        p.lchown(new_uid, new_gid)
-        chown_mock.assert_called_with(new_uid, new_gid, dir_fd=None, follow_symlinks=False)
-
-    @only_nt
-    def test_lchown_windows(self):
-        p = self.cls(BASE) / 'fileA'
-
-        new_uid = 503
-        new_gid = 503
-        with self.assertRaises(NotImplementedError):
-            p.lchown(uid=new_uid, gid=new_gid)
 
     # On Windows, os.chmod does not follow symlinks (issue #15411)
     @only_posix

--- a/Misc/NEWS.d/next/Library/2022-02-08-12-26-20.bpo-20779.Gha5Fa.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-08-12-26-20.bpo-20779.Gha5Fa.rst
@@ -1,0 +1,2 @@
+Add :func:`pathlib.Path.chown` and :func:`pathlib.Path.lchown`
+to :class:`pathlib.Path`. Patch by Jaspar Stach.

--- a/Misc/NEWS.d/next/Library/2022-02-08-12-26-20.bpo-20779.Gha5Fa.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-08-12-26-20.bpo-20779.Gha5Fa.rst
@@ -1,2 +1,1 @@
-Add :func:`pathlib.Path.chown` and :func:`pathlib.Path.lchown`
-to :class:`pathlib.Path`. Patch by Jaspar Stach.
+Add :func:`pathlib.Path.chown` to :class:`pathlib.Path`. Patch by Jaspar Stach.

--- a/Misc/NEWS.d/next/Library/2022-02-08-12-26-20.bpo-20779.Gha5Fa.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-08-12-26-20.bpo-20779.Gha5Fa.rst
@@ -1,1 +1,2 @@
-Add :func:`pathlib.Path.chown` to :class:`pathlib.Path`. Patch by Jaspar Stach.
+Add :meth:`pathlib.Path.chown` method that changes file ownership.
+Patch by Jaspar Stach.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
[bpo-20779](https://bugs.python.org/issue20779): Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This PR adds `chown()` and `lchown()` to the `pathlib` library.

As for `chmod` and other existing functions, this is achieved by using `os.chown()` within the new functions.

<!-- issue-number: [bpo-20779](https://bugs.python.org/issue20779) -->
- Issue: https://github.com/python/cpython/issues/64978
<!-- /issue-number -->
