### PR TITLE
bpo-40255: Implement Immortal Instances - Optimizations Combined

### DIFF
--- a/Include/boolobject.h
+++ b/Include/boolobject.h
@@ -31,8 +31,8 @@ PyAPI_FUNC(int) Py_IsFalse(PyObject *x);
 #define Py_IsFalse(x) Py_Is((x), Py_False)
 
 /* Macros for returning Py_True or Py_False, respectively */
-#define Py_RETURN_TRUE return Py_NewRef(Py_True)
-#define Py_RETURN_FALSE return Py_NewRef(Py_False)
+#define Py_RETURN_TRUE return Py_True
+#define Py_RETURN_FALSE return Py_False
 
 /* Function to return a bool from a C long */
 PyAPI_FUNC(PyObject *) PyBool_FromLong(long);

--- a/Include/cpython/sysmodule.h
+++ b/Include/cpython/sysmodule.h
@@ -7,6 +7,8 @@ PyAPI_FUNC(PyObject *) _PySys_GetAttr(PyThreadState *tstate,
 PyAPI_FUNC(PyObject *) _PySys_GetObjectId(_Py_Identifier *key);
 PyAPI_FUNC(int) _PySys_SetObjectId(_Py_Identifier *key, PyObject *);
 
+PyAPI_FUNC(PyObject *) _PySys_StdlibModuleNameList(void);
+
 PyAPI_FUNC(size_t) _PySys_GetSizeOf(PyObject *);
 
 typedef int(*Py_AuditHookFunction)(const char *, PyObject *, void *);

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #define _PyObject_IMMORTAL_INIT(type) \
     { \
-        .ob_refcnt = 999999999, \
+        .ob_refcnt = _Py_IMMORTAL_REFCNT, \
         .ob_type = type, \
     }
 #define _PyVarObject_IMMORTAL_INIT(type, size) \

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -29,6 +29,7 @@ Py_DEPRECATED(3.2) PyAPI_FUNC(const char *) PyModule_GetFilename(PyObject *);
 PyAPI_FUNC(PyObject *) PyModule_GetFilenameObject(PyObject *);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(void) _PyModule_Clear(PyObject *);
+PyAPI_FUNC(void) _PyModule_PhasedClear(PyObject *, int phase);
 PyAPI_FUNC(void) _PyModule_ClearDict(PyObject *);
 PyAPI_FUNC(int) _PyModuleSpec_IsInitializing(PyObject *);
 #endif
@@ -48,11 +49,13 @@ typedef struct PyModuleDef_Base {
   PyObject* m_copy;
 } PyModuleDef_Base;
 
-#define PyModuleDef_HEAD_INIT { \
-    PyObject_HEAD_INIT(NULL)    \
-    NULL, /* m_init */          \
-    0,    /* m_index */         \
-    NULL, /* m_copy */          \
+// TODO(eduardo-elizondo): This is only used to simplify the review of GH-19474
+// Rather than changing this API, we'll introduce PyModuleDef_HEAD_IMMORTAL_INIT
+#define PyModuleDef_HEAD_INIT {       \
+    PyObject_HEAD_IMMORTAL_INIT(NULL) \
+    NULL, /* m_init */                \
+    0,    /* m_index */               \
+    NULL, /* m_copy */                \
   }
 
 struct PyModuleDef_Slot;

--- a/Include/object.h
+++ b/Include/object.h
@@ -81,12 +81,34 @@ typedef struct _typeobject PyTypeObject;
 /* PyObject_HEAD defines the initial segment of every PyObject. */
 #define PyObject_HEAD                   PyObject ob_base;
 
+/*
+Immortalization:
+
+This marks the reference count bit that will be used to define immortality.
+The GC bit-shifts refcounts left by two, and after that shift it still needs
+to be larger than zero, so it's placed after the first three high bits.
+
+For backwards compatibility the actual reference count of an immortal instance
+is set to higher than just the immortal bit. This will ensure that the immortal
+bit will remain active, even with extensions compiled without the updated checks
+in Py_INCREF and Py_DECREF. This can be safely changed to a smaller value if
+additional bits are needed in the reference count field.
+*/
+#define _Py_IMMORTAL_BIT_OFFSET (8 * sizeof(Py_ssize_t) - 4)
+#define _Py_IMMORTAL_BIT (1LL << _Py_IMMORTAL_BIT_OFFSET)
+#define _Py_IMMORTAL_REFCNT (_Py_IMMORTAL_BIT + (_Py_IMMORTAL_BIT / 2))
+
 #define PyObject_HEAD_INIT(type)        \
     { _PyObject_EXTRA_INIT              \
     1, type },
 
+#define PyObject_HEAD_IMMORTAL_INIT(type)        \
+    { _PyObject_EXTRA_INIT _Py_IMMORTAL_REFCNT, type },
+
+// TODO(eduardo-elizondo): This is only used to simplify the review of GH-19474
+// Rather than changing this API, we'll introduce PyVarObject_HEAD_IMMORTAL_INIT
 #define PyVarObject_HEAD_INIT(type, size)       \
