### PR TITLE
bpo-40255: Implement Immortal Instances - Optimization 1

### DIFF
--- a/Include/boolobject.h
+++ b/Include/boolobject.h
@@ -31,8 +31,8 @@ PyAPI_FUNC(int) Py_IsFalse(PyObject *x);
 #define Py_IsFalse(x) Py_Is((x), Py_False)
 
 /* Macros for returning Py_True or Py_False, respectively */
-#define Py_RETURN_TRUE return Py_NewRef(Py_True)
-#define Py_RETURN_FALSE return Py_NewRef(Py_False)
+#define Py_RETURN_TRUE return Py_True
+#define Py_RETURN_FALSE return Py_False
 
 /* Function to return a bool from a C long */
 PyAPI_FUNC(PyObject *) PyBool_FromLong(long);

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #define _PyObject_IMMORTAL_INIT(type) \
     { \
-        .ob_refcnt = 999999999, \
+        .ob_refcnt = _Py_IMMORTAL_REFCNT, \
         .ob_type = type, \
     }
 #define _PyVarObject_IMMORTAL_INIT(type, size) \

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -48,11 +48,13 @@ typedef struct PyModuleDef_Base {
   PyObject* m_copy;
 } PyModuleDef_Base;
 
-#define PyModuleDef_HEAD_INIT { \
-    PyObject_HEAD_INIT(NULL)    \
-    NULL, /* m_init */          \
-    0,    /* m_index */         \
-    NULL, /* m_copy */          \
+// TODO(eduardo-elizondo): This is only used to simplify the review of GH-19474
+// Rather than changing this API, we'll introduce PyModuleDef_HEAD_IMMORTAL_INIT
+#define PyModuleDef_HEAD_INIT {       \
+    PyObject_HEAD_IMMORTAL_INIT(NULL) \
+    NULL, /* m_init */                \
+    0,    /* m_index */               \
+    NULL, /* m_copy */                \
   }
 
 struct PyModuleDef_Slot;

--- a/Include/object.h
+++ b/Include/object.h
@@ -81,12 +81,34 @@ typedef struct _typeobject PyTypeObject;
 /* PyObject_HEAD defines the initial segment of every PyObject. */
 #define PyObject_HEAD                   PyObject ob_base;
 
+/*
+Immortalization:
+
+This marks the reference count bit that will be used to define immortality.
+The GC bit-shifts refcounts left by two, and after that shift it still needs
+to be larger than zero, so it's placed after the first three high bits.
+
+For backwards compatibility the actual reference count of an immortal instance
+is set to higher than just the immortal bit. This will ensure that the immortal
+bit will remain active, even with extensions compiled without the updated checks
+in Py_INCREF and Py_DECREF. This can be safely changed to a smaller value if
+additional bits are needed in the reference count field.
+*/
+#define _Py_IMMORTAL_BIT_OFFSET (8 * sizeof(Py_ssize_t) - 4)
+#define _Py_IMMORTAL_BIT (1LL << _Py_IMMORTAL_BIT_OFFSET)
+#define _Py_IMMORTAL_REFCNT (_Py_IMMORTAL_BIT + (_Py_IMMORTAL_BIT / 2))
+
 #define PyObject_HEAD_INIT(type)        \
     { _PyObject_EXTRA_INIT              \
     1, type },
 
+#define PyObject_HEAD_IMMORTAL_INIT(type)        \
+    { _PyObject_EXTRA_INIT _Py_IMMORTAL_REFCNT, type },
+
+// TODO(eduardo-elizondo): This is only used to simplify the review of GH-19474
+// Rather than changing this API, we'll introduce PyVarObject_HEAD_IMMORTAL_INIT
 #define PyVarObject_HEAD_INIT(type, size)       \
