### PR TITLE
bpo-46848: Move _PyBytes_Find() to internal C API

### DIFF
--- a/Include/cpython/bytesobject.h
+++ b/Include/cpython/bytesobject.h
@@ -116,22 +116,3 @@ PyAPI_FUNC(void*) _PyBytesWriter_WriteBytes(_PyBytesWriter *writer,
     void *str,
     const void *bytes,
     Py_ssize_t size);
-
-/* Substring Search.
-
-   Returns the index of the first occurence of
-   a substring ("needle") in a larger text ("haystack").
-   If the needle is not found, return -1.
-   If the needle is found, add offset to the index.
-*/
-
-PyAPI_FUNC(Py_ssize_t)
-_PyBytes_Find(const char *haystack, Py_ssize_t len_haystack,
-              const char *needle, Py_ssize_t len_needle,
-              Py_ssize_t offset);
-
-/* Same as above, but search right-to-left */
-PyAPI_FUNC(Py_ssize_t)
-_PyBytes_ReverseFind(const char *haystack, Py_ssize_t len_haystack,
-                     const char *needle, Py_ssize_t len_needle,
-                     Py_ssize_t offset);

--- a/Include/internal/pycore_bytesobject.h
+++ b/Include/internal/pycore_bytesobject.h
@@ -14,6 +14,25 @@ extern "C" {
 extern PyStatus _PyBytes_InitTypes(PyInterpreterState *);
 
 
+/* Substring Search.
+
+   Returns the index of the first occurence of
+   a substring ("needle") in a larger text ("haystack").
+   If the needle is not found, return -1.
+   If the needle is found, add offset to the index.
+*/
+
+PyAPI_FUNC(Py_ssize_t)
+_PyBytes_Find(const char *haystack, Py_ssize_t len_haystack,
+              const char *needle, Py_ssize_t len_needle,
+              Py_ssize_t offset);
+
+/* Same as above, but search right-to-left */
+PyAPI_FUNC(Py_ssize_t)
+_PyBytes_ReverseFind(const char *haystack, Py_ssize_t len_haystack,
+                     const char *needle, Py_ssize_t len_needle,
+                     Py_ssize_t offset);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -24,6 +24,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include "pycore_bytesobject.h"   // _PyBytes_Find()
 #include "pycore_fileutils.h"     // _Py_stat_struct
 #include "structmember.h"         // PyMemberDef
 #include <stddef.h>               // offsetof()

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -4,6 +4,7 @@
 
 #include "Python.h"
 #include "pycore_abstract.h"      // _PyIndex_Check()
+#include "pycore_bytesobject.h"   // _PyBytes_Find()
 #include "pycore_bytes_methods.h" // _Py_bytes_startswith()
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_format.h"        // F_LJUST


### PR DESCRIPTION
Move _PyBytes_Find() and _PyBytes_ReverseFind() functions to the
internal C API.

bytesobject.c now includes pycore_bytesobject.h.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46848](https://bugs.python.org/issue46848) -->
https://bugs.python.org/issue46848
<!-- /issue-number -->
