### PR TITLE
[3.9] bpo-45948: Remove constructor discrepancy in C version of ElementTree.XMLParser (GH-31152)

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -740,6 +740,15 @@ class ElementTreeTest(unittest.TestCase):
                 ('end-ns', ''),
             ])
 
+    def test_initialize_parser_without_target(self):
+        # Explicit None
+        parser = ET.XMLParser(target=None)
+        self.assertIsInstance(parser.target, ET.TreeBuilder)
+
+        # Implicit None
+        parser2 = ET.XMLParser()
+        self.assertIsInstance(parser2.target, ET.TreeBuilder)
+
     def test_children(self):
         # Test Element children iteration
 

--- a/Misc/NEWS.d/next/Library/2022-02-05-18-22-05.bpo-45948.w4mCnE.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-05-18-22-05.bpo-45948.w4mCnE.rst
@@ -1,0 +1,5 @@
+Fixed a discrepancy in the C implementation of the
+:mod:`xml.etree.ElementTree` module. Now, instantiating an
+:class:`xml.etree.ElementTree.XMLParser` with a ``target=None``
+keyword provides a default :class:`xml.etree.ElementTree.TreeBuilder`
+target as the Python implementation does.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3636,7 +3636,7 @@ ignore_attribute_error(PyObject *value)
 _elementtree.XMLParser.__init__
 
     *
-    target: object = NULL
+    target: object = None
     encoding: str(accept={str, NoneType}) = None
 
 [clinic start generated code]*/
@@ -3644,7 +3644,7 @@ _elementtree.XMLParser.__init__
 static int
 _elementtree_XMLParser___init___impl(XMLParserObject *self, PyObject *target,
                                      const char *encoding)
-/*[clinic end generated code: output=3ae45ec6cdf344e4 input=53e35a829ae043e8]*/
+/*[clinic end generated code: output=3ae45ec6cdf344e4 input=7e716dd6e4f3e439]*/
 {
     self->entity = PyDict_New();
     if (!self->entity)
@@ -3669,7 +3669,7 @@ _elementtree_XMLParser___init___impl(XMLParserObject *self, PyObject *target,
                            (unsigned long)_Py_HashSecret.expat.hashsalt);
     }
 
-    if (target) {
+    if (target != Py_None) {
         Py_INCREF(target);
     } else {
         target = treebuilder_new(&TreeBuilder_Type, NULL, NULL);

--- a/Modules/clinic/_elementtree.c.h
+++ b/Modules/clinic/_elementtree.c.h
@@ -920,4 +920,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=992733cfc7390590 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=18ddc3c84139443d input=a9049054013a1b77]*/

--- a/Modules/clinic/_elementtree.c.h
+++ b/Modules/clinic/_elementtree.c.h
@@ -812,7 +812,7 @@ _elementtree_XMLParser___init__(PyObject *self, PyObject *args, PyObject *kwargs
     PyObject * const *fastargs;
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     Py_ssize_t noptargs = nargs + (kwargs ? PyDict_GET_SIZE(kwargs) : 0) - 0;
-    PyObject *target = NULL;
+    PyObject *target = Py_None;
     const char *encoding = NULL;
 
     fastargs = _PyArg_UnpackKeywords(_PyTuple_CAST(args)->ob_item, nargs, kwargs, NULL, &_parser, 0, 0, 0, argsbuf);
@@ -920,4 +920,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b7f6a32462fc42a9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=992733cfc7390590 input=a9049054013a1b77]*/


### PR DESCRIPTION
Both implementations accept target=None now.
(cherry picked from commit https://github.com/python/cpython/commit/168fd6453b5de15236116f9261d64601d92571ac)

Co-authored-by: Jacob Walls [jacobtylerwalls@gmail.com](mailto:jacobtylerwalls@gmail.com)

https://bugs.python.org/issue45948

<!-- issue-number: [bpo-45948](https://bugs.python.org/issue45948) -->
https://bugs.python.org/issue45948
<!-- /issue-number -->
