### PR TITLE
bpo-46936: Update grammar_grapher with the new forced (&&) directive

### DIFF
--- a/Tools/peg_generator/scripts/grammar_grapher.py
+++ b/Tools/peg_generator/scripts/grammar_grapher.py
@@ -29,6 +29,7 @@ from pegen.build import build_parser
 from pegen.grammar import (
     Alt,
     Cut,
+    Forced,
     Grammar,
     Group,
     Leaf,
@@ -60,6 +61,8 @@ def references_for_item(item: Any) -> List[Any]:
         return [_ref for _item in item.items for _ref in references_for_item(_item)]
     elif isinstance(item, Cut):
         return []
+    elif isinstance(item, Forced):
+        return references_for_item(item.node)
     elif isinstance(item, Group):
         return references_for_item(item.rhs)
     elif isinstance(item, Lookahead):


### PR DESCRIPTION
The `grammar_grapher.py`utility has not been updated after the introduction  of the new "forced" directive ('&&') in the grammar (see https://github.com/python/cpython/pull/24292) and fails to visualize the current Python grammar.


<!-- issue-number: [bpo-46936](https://bugs.python.org/issue46936) -->
https://bugs.python.org/issue46936
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal