### PR TITLE
bpo-45756: Fix mock triggers dynamic lookup via the descriptor protocol.

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -496,8 +496,8 @@ class NonCallableMock(Base):
         _spec_signature = None
         _spec_asyncs = []
 
-        for attr in dir(spec):
-            if iscoroutinefunction(getattr(spec, attr, None)):
+        for attr, value in inspect.getmembers_static(spec):
+            if iscoroutinefunction(value):
                 _spec_asyncs.append(attr)
 
         if spec is not None and not _is_list(spec):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -496,9 +496,8 @@ class NonCallableMock(Base):
         _spec_signature = None
         _spec_asyncs = []
 
-        for attr, value in inspect.getmembers_static(spec):
-            if iscoroutinefunction(value):
-                _spec_asyncs.append(attr)
+        for attr, _ in inspect.getmembers_static(spec, iscoroutinefunction):
+            _spec_asyncs.append(attr)
 
         if spec is not None and not _is_list(spec):
             if isinstance(spec, type):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -325,6 +325,20 @@ class MockTest(unittest.TestCase):
             "call_args_list not set")
 
 
+    def test_not_called_descriptor_protocol(self):
+        import types
+        class A:
+            @property
+            def name(self):
+                raise NotImplementedError
+            @types.DynamicClassAttribute
+            def eggs(self):
+                raise NotImplementedError
+
+        self.assertIsInstance(Mock(spec=A), A)
+        self.assertIsInstance(Mock(spec=A()), A)
+
+
     def test_call_args_comparison(self):
         mock = Mock()
         mock()

--- a/Misc/NEWS.d/next/Library/2022-02-15-14-29-41.bpo-45756.P0sGlU.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-15-14-29-41.bpo-45756.P0sGlU.rst
@@ -1,0 +1,2 @@
+Fix :mod:`unittest.mock` triggers dynamic lookup via the descriptor
+protocol. Patch by Weipeng Hong.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45756](https://bugs.python.org/issue45756) -->
https://bugs.python.org/issue45756
<!-- /issue-number -->
