### PR TITLE
bpo-46072: Add detailed failure stats for `BINARY_OP`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-11-13-47-58.bpo-46072.PDS6Ke.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-11-13-47-58.bpo-46072.PDS6Ke.rst
@@ -1,0 +1,1 @@
+Add more detailed specialization failure statistics for :opcode:`BINARY_OP`.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -543,9 +543,24 @@ initial_counter_value(void) {
 #define SPEC_FAIL_SUBSCR_PY_OTHER 21
 #define SPEC_FAIL_SUBSCR_DICT_SUBCLASS_NO_OVERRIDE 22
 
-/* Binary add */
+/* Binary op */
 
-#define SPEC_FAIL_BINARY_OP_DIFFERENT_TYPES 12
+#define SPEC_FAIL_BINARY_OP_ADD_DIFFERENT_TYPES       8
+#define SPEC_FAIL_BINARY_OP_ADD_OTHER                 9
+#define SPEC_FAIL_BINARY_OP_AND                      10
+#define SPEC_FAIL_BINARY_OP_FLOOR_DIVIDE             11
+#define SPEC_FAIL_BINARY_OP_LSHIFT                   12
+#define SPEC_FAIL_BINARY_OP_MATRIX_MULTIPLY          13
+#define SPEC_FAIL_BINARY_OP_MULTIPLY_DIFFERENT_TYPES 14
+#define SPEC_FAIL_BINARY_OP_MULTIPLY_OTHER           15
+#define SPEC_FAIL_BINARY_OP_OR                       16
+#define SPEC_FAIL_BINARY_OP_POWER                    17
+#define SPEC_FAIL_BINARY_OP_REMAINDER                18
+#define SPEC_FAIL_BINARY_OP_RSHIFT                   19
+#define SPEC_FAIL_BINARY_OP_SUBTRACT_DIFFERENT_TYPES 20
+#define SPEC_FAIL_BINARY_OP_SUBTRACT_OTHER           21
+#define SPEC_FAIL_BINARY_OP_TRUE_DIVIDE              22
+#define SPEC_FAIL_BINARY_OP_XOR                      23
 
 /* Calls */
 #define SPEC_FAIL_CALL_COMPLEX_PARAMETERS 9
@@ -1739,81 +1754,124 @@ void
 _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
                         SpecializedCacheEntry *cache)
 {
+    int result;
     _PyAdaptiveEntry *adaptive = &cache->adaptive;
     switch (adaptive->original_oparg) {
         case NB_ADD:
         case NB_INPLACE_ADD:
             if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
-                SPECIALIZATION_FAIL(BINARY_OP, SPEC_FAIL_BINARY_OP_DIFFERENT_TYPES);
+                result = SPEC_FAIL_BINARY_OP_ADD_DIFFERENT_TYPES;
                 goto failure;
             }
             if (PyUnicode_CheckExact(lhs)) {
                 if (_Py_OPCODE(instr[1]) == STORE_FAST && Py_REFCNT(lhs) == 2) {
-                    *instr = _Py_MAKECODEUNIT(BINARY_OP_INPLACE_ADD_UNICODE,
-                                              _Py_OPARG(*instr));
+                    result = BINARY_OP_INPLACE_ADD_UNICODE;
                     goto success;
                 }
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_UNICODE,
-                                          _Py_OPARG(*instr));
+                result = BINARY_OP_ADD_UNICODE;
                 goto success;
             }
             if (PyLong_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_INT, _Py_OPARG(*instr));
+                result = BINARY_OP_ADD_INT;
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_FLOAT,
-                                          _Py_OPARG(*instr));
+                result = BINARY_OP_ADD_FLOAT;
                 goto success;
             }
-            break;
+            result = SPEC_FAIL_BINARY_OP_ADD_OTHER;
+            goto failure;
+        case NB_AND:
+        case NB_INPLACE_AND:
+            result = SPEC_FAIL_BINARY_OP_AND;
+            goto unadapt;
+        case NB_FLOOR_DIVIDE:
+        case NB_INPLACE_FLOOR_DIVIDE:
+            result = SPEC_FAIL_BINARY_OP_FLOOR_DIVIDE;
+            goto unadapt;
+        case NB_LSHIFT:
+        case NB_INPLACE_LSHIFT:
+            result = SPEC_FAIL_BINARY_OP_LSHIFT;
+            goto unadapt;
+        case NB_MATRIX_MULTIPLY:
+        case NB_INPLACE_MATRIX_MULTIPLY:
+            result = SPEC_FAIL_BINARY_OP_MATRIX_MULTIPLY;
+            goto unadapt;
         case NB_MULTIPLY:
         case NB_INPLACE_MULTIPLY:
             if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
