### PR TITLE
Fix 3.11 what's new formatting

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -65,10 +65,15 @@ Summary -- Release highlights
 
 .. PEP-sized items next.
 
-PEP-654: Exception Groups and ``except*``.
-(Contributed by Irit Katriel in :issue:`45292`.)
-PEP-673: ``Self`` Type.
-(Contributed by James Hilton-Balfe and Pradeep Kumar in :issue:`30924`.)
+New syntax features:
+
+* :pep:`654`: Exception Groups and ``except*``.
+  (Contributed by Irit Katriel in :issue:`45292`.)
+
+New typing features:
+
+* :pep:`673`: ``Self`` Type.
+  (Contributed by James Hilton-Balfe and Pradeep Kumar in :issue:`30924`.)
 
 New Features
 ============


### PR DESCRIPTION
Currently it looks like this:

![image](https://user-images.githubusercontent.com/28750310/157265223-71c56be5-6d02-4c83-8904-815d924fc9ae.png)

After this PR:
![image](https://user-images.githubusercontent.com/28750310/157267773-3b75b3fd-5477-4922-965d-ef89a8095071.png)
