### PR TITLE
bpo-46841: Add a `_Py_SET_OPCODE` macro

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -23,6 +23,8 @@ typedef uint16_t _Py_CODEUNIT;
 #  define _Py_MAKECODEUNIT(opcode, oparg) ((opcode)|((oparg)<<8))
 #endif
 
+#define _Py_SET_OPCODE(word, opcode) (((uint8_t *)&(word))[0] = (opcode))
+
 
 /* Bytecode object */
 struct PyCodeObject {

--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -23,7 +23,8 @@ typedef uint16_t _Py_CODEUNIT;
 #  define _Py_MAKECODEUNIT(opcode, oparg) ((opcode)|((oparg)<<8))
 #endif
 
-#define _Py_SET_OPCODE(word, opcode) (((uint8_t *)&(word))[0] = (opcode))
+// Use "unsigned char" instead of "uint8_t" here to avoid illegal aliasing:
+#define _Py_SET_OPCODE(word, opcode) (((unsigned char *)&(word))[0] = (opcode))
 
 
 /* Bytecode object */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5517,7 +5517,7 @@ opname ## _miss: \
         _Py_CODEUNIT *counter = (_Py_CODEUNIT *)next_instr; \
         *counter -= 1; \
         if (*counter == 0) { \
-            next_instr[-1] = _Py_MAKECODEUNIT(opname ## _ADAPTIVE, _Py_OPARG(next_instr[-1])); \
+            _Py_SET_OPCODE(next_instr[-1], opname ## _ADAPTIVE); \
             STAT_INC(opname, deopt); \
             *counter = ADAPTIVE_CACHE_BACKOFF; \
         } \

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -294,59 +294,55 @@ static void
 optimize(_Py_CODEUNIT *instructions, int len)
 {
     int previous_opcode = -1;
-    int previous_oparg = -1;
     for(int i = 0; i < len; i++) {
         int opcode = _Py_OPCODE(instructions[i]);
-        int oparg = _Py_OPARG(instructions[i]);
         uint8_t adaptive_opcode = adaptive_opcodes[opcode];
         if (adaptive_opcode) {
-            instructions[i] = _Py_MAKECODEUNIT(adaptive_opcode, oparg);
+            _Py_SET_OPCODE(instructions[i], adaptive_opcode);
             // Make sure the adaptive counter is zero:
             assert(instructions[i + 1] == 0);
             previous_opcode = -1;
-            previous_oparg = -1;
             i += _PyOpcode_InlineCacheEntries[opcode];
         }
         else {
             assert(!_PyOpcode_InlineCacheEntries[opcode]);
             switch (opcode) {
                 case JUMP_ABSOLUTE:
-                    instructions[i] = _Py_MAKECODEUNIT(JUMP_ABSOLUTE_QUICK, oparg);
+                    _Py_SET_OPCODE(instructions[i], JUMP_ABSOLUTE_QUICK);
                     break;
                 case RESUME:
-                    instructions[i] = _Py_MAKECODEUNIT(RESUME_QUICK, oparg);
+                    _Py_SET_OPCODE(instructions[i], RESUME_QUICK);
                     break;
                 case LOAD_FAST:
                     switch(previous_opcode) {
                         case LOAD_FAST:
-                            assert(0 <= previous_oparg);
-                            instructions[i-1] = _Py_MAKECODEUNIT(LOAD_FAST__LOAD_FAST, previous_oparg);
+                            _Py_SET_OPCODE(instructions[i - 1],
+                                           LOAD_FAST__LOAD_FAST);
                             break;
                         case STORE_FAST:
-                            assert(0 <= previous_oparg);
-                            instructions[i-1] = _Py_MAKECODEUNIT(STORE_FAST__LOAD_FAST, previous_oparg);
+                            _Py_SET_OPCODE(instructions[i - 1],
+                                           STORE_FAST__LOAD_FAST);
                             break;
                         case LOAD_CONST:
-                            assert(0 <= previous_oparg);
-                            instructions[i-1] = _Py_MAKECODEUNIT(LOAD_CONST__LOAD_FAST, previous_oparg);
+                            _Py_SET_OPCODE(instructions[i - 1],
+                                           LOAD_CONST__LOAD_FAST);
                             break;
                     }
                     break;
                 case STORE_FAST:
                     if (previous_opcode == STORE_FAST) {
-                        assert(0 <= previous_oparg);
-                        instructions[i-1] = _Py_MAKECODEUNIT(STORE_FAST__STORE_FAST, previous_oparg);
+                        _Py_SET_OPCODE(instructions[i - 1],
+                                       STORE_FAST__STORE_FAST);
                     }
                     break;
                 case LOAD_CONST:
                     if (previous_opcode == LOAD_FAST) {
-                        assert(0 <= previous_oparg);
-                        instructions[i-1] = _Py_MAKECODEUNIT(LOAD_FAST__LOAD_CONST, previous_oparg);
+                        _Py_SET_OPCODE(instructions[i - 1],
+                                       LOAD_FAST__LOAD_CONST);
                     }
                     break;
             }
             previous_opcode = opcode;
-            previous_oparg = oparg;
         }
     }
 }
@@ -573,7 +569,7 @@ specialize_module_load_attr(PyObject *owner, _Py_CODEUNIT *instr,
     }
     write_u32(cache->version, keys_version);
     cache->index = (uint16_t)index;
-    *instr = _Py_MAKECODEUNIT(opcode_module, _Py_OPARG(*instr));
+    _Py_SET_OPCODE(*instr, opcode_module);
     return 0;
 }
 
@@ -684,7 +680,7 @@ specialize_dict_access(
         }
         write_u32(cache->version, type->tp_version_tag);
         cache->index = (uint16_t)index;
-        *instr = _Py_MAKECODEUNIT(values_op, _Py_OPARG(*instr));
+        _Py_SET_OPCODE(*instr, values_op);
     }
     else {
         if (!PyDict_CheckExact(dict)) {
@@ -701,7 +697,7 @@ specialize_dict_access(
         }
         cache->index = (uint16_t)hint;
         write_u32(cache->version, type->tp_version_tag);
-        *instr = _Py_MAKECODEUNIT(hint_op, _Py_OPARG(*instr));
+        _Py_SET_OPCODE(*instr, hint_op);
     }
     return 1;
 }
@@ -755,7 +751,7 @@ _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name)
             assert(offset > 0);
             cache->index = (uint16_t)offset;
             write_u32(cache->version, type->tp_version_tag);