-                SPECIALIZATION_FAIL(BINARY_OP, SPEC_FAIL_BINARY_OP_DIFFERENT_TYPES);
+                result = SPEC_FAIL_BINARY_OP_MULTIPLY_DIFFERENT_TYPES;
                 goto failure;
             }
             if (PyLong_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_MULTIPLY_INT,
-                                          _Py_OPARG(*instr));
+                result = BINARY_OP_MULTIPLY_INT;
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_MULTIPLY_FLOAT,
-                                          _Py_OPARG(*instr));
+                result = BINARY_OP_MULTIPLY_FLOAT;
                 goto success;
             }
-            break;
+            result = SPEC_FAIL_BINARY_OP_MULTIPLY_OTHER;
+            goto failure;
+        case NB_OR:
+        case NB_INPLACE_OR:
+            result = SPEC_FAIL_BINARY_OP_OR;
+            goto unadapt;
+        case NB_POWER:
+        case NB_INPLACE_POWER:
+            result = SPEC_FAIL_BINARY_OP_POWER;
+            goto unadapt;
+        case NB_REMAINDER:
+        case NB_INPLACE_REMAINDER:
+            result = SPEC_FAIL_BINARY_OP_REMAINDER;
+            goto unadapt;
+        case NB_RSHIFT:
+        case NB_INPLACE_RSHIFT:
+            result = SPEC_FAIL_BINARY_OP_RSHIFT;
+            goto unadapt;
         case NB_SUBTRACT:
         case NB_INPLACE_SUBTRACT:
             if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
-                SPECIALIZATION_FAIL(BINARY_OP, SPEC_FAIL_BINARY_OP_DIFFERENT_TYPES);
+                result = SPEC_FAIL_BINARY_OP_SUBTRACT_DIFFERENT_TYPES;
                 goto failure;
             }
             if (PyLong_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_SUBTRACT_INT,
-                                          _Py_OPARG(*instr));
+                result = BINARY_OP_SUBTRACT_INT;
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_SUBTRACT_FLOAT,
-                                          _Py_OPARG(*instr));
+                result = BINARY_OP_SUBTRACT_FLOAT;
                 goto success;
             }
-            break;
-        default:
-            // These operators don't have any available specializations. Rather
-            // than repeatedly attempting to specialize them, just convert them
-            // back to BINARY_OP (while still recording a failure, of course)!
-            *instr = _Py_MAKECODEUNIT(BINARY_OP, adaptive->original_oparg);
+            result = SPEC_FAIL_BINARY_OP_SUBTRACT_OTHER;
+            goto failure;
+        case NB_TRUE_DIVIDE:
+        case NB_INPLACE_TRUE_DIVIDE:
+            result = SPEC_FAIL_BINARY_OP_TRUE_DIVIDE;
+            goto unadapt;
+        case NB_XOR:
+        case NB_INPLACE_XOR:
+            result = SPEC_FAIL_BINARY_OP_XOR;
+            goto unadapt;
     }
-    SPECIALIZATION_FAIL(BINARY_OP, SPEC_FAIL_OTHER);
+    Py_UNREACHABLE();
+unadapt:
+    // These operators don't have any available specializations. Just convert
+    // them back to BINARY_OP to avoid repeated failed specialization attempts.
+    // (Skip this when collecting stats, though, to get accurate hit counts for
+    // unadaptive version and each of the different failure types).
+#ifndef Py_STATS
+    *instr = _Py_MAKECODEUNIT(BINARY_OP, adaptive->original_oparg);
+    return;
+#endif
 failure:
     STAT_INC(BINARY_OP, failure);
+    SPECIALIZATION_FAIL(BINARY_OP, result);
     cache_backoff(adaptive);
     return;
 success:
     STAT_INC(BINARY_OP, success);
