### PR TITLE
bpo-45316: Move private PyCode C API to internal C API

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -174,13 +174,6 @@ PyAPI_FUNC(int) PyCode_Addr2Line(PyCodeObject *, int);
 
 PyAPI_FUNC(int) PyCode_Addr2Location(PyCodeObject *, int, int *, int *, int *, int *);
 
-/* Return the ending source code line number from a bytecode index. */
-PyAPI_FUNC(int) _PyCode_Addr2EndLine(PyCodeObject *, int);
-/* Return the starting source code column offset from a bytecode index. */
-PyAPI_FUNC(int) _PyCode_Addr2Offset(PyCodeObject *, int);
-/* Return the ending source code column offset from a bytecode index. */
-PyAPI_FUNC(int) _PyCode_Addr2EndOffset(PyCodeObject *, int);
-
 /* for internal use only */
 struct _opaque {
     int computed_line;
@@ -217,15 +210,3 @@ PyAPI_FUNC(int) _PyCode_GetExtra(PyObject *code, Py_ssize_t index,
                                  void **extra);
 PyAPI_FUNC(int) _PyCode_SetExtra(PyObject *code, Py_ssize_t index,
                                  void *extra);
-
-/** API for initializing the line number tables. */
-int _PyCode_InitAddressRange(PyCodeObject* co, PyCodeAddressRange *bounds);
-int _PyCode_InitEndAddressRange(PyCodeObject* co, PyCodeAddressRange* bounds);
-
-/** Out of process API for initializing the line number table. */
-void PyLineTable_InitAddressRange(const char *linetable, Py_ssize_t length, int firstlineno, PyCodeAddressRange *range);
-
-/** API for traversing the line number table. */
-int PyLineTable_NextAddressRange(PyCodeAddressRange *range);
-int PyLineTable_PreviousAddressRange(PyCodeAddressRange *range);
-

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -259,9 +259,35 @@ PyAPI_FUNC(PyCodeObject *) _PyCode_New(struct _PyCodeConstructor *);
 /* Private API */
 
 /* Getters for internal PyCodeObject data. */
-PyAPI_FUNC(PyObject *) _PyCode_GetVarnames(PyCodeObject *);
-PyAPI_FUNC(PyObject *) _PyCode_GetCellvars(PyCodeObject *);
-PyAPI_FUNC(PyObject *) _PyCode_GetFreevars(PyCodeObject *);
+extern PyObject* _PyCode_GetVarnames(PyCodeObject *);
+extern PyObject* _PyCode_GetCellvars(PyCodeObject *);
+extern PyObject* _PyCode_GetFreevars(PyCodeObject *);
+
+/* Return the ending source code line number from a bytecode index. */
+extern int _PyCode_Addr2EndLine(PyCodeObject *, int);
+
+/* Return the ending source code line number from a bytecode index. */
+extern int _PyCode_Addr2EndLine(PyCodeObject *, int);
+/* Return the starting source code column offset from a bytecode index. */
+extern int _PyCode_Addr2Offset(PyCodeObject *, int);
+/* Return the ending source code column offset from a bytecode index. */
+extern int _PyCode_Addr2EndOffset(PyCodeObject *, int);
+
+/** API for initializing the line number tables. */
+extern int _PyCode_InitAddressRange(PyCodeObject* co, PyCodeAddressRange *bounds);
+extern int _PyCode_InitEndAddressRange(PyCodeObject* co, PyCodeAddressRange* bounds);
+
+/** Out of process API for initializing the line number table. */
+extern void _PyLineTable_InitAddressRange(
+    const char *linetable,
+    Py_ssize_t length,
+    int firstlineno,
+    PyCodeAddressRange *range);
+
+/** API for traversing the line number table. */
+extern int _PyLineTable_NextAddressRange(PyCodeAddressRange *range);
+extern int _PyLineTable_PreviousAddressRange(PyCodeAddressRange *range);
+
 
 #define ADAPTIVE_CACHE_BACKOFF 64
 
@@ -272,26 +298,26 @@ cache_backoff(_PyAdaptiveEntry *entry) {
 
 /* Specialization functions */
 
-int _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, SpecializedCacheEntry *cache);
-int _Py_Specialize_StoreAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, SpecializedCacheEntry *cache);
-int _Py_Specialize_LoadGlobal(PyObject *globals, PyObject *builtins, _Py_CODEUNIT *instr, PyObject *name, SpecializedCacheEntry *cache);
-int _Py_Specialize_LoadMethod(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, SpecializedCacheEntry *cache);
-int _Py_Specialize_BinarySubscr(PyObject *sub, PyObject *container, _Py_CODEUNIT *instr, SpecializedCacheEntry *cache);
-int _Py_Specialize_StoreSubscr(PyObject *container, PyObject *sub, _Py_CODEUNIT *instr);
-int _Py_Specialize_Call(PyObject *callable, _Py_CODEUNIT *instr, int nargs,
+extern int _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, SpecializedCacheEntry *cache);
+extern int _Py_Specialize_StoreAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, SpecializedCacheEntry *cache);
+extern int _Py_Specialize_LoadGlobal(PyObject *globals, PyObject *builtins, _Py_CODEUNIT *instr, PyObject *name, SpecializedCacheEntry *cache);
+extern int _Py_Specialize_LoadMethod(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name, SpecializedCacheEntry *cache);
+extern int _Py_Specialize_BinarySubscr(PyObject *sub, PyObject *container, _Py_CODEUNIT *instr, SpecializedCacheEntry *cache);
+extern int _Py_Specialize_StoreSubscr(PyObject *container, PyObject *sub, _Py_CODEUNIT *instr);
+extern int _Py_Specialize_Call(PyObject *callable, _Py_CODEUNIT *instr, int nargs,
     PyObject *kwnames, SpecializedCacheEntry *cache);
