### PR TITLE
bpo-46841: Don't use an oparg counter for `STORE_SUBSCR`

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -86,6 +86,12 @@ typedef struct {
 
 #define INLINE_CACHE_ENTRIES_PRECALL CACHE_ENTRIES(_PyPrecallCache)
 
+typedef struct {
+    _Py_CODEUNIT counter;
+} _PyStoreSubscrCache;
+
+#define INLINE_CACHE_ENTRIES_STORE_SUBSCR CACHE_ENTRIES(_PyStoreSubscrCache)
+
 /* Maximum size of code to quicken, in code units. */
 #define MAX_SIZE_TO_QUICKEN 10000
 

--- a/Include/opcode.h
+++ b/Include/opcode.h
@@ -211,6 +211,7 @@ static const uint32_t _PyOpcode_Jump[8] = {
 
 const uint8_t _PyOpcode_InlineCacheEntries[256] = {
     [BINARY_SUBSCR] = 4,
+    [STORE_SUBSCR] = 1,
     [UNPACK_SEQUENCE] = 1,
     [STORE_ATTR] = 4,
     [LOAD_ATTR] = 4,

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -394,6 +394,7 @@ _code_type = type(_write_atomic.__code__)
 #                         STORE_ATTR)
 #     Python 3.11a5 3485 (Add an oparg to GET_AWAITABLE)
 #     Python 3.11a6 3486 (Use inline caching for PRECALL and CALL)
+#     Python 3.11a6 3487 (Remove the adaptive "oparg counter" mechanism)
 
 #     Python 3.12 will start with magic number 3500
 
@@ -408,7 +409,7 @@ _code_type = type(_write_atomic.__code__)
 # Whenever MAGIC_NUMBER is changed, the ranges in the magic_values array
 # in PC/launcher.c must also be updated.
 
-MAGIC_NUMBER = (3486).to_bytes(2, 'little') + b'\r\n'
+MAGIC_NUMBER = (3487).to_bytes(2, 'little') + b'\r\n'
 _RAW_MAGIC_NUMBER = int.from_bytes(MAGIC_NUMBER, 'little')  # For import.c
 
 _PYCACHE = '__pycache__'

--- a/Lib/opcode.py
+++ b/Lib/opcode.py
@@ -84,7 +84,7 @@ def_op('BEFORE_ASYNC_WITH', 52)
 def_op('BEFORE_WITH', 53)
 def_op('END_ASYNC_FOR', 54)
 
-def_op('STORE_SUBSCR', 60)
+def_op('STORE_SUBSCR', 60, 1)
 def_op('DELETE_SUBSCR', 61)
 
 def_op('GET_ITER', 68)

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-07-15-54-39.bpo-46841.7wG92r.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-07-15-54-39.bpo-46841.7wG92r.rst
@@ -1,0 +1,2 @@
+Modify :opcode:`STORE_SUBSCR` to use an inline cache entry (rather than its
+oparg) as an adaptive counter.


### PR DESCRIPTION
Remove this special-case code, since it's a bit hacky and doesn't really pay off anymore.

<!-- issue-number: [bpo-46841](https://bugs.python.org/issue46841) -->
https://bugs.python.org/issue46841
<!-- /issue-number -->