-    { PyObject_HEAD_INIT(type) size },
+    { PyObject_HEAD_IMMORTAL_INIT(type) size },
 
 /* PyObject_VAR_HEAD defines the initial segment of all variable-size
  * container objects.  These end with a declaration of an array with 1
@@ -146,6 +168,18 @@ static inline Py_ssize_t Py_SIZE(const PyVarObject *ob) {
 #define Py_SIZE(ob) Py_SIZE(_PyVarObject_CAST_CONST(ob))
 
 
+static inline int _Py_IsImmortal(PyObject *op)
+{
+    return (op->ob_refcnt & _Py_IMMORTAL_BIT) != 0;
+}
+
+static inline void _Py_SetImmortal(PyObject *op)
+{
+    if (op) {
+        op->ob_refcnt = _Py_IMMORTAL_REFCNT;
+    }
+}
+
 static inline int Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
     // bpo-44378: Don't use Py_TYPE() since Py_TYPE() requires a non-const
     // object.
@@ -155,6 +189,9 @@ static inline int Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
 
 
 static inline void Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
+    if (_Py_IsImmortal(ob)) {
+        return;
+    }
     ob->ob_refcnt = refcnt;
 }
 #define Py_SET_REFCNT(ob, refcnt) Py_SET_REFCNT(_PyObject_CAST(ob), refcnt)
@@ -483,6 +520,9 @@ static inline void Py_INCREF(PyObject *op)
 #else
     // Non-limited C API and limited C API for Python 3.9 and older access
     // directly PyObject.ob_refcnt.
+    if (_Py_IsImmortal(op)) {
+        return;
+    }
 #ifdef Py_REF_DEBUG
     _Py_RefTotal++;
 #endif
@@ -503,6 +543,9 @@ static inline void Py_DECREF(
 #else
     // Non-limited C API and limited C API for Python 3.9 and older access
     // directly PyObject.ob_refcnt.
+    if (_Py_IsImmortal(op)) {
+        return;
+    }
 #ifdef Py_REF_DEBUG
     _Py_RefTotal--;
 #endif
@@ -627,7 +670,7 @@ PyAPI_FUNC(int) Py_IsNone(PyObject *x);
 #define Py_IsNone(x) Py_Is((x), Py_None)
 
 /* Macro for returning Py_None from a function */
-#define Py_RETURN_NONE return Py_NewRef(Py_None)
+#define Py_RETURN_NONE return Py_None
 
 /*
 Py_NotImplemented is a singleton used to signal that an operation is

--- a/Lib/ctypes/test/test_python_api.py
+++ b/Lib/ctypes/test/test_python_api.py
@@ -46,7 +46,8 @@ class PythonAPITestCase(unittest.TestCase):
         pythonapi.PyLong_AsLong.restype = c_long
 
         res = pythonapi.PyLong_AsLong(42)
-        self.assertEqual(grc(res), ref42 + 1)
+        # Small int refcnts don't change
+        self.assertEqual(grc(res), ref42)
         del res
         self.assertEqual(grc(42), ref42)
 

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -27,7 +27,7 @@ from textwrap import dedent
 from types import AsyncGeneratorType, FunctionType
 from operator import neg
 from test import support
-from test.support import (swap_attr, maybe_get_event_loop_policy)
+from test.support import (cpython_only, swap_attr, maybe_get_event_loop_policy)
 from test.support.os_helper import (EnvironmentVarGuard, TESTFN, unlink)
 from test.support.script_helper import assert_python_ok
 from test.support.warnings_helper import check_warnings
@@ -2212,6 +2212,29 @@ class ShutdownTest(unittest.TestCase):
         rc, out, err = assert_python_ok("-c", code,
                                         PYTHONIOENCODING="ascii")
         self.assertEqual(["before", "after"], out.decode().splitlines())
+
+
+@cpython_only
+class ImmortalTests(unittest.TestCase):
+    def test_immortal(self):
+        none_refcount = sys.getrefcount(None)
+        true_refcount = sys.getrefcount(True)
+        false_refcount = sys.getrefcount(False)
+        smallint_refcount = sys.getrefcount(100)
+
+        # Assert that all of these immortal instances have large ref counts
+        self.assertGreater(none_refcount, 1e8)
+        self.assertGreater(true_refcount, 1e8)
+        self.assertGreater(false_refcount, 1e8)
+        self.assertGreater(smallint_refcount, 1e8)
+
+        # Confirm that the refcount doesn't change even with a new ref to them
+        l = [None, True, False, 100]
+        self.assertEqual(sys.getrefcount(None), none_refcount)
+        self.assertEqual(sys.getrefcount(True), true_refcount)
+        self.assertEqual(sys.getrefcount(False), false_refcount)
+        self.assertEqual(sys.getrefcount(100), smallint_refcount)
+
 
 
 class TestType(unittest.TestCase):

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -915,7 +915,7 @@ class ArgsTestCase(BaseTestCase):
                 def test_leak(self):
                     GLOBAL_LIST.append(object())
         """)
-        self.check_leak(code, 'references')
+        self.check_leak(code, 'memory blocks')
 
     @unittest.skipUnless(Py_DEBUG, 'need a debug build')
     def test_huntrleaks_fd_leak(self):

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -385,7 +385,8 @@ class SysModuleTest(unittest.TestCase):
         self.assertRaises(TypeError, sys.getrefcount)
         c = sys.getrefcount(None)
         n = None
-        self.assertEqual(sys.getrefcount(None), c+1)
+        # Singleton refcnts don't change
+        self.assertEqual(sys.getrefcount(None), c)
         del n
         self.assertEqual(sys.getrefcount(None), c)
         if hasattr(sys, "gettotalrefcount"):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-18-08-57-24.bpo-40255.XDDrSO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-18-08-57-24.bpo-40255.XDDrSO.rst
@@ -1,0 +1,2 @@
+This introduces Immortal Instances which allows objects to bypass reference
+counting and remain alive throughout the execution of the runtime

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -47,9 +47,7 @@ static PyObject *
 get_small_int(sdigit ival)
 {
     assert(IS_SMALL_INT(ival));
-    PyObject *v = (PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS + ival];
-    Py_INCREF(v);
-    return v;
+    return (PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS + ival];
 }
 
 static PyLongObject *

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1705,7 +1705,8 @@ PyTypeObject _PyNone_Type = {
 
 PyObject _Py_NoneStruct = {
   _PyObject_EXTRA_INIT
-  1, &_PyNone_Type
+  _Py_IMMORTAL_REFCNT,
+  &_PyNone_Type
 };
 
 /* NotImplemented is an object that can be used to signal that an
@@ -1994,7 +1995,9 @@ _Py_NewReference(PyObject *op)
 #ifdef Py_REF_DEBUG
     _Py_RefTotal++;
 #endif
-    Py_SET_REFCNT(op, 1);
+    /* Do not use Py_SET_REFCNT to skip the Immortal Instance check. This
+     * API guarantees that an instance will always be set to a refcnt of 1 */
+    op->ob_refcnt = 1;
 #ifdef Py_TRACE_REFS
     _Py_AddToAllObjects(op, 1);
 #endif

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -1941,26 +1941,6 @@ unicode_dealloc(PyObject *unicode)
     case SSTATE_NOT_INTERNED:
         break;
 
