### PR TITLE
bpo-46333: include `module` in `ForwardRef.__repr__`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2862,6 +2862,8 @@ class ForwardRefTests(BaseTestCase):
 
     def test_forward_repr(self):
         self.assertEqual(repr(List['int']), "typing.List[ForwardRef('int')]")
+        self.assertEqual(repr(List[ForwardRef('int', module='mod')]), 
+                         "typing.List[ForwardRef('int', module='mod')]")	
 
     def test_union_forward(self):
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -779,7 +779,11 @@ class ForwardRef(_Final, _root=True):
         return Union[other, self]
 
     def __repr__(self):
-        return f'ForwardRef({self.__forward_arg__!r})'
+        if self.__forward_module__ is None:
+            module_repr = ''
+        else:
+            module_repr = f', module={self.__forward_module__!r}'
+        return f'ForwardRef({self.__forward_arg__!r}{module_repr})'
 
 class _TypeVarLike:
     """Mixin for TypeVar-like types (TypeVar and ParamSpec)."""

--- a/Misc/NEWS.d/next/Library/2022-02-11-20-01-49.bpo-46333.PMTBY9.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-11-20-01-49.bpo-46333.PMTBY9.rst
@@ -1,0 +1,3 @@
+The :meth:`__repr__` method of :class:`typing.ForwardRef` now 
+includes the ``module`` parameter of :class:`typing.ForwardRef` 
+when it is set.

--- a/Misc/NEWS.d/next/Library/2022-02-11-20-01-49.bpo-46333.PMTBY9.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-11-20-01-49.bpo-46333.PMTBY9.rst
@@ -1,3 +1,3 @@
-The :meth:`__repr__` method of :class:`typing.ForwardRef` now 
-includes the ``module`` parameter of :class:`typing.ForwardRef` 
+The :meth:`__repr__` method of :class:`typing.ForwardRef` now
+includes the ``module`` parameter of :class:`typing.ForwardRef`
 when it is set.


### PR DESCRIPTION
The module parameter carries semantic information about the forward ref.
Show to the user that forward refs with same argument but different
module are different.

This is the split-off part from GH-30536 which should not be backported.

<!-- issue-number: [bpo-46333](https://bugs.python.org/issue46333) -->
https://bugs.python.org/issue46333
<!-- /issue-number -->
