### PR TITLE
bpo-46943: fix[imaplib]: call Exception with string instance

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -609,7 +609,7 @@ class IMAP4:
         """
         typ, dat = self._simple_command('LOGIN', user, self._quote(password))
         if typ != 'OK':
-            raise self.error(dat[-1])
+            raise self.error(dat[-1].decode('UTF-8', 'replace'))
         self.state = 'AUTH'
         return typ, dat
 


### PR DESCRIPTION
Adjust the behavior of `login` similar to `authenticate()` where `self.error` is called with a `str` instance.

Especially for Python3 with strict bytes mode (-bb) this is helpful and prevents:
    
```
    Traceback (most recent call last):
      in "<stdin>"
        self.login(email, password)
      File "/usr/lib/python3.7/imaplib.py", line 598, in login
        raise self.error(dat[-1])
    imaplib.error: <exception str() failed>
    
    During handling of the above exception, another exception occurred:
    Traceback (most recent call last):
      in "<stdin>"
        str(exc)
    BytesWarning: str() on a bytes instance
```

<!-- issue-number: [bpo-46943](https://bugs.python.org/issue46943) -->
https://bugs.python.org/issue46943
<!-- /issue-number -->
