### PR TITLE
[3.10] bpo-46708: Fix warning: asyncio.events._event_loop_policy was modified by test_asyncio (GH-31253)

### DIFF
--- a/Lib/test/test_asyncio/test_futures2.py
+++ b/Lib/test/test_asyncio/test_futures2.py
@@ -3,6 +3,10 @@ import asyncio
 import unittest
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class FutureTests(unittest.IsolatedAsyncioTestCase):
     async def test_recursive_repr_for_pending_tasks(self):
         # The call crashes if the guard for recursive call

--- a/Lib/test/test_asyncio/test_protocols.py
+++ b/Lib/test/test_asyncio/test_protocols.py
@@ -4,6 +4,12 @@ from unittest import mock
 import asyncio
 
 
+def tearDownModule():
+    # not needed for the test file but added for uniformness with all other
+    # asyncio test files for the sake of unified cleanup
+    asyncio.set_event_loop_policy(None)
+
+
 class ProtocolsAbsTests(unittest.TestCase):
 
     def test_base_protocol(self):

--- a/Lib/test/test_asyncio/test_runners.py
+++ b/Lib/test/test_asyncio/test_runners.py
@@ -5,6 +5,10 @@ from unittest import mock
 from test.test_asyncio import utils as test_utils
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class TestPolicy(asyncio.AbstractEventLoopPolicy):
 
     def __init__(self, loop_factory):

--- a/Lib/test/test_asyncio/test_sock_lowlevel.py
+++ b/Lib/test/test_asyncio/test_sock_lowlevel.py
@@ -10,6 +10,10 @@ from test import support
 from test.support import socket_helper
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class MyProto(asyncio.Protocol):
     connected = None
     done = None

--- a/Lib/test/test_asyncio/test_transports.py
+++ b/Lib/test/test_asyncio/test_transports.py
@@ -7,6 +7,12 @@ import asyncio
 from asyncio import transports
 
 
+def tearDownModule():
+    # not needed for the test file but added for uniformness with all other
+    # asyncio test files for the sake of unified cleanup
+    asyncio.set_event_loop_policy(None)
+
+
 class TransportTests(unittest.TestCase):
 
     def test_ctor_extra_is_none(self):

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -26,6 +26,10 @@ from asyncio import unix_events
 from test.test_asyncio import utils as test_utils
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 MOCK_ANY = mock.ANY
 
 
@@ -37,10 +41,6 @@ def SIGNAL(signum):
     if not 1 <= signum <= 68:
         raise AssertionError(f'invalid signum {signum}')
     return 32768 - signum
-
-
-def tearDownModule():
-    asyncio.set_event_loop_policy(None)
 
 
 def close_pipe_transport(transport):

--- a/Misc/NEWS.d/next/Tests/2022-02-10-14-33-47.bpo-46708.avLfCb.rst
+++ b/Misc/NEWS.d/next/Tests/2022-02-10-14-33-47.bpo-46708.avLfCb.rst
@@ -1,0 +1,2 @@
+Prevent default asyncio event loop policy modification warning after
+``test_asyncio`` execution.


### PR DESCRIPTION
(cherry picked from commit 012e77eb5c3ba3d411f5967a7f368ebdb42ab88c)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>


<!-- issue-number: [bpo-46708](https://bugs.python.org/issue46708) -->
https://bugs.python.org/issue46708
<!-- /issue-number -->
