### PR TITLE
bpo-46920: Remove an old, elementtree-specific leak detector

### DIFF
--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -36,17 +36,6 @@
 
 /* -------------------------------------------------------------------- */
 
-#if 0
-static int memory = 0;
-#define ALLOC(size, comment)\
-do { memory += size; printf("%8d - %s\n", memory, comment); } while (0)
-#define RELEASE(size, comment)\
-do { memory -= size; printf("%8d - %s\n", memory, comment); } while (0)
-#else
-#define ALLOC(size, comment)
-#define RELEASE(size, comment)
-#endif
-
 /* compiler tweaks */
 #if defined(_MSC_VER)
 #define LOCAL(type) static __inline type __fastcall
@@ -301,7 +290,6 @@ create_new_element(PyObject* tag, PyObject* attrib)
 
     self->weakreflist = NULL;
 
-    ALLOC(sizeof(ElementObject), "create element");
     PyObject_GC_Track(self);
 
     if (attrib != NULL && !is_empty_dict(attrib)) {
@@ -676,7 +664,6 @@ element_dealloc(ElementObject* self)
     */
     element_gc_clear(self);
 
-    RELEASE(sizeof(ElementObject), "destroy element");
     Py_TYPE(self)->tp_free((PyObject *)self);
     Py_TRASHCAN_END
 }


### PR DESCRIPTION
Currently, CPython has a universal refleak detector that reports on interpreter termination. As a result, no commented out `elementtree`-specific detector is required, especially when it prints into stdout for each `ElementObject` creation and destruction.

*This PR is separated from a large, umbrella GH-31681 to simplify review.*

<!-- issue-number: [bpo-46920](https://bugs.python.org/issue46920) -->
https://bugs.python.org/issue46920
<!-- /issue-number -->