-    { PyObject_HEAD_INIT(type) size },
+    { PyObject_HEAD_IMMORTAL_INIT(type) size },
 
 /* PyObject_VAR_HEAD defines the initial segment of all variable-size
  * container objects.  These end with a declaration of an array with 1
@@ -145,6 +167,20 @@ static inline Py_ssize_t Py_SIZE(const PyVarObject *ob) {
 }
 #define Py_SIZE(ob) Py_SIZE(_PyVarObject_CAST_CONST(ob))
 
+PyAPI_FUNC(PyObject *) _PyGC_ImmortalizeHeap(void);
+PyAPI_FUNC(PyObject *) _PyGC_TransitiveImmortalize(PyObject *obj);
+
+static inline int _Py_IsImmortal(PyObject *op)
+{
+    return (op->ob_refcnt & _Py_IMMORTAL_BIT) != 0;
+}
+
+static inline void _Py_SetImmortal(PyObject *op)
+{
+    if (op) {
+        op->ob_refcnt = _Py_IMMORTAL_REFCNT;
+    }
+}
 
 static inline int Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
     // bpo-44378: Don't use Py_TYPE() since Py_TYPE() requires a non-const
@@ -155,6 +191,9 @@ static inline int Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
 
 
 static inline void Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
+    if (_Py_IsImmortal(ob)) {
+        return;
+    }
     ob->ob_refcnt = refcnt;
 }
 #define Py_SET_REFCNT(ob, refcnt) Py_SET_REFCNT(_PyObject_CAST(ob), refcnt)
@@ -483,6 +522,9 @@ static inline void Py_INCREF(PyObject *op)
 #else
     // Non-limited C API and limited C API for Python 3.9 and older access
     // directly PyObject.ob_refcnt.
+    if (_Py_IsImmortal(op)) {
+        return;
+    }
 #ifdef Py_REF_DEBUG
     _Py_RefTotal++;
 #endif
@@ -503,6 +545,9 @@ static inline void Py_DECREF(
 #else
     // Non-limited C API and limited C API for Python 3.9 and older access
     // directly PyObject.ob_refcnt.
+    if (_Py_IsImmortal(op)) {
+        return;
+    }
 #ifdef Py_REF_DEBUG
     _Py_RefTotal--;
 #endif
@@ -627,7 +672,7 @@ PyAPI_FUNC(int) Py_IsNone(PyObject *x);
 #define Py_IsNone(x) Py_Is((x), Py_None)
 
 /* Macro for returning Py_None from a function */