-    case SSTATE_INTERNED_MORTAL:
-    {
-#ifdef INTERNED_STRINGS
-        /* Revive the dead object temporarily. PyDict_DelItem() removes two
-           references (key and value) which were ignored by
-           PyUnicode_InternInPlace(). Use refcnt=3 rather than refcnt=2
-           to prevent calling unicode_dealloc() again. Adjust refcnt after
-           PyDict_DelItem(). */
-        assert(Py_REFCNT(unicode) == 0);
-        Py_SET_REFCNT(unicode, 3);
-        if (PyDict_DelItem(interned, unicode) != 0) {
-            _PyErr_WriteUnraisableMsg("deletion of interned string failed",
-                                      NULL);
-        }
-        assert(Py_REFCNT(unicode) == 1);
-        Py_SET_REFCNT(unicode, 0);
-#endif
-        break;
-    }
-
     case SSTATE_INTERNED_IMMORTAL:
         _PyObject_ASSERT_FAILED_MSG(unicode, "Immortal interned string died");
         break;
@@ -15608,16 +15588,12 @@ PyUnicode_InternInPlace(PyObject **p)
     }
 
     if (t != s) {
-        Py_INCREF(t);
         Py_SETREF(*p, t);
         return;
     }
 
-    /* The two references in interned dict (key and value) are not counted by
-       refcnt. unicode_dealloc() and _PyUnicode_ClearInterned() take care of
-       this. */
     _Py_SetImmortal(s);
-    _PyUnicode_STATE(s).interned = SSTATE_INTERNED_MORTAL;
+    _PyUnicode_STATE(*p).interned = SSTATE_INTERNED_IMMORTAL;
 #else
     // PyDict expects that interned strings have their hash
     // (PyASCIIObject.hash) already computed.
@@ -15638,10 +15614,6 @@ PyUnicode_InternImmortal(PyObject **p)
     }
 
     PyUnicode_InternInPlace(p);
-    if (PyUnicode_CHECK_INTERNED(*p) != SSTATE_INTERNED_IMMORTAL) {
-        _PyUnicode_STATE(*p).interned = SSTATE_INTERNED_IMMORTAL;
-        Py_INCREF(*p);
-    }
 }
 
 PyObject *
