### PR TITLE
bpo-46733: move `pathlib.Path.owner()` and `group()` to `PosixPath`

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -821,6 +821,8 @@ call fails (for example because the path doesn't exist).
    Return the name of the group owning the file.  :exc:`KeyError` is raised
    if the file's gid isn't found in the system database.
 
+   .. availability:: Unix.
+
 
 .. method:: Path.is_dir()
 
@@ -847,7 +849,9 @@ call fails (for example because the path doesn't exist).
    function checks whether *path*'s parent, :file:`path/..`, is on a different
    device than *path*, or whether :file:`path/..` and *path* point to the same
    i-node on the same device --- this should detect mount points for all Unix
-   and POSIX variants.  Not implemented on Windows.
+   and POSIX variants.
+
+   .. availability:: Unix.
 
    .. versionadded:: 3.7
 
@@ -970,6 +974,8 @@ call fails (for example because the path doesn't exist).
 
    Return the name of the user owning the file.  :exc:`KeyError` is raised
    if the file's uid isn't found in the system database.
+
+   .. availability:: Unix.
 
 
 .. method:: Path.read_bytes()

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -849,9 +849,7 @@ call fails (for example because the path doesn't exist).
    function checks whether *path*'s parent, :file:`path/..`, is on a different
    device than *path*, or whether :file:`path/..` and *path* point to the same
    i-node on the same device --- this should detect mount points for all Unix
-   and POSIX variants.
-
-   .. availability:: Unix.
+   and POSIX variants.  Not implemented on Windows.
 
    .. versionadded:: 3.7
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1246,6 +1246,25 @@ class Path(PurePath):
             # Non-encodable path
             return False
 
+    def is_mount(self):
+        """
+        Check if this path is a POSIX mount point
+        """
+        # Need to exist and be a dir
+        if not self.exists() or not self.is_dir():
+            return False
+
+        try:
+            parent_dev = self.parent.stat().st_dev
+        except OSError:
+            return False
+
+        dev = self.stat().st_dev
+        if dev != parent_dev:
+            return True
+        ino = self.stat().st_ino
+        parent_ino = self.parent.stat().st_ino
+        return ino == parent_ino
 
     def is_symlink(self):
         """
@@ -1361,26 +1380,6 @@ class PosixPath(Path, PurePosixPath):
         import grp
         return grp.getgrgid(self.stat().st_gid).gr_name
 
-    def is_mount(self):
-        """
-        Check if this path is a POSIX mount point
-        """
-        # Need to exist and be a dir
-        if not self.exists() or not self.is_dir():
-            return False
-
-        try:
-            parent_dev = self.parent.stat().st_dev
-        except OSError:
-            return False
-
-        dev = self.stat().st_dev
-        if dev != parent_dev:
-            return True
-        ino = self.stat().st_ino
-        parent_ino = self.parent.stat().st_ino
-        return ino == parent_ino
-
 
 class WindowsPath(Path, PureWindowsPath):
     """Path subclass for Windows systems.
@@ -1408,10 +1407,4 @@ class WindowsPath(Path, PureWindowsPath):
         raise NotImplementedError("Path.group() is unsupported on this system")
 
     def is_mount(self):
-        """
-        Check if this path is a POSIX mount point
-        """
-        warnings.warn("pathlib.WindowsPath.is_mount() is deprecated and "
-                      "scheduled for removal in Python 3.13.",
-                      DeprecationWarning, stacklevel=2)
         raise NotImplementedError("Path.is_mount() is unsupported on this system")

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1004,27 +1004,6 @@ class Path(PurePath):
         """
         return os.stat(self, follow_symlinks=follow_symlinks)
 
-    def owner(self):
-        """
-        Return the login name of the file owner.
-        """
-        try:
-            import pwd
-            return pwd.getpwuid(self.stat().st_uid).pw_name
-        except ImportError:
-            raise NotImplementedError("Path.owner() is unsupported on this system")
-
-    def group(self):
-        """
-        Return the group name of the file gid.
-        """
-
-        try:
-            import grp
-            return grp.getgrgid(self.stat().st_gid).gr_name
-        except ImportError:
-            raise NotImplementedError("Path.group() is unsupported on this system")
-
     def open(self, mode='r', buffering=-1, encoding=None,
              errors=None, newline=None):
         """
@@ -1267,25 +1246,6 @@ class Path(PurePath):
             # Non-encodable path
             return False
 
-    def is_mount(self):
-        """
-        Check if this path is a POSIX mount point
-        """
-        # Need to exist and be a dir
-        if not self.exists() or not self.is_dir():
-            return False
-
-        try:
-            parent_dev = self.parent.stat().st_dev
-        except OSError:
-            return False
-
-        dev = self.stat().st_dev
-        if dev != parent_dev:
-            return True
-        ino = self.stat().st_ino
-        parent_ino = self.parent.stat().st_ino
-        return ino == parent_ino
 
     def is_symlink(self):
         """
@@ -1387,6 +1347,41 @@ class PosixPath(Path, PurePosixPath):
     """
     __slots__ = ()
 
+    def owner(self):
+        """
+        Return the login name of the file owner.
+        """
+        import pwd
+        return pwd.getpwuid(self.stat().st_uid).pw_name
+
+    def group(self):
+        """
+        Return the group name of the file gid.
+        """
+        import grp
+        return grp.getgrgid(self.stat().st_gid).gr_name
+
+    def is_mount(self):
+        """
+        Check if this path is a POSIX mount point
+        """
+        # Need to exist and be a dir
+        if not self.exists() or not self.is_dir():
+            return False
+
+        try:
+            parent_dev = self.parent.stat().st_dev
+        except OSError:
+            return False
+
+        dev = self.stat().st_dev
+        if dev != parent_dev:
+            return True
+        ino = self.stat().st_ino
+        parent_ino = self.parent.stat().st_ino
+        return ino == parent_ino
+
+
 class WindowsPath(Path, PureWindowsPath):
     """Path subclass for Windows systems.
 
@@ -1394,5 +1389,29 @@ class WindowsPath(Path, PureWindowsPath):
     """
     __slots__ = ()
 
+    def owner(self):
+        """
+        Return the login name of the file owner.
+        """
+        warnings.warn("pathlib.WindowsPath.owner() is deprecated and "
+                      "scheduled for removal in Python 3.13.",
+                      DeprecationWarning, stacklevel=2)
+        raise NotImplementedError("Path.owner() is unsupported on this system")
+
+    def group(self):
+        """
+        Return the group name of the file gid.
+        """
+        warnings.warn("pathlib.WindowsPath.group() is deprecated and "
+                      "scheduled for removal in Python 3.13.",
+                      DeprecationWarning, stacklevel=2)
+        raise NotImplementedError("Path.group() is unsupported on this system")
+
     def is_mount(self):
+        """
+        Check if this path is a POSIX mount point
+        """
+        warnings.warn("pathlib.WindowsPath.is_mount() is deprecated and "
+                      "scheduled for removal in Python 3.13.",
+                      DeprecationWarning, stacklevel=2)
         raise NotImplementedError("Path.is_mount() is unsupported on this system")

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1373,12 +1373,6 @@ class WindowsPathAsPureTest(PureWindowsPathTest):
             with self.assertRaises(NotImplementedError):
                 P('c:/').group()
 
-    def test_is_mount(self):
-        P = self.cls
-        with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(NotImplementedError):
-                P('c:/').is_mount()
-
 
 class _BasePathTest(object):
     """Tests for the FS-accessing functionalities of the Path classes."""

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1363,13 +1363,21 @@ class WindowsPathAsPureTest(PureWindowsPathTest):
 
     def test_owner(self):
         P = self.cls
-        with self.assertRaises(NotImplementedError):
-            P('c:/').owner()
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                P('c:/').owner()
 
     def test_group(self):
         P = self.cls
-        with self.assertRaises(NotImplementedError):
-            P('c:/').group()
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                P('c:/').group()
+
+    def test_is_mount(self):
+        P = self.cls
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                P('c:/').is_mount()
 
 
 class _BasePathTest(object):

--- a/Misc/NEWS.d/next/Library/2022-02-14-19-21-41.bpo-46733.Uj2A4Y.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-14-19-21-41.bpo-46733.Uj2A4Y.rst
@@ -1,3 +1,2 @@
-Deprecate :meth:`pathlib.WindowsPath.owner()`,
-:meth:`~pathlib.WindowsPath.group()` and
-:meth:`~pathlib.WindowsPath.is_mount()`.
+Deprecate :meth:`pathlib.WindowsPath.owner()` and
+:meth:`~pathlib.WindowsPath.group()`.

--- a/Misc/NEWS.d/next/Library/2022-02-14-19-21-41.bpo-46733.Uj2A4Y.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-14-19-21-41.bpo-46733.Uj2A4Y.rst
@@ -1,0 +1,3 @@
+Deprecate :meth:`pathlib.WindowsPath.owner()`,
+:meth:`~pathlib.WindowsPath.group()` and
+:meth:`~pathlib.WindowsPath.is_mount()`.


### PR DESCRIPTION
Following [an idea](https://bugs.python.org/issue46733#msg413144) from Alex Waygood:

> Here's my two cents, as a non-expert when it comes to pathlib:
> 
> I'm not really sure why `is_mount()` exists on WindowsPath objects, given that it unconditionally raises `NotImplementedError` on WindowsPath objects -- that seems *very* strange to me. It seems to me like it should probably be a method on the `PosixPath` class rather than on the `Path` class.
> 
> The other methods that raise NotImplementedError don't seem as egregious, because none of them *unconditionally* raise NotImplementedError. We could debate whether some of them would raise different errors in an ideal world, but changing them now might have implications for backwards compatibility, and it doesn't seem like a *major* issue to me.
> 
> I suppose it might also be worth considering moving `owner()` and `group()` to PosixPath. In practice, these unconditionally raise NotImplementedError on Windows, since the pwd and grp modules are not available on Windows. So, in an ideal world, they probably wouldn't exist on the common base class.
> 
> Again, though, that needs to be weighed against backwards-compatibility considerations.

This makes a lot of sense to me, and lets us fix ~three~ two inappropriate uses of `NotImplementedError`.

<!-- issue-number: [bpo-46733](https://bugs.python.org/issue46733) -->
https://bugs.python.org/issue46733
<!-- /issue-number -->
