### PR TITLE
bpo-46841: Improve the failure stats for `COMPARE_OP`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-03-10-46-13.bpo-46841.7CkuZx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-03-10-46-13.bpo-46841.7CkuZx.rst
@@ -1,0 +1,2 @@
+Add more detailed specialization failure stats for :opcode:`COMPARE_OP`
+followed by :opcode:`EXTENDED_ARG`.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -616,6 +616,7 @@ initial_counter_value(void) {
 #define SPEC_FAIL_COMPARE_OP_BASEOBJECT 21
 #define SPEC_FAIL_COMPARE_OP_FLOAT_LONG 22
 #define SPEC_FAIL_COMPARE_OP_LONG_FLOAT 23
+#define SPEC_FAIL_COMPARE_OP_EXTENDED_ARG 24
 
 /* FOR_ITER */
 #define SPEC_FAIL_FOR_ITER_GENERATOR 10
@@ -2080,6 +2081,10 @@ _Py_Specialize_CompareOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
         *instr = _Py_MAKECODEUNIT(COMPARE_OP, oparg);
         return;
 #endif
+        if (next_opcode == EXTENDED_ARG) {
+            SPECIALIZATION_FAIL(COMPARE_OP, SPEC_FAIL_COMPARE_OP_EXTENDED_ARG);
+            goto failure;
+        }
         SPECIALIZATION_FAIL(COMPARE_OP, SPEC_FAIL_COMPARE_OP_NOT_FOLLOWED_BY_COND_JUMP);
         goto failure;
     }


### PR DESCRIPTION
With the move to inline caching, jumps are getting a bit longer. This adds new category of `COMPARE_OP` failures for the (increasingly more common) case where a `COMPARE_OP` instruction is followed by an `EXTENDED_ARG`.

New stats for a full `pyperformance` run:

|Kind | Count | Ratio | 
|---|---|---|
|  unquickened |      7348739 | 0.4% |
| specialization.deferred |    359371048 | 21.7% |
| specialization.deopt |        15730 | 0.0% |
|          hit |   1289210975 | 77.8% |
|         miss |       943057 | 0.1% |

#### Specialization attempts

| | Count | Ratio | 
|---|---:|---:|
| Success | 289083 | 4.8% |
| Failure | 5723386 | 95.2% |

|Failure kind | Count | Ratio | 
|---|---:|---:|
| extended arg | 2473174 | 43.2% |
| not followed by cond jump | 1258612 | 22.0% |
| float long | 671682 | 11.7% |
| set | 579241 | 10.1% |
| different types | 165539 | 2.9% |
| bool | 137038 | 2.4% |
| tuple | 119632 | 2.1% |
| other | 115566 | 2.0% |
| big int | 95547 | 1.7% |
| bytes | 46481 | 0.8% |
| baseobject | 37335 | 0.7% |
| list | 22634 | 0.4% |
| string | 704 | 0.0% |
| long float | 201 | 0.0% |


<!-- issue-number: [bpo-46841](https://bugs.python.org/issue46841) -->
https://bugs.python.org/issue46841
<!-- /issue-number -->
