### PR TITLE
Corrections to format precision description.

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -428,7 +428,7 @@ character of ``'0'`` with an *alignment* type of ``'='``.
    Preceding the *width* field by ``'0'`` no longer affects the default
    alignment for strings.
 
-The *precision* is an integer indicating how many digits should be
+The *precision* is a decimal integer indicating how many digits should be
 displayed after the decimal point for presentation types
 ``'f'`` and ``'F'``, or before and after the decimal point for presentation
 types ``'g'`` or ``'G'``.  For string presentation types the field

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -428,12 +428,13 @@ character of ``'0'`` with an *alignment* type of ``'='``.
    Preceding the *width* field by ``'0'`` no longer affects the default
    alignment for strings.
 
-The *precision* is a decimal number indicating how many digits should be
-displayed after the decimal point for a floating point value formatted with
-``'f'`` and ``'F'``, or before and after the decimal point for a floating point
-value formatted with ``'g'`` or ``'G'``.  For non-number types the field
+The *precision* is an integer indicating how many digits should be
+displayed after the decimal point for presentation types
+``'f'`` and ``'F'``, or before and after the decimal point for presentation
+types ``'g'`` or ``'G'``.  For string presentation types the field
 indicates the maximum field size - in other words, how many characters will be
-used from the field content. The *precision* is not allowed for integer values.
+used from the field content.  The *precision* is not allowed for integer
+presentation types.
 
 Finally, the *type* determines how the data should be presented.
 


### PR DESCRIPTION
  * `precision` field is a decimal integer
  * clarify that stated limitations are on presentation type
    rather than input value type.  Especially misleading is
    "precision is not allowed for integer values", since integer
    value input to a format like `.1f` is fine.
  * regarding max field size, replace "non-number" with "string",
    which is the only non-numeric presentation type

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:ericvsmith