### PR TITLE
bpo-45490: Rename static inline functions

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -434,12 +434,12 @@ enum PyUnicode_Kind {
         (0x10ffffU)))))
 
 Py_DEPRECATED(3.3)
-static inline Py_ssize_t _PyUnicode_get_wstr_length(PyObject *op) {
+static inline Py_ssize_t PyUnicode_WSTR_LENGTH(PyObject *op) {
     return PyUnicode_IS_COMPACT_ASCII(op) ?
             ((PyASCIIObject*)op)->length :
             ((PyCompactUnicodeObject*)op)->wstr_length;
 }
-#define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
+#define PyUnicode_WSTR_LENGTH(op) PyUnicode_WSTR_LENGTH(_PyObject_CAST(op))
 
 /* === Public API ========================================================= */
 

--- a/Include/object.h
+++ b/Include/object.h
@@ -127,49 +127,49 @@ PyAPI_FUNC(int) Py_Is(PyObject *x, PyObject *y);
 #define Py_Is(x, y) ((x) == (y))
 
 
-static inline Py_ssize_t _Py_REFCNT(const PyObject *ob) {
+static inline Py_ssize_t Py_REFCNT(const PyObject *ob) {
     return ob->ob_refcnt;
 }
-#define Py_REFCNT(ob) _Py_REFCNT(_PyObject_CAST_CONST(ob))
+#define Py_REFCNT(ob) Py_REFCNT(_PyObject_CAST_CONST(ob))
 
 
 // bpo-39573: The Py_SET_TYPE() function must be used to set an object type.
-static inline PyTypeObject* _Py_TYPE(const PyObject *ob) {
+static inline PyTypeObject* Py_TYPE(const PyObject *ob) {
     return ob->ob_type;
 }
-#define Py_TYPE(ob) _Py_TYPE(_PyObject_CAST_CONST(ob))
+#define Py_TYPE(ob) Py_TYPE(_PyObject_CAST_CONST(ob))
 
 // bpo-39573: The Py_SET_SIZE() function must be used to set an object size.
-static inline Py_ssize_t _Py_SIZE(const PyVarObject *ob) {
+static inline Py_ssize_t Py_SIZE(const PyVarObject *ob) {
     return ob->ob_size;
 }
-#define Py_SIZE(ob) _Py_SIZE(_PyVarObject_CAST_CONST(ob))
+#define Py_SIZE(ob) Py_SIZE(_PyVarObject_CAST_CONST(ob))
 
 
-static inline int _Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
+static inline int Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
     // bpo-44378: Don't use Py_TYPE() since Py_TYPE() requires a non-const
     // object.
     return ob->ob_type == type;
 }
-#define Py_IS_TYPE(ob, type) _Py_IS_TYPE(_PyObject_CAST_CONST(ob), type)
+#define Py_IS_TYPE(ob, type) Py_IS_TYPE(_PyObject_CAST_CONST(ob), type)
 
 
-static inline void _Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
+static inline void Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
     ob->ob_refcnt = refcnt;
 }
-#define Py_SET_REFCNT(ob, refcnt) _Py_SET_REFCNT(_PyObject_CAST(ob), refcnt)
+#define Py_SET_REFCNT(ob, refcnt) Py_SET_REFCNT(_PyObject_CAST(ob), refcnt)
 
 
-static inline void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type) {
+static inline void Py_SET_TYPE(PyObject *ob, PyTypeObject *type) {
     ob->ob_type = type;
 }
-#define Py_SET_TYPE(ob, type) _Py_SET_TYPE(_PyObject_CAST(ob), type)
+#define Py_SET_TYPE(ob, type) Py_SET_TYPE(_PyObject_CAST(ob), type)
 
 
-static inline void _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size) {
+static inline void Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size) {
     ob->ob_size = size;
 }
-#define Py_SET_SIZE(ob, size) _Py_SET_SIZE(_PyVarObject_CAST(ob), size)
+#define Py_SET_SIZE(ob, size) Py_SET_SIZE(_PyVarObject_CAST(ob), size)
 
 
 /*
@@ -253,10 +253,10 @@ PyAPI_FUNC(PyObject *) PyType_GetQualName(PyTypeObject *);
 /* Generic type check */
 PyAPI_FUNC(int) PyType_IsSubtype(PyTypeObject *, PyTypeObject *);
 
-static inline int _PyObject_TypeCheck(PyObject *ob, PyTypeObject *type) {
+static inline int PyObject_TypeCheck(PyObject *ob, PyTypeObject *type) {
     return Py_IS_TYPE(ob, type) || PyType_IsSubtype(Py_TYPE(ob), type);
 }
-#define PyObject_TypeCheck(ob, type) _PyObject_TypeCheck(_PyObject_CAST(ob), type)
+#define PyObject_TypeCheck(ob, type) PyObject_TypeCheck(_PyObject_CAST(ob), type)
 
 PyAPI_DATA(PyTypeObject) PyType_Type; /* built-in 'type' */
 PyAPI_DATA(PyTypeObject) PyBaseObject_Type; /* built-in 'object' */
@@ -475,7 +475,7 @@ PyAPI_FUNC(void) Py_DecRef(PyObject *);
 PyAPI_FUNC(void) _Py_IncRef(PyObject *);
 PyAPI_FUNC(void) _Py_DecRef(PyObject *);
 
-static inline void _Py_INCREF(PyObject *op)
+static inline void Py_INCREF(PyObject *op)
 {
 #if defined(Py_REF_DEBUG) && defined(Py_LIMITED_API) && Py_LIMITED_API+0 >= 0x030A0000
     // Stable ABI for Python 3.10 built in debug mode.
@@ -489,9 +489,9 @@ static inline void _Py_INCREF(PyObject *op)
     op->ob_refcnt++;
 #endif
 }
-#define Py_INCREF(op) _Py_INCREF(_PyObject_CAST(op))
+#define Py_INCREF(op) Py_INCREF(_PyObject_CAST(op))
 
-static inline void _Py_DECREF(
+static inline void Py_DECREF(
 #if defined(Py_REF_DEBUG) && !(defined(Py_LIMITED_API) && Py_LIMITED_API+0 >= 0x030A0000)
     const char *filename, int lineno,
 #endif
@@ -519,9 +519,9 @@ static inline void _Py_DECREF(
 #endif
 }
 #if defined(Py_REF_DEBUG) && !(defined(Py_LIMITED_API) && Py_LIMITED_API+0 >= 0x030A0000)
-#  define Py_DECREF(op) _Py_DECREF(__FILE__, __LINE__, _PyObject_CAST(op))
+#  define Py_DECREF(op) Py_DECREF(__FILE__, __LINE__, _PyObject_CAST(op))
 #else
-#  define Py_DECREF(op) _Py_DECREF(_PyObject_CAST(op))
+#  define Py_DECREF(op) Py_DECREF(_PyObject_CAST(op))
 #endif
 
 
@@ -569,23 +569,23 @@ static inline void _Py_DECREF(
     } while (0)
 
 /* Function to use in case the object pointer can be NULL: */
-static inline void _Py_XINCREF(PyObject *op)
+static inline void Py_XINCREF(PyObject *op)
 {
     if (op != NULL) {
         Py_INCREF(op);
     }
 }
 
-#define Py_XINCREF(op) _Py_XINCREF(_PyObject_CAST(op))
+#define Py_XINCREF(op) Py_XINCREF(_PyObject_CAST(op))
 
-static inline void _Py_XDECREF(PyObject *op)
+static inline void Py_XDECREF(PyObject *op)
 {
     if (op != NULL) {
         Py_DECREF(op);
     }
 }
 
-#define Py_XDECREF(op) _Py_XDECREF(_PyObject_CAST(op))
+#define Py_XDECREF(op) Py_XDECREF(_PyObject_CAST(op))
 
 // Create a new strong reference to an object:
 // increment the reference count of the object and return the object.
@@ -750,17 +750,17 @@ PyType_HasFeature(PyTypeObject *type, unsigned long feature)
 
 #define PyType_FastSubclass(type, flag) PyType_HasFeature(type, flag)
 
-static inline int _PyType_Check(PyObject *op) {
+static inline int PyType_Check(PyObject *op) {
     return PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_TYPE_SUBCLASS);
 }
-#define PyType_Check(op) _PyType_Check(_PyObject_CAST(op))
+#define PyType_Check(op) PyType_Check(_PyObject_CAST(op))
 
 #define _PyType_CAST(op) (assert(PyType_Check(op)), (PyTypeObject*)(op))
 
-static inline int _PyType_CheckExact(PyObject *op) {
+static inline int PyType_CheckExact(PyObject *op) {
     return Py_IS_TYPE(op, &PyType_Type);
 }
-#define PyType_CheckExact(op) _PyType_CheckExact(_PyObject_CAST(op))
+#define PyType_CheckExact(op) PyType_CheckExact(_PyObject_CAST(op))
 
 #ifdef __cplusplus
 }

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1917,7 +1917,7 @@ int
     if (PyAsyncGen_CheckExact(iter)) {
         return SPEC_FAIL_ITER_ASYNC_GENERATOR;
     }
-    PyTypeObject *t = _Py_TYPE(iter);
+    PyTypeObject *t = Py_TYPE(iter);
     if (t == &PyListIter_Type) {
         return SPEC_FAIL_ITER_LIST;
     }


### PR DESCRIPTION
When a static inline function is wrapped by a macro which casts its
arguments to the expected type, there is no need that the function
has a different name than the macro. Use the same name for the macro
and the function to avoid confusion.

Rename _PyUnicode_get_wstr_length() to PyUnicode_WSTR_LENGTH().

Don't rename static inline _Py_NewRef() and _Py_XNewRef() functions,
since the C API exports Py_NewRef() and Py_XNewRef() functions as
regular functions. The name cannot be reused in this case.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45490](https://bugs.python.org/issue45490) -->
https://bugs.python.org/issue45490
<!-- /issue-number -->
