### PR TITLE
[3.7] bpo-45618: Fix documentation build by pinning Docutils version to 0.17.1

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -127,7 +127,7 @@ clean:
 
 venv:
 	$(PYTHON) -m venv $(VENVDIR)
-	$(VENVDIR)/bin/python3 -m pip install -U Sphinx==2.3.1 blurb
+	$(VENVDIR)/bin/python3 -m pip install -U Sphinx==2.3.1 blurb docutils==0.17.1
 	@echo "The venv has been created in the $(VENVDIR) directory"
 
 dist:


### PR DESCRIPTION


<!-- issue-number: [bpo-45618](https://bugs.python.org/issue45618) -->
https://bugs.python.org/issue45618
<!-- /issue-number -->
