### PR TITLE
Fix a typo in Doc/faq/programming.rst

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1908,7 +1908,7 @@ The *cached_property* approach only works with methods that do not take
 any arguments.  It does not create a reference to the instance.  The
 cached method result will be kept only as long as the instance is alive.
 
-The advantage is that when an instance is not longer used, the cached
+The advantage is that when an instance is no longer used, the cached
 method result will be released right away.  The disadvantage is that if
 instances accumulate, so too will the accumulated method results.  They
 can grow without bound.


### PR DESCRIPTION
I don't have a bpo or anything but just fixed the typo.
I checked https://devguide.python.org and it said a typo fix does not need a BPO/issue to be created.