### PR TITLE
Implement asyncio.Task.__cancel_requested__

### DIFF
--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -496,6 +496,25 @@ class BaseTaskTests:
         # This also distinguishes from the initial has_cycle=None.
         self.assertEqual(has_cycle, False)
 
+    def test___cancel_requested__(self):
+        loop = asyncio.new_event_loop()
+
+        async def task():
+            await asyncio.sleep(10)
+            return 12
+
+        try:
+            t = self.new_task(loop, task())
+            self.assertFalse(t.__cancel_requested__)
+            self.assertTrue(t.cancel())
+            self.assertTrue(t.__cancel_requested__)
+            self.assertFalse(t.cancel())
+
+            with self.assertRaises(asyncio.CancelledError):
+                loop.run_until_complete(t)
+        finally:
+            loop.close()
+
     def test_cancel(self):
 
         def gen():

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2506,8 +2506,8 @@ static PyGetSetDef TaskType_getsetlist[] = {
     {"_must_cancel", (getter)TaskObj_get_must_cancel, NULL, NULL},
     {"_coro", (getter)TaskObj_get_coro, NULL, NULL},
     {"_fut_waiter", (getter)TaskObj_get_fut_waiter, NULL, NULL},
-    {"__task_cancel_requested__", (getter)TaskObj_get_cancel_requested,
-                                  (setter)TaskObj_set_cancel_requested, NULL},
+    {"__cancel_requested__", (getter)TaskObj_get_cancel_requested,
+                             (setter)TaskObj_set_cancel_requested, NULL},
     {NULL} /* Sentinel */
 };
 


### PR DESCRIPTION
Add `__cancel_requested__` property as discussed in #31270.

`cancel()` returns `False` is the task was previously cancelled already.

No test is failing during the `cancel()` behavior change.