### PR TITLE
bpo-46733: raise `TypeError` when constructing foreign `pathlib.Path` flavour

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -673,7 +673,7 @@ bugs or failures in your application)::
      File "<stdin>", line 1, in <module>
      File "pathlib.py", line 798, in __new__
        % (cls.__name__,))
-   NotImplementedError: cannot instantiate 'WindowsPath' on your system
+   TypeError: cannot instantiate 'WindowsPath' on your system
 
 
 Methods

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -866,8 +866,8 @@ class Path(PurePath):
             cls = WindowsPath if os.name == 'nt' else PosixPath
         self = cls._from_parts(args)
         if not self._flavour.is_supported:
-            raise NotImplementedError("cannot instantiate %r on your system"
-                                      % (cls.__name__,))
+            raise TypeError("cannot instantiate %r on your system"
+                            % (cls.__name__,))
         return self
 
     def _make_child_relpath(self, part):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2464,9 +2464,9 @@ class PathTest(_BasePathTest, unittest.TestCase):
 
     def test_unsupported_flavour(self):
         if os.name == 'nt':
-            self.assertRaises(NotImplementedError, pathlib.PosixPath)
+            self.assertRaises(TypeError, pathlib.PosixPath)
         else:
-            self.assertRaises(NotImplementedError, pathlib.WindowsPath)
+            self.assertRaises(TypeError, pathlib.WindowsPath)
 
     def test_glob_empty_pattern(self):
         p = self.cls()

--- a/Misc/NEWS.d/next/Library/2022-02-14-19-27-58.bpo-46733.n_zjxm.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-14-19-27-58.bpo-46733.n_zjxm.rst
@@ -1,0 +1,3 @@
+Attempting to construct a :class:`pathlib.PosixPath` object on Windows, or
+vice-versa, now raises :exc:`TypeError`. Previously it raised
+:exc:`NotImplementedError`.


### PR DESCRIPTION
A backwards-incompatible change. Probably not worth it, but adding a PR for completeness.

(See also other PRs against this bug)

<!-- issue-number: [bpo-46733](https://bugs.python.org/issue46733) -->
https://bugs.python.org/issue46733
<!-- /issue-number -->
