### PR TITLE
bpo-46709: fix race conditions in `unittest/test_brake`

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4690,6 +4690,7 @@ handle_eval_breaker:
             Py_DECREF(obj);
             STACK_SHRINK(call_shape.postcall_shrink);
             SET_TOP(res);
+            CHECK_EVAL_BREAKER();
             NOTRACE_DISPATCH();
         }
 
@@ -4710,6 +4711,7 @@ handle_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
+            CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
@@ -4729,6 +4731,7 @@ handle_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
+            CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
@@ -4753,6 +4756,7 @@ handle_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
+            CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
@@ -4784,6 +4788,7 @@ handle_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
+            CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
@@ -4822,6 +4827,7 @@ handle_eval_breaker:
                 */
                 goto error;
             }
+            CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
@@ -4864,6 +4870,7 @@ handle_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
+            CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
@@ -4895,6 +4902,7 @@ handle_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
+            CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
@@ -4928,6 +4936,7 @@ handle_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
+            CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
@@ -4952,6 +4961,7 @@ handle_eval_breaker:
             Py_INCREF(Py_None);
             SET_TOP(Py_None);
             Py_DECREF(call_shape.callable);
+            CHECK_EVAL_BREAKER();
             NOTRACE_DISPATCH();
         }
 
@@ -4981,6 +4991,7 @@ handle_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
+            CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
@@ -5008,6 +5019,7 @@ handle_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
+            CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
@@ -5035,6 +5047,7 @@ handle_eval_breaker:
             if (res == NULL) {
                 goto error;
             }
+            CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 


### PR DESCRIPTION
Affected tests:
- `./python.exe -m test -m unittest.test.test_break.TestBreakDefaultIntHandler.testInterruptCaught test_unittest -F`
- `./python.exe -m test -m unittest.test.test_break.TestBreakDefaultIntHandler.testSecondInterrupt test_unittest -F`
- `./python.exe -m test -m unittest.test.test_break.TestBreakDefaultIntHandler.testTwoResults test_unittest -F`
- `./python.exe -m test -m unittest.test.test_break.TestBreakDefaultIntHandler.testHandlerReplacedButCalled test_unittest -F`

Before:
<img width="752" alt="Снимок экрана 2022-02-11 в 12 05 51" src="https://user-images.githubusercontent.com/4660275/153564152-b2709ba0-536c-4789-b570-5a268ae83d0f.png">

After (manually terminated):
<img width="752" alt="Снимок экрана 2022-02-11 в 12 05 35" src="https://user-images.githubusercontent.com/4660275/153564192-b155ca4a-18bd-48dc-94a5-cb5d7666cdbd.png">

I simply re-arranged `assert` statements to make this pass: https://docs.python.org/3/library/signal.html#execution-of-python-signal-handlers

Maybe there's something more clever to do instead? 🙂 

<!-- issue-number: [bpo-46709](https://bugs.python.org/issue46709) -->
https://bugs.python.org/issue46709
<!-- /issue-number -->
