### PR TITLE
bpo-46801: suppress deprecation warnings in test_typing

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4586,7 +4586,9 @@ class TypedDictTests(BaseTestCase):
         with self.assertRaises(TypeError):
             TypedDict(_typename='Emp', name=str, id=int)
         with self.assertRaises(TypeError):
-            TypedDict('Emp', _fields={'name': str, 'id': int})
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', DeprecationWarning)
+                TypedDict('Emp', _fields={'name': str, 'id': int})
 
     def test_typeddict_errors(self):
         Emp = TypedDict('Emp', {'name': str, 'id': int})
@@ -4599,7 +4601,9 @@ class TypedDictTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(dict, Emp)
         with self.assertRaises(TypeError):
-            TypedDict('Hi', x=1)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', DeprecationWarning)
+                TypedDict('Hi', x=1)
         with self.assertRaises(TypeError):
             TypedDict('Hi', [('x', int), ('y', 1)])
         with self.assertRaises(TypeError):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46801](https://bugs.python.org/issue46801) -->
https://bugs.python.org/issue46801
<!-- /issue-number -->
