### PR TITLE
bpo-46730: Add more info to @property AttributeError messages

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -1456,7 +1456,7 @@ attributes stored in ``__slots__``:
     >>> mark.dept = 'Space Pirate'
     Traceback (most recent call last):
         ...
-    AttributeError: no setter was defined for property
+    AttributeError: property 'dept' of 'Immutable' object has no setter
     >>> mark.location = 'Mars'
     Traceback (most recent call last):
         ...

--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -991,17 +991,17 @@ here is a pure Python equivalent:
             if obj is None:
                 return self
             if self.fget is None:
-                raise AttributeError(f'unreadable attribute {self._name}')
+                raise AttributeError(f'unreadable property {self._name}')
             return self.fget(obj)
 
         def __set__(self, obj, value):
             if self.fset is None:
-                raise AttributeError(f"can't set attribute {self._name}")
+                raise AttributeError(f"no setter was defined for property {self._name}")
             self.fset(obj, value)
 
         def __delete__(self, obj):
             if self.fdel is None:
-                raise AttributeError(f"can't delete attribute {self._name}")
+                raise AttributeError(f"no deleter was defined for property {self._name}")
             self.fdel(obj)
 
         def getter(self, fget):
@@ -1456,7 +1456,7 @@ attributes stored in ``__slots__``:
     >>> mark.dept = 'Space Pirate'
     Traceback (most recent call last):
         ...
-    AttributeError: can't set attribute
+    AttributeError: no setter was defined for property
     >>> mark.location = 'Mars'
     Traceback (most recent call last):
         ...

--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -991,17 +991,17 @@ here is a pure Python equivalent:
             if obj is None:
                 return self
             if self.fget is None:
-                raise AttributeError(f'unreadable property {self._name}')
+                raise AttributeError(f"property '{self._name}' has no getter")
             return self.fget(obj)
 
         def __set__(self, obj, value):
             if self.fset is None:
-                raise AttributeError(f"no setter was defined for property {self._name}")
+                raise AttributeError(f"property '{self._name}' has no setter")
             self.fset(obj, value)
 
         def __delete__(self, obj):
             if self.fdel is None:
-                raise AttributeError(f"no deleter was defined for property {self._name}")
+                raise AttributeError(f"property '{self._name}' has no deleter")
             self.fdel(obj)
 
         def getter(self, fget):

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -335,14 +335,14 @@ class _PropertyUnreachableAttribute:
 
 
 class PropertyUnreachableAttributeWithName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = "^property 'foo' originating from 'cls' {}$"
+    msg_format = "^property 'foo' in object of type 'PropertyUnreachableAttributeWithName.cls' {}$"
 
     class cls:
         foo = property()
 
 
 class PropertyUnreachableAttributeNoName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = "^property {}$"
+    msg_format = "^property in object of type 'PropertyUnreachableAttributeNoName.cls' {}$"
 
     class cls:
         pass

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -322,15 +322,15 @@ class _PropertyUnreachableAttribute:
         cls.obj = cls.cls()
 
     def test_get_property(self):
-        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("unreadable attribute")):
+        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("unreadable property")):
             self.obj.foo
 
     def test_set_property(self):
-        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("can't set attribute")):
+        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("no setter was defined for property")):
             self.obj.foo = None
 
     def test_del_property(self):
-        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("can't delete attribute")):
+        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("no deleter was defined for property")):
             del self.obj.foo
 
 

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -335,14 +335,14 @@ class _PropertyUnreachableAttribute:
 
 
 class PropertyUnreachableAttributeWithName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = r"^property 'foo' of object 'PropertyUnreachableAttributeWithName\.cls' {}$"
+    msg_format = r"^property 'foo' of 'PropertyUnreachableAttributeWithName\.cls' object {}$"
 
     class cls:
         foo = property()
 
 
 class PropertyUnreachableAttributeNoName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = "^property of object 'PropertyUnreachableAttributeNoName\.cls' {}$"
+    msg_format = "^property of 'PropertyUnreachableAttributeNoName\.cls' object {}$"
 
     class cls:
         pass

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -314,35 +314,35 @@ class _PropertyUnreachableAttribute:
     obj = None
     cls = None
 
