### PR TITLE
bpo-46430: fix error-handling in _Py_Deepfreeze_Init

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -317,7 +317,7 @@ extern void _Py_Specialize_UnpackSequence(PyObject *seq, _Py_CODEUNIT *instr,
 /* Deallocator function for static codeobjects used in deepfreeze.py */
 extern void _PyStaticCode_Dealloc(PyCodeObject *co);
 /* Function to intern strings of codeobjects */
-extern void _PyStaticCode_InternStrings(PyCodeObject *co);
+extern int _PyStaticCode_InternStrings(PyCodeObject *co);
 
 #ifdef Py_STATS
 

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -65,7 +65,7 @@ extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 extern PyStatus _PyImportZip_Init(PyThreadState *tstate);
 extern PyStatus _PyGC_Init(PyInterpreterState *interp);
 extern PyStatus _PyAtExit_Init(PyInterpreterState *interp);
-extern void _Py_Deepfreeze_Init(void);
+extern int _Py_Deepfreeze_Init(void);
 
 /* Various internal finalizers */
 

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1931,14 +1931,20 @@ _PyStaticCode_Dealloc(PyCodeObject *co)
     }
 }
 
-void
+int
 _PyStaticCode_InternStrings(PyCodeObject *co)
 {
     int res = intern_strings(co->co_names);
-    assert(res == 0);
+    if (res < 0) {
+        return -1;
+    }
     res = intern_string_constants(co->co_consts, NULL);
-    assert(res == 0);
+    if (res < 0) {
+        return -1;
+    }
     res = intern_strings(co->co_localsplusnames);
-    assert(res == 0);
-    (void)res;
+    if (res < 0) {
+        return -1;
+    }
+    return 0;
 }

--- a/Programs/_bootstrap_python.c
+++ b/Programs/_bootstrap_python.c
@@ -15,8 +15,9 @@
 /* End includes */
 
 /* Empty initializer for deepfrozen modules */
-void _Py_Deepfreeze_Init(void)
+int _Py_Deepfreeze_Init(void)
 {
+    return 0;
 }
 /* Empty finalizer for deepfrozen modules */
 void

--- a/Programs/_freeze_module.c
+++ b/Programs/_freeze_module.c
@@ -23,8 +23,9 @@
 #endif
 
 /* Empty initializer for deepfrozen modules */
-void _Py_Deepfreeze_Init(void)
+int _Py_Deepfreeze_Init(void)
 {
+    return 0;
 }
 /* Empty finalizer for deepfrozen modules */
 void

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -828,7 +828,9 @@ pycore_interp_init(PyThreadState *tstate)
     }
     // Intern strings in deep-frozen modules first so that others
     // can use it instead of creating a heap allocated string.
-    _Py_Deepfreeze_Init();
+    if (_Py_Deepfreeze_Init() < 0) {
+        return _PyStatus_ERR("failed to initialize deep-frozen modules");
+    }
 
     status = pycore_init_types(interp);
     if (_PyStatus_EXCEPTION(status)) {

--- a/Tools/scripts/deepfreeze.py
+++ b/Tools/scripts/deepfreeze.py
@@ -283,7 +283,7 @@ class Printer:
             self.write(f".co_cellvars = {co_cellvars},")
             self.write(f".co_freevars = {co_freevars},")
         self.deallocs.append(f"_PyStaticCode_Dealloc(&{name});")
-        self.interns.append(f"_PyStaticCode_InternStrings(&{name});")
+        self.interns.append(f"_PyStaticCode_InternStrings(&{name})")
         return f"& {name}.ob_base"
 
     def generate_tuple(self, name: str, t: Tuple[object, ...]) -> str:
@@ -450,9 +450,11 @@ def generate(args: list[str], output: TextIO) -> None:
     with printer.block(f"void\n_Py_Deepfreeze_Fini(void)"):
             for p in printer.deallocs:
                 printer.write(p)
-    with printer.block(f"void\n_Py_Deepfreeze_Init(void)"):
+    with printer.block(f"int\n_Py_Deepfreeze_Init(void)"):
             for p in printer.interns:
-                printer.write(p)
+                with printer.block(f"if ({p} < 0)"):
+                    printer.write("return -1;")
+            printer.write("return 0;")
     if verbose:
         print(f"Cache hits: {printer.hits}, misses: {printer.misses}")
 


### PR DESCRIPTION
Fixes error-handling in interning of strings in deep-frozen modules.