### PR TITLE
[3.9] Docstring: replace pysqlite with sqlite3 (GH-31758)

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -744,11 +744,11 @@ Cursor Objects
 
    .. method:: setinputsizes(sizes)
 
-      Required by the DB-API. Is a no-op in :mod:`sqlite3`.
+      Required by the DB-API. Does nothing in :mod:`sqlite3`.
 
    .. method:: setoutputsize(size [, column])
 
-      Required by the DB-API. Is a no-op in :mod:`sqlite3`.
+      Required by the DB-API. Does nothing in :mod:`sqlite3`.
 
    .. attribute:: rowcount
 

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -882,7 +882,7 @@ static PyMethodDef cursor_methods[] = {
     {"executemany", (PyCFunction)pysqlite_cursor_executemany, METH_VARARGS,
         PyDoc_STR("Repeatedly executes a SQL statement.")},
     {"executescript", (PyCFunction)pysqlite_cursor_executescript, METH_VARARGS,
-        PyDoc_STR("Executes a multiple SQL statements at once.")},
+        PyDoc_STR("Executes multiple SQL statements at once.")},
     {"fetchone", (PyCFunction)pysqlite_cursor_fetchone, METH_NOARGS,
         PyDoc_STR("Fetches one row from the resultset.")},
     {"fetchmany", (PyCFunction)(void(*)(void))pysqlite_cursor_fetchmany, METH_VARARGS|METH_KEYWORDS,
@@ -892,9 +892,9 @@ static PyMethodDef cursor_methods[] = {
     {"close", (PyCFunction)pysqlite_cursor_close, METH_NOARGS,
         PyDoc_STR("Closes the cursor.")},
     {"setinputsizes", (PyCFunction)pysqlite_noop, METH_VARARGS,
-        PyDoc_STR("Required by DB-API. Does nothing in pysqlite.")},
+        PyDoc_STR("Required by DB-API. Does nothing in sqlite3.")},
     {"setoutputsize", (PyCFunction)pysqlite_noop, METH_VARARGS,
-        PyDoc_STR("Required by DB-API. Does nothing in pysqlite.")},
+        PyDoc_STR("Required by DB-API. Does nothing in sqlite3.")},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
Replace two instances of "pysqlite" with "sqlite3" in sqlite3
docstrings. Also reword "is a no-op" to "does nothing" for clarity..
(cherry picked from commit b33a1ae703338e09dc0af5fbfd8ffa01d3ff75da)

Co-authored-by: Erlend Egeberg Aasland <erlend.aasland@innova.no>