### PR TITLE
bpo-46724: Fix dis support for overflow args

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -518,36 +518,7 @@ disco = disassemble                     # XXX For backwards compatibility
 
 
 def _unpack_opargs(code):
-
-    # When the ctypes import is at the top level, the tests raise an error, so it is imported inline:
-    # Traceback (most recent call last):
-    #   File "<frozen runpy>", line 198, in _run_module_as_main
-    #   File "<frozen runpy>", line 88, in _run_code
-    #   File "/home/runner/work/cpython/cpython/Lib/sysconfig.py", line 810, in <module>
-    #     _main()
-    #     ^^^^^^^
-    #   File "/home/runner/work/cpython/cpython/Lib/sysconfig.py", line 798, in _main
-    #     _generate_posix_vars()
-    #     ^^^^^^^^^^^^^^^^^^^^^^
-    #   File "/home/runner/work/cpython/cpython/Lib/sysconfig.py", line 418, in _generate_posix_vars
-    #     import pprint
-    #     ^^^^^^^^^^^^^
-    #   File "/home/runner/work/cpython/cpython/Lib/pprint.py", line 38, in <module>
-    #     import dataclasses as _dataclasses
-    #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    #   File "/home/runner/work/cpython/cpython/Lib/dataclasses.py", line 5, in <module>
-    #     import inspect
-    #     ^^^^^^^^^^^^^^
-    #   File "/home/runner/work/cpython/cpython/Lib/inspect.py", line 137, in <module>
-    #     import dis
-    #     ^^^^^^^^^^
-    #   File "/home/runner/work/cpython/cpython/Lib/dis.py", line 7, in <module>
-    #     import ctypes
-    #     ^^^^^^^^^^^^^
-    #   File "/home/runner/work/cpython/cpython/Lib/ctypes/__init__.py", line 8, in <module>
-    #     from _ctypes import Union, Structure, Array
-    #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    # ModuleNotFoundError: No module named '_ctypes'
+    # Can't import ctypes at the top level because it's unavailable in some tests that need dis
     import ctypes
     # The number of bits in a signed int
     c_int_bit_size = ctypes.sizeof(ctypes.c_int()) * 8

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -518,8 +518,8 @@ disco = disassemble                     # XXX For backwards compatibility
 
 # Rely on C `int` being 32 bits for oparg
 _INT_BITS = 32
-# Maximum value for a c int
-_INT_MAX = 2 ** (_INT_BITS - 1)
+# Value for c int when it overflows
+_INT_OVERFLOW = 2 ** (_INT_BITS - 1)
 
 def _unpack_opargs(code):
     extended_arg = 0
@@ -531,8 +531,8 @@ def _unpack_opargs(code):
             # The oparg is stored as a signed integer
             # If the value exceeds its upper limit, it will overflow and wrap
             # to a negative integer
-            if extended_arg >= _INT_MAX:
-                extended_arg -= 2 * _INT_MAX
+            if extended_arg >= _INT_OVERFLOW:
+                extended_arg -= 2 * _INT_OVERFLOW
         else:
             arg = None
             extended_arg = 0

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -517,9 +517,9 @@ disco = disassemble                     # XXX For backwards compatibility
 
 
 # Rely on C `int` being 32 bits for oparg
-INT_BITS = 32
+_INT_BITS = 32
 # Maximum value for a c int
-INT_MAX = 2 ** (INT_BITS - 1)
+_INT_MAX = 2 ** (_INT_BITS - 1)
 
 def _unpack_opargs(code):
     extended_arg = 0

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -531,8 +531,8 @@ def _unpack_opargs(code):
             # The oparg is stored as a signed integer
             # If the value exceeds its upper limit, it will overflow and wrap
             # to a negative integer
-            if extended_arg >= INT_MAX:
-                extended_arg -= 2 * INT_MAX
+            if extended_arg >= _INT_MAX:
+                extended_arg -= 2 * _INT_MAX
         else:
             arg = None
             extended_arg = 0

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -705,7 +705,7 @@ class DisTests(DisTestBase):
         self.do_disassembly_test(code_bug_45757, dis_bug_45757)
 
     def test_bug_46724(self):
-        # Test that overflow operargs wrap
+        # Test that negative operargs are handled properly
         self.do_disassembly_test(bug46724, dis_bug46724)
 
     def test_big_linenos(self):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1,14 +1,15 @@
 # Minimal tests for dis module
 
