### PR TITLE
docs: Link `match` statement in tutorial

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -250,7 +250,7 @@ at a more abstract level.  The :keyword:`!pass` is silently ignored::
 :keyword:`!match` Statements
 ============================
 
-A match statement takes an expression and compares its value to successive
+A :keyword:`match` statement takes an expression and compares its value to successive
 patterns given as one or more case blocks.  This is superficially
 similar to a switch statement in C, Java or JavaScript (and many
 other languages), but it can also extract components (sequence elements or


### PR DESCRIPTION
Add a link to the `match` statement from its section in the tutorial.

This should be backported to 3.10.

[Initially submitted as #31395 but against the wrong branch. Thanks @Mariatta]

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:Mariatta