### PR TITLE
Fix copyright years in `README.rst`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ This is Python version 3.11.0 alpha 5
    :target: https://discuss.python.org/
 
 
-Copyright © 2001-2021 Python Software Foundation.  All rights reserved.
+Copyright © 2001-2022 Python Software Foundation.  All rights reserved.
 
 See the end of this file for further copyright and license information.
 
@@ -244,7 +244,7 @@ Copyright and License Information
 ---------------------------------
 
 
-Copyright © 2001-2021 Python Software Foundation.  All rights reserved.
+Copyright © 2001-2022 Python Software Foundation.  All rights reserved.
 
 Copyright © 2000 BeOpen.com.  All rights reserved.
 


### PR DESCRIPTION
Looks like https://github.com/python/cpython/pull/25514 accidentally changed the copy-right year back to 2021.

Commit: https://github.com/python/cpython/commit/965be0e940649c851807b9936bf56fb668600f1f
I am changing it back 🙂 

CC @Mariatta 