### PR TITLE
bpo-20923 : [doc] Explain ConfigParser 'valid section name'  and .SECTCRE

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -267,6 +267,9 @@ out.  Values can also span multiple lines, as long as they are indented deeper
 than the first line of the value.  Depending on the parser's mode, blank lines
 may be treated as parts of multiline values or ignored.
 
+By default,  a legal section name can be any string that does not contain '\\n' or ']'.  
+To change this, see :attr:`ConfigParser.SECTCRE`.
+
 Configuration files may include comments, prefixed by specific
 characters (``#`` and ``;`` by default [1]_).  Comments may appear on
 their own on an otherwise empty line, possibly indented. [1]_

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -267,7 +267,7 @@ out.  Values can also span multiple lines, as long as they are indented deeper
 than the first line of the value.  Depending on the parser's mode, blank lines
 may be treated as parts of multiline values or ignored.
 
-By default,  a valid section name can be any string that does not contain '\\n' or ']'. 
+By default,  a valid section name can be any string that does not contain '\\n' or ']'.
 To change this, see :attr:`ConfigParser.SECTCRE`.
 
 Configuration files may include comments, prefixed by specific

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -267,7 +267,7 @@ out.  Values can also span multiple lines, as long as they are indented deeper
 than the first line of the value.  Depending on the parser's mode, blank lines
 may be treated as parts of multiline values or ignored.
 
-By default,  a legal section name can be any string that does not contain '\\n' or ']'.  
+By default,  a valid section name can be any string that does not contain '\\n' or ']'.  
 To change this, see :attr:`ConfigParser.SECTCRE`.
 
 Configuration files may include comments, prefixed by specific

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -267,7 +267,7 @@ out.  Values can also span multiple lines, as long as they are indented deeper
 than the first line of the value.  Depending on the parser's mode, blank lines
 may be treated as parts of multiline values or ignored.
 
-By default,  a valid section name can be any string that does not contain '\\n' or ']'.  
+By default,  a valid section name can be any string that does not contain '\\n' or ']'. 
 To change this, see :attr:`ConfigParser.SECTCRE`.
 
 Configuration files may include comments, prefixed by specific


### PR DESCRIPTION
Added "By default,  a legal section name can be any string that does not contain '\\n' or ']'.  
To change this, see :attr:`ConfigParser.SECTCRE`." in configparser.rst.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-20923](https://bugs.python.org/issue20923) -->
https://bugs.python.org/issue20923
<!-- /issue-number -->