-int _Py_Specialize_Precall(PyObject *callable, _Py_CODEUNIT *instr, int nargs,
+extern int _Py_Specialize_Precall(PyObject *callable, _Py_CODEUNIT *instr, int nargs,
     PyObject *kwnames, SpecializedCacheEntry *cache, PyObject *builtins);
-void _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
+extern void _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
                              int oparg);
-void _Py_Specialize_CompareOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr, SpecializedCacheEntry *cache);
-void _Py_Specialize_UnpackSequence(PyObject *seq, _Py_CODEUNIT *instr,
+extern void _Py_Specialize_CompareOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr, SpecializedCacheEntry *cache);
+extern void _Py_Specialize_UnpackSequence(PyObject *seq, _Py_CODEUNIT *instr,
                                    SpecializedCacheEntry *cache);
 
 /* Deallocator function for static codeobjects used in deepfreeze.py */
-void _PyStaticCode_Dealloc(PyCodeObject *co);
+extern void _PyStaticCode_Dealloc(PyCodeObject *co);
 /* Function to intern strings of codeobjects */
-void _PyStaticCode_InternStrings(PyCodeObject *co);
+extern void _PyStaticCode_InternStrings(PyCodeObject *co);
 
 #ifdef Py_STATS
 
@@ -343,9 +369,9 @@ extern PyStats _py_stats;
 #define CALL_STAT_INC(name) _py_stats.call_stats.name++
 #define OBJECT_STAT_INC(name) _py_stats.object_stats.name++
 
-void _Py_PrintSpecializationStats(int to_file);
+extern void _Py_PrintSpecializationStats(int to_file);
 
-PyAPI_FUNC(PyObject*) _Py_GetSpecializationStats(void);
+extern PyObject* _Py_GetSpecializationStats(void);
 
 #else
 #define STAT_INC(opname, name) ((void)0)

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -676,7 +676,7 @@ _PyCode_Addr2EndOffset(PyCodeObject* co, int addrq)
 }
 
 void
