### PR TITLE
bpo-46968: Query altstack size dynamically on Linux kernel >=5.14

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-03-10-14-51-11.bpo-46968.ym2QxL.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-10-14-51-11.bpo-46968.ym2QxL.rst
@@ -1,0 +1,5 @@
+:mod:`faulthandler`: On Linux 5.14 and newer, dynamically determine size of
+signal handler stack size CPython allocates using ``getauxval(AT_MINSIGSTKSZ)``.
+This changes allows for Python extension's request to Linux kernel to use
+AMX_TILE instruction set on Sapphire Rapids Xeon processor to succeed,
+unblocking use of the ISA in frameworks.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -20,6 +20,17 @@
 #  include <sys/resource.h>
 #endif
 
+/* Using an alternative stack requires sigaltstack()
+   and sigaction() SA_ONSTACK */
+#if defined(HAVE_SIGALTSTACK) && defined(HAVE_SIGACTION)
+#  define FAULTHANDLER_USE_ALT_STACK
+#endif
+
+#if defined(FAULTHANDLER_USE_ALT_STACK) && defined(HAVE_LINUX_AUXVEC_H)
+#  include <linux/auxvec.h>
+#  include <sys/auxv.h>
+#endif
+
 /* Allocate at maximum 100 MiB of the stack to raise the stack overflow */
 #define STACK_OVERFLOW_MAX_SIZE (100 * 1024 * 1024)
 
@@ -136,12 +147,6 @@ static fault_handler_t faulthandler_handlers[] = {
 };
 static const size_t faulthandler_nsignals = \
     Py_ARRAY_LENGTH(faulthandler_handlers);
-
-/* Using an alternative stack requires sigaltstack()
-   and sigaction() SA_ONSTACK */
-#if defined(HAVE_SIGALTSTACK) && defined(HAVE_SIGACTION)
-#  define FAULTHANDLER_USE_ALT_STACK
-#endif
 
 #ifdef FAULTHANDLER_USE_ALT_STACK
 static stack_t stack;
@@ -1373,6 +1378,15 @@ _PyFaulthandler_Init(int enable)
        signal handler uses more than SIGSTKSZ bytes of stack memory on some
        platforms. */
     stack.ss_size = SIGSTKSZ * 2;
+#ifdef AT_MINSIGSTKSZ
+    /* bpo-46968: Query Linux for minimal stack size to ensure signal delivery
+       for the hardware running CPython. This OS feature is available in
+       Linux kernel version >= 5.14 */
+    unsigned long at_minstack_size = getauxval(AT_MINSIGSTKSZ);
+    if (at_minstack_size != 0) {
+        stack.ss_size = SIGSTKSZ + at_minstack_size;
+    }
+#endif
 #endif
 
     memset(&thread, 0, sizeof(thread));

--- a/configure
+++ b/configure
@@ -8652,7 +8652,7 @@ $as_echo "#define STDC_HEADERS 1" >>confdefs.h
 # checks for header files
 for ac_header in  \
   alloca.h asm/types.h bluetooth.h conio.h crypt.h direct.h dlfcn.h endian.h errno.h fcntl.h grp.h \
-  ieeefp.h io.h langinfo.h libintl.h libutil.h linux/memfd.h linux/random.h linux/soundcard.h \
+  ieeefp.h io.h langinfo.h libintl.h libutil.h linux/auxvec.h linux/memfd.h linux/random.h linux/soundcard.h \
   linux/tipc.h linux/wait.h netinet/in.h netpacket/packet.h poll.h process.h pthread.h pty.h \
   sched.h setjmp.h shadow.h signal.h spawn.h stropts.h sys/audioio.h sys/bsdtty.h sys/devpoll.h \
   sys/endian.h sys/epoll.h sys/event.h sys/eventfd.h sys/file.h sys/ioctl.h sys/kern_control.h \

--- a/configure.ac
+++ b/configure.ac
@@ -2375,7 +2375,7 @@ AC_DEFINE(STDC_HEADERS, 1, [Define to 1 if you have the ANSI C header files.])
 # checks for header files
 AC_CHECK_HEADERS([ \
   alloca.h asm/types.h bluetooth.h conio.h crypt.h direct.h dlfcn.h endian.h errno.h fcntl.h grp.h \
-  ieeefp.h io.h langinfo.h libintl.h libutil.h linux/memfd.h linux/random.h linux/soundcard.h \
+  ieeefp.h io.h langinfo.h libintl.h libutil.h linux/auxvec.h linux/memfd.h linux/random.h linux/soundcard.h \
   linux/tipc.h linux/wait.h netinet/in.h netpacket/packet.h poll.h process.h pthread.h pty.h \
   sched.h setjmp.h shadow.h signal.h spawn.h stropts.h sys/audioio.h sys/bsdtty.h sys/devpoll.h \
   sys/endian.h sys/epoll.h sys/event.h sys/eventfd.h sys/file.h sys/ioctl.h sys/kern_control.h \

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -661,6 +661,9 @@
 /* Define to 1 if you have the `linkat' function. */
 #undef HAVE_LINKAT
 
+/* Define to 1 if you have the <linux/auxvec.h> header file. */
+#undef HAVE_LINUX_AUXVEC_H
+
 /* Define to 1 if you have the <linux/can/bcm.h> header file. */
 #undef HAVE_LINUX_CAN_BCM_H
 


### PR DESCRIPTION
In Linux kernel 5.14 one can dynamically request size of altstacksize
needed to handle signals based on hardware capabilities. 
This patch sets stack size to be the maximum of current value of SIGSTKSZ * 2 and
SIGSTKSZ + getauxval(AT_MINSIGSTKSZ).

This changes allows for Python extension's request to Linux kernel
to use AMX_TILE instruction set on Sapphire Rapids Xeon processor
to succeed, unblocking use of the ISA in frameworks.

This change proposes a solution to the problem described 
in https://bugs.python.org/msg414809



<!-- issue-number: [bpo-46968](https://bugs.python.org/issue46968) -->
https://bugs.python.org/issue46968
<!-- /issue-number -->