-            *instr = _Py_MAKECODEUNIT(LOAD_ATTR_SLOT, _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, LOAD_ATTR_SLOT);
             goto success;
         }
         case DUNDER_CLASS:
@@ -764,7 +760,7 @@ _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name)
             assert(offset == (uint16_t)offset);
             cache->index = (uint16_t)offset;
             write_u32(cache->version, type->tp_version_tag);
-            *instr = _Py_MAKECODEUNIT(LOAD_ATTR_SLOT, _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, LOAD_ATTR_SLOT);
             goto success;
         }
         case OTHER_SLOT:
@@ -845,7 +841,7 @@ _Py_Specialize_StoreAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name)
             assert(offset > 0);
             cache->index = (uint16_t)offset;
             write_u32(cache->version, type->tp_version_tag);
-            *instr = _Py_MAKECODEUNIT(STORE_ATTR_SLOT, _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, STORE_ATTR_SLOT);
             goto success;
         }
         case DUNDER_CLASS:
@@ -938,7 +934,7 @@ specialize_class_load_method(PyObject *owner, _Py_CODEUNIT *instr,
         case NON_DESCRIPTOR:
             write_u32(cache->type_version, ((PyTypeObject *)owner)->tp_version_tag);
             write_obj(cache->descr, descr);
-            *instr = _Py_MAKECODEUNIT(LOAD_METHOD_CLASS, _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, LOAD_METHOD_CLASS);
             return 0;
 #ifdef Py_STATS
         case ABSENT:
@@ -1052,19 +1048,19 @@ _Py_Specialize_LoadMethod(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name)
     }
     switch(dictkind) {
         case NO_DICT:
-            *instr = _Py_MAKECODEUNIT(LOAD_METHOD_NO_DICT, _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, LOAD_METHOD_NO_DICT);
             break;
         case MANAGED_VALUES:
-            *instr = _Py_MAKECODEUNIT(LOAD_METHOD_WITH_VALUES, _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, LOAD_METHOD_WITH_VALUES);
             break;
         case MANAGED_DICT:
             *(int16_t *)&cache->dict_offset = (int16_t)MANAGED_DICT_OFFSET;
-            *instr = _Py_MAKECODEUNIT(LOAD_METHOD_WITH_DICT, _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, LOAD_METHOD_WITH_DICT);
             break;
         case OFFSET_DICT:
             assert(owner_cls->tp_dictoffset > 0 && owner_cls->tp_dictoffset <= INT16_MAX);
             cache->dict_offset = (uint16_t)owner_cls->tp_dictoffset;
-            *instr = _Py_MAKECODEUNIT(LOAD_METHOD_WITH_DICT, _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, LOAD_METHOD_WITH_DICT);
             break;
     }
     /* `descr` is borrowed. This is safe for methods (even inherited ones from
@@ -1130,7 +1126,7 @@ _Py_Specialize_LoadGlobal(
         }
         cache->index = (uint16_t)index;
         write_u32(cache->module_keys_version, keys_version);
-        *instr = _Py_MAKECODEUNIT(LOAD_GLOBAL_MODULE, _Py_OPARG(*instr));
+        _Py_SET_OPCODE(*instr, LOAD_GLOBAL_MODULE);
         goto success;
     }
     if (!PyDict_CheckExact(builtins)) {
@@ -1166,7 +1162,7 @@ _Py_Specialize_LoadGlobal(
     cache->index = (uint16_t)index;
     write_u32(cache->module_keys_version, globals_version);
     cache->builtin_keys_version = (uint16_t)builtins_version;
-    *instr = _Py_MAKECODEUNIT(LOAD_GLOBAL_BUILTIN, _Py_OPARG(*instr));
+    _Py_SET_OPCODE(*instr, LOAD_GLOBAL_BUILTIN);
     goto success;
 fail:
     STAT_INC(LOAD_GLOBAL, failure);
@@ -1245,7 +1241,7 @@ _Py_Specialize_BinarySubscr(
     PyTypeObject *container_type = Py_TYPE(container);
     if (container_type == &PyList_Type) {
         if (PyLong_CheckExact(sub)) {
-            *instr = _Py_MAKECODEUNIT(BINARY_SUBSCR_LIST_INT, _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, BINARY_SUBSCR_LIST_INT);
             goto success;
         }
         SPECIALIZATION_FAIL(BINARY_SUBSCR,
@@ -1254,7 +1250,7 @@ _Py_Specialize_BinarySubscr(
     }
     if (container_type == &PyTuple_Type) {
         if (PyLong_CheckExact(sub)) {
-            *instr = _Py_MAKECODEUNIT(BINARY_SUBSCR_TUPLE_INT, _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, BINARY_SUBSCR_TUPLE_INT);
             goto success;
         }
         SPECIALIZATION_FAIL(BINARY_SUBSCR,
@@ -1262,7 +1258,7 @@ _Py_Specialize_BinarySubscr(
         goto fail;
     }
     if (container_type == &PyDict_Type) {
-        *instr = _Py_MAKECODEUNIT(BINARY_SUBSCR_DICT, _Py_OPARG(*instr));
+        _Py_SET_OPCODE(*instr, BINARY_SUBSCR_DICT);
         goto success;
     }
     PyTypeObject *cls = Py_TYPE(container);
@@ -1292,7 +1288,7 @@ _Py_Specialize_BinarySubscr(
         }
         cache->func_version = version;
         ((PyHeapTypeObject *)container_type)->_spec_cache.getitem = descriptor;
-        *instr = _Py_MAKECODEUNIT(BINARY_SUBSCR_GETITEM, _Py_OPARG(*instr));
+        _Py_SET_OPCODE(*instr, BINARY_SUBSCR_GETITEM);
         goto success;
     }
     SPECIALIZATION_FAIL(BINARY_SUBSCR,
@@ -1319,8 +1315,7 @@ _Py_Specialize_StoreSubscr(PyObject *container, PyObject *sub, _Py_CODEUNIT *ins
             if ((Py_SIZE(sub) == 0 || Py_SIZE(sub) == 1)
                 && ((PyLongObject *)sub)->ob_digit[0] < (size_t)PyList_GET_SIZE(container))
             {
-                *instr = _Py_MAKECODEUNIT(STORE_SUBSCR_LIST_INT,
-                                          _Py_OPARG(*instr));
+                _Py_SET_OPCODE(*instr, STORE_SUBSCR_LIST_INT);
                 goto success;
             }
             else {
@@ -1338,7 +1333,7 @@ _Py_Specialize_StoreSubscr(PyObject *container, PyObject *sub, _Py_CODEUNIT *ins
         }
     }
     if (container_type == &PyDict_Type) {
-        *instr = _Py_MAKECODEUNIT(STORE_SUBSCR_DICT, _Py_OPARG(*instr));
+        _Py_SET_OPCODE(*instr, STORE_SUBSCR_DICT);
          goto success;
     }
 #ifdef Py_STATS
@@ -1427,20 +1422,20 @@ specialize_class_call(PyObject *callable, _Py_CODEUNIT *instr, int nargs,
     if (tp->tp_flags & Py_TPFLAGS_IMMUTABLETYPE) {
         if (nargs == 1 && kwnames == NULL && oparg == 1) {
             if (tp == &PyUnicode_Type) {
-                *instr = _Py_MAKECODEUNIT(PRECALL_NO_KW_STR_1, _Py_OPARG(*instr));
+                _Py_SET_OPCODE(*instr, PRECALL_NO_KW_STR_1);
                 return 0;
             }
             else if (tp == &PyType_Type) {
-                *instr = _Py_MAKECODEUNIT(PRECALL_NO_KW_TYPE_1, _Py_OPARG(*instr));
+                _Py_SET_OPCODE(*instr, PRECALL_NO_KW_TYPE_1);
                 return 0;
             }
             else if (tp == &PyTuple_Type) {
-                *instr = _Py_MAKECODEUNIT(PRECALL_NO_KW_TUPLE_1, _Py_OPARG(*instr));
+                _Py_SET_OPCODE(*instr, PRECALL_NO_KW_TUPLE_1);
                 return 0;
             }
         }
         if (tp->tp_vectorcall != NULL) {
-            *instr = _Py_MAKECODEUNIT(PRECALL_BUILTIN_CLASS, _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, PRECALL_BUILTIN_CLASS);
             return 0;
         }
         SPECIALIZATION_FAIL(PRECALL, tp == &PyUnicode_Type ?
@@ -1493,8 +1488,7 @@ specialize_method_descriptor(PyMethodDescrObject *descr, _Py_CODEUNIT *instr,
                 SPECIALIZATION_FAIL(PRECALL, SPEC_FAIL_WRONG_NUMBER_ARGUMENTS);
                 return -1;
             }
-            *instr = _Py_MAKECODEUNIT(PRECALL_NO_KW_METHOD_DESCRIPTOR_NOARGS,
-                _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, PRECALL_NO_KW_METHOD_DESCRIPTOR_NOARGS);
             return 0;
         }
         case METH_O: {
@@ -1505,17 +1499,14 @@ specialize_method_descriptor(PyMethodDescrObject *descr, _Py_CODEUNIT *instr,
             PyInterpreterState *interp = _PyInterpreterState_GET();
             PyObject *list_append = interp->callable_cache.list_append;
             if ((PyObject *)descr == list_append && oparg == 1) {
-                *instr = _Py_MAKECODEUNIT(PRECALL_NO_KW_LIST_APPEND,
-                                          _Py_OPARG(*instr));
+                _Py_SET_OPCODE(*instr, PRECALL_NO_KW_LIST_APPEND);
                 return 0;
             }
-            *instr = _Py_MAKECODEUNIT(PRECALL_NO_KW_METHOD_DESCRIPTOR_O,
-                _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, PRECALL_NO_KW_METHOD_DESCRIPTOR_O);
             return 0;
         }
         case METH_FASTCALL: {
-            *instr = _Py_MAKECODEUNIT(PRECALL_NO_KW_METHOD_DESCRIPTOR_FAST,
-                _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, PRECALL_NO_KW_METHOD_DESCRIPTOR_FAST);
             return 0;
         }
     }
@@ -1562,10 +1553,10 @@ specialize_py_call(PyFunctionObject *func, _Py_CODEUNIT *instr, int nargs,
     write_u32(cache->func_version, version);
     cache->min_args = min_args;
     if (argcount == nargs) {
-        *instr = _Py_MAKECODEUNIT(CALL_PY_EXACT_ARGS, _Py_OPARG(*instr));
+        _Py_SET_OPCODE(*instr, CALL_PY_EXACT_ARGS);
     }
     else {
-        *instr = _Py_MAKECODEUNIT(CALL_PY_WITH_DEFAULTS, _Py_OPARG(*instr));
+        _Py_SET_OPCODE(*instr, CALL_PY_WITH_DEFAULTS);
     }
     return 0;
 }
@@ -1593,12 +1584,10 @@ specialize_c_call(PyObject *callable, _Py_CODEUNIT *instr, int nargs,
             /* len(o) */
             PyInterpreterState *interp = _PyInterpreterState_GET();
             if (callable == interp->callable_cache.len) {
-                *instr = _Py_MAKECODEUNIT(PRECALL_NO_KW_LEN,
-                    _Py_OPARG(*instr));
+                _Py_SET_OPCODE(*instr, PRECALL_NO_KW_LEN);
                 return 0;
             }
