### PR TITLE
[3.9] bpo-46852: Rename float.__set_format__() to float.__setformat__() (GH-31558)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-25-02-01-42.bpo-46852._3zg8D.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-25-02-01-42.bpo-46852._3zg8D.rst
@@ -1,0 +1,3 @@
+Rename the private undocumented ``float.__set_format__()`` method to
+``float.__setformat__()`` to fix a typo introduced in Python 3.7. The method
+is only used by test_float. Patch by Victor Stinner.

--- a/Objects/clinic/floatobject.c.h
+++ b/Objects/clinic/floatobject.c.h
@@ -289,8 +289,8 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(float___set_format____doc__,
-"__set_format__($type, typestr, fmt, /)\n"
+PyDoc_STRVAR(float___setformat____doc__,
+"__setformat__($type, typestr, fmt, /)\n"
 "--\n"
 "\n"
 "You probably don\'t want to use this function.\n"
@@ -307,25 +307,25 @@ PyDoc_STRVAR(float___set_format____doc__,
 "Override the automatic determination of C-level floating point type.\n"
 "This affects how floats are converted to and from binary strings.");
 
-#define FLOAT___SET_FORMAT___METHODDEF    \
-    {"__set_format__", (PyCFunction)(void(*)(void))float___set_format__, METH_FASTCALL|METH_CLASS, float___set_format____doc__},
+#define FLOAT___SETFORMAT___METHODDEF    \
+    {"__setformat__", (PyCFunction)(void(*)(void))float___setformat__, METH_FASTCALL|METH_CLASS, float___setformat____doc__},
 
 static PyObject *
-float___set_format___impl(PyTypeObject *type, const char *typestr,
-                          const char *fmt);
+float___setformat___impl(PyTypeObject *type, const char *typestr,
+                         const char *fmt);
 
 static PyObject *
-float___set_format__(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs)
+float___setformat__(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *typestr;
     const char *fmt;
 
-    if (!_PyArg_CheckPositional("__set_format__", nargs, 2, 2)) {
+    if (!_PyArg_CheckPositional("__setformat__", nargs, 2, 2)) {
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
-        _PyArg_BadArgument("__set_format__", "argument 1", "str", args[0]);
+        _PyArg_BadArgument("__setformat__", "argument 1", "str", args[0]);
         goto exit;
     }
     Py_ssize_t typestr_length;
@@ -338,7 +338,7 @@ float___set_format__(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs
         goto exit;
     }
     if (!PyUnicode_Check(args[1])) {
-        _PyArg_BadArgument("__set_format__", "argument 2", "str", args[1]);
+        _PyArg_BadArgument("__setformat__", "argument 2", "str", args[1]);
         goto exit;
     }
     Py_ssize_t fmt_length;
@@ -350,7 +350,7 @@ float___set_format__(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs
         PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
-    return_value = float___set_format___impl(type, typestr, fmt);
+    return_value = float___setformat___impl(type, typestr, fmt);
 
 exit:
     return return_value;
@@ -387,4 +387,4 @@ float___format__(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=25fbbe253f44e2df input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a6af179ec5f83fba input=a9049054013a1b77]*/

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1702,7 +1702,7 @@ float___getformat___impl(PyTypeObject *type, const char *typestr)
 
 /*[clinic input]
 @classmethod
-float.__set_format__
+float.__setformat__
 
     typestr: str
         Must be 'double' or 'float'.
@@ -1721,9 +1721,9 @@ This affects how floats are converted to and from binary strings.
 [clinic start generated code]*/
 
 static PyObject *
-float___set_format___impl(PyTypeObject *type, const char *typestr,
-                          const char *fmt)
-/*[clinic end generated code: output=504460f5dc85acbd input=5306fa2b81a997e4]*/
+float___setformat___impl(PyTypeObject *type, const char *typestr,
+                         const char *fmt)
+/*[clinic end generated code: output=06864de1fb5f1f04 input=c0e9e04dd87f9988]*/
 {
     float_format_type f;
     float_format_type detected;
@@ -1825,7 +1825,7 @@ static PyMethodDef float_methods[] = {
     FLOAT_IS_INTEGER_METHODDEF
     FLOAT___GETNEWARGS___METHODDEF
     FLOAT___GETFORMAT___METHODDEF
-    FLOAT___SET_FORMAT___METHODDEF
+    FLOAT___SETFORMAT___METHODDEF
     FLOAT___FORMAT___METHODDEF
     {NULL,              NULL}           /* sentinel */
 };


### PR DESCRIPTION
Rename the private undocumented float.__set_format__() method to
float.__setformat__() to fix a typo introduced in Python 3.7. The
method is only used by test_float.

The change enables again test_float tests on the float format which
were previously skipped because of the typo.

The typo was introduced in Python 3.7 by [bpo-20185](https://bugs.python.org/issue20185)
in commit b5c51d3dd95bbfde533655fb86ac0f96f771ba7b.

(cherry picked from commit 7d03c8be5af2f1559dbc35b775b3116dfd63cfb6)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
