### PR TITLE
bpo-44807: Allow Protocol classes to define __init__

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1082,7 +1082,6 @@ class ProtocolTests(BaseTestCase):
             x: int
             def __init__(self, x: int) -> None:
                 self.x = x
-        
         class C: pass
 
         c = C()

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1074,7 +1074,7 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             CG[int](42)
 
-    def test_protocol_defining_init_does_not_get_overriden(self):
+    def test_protocol_defining_init_does_not_get_overridden(self):
         # check that P.__init__ doesn't get clobbered
         # see https://bugs.python.org/issue44807
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1074,6 +1074,26 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             CG[int](42)
 
+    def test_protocol_defining_init(self):
+        class P(Protocol):
+            x: int
+            def __init__(self, x: int) -> None:
+                self.x = x
+
+        # the protocol itself cannot be instantiated
+        with self.assertRaises(TypeError):
+            P()
+
+        # but a concrete subclass can
+        class C(P): pass
+
+        c = C(1)
+        self.assertIsInstance(c, C)
+
+        # and this concrete subclass can inherit the __init__
+        # implementation from Protocol
+        self.assertEqual(c.x, 1)
+
     def test_cannot_instantiate_abstract(self):
         @runtime_checkable
         class P(Protocol):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1074,24 +1074,31 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             CG[int](42)
 
-    def test_protocol_defining_init(self):
+    def test_protocol_defining_init_does_not_get_overriden(self):
+        # check that P.__init__ doesn't get clobbered
+        # see https://bugs.python.org/issue44807
+
+        class P(Protocol):
+            x: int
+            def __init__(self, x: int) -> None:
+                self.x = x
+        
+        class C: pass
+
+        c = C()
+        P.__init__(c, 1)
+        self.assertEqual(c.x, 1)
+
+    def test_concrete_class_inherting_init_from_protocol(self):
         class P(Protocol):
             x: int
             def __init__(self, x: int) -> None:
                 self.x = x
 
-        # the protocol itself cannot be instantiated
-        with self.assertRaises(TypeError):
-            P()
-
-        # but a concrete subclass can
         class C(P): pass
 
         c = C(1)
         self.assertIsInstance(c, C)
-
-        # and this concrete subclass can inherit the __init__
-        # implementation from Protocol
         self.assertEqual(c.x, 1)
 
     def test_cannot_instantiate_abstract(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1089,7 +1089,7 @@ class ProtocolTests(BaseTestCase):
         P.__init__(c, 1)
         self.assertEqual(c.x, 1)
 
-    def test_concrete_class_inherting_init_from_protocol(self):
+    def test_concrete_class_inheriting_init_from_protocol(self):
         class P(Protocol):
             x: int
             def __init__(self, x: int) -> None:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1741,7 +1741,8 @@ class Protocol(Generic, metaclass=_ProtocolMeta):
                     issubclass(base, Generic) and base._is_protocol):
                 raise TypeError('Protocols can only inherit from other'
                                 ' protocols, got %r' % base)
-        cls.__init__ = _no_init_or_replace_init
+        if cls.__init__ is Protocol.__init__:
+            cls.__init__ = _no_init_or_replace_init
 
 
 class _AnnotatedAlias(_GenericAlias, _root=True):

--- a/Misc/NEWS.d/next/Library/2022-03-02-04-25-58.bpo-44807.gHNC9J.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-02-04-25-58.bpo-44807.gHNC9J.rst
@@ -1,1 +1,1 @@
-:class:`typing.Protocol` no longer silently replaces __init__ methods defined on subclasses
+:class:`typing.Protocol` no longer silently replaces :meth:`__init__` methods defined on subclasses. Patch by Adrian Garcia Badaracco.

--- a/Misc/NEWS.d/next/Library/2022-03-02-04-25-58.bpo-44807.gHNC9J.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-02-04-25-58.bpo-44807.gHNC9J.rst
@@ -1,0 +1,1 @@
+:class:`typing.Protocol` no longer silently replaces __init__ methods defined on subclasses


### PR DESCRIPTION
<!-- issue-number: [bpo-44807](https://bugs.python.org/issue44807) -->
https://bugs.python.org/issue44807
<!-- /issue-number -->