+    *instr = _Py_MAKECODEUNIT(result, _Py_OPARG(*instr));
     adaptive->counter = initial_counter_value();
 }
 

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -545,22 +545,26 @@ initial_counter_value(void) {
 
 /* Binary op */
 
-#define SPEC_FAIL_BINARY_OP_ADD_DIFFERENT_TYPES       8
-#define SPEC_FAIL_BINARY_OP_ADD_OTHER                 9
-#define SPEC_FAIL_BINARY_OP_AND                      10
-#define SPEC_FAIL_BINARY_OP_FLOOR_DIVIDE             11
-#define SPEC_FAIL_BINARY_OP_LSHIFT                   12
-#define SPEC_FAIL_BINARY_OP_MATRIX_MULTIPLY          13
-#define SPEC_FAIL_BINARY_OP_MULTIPLY_DIFFERENT_TYPES 14
-#define SPEC_FAIL_BINARY_OP_MULTIPLY_OTHER           15
-#define SPEC_FAIL_BINARY_OP_OR                       16
-#define SPEC_FAIL_BINARY_OP_POWER                    17
-#define SPEC_FAIL_BINARY_OP_REMAINDER                18
-#define SPEC_FAIL_BINARY_OP_RSHIFT                   19
-#define SPEC_FAIL_BINARY_OP_SUBTRACT_DIFFERENT_TYPES 20
-#define SPEC_FAIL_BINARY_OP_SUBTRACT_OTHER           21
-#define SPEC_FAIL_BINARY_OP_TRUE_DIVIDE              22
-#define SPEC_FAIL_BINARY_OP_XOR                      23
+#define SPEC_FAIL_BINARY_OP_ADD_DIFFERENT_TYPES          8
+#define SPEC_FAIL_BINARY_OP_ADD_OTHER                    9
+#define SPEC_FAIL_BINARY_OP_AND_DIFFERENT_TYPES         10
+#define SPEC_FAIL_BINARY_OP_AND_INT                     11
+#define SPEC_FAIL_BINARY_OP_AND_OTHER                   12
+#define SPEC_FAIL_BINARY_OP_FLOOR_DIVIDE                13
+#define SPEC_FAIL_BINARY_OP_LSHIFT                      14
+#define SPEC_FAIL_BINARY_OP_MATRIX_MULTIPLY             15
+#define SPEC_FAIL_BINARY_OP_MULTIPLY_DIFFERENT_TYPES    16
+#define SPEC_FAIL_BINARY_OP_MULTIPLY_OTHER              17
+#define SPEC_FAIL_BINARY_OP_OR                          18
+#define SPEC_FAIL_BINARY_OP_POWER                       19
+#define SPEC_FAIL_BINARY_OP_REMAINDER                   20
+#define SPEC_FAIL_BINARY_OP_RSHIFT                      21
+#define SPEC_FAIL_BINARY_OP_SUBTRACT_DIFFERENT_TYPES    22
+#define SPEC_FAIL_BINARY_OP_SUBTRACT_OTHER              23
+#define SPEC_FAIL_BINARY_OP_TRUE_DIVIDE_DIFFERENT_TYPES 24
+#define SPEC_FAIL_BINARY_OP_TRUE_DIVIDE_FLOAT           25
+#define SPEC_FAIL_BINARY_OP_TRUE_DIVIDE_OTHER           26
+#define SPEC_FAIL_BINARY_OP_XOR                         27
 
 /* Calls */
 #define SPEC_FAIL_CALL_COMPLEX_PARAMETERS 9
@@ -1750,128 +1754,157 @@ _Py_Specialize_CallNoKw(
     return 0;
 }
 
+#ifdef Py_STATS
+static int
+binary_op_fail_kind(int oparg, PyObject *lhs, PyObject *rhs)
+{
+    switch (oparg) {
+        case NB_ADD:
+        case NB_INPLACE_ADD:
+            if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
+                return SPEC_FAIL_BINARY_OP_ADD_DIFFERENT_TYPES;
+            }
+            return SPEC_FAIL_BINARY_OP_ADD_OTHER;
+        case NB_AND:
+        case NB_INPLACE_AND:
+            if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
+                return SPEC_FAIL_BINARY_OP_AND_DIFFERENT_TYPES;
+            }
+            if (PyLong_CheckExact(lhs)) {
+                return SPEC_FAIL_BINARY_OP_AND_INT;
+            }
+            return SPEC_FAIL_BINARY_OP_AND_OTHER;
+        case NB_FLOOR_DIVIDE:
+        case NB_INPLACE_FLOOR_DIVIDE:
+            return SPEC_FAIL_BINARY_OP_FLOOR_DIVIDE;
+        case NB_LSHIFT:
+        case NB_INPLACE_LSHIFT:
+            return SPEC_FAIL_BINARY_OP_LSHIFT;
+        case NB_MATRIX_MULTIPLY:
+        case NB_INPLACE_MATRIX_MULTIPLY:
+            return SPEC_FAIL_BINARY_OP_MATRIX_MULTIPLY;
+        case NB_MULTIPLY:
+        case NB_INPLACE_MULTIPLY:
+            if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
+                return SPEC_FAIL_BINARY_OP_MULTIPLY_DIFFERENT_TYPES;
+            }
+            return SPEC_FAIL_BINARY_OP_MULTIPLY_OTHER;
+        case NB_OR:
+        case NB_INPLACE_OR:
+            return SPEC_FAIL_BINARY_OP_OR;
+        case NB_POWER:
+        case NB_INPLACE_POWER:
+            return SPEC_FAIL_BINARY_OP_POWER;
+        case NB_REMAINDER:
+        case NB_INPLACE_REMAINDER:
+            return SPEC_FAIL_BINARY_OP_REMAINDER;
+        case NB_RSHIFT:
+        case NB_INPLACE_RSHIFT:
+            return SPEC_FAIL_BINARY_OP_RSHIFT;
+        case NB_SUBTRACT:
+        case NB_INPLACE_SUBTRACT:
+            if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
+                return SPEC_FAIL_BINARY_OP_SUBTRACT_DIFFERENT_TYPES;
+            }
+            return SPEC_FAIL_BINARY_OP_SUBTRACT_OTHER;
+        case NB_TRUE_DIVIDE:
+        case NB_INPLACE_TRUE_DIVIDE:
+            if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
+                return SPEC_FAIL_BINARY_OP_TRUE_DIVIDE_DIFFERENT_TYPES;
+            }
+            if (PyFloat_CheckExact(lhs)) {
+                return SPEC_FAIL_BINARY_OP_TRUE_DIVIDE_FLOAT;
+            }
+            return SPEC_FAIL_BINARY_OP_TRUE_DIVIDE_OTHER;
+        case NB_XOR:
+        case NB_INPLACE_XOR:
+            return SPEC_FAIL_BINARY_OP_XOR;
+    }
+    Py_UNREACHABLE();
+}
+#endif
+
 void
 _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
                         SpecializedCacheEntry *cache)
 {
-    int result;
     _PyAdaptiveEntry *adaptive = &cache->adaptive;
     switch (adaptive->original_oparg) {
         case NB_ADD:
         case NB_INPLACE_ADD:
             if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
-                result = SPEC_FAIL_BINARY_OP_ADD_DIFFERENT_TYPES;
-                goto failure;
+                break;
             }
             if (PyUnicode_CheckExact(lhs)) {
                 if (_Py_OPCODE(instr[1]) == STORE_FAST && Py_REFCNT(lhs) == 2) {
-                    result = BINARY_OP_INPLACE_ADD_UNICODE;
+                    *instr = _Py_MAKECODEUNIT(BINARY_OP_INPLACE_ADD_UNICODE,
+                                              _Py_OPARG(*instr));
                     goto success;
                 }
-                result = BINARY_OP_ADD_UNICODE;
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_UNICODE,
+                                          _Py_OPARG(*instr));
                 goto success;
             }
             if (PyLong_CheckExact(lhs)) {
-                result = BINARY_OP_ADD_INT;
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_INT,
+                                          _Py_OPARG(*instr));
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                result = BINARY_OP_ADD_FLOAT;
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_FLOAT, 
+                                          _Py_OPARG(*instr));
                 goto success;
             }
