### PR TITLE
bpo-46884: Use module directive to document msilib submodules

### DIFF
--- a/Doc/library/msilib.rst
+++ b/Doc/library/msilib.rst
@@ -539,22 +539,29 @@ Precomputed tables
 :mod:`msilib` provides a few subpackages that contain only schema and table
 definitions. Currently, these definitions are based on MSI version 2.0.
 
+.. module:: msilib.schema
 
-.. data:: schema
+msilib.schema
+^^^^^^^^^^^^^
 
-   This is the standard MSI schema for MSI 2.0, with the *tables* variable
-   providing a list of table definitions, and *_Validation_records* providing the
-   data for MSI validation.
+This is the standard MSI schema for MSI 2.0, with the *tables* variable
+providing a list of table definitions, and *_Validation_records* providing the
+data for MSI validation.
+
+.. module:: msilib.sequence
+
+msilib.sequence
+^^^^^^^^^^^^^^^
+
+This module contains table contents for the standard sequence tables:
+*AdminExecuteSequence*, *AdminUISequence*, *AdvtExecuteSequence*,
+*InstallExecuteSequence*, and *InstallUISequence*.
 
 
-.. data:: sequence
+.. module:: msilib.text
 
-   This module contains table contents for the standard sequence tables:
-   *AdminExecuteSequence*, *AdminUISequence*, *AdvtExecuteSequence*,
-   *InstallExecuteSequence*, and *InstallUISequence*.
+msilib.text
+^^^^^^^^^^^
 
-
-.. data:: text
-
-   This module contains definitions for the UIText and ActionText tables, for the
-   standard installer actions.
+This module contains definitions for the UIText and ActionText tables, for the
+standard installer actions.


### PR DESCRIPTION
The data directive is meant to be used to document data in a module.
For the submodules the module directive is to be used.
Otherwise these modules show up in the wrong domain in the Sphinx
inventory (objects.inv) and do not show up in the Python Module Index.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46884](https://bugs.python.org/issue46884) -->
https://bugs.python.org/issue46884
<!-- /issue-number -->