-#define Py_RETURN_NONE return Py_NewRef(Py_None)
+#define Py_RETURN_NONE return Py_None
 
 /*
 Py_NotImplemented is a singleton used to signal that an operation is

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -288,6 +288,8 @@ class _ExecutorManagerThread(threading.Thread):
         self.thread_wakeup = executor._executor_manager_thread_wakeup
         self.shutdown_lock = executor._shutdown_lock
 
+        # Make mp.util.debug available even during runtime shutdown
+        self._debugp = mp.util.debug
         # A weakref.ref to the ProcessPoolExecutor that owns this thread. Used
         # to determine if the ProcessPoolExecutor has been garbage collected
         # and that the manager can exit.
@@ -297,8 +299,9 @@ class _ExecutorManagerThread(threading.Thread):
         def weakref_cb(_,
                        thread_wakeup=self.thread_wakeup,
                        shutdown_lock=self.shutdown_lock):
-            mp.util.debug('Executor collected: triggering callback for'
+            self._debugp('Executor collected: triggering callback for'
                           ' QueueManager wakeup')
+            # ./python Lib/test/test_concurrent_futures.py ProcessPoolForkProcessPoolShutdownTest.test_interpreter_shutdown
             with shutdown_lock:
                 thread_wakeup.wakeup()
 

--- a/Lib/ctypes/test/test_python_api.py
+++ b/Lib/ctypes/test/test_python_api.py
@@ -46,7 +46,8 @@ class PythonAPITestCase(unittest.TestCase):
         pythonapi.PyLong_AsLong.restype = c_long
 
         res = pythonapi.PyLong_AsLong(42)
-        self.assertEqual(grc(res), ref42 + 1)
+        # Small int refcnts don't change
+        self.assertEqual(grc(res), ref42)
         del res
         self.assertEqual(grc(42), ref42)
 

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1448,6 +1448,8 @@ class Logger(Filterer):
         self.handlers = []
         self.disabled = False
         self._cache = {}
+        # Make normcase available even during runtime shutdown
+        self._normcase = os.path.normcase
 
     def setLevel(self, level):
         """
@@ -1569,7 +1571,7 @@ class Logger(Filterer):
         rv = "(unknown file)", 0, "(unknown function)", None
         while hasattr(f, "f_code"):
             co = f.f_code
-            filename = os.path.normcase(co.co_filename)
+            filename = self._normcase(co.co_filename)
             if filename == _srcfile:
                 f = f.f_back
                 continue

--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -1334,10 +1334,14 @@ if HAS_SHMEM:
                 from . import resource_tracker
                 resource_tracker.ensure_running()
             BaseManager.__init__(self, *args, **kwargs)
-            util.debug(f"{self.__class__.__name__} created by pid {getpid()}")
+
+            # Make util.debug available even during runtime shutdown
+            self._debugp = util.debug
+
+            self._debugp(f"{self.__class__.__name__} created by pid {getpid()}")
 
         def __del__(self):
-            util.debug(f"{self.__class__.__name__}.__del__ by pid {getpid()}")
+            self._debugp(f"{self.__class__.__name__}.__del__ by pid {getpid()}")
 
         def get_server(self):
             'Better than monkeypatching for now; merge into Server ultimately'

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -804,6 +804,9 @@ class TemporaryDirectory:
             warn_message="Implicitly cleaning up {!r}".format(self),
             ignore_errors=self._ignore_cleanup_errors)
 
+        # Make _os.path.exists available even during runtime shutdown
+        self._exists = _os.path.exists
+
     @classmethod
     def _rmtree(cls, name, ignore_errors=False):
         def onerror(func, path, exc_info):
@@ -850,7 +853,7 @@ class TemporaryDirectory:
         self.cleanup()
 
     def cleanup(self):
-        if self._finalizer.detach() or _os.path.exists(self.name):
+        if self._finalizer.detach() or self._exists(self.name):
             self._rmtree(self.name, ignore_errors=self._ignore_cleanup_errors)
 
     __class_getitem__ = classmethod(_types.GenericAlias)

--- a/Lib/test/final_a.py
+++ b/Lib/test/final_a.py
@@ -3,17 +3,18 @@ Fodder for module finalization tests in test_module.
 """
 
 import shutil
+import sys
 import test.final_b
 
 x = 'a'
 
 class C:
-    def __del__(self):
+    def __del__(self, sys=sys):
         # Inspect module globals and builtins
-        print("x =", x)
-        print("final_b.x =", test.final_b.x)
-        print("shutil.rmtree =", getattr(shutil.rmtree, '__name__', None))
-        print("len =", getattr(len, '__name__', None))
+        print("x =", x, file=sys.stderr)
+        print("final_b.x =", test.final_b.x, file=sys.stderr)
+        print("shutil.rmtree =", getattr(shutil.rmtree, '__name__', None), sys.stderr)
+        print("len =", getattr(len, '__name__', None), sys.stderr)
 
 c = C()
 _underscored = C()

--- a/Lib/test/final_b.py
+++ b/Lib/test/final_b.py
@@ -3,17 +3,18 @@ Fodder for module finalization tests in test_module.
 """
 
 import shutil
+import sys
 import test.final_a
 
 x = 'b'
 
 class C:
-    def __del__(self):
+    def __del__(self, sys=sys):
         # Inspect module globals and builtins
-        print("x =", x)
-        print("final_a.x =", test.final_a.x)
-        print("shutil.rmtree =", getattr(shutil.rmtree, '__name__', None))
-        print("len =", getattr(len, '__name__', None))
+        print("x =", x, file=sys.stderr)
+        print("final_a.x =", test.final_a.x, file=sys.stderr)
+        print("shutil.rmtree =", getattr(shutil.rmtree, '__name__', None), file=sys.stderr)
+        print("len =", getattr(len, '__name__', None), file=sys.stderr)
 
 c = C()
 _underscored = C()

--- a/Lib/test/test_module.py
+++ b/Lib/test/test_module.py
@@ -269,15 +269,20 @@ a = A(destroyed)"""
     def test_module_finalization_at_shutdown(self):
         # Module globals and builtins should still be available during shutdown
         rc, out, err = assert_python_ok("-c", "from test import final_a")
-        self.assertFalse(err)
-        lines = out.splitlines()
+        lines = err.splitlines()
         self.assertEqual(set(lines), {
-            b"x = a",
-            b"x = b",
-            b"final_a.x = a",
-            b"final_b.x = b",
-            b"len = len",
-            b"shutil.rmtree = rmtree"})
+            b'x = a',
+            b'final_b.x = b',
+            b'x = b',
+            b'final_a.x = a',
+            b'shutil.rmtree = rmtree',
+            b'len = len',
+            b'x = None',
+            b'final_b.x = b',
+            b'x = None',
+            b'final_a.x = None',
+            b'shutil.rmtree = rmtree',
+            b'len = len'})
 
     def test_descriptor_errors_propagate(self):
         class Descr:

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -915,7 +915,7 @@ class ArgsTestCase(BaseTestCase):
                 def test_leak(self):
                     GLOBAL_LIST.append(object())
         """)
-        self.check_leak(code, 'references')
+        self.check_leak(code, 'memory blocks')
 
     @unittest.skipUnless(Py_DEBUG, 'need a debug build')
     def test_huntrleaks_fd_leak(self):

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -385,7 +385,8 @@ class SysModuleTest(unittest.TestCase):
         self.assertRaises(TypeError, sys.getrefcount)
         c = sys.getrefcount(None)
         n = None
-        self.assertEqual(sys.getrefcount(None), c+1)
+        # Singleton refcnts don't change
+        self.assertEqual(sys.getrefcount(None), c)
         del n
         self.assertEqual(sys.getrefcount(None), c)
         if hasattr(sys, "gettotalrefcount"):
@@ -977,14 +978,14 @@ class SysModuleTest(unittest.TestCase):
             import sys
             class A:
                 def __del__(self, sys=sys):
-                    print(sys.flags)
-                    print(sys.float_info)
+                    print(sys.flags, file=sys.stderr)
+                    print(sys.float_info, file=sys.stderr)
             a = A()
             """
         rc, out, err = assert_python_ok('-c', code)
-        out = out.splitlines()
-        self.assertIn(b'sys.flags', out[0])
-        self.assertIn(b'sys.float_info', out[1])
+        err = err.splitlines()
+        self.assertIn(b'sys.flags', err[0])
+        self.assertIn(b'sys.float_info', err[1])
 
     def test_sys_ignores_cleaning_up_user_data(self):
         code = """if 1:

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -649,28 +649,29 @@ class ThreadTests(BaseTestCase):
         # bpo-31516: current_thread() should still point to the main thread
         # at shutdown
         code = """if 1:
-            import gc, threading
+            import gc, sys, threading
 
             main_thread = threading.current_thread()
             assert main_thread is threading.main_thread()  # sanity check
 
             class RefCycle:
-                def __init__(self):
+                def __init__(self, main_thread):
                     self.cycle = self
+                    self.main_thread = main_thread
 
-                def __del__(self):
+                def __del__(self, sys=sys):
                     print("GC:",
-                          threading.current_thread() is main_thread,
-                          threading.main_thread() is main_thread,
-                          threading.enumerate() == [main_thread])
+                          threading.current_thread() is self.main_thread,
+                          threading.main_thread() is self.main_thread,
+                          threading.enumerate() == [self.main_thread],
+                          file=sys.stderr)
 
-            RefCycle()
+            RefCycle(main_thread)
             gc.collect()  # sanity check
-            x = RefCycle()
+            x = RefCycle(main_thread)
         """
         _, out, err = assert_python_ok("-c", code)
-        data = out.decode()
-        self.assertEqual(err, b"")
+        data = err.decode()
         self.assertEqual(data.splitlines(),
                          ["GC: True True True"] * 2)
 
@@ -878,18 +879,19 @@ class ThreadTests(BaseTestCase):
         # bpo-19466: thread locals must not be deleted before destructors
         # are called
         rc, out, err = assert_python_ok("-c", """if 1:
+            import sys
             import threading
 
             class Atexit:
-                def __del__(self):
-                    print("thread_dict.atexit = %r" % thread_dict.atexit)
+                def __del__(self, sys=sys):
+                    print("thread_dict.atexit = %r" % thread_dict.atexit, file=sys.stderr)
 
             thread_dict = threading.local()
             thread_dict.atexit = "value"
 
-            atexit = Atexit()
+            _atexit = Atexit()
         """)
-        self.assertEqual(out.rstrip(), b"thread_dict.atexit = 'value'")
+        self.assertEqual(err.rstrip(), b"thread_dict.atexit = 'value'")
 
     def test_boolean_target(self):
         # bpo-41149: A thread that had a boolean value of False would not

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -1238,17 +1238,16 @@ class FinalizationTest(unittest.TestCase):
         # during Python finalization
         code = """
 import warnings
-warn = warnings.warn
 
 class A:
     def __del__(self):
-        warn("test")
+        warnings.warn("test")
 
 a=A()
         """
         rc, out, err = assert_python_ok("-c", code)
         self.assertEqual(err.decode().rstrip(),
-                         '<string>:7: UserWarning: test')
+                         '<string>:6: UserWarning: test')
 
     def test_late_resource_warning(self):
         # Issue #21925: Emitting a ResourceWarning late during the Python

--- a/Misc/NEWS.d/next/Core and Builtins/2021-12-18-08-57-24.bpo-40255.XDDrSO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-12-18-08-57-24.bpo-40255.XDDrSO.rst
@@ -1,0 +1,2 @@
+This introduces Immortal Instances which allows objects to bypass reference
+counting and remain alive throughout the execution of the runtime

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -281,8 +281,12 @@ gc_list_move(PyGC_Head *node, PyGC_Head *list)
     /* Unlink from current list. */
     PyGC_Head *from_prev = GC_PREV(node);
     PyGC_Head *from_next = GC_NEXT(node);
