### PR TITLE
bpo-46072: Output stats as markdown with collapsible sections.

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -480,112 +480,123 @@ initial_counter_value(void) {
 #define SPEC_FAIL_OUT_OF_VERSIONS 3
 #define SPEC_FAIL_OUT_OF_RANGE 4
 #define SPEC_FAIL_EXPECTED_ERROR 5
+#define SPEC_FAIL_WRONG_NUMBER_ARGUMENTS 6
+
+#define SPEC_FAIL_LOAD_GLOBAL_NON_STRING_OR_SPLIT 18
 
 /* Attributes */
 
-#define SPEC_FAIL_NON_STRING_OR_SPLIT 6
-#define SPEC_FAIL_MODULE_ATTR_NOT_FOUND 7
-#define SPEC_FAIL_OVERRIDING_DESCRIPTOR 8
-#define SPEC_FAIL_NON_OVERRIDING_DESCRIPTOR 9
-#define SPEC_FAIL_NOT_DESCRIPTOR 10
-#define SPEC_FAIL_METHOD 11
-#define SPEC_FAIL_MUTABLE_CLASS 12
-#define SPEC_FAIL_PROPERTY 13
-#define SPEC_FAIL_NON_OBJECT_SLOT 14
-#define SPEC_FAIL_READ_ONLY 15
-#define SPEC_FAIL_AUDITED_SLOT 16
-#define SPEC_FAIL_NOT_MANAGED_DICT 17
+#define SPEC_FAIL_ATTR_OVERRIDING_DESCRIPTOR 8
+#define SPEC_FAIL_ATTR_NON_OVERRIDING_DESCRIPTOR 9
+#define SPEC_FAIL_ATTR_NOT_DESCRIPTOR 10
+#define SPEC_FAIL_ATTR_METHOD 11
+#define SPEC_FAIL_ATTR_MUTABLE_CLASS 12
+#define SPEC_FAIL_ATTR_PROPERTY 13
+#define SPEC_FAIL_ATTR_NON_OBJECT_SLOT 14
+#define SPEC_FAIL_ATTR_READ_ONLY 15
+#define SPEC_FAIL_ATTR_AUDITED_SLOT 16
+#define SPEC_FAIL_ATTR_NOT_MANAGED_DICT 17
+#define SPEC_FAIL_ATTR_NON_STRING_OR_SPLIT 18
+#define SPEC_FAIL_ATTR_MODULE_ATTR_NOT_FOUND 19
 
 /* Methods */
 
-#define SPEC_FAIL_IS_ATTR 15
-#define SPEC_FAIL_DICT_SUBCLASS 16
-#define SPEC_FAIL_BUILTIN_CLASS_METHOD 17
-#define SPEC_FAIL_CLASS_METHOD_OBJ 18
-#define SPEC_FAIL_OBJECT_SLOT 19
-#define SPEC_FAIL_HAS_DICT 20
-#define SPEC_FAIL_HAS_MANAGED_DICT 21
-#define SPEC_FAIL_INSTANCE_ATTRIBUTE 22
-#define SPEC_FAIL_METACLASS_ATTRIBUTE 23
+#define SPEC_FAIL_LOAD_METHOD_OVERRIDING_DESCRIPTOR 8
+#define SPEC_FAIL_LOAD_METHOD_NON_OVERRIDING_DESCRIPTOR 9
+#define SPEC_FAIL_LOAD_METHOD_NOT_DESCRIPTOR 10
+#define SPEC_FAIL_LOAD_METHOD_METHOD 11
+#define SPEC_FAIL_LOAD_METHOD_MUTABLE_CLASS 12
+#define SPEC_FAIL_LOAD_METHOD_PROPERTY 13
+#define SPEC_FAIL_LOAD_METHOD_NON_OBJECT_SLOT 14
+#define SPEC_FAIL_LOAD_METHOD_IS_ATTR 15
+#define SPEC_FAIL_LOAD_METHOD_DICT_SUBCLASS 16
+#define SPEC_FAIL_LOAD_METHOD_BUILTIN_CLASS_METHOD 17
+#define SPEC_FAIL_LOAD_METHOD_CLASS_METHOD_OBJ 18
+#define SPEC_FAIL_LOAD_METHOD_OBJECT_SLOT 19
+#define SPEC_FAIL_LOAD_METHOD_HAS_DICT 20
+#define SPEC_FAIL_LOAD_METHOD_HAS_MANAGED_DICT 21
+#define SPEC_FAIL_LOAD_METHOD_INSTANCE_ATTRIBUTE 22
+#define SPEC_FAIL_LOAD_METHOD_METACLASS_ATTRIBUTE 23
 
-/* Binary subscr */
+/* Binary subscr and store subscr */
 
-#define SPEC_FAIL_ARRAY_INT 8
-#define SPEC_FAIL_ARRAY_SLICE 9
-#define SPEC_FAIL_LIST_SLICE 10
-#define SPEC_FAIL_TUPLE_SLICE 11
-#define SPEC_FAIL_STRING_INT 12
-#define SPEC_FAIL_STRING_SLICE 13
-#define SPEC_FAIL_BUFFER_INT 15
-#define SPEC_FAIL_BUFFER_SLICE 16
-#define SPEC_FAIL_SEQUENCE_INT 17
+#define SPEC_FAIL_SUBSCR_ARRAY_INT 8
+#define SPEC_FAIL_SUBSCR_ARRAY_SLICE 9
+#define SPEC_FAIL_SUBSCR_LIST_SLICE 10
+#define SPEC_FAIL_SUBSCR_TUPLE_SLICE 11
+#define SPEC_FAIL_SUBSCR_STRING_INT 12
+#define SPEC_FAIL_SUBSCR_STRING_SLICE 13
+#define SPEC_FAIL_SUBSCR_BUFFER_INT 15
+#define SPEC_FAIL_SUBSCR_BUFFER_SLICE 16
+#define SPEC_FAIL_SUBSCR_SEQUENCE_INT 17
 
 /* Store subscr */
-#define SPEC_FAIL_BYTEARRAY_INT 18
-#define SPEC_FAIL_BYTEARRAY_SLICE 19
-#define SPEC_FAIL_PY_SIMPLE 20
-#define SPEC_FAIL_PY_OTHER 21
-#define SPEC_FAIL_DICT_SUBCLASS_NO_OVERRIDE 22
+#define SPEC_FAIL_SUBSCR_BYTEARRAY_INT 18
+#define SPEC_FAIL_SUBSCR_BYTEARRAY_SLICE 19
+#define SPEC_FAIL_SUBSCR_PY_SIMPLE 20
+#define SPEC_FAIL_SUBSCR_PY_OTHER 21
+#define SPEC_FAIL_SUBSCR_DICT_SUBCLASS_NO_OVERRIDE 22
 
 /* Binary add */
 
-#define SPEC_FAIL_NON_FUNCTION_SCOPE 11
-#define SPEC_FAIL_DIFFERENT_TYPES 12
+#define SPEC_FAIL_BINARY_OP_DIFFERENT_TYPES 12
 
 /* Calls */
-#define SPEC_FAIL_COMPLEX_PARAMETERS 8
-#define SPEC_FAIL_WRONG_NUMBER_ARGUMENTS 9
-#define SPEC_FAIL_CO_NOT_OPTIMIZED 10
+#define SPEC_FAIL_CALL_COMPLEX_PARAMETERS 9
+#define SPEC_FAIL_CALL_CO_NOT_OPTIMIZED 10
 /* SPEC_FAIL_METHOD  defined as 11 above */
 
-#define SPEC_FAIL_PYCFUNCTION 13
-#define SPEC_FAIL_PYCFUNCTION_WITH_KEYWORDS 14
-#define SPEC_FAIL_PYCFUNCTION_FAST_WITH_KEYWORDS 15
-#define SPEC_FAIL_PYCFUNCTION_NOARGS 16
-#define SPEC_FAIL_BAD_CALL_FLAGS 17
-#define SPEC_FAIL_CLASS 18
-#define SPEC_FAIL_PYTHON_CLASS 19
-#define SPEC_FAIL_C_METHOD_CALL 20
-#define SPEC_FAIL_BOUND_METHOD 21
+#define SPEC_FAIL_CALL_INSTANCE_METHOD 11
+#define SPEC_FAIL_CALL_CMETHOD 12
+#define SPEC_FAIL_CALL_PYCFUNCTION 13
+#define SPEC_FAIL_CALL_PYCFUNCTION_WITH_KEYWORDS 14
+#define SPEC_FAIL_CALL_PYCFUNCTION_FAST_WITH_KEYWORDS 15
+#define SPEC_FAIL_CALL_PYCFUNCTION_NOARGS 16
+#define SPEC_FAIL_CALL_BAD_CALL_FLAGS 17
+#define SPEC_FAIL_CALL_CLASS 18
+#define SPEC_FAIL_CALL_PYTHON_CLASS 19
+#define SPEC_FAIL_CALL_C_METHOD_CALL 20
+#define SPEC_FAIL_CALL_BOUND_METHOD 21
 #define SPEC_FAIL_CALL_STR 22
-#define SPEC_FAIL_CLASS_NO_VECTORCALL 23
-#define SPEC_FAIL_CLASS_MUTABLE 24
-#define SPEC_FAIL_KWNAMES 25
-#define SPEC_FAIL_METHOD_WRAPPER 26
-#define SPEC_FAIL_OPERATOR_WRAPPER 27
+#define SPEC_FAIL_CALL_CLASS_NO_VECTORCALL 23
+#define SPEC_FAIL_CALL_CLASS_MUTABLE 24
+#define SPEC_FAIL_CALL_KWNAMES 25
+#define SPEC_FAIL_CALL_METHOD_WRAPPER 26
+#define SPEC_FAIL_CALL_OPERATOR_WRAPPER 27
 
 /* COMPARE_OP */
-#define SPEC_FAIL_STRING_COMPARE 13
-#define SPEC_FAIL_NOT_FOLLOWED_BY_COND_JUMP 14
-#define SPEC_FAIL_BIG_INT 15
-#define SPEC_FAIL_COMPARE_BYTES 16
-#define SPEC_FAIL_COMPARE_TUPLE 17
-#define SPEC_FAIL_COMPARE_LIST 18
-#define SPEC_FAIL_COMPARE_SET 19
-#define SPEC_FAIL_COMPARE_BOOL 20
-#define SPEC_FAIL_COMPARE_BASEOBJECT 21
-#define SPEC_FAIL_COMPARE_FLOAT_LONG 22
-#define SPEC_FAIL_COMPARE_LONG_FLOAT 23
+#define SPEC_FAIL_COMPARE_OP_DIFFERENT_TYPES 12
+#define SPEC_FAIL_COMPARE_OP_STRING 13
+#define SPEC_FAIL_COMPARE_OP_NOT_FOLLOWED_BY_COND_JUMP 14
+#define SPEC_FAIL_COMPARE_OP_BIG_INT 15
+#define SPEC_FAIL_COMPARE_OP_BYTES 16
+#define SPEC_FAIL_COMPARE_OP_TUPLE 17
+#define SPEC_FAIL_COMPARE_OP_LIST 18
+#define SPEC_FAIL_COMPARE_OP_SET 19
+#define SPEC_FAIL_COMPARE_OP_BOOL 20
+#define SPEC_FAIL_COMPARE_OP_BASEOBJECT 21
+#define SPEC_FAIL_COMPARE_OP_FLOAT_LONG 22
+#define SPEC_FAIL_COMPARE_OP_LONG_FLOAT 23
 
 /* FOR_ITER */
-#define SPEC_FAIL_ITER_GENERATOR 10
-#define SPEC_FAIL_ITER_COROUTINE 11
-#define SPEC_FAIL_ITER_ASYNC_GENERATOR 12
-#define SPEC_FAIL_ITER_LIST 13
-#define SPEC_FAIL_ITER_TUPLE 14
-#define SPEC_FAIL_ITER_SET 15
-#define SPEC_FAIL_ITER_STRING 16
-#define SPEC_FAIL_ITER_BYTES 17
-#define SPEC_FAIL_ITER_RANGE 18
-#define SPEC_FAIL_ITER_ITERTOOLS 19
-#define SPEC_FAIL_ITER_DICT_KEYS 20
-#define SPEC_FAIL_ITER_DICT_ITEMS 21
-#define SPEC_FAIL_ITER_DICT_VALUES 22
-#define SPEC_FAIL_ITER_ENUMERATE 23
+#define SPEC_FAIL_FOR_ITER_GENERATOR 10
+#define SPEC_FAIL_FOR_ITER_COROUTINE 11
+#define SPEC_FAIL_FOR_ITER_ASYNC_GENERATOR 12
+#define SPEC_FAIL_FOR_ITER_LIST 13
+#define SPEC_FAIL_FOR_ITER_TUPLE 14
+#define SPEC_FAIL_FOR_ITER_SET 15
+#define SPEC_FAIL_FOR_ITER_STRING 16
+#define SPEC_FAIL_FOR_ITER_BYTES 17
+#define SPEC_FAIL_FOR_ITER_RANGE 18
+#define SPEC_FAIL_FOR_ITER_ITERTOOLS 19
+#define SPEC_FAIL_FOR_ITER_DICT_KEYS 20
+#define SPEC_FAIL_FOR_ITER_DICT_ITEMS 21
+#define SPEC_FAIL_FOR_ITER_DICT_VALUES 22
+#define SPEC_FAIL_FOR_ITER_ENUMERATE 23
 
 /* UNPACK_SEQUENCE */
-#define SPEC_FAIL_TUPLE 10
-#define SPEC_FAIL_LIST 11
+#define SPEC_FAIL_UNPACK_SEQUENCE_TUPLE 10
+#define SPEC_FAIL_UNPACK_SEQUENCE_LIST 11
 
 
 static int
@@ -605,7 +616,7 @@ specialize_module_load_attr(
         return -1;
     }
     if (dict->ma_keys->dk_kind != DICT_KEYS_UNICODE) {
-        SPECIALIZATION_FAIL(opcode, SPEC_FAIL_NON_STRING_OR_SPLIT);
+        SPECIALIZATION_FAIL(opcode, SPEC_FAIL_ATTR_NON_STRING_OR_SPLIT);
         return -1;
     }
     getattr = _PyUnicode_FromId(&PyId___getattr__); /* borrowed */
@@ -617,7 +628,7 @@ specialize_module_load_attr(
     Py_ssize_t index = _PyDict_GetItemHint(dict, getattr, -1,  &value);
     assert(index != DKIX_ERROR);
     if (index != DKIX_EMPTY) {
-        SPECIALIZATION_FAIL(opcode, SPEC_FAIL_MODULE_ATTR_NOT_FOUND);
+        SPECIALIZATION_FAIL(opcode, SPEC_FAIL_ATTR_MODULE_ATTR_NOT_FOUND);
         return -1;
     }
     index = _PyDict_GetItemHint(dict, name, -1, &value);
@@ -727,7 +738,7 @@ specialize_dict_access(
         kind == BUILTIN_CLASSMETHOD || kind == PYTHON_CLASSMETHOD);
     // No descriptor, or non overriding.
     if ((type->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0) {
-        SPECIALIZATION_FAIL(base_op, SPEC_FAIL_NOT_MANAGED_DICT);
+        SPECIALIZATION_FAIL(base_op, SPEC_FAIL_ATTR_NOT_MANAGED_DICT);
         return 0;
     }
     PyObject **dictptr = _PyObject_ManagedDictPointer(owner);
@@ -789,13 +800,13 @@ _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, Sp
     DescriptorClassification kind = analyze_descriptor(type, name, &descr, 0);
     switch(kind) {
         case OVERRIDING:
-            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_OVERRIDING_DESCRIPTOR);
+            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_OVERRIDING_DESCRIPTOR);
             goto fail;
         case METHOD:
-            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_METHOD);
+            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_METHOD);
             goto fail;
         case PROPERTY:
