### PR TITLE
[doc] Add a note in howto/logging.rst about "do not log to root logger in libraries"

### DIFF
--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -831,6 +831,12 @@ should have the desired effect. If an organisation produces a number of
 libraries, then the logger name specified can be 'orgname.foo' rather than
 just 'foo'.
 
+.. note:: It is strongly advised that you *do not log to the root logger*
+   in your library. Instead, use a logger with a unique and easily identifiable 
+   name, such as `__name__`. This can avoid writing to the a logger that's used 
+   by other libraries or the application, which will make it difficult for the 
+   application developer to configure handlers.
+
 .. note:: It is strongly advised that you *do not add any handlers other
    than* :class:`~logging.NullHandler` *to your library's loggers*. This is
    because the configuration of handlers is the prerogative of the application

--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -833,10 +833,10 @@ just 'foo'.
 
 .. note:: It is strongly advised that you *do not log to the root logger*
    in your library. Instead, use a logger with a unique and easily
-   identifiable name, such as your library's ``__name__``. This can avoid
-   writing to a logger that's used by other libraries or the application,
-   which will make it difficult for the application developer to configure
-   handlers.
+   identifiable name, such as the ``__name__`` for your library's top-level package
+   or module. Logging to the root logger will make it difficult or impossible for
+   the application developer to configure the logging verbosity or handlers of
+   your library as they wish.
 
 .. note:: It is strongly advised that you *do not add any handlers other
    than* :class:`~logging.NullHandler` *to your library's loggers*. This is

--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -832,10 +832,10 @@ libraries, then the logger name specified can be 'orgname.foo' rather than
 just 'foo'.
 
 .. note:: It is strongly advised that you *do not log to the root logger*
-   in your library. Instead, use a logger with a unique and easily 
-   identifiable name, such as your library's ``__name__``. This can avoid 
-   writing to a logger that's used by other libraries or the application, 
-   which will make it difficult for the application developer to configure 
+   in your library. Instead, use a logger with a unique and easily
+   identifiable name, such as your library's ``__name__``. This can avoid
+   writing to a logger that's used by other libraries or the application,
+   which will make it difficult for the application developer to configure
    handlers.
 
 .. note:: It is strongly advised that you *do not add any handlers other

--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -832,10 +832,11 @@ libraries, then the logger name specified can be 'orgname.foo' rather than
 just 'foo'.
 
 .. note:: It is strongly advised that you *do not log to the root logger*
-   in your library. Instead, use a logger with a unique and easily identifiable 
-   name, such as `__name__`. This can avoid writing to the a logger that's used 
-   by other libraries or the application, which will make it difficult for the 
-   application developer to configure handlers.
+   in your library. Instead, use a logger with a unique and easily 
+   identifiable name, such as your library's ``__name__``. This can avoid 
+   writing to a logger that's used by other libraries or the application, 
+   which will make it difficult for the application developer to configure 
+   handlers.
 
 .. note:: It is strongly advised that you *do not add any handlers other
    than* :class:`~logging.NullHandler` *to your library's loggers*. This is


### PR DESCRIPTION
Inside the `Configuring Logging for a Library` section, there is already a note here for library developers about "do not add handlers to library's loggers".
In similar spirit, I'm adding a note above it about "do not use root logger". This might sound obvious but I believe this antipattern happen more frequently than the existing note.

Please let me know if this looks reasonable. Thanks!
