### PR TITLE
bpo-46808: remove NEXT_BLOCK() from compile.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-20-23-10-14.bpo-46808.vouNSF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-20-23-10-14.bpo-46808.vouNSF.rst
@@ -1,0 +1,1 @@
+Remove the ``NEXT_BLOCK`` macro from compile.c, and make the compiler automatically generate implicit blocks when they are needed.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46808](https://bugs.python.org/issue46808) -->
https://bugs.python.org/issue46808
<!-- /issue-number -->
