### PR TITLE
bpo-45316: Move private functions to internal C API

### DIFF
--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -13,11 +13,6 @@ PyAPI_DATA(PyTypeObject) PyFrame_Type;
 PyAPI_FUNC(PyFrameObject *) PyFrame_New(PyThreadState *, PyCodeObject *,
                                         PyObject *, PyObject *);
 
-/* only internal use */
-PyFrameObject*
-_PyFrame_New_NoTrack(PyCodeObject *code);
-
-
 /* The rest of the interface is specific for frame objects */
 
 /* Conversions between "fast locals" and locals in dictionary */

--- a/Include/cpython/funcobject.h
+++ b/Include/cpython/funcobject.h
@@ -82,8 +82,6 @@ PyAPI_FUNC(PyObject *) _PyFunction_Vectorcall(
     size_t nargsf,
     PyObject *kwnames);
 
-uint32_t _PyFunction_GetVersionForCurrentState(PyFunctionObject *func);
-
 /* Macros for direct access to these values. Type checks are *not*
    done, so use with care. */
 #define PyFunction_GET_CODE(func) \

--- a/Include/cpython/genobject.h
+++ b/Include/cpython/genobject.h
@@ -45,7 +45,6 @@ PyAPI_FUNC(PyObject *) PyGen_NewWithQualName(PyFrameObject *,
     PyObject *name, PyObject *qualname);
 PyAPI_FUNC(int) _PyGen_SetStopIterationValue(PyObject *);
 PyAPI_FUNC(int) _PyGen_FetchStopIterationValue(PyObject **);
-PyObject *_PyGen_yf(PyGenObject *);
 PyAPI_FUNC(void) _PyGen_Finalize(PyObject *self);
 
 
@@ -59,7 +58,6 @@ PyAPI_DATA(PyTypeObject) PyCoro_Type;
 PyAPI_DATA(PyTypeObject) _PyCoroWrapper_Type;
 
 #define PyCoro_CheckExact(op) Py_IS_TYPE(op, &PyCoro_Type)
-PyObject *_PyCoro_GetAwaitableIter(PyObject *o);
 PyAPI_FUNC(PyObject *) PyCoro_New(PyFrameObject *,
     PyObject *name, PyObject *qualname);
 
@@ -79,8 +77,6 @@ PyAPI_FUNC(PyObject *) PyAsyncGen_New(PyFrameObject *,
     PyObject *name, PyObject *qualname);
 
 #define PyAsyncGen_CheckExact(op) Py_IS_TYPE(op, &PyAsyncGen_Type)
-
-PyObject *_PyAsyncGenValueWrapperNew(PyObject *);
 
 
 #undef _PyGenObject_HEAD

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -19,6 +19,8 @@ struct _frame {
     PyObject *_f_frame_data[1];
 };
 
+extern PyFrameObject* _PyFrame_New_NoTrack(PyCodeObject *code);
+
 /* runtime lifecycle */
 
 extern void _PyFrame_Fini(PyInterpreterState *interp);

--- a/Include/internal/pycore_function.h
+++ b/Include/internal/pycore_function.h
@@ -1,11 +1,18 @@
 #ifndef Py_INTERNAL_FUNCTION_H
 #define Py_INTERNAL_FUNCTION_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
 
-#include "Python.h"
+extern PyFunctionObject* _PyFunction_FromConstructor(PyFrameConstructor *constr);
 
-PyFunctionObject *
-_PyFunction_FromConstructor(PyFrameConstructor *constr);
+extern uint32_t _PyFunction_GetVersionForCurrentState(PyFunctionObject *func);
 
-
+#ifdef __cplusplus
+}
+#endif
 #endif /* !Py_INTERNAL_FUNCTION_H */

--- a/Include/internal/pycore_genobject.h
+++ b/Include/internal/pycore_genobject.h
@@ -8,6 +8,9 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+extern PyObject *_PyGen_yf(PyGenObject *);
+extern PyObject *_PyCoro_GetAwaitableIter(PyObject *o);
+extern PyObject *_PyAsyncGenValueWrapperNew(PyObject *);
 
 /* runtime lifecycle */
 

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1,6 +1,7 @@
 #include "Python.h"
 #include "pycore_code.h"
 #include "pycore_dict.h"
+#include "pycore_function.h"      // _PyFunction_GetVersionForCurrentState()
 #include "pycore_global_strings.h"  // _Py_ID()
 #include "pycore_long.h"
 #include "pycore_moduleobject.h"
@@ -1928,7 +1929,7 @@ void
 _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
                         int oparg)
 {
-    assert(_PyOpcode_InlineCacheEntries[BINARY_OP] == 
+    assert(_PyOpcode_InlineCacheEntries[BINARY_OP] ==
            INLINE_CACHE_ENTRIES_BINARY_OP);
     _PyBinaryOpCache *cache = (_PyBinaryOpCache *)(instr + 1);
     switch (oparg) {


### PR DESCRIPTION
Move the unexported private functions to the internal C API:

* pycore_frame.h: _PyFrame_New_NoTrack()
* pycore_function.h: _PyFunction_GetVersionForCurrentState()
* pycore_genobject.h: _PyAsyncGenValueWrapperNew()
* pycore_genobject.h: _PyCoro_GetAwaitableIter()
* pycore_genobject.h: _PyGen_yf()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45316](https://bugs.python.org/issue45316) -->
https://bugs.python.org/issue45316
<!-- /issue-number -->
