### PR TITLE
bpo-46733: deprecate `pathlib` link methods when lacking needed `os` functions

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1011,6 +1011,8 @@ call fails (for example because the path doesn't exist).
       >>> p.readlink()
       PosixPath('setup.py')
 
+   .. availability:: Unix, Windows.
+
    .. versionadded:: 3.9
 
 
@@ -1152,6 +1154,8 @@ call fails (for example because the path doesn't exist).
       The order of arguments (link, target) is the reverse
       of :func:`os.symlink`'s.
 
+   .. availability:: Unix, Windows.
+
 .. method:: Path.hardlink_to(target)
 
    Make this path a hard link to the same file as *target*.
@@ -1161,6 +1165,8 @@ call fails (for example because the path doesn't exist).
       of :func:`os.link`'s.
 
    .. versionadded:: 3.10
+
+   .. availability:: Unix, Windows.
 
 .. method:: Path.link_to(target)
 
@@ -1172,6 +1178,8 @@ call fails (for example because the path doesn't exist).
       the implication of the function and argument names. The argument order
       (target, link) is the reverse of :func:`Path.symlink_to` and
       :func:`Path.hardlink_to`, but matches that of :func:`os.link`.
+
+   .. availability:: Unix, Windows.
 
    .. versionadded:: 3.8
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1075,6 +1075,9 @@ class Path(PurePath):
         Return the path to which the symbolic link points.
         """
         if not hasattr(os, "readlink"):
+            warnings.warn("From Python 3.13, pathlib.Path.readlink() will "
+                          "not be available in builds lacking os.readlink().",
+                          DeprecationWarning, stacklevel=2)
             raise NotImplementedError("os.readlink() not available on this system")
         return self._from_parts((os.readlink(self),))
 
@@ -1186,6 +1189,9 @@ class Path(PurePath):
         Note the order of arguments (link, target) is the reverse of os.symlink.
         """
         if not hasattr(os, "symlink"):
+            warnings.warn("From Python 3.13, pathlib.Path.symlink_to() will "
+                          "not be available in builds lacking os.symlink().",
+                          DeprecationWarning, stacklevel=2)
             raise NotImplementedError("os.symlink() not available on this system")
         os.symlink(target, self, target_is_directory)
 
@@ -1196,6 +1202,9 @@ class Path(PurePath):
         Note the order of arguments (self, target) is the reverse of os.link's.
         """
         if not hasattr(os, "link"):
+            warnings.warn("From Python 3.13, pathlib.Path.hardlink_to() will "
+                          "not be available in builds lacking os.link().",
+                          DeprecationWarning, stacklevel=2)
             raise NotImplementedError("os.link() not available on this system")
         os.link(target, self)
 

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2012,8 +2012,27 @@ class _BasePathTest(object):
         p = P / 'fileA'
         # linking to another path.
         q = P / 'dirA' / 'fileAA'
-        with self.assertRaises(NotImplementedError):
-            p.link_to(q)
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                p.link_to(q)
+
+    @unittest.skipIf(hasattr(os, "symlink"), "os.symlink() is present")
+    def test_symlink_to_not_implemented(self):
+        P = self.cls(BASE)
+        p = P / 'fileA'
+        # linking to another path.
+        q = P / 'dirA' / 'fileAA'
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                p.symlink_to(q)
+
+    @unittest.skipIf(hasattr(os, "readlink"), "os.readlink() is present")
+    def test_readlink_not_implemented(self):
+        P = self.cls(BASE)
+        p = P / 'fileA'
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                p.readlink()
 
     def test_rename(self):
         P = self.cls(BASE)

--- a/Misc/NEWS.d/next/Library/2022-02-14-19-37-11.bpo-46733.1C0yQt.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-14-19-37-11.bpo-46733.1C0yQt.rst
@@ -1,0 +1,3 @@
+Deprecate :meth:`pathlib.Path.readlink`, :meth:`~pathlib.Path.symlink_to`
+and :meth:`~pathlib.Path.hardlink_to` methods when corresponding functions
+in the :mod:`os` module are unavailable.


### PR DESCRIPTION
This makes `pathlib.Path` more similar to `os` -- methods/functions are unavailable when the Python build doesn't support them.

<!-- issue-number: [bpo-46733](https://bugs.python.org/issue46733) -->
https://bugs.python.org/issue46733
<!-- /issue-number -->
