### PR TITLE
[3.10] docs: Don't use code formatting for emphasis (GH-30519)

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -884,7 +884,7 @@ zero or more normal arguments may occur. ::
        file.write(separator.join(args))
 
 
-Normally, these ``variadic`` arguments will be last in the list of formal
+Normally, these *variadic* arguments will be last in the list of formal
 parameters, because they scoop up all remaining input arguments that are
 passed to the function. Any formal parameters which occur after the ``*args``
 parameter are 'keyword-only' arguments, meaning that they can only be used as


### PR DESCRIPTION
(cherry picked from commit badb637c8ce91625122d5f4d71276bfe1a8ed5e9)

Co-authored-by: William Andrea <william.j.andrea@gmail.com>