### PR TITLE
bpo-28516: contextlib.ExitStack.__enter__ has trivial but undocument…

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -502,7 +502,7 @@ Functions and classes provided:
           # the with statement, even if attempts to open files later
           # in the list raise an exception
 
-   The :meth:`__enter__` method returns the :class:`ExitStack` instance, and 
+   The :meth:`__enter__` method returns the :class:`ExitStack` instance, and
    performs no additional operations.
 
    Each instance maintains a stack of registered callbacks that are called in

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -508,8 +508,8 @@ Functions and classes provided:
    Each instance maintains a stack of registered callbacks that are called in
    reverse order when the instance is closed (either explicitly or implicitly
    at the end of a :keyword:`with` statement). Note that callbacks are *not*
-   invoked implicitly when the context stack instance is garbage collected.
-   This stack model is used so that context managers that acquire their
+   invoked implicitly when the context stack instance is garbage collected. This 
+   stack model is used so that context managers that acquire their
    resources in their ``__init__`` method (such as file objects) can be
    handled correctly.
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -508,8 +508,9 @@ Functions and classes provided:
    Each instance maintains a stack of registered callbacks that are called in
    reverse order when the instance is closed (either explicitly or implicitly
    at the end of a :keyword:`with` statement). Note that callbacks are *not*
-   invoked implicitly when the context stack instance is garbage collected. This 
-   stack model is used so that context managers that acquire their
+   invoked implicitly when the context stack instance is garbage collected.
+
+   This stack model is used so that context managers that acquire their
    resources in their ``__init__`` method (such as file objects) can be
    handled correctly.
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -529,8 +529,8 @@ Functions and classes provided:
 
       Enters a new context manager and adds its :meth:`__exit__` method to
       the callback stack. The return value is the result of the context
-      manager's own :meth:`__enter__` method.The :meth:`__enter__` method 
-      returns the ExitStack instance, and performs no additional operations.
+      manager's own :meth:`__enter__` method. The :meth:`__enter__` method 
+      returns the :class:`ExitStack` instance, and performs no additional operations.
 
       These context managers may suppress exceptions just as they normally
       would if used directly as part of a :keyword:`with` statement.

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -504,12 +504,12 @@ Functions and classes provided:
 
    The :meth:`__enter__` method returns the :class:`ExitStack` instance, and 
    performs no additional operations.
-   
+
    Each instance maintains a stack of registered callbacks that are called in
    reverse order when the instance is closed (either explicitly or implicitly
    at the end of a :keyword:`with` statement). Note that callbacks are *not*
    invoked implicitly when the context stack instance is garbage collected.
-   
+
    This stack model is used so that context managers that acquire their
    resources in their ``__init__`` method (such as file objects) can be
    handled correctly.

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -532,7 +532,7 @@ Functions and classes provided:
 
       Enters a new context manager and adds its :meth:`__exit__` method to
       the callback stack. The return value is the result of the context
-      manager's own :meth:`__enter__` method. 
+      manager's own :meth:`__enter__` method.
 
       These context managers may suppress exceptions just as they normally
       would if used directly as part of a :keyword:`with` statement.
@@ -547,7 +547,7 @@ Functions and classes provided:
 
       As ``__enter__`` is *not* invoked, this method can be used to cover
       part of an :meth:`__enter__` implementation with a context manager's own
-      :meth:`__exit__` method. 
+      :meth:`__exit__` method.
 
       If passed an object that is not a context manager, this method assumes
       it is a callback with the same signature as a context manager's

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -529,7 +529,7 @@ Functions and classes provided:
 
       Enters a new context manager and adds its :meth:`__exit__` method to
       the callback stack. The return value is the result of the context
-      manager's own :meth:`__enter__` method. The :meth:`__enter__` method 
+      manager's own :meth:`__enter__` method. The :meth:`__enter__` method
       returns the :class:`ExitStack` instance, and performs no additional operations.
 
       These context managers may suppress exceptions just as they normally

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -529,7 +529,8 @@ Functions and classes provided:
 
       Enters a new context manager and adds its :meth:`__exit__` method to
       the callback stack. The return value is the result of the context
-      manager's own :meth:`__enter__` method.
+      manager's own :meth:`__enter__` method.The :meth:`__enter__` method 
+      returns the ExitStack instance, and performs no additional operations.
 
       These context managers may suppress exceptions just as they normally
       would if used directly as part of a :keyword:`with` statement.

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -509,7 +509,6 @@ Functions and classes provided:
    reverse order when the instance is closed (either explicitly or implicitly
    at the end of a :keyword:`with` statement). Note that callbacks are *not*
    invoked implicitly when the context stack instance is garbage collected.
-
    This stack model is used so that context managers that acquire their
    resources in their ``__init__`` method (such as file objects) can be
    handled correctly.

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -502,11 +502,14 @@ Functions and classes provided:
           # the with statement, even if attempts to open files later
           # in the list raise an exception
 
+   The :meth:`__enter__` method returns the :class:`ExitStack` instance, and 
+   performs no additional operations.
+   
    Each instance maintains a stack of registered callbacks that are called in
    reverse order when the instance is closed (either explicitly or implicitly
    at the end of a :keyword:`with` statement). Note that callbacks are *not*
    invoked implicitly when the context stack instance is garbage collected.
-
+      
    This stack model is used so that context managers that acquire their
    resources in their ``__init__`` method (such as file objects) can be
    handled correctly.
@@ -529,8 +532,7 @@ Functions and classes provided:
 
       Enters a new context manager and adds its :meth:`__exit__` method to
       the callback stack. The return value is the result of the context
-      manager's own :meth:`__enter__` method. The :meth:`__enter__` method
-      returns the :class:`ExitStack` instance, and performs no additional operations.
+      manager's own :meth:`__enter__` method. 
 
       These context managers may suppress exceptions just as they normally
       would if used directly as part of a :keyword:`with` statement.
@@ -545,7 +547,7 @@ Functions and classes provided:
 
       As ``__enter__`` is *not* invoked, this method can be used to cover
       part of an :meth:`__enter__` implementation with a context manager's own
-      :meth:`__exit__` method.
+      :meth:`__exit__` method. 
 
       If passed an object that is not a context manager, this method assumes
       it is a callback with the same signature as a context manager's

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -509,7 +509,7 @@ Functions and classes provided:
    reverse order when the instance is closed (either explicitly or implicitly
    at the end of a :keyword:`with` statement). Note that callbacks are *not*
    invoked implicitly when the context stack instance is garbage collected.
-      
+   
    This stack model is used so that context managers that acquire their
    resources in their ``__init__`` method (such as file objects) can be
    handled correctly.


### PR DESCRIPTION

The enter_context is updated with following information: 'The :meth:`__enter__` method 
      returns the ExitStack instance, and performs no additional operations.'

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-28516](https://bugs.python.org/issue28516) -->
https://bugs.python.org/issue28516
<!-- /issue-number -->
