### PR TITLE
bpo-46643: Fix stringized P.args/P.kwargs with get_type_hints

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5004,6 +5004,18 @@ class ParamSpecTests(BaseTestCase):
         self.assertEqual(repr(P.args), "P.args")
         self.assertEqual(repr(P.kwargs), "P.kwargs")
 
+    def test_stringized(self):
+        P = ParamSpec('P')
+        class C(Generic[P]):
+            func: Callable["P", int]
+            def foo(self, *args: "P.args", **kwargs: "P.kwargs"):
+                pass
+
+        self.assertEqual(gth(C, globals(), locals()), {"func": Callable[P, int]})
+        self.assertEqual(
+            gth(C.foo, globals(), locals()), {"args": P.args, "kwargs": P.kwargs}
+        )
+
     def test_user_generics(self):
         T = TypeVar("T")
         P = ParamSpec("P")

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -181,7 +181,8 @@ def _type_check(arg, msg, is_argument=True, module=None, *, allow_special_forms=
         return arg
     if isinstance(arg, _SpecialForm) or arg in (Generic, Protocol):
         raise TypeError(f"Plain {arg} is not valid as type argument")
-    if isinstance(arg, (type, TypeVar, ForwardRef, types.UnionType, ParamSpec)):
+    if isinstance(arg, (type, TypeVar, ForwardRef, types.UnionType, ParamSpec,
+                        ParamSpecArgs, ParamSpecKwargs)):
         return arg
     if not callable(arg):
         raise TypeError(f"{msg} Got {arg!r:.100}.")

--- a/Misc/NEWS.d/next/Library/2022-02-09-22-40-11.bpo-46643.aBlIx1.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-09-22-40-11.bpo-46643.aBlIx1.rst
@@ -1,0 +1,1 @@
+In :func:`typing.get_type_hints`, support evaluating stringified ``ParamSpecArgs`` and ``ParamSpecKwargs`` annotations. Patch by Gregory Beauregard.


### PR DESCRIPTION
There's discussion since fixing this also allows using `P.args` and `P.kwargs` inside `typing.Annotated`. See the bpo issue. We should wait for that discussion to resolve first.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46643](https://bugs.python.org/issue46643) -->
https://bugs.python.org/issue46643
<!-- /issue-number -->
