### PR TITLE
[3.10] bpo-46747: Add missing key parameters in the bisect docs (GH-31323)

### DIFF
--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -43,7 +43,7 @@ The following functions are provided:
 
 
 .. function:: bisect_right(a, x, lo=0, hi=len(a), *, key=None)
-              bisect(a, x, lo=0, hi=len(a))
+              bisect(a, x, lo=0, hi=len(a), *, key=None)
 
    Similar to :func:`bisect_left`, but returns an insertion point which comes
    after (to the right of) any existing entries of *x* in *a*.
@@ -80,7 +80,7 @@ The following functions are provided:
 
 
 .. function:: insort_right(a, x, lo=0, hi=len(a), *, key=None)
-              insort(a, x, lo=0, hi=len(a))
+              insort(a, x, lo=0, hi=len(a), *, key=None)
 
    Similar to :func:`insort_left`, but inserting *x* in *a* after any existing
    entries of *x*.


### PR DESCRIPTION
Added *key* parameter to `bisect.bisect()` and `bisect.insort()` in bisect module docs.
(cherry picked from commit 96084f4256d2d523b0a4d7d900322b032326e3ed)

Co-authored-by: Zackery Spytz <zspytz@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46747](https://bugs.python.org/issue46747) -->
https://bugs.python.org/issue46747
<!-- /issue-number -->

Automerge-Triggered-By: GH:sweeneyde