### PR TITLE
bpo-46903: Use assertEqual, not assertEquals in test_unicode

### DIFF
--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -3055,18 +3055,18 @@ class StringModuleTest(unittest.TestCase):
         with self.assertRaises(AttributeError):
             delattr(o, name)
         setattr(o, name, 1)
-        self.assertEquals(o.name, 1)
+        self.assertEqual(o.name, 1)
         o.name = 2
-        self.assertEquals(list(o.__dict__), [name])
+        self.assertEqual(list(o.__dict__), [name])
 
         with self.assertRaises(AttributeError):
             delattr(o, name2)
         with self.assertRaises(AttributeError):
             del o.name2
         setattr(o, name2, 3)
-        self.assertEquals(o.name2, 3)
+        self.assertEqual(o.name2, 3)
         o.name2 = 4
-        self.assertEquals(list(o.__dict__), [name, name2])
+        self.assertEqual(list(o.__dict__), [name, name2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46903](https://bugs.python.org/issue46903) -->
https://bugs.python.org/issue46903
<!-- /issue-number -->

Automerge-Triggered-By: GH:sweeneyde