### PR TITLE
Replace key if not identical to old key in dict

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -618,6 +618,21 @@ class DictTest(unittest.TestCase):
         with self.assertRaises(Exc):
             d1 == d2
 
+    def test_eq_replace(self):
+        class AlwaysEqualCmp(object):
+            def __eq__(self, other):
+                return True
+
+            def __hash__(self):
+                return 1
+
+        o1 = AlwaysEqualCmp()
+        d3 = {}
+        d3[o1] = 1
+        o2 = AlwaysEqualCmp()
+        d3[o2] = 2
+        assert tuple(d3.keys())[0] is o2
+
     def test_keys_contained(self):
         self.helper_keys_contained(lambda x: x.keys())
         self.helper_keys_contained(lambda x: x.items())

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1797,6 +1797,19 @@ class MappingTestCase(TestBase):
         self.assertRaises(TypeError, d.__getitem__,  13)
         self.assertRaises(TypeError, d.__setitem__,  13, 13)
 
+    def test_weak_keyed_equal_replacement(self):
+        d = weakref.WeakKeyDictionary()
+        o1 = Object('1')
+        o2 = Object('1')
+        d[o1] = 1
+        d[o2] = 2
+        assert len(d) == 1
+        assert d[o2] == 2
+        assert tuple(d.keys())[0] is o2
+        del o1
+        assert len(d) == 1
+        assert tuple(d.keys())[0] is o2
+
     def test_weak_keyed_cascading_deletes(self):
         # SF bug 742860.  For some reason, before 2.3 __delitem__ iterated
         # over the keys via self.data.iterkeys().  If things vanished from

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1222,6 +1222,7 @@ Consumes key and value references.
 static int
 insertdict(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject *value)
 {
+    PyObject *old_key;
     PyObject *old_value;
 
     if (DK_IS_UNICODE(mp->ma_keys) && !PyUnicode_CheckExact(key)) {
@@ -1277,6 +1278,15 @@ insertdict(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject *value)
         assert(mp->ma_keys->dk_usable >= 0);
         ASSERT_CONSISTENT(mp);
         return 0;
+    }
+
+    if (!DK_IS_UNICODE(mp->ma_keys)) {
+        PyDictKeyEntry *ep = &DK_ENTRIES(mp->ma_keys)[ix];
+        old_key = ep->me_key;
+        if (old_key != key) {
+            ep->me_key = key;
+            key = old_key;
+        }
     }
 
     if (old_value != value) {


### PR DESCRIPTION
This fixes an issue in `dict` and by extension in `weakref.WeakKeyDictionary` which arises when a key that is equal to an existing key is used to set a new value – where the key itself is not replaced.

To appreciate this situation, consider when the keys are type `weakref.ref`.

In this case, the lifetime of the key after replacing the value is now that of the initial key and not the one that's been set subsequently – since the key entry is still the initial object. If the first key falls to refcount zero, the key is removed from the `weakref.WeakKeyDictionary` – which is unexpected because we have set a newer key which might have refcount greater than zero.

In the general case where a value is replaced for the exact same key (object identity), there is no practical difference with this change – and when a new key is used to replace a value, the cost is only a write to memory.

Thanks to @potiuk and @ashb for helping finding this issue which was discovered during flaky test runs in [Apache Airflow](https://airflow.apache.org/).
