### PR TITLE
bpo-31327: Update time documentation to reflect possible errors

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -257,12 +257,11 @@ Functions
    :const:`None`, the current time as returned by :func:`.time` is used.  The dst
    flag is set to ``1`` when DST applies to the given time.
 
-   :func:`localtime` may raise :exc:`OverflowError`, if the timestamp is out of
-   the range of values supported by the platform C :c:func:`localtime` or
-   :c:func:`gmtime` functions, and :exc:`OSError` on :c:func:`localtime` or
-   :c:func:`gmtime` failure.
-   It's common for this to be restricted to years in
-   1970 through 2038.
+   :func:`localtime` may raise :exc:`OverflowError`, if the timestamp is
+   outside the range of values supported by the platform C :c:func:`localtime`
+   or :c:func:`gmtime` functions, and :exc:`OSError` on :c:func:`localtime` or
+   :c:func:`gmtime` failure. It's common for this to be restricted to years
+   between 1970 and 2038.
 
 
 .. function:: mktime(t)

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -256,6 +256,13 @@ Functions
    Like :func:`gmtime` but converts to local time.  If *secs* is not provided or
    :const:`None`, the current time as returned by :func:`.time` is used.  The dst
    flag is set to ``1`` when DST applies to the given time.
+   
+   :func:`localtime` may raise :exc:`OverflowError`, if the timestamp is out of
+   the range of values supported by the platform C :c:func:`localtime` or
+   :c:func:`gmtime` functions, and :exc:`OSError` on :c:func:`localtime` or
+   :c:func:`gmtime` failure.
+   It's common for this to be restricted to years in
+   1970 through 2038. 
 
 
 .. function:: mktime(t)

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -256,13 +256,13 @@ Functions
    Like :func:`gmtime` but converts to local time.  If *secs* is not provided or
    :const:`None`, the current time as returned by :func:`.time` is used.  The dst
    flag is set to ``1`` when DST applies to the given time.
-   
+
    :func:`localtime` may raise :exc:`OverflowError`, if the timestamp is out of
    the range of values supported by the platform C :c:func:`localtime` or
    :c:func:`gmtime` functions, and :exc:`OSError` on :c:func:`localtime` or
    :c:func:`gmtime` failure.
    It's common for this to be restricted to years in
-   1970 through 2038. 
+   1970 through 2038.
 
 
 .. function:: mktime(t)


### PR DESCRIPTION
As per the comments, this mirrors the [datetime documentation](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp). 

```
>>> import time
>>> time.localtime(999999999999999999999)
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
OverflowError: timestamp out of range for platform time_t
>>> time.localtime(-3600)
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
OSError: [Errno 22] Invalid argument 
```

<!-- issue-number: [bpo-31327](https://bugs.python.org/issue31327) -->
https://bugs.python.org/issue31327
<!-- /issue-number -->

Automerge-Triggered-By: GH:pganssle