### PR TITLE
bpo-9305: Remove east/west references from datetime

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1954,7 +1954,7 @@ Examples of working with a :class:`.time` object::
 
 .. method:: tzinfo.utcoffset(dt)
 
-   Returns the dfference between local time and UTC as a :class:`timedelta` object.
+   Return the difference between local time and UTC as a :class:`timedelta` object.
    One must add this offset to UTC to arrive at local time.
 
    This represents the *total* offset from UTC; for example, if a

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1954,8 +1954,8 @@ Examples of working with a :class:`.time` object::
 
 .. method:: tzinfo.utcoffset(dt)
 
-   Return offset of local time from UTC, as a :class:`timedelta` object that is
-   positive east of UTC. If local time is west of UTC, this should be negative.
+   Returns the dfference between local time and UTC as a :class:`timedelta` object.
+   One must add this offset to UTC to arrive at local time.
 
    This represents the *total* offset from UTC; for example, if a
    :class:`tzinfo` object represents both time zone and DST adjustments,

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1127,7 +1127,7 @@ class tzinfo:
         raise NotImplementedError("tzinfo subclass must override utcoffset()")
 
     def dst(self, dt):
-        """Returns the DST offset as a timedelta object.
+        """Return the DST offset as a timedelta object.
 
         Return 0 if DST not in effect.  utcoffset() must include the DST
         offset.
@@ -1466,7 +1466,7 @@ class time:
     # Timezone functions
 
     def utcoffset(self):
-        """Returns the difference between local time and UTC as a timedelta object."""
+        """Return the difference between local time and UTC as a timedelta object."""
         if self._tzinfo is None:
             return None
         offset = self._tzinfo.utcoffset(None)
@@ -1487,7 +1487,7 @@ class time:
         return name
 
     def dst(self):
-        """Returns the DST offset as a timedelta object, or timedelta(0) if
+        """Return the DST offset as a timedelta object, or timedelta(0) if
         DST is not in effect.
 
         This is purely informational; the DST offset has already been added to
@@ -1950,7 +1950,7 @@ class datetime(date):
         return _strptime._strptime_datetime(cls, date_string, format)
 
     def utcoffset(self):
-        """Returns the difference between local time and UTC as a timedelta object."""
+        """Return the difference between local time and UTC as a timedelta object."""
         if self._tzinfo is None:
             return None
         offset = self._tzinfo.utcoffset(self)
@@ -1971,7 +1971,7 @@ class datetime(date):
         return name
 
     def dst(self):
-        """Returns the DST offset as a timedelta object, or timedelta(0) if
+        """Return the DST offset as a timedelta object, or timedelta(0) if
         DST is not in effect.
 
         This is purely informational; the DST offset has already been added to

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1123,7 +1123,7 @@ class tzinfo:
         raise NotImplementedError("tzinfo subclass must override tzname()")
 
     def utcoffset(self, dt):
-        "Returns the difference between local time and UTC as a timedelta object."
+        "Return the difference between local time and UTC as a timedelta object."
         raise NotImplementedError("tzinfo subclass must override utcoffset()")
 
     def dst(self, dt):

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1487,8 +1487,8 @@ class time:
         return name
 
     def dst(self):
-         """Returns the DST offset as a timedelta object, or timedelta(0) if
-         DST is not in effect.
+        """Returns the DST offset as a timedelta object, or timedelta(0) if
+        DST is not in effect.
 
         This is purely informational; the DST offset has already been added to
         the UTC offset returned by utcoffset() if applicable, so there's no

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1123,11 +1123,11 @@ class tzinfo:
         raise NotImplementedError("tzinfo subclass must override tzname()")
 
     def utcoffset(self, dt):
-        "datetime -> timedelta, positive for east of UTC, negative for west of UTC"
+        "Returns the difference between local time and UTC as a timedelta object."
         raise NotImplementedError("tzinfo subclass must override utcoffset()")
 
     def dst(self, dt):
-        """datetime -> DST offset as timedelta, positive for east of UTC.
+        """Returns the DST offset as a timedelta object.
 
         Return 0 if DST not in effect.  utcoffset() must include the DST
         offset.
@@ -1466,8 +1466,7 @@ class time:
     # Timezone functions
 
     def utcoffset(self):
-        """Return the timezone offset as timedelta, positive east of UTC
-         (negative west of UTC)."""
+        """Returns the difference between local time and UTC as a timedelta object."""
         if self._tzinfo is None:
             return None
         offset = self._tzinfo.utcoffset(None)
@@ -1488,8 +1487,8 @@ class time:
         return name
 
     def dst(self):
-        """Return 0 if DST is not in effect, or the DST offset (as timedelta
-        positive eastward) if DST is in effect.
+         """Returns the DST offset as a timedelta object, or timedelta(0) if
+         DST is not in effect.
 
         This is purely informational; the DST offset has already been added to
         the UTC offset returned by utcoffset() if applicable, so there's no
@@ -1951,8 +1950,7 @@ class datetime(date):
         return _strptime._strptime_datetime(cls, date_string, format)
 
     def utcoffset(self):
-        """Return the timezone offset as timedelta positive east of UTC (negative west of
-        UTC)."""
+        """Returns the difference between local time and UTC as a timedelta object."""
         if self._tzinfo is None:
             return None
         offset = self._tzinfo.utcoffset(self)