-            result = SPEC_FAIL_BINARY_OP_ADD_OTHER;
-            goto failure;
-        case NB_AND:
-        case NB_INPLACE_AND:
-            result = SPEC_FAIL_BINARY_OP_AND;
-            goto unadapt;
-        case NB_FLOOR_DIVIDE:
-        case NB_INPLACE_FLOOR_DIVIDE:
-            result = SPEC_FAIL_BINARY_OP_FLOOR_DIVIDE;
-            goto unadapt;
-        case NB_LSHIFT:
-        case NB_INPLACE_LSHIFT:
-            result = SPEC_FAIL_BINARY_OP_LSHIFT;
-            goto unadapt;
-        case NB_MATRIX_MULTIPLY:
-        case NB_INPLACE_MATRIX_MULTIPLY:
-            result = SPEC_FAIL_BINARY_OP_MATRIX_MULTIPLY;
-            goto unadapt;
+            break;
         case NB_MULTIPLY:
         case NB_INPLACE_MULTIPLY:
             if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
-                result = SPEC_FAIL_BINARY_OP_MULTIPLY_DIFFERENT_TYPES;
-                goto failure;
+                break;
             }
             if (PyLong_CheckExact(lhs)) {
-                result = BINARY_OP_MULTIPLY_INT;
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_MULTIPLY_INT,
+                                          _Py_OPARG(*instr));
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                result = BINARY_OP_MULTIPLY_FLOAT;
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_MULTIPLY_FLOAT, 
+                                          _Py_OPARG(*instr));
                 goto success;
             }