-            *instr = _Py_MAKECODEUNIT(PRECALL_NO_KW_BUILTIN_O,
-                _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, PRECALL_NO_KW_BUILTIN_O);
             return 0;
         }
         case METH_FASTCALL: {
@@ -1610,18 +1599,15 @@ specialize_c_call(PyObject *callable, _Py_CODEUNIT *instr, int nargs,
                 /* isinstance(o1, o2) */
                 PyInterpreterState *interp = _PyInterpreterState_GET();
                 if (callable == interp->callable_cache.isinstance) {
-                    *instr = _Py_MAKECODEUNIT(PRECALL_NO_KW_ISINSTANCE,
-                        _Py_OPARG(*instr));
+                    _Py_SET_OPCODE(*instr, PRECALL_NO_KW_ISINSTANCE);
                     return 0;
                 }
             }
-            *instr = _Py_MAKECODEUNIT(PRECALL_NO_KW_BUILTIN_FAST,
-                _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, PRECALL_NO_KW_BUILTIN_FAST);
             return 0;
         }
         case METH_FASTCALL | METH_KEYWORDS: {
-            *instr = _Py_MAKECODEUNIT(PRECALL_BUILTIN_FAST_WITH_KEYWORDS,
-                _Py_OPARG(*instr));
+            _Py_SET_OPCODE(*instr, PRECALL_BUILTIN_FAST_WITH_KEYWORDS);
             return 0;
         }
         default:
