### PR TITLE
bpo-46752: Reduce flakiness of taskgroups test 13

### DIFF
--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -372,7 +372,7 @@ class TestTaskGroup(unittest.IsolatedAsyncioTestCase):
                 g1.create_task(crash_after(0.1))
 
                 async with taskgroups.TaskGroup() as g2:
-                    g2.create_task(crash_after(0.2))
+                    g2.create_task(crash_after(10))
 
         r = asyncio.create_task(runner())
         with self.assertRaises(ExceptionGroup) as cm:


### PR DESCRIPTION
This test occasionally [failed](https://github.com/python/cpython/runs/5243359899?check_suite_focus=true) -- I presume on a slow machine. By increasing the longer timeout (which is interrupted anyway) that should no longer happen.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46752](https://bugs.python.org/issue46752) -->
https://bugs.python.org/issue46752
<!-- /issue-number -->