-            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_PROPERTY);
+            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_PROPERTY);
             goto fail;
         case OBJECT_SLOT:
         {
@@ -803,7 +814,7 @@ _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, Sp
             struct PyMemberDef *dmem = member->d_member;
             Py_ssize_t offset = dmem->offset;
             if (dmem->flags & PY_AUDIT_READ) {
-                SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_AUDITED_SLOT);
+                SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_AUDITED_SLOT);
                 goto fail;
             }
             if (offset != (uint16_t)offset) {
@@ -827,10 +838,10 @@ _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, Sp
             goto success;
         }
         case OTHER_SLOT:
-            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_NON_OBJECT_SLOT);
+            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_NON_OBJECT_SLOT);
             goto fail;
         case MUTABLE:
-            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_MUTABLE_CLASS);
+            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_MUTABLE_CLASS);
             goto fail;
         case GETSET_OVERRIDDEN:
             SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_OVERRIDDEN);
@@ -878,13 +889,13 @@ _Py_Specialize_StoreAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, S
     DescriptorClassification kind = analyze_descriptor(type, name, &descr, 1);
     switch(kind) {
         case OVERRIDING:
-            SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_OVERRIDING_DESCRIPTOR);
+            SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_ATTR_OVERRIDING_DESCRIPTOR);
             goto fail;
         case METHOD:
-            SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_METHOD);
+            SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_ATTR_METHOD);
             goto fail;
         case PROPERTY:
-            SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_PROPERTY);
+            SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_ATTR_PROPERTY);
             goto fail;
         case OBJECT_SLOT:
         {
@@ -892,7 +903,7 @@ _Py_Specialize_StoreAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, S
             struct PyMemberDef *dmem = member->d_member;
             Py_ssize_t offset = dmem->offset;
             if (dmem->flags & READONLY) {
-                SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_READ_ONLY);
+                SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_ATTR_READ_ONLY);
                 goto fail;
             }
             if (offset != (uint16_t)offset) {
@@ -908,10 +919,10 @@ _Py_Specialize_StoreAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, S
         }
         case DUNDER_CLASS:
         case OTHER_SLOT:
-            SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_NON_OBJECT_SLOT);
+            SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_ATTR_NON_OBJECT_SLOT);
             goto fail;
         case MUTABLE:
-            SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_MUTABLE_CLASS);
+            SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_ATTR_MUTABLE_CLASS);
             goto fail;
         case GETSET_OVERRIDDEN:
             SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_OVERRIDDEN);
