### PR TITLE
bpo-46850: Move private _PyEval functions to internal C API

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1025,3 +1025,21 @@ Removed
 * Remove the ``HAVE_PY_SET_53BIT_PRECISION`` macro (moved to the internal C
   API).
   (Contributed by Victor Stinner in :issue:`45412`.)
+
+* Remove the following ``_PyEval`` private functions (moved to the internal C
+  API headers):
+
+  * ``_PyEval_CallTracing()``
+  * ``_PyEval_EvalFrameDefault()``
+  * ``_PyEval_GetAsyncGenFinalizer()``
+  * ``_PyEval_GetAsyncGenFirstiter()``
+  * ``_PyEval_GetCoroutineOriginTrackingDepth()``
+  * ``_PyEval_GetSwitchInterval()``
+  * ``_PyEval_RequestCodeExtraIndex()``
+  * ``_PyEval_SetAsyncGenFinalizer()``
+  * ``_PyEval_SetAsyncGenFirstiter()``
+  * ``_PyEval_SetProfile()``
+  * ``_PyEval_SetSwitchInterval()``
+  * ``_PyEval_SetTrace()``
+
+  (Contributed by Victor Stinner in :issue:`46850`.)

--- a/Include/cpython/ceval.h
+++ b/Include/cpython/ceval.h
@@ -2,32 +2,17 @@
 #  error "this header file must not be included directly"
 #endif
 
-PyAPI_FUNC(PyObject *) _PyEval_CallTracing(PyObject *func, PyObject *args);
-
 PyAPI_FUNC(void) PyEval_SetProfile(Py_tracefunc, PyObject *);
-PyAPI_DATA(int) _PyEval_SetProfile(PyThreadState *tstate, Py_tracefunc func, PyObject *arg);
 PyAPI_FUNC(void) PyEval_SetTrace(Py_tracefunc, PyObject *);
-PyAPI_FUNC(int) _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg);
-PyAPI_FUNC(int) _PyEval_GetCoroutineOriginTrackingDepth(void);
-PyAPI_FUNC(int) _PyEval_SetAsyncGenFirstiter(PyObject *);
-PyAPI_FUNC(PyObject *) _PyEval_GetAsyncGenFirstiter(void);
-PyAPI_FUNC(int) _PyEval_SetAsyncGenFinalizer(PyObject *);
-PyAPI_FUNC(PyObject *) _PyEval_GetAsyncGenFinalizer(void);
 
 /* Helper to look up a builtin object */
 PyAPI_FUNC(PyObject *) _PyEval_GetBuiltin(PyObject *);
 PyAPI_FUNC(PyObject *) _PyEval_GetBuiltinId(_Py_Identifier *);
+
 /* Look at the current frame's (if any) code's co_flags, and turn on
    the corresponding compiler flags in cf->cf_flags.  Return 1 if any
    flag was set, else return 0. */
 PyAPI_FUNC(int) PyEval_MergeCompilerFlags(PyCompilerFlags *cf);
-
-PyAPI_FUNC(PyObject *) _PyEval_EvalFrameDefault(PyThreadState *tstate, struct _interpreter_frame *f, int exc);
-
-PyAPI_FUNC(void) _PyEval_SetSwitchInterval(unsigned long microseconds);
-PyAPI_FUNC(unsigned long) _PyEval_GetSwitchInterval(void);
-
-PyAPI_FUNC(Py_ssize_t) _PyEval_RequestCodeExtraIndex(freefunc);
 
 PyAPI_FUNC(int) _PyEval_SliceIndex(PyObject *, Py_ssize_t *);
 PyAPI_FUNC(int) _PyEval_SliceIndexNotNone(PyObject *, Py_ssize_t *);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -20,6 +20,23 @@ struct _ceval_runtime_state;
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 
 
