### PR TITLE
bpo-46857: Fix refleak in OSError INIT_ALIAS()

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1657,16 +1657,8 @@ class MiscTests(EmbeddingTestsMixin, unittest.TestCase):
             self.fail(f"unexpected output: {out!a}")
         refs = int(match.group(1))
         blocks = int(match.group(2))
-        if not MS_WINDOWS:
-            # bpo-46417: Tolerate negative reference count which can occur because
-            # of bugs in C extensions. It is only wrong if it's greater than 0.
-            self.assertLessEqual(refs, 0, out)
-            self.assertEqual(blocks, 0, out)
-        else:
-            # bpo-46857: on Windows, Python still leaks 1 reference and 1
-            # memory block at exit.
-            self.assertLessEqual(refs, 1, out)
-            self.assertIn(blocks, (0, 1), out)
+        self.assertEqual(refs, 0, out)
+        self.assertEqual(blocks, 0, out)
 
 
 class StdPrinterTests(EmbeddingTestsMixin, unittest.TestCase):

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1658,7 +1658,11 @@ class MiscTests(EmbeddingTestsMixin, unittest.TestCase):
         refs = int(match.group(1))
         blocks = int(match.group(2))
         self.assertEqual(refs, 0, out)
-        self.assertEqual(blocks, 0, out)
+        if not MS_WINDOWS:
+            self.assertEqual(blocks, 0, out)
+        else:
+            # bpo-46857: on Windows, Python still leaks 1 memory block at exit
+            self.assertIn(blocks, (0, 1), out)
 
 
 class StdPrinterTests(EmbeddingTestsMixin, unittest.TestCase):

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -15,10 +15,10 @@
 
 
 /* Compatibility aliases */
-PyObject *PyExc_EnvironmentError = NULL;
-PyObject *PyExc_IOError = NULL;
+PyObject *PyExc_EnvironmentError = NULL;  // borrowed ref
+PyObject *PyExc_IOError = NULL;  // borrowed ref
 #ifdef MS_WINDOWS
-PyObject *PyExc_WindowsError = NULL;
+PyObject *PyExc_WindowsError = NULL;  // borrowed ref
 #endif
 
 
@@ -3647,10 +3647,8 @@ _PyBuiltins_AddExceptions(PyObject *bltinmod)
 
 #define INIT_ALIAS(NAME, TYPE) \
     do { \
-        Py_INCREF(PyExc_ ## TYPE); \
-        Py_XDECREF(PyExc_ ## NAME); \
         PyExc_ ## NAME = PyExc_ ## TYPE; \
-        if (PyDict_SetItemString(mod_dict, # NAME, PyExc_ ## NAME)) { \
+        if (PyDict_SetItemString(mod_dict, # NAME, PyExc_ ## TYPE)) { \
             return -1; \
         } \
     } while (0)

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -61,12 +61,7 @@ Py_ssize_t _Py_RefTotal;
 Py_ssize_t
 _Py_GetRefTotal(void)
 {
-    PyObject *o;
-    Py_ssize_t total = _Py_RefTotal;
-    o = _PySet_Dummy;
-    if (o != NULL)
-        total -= Py_REFCNT(o);
-    return total;
+    return _Py_RefTotal;
 }
 
 void


### PR DESCRIPTION
_Py_GetRefTotal() no longer decrements _PySet_Dummy refcount.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46857](https://bugs.python.org/issue46857) -->
https://bugs.python.org/issue46857
<!-- /issue-number -->
