### PR TITLE
bpo-43292: Fix file leak in `ET.iterparse()` when not exhausted

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -658,6 +658,11 @@ class ElementTreeTest(unittest.TestCase):
                     'junk after document element: line 1, column 12')
             del cm, it
 
+        # Not exhausting the iterator still closes the resource (bpo-43292)
+        with warnings_helper.check_no_resource_warning(self):
+            it = iterparse(TESTFN)
+            del it
+
     def test_writefile(self):
         elem = ET.Element("tag")
         elem.text = "text"

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -663,6 +663,9 @@ class ElementTreeTest(unittest.TestCase):
             it = iterparse(TESTFN)
             del it
 
+        with self.assertRaises(FileNotFoundError):
+            iterparse("nonexistent")
+
     def test_writefile(self):
         elem = ET.Element("tag")
         elem.text = "text"

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1245,13 +1245,13 @@ def iterparse(source, events=None, parser=None):
     # parser argument of iterparse is removed, this can be killed.
     pullparser = XMLPullParser(events=events, _parser=parser)
 
-    def iterator():
-        nonlocal source
+    def iterator(source):
         close_source = False
-        if not hasattr(source, "read"):
-            source = open(source, "rb")
-            close_source = True
         try:
+            if not hasattr(source, "read"):
+                source = open(source, "rb")
+                close_source = True
+            yield None
             while True:
                 yield from pullparser.read_events()
                 # load event buffer
@@ -1267,11 +1267,12 @@ def iterparse(source, events=None, parser=None):
                 source.close()
 
     class IterParseIterator(collections.abc.Iterator):
-        __next__ = iterator().__next__
+        __next__ = iterator(source).__next__
     it = IterParseIterator()
     it.root = None
     del iterator, IterParseIterator
 
+    next(it)
     return it
 
 

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1244,7 +1244,13 @@ def iterparse(source, events=None, parser=None):
     # Use the internal, undocumented _parser argument for now; When the
     # parser argument of iterparse is removed, this can be killed.
     pullparser = XMLPullParser(events=events, _parser=parser)
+
     def iterator():
+        nonlocal source
+        close_source = False
+        if not hasattr(source, "read"):
+            source = open(source, "rb")
+            close_source = True
         try:
             while True:
                 yield from pullparser.read_events()
@@ -1265,11 +1271,6 @@ def iterparse(source, events=None, parser=None):
     it = IterParseIterator()
     it.root = None
     del iterator, IterParseIterator
-
-    close_source = False
-    if not hasattr(source, "read"):
-        source = open(source, "rb")
-        close_source = True
 
     return it
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1879,6 +1879,7 @@ Wojtek Walczak
 Charles Waldman
 Richard Walker
 Larry Wall
+Jacob Walls
 Kevin Walzer
 Rodrigo Steinmuller Wanderley
 Dingyuan Wang

--- a/Misc/NEWS.d/next/Library/2022-03-05-09-43-53.bpo-25707.gTlclP.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-05-09-43-53.bpo-25707.gTlclP.rst
@@ -1,0 +1,2 @@
+Fixed a file leak in :func:`xml.etree.ElementTree.iterparse` when the
+iterator is not exhausted. Patch by Jacob Walls.


### PR DESCRIPTION
[bpo-43292](https://bugs.python.org/issue43292): This fixes the file leak in `xml.etree.ElementTree.iterparse` when the iterator is garbage collected before being exhausted.

Regression test fails on main.
***
Related, but not done in this PR: [bpo-25707](https://bugs.python.org/issue25707) is a request for an explicit `close()` method for `iterparse()`. I am not certain if that feature would still be desired after this change.

<!-- issue-number: [bpo-43292](https://bugs.python.org/issue43292) -->
https://bugs.python.org/issue43292
<!-- /issue-number -->
