### PR TITLE
[3.9] Corrections to format precision description. (GH-31291)

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -424,12 +424,13 @@ When no explicit alignment is given, preceding the *width* field by a zero
 sign-aware zero-padding for numeric types.  This is equivalent to a *fill*
 character of ``'0'`` with an *alignment* type of ``'='``.
 
-The *precision* is a decimal number indicating how many digits should be
-displayed after the decimal point for a floating point value formatted with
-``'f'`` and ``'F'``, or before and after the decimal point for a floating point
-value formatted with ``'g'`` or ``'G'``.  For non-number types the field
+The *precision* is a decimal integer indicating how many digits should be
+displayed after the decimal point for presentation types
+``'f'`` and ``'F'``, or before and after the decimal point for presentation
+types ``'g'`` or ``'G'``.  For string presentation types the field
 indicates the maximum field size - in other words, how many characters will be
-used from the field content. The *precision* is not allowed for integer values.
+used from the field content.  The *precision* is not allowed for integer
+presentation types.
 
 Finally, the *type* determines how the data should be presented.
 


### PR DESCRIPTION
  * `precision` field is a decimal integer
  * clarify that stated limitations are on presentation type
    rather than input value type.  Especially misleading is
    "precision is not allowed for integer values", since integer
    value input to a format like `.1f` is fine.
  * regarding max field size, replace "non-number" with "string",
    which is the only non-numeric presentation type

Automerge-Triggered-By: GH:ericvsmith.
(cherry picked from commit 1d6ce67c29aa2166ef326952cb605b908fb4f987)

Co-authored-by: John Belmonte <john@neggie.net>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:ericvsmith

Automerge-Triggered-By: GH:ericvsmith