### PR TITLE
gh-91099: fix[imaplib]: call Exception with string instance

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -712,7 +712,7 @@ class IMAP4:
         """
         typ, dat = self._simple_command('LOGIN', user, self._quote(password))
         if typ != 'OK':
-            raise self.error(dat[-1])
+            raise self.error(dat[-1].decode('UTF-8', 'replace'))
         self.state = 'AUTH'
         return typ, dat
 

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -434,6 +434,16 @@ class NewIMAPTestsMixin:
                 r'\[AUTHENTICATIONFAILED\] invalid'):
             client.authenticate('MYAUTH', lambda x: b'fake')
 
+    def test_invalid_login(self):
+        class MyServer(SimpleIMAPHandler):
+            def cmd_LOGIN(self, tag, args):
+                self.server.logged = args[0]
+                self._send_tagged(tag, 'NO', '[LOGIN] failed')
+        client, _ = self._setup(MyServer)
+        with self.assertRaisesRegex(imaplib.IMAP4.error,
+                r'\[LOGIN\] failed'):
+            client.login('user', 'wrongpass')
+
     def test_valid_authentication_bytes(self):
         class MyServer(SimpleIMAPHandler):
             def cmd_AUTHENTICATE(self, tag, args):

--- a/Misc/NEWS.d/next/Library/2023-02-26-14-07-18.gh-issue-91099._QPbEL.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-26-14-07-18.gh-issue-91099._QPbEL.rst
@@ -1,0 +1,2 @@
+:meth:`imaplib.IMAP4.login` now raises exceptions with :class:`str` instead of
+:class:`bytes`. Patch by Florian Best.


### PR DESCRIPTION
Adjust the behavior of `login()` similar to `authenticate()` where `self.error` is called with a `str` instance.

Especially for Python3 with strict bytes mode (-bb) this is helpful and prevents:
    
```
    Traceback (most recent call last):
      in "<stdin>"
        self.login(email, password)
      File "/usr/lib/python3.7/imaplib.py", line 598, in login
        raise self.error(dat[-1])
    imaplib.error: <exception str() failed>
    
    During handling of the above exception, another exception occurred:
    Traceback (most recent call last):
      in "<stdin>"
        str(exc)
    BytesWarning: str() on a bytes instance
```

<!-- issue-number: [bpo-46943](https://bugs.python.org/issue46943) -->
https://bugs.python.org/issue46943
<!-- /issue-number -->


<!-- gh-issue-number: gh-91099 -->
* Issue: gh-91099
<!-- /gh-issue-number -->
