### PR TITLE
bpo-46724: Use `JUMP_ABSOLUTE` for all backward jumps.

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1008,6 +1008,16 @@ if 1:
             elif instr.opname in HANDLED_JUMPS:
                 self.assertNotEqual(instr.arg, (line + 1)*INSTR_SIZE)
 
+    def test_no_wraparound_jump(self):
+        # See https://bugs.python.org/issue46724
+
+        def while_not_chained(a, b, c):
+            while not (a < b < c):
+                pass
+
+        for instr in dis.Bytecode(while_not_chained):
+            self.assertNotEqual(instr.opname, "EXTENDED_ARG")
+
 @requires_debug_ranges()
 class TestSourcePositions(unittest.TestCase):
     # Ensure that compiled code snippets have correct line and column numbers

--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-14-14-44-06.bpo-46724.jym_K6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-14-14-44-06.bpo-46724.jym_K6.rst
@@ -1,0 +1,2 @@
+Make sure that all backwards jumps use the JUMP_ABSOLUTE instruction, rather
+than a JUMP_FORWARD jump of (2**32)+offset.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-14-14-44-06.bpo-46724.jym_K6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-14-14-44-06.bpo-46724.jym_K6.rst
@@ -1,2 +1,2 @@
-Make sure that all backwards jumps use the JUMP_ABSOLUTE instruction, rather
-than a JUMP_FORWARD jump of (2**32)+offset.
+Make sure that all backwards jumps use the ``JUMP_ABSOLUTE`` instruction, rather
+than ``JUMP_FORWARD`` with an argument of ``(2**32)+offset``.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7530,6 +7530,11 @@ normalize_jumps(struct assembler *a)
                 last->i_opcode = JUMP_FORWARD;
             }
         }
+        if (last->i_opcode == JUMP_FORWARD) {
+            if (last->i_target->b_visited) {
+                last->i_opcode = JUMP_ABSOLUTE;
+            }
+        }
     }
 }
 

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7531,7 +7531,7 @@ normalize_jumps(struct assembler *a)
             }
         }
         if (last->i_opcode == JUMP_FORWARD) {
-            if (last->i_target->b_visited) {
+            if (last->i_target->b_visited == 1) {
                 last->i_opcode = JUMP_ABSOLUTE;
             }
         }


### PR DESCRIPTION


<!-- issue-number: [bpo-46724](https://bugs.python.org/issue46724) -->
https://bugs.python.org/issue46724
<!-- /issue-number -->
