### PR TITLE
bpo-45274: Fix one race condition Thread.join

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1121,12 +1121,14 @@ class Thread:
             assert self._is_stopped
             return
 
+        locked = False
+
         try:
-            if lock.acquire(block, timeout):
+            if locked := lock.acquire(block, timeout):
                 lock.release()
                 self._stop()
         except:
-            if lock.locked():
+            if locked:
                 # bpo-45274: lock.acquire() acquired the lock, but the function
                 # was interrupted with an exception before reaching the
                 # lock.release(). It can happen if a signal handler raises an


### PR DESCRIPTION
If the tstate lock acquire() fails,
the tstate lock might still be locked,
and the thread still running.

This change makes sure we check that *we* acquired the lock,
and not just that it is held (by someone),
only then do we know that the thread should be stopped.


<!-- issue-number: [bpo-45274](https://bugs.python.org/issue45274) -->
https://bugs.python.org/issue45274
<!-- /issue-number -->
