### PR TITLE
[3.9] bpo-46198: rename duplicate tests and remove unused code (GH-30297)

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1861,8 +1861,6 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
 
     def test_fromisoformat_fails_typeerror(self):
         # Test that fromisoformat fails when passed the wrong type
-        import io
-
         bad_types = [b'2009-03-01', None, io.StringIO('2009-03-01')]
         for bad_type in bad_types:
             with self.assertRaises(TypeError):
@@ -3985,8 +3983,6 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
 
     def test_fromisoformat_fails_typeerror(self):
         # Test the fromisoformat fails when passed the wrong type
-        import io
-
         bad_types = [b'12:30:45', None, io.StringIO('12:30:45')]
 
         for bad_type in bad_types:

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2390,9 +2390,6 @@ class PythonSymlink:
 
         self._platform_specific()
 
-    def _platform_specific(self):
-        pass
-
     if sys.platform == "win32":
         def _platform_specific(self):
             import _winapi
@@ -2419,6 +2416,9 @@ class PythonSymlink:
             self._env["PYTHONHOME"] = os.path.dirname(self.real)
             if sysconfig.is_python_build(True):
                 self._env["PYTHONPATH"] = os.path.dirname(os.__file__)
+    else:
+        def _platform_specific(self):
+            pass
 
     def __enter__(self):
         os.symlink(self.real, self.link)

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -2,7 +2,6 @@
 
 import logging
 import socket
-from test import support
 import unittest
 import weakref
 from unittest import mock

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -30,7 +30,7 @@ def coding_checker(self, coder):
 # On small versions of Windows like Windows IoT or Windows Nano Server not all codepages are present
 def is_code_page_present(cp):
     from ctypes import POINTER, WINFUNCTYPE, WinDLL
-    from ctypes.wintypes import BOOL, UINT, BYTE, WCHAR, UINT, DWORD
+    from ctypes.wintypes import BOOL, BYTE, WCHAR, UINT, DWORD
 
     MAX_LEADBYTES = 12  # 5 ranges, 2 bytes ea., 0 term.
     MAX_DEFAULTCHAR = 2 # single or double byte

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1435,7 +1435,7 @@ class DictTest(unittest.TestCase):
         self.assertTrue(gc.is_tracked(next(it)))
 
     @support.cpython_only
-    def test_dict_items_result_gc(self):
+    def test_dict_items_result_gc_reversed(self):
         # Same as test_dict_items_result_gc above, but reversed.
         it = reversed({None: []}.items())
         gc.collect()

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -395,7 +395,7 @@ class TestParser(TestParserMixin, TestEmailBase):
             [errors.InvalidHeaderDefect],
             '')
 
-    def test_get_unstructured_invalid_ew(self):
+    def test_get_unstructured_invalid_ew2(self):
         self._test_get_x(self._get_unst,
             '=?utf-8?q?=somevalue?=',
             '=?utf-8?q?=somevalue?=',

--- a/Lib/test/test_tabnanny.py
+++ b/Lib/test/test_tabnanny.py
@@ -4,7 +4,6 @@ Glossary:
     * errored    : Whitespace related problems present in file.
 """
 from unittest import TestCase, mock
-from unittest import mock
 import errno
 import os
 import tabnanny


### PR DESCRIPTION
(cherry picked from commit 6c83c8e6b56b57a8a794e7b6c07837be4ce3bb97)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>

<!-- issue-number: [bpo-46198](https://bugs.python.org/issue46198) -->
https://bugs.python.org/issue46198
<!-- /issue-number -->