@@ -953,31 +964,31 @@ load_method_fail_kind(DescriptorClassification kind)
 {
     switch (kind) {
         case OVERRIDING:
-            return SPEC_FAIL_OVERRIDING_DESCRIPTOR;
+            return SPEC_FAIL_LOAD_METHOD_OVERRIDING_DESCRIPTOR;
         case METHOD:
-            return SPEC_FAIL_METHOD;
+            return SPEC_FAIL_LOAD_METHOD_METHOD;
         case PROPERTY:
-            return SPEC_FAIL_PROPERTY;
+            return SPEC_FAIL_LOAD_METHOD_PROPERTY;
         case OBJECT_SLOT:
-            return SPEC_FAIL_OBJECT_SLOT;
+            return SPEC_FAIL_LOAD_METHOD_OBJECT_SLOT;
         case OTHER_SLOT:
-            return SPEC_FAIL_NON_OBJECT_SLOT;
+            return SPEC_FAIL_LOAD_METHOD_NON_OBJECT_SLOT;
         case DUNDER_CLASS:
             return SPEC_FAIL_OTHER;
         case MUTABLE:
-            return SPEC_FAIL_MUTABLE_CLASS;
+            return SPEC_FAIL_LOAD_METHOD_MUTABLE_CLASS;
         case GETSET_OVERRIDDEN:
             return SPEC_FAIL_OVERRIDDEN;
         case BUILTIN_CLASSMETHOD:
-            return SPEC_FAIL_BUILTIN_CLASS_METHOD;
+            return SPEC_FAIL_LOAD_METHOD_BUILTIN_CLASS_METHOD;
         case PYTHON_CLASSMETHOD:
-            return SPEC_FAIL_CLASS_METHOD_OBJ;
+            return SPEC_FAIL_LOAD_METHOD_CLASS_METHOD_OBJ;
         case NON_OVERRIDING:
-            return SPEC_FAIL_NON_OVERRIDING_DESCRIPTOR;
+            return SPEC_FAIL_LOAD_METHOD_NON_OVERRIDING_DESCRIPTOR;
         case NON_DESCRIPTOR:
-            return SPEC_FAIL_NOT_DESCRIPTOR;
+            return SPEC_FAIL_LOAD_METHOD_NOT_DESCRIPTOR;
         case ABSENT:
-            return SPEC_FAIL_INSTANCE_ATTRIBUTE;
+            return SPEC_FAIL_LOAD_METHOD_INSTANCE_ATTRIBUTE;
     }
     Py_UNREACHABLE();
 }
@@ -1001,7 +1012,7 @@ specialize_class_load_method(PyObject *owner, _Py_CODEUNIT *instr, PyObject *nam
 #ifdef Py_STATS
         case ABSENT:
             if (_PyType_Lookup(Py_TYPE(owner), name) != NULL) {
-                SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_METACLASS_ATTRIBUTE);
+                SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_LOAD_METHOD_METACLASS_ATTRIBUTE);
             }
             else {
                 SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_EXPECTED_ERROR);
@@ -1057,13 +1068,13 @@ _Py_Specialize_LoadMethod(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, 
     if (owner_cls->tp_flags & Py_TPFLAGS_MANAGED_DICT) {
         PyObject **owner_dictptr = _PyObject_ManagedDictPointer(owner);
         if (*owner_dictptr) {
-            SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_HAS_MANAGED_DICT);
+            SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_LOAD_METHOD_HAS_MANAGED_DICT);
             goto fail;
         }
         PyDictKeysObject *keys = ((PyHeapTypeObject *)owner_cls)->ht_cached_keys;
         Py_ssize_t index = _PyDictKeys_StringLookup(keys, name);
         if (index != DKIX_EMPTY) {
-            SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_IS_ATTR);
+            SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_LOAD_METHOD_IS_ATTR);
             goto fail;
         }
         uint32_t keys_version = _PyDictKeys_GetVersionForCurrentState(keys);
@@ -1079,7 +1090,7 @@ _Py_Specialize_LoadMethod(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, 
             *instr = _Py_MAKECODEUNIT(LOAD_METHOD_NO_DICT, _Py_OPARG(*instr));
         }
         else {
-            SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_HAS_DICT);
+            SPECIALIZATION_FAIL(LOAD_METHOD, SPEC_FAIL_LOAD_METHOD_HAS_DICT);
             goto fail;
         }
     }
@@ -1128,7 +1139,7 @@ _Py_Specialize_LoadGlobal(
     PyDictKeysObject * globals_keys = ((PyDictObject *)globals)->ma_keys;
     Py_ssize_t index = _PyDictKeys_StringLookup(globals_keys, name);
     if (index == DKIX_ERROR) {
-        SPECIALIZATION_FAIL(LOAD_GLOBAL, SPEC_FAIL_NON_STRING_OR_SPLIT);
+        SPECIALIZATION_FAIL(LOAD_GLOBAL, SPEC_FAIL_LOAD_GLOBAL_NON_STRING_OR_SPLIT);
         goto fail;
     }
     if (index != DKIX_EMPTY) {
@@ -1150,7 +1161,7 @@ _Py_Specialize_LoadGlobal(
     PyDictKeysObject * builtin_keys = ((PyDictObject *)builtins)->ma_keys;
     index = _PyDictKeys_StringLookup(builtin_keys, name);
     if (index == DKIX_ERROR) {
-        SPECIALIZATION_FAIL(LOAD_GLOBAL, SPEC_FAIL_NON_STRING_OR_SPLIT);
+        SPECIALIZATION_FAIL(LOAD_GLOBAL, SPEC_FAIL_LOAD_GLOBAL_NON_STRING_OR_SPLIT);
         goto fail;
     }
     if (index != (uint16_t)index) {
@@ -1189,34 +1200,34 @@ binary_subscr_fail_kind(PyTypeObject *container_type, PyObject *sub)
 {
     if (container_type == &PyUnicode_Type) {
         if (PyLong_CheckExact(sub)) {
-            return SPEC_FAIL_STRING_INT;
+            return SPEC_FAIL_SUBSCR_STRING_INT;
         }
         if (PySlice_Check(sub)) {
-            return SPEC_FAIL_STRING_SLICE;
+            return SPEC_FAIL_SUBSCR_STRING_SLICE;
         }
         return SPEC_FAIL_OTHER;
     }
     else if (strcmp(container_type->tp_name, "array.array") == 0) {
         if (PyLong_CheckExact(sub)) {
-            return SPEC_FAIL_ARRAY_INT;
+            return SPEC_FAIL_SUBSCR_ARRAY_INT;
         }
         if (PySlice_Check(sub)) {
-            return SPEC_FAIL_ARRAY_SLICE;
+            return SPEC_FAIL_SUBSCR_ARRAY_SLICE;
         }
         return SPEC_FAIL_OTHER;
     }
     else if (container_type->tp_as_buffer) {
         if (PyLong_CheckExact(sub)) {
-            return SPEC_FAIL_BUFFER_INT;
+            return SPEC_FAIL_SUBSCR_BUFFER_INT;
         }
         if (PySlice_Check(sub)) {
-            return SPEC_FAIL_BUFFER_SLICE;
+            return SPEC_FAIL_SUBSCR_BUFFER_SLICE;
         }
         return SPEC_FAIL_OTHER;
     }
     else if (container_type->tp_as_sequence) {
         if (PyLong_CheckExact(sub) && container_type->tp_as_sequence->sq_item) {
-            return SPEC_FAIL_SEQUENCE_INT;
+            return SPEC_FAIL_SUBSCR_SEQUENCE_INT;
         }
     }
     return SPEC_FAIL_OTHER;
@@ -1231,10 +1242,10 @@ static int
 function_kind(PyCodeObject *code) {
     int flags = code->co_flags;
     if ((flags & (CO_VARKEYWORDS | CO_VARARGS)) || code->co_kwonlyargcount) {
-        return SPEC_FAIL_COMPLEX_PARAMETERS;
+        return SPEC_FAIL_CALL_COMPLEX_PARAMETERS;
     }
     if ((flags & CO_OPTIMIZED) == 0) {
-        return SPEC_FAIL_CO_NOT_OPTIMIZED;
+        return SPEC_FAIL_CALL_CO_NOT_OPTIMIZED;
     }
     return SIMPLE_FUNCTION;
 }
@@ -1251,7 +1262,7 @@ _Py_Specialize_BinarySubscr(
             goto success;
         }
         SPECIALIZATION_FAIL(BINARY_SUBSCR,
-            PySlice_Check(sub) ? SPEC_FAIL_LIST_SLICE : SPEC_FAIL_OTHER);
+            PySlice_Check(sub) ? SPEC_FAIL_SUBSCR_LIST_SLICE : SPEC_FAIL_OTHER);
         goto fail;
     }
     if (container_type == &PyTuple_Type) {
@@ -1260,7 +1271,7 @@ _Py_Specialize_BinarySubscr(
             goto success;
         }
         SPECIALIZATION_FAIL(BINARY_SUBSCR,
-            PySlice_Check(sub) ? SPEC_FAIL_TUPLE_SLICE : SPEC_FAIL_OTHER);
+            PySlice_Check(sub) ? SPEC_FAIL_SUBSCR_TUPLE_SLICE : SPEC_FAIL_OTHER);
         goto fail;
     }
     if (container_type == &PyDict_Type) {
@@ -1326,7 +1337,7 @@ _Py_Specialize_StoreSubscr(PyObject *container, PyObject *sub, _Py_CODEUNIT *ins
             }
         }
         else if (PySlice_Check(sub)) {
-            SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_LIST_SLICE);
+            SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_SUBSCR_LIST_SLICE);
             goto fail;
         }
         else {
@@ -1343,7 +1354,7 @@ _Py_Specialize_StoreSubscr(PyObject *container, PyObject *sub, _Py_CODEUNIT *ins
     PyMappingMethods *as_mapping = container_type->tp_as_mapping;
     if (as_mapping && (as_mapping->mp_ass_subscript
                        == PyDict_Type.tp_as_mapping->mp_ass_subscript)) {
-        SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_DICT_SUBCLASS_NO_OVERRIDE);
+        SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_SUBSCR_DICT_SUBCLASS_NO_OVERRIDE);
         goto fail;
     }
     if (PyObject_CheckBuffer(container)) {
@@ -1352,10 +1363,10 @@ _Py_Specialize_StoreSubscr(PyObject *container, PyObject *sub, _Py_CODEUNIT *ins
         }
         else if (strcmp(container_type->tp_name, "array.array") == 0) {
             if (PyLong_CheckExact(sub)) {
-                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_ARRAY_INT);
+                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_SUBSCR_ARRAY_INT);
             }
             else if (PySlice_Check(sub)) {
-                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_ARRAY_SLICE);
+                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_SUBSCR_ARRAY_SLICE);
             }
             else {
                 SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_OTHER);
