### PR TITLE
bpo-34429: Noted TemporaryFile behavior on non-Posix/non-Cygwin systems

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -62,8 +62,8 @@ The module defines the following user-callable items:
    The :py:data:`os.O_TMPFILE` flag is used if it is available and works
    (Linux-specific, requires Linux kernel 3.11 or later).
 
-   On platforms that are neither Posix nor Cygwin, TemporaryFile behaves exactly
-   like NamedTemporaryFile.
+   On platforms that are neither Posix nor Cygwin, TemporaryFile is an alias
+   for NamedTemporaryFile.
 
    .. audit-event:: tempfile.mkstemp fullpath tempfile.TemporaryFile
 

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -62,6 +62,9 @@ The module defines the following user-callable items:
    The :py:data:`os.O_TMPFILE` flag is used if it is available and works
    (Linux-specific, requires Linux kernel 3.11 or later).
 
+   On platforms that are neither Posix nor Cygwin, TemporaryFile behaves exactly
+   like NamedTemporaryFile.
+
    .. audit-event:: tempfile.mkstemp fullpath tempfile.TemporaryFile
 
    .. versionchanged:: 3.5


### PR DESCRIPTION
I applied the suggested wording, but is it be accurate to say `TemporaryFile` 'behaves exactly like' `NamedTemporaryFile`? Saying 'behaves exactly like' seems to imply that `TemporaryFile` is an imitation of sorts, while the implementation of `TemporaryFile = NamedTemporaryFile` would appear to make them completely identical

<!-- issue-number: [bpo-34429](https://bugs.python.org/issue34429) -->
https://bugs.python.org/issue34429
<!-- /issue-number -->
