### PR TITLE
bpo-44549: Update bzip2 to 1.0.8 in Windows builds to mitigate CVE-2016-3189 and CVE-2019-12900

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-03-07-17-46-40.bpo-44549.SPrGS9.rst
+++ b/Misc/NEWS.d/next/Windows/2022-03-07-17-46-40.bpo-44549.SPrGS9.rst
@@ -1,0 +1,2 @@
+Update bzip2 to 1.0.8 in Windows builds to mitigate CVE-2016-3189 and
+CVE-2019-12900

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -51,7 +51,7 @@ if NOT DEFINED PYTHON (
 echo.Fetching external libraries...
 
 set libraries=
-set libraries=%libraries%                                       bzip2-1.0.6
+set libraries=%libraries%                                       bzip2-1.0.8
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.4.2
 if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1m
 set libraries=%libraries%                                       sqlite-3.37.2.0

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -62,7 +62,7 @@
     <ExternalsDir Condition="$(ExternalsDir) == ''">$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals`))</ExternalsDir>
     <ExternalsDir Condition="!HasTrailingSlash($(ExternalsDir))">$(ExternalsDir)\</ExternalsDir>
     <sqlite3Dir>$(ExternalsDir)sqlite-3.37.2.0\</sqlite3Dir>
-    <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
+    <bz2Dir>$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
     <libffiDir>$(ExternalsDir)libffi-3.4.2\</libffiDir>
     <libffiOutDir>$(ExternalsDir)libffi-3.4.2\$(ArchName)\</libffiOutDir>

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -162,7 +162,7 @@ interpreter, but they do implement several major features.  See the
 about getting the source for building these libraries.  The sub-projects
 are:
 _bz2
-    Python wrapper for version 1.0.6 of the libbzip2 compression library
+    Python wrapper for version 1.0.8 of the libbzip2 compression library
     Homepage:
         http://www.bzip.org/
 _lzma


### PR DESCRIPTION


<!-- issue-number: [bpo-44549](https://bugs.python.org/issue44549) -->
https://bugs.python.org/issue44549
<!-- /issue-number -->
