### PR TITLE
bpo-44886: Inherit asyncio proactor datagram transport from asyncio.DatagramTransport

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -452,7 +452,8 @@ class _ProactorWritePipeTransport(_ProactorBaseWritePipeTransport):
             self.close()
 
 
-class _ProactorDatagramTransport(_ProactorBasePipeTransport):
+class _ProactorDatagramTransport(_ProactorBasePipeTransport,
+                                 transports.DatagramTransport):
     max_size = 256 * 1024
     def __init__(self, loop, sock, protocol, address=None,
                  waiter=None, extra=None):

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -839,6 +839,7 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
     def test_make_datagram_transport(self):
         tr = self.datagram_transport()
         self.assertIsInstance(tr, _ProactorDatagramTransport)
+        self.assertIsInstance(tr, asyncio.DatagramTransport)
         close_transport(tr)
 
     def test_datagram_loop_writing(self):

--- a/Misc/NEWS.d/next/Library/2022-02-23-00-55-59.bpo-44886.I40Mbr.rst
+++ b/Misc/NEWS.d/next/Library/2022-02-23-00-55-59.bpo-44886.I40Mbr.rst
@@ -1,0 +1,2 @@
+Inherit asyncio proactor datagram transport from
+:class:`asyncio.DatagramTransport`.


### PR DESCRIPTION


<!-- issue-number: [bpo-44886](https://bugs.python.org/issue44886) -->
https://bugs.python.org/issue44886
<!-- /issue-number -->
