### PR TITLE
bpo-46644: Fix test_typing test broken by GH-31151 due to a merge race

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -377,7 +377,7 @@ class TypeVarTests(BaseTestCase):
         T = TypeVar('T')
         P = ParamSpec("P")
         bad_args = (
-            42, ..., [int], (), (int, str), Union,
+            (), (int, str), Union,
             Generic, Generic[T], Protocol, Protocol[T],
             Final, Final[int], ClassVar, ClassVar[int],
         )


### PR DESCRIPTION


<!-- issue-number: [bpo-46644](https://bugs.python.org/issue46644) -->
https://bugs.python.org/issue46644
<!-- /issue-number -->
