### PR TITLE
bpo-46814: Clarify requirements of abstract base classes

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -444,7 +444,8 @@ attributes:
 
 .. function:: isabstract(object)
 
-   Return ``True`` if the object is an abstract base class.
+   Return ``True`` if the object is an abstract base class. Note that a
+   class must have at least one abstract method to be considered abstract.
 
 
 .. function:: ismethoddescriptor(object)

--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -83,22 +83,13 @@ class abstractproperty(property):
 
 
 try:
-    from _abc import (
-        get_cache_token,
-        _abc_init,
-        _abc_register,
-        _abc_instancecheck,
-        _abc_subclasscheck,
-        _get_dump,
-        _reset_registry,
-        _reset_caches,
-    )
+    from _abc import (get_cache_token, _abc_init, _abc_register,
+                      _abc_instancecheck, _abc_subclasscheck, _get_dump,
+                      _reset_registry, _reset_caches)
 except ImportError:
     from _py_abc import ABCMeta, get_cache_token
-
-    ABCMeta.__module__ = "abc"
+    ABCMeta.__module__ = 'abc'
 else:
-
     class ABCMeta(type):
         """Metaclass for defining Abstract Base Classes (ABCs).
 
@@ -112,11 +103,10 @@ else:
         implementations defined by the registering ABC be callable (not
         even via super()).
 
-        Note that a class with the :class:`ABCMeta` metaclass will be
-        considered abstract only if has at least one abstract method
-        that has not been overridden.
+        Note that a class with the ABCMeta metaclass will be considered
+        abstract only if has at least one abstract method that has not
+        been overridden.
         """
-
         def __new__(mcls, name, bases, namespace, **kwargs):
             cls = super().__new__(mcls, name, bases, namespace, **kwargs)
             _abc_init(cls)
@@ -141,19 +131,13 @@ else:
             """Debug helper to print the ABC registry."""
             print(f"Class: {cls.__module__}.{cls.__qualname__}", file=file)
             print(f"Inv. counter: {get_cache_token()}", file=file)
-            (
-                _abc_registry,
-                _abc_cache,
-                _abc_negative_cache,
-                _abc_negative_cache_version,
-            ) = _get_dump(cls)
+            (_abc_registry, _abc_cache, _abc_negative_cache,
+             _abc_negative_cache_version) = _get_dump(cls)
             print(f"_abc_registry: {_abc_registry!r}", file=file)
             print(f"_abc_cache: {_abc_cache!r}", file=file)
             print(f"_abc_negative_cache: {_abc_negative_cache!r}", file=file)
-            print(
-                f"_abc_negative_cache_version: {_abc_negative_cache_version!r}",
-                file=file,
-            )
+            print(f"_abc_negative_cache_version: {_abc_negative_cache_version!r}",
+                  file=file)
 
         def _abc_registry_clear(cls):
             """Clear the registry (for debugging or testing)."""
@@ -180,7 +164,7 @@ def update_abstractmethods(cls):
 
     If cls is not an instance of ABCMeta, does nothing.
     """
-    if not hasattr(cls, "__abstractmethods__"):
+    if not hasattr(cls, '__abstractmethods__'):
         # We check for __abstractmethods__ here because cls might by a C
         # implementation or a python implementation (especially during
         # testing), and we want to handle both cases.
@@ -190,7 +174,7 @@ def update_abstractmethods(cls):
     # Check the existing abstract methods of the parents, keep only the ones
     # that are not implemented.
     for scls in cls.__bases__:
-        for name in getattr(scls, "__abstractmethods__", ()):
+        for name in getattr(scls, '__abstractmethods__', ()):
             value = getattr(cls, name, None)
             if getattr(value, "__isabstractmethod__", False):
                 abstracts.add(name)
@@ -206,5 +190,4 @@ class ABC(metaclass=ABCMeta):
     """Helper class that provides a standard way to create an ABC using
     inheritance.
     """
-
     __slots__ = ()

--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -9,7 +9,8 @@ def abstractmethod(funcobj):
 
     Requires that the metaclass is ABCMeta or derived from it.  A
     class that has a metaclass derived from ABCMeta cannot be
-    instantiated unless all of its abstract methods are overridden.
+    instantiated unless it has no abstract methods and all of its
+    parent's abstract methods and properties have been overridden.
     The abstract methods can be called using any of the normal
     'super' call mechanisms.  abstractmethod() may be used to declare
     abstract methods for properties and descriptors.
@@ -82,13 +83,22 @@ class abstractproperty(property):
 
 
 try:
-    from _abc import (get_cache_token, _abc_init, _abc_register,
-                      _abc_instancecheck, _abc_subclasscheck, _get_dump,
-                      _reset_registry, _reset_caches)
+    from _abc import (
+        get_cache_token,
+        _abc_init,
+        _abc_register,
+        _abc_instancecheck,
+        _abc_subclasscheck,
+        _get_dump,
+        _reset_registry,
+        _reset_caches,
+    )
 except ImportError:
     from _py_abc import ABCMeta, get_cache_token
-    ABCMeta.__module__ = 'abc'
+
+    ABCMeta.__module__ = "abc"
 else:
+
     class ABCMeta(type):
         """Metaclass for defining Abstract Base Classes (ABCs).
 
