### PR TITLE
[3.10] replace `self` param with more appropriate `cls` in classmethods (GH-31402)

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -871,7 +871,7 @@ class KeysView(MappingView, Set):
     __slots__ = ()
 
     @classmethod
-    def _from_iterable(self, it):
+    def _from_iterable(cls, it):
         return set(it)
 
     def __contains__(self, key):
@@ -889,7 +889,7 @@ class ItemsView(MappingView, Set):
     __slots__ = ()
 
     @classmethod
-    def _from_iterable(self, it):
+    def _from_iterable(cls, it):
         return set(it)
 
     def __contains__(self, item):


### PR DESCRIPTION
(cherry picked from commit a3fcca4af1cb418dc802feb75100ecc1a286afaa)

Co-authored-by: Josh Smith <cmyuiosu@gmail.com>