@@ -15668,49 +15640,7 @@ _PyUnicode_ClearInterned(PyInterpreterState *interp)
     }
     assert(PyDict_CheckExact(interned));
 
-    /* Interned unicode strings are not forcibly deallocated; rather, we give
-       them their stolen references back, and then clear and DECREF the
-       interned dict. */
-
-#ifdef INTERNED_STATS
-    fprintf(stderr, "releasing %zd interned strings\n",
-            PyDict_GET_SIZE(interned));
-
-    Py_ssize_t immortal_size = 0, mortal_size = 0;
-#endif
-    Py_ssize_t pos = 0;
-    PyObject *s, *ignored_value;
-    while (PyDict_Next(interned, &pos, &s, &ignored_value)) {
-        assert(PyUnicode_IS_READY(s));
-
-        switch (PyUnicode_CHECK_INTERNED(s)) {
-        case SSTATE_INTERNED_IMMORTAL:
-            Py_SET_REFCNT(s, Py_REFCNT(s) + 1);
-#ifdef INTERNED_STATS
-            immortal_size += PyUnicode_GET_LENGTH(s);
-#endif
-            break;
-        case SSTATE_INTERNED_MORTAL:
-            // Restore the two references (key and value) ignored
-            // by PyUnicode_InternInPlace().
-            Py_SET_REFCNT(s, Py_REFCNT(s) + 2);
-#ifdef INTERNED_STATS
-            mortal_size += PyUnicode_GET_LENGTH(s);
-#endif
-            break;
-        case SSTATE_NOT_INTERNED:
-            /* fall through */
-        default:
-            Py_UNREACHABLE();
-        }
-        _PyUnicode_STATE(s).interned = SSTATE_NOT_INTERNED;
-    }
-#ifdef INTERNED_STATS
-    fprintf(stderr,
-            "total size of all interned strings: %zd/%zd mortal/immortal\n",
-            mortal_size, immortal_size);
-#endif
-
+    /* Interned unicode strings are not forcibly deallocated */
     PyDict_Clear(interned);
     Py_CLEAR(interned);
 }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15616,7 +15616,7 @@ PyUnicode_InternInPlace(PyObject **p)
     /* The two references in interned dict (key and value) are not counted by
        refcnt. unicode_dealloc() and _PyUnicode_ClearInterned() take care of
        this. */
-    Py_SET_REFCNT(s, Py_REFCNT(s) - 2);
+    _Py_SetImmortal(s);
     _PyUnicode_STATE(s).interned = SSTATE_INTERNED_MORTAL;
 #else
     // PyDict expects that interned strings have their hash

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1829,7 +1829,7 @@ static int test_unicode_id_init(void)
 
         str1 = _PyUnicode_FromId(&PyId_test_unicode_id_init);
         assert(str1 != NULL);
-        assert(Py_REFCNT(str1) == 1);
+        assert(_Py_IsImmortal(str1));
 
         str2 = PyUnicode_FromString("test_unicode_id_init");
         assert(str2 != NULL);


### PR DESCRIPTION
# Immortalizing Interned Strings

