### PR TITLE
bpo-45459: Fix object.h: don't define PyObject type twice

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -102,11 +102,11 @@ typedef struct _typeobject PyTypeObject;
  * by hand.  Similarly every pointer to a variable-size Python object can,
  * in addition, be cast to PyVarObject*.
  */
-typedef struct _object {
+struct _object {
     _PyObject_HEAD_EXTRA
     Py_ssize_t ob_refcnt;
     PyTypeObject *ob_type;
-} PyObject;
+};
 
 /* Cast argument to PyObject* type. */
 #define _PyObject_CAST(op) ((PyObject*)(op))

--- a/Include/pybuffer.h
+++ b/Include/pybuffer.h
@@ -6,6 +6,10 @@
 extern "C" {
 #endif
 
+// Forward declaration to be able to include pybuffer.h before object.h:
+// pybuffer.h uses PyObject and object.h uses Py_buffer.
+typedef struct _object PyObject;
+
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030b0000
 
 /* === New Buffer API ============================================
@@ -16,10 +20,6 @@ extern "C" {
  * break the ABI.
  *
  */
-
-// Forward declaration to be able to include pybuffer.h before object.h:
-// pybuffer.h uses PyObject and object.h uses Py_buffer.
-typedef struct _object PyObject;
 
 typedef struct {
     void *buf;


### PR DESCRIPTION
It's already defined in pybuffer.h.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45459](https://bugs.python.org/issue45459) -->
https://bugs.python.org/issue45459
<!-- /issue-number -->
