### PR TITLE
bpo-45492: Corrected documentation for co_names in inspect library

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -191,8 +191,9 @@ attributes:
 |           |                   | which this code object    |
 |           |                   | was defined               |
 +-----------+-------------------+---------------------------+
-|           | co_names          | tuple of names of local   |
-|           |                   | variables                 |
+|           | co_names          | tuple of names of used    |
+|           |                   | global and built-in       |
+|           |                   | references                |
 +-----------+-------------------+---------------------------+
 |           | co_nlocals        | number of local variables |
 +-----------+-------------------+---------------------------+

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -191,9 +191,9 @@ attributes:
 |           |                   | which this code object    |
 |           |                   | was defined               |
 +-----------+-------------------+---------------------------+
-|           | co_names          | tuple of names of used    |
-|           |                   | global and built-in       |
-|           |                   | references                |
+|           | co_names          | tuple of names other      |
+|           |                   | than arguments and        |
+|           |                   | function locals           |
 +-----------+-------------------+---------------------------+
 |           | co_nlocals        | number of local variables |
 +-----------+-------------------+---------------------------+


### PR DESCRIPTION
Updated documentation to mirror [`inspect.py`](https://github.com/python/cpython/blob/be095f6c32188bba02079d086ac8639ea37cec3c/Lib/inspect.py#L498)


<!-- issue-number: [bpo-45492](https://bugs.python.org/issue45492) -->
https://bugs.python.org/issue45492
<!-- /issue-number -->
