### PR TITLE
bpo-46913: Skip test_ctypes.test_shorts() on UBSan

### DIFF
--- a/Lib/ctypes/test/test_bitfields.py
+++ b/Lib/ctypes/test/test_bitfields.py
@@ -1,5 +1,6 @@
 from ctypes import *
 from ctypes.test import need_symbol
+from test import support
 import unittest
 import os
 
@@ -39,6 +40,8 @@ class C_Test(unittest.TestCase):
                 setattr(b, name, i)
                 self.assertEqual(getattr(b, name), func(byref(b), name.encode('ascii')))
 
+    # bpo-46913: _ctypes/cfield.c h_get() has an undefined behavior
+    @support.skip_if_sanitizer(ub=True)
     def test_shorts(self):
         b = BITS()
         name = "M"


### PR DESCRIPTION
If Python is built with UBSan, test_ctypes now skips test_shorts().
This change allows to run test_ctypes to check for UBSan regression,
but the test_shorts() undefined behavior must be fixed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46913](https://bugs.python.org/issue46913) -->
https://bugs.python.org/issue46913
<!-- /issue-number -->
