### PR TITLE
bpo-46845: Move check for str-only keys in LOAD_GLOBAL to specialization time.

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1219,6 +1219,10 @@ _Py_Specialize_LoadGlobal(
         goto fail;
     }
     PyDictKeysObject * globals_keys = ((PyDictObject *)globals)->ma_keys;
+    if (!DK_IS_UNICODE(globals_keys)) {
+        SPECIALIZATION_FAIL(LOAD_GLOBAL, SPEC_FAIL_LOAD_GLOBAL_NON_STRING_OR_SPLIT);
+        goto fail;
+    }
     Py_ssize_t index = _PyDictKeys_StringLookup(globals_keys, name);
     if (index == DKIX_ERROR) {
         SPECIALIZATION_FAIL(LOAD_GLOBAL, SPEC_FAIL_LOAD_GLOBAL_NON_STRING_OR_SPLIT);
@@ -1241,6 +1245,10 @@ _Py_Specialize_LoadGlobal(
         goto fail;
     }
     PyDictKeysObject * builtin_keys = ((PyDictObject *)builtins)->ma_keys;
+    if (!DK_IS_UNICODE(builtin_keys)) {
+        SPECIALIZATION_FAIL(LOAD_GLOBAL, SPEC_FAIL_LOAD_GLOBAL_NON_STRING_OR_SPLIT);
+        goto fail;
+    }
     index = _PyDictKeys_StringLookup(builtin_keys, name);
     if (index == DKIX_ERROR) {
         SPECIALIZATION_FAIL(LOAD_GLOBAL, SPEC_FAIL_LOAD_GLOBAL_NON_STRING_OR_SPLIT);


### PR DESCRIPTION
https://github.com/python/cpython/pull/31564 added some tests to the fast path of `LOAD_GLOBAL_MODULE` and `LOAD_GLOBAL_BUILTIN`.
This PR moves those tests to specialization time.
The success rate for specialization of `LOAD_GLOBAL` remains at 100%.

<!-- issue-number: [bpo-46845](https://bugs.python.org/issue46845) -->
https://bugs.python.org/issue46845
<!-- /issue-number -->