-    def _format_exc_msg(self, msg):
-        return self.msg_format.format(msg)
+    def _format_exc_msg(self, *msg):
+        return self.msg_format.format(*msg)
 
     @classmethod
     def setUpClass(cls):
         cls.obj = cls.cls()
 
     def test_get_property(self):
-        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("unreadable property")):
+        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("has no getter")):
             self.obj.foo
 
     def test_set_property(self):
-        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("no setter was defined for property")):
+        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("has no setter")):
             self.obj.foo = None
 
     def test_del_property(self):
-        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("no deleter was defined for property")):
+        with self.assertRaisesRegex(AttributeError, self._format_exc_msg("has no deleter")):
             del self.obj.foo
 
 
 class PropertyUnreachableAttributeWithName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = "^{} 'foo'$"
+    msg_format = "^property 'foo' originating from 'cls' {}$"
 
     class cls:
         foo = property()
 
 
 class PropertyUnreachableAttributeNoName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = "^{}$"
+    msg_format = "^property {}$"
 
     class cls:
         pass

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -335,14 +335,14 @@ class _PropertyUnreachableAttribute:
 
 
 class PropertyUnreachableAttributeWithName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = r"^property 'foo' in object of type 'PropertyUnreachableAttributeWithName\.cls' {}$"
+    msg_format = r"^property 'foo' of object of type 'PropertyUnreachableAttributeWithName\.cls' {}$"
 
     class cls:
         foo = property()
 
 
 class PropertyUnreachableAttributeNoName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = "^property in object of type 'PropertyUnreachableAttributeNoName\.cls' {}$"
+    msg_format = "^property of object of type 'PropertyUnreachableAttributeNoName\.cls' {}$"
 
     class cls:
         pass

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -335,14 +335,14 @@ class _PropertyUnreachableAttribute:
 
 
 class PropertyUnreachableAttributeWithName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = r"^property 'foo' of object of type 'PropertyUnreachableAttributeWithName\.cls' {}$"
+    msg_format = r"^property 'foo' of object 'PropertyUnreachableAttributeWithName\.cls' {}$"
 
     class cls:
         foo = property()
 
 
 class PropertyUnreachableAttributeNoName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = "^property of object of type 'PropertyUnreachableAttributeNoName\.cls' {}$"
+    msg_format = "^property of object 'PropertyUnreachableAttributeNoName\.cls' {}$"
 
     class cls:
         pass

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -314,8 +314,8 @@ class _PropertyUnreachableAttribute:
     obj = None
     cls = None
 
-    def _format_exc_msg(self, *msg):
-        return self.msg_format.format(*msg)
+    def _format_exc_msg(self, msg):
+        return self.msg_format.format(msg)
 
     @classmethod
     def setUpClass(cls):
@@ -335,14 +335,14 @@ class _PropertyUnreachableAttribute:
 
 
 class PropertyUnreachableAttributeWithName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = "^property 'foo' in object of type 'PropertyUnreachableAttributeWithName.cls' {}$"
+    msg_format = r"^property 'foo' in object of type 'PropertyUnreachableAttributeWithName\.cls' {}$"
 
     class cls:
         foo = property()
 
 
 class PropertyUnreachableAttributeNoName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = "^property in object of type 'PropertyUnreachableAttributeNoName.cls' {}$"
+    msg_format = "^property in object of type 'PropertyUnreachableAttributeNoName\.cls' {}$"
 
     class cls:
         pass

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1450,7 +1450,7 @@ class SizeofTest(unittest.TestCase):
             def setx(self, value): self.__x = value
             def delx(self): del self.__x
             x = property(getx, setx, delx, "")
-            check(x, size('6Pi'))
+            check(x, size('5Pi'))
         # PyCapsule
         # XXX
         # rangeiterator

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1450,7 +1450,7 @@ class SizeofTest(unittest.TestCase):
             def setx(self, value): self.__x = value
             def delx(self): del self.__x
             x = property(getx, setx, delx, "")
-            check(x, size('5Pi'))
+            check(x, size('6Pi'))
         # PyCapsule
         # XXX
         # rangeiterator

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -985,6 +985,7 @@ Erno Kuusela
 Ross Lagerwall
 Cameron Laird
 Loïc Lajeanne
+Alexander Lakeev
 David Lam
 Thomas Lamb
 Valerie Lambert

