### PR TITLE
bpo-46848: Optimize mmap.find() with memmem(3)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-24-15-03-47.bpo-46848.Vh51d9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-24-15-03-47.bpo-46848.Vh51d9.rst
@@ -1,0 +1,2 @@
+``mmap.find()`` was optimized by using libc's ``memmem(3)`` function (which is optimized) instead of using a trivial ``for`` loop.
+For trivial use cases, such as counting new lines in a large file, the performance boost can be up to 100%.

--- a/configure
+++ b/configure
@@ -14118,6 +14118,42 @@ fi
 
 
 
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for memmem" >&5
+$as_echo_n "checking for memmem... " >&6; }
+if ${ac_cv_func_memmem+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <string.h>
+int
+main ()
+{
+void *x=memmem
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_memmem=yes
+else
+  ac_cv_func_memmem=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_memmem" >&5
+$as_echo "$ac_cv_func_memmem" >&6; }
+  if test "x$ac_cv_func_memmem" = xyes; then :
+
+$as_echo "#define HAVE_MEMMEM 1" >>confdefs.h
+
+fi
+
+
+
+
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for kqueue" >&5
 $as_echo_n "checking for kqueue... " >&6; }
 if ${ac_cv_func_kqueue+:} false; then :

--- a/configure.ac
+++ b/configure.ac
@@ -4215,6 +4215,7 @@ PY_CHECK_FUNC([fsync], [#include <unistd.h>])
 PY_CHECK_FUNC([fdatasync], [#include <unistd.h>])
 PY_CHECK_FUNC([epoll_create], [#include <sys/epoll.h>], [HAVE_EPOLL])
 PY_CHECK_FUNC([epoll_create1], [#include <sys/epoll.h>])
+PY_CHECK_FUNC([memmem], [#include <string.h>], [HAVE_MEMMEM])
 PY_CHECK_FUNC([kqueue],[
 #include <sys/types.h>
 #include <sys/event.h>

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -733,6 +733,9 @@
 /* Define if you have the 'memfd_create' function. */
 #undef HAVE_MEMFD_CREATE
 
+/* Define if you have the 'memmem' function. */
+#undef HAVE_MEMMEM
+
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 


### PR DESCRIPTION
This merge requests optimizes `mmap.find()` by using libc's `memmem(3)` function (which is optimized) instead of using a trivial for loop. I could not find an equivalent solution for `mmap.rfind()` yet. 

The following snippet runs 100% faster with this patch applied. The file used is a logfile of 2.3 GB size

``` python
with open(sys.argv[1], 'r+b') as file_:
    with mmap.mmap(file_.fileno(), 0, access=mmap.ACCESS_READ) as file:
        cur_offset = 0
        while True:
            cur_offset = file.find(b"\n", cur_offset)
            if cur_offset == -1:
                break
            cur_offset += 1
```


With this patch applied:
```
rumpelsepp@kronos ~/P/v/c/debug (main)> time ./python test.py /tmp/log

________________________________________________________
Executed in    3,12 secs    fish           external
   usr time    2,94 secs    1,34 millis    2,94 secs
   sys time    0,15 secs    0,00 millis    0,15 secs

```

Without this patch:
```
rumpelsepp@kronos ~/P/v/c/debug (mmap)> time ./python test.py /tmp/log

________________________________________________________
Executed in    6,47 secs    fish           external
   usr time    6,53 secs  248,91 millis    6,29 secs
   sys time    0,18 secs   32,26 millis    0,15 secs
```

<!-- issue-number: [bpo-46848](https://bugs.python.org/issue46848) -->
https://bugs.python.org/issue46848
<!-- /issue-number -->
