### PR TITLE
bpo-46483: [doc] Remove `pathlib` classes from list of stdlib classes that can be parameterized at runtime

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4997,10 +4997,6 @@ list is non-exhaustive.
 * :class:`functools.cached_property`
 * :class:`functools.partialmethod`
 * :class:`os.PathLike`
-* :class:`pathlib.Path`
-* :class:`pathlib.PurePath`
-* :class:`pathlib.PurePosixPath`
-* :class:`pathlib.PureWindowsPath`
 * :class:`queue.LifoQueue`
 * :class:`queue.Queue`
 * :class:`queue.PriorityQueue`


### PR DESCRIPTION
`__class_getitem__` has been removed from `pathlib.PurePath` due to the fact that it was only added to the class by mistake (the class was never really generic). This means that `PurePath` (and subclasses of `PurePath`) can no longer be parameterized at runtime. Therefore, these `pathlib` classes should be removed from the list in `stdtypes.rst` of classes that can be parameterized at runtime.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46483](https://bugs.python.org/issue46483) -->
https://bugs.python.org/issue46483
<!-- /issue-number -->
