### PR TITLE
bpo-45316: Move _PyArg_Fini() to internal C API

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -84,6 +84,7 @@ extern void _PyAST_Fini(PyInterpreterState *interp);
 extern void _PyAtExit_Fini(PyInterpreterState *interp);
 extern void _PyThread_FiniType(PyInterpreterState *interp);
 extern void _Py_Deepfreeze_Fini(void);
+extern void _PyArg_Fini(void);
 
 extern PyStatus _PyGILState_Init(_PyRuntimeState *runtime);
 extern PyStatus _PyGILState_SetTstate(PyThreadState *tstate);

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -141,8 +141,6 @@ PyAPI_FUNC(PyObject * const *) _PyArg_UnpackKeywordsWithVararg(
       (minpos) <= (nargs) && (nargs) <= (maxpos) && args != NULL) ? (args) : \
      _PyArg_UnpackKeywords((args), (nargs), (kwargs), (kwnames), (parser), \
                            (minpos), (maxpos), (minkw), (buf)))
-
-void _PyArg_Fini(void);
 #endif   /* Py_LIMITED_API */
 
 // Add an attribute with name 'name' and value 'obj' to the module 'mod.

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -3,6 +3,7 @@
 
 #include "Python.h"
 #include "pycore_tuple.h"         // _PyTuple_ITEMS()
+#include "pycore_pylifecycle.h"   // _PyArg_Fini
 
 #include <ctype.h>
 #include <float.h>

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -829,7 +829,7 @@ pycore_interp_init(PyThreadState *tstate)
     // Intern strings in deep-frozen modules first so that others
     // can use it instead of creating a heap allocated string.
     _Py_Deepfreeze_Init();
-    
+
     status = pycore_init_types(interp);
     if (_PyStatus_EXCEPTION(status)) {
         goto done;


### PR DESCRIPTION
Move the private unexported _PyArg_Fini() function to the internal C
API: to the pycore_pylifecycle.h header file.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45316](https://bugs.python.org/issue45316) -->
https://bugs.python.org/issue45316
<!-- /issue-number -->
