### PR TITLE
[3.9] bpo-46948: Fix CVE-2022-26488 by ensuring the Windows Installer correctly uses the install path during repair

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-03-07-16-34-11.bpo-46948.Ufd4tG.rst
+++ b/Misc/NEWS.d/next/Windows/2022-03-07-16-34-11.bpo-46948.Ufd4tG.rst
@@ -1,0 +1,2 @@
+Prevent CVE-2022-26488 by ensuring the Add to PATH option in the Windows
+installer uses the correct path when being repaired.

--- a/Tools/msi/bundle/bundle.wxs
+++ b/Tools/msi/bundle/bundle.wxs
@@ -95,8 +95,8 @@
     <Chain ParallelCache="yes">
       <PackageGroupRef Id="crt" />
       <PackageGroupRef Id="core" />
-      <PackageGroupRef Id="dev" />
       <PackageGroupRef Id="exe" />
+      <PackageGroupRef Id="dev" />
       <PackageGroupRef Id="lib" />
       <PackageGroupRef Id="test" />
       <PackageGroupRef Id="doc" />

--- a/Tools/msi/common.wxs
+++ b/Tools/msi/common.wxs
@@ -53,11 +53,23 @@
     </Fragment>
     
     <Fragment>
-    <?ifdef InstallDirectoryGuidSeed ?>
         <Directory Id="TARGETDIR" Name="SourceDir">
+        <?ifdef InstallDirectoryGuidSeed ?>
             <Directory Id="InstallDirectory" ComponentGuidGenerationSeed="$(var.InstallDirectoryGuidSeed)" />
+        <?endif ?>
         </Directory>
-    <?endif ?>
+    </Fragment>
+
+    <Fragment>
+        <!-- Locate TARGETDIR automatically assuming we have executables installed -->
+        <Property Id="TARGETDIR">
+            <ComponentSearch Id="PythonExe_Directory" Guid="$(var.PythonExeComponentGuid)">
+                <DirectorySearch Id="PythonExe_Directory" AssignToProperty="yes" Path=".">
+                    <FileSearch Id="PythonExe_DirectoryFile" Name="python.exe" />
+                </DirectorySearch>
+            </ComponentSearch>
+        </Property>
+        <Property Id="DetectTargetDir" Value="1" />
     </Fragment>
     
     <!-- Top-level directories -->

--- a/Tools/msi/dev/dev.wxs
+++ b/Tools/msi/dev/dev.wxs
@@ -4,6 +4,7 @@
         <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
+        <PropertyRef Id="DetectTargetDir" />
         <PropertyRef Id="UpgradeTable" />
         
         <Feature Id="DefaultFeature" AllowAdvertise="no" Title="!(loc.Title)" Description="!(loc.Description)">

--- a/Tools/msi/doc/doc.wxs
+++ b/Tools/msi/doc/doc.wxs
@@ -4,6 +4,7 @@
         <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
+        <PropertyRef Id="DetectTargetDir" />
         <PropertyRef Id="UpgradeTable" />
         <PropertyRef Id="REGISTRYKEY" />
         

--- a/Tools/msi/lib/lib.wxs
+++ b/Tools/msi/lib/lib.wxs
@@ -4,6 +4,7 @@
         <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
+        <PropertyRef Id="DetectTargetDir" />
         <PropertyRef Id="UpgradeTable" />
         <PropertyRef Id="REGISTRYKEY" />
         

--- a/Tools/msi/path/path.wxs
+++ b/Tools/msi/path/path.wxs
@@ -2,7 +2,8 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
         <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
-        
+
+        <PropertyRef Id="DetectTargetDir" />
         <PropertyRef Id="UpgradeTable" />
         <PropertyRef Id="REGISTRYKEY" />
         

--- a/Tools/msi/tcltk/tcltk.wxs
+++ b/Tools/msi/tcltk/tcltk.wxs
@@ -4,6 +4,7 @@
         <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
+        <PropertyRef Id="DetectTargetDir" />
         <PropertyRef Id="UpgradeTable" />
         <PropertyRef Id="REGISTRYKEY" />
         

--- a/Tools/msi/test/test.wxs
+++ b/Tools/msi/test/test.wxs
@@ -4,6 +4,7 @@
         <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
+        <PropertyRef Id="DetectTargetDir" />
         <PropertyRef Id="UpgradeTable" />
         <PropertyRef Id="REGISTRYKEY" />
         

--- a/Tools/msi/tools/tools.wxs
+++ b/Tools/msi/tools/tools.wxs
@@ -4,6 +4,7 @@
         <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
+        <PropertyRef Id="DetectTargetDir" />
         <PropertyRef Id="UpgradeTable" />
         
         <Feature Id="DefaultFeature" AllowAdvertise="no" Title="!(loc.Title)" Description="!(loc.Description)">

--- a/Tools/msi/ucrt/ucrt.wxs
+++ b/Tools/msi/ucrt/ucrt.wxs
@@ -4,6 +4,7 @@
         <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
         
+        <PropertyRef Id="DetectTargetDir" />
         <PropertyRef Id="UpgradeTable" />
         <PropertyRef Id="REGISTRYKEY" />
         


### PR DESCRIPTION


<!-- issue-number: [bpo-46948](https://bugs.python.org/issue46948) -->
https://bugs.python.org/issue46948
<!-- /issue-number -->
