### PR TITLE
bpo-43224: Work around substitution of unpacked TypeVarTuple

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -390,6 +390,10 @@ class UnpackTests(BaseTestCase):
 
 class TypeVarTupleTests(BaseTestCase):
 
+    def assertEndsWith(self, string, tail):
+        if not string.endswith(tail):
+            self.fail(f"String {string!r} does not end with {tail!r}")
+
     def test_instance_is_equal_to_itself(self):
         Ts = TypeVarTuple('Ts')
         self.assertEqual(Ts, Ts)
@@ -449,78 +453,74 @@ class TypeVarTupleTests(BaseTestCase):
         Ts = TypeVarTuple('Ts')
         class A(Generic[Unpack[Ts]]): pass
 
-        self.assertTrue(repr(A[()]).endswith('A[()]'))
-        self.assertTrue(repr(A[float]).endswith('A[float]'))
-        self.assertTrue(repr(A[float, str]).endswith('A[float, str]'))
-        self.assertTrue(repr(
-            A[Unpack[tuple[int, ...]]]
-        ).endswith(
+        self.assertEndsWith(repr(A[()]), 'A[()]')
+        self.assertEndsWith(repr(A[float]), 'A[float]')
+        self.assertEndsWith(repr(A[float, str]), 'A[float, str]')
+        self.assertEndsWith(
+            repr( A[Unpack[tuple[int, ...]]]),
             'A[*tuple[int, ...]]'
-        ))
-        self.assertTrue(repr(
-            A[float, Unpack[tuple[int, ...]]]
-        ).endswith(
+        )
+        self.assertEndsWith(
+            repr(A[float, Unpack[tuple[int, ...]]]),
             'A[float, *tuple[int, ...]]'
-        ))
-        self.assertTrue(repr(
-            A[Unpack[tuple[int, ...]], str]
-        ).endswith(
+        )
+        self.assertEndsWith(
+            repr(A[Unpack[tuple[int, ...]], str]),
             'A[*tuple[int, ...], str]'
-        ))
-        self.assertTrue(repr(
-            A[float, Unpack[tuple[int, ...]], str]
-        ).endswith(
+        )
+        self.assertEndsWith(
+            repr(A[float, Unpack[tuple[int, ...]], str]),
             'A[float, *tuple[int, ...], str]'
-        ))
+        )
 
-    def test_variadic_class_alias_repr_is_correct(self):
+    def test_single_parameters_variadic_class_alias_repr_is_correct(self):
         Ts = TypeVarTuple('Ts')
         class A(Generic[Unpack[Ts]]): pass
 
         B = A[Unpack[Ts]]
-        self.assertTrue(repr(B).endswith('A[*Ts]'))
-        with self.assertRaises(NotImplementedError):
-            B[()]
-        with self.assertRaises(NotImplementedError):
-            B[float]
-        with self.assertRaises(NotImplementedError):
-            B[float, str]
+        self.assertEndsWith(repr(B), 'A[*Ts]')
+        self.assertEndsWith(repr(B[()]), 'A[*Ts][()]')
+        self.assertEndsWith(repr(B[float]), 'A[*Ts][float]')
+        self.assertEndsWith(repr(B[float, str]), 'A[*Ts][float, str]')
 
         C = A[Unpack[Ts], int]
-        self.assertTrue(repr(C).endswith('A[*Ts, int]'))
-        with self.assertRaises(NotImplementedError):
-            C[()]
-        with self.assertRaises(NotImplementedError):
-            C[float]
-        with self.assertRaises(NotImplementedError):
-            C[float, str]
+        self.assertEndsWith(repr(C), 'A[*Ts, int]')
+        self.assertEndsWith(repr(C[()]), 'A[*Ts, int][()]')
+        self.assertEndsWith(repr(C[float]), 'A[*Ts, int][float]')
+        self.assertEndsWith(repr(C[float, str]), 'A[*Ts, int][float, str]')
 
         D = A[int, Unpack[Ts]]
