### PR TITLE
Removed confusing reference to sys

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -84,9 +84,9 @@ considered a package.
 
 All modules have a name.  Subpackage names are separated from their parent
 package name by a dot, akin to Python's standard attribute access syntax.  Thus
-you might have a module called :mod:`sys` and a package called :mod:`email`,
-which in turn has a subpackage called :mod:`email.mime` and a module within
-that subpackage called :mod:`email.mime.text`.
+you might have a package called :mod:`email`, which in turn has a subpackage
+called :mod:`email.mime` and a module within that subpackage called
+:mod:`email.mime.text`.
 
 
 Regular packages


### PR DESCRIPTION
I've removed the words "a module called sys and", the diff makes it a bit hard to see. The reference didn't seem to make sense, or at least the point seems clearer without it.

Current page: https://docs.python.org/3/reference/import.html#packages
![image](https://user-images.githubusercontent.com/4443482/156248886-4270b682-a392-43a3-a06c-23c1f7f4e249.png)


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
