### PR TITLE
bpo-46748: Don't import <stdbool.h> in public headers

### DIFF
--- a/Include/cpython/import.h
+++ b/Include/cpython/import.h
@@ -32,7 +32,7 @@ struct _frozen {
     const char *name;                 /* ASCII encoded string */
     const unsigned char *code;
     int size;
-    bool is_package;
+    int is_package;
     PyObject *(*get_code)(void);
 };
 

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -2,8 +2,6 @@
 #  error "this header file must not be included directly"
 #endif
 
-#include <stdbool.h>
-
 
 PyAPI_FUNC(int) _PyInterpreterState_RequiresIDRef(PyInterpreterState *);
 PyAPI_FUNC(void) _PyInterpreterState_RequireIDRef(PyInterpreterState *, int);
@@ -94,7 +92,7 @@ struct _ts {
     int _initialized;
 
     /* Was this thread state statically allocated? */
-    bool _static;
+    int _static;
 
     int recursion_remaining;
     int recursion_limit;

--- a/Misc/NEWS.d/next/C API/2022-02-24-13-13-16.bpo-46748.aG1zb3.rst
+++ b/Misc/NEWS.d/next/C API/2022-02-24-13-13-16.bpo-46748.aG1zb3.rst
@@ -1,0 +1,2 @@
+Python's public headers no longer import ``<stdbool.h>``, leaving code that
+embedd/extends Python free to define ``bool``, ``true`` and ``false``.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -40,6 +40,9 @@
 #  error "_testcapi must test the public Python C API, not CPython internal C API"
 #endif
 
+#ifdef bool
+#  error "The public headers should not include <stdbool.h>, see bpo-46748"
+#endif
 
 // Forward declarations
 static struct PyModuleDef _testcapimodule;

--- a/Python/frozen.c
+++ b/Python/frozen.c
@@ -38,6 +38,8 @@
 #include "Python.h"
 #include "pycore_import.h"
 
+#include <stdbool.h>
+
 /* Includes for frozen modules: */
 /* End includes */
 

--- a/Tools/freeze/makefreeze.py
+++ b/Tools/freeze/makefreeze.py
@@ -45,9 +45,9 @@ def makefreeze(base, dict, debug=0, entry_point=None, fail_import=()):
                     print("freezing", mod, "...")
                 str = marshal.dumps(m.__code__)
                 size = len(str)
-                is_package = 'false'
+                is_package = '0'
                 if m.__path__:
-                    is_package = 'true'
+                    is_package = '1'
                 done.append((mod, mangled, size, is_package))
                 writecode(outfp, mangled, str)
     if debug:


### PR DESCRIPTION
``<stdbool.h>`` is the standard/modern way to define embedd/extends Python free to define ``bool``, ``true`` and ``false``, but there are existing applications that use slightly different redefinitions, which fail if the header is included.

It's OK to use stdbool outside the public headers, though.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46748](https://bugs.python.org/issue46748) -->
https://bugs.python.org/issue46748
<!-- /issue-number -->

Automerge-Triggered-By: GH:encukou