-    _PyGCHead_SET_NEXT(from_prev, from_next);
-    _PyGCHead_SET_PREV(from_next, from_prev);
+    if (from_next) {
+      _PyGCHead_SET_NEXT(from_prev, from_next);
+    }
+    if (from_prev) {
+      _PyGCHead_SET_PREV(from_next, from_prev);
+    }
 
     /* Relink at end of new list. */
     // list must not have flags.  So we can skip macros.
@@ -1950,6 +1954,95 @@ gc_get_freeze_count_impl(PyObject *module)
 {
     GCState *gcstate = get_gc_state();
     return gc_list_size(&gcstate->permanent_generation.head);
+}
+
+static int
+immortalize_object(PyObject *obj, PyObject *Py_UNUSED(ignored))
+{
+    _Py_SetImmortal(obj);
+    /* Special case for PyCodeObjects since they don't have a tp_traverse */
+    if (PyCode_Check(obj)) {
+        PyCodeObject *code = (PyCodeObject *)obj;
+        _Py_SetImmortal(code->co_code);
+        _Py_SetImmortal(code->co_consts);
+        _Py_SetImmortal(code->co_names);
+        _Py_SetImmortal(code->co_varnames);
+        _Py_SetImmortal(code->co_freevars);
+        _Py_SetImmortal(code->co_cellvars);
+        _Py_SetImmortal(code->co_filename);
+        _Py_SetImmortal(code->co_name);
+        _Py_SetImmortal(code->co_linetable);
+    }
+    return 0;
+}
+
+PyObject *
+_PyGC_ImmortalizeHeap(void) {
+    PyGC_Head *gc, *list;
+    PyThreadState *tstate = _PyThreadState_GET();
+    GCState *gcstate = &tstate->interp->gc;
+
+    /* Remove any dead objects to avoid immortalizing them */
+    PyGC_Collect();
+
+    /* Move all instances into the permanent generation */
+    gc_freeze_impl(NULL);
+
+    /* Immortalize all instances in the permanent generation */
+    list = &gcstate->permanent_generation.head;
+    for (gc = GC_NEXT(list); gc != list; gc = GC_NEXT(gc)) {
+        _Py_SetImmortal(FROM_GC(gc));
+        /* This can traverse to non-GC-tracked objects, and some of those
+         * non-GC-tracked objects (e.g. dicts) can later become GC-tracked, and
+         * not be in the permanent generation. So it is possible for immortal
+         * objects to enter GC collection. Currently what happens in that case
+         * is that their immortal bit makes it look like they have a very large
+         * refcount, so they are not collected. */
+        Py_TYPE(FROM_GC(gc))->tp_traverse(
+              FROM_GC(gc), (visitproc)immortalize_object, NULL);
+    }
+    Py_RETURN_NONE;
+}
+
+static int
+transitive_immortalize(PyObject *obj, PyGC_Head *permanent_gen)
+{
+    if (_Py_IsImmortal(obj)) {
+      return 0;
+    }
+
+    _Py_SetImmortal(obj);
+    /* Special case for PyCodeObjects since they don't have a tp_traverse */
+    if (PyCode_Check(obj)) {
+        PyCodeObject *code = (PyCodeObject *)obj;
+        _Py_SetImmortal(code->co_code);
+        _Py_SetImmortal(code->co_consts);
+        _Py_SetImmortal(code->co_names);
+        _Py_SetImmortal(code->co_varnames);
+        _Py_SetImmortal(code->co_freevars);
+        _Py_SetImmortal(code->co_cellvars);
+        _Py_SetImmortal(code->co_filename);
+        _Py_SetImmortal(code->co_name);
+        _Py_SetImmortal(code->co_linetable);
+    }
+
+    PyTypeObject* tp = Py_TYPE(obj);
+    if (tp->tp_traverse) {
+        gc_list_move(AS_GC(obj), permanent_gen);
+        tp->tp_traverse(obj, (visitproc)transitive_immortalize, permanent_gen);
+    }
+    return 0;
+}
+
+PyObject *
+_PyGC_TransitiveImmortalize(PyObject *obj) {
+    _Py_SetImmortal(obj);
+    Py_TYPE(obj)->tp_traverse(
+        obj,
+        (visitproc)transitive_immortalize,
+        &_PyThreadState_GET()->interp->gc.permanent_generation.head
+    );
+    Py_RETURN_NONE;
 }
 
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -698,6 +698,8 @@ pymain_main(_PyArgv *args)
         pymain_exit_error(status);
     }
 
