### PR TITLE
bpo-46920: Remove disabled debug code added decades ago and likely unnecessary

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -13621,14 +13621,6 @@ unicode_zfill_impl(PyObject *self, Py_ssize_t width)
     return u;
 }
 
-#if 0
-static PyObject *
-unicode__decimal2ascii(PyObject *self)
-{
-    return PyUnicode_TransformDecimalAndSpaceToASCII(self);
-}
-#endif
-
 PyDoc_STRVAR(startswith__doc__,
              "S.startswith(prefix[, start[, end]]) -> bool\n\
 \n\
@@ -14214,11 +14206,6 @@ static PyMethodDef unicode_methods[] = {
     UNICODE___FORMAT___METHODDEF
     UNICODE_MAKETRANS_METHODDEF
     UNICODE_SIZEOF_METHODDEF
-#if 0
-    /* These methods are just used for debugging the implementation. */
-    {"_decimal2ascii", (PyCFunction) unicode__decimal2ascii, METH_NOARGS},
-#endif
-
     {"__getnewargs__",  unicode_getnewargs, METH_NOARGS},
     {NULL, NULL}
 };

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -37,17 +37,6 @@ _PyPegen_byte_offset_to_character_offset(PyObject *line, Py_ssize_t col_offset)
     return size;
 }
 
-#if 0
-static const char *
-token_name(int type)
-{
-    if (0 <= type && type <= N_TOKENS) {
-        return _PyParser_TokenNames[type];
-    }
-    return "<Huh?>";
-}
-#endif
-
 // Here, mark is the start of the node, while p->mark is the end.
 // If node==NULL, they should be the same.
 int

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -137,24 +137,6 @@ typedef struct {
     Py_UCS4 type;
 } InternalFormatSpec;
 
-#if 0
-/* Occasionally useful for debugging. Should normally be commented out. */
-static void
-DEBUG_PRINT_FORMAT_SPEC(InternalFormatSpec *format)
-{
-    printf("internal format spec: fill_char %d\n", format->fill_char);
-    printf("internal format spec: align %d\n", format->align);
-    printf("internal format spec: alternate %d\n", format->alternate);
-    printf("internal format spec: sign %d\n", format->sign);
-    printf("internal format spec: width %zd\n", format->width);
-    printf("internal format spec: thousands_separators %d\n",
-           format->thousands_separators);
-    printf("internal format spec: precision %zd\n", format->precision);
-    printf("internal format spec: type %c\n", format->type);
-    printf("\n");
-}
-#endif
-
 
 /*
   ptr points to the start of the format_spec, end points just past its end.


### PR DESCRIPTION
- `unicode._decimal2ascii` - `used for debugging the implementation`, disabled on 27 Aug 2007 in e226b55
- `token_name` - used nowhere, disabled on 23 Apr 2020 in c5fc156
- `printf("internal format spec: [...]` - demands an extra definition of `DEBUG_PRINT_FORMAT_SPEC`, disabled on 27 Aug 2007 in e226b55

*This PR is separated from a large, umbrella GH-31681 to simplify review.*

<!-- issue-number: [bpo-46920](https://bugs.python.org/issue46920) -->
https://bugs.python.org/issue46920
<!-- /issue-number -->
