### PR TITLE
bpo-46329: Fix test failure when `Py_STATS` is enabled

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-22-14-03-56.bpo-46329.RX_AzJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-22-14-03-56.bpo-46329.RX_AzJ.rst
@@ -1,0 +1,1 @@
+Fix specialization stats gathering for :opcode:`PRECALL` instructions.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -160,6 +160,7 @@ _Py_GetSpecializationStats(void) {
     err += add_stat_dict(stats, BINARY_OP, "binary_op");
     err += add_stat_dict(stats, COMPARE_OP, "compare_op");
     err += add_stat_dict(stats, UNPACK_SEQUENCE, "unpack_sequence");
+    err += add_stat_dict(stats, PRECALL, "precall");
     if (err < 0) {
         Py_DECREF(stats);
         return NULL;
@@ -180,8 +181,6 @@ print_spec_stats(FILE *out, OpcodeStats *stats)
     /* Mark some opcodes as specializable for stats,
      * even though we don't specialize them yet. */
     fprintf(out, "opcode[%d].specializable : 1\n", FOR_ITER);
-    fprintf(out, "opcode[%d].specializable : 1\n", PRECALL);
-    fprintf(out, "opcode[%d].specializable : 1\n", UNPACK_SEQUENCE);
     for (int i = 0; i < 256; i++) {
         if (adaptive_opcodes[i]) {
             fprintf(out, "opcode[%d].specializable : 1\n", i);


### PR DESCRIPTION
```
======================================================================
FAIL: test_specialization_stats (test.test__opcode.SpecializationStatsTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/brandtbucher/cpython/Lib/test/test__opcode.py", line 81, in test_specialization_stats
    self.assertCountEqual(stats.keys(), specialized_opcodes)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Element counts were not equal:
First has 0, Second has 1:  'precall'

----------------------------------------------------------------------
```

<!-- issue-number: [bpo-46329](https://bugs.python.org/issue46329) -->
https://bugs.python.org/issue46329
<!-- /issue-number -->
