### PR TITLE
bpo-46712: Share global string identifiers in deepfreeze

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-24-07-50-43.bpo-46712.pw7vQV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-24-07-50-43.bpo-46712.pw7vQV.rst
@@ -1,0 +1,1 @@
+Share global string identifiers in deep-frozen modules.

--- a/Tools/scripts/deepfreeze.py
+++ b/Tools/scripts/deepfreeze.py
@@ -13,8 +13,9 @@ import re
 import time
 import types
 from typing import Dict, FrozenSet, TextIO, Tuple
-from generate_global_objects import get_identifiers_and_strings
+
 import umarshal
+from generate_global_objects import get_identifiers_and_strings
 
 verbose = False
 identifiers = get_identifiers_and_strings()[0]

--- a/Tools/scripts/deepfreeze.py
+++ b/Tools/scripts/deepfreeze.py
@@ -13,11 +13,11 @@ import re
 import time
 import types
 from typing import Dict, FrozenSet, TextIO, Tuple
-
+from generate_global_objects import get_identifiers_and_strings
 import umarshal
 
 verbose = False
-
+identifiers = get_identifiers_and_strings()[0]
 
 def isprintable(b: bytes) -> bool:
     return all(0x20 <= c < 0x7f for c in b)
@@ -166,6 +166,8 @@ class Printer:
         return f"& {name}.ob_base.ob_base"
 
     def generate_unicode(self, name: str, s: str) -> str:
+        if s in identifiers:
+            return f"&_Py_ID({s})"
         kind, ascii = analyze_character_width(s)
         if kind == PyUnicode_1BYTE_KIND:
             datatype = "uint8_t"

--- a/Tools/scripts/generate_global_objects.py
+++ b/Tools/scripts/generate_global_objects.py
@@ -256,13 +256,10 @@ def generate_runtime_init(identifiers, strings):
         printer.write(after)
 
 
-#######################################
-# the script
-
-def main() -> None:
+def get_identifiers_and_strings() -> tuple[set[str], dict[str, str]]:
     identifiers = set(IDENTIFIERS)
     strings = dict(STRING_LITERALS)
-    for name, string, filename, lno, _ in iter_global_strings():
+    for name, string, *_ in iter_global_strings():
         if string is None:
             if name not in IGNORED:
                 identifiers.add(name)
@@ -271,6 +268,13 @@ def main() -> None:
                 strings[name] = string
             elif string != strings[name]:
                 raise ValueError(f'string mismatch for {name!r} ({string!r} != {strings[name]!r}')
+    return identifiers, strings
+
+#######################################
+# the script
+
+def main() -> None:
+    identifiers, strings = get_identifiers_and_strings()
 
     generate_global_strings(identifiers, strings)
     generate_runtime_init(identifiers, strings)


### PR DESCRIPTION
Since [bpo-46541](https://bugs.python.org/issue46541), the global strings are statically allocated so they can now be referenced by deep-frozen modules just like any other singleton. Sharing identifiers with deepfreeze will reduce the duplicated strings hence it would save space.

See https://github.com/faster-cpython/ideas/issues/218
See https://github.com/faster-cpython/ideas/issues/230

```console
❯ cat Python/deepfreeze/deepfreeze.c | grep "_Py_ID" | wc -l 
1850
```

---

<!-- issue-number: [bpo-46712](https://bugs.python.org/issue46712) -->
https://bugs.python.org/issue46712
<!-- /issue-number -->
