### PR TITLE
bpo-30677: [doc] mention that os.mkdir() can raise FileNotFoundError

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2051,7 +2051,7 @@ features:
    Create a directory named *path* with numeric mode *mode*.
 
    If the directory already exists, :exc:`FileExistsError` is raised. If a parent
-   directory in the path doesn't exist, :exc:`FileNotFoundError` is raised.
+   directory in the path does not exist, :exc:`FileNotFoundError` is raised.
 
    .. _mkdir_modebits:
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2050,7 +2050,8 @@ features:
 
    Create a directory named *path* with numeric mode *mode*.
 
-   If the directory already exists, :exc:`FileExistsError` is raised.
+   If the directory already exists, :exc:`FileExistsError` is raised. If a parent
+   directory in the path doesn't exist, :exc:`FileNotFoundError` is raised.
 
    .. _mkdir_modebits:
 


### PR DESCRIPTION
Used the 'parent directory' wording to mirror [mkdir's](https://man7.org/linux/man-pages/man1/mkdir.1.html) `-p` flag in bash, though [`os.makedirs()`](https://docs.python.org/3/library/os.html#os.makedirs) says `...intermediate-level directories...`, so another option's to say

```
If an intermediate-level directory in the path ...
```

However, both 'intermediate' and 'parent' are used throughout the document so not too certain which one's preferred here. 

<!-- issue-number: [bpo-30677](https://bugs.python.org/issue30677) -->
https://bugs.python.org/issue30677
<!-- /issue-number -->
