### PR TITLE
bpo-45885: Don't un-adapt `COMPARE_OP` when collecting stats

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-22-15-48-32.bpo-45885.W2vkaI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-22-15-48-32.bpo-45885.W2vkaI.rst
@@ -1,0 +1,1 @@
+Don't deopt :opcode:`COMPARE_OP` when collecting stats.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-22-15-48-32.bpo-45885.W2vkaI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-22-15-48-32.bpo-45885.W2vkaI.rst
@@ -1,1 +1,1 @@
-Don't deopt :opcode:`COMPARE_OP` when collecting stats.
+Don't un-adapt :opcode:`COMPARE_OP` when collecting specialization stats.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2014,9 +2014,15 @@ _Py_Specialize_CompareOp(PyObject *lhs, PyObject *rhs,
     int op = adaptive->original_oparg;
     int next_opcode = _Py_OPCODE(instr[1]);
     if (next_opcode != POP_JUMP_IF_FALSE && next_opcode != POP_JUMP_IF_TRUE) {
-        // Can't ever combine, so don't don't bother being adaptive.
-        SPECIALIZATION_FAIL(COMPARE_OP, SPEC_FAIL_COMPARE_OP_NOT_FOLLOWED_BY_COND_JUMP);
+        // Can't ever combine, so don't don't bother being adaptive (unless
+        // we're collecting stats, where it's more important to get accurate hit
+        // counts for the unadaptive version and each of the different failure
+        // types):
+#ifndef Py_STATS
         *instr = _Py_MAKECODEUNIT(COMPARE_OP, adaptive->original_oparg);
+        return;
+#endif
+        SPECIALIZATION_FAIL(COMPARE_OP, SPEC_FAIL_COMPARE_OP_NOT_FOLLOWED_BY_COND_JUMP);
         goto failure;
     }
     assert(op <= Py_GE);


### PR DESCRIPTION
The current stats obscure the fact that "not followed by conditional jump" accounts for a significant portion of possible `COMPARE_OP` hits. This patch takes the same approach that `BINARY_OP` uses of only un-adapting the instruction when stats *aren't* being collected.

New stats:

### COMPARE_OP

<details>
<summary> specialization stats for COMPARE_OP family </summary>

|Kind | Count | Ratio | 
|---|---|---|
|  unquickened |      7362156 | 0.4% |
| specialization.deferred |    288102012 | 17.2% |
| specialization.deopt |        15642 | 0.0% |
|          hit |   1374191464 | 82.3% |
|         miss |       959440 | 0.1% |

#### Specialization attempts

| | Count | Ratio | 
|---|---:|---:|
| Success | 373171 | 7.4% |
| Failure | 4650804 | 92.6% |

|Failure kind | Count | Ratio | 
|---|---:|---:|
| not followed by cond jump | 2647332 | 56.9% |
| float long | 665643 | 14.3% |
| set | 580212 | 12.5% |
| different types | 151788 | 3.3% |
| bool | 137583 | 3.0% |
| other | 127248 | 2.7% |
| tuple | 120230 | 2.6% |
| big int | 101401 | 2.2% |
| bytes | 52839 | 1.1% |
| baseobject | 42585 | 0.9% |
| list | 23036 | 0.5% |
| string | 706 | 0.0% |
| long float | 201 | 0.0% |

<!-- issue-number: [bpo-45885](https://bugs.python.org/issue45885) -->
https://bugs.python.org/issue45885
<!-- /issue-number -->
