### PR TITLE
bpo-25415: Remove confusing sentence from IOBase docstrings

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -306,8 +306,7 @@ I/O Base Classes
 
 .. class:: IOBase
 
-   The abstract base class for all I/O classes. The constructor accepts no
-   arguments.
+   The abstract base class for all I/O classes.
 
    This class provides empty abstract implementations for many methods
    that derived classes can override selectively; the default
@@ -461,8 +460,7 @@ I/O Base Classes
 
 .. class:: RawIOBase
 
-   Base class for raw binary streams.  It inherits :class:`IOBase`. The
-   constructor accepts no arguments.
+   Base class for raw binary streams.  It inherits :class:`IOBase`.
 
    Raw binary streams typically provide low-level access to an underlying OS
    device or API, and do not try to encapsulate it in high-level primitives
@@ -515,7 +513,7 @@ I/O Base Classes
 .. class:: BufferedIOBase
 
    Base class for binary streams that support some kind of buffering.
-   It inherits :class:`IOBase`. The constructor accepts no arguments.
+   It inherits :class:`IOBase`.
 
    The main difference with :class:`RawIOBase` is that methods :meth:`read`,
    :meth:`readinto` and :meth:`write` will try (respectively) to read as much
@@ -853,7 +851,6 @@ Text I/O
 
    Base class for text streams.  This class provides a character and line based
    interface to stream I/O.  It inherits :class:`IOBase`.
-   The constructor accepts no arguments.
 
    :class:`TextIOBase` provides or overrides these data attributes and
    methods in addition to those from :class:`IOBase`:

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -306,8 +306,8 @@ I/O Base Classes
 
 .. class:: IOBase
 
-   The abstract base class for all I/O classes, acting on streams of bytes.
-   There is no public constructor.
+   The abstract base class for all I/O classes. The constructor accepts no
+   arguments.
 
    This class provides empty abstract implementations for many methods
    that derived classes can override selectively; the default
@@ -461,8 +461,8 @@ I/O Base Classes
 
 .. class:: RawIOBase
 
-   Base class for raw binary streams.  It inherits :class:`IOBase`.  There is no
-   public constructor.
+   Base class for raw binary streams.  It inherits :class:`IOBase`. The
+   constructor accepts no arguments.
 
    Raw binary streams typically provide low-level access to an underlying OS
    device or API, and do not try to encapsulate it in high-level primitives
@@ -515,7 +515,7 @@ I/O Base Classes
 .. class:: BufferedIOBase
 
    Base class for binary streams that support some kind of buffering.
-   It inherits :class:`IOBase`. There is no public constructor.
+   It inherits :class:`IOBase`. The constructor accepts no arguments.
 
    The main difference with :class:`RawIOBase` is that methods :meth:`read`,
    :meth:`readinto` and :meth:`write` will try (respectively) to read as much
@@ -852,8 +852,8 @@ Text I/O
 .. class:: TextIOBase
 
    Base class for text streams.  This class provides a character and line based
-   interface to stream I/O.  It inherits :class:`IOBase`.  There is no public
-   constructor.
+   interface to stream I/O.  It inherits :class:`IOBase`.
+   The constructor accepts no arguments.
 
    :class:`TextIOBase` provides or overrides these data attributes and
    methods in addition to those from :class:`IOBase`:

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -326,8 +326,7 @@ except AttributeError:
 
 class IOBase(metaclass=abc.ABCMeta):
 
-    """The abstract base class for all I/O classes. The constructor accepts
-    no arguments.
+    """The abstract base class for all I/O classes.
 
     This class provides dummy implementations for many methods that
     derived classes can override selectively; the default implementations
@@ -1833,7 +1832,7 @@ class TextIOBase(IOBase):
     """Base class for text I/O.
 
     This class provides a character and line based interface to stream
-    I/O. The constructor accepts no arguments.
+    I/O.
     """
 
     def read(self, size=-1):

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -326,8 +326,8 @@ except AttributeError:
 
 class IOBase(metaclass=abc.ABCMeta):
 
-    """The abstract base class for all I/O classes, acting on streams of
-    bytes. There is no public constructor.
+    """The abstract base class for all I/O classes. The constructor accepts
+    no arguments.
 
     This class provides dummy implementations for many methods that
     derived classes can override selectively; the default implementations
@@ -1833,7 +1833,7 @@ class TextIOBase(IOBase):
     """Base class for text I/O.
 
     This class provides a character and line based interface to stream
-    I/O. There is no public constructor.
+    I/O. The constructor accepts no arguments.
     """
 
     def read(self, size=-1):

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -34,8 +34,8 @@ typedef struct {
 } iobase;
 
 PyDoc_STRVAR(iobase_doc,
-    "The abstract base class for all I/O classes, acting on streams of\n"
-    "bytes. There is no public constructor.\n"
+    "The abstract base class for all I/O classes. The constructor accepts\n"
+    "no arguments.\n"
     "\n"
     "This class provides dummy implementations for many methods that\n"
     "derived classes can override selectively; the default implementations\n"

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -34,7 +34,7 @@ typedef struct {
 } iobase;
 
 PyDoc_STRVAR(iobase_doc,
-    "The abstract base class for all I/O classes."
+    "The abstract base class for all I/O classes.\n"
     "\n"
     "This class provides dummy implementations for many methods that\n"
     "derived classes can override selectively; the default implementations\n"

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -34,8 +34,7 @@ typedef struct {
 } iobase;
 
 PyDoc_STRVAR(iobase_doc,
-    "The abstract base class for all I/O classes. The constructor accepts\n"
-    "no arguments.\n"
+    "The abstract base class for all I/O classes."
     "\n"
     "This class provides dummy implementations for many methods that\n"
     "derived classes can override selectively; the default implementations\n"

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -30,7 +30,7 @@ PyDoc_STRVAR(textiobase_doc,
     "\n"
     "This class provides a character and line based interface to stream\n"
     "I/O. There is no readinto method because Python's character strings\n"
-    "are immutable. The constructor accepts no arguments.\n"
+    "are immutable.\n"
     );
 
 static PyObject *

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -30,7 +30,7 @@ PyDoc_STRVAR(textiobase_doc,
     "\n"
     "This class provides a character and line based interface to stream\n"
     "I/O. There is no readinto method because Python's character strings\n"
-    "are immutable. There is no public constructor.\n"
+    "are immutable. The constructor accepts no arguments.\n"
     );
 
 static PyObject *


### PR DESCRIPTION
<!-- issue-number: [bpo-25415](https://bugs.python.org/issue25415) -->
https://bugs.python.org/issue25415
<!-- /issue-number -->
