### PR TITLE
bpo-46733: raise `ValueError` when `pathlib.Path.glob()` is called with an absolute pattern

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -942,7 +942,7 @@ class Path(PurePath):
             raise ValueError("Unacceptable pattern: {!r}".format(pattern))
         drv, root, pattern_parts = self._flavour.parse_parts((pattern,))
         if drv or root:
-            raise NotImplementedError("Non-relative patterns are unsupported")
+            raise ValueError("Unacceptable pattern: {!r}".format(pattern))
         selector = _make_selector(tuple(pattern_parts), self._flavour)
         for p in selector.select_from(self):
             yield p
@@ -955,7 +955,7 @@ class Path(PurePath):
         sys.audit("pathlib.Path.rglob", self, pattern)
         drv, root, pattern_parts = self._flavour.parse_parts((pattern,))
         if drv or root:
-            raise NotImplementedError("Non-relative patterns are unsupported")
+            raise ValueError("Unacceptable pattern: {!r}".format(pattern))
         selector = _make_selector(("**",) + tuple(pattern_parts), self._flavour)
         for p in selector.select_from(self):
             yield p

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2473,6 +2473,11 @@ class PathTest(_BasePathTest, unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'Unacceptable pattern'):
             list(p.glob(''))
 
+    def test_glob_absolute_pattern(self):
+        p = self.cls()
+        with self.assertRaisesRegex(ValueError, 'Unacceptable pattern'):
+            list(p.glob('/'))
+
 
 @only_posix
 class PosixPathTest(_BasePathTest, unittest.TestCase):


### PR DESCRIPTION
Fairly minor bugfix, I think.

<!-- issue-number: [bpo-46733](https://bugs.python.org/issue46733) -->
https://bugs.python.org/issue46733
<!-- /issue-number -->
