### PR TITLE
bpo-43923: Revert "bpo-40185: Refactor typing.NamedTuple (GH-19371)"

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4441,11 +4441,9 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(CoolEmployeeWithDefault._field_defaults, dict(cool=0))
 
         with self.assertRaises(TypeError):
-            exec("""
-class NonDefaultAfterDefault(NamedTuple):
-    x: int = 3
-    y: int
-""")
+            class NonDefaultAfterDefault(NamedTuple):
+                x: int = 3
+                y: int
 
     def test_annotation_usage_with_methods(self):
         self.assertEqual(XMeth(1).double(), 2)
@@ -4454,20 +4452,16 @@ class NonDefaultAfterDefault(NamedTuple):
         self.assertEqual(XRepr(1, 2) + XRepr(3), 0)
 
         with self.assertRaises(AttributeError):
-            exec("""
-class XMethBad(NamedTuple):
-    x: int
-    def _fields(self):
-        return 'no chance for this'
-""")
+            class XMethBad(NamedTuple):
+                x: int
+                def _fields(self):
+                    return 'no chance for this'
 
         with self.assertRaises(AttributeError):
-            exec("""
-class XMethBad2(NamedTuple):
-    x: int
-    def _source(self):
-        return 'no chance for this as well'
-""")
+            class XMethBad2(NamedTuple):
+                x: int
+                def _source(self):
+                    return 'no chance for this as well'
 
     def test_multiple_inheritance(self):
         class A:

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4441,9 +4441,11 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(CoolEmployeeWithDefault._field_defaults, dict(cool=0))
 
         with self.assertRaises(TypeError):
-            class NonDefaultAfterDefault(NamedTuple):
-                x: int = 3
-                y: int
+            exec("""
+class NonDefaultAfterDefault(NamedTuple):
+    x: int = 3
+    y: int
+""")
 
     def test_annotation_usage_with_methods(self):
         self.assertEqual(XMeth(1).double(), 2)
@@ -4452,16 +4454,20 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(XRepr(1, 2) + XRepr(3), 0)
 
         with self.assertRaises(AttributeError):
-            class XMethBad(NamedTuple):
-                x: int
-                def _fields(self):
-                    return 'no chance for this'
+            exec("""
+class XMethBad(NamedTuple):
+    x: int
+    def _fields(self):
+        return 'no chance for this'
+""")
 
         with self.assertRaises(AttributeError):
-            class XMethBad2(NamedTuple):
-                x: int
-                def _source(self):
-                    return 'no chance for this as well'
+            exec("""
+class XMethBad2(NamedTuple):
+    x: int
+    def _source(self):
+        return 'no chance for this as well'
+""")
 
     def test_multiple_inheritance(self):
         class A:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2409,11 +2409,11 @@ def _make_nmtuple(name, types):
 
 
 # attributes prohibited to set in NamedTuple class syntax
-_prohibited = {'__new__', '__init__', '__slots__', '__getnewargs__',
-               '_fields', '_field_defaults',
-               '_make', '_replace', '_asdict', '_source'}
+_prohibited = frozenset({'__new__', '__init__', '__slots__', '__getnewargs__',
+                         '_fields', '_field_defaults',
+                         '_make', '_replace', '_asdict', '_source'})
 
-_special = {'__module__', '__name__', '__annotations__'}
+_special = frozenset({'__module__', '__name__', '__annotations__'})
 
 
 class NamedTupleMeta(type):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2396,41 +2396,51 @@ class SupportsRound(Protocol[T_co]):
         pass
 
 
-def _make_nmtuple(name, types, module, defaults = ()):
-    fields = [n for n, t in types]
-    types = {n: _type_check(t, f"field {n} annotation must be a type")
-             for n, t in types}
-    nm_tpl = collections.namedtuple(name, fields,
-                                    defaults=defaults, module=module)
-    nm_tpl.__annotations__ = nm_tpl.__new__.__annotations__ = types
+def _make_nmtuple(name, types):
+    msg = "NamedTuple('Name', [(f0, t0), (f1, t1), ...]); each t must be a type"
+    types = [(n, _type_check(t, msg)) for n, t in types]
+    nm_tpl = collections.namedtuple(name, [n for n, t in types])
+    nm_tpl.__annotations__ = dict(types)
+    try:
+        nm_tpl.__module__ = sys._getframe(2).f_globals.get('__name__', '__main__')
+    except (AttributeError, ValueError):
+        pass
     return nm_tpl
 
 
 # attributes prohibited to set in NamedTuple class syntax
