### PR TITLE
bpo-45138: Revert GH-28240: Expand traced SQL statements

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -560,9 +560,6 @@ Connection Objects
 
       Passing :const:`None` as *trace_callback* will disable the trace callback.
 
-      For SQLite 3.14.0 and newer, bound parameters are expanded in the passed
-      statement string.
-
       .. note::
          Exceptions raised in the trace callback are not propagated. As a
          development and debugging aid, use
@@ -570,9 +567,6 @@ Connection Objects
          tracebacks from exceptions raised in the trace callback.
 
       .. versionadded:: 3.3
-
-      .. versionchanged:: 3.11
-         Added support for expanded SQL statements.
 
 
    .. method:: enable_load_extension(enabled)

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -322,10 +322,6 @@ sqlite3
   Instead we leave it to the SQLite library to handle these cases.
   (Contributed by Erlend E. Aasland in :issue:`44092`.)
 
-* For SQLite 3.14.0 and newer, bound parameters are expanded in the statement
-  string passed to the trace callback. See :meth:`~sqlite3.Connection.set_trace_callback`.
-  (Contributed by Erlend E. Aasland in :issue:`45138`.)
-
 
 sys
 ---

--- a/Misc/NEWS.d/next/Library/2021-09-08-16-21-03.bpo-45138.yghUrK.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-08-16-21-03.bpo-45138.yghUrK.rst
@@ -1,3 +1,0 @@
-For SQLite 3.14.0 and newer, bound parameters are expanded in the statement
-string passed to the :mod:`sqlite3` trace callback. Patch by Erlend E.
-Aasland.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1079,10 +1079,11 @@ progress_callback(void *ctx)
  * to ensure future compatibility.
  */
 static int
-trace_callback(unsigned int type, void *ctx, void *stmt, void *sql)
+trace_callback(unsigned int type, void *ctx, void *prepared_statement,
+               void *statement_string)
 #else
 static void
-trace_callback(void *ctx, const char *sql)
+trace_callback(void *ctx, const char *statement_string)
 #endif
 {
 #ifdef HAVE_TRACE_V2
@@ -1093,46 +1094,24 @@ trace_callback(void *ctx, const char *sql)
 
     PyGILState_STATE gilstate = PyGILState_Ensure();
 
-    assert(ctx != NULL);
     PyObject *py_statement = NULL;
-#ifdef HAVE_TRACE_V2
-    assert(stmt != NULL);
-    const char *expanded_sql = sqlite3_expanded_sql((sqlite3_stmt *)stmt);
-    if (expanded_sql == NULL) {
-        sqlite3 *db = sqlite3_db_handle((sqlite3_stmt *)stmt);
-        if (sqlite3_errcode(db) == SQLITE_NOMEM) {
-            (void)PyErr_NoMemory();
-            goto exit;
-        }
-
-        pysqlite_state *state = ((callback_context *)ctx)->state;
-        assert(state != NULL);
-        PyErr_SetString(state->DataError,
-                        "Expanded SQL string exceeds the maximum string "
-                        "length");
-        print_or_clear_traceback((callback_context *)ctx);
-
-        // Fall back to unexpanded sql
-        py_statement = PyUnicode_FromString((const char *)sql);
-    }
-    else {
-        py_statement = PyUnicode_FromString(expanded_sql);
-        sqlite3_free((void *)expanded_sql);
-    }
-#else
-    py_statement = PyUnicode_FromString(sql);
-#endif
+    PyObject *ret = NULL;
+    py_statement = PyUnicode_DecodeUTF8(statement_string,
+            strlen(statement_string), "replace");
+    assert(ctx != NULL);
     if (py_statement) {
         PyObject *callable = ((callback_context *)ctx)->callable;
-        PyObject *ret = PyObject_CallOneArg(callable, py_statement);
+        ret = PyObject_CallOneArg(callable, py_statement);
         Py_DECREF(py_statement);
-        Py_XDECREF(ret);
     }
 
-exit:
-    if (PyErr_Occurred()) {
-        print_or_clear_traceback((callback_context *)ctx);
+    if (ret) {
+        Py_DECREF(ret);
     }
+    else {
+        print_or_clear_traceback(ctx);
+    }
+
     PyGILState_Release(gilstate);
 #ifdef HAVE_TRACE_V2
     return 0;


### PR DESCRIPTION
This reverts commit d1777515f9f53b452a4231d68196a7c0e5deb879.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45138](https://bugs.python.org/issue45138) -->
https://bugs.python.org/issue45138
<!-- /issue-number -->

Automerge-Triggered-By: GH:JelleZijlstra