### PR TITLE
gh-56374: Clarify nonlocal scope definition

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -1004,10 +1004,10 @@ When the definition of a function or class is nested within the definitions of
 other functions, its nonlocal scopes are the local scopes of the enclosing
 function. The :keyword:`nonlocal` statement causes the listed identifiers to
 refer to previously bound variables in the nearest nonlocal enclosing scope,
-which excludes globals. This is important because the default behavior for
-binding is to search the local namespace first.  The statement allows
-encapsulated code to rebind variables outside of the local scope besides the
-global (module) scope.
+which excludes globals.
+This is important because the default behavior for binding is to search the
+local namespace first.  The statement allows encapsulated code to rebind
+variables outside of the local scope besides the global (module) scope.
 
 .. XXX not implemented
    The :keyword:`nonlocal` statement may prepend an assignment or augmented

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -1019,7 +1019,7 @@ enclosing scope, otherwise a ``SyntaxError`` is raised (the scope in which a new
 binding should be created cannot be determined unambiguously).
 
 Names listed in a :keyword:`nonlocal` statement must not collide with
-pre-existing bindings in the local scope, otherwise a ``SyntaxError` is raised.
+pre-existing bindings in the local scope, otherwise a ``SyntaxError`` is raised.
 
 .. seealso::
 

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -1000,11 +1000,11 @@ The :keyword:`!nonlocal` statement
                 : ["=" (`target_list` "=")+ starred_expression]
                 : | "nonlocal" identifier augop expression_list
 
-When the definition of a function or class is nested within the definitions of
-other functions, its nonlocal scopes are the local scopes of the enclosing
-function. The :keyword:`nonlocal` statement causes the listed identifiers to
-refer to previously bound variables in the nearest nonlocal enclosing scope,
-which excludes globals.
+When a function or class definition is nested within other function definitions,
+its nonlocal scopes are the local scopes of the enclosing function.
+The :keyword:`nonlocal` statement causes the listed identifiers to
+refer to names previously bound in nonlocal enclosing scope.
+If the name is bound in more than one nonlocal scope, the nearest binding is used.
 This is important because the default behavior for binding is to search the
 local namespace first.  The statement allows encapsulated code to rebind
 variables outside of the local scope besides the global (module) scope.
@@ -1015,11 +1015,11 @@ variables outside of the local scope besides the global (module) scope.
 
 Names listed in a :keyword:`nonlocal` statement, unlike those listed in a
 :keyword:`global` statement, must refer to pre-existing bindings in an
-enclosing scope (the scope in which a new binding should be created cannot
-be determined unambiguously).
+enclosing scope, otherwise a ``SyntaxError`` is raised (the scope in which a new
+binding should be created cannot be determined unambiguously).
 
 Names listed in a :keyword:`nonlocal` statement must not collide with
-pre-existing bindings in the local scope.
+pre-existing bindings in the local scope, otherwise a ``SyntaxError` is raised.
 
 .. seealso::
 

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -1001,13 +1001,14 @@ The :keyword:`!nonlocal` statement
                 : ["=" (`target_list` "=")+ starred_expression]
                 : | "nonlocal" identifier augop expression_list
 
-When the definition of a function is nested within the definitions of other
-functions, its nonlocal scopes are the local scopes of the enclosing function.
-The :keyword:`nonlocal` statement causes the listed identifiers to refer to
-previously bound variables in the nearest nonlocal enclosing scope, which
-excludes globals. This is important because the default behavior for binding is
-to search the local namespace first.  The statement allows encapsulated code to
-rebind variables outside of the local scope besides the global (module) scope.
+When the definition of a function or class is nested within the definitions of
+other functions, its nonlocal scopes are the local scopes of the enclosing
+function. The :keyword:`nonlocal` statement causes the listed identifiers to
+refer to previously bound variables in the nearest nonlocal enclosing scope,
+which excludes globals. This is important because the default behavior for
+binding is to search the local namespace first.  The statement allows
+encapsulated code to rebind variables outside of the local scope besides the
+global (module) scope.
 
 .. XXX not implemented
    The :keyword:`nonlocal` statement may prepend an assignment or augmented

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -961,8 +961,7 @@ Names listed in a :keyword:`global` statement must not be used in the same code
 block textually preceding that :keyword:`!global` statement.
 
 Names listed in a :keyword:`global` statement must not be defined as formal
-parameters, or as targets in :keyword:`with` statements or :keyword:`except`
-clauses, or in a :keyword:`for` target list, :keyword:`class`
+parameters, or as targets in :keyword:`with` statements or :keyword:`except` clauses, or in a :keyword:`for` target list, :keyword:`class`
 definition, function definition, :keyword:`import` statement, or variable
 annotation.
 

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -961,7 +961,8 @@ Names listed in a :keyword:`global` statement must not be used in the same code
 block textually preceding that :keyword:`!global` statement.
 
 Names listed in a :keyword:`global` statement must not be defined as formal
-parameters, or as targets in :keyword:`with` statements or :keyword:`except` clauses, or in a :keyword:`for` target list, :keyword:`class`
+parameters, or as targets in :keyword:`with` statements or :keyword:`except`
+clauses, or in a :keyword:`for` target list, :keyword:`class`
 definition, function definition, :keyword:`import` statement, or variable
 annotation.
 
@@ -1000,10 +1001,12 @@ The :keyword:`!nonlocal` statement
                 : ["=" (`target_list` "=")+ starred_expression]
                 : | "nonlocal" identifier augop expression_list
 
+When the definition of a function is nested within the definitions of other
+functions, its nonlocal scopes are the local scopes of the enclosing function.
 The :keyword:`nonlocal` statement causes the listed identifiers to refer to
-previously bound variables in the nearest enclosing scope excluding globals.
-This is important because the default behavior for binding is to search the
-local namespace first.  The statement allows encapsulated code to rebind
+previously bound variables in the nearest nonlocal enclosing scope, excluding
+globals. This is important because the default behavior for binding is to search
+the local namespace first.  The statement allows encapsulated code to rebind
 variables outside of the local scope besides the global (module) scope.
 
 .. XXX not implemented

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -1004,10 +1004,10 @@ The :keyword:`!nonlocal` statement
 When the definition of a function is nested within the definitions of other
 functions, its nonlocal scopes are the local scopes of the enclosing function.
 The :keyword:`nonlocal` statement causes the listed identifiers to refer to
-previously bound variables in the nearest nonlocal enclosing scope, excluding
-globals. This is important because the default behavior for binding is to search
-the local namespace first.  The statement allows encapsulated code to rebind
-variables outside of the local scope besides the global (module) scope.
+previously bound variables in the nearest nonlocal enclosing scope, which
+excludes globals. This is important because the default behavior for binding is
+to search the local namespace first.  The statement allows encapsulated code to
+rebind variables outside of the local scope besides the global (module) scope.
 
 .. XXX not implemented
    The :keyword:`nonlocal` statement may prepend an assignment or augmented


### PR DESCRIPTION
New comment to include this behavior:

```
def f():
    x = 1
    class T:
        nonlocal x
        x = 2
    T()
    print(x)
f()
```

prints 2

<!-- issue-number: [bpo-12165](https://bugs.python.org/issue12165) -->
https://bugs.python.org/issue12165
<!-- /issue-number -->


<!-- gh-issue-number: gh-56374 -->
* Issue: gh-56374
<!-- /gh-issue-number -->
