### PR TITLE
bpo-46955: Expose asyncio.base_events.Server as asyncio.Server

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -49,7 +49,7 @@ from . import trsock
 from .log import logger
 
 
-__all__ = 'BaseEventLoop',
+__all__ = 'BaseEventLoop','Server',
 
 
 # Minimum number of _scheduled timer handles before cleanup of

--- a/Misc/NEWS.d/next/Library/2022-03-08-22-41-59.bpo-46955.IOoonN.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-08-22-41-59.bpo-46955.IOoonN.rst
@@ -1,0 +1,2 @@
+Expose :class:`asyncio.base_events.Server` as :class:`asyncio.Server`. Patch
+by Stefan Zabka.


### PR DESCRIPTION
This change aligns the documentation at https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.Server with the actual implementation



<!-- issue-number: [bpo-46955](https://bugs.python.org/issue46955) -->
https://bugs.python.org/issue46955
<!-- /issue-number -->
