### PR TITLE
bpo-46656: Building Python now requires a C11 compiler

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -618,6 +618,9 @@ Changes in the Python API
 Build Changes
 =============
 
+* Building Python now requires a C11 compiler without optional C11 features.
+  (Contributed by Victor Stinner in :issue:`46656`.)
+
 * CPython can now be built with the ThinLTO option via ``--with-lto=thin``.
   (Contributed by Dong-hee Na and Brett Holman in :issue:`44340`.)
 

--- a/Misc/NEWS.d/next/Build/2022-02-25-00-51-16.bpo-46656.MD783M.rst
+++ b/Misc/NEWS.d/next/Build/2022-02-25-00-51-16.bpo-46656.MD783M.rst
@@ -1,0 +1,2 @@
+Building Python now requires a C11 compiler without optional C11 features.
+Patch by Victor Stinner.


### PR DESCRIPTION
See PEP 7: https://python.github.io/peps/pep-0007/#c-dialect


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46656](https://bugs.python.org/issue46656) -->
https://bugs.python.org/issue46656
<!-- /issue-number -->
