### PR TITLE
bpo-46430: fix memory leak in interned strings of deep-frozen modules

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -65,7 +65,7 @@ extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 extern PyStatus _PyImportZip_Init(PyThreadState *tstate);
 extern PyStatus _PyGC_Init(PyInterpreterState *interp);
 extern PyStatus _PyAtExit_Init(PyInterpreterState *interp);
-
+extern void _Py_Deepfreeze_Init(void);
 
 /* Various internal finalizers */
 

--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-24-07-33-29.bpo-46430.c91TAg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-24-07-33-29.bpo-46430.c91TAg.rst
@@ -1,0 +1,1 @@
+Fix memory leak in interned strings of deep-frozen modules.

--- a/Programs/_bootstrap_python.c
+++ b/Programs/_bootstrap_python.c
@@ -14,9 +14,13 @@
 #include "Python/frozen_modules/importlib._bootstrap_external.h"
 /* End includes */
 
-/* Empty finalizer for deepfrozen modules*/
+/* Empty initializer for deepfrozen modules */
+void _Py_Deepfreeze_Init(void)
+{
+}
+/* Empty finalizer for deepfrozen modules */
 void
-_Py_Deepfreeze_Fini(void) 
+_Py_Deepfreeze_Fini(void)
 {
 }
 

--- a/Programs/_freeze_module.c
+++ b/Programs/_freeze_module.c
@@ -22,6 +22,10 @@
 #include <unistd.h>
 #endif
 
+/* Empty initializer for deepfrozen modules */
+void _Py_Deepfreeze_Init(void)
+{
+}
 /* Empty finalizer for deepfrozen modules */
 void
 _Py_Deepfreeze_Fini(void)

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -754,7 +754,6 @@ pycore_init_types(PyInterpreterState *interp)
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
-
     return _PyStatus_OK();
 }
 
@@ -827,7 +826,10 @@ pycore_interp_init(PyThreadState *tstate)
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
-
+    // Intern strings in deep-frozen modules first so that others
+    // can use it instead of creating a heap allocated string.
+    _Py_Deepfreeze_Init();
+    
     status = pycore_init_types(interp);
     if (_PyStatus_EXCEPTION(status)) {
         goto done;


### PR DESCRIPTION
Valgrind log after fix:
```console
==17044== 
==17044== HEAP SUMMARY:
==17044==     in use at exit: 0 bytes in 0 blocks
==17044==   total heap usage: 18,385 allocs, 18,385 frees, 2,558,621 bytes allocated
==17044== 
==17044== All heap blocks were freed -- no leaks are possible
==17044== 
==17044== Use --track-origins=yes to see where uninitialised values come from
==17044== For lists of detected and suppressed errors, rerun with: -s
==17044== ERROR SUMMARY: 39 errors from 11 contexts (suppressed: 0 from 0)

```

Python output:
```console
@kumaraditya303 ➜ /workspaces/cpython (mem ✗) $ ./python -X showrefcount -c pass
[0 refs, 0 blocks]
```



<!-- issue-number: [bpo-46430](https://bugs.python.org/issue46430) -->
https://bugs.python.org/issue46430
<!-- /issue-number -->
