### PR TITLE
CI: Process more stale PRs, oldest first

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,6 +23,8 @@ jobs:
         stale-pr-label: 'stale'
         days-before-stale: 30
         days-before-close: -1
+        ascending: true
+        operations-per-run: 120
 
     - name: "Check PRs with 'CLA not signed' label"
       uses: actions/stale@v4
@@ -34,3 +36,5 @@ jobs:
         close-pr-message: 'Closing this stale PR because the CLA is still not signed.'
         days-before-stale: 30
         days-before-close: 14
+        ascending: true
+        operations-per-run: 120


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Follow up for https://github.com/python/core-workflow/issues/93.

The [GitHub Action to process stale PRs](https://github.com/python/cpython/actions/workflows/stale.yml) only runs on a subset of open PRs.

Let's run on more, and process the older ones first, they're more likely to be stale/abandoned.

More details: https://github.com/python/core-workflow/issues/93#issuecomment-1044058847