+    _PyGC_ImmortalizeHeap();
+
     return Py_RunMain();
 }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -47,9 +47,7 @@ static PyObject *
 get_small_int(sdigit ival)
 {
     assert(IS_SMALL_INT(ival));
-    PyObject *v = (PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS + ival];
-    Py_INCREF(v);
-    return v;
+    return (PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS + ival];
 }
 
 static PyLongObject *

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1705,7 +1705,8 @@ PyTypeObject _PyNone_Type = {
 
 PyObject _Py_NoneStruct = {
   _PyObject_EXTRA_INIT
-  1, &_PyNone_Type
+  _Py_IMMORTAL_REFCNT,
+  &_PyNone_Type
 };
 
 /* NotImplemented is an object that can be used to signal that an
@@ -1994,7 +1995,9 @@ _Py_NewReference(PyObject *op)
 #ifdef Py_REF_DEBUG
     _Py_RefTotal++;
 #endif
-    Py_SET_REFCNT(op, 1);
+    /* Do not use Py_SET_REFCNT to skip the Immortal Instance check. This
+     * API guarantees that an instance will always be set to a refcnt of 1 */
+    op->ob_refcnt = 1;
 #ifdef Py_TRACE_REFS
     _Py_AddToAllObjects(op, 1);
 #endif

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1829,7 +1829,7 @@ static int test_unicode_id_init(void)
 
         str1 = _PyUnicode_FromId(&PyId_test_unicode_id_init);
         assert(str1 != NULL);
-        assert(Py_REFCNT(str1) == 1);
+        assert(_Py_IsImmortal(str1));
 
         str2 = PyUnicode_FromString("test_unicode_id_init");
         assert(str2 != NULL);

--- a/Python/import.c
+++ b/Python/import.c
@@ -1829,6 +1829,10 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
         if (mod == NULL) {
             goto error;
         }
+        // Immortalize top level modules
+        if (tstate->recursion_limit - tstate->recursion_remaining == 1) {
+            _PyGC_TransitiveImmortalize(mod);
+        }
     }
 
     has_from = 0;

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1362,17 +1362,29 @@ finalize_modules_delete_special(PyThreadState *tstate, int verbose)
 static PyObject*
 finalize_remove_modules(PyObject *modules, int verbose)
 {
-    PyObject *weaklist = PyList_New(0);
-    if (weaklist == NULL) {
+    PyObject *stdlib_weaklist = PyList_New(0);
+    if (stdlib_weaklist == NULL) {
+        PyErr_WriteUnraisable(NULL);
+    }
+    PyObject *user_weaklist = PyList_New(0);
+    if (user_weaklist == NULL) {
+        PyErr_WriteUnraisable(NULL);
+    }
+    PyObject *stdlib_list = _PySys_StdlibModuleNameList();
+    if (stdlib_list == NULL) {
         PyErr_WriteUnraisable(NULL);
     }
 
 #define STORE_MODULE_WEAKREF(name, mod) \
-        if (weaklist != NULL) { \
+        if (stdlib_list != NULL) { \
+            PyObject *list = user_weaklist; \
+            if (PySequence_Contains(stdlib_list, name)) { \
+                list = stdlib_weaklist; \
+            } \
             PyObject *wr = PyWeakref_NewRef(mod, NULL); \
             if (wr) { \
                 PyObject *tup = PyTuple_Pack(2, name, wr); \
-                if (!tup || PyList_Append(weaklist, tup) < 0) { \
+                if (!tup || PyList_Append(list, tup) < 0) { \
                     PyErr_WriteUnraisable(NULL); \
                 } \
                 Py_XDECREF(tup); \
@@ -1427,7 +1439,11 @@ finalize_remove_modules(PyObject *modules, int verbose)
 #undef CLEAR_MODULE
 #undef STORE_MODULE_WEAKREF
 
-    return weaklist;
+    PyObject *result = PyTuple_Pack(2, stdlib_weaklist, user_weaklist);
+    if (result == NULL) {
+        PyErr_WriteUnraisable(NULL);
+    }
+    return result;
 }
 
 
@@ -1462,28 +1478,35 @@ finalize_restore_builtins(PyThreadState *tstate)
 
 
 static void
-finalize_modules_clear_weaklist(PyInterpreterState *interp,
+finalize_modules_clear_weaklist(PyThreadState *tstate,
+                                PyInterpreterState *interp,
                                 PyObject *weaklist, int verbose)
 {
     // First clear modules imported later
-    for (Py_ssize_t i = PyList_GET_SIZE(weaklist) - 1; i >= 0; i--) {
-        PyObject *tup = PyList_GET_ITEM(weaklist, i);
-        PyObject *name = PyTuple_GET_ITEM(tup, 0);
-        PyObject *mod = PyWeakref_GET_OBJECT(PyTuple_GET_ITEM(tup, 1));
-        if (mod == Py_None) {
-            continue;
+    int max_module_phase = 3;
+    for (int phase = 1; phase <= max_module_phase; phase++) {
+        for (Py_ssize_t i = PyList_GET_SIZE(weaklist) - 1; i >= 0; i--) {
+            PyObject *tup = PyList_GET_ITEM(weaklist, i);
+            PyObject *name = PyTuple_GET_ITEM(tup, 0);
+            PyObject *mod = PyWeakref_GET_OBJECT(PyTuple_GET_ITEM(tup, 1));
+            if (mod == Py_None) {
+                continue;
+            }
+            assert(PyModule_Check(mod));
+            PyObject *dict = PyModule_GetDict(mod);
+            if (dict == interp->builtins || dict == interp->sysdict) {
+                continue;
+            }
+            Py_INCREF(mod);
+            if (verbose && PyUnicode_Check(name)) {
+                PySys_FormatStderr("# cleanup[3] wiping %U\n", name);
+            }
+            _PyModule_PhasedClear(mod, phase);
+            if (max_module_phase) {
+              Py_DECREF(mod);
+            }
         }
-        assert(PyModule_Check(mod));
-        PyObject *dict = PyModule_GetDict(mod);
-        if (dict == interp->builtins || dict == interp->sysdict) {
-            continue;
-        }
-        Py_INCREF(mod);
-        if (verbose && PyUnicode_Check(name)) {
-            PySys_FormatStderr("# cleanup[3] wiping %U\n", name);
-        }
-        _PyModule_Clear(mod);
-        Py_DECREF(mod);
+        _PyGC_CollectNoFail(tstate);
     }
 }
 
@@ -1529,11 +1552,16 @@ finalize_modules(PyThreadState *tstate)
     // Remove all modules from sys.modules, hoping that garbage collection
     // can reclaim most of them: set all sys.modules values to None.
     //
-    // We prepare a list which will receive (name, weakref) tuples of
-    // modules when they are removed from sys.modules.  The name is used
-    // for diagnosis messages (in verbose mode), while the weakref helps
-    // detect those modules which have been held alive.
-    PyObject *weaklist = finalize_remove_modules(modules, verbose);
+    // This prepares two lists, the user defined list of modules as well
+    // as stdlib list of modules. The user modules will be destroyed first in
+    // order to guarantee builtin module and type availability within a user
+    // defined `__del__` during the runtime shutdown.
+    //
+    // These lists will receive (name, weakref) tuples of modules when they are
+    // removed from sys.modules.  The name is used for diagnosis messages (in
+    // verbose mode), while the weakref helps detect those modules which have
+    // been held alive.
+    PyObject *weaklist_tuple = finalize_remove_modules(modules, verbose);
 
     // Clear the modules dict
     finalize_clear_modules_dict(modules);
@@ -1549,24 +1577,45 @@ finalize_modules(PyThreadState *tstate)
     // machinery.
     _PyGC_DumpShutdownStats(interp);
 
-    if (weaklist != NULL) {
-        // Now, if there are any modules left alive, clear their globals to
-        // minimize potential leaks.  All C extension modules actually end
-        // up here, since they are kept alive in the interpreter state.
-        //
-        // The special treatment of "builtins" here is because even
-        // when it's not referenced as a module, its dictionary is
-        // referenced by almost every module's __builtins__.  Since
-        // deleting a module clears its dictionary (even if there are
-        // references left to it), we need to delete the "builtins"
-        // module last.  Likewise, we don't delete sys until the very
-        // end because it is implicitly referenced (e.g. by print).
-        //
-        // Since dict is ordered in CPython 3.6+, modules are saved in
-        // importing order.  First clear modules imported later.
-        finalize_modules_clear_weaklist(interp, weaklist, verbose);
-        Py_DECREF(weaklist);
+    // Finally, clear the module globals to minimize potential leaks as well
+    // as clearing up the immortal modules. All C extension modules actually
+    // end up here, since they are kept alive in the interpreter state.
+    //
+    // The module cleanup order is as follows:
+    //   User defined modules:
+    //     1) Globals starting with '_', excluding modules
+    //     2) Globals, excluding modules and __builtins__
+    //     3) Modules and __builtins__
+    //   Stdlib modules:
+    //     4) Globals starting with '_', excluding modules
+    //     5) Globals, excluding modules and __builtins__
+    //     6) Modules and __builtins__
+    //
+    // After each of these steps, a full GC collection is triggered in order
+    // to clear cycles and trigger the execution of `__del__` functions
+    // while other modules and types are still available to be used.
+    //
+    // The special treatment of "builtins" here is because even
+    // when it's not referenced as a module, its dictionary is
+    // referenced by almost every module's __builtins__.  Since
+    // deleting a module clears its dictionary (even if there are
+    // references left to it), we need to delete the "builtins"
+    // module last.  Likewise, we don't delete sys until the very
+    // end because it is implicitly referenced (e.g. by print).
+    if (weaklist_tuple != NULL) {
+        PyObject *user_weaklist = PyTuple_GET_ITEM(weaklist_tuple, 1);
+        if (user_weaklist != NULL) {
+            finalize_modules_clear_weaklist(tstate, interp, user_weaklist, verbose);
+        }
+        Py_XDECREF(user_weaklist);
+
+        PyObject *stdlib_weaklist = PyTuple_GET_ITEM(weaklist_tuple, 0);
+        if (stdlib_weaklist != NULL) {
+            finalize_modules_clear_weaklist(tstate, interp, stdlib_weaklist, verbose);
+        }
+        Py_XDECREF(stdlib_weaklist);
     }
+    Py_XDECREF(weaklist_tuple);
 
     // Clear sys and builtins modules dict
     finalize_clear_sys_builtins_dict(interp, verbose);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2074,8 +2074,8 @@ error:
 }
 
 
-static PyObject *
-list_stdlib_module_names(void)
+PyObject *
+_PySys_StdlibModuleNameList(void)
 {
     Py_ssize_t len = Py_ARRAY_LENGTH(_Py_stdlib_module_names);
     PyObject *names = PyTuple_New(len);
@@ -2810,7 +2810,7 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
     SET_SYS("hash_info", get_hash_info(tstate));
     SET_SYS("maxunicode", PyLong_FromLong(0x10FFFF));
     SET_SYS("builtin_module_names", list_builtin_module_names());
-    SET_SYS("stdlib_module_names", list_stdlib_module_names());
+    SET_SYS("stdlib_module_names", _PySys_StdlibModuleNameList());
 #if PY_BIG_ENDIAN
     SET_SYS_FROM_STRING("byteorder", "big");
 #else


### PR DESCRIPTION
This is an optimization on top of [PR19474](https://github.com/python/cpython/pull/19474).

It combines [PR31488](https://github.com/python/cpython/pull/31488), [PR31489](https://github.com/python/cpython/pull/31489), and [PR31490](https://github.com/python/cpython/pull/31490) into a single change to measure the combined performance benefits.

These results do not change too much from what was already achieved independently by these optimizations (as some of the immortalized instances start overlaping with each other). That being said, performance will keep scaling as the application scales as well. The current microbenchmarks do not measure applications that contain hundreds of imports or thousands of interned strings. Nonetheless, it is still worthwhile to consider all of these improvements in conjunction when thinking about larger scale applications.

## Benchmark Results

Overall: **0% faster** compared to the main branch and the highest number of non-stat significant benchmarks (18)

<details>
<summary>pyperformance results</summary>

```
2to3: Mean +- std dev: [cpython_master] 432 ms +- 15 ms -> [immortal_instances_opt_combined_v3] 451 ms +- 16 ms: 1.04x slower
chaos: Mean +- std dev: [cpython_master] 126 ms +- 4 ms -> [immortal_instances_opt_combined_v3] 123 ms +- 4 ms: 1.03x faster
deltablue: Mean +- std dev: [cpython_master] 7.35 ms +- 0.20 ms -> [immortal_instances_opt_combined_v3] 7.74 ms +- 0.41 ms: 1.05x slower
django_template: Mean +- std dev: [cpython_master] 62.2 ms +- 2.0 ms -> [immortal_instances_opt_combined_v3] 63.7 ms +- 2.4 ms: 1.02x slower
fannkuch: Mean +- std dev: [cpython_master] 664 ms +- 15 ms -> [immortal_instances_opt_combined_v3] 677 ms +- 18 ms: 1.02x slower
float: Mean +- std dev: [cpython_master] 128 ms +- 4 ms -> [immortal_instances_opt_combined_v3] 135 ms +- 7 ms: 1.05x slower
go: Mean +- std dev: [cpython_master] 244 ms +- 10 ms -> [immortal_instances_opt_combined_v3] 228 ms +- 14 ms: 1.07x faster
json_dumps: Mean +- std dev: [cpython_master] 19.2 ms +- 0.7 ms -> [immortal_instances_opt_combined_v3] 20.1 ms +- 0.8 ms: 1.04x slower
logging_format: Mean +- std dev: [cpython_master] 10.4 us +- 0.3 us -> [immortal_instances_opt_combined_v3] 11.0 us +- 0.4 us: 1.06x slower
logging_silent: Mean +- std dev: [cpython_master] 201 ns +- 8 ns -> [immortal_instances_opt_combined_v3] 205 ns +- 7 ns: 1.02x slower
logging_simple: Mean +- std dev: [cpython_master] 9.77 us +- 0.32 us -> [immortal_instances_opt_combined_v3] 10.2 us +- 0.4 us: 1.04x slower
nqueens: Mean +- std dev: [cpython_master] 159 ms +- 5 ms -> [immortal_instances_opt_combined_v3] 154 ms +- 3 ms: 1.03x faster
pickle: Mean +- std dev: [cpython_master] 16.0 us +- 0.5 us -> [immortal_instances_opt_combined_v3] 16.6 us +- 0.7 us: 1.04x slower
pickle_dict: Mean +- std dev: [cpython_master] 37.3 us +- 0.6 us -> [immortal_instances_opt_combined_v3] 35.6 us +- 2.1 us: 1.05x faster
pidigits: Mean +- std dev: [cpython_master] 284 ms +- 15 ms -> [immortal_instances_opt_combined_v3] 273 ms +- 9 ms: 1.04x faster
pyflate: Mean +- std dev: [cpython_master] 770 ms +- 28 ms -> [immortal_instances_opt_combined_v3] 746 ms +- 24 ms: 1.03x faster
python_startup: Mean +- std dev: [cpython_master] 12.6 ms +- 0.4 ms -> [immortal_instances_opt_combined_v3] 11.6 ms +- 0.6 ms: 1.08x faster
python_startup_no_site: Mean +- std dev: [cpython_master] 8.89 ms +- 0.39 ms -> [immortal_instances_opt_combined_v3] 8.11 ms +- 0.43 ms: 1.10x faster
raytrace: Mean +- std dev: [cpython_master] 529 ms +- 16 ms -> [immortal_instances_opt_combined_v3] 544 ms +- 17 ms: 1.03x slower
scimark_fft: Mean +- std dev: [cpython_master] 571 ms +- 12 ms -> [immortal_instances_opt_combined_v3] 589 ms +- 13 ms: 1.03x slower
scimark_lu: Mean +- std dev: [cpython_master] 195 ms +- 6 ms -> [immortal_instances_opt_combined_v3] 205 ms +- 7 ms: 1.05x slower
scimark_sor: Mean +- std dev: [cpython_master] 211 ms +- 6 ms -> [immortal_instances_opt_combined_v3] 216 ms +- 6 ms: 1.03x slower
scimark_sparse_mat_mult: Mean +- std dev: [cpython_master] 8.28 ms +- 0.40 ms -> [immortal_instances_opt_combined_v3] 8.66 ms +- 0.30 ms: 1.05x slower
sympy_expand: Mean +- std dev: [cpython_master] 878 ms +- 34 ms -> [immortal_instances_opt_combined_v3] 850 ms +- 27 ms: 1.03x faster
sympy_integrate: Mean +- std dev: [cpython_master] 35.2 ms +- 1.0 ms -> [immortal_instances_opt_combined_v3] 36.6 ms +- 1.5 ms: 1.04x slower
sympy_sum: Mean +- std dev: [cpython_master] 291 ms +- 13 ms -> [immortal_instances_opt_combined_v3] 309 ms +- 7 ms: 1.06x slower
sympy_str: Mean +- std dev: [cpython_master] 514 ms +- 11 ms -> [immortal_instances_opt_combined_v3] 535 ms +- 13 ms: 1.04x slower
telco: Mean +- std dev: [cpython_master] 10.4 ms +- 0.2 ms -> [immortal_instances_opt_combined_v3] 10.7 ms +- 0.5 ms: 1.03x slower
unpack_sequence: Mean +- std dev: [cpython_master] 77.9 ns +- 2.3 ns -> [immortal_instances_opt_combined_v3] 70.6 ns +- 2.0 ns: 1.10x faster
unpickle_list: Mean +- std dev: [cpython_master] 6.77 us +- 0.25 us -> [immortal_instances_opt_combined_v3] 6.95 us +- 0.22 us: 1.03x slower
xml_etree_parse: Mean +- std dev: [cpython_master] 245 ms +- 6 ms -> [immortal_instances_opt_combined_v3] 238 ms +- 5 ms: 1.03x faster
xml_etree_generate: Mean +- std dev: [cpython_master] 146 ms +- 4 ms -> [immortal_instances_opt_combined_v3] 143 ms +- 6 ms: 1.02x faster
xml_etree_process: Mean +- std dev: [cpython_master] 102 ms +- 2 ms -> [immortal_instances_opt_combined_v3] 100 ms +- 3 ms: 1.02x faster

Benchmark hidden because not significant (18): hexiom, html5lib, json_loads, meteor_contest, nbody, pathlib, pickle_list, pickle_pure_python, regex_compile, regex_dna, regex_effbot, regex_v8, richards, scimark_monte_carlo, spectral_norm, unpickle, unpickle_pure_python, xml_etree_iterparse

Geometric mean: 1.00x faster
```

</details>

<!-- issue-number: [bpo-40255](https://bugs.python.org/issue40255) -->
https://bugs.python.org/issue40255
<!-- /issue-number -->