### PR TITLE
bpo-40421: Fix PyFrame_GetCode() documentation

### DIFF
--- a/Doc/c-api/reflection.rst
+++ b/Doc/c-api/reflection.rst
@@ -31,7 +31,7 @@ Reflection
    See also :c:func:`PyThreadState_GetFrame`.
 
 
-.. c:function:: int PyFrame_GetBack(PyFrameObject *frame)
+.. c:function:: PyFrameObject* PyFrame_GetBack(PyFrameObject *frame)
 
    Get the *frame* next outer frame.
 
@@ -42,7 +42,7 @@ Reflection
    .. versionadded:: 3.9
 
 
-.. c:function:: int PyFrame_GetCode(PyFrameObject *frame)
+.. c:function:: PyCodeObject* PyFrame_GetCode(PyFrameObject *frame)
 
    Get the *frame* code.
 


### PR DESCRIPTION
Fix PyFrame_GetBack() and PyFrame_GetCode() return type in
the documentation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40421](https://bugs.python.org/issue40421) -->
https://bugs.python.org/issue40421
<!-- /issue-number -->
