### PR TITLE
bpo-46541: Remove usage of _Py_IDENTIFIER from lzma module

### DIFF
--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -6,7 +6,6 @@
 */
 
 #define PY_SSIZE_T_CLEAN
-#define NEEDS_PY_IDENTIFIER
 
 #include "Python.h"
 #include "structmember.h"         // PyMemberDef
@@ -431,17 +430,19 @@ parse_filter_chain_spec(_lzma_state *state, lzma_filter filters[], PyObject *fil
    Python-level filter specifiers (represented as dicts). */
 
 static int
-spec_add_field(PyObject *spec, _Py_Identifier *key, unsigned long long value)
+spec_add_field(PyObject *spec, const char *key, unsigned long long value)
 {
-    int status;
-    PyObject *value_object;
-
-    value_object = PyLong_FromUnsignedLongLong(value);
+    PyObject *value_object = PyLong_FromUnsignedLongLong(value);
     if (value_object == NULL) {
         return -1;
     }
-
-    status = _PyDict_SetItemId(spec, key, value_object);
+    PyObject *key_object = PyUnicode_InternFromString(key);
+    if (key_object == NULL) {
+        Py_DECREF(value_object);
+        return -1;
+    }
+    int status = PyDict_SetItem(spec, key_object, value_object);
+    Py_DECREF(key_object);
     Py_DECREF(value_object);
     return status;
 }
@@ -458,8 +459,7 @@ build_filter_spec(const lzma_filter *f)
 
 #define ADD_FIELD(SOURCE, FIELD) \
     do { \
-        _Py_IDENTIFIER(FIELD); \
-        if (spec_add_field(spec, &PyId_##FIELD, SOURCE->FIELD) == -1) \
+        if (spec_add_field(spec, #FIELD, SOURCE->FIELD) == -1) \
             goto error;\
     } while (0)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46541](https://bugs.python.org/issue46541) -->
https://bugs.python.org/issue46541
<!-- /issue-number -->
