### PR TITLE
[3.10] bpo-46936: Update grammar_grapher with the new forced (&&) directive (GH-31704)

### DIFF
--- a/Tools/peg_generator/scripts/grammar_grapher.py
+++ b/Tools/peg_generator/scripts/grammar_grapher.py
@@ -29,6 +29,7 @@ from pegen.build import build_parser
 from pegen.grammar import (
     Alt,
     Cut,
+    Forced,
     Grammar,
     Group,
     Leaf,
@@ -57,6 +58,8 @@ def references_for_item(item: Any) -> List[Any]:
         return [_ref for _item in item.items for _ref in references_for_item(_item)]
     elif isinstance(item, Cut):
         return []
+    elif isinstance(item, Forced):
+        return references_for_item(item.node)
     elif isinstance(item, Group):
         return references_for_item(item.rhs)
     elif isinstance(item, Lookahead):


### PR DESCRIPTION
(cherry picked from commit 7f07b5ee9c2d17f837c44440bf066c73f92dac14)

Co-authored-by: Luca Chiodini <luca@chiodini.org>


<!-- issue-number: [bpo-46936](https://bugs.python.org/issue46936) -->
https://bugs.python.org/issue46936
<!-- /issue-number -->
