### PR TITLE
bpo-46198: Fix `test_asyncio.test_sslproto`

### DIFF
--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -4,6 +4,7 @@ import logging
 import socket
 import unittest
 import weakref
+from test import support
 from unittest import mock
 try:
     import ssl


### PR DESCRIPTION
GH-30297 removed a duplicate `from test import support` statement from `test_asyncio.test_sslproto`. However, in between that PR being filed and it being merged, GH-31275 removed the _other_ `from test import support` statement. This means that `support` is now undefined in `test_asyncio.test_sslproto`, causing the CI to fail on all platforms for all PRs (e.g. https://github.com/python/cpython/runs/5501039134?check_suite_focus=true)


<!-- issue-number: [bpo-46198](https://bugs.python.org/issue46198) -->
https://bugs.python.org/issue46198
<!-- /issue-number -->

Automerge-Triggered-By: GH:JelleZijlstra