### PR TITLE
bpo-21910: Clarified codecs writelines method

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -697,8 +697,7 @@ compatible with the Python codec registry.
 
    .. method:: writelines(list)
 
-      Writes the concatenated list of strings to the stream by reusing
-      the :meth:`write` method, and does not support infinite or very large generators. The standard bytes-to-bytes codecs
+      Concatenates the string iterable and writes it to the stream. Infinite or very large iterables are not supported. The standard bytes-to-bytes codecs
       do not support this method.
 
 

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -697,8 +697,8 @@ compatible with the Python codec registry.
 
    .. method:: writelines(list)
 
-      Writes the concatenated list of strings to the stream (possibly by reusing
-      the :meth:`write` method). The standard bytes-to-bytes codecs
+      Writes the concatenated list of strings to the stream by reusing
+      the :meth:`write` method, and does not support infinite or very large generators. The standard bytes-to-bytes codecs
       do not support this method.
 
 

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -697,7 +697,7 @@ compatible with the Python codec registry.
 
    .. method:: writelines(list)
 
-      Concatenates the string iterable and writes it to the stream. Infinite or
+      Writes the concatenated iterable of strings to the stream. Infinite or
       very large iterables are not supported. The standard bytes-to-bytes codecs
       do not support this method.
 

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -697,7 +697,8 @@ compatible with the Python codec registry.
 
    .. method:: writelines(list)
 
-      Concatenates the string iterable and writes it to the stream. Infinite or very large iterables are not supported. The standard bytes-to-bytes codecs
+      Concatenates the string iterable and writes it to the stream. Infinite or
+      very large iterables are not supported. The standard bytes-to-bytes codecs
       do not support this method.
 
 

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -697,7 +697,8 @@ compatible with the Python codec registry.
 
    .. method:: writelines(list)
 
-      Writes the concatenated iterable of strings to the stream. Infinite or
+      Writes the concatenated iterable of strings to the stream (possibly by reusing
+      the :meth:`write` method). Infinite or
       very large iterables are not supported. The standard bytes-to-bytes codecs
       do not support this method.
 


### PR DESCRIPTION
See [issue](https://bugs.python.org/issue21910). [`writelines`](https://github.com/python/cpython/blob/main/Lib/codecs.py#L385) uses `.join()` instead of some streaming implementation so for infinite / very large generators the method will freeze. Updated documentation so it reflects this behavior

<!-- issue-number: [bpo-21910](https://bugs.python.org/issue21910) -->
https://bugs.python.org/issue21910
<!-- /issue-number -->
