### PR TITLE
bpo-46622: Async support for cached_property

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -109,6 +109,8 @@ The :mod:`functools` module defines the following functions:
 
    .. versionadded:: 3.8
 
+   .. versionchanged:: 3.11
+      Added support for caching an async function's return value.
 
 .. function:: cmp_to_key(func)
 

--- a/Lib/test/support/async_helper.py
+++ b/Lib/test/support/async_helper.py
@@ -1,0 +1,17 @@
+import asyncio
+import functools
+
+
+def async_test(func):
+    """Decorator to turn an async function into a test case."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        coro = func(*args, **kwargs)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+            asyncio.set_event_loop_policy(None)
+    return wrapper

--- a/Lib/test/test_contextlib_async.py
+++ b/Lib/test/test_contextlib_async.py
@@ -2,31 +2,16 @@ import asyncio
 from contextlib import (
     asynccontextmanager, AbstractAsyncContextManager,
     AsyncExitStack, nullcontext, aclosing, contextmanager)
-import functools
 from test import support
+from test.support.async_helper import async_test
 import unittest
 
 from test.test_contextlib import TestBaseExitStack
 
 
-def _async_test(func):
-    """Decorator to turn an async function into a test case."""
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        coro = func(*args, **kwargs)
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            return loop.run_until_complete(coro)
-        finally:
-            loop.close()
-            asyncio.set_event_loop_policy(None)
-    return wrapper
-
-
 class TestAbstractAsyncContextManager(unittest.TestCase):
 
-    @_async_test
+    @async_test
     async def test_enter(self):
         class DefaultEnter(AbstractAsyncContextManager):
             async def __aexit__(self, *args):
@@ -38,7 +23,7 @@ class TestAbstractAsyncContextManager(unittest.TestCase):
         async with manager as context:
             self.assertIs(manager, context)
 
-    @_async_test
+    @async_test
     async def test_async_gen_propagates_generator_exit(self):
         # A regression test for https://bugs.python.org/issue33786.
 
@@ -95,7 +80,7 @@ class TestAbstractAsyncContextManager(unittest.TestCase):
 
 class AsyncContextManagerTestCase(unittest.TestCase):
 
-    @_async_test
+    @async_test
     async def test_contextmanager_plain(self):
         state = []
         @asynccontextmanager
@@ -109,7 +94,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
             state.append(x)
         self.assertEqual(state, [1, 42, 999])
 
-    @_async_test
+    @async_test
     async def test_contextmanager_finally(self):
         state = []
         @asynccontextmanager
@@ -127,7 +112,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
                 raise ZeroDivisionError()
         self.assertEqual(state, [1, 42, 999])
 
-    @_async_test
+    @async_test
     async def test_contextmanager_no_reraise(self):
         @asynccontextmanager
         async def whee():
@@ -137,7 +122,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         # Calling __aexit__ should not result in an exception
         self.assertFalse(await ctx.__aexit__(TypeError, TypeError("foo"), None))
 
-    @_async_test
+    @async_test
     async def test_contextmanager_trap_yield_after_throw(self):
         @asynccontextmanager
         async def whoo():
@@ -150,7 +135,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             await ctx.__aexit__(TypeError, TypeError('foo'), None)
 
-    @_async_test
+    @async_test
     async def test_contextmanager_trap_no_yield(self):
         @asynccontextmanager
         async def whoo():
@@ -160,7 +145,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             await ctx.__aenter__()
 
-    @_async_test
+    @async_test
     async def test_contextmanager_trap_second_yield(self):
         @asynccontextmanager
         async def whoo():
@@ -171,7 +156,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             await ctx.__aexit__(None, None, None)
 
-    @_async_test
+    @async_test
     async def test_contextmanager_non_normalised(self):
         @asynccontextmanager
         async def whoo():
@@ -185,7 +170,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             await ctx.__aexit__(RuntimeError, None, None)
 
-    @_async_test
+    @async_test
     async def test_contextmanager_except(self):
         state = []
         @asynccontextmanager
@@ -203,7 +188,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
             raise ZeroDivisionError(999)
         self.assertEqual(state, [1, 42, 999])
 
-    @_async_test
+    @async_test
     async def test_contextmanager_except_stopiter(self):
         @asynccontextmanager
         async def woohoo():
@@ -230,7 +215,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
                 else:
                     self.fail(f'{stop_exc} was suppressed')
 
-    @_async_test
+    @async_test
     async def test_contextmanager_wrap_runtimeerror(self):
         @asynccontextmanager
         async def woohoo():
@@ -275,14 +260,14 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         self.assertEqual(baz.__doc__, "Whee!")
 
     @support.requires_docstrings
-    @_async_test
+    @async_test
     async def test_instance_docstring_given_cm_docstring(self):
         baz = self._create_contextmanager_attribs()(None)
         self.assertEqual(baz.__doc__, "Whee!")
         async with baz:
             pass  # suppress warning
 
-    @_async_test
+    @async_test
     async def test_keywords(self):
         # Ensure no keyword arguments are inhibited
         @asynccontextmanager
@@ -291,7 +276,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         async with woohoo(self=11, func=22, args=33, kwds=44) as target:
             self.assertEqual(target, (11, 22, 33, 44))
 
-    @_async_test
+    @async_test
     async def test_recursive(self):
         depth = 0
         ncols = 0
@@ -318,7 +303,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         self.assertEqual(ncols, 10)
         self.assertEqual(depth, 0)
 
-    @_async_test
+    @async_test
     async def test_decorator(self):
         entered = False
 
@@ -337,7 +322,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         await test()
         self.assertFalse(entered)
 
-    @_async_test
+    @async_test
     async def test_decorator_with_exception(self):
         entered = False
 
@@ -360,7 +345,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
             await test()
         self.assertFalse(entered)
 
-    @_async_test
+    @async_test
     async def test_decorating_method(self):
 
         @asynccontextmanager
@@ -403,7 +388,7 @@ class AclosingTestCase(unittest.TestCase):
         obj = aclosing(None)
         self.assertEqual(obj.__doc__, cm_docstring)
 
-    @_async_test
+    @async_test
     async def test_aclosing(self):
         state = []
         class C:
@@ -415,7 +400,7 @@ class AclosingTestCase(unittest.TestCase):
             self.assertEqual(x, y)
         self.assertEqual(state, [1])
 
-    @_async_test
+    @async_test
     async def test_aclosing_error(self):
         state = []
         class C:
@@ -429,7 +414,7 @@ class AclosingTestCase(unittest.TestCase):
                 1 / 0
         self.assertEqual(state, [1])
 
-    @_async_test
+    @async_test
     async def test_aclosing_bpo41229(self):
         state = []
 
@@ -493,7 +478,7 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
         self.addCleanup(self.loop.close)
         self.addCleanup(asyncio.set_event_loop_policy, None)
 
-    @_async_test
+    @async_test
     async def test_async_callback(self):
         expected = [
             ((), {}),
@@ -536,7 +521,7 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
                 stack.push_async_callback(callback=_exit, arg=3)
         self.assertEqual(result, [])
 
-    @_async_test
+    @async_test
     async def test_async_push(self):
         exc_raised = ZeroDivisionError
         async def _expect_exc(exc_type, exc, exc_tb):
@@ -572,7 +557,7 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
             self.assertIs(stack._exit_callbacks[-1][1], _expect_exc)
             1/0
 
-    @_async_test
+    @async_test
     async def test_enter_async_context(self):
         class TestCM(object):
             async def __aenter__(self):
@@ -594,7 +579,7 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
 
         self.assertEqual(result, [1, 2, 3, 4])
 
-    @_async_test
+    @async_test
     async def test_enter_async_context_errors(self):
         class LacksEnterAndExit:
             pass
@@ -614,7 +599,7 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
                 await stack.enter_async_context(LacksExit())
             self.assertFalse(stack._exit_callbacks)
 
-    @_async_test
+    @async_test
     async def test_async_exit_exception_chaining(self):
         # Ensure exception chaining matches the reference behaviour
         async def raise_exc(exc):
@@ -646,7 +631,7 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
         self.assertIsInstance(inner_exc, ValueError)
         self.assertIsInstance(inner_exc.__context__, ZeroDivisionError)
 
-    @_async_test
+    @async_test
     async def test_async_exit_exception_explicit_none_context(self):
         # Ensure AsyncExitStack chaining matches actual nested `with` statements
         # regarding explicit __context__ = None.
@@ -681,7 +666,7 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
                 else:
                     self.fail("Expected IndexError, but no exception was raised")
 
-    @_async_test
+    @async_test
     async def test_instance_bypass_async(self):
         class Example(object): pass
         cm = Example()
@@ -695,7 +680,7 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
 
 
 class TestAsyncNullcontext(unittest.TestCase):
-    @_async_test
+    @async_test
     async def test_async_nullcontext(self):
         class C:
             pass

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -21,6 +21,7 @@ import contextlib
 
 from test.support import import_helper
 from test.support import threading_helper
+from test.support.async_helper import async_test
 from test.support.script_helper import assert_python_ok
 
 import functools
@@ -2909,6 +2910,15 @@ class CachedCostItemWithSlots:
         raise RuntimeError('never called, slots not supported')
 
 
+class CachedCostItemAsync:
+    _cost = 1
+
+    @py_functools.cached_property
+    async def cost(self):
+        self._cost += 1
+        return self._cost
+
+
 class TestCachedProperty(unittest.TestCase):
     def test_cached(self):
         item = CachedCostItem()
@@ -3021,6 +3031,12 @@ class TestCachedProperty(unittest.TestCase):
 
     def test_doc(self):
         self.assertEqual(CachedCostItem.cost.__doc__, "The cost of the item.")
+
+    @async_test
+    async def test_async(self):
+        item = CachedCostItemAsync()
+        self.assertEqual(await item.cost, 2)
+        self.assertEqual(await item.cost, 2)  # not 3
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2022-02-13-21-45-35.bpo-46622.fqpDS9.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-13-21-45-35.bpo-46622.fqpDS9.rst
@@ -1,0 +1,3 @@
+The :func:`functools.cached_property` can now decorate an async function. It
+would cache a wrapper to the coroutine returned by the function, and await
+it when the wrapper is first awaited.


### PR DESCRIPTION
The functools.cached_property can now decorate an async function. It would cache a wrapper to the coroutine returned by the function, and await it when the wrapper is first awaited.

<!-- issue-number: [bpo-46622](https://bugs.python.org/issue46622) -->
https://bugs.python.org/issue46622
<!-- /issue-number -->