@@ -101,7 +111,12 @@ else:
         their MRO (Method Resolution Order) nor will method
         implementations defined by the registering ABC be callable (not
         even via super()).
+
+        Note that a class with the :class:`ABCMeta` metaclass will be
+        considered abstract only if has at least one abstract method
+        that has not been overridden.
         """
+
         def __new__(mcls, name, bases, namespace, **kwargs):
             cls = super().__new__(mcls, name, bases, namespace, **kwargs)
             _abc_init(cls)
@@ -126,13 +141,19 @@ else:
             """Debug helper to print the ABC registry."""
             print(f"Class: {cls.__module__}.{cls.__qualname__}", file=file)
             print(f"Inv. counter: {get_cache_token()}", file=file)
-            (_abc_registry, _abc_cache, _abc_negative_cache,
-             _abc_negative_cache_version) = _get_dump(cls)
+            (
+                _abc_registry,
+                _abc_cache,
+                _abc_negative_cache,
+                _abc_negative_cache_version,
+            ) = _get_dump(cls)
             print(f"_abc_registry: {_abc_registry!r}", file=file)
             print(f"_abc_cache: {_abc_cache!r}", file=file)
             print(f"_abc_negative_cache: {_abc_negative_cache!r}", file=file)
-            print(f"_abc_negative_cache_version: {_abc_negative_cache_version!r}",
-                  file=file)
+            print(
+                f"_abc_negative_cache_version: {_abc_negative_cache_version!r}",
+                file=file,
+            )
 
         def _abc_registry_clear(cls):
             """Clear the registry (for debugging or testing)."""
@@ -159,7 +180,7 @@ def update_abstractmethods(cls):
 
     If cls is not an instance of ABCMeta, does nothing.
     """
-    if not hasattr(cls, '__abstractmethods__'):
+    if not hasattr(cls, "__abstractmethods__"):
         # We check for __abstractmethods__ here because cls might by a C
         # implementation or a python implementation (especially during
         # testing), and we want to handle both cases.
@@ -169,7 +190,7 @@ def update_abstractmethods(cls):
     # Check the existing abstract methods of the parents, keep only the ones
     # that are not implemented.
     for scls in cls.__bases__:
-        for name in getattr(scls, '__abstractmethods__', ()):
+        for name in getattr(scls, "__abstractmethods__", ()):
             value = getattr(cls, name, None)
             if getattr(value, "__isabstractmethod__", False):
                 abstracts.add(name)
@@ -185,4 +206,5 @@ class ABC(metaclass=ABCMeta):
     """Helper class that provides a standard way to create an ABC using
     inheritance.
     """
+
     __slots__ = ()


### PR DESCRIPTION
The documentation for the `abc` module is generally written towards users wanting to use the virtual subclassing features of ABCs. This PR adds documentation explaining the (more common?) abstract method use case in greater detail, as well as clarifying the requirement that an abstract class must implement at least one abstract method.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46814](https://bugs.python.org/issue46814) -->
https://bugs.python.org/issue46814
<!-- /issue-number -->
