### PR TITLE
bpo-29418: Add inspect.ismethodwrapper to whatsnew

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -240,6 +240,8 @@ inspect
   triggering dynamic lookup via the descriptor protocol. (Contributed by
   Weipeng Hong in :issue:`30533`.)
 
+* Add :func:`inspect.ismethodwrapper` for checking if the type of an object is a
+:class:`~types.MethodWrapperType`. (Contributed by Hakan Çelik in :issue:`29418`.)
 
 math
 ----

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -241,7 +241,7 @@ inspect
   Weipeng Hong in :issue:`30533`.)
 
 * Add :func:`inspect.ismethodwrapper` for checking if the type of an object is a
-:class:`~types.MethodWrapperType`. (Contributed by Hakan Çelik in :issue:`29418`.)
+  :class:`~types.MethodWrapperType`. (Contributed by Hakan Çelik in :issue:`29418`.)
 
 math
 ----


### PR DESCRIPTION
Related previous PR -> https://github.com/python/cpython/pull/19261

<!-- issue-number: [bpo-29418](https://bugs.python.org/issue29418) -->
https://bugs.python.org/issue29418
<!-- /issue-number -->
