### PR TITLE
bpo-46784: Add newly exported expat symbols to the namespace.

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-02-18-22-10-30.bpo-46784.SVOQJx.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-18-22-10-30.bpo-46784.SVOQJx.rst
@@ -1,0 +1,1 @@
+Fix libexpat symbols collisions with user dynamically loaded or statically linked libexpat in embedded Python.

--- a/Modules/expat/pyexpatns.h
+++ b/Modules/expat/pyexpatns.h
@@ -38,6 +38,9 @@
 #ifndef PYEXPATNS_H
 #define PYEXPATNS_H
 
+#define testingAccountingGetCountBytesDirect PyExpat_testingAccountingGetCountBytesDirect
+#define testingAccountingGetCountBytesIndirect PyExpat_testingAccountingGetCountBytesIndirect
+#define unsignedCharToPrintable PyExpat_unsignedCharToPrintable
 #define XML_DefaultCurrent              PyExpat_XML_DefaultCurrent
 #define XML_ErrorString                 PyExpat_XML_ErrorString
 #define XML_ExpatVersion                PyExpat_XML_ExpatVersion
@@ -81,6 +84,8 @@
 #define XML_ResumeParser                PyExpat_XML_ResumeParser
 #define XML_SetAttlistDeclHandler       PyExpat_XML_SetAttlistDeclHandler
 #define XML_SetBase                     PyExpat_XML_SetBase
+#define XML_SetBillionLaughsAttackProtectionActivationThreshold PyExpat_XML_SetBillionLaughsAttackProtectionActivationThreshold
+#define XML_SetBillionLaughsAttackProtectionMaximumAmplification PyExpat_XML_SetBillionLaughsAttackProtectionMaximumAmplification
 #define XML_SetCdataSectionHandler      PyExpat_XML_SetCdataSectionHandler
 #define XML_SetCharacterDataHandler     PyExpat_XML_SetCharacterDataHandler
 #define XML_SetCommentHandler           PyExpat_XML_SetCommentHandler


### PR DESCRIPTION
The libexpat 2.4.1 upgrade from https://bugs.python.org/issue44394 introduced the following new exported symbols:

* `testingAccountingGetCountBytesDirect`
* `testingAccountingGetCountBytesIndirect`
* `unsignedCharToPrintable`
* `XML_SetBillionLaughsAttackProtectionActivationThreshold`
* `XML_SetBillionLaughsAttackProtectionMaximumAmplification`

We need to adjust [Modules/expat/pyexpatns.h](https://github.com/python/cpython/blob/master/Modules/expat/pyexpatns.h)

(The newer libexpat upgrade https://bugs.python.org/issue46400 has no new symbols).

<!-- issue-number: [bpo-46784](https://bugs.python.org/issue46784) -->
https://bugs.python.org/issue46784
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead