### PR TITLE
bpo-46705: Memory optimization for set.issubset

### DIFF
--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1713,10 +1713,10 @@ set_issubset(PySetObject *so, PyObject *other)
 
     if (!PyAnySet_Check(other)) {
         PyObject *tmp, *result;
-        tmp = make_new_set(&PySet_Type, other);
+        tmp = set_intersection(so, other);
         if (tmp == NULL)
             return NULL;
-        result = set_issubset(so, tmp);
+        result = (PySet_GET_SIZE(so, tmp) == PySet_GET_SIZE(so));
         Py_DECREF(tmp);
         return result;
     }


### PR DESCRIPTION
Instead of using `set(other)` during `set.issubset`, use `self.intersection(other)` to avoid using unnecessary memory.

<!-- issue-number: [bpo-46705](https://bugs.python.org/issue46705) -->
https://bugs.python.org/issue46705
<!-- /issue-number -->