@@ -1685,7 +1671,7 @@ _Py_Specialize_Precall(PyObject *callable, _Py_CODEUNIT *instr, int nargs,
         fail = specialize_c_call(callable, instr, nargs, kwnames);
     }
     else if (PyFunction_Check(callable)) {
-        *instr = _Py_MAKECODEUNIT(PRECALL_PYFUNC, _Py_OPARG(*instr));
+        _Py_SET_OPCODE(*instr, PRECALL_PYFUNC);
         fail = 0;
     }
     else if (PyType_Check(callable)) {
@@ -1696,7 +1682,7 @@ _Py_Specialize_Precall(PyObject *callable, _Py_CODEUNIT *instr, int nargs,
                                             instr, nargs, kwnames, oparg);
     }
     else if (Py_TYPE(callable) == &PyMethod_Type) {
-        *instr = _Py_MAKECODEUNIT(PRECALL_BOUND_METHOD, _Py_OPARG(*instr));
+        _Py_SET_OPCODE(*instr, PRECALL_BOUND_METHOD);
         fail = 0;
     }
     else {
@@ -1834,19 +1820,18 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
             if (PyUnicode_CheckExact(lhs)) {
                 _Py_CODEUNIT next = instr[INLINE_CACHE_ENTRIES_BINARY_OP + 1];
                 if (_Py_OPCODE(next) == STORE_FAST && Py_REFCNT(lhs) == 2) {
-                    *instr = _Py_MAKECODEUNIT(BINARY_OP_INPLACE_ADD_UNICODE,
-                                              oparg);
+                    _Py_SET_OPCODE(*instr, BINARY_OP_INPLACE_ADD_UNICODE);
                     goto success;
                 }
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_UNICODE, oparg);
+                _Py_SET_OPCODE(*instr, BINARY_OP_ADD_UNICODE);
                 goto success;
             }
             if (PyLong_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_INT, oparg);
