### PR TITLE
bpo-46762: Fix an assert failure in f-strings where > or < is the last character if the f-string is missing a trailing right brace.

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1053,6 +1053,9 @@ x = (
                              "f'{{{'",
                              "f'{{}}{'",
                              "f'{'",
+                             "f'x{<'",  # See bpo-46762.
+                             "f'x{>'",
+                             "f'x{='",
                              ])
 
         # But these are just normal strings.

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1055,7 +1055,6 @@ x = (
                              "f'{'",
                              "f'x{<'",  # See bpo-46762.
                              "f'x{>'",
-                             "f'x{='",
                              ])
 
         # But these are just normal strings.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-15-20-26-46.bpo-46762.1H7vab.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-15-20-26-46.bpo-46762.1H7vab.rst
@@ -1,0 +1,2 @@
+Fix an assert failure in debug builds when a '<', '>', or '=' is the last
+character in an f-string that's missing a closing right brace.

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -670,7 +670,7 @@ fstring_find_expr(Parser *p, const char **str, const char *end, int raw, int rec
             /* Don't get out of the loop for these, if they're single
                chars (not part of 2-char tokens). If by themselves, they
                don't end an expression (unlike say '!'). */
-            if (ch == '=' || ch == '>' || ch == '<') {
+            if (ch == '>' || ch == '<') {
                 continue;
             }
 

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -653,8 +653,8 @@ fstring_find_expr(Parser *p, const char **str, const char *end, int raw, int rec
                    (ch == '!' || ch == ':' || ch == '}' ||
                     ch == '=' || ch == '>' || ch == '<')) {
             /* See if there's a next character. */
-            if (*str + 1 < end) {
-                char next = *(*str + 1);
+            if (*str+1 < end) {
+                char next = *(*str+1);
 
                 /* For "!=". since '=' is not an allowed conversion character,
                    nothing is lost in this test. */
@@ -698,10 +698,10 @@ fstring_find_expr(Parser *p, const char **str, const char *end, int raw, int rec
         }
     }
     expr_end = *str;
-    /* If we leave this loop in a string or with mismatched parens, we
-       don't care. We'll get a syntax error when compiling the
-       expression. But, we can produce a better error message, so
-       let's just do that.*/
+    /* If we leave the above loop in a string or with mismatched parens, we
+       don't really care. We'll get a syntax error when compiling the
+       expression. But, we can produce a better error message, so let's just
+       do that.*/
     if (quote_char) {
         RAISE_SYNTAX_ERROR("f-string: unterminated string");
         goto error;

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -653,8 +653,8 @@ fstring_find_expr(Parser *p, const char **str, const char *end, int raw, int rec
                    (ch == '!' || ch == ':' || ch == '}' ||
                     ch == '=' || ch == '>' || ch == '<')) {
             /* See if there's a next character. */
-            if (*str+1 < end) {
-                char next = *(*str+1);
+            if (*str + 1 < end) {
+                char next = *(*str + 1);
 
                 /* For "!=". since '=' is not an allowed conversion character,
                    nothing is lost in this test. */
@@ -666,12 +666,12 @@ fstring_find_expr(Parser *p, const char **str, const char *end, int raw, int rec
                     *str += 1;
                     continue;
                 }
-                /* Don't get out of the loop for these, if they're single
-                   chars (not part of 2-char tokens). If by themselves, they
-                   don't end an expression (unlike say '!'). */
-                if (ch == '>' || ch == '<') {
-                    continue;
-                }
+            }
+            /* Don't get out of the loop for these, if they're single
+               chars (not part of 2-char tokens). If by themselves, they
+               don't end an expression (unlike say '!'). */
+            if (ch == '=' || ch == '>' || ch == '<') {
+                continue;
             }
 
             /* Normal way out of this loop. */


### PR DESCRIPTION


<!-- issue-number: [bpo-46762](https://bugs.python.org/issue46762) -->
https://bugs.python.org/issue46762
<!-- /issue-number -->
