### PR TITLE
bpo-40280: Disable AF_UNIX, AF_PACKET, SO_REUSE* on Emscripten

### DIFF
--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -465,9 +465,9 @@ class TCPServer(BaseServer):
         May be overridden.
 
         """
-        if self.allow_reuse_address:
+        if self.allow_reuse_address and hasattr(socket, "SO_REUSEADDR"):
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        if self.allow_reuse_port:
+        if self.allow_reuse_port and hasattr(socket, "SO_REUSEPORT"):
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         self.socket.bind(self.server_address)
         self.server_address = self.socket.getsockname()

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7933,7 +7933,7 @@ PyInit__socket(void)
 #ifdef  IPPROTO_VRRP
     PyModule_AddIntMacro(m, IPPROTO_VRRP);
 #endif
-#if defined(IPPROTO_SCTP) && !defined(__EMSCRIPTEN__)
+#ifdef  IPPROTO_SCTP
     PyModule_AddIntMacro(m, IPPROTO_SCTP);
 #endif
 #ifdef  IPPROTO_BIP

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -192,6 +192,21 @@ typedef int socklen_t;
 
 #endif /* HAVE_SOCKADDR_ALG */
 
+#ifdef __EMSCRIPTEN__
+// wasm32-emscripten sockets only support subset of IPv4 and IPv6.
+// SCTP protocol crashes runtime.
+#ifdef IPPROTO_SCTP
+#  undef IPPROTO_SCTP
+#endif
+// setsockopt() fails with ENOPROTOOPT, getsockopt only supports SO_ERROR.
+// undef SO_REUSEADDR and SO_REUSEPORT so they cannot be used.
+#ifdef SO_REUSEADDR
+#  undef SO_REUSEADDR
+#endif
+#ifdef SO_REUSEPORT
+#  undef SO_REUSEPORT
+#endif
+#endif // __EMSCRIPTEN__
 
 #ifndef Py__SOCKET_H
 #define Py__SOCKET_H

--- a/Tools/wasm/config.site-wasm32-emscripten
+++ b/Tools/wasm/config.site-wasm32-emscripten
@@ -74,8 +74,10 @@ ac_cv_func_posix_fallocate=no
 ac_cv_func_utimensat=no
 ac_cv_header_sys_ioctl_h=no
 
-# sockets are supported, but only in non-blocking mode
-# ac_cv_header_sys_socket_h=no
+# sockets are supported, but only AF_INET / AF_INET6 in non-blocking mode.
+# Disable AF_UNIX and AF_PACKET support, see socketmodule.h.
+ac_cv_header_sys_un_h=no
+ac_cv_header_netpacket_packet_h=no
 
 # aborts with bad ioctl
 ac_cv_func_openpty=no


### PR DESCRIPTION
Emscripten's socket emulation is limited. AF_UNIX, AF_PACKET,
setsockopt(), and most SO_* constants are not supported.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