-            result = SPEC_FAIL_BINARY_OP_MULTIPLY_OTHER;
-            goto failure;
-        case NB_OR:
-        case NB_INPLACE_OR:
-            result = SPEC_FAIL_BINARY_OP_OR;
-            goto unadapt;
-        case NB_POWER:
-        case NB_INPLACE_POWER:
-            result = SPEC_FAIL_BINARY_OP_POWER;
-            goto unadapt;
-        case NB_REMAINDER:
-        case NB_INPLACE_REMAINDER:
-            result = SPEC_FAIL_BINARY_OP_REMAINDER;
-            goto unadapt;
-        case NB_RSHIFT:
-        case NB_INPLACE_RSHIFT:
-            result = SPEC_FAIL_BINARY_OP_RSHIFT;
-            goto unadapt;
+            break;
         case NB_SUBTRACT:
         case NB_INPLACE_SUBTRACT:
             if (!Py_IS_TYPE(lhs, Py_TYPE(rhs))) {
-                result = SPEC_FAIL_BINARY_OP_SUBTRACT_DIFFERENT_TYPES;
-                goto failure;
+                break;
             }
             if (PyLong_CheckExact(lhs)) {
-                result = BINARY_OP_SUBTRACT_INT;
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_SUBTRACT_INT, 
+                                          _Py_OPARG(*instr));
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                result = BINARY_OP_SUBTRACT_FLOAT;
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_SUBTRACT_FLOAT, 
+                                          _Py_OPARG(*instr));
                 goto success;
             }
-            result = SPEC_FAIL_BINARY_OP_SUBTRACT_OTHER;
-            goto failure;
-        case NB_TRUE_DIVIDE:
-        case NB_INPLACE_TRUE_DIVIDE:
-            result = SPEC_FAIL_BINARY_OP_TRUE_DIVIDE;
-            goto unadapt;
-        case NB_XOR:
-        case NB_INPLACE_XOR:
-            result = SPEC_FAIL_BINARY_OP_XOR;
-            goto unadapt;
-    }
-    Py_UNREACHABLE();
-unadapt:
-    // These operators don't have any available specializations. Just convert
-    // them back to BINARY_OP to avoid repeated failed specialization attempts.
-    // (Skip this when collecting stats, though, to get accurate hit counts for
-    // unadaptive version and each of the different failure types).
+            break;
 #ifndef Py_STATS
-    *instr = _Py_MAKECODEUNIT(BINARY_OP, adaptive->original_oparg);
-    return;
+        default:
+            // These operators don't have any specializations. Convert them back
+            // to BINARY_OP to avoid repeated failed specialization attempts.
+            // (Skip this when collecting stats, though, to get accurate hit
+            // counts for unadaptive version and each of the failure types).
+            *instr = _Py_MAKECODEUNIT(BINARY_OP, adaptive->original_oparg);
+            return;
 #endif
