### PR TITLE
bpo-45459: Fix PyModuleDef_Slot type in the limited C API

### DIFF
--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -55,14 +55,12 @@ typedef struct PyModuleDef_Base {
     NULL, /* m_copy */          \
   }
 
-struct PyModuleDef_Slot;
-
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03050000
 /* New in 3.5 */
-typedef struct PyModuleDef_Slot{
+struct PyModuleDef_Slot {
     int slot;
     void *value;
-} PyModuleDef_Slot;
+};
 
 #define Py_mod_create 1
 #define Py_mod_exec 2

--- a/Include/pytypedefs.h
+++ b/Include/pytypedefs.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 typedef struct PyModuleDef PyModuleDef;
+typedef struct PyModuleDef_Slot PyModuleDef_Slot;
 typedef struct PyMethodDef PyMethodDef;
 typedef struct PyGetSetDef PyGetSetDef;
 typedef struct PyMemberDef PyMemberDef;


### PR DESCRIPTION
Move the type definition to pytypedefs.h.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45459](https://bugs.python.org/issue45459) -->
https://bugs.python.org/issue45459
<!-- /issue-number -->
