### PR TITLE
bpo-45459: Use type names in the internal C API

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -79,12 +79,12 @@ struct atexit_state {
    */
 struct _is {
 
-    struct _is *next;
+    PyInterpreterState *next;
 
     struct pythreads {
         uint64_t next_unique_id;
         /* The linked list of threads, newest first. */
-        struct _ts *head;
+        PyThreadState *head;
         /* Used in Modules/_threadmodule.c. */
         long count;
         /* Support for runtime thread stack size tuning.
@@ -190,7 +190,7 @@ struct _is {
        */
 
     /* the initial PyInterpreterState.threads.head */
-    struct _ts _initial_thread;
+    PyThreadState _initial_thread;
 };
 
 
@@ -214,11 +214,11 @@ struct _xidregitem {
     struct _xidregitem *next;
 };
 
-PyAPI_FUNC(struct _is*) _PyInterpreterState_LookUpID(int64_t);
+PyAPI_FUNC(PyInterpreterState*) _PyInterpreterState_LookUpID(int64_t);
 
-PyAPI_FUNC(int) _PyInterpreterState_IDInitref(struct _is *);
-PyAPI_FUNC(int) _PyInterpreterState_IDIncref(struct _is *);
-PyAPI_FUNC(void) _PyInterpreterState_IDDecref(struct _is *);
+PyAPI_FUNC(int) _PyInterpreterState_IDInitref(PyInterpreterState *);
+PyAPI_FUNC(int) _PyInterpreterState_IDIncref(PyInterpreterState *);
+PyAPI_FUNC(void) _PyInterpreterState_IDDecref(PyInterpreterState *);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_moduleobject.h
+++ b/Include/internal/pycore_moduleobject.h
@@ -11,7 +11,7 @@ extern "C" {
 typedef struct {
     PyObject_HEAD
     PyObject *md_dict;
-    struct PyModuleDef *md_def;
+    PyModuleDef *md_def;
     void *md_state;
     PyObject *md_weaklist;
     // for logging purposes after md_dict is cleared

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -172,7 +172,7 @@ extern void _PySignal_AfterFork(void);
 PyAPI_FUNC(int) _PyState_AddModule(
     PyThreadState *tstate,
     PyObject* module,
-    struct PyModuleDef* def);
+    PyModuleDef* def);
 
 
 PyAPI_FUNC(int) _PyOS_InterruptOccurred(PyThreadState *tstate);

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -11,7 +11,7 @@ extern "C" {
 #include "pycore_atomic.h"          /* _Py_atomic_address */
 #include "pycore_gil.h"             // struct _gil_runtime_state
 #include "pycore_global_objects.h"  // struct _Py_global_objects
-#include "pycore_interp.h"          // struct _is
+#include "pycore_interp.h"          // PyInterpreterState
 #include "pycore_unicodeobject.h"   // struct _Py_unicode_runtime_ids
 
 

--- a/Include/internal/pycore_traceback.h
+++ b/Include/internal/pycore_traceback.h
@@ -8,9 +8,6 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-/* Forward declaration */
-struct _is;
-
 /* Write the Python traceback into the file 'fd'. For example:
 
        Traceback (most recent call first):
@@ -57,7 +54,7 @@ PyAPI_FUNC(void) _Py_DumpTraceback(
 
 PyAPI_FUNC(const char*) _Py_DumpTracebackThreads(
     int fd,
-    struct _is *interp,
+    PyInterpreterState *interp,
     PyThreadState *current_tstate);
 
 /* Write a Unicode object into the file descriptor fd. Encode the string to


### PR DESCRIPTION
Replace "struct xxx" with "xxx" types in the internal C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45459](https://bugs.python.org/issue45459) -->
https://bugs.python.org/issue45459
<!-- /issue-number -->