--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-14-21-04-43.bpo-46730.rYJ1w5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-14-21-04-43.bpo-46730.rYJ1w5.rst
@@ -1,0 +1,3 @@
+Message of AttributeError caused by getting, setting or deleting a property
+without the corresponding function now mentions that the attribute is in fact
+a property and also specifies type of the class that it belongs to.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1590,7 +1590,8 @@ property_descr_get(PyObject *self, PyObject *obj, PyObject *type)
                          "property %R in object of type %R has no getter",
                          gs->prop_name,
                          PyType_GetQualName(Py_TYPE(obj)));
-        } else {
+        }
+        else {
             PyErr_Format(PyExc_AttributeError,
                          "property in object of type %R has no getter",
                          PyType_GetQualName(Py_TYPE(obj)));
@@ -1623,13 +1624,15 @@ property_descr_set(PyObject *self, PyObject *obj, PyObject *value)
                         "property %R in object of type %R has no setter",
                         gs->prop_name,
                         PyType_GetQualName(Py_TYPE(obj)));
-        } else if (obj != NULL) {
+        }
+        else if (obj != NULL) {
             PyErr_Format(PyExc_AttributeError,
                             value == NULL ?
                             "property in object of type %R has no deleter" :
                             "property in object of type %R has no setter",
                             PyType_GetQualName(Py_TYPE(obj)));
-        } else {
+        }
+        else {
             PyErr_SetString(PyExc_AttributeError,
                          value == NULL ?
                          "property has no deleter" :

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1587,13 +1587,13 @@ property_descr_get(PyObject *self, PyObject *obj, PyObject *type)
     if (gs->prop_get == NULL) {
         if (gs->prop_name != NULL) {
             PyErr_Format(PyExc_AttributeError,
-                         "property %R of object of type %R has no getter",
+                         "property %R of object %R has no getter",
                          gs->prop_name,
                          PyType_GetQualName(Py_TYPE(obj)));
         }
         else {
             PyErr_Format(PyExc_AttributeError,
-                         "property of object of type %R has no getter",
+                         "property of object %R has no getter",
                          PyType_GetQualName(Py_TYPE(obj)));
         }
 
@@ -1620,16 +1620,16 @@ property_descr_set(PyObject *self, PyObject *obj, PyObject *value)
         if (gs->prop_name != NULL && obj != NULL) {
             PyErr_Format(PyExc_AttributeError,
                         value == NULL ?
-                        "property %R of object of type %R has no deleter" :
-                        "property %R of object of type %R has no setter",
+                        "property %R of object %R has no deleter" :
+                        "property %R of object %R has no setter",
                         gs->prop_name,
                         PyType_GetQualName(Py_TYPE(obj)));
         }
         else if (obj != NULL) {
             PyErr_Format(PyExc_AttributeError,
                             value == NULL ?
-                            "property of object of type %R has no deleter" :
-                            "property of object of type %R has no setter",
+                            "property of object %R has no deleter" :
+                            "property of object %R has no setter",
                             PyType_GetQualName(Py_TYPE(obj)));
         }
         else {

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1587,13 +1587,13 @@ property_descr_get(PyObject *self, PyObject *obj, PyObject *type)
     if (gs->prop_get == NULL) {
         if (gs->prop_name != NULL) {
             PyErr_Format(PyExc_AttributeError,
-                         "property %R of object %R has no getter",
+                         "property %R of %R object has no getter",
                          gs->prop_name,
                          PyType_GetQualName(Py_TYPE(obj)));
         }
         else {
             PyErr_Format(PyExc_AttributeError,
-                         "property of object %R has no getter",
+                         "property of %R object has no getter",
                          PyType_GetQualName(Py_TYPE(obj)));
         }
 
@@ -1620,16 +1620,16 @@ property_descr_set(PyObject *self, PyObject *obj, PyObject *value)
         if (gs->prop_name != NULL && obj != NULL) {
             PyErr_Format(PyExc_AttributeError,
                         value == NULL ?
-                        "property %R of object %R has no deleter" :
-                        "property %R of object %R has no setter",
+                        "property %R of %R object has no deleter" :
+                        "property %R of %R object has no setter",
                         gs->prop_name,
                         PyType_GetQualName(Py_TYPE(obj)));
         }
         else if (obj != NULL) {
             PyErr_Format(PyExc_AttributeError,
                             value == NULL ?
-                            "property of object %R has no deleter" :
-                            "property of object %R has no setter",
+                            "property of %R object has no deleter" :
+                            "property of %R object has no setter",
                             PyType_GetQualName(Py_TYPE(obj)));
         }
         else {

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1586,9 +1586,9 @@ property_descr_get(PyObject *self, PyObject *obj, PyObject *type)
     propertyobject *gs = (propertyobject *)self;
     if (gs->prop_get == NULL) {
         if (gs->prop_name != NULL) {
-            PyErr_Format(PyExc_AttributeError, "unreadable attribute %R", gs->prop_name);
+            PyErr_Format(PyExc_AttributeError, "unreadable property %R", gs->prop_name);
         } else {
-            PyErr_SetString(PyExc_AttributeError, "unreadable attribute");
+            PyErr_SetString(PyExc_AttributeError, "unreadable property");
         }
 
         return NULL;
@@ -1614,15 +1614,15 @@ property_descr_set(PyObject *self, PyObject *obj, PyObject *value)
         if (gs->prop_name != NULL) {
             PyErr_Format(PyExc_AttributeError,
                         value == NULL ?
-                        "can't delete attribute %R" :
-                        "can't set attribute %R",
+                        "no deleter was defined for property %R" :
+                        "no setter was defined for property %R",
                         gs->prop_name);
         }
         else {
             PyErr_SetString(PyExc_AttributeError,
                             value == NULL ?
-                            "can't delete attribute" :
-                            "can't set attribute");
+                            "no deleter was defined for property" :
+                            "no setter was defined for property");
         }
         return -1;
     }

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1463,17 +1463,17 @@ class property(object):
         if inst is None:
             return self
         if self.__get is None:
-            raise AttributeError, "unreadable attribute"
+            raise AttributeError, "property has no getter"
         return self.__get(inst)
 
     def __set__(self, inst, value):
         if self.__set is None:
-            raise AttributeError, "can't set attribute"
+            raise AttributeError, "property has no setter"
         return self.__set(inst, value)
 
     def __delete__(self, inst):
         if self.__del is None:
-            raise AttributeError, "can't delete attribute"
+            raise AttributeError, "property has no deleter"
         return self.__del(inst)
 
 */

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1587,13 +1587,13 @@ property_descr_get(PyObject *self, PyObject *obj, PyObject *type)
     if (gs->prop_get == NULL) {
         if (gs->prop_name != NULL) {
             PyErr_Format(PyExc_AttributeError,
-                         "property %R in object of type %R has no getter",
+                         "property %R of object of type %R has no getter",
                          gs->prop_name,
                          PyType_GetQualName(Py_TYPE(obj)));
         }
         else {
             PyErr_Format(PyExc_AttributeError,
-                         "property in object of type %R has no getter",
+                         "property of object of type %R has no getter",
                          PyType_GetQualName(Py_TYPE(obj)));
         }
 
@@ -1620,16 +1620,16 @@ property_descr_set(PyObject *self, PyObject *obj, PyObject *value)
         if (gs->prop_name != NULL && obj != NULL) {
             PyErr_Format(PyExc_AttributeError,
                         value == NULL ?
-                        "property %R in object of type %R has no deleter" :
-                        "property %R in object of type %R has no setter",
+                        "property %R of object of type %R has no deleter" :
+                        "property %R of object of type %R has no setter",
                         gs->prop_name,
                         PyType_GetQualName(Py_TYPE(obj)));
         }
         else if (obj != NULL) {
             PyErr_Format(PyExc_AttributeError,
                             value == NULL ?
-                            "property in object of type %R has no deleter" :
-                            "property in object of type %R has no setter",
+                            "property of object of type %R has no deleter" :
+                            "property of object of type %R has no setter",
                             PyType_GetQualName(Py_TYPE(obj)));
         }
         else {


### PR DESCRIPTION
The property decorator raises AttributeErrors with messages
that neither help to identify the problem nor lead to a possible solution.
This PR proposes changes in error messages to address the issue.

<!-- issue-number: [bpo-46730](https://bugs.python.org/issue46730) -->
https://bugs.python.org/issue46730
<!-- /issue-number -->
