### PR TITLE
bpo-46920: Remove code that has explainers why it was disabled

### DIFF
--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -3440,11 +3440,5 @@ PyInit__tkinter(void)
         return NULL;
     }
 
-#if 0
-    /* This was not a good idea; through <Destroy> bindings,
-       Tcl_Finalize() may invoke Python code but at that point the
-       interpreter and thread state have already been destroyed! */
-    Py_AtExit(Tcl_Finalize);
-#endif
     return m;
 }

--- a/Modules/sre_lib.h
+++ b/Modules/sre_lib.h
@@ -333,34 +333,6 @@ SRE(count)(SRE_STATE* state, const SRE_CODE* pattern, Py_ssize_t maxcount)
     return ptr - (SRE_CHAR*) state->ptr;
 }
 
-#if 0 /* not used in this release */
-LOCAL(int)
-SRE(info)(SRE_STATE* state, const SRE_CODE* pattern)
-{
-    /* check if an SRE_OP_INFO block matches at the current position.
-       returns the number of SRE_CODE objects to skip if successful, 0
-       if no match */
-
-    const SRE_CHAR* end = (const SRE_CHAR*) state->end;
-    const SRE_CHAR* ptr = (const SRE_CHAR*) state->ptr;
-    Py_ssize_t i;
-
-    /* check minimal length */
-    if (pattern[3] && end - ptr < pattern[3])
-        return 0;
-
-    /* check known prefix */
-    if (pattern[2] & SRE_INFO_PREFIX && pattern[5] > 1) {
-        /* <length> <skip> <prefix data> <overlap data> */
-        for (i = 0; i < pattern[5]; i++)
-            if ((SRE_CODE) ptr[i] != pattern[7 + i])
-                return 0;
-        return pattern[0] + 2 * pattern[6];
-    }
-    return pattern[0];
-}
-#endif
-
 /* The macros below should be used to protect recursive SRE(match)()
  * calls that *failed* and do *not* return immediately (IOW, those
  * that will backtrack). Explaining:

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -282,30 +282,6 @@ check_bom(int get_char(struct tok_state *),
             unget_char(ch1, tok);
             return 1;
         }
-#if 0
-    /* Disable support for UTF-16 BOMs until a decision
-       is made whether this needs to be supported.  */
-    } else if (ch1 == 0xFE) {
-        ch2 = get_char(tok);
-        if (ch2 != 0xFF) {
-            unget_char(ch2, tok);
-            unget_char(ch1, tok);
-            return 1;
-        }
-        if (!set_readline(tok, "utf-16-be"))
-            return 0;
-        tok->decoding_state = STATE_NORMAL;
-    } else if (ch1 == 0xFF) {
-        ch2 = get_char(tok);
-        if (ch2 != 0xFE) {
-            unget_char(ch2, tok);
-            unget_char(ch1, tok);
-            return 1;
-        }
-        if (!set_readline(tok, "utf-16-le"))
-            return 0;
-        tok->decoding_state = STATE_NORMAL;
-#endif
     } else {
         unget_char(ch1, tok);
         return 1;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -6997,12 +6997,6 @@ PyEval_MergeCompilerFlags(PyCompilerFlags *cf)
             result = 1;
             cf->cf_flags |= compilerflags;
         }
-#if 0 /* future keyword */
-        if (codeflags & CO_GENERATOR_ALLOWED) {
-            result = 1;
-            cf->cf_flags |= CO_GENERATOR_ALLOWED;
-        }
-#endif
     }
     return result;
 }


### PR DESCRIPTION
- `This was not a good idea` - appeared on 14 Jul 1998 in 43ff868
- `not used in this release` - appeared on 26 Oct 2013 in 8444ebb
- `Disable [...] until a decision is made` - appeared on 4 Aug 2002 in
   00f1e3f
- `future keyword` - appeared on 23 Mar 2002 in c24ea08

*This PR is separated from a large, umbrella GH-31681 to simplify review.*

<!-- issue-number: [bpo-46920](https://bugs.python.org/issue46920) -->
https://bugs.python.org/issue46920
<!-- /issue-number -->
