### PR TITLE
CI: Fix patchcheck

### DIFF
--- a/.azure-pipelines/posix-steps.yml
+++ b/.azure-pipelines/posix-steps.yml
@@ -66,7 +66,9 @@ steps:
         COMMAND: make
 
 - ${{ if eq(parameters.patchcheck, 'true') }}:
-  - script: ./python Tools/scripts/patchcheck.py --ci true
+  - script: |
+      git fetch origin
+      ./python Tools/scripts/patchcheck.py --ci true
     displayName: 'Run patchcheck.py'
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
 

--- a/Tools/scripts/patchcheck.py
+++ b/Tools/scripts/patchcheck.py
@@ -130,6 +130,8 @@ def changed_files(base_branch=None):
         with subprocess.Popen(cmd.split(),
                               stdout=subprocess.PIPE,
                               cwd=SRCDIR) as st:
+            if st.wait() != 0:
+                sys.exit(f'error running {cmd}')
             for line in st.stdout:
                 line = line.decode().rstrip()
                 status_text, filename = line.split(maxsplit=1)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

patchcheck was erroring on the CI but not reporting as a failure. It wasn't not actually checking any files:
```
Getting the list of files that have been added/changed ... fatal: ambiguous argument 'origin/main': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
0 files
```

Two fixes here:

* Make errors noisy: report then non-zero exit
* Fix the error: CI was in detached HEAD, need to `git fetch origin` so it has access to diff `origin/main`
