### PR TITLE
bpo-46744: Support "-Win32" and make platform flags case insensitive on Windows build scripts

### DIFF
--- a/Tools/msi/build.bat
+++ b/Tools/msi/build.bat
@@ -12,15 +12,16 @@ set BUILDPACK=
 set REBUILD=
 
 :CheckOpts
-if "%~1" EQU "-h" goto Help
-if "%~1" EQU "-x86" (set BUILDX86=1) && shift && goto CheckOpts
-if "%~1" EQU "-x64" (set BUILDX64=1) && shift && goto CheckOpts
-if "%~1" EQU "-arm64" (set BUILDARM64=1) && shift && goto CheckOpts
-if "%~1" EQU "--doc" (set BUILDDOC=1) && shift && goto CheckOpts
-if "%~1" EQU "--no-test-marker" (set BUILDTEST=) && shift && goto CheckOpts
-if "%~1" EQU "--test-marker" (set BUILDTEST=--test-marker) && shift && goto CheckOpts
-if "%~1" EQU "--pack" (set BUILDPACK=1) && shift && goto CheckOpts
-if "%~1" EQU "-r" (set REBUILD=-r) && shift && goto CheckOpts
+if    "%~1" EQU "-h" goto Help
+if /I "%~1" EQU "-x86" (set BUILDX86=1) && shift && goto CheckOpts
+if /I "%~1" EQU "-Win32" (set BUILDX86=1) && shift && goto CheckOpts
+if /I "%~1" EQU "-x64" (set BUILDX64=1) && shift && goto CheckOpts
+if /I "%~1" EQU "-arm64" (set BUILDARM64=1) && shift && goto CheckOpts
+if    "%~1" EQU "--doc" (set BUILDDOC=1) && shift && goto CheckOpts
+if    "%~1" EQU "--no-test-marker" (set BUILDTEST=) && shift && goto CheckOpts
+if    "%~1" EQU "--test-marker" (set BUILDTEST=--test-marker) && shift && goto CheckOpts
+if    "%~1" EQU "--pack" (set BUILDPACK=1) && shift && goto CheckOpts
+if    "%~1" EQU "-r" (set REBUILD=-r) && shift && goto CheckOpts
 
 if not defined BUILDX86 if not defined BUILDX64 if not defined BUILDARM64 (set BUILDX86=1) && (set BUILDX64=1)
 

--- a/Tools/msi/buildrelease.bat
+++ b/Tools/msi/buildrelease.bat
@@ -44,27 +44,28 @@ set BUILDZIP=1
 
 
 :CheckOpts
-if "%1" EQU "-h" goto Help
-if "%1" EQU "-c" (set CERTNAME=%~2) && shift && shift && goto CheckOpts
-if "%1" EQU "--certificate" (set CERTNAME=%~2) && shift && shift && goto CheckOpts
-if "%1" EQU "-o" (set OUTDIR=%~2) && shift && shift && goto CheckOpts
-if "%1" EQU "--out" (set OUTDIR=%~2) && shift && shift && goto CheckOpts
-if "%1" EQU "-D" (set SKIPDOC=1) && shift && goto CheckOpts
-if "%1" EQU "--skip-doc" (set SKIPDOC=1) && shift && goto CheckOpts
-if "%1" EQU "-B" (set SKIPBUILD=1) && shift && goto CheckOpts
-if "%1" EQU "--skip-build" (set SKIPBUILD=1) && shift && goto CheckOpts
-if "%1" EQU "--download" (set DOWNLOAD_URL=%~2) && shift && shift && goto CheckOpts
-if "%1" EQU "--test" (set TESTTARGETDIR=%~2) && shift && shift && goto CheckOpts
-if "%1" EQU "-b" (set TARGET=Build) && shift && goto CheckOpts
-if "%1" EQU "--build" (set TARGET=Build) && shift && goto CheckOpts
-if "%1" EQU "-x86" (set BUILDX86=1) && shift && goto CheckOpts
-if "%1" EQU "-x64" (set BUILDX64=1) && shift && goto CheckOpts
-if "%1" EQU "-arm64" (set BUILDARM64=1) && shift && goto CheckOpts
-if "%1" EQU "--pgo" (set PGO=%~2) && shift && shift && goto CheckOpts
-if "%1" EQU "--skip-pgo" (set PGO=) && shift && goto CheckOpts
-if "%1" EQU "--skip-nuget" (set BUILDNUGET=) && shift && goto CheckOpts
-if "%1" EQU "--skip-zip" (set BUILDZIP=) && shift && goto CheckOpts
-if "%1" EQU "--skip-msi" (set BUILDMSI=) && shift && goto CheckOpts
+if    "%1" EQU "-h" goto Help
+if    "%1" EQU "-c" (set CERTNAME=%~2) && shift && shift && goto CheckOpts
+if    "%1" EQU "--certificate" (set CERTNAME=%~2) && shift && shift && goto CheckOpts
+if    "%1" EQU "-o" (set OUTDIR=%~2) && shift && shift && goto CheckOpts
+if    "%1" EQU "--out" (set OUTDIR=%~2) && shift && shift && goto CheckOpts
+if    "%1" EQU "-D" (set SKIPDOC=1) && shift && goto CheckOpts
+if    "%1" EQU "--skip-doc" (set SKIPDOC=1) && shift && goto CheckOpts
+if    "%1" EQU "-B" (set SKIPBUILD=1) && shift && goto CheckOpts
+if    "%1" EQU "--skip-build" (set SKIPBUILD=1) && shift && goto CheckOpts
+if    "%1" EQU "--download" (set DOWNLOAD_URL=%~2) && shift && shift && goto CheckOpts
+if    "%1" EQU "--test" (set TESTTARGETDIR=%~2) && shift && shift && goto CheckOpts
+if    "%1" EQU "-b" (set TARGET=Build) && shift && goto CheckOpts
+if    "%1" EQU "--build" (set TARGET=Build) && shift && goto CheckOpts
+if /I "%1" EQU "-x86" (set BUILDX86=1) && shift && goto CheckOpts
+if /I "%1" EQU "-Win32" (set BUILDX86=1) && shift && goto CheckOpts
+if /I "%1" EQU "-x64" (set BUILDX64=1) && shift && goto CheckOpts
+if /I "%1" EQU "-arm64" (set BUILDARM64=1) && shift && goto CheckOpts
+if    "%1" EQU "--pgo" (set PGO=%~2) && shift && shift && goto CheckOpts
+if    "%1" EQU "--skip-pgo" (set PGO=) && shift && goto CheckOpts
+if    "%1" EQU "--skip-nuget" (set BUILDNUGET=) && shift && goto CheckOpts
+if    "%1" EQU "--skip-zip" (set BUILDZIP=) && shift && goto CheckOpts
+if    "%1" EQU "--skip-msi" (set BUILDMSI=) && shift && goto CheckOpts
 
 if "%1" NEQ "" echo Invalid option: "%1" && exit /B 1
 


### PR DESCRIPTION
Minor issue I noticed during discussion in https://bugs.python.org/issue46744: The help string says to use "-ARM64" but the build script expects "-arm64".

This change makes the string compare case insensitive, makes the string compares for "-x86" and "-x64" case-insensitive too (just in case), and adds "-Win32" to the MSI build scripts to match the platform name passed to `PCBuild/build.bat`.

@zooba 

<!-- issue-number: [bpo-46744](https://bugs.python.org/issue46744) -->
https://bugs.python.org/issue46744
<!-- /issue-number -->
