### PR TITLE
bpo-46889 Add compile flag for math support for sqlite3 on macos

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -369,6 +369,7 @@ def library_recipes():
                             '-DSQLITE_ENABLE_RTREE '
                             '-DSQLITE_OMIT_AUTOINIT '
                             '-DSQLITE_TCL=0 '
+                            '-DSQLITE_ENABLE_MATH_FUNCTIONS'
                             ),
               configure_pre=[
                   '--enable-threadsafe',

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -369,7 +369,7 @@ def library_recipes():
                             '-DSQLITE_ENABLE_RTREE '
                             '-DSQLITE_OMIT_AUTOINIT '
                             '-DSQLITE_TCL=0 '
-                            '-DSQLITE_ENABLE_MATH_FUNCTIONS'
+                            '-DSQLITE_ENABLE_MATH_FUNCTIONS '
                             ),
               configure_pre=[
                   '--enable-threadsafe',


### PR DESCRIPTION
Adds support for sqlite3 math functions on macos: https://bugs.python.org/issue46889 

<!-- issue-number: [bpo-46889](https://bugs.python.org/issue46889) -->
https://bugs.python.org/issue46889
<!-- /issue-number -->
