### PR TITLE
replace `self` param with more appropriate `cls` in classmethods

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -871,7 +871,7 @@ class KeysView(MappingView, Set):
     __slots__ = ()
 
     @classmethod
-    def _from_iterable(self, it):
+    def _from_iterable(cls, it):
         return set(it)
 
     def __contains__(self, key):
@@ -889,7 +889,7 @@ class ItemsView(MappingView, Set):
     __slots__ = ()
 
     @classmethod
-    def _from_iterable(self, it):
+    def _from_iterable(cls, it):
         return set(it)
 
     def __contains__(self, item):


### PR DESCRIPTION
No worries if this is nitpicky & denied, just noticed while reading through the code & thought I'd PR a fix.

Named correctly in other places such as https://github.com/python/cpython/blob/main/Lib/_collections_abc.py#L622

Also is there any reason why not to use a staticmethod? I'm interested in learning :)