### PR TITLE
bpo-45490: Convert unicodeobject.h macros to static inline functions

### DIFF
--- a/Include/internal/pycore_strhex.h
+++ b/Include/internal/pycore_strhex.h
@@ -22,12 +22,12 @@ PyAPI_FUNC(PyObject*) _Py_strhex_bytes(
 PyAPI_FUNC(PyObject*) _Py_strhex_with_sep(
     const char* argbuf,
     const Py_ssize_t arglen,
-    const PyObject* sep,
+    PyObject* sep,
     const int bytes_per_group);
 PyAPI_FUNC(PyObject*) _Py_strhex_bytes_with_sep(
     const char* argbuf,
     const Py_ssize_t arglen,
-    const PyObject* sep,
+    PyObject* sep,
     const int bytes_per_group);
 
 #ifdef __cplusplus

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1895,7 +1895,7 @@ is_space(enum PyUnicode_Kind kind, const void *data, Py_ssize_t pos)
    Return NULL if malloc fails and an empty string if invalid characters
    are found. */
 static char *
-numeric_as_ascii(const PyObject *u, int strip_ws, int ignore_underscores)
+numeric_as_ascii(PyObject *u, int strip_ws, int ignore_underscores)
 {
     enum PyUnicode_Kind kind;
     const void *data;
@@ -2009,7 +2009,7 @@ PyDecType_FromCStringExact(PyTypeObject *type, const char *s,
 
 /* Return a new PyDecObject or a subtype from a PyUnicodeObject. */
 static PyObject *
-PyDecType_FromUnicode(PyTypeObject *type, const PyObject *u,
+PyDecType_FromUnicode(PyTypeObject *type, PyObject *u,
                       PyObject *context)
 {
     PyObject *dec;
@@ -2029,7 +2029,7 @@ PyDecType_FromUnicode(PyTypeObject *type, const PyObject *u,
  * conversion. If the conversion is not exact, fail with InvalidOperation.
  * Allow leading and trailing whitespace in the input operand. */
 static PyObject *
-PyDecType_FromUnicodeExactWS(PyTypeObject *type, const PyObject *u,
+PyDecType_FromUnicodeExactWS(PyTypeObject *type, PyObject *u,
                              PyObject *context)
 {
     PyObject *dec;

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -505,7 +505,7 @@ nfd_nfkd(PyObject *self, PyObject *input, int k)
     Py_UCS4 *output;
     Py_ssize_t i, o, osize;
     int kind;
-    const void *data;
+    void *data;
     /* Longest decomposition in Unicode 3.2: U+FDFA */
     Py_UCS4 stack[20];
     Py_ssize_t space, isize;

--- a/Objects/stringlib/eq.h
+++ b/Objects/stringlib/eq.h
@@ -4,15 +4,12 @@
  * unicode_eq() is called when the hash of two unicode objects is equal.
  */
 Py_LOCAL_INLINE(int)
-unicode_eq(PyObject *aa, PyObject *bb)
+unicode_eq(PyObject *a, PyObject *b)
 {
-    assert(PyUnicode_Check(aa));
-    assert(PyUnicode_Check(bb));
-    assert(PyUnicode_IS_READY(aa));
-    assert(PyUnicode_IS_READY(bb));
-
-    PyUnicodeObject *a = (PyUnicodeObject *)aa;
-    PyUnicodeObject *b = (PyUnicodeObject *)bb;
+    assert(PyUnicode_Check(a));
+    assert(PyUnicode_Check(b));
+    assert(PyUnicode_IS_READY(a));
+    assert(PyUnicode_IS_READY(b));
 
     if (PyUnicode_GET_LENGTH(a) != PyUnicode_GET_LENGTH(b))
         return 0;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -599,7 +599,7 @@ _PyUnicode_CheckConsistency(PyObject *op, int check_content)
         const void *data;
         Py_UCS4 ch;
 
-        data = PyUnicode_DATA(ascii);
+        data = PyUnicode_DATA(op);
         for (i=0; i < ascii->length; i++)
         {
             ch = PyUnicode_READ(kind, data, i);
@@ -13649,7 +13649,7 @@ unicode_zfill_impl(PyObject *self, Py_ssize_t width)
     Py_ssize_t fill;
     PyObject *u;
     int kind;
-    const void *data;
+    void *data;
     Py_UCS4 chr;
 
     if (PyUnicode_READY(self) == -1)

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -618,7 +618,7 @@ fill_number(_PyUnicodeWriter *writer, const NumberFieldWidths *spec,
     /* Used to keep track of digits, decimal, and remainder. */
     Py_ssize_t d_pos = d_start;
     const unsigned int kind = writer->kind;
-    const void *data = writer->data;
+    void *data = writer->data;
     Py_ssize_t r;
 
     if (spec->n_lpadding) {

--- a/Python/pystrhex.c
+++ b/Python/pystrhex.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>               // abs()
 
 static PyObject *_Py_strhex_impl(const char* argbuf, const Py_ssize_t arglen,
-                                 const PyObject* sep, int bytes_per_sep_group,
+                                 PyObject* sep, int bytes_per_sep_group,
                                  const int return_bytes)
 {
     assert(arglen >= 0);
@@ -159,14 +159,14 @@ PyObject * _Py_strhex_bytes(const char* argbuf, const Py_ssize_t arglen)
 
 /* These variants include support for a separator between every N bytes: */
 
-PyObject * _Py_strhex_with_sep(const char* argbuf, const Py_ssize_t arglen, const PyObject* sep, const int bytes_per_group)
+PyObject* _Py_strhex_with_sep(const char* argbuf, const Py_ssize_t arglen, PyObject* sep, const int bytes_per_group)
 {
     return _Py_strhex_impl(argbuf, arglen, sep, bytes_per_group, 0);
 }
 
 /* Same as above but returns a bytes() instead of str() to avoid the
  * need to decode the str() when bytes are needed. */
-PyObject * _Py_strhex_bytes_with_sep(const char* argbuf, const Py_ssize_t arglen, const PyObject* sep, const int bytes_per_group)
+PyObject* _Py_strhex_bytes_with_sep(const char* argbuf, const Py_ssize_t arglen, PyObject* sep, const int bytes_per_group)
 {
     return _Py_strhex_impl(argbuf, arglen, sep, bytes_per_group, 1);
 }


### PR DESCRIPTION
* Convert unicodeobject.h macros to static inline functions.
* Reorder functions to declare functions before their first usage.
* Add "kind" variable to PyUnicode_READ_CHAR() and
  PyUnicode_MAX_CHAR_VALUE() functions to only call PyUnicode_KIND()
  once.
* PyUnicode_KIND() now returns an "enum PyUnicode_Kind".
* Simplify PyUnicode_GET_SIZE().
* Add assertions to PyUnicode_WRITE() on the max value.
* Add cast macros:

  * _PyASCIIObject_CAST()
  * _PyCompactUnicodeObject_CAST()
  * _PyUnicodeObject_CAST()

* The following functions are now declared as deprecated using
  Py_DEPRECATED(3.3):

  * PyUnicode_GET_SIZE()
  * PyUnicode_GET_DATA_SIZE()
  * PyUnicode_AS_UNICODE()
  * PyUnicode_AS_DATA()
  * The implementation of these functions disable deprecation
    warnings in their body.

* PyUnicode_READ_CHAR() now uses PyUnicode_1BYTE_DATA(),
  PyUnicode_2BYTE_DATA() and PyUnicode_4BYTE_DATA().
* Replace "const PyObject*" with "PyObject*" in _decimal.c
  and pystrhex.c: PyUnicode_READY() can modify the object.
* Replace "const void *data" with "void *data" in some unicodedata.c
  and unicodeobject.c functions which use PyUnicode_WRITE(): data is
  used to modify the string.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45490](https://bugs.python.org/issue45490) -->
https://bugs.python.org/issue45490
<!-- /issue-number -->
