### PR TITLE
bpo-46891: Fix creating a new instance of a module subclass with slots

### DIFF
--- a/Lib/test/test_module.py
+++ b/Lib/test/test_module.py
@@ -346,6 +346,25 @@ a = A(destroyed)"""
 
     # frozen and namespace module reprs are tested in importlib.
 
+    def test_subclass_with_slots(self):
+        # In 3.11alpha this crashed, as the slots weren't NULLed.
+
+        class ModuleWithSlots(ModuleType):
+            __slots__ = ("a", "b")
+
+            def __init__(self, name):
+                super().__init__(name)
+
+        m = ModuleWithSlots("name")
+        with self.assertRaises(AttributeError):
+            m.a
+        with self.assertRaises(AttributeError):
+            m.b
+        m.a, m.b = 1, 2
+        self.assertEqual(m.a, 1)
+        self.assertEqual(m.b, 2)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-02-15-04-08.bpo-46891.aIAgTD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-02-15-04-08.bpo-46891.aIAgTD.rst
@@ -1,0 +1,3 @@
+Fix bug introduced during 3.11alpha where subclasses of ``types.ModuleType``
+with ``__slots__`` were not initialized correctly, resulting in an
+interpreter crash.

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -4,6 +4,7 @@
 #include "Python.h"
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_interp.h"        // PyInterpreterState.importlib
+#include "pycore_object.h"        // _PyType_AllocNoTrack
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
 #include "pycore_moduleobject.h"  // _PyModule_GetDef()
 #include "structmember.h"         // PyMemberDef
@@ -80,7 +81,7 @@ static PyModuleObject *
 new_module_notrack(PyTypeObject *mt)
 {
     PyModuleObject *m;
-    m = PyObject_GC_New(PyModuleObject, mt);
+    m = (PyModuleObject *)_PyType_AllocNoTrack(mt, 0);
     if (m == NULL)
         return NULL;
     m->md_def = NULL;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46891](https://bugs.python.org/issue46891) -->
https://bugs.python.org/issue46891
<!-- /issue-number -->
