### PR TITLE
 bpo-46771:  cancel counts

### DIFF
--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -1,5 +1,6 @@
 import enum
 
+from dataclasses import dataclass
 from types import TracebackType
 from typing import final, Any, Dict, Optional, Type
 

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -106,19 +106,6 @@ class Timeout:
         self._state = _State.CANCELLING
         # drop the reference early
         self._timeout_handler = None
-        counter = _COUNTERS.get(self._task)
-        if counter is None:
-            _COUNTERS[self._task] = 1
-            self._task.add_done_callback(_drop_task)
-        else:
-            _COUNTERS[self._task] = counter + 1
-
-
-_COUNTERS: Dict[tasks.Task, int] = {}
-
-
-def _drop_task(task: tasks.Task) -> None:
-    del _COUNTERS[task]
 
 
 def timeout(delay: Optional[float]) -> Timeout:

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -90,11 +90,11 @@ class Timeout:
 
         if self._state is _State.CANCELLING:
             self._state = _State.CANCELLED
-            counter = _COUNTERS[self._task]
-            if counter == 1:
-                raise TimeoutError
-            else:
-                _COUNTERS[self._task] = counter - 1
+
+            if self._task.uncancel() == 0:
+                # Since there are no outstanding cancel requests, we're
+                # handling this.
+                return True
         elif self._state is _State.ENTERED:
             self._state = _State.EXITED
 

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -94,7 +94,7 @@ class Timeout:
             if self._task.uncancel() == 0:
                 # Since there are no outstanding cancel requests, we're
                 # handling this.
-                return True
+                raise TimeoutError
         elif self._state is _State.ENTERED:
             self._state = _State.EXITED
 

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -1,6 +1,5 @@
 import enum
 
-from dataclasses import dataclass
 from types import TracebackType
 from typing import final, Any, Dict, Optional, Type
 

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -91,7 +91,7 @@ typedef struct {
     PyObject *task_context;
     int task_must_cancel;
     int task_log_destroy_pending;
-    int task_cancel_requested;
+    int task_num_cancels_requested;
 } TaskObj;
 
 typedef struct {
@@ -2040,7 +2040,7 @@ _asyncio_Task___init___impl(TaskObj *self, PyObject *coro, PyObject *loop,
     Py_CLEAR(self->task_fut_waiter);
     self->task_must_cancel = 0;
     self->task_log_destroy_pending = 1;
-    self->task_cancel_requested = 0;
+    self->task_num_cancels_requested = 0;
     Py_INCREF(coro);
     Py_XSETREF(self->task_coro, coro);
 
@@ -2207,10 +2207,10 @@ _asyncio_Task_cancel_impl(TaskObj *self, PyObject *msg)
         Py_RETURN_FALSE;
     }
 
-    if (self->task_cancel_requested) {
+    self->task_num_cancels_requested += 1;
+    if (self->task_num_cancels_requested > 1) {
         Py_RETURN_FALSE;
     }
-    self->task_cancel_requested = 1;
 
     if (self->task_fut_waiter) {
         PyObject *res;
@@ -2256,12 +2256,7 @@ _asyncio_Task_cancelling_impl(TaskObj *self)
 /*[clinic end generated code: output=803b3af96f917d7e input=c50e50f9c3ca4676]*/
 /*[clinic end generated code]*/
 {
-    if (self->task_cancel_requested) {
-        Py_RETURN_TRUE;
-    }
-    else {
-        Py_RETURN_FALSE;
-    }
+    return PyLong_FromLong(self->task_num_cancels_requested);
 }
 
 /*[clinic input]
@@ -2280,13 +2275,10 @@ _asyncio_Task_uncancel_impl(TaskObj *self)
 /*[clinic end generated code: output=58184d236a817d3c input=5db95e28fcb6f7cd]*/
 /*[clinic end generated code]*/
 {
-    if (self->task_cancel_requested) {
-        self->task_cancel_requested = 0;
-        Py_RETURN_TRUE;
+    if (self->task_num_cancels_requested > 0) {
+        self->task_num_cancels_requested -= 1;
     }
-    else {
-        Py_RETURN_FALSE;
-    }
+    return PyLong_FromLong(self->task_num_cancels_requested);
 }
 
 /*[clinic input]


### PR DESCRIPTION
Changes:

* `Task._cancel_requested: bool` is now `Task._num_cancels_requested: int`
* `Task.cancelling` now returns an int
* `Task.uncancel` also returns an int, the number of remaining cancel requests
* the CancelScope no longer cancels with a nonce
* the CancelScope uncancels in `__exit__`, and propagates the CancelError if there are more cancel requests
* ~~`CancelScope.cancelled` is now a property~~
* added a couple of tests, not final

I have not updated any of the comments or docs yet.

<!-- issue-number: [bpo-46771](https://bugs.python.org/issue46771) -->
https://bugs.python.org/issue46771
<!-- /issue-number -->
