### PR TITLE
gh-81536: For nonblocking sockets, add `SSLSocket.eager_recv` to call `SSL_read` in a loop

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1315,6 +1315,20 @@ SSL sockets also have the following additional methods and attributes:
 
    .. versionadded:: 3.2
 
+.. attribute:: SSLSocket.eager_recv
+
+   If set to ``True``, a call to :meth:`~socket.socket.recv()` or
+   :meth:`~socket.socket.recv_into()` on a
+   :ref:`non-blocking <ssl-nonblocking>` TLS socket
+   will drop the GIL once to read the entire buffer instead of reading at most
+   one TLS record (16 KB).
+
+   .. note::
+      Reading the entire buffer can include the TLS EOF segment, which will
+      close the TLS layer without raising :exc:`SSLEOFError`.
+
+   .. versionadded:: 3.12
+
 .. attribute:: SSLSocket.server_side
 
    A boolean which is ``True`` for server-side sockets and ``False`` for

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -837,6 +837,15 @@ class SSLObject:
         return self._sslobj.session_reused
 
     @property
+    def eager_recv(self):
+        """If data is read from the socket eagerly, ignoring possible TLS EOF packets."""
+        return self._sslobj.eager_recv
+
+    @eager_recv.setter
+    def eager_recv(self, eager_recv):
+        self._sslobj.eager_recv = eager_recv
+
+    @property
     def server_side(self):
         """Whether this is a server-side socket."""
         return self._sslobj.server_side
@@ -1043,6 +1052,17 @@ class SSLSocket(socket):
     def session_reused(self):
         if self._sslobj is not None:
             return self._sslobj.session_reused
