### PR TITLE
bpo-46820: Fix a SyntaxError in a numeric literal followed by "not in"

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -251,6 +251,15 @@ class TokenTests(unittest.TestCase):
         check("1e3in x")
         check("1jin x")
 
+        check("0xfnot in x")
+        check("0o7not in x")
+        check("0b1not in x")
+        check("9not in x")
+        check("0not in x")
+        check("1.not in x")
+        check("1e3not in x")
+        check("1jnot in x")
+
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', SyntaxWarning)
             check("0xfis x")

--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-21-21-55-23.bpo-46820.4RfUZh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-21-21-55-23.bpo-46820.4RfUZh.rst
@@ -1,0 +1,3 @@
+Fix parsing a numeric literal immediately (without spaces) followed by "not
+in" keywords, like in ``1not in x``. Now the parser only emits a warning,
+not a syntax error.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1253,6 +1253,9 @@ verify_end_of_number(struct tok_state *tok, int c, const char *kind)
     else if (c == 'o') {
         r = lookahead(tok, "r");
     }
+    else if (c == 'n') {
+        r = lookahead(tok, "ot");
+    }
     if (r) {
         tok_backup(tok, c);
         if (parser_warn(tok, "invalid %s literal", kind)) {


### PR DESCRIPTION
Fix parsing a numeric literal immediately (without spaces) followed by
"not in" keywords, like in "1not in x". Now the parser only emits
a warning, not a syntax error.


<!-- issue-number: [bpo-46820](https://bugs.python.org/issue46820) -->
https://bugs.python.org/issue46820
<!-- /issue-number -->
