### PR TITLE
bpo-46917: Require IEEE 754 to build Python

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -645,6 +645,9 @@ Build Changes
 * Building Python now requires a C11 compiler without optional C11 features.
   (Contributed by Victor Stinner in :issue:`46656`.)
 
+* Building Python now requires support of IEEE 754 floating point numbers.
+  (Contributed by Victor Stinner in :issue:`46917`.)
+
 * CPython can now be built with the ThinLTO option via ``--with-lto=thin``.
   (Contributed by Dong-hee Na and Brett Holman in :issue:`44340`.)
 

--- a/Misc/NEWS.d/next/Build/2022-03-10-09-37-05.bpo-46917.fry4aK.rst
+++ b/Misc/NEWS.d/next/Build/2022-03-10-09-37-05.bpo-46917.fry4aK.rst
@@ -1,0 +1,2 @@
+Building Python now requires support of IEEE 754 floating point numbers.
+Patch by Victor Stinner.


### PR DESCRIPTION
Building Python now requires support of IEEE 754 floating point
numbers.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46917](https://bugs.python.org/issue46917) -->
https://bugs.python.org/issue46917
<!-- /issue-number -->
