### PR TITLE
bpo-46541: Remove usage of _Py_IDENTIFIER from dbms modules

### DIFF
--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -37,7 +37,6 @@
 typedef struct {
     PyTypeObject *dbm_type;
     PyObject *dbm_error;
-    PyObject *str_close;
 } _dbm_state;
 
 static inline _dbm_state*
@@ -396,9 +395,7 @@ dbm__enter__(PyObject *self, PyObject *args)
 static PyObject *
 dbm__exit__(PyObject *self, PyObject *args)
 {
-    _dbm_state *state = PyType_GetModuleState(Py_TYPE(self));
-    assert(state != NULL);
-    return PyObject_CallMethodNoArgs(self, state->str_close);
+    return _dbm_dbm_close_impl((dbmobject *)self);
 }
 
 static PyMethodDef dbm_methods[] = {
@@ -527,12 +524,6 @@ _dbm_exec(PyObject *module)
     if (PyModule_AddType(module, (PyTypeObject *)state->dbm_error) < 0) {
         return -1;
     }
-
-    PyObject *str_close = PyUnicode_InternFromString("close");
-    if (str_close == NULL) {
-        return -1;
-    }
-    state->str_close = str_close;
     return 0;
 }
 
@@ -542,7 +533,6 @@ _dbm_module_traverse(PyObject *module, visitproc visit, void *arg)
     _dbm_state *state = get_dbm_state(module);
     Py_VISIT(state->dbm_error);
     Py_VISIT(state->dbm_type);
-    Py_VISIT(state->str_close);
     return 0;
 }
 
@@ -552,7 +542,6 @@ _dbm_module_clear(PyObject *module)
     _dbm_state *state = get_dbm_state(module);
     Py_CLEAR(state->dbm_error);
     Py_CLEAR(state->dbm_type);
-    Py_CLEAR(state->str_close);
     return 0;
 }
 

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -1,6 +1,7 @@
 
 /* DBM module using dictionary interface */
 
+
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -20,7 +20,6 @@ extern const char * gdbm_strerror(gdbm_error);
 typedef struct {
     PyTypeObject *gdbm_type;
     PyObject *gdbm_error;
-    PyObject *str_close;
 } _gdbm_state;
 
 static inline _gdbm_state*
@@ -545,9 +544,7 @@ gdbm__enter__(PyObject *self, PyObject *args)
 static PyObject *
 gdbm__exit__(PyObject *self, PyObject *args)
 {
-    _gdbm_state *state = PyType_GetModuleState(Py_TYPE(self));
-    assert(state != NULL);
-    return PyObject_CallMethodNoArgs(self, state->str_close);
+    return _gdbm_gdbm_close_impl((gdbmobject *)self);
 }
 
 static PyMethodDef gdbm_methods[] = {
@@ -741,11 +738,6 @@ _gdbm_exec(PyObject *module)
         return -1;
     }
 #endif
-    PyObject *str_close = PyUnicode_InternFromString("close");
-    if (str_close == NULL) {
-        return -1;
-    }
-    state->str_close = str_close;
     return 0;
 }
 
@@ -755,7 +747,6 @@ _gdbm_module_traverse(PyObject *module, visitproc visit, void *arg)
     _gdbm_state *state = get_gdbm_state(module);
     Py_VISIT(state->gdbm_error);
     Py_VISIT(state->gdbm_type);
-    Py_VISIT(state->str_close);
     return 0;
 }
 
@@ -765,7 +756,6 @@ _gdbm_module_clear(PyObject *module)
     _gdbm_state *state = get_gdbm_state(module);
     Py_CLEAR(state->gdbm_error);
     Py_CLEAR(state->gdbm_type);
-    Py_CLEAR(state->str_close);
     return 0;
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46541](https://bugs.python.org/issue46541) -->
https://bugs.python.org/issue46541
<!-- /issue-number -->
