### PR TITLE
bpo-46887: Work around clang MSAN bug on stat()/fstat()

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2484,6 +2484,12 @@ posix_do_stat(PyObject *module, const char *function_name, path_t *path,
     STRUCT_STAT st;
     int result;
 
+#  if __has_feature(memory_sanitizer)
+    // bpo-46887: Work around clang MSAN bug:
+    // https://github.com/llvm/llvm-project/issues/54131
+    memset(&st, 0, sizeof(st));
+#  endif
+
 #ifdef HAVE_FSTATAT
     int fstatat_unavailable = 0;
 #endif


### PR DESCRIPTION
Initialize the input "struct stat" buffer with zeros to prevent a
false alarm on calling stat() and fstat().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46887](https://bugs.python.org/issue46887) -->
https://bugs.python.org/issue46887
<!-- /issue-number -->
