### PR TITLE
[3.9] bpo-46672: fix `NameError` in `asyncio.gather` if type check fails (GH-31187)

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -823,7 +823,6 @@ def _gather(*coros_or_futures, loop=None, return_exceptions=False):
     children = []
     nfuts = 0
     nfinished = 0
-    loop = None
     outer = None  # bpo-46672
     for arg in coros_or_futures:
         if arg not in arg_to_fut:

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -768,7 +768,7 @@ def _gather(*coros_or_futures, loop=None, return_exceptions=False):
         nonlocal nfinished
         nfinished += 1
 
-        if outer.done():
+        if outer is None or outer.done():
             if not fut.cancelled():
                 # Mark exception retrieved.
                 fut.exception()
@@ -823,6 +823,8 @@ def _gather(*coros_or_futures, loop=None, return_exceptions=False):
     children = []
     nfuts = 0
     nfinished = 0
+    loop = None
+    outer = None  # bpo-46672
     for arg in coros_or_futures:
         if arg not in arg_to_fut:
             fut = ensure_future(arg, loop=loop)

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3488,6 +3488,20 @@ class CoroutineGatherTests(GatherTestsBase, test_utils.TestCase):
         test_utils.run_briefly(self.one_loop)
         self.assertIsInstance(f.exception(), RuntimeError)
 
+    def test_issue46672(self):
+        with mock.patch(
+            'asyncio.base_events.BaseEventLoop.call_exception_handler',
+        ):
+            async def coro(s):
+                return s
+            c = coro('abc')
+
+            with self.assertRaises(TypeError):
+                self._gather(c, {})
+            self._run_loop(self.one_loop)
+            # NameError should not happen:
+            self.one_loop.call_exception_handler.assert_not_called()
+
 
 class RunCoroutineThreadsafeTests(test_utils.TestCase):
     """Test case for asyncio.run_coroutine_threadsafe."""

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3407,6 +3407,11 @@ class CoroutineGatherTests(GatherTestsBase, test_utils.TestCase):
             coros.append(coro())
         return coros
 
+    def _gather(self, *args, **kwargs):
+        async def coro():
+            return asyncio.gather(*args, **kwargs)
+        return self.one_loop.run_until_complete(coro())
+
     def test_constructor_loop_selection(self):
         async def coro():
             return 'abc'

--- a/Misc/NEWS.d/next/Library/2022-02-07-13-15-16.bpo-46672.4swIjx.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-07-13-15-16.bpo-46672.4swIjx.rst
@@ -1,0 +1,1 @@
+Fix ``NameError`` in :func:`asyncio.gather` when initial type check fails.


### PR DESCRIPTION
Co-authored-by: Alex Waygood <Alex.Waygood@Gmail.com>.
(cherry picked from commit 4ab8167b9c60d1a04b2e3116d0c52db254b68cda)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>


<!-- issue-number: [bpo-46672](https://bugs.python.org/issue46672) -->
https://bugs.python.org/issue46672
<!-- /issue-number -->

Automerge-Triggered-By: GH:asvetlov