### PR TITLE
bpo-46740: speedup telnetlib's buffer transfers

### DIFF
--- a/Lib/telnetlib.py
+++ b/Lib/telnetlib.py
@@ -432,7 +432,7 @@ class Telnet:
         try:
             while self.rawq:
                 if not self.iacseq:
-                    slice = self._rawq_getslice()
+                    slice = self._next_nonIAC_slice()
                     if slice:
                         buf[self.sb] = buf[self.sb] + slice
                     else:


### PR DESCRIPTION
This patch leverages the very low frequency of IAC (control) characters: instead of reading/interpreting/appending per character, it's much faster to search them linearly (if any), then copy the data (non-IAC) slice to the cooked queue. `rawq` index handling in `_next_nonIAC_slice` is almost copied from `rawq_getchar`.

Also calls `socket.recv` with the currently recommended buffer size, 4096.

Patching `process_rawq` patching was inspired by point 2) in this very old Python-dev topic
https://python-dev.python.narkive.com/A86fs3PG/patch-to-telnetlib-py
and yields a 5x speedup too.

<!-- issue-number: [bpo-46740](https://bugs.python.org/issue46740) -->
https://bugs.python.org/issue46740
<!-- /issue-number -->