+                _Py_SET_OPCODE(*instr, BINARY_OP_ADD_INT);
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_ADD_FLOAT, oparg);
+                _Py_SET_OPCODE(*instr, BINARY_OP_ADD_FLOAT);
                 goto success;
             }
             break;
@@ -1856,11 +1841,11 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
                 break;
             }
             if (PyLong_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_MULTIPLY_INT, oparg);
+                _Py_SET_OPCODE(*instr, BINARY_OP_MULTIPLY_INT);
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_MULTIPLY_FLOAT, oparg);
+                _Py_SET_OPCODE(*instr, BINARY_OP_MULTIPLY_FLOAT);
                 goto success;
             }
             break;
@@ -1870,11 +1855,11 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
                 break;
             }
             if (PyLong_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_SUBTRACT_INT, oparg);
+                _Py_SET_OPCODE(*instr, BINARY_OP_SUBTRACT_INT);
                 goto success;
             }
             if (PyFloat_CheckExact(lhs)) {
-                *instr = _Py_MAKECODEUNIT(BINARY_OP_SUBTRACT_FLOAT, oparg);
+                _Py_SET_OPCODE(*instr, BINARY_OP_SUBTRACT_FLOAT);
                 goto success;
             }
             break;
@@ -1885,7 +1870,7 @@ _Py_Specialize_BinaryOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
             // back to BINARY_OP (unless we're collecting stats, where it's more
             // important to get accurate hit counts for the unadaptive version
             // and each of the different failure types):