@@ -1363,10 +1374,10 @@ _Py_Specialize_StoreSubscr(PyObject *container, PyObject *sub, _Py_CODEUNIT *ins
         }
         else if (PyByteArray_CheckExact(container)) {
             if (PyLong_CheckExact(sub)) {
-                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_BYTEARRAY_INT);
+                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_SUBSCR_BYTEARRAY_INT);
             }
             else if (PySlice_Check(sub)) {
-                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_BYTEARRAY_SLICE);
+                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_SUBSCR_BYTEARRAY_SLICE);
             }
             else {
                 SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_OTHER);
@@ -1374,10 +1385,10 @@ _Py_Specialize_StoreSubscr(PyObject *container, PyObject *sub, _Py_CODEUNIT *ins
         }
         else {
             if (PyLong_CheckExact(sub)) {
-                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_BUFFER_INT);
+                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_SUBSCR_BUFFER_INT);
             }
             else if (PySlice_Check(sub)) {
-                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_BUFFER_SLICE);
+                SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_SUBSCR_BUFFER_SLICE);
             }
             else {
                 SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_OTHER);
@@ -1392,10 +1403,10 @@ _Py_Specialize_StoreSubscr(PyObject *container, PyObject *sub, _Py_CODEUNIT *ins
         PyCodeObject *code = (PyCodeObject *)func->func_code;
         int kind = function_kind(code);
         if (kind == SIMPLE_FUNCTION) {
-            SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_PY_SIMPLE);
+            SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_SUBSCR_PY_SIMPLE);
         }
         else {
-            SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_PY_OTHER);
+            SPECIALIZATION_FAIL(STORE_SUBSCR, SPEC_FAIL_SUBSCR_PY_OTHER);
         }
         goto fail;
     }
@@ -1419,7 +1430,7 @@ specialize_class_call(
 {
     PyTypeObject *tp = _PyType_CAST(callable);
     if (tp->tp_new == PyBaseObject_Type.tp_new) {
-        SPECIALIZATION_FAIL(CALL, SPEC_FAIL_PYTHON_CLASS);
+        SPECIALIZATION_FAIL(CALL, SPEC_FAIL_CALL_PYTHON_CLASS);
         return -1;
     }
     if (tp->tp_flags & Py_TPFLAGS_IMMUTABLETYPE) {
@@ -1442,10 +1453,10 @@ specialize_class_call(
             return 0;
         }
         SPECIALIZATION_FAIL(CALL, tp == &PyUnicode_Type ?
-            SPEC_FAIL_CALL_STR : SPEC_FAIL_CLASS_NO_VECTORCALL);
+            SPEC_FAIL_CALL_STR : SPEC_FAIL_CALL_CLASS_NO_VECTORCALL);
         return -1;
     }
-    SPECIALIZATION_FAIL(CALL, SPEC_FAIL_CLASS_MUTABLE);
+    SPECIALIZATION_FAIL(CALL, SPEC_FAIL_CALL_CLASS_MUTABLE);
     return -1;
 }
 
@@ -1456,19 +1467,19 @@ builtin_call_fail_kind(int ml_flags)
     switch (ml_flags & (METH_VARARGS | METH_FASTCALL | METH_NOARGS | METH_O |
         METH_KEYWORDS | METH_METHOD)) {
         case METH_VARARGS:
-            return SPEC_FAIL_PYCFUNCTION;
+            return SPEC_FAIL_CALL_PYCFUNCTION;
         case METH_VARARGS | METH_KEYWORDS:
-            return SPEC_FAIL_PYCFUNCTION_WITH_KEYWORDS;
+            return SPEC_FAIL_CALL_PYCFUNCTION_WITH_KEYWORDS;
         case METH_FASTCALL | METH_KEYWORDS:
-            return SPEC_FAIL_PYCFUNCTION_FAST_WITH_KEYWORDS;
+            return SPEC_FAIL_CALL_PYCFUNCTION_FAST_WITH_KEYWORDS;
         case METH_NOARGS:
-            return SPEC_FAIL_PYCFUNCTION_NOARGS;
+            return SPEC_FAIL_CALL_PYCFUNCTION_NOARGS;
         /* This case should never happen with PyCFunctionObject -- only
             PyMethodObject. See zlib.compressobj()'s methods for an example.
         */
         case METH_METHOD | METH_FASTCALL | METH_KEYWORDS:
         default:
-            return SPEC_FAIL_BAD_CALL_FLAGS;
+            return SPEC_FAIL_CALL_BAD_CALL_FLAGS;
     }
 }
 #endif
