### PR TITLE
bpo-46913: test_hashlib skips _sha3 tests on UBSan

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -64,6 +64,10 @@ except ImportError:
 
 requires_blake2 = unittest.skipUnless(_blake2, 'requires _blake2')
 
+# bpo-46913: Don't test the _sha3 extension on a Python UBSAN build
+SKIP_SHA3 = support.check_sanitizer(ub=True)
+requires_sha3 = unittest.skipUnless(not SKIP_SHA3, 'requires _sha3')
+
 
 def hexstr(s):
     assert isinstance(s, bytes), repr(s)
@@ -125,6 +129,8 @@ class HashLibTestCase(unittest.TestCase):
 
         self.constructors_to_test = {}
         for algorithm in algorithms:
+            if SKIP_SHA3 and algorithm.startswith('sha3_'):
+                continue
             self.constructors_to_test[algorithm] = set()
 
         # For each algorithm, test the direct constructor and the use
@@ -177,14 +183,15 @@ class HashLibTestCase(unittest.TestCase):
             add_builtin_constructor('blake2s')
             add_builtin_constructor('blake2b')
 
-        _sha3 = self._conditional_import_module('_sha3')
-        if _sha3:
-            add_builtin_constructor('sha3_224')
-            add_builtin_constructor('sha3_256')
-            add_builtin_constructor('sha3_384')
-            add_builtin_constructor('sha3_512')
-            add_builtin_constructor('shake_128')
-            add_builtin_constructor('shake_256')
+        if not SKIP_SHA3:
+            _sha3 = self._conditional_import_module('_sha3')
+            if _sha3:
+                add_builtin_constructor('sha3_224')
+                add_builtin_constructor('sha3_256')
+                add_builtin_constructor('sha3_384')
+                add_builtin_constructor('sha3_512')
+                add_builtin_constructor('shake_128')
+                add_builtin_constructor('shake_256')
 
         super(HashLibTestCase, self).__init__(*args, **kwargs)
 
@@ -383,6 +390,7 @@ class HashLibTestCase(unittest.TestCase):
         self.check_no_unicode('blake2b')
         self.check_no_unicode('blake2s')
 
+    @requires_sha3
     def test_no_unicode_sha3(self):
         self.check_no_unicode('sha3_224')
         self.check_no_unicode('sha3_256')
@@ -418,6 +426,7 @@ class HashLibTestCase(unittest.TestCase):
         self.check_blocksize_name('sha384', 128, 48)
         self.check_blocksize_name('sha512', 128, 64)
 
+    @requires_sha3
     def test_blocksize_name_sha3(self):
         self.check_blocksize_name('sha3_224', 144, 28)
         self.check_blocksize_name('sha3_256', 136, 32)
@@ -438,6 +447,7 @@ class HashLibTestCase(unittest.TestCase):
             self.assertEqual(m._rate_bits, rate)
             self.assertEqual(m._suffix, suffix)
 
+    @requires_sha3
     def test_extra_sha3(self):
         self.check_sha3('sha3_224', 448, 1152, b'\x06')
         self.check_sha3('sha3_256', 512, 1088, b'\x06')
@@ -777,36 +787,44 @@ class HashLibTestCase(unittest.TestCase):
             key = bytes.fromhex(key)
             self.check('blake2s', msg, md, key=key)
 
+    @requires_sha3
     def test_case_sha3_224_0(self):
         self.check('sha3_224', b"",
           "6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7")
 
+    @requires_sha3
     def test_case_sha3_224_vector(self):
         for msg, md in read_vectors('sha3_224'):
             self.check('sha3_224', msg, md)
 
+    @requires_sha3
     def test_case_sha3_256_0(self):
         self.check('sha3_256', b"",
           "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a")
 
+    @requires_sha3
     def test_case_sha3_256_vector(self):
         for msg, md in read_vectors('sha3_256'):
             self.check('sha3_256', msg, md)
 
+    @requires_sha3
     def test_case_sha3_384_0(self):
         self.check('sha3_384', b"",
           "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2a"+
           "c3713831264adb47fb6bd1e058d5f004")
 
+    @requires_sha3
     def test_case_sha3_384_vector(self):
         for msg, md in read_vectors('sha3_384'):
             self.check('sha3_384', msg, md)
 
+    @requires_sha3
     def test_case_sha3_512_0(self):
         self.check('sha3_512', b"",
           "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a6"+
           "15b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26")
 
+    @requires_sha3
     def test_case_sha3_512_vector(self):
         for msg, md in read_vectors('sha3_512'):
             self.check('sha3_512', msg, md)


### PR DESCRIPTION
If Python is built with UBSan, test_hashlib skips tests on the _sha3
extension which currently has undefined behaviors. Change made to run
more tests on the UBSan buildbot, but _sha3 should be fixed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46913](https://bugs.python.org/issue46913) -->
https://bugs.python.org/issue46913
<!-- /issue-number -->
