### PR TITLE
bpo-46494: Mention the typing_extensions pkg in typing docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -32,9 +32,9 @@ In the function ``greeting``, the argument ``name`` is expected to be of type
 :class:`str` and the return type :class:`str`. Subtypes are accepted as
 arguments.
 
-New features have been added to the typing module in each version of Python.
+New features are frequently added to the ``typing`` module.
 The `typing_extensions <https://pypi.org/project/typing-extensions/>`_ package
-provides backports of new ``typing`` features to older versions of Python.
+provides backports of these new features to older versions of Python.
 
 .. _relevant-peps:
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -32,10 +32,8 @@ In the function ``greeting``, the argument ``name`` is expected to be of type
 :class:`str` and the return type :class:`str`. Subtypes are accepted as
 arguments.
 
-New features have been added to the typing module in each major version of
-Python. The `typing_extensions <https://pypi.org/project/typing-extensions/>`_
-package provides backports to all supported versions of Python 3 for almost
-all of these features.
+The `typing_extensions <https://pypi.org/project/typing-extensions/>`_ package
+provides backports of new ``typing`` features to older versions of Python.
 
 .. _relevant-peps:
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -32,6 +32,7 @@ In the function ``greeting``, the argument ``name`` is expected to be of type
 :class:`str` and the return type :class:`str`. Subtypes are accepted as
 arguments.
 
+New features have been added to the typing module in each version of Python.
 The `typing_extensions <https://pypi.org/project/typing-extensions/>`_ package
 provides backports of new ``typing`` features to older versions of Python.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -32,6 +32,11 @@ In the function ``greeting``, the argument ``name`` is expected to be of type
 :class:`str` and the return type :class:`str`. Subtypes are accepted as
 arguments.
 
+New features have been added to the typing module in each major version of
+Python. The `typing_extensions <https://pypi.org/project/typing-extensions/>`_
+package provides backports to all supported versions of Python 3 for almost
+all of these features.
+
 .. _relevant-peps:
 
 Relevant PEPs


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46494](https://bugs.python.org/issue46494) -->
https://bugs.python.org/issue46494
<!-- /issue-number -->