+
+    @property
+    @_sslcopydoc
+    def eager_recv(self):
+        if self._sslobj is not None:
+            return self._sslobj.eager_recv
+
+    @eager_recv.setter
+    def eager_recv(self, eager_recv):
+        if self._sslobj is not None:
+            self._sslobj.eager_recv = eager_recv
 
     def dup(self):
         raise NotImplementedError("Can't dup() %s instances" %

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2123,7 +2123,6 @@ class SimpleBackgroundTests(unittest.TestCase):
         # In nonblocking mode, we should be able to read all four in a single
         # drop of the GIL.
         size = 65536
-        trips = []
 
         client_context, server_context, hostname = testing_context()
         server = ThreadedEchoServer(context=server_context, chatty=False,
@@ -2133,7 +2132,7 @@ class SimpleBackgroundTests(unittest.TestCase):
             sock.settimeout(0.0)
             s = client_context.wrap_socket(sock, server_hostname=hostname,
                                            do_handshake_on_connect=False)
-
+            s.eager_recv = True
             with s:
                 while True:
                     try:
@@ -2160,7 +2159,7 @@ class SimpleBackgroundTests(unittest.TestCase):
                             return
                         size -= count
 
-            raise AssertionError("All TLS reads were smaller than 16KB")
+            self.fail("All TLS reads were smaller than 16KB")
 
 
 @support.requires_resource('network')

--- a/Misc/NEWS.d/next/Library/2021-04-19-15-53-03.bpo-37355.3pie1n.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-19-15-53-03.bpo-37355.3pie1n.rst
@@ -1,0 +1,3 @@
+When reading from a nonblocking TLS socket, drop the GIL once to read up to
+the entire buffer. Previously we would read at most one TLS record (16 KB).
+Patch by Josh Snyder.

--- a/Misc/NEWS.d/next/Library/2021-04-19-15-53-03.bpo-37355.3pie1n.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-19-15-53-03.bpo-37355.3pie1n.rst
@@ -1,3 +1,3 @@
-When reading from a nonblocking TLS socket, drop the GIL once to read up to
-the entire buffer. Previously we would read at most one TLS record (16 KB).
-Patch by Josh Snyder.
+Added :attr:`ssl.SSLSocket.eager_recv`, if enabled a :ref:`non-blocking <ssl-nonblocking>`
+TLS socket will drop the GIL once to read up to the entire buffer instead of reading at
+most TLS record (16 KB). Patch by Josh Snyder and Safihre.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2430,10 +2430,11 @@ _ssl__SSLSocket_read_impl(PySSLSocket *self, Py_ssize_t len,
     PyObject *dest = NULL;
     char *mem;
     size_t count = 0;
+    size_t got = 0;
     int retval;
     int sockstate;
     _PySSLError err;
-    int nonblocking;
+    int nonblocking = 0;
     PySocketSockObject *sock = GET_SOCKET(self);
     _PyTime_t timeout, deadline = 0;
     int has_timeout;
@@ -2493,10 +2494,22 @@ _ssl__SSLSocket_read_impl(PySSLSocket *self, Py_ssize_t len,
 
     do {
         PySSL_BEGIN_ALLOW_THREADS
-        retval = SSL_read_ex(self->ssl, mem, (size_t)len, &count);
+        do {
+            retval = SSL_read_ex(self->ssl, mem + got, len, &count);
+            if(retval <= 0) {
+                break;
+            }
+
+            got += count;
+            len -= count;
+        } while(nonblocking && len > 0);
         err = _PySSL_errno(retval == 0, self->ssl, retval);
         PySSL_END_ALLOW_THREADS
         self->err = err;
+
+        if(got > 0) {
+            break;
+        }
 
         if (PyErr_CheckSignals())
             goto error;
@@ -2512,7 +2525,7 @@ _ssl__SSLSocket_read_impl(PySSLSocket *self, Py_ssize_t len,
         } else if (err.ssl == SSL_ERROR_ZERO_RETURN &&
                    SSL_get_shutdown(self->ssl) == SSL_RECEIVED_SHUTDOWN)
         {
-            count = 0;
+            got = 0;
             goto done;
         }
         else
@@ -2528,7 +2541,7 @@ _ssl__SSLSocket_read_impl(PySSLSocket *self, Py_ssize_t len,
     } while (err.ssl == SSL_ERROR_WANT_READ ||
              err.ssl == SSL_ERROR_WANT_WRITE);
 
-    if (retval == 0) {
+    if (got == 0) {
         PySSL_SetError(self, retval, __FILE__, __LINE__);
         goto error;
     }
@@ -2538,11 +2551,11 @@ _ssl__SSLSocket_read_impl(PySSLSocket *self, Py_ssize_t len,
 done:
     Py_XDECREF(sock);
     if (!group_right_1) {
-        _PyBytes_Resize(&dest, count);
+        _PyBytes_Resize(&dest, got);
         return dest;
     }
     else {
-        return PyLong_FromSize_t(count);
+        return PyLong_FromSize_t(got);
     }
 
 error:


### PR DESCRIPTION
This PR is a continuation of #25478, that was no longer updated by the author @hashbrowncipher.
I implemented all the requested changes.


However, the optimization changes behavior of an `SSLSocket.recv`. Therefore I introduced a parameter to enable this new behavior only when desired.

The change in behavior if we don't add an opt-in:

> Right now callers can rely on fact that either SSLSocket.read returns bytes OR it reads a TLS close_notify message, producing an exception; it never does both. With this change, it becomes possible to read application data and also read a TLS close_notify message, which will be processed by OpenSSL. `select/poll/epoll` will all now indicate that the socket has no bytes available (which is true), but OpenSSL knows that no additional bytes will ever arrive on the socket. I validated my theory by patching the test_ftplib code to check for EOF after successful reads. With this change, the tests all passed.

> That said, I don't imagine it's acceptable to change behavior like this. I think that to roll out this optimization would require calling code to opt in by passing a flag indicating "Please read eagerly from the socket; I know that I am responsible for explicitly checking for EOF before calling select() on the underlying OS socket."

It was requested in the review to also implement this for `write()`, however, that is not needed as OpenSSL's `SSL_write_ex` already writes the whole buffer at once. Only reading OpenSSL does in the 16k segments.

----
Original PR-text: 

> Continue looping until data is exhausted, and only then reacquire the GIL. This makes it possible to perform multi-threaded TLS downloads without saturating the GIL. On a test workload performing HTTPS download with 32 threads pinned to 16 cores, this produces a 4x speedup.
> 
> ```
>                           before     after
> wall clock time (s)  :    29.637     7.116
> user time (s)        :     8.793    12.584
> system time (s)      :   105.118    30.010
> voluntary switches   : 1,653,065   248,484
> speed (MB/s)         :      4733     19712
> ```
> https://bugs.python.org/issue37355





Closes #25478.
Closes #81536

<!-- issue-number: [bpo-37355](https://bugs.python.org/issue37355) -->
https://bugs.python.org/issue37355
<!-- /issue-number -->


<!-- gh-issue-number: gh-81536 -->
* Issue: gh-81536
<!-- /gh-issue-number -->
