### PR TITLE
[3.10] bpo-46724: Use `JUMP_ABSOLUTE` for all backward jumps.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-14-14-44-06.bpo-46724.jym_K6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-14-14-44-06.bpo-46724.jym_K6.rst
@@ -1,0 +1,2 @@
+Make sure that all backwards jumps use the ``JUMP_ABSOLUTE`` instruction, rather
+than ``JUMP_FORWARD`` with an argument of ``(2**32)+offset``.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6702,6 +6702,11 @@ assemble_emit(struct assembler *a, struct instr *i)
 }
 
 static void
+        if (last->i_opcode == JUMP_FORWARD) {
+            if (last->i_target->b_visited == 1) {
+                last->i_opcode = JUMP_ABSOLUTE;
+            }
+        }
 assemble_jump_offsets(struct assembler *a, struct compiler *c)
 {
     basicblock *b;


### PR DESCRIPTION


<!-- issue-number: [bpo-46724](https://bugs.python.org/issue46724) -->
https://bugs.python.org/issue46724
<!-- /issue-number -->
