### PR TITLE
bpo-46813: Allow developer to resize the dictionary

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -856,6 +856,12 @@ class DictTest(unittest.TestCase):
         resizing = True
         d[9] = 6
 
+    def test_resize3(self):
+        d = {}
+        orig_size = sys.getsizeof(d)
+        d.resize(9)
+        self.assertGreater(sys.getsizeof(d), orig_size)
+
     def test_empty_presized_dict_in_freelist(self):
         # Bug #3537: if an empty but presized dict with a size larger
         # than 7 was in the freelist, it triggered an assertion failure

--- a/Misc/NEWS.d/next/Library/2022-02-21-07-44-41.bpo-46813.5aDp0t.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-21-07-44-41.bpo-46813.5aDp0t.rst
@@ -1,0 +1,1 @@
+Implement :func:`dict.resize`. Allow developers to resize dict on demand.

--- a/Objects/clinic/dictobject.c.h
+++ b/Objects/clinic/dictobject.c.h
@@ -79,6 +79,42 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(dict_resize__doc__,
+"resize($self, size, /)\n"
+"--\n"
+"\n"
+"Resize the dict and return the self.");
+
+#define DICT_RESIZE_METHODDEF    \
+    {"resize", (PyCFunction)dict_resize, METH_O, dict_resize__doc__},
+
+static PyObject *
+dict_resize_impl(PyDictObject *self, Py_ssize_t size);
+
+static PyObject *
+dict_resize(PyDictObject *self, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    Py_ssize_t size;
+
+    {
+        Py_ssize_t ival = -1;
+        PyObject *iobj = _PyNumber_Index(arg);
+        if (iobj != NULL) {
+            ival = PyLong_AsSsize_t(iobj);
+            Py_DECREF(iobj);
+        }
+        if (ival == -1 && PyErr_Occurred()) {
+            goto exit;
+        }
+        size = ival;
+    }
+    return_value = dict_resize_impl(self, size);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(dict_setdefault__doc__,
 "setdefault($self, key, default=None, /)\n"
 "--\n"
@@ -191,4 +227,4 @@ dict___reversed__(PyDictObject *self, PyObject *Py_UNUSED(ignored))
 {
     return dict___reversed___impl(self);
 }
-/*[clinic end generated code: output=7b77c16e43d6735a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=46aa68e9db20868d input=a9049054013a1b77]*/

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3001,6 +3001,23 @@ dict_get_impl(PyDictObject *self, PyObject *key, PyObject *default_value)
     return val;
 }
 
+/*[clinic input]
+dict.resize
+
+    size: Py_ssize_t
+    /
+
+Resize the dict and return the self.
+[clinic start generated code]*/
+
+static PyObject *
+dict_resize_impl(PyDictObject *self, Py_ssize_t size)
+/*[clinic end generated code: output=3202407fa0857c33 input=ba90a50f016b102e]*/
+{
+    int res = dictresize(self, calculate_log2_keysize(size));
+    return res == 0 ? (Py_INCREF(self), (PyObject *)self) : Py_None;
+}
+
 PyObject *
 PyDict_SetDefault(PyObject *d, PyObject *key, PyObject *defaultobj)
 {
@@ -3368,6 +3385,7 @@ static PyMethodDef mapp_methods[] = {
      copy__doc__},
     DICT___REVERSED___METHODDEF
     {"__class_getitem__", Py_GenericAlias, METH_O|METH_CLASS, PyDoc_STR("See PEP 585")},
+    DICT_RESIZE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Exposing `dict_resize` API, allow developers to resize on demand.

https://github.com/faster-cpython/ideas/discussions/288


<!-- issue-number: [bpo-46813](https://bugs.python.org/issue46813) -->
https://bugs.python.org/issue46813
<!-- /issue-number -->
