### PR TITLE
gh-90839: Forward gzip.compress() compresslevel to zlib

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -587,7 +587,8 @@ def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=None):
     header = _create_simple_gzip_header(compresslevel, mtime)
     trailer = struct.pack("<LL", zlib.crc32(data), (len(data) & 0xffffffff))
     # Wbits=-15 creates a raw deflate block.
-    return header + zlib.compress(data, wbits=-15) + trailer
+    return (header + zlib.compress(data, level=compresslevel, wbits=-15) +
+            trailer)
 
 
 def decompress(data):

--- a/Misc/NEWS.d/next/Library/2022-03-21-13-50-07.bpo-46681.RRhopn.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-21-13-50-07.bpo-46681.RRhopn.rst
@@ -1,0 +1,1 @@
+Forward gzip.compress() compresslevel to zlib.


### PR DESCRIPTION
`gzip.compress()` does not forward `compresslevel` to `zlib.compress()` - no matter what the user specifies, the actual compression level ends up being 6. This started with ea23e7820f02840368569db8082bd0ca4d59b62a. Fix by adding the missing kwarg to `zlib.compress()` call.

<!-- issue-number: [bpo-46681](https://bugs.python.org/issue46681) -->
https://bugs.python.org/issue46681
<!-- /issue-number -->
