### PR TITLE
gh-90898: Add "-d 123" / "--trace_fd 123" option to the trace module…

### DIFF
--- a/Doc/library/trace.rst
+++ b/Doc/library/trace.rst
@@ -96,6 +96,15 @@ Modifiers
    Directory where the report files go.  The coverage report for
    ``package.module`` is written to file :file:`{dir}/{package}/{module}.cover`.
 
+.. cmdoption:: -d, --trace_fd
+
+   Specify which file descriptor to write trace information to.
+   (1=stdout, 2=stderr, or any integer fd)
+
+.. code-block:: shell-session
+
+   $ python -m trace -t -d 111 your_program.py 111> /tmp/your_trace.txt
+
 .. cmdoption:: -m, --missing
 
    When generating annotated listings, mark lines which were not executed with

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -385,7 +385,7 @@ def _find_executable_linenos(filename):
     return _find_lines(code, strs)
 
 class Trace:
-    def __init__(self, count=1, trace=1, countfuncs=0, countcallers=0,
+    def __init__(self, count=1, trace=1, trace_fd=1, countfuncs=0, countcallers=0,
                  ignoremods=(), ignoredirs=(), infile=None, outfile=None,
                  timing=False):
         """
@@ -393,6 +393,8 @@ class Trace:
                      line is executed
         @param trace true iff it should print out each line that is
                      being counted
+        @param trace_fd file descriptor (int) for writing trace output, defaults
+                     to stdout
         @param countfuncs true iff it should just output a list of
                      (filename, modulename, funcname,) for functions
                      that were called at least once;  This overrides
@@ -412,6 +414,7 @@ class Trace:
         self.pathtobasename = {} # for memoizing os.path.basename
         self.donothing = 0
         self.trace = trace
+        self.trace_fd = trace_fd
         self._calledfuncs = {}
         self._callers = {}
         self._caller_cache = {}
@@ -542,8 +545,9 @@ class Trace:
                     ignore_it = self.ignore.names(filename, modulename)
                     if not ignore_it:
                         if self.trace:
-                            print((" --- modulename: %s, funcname: %s"
-                                   % (modulename, code.co_name)))
+                            with os.fdopen(self.trace_fd, "w", closefd=False) as trace_fp:
+                                print((" --- modulename: %s, funcname: %s"
+                                       % (modulename, code.co_name)), file=trace_fp)
                         return self.localtrace
             else:
                 return None
@@ -559,8 +563,9 @@ class Trace:
             if self.start_time:
                 print('%.2f' % (_time() - self.start_time), end=' ')
             bname = os.path.basename(filename)
-            print("%s(%d): %s" % (bname, lineno,
-                                  linecache.getline(filename, lineno)), end='')
+            with os.fdopen(self.trace_fd, "w", closefd=False) as trace_fp:
+                print("%s(%d): %s" % (bname, lineno,
+                                  linecache.getline(filename, lineno)), end='', file=trace_fp)
         return self.localtrace
 
     def localtrace_trace(self, frame, why, arg):
@@ -572,8 +577,9 @@ class Trace:
             if self.start_time:
                 print('%.2f' % (_time() - self.start_time), end=' ')
             bname = os.path.basename(filename)
-            print("%s(%d): %s" % (bname, lineno,
-                                  linecache.getline(filename, lineno)), end='')
+            with os.fdopen(self.trace_fd, "w", closefd=False) as trace_fp:
+                print("%s(%d): %s" % (bname, lineno,
+                                  linecache.getline(filename, lineno)), end='', file=trace_fp)
         return self.localtrace
 
     def localtrace_count(self, frame, why, arg):
@@ -632,6 +638,10 @@ def main():
             help='Directory where the report files go. The coverage report '
                  'for <package>.<module> will be written to file '
                  '<dir>/<package>/<module>.cover')
+    grp.add_argument('-d', '--trace_fd', type=int, default=1,
+            help='Specify which file descriptor to write trace information to '
+                 '(1=stdout, 2=stderr, or any integer fd).  '
+                 'Example: `python -m trace -t -d 111 your_program.py 111> /tmp/your_trace.txt`')
     grp.add_argument('-m', '--missing', action='store_true',
             help='Annotate executable lines that were not executed with '
                  '">>>>>> "')
@@ -694,7 +704,7 @@ def main():
     if opts.progname is None:
         parser.error('progname is missing: required with the main options')
 
-    t = Trace(opts.count, opts.trace, countfuncs=opts.listfuncs,
+    t = Trace(opts.count, opts.trace, opts.trace_fd, countfuncs=opts.listfuncs,
               countcallers=opts.trackcalls, ignoremods=opts.ignore_module,
               ignoredirs=opts.ignore_dir, infile=opts.file,
               outfile=opts.file, timing=opts.timing)

--- a/Misc/NEWS.d/next/Library/2022-02-13-13-49-59.bpo-46742.SI1o6R.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-13-13-49-59.bpo-46742.SI1o6R.rst
@@ -1,0 +1,4 @@
+The :mod:`trace` module now has a ``-d 123`` / ``--trace_fd 123`` option to
+send the output of ``-t`` to a file descriptor other than the default of
+standard output.  This makes it trivial to separate it from normal program
+output.


### PR DESCRIPTION
… to send trace logs to a different file descriptor.

Note: this does an fdopen on every write, because I could not find a way to do `self.trace_fp = os.fdopen(trace_fd,"w",closefd=False)` without triggering a warning from pytest about an unclosed file pointer (e.g. a file pointer leak).  Creating an __exit__() function to close self.trace_fp didn't appear to work. Fortunately, os.fdopen() is not a very cpu-intensive function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46742](https://bugs.python.org/issue46742) -->
https://bugs.python.org/issue46742
<!-- /issue-number -->

<!-- gh-issue-number: gh-90898 -->
* Issue: gh-90898
<!-- /gh-issue-number -->
