### PR TITLE
Fix mistake in barry_as_FLUFL test

### DIFF
--- a/Lib/test/test_flufl.py
+++ b/Lib/test/test_flufl.py
@@ -17,7 +17,7 @@ class FLUFLTests(unittest.TestCase):
         self.assertIn('2 != 3', cm.exception.text)
         self.assertEqual(cm.exception.filename, '<FLUFL test>')
 
-        self.assertTrue(cm.exception.lineno, 2)
+        self.assertEqual(cm.exception.lineno, 2)
         # The old parser reports the end of the token and the new
         # parser reports the start of the token
         self.assertEqual(cm.exception.offset, 3)


### PR DESCRIPTION
In `Lib/tests/test_flufl.py` (which tests the `from __future__ import barry_as_FLUFL` easter-egg, there is (was) a mistake:

```python
self.assertTrue(cm.exception.lineno, 2)
```

This causes `cm.exception.lineno` to be checked for truthiness, with `2` being unintentionally passed as the `msg` parameter instead. This test will therefore have false negatives, if `lineno` is for some reason nonzero but incorrect.

(How do I do the "skip news" and "skip issue" things for minor changes like this again?)