### PR TITLE
[3.10] bpo-45116: Fix inlining regressions on Windows Release build

### DIFF
--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -100,6 +100,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>/Zm200  %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/d2inlinelogfull:FrameDefault %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(PySourcePath)Python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="$(IncludeExternals)">$(zlibDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_USRDLL;Py_BUILD_CORE;Py_BUILD_CORE_BUILTIN;Py_ENABLE_SHARED;MS_DLL_ID="$(SysWinVer)";%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -100,7 +100,6 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>/Zm200  %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions>/d2inlinelogfull:FrameDefault %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(PySourcePath)Python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="$(IncludeExternals)">$(zlibDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_USRDLL;Py_BUILD_CORE;Py_BUILD_CORE_BUILTIN;Py_ENABLE_SHARED;MS_DLL_ID="$(SysWinVer)";%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -94,6 +94,7 @@ static PyObject * special_lookup(PyThreadState *, PyObject *, _Py_Identifier *);
 static int check_args_iterable(PyThreadState *, PyObject *func, PyObject *vararg);
 static void format_kwargs_error(PyThreadState *, PyObject *func, PyObject *kwargs);
 static void format_awaitable_error(PyThreadState *, PyTypeObject *, int, int);
+static void unknown_opcode_error(PyThreadState *, PyFrameObject *, int);
 
 #define NAME_ERROR_MSG \
     "name '%.200s' is not defined"
@@ -4418,11 +4419,7 @@ main_loop:
         _unknown_opcode:
 #endif
         default:
-            fprintf(stderr,
-                "XXX lineno: %d, opcode: %d\n",
-                PyFrame_GetLineNumber(f),
-                opcode);
-            _PyErr_SetString(tstate, PyExc_SystemError, "unknown opcode");
+            unknown_opcode_error(tstate, f, opcode);
             goto error;
 
         } /* switch */
@@ -6308,6 +6305,16 @@ format_awaitable_error(PyThreadState *tstate, PyTypeObject *type, int prevprevop
                           type->tp_name);
         }
     }
+}
+
+_Py_NO_INLINE static void
+unknown_opcode_error(PyThreadState *tstate, PyFrameObject *f, int opcode)
+{
+    fprintf(stderr,
+        "XXX lineno: %d, opcode: %d\n",
+        PyFrame_GetLineNumber(f),
+        opcode);
+    _PyErr_SetString(tstate, PyExc_SystemError, "unknown opcode");
 }
 
 static PyObject *