This is an optimization on top of [PR19474](https://github.com/python/cpython/pull/19474).

The improvement here uses the assumption that all interned strings are alive during the entire lifecycle of the runtime. Thus, every time that a string is interned, it is automatically immortalized.

## Benchmark Results

Overall: **1% slower** compared to the master branch

<details>
<summary>pyperformance results</summary>
<pre>
2to3: Mean +- std dev: [cpython_master] 432 ms +- 15 ms -> [immortal_instances_opt1] 437 ms +- 15 ms: 1.01x slower
chaos: Mean +- std dev: [cpython_master] 126 ms +- 4 ms -> [immortal_instances_opt1] 122 ms +- 5 ms: 1.03x faster
deltablue: Mean +- std dev: [cpython_master] 7.35 ms +- 0.20 ms -> [immortal_instances_opt1] 7.49 ms +- 0.22 ms: 1.02x slower
fannkuch: Mean +- std dev: [cpython_master] 664 ms +- 15 ms -> [immortal_instances_opt1] 654 ms +- 20 ms: 1.02x faster
float: Mean +- std dev: [cpython_master] 128 ms +- 4 ms -> [immortal_instances_opt1] 133 ms +- 3 ms: 1.04x slower
go: Mean +- std dev: [cpython_master] 244 ms +- 10 ms -> [immortal_instances_opt1] 232 ms +- 5 ms: 1.05x faster
html5lib: Mean +- std dev: [cpython_master] 97.9 ms +- 4.2 ms -> [immortal_instances_opt1] 99.7 ms +- 5.3 ms: 1.02x slower
json_dumps: Mean +- std dev: [cpython_master] 19.2 ms +- 0.7 ms -> [immortal_instances_opt1] 19.7 ms +- 0.7 ms: 1.02x slower
json_loads: Mean +- std dev: [cpython_master] 39.5 us +- 0.9 us -> [immortal_instances_opt1] 39.1 us +- 1.3 us: 1.01x faster
logging_format: Mean +- std dev: [cpython_master] 10.4 us +- 0.3 us -> [immortal_instances_opt1] 10.7 us +- 0.4 us: 1.03x slower
meteor_contest: Mean +- std dev: [cpython_master] 164 ms +- 5 ms -> [immortal_instances_opt1] 161 ms +- 6 ms: 1.02x faster
nbody: Mean +- std dev: [cpython_master] 163 ms +- 6 ms -> [immortal_instances_opt1] 160 ms +- 4 ms: 1.02x faster
nqueens: Mean +- std dev: [cpython_master] 159 ms +- 5 ms -> [immortal_instances_opt1] 149 ms +- 5 ms: 1.07x faster
pathlib: Mean +- std dev: [cpython_master] 28.5 ms +- 0.7 ms -> [immortal_instances_opt1] 27.5 ms +- 0.7 ms: 1.04x faster
pickle: Mean +- std dev: [cpython_master] 16.0 us +- 0.5 us -> [immortal_instances_opt1] 16.3 us +- 0.4 us: 1.02x slower
pickle_dict: Mean +- std dev: [cpython_master] 37.3 us +- 0.6 us -> [immortal_instances_opt1] 35.4 us +- 1.0 us: 1.05x faster
pickle_list: Mean +- std dev: [cpython_master] 5.77 us +- 0.24 us -> [immortal_instances_opt1] 5.70 us +- 0.15 us: 1.01x faster
pickle_pure_python: Mean +- std dev: [cpython_master] 572 us +- 14 us -> [immortal_instances_opt1] 582 us +- 24 us: 1.02x slower
pidigits: Mean +- std dev: [cpython_master] 284 ms +- 15 ms -> [immortal_instances_opt1] 273 ms +- 8 ms: 1.04x faster
pyflate: Mean +- std dev: [cpython_master] 770 ms +- 28 ms -> [immortal_instances_opt1] 742 ms +- 24 ms: 1.04x faster
python_startup: Mean +- std dev: [cpython_master] 12.6 ms +- 0.4 ms -> [immortal_instances_opt1] 13.0 ms +- 0.6 ms: 1.04x slower
python_startup_no_site: Mean +- std dev: [cpython_master] 8.89 ms +- 0.39 ms -> [immortal_instances_opt1] 8.97 ms +- 0.35 ms: 1.01x slower
raytrace: Mean +- std dev: [cpython_master] 529 ms +- 16 ms -> [immortal_instances_opt1] 539 ms +- 10 ms: 1.02x slower
regex_compile: Mean +- std dev: [cpython_master] 233 ms +- 6 ms -> [immortal_instances_opt1] 243 ms +- 6 ms: 1.04x slower
regex_dna: Mean +- std dev: [cpython_master] 239 ms +- 6 ms -> [immortal_instances_opt1] 244 ms +- 7 ms: 1.02x slower
regex_effbot: Mean +- std dev: [cpython_master] 4.53 ms +- 0.12 ms -> [immortal_instances_opt1] 4.73 ms +- 0.16 ms: 1.04x slower
regex_v8: Mean +- std dev: [cpython_master] 33.2 ms +- 0.8 ms -> [immortal_instances_opt1] 33.6 ms +- 0.9 ms: 1.01x slower
richards: Mean +- std dev: [cpython_master] 82.8 ms +- 3.7 ms -> [immortal_instances_opt1] 86.2 ms +- 5.2 ms: 1.04x slower
scimark_fft: Mean +- std dev: [cpython_master] 571 ms +- 12 ms -> [immortal_instances_opt1] 603 ms +- 19 ms: 1.06x slower
scimark_lu: Mean +- std dev: [cpython_master] 195 ms +- 6 ms -> [immortal_instances_opt1] 211 ms +- 4 ms: 1.08x slower
scimark_monte_carlo: Mean +- std dev: [cpython_master] 116 ms +- 5 ms -> [immortal_instances_opt1] 119 ms +- 4 ms: 1.03x slower
scimark_sor: Mean +- std dev: [cpython_master] 211 ms +- 6 ms -> [immortal_instances_opt1] 222 ms +- 4 ms: 1.05x slower
scimark_sparse_mat_mult: Mean +- std dev: [cpython_master] 8.28 ms +- 0.40 ms -> [immortal_instances_opt1] 8.51 ms +- 0.23 ms: 1.03x slower
spectral_norm: Mean +- std dev: [cpython_master] 208 ms +- 9 ms -> [immortal_instances_opt1] 211 ms +- 4 ms: 1.01x slower
sympy_expand: Mean +- std dev: [cpython_master] 878 ms +- 34 ms -> [immortal_instances_opt1] 860 ms +- 24 ms: 1.02x faster
sympy_integrate: Mean +- std dev: [cpython_master] 35.2 ms +- 1.0 ms -> [immortal_instances_opt1] 35.6 ms +- 1.0 ms: 1.01x slower
sympy_sum: Mean +- std dev: [cpython_master] 291 ms +- 13 ms -> [immortal_instances_opt1] 300 ms +- 8 ms: 1.03x slower
sympy_str: Mean +- std dev: [cpython_master] 514 ms +- 11 ms -> [immortal_instances_opt1] 522 ms +- 17 ms: 1.02x slower
telco: Mean +- std dev: [cpython_master] 10.4 ms +- 0.2 ms -> [immortal_instances_opt1] 10.6 ms +- 0.5 ms: 1.02x slower
unpack_sequence: Mean +- std dev: [cpython_master] 77.9 ns +- 2.3 ns -> [immortal_instances_opt1] 78.8 ns +- 2.3 ns: 1.01x slower
unpickle_list: Mean +- std dev: [cpython_master] 6.77 us +- 0.25 us -> [immortal_instances_opt1] 6.90 us +- 0.16 us: 1.02x slower
unpickle_pure_python: Mean +- std dev: [cpython_master] 463 us +- 17 us -> [immortal_instances_opt1] 448 us +- 9 us: 1.03x faster
xml_etree_parse: Mean +- std dev: [cpython_master] 245 ms +- 6 ms -> [immortal_instances_opt1] 250 ms +- 11 ms: 1.02x slower
xml_etree_generate: Mean +- std dev: [cpython_master] 146 ms +- 4 ms -> [immortal_instances_opt1] 144 ms +- 5 ms: 1.01x faster
xml_etree_process: Mean +- std dev: [cpython_master] 102 ms +- 2 ms -> [immortal_instances_opt1] 100.0 ms +- 3.0 ms: 1.02x faster

Benchmark hidden because not significant (6): django_template, hexiom, logging_silent, logging_simple, unpickle, xml_etree_iterparse

Geometric mean: 1.01x slower
</pre></details>

## Implementation Details

Any time that `PyUnicode_InternInPlace` is called, the string will be automatically immortalized. This also re-utilizes the string state mechanism by setting the state to `SSTATE_INTERNED_IMMORTAL`. Given that all interned strings are now immortal, the `SSTATE_INTERNED_MORTAL` usage has been deprecated.

## Interned String Finalization

The current change does not attempt to fully clean up the strings during the runtime shutdown. The main reason being that interned strings include both statically allocated strings (i.e `Py_Identifiers`) and dynamically allocated strings (i.e `PyUnicode_New`). During the runtime shutdown, it is hard to determined which strings in the `interned` dictionary are statically allocated vs dynamically allocated. Blindly calling the deallocation function will end up calling `PyMem_RawFree` on statically allocated memory which will crash the program.

This could be in theory fixed by having a way to mark these statics strings differently than the dynamically allocated strings. If we distinguish them during the runtime shutdown, we can run the deallocation function on the dynamic strings. However, all the fields within these instances are already used and have no way to cleanly embed this information. Another option is to use the memory allocation range of `_PyRuntime.global_objects.singletons.strings` up to `sizeof(_Py_global_strings)` and anything outside of this is a dynamic string. However, this relies in exposing the internal `_Py_global_strings` struct. Given there's no clean option, I’ve decided to leave the interned strings as is and let the OS free the memory after the runtime shuts down.


<!-- issue-number: [bpo-40255](https://bugs.python.org/issue40255) -->
https://bugs.python.org/issue40255
<!-- /issue-number -->