### PR TITLE
bpo-46752: Taskgroup tweaks

### DIFF
--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -66,31 +66,28 @@ class TaskGroup:
                 self._base_error is None):
             self._base_error = exc
 
-        if et is exceptions.CancelledError:
-            if self._parent_cancel_requested:
-                # Only if we did request task to cancel ourselves
-                # we mark it as no longer cancelled.
-                self._parent_task.uncancel()
-            else:
-                propagate_cancellation_error = et
-
-        if et is not None and not self._aborting:
-            # Our parent task is being cancelled:
-            #
-            #    async with TaskGroup() as g:
-            #        g.create_task(...)
-            #        await ...  # <- CancelledError
-            #
+        if et is not None:
             if et is exceptions.CancelledError:
-                propagate_cancellation_error = et
+                if self._parent_cancel_requested and not self._parent_task.uncancel():
+                    # Do nothing, i.e. swallow the error.
+                    pass
+                else:
+                    propagate_cancellation_error = exc
 
-            # or there's an exception in "async with":
-            #
-            #    async with TaskGroup() as g:
-            #        g.create_task(...)
-            #        1 / 0
-            #
-            self._abort()
+            if not self._aborting:
+                # Our parent task is being cancelled:
+                #
+                #    async with TaskGroup() as g:
+                #        g.create_task(...)
+                #        await ...  # <- CancelledError
+                #
+                # or there's an exception in "async with":
+                #
+                #    async with TaskGroup() as g:
+                #        g.create_task(...)
+                #        1 / 0
+                #
+                self._abort()
 
         # We use while-loop here because "self._on_completed_fut"
         # can be cancelled multiple times if our parent task
@@ -118,7 +115,6 @@ class TaskGroup:
             self._on_completed_fut = None
 
         assert self._unfinished_tasks == 0
-        self._on_completed_fut = None  # no longer needed
 
         if self._base_error is not None:
             raise self._base_error
@@ -199,8 +195,7 @@ class TaskGroup:
             })
             return
 
-        self._abort()
-        if not self._parent_task.cancelling():
+        if not self._aborting and not self._parent_cancel_requested:
             # If parent task *is not* being cancelled, it means that we want
             # to manually cancel it to abort whatever is being run right now
             # in the TaskGroup.  But we want to mark parent task as
@@ -219,5 +214,6 @@ class TaskGroup:
             #            pass
             #        await something_else     # this line has to be called
             #                                 # after TaskGroup is finished.
+            self._abort()
             self._parent_cancel_requested = True
             self._parent_task.cancel()


### PR DESCRIPTION
Here are some taskgroup tweaks, mostly from the cancellation changes and @gvanrossum 's comments in https://github.com/python/cpython/pull/31513#issuecomment-1049232006.

* check the return value of `.uncancel()` to decide whether to propagate the CancelledError
* propagate the CancelledError exception properly in some cases
* `_abort()` only once, instead of potentially multiple times (unsure if it could've happened in reality)
* renamed a couple of tests that I worked on to be a little more descriptive

<!-- issue-number: [bpo-46752](https://bugs.python.org/issue46752) -->
https://bugs.python.org/issue46752
<!-- /issue-number -->