-failure:
+    }
+    SPECIALIZATION_FAIL(
+        BINARY_OP, binary_op_fail_kind(adaptive->original_oparg, lhs, rhs));
     STAT_INC(BINARY_OP, failure);
-    SPECIALIZATION_FAIL(BINARY_OP, result);
     cache_backoff(adaptive);
     return;
 success:
     STAT_INC(BINARY_OP, success);
-    *instr = _Py_MAKECODEUNIT(result, _Py_OPARG(*instr));
     adaptive->counter = initial_counter_value();
 }
 

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1851,7 +1851,7 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_FLOAT, 
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_FLOAT,
                                           _Py_OPARG(*instr));
                 goto success;
             }
@@ -1867,7 +1867,7 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_MULTIPLY_FLOAT, 
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_MULTIPLY_FLOAT,
                                           _Py_OPARG(*instr));
                 goto success;
             }
@@ -1878,12 +1878,12 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
                 break;
             }
             if (PyLong_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_SUBTRACT_INT, 
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_SUBTRACT_INT,
                                           _Py_OPARG(*instr));
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_SUBTRACT_FLOAT, 
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_SUBTRACT_FLOAT,
                                           _Py_OPARG(*instr));
                 goto success;
             }

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1846,8 +1846,7 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
                 goto success;
             }
             if (PyLong_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_INT,
-                                          _Py_OPARG(*instr));
+                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_INT, _Py_OPARG(*instr));
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
@@ -1890,10 +1889,11 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
             break;
 #ifndef Py_STATS
         default:
-            // These operators don't have any specializations. Convert them back
-            // to BINARY_OP to avoid repeated failed specialization attempts.
-            // (Skip this when collecting stats, though, to get accurate hit
-            // counts for unadaptive version and each of the failure types).
+            // These operators don't have any available specializations. Rather
+            // than repeatedly attempting to specialize them, just convert them
+            // back to BINARY_OP (unless we're collecting stats, where it's more
+            // important to get accurate hit counts for the unadaptive version
+            // and each of the different failure types):
             *instr = _Py_MAKECODEUNIT(BINARY_OP, adaptive->original_oparg);
             return;
 #endif


### PR DESCRIPTION
On further reflection, I think it's definitely possible to get our current ~80% hit rate up to ~90%. These detailed failure stats will help guide my work on this.

Example full `pyperformance` run with this patch applied:

|Kind | Count | Ratio | 
|---|---|---|
|  unquickened |      7837567 | 0.1% |
|     deferred |   1187894724 | 19.8% |
|        deopt |       600612 | 0.0% |
|          hit |   4756557559 | 79.5% |
|         miss |     32075102 | 0.5% |

#### Specialization attempts

| | Count | Ratio | 
|---|---:|---:|
| Success | 948284 | 5.0% |
| Failure | 18123381 | 95.0% |

|Failure kind | Count | Ratio | 
|---|---:|---:|
| and int | 2841285 | 15.7% |
| rshift | 1964549 | 10.8% |
| lshift | 1690147 | 9.3% |
| xor | 1608323 | 8.9% |
| remainder | 1574409 | 8.7% |
| add other | 1411333 | 7.8% |
| true divide different types | 1272004 | 7.0% |
| floor divide | 993317 | 5.5% |
| true divide float | 855450 | 4.7% |
| multiply different types | 806998 | 4.5% |
| subtract different types | 782979 | 4.3% |
| subtract other | 722394 | 4.0% |
| power | 598295 | 3.3% |
| or | 345072 | 1.9% |
| add different types | 326248 | 1.8% |
| multiply other | 165969 | 0.9% |
| and other | 140198 | 0.8% |
| true divide other | 17550 | 0.1% |
| and different types | 6861 | 0.0% |

Note that "add other" and "multiply different types" also correspond more specifically to sequence concatenation and repetition, respectively. Similarly, "remainder" probably contains many examples of old-style string formatting.

I figure it's not worth the clutter of breaking out specific stats for these non-numeric cases yet, since their proportion of the total failures is still pretty low (and the benefit of specialization seems slim).

<!-- issue-number: [bpo-46072](https://bugs.python.org/issue46072) -->
https://bugs.python.org/issue46072
<!-- /issue-number -->
