### PR TITLE
bpo-46864: Deprecate PyBytesObject.ob_shash.

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -967,6 +967,9 @@ Deprecated
   <init-config>` instead (:pep:`587`).
   (Contributed by Victor Stinner in :issue:`44113`.)
 
+* Deprecate the ``ob_shash`` member of the :c:type:`PyBytesObject`. Use :c:func:`PyObject_Hash` instead.
+  (Contributed by Inada Naoki in :issue:`46864`.)
+
 Removed
 -------
 

--- a/Include/cpython/bytesobject.h
+++ b/Include/cpython/bytesobject.h
@@ -4,7 +4,7 @@
 
 typedef struct {
     PyObject_VAR_HEAD
-    Py_hash_t ob_shash Py_DEPRECATED(3.11);
+    Py_DEPRECATED(3.11) Py_hash_t ob_shash;
     char ob_sval[1];
 
     /* Invariants:

--- a/Include/cpython/bytesobject.h
+++ b/Include/cpython/bytesobject.h
@@ -4,7 +4,7 @@
 
 typedef struct {
     PyObject_VAR_HEAD
-    Py_hash_t ob_shash;
+    Py_hash_t ob_shash Py_DEPRECATED(3.11);
     char ob_sval[1];
 
     /* Invariants:

--- a/Misc/NEWS.d/next/Core and Builtins/2022-02-26-19-26-36.bpo-46864.EmLgFp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-02-26-19-26-36.bpo-46864.EmLgFp.rst
@@ -1,0 +1,1 @@
+Deprecate ``PyBytesObject.ob_shash``. It will be removed in Python 3.13.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -104,7 +104,10 @@ _PyBytes_FromSize(Py_ssize_t size, int use_calloc)
         return PyErr_NoMemory();
     }
     _PyObject_InitVar((PyVarObject*)op, &PyBytes_Type, size);
+_Py_COMP_DIAG_PUSH
+_Py_COMP_DIAG_IGNORE_DEPR_DECLS
     op->ob_shash = -1;
+_Py_COMP_DIAG_POP
     if (!use_calloc) {
         op->ob_sval[size] = '\0';
     }
@@ -168,7 +171,10 @@ PyBytes_FromString(const char *str)
         return PyErr_NoMemory();
     }
     _PyObject_InitVar((PyVarObject*)op, &PyBytes_Type, size);
+_Py_COMP_DIAG_PUSH
+_Py_COMP_DIAG_IGNORE_DEPR_DECLS
     op->ob_shash = -1;
+_Py_COMP_DIAG_POP
     memcpy(op->ob_sval, str, size+1);
     return (PyObject *) op;
 }
@@ -1427,7 +1433,10 @@ bytes_repeat(PyBytesObject *a, Py_ssize_t n)
         return PyErr_NoMemory();
     }
     _PyObject_InitVar((PyVarObject*)op, &PyBytes_Type, size);
+_Py_COMP_DIAG_PUSH
+_Py_COMP_DIAG_IGNORE_DEPR_DECLS
     op->ob_shash = -1;
+_Py_COMP_DIAG_POP
     op->ob_sval[size] = '\0';
     if (Py_SIZE(a) == 1 && n > 0) {
         memset(op->ob_sval, a->ob_sval[0] , n);
@@ -1543,11 +1552,14 @@ bytes_richcompare(PyBytesObject *a, PyBytesObject *b, int op)
 static Py_hash_t
 bytes_hash(PyBytesObject *a)
 {
+_Py_COMP_DIAG_PUSH
+_Py_COMP_DIAG_IGNORE_DEPR_DECLS
     if (a->ob_shash == -1) {
         /* Can't fail */
         a->ob_shash = _Py_HashBytes(a->ob_sval, Py_SIZE(a));
     }
     return a->ob_shash;
+_Py_COMP_DIAG_POP
 }
 
 static PyObject*
@@ -2849,8 +2861,11 @@ bytes_subtype_new(PyTypeObject *type, PyObject *tmp)
     if (pnew != NULL) {
         memcpy(PyBytes_AS_STRING(pnew),
                   PyBytes_AS_STRING(tmp), n+1);
+_Py_COMP_DIAG_PUSH
+_Py_COMP_DIAG_IGNORE_DEPR_DECLS
         ((PyBytesObject *)pnew)->ob_shash =
             ((PyBytesObject *)tmp)->ob_shash;
+_Py_COMP_DIAG_POP
     }
     return pnew;
 }
@@ -3032,7 +3047,10 @@ _PyBytes_Resize(PyObject **pv, Py_ssize_t newsize)
     sv = (PyBytesObject *) *pv;
     Py_SET_SIZE(sv, newsize);
     sv->ob_sval[newsize] = '\0';
+_Py_COMP_DIAG_PUSH
+_Py_COMP_DIAG_IGNORE_DEPR_DECLS
     sv->ob_shash = -1;          /* invalidate cached hash value */
+_Py_COMP_DIAG_POP
     return 0;
 error:
     *pv = 0;


### PR DESCRIPTION


<!-- issue-number: [bpo-46864](https://bugs.python.org/issue46864) -->
https://bugs.python.org/issue46864
<!-- /issue-number -->
