### PR TITLE
bpo-6634: [doc] clarify that sys.exit() does not always exit the interpreter

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -466,7 +466,7 @@ always available.
 
    Since :func:`exit` ultimately "only" raises an exception, it will only exit
    the process when called from the main thread, and the exception is not
-   intercepted.  Cleanup actions specified by finally clauses of :keyword:`try` statements
+   intercepted. Cleanup actions specified by finally clauses of :keyword:`try` statements
    are honored, and it is possible to intercept the exit attempt at an outer level.
 
    .. versionchanged:: 3.6

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -449,10 +449,12 @@ always available.
 
 .. function:: exit([arg])
 
-   Exit from Python.  This is implemented by raising the :exc:`SystemExit`
+   Exit from Python.  If called in the main thread, this raises the :exc:`SystemExit`
    exception, so cleanup actions specified by finally clauses of :keyword:`try`
    statements are honored, and it is possible to intercept the exit attempt at
-   an outer level.
+   an outer level. When called from a thread other than the main thread, this
+   causes the thread to exit silently, nothing is printed and is equivalent to calling
+   :func:`thread.exit`.
 
    The optional argument *arg* can be an integer giving the exit status
    (defaulting to zero), or another type of object.  If it is an integer, zero

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -450,8 +450,6 @@ always available.
 .. function:: exit([arg])
 
    Raise a :exc:`SystemExit` exception, signaling an intention to exit the interpreter.
-   Cleanup actions specified by finally clauses of :keyword:`try` statements are honored, 
-   and it is possible to intercept the exit attempt at an outer level. 
 
    The optional argument *arg* can be an integer giving the exit status
    (defaulting to zero), or another type of object.  If it is an integer, zero
@@ -470,6 +468,9 @@ always available.
    the process when called from the main thread, and the exception is not
    intercepted.
 
+   Cleanup actions specified by finally clauses of :keyword:`try` statements are honored, 
+   and it is possible to intercept the exit attempt at an outer level. 
+   
    .. versionchanged:: 3.6
       If an error occurs in the cleanup after the Python interpreter
       has caught :exc:`SystemExit` (such as an error flushing buffered data

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -466,10 +466,8 @@ always available.
 
    Since :func:`exit` ultimately "only" raises an exception, it will only exit
    the process when called from the main thread, and the exception is not
-   intercepted.
-
-   Cleanup actions specified by finally clauses of :keyword:`try` statements are honored, 
-   and it is possible to intercept the exit attempt at an outer level. 
+   intercepted.  Cleanup actions specified by finally clauses of :keyword:`try` statements
+   are honored, and it is possible to intercept the exit attempt at an outer level. 
    
    .. versionchanged:: 3.6
       If an error occurs in the cleanup after the Python interpreter

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -467,8 +467,8 @@ always available.
    Since :func:`exit` ultimately "only" raises an exception, it will only exit
    the process when called from the main thread, and the exception is not
    intercepted.  Cleanup actions specified by finally clauses of :keyword:`try` statements
-   are honored, and it is possible to intercept the exit attempt at an outer level. 
-   
+   are honored, and it is possible to intercept the exit attempt at an outer level.
+
    .. versionchanged:: 3.6
       If an error occurs in the cleanup after the Python interpreter
       has caught :exc:`SystemExit` (such as an error flushing buffered data

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -449,8 +449,8 @@ always available.
 
 .. function:: exit([arg])
 
-   This is implemented by raising the :exc:`SystemExit` exception, so cleanup 
-   actions specified by finally clauses of :keyword:`try` statements are honored, 
+   Raise a :exc:`SystemExit` exception, signaling an intention to exit the interpreter.
+   Cleanup actions specified by finally clauses of :keyword:`try` statements are honored, 
    and it is possible to intercept the exit attempt at an outer level. 
 
    The optional argument *arg* can be an integer giving the exit status

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -449,12 +449,9 @@ always available.
 
 .. function:: exit([arg])
 
-   Exit from Python.  If called in the main thread, this raises the :exc:`SystemExit`
-   exception, so cleanup actions specified by finally clauses of :keyword:`try`
-   statements are honored, and it is possible to intercept the exit attempt at
-   an outer level. When called from a thread other than the main thread, this
-   causes the thread to exit silently, nothing is printed and is equivalent to calling
-   :func:`thread.exit`.
+   This raises the :exc:`SystemExit` exception, so cleanup actions specified by finally 
+   clauses of :keyword:`try`statements are honored, and it is possible to intercept the 
+   exit attempt at an outer level. 
 
    The optional argument *arg* can be an integer giving the exit status
    (defaulting to zero), or another type of object.  If it is an integer, zero

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -449,9 +449,9 @@ always available.
 
 .. function:: exit([arg])
 
-   This raises the :exc:`SystemExit` exception, so cleanup actions specified by finally 
-   clauses of :keyword:`try`statements are honored, and it is possible to intercept the 
-   exit attempt at an outer level. 
+   This is implemented by raising the :exc:`SystemExit` exception, so cleanup 
+   actions specified by finally clauses of :keyword:`try` statements are honored, 
+   and it is possible to intercept the exit attempt at an outer level. 
 
    The optional argument *arg* can be an integer giving the exit status
    (defaulting to zero), or another type of object.  If it is an integer, zero


### PR DESCRIPTION
Updated the document at Exit() for main thread and non-primary threads.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-6634](https://bugs.python.org/issue6634) -->
https://bugs.python.org/issue6634
<!-- /issue-number -->
