### PR TITLE
gh-90906: only import idna when required on several common code paths

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -503,7 +503,12 @@ class SSLContext(_SSLContext):
         if hostname is None:
             return None
         elif isinstance(hostname, str):
-            return hostname.encode('idna').decode('ascii')
+            # don't import idna unless it's necessary:
+            try:
+                hostname.encode('ascii')
+                return hostname
+            except UnicodeEncodeError:
+                return hostname.encode('idna').decode('ascii')
         else:
             return hostname.decode('ascii')
 

--- a/Misc/NEWS.d/next/Library/2022-02-14-11-21-36.bpo-46750.RHz0RU.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-14-11-21-36.bpo-46750.RHz0RU.rst
@@ -1,2 +1,2 @@
-Only import the `idna` encoding in :mod:`ssl` and :mod:`_socket` when
+Only import the idna encoding in :mod:`ssl` and :mod:`_socket` when
 necessary.

--- a/Misc/NEWS.d/next/Library/2022-02-14-11-21-36.bpo-46750.RHz0RU.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-14-11-21-36.bpo-46750.RHz0RU.rst
@@ -1,0 +1,2 @@
+Only import the `idna` encoding in :mod:`ssl` and :mod:`_socket` when
+necessary.


### PR DESCRIPTION
This fixes the linked issue. The reproduction case is:

```
python3 -c "import sys, urllib.request; urllib.request.urlopen('https://www.google.com'); assert 'encodings.idna' not in sys.modules"
```

One caveat is that this changes the exception type for `socket.getaddrinfo` (and probably other socket calls) when the hostname contains a null byte or codepoint: formerly, `socket.getaddrinfo("a\^@b", 443)` or `socket.getaddrinfo(b'a\x00b', 443)` would throw `socket.gaierror: [Errno -2] Name or service not known`, but now they throw `TypeError: host name must not contain null character`.

I signed the CLA earlier today but it isn't recognized yet, I figured I might as well open the PR now.

Thanks very much for your time.

<!-- issue-number: [bpo-46750](https://bugs.python.org/issue46750) -->
https://bugs.python.org/issue46750
<!-- /issue-number -->

<!-- gh-issue-number: gh-90906 -->
* Issue: gh-90906
<!-- /gh-issue-number -->
