### PR TITLE
bpo-46730: Use raw string to avoid deprecation warning

### DIFF
--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -342,7 +342,7 @@ class PropertyUnreachableAttributeWithName(_PropertyUnreachableAttribute, unitte
 
 
 class PropertyUnreachableAttributeNoName(_PropertyUnreachableAttribute, unittest.TestCase):
-    msg_format = "^property of 'PropertyUnreachableAttributeNoName\.cls' object {}$"
+    msg_format = r"^property of 'PropertyUnreachableAttributeNoName\.cls' object {}$"
 
     class cls:
         pass


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46730](https://bugs.python.org/issue46730) -->
https://bugs.python.org/issue46730
<!-- /issue-number -->
