### PR TITLE
Warn user when calling basicConfig twice

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -2023,6 +2023,11 @@ def basicConfig(**kwargs):
             for h in root.handlers[:]:
                 root.removeHandler(h)
                 h.close()
+        else:
+            if basicConfig.has_been_called and root.handlers:
+                import warnings
+                warnings.warn("Duplicate call to basicConfig will have no effect")
+        basicConfig.has_been_called = True
         if len(root.handlers) == 0:
             handlers = kwargs.pop("handlers", None)
             if handlers is None:
@@ -2066,6 +2071,8 @@ def basicConfig(**kwargs):
                 raise ValueError('Unrecognised argument(s): %s' % keys)
     finally:
         _releaseLock()
+
+basicConfig.has_been_called = False
 
 #---------------------------------------------------------------------------
 # Utility functions at module level.


### PR DESCRIPTION
When the user calls basicConfig twice, the second call will do nothing (as the first one already set the root logger's handlers). Currently this fails silently. We should at least warn the programmer, especially because an imported package might already have configured handlers invisibly to the programmer.

References:
- https://stackoverflow.com/q/20240464/2111778

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
