### PR TITLE
bpo-46711: increase timeout for `test_logging::test_post_fork_child_no_deadlock`

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2065,7 +2065,8 @@ def wait_process(pid, *, exitcode, timeout=None):
                     pass
 
                 raise AssertionError(f"process {pid} is still running "
-                                     f"after {dt:.1f} seconds")
+                                     f"after {dt:.1f} seconds, "
+                                     f"timeout is {timeout} seconds")
 
             sleep = min(sleep * 2, max_sleep)
             time.sleep(sleep)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2056,7 +2056,7 @@ def wait_process(pid, *, exitcode, timeout=None):
             # process is still running
 
             dt = time.monotonic() - t0
-            if dt > SHORT_TIMEOUT:
+            if dt > timeout:
                 try:
                     os.kill(pid, signal.SIGKILL)
                     os.waitpid(pid, 0)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -747,7 +747,7 @@ class HandlerTest(BaseTest):
             fork_happened__release_locks_and_end_thread.set()
             lock_holder_thread.join()
 
-            support.wait_process(pid, exitcode=0)
+            support.wait_process(pid, exitcode=0, timeout=support.LONG_TIMEOUT)
 
 
 class BadStream(object):


### PR DESCRIPTION


Closes https://github.com/python/cpython/pull/31205
Thank you, @notarealdeveloper for noticing it!

However, I am not sure how to proceed here:
- We can merge https://github.com/python/cpython/pull/31205 first, then I rebase this PR (this way the original author will get a credit for fixing the problem)
- Or we can just merge this one (it is easier)

<!-- issue-number: [bpo-46711](https://bugs.python.org/issue46711) -->
https://bugs.python.org/issue46711
<!-- /issue-number -->
