### PR TITLE
gh-90937: Tracing: c_return doesn't report the result

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-17-21-18-00.bpo-46781.fueIux.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-17-21-18-00.bpo-46781.fueIux.rst
@@ -1,0 +1,3 @@
+When profiling, the ``c_return`` and ``c_exception`` events now
+contain the returned value and the exception thruple, respectively,
+mirroring ``return`` and ``exception``.


### PR DESCRIPTION
When tracing/profiling, the "return" event reports the value returned by
the exiting function.

However, this does not work for C functions. The profiler's "c_return"
hook is called with the same C function object as "c_call". This
unnecessarily complicates debugging and should be fixed.

Likewise for c_exception, which should report the exception thruple.

TODO: This breaks the cprofile testcase.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46781](https://bugs.python.org/issue46781) -->
https://bugs.python.org/issue46781
<!-- /issue-number -->

<!-- gh-issue-number: gh-90937 -->
* Issue: gh-90937
<!-- /gh-issue-number -->
