### PR TITLE
bpo-46323: Reduce stack usage of ctypes python callback function.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-10-02-29-12.bpo-46323.HK_cs0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-10-02-29-12.bpo-46323.HK_cs0.rst
@@ -1,0 +1,3 @@
+:mod:`ctypes` now allocates memory on the stack instead of on the heap
+to pass arguments while calling a Python callback function.
+Patch by Dong-hee Na.

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -165,16 +165,12 @@ static void _CallPythonObject(void *mem,
         goto Done;
     }
 
-    PyObject *args_stack[_PY_FASTCALL_SMALL_STACK];
-    if (nargs <= _PY_FASTCALL_SMALL_STACK) {
-        args = args_stack;
+    assert(nargs <= CTYPES_MAX_ARGCOUNT);
+    if (nargs == 0) {
+        args = NULL;
     }
     else {
-        args = (PyObject **)alloca(nargs * sizeof(PyObject *));
-        if (args == NULL) {
-            PyErr_NoMemory();
-            goto Done;
-        }
+        args = alloca(nargs * sizeof(PyObject *));
     }
 
     PyObject **cnvs = PySequence_Fast_ITEMS(converters);

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -13,6 +13,10 @@
 
 #include <stdbool.h>
 
+#ifdef MS_WIN32
+#  include <malloc.h>
+#endif
+
 #include <ffi.h>
 #include "ctypes.h"
 

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -164,17 +164,12 @@ static void _CallPythonObject(void *mem,
 
     assert(PyTuple_Check(converters));
     nargs = PyTuple_GET_SIZE(converters);
-    if (nargs < 0) {
-        PrintError("BUG: PySequence_Length");
-        goto Done;
-    }
-
     assert(nargs <= CTYPES_MAX_ARGCOUNT);
-    if (nargs == 0) {
-        args = NULL;
+    if (nargs > 0) {
+        args = alloca(nargs * sizeof(PyObject *));
     }
     else {
-        args = alloca(nargs * sizeof(PyObject *));
+        args = NULL;
     }
 
     PyObject **cnvs = PySequence_Fast_ITEMS(converters);

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -156,7 +156,6 @@ static void _CallPythonObject(void *mem,
                               void **pArgs)
 {
     PyObject *result = NULL;
-    PyObject **args = NULL;
     Py_ssize_t i = 0, j = 0, nargs = 0;
     PyObject *error_object = NULL;
     int *space;
@@ -165,11 +164,9 @@ static void _CallPythonObject(void *mem,
     assert(PyTuple_Check(converters));
     nargs = PyTuple_GET_SIZE(converters);
     assert(nargs <= CTYPES_MAX_ARGCOUNT);
+    PyObject **args = NULL;
     if (nargs > 0) {
         args = alloca(nargs * sizeof(PyObject *));
-    }
-    else {
-        args = NULL;
     }
 
     PyObject **cnvs = PySequence_Fast_ITEMS(converters);

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1160,11 +1160,7 @@ PyObject *_ctypes_callproc(PPROC pProc,
         return NULL;
     }
 
-    args = (struct argument *)alloca(sizeof(struct argument) * argcount);
-    if (!args) {
-        PyErr_NoMemory();
-        return NULL;
-    }
+    args = alloca(sizeof(struct argument) * argcount);
     memset(args, 0, sizeof(struct argument) * argcount);
     argtype_count = argtypes ? PyTuple_GET_SIZE(argtypes) : 0;
 #ifdef MS_WIN32


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46323](https://bugs.python.org/issue46323) -->
https://bugs.python.org/issue46323
<!-- /issue-number -->

````
Mean +- std dev: [before-vectorcall] 1.29 us +- 0.02 us -> [opt] 1.12 us +- 0.02 us: 1.16x faster

````
````
Mean +- std dev: [main] 1.20 us +- 0.02 us -> [opt] 1.12 us +- 0.02 us: 1.07x faster
````