### PR TITLE
bpo-46841: Fix `BINARY_OP`'s handling of inline caches

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-03-14-31-53.bpo-46841.agf-3X.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-03-14-31-53.bpo-46841.agf-3X.rst
@@ -1,0 +1,2 @@
+Fix incorrect handling of inline cache entries when specializing
+:opcode:`BINARY_OP`.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2042,8 +2042,9 @@ handle_eval_breaker:
             DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
             DEOPT_IF(Py_TYPE(right) != Py_TYPE(left), BINARY_OP);
             DEOPT_IF(Py_REFCNT(left) != 2, BINARY_OP);
-            int next_oparg = _Py_OPARG(*next_instr);
-            assert(_Py_OPCODE(*next_instr) == STORE_FAST);
+            _Py_CODEUNIT true_next = next_instr[INLINE_CACHE_ENTRIES_BINARY_OP];
+            int next_oparg = _Py_OPARG(true_next);
+            assert(_Py_OPCODE(true_next) == STORE_FAST);
             /* In the common case, there are 2 references to the value
             * stored in 'variable' when the v = v + ... is performed: one
             * on the value stack (in 'v') and one still stored in the

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1949,7 +1949,8 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
                 break;
             }
             if (PyUnicode_CheckExact(lhs)) {
-                if (_Py_OPCODE(instr[1]) == STORE_FAST && Py_REFCNT(lhs) == 2) {
+                _Py_CODEUNIT next = instr[INLINE_CACHE_ENTRIES_BINARY_OP + 1];
+                if (_Py_OPCODE(next) == STORE_FAST && Py_REFCNT(lhs) == 2) {
                     *instr = _Py_MAKECODEUNIT(BINARY_OP_INPLACE_ADD_UNICODE,
                                               oparg);
                     goto success;


### PR DESCRIPTION


<!-- issue-number: [bpo-46841](https://bugs.python.org/issue46841) -->
https://bugs.python.org/issue46841
<!-- /issue-number -->