-from test.support import captured_stdout, requires_debug_ranges
-from test.support.bytecode_helper import BytecodeTestCase
-import unittest
-import sys
+import contextlib
 import dis
 import io
 import re
+import sys
 import types
-import contextlib
+import unittest
+from test.support import captured_stdout, requires_debug_ranges
+from test.support.bytecode_helper import BytecodeTestCase
+
 
 def get_tb():
     def _error():
@@ -229,10 +230,10 @@ bug46724 = bytes([
 
 
 dis_bug46724 = """\
-    >>    0 EXTENDED_ARG           255
-          2 EXTENDED_ARG         65535
-          4 EXTENDED_ARG         16777215
-          6 JUMP_FORWARD            -4 (to 0)
+    >> EXTENDED_ARG           255
+       EXTENDED_ARG         65535
+       EXTENDED_ARG         16777215
+       JUMP_FORWARD            -4 (to 0)
 """
 
 _BIG_LINENO_FORMAT = """\

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -219,6 +219,45 @@ dis_bug_45757 = """\
        RETURN_VALUE
 """
 
+bug46724 = compile("while not (a < b < c):\n    pass", "", "exec")
+
+dis_bug46724 = """\
+              0 RESUME                   0
+
+  1           2 LOAD_NAME                0 (a)
+              4 LOAD_NAME                1 (b)
+              6 SWAP                     2
+              8 COPY                     2
+             10 COMPARE_OP               0 (<)
+             12 POP_JUMP_IF_FALSE       11 (to 22)
+             14 LOAD_NAME                2 (c)
+             16 COMPARE_OP               0 (<)
+             18 POP_JUMP_IF_TRUE        29 (to 58)
+             20 JUMP_FORWARD             1 (to 24)
+        >>   22 POP_TOP
+
+  2     >>   24 NOP
+
+  1          26 LOAD_NAME                0 (a)
+             28 LOAD_NAME                1 (b)
+             30 SWAP                     2
+             32 COPY                     2
+             34 COMPARE_OP               0 (<)
+             36 POP_JUMP_IF_FALSE       24 (to 48)
+             38 LOAD_NAME                2 (c)
+             40 COMPARE_OP               0 (<)
+             42 POP_JUMP_IF_FALSE       12 (to 24)
+             44 LOAD_CONST               0 (None)
+             46 RETURN_VALUE
+        >>   48 POP_TOP
+             50 EXTENDED_ARG           255
+             52 EXTENDED_ARG         65535
+             54 EXTENDED_ARG         16777215
+             56 JUMP_FORWARD           -17 (to 24)
+        >>   58 LOAD_CONST               0 (None)
+             60 RETURN_VALUE
+"""
+
 _BIG_LINENO_FORMAT = """\
   1        RESUME                   0
 
@@ -687,6 +726,10 @@ class DisTests(DisTestBase):
     def test_bug_45757(self):
         # Extended arg followed by NOP
         self.do_disassembly_test(code_bug_45757, dis_bug_45757)
+
+    def test_bug_46724(self):
+        # Test that overflow operargs wrap
+        self.do_disassembly_test(bug46724, dis_bug46724)
 
     def test_big_linenos(self):
         def func(count):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -219,43 +219,43 @@ dis_bug_45757 = """\
        RETURN_VALUE
 """
 
-bug46724 = compile("while not (a < b < c):\n    pass", "", "exec")
+# Result of compile("while not (a < b < c):\n    pass", "", "exec").co_code
+# but added as constant to make agnostic to compile behavior
+bug46724 = b'\x97\x00e\x00e\x01c\x02x\x02k\x00r\x0be\x02k\x00s\x1dn\x01\x01\x00\t\x00e\x00e\x01c\x02x\x02k\x00r\x18e\x02k\x00r\x0cd\x00S\x00\x01\x00\x90\xff\x90\xff\x90\xffn\xefd\x00S\x00'
+
 
 dis_bug46724 = """\
-              0 RESUME                   0
-
-  1           2 LOAD_NAME                0 (a)
-              4 LOAD_NAME                1 (b)
-              6 SWAP                     2
-              8 COPY                     2
-             10 COMPARE_OP               0 (<)
-             12 POP_JUMP_IF_FALSE       11 (to 22)
-             14 LOAD_NAME                2 (c)
-             16 COMPARE_OP               0 (<)
-             18 POP_JUMP_IF_TRUE        29 (to 58)
-             20 JUMP_FORWARD             1 (to 24)
-        >>   22 POP_TOP
-
-  2     >>   24 NOP
-
-  1          26 LOAD_NAME                0 (a)
-             28 LOAD_NAME                1 (b)
-             30 SWAP                     2
-             32 COPY                     2
-             34 COMPARE_OP               0 (<)
-             36 POP_JUMP_IF_FALSE       24 (to 48)
-             38 LOAD_NAME                2 (c)
-             40 COMPARE_OP               0 (<)
-             42 POP_JUMP_IF_FALSE       12 (to 24)
-             44 LOAD_CONST               0 (None)
-             46 RETURN_VALUE
-        >>   48 POP_TOP
-             50 EXTENDED_ARG           255
-             52 EXTENDED_ARG         65535
-             54 EXTENDED_ARG         16777215
-             56 JUMP_FORWARD           -17 (to 24)
-        >>   58 LOAD_CONST               0 (None)
-             60 RETURN_VALUE
+          0 RESUME                   0
+          2 LOAD_NAME                0
+          4 LOAD_NAME                1
+          6 SWAP                     2
+          8 COPY                     2
+         10 COMPARE_OP               0 (<)
+         12 POP_JUMP_IF_FALSE       11 (to 22)
+         14 LOAD_NAME                2
+         16 COMPARE_OP               0 (<)
+         18 POP_JUMP_IF_TRUE        29 (to 58)
+         20 JUMP_FORWARD             1 (to 24)
+    >>   22 POP_TOP
+    >>   24 NOP
+         26 LOAD_NAME                0
+         28 LOAD_NAME                1
+         30 SWAP                     2
+         32 COPY                     2
+         34 COMPARE_OP               0 (<)
+         36 POP_JUMP_IF_FALSE       24 (to 48)
+         38 LOAD_NAME                2
+         40 COMPARE_OP               0 (<)
+         42 POP_JUMP_IF_FALSE       12 (to 24)
+         44 LOAD_CONST               0
+         46 RETURN_VALUE
+    >>   48 POP_TOP
+         50 EXTENDED_ARG           255
+         52 EXTENDED_ARG         65535
+         54 EXTENDED_ARG         16777215
+         56 JUMP_FORWARD           -17 (to 24)
+    >>   58 LOAD_CONST               0
+         60 RETURN_VALUE
 """
 
 _BIG_LINENO_FORMAT = """\

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -219,43 +219,20 @@ dis_bug_45757 = """\
        RETURN_VALUE
 """
 
-# Result of compile("while not (a < b < c):\n    pass", "", "exec").co_code
-# but added as constant to make agnostic to compile behavior
-bug46724 = b'\x97\x00e\x00e\x01c\x02x\x02k\x00r\x0be\x02k\x00s\x1dn\x01\x01\x00\t\x00e\x00e\x01c\x02x\x02k\x00r\x18e\x02k\x00r\x0cd\x00S\x00\x01\x00\x90\xff\x90\xff\x90\xffn\xefd\x00S\x00'
+# [255, 255, 255, 252] is -4 in a 4 byte signed integer
+bug46724 = bytes([
+    144, 255, # EXTENDED_ARG
+    144, 255,
+    144, 255,
+    110, 252, # JUMP_FORWARD
+])
 
 
 dis_bug46724 = """\
-          0 RESUME                   0
-          2 LOAD_NAME                0
-          4 LOAD_NAME                1
-          6 SWAP                     2
-          8 COPY                     2
-         10 COMPARE_OP               0 (<)
-         12 POP_JUMP_IF_FALSE       11 (to 22)
-         14 LOAD_NAME                2
-         16 COMPARE_OP               0 (<)
-         18 POP_JUMP_IF_TRUE        29 (to 58)
-         20 JUMP_FORWARD             1 (to 24)
-    >>   22 POP_TOP
-    >>   24 NOP
-         26 LOAD_NAME                0
-         28 LOAD_NAME                1
-         30 SWAP                     2
-         32 COPY                     2
-         34 COMPARE_OP               0 (<)
-         36 POP_JUMP_IF_FALSE       24 (to 48)
-         38 LOAD_NAME                2
-         40 COMPARE_OP               0 (<)
-         42 POP_JUMP_IF_FALSE       12 (to 24)
-         44 LOAD_CONST               0
-         46 RETURN_VALUE
-    >>   48 POP_TOP
-         50 EXTENDED_ARG           255
-         52 EXTENDED_ARG         65535
-         54 EXTENDED_ARG         16777215
-         56 JUMP_FORWARD           -17 (to 24)
-    >>   58 LOAD_CONST               0
-         60 RETURN_VALUE
+    >>    0 EXTENDED_ARG           255
+          2 EXTENDED_ARG         65535
+          4 EXTENDED_ARG         16777215
+          6 JUMP_FORWARD            -4 (to 0)
 """
 
 _BIG_LINENO_FORMAT = """\

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -10,6 +10,8 @@ import unittest
 from test.support import captured_stdout, requires_debug_ranges
 from test.support.bytecode_helper import BytecodeTestCase
 
+import opcode
+
 
 def get_tb():
     def _error():
@@ -222,10 +224,10 @@ dis_bug_45757 = """\
 
 # [255, 255, 255, 252] is -4 in a 4 byte signed integer
 bug46724 = bytes([
-    144, 255, # EXTENDED_ARG
-    144, 255,
-    144, 255,
-    110, 252, # JUMP_FORWARD
+    opcode.EXTENDED_ARG, 255,
+    opcode.EXTENDED_ARG, 255,
+    opcode.EXTENDED_ARG, 255,
+    opcode.opmap['JUMP_FORWARD'], 252,
 ])
 
 

--- a/Misc/NEWS.d/next/Library/2022-02-11-20-41-17.bpo-46724.eU52_N.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-11-20-41-17.bpo-46724.eU52_N.rst
@@ -1,1 +1,1 @@
-Fixes dis behavior on bytecode arguments which overflow to match Python interpreter
+Fixes dis behavior on bytecode arguments which overflow to support negative args

--- a/Misc/NEWS.d/next/Library/2022-02-11-20-41-17.bpo-46724.eU52_N.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-11-20-41-17.bpo-46724.eU52_N.rst
@@ -1,0 +1,1 @@
+Fixes dis behavior on bytecode arguments which overflow to match Python interpreter

--- a/Misc/NEWS.d/next/Library/2022-02-11-20-41-17.bpo-46724.eU52_N.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-11-20-41-17.bpo-46724.eU52_N.rst
@@ -1,1 +1,1 @@
-Fixes dis behavior on bytecode arguments which overflow to support negative args
+Fix :mod:`dis` behavior on negative jump offsets.


### PR DESCRIPTION
This PR makes dis aware that currently Python's opargs wrap after a certain value. This is used in Python 3.10+ for code which includes negative args to represent negative jumps, like this:

```python
while not (x < y < z):
    pass
```

which produces this `dis` output after this PR:

```
              0 RESUME                   0

  1           2 LOAD_NAME                0 (a)
              4 LOAD_NAME                1 (b)
              6 SWAP                     2
              8 COPY                     2
             10 COMPARE_OP               0 (<)
             12 POP_JUMP_IF_FALSE       11 (to 22)
             14 LOAD_NAME                2 (c)
             16 COMPARE_OP               0 (<)
             18 POP_JUMP_IF_TRUE        28 (to 56)
             20 JUMP_FORWARD             1 (to 24)
        >>   22 POP_TOP
        >>   24 LOAD_NAME                0 (a)
             26 LOAD_NAME                1 (b)
             28 SWAP                     2
             30 COPY                     2
             32 COMPARE_OP               0 (<)
             34 POP_JUMP_IF_FALSE       23 (to 46)
             36 LOAD_NAME                2 (c)
             38 COMPARE_OP               0 (<)
             40 POP_JUMP_IF_FALSE       12 (to 24)
             42 LOAD_CONST               0 (None)
             44 RETURN_VALUE
        >>   46 POP_TOP
             48 EXTENDED_ARG           255
             50 EXTENDED_ARG         65535
             52 EXTENDED_ARG         16777215
             54 JUMP_FORWARD           -16 (to 24)
        >>   56 LOAD_CONST               0 (None)
             58 RETURN_VALUE
```

Before this PR, the `JUMP_FORWARD` on line 54 had a huge value that did not match the Python interpreters behavior.

It is unclear to me whether producing this sort of bytecode is intended (I assume it's not), but at least with this fix the `dis` output more closes matches the current implementation.

<!-- issue-number: [bpo-46724](https://bugs.python.org/issue46724) -->
https://bugs.python.org/issue46724
<!-- /issue-number -->
