### PR TITLE
bpo-46927: Include the type's name in the error message for subscripting non-generic types

### DIFF
--- a/Lib/test/test_exception_group.py
+++ b/Lib/test/test_exception_group.py
@@ -11,7 +11,7 @@ class TestExceptionGroupTypeHierarchy(unittest.TestCase):
         self.assertTrue(issubclass(BaseExceptionGroup, BaseException))
 
     def test_exception_is_not_generic_type(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, 'Exception'):
             Exception[OSError]
 
     def test_exception_group_is_generic_type(self):

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -109,7 +109,7 @@ class BaseTest(unittest.TestCase):
         for t in int, str, float, Sized, Hashable:
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):
-                with self.assertRaises(TypeError):
+                with self.assertRaisesRegex(TypeError, tname):
                     t[int]
 
     def test_instantiate(self):
@@ -275,7 +275,7 @@ class BaseTest(unittest.TestCase):
     def test_type_subclass_generic(self):
         class MyType(type):
             pass
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, 'MyType'):
             MyType[int]
 
     def test_pickle(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-05-12-23-58.bpo-46927.URbHBi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-05-12-23-58.bpo-46927.URbHBi.rst
@@ -1,2 +1,2 @@
-Include the type's name in the error message for subscribing non-generic
+Include the type's name in the error message for subscripting non-generic
 types.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-05-12-23-58.bpo-46927.URbHBi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-05-12-23-58.bpo-46927.URbHBi.rst
@@ -1,0 +1,2 @@
+Include the type's name in the error message for subscribing non-generic
+types.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -190,6 +190,9 @@ PyObject_GetItem(PyObject *o, PyObject *key)
             Py_DECREF(meth);
             return result;
         }
+        PyErr_Format(PyExc_TypeError, "type '%.200s' is not subscriptable",
+                     ((PyTypeObject *)o)->tp_name);
+        return NULL;
     }
 
     return type_error("'%.200s' object is not subscriptable", o);


### PR DESCRIPTION


<!-- issue-number: [bpo-46927](https://bugs.python.org/issue46927) -->
https://bugs.python.org/issue46927
<!-- /issue-number -->
