### PR TITLE
[3.9] sqlite3: normalise pre-acronym determiners (GH-31772)

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -17,7 +17,7 @@ SQLite for internal data storage.  It's also possible to prototype an
 application using SQLite and then port the code to a larger database such as
 PostgreSQL or Oracle.
 
-The sqlite3 module was written by Gerhard Häring.  It provides a SQL interface
+The sqlite3 module was written by Gerhard Häring.  It provides an SQL interface
 compliant with the DB-API 2.0 specification described by :pep:`249`.
 
 To use the module, start by creating a :class:`Connection` object that
@@ -332,7 +332,7 @@ Connection Objects
 
 .. class:: Connection
 
-   A SQLite database connection has the following attributes and methods:
+   An SQLite database connection has the following attributes and methods:
 
    .. attribute:: isolation_level
 
@@ -534,7 +534,7 @@ Connection Objects
 
    .. method:: load_extension(path)
 
-      This routine loads a SQLite extension from a shared library.  You have to
+      This routine loads an SQLite extension from a shared library.  You have to
       enable extension loading with :meth:`enable_load_extension` before you can
       use this routine.
 
@@ -605,7 +605,7 @@ Connection Objects
 
    .. method:: backup(target, *, pages=-1, progress=None, name="main", sleep=0.250)
 
-      This method makes a backup of a SQLite database even while it's being accessed
+      This method makes a backup of an SQLite database even while it's being accessed
       by other clients, or concurrently by the same connection.  The copy will be
       written into the mandatory argument *target*, that must be another
       :class:`Connection` instance.
@@ -965,7 +965,7 @@ This is how SQLite types are converted to Python types by default:
 +-------------+----------------------------------------------+
 
 The type system of the :mod:`sqlite3` module is extensible in two ways: you can
-store additional Python types in a SQLite database via object adaptation, and
+store additional Python types in an SQLite database via object adaptation, and
 you can let the :mod:`sqlite3` module convert SQLite types to different Python
 types via converters.
 

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -878,9 +878,9 @@ PyObject* pysqlite_cursor_close(pysqlite_Cursor* self, PyObject* args)
 
 static PyMethodDef cursor_methods[] = {
     {"execute", (PyCFunction)pysqlite_cursor_execute, METH_VARARGS,
-        PyDoc_STR("Executes a SQL statement.")},
+        PyDoc_STR("Executes an SQL statement.")},
     {"executemany", (PyCFunction)pysqlite_cursor_executemany, METH_VARARGS,
-        PyDoc_STR("Repeatedly executes a SQL statement.")},
+        PyDoc_STR("Repeatedly executes an SQL statement.")},
     {"executescript", (PyCFunction)pysqlite_cursor_executescript, METH_VARARGS,
         PyDoc_STR("Executes multiple SQL statements at once.")},
     {"fetchone", (PyCFunction)pysqlite_cursor_fetchone, METH_NOARGS,


### PR DESCRIPTION
For consistency, replace "a SQL" with "an SQL"..
(cherry picked from commit 2d5835a019a46573d5b1b614c8ef88d6b564d8d4)

Co-authored-by: Erlend Egeberg Aasland <erlend.aasland@innova.no>