### PR TITLE
bpo-46816: Remove declarations for non-__STDC__ compilers

### DIFF
--- a/Include/internal/pycore_pymath.h
+++ b/Include/internal/pycore_pymath.h
@@ -8,15 +8,6 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-// Extra declarations
-#if !defined(_MSC_VER) && !defined(__STDC__)
-extern double fmod (double, double);
-extern double frexp (double, int *);
-extern double ldexp (double, int);
-extern double modf (double, double *);
-extern double pow(double, double);
-#endif  // !defined(_MSC_VER) && !defined(__STDC__)
-
 
 /* _Py_ADJUST_ERANGE1(x)
  * _Py_ADJUST_ERANGE2(x, y)

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -10,12 +10,6 @@
 #include "pycore_sysmodule.h"     // _PySys_Audit()
 #include "pycore_traceback.h"     // _PyTraceBack_FromFrame()
 
-#ifndef __STDC__
-#ifndef MS_WINDOWS
-extern char *strerror(int);
-#endif
-#endif
-
 #include <ctype.h>
 #ifdef MS_WINDOWS
 #  include <windows.h>


### PR DESCRIPTION
Currently, Python code contains two places where presence of __STDC__ is checked:

- Include/internal/pycore_pymath.h:12
- Python/errors.c:13

These checks are used to add extern functions missing in non-standard versions of math.h.

However, after Python switched to C99, there is a guarantee that every compiler conforms to ISO C so checks of __STDC__ have no sense anymore.

Note, that:

- errors.c check was added by 53e8d44 on 9 Mar 1995
- pycore_pymath.h check was initially added into Objects/floatobject.c by eddc144 on 20 Nov 2003 then moved to pycore_pymath by 53876d9.

<!-- issue-number: [bpo-46816](https://bugs.python.org/issue46816) -->
https://bugs.python.org/issue46816
<!-- /issue-number -->
