### PR TITLE
bpo-46685: cover `TypeError` of `ForwardRef(1)` in `test_typing`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2792,6 +2792,10 @@ class ForwardRefTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(int, fr)
 
+    def test_forwardref_only_str_arg(self):
+        with self.assertRaises(TypeError):
+            typing.ForwardRef(1)  # only `str` type is allowed
+
     def test_forward_equality(self):
         fr = typing.ForwardRef('int')
         self.assertEqual(fr, typing.ForwardRef('int'))


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/31222

<!-- issue-number: [bpo-46685](https://bugs.python.org/issue46685) -->
https://bugs.python.org/issue46685
<!-- /issue-number -->
