### PR TITLE
bpo-46072: Fix sys.getdxp().

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -7454,7 +7454,7 @@ _Py_GetDXProfile(PyObject *self, PyObject *args)
     int i;
     PyObject *l = PyList_New(257);
     if (l == NULL) return NULL;
-    for (i = 0; i < 257; i++) {
+    for (i = 0; i < 256; i++) {
         PyObject *x = getarray(_py_stats.opcode_stats[i].pair_count);
         if (x == NULL) {
             Py_DECREF(l);
@@ -7462,6 +7462,22 @@ _Py_GetDXProfile(PyObject *self, PyObject *args)
         }
         PyList_SET_ITEM(l, i, x);
     }
+    PyObject *counts = PyList_New(256);
+    if (counts == NULL) {
+        Py_DECREF(l);
+        return NULL;
+    }
+    for (i = 0; i < 256; i++) {
+        PyObject *x = PyLong_FromUnsignedLongLong(
+            _py_stats.opcode_stats[i].execution_count);
+        if (x == NULL) {
+            Py_DECREF(counts);
+            Py_DECREF(l);
+            return NULL;
+        }
+        PyList_SET_ITEM(counts, i, x);
+    }
+    PyList_SET_ITEM(l, 256, counts);
     return l;
 }
 


### PR DESCRIPTION
In the flurry of PRs adding stats, I broke `sys.getdxp()`, as the 256th entry (counting from 0) was filled with invalid junk.

To recreate the failure:
```
./configure --enable-pystats
./python -m test -v test.test_tools.test_sundry
```

This PR fixes that by putting the unpaired counts in the 256th entry.


<!-- issue-number: [bpo-46072](https://bugs.python.org/issue46072) -->
https://bugs.python.org/issue46072
<!-- /issue-number -->