@@ -1973,8 +1971,8 @@ class datetime(date):
         return name
 
     def dst(self):
-        """Return 0 if DST is not in effect, or the DST offset (as timedelta
-        positive eastward) if DST is in effect.
+        """Returns the DST offset as a timedelta object, or timedelta(0) if
+        DST is not in effect.
 
         This is purely informational; the DST offset has already been added to
         the UTC offset returned by utcoffset() if applicable, so there's no

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1199,7 +1199,7 @@ call_tzinfo_method(PyObject *tzinfo, const char *name, PyObject *tzinfoarg)
  * doesn't return None or timedelta, TypeError is raised and this returns -1.
  * If utcoffset() returns an out of range timedelta,
  * ValueError is raised and this returns -1.  Else *none is
- * set to 0 and the offset from UTC is returned as int number of minutes.
+ * set to 0 and the offset from UTC is returned as an int number of minutes.
  */
 static PyObject *
 call_utcoffset(PyObject *tzinfo, PyObject *tzinfoarg)

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1199,7 +1199,7 @@ call_tzinfo_method(PyObject *tzinfo, const char *name, PyObject *tzinfoarg)
  * doesn't return None or timedelta, TypeError is raised and this returns -1.
  * If utcoffset() returns an out of range timedelta,
  * ValueError is raised and this returns -1.  Else *none is
- * set to 0 and the offset from UTC is returned as int # of minutes.
+ * set to 0 and the offset from UTC is returned as int number of minutes.
  */
 static PyObject *
 call_utcoffset(PyObject *tzinfo, PyObject *tzinfoarg)
@@ -1213,7 +1213,7 @@ call_utcoffset(PyObject *tzinfo, PyObject *tzinfoarg)
  * doesn't return None or timedelta, TypeError is raised and this
  * returns -1.  If dst() returns an invalid timedelta for a UTC offset,
  * ValueError is raised and this returns -1.  Else *none is set to 0 and
- * the offset from local time is returned as an int # of minutes.
+ * the offset from local time is returned as an int number of minutes.
  */
 static PyObject *
 call_dst(PyObject *tzinfo, PyObject *tzinfoarg)
@@ -3790,11 +3790,11 @@ static PyMethodDef tzinfo_methods[] = {
      PyDoc_STR("datetime -> string name of time zone.")},
 
     {"utcoffset",       (PyCFunction)tzinfo_utcoffset,          METH_O,
-     PyDoc_STR("Returns the difference between local time and UTC as a timedelta "
+     PyDoc_STR("Return the difference between local time and UTC as a timedelta "
         "object.")},
 
     {"dst",             (PyCFunction)tzinfo_dst,                METH_O,
-     PyDoc_STR("Returns the DST offset as a timedelta object.")},
+     PyDoc_STR("Return the DST offset as a timedelta object.")},
 
     {"fromutc",         (PyCFunction)tzinfo_fromutc,            METH_O,
      PyDoc_STR("datetime in UTC -> datetime in local time.")},

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1199,7 +1199,7 @@ call_tzinfo_method(PyObject *tzinfo, const char *name, PyObject *tzinfoarg)
  * doesn't return None or timedelta, TypeError is raised and this returns -1.
  * If utcoffset() returns an out of range timedelta,
  * ValueError is raised and this returns -1.  Else *none is
- * set to 0 and the offset is returned (as timedelta, positive east of UTC).
+ * set to 0 and the offset from UTC is returned as int # of minutes.
  */
 static PyObject *
 call_utcoffset(PyObject *tzinfo, PyObject *tzinfoarg)
@@ -1213,7 +1213,7 @@ call_utcoffset(PyObject *tzinfo, PyObject *tzinfoarg)
  * doesn't return None or timedelta, TypeError is raised and this
  * returns -1.  If dst() returns an invalid timedelta for a UTC offset,
  * ValueError is raised and this returns -1.  Else *none is set to 0 and
- * the offset is returned (as timedelta, positive east of UTC).
+ * the offset from local time is returned as an int # of minutes.
  */
 static PyObject *
 call_dst(PyObject *tzinfo, PyObject *tzinfoarg)
@@ -3790,11 +3790,11 @@ static PyMethodDef tzinfo_methods[] = {
      PyDoc_STR("datetime -> string name of time zone.")},
 
     {"utcoffset",       (PyCFunction)tzinfo_utcoffset,          METH_O,
-     PyDoc_STR("datetime -> timedelta showing offset from UTC, negative "
-           "values indicating West of UTC")},
+     PyDoc_STR("Returns the difference between local time and UTC as a timedelta "
+        "object.")},
 
     {"dst",             (PyCFunction)tzinfo_dst,                METH_O,
-     PyDoc_STR("datetime -> DST offset as timedelta positive east of UTC.")},
+     PyDoc_STR("Returns the DST offset as a timedelta object.")},
 
     {"fromutc",         (PyCFunction)tzinfo_fromutc,            METH_O,
      PyDoc_STR("datetime in UTC -> datetime in local time.")},


### PR DESCRIPTION


<!-- issue-number: [bpo-9305](https://bugs.python.org/issue9305) -->
https://bugs.python.org/issue9305
<!-- /issue-number -->