@@ -1482,7 +1493,7 @@ specialize_method_descriptor(
     int nargs, PyObject *kwnames, SpecializedCacheEntry *cache)
 {
     if (kwnames) {
-        SPECIALIZATION_FAIL(CALL, SPEC_FAIL_KWNAMES);
+        SPECIALIZATION_FAIL(CALL, SPEC_FAIL_CALL_KWNAMES);
         return -1;
     }
     if (_list_append == NULL) {
@@ -1536,7 +1547,7 @@ specialize_py_call(
     PyCodeObject *code = (PyCodeObject *)func->func_code;
     int kind = function_kind(code);
     if (kwnames) {
-        SPECIALIZATION_FAIL(CALL, SPEC_FAIL_KWNAMES);
+        SPECIALIZATION_FAIL(CALL, SPEC_FAIL_CALL_KWNAMES);
         return -1;
     }
     if (kind != SIMPLE_FUNCTION) {
@@ -1593,7 +1604,7 @@ specialize_c_call(PyObject *callable, _Py_CODEUNIT *instr, int nargs,
         METH_KEYWORDS | METH_METHOD)) {
         case METH_O: {
             if (kwnames) {
-                SPECIALIZATION_FAIL(CALL, SPEC_FAIL_KWNAMES);
+                SPECIALIZATION_FAIL(CALL, SPEC_FAIL_CALL_KWNAMES);
                 return -1;
             }
             if (nargs != 1) {
@@ -1614,7 +1625,7 @@ specialize_c_call(PyObject *callable, _Py_CODEUNIT *instr, int nargs,
         }
         case METH_FASTCALL: {
             if (kwnames) {
-                SPECIALIZATION_FAIL(CALL, SPEC_FAIL_KWNAMES);
+                SPECIALIZATION_FAIL(CALL, SPEC_FAIL_CALL_KWNAMES);
                 return -1;
             }
             if (nargs == 2) {
@@ -1649,26 +1660,23 @@ static int
 call_fail_kind(PyObject *callable)
 {
     if (PyInstanceMethod_Check(callable)) {
-        return SPEC_FAIL_METHOD;
+        return SPEC_FAIL_CALL_INSTANCE_METHOD;
     }
     else if (PyMethod_Check(callable)) {
-        return SPEC_FAIL_METHOD;
+        return SPEC_FAIL_CALL_BOUND_METHOD;
     }
     // builtin method
     else if (PyCMethod_Check(callable)) {
-        return SPEC_FAIL_METHOD;
+        return SPEC_FAIL_CALL_CMETHOD;
     }
     else if (PyType_Check(callable)) {
-        return  SPEC_FAIL_CLASS;
+        return  SPEC_FAIL_CALL_CLASS;
     }
     else if (Py_TYPE(callable) == &PyWrapperDescr_Type) {
-        return SPEC_FAIL_OPERATOR_WRAPPER;
+        return SPEC_FAIL_CALL_OPERATOR_WRAPPER;
     }
     else if (Py_TYPE(callable) == &_PyMethodWrapper_Type) {
-        return SPEC_FAIL_METHOD_WRAPPER;
-    }
-    else if (Py_TYPE(callable) == &PyMethod_Type) {
-        return SPEC_FAIL_BOUND_METHOD;
+        return SPEC_FAIL_CALL_METHOD_WRAPPER;
     }
     return SPEC_FAIL_OTHER;
 }
@@ -1724,7 +1732,7 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
         case NB_ADD:
         case NB_INPLACE_ADD:
             if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
-                SPECIALIZATION_FAIL(BINARY_OP, SPEC_FAIL_DIFFERENT_TYPES);
+                SPECIALIZATION_FAIL(BINARY_OP, SPEC_FAIL_BINARY_OP_DIFFERENT_TYPES);
                 goto failure;
             }
             if (PyUnicode_CheckExact(lhs)) {
@@ -1750,7 +1758,7 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
         case NB_MULTIPLY:
         case NB_INPLACE_MULTIPLY:
             if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
-                SPECIALIZATION_FAIL(BINARY_OP, SPEC_FAIL_DIFFERENT_TYPES);
+                SPECIALIZATION_FAIL(BINARY_OP, SPEC_FAIL_BINARY_OP_DIFFERENT_TYPES);
                 goto failure;
             }
             if (PyLong_CheckExact(lhs)) {
@@ -1767,7 +1775,7 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
         case NB_SUBTRACT:
         case NB_INPLACE_SUBTRACT:
             if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
-                SPECIALIZATION_FAIL(BINARY_OP, SPEC_FAIL_DIFFERENT_TYPES);
+                SPECIALIZATION_FAIL(BINARY_OP, SPEC_FAIL_BINARY_OP_DIFFERENT_TYPES);
                 goto failure;
             }
             if (PyLong_CheckExact(lhs)) {
@@ -1804,30 +1812,30 @@ compare_op_fail_kind(PyObject *lhs, PyObject *rhs)
 {
     if (Py_TYPE(lhs) != Py_TYPE(rhs)) {
         if (PyFloat_CheckExact(lhs) && PyLong_CheckExact(rhs)) {
-            return SPEC_FAIL_COMPARE_FLOAT_LONG;
+            return SPEC_FAIL_COMPARE_OP_FLOAT_LONG;
         }
         if (PyLong_CheckExact(lhs) && PyFloat_CheckExact(rhs)) {
-            return SPEC_FAIL_COMPARE_LONG_FLOAT;
+            return SPEC_FAIL_COMPARE_OP_LONG_FLOAT;
         }
-        return SPEC_FAIL_DIFFERENT_TYPES;
+        return SPEC_FAIL_COMPARE_OP_DIFFERENT_TYPES;
     }
     if (PyBytes_CheckExact(lhs)) {
-        return SPEC_FAIL_COMPARE_BYTES;
+        return SPEC_FAIL_COMPARE_OP_BYTES;
     }
     if (PyTuple_CheckExact(lhs)) {
-        return SPEC_FAIL_COMPARE_TUPLE;
+        return SPEC_FAIL_COMPARE_OP_TUPLE;
     }
     if (PyList_CheckExact(lhs)) {
-        return SPEC_FAIL_COMPARE_LIST;
+        return SPEC_FAIL_COMPARE_OP_LIST;
     }
     if (PySet_CheckExact(lhs) || PyFrozenSet_CheckExact(lhs)) {
-        return SPEC_FAIL_COMPARE_SET;
+        return SPEC_FAIL_COMPARE_OP_SET;
     }
     if (PyBool_Check(lhs)) {
-        return SPEC_FAIL_COMPARE_BOOL;
+        return SPEC_FAIL_COMPARE_OP_BOOL;
     }
     if (Py_TYPE(lhs)->tp_richcompare == PyBaseObject_Type.tp_richcompare) {
-        return SPEC_FAIL_COMPARE_BASEOBJECT;
+        return SPEC_FAIL_COMPARE_OP_BASEOBJECT;
     }
     return SPEC_FAIL_OTHER;
 }
@@ -1855,7 +1863,7 @@ _Py_Specialize_CompareOp(PyObject *lhs, PyObject *rhs,
     int next_opcode = _Py_OPCODE(instr[1]);
     if (next_opcode != POP_JUMP_IF_FALSE && next_opcode != POP_JUMP_IF_TRUE) {
         // Can't ever combine, so don't don't bother being adaptive.
-        SPECIALIZATION_FAIL(COMPARE_OP, SPEC_FAIL_NOT_FOLLOWED_BY_COND_JUMP);
+        SPECIALIZATION_FAIL(COMPARE_OP, SPEC_FAIL_COMPARE_OP_NOT_FOLLOWED_BY_COND_JUMP);
         *instr = _Py_MAKECODEUNIT(COMPARE_OP, adaptive->original_oparg);
         goto failure;
     }
@@ -1880,13 +1888,13 @@ _Py_Specialize_CompareOp(PyObject *lhs, PyObject *rhs,
             goto success;
         }
         else {
-            SPECIALIZATION_FAIL(COMPARE_OP, SPEC_FAIL_BIG_INT);
+            SPECIALIZATION_FAIL(COMPARE_OP, SPEC_FAIL_COMPARE_OP_BIG_INT);
             goto failure;
         }
     }
     if (PyUnicode_CheckExact(lhs)) {
         if (op != Py_EQ && op != Py_NE) {
-            SPECIALIZATION_FAIL(COMPARE_OP, SPEC_FAIL_STRING_COMPARE);
+            SPECIALIZATION_FAIL(COMPARE_OP, SPEC_FAIL_COMPARE_OP_STRING);
             goto failure;
         }
         else {
@@ -1909,48 +1917,48 @@ int
  _PySpecialization_ClassifyIterator(PyObject *iter)
 {
     if (PyGen_CheckExact(iter)) {
-        return SPEC_FAIL_ITER_GENERATOR;
+        return SPEC_FAIL_FOR_ITER_GENERATOR;
     }
     if (PyCoro_CheckExact(iter)) {
-        return SPEC_FAIL_ITER_COROUTINE;
+        return SPEC_FAIL_FOR_ITER_COROUTINE;
     }
     if (PyAsyncGen_CheckExact(iter)) {
-        return SPEC_FAIL_ITER_ASYNC_GENERATOR;
+        return SPEC_FAIL_FOR_ITER_ASYNC_GENERATOR;
     }
     PyTypeObject *t = _Py_TYPE(iter);
     if (t == &PyListIter_Type) {
-        return SPEC_FAIL_ITER_LIST;
+        return SPEC_FAIL_FOR_ITER_LIST;
     }
     if (t == &PyTupleIter_Type) {
-        return SPEC_FAIL_ITER_TUPLE;
+        return SPEC_FAIL_FOR_ITER_TUPLE;
     }
     if (t == &PyDictIterKey_Type) {
-        return SPEC_FAIL_ITER_DICT_KEYS;
+        return SPEC_FAIL_FOR_ITER_DICT_KEYS;
     }
     if (t == &PyDictIterValue_Type) {
-        return SPEC_FAIL_ITER_DICT_VALUES;
+        return SPEC_FAIL_FOR_ITER_DICT_VALUES;
     }
     if (t == &PyDictIterItem_Type) {
-        return SPEC_FAIL_ITER_DICT_ITEMS;
+        return SPEC_FAIL_FOR_ITER_DICT_ITEMS;
     }
     if (t == &PySetIter_Type) {
-        return SPEC_FAIL_ITER_SET;
+        return SPEC_FAIL_FOR_ITER_SET;
     }
     if (t == &PyUnicodeIter_Type) {
-        return SPEC_FAIL_ITER_STRING;
+        return SPEC_FAIL_FOR_ITER_STRING;
     }
     if (t == &PyBytesIter_Type) {
-        return SPEC_FAIL_ITER_BYTES;
+        return SPEC_FAIL_FOR_ITER_BYTES;
     }
     if (t == &PyRangeIter_Type) {
-        return SPEC_FAIL_ITER_RANGE;
+        return SPEC_FAIL_FOR_ITER_RANGE;
     }
     if (t == &PyEnum_Type) {
-        return SPEC_FAIL_ITER_ENUMERATE;
+        return SPEC_FAIL_FOR_ITER_ENUMERATE;
     }
 
     if (strncmp(t->tp_name, "itertools", 8) == 0) {
-        return SPEC_FAIL_ITER_ITERTOOLS;
+        return SPEC_FAIL_FOR_ITER_ITERTOOLS;
     }
     return SPEC_FAIL_OTHER;
 }
@@ -1959,10 +1967,10 @@ int
 _PySpecialization_ClassifySequence(PyObject *seq)
 {
     if (PyTuple_CheckExact(seq)) {
-        return SPEC_FAIL_TUPLE;
+        return SPEC_FAIL_UNPACK_SEQUENCE_TUPLE;
     }
     if (PyList_CheckExact(seq)) {
-        return SPEC_FAIL_LIST;
+        return SPEC_FAIL_UNPACK_SEQUENCE_LIST;
     }
     return SPEC_FAIL_OTHER;
 }

--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -31,47 +31,47 @@ def print_specialization_stats(name, family_stats, defines):
     total = sum(family_stats.get(kind, 0) for kind in TOTAL)
     if total == 0:
         return
-    print_title(name, 3)
-    rows = []
-    for key in sorted(family_stats):
-        if key.startswith("specialization.failure_kinds"):
-            continue
-        if key.startswith("specialization."):
+    with Section(name, 3, f"specialization stats for {name} family"):
+        rows = []
+        for key in sorted(family_stats):
+            if key.startswith("specialization.failure_kinds"):
+                continue
+            if key.startswith("specialization."):
+                label = key[len("specialization."):]
+            elif key == "execution_count":
+                label = "unquickened"
+            else:
+                label = key
+            if key not in ("specialization.success",  "specialization.failure", "specializable"):
+                rows.append((f"{label:>12}", f"{family_stats[key]:>12}", f"{100*family_stats[key]/total:0.1f}%"))
+        emit_table(("Kind", "Count", "Ratio"), rows)
+        print_title("Specialization attempts", 4)
+        total_attempts = 0
+        for key in ("specialization.success",  "specialization.failure"):
+            total_attempts += family_stats.get(key, 0)
+        rows = []
+        for key in ("specialization.success",  "specialization.failure"):
             label = key[len("specialization."):]
-        elif key == "execution_count":
-            label = "unquickened"
-        else:
-            label = key
-        if key not in ("specialization.success",  "specialization.failure", "specializable"):
-            rows.append((f"{label:>12}", f"{family_stats[key]:>12}", f"{100*family_stats[key]/total:0.1f}%"))
-    emit_table(("Kind", "Count", "Ratio"), rows)
-    print_title("Specialization attempts", 4)
-    total_attempts = 0
-    for key in ("specialization.success",  "specialization.failure"):
-        total_attempts += family_stats.get(key, 0)
-    rows = []
-    for key in ("specialization.success",  "specialization.failure"):
-        label = key[len("specialization."):]
-        label = label[0].upper() + label[1:]
-        val = family_stats.get(key, 0)
-        rows.append((label, val, f"{100*val/total_attempts:0.1f}%"))
-    emit_table(("", "Count", "Ratio"), rows)
-    total_failures = family_stats.get("specialization.failure", 0)
-    failure_kinds = [ 0 ] * 30
-    for key in family_stats:
-        if not key.startswith("specialization.failure_kind"):
-            continue
-        _, index = key[:-1].split("[")
-        index =  int(index)
-        failure_kinds[index] = family_stats[key]
-    failures = [(value, index) for (index, value) in enumerate(failure_kinds)]
-    failures.sort(reverse=True)
-    rows = []
-    for value, index in failures:
-        if not value:
-            continue
-        rows.append((kind_to_text(index, defines, name), value, f"{100*value/total_failures:0.1f}%"))
-    emit_table(("Failure kind", "Count", "Ratio"), rows)
+            label = label[0].upper() + label[1:]
+            val = family_stats.get(key, 0)
+            rows.append((label, val, f"{100*val/total_attempts:0.1f}%"))
+        emit_table(("", "Count", "Ratio"), rows)
+        total_failures = family_stats.get("specialization.failure", 0)
+        failure_kinds = [ 0 ] * 30
+        for key in family_stats:
+            if not key.startswith("specialization.failure_kind"):
+                continue
+            _, index = key[:-1].split("[")
+            index =  int(index)
+            failure_kinds[index] = family_stats[key]
+        failures = [(value, index) for (index, value) in enumerate(failure_kinds)]
+        failures.sort(reverse=True)
+        rows = []
+        for value, index in failures:
+            if not value:
+                continue
+            rows.append((kind_to_text(index, defines, name), value, f"{100*value/total_failures:0.1f}%"))
+        emit_table(("Failure kind", "Count", "Ratio"), rows)
 
 def gather_stats():
     stats = collections.Counter()


### PR DESCRIPTION
Stats now look like this:



## Execution counts

<details>
<summary> execution counts for all instructions </summary>

| Name | Count | Self | Cumulative | Miss ratio |
| --- | --- | --- | --- | --- |
| LOAD_FAST | 10015908847 | 13.9% | 13.9% |  |
| LOAD_CONST | 3527515262 | 4.9% | 18.9% |  |
| STORE_FAST__LOAD_FAST | 3282963275 | 4.6% | 23.4% |  |
| LOAD_FAST__LOAD_FAST | 3053500998 | 4.3% | 27.7% |  |
| LOAD_ATTR_INSTANCE_VALUE | 2619242897 | 3.6% | 31.3% | 1.6% |
| RESUME | 2189727369 | 3.0% | 34.4% |  |
| PRECALL_FUNCTION | 2145301389 | 3.0% | 37.4% |  |
| PRECALL_METHOD | 2078128416 | 2.9% | 40.3% |  |
| STORE_FAST__STORE_FAST | 2053133282 | 2.9% | 43.1% |  |
| RETURN_VALUE | 1978483339 | 2.8% | 45.9% |  |
| POP_JUMP_IF_FALSE | 1727419292 | 2.4% | 48.3% |  |
| FOR_ITER | 1637424853 | 2.3% | 50.6% |  |
| LOAD_FAST__LOAD_CONST | 1563374197 | 2.2% | 52.7% |  |
| BINARY_OP_ADD_INT | 1503815388 | 2.1% | 54.8% | 0.0% |
| JUMP_ABSOLUTE_QUICK | 1412971196 | 2.0% | 56.8% |  |
| LOAD_GLOBAL_BUILTIN | 1399179490 | 1.9% | 58.7% | 0.6% |
| SWAP | 1297004089 | 1.8% | 60.5% |  |
| COPY | 1254900580 | 1.7% | 62.3% |  |
| BINARY_SUBSCR_ADAPTIVE | 1252617878 | 1.7% | 64.0% |  |
| COMPARE_OP_INT_JUMP | 1207955445 | 1.7% | 65.7% | 0.0% |
| LOAD_GLOBAL_MODULE | 1207001561 | 1.7% | 67.4% | 0.3% |
| STORE_FAST | 1200906582 | 1.7% | 69.1% |  |
| POP_TOP | 1161459114 | 1.6% | 70.7% |  |
| CALL_PY_EXACT_ARGS | 1098770282 | 1.5% | 72.2% | 4.2% |
| BINARY_SUBSCR_LIST_INT | 1088718270 | 1.5% | 73.7% | 1.1% |
| UNPACK_SEQUENCE | 932705567 | 1.3% | 75.0% |  |
| BINARY_OP_MULTIPLY_FLOAT | 879473594 | 1.2% | 76.3% | 1.0% |
| LOAD_METHOD_NO_DICT | 877108561 | 1.2% | 77.5% | 0.7% |
| CALL_ADAPTIVE | 875748958 | 1.2% | 78.7% |  |
| LOAD_METHOD_CACHED | 818676036 | 1.1% | 79.8% | 3.0% |
| BINARY_OP | 689223617 | 1.0% | 80.8% |  |
| STORE_SUBSCR_ADAPTIVE | 668109415 | 0.9% | 81.7% |  |
| LOAD_ATTR_ADAPTIVE | 631678564 | 0.9% | 82.6% |  |
| LOAD_CONST__LOAD_FAST | 596799528 | 0.8% | 83.4% |  |
| POP_JUMP_IF_TRUE | 558869963 | 0.8% | 84.2% |  |
| BINARY_OP_ADD_FLOAT | 550543032 | 0.8% | 85.0% | 1.3% |
| STORE_ATTR_INSTANCE_VALUE | 502909879 | 0.7% | 85.7% | 1.3% |
| CALL_NO_KW_METHOD_DESCRIPTOR_FAST | 485748209 | 0.7% | 86.4% |  |
| BINARY_OP_SUBTRACT_INT | 460030754 | 0.6% | 87.0% | 0.6% |
| BUILD_SLICE | 436521266 | 0.6% | 87.6% |  |
| LOAD_DEREF | 405856260 | 0.6% | 88.2% |  |
| CALL_NO_KW_BUILTIN_O | 373793491 | 0.5% | 88.7% | 0.5% |
| STORE_SUBSCR_LIST_INT | 365835186 | 0.5% | 89.2% |  |
| BINARY_OP_SUBTRACT_FLOAT | 354202390 | 0.5% | 89.7% | 2.9% |
| JUMP_FORWARD | 344646404 | 0.5% | 90.2% |  |
| CALL_NO_KW_ISINSTANCE | 309611126 | 0.4% | 90.6% |  |
| LOAD_METHOD_ADAPTIVE | 282533823 | 0.4% | 91.0% |  |
| LOAD_ATTR_WITH_HINT | 282161080 | 0.4% | 91.4% | 4.9% |
| BINARY_OP_ADAPTIVE | 279513150 | 0.4% | 91.8% |  |
| CONTAINS_OP | 255213989 | 0.4% | 92.1% |  |
| BUILD_TUPLE | 253914017 | 0.4% | 92.5% |  |
| CALL_NO_KW_LEN | 248031824 | 0.3% | 92.8% |  |
| GET_ITER | 244880997 | 0.3% | 93.2% |  |
| IS_OP | 241918939 | 0.3% | 93.5% |  |
| LOAD_ATTR_SLOT | 238559188 | 0.3% | 93.8% | 11.3% |
| BINARY_OP_MULTIPLY_INT | 232387235 | 0.3% | 94.2% | 0.8% |
| CALL_NO_KW_BUILTIN_FAST | 226225668 | 0.3% | 94.5% | 0.0% |
| NOP | 215479641 | 0.3% | 94.8% |  |
| YIELD_VALUE | 207842584 | 0.3% | 95.1% |  |
| EXTENDED_ARG | 207593435 | 0.3% | 95.4% |  |
| POP_JUMP_IF_NONE | 180809328 | 0.3% | 95.6% |  |
| COMPARE_OP | 177263861 | 0.2% | 95.9% |  |
| POP_JUMP_IF_NOT_NONE | 161641966 | 0.2% | 96.1% |  |
| BINARY_SUBSCR_GETITEM | 144772769 | 0.2% | 96.3% | 0.0% |
| COMPARE_OP_ADAPTIVE | 127146855 | 0.2% | 96.5% |  |
| CALL_NO_KW_LIST_APPEND | 123929865 | 0.2% | 96.6% |  |
| BINARY_SUBSCR_DICT | 118628216 | 0.2% | 96.8% |  |
| LOAD_ATTR_MODULE | 113061315 | 0.2% | 97.0% | 2.0% |
| BINARY_SUBSCR_TUPLE_INT | 112749428 | 0.2% | 97.1% | 2.0% |
| STORE_ATTR_SLOT | 103841422 | 0.1% | 97.3% | 1.7% |
| CALL_NO_KW_METHOD_DESCRIPTOR_NOARGS | 102870874 | 0.1% | 97.4% | 0.0% |
| CALL_BUILTIN_CLASS | 90751541 | 0.1% | 97.5% | 0.0% |
| COPY_FREE_VARS | 75778141 | 0.1% | 97.6% |  |
| LIST_APPEND | 64297136 | 0.1% | 97.7% |  |
| BINARY_OP_ADD_UNICODE | 62149097 | 0.1% | 97.8% | 0.1% |
| MAKE_FUNCTION | 60885473 | 0.1% | 97.9% |  |
| BUILD_LIST | 59954007 | 0.1% | 98.0% |  |
| BUILD_MAP | 59024394 | 0.1% | 98.1% |  |
| MAKE_CELL | 57709837 | 0.1% | 98.1% |  |
| CALL_NO_KW_STR_1 | 56241963 | 0.1% | 98.2% |  |
| KW_NAMES | 55617500 | 0.1% | 98.3% |  |
| JUMP_IF_FALSE_OR_POP | 55028631 | 0.1% | 98.4% |  |
| LOAD_METHOD_CLASS | 54956687 | 0.1% | 98.5% | 0.1% |
| CALL_BUILTIN_FAST_WITH_KEYWORDS | 53194058 | 0.1% | 98.5% | 0.6% |
| CALL | 51593800 | 0.1% | 98.6% |  |
| CALL_NO_KW_TYPE_1 | 50692325 | 0.1% | 98.7% |  |
| COMPARE_OP_STR_JUMP | 50180983 | 0.1% | 98.7% | 0.6% |
| STORE_ATTR_WITH_HINT | 47525952 | 0.1% | 98.8% | 2.4% |
| LOAD_GLOBAL | 46661201 | 0.1% | 98.9% |  |
| COMPARE_OP_FLOAT_JUMP | 46517199 | 0.1% | 98.9% | 0.1% |
| SEND | 42709608 | 0.1% | 99.0% |  |
| RETURN_GENERATOR | 42258870 | 0.1% | 99.1% |  |
| CALL_FUNCTION_EX | 42248179 | 0.1% | 99.1% |  |
| CALL_NO_KW_METHOD_DESCRIPTOR_O | 40835708 | 0.1% | 99.2% | 0.0% |
| JUMP_NO_INTERRUPT | 38615009 | 0.1% | 99.2% |  |
| CALL_PY_WITH_DEFAULTS | 37537440 | 0.1% | 99.3% | 0.1% |
| STORE_SUBSCR_DICT | 37341924 | 0.1% | 99.3% |  |
| STORE_ATTR_ADAPTIVE | 36311596 | 0.1% | 99.4% |  |
| LOAD_METHOD | 35213122 | 0.0% | 99.4% |  |
| LOAD_CLOSURE | 34259993 | 0.0% | 99.5% |  |
| JUMP_IF_TRUE_OR_POP | 33977545 | 0.0% | 99.5% |  |
| DICT_MERGE | 33334753 | 0.0% | 99.6% |  |
| UNARY_NOT | 33046769 | 0.0% | 99.6% |  |
| STORE_DEREF | 28800293 | 0.0% | 99.7% |  |
| STORE_NAME | 22067336 | 0.0% | 99.7% |  |
| LOAD_ATTR | 20485566 | 0.0% | 99.7% |  |
| LOAD_METHOD_MODULE | 15133935 | 0.0% | 99.7% | 0.5% |
| UNARY_NEGATIVE | 14893740 | 0.0% | 99.8% |  |
| MAP_ADD | 14658087 | 0.0% | 99.8% |  |
| CALL_NO_KW_TUPLE_1 | 14049584 | 0.0% | 99.8% | 0.0% |
| UNARY_INVERT | 13718901 | 0.0% | 99.8% |  |
| LOAD_NAME | 13306517 | 0.0% | 99.8% |  |
| IMPORT_FROM | 11221807 | 0.0% | 99.8% |  |
| IMPORT_NAME | 9961297 | 0.0% | 99.9% |  |
| STORE_GLOBAL | 8786741 | 0.0% | 99.9% |  |
| DELETE_SUBSCR | 8682250 | 0.0% | 99.9% |  |
| LOAD_GLOBAL_ADAPTIVE | 7941524 | 0.0% | 99.9% |  |
| FORMAT_VALUE | 7634971 | 0.0% | 99.9% |  |
| PUSH_EXC_INFO | 7046170 | 0.0% | 99.9% |  |
| POP_EXCEPT | 7046170 | 0.0% | 99.9% |  |
| JUMP_IF_NOT_EXC_MATCH | 6947561 | 0.0% | 99.9% |  |
| LIST_EXTEND | 6373054 | 0.0% | 99.9% |  |
| LIST_TO_TUPLE | 5639578 | 0.0% | 100.0% |  |
| STORE_ATTR | 4987862 | 0.0% | 100.0% |  |
| BUILD_STRING | 4512471 | 0.0% | 100.0% |  |
| BEFORE_WITH | 4053053 | 0.0% | 100.0% |  |
| GET_YIELD_FROM_ITER | 3615799 | 0.0% | 100.0% |  |
| BINARY_SUBSCR | 3243141 | 0.0% | 100.0% |  |
| DELETE_ATTR | 2079384 | 0.0% | 100.0% |  |
| JUMP_ABSOLUTE | 1864910 | 0.0% | 100.0% |  |
| DELETE_FAST | 1684730 | 0.0% | 100.0% |  |
| BUILD_CONST_KEY_MAP | 1228479 | 0.0% | 100.0% |  |
| LOAD_BUILD_CLASS | 1154271 | 0.0% | 100.0% |  |
| BUILD_SET | 1115570 | 0.0% | 100.0% |  |
| STORE_SUBSCR | 937780 | 0.0% | 100.0% |  |
| RERAISE | 767983 | 0.0% | 100.0% |  |
| RAISE_VARARGS | 582405 | 0.0% | 100.0% |  |
| GET_AWAITABLE | 478800 | 0.0% | 100.0% |  |
| DICT_UPDATE | 327195 | 0.0% | 100.0% |  |
| BINARY_OP_INPLACE_ADD_UNICODE | 326602 | 0.0% | 100.0% | 73.8% |
| DELETE_NAME | 183542 | 0.0% | 100.0% |  |
| SET_ADD | 157780 | 0.0% | 100.0% |  |
| IMPORT_STAR | 49491 | 0.0% | 100.0% |  |
| SET_UPDATE | 18277 | 0.0% | 100.0% |  |
| WITH_EXCEPT_START | 16363 | 0.0% | 100.0% |  |
| LOAD_CLASSDEREF | 1966 | 0.0% | 100.0% |  |
| DELETE_DEREF | 1680 | 0.0% | 100.0% |  |
| SETUP_ANNOTATIONS | 1507 | 0.0% | 100.0% |  |
| PRINT_EXPR | 3 | 0.0% | 100.0% |  |


</details>

## Specialization stats

<details>
<summary> specialization stats by family </summary>

### BINARY_SUBSCR

| Kind | Count | Ratio |
| --- | --- | --- |
|  unquickened |      3243141 | 0.1% |
|     deferred |   1232956692 | 48.2% |
|        deopt |       273283 | 0.0% |
|          hit |   1305518971 | 51.1% |
|         miss |     14578268 | 0.6% |

#### Specialization attempts

|  | Count | Ratio |
| --- | --- | --- |
| Success | 583769 | 3.0% |
| Failure | 19077417 | 97.0% |

| Failure kind | Count | Ratio |
| --- | --- | --- |
| array int | 10149228 | 53.2% |
| list slice | 3527322 | 18.5% |
| other | 2559637 | 13.4% |
| buffer int | 1632926 | 8.6% |
| buffer slice | 522577 | 2.7% |
| string int | 375523 | 2.0% |
| string slice | 233203 | 1.2% |
| tuple slice | 69960 | 0.4% |
| sequence int | 7041 | 0.0% |

### STORE_SUBSCR

| Kind | Count | Ratio |
| --- | --- | --- |
|  unquickened |       937780 | 0.1% |
|     deferred |    657624866 | 61.9% |
|          hit |    403177110 | 38.0% |

#### Specialization attempts

|  | Count | Ratio |
| --- | --- | --- |
| Success | 195282 | 1.9% |
| Failure | 10289267 | 98.1% |

| Failure kind | Count | Ratio |
| --- | --- | --- |
| array int | 4081958 | 39.7% |
| list slice | 2486943 | 24.2% |
| other | 2101793 | 20.4% |
| bytearray int | 996215 | 9.7% |
| dict subclass no override | 323195 | 3.1% |
| py simple | 185399 | 1.8% |
| out of range | 113595 | 1.1% |
| array slice | 147 | 0.0% |
| py other | 22 | 0.0% |

### UNPACK_SEQUENCE

| Kind | Count | Ratio |
| --- | --- | --- |
|  unquickened |    932705567 | 100.0% |

#### Specialization attempts

|  | Count | Ratio |
| --- | --- | --- |
| Success | 0 | 0.0% |
| Failure | 932705567 | 100.0% |

| Failure kind | Count | Ratio |
| --- | --- | --- |
| tuple | 616011096 | 66.0% |
| list | 316485295 | 33.9% |
| other | 209176 | 0.0% |

### FOR_ITER

| Kind | Count | Ratio |
| --- | --- | --- |
|  unquickened |   1637424853 | 100.0% |

#### Specialization attempts

|  | Count | Ratio |
| --- | --- | --- |
| Success | 0 | 0.0% |
| Failure | 1637424853 | 100.0% |

| Failure kind | Count | Ratio |
| --- | --- | --- |
| list | 557604884 | 34.1% |
| range | 516065065 | 31.5% |
| other | 244770440 | 14.9% |
| enumerate | 90132930 | 5.5% |
| set | 66362854 | 4.1% |
| dict items | 61249597 | 3.7% |
| tuple | 59661653 | 3.6% |
| generator | 30907053 | 1.9% |
| itertools | 7138121 | 0.4% |
| bytes | 1190341 | 0.1% |
| string | 1079261 | 0.1% |
| dict keys | 1037556 | 0.1% |
| dict values | 225098 | 0.0% |

### STORE_ATTR

| Kind | Count | Ratio |
| --- | --- | --- |
|  unquickened |      4987862 | 0.7% |
|     deferred |     35168335 | 5.1% |
|        deopt |       171158 | 0.0% |
|          hit |    644684550 | 92.8% |
|         miss |      9592703 | 1.4% |

#### Specialization attempts

|  | Count | Ratio |
| --- | --- | --- |
| Success | 639324 | 55.9% |
| Failure | 503937 | 44.1% |

| Failure kind | Count | Ratio |
| --- | --- | --- |
| overriding descriptor | 159794 | 31.7% |
| overridden | 151314 | 30.0% |
| out of range | 97800 | 19.4% |
| not managed dict | 38104 | 7.6% |
| method | 27246 | 5.4% |
| mutable class | 18691 | 3.7% |
| non object slot | 9873 | 2.0% |
| property | 1115 | 0.2% |

### LOAD_ATTR

| Kind | Count | Ratio |
| --- | --- | --- |
|  unquickened |     20485566 | 0.5% |
|     deferred |    620320925 | 15.9% |
|        deopt |      1559790 | 0.0% |
|          hit |   3168215975 | 81.4% |
|         miss |     84808505 | 2.2% |

#### Specialization attempts

|  | Count | Ratio |
| --- | --- | --- |
| Success | 2798998 | 24.6% |
| Failure | 8558641 | 75.4% |

| Failure kind | Count | Ratio |
| --- | --- | --- |
| overridden | 2772518 | 32.4% |
| overriding descriptor | 1685495 | 19.7% |
| out of range | 1594375 | 18.6% |
| not managed dict | 998211 | 11.7% |
| property | 632078 | 7.4% |
| method | 544046 | 6.4% |
| non object slot | 199135 | 2.3% |
| mutable class | 125167 | 1.5% |
| kind 7 | 7616 | 0.1% |

### COMPARE_OP

| Kind | Count | Ratio |
| --- | --- | --- |
|  unquickened |    177263861 | 11.0% |
|     deferred |    124773910 | 7.8% |
|        deopt |        15712 | 0.0% |
|          hit |   1303738908 | 81.1% |
|         miss |       914719 | 0.1% |

#### Specialization attempts

|  | Count | Ratio |
| --- | --- | --- |
| Success | 266527 | 11.2% |
| Failure | 2106418 | 88.8% |

| Failure kind | Count | Ratio |
| --- | --- | --- |
| float long | 665583 | 31.6% |
| set | 579290 | 27.5% |
| different types | 201766 | 9.6% |
| other | 125478 | 6.0% |
| not followed by cond jump | 121444 | 5.8% |
| bool | 112173 | 5.3% |
| tuple | 100667 | 4.8% |
| big int | 96036 | 4.6% |
| bytes | 44845 | 2.1% |
| baseobject | 34480 | 1.6% |
| list | 20760 | 1.0% |
| long float | 3766 | 0.2% |
| string | 130 | 0.0% |

### LOAD_GLOBAL

| Kind | Count | Ratio |
| --- | --- | --- |
|  unquickened |     46661201 | 1.8% |
|     deferred |      5065600 | 0.2% |
|        deopt |       100400 | 0.0% |
|          hit |   2594874699 | 97.6% |
|         miss |     11306352 | 0.4% |

#### Specialization attempts

|  | Count | Ratio |
| --- | --- | --- |
| Success | 2875923 | 100.0% |
| Failure | 1 | 0.0% |

| Failure kind | Count | Ratio |
| --- | --- | --- |

### BINARY_OP

| Kind | Count | Ratio |
| --- | --- | --- |
|  unquickened |    689223617 | 13.8% |
|     deferred |    274799065 | 5.5% |
|        deopt |       594194 | 0.0% |
|          hit |   4011268425 | 80.1% |
|         miss |     31659667 | 0.6% |

#### Specialization attempts

|  | Count | Ratio |
| --- | --- | --- |
| Success | 847469 | 18.0% |
| Failure | 3866616 | 82.0% |

| Failure kind | Count | Ratio |
| --- | --- | --- |
| other | 2210966 | 57.2% |
| different types | 1655650 | 42.8% |

### LOAD_METHOD

| Kind | Count | Ratio |
| --- | --- | --- |
|  unquickened |     35213122 | 1.7% |
|     deferred |    277175598 | 13.3% |
|        deopt |       568915 | 0.0% |
|          hit |   1735425163 | 83.5% |
|         miss |     30450056 | 1.5% |

#### Specialization attempts

|  | Count | Ratio |
| --- | --- | --- |
| Success | 1478012 | 27.6% |
| Failure | 3880213 | 72.4% |

| Failure kind | Count | Ratio |
| --- | --- | --- |
| has managed dict | 1266183 | 32.6% |
| has dict | 1095383 | 28.2% |
| instance attribute | 696057 | 17.9% |
| overridden | 253287 | 6.5% |
| class method obj | 216436 | 5.6% |
| metaclass attribute | 210110 | 5.4% |
| non overriding descriptor | 51693 | 1.3% |
| not descriptor | 32850 | 0.8% |
| builtin class method | 23533 | 0.6% |
| mutable class | 13843 | 0.4% |
| other | 8448 | 0.2% |
| property | 7182 | 0.2% |
| is attr | 2944 | 0.1% |
| overriding descriptor | 1634 | 0.0% |
| kind 7 | 420 | 0.0% |
| object slot | 147 | 0.0% |
| non object slot | 63 | 0.0% |

### CALL

| Kind | Count | Ratio |
| --- | --- | --- |
|  unquickened |     51593800 | 1.7% |
|     deferred |    859552047 | 27.9% |
|        deopt |       884454 | 0.0% |
|          hit |   2123117580 | 68.9% |
|         miss |     48025730 | 1.6% |

#### Specialization attempts

|  | Count | Ratio |
| --- | --- | --- |
| Success | 2922328 | 18.0% |
| Failure | 13274583 | 82.0% |

| Failure kind | Count | Ratio |
| --- | --- | --- |
| class no vectorcall | 2815506 | 21.2% |
| instance method | 2284178 | 17.2% |
| pycfunction fast with keywords | 2254602 | 17.0% |
| python class | 1247479 | 9.4% |
| kind 8 | 1242332 | 9.4% |
| pycfunction with keywords | 887033 | 6.7% |
| kwnames | 665610 | 5.0% |
| pycfunction | 607841 | 4.6% |
| pycfunction noargs | 409182 | 3.1% |
| class mutable | 326822 | 2.5% |
| other | 222473 | 1.7% |
| bad call flags | 179723 | 1.4% |
| str | 79833 | 0.6% |
| method wrapper | 32586 | 0.2% |
| complex parameters | 12278 | 0.1% |
| operator wrapper | 4767 | 0.0% |
| bound method | 2333 | 0.0% |
| cmethod | 4 | 0.0% |
| wrong number arguments | 1 | 0.0% |


</details>

## Specialization effectiveness

<details>
<summary> specialization effectiveness </summary>

| Instructions | Count | Ratio |
| --- | --- | --- |
| Basic | 43841140325 | 61.0% |
| Not specialized | 7992678133 | 11.1% |
| Specialized | 19988904669 | 27.8% |


</details>

## Call stats

<details>
<summary> Inlined calls and frame stats </summary>

|  | Count | Ratio |
| --- | --- | --- |
| Calls to PyEval_EvalDefault | 628153193 | 28.0% |
| Calls to Python functions inlined | 1612430405 | 72.0% |
| Frames pushed | 1990482168 | 88.8% |
| Frame objects created | 21863593 | 1.0% |


</details>

## Object stats

<details>
<summary> allocations, frees and dict materializatons </summary>

|  | Count | Ratio |
| --- | --- | --- |
| Allocations | 4888497405 |  |
| Frees | 4805554593 |  |
| New values | 71221115 |  |
| Materialize dict (on request) | 3022151 | 4.2% |
| Materialize dict (new key) | 1949271 | 2.7% |
| Materialize dict (too big) | 0 | 0.0% |


</details>

---
Stats gathered on: 2022-02-09



<!-- issue-number: [bpo-46072](https://bugs.python.org/issue46072) -->
https://bugs.python.org/issue46072
<!-- /issue-number -->