### PR DESCRIPTION
The main interpreter loop needs to shrink a bit to keep small functions there inlined consistently.
<br>
3.10.2+ (f1916cd)
<details>
<summary>Benchmark x64 1.03x recovery</summary>
<pre>
<code>
Slower (5):
- unpack_sequence: 80.3 ns +- 0.1 ns -> 85.5 ns +- 5.0 ns: 1.06x slower
- scimark_monte_carlo: 145 ms +- 3 ms -> 151 ms +- 4 ms: 1.04x slower
- tornado_http: 411 ms +- 14 ms -> 425 ms +- 52 ms: 1.04x slower
- nbody: 199 ms +- 4 ms -> 205 ms +- 5 ms: 1.03x slower
- telco: 12.8 ms +- 0.1 ms -> 13.1 ms +- 0.2 ms: 1.02x slower
Faster (34):
- scimark_lu: 233 ms +- 2 ms -> 202 ms +- 8 ms: 1.15x faster
- xml_etree_parse: 246 ms +- 9 ms -> 220 ms +- 4 ms: 1.12x faster
- unpickle_pure_python: 482 us +- 13 us -> 436 us +- 9 us: 1.11x faster
- logging_format: 25.7 us +- 1.6 us -> 23.8 us +- 0.5 us: 1.08x faster
- hexiom: 14.0 ms +- 0.3 ms -> 13.0 ms +- 0.1 ms: 1.08x faster
- xml_etree_generate: 159 ms +- 5 ms -> 148 ms +- 2 ms: 1.08x faster
- django_template: 104 ms +- 4 ms -> 96.6 ms +- 2.6 ms: 1.07x faster
- meteor_contest: 141 ms +- 2 ms -> 132 ms +- 4 ms: 1.07x faster
- logging_silent: 260 ns +- 8 ns -> 243 ns +- 13 ns: 1.07x faster
- go: 381 ms +- 4 ms -> 357 ms +- 4 ms: 1.07x faster
- sympy_integrate: 39.9 ms +- 1.1 ms -> 37.4 ms +- 0.6 ms: 1.07x faster
- sympy_expand: 940 ms +- 20 ms -> 882 ms +- 13 ms: 1.07x faster
- regex_compile: 276 ms +- 4 ms -> 260 ms +- 5 ms: 1.06x faster
- logging_simple: 23.2 us +- 1.2 us -> 21.8 us +- 0.8 us: 1.06x faster
- sympy_sum: 333 ms +- 20 ms -> 314 ms +- 8 ms: 1.06x faster
- pathlib: 172 ms +- 10 ms -> 162 ms +- 15 ms: 1.06x faster
- chameleon: 19.2 ms +- 0.5 ms -> 18.1 ms +- 0.2 ms: 1.06x faster
- pickle_pure_python: 799 us +- 7 us -> 757 us +- 14 us: 1.05x faster
- scimark_sor: 282 ms +- 3 ms -> 268 ms +- 2 ms: 1.05x faster
- nqueens: 171 ms +- 3 ms -> 163 ms +- 3 ms: 1.05x faster
- dulwich_log: 214 ms +- 14 ms -> 204 ms +- 6 ms: 1.05x faster
- float: 170 ms +- 4 ms -> 162 ms +- 2 ms: 1.05x faster
- chaos: 182 ms +- 4 ms -> 173 ms +- 7 ms: 1.05x faster
- raytrace: 810 ms +- 7 ms -> 776 ms +- 8 ms: 1.04x faster
- xml_etree_iterparse: 177 ms +- 2 ms -> 170 ms +- 10 ms: 1.04x faster
- sympy_str: 575 ms +- 13 ms -> 553 ms +- 12 ms: 1.04x faster
- fannkuch: 657 ms +- 18 ms -> 632 ms +- 7 ms: 1.04x faster
- deltablue: 11.1 ms +- 0.4 ms -> 10.7 ms +- 0.3 ms: 1.04x faster
- json_dumps: 21.8 ms +- 0.5 ms -> 21.1 ms +- 0.2 ms: 1.04x faster
- crypto_pyaes: 169 ms +- 3 ms -> 163 ms +- 4 ms: 1.03x faster
- python_startup: 14.4 ms +- 1.8 ms -> 14.0 ms +- 1.0 ms: 1.03x faster
- pyflate: 1.04 sec +- 0.01 sec -> 1.00 sec +- 0.01 sec: 1.03x faster
- xml_etree_process: 133 ms +- 2 ms -> 129 ms +- 3 ms: 1.03x faster
- unpickle: 22.9 us +- 0.3 us -> 22.4 us +- 0.3 us: 1.02x faster
Benchmark hidden because not significant (19): 2to3, json_loads, mako, pickle, pickle_dict, pickle_l
ist, pidigits, python_startup_no_site, regex_dna, regex_effbot, regex_v8, richards, scimark_fft, sci
mark_sparse_mat_mult, spectral_norm, sqlalchemy_declarative, sqlalchemy_imperative, sqlite_synth, un
pickle_list