+PyAPI_FUNC(PyObject *) _PyEval_CallTracing(PyObject *func, PyObject *args);
+PyAPI_DATA(int) _PyEval_SetProfile(PyThreadState *tstate, Py_tracefunc func, PyObject *arg);
+PyAPI_FUNC(int) _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg);
+PyAPI_FUNC(int) _PyEval_GetCoroutineOriginTrackingDepth(void);
+PyAPI_FUNC(int) _PyEval_SetAsyncGenFirstiter(PyObject *);
+PyAPI_FUNC(PyObject *) _PyEval_GetAsyncGenFirstiter(void);
+PyAPI_FUNC(int) _PyEval_SetAsyncGenFinalizer(PyObject *);
+PyAPI_FUNC(PyObject *) _PyEval_GetAsyncGenFinalizer(void);
+
+PyAPI_FUNC(PyObject *) _PyEval_EvalFrameDefault(PyThreadState *tstate, struct _interpreter_frame *f, int exc);
+
+PyAPI_FUNC(void) _PyEval_SetSwitchInterval(unsigned long microseconds);
+PyAPI_FUNC(unsigned long) _PyEval_GetSwitchInterval(void);
+
+PyAPI_FUNC(Py_ssize_t) _PyEval_RequestCodeExtraIndex(freefunc);
+
+
 extern void _Py_FinishPendingCalls(PyThreadState *tstate);
 extern void _PyEval_InitRuntimeState(struct _ceval_runtime_state *);
 extern void _PyEval_InitState(struct _ceval_state *, PyThread_type_lock);

--- a/Misc/NEWS.d/next/C API/2022-02-24-16-39-59.bpo-46850.mQcF8i.rst
+++ b/Misc/NEWS.d/next/C API/2022-02-24-16-39-59.bpo-46850.mQcF8i.rst
@@ -1,0 +1,17 @@
+Remove the following ``_PyEval`` private functions (moved to the internal C
+API headers):
+
+* ``_PyEval_CallTracing()``
+* ``_PyEval_EvalFrameDefault()``
+* ``_PyEval_GetAsyncGenFinalizer()``
+* ``_PyEval_GetAsyncGenFirstiter()``
+* ``_PyEval_GetCoroutineOriginTrackingDepth()``
+* ``_PyEval_GetSwitchInterval()``
+* ``_PyEval_RequestCodeExtraIndex()``
+* ``_PyEval_SetAsyncGenFinalizer()``
+* ``_PyEval_SetAsyncGenFirstiter()``
+* ``_PyEval_SetProfile()``
+* ``_PyEval_SetSwitchInterval()``
+* ``_PyEval_SetTrace()``
+
+Patch by Victor Stinner.

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -4,6 +4,7 @@
 
 #include "Python.h"
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
+#include "pycore_ceval.h"         // _PyEval_SetProfile()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "rotatingtree.h"
 


### PR DESCRIPTION
Move the following private functions to the internal C API:

* _PyEval_CallTracing()
* _PyEval_EvalFrameDefault()
* _PyEval_GetAsyncGenFinalizer()
* _PyEval_GetAsyncGenFirstiter()
* _PyEval_GetCoroutineOriginTrackingDepth()
* _PyEval_GetSwitchInterval()
* _PyEval_RequestCodeExtraIndex()
* _PyEval_SetAsyncGenFinalizer()
* _PyEval_SetAsyncGenFirstiter()
* _PyEval_SetProfile()
* _PyEval_SetSwitchInterval()
* _PyEval_SetTrace()

_PyEval_EvalFrameDefault() uses "struct _interpreter_frame" which is
part of the internal C API.

Keep the following functions in Include/cpython/ceval.h:

* _PyEval_GetBuiltin()
* _PyEval_GetBuiltinId()
* _PyEval_SliceIndex()
* _PyEval_SliceIndexNotNone()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46850](https://bugs.python.org/issue46850) -->
https://bugs.python.org/issue46850
<!-- /issue-number -->