-        self.assertTrue(repr(D).endswith('A[int, *Ts]'))
-        with self.assertRaises(NotImplementedError):
-            D[()]
-        with self.assertRaises(NotImplementedError):
-            D[float]
-        with self.assertRaises(NotImplementedError):
-            D[float, str]
+        self.assertEndsWith(repr(D), 'A[int, *Ts]')
+        self.assertEndsWith(repr(D[()]), 'A[int, *Ts][()]')
+        self.assertEndsWith(repr(D[float]), 'A[int, *Ts][float]')
+        self.assertEndsWith(repr(D[float, str]), 'A[int, *Ts][float, str]')
 
         E = A[int, Unpack[Ts], str]
-        self.assertTrue(repr(E).endswith('A[int, *Ts, str]'))
-        with self.assertRaises(NotImplementedError):
-            E[()]
-        with self.assertRaises(NotImplementedError):
-            E[float]
-        with self.assertRaises(NotImplementedError):
-            E[float, bool]
+        self.assertEndsWith(repr(E), 'A[int, *Ts, str]')
+        self.assertEndsWith(repr(E[()]), 'A[int, *Ts, str][()]')
+        self.assertEndsWith(repr(E[float]), 'A[int, *Ts, str][float]')
+        self.assertEndsWith(
+            repr(E[float, bool]),
+            'A[int, *Ts, str][float, bool]'
+        )
 
         F = A[Unpack[Ts], Unpack[tuple[str, ...]]]
-        self.assertTrue(repr(F).endswith('A[*Ts, *tuple[str, ...]]'))
-        with self.assertRaises(NotImplementedError):
-            F[()]
-        with self.assertRaises(NotImplementedError):
-            F[float]
-        with self.assertRaises(NotImplementedError):
-            F[float, int]
+        self.assertEndsWith(repr(F), 'A[*Ts, *tuple[str, ...]]')
+        self.assertEndsWith(repr(F[()]), 'A[*Ts, *tuple[str, ...]][()]')
+        self.assertEndsWith(repr(F[float]), 'A[*Ts, *tuple[str, ...]][float]')
+        self.assertEndsWith(
+            repr(F[float, int]),
+            'A[*Ts, *tuple[str, ...]][float, int]'
+        )
+
+        G = A[T, Unpack[Ts]]
+        self.assertEndsWith(repr(G), 'A[~T, *Ts]')
+        self.assertEndsWith(repr(G[()]), 'A[~T, *Ts][()]')
+        self.assertEndsWith(repr(G[float]), 'A[~T, *Ts][float]')
+        self.assertEndsWith(
+            repr(G[float, int]),
+            'A[~T, *Ts][float, int]'
+        )
 
     def test_cannot_subclass_class(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Following up on the discussion in https://github.com/python/cpython/pull/31021 about how to handle substitution of `TypeVarTuple`s, here's a first attempt at the solution Jelle suggested: when `TypeVarTuple`s` are involved, don't perform the substitution at all, instead returning an object whose repr() reflects that.

(What Jelle actually suggested was to return a new `_GenericAlias` here. I've tested that too, and it seems to work fine, but I'm a bit wary about giving `_GenericAlias` _too_ many hats to wear - as a newcomer to this codebase, I've struggled with how overloaded classes already are, making it predict what the effects of a change will be. Having said that, Jelle, I remember you mentioning you'd prefer to keep the number of classes in `typing.py` small, so if you think the tradeoff isn't worth it, I respect your judgement, and we can re-use `_GenericAlias`, coping with the extra functionality with extra documentation comments.)

The main alternative I'm aware of is the logic we cut out in https://github.com/python/cpython/pull/31021/commits/b9b1c80913f1fbc21ea60257bed6562e18c49802 - about 200 lines of logic, and another 100 lines of tests. @serhiy-storchaka also has a partial solution in https://github.com/python/cpython/pull/31800, which could also be an option - making the substitutions only when it's easy, and otherwise falling back to the approach in this PR.

I've also pulled in @serhiy-storchaka's nice `assertEndsWith` helper from https://github.com/python/cpython/pull/31800 :)

@JelleZijlstra @pradeep90 

<!-- issue-number: [bpo-43224](https://bugs.python.org/issue43224) -->
https://bugs.python.org/issue43224
<!-- /issue-number -->