Geometric mean: 1.03x faster
</code>
</pre>
</details>
<details>
<summary>Benchmark x86 1.04x recovery</summary>
<pre>
<code>
Slower (6):
- scimark_sparse_mat_mult: 8.52 ms +- 0.22 ms -> 8.97 ms +- 0.18 ms: 1.05x slower
- json_dumps: 21.6 ms +- 0.1 ms -> 22.6 ms +- 0.9 ms: 1.05x slower
- regex_effbot: 3.41 ms +- 0.04 ms -> 3.56 ms +- 0.05 ms: 1.04x slower
- logging_format: 24.4 us +- 0.3 us -> 25.4 us +- 1.0 us: 1.04x slower
- logging_simple: 22.4 us +- 0.5 us -> 22.9 us +- 0.9 us: 1.02x slower
- pathlib: 167 ms +- 8 ms -> 170 ms +- 6 ms: 1.02x slower
Faster (39):
- sqlalchemy_imperative: 53.1 ms +- 3.3 ms -> 43.1 ms +- 5.1 ms: 1.23x faster
- logging_silent: 318 ns +- 16 ns -> 275 ns +- 13 ns: 1.15x faster
- richards: 143 ms +- 4 ms -> 126 ms +- 3 ms: 1.14x faster
- scimark_monte_carlo: 179 ms +- 3 ms -> 162 ms +- 3 ms: 1.10x faster
- hexiom: 16.6 ms +- 0.2 ms -> 15.1 ms +- 0.1 ms: 1.10x faster
- unpickle_pure_python: 564 us +- 7 us -> 513 us +- 4 us: 1.10x faster
- deltablue: 13.0 ms +- 0.4 ms -> 11.9 ms +- 0.3 ms: 1.09x faster
- scimark_sor: 366 ms +- 5 ms -> 336 ms +- 5 ms: 1.09x faster
- sqlalchemy_declarative: 293 ms +- 22 ms -> 270 ms +- 8 ms: 1.09x faster
- django_template: 104 ms +- 3 ms -> 97.2 ms +- 0.9 ms: 1.07x faster
- sympy_integrate: 39.3 ms +- 3.0 ms -> 36.7 ms +- 0.9 ms: 1.07x faster
- chaos: 207 ms +- 5 ms -> 193 ms +- 5 ms: 1.07x faster
- scimark_lu: 332 ms +- 6 ms -> 310 ms +- 4 ms: 1.07x faster
- regex_compile: 303 ms +- 5 ms -> 283 ms +- 6 ms: 1.07x faster
- pyflate: 1.22 sec +- 0.01 sec -> 1.14 sec +- 0.01 sec: 1.07x faster
- float: 196 ms +- 1 ms -> 184 ms +- 2 ms: 1.07x faster
- pickle_pure_python: 868 us +- 7 us -> 814 us +- 5 us: 1.07x faster
- go: 413 ms +- 5 ms -> 387 ms +- 12 ms: 1.07x faster
- raytrace: 916 ms +- 23 ms -> 868 ms +- 9 ms: 1.06x faster
- unpack_sequence: 87.2 ns +- 1.0 ns -> 83.3 ns +- 1.6 ns: 1.05x faster
- nqueens: 188 ms +- 2 ms -> 179 ms +- 1 ms: 1.05x faster
- telco: 12.5 ms +- 0.1 ms -> 11.9 ms +- 0.0 ms: 1.04x faster
- tornado_http: 379 ms +- 9 ms -> 364 ms +- 5 ms: 1.04x faster
- spectral_norm: 285 ms +- 9 ms -> 273 ms +- 4 ms: 1.04x faster
- xml_etree_parse: 253 ms +- 5 ms -> 243 ms +- 4 ms: 1.04x faster
- sympy_str: 558 ms +- 19 ms -> 538 ms +- 5 ms: 1.04x faster
- mako: 25.8 ms +- 0.5 ms -> 24.8 ms +- 0.6 ms: 1.04x faster
- fannkuch: 844 ms +- 5 ms -> 814 ms +- 5 ms: 1.04x faster
- xml_etree_generate: 164 ms +- 2 ms -> 159 ms +- 2 ms: 1.04x faster
- meteor_contest: 147 ms +- 1 ms -> 142 ms +- 1 ms: 1.04x faster
- xml_etree_process: 136 ms +- 1 ms -> 132 ms +- 1 ms: 1.03x faster
- unpickle_list: 6.00 us +- 0.15 us -> 5.81 us +- 0.20 us: 1.03x faster
- crypto_pyaes: 204 ms +- 3 ms -> 198 ms +- 1 ms: 1.03x faster
- chameleon: 19.5 ms +- 0.3 ms -> 18.9 ms +- 0.5 ms: 1.03x faster
- sympy_sum: 302 ms +- 12 ms -> 294 ms +- 13 ms: 1.03x faster
- dulwich_log: 196 ms +- 15 ms -> 191 ms +- 2 ms: 1.03x faster
- pickle_list: 6.35 us +- 0.03 us -> 6.18 us +- 0.04 us: 1.03x faster
- xml_etree_iterparse: 169 ms +- 2 ms -> 165 ms +- 2 ms: 1.02x faster
- sympy_expand: 939 ms +- 47 ms -> 918 ms +- 30 ms: 1.02x faster

Benchmark hidden because not significant (13): 2to3, json_loads, nbody, pickle, pickle_dict, pidigit
s, python_startup, python_startup_no_site, regex_dna, regex_v8, scimark_fft, sqlite_synth, unpickle

Geometric mean: 1.04x faster
</code>
</pre>
</details>

**PGO builds don't change performance with this.**

<!-- issue-number: [bpo-45116](https://bugs.python.org/issue45116) -->
https://bugs.python.org/issue45116
<!-- /issue-number -->