-            *instr = _Py_MAKECODEUNIT(BINARY_OP, oparg);
+            _Py_SET_OPCODE(*instr, BINARY_OP);
             return;
 #endif
     }
@@ -1961,7 +1946,7 @@ _Py_Specialize_CompareOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
         // counts for the unadaptive version and each of the different failure
         // types):
 #ifndef Py_STATS
-        *instr = _Py_MAKECODEUNIT(COMPARE_OP, oparg);
+        _Py_SET_OPCODE(*instr, COMPARE_OP);
         return;
 #endif
         if (next_opcode == EXTENDED_ARG) {
@@ -1981,13 +1966,13 @@ _Py_Specialize_CompareOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
         goto failure;
     }
     if (PyFloat_CheckExact(lhs)) {
-        *instr = _Py_MAKECODEUNIT(COMPARE_OP_FLOAT_JUMP, oparg);
+        _Py_SET_OPCODE(*instr, COMPARE_OP_FLOAT_JUMP);
         cache->mask = when_to_jump_mask;
         goto success;
     }
     if (PyLong_CheckExact(lhs)) {
         if (Py_ABS(Py_SIZE(lhs)) <= 1 && Py_ABS(Py_SIZE(rhs)) <= 1) {
-            *instr = _Py_MAKECODEUNIT(COMPARE_OP_INT_JUMP, oparg);
+            _Py_SET_OPCODE(*instr, COMPARE_OP_INT_JUMP);
             cache->mask = when_to_jump_mask;
             goto success;
         }
@@ -2002,7 +1987,7 @@ _Py_Specialize_CompareOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
             goto failure;
         }
         else {
-            *instr = _Py_MAKECODEUNIT(COMPARE_OP_STR_JUMP, oparg);
+            _Py_SET_OPCODE(*instr, COMPARE_OP_STR_JUMP);
             cache->mask = (when_to_jump_mask & 2) == 0;
             goto success;
         }
@@ -2043,10 +2028,10 @@ _Py_Specialize_UnpackSequence(PyObject *seq, _Py_CODEUNIT *instr, int oparg)
             goto failure;
         }
         if (PyTuple_GET_SIZE(seq) == 2) {
-            *instr = _Py_MAKECODEUNIT(UNPACK_SEQUENCE_TWO_TUPLE, oparg);
+            _Py_SET_OPCODE(*instr, UNPACK_SEQUENCE_TWO_TUPLE);
             goto success;
         }
-        *instr = _Py_MAKECODEUNIT(UNPACK_SEQUENCE_TUPLE, oparg);
+        _Py_SET_OPCODE(*instr, UNPACK_SEQUENCE_TUPLE);
         goto success;
     }
     if (PyList_CheckExact(seq)) {
@@ -2054,7 +2039,7 @@ _Py_Specialize_UnpackSequence(PyObject *seq, _Py_CODEUNIT *instr, int oparg)
             SPECIALIZATION_FAIL(UNPACK_SEQUENCE, SPEC_FAIL_EXPECTED_ERROR);
             goto failure;
         }
-        *instr = _Py_MAKECODEUNIT(UNPACK_SEQUENCE_LIST, oparg);
+        _Py_SET_OPCODE(*instr, UNPACK_SEQUENCE_LIST);
         goto success;
     }
     SPECIALIZATION_FAIL(UNPACK_SEQUENCE, unpack_sequence_fail_kind(seq));


### PR DESCRIPTION
Now that we don't modify opargs anymore, this is a cleaner (and slighly more efficient) way of performing this common move.

<!-- issue-number: [bpo-46841](https://bugs.python.org/issue46841) -->
https://bugs.python.org/issue46841
<!-- /issue-number -->