-PyLineTable_InitAddressRange(const char *linetable, Py_ssize_t length, int firstlineno, PyCodeAddressRange *range)
+_PyLineTable_InitAddressRange(const char *linetable, Py_ssize_t length, int firstlineno, PyCodeAddressRange *range)
 {
     range->opaque.lo_next = linetable;
     range->opaque.limit = range->opaque.lo_next + length;
@@ -691,7 +691,7 @@ _PyCode_InitAddressRange(PyCodeObject* co, PyCodeAddressRange *bounds)
 {
     const char *linetable = PyBytes_AS_STRING(co->co_linetable);
     Py_ssize_t length = PyBytes_GET_SIZE(co->co_linetable);
-    PyLineTable_InitAddressRange(linetable, length, co->co_firstlineno, bounds);
+    _PyLineTable_InitAddressRange(linetable, length, co->co_firstlineno, bounds);
     return bounds->ar_line;
 }
 
@@ -700,7 +700,7 @@ _PyCode_InitEndAddressRange(PyCodeObject* co, PyCodeAddressRange* bounds)
 {
     char* linetable = PyBytes_AS_STRING(co->co_endlinetable);
     Py_ssize_t length = PyBytes_GET_SIZE(co->co_endlinetable);
-    PyLineTable_InitAddressRange(linetable, length, co->co_firstlineno, bounds);
+    _PyLineTable_InitAddressRange(linetable, length, co->co_firstlineno, bounds);
     return bounds->ar_line;
 }
 
@@ -710,12 +710,12 @@ int
 _PyCode_CheckLineNumber(int lasti, PyCodeAddressRange *bounds)
 {
     while (bounds->ar_end <= lasti) {
-        if (!PyLineTable_NextAddressRange(bounds)) {
+        if (!_PyLineTable_NextAddressRange(bounds)) {
             return -1;
         }
     }
     while (bounds->ar_start > lasti) {
-        if (!PyLineTable_PreviousAddressRange(bounds)) {
+        if (!_PyLineTable_PreviousAddressRange(bounds)) {
             return -1;
         }
     }
@@ -765,7 +765,7 @@ at_end(PyCodeAddressRange *bounds) {
 }
 
 int
-PyLineTable_PreviousAddressRange(PyCodeAddressRange *range)
+_PyLineTable_PreviousAddressRange(PyCodeAddressRange *range)
 {
     if (range->ar_start <= 0) {
         return 0;
@@ -779,7 +779,7 @@ PyLineTable_PreviousAddressRange(PyCodeAddressRange *range)
 }
 
 int
-PyLineTable_NextAddressRange(PyCodeAddressRange *range)
+_PyLineTable_NextAddressRange(PyCodeAddressRange *range)
 {
     if (at_end(range)) {
         return 0;
@@ -847,7 +847,7 @@ decode_linetable(PyCodeObject *code)
         return NULL;
     }
     _PyCode_InitAddressRange(code, &bounds);
-    while (PyLineTable_NextAddressRange(&bounds)) {
+    while (_PyLineTable_NextAddressRange(&bounds)) {
         if (bounds.opaque.computed_line != line) {
             int bdelta = bounds.ar_start - code_offset;
             int ldelta = bounds.opaque.computed_line - line;
@@ -883,7 +883,7 @@ static PyObject *
 lineiter_next(lineiterator *li)
 {
     PyCodeAddressRange *bounds = &li->li_line;
-    if (!PyLineTable_NextAddressRange(bounds)) {
+    if (!_PyLineTable_NextAddressRange(bounds)) {
         return NULL;
     }
     PyObject *start = NULL;

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -377,9 +377,9 @@ marklines(PyCodeObject *code, int len)
         linestarts[i] = -1;
     }
 
-    while (PyLineTable_NextAddressRange(&bounds)) {
-        assert(bounds.ar_start/(int)sizeof(_Py_CODEUNIT) < len);
-        linestarts[bounds.ar_start/sizeof(_Py_CODEUNIT)] = bounds.ar_line;
+    while (_PyLineTable_NextAddressRange(&bounds)) {
+        assert(bounds.ar_start / (int)sizeof(_Py_CODEUNIT) < len);
+        linestarts[bounds.ar_start / sizeof(_Py_CODEUNIT)] = bounds.ar_line;
     }
     return linestarts;
 }


### PR DESCRIPTION
Rename private functions (no exported), add an underscore prefix:

* PyLineTable_InitAddressRange() => _PyLineTable_InitAddressRange()
* PyLineTable_NextAddressRange() => _PyLineTable_NextAddressRange()
* PyLineTable_PreviousAddressRange() => _PyLineTable_PreviousAddressRange()

Move private functions to the internal C API:

* _PyCode_Addr2EndLine()
* _PyCode_Addr2EndOffset()
* _PyCode_Addr2Offset()
* _PyCode_InitAddressRange()
* _PyCode_InitEndAddressRange(
* _PyLineTable_InitAddressRange()
* _PyLineTable_NextAddressRange()
* _PyLineTable_PreviousAddressRange()

No longer export the following internal functions:

* _PyCode_GetVarnames()
* _PyCode_GetCellvars()
* _PyCode_GetFreevars()
* _Py_GetSpecializationStats()

Add "extern" to pycore_code.h functions to identify them more easiliy
(they are still not exported).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45316](https://bugs.python.org/issue45316) -->
https://bugs.python.org/issue45316
<!-- /issue-number -->
