### PR TITLE
bpo-46920: Remove code that has no explainer why it was disabled

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1418,49 +1418,12 @@ static PyGetSetDef WCharArray_getsets[] = {
 };
 
 /*
-  The next three functions copied from Python's typeobject.c.
+  The next function is copied from Python's typeobject.c.
 
-  They are used to attach methods, members, or getsets to a type *after* it
+  It is used to attach getsets to a type *after* it
   has been created: Arrays of characters have additional getsets to treat them
   as strings.
  */
-/*
-static int
-add_methods(PyTypeObject *type, PyMethodDef *meth)
-{
-    PyObject *dict = type->tp_dict;
-    for (; meth->ml_name != NULL; meth++) {
-        PyObject *descr;
-        descr = PyDescr_NewMethod(type, meth);
-        if (descr == NULL)
-            return -1;
-        if (PyDict_SetItemString(dict, meth->ml_name, descr) < 0) {
-            Py_DECREF(descr);
-            return -1;
-        }
-        Py_DECREF(descr);
-    }
-    return 0;
-}
-
-static int
-add_members(PyTypeObject *type, PyMemberDef *memb)
-{
-    PyObject *dict = type->tp_dict;
-    for (; memb->name != NULL; memb++) {
-        PyObject *descr;
-        descr = PyDescr_NewMember(type, memb);
-        if (descr == NULL)
-            return -1;
-        if (PyDict_SetItemString(dict, memb->name, descr) < 0) {
-            Py_DECREF(descr);
-            return -1;
-        }
-        Py_DECREF(descr);
-    }
-    return 0;
-}
-*/
 
 static int
 add_getset(PyTypeObject *type, PyGetSetDef *gsp)

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -516,22 +516,6 @@ instancemethod_repr(PyObject *self)
     return result;
 }
 
-/*
-static long
-instancemethod_hash(PyObject *self)
-{
-    long x, y;
-    x = (long)self;
-    y = PyObject_Hash(PyInstanceMethod_GET_FUNCTION(self));
-    if (y == -1)
-        return -1;
-    x = x ^ y;
-    if (x == -1)
-        x = -2;
-    return x;
-}
-*/
-
 PyDoc_STRVAR(instancemethod_doc,
 "instancemethod(function)\n\
 \n\
@@ -569,7 +553,7 @@ PyTypeObject PyInstanceMethod_Type = {
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */
-    0, /*(hashfunc)instancemethod_hash,         tp_hash  */
+    0,                                          /* tp_hash  */
     instancemethod_call,                        /* tp_call */
     0,                                          /* tp_str */
     instancemethod_getattro,                    /* tp_getattro */


### PR DESCRIPTION
Indeed, disabling date shows that these functions will never come into production.

- `The next three functions copied from Python's typeobject.c` - two of them are commented out on 8 Mar 2006 in d4c9320
- `instancemethod.__hash__` was commented out from the very beginning on 11 Dec 2007 in a3534a6

*This PR is separated from a large, umbrella GH-31681 to simplify review.*

<!-- issue-number: [bpo-46920](https://bugs.python.org/issue46920) -->
https://bugs.python.org/issue46920
<!-- /issue-number -->