-_prohibited = frozenset({'__new__', '__init__', '__slots__', '__getnewargs__',
-                         '_fields', '_field_defaults',
-                         '_make', '_replace', '_asdict', '_source'})
+_prohibited = {'__new__', '__init__', '__slots__', '__getnewargs__',
+               '_fields', '_field_defaults',
+               '_make', '_replace', '_asdict', '_source'}
 
-_special = frozenset({'__module__', '__name__', '__annotations__'})
+_special = {'__module__', '__name__', '__annotations__'}
 
 
 class NamedTupleMeta(type):
 
     def __new__(cls, typename, bases, ns):
-        assert bases[0] is _NamedTuple
+        if ns.get('_root', False):
+            return super().__new__(cls, typename, bases, ns)
+        if len(bases) > 1:
+            raise TypeError("Multiple inheritance with NamedTuple is not supported")
+        assert bases[0] is NamedTuple
         types = ns.get('__annotations__', {})
-        default_names = []
+        nm_tpl = _make_nmtuple(typename, types.items())
+        defaults = []
+        defaults_dict = {}
         for field_name in types:
             if field_name in ns:
-                default_names.append(field_name)
-            elif default_names:
-                raise TypeError(f"Non-default namedtuple field {field_name} "
-                                f"cannot follow default field"
-                                f"{'s' if len(default_names) > 1 else ''} "
-                                f"{', '.join(default_names)}")
-        nm_tpl = _make_nmtuple(typename, types.items(),
-                               defaults=[ns[n] for n in default_names],
-                               module=ns['__module__'])
+                default_value = ns[field_name]
+                defaults.append(default_value)
+                defaults_dict[field_name] = default_value
+            elif defaults:
+                raise TypeError("Non-default namedtuple field {field_name} cannot "
+                                "follow default field(s) {default_names}"
+                                .format(field_name=field_name,
+                                        default_names=', '.join(defaults_dict.keys())))
+        nm_tpl.__new__.__annotations__ = dict(types)
+        nm_tpl.__new__.__defaults__ = tuple(defaults)
+        nm_tpl._field_defaults = defaults_dict
         # update from user namespace without overriding special namedtuple attributes
         for key in ns:
             if key in _prohibited:
@@ -2440,7 +2450,7 @@ class NamedTupleMeta(type):
         return nm_tpl
 
 
-def NamedTuple(typename, fields=None, /, **kwargs):
+class NamedTuple(metaclass=NamedTupleMeta):
     """Typed version of namedtuple.
 
     Usage in Python versions >= 3.6::
@@ -2464,22 +2474,15 @@ def NamedTuple(typename, fields=None, /, **kwargs):
 
         Employee = NamedTuple('Employee', [('name', str), ('id', int)])
     """
-    if fields is None:
-        fields = kwargs.items()
-    elif kwargs:
-        raise TypeError("Either list of fields or keywords"
-                        " can be provided to NamedTuple, not both")
-    return _make_nmtuple(typename, fields, module=_caller())
+    _root = True
 
-_NamedTuple = type.__new__(NamedTupleMeta, 'NamedTuple', (), {})
-
-def _namedtuple_mro_entries(bases):
-    if len(bases) > 1:
-        raise TypeError("Multiple inheritance with NamedTuple is not supported")
-    assert bases[0] is NamedTuple
-    return (_NamedTuple,)
-
-NamedTuple.__mro_entries__ = _namedtuple_mro_entries
+    def __new__(cls, typename, fields=None, /, **kwargs):
+        if fields is None:
+            fields = kwargs.items()
+        elif kwargs:
+            raise TypeError("Either list of fields or keywords"
+                            " can be provided to NamedTuple, not both")
+        return _make_nmtuple(typename, fields)
 
 
 class _TypedDictMeta(type):


### PR DESCRIPTION
This reverts commit a2ec06938f46683e33692615aca3875d8b8e110c.

<!-- issue-number: [bpo-43923](https://bugs.python.org/issue43923) -->
https://bugs.python.org/issue43923
<!-- /issue-number -->
