### PR TITLE
bpo-46993: Speed up bytearray creation from list and tuple

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-12-09-44-31.bpo-46993.-13hGo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-12-09-44-31.bpo-46993.-13hGo.rst
@@ -1,0 +1,1 @@
+Speed up :class:`bytearray` creation from :class:`list` and :class:`tuple` by 40%. Patch by Kumar Aditya.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -850,17 +850,21 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
             return -1;
         }
         PyObject **items = PySequence_Fast_ITEMS(arg);
-
+        char *s = PyByteArray_AS_STRING(self);
         for (Py_ssize_t i = 0; i < size; i++) {
             int value;
+            if (!PyLong_CheckExact(items[i])) {
+                goto slowpath;
+            }
             int rc = _getbytevalue(items[i], &value);
             if (!rc) {
                 return -1;
             }
-            PyByteArray_AS_STRING(self)[i] = value;
+            s[i] = value;
         }
         return 0;
     }
+slowpath:
     /* Get the iterator */
     it = PyObject_GetIter(arg);
     if (it == NULL) {

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -865,6 +865,10 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
         return 0;
     }
 slowpath:
+    if (Py_SIZE(self) != 0) {
+        if (PyByteArray_Resize((PyObject *)self, 0) < 0)
+            return -1;
+    }
     /* Get the iterator */
     it = PyObject_GetIter(arg);
     if (it == NULL) {

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -854,6 +854,12 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
         for (Py_ssize_t i = 0; i < size; i++) {
             int value;
             if (!PyLong_CheckExact(items[i])) {
+                /* Resize to 0 and go through slowpath */
+                if (Py_SIZE(self) != 0) {
+                   if (PyByteArray_Resize((PyObject *)self, 0) < 0) {
+                       return -1;
+                   }
+                }
                 goto slowpath;
             }
             int rc = _getbytevalue(items[i], &value);
@@ -865,10 +871,6 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
         return 0;
     }
 slowpath:
-    if (Py_SIZE(self) != 0) {
-        if (PyByteArray_Resize((PyObject *)self, 0) < 0)
-            return -1;
-    }
     /* Get the iterator */
     it = PyObject_GetIter(arg);
     if (it == NULL) {


### PR DESCRIPTION
Speeds up bytearray creation from list and tuples.

Benchmark:
```py
import pyperf

runner = pyperf.Runner()
runner.timeit(name="bench bytearray",
              stmt="bytearray([42]*10000)",)
```

Result:
```console
Mean +- std dev: [base] 74.8 us +- 5.5 us -> [patch] 53.2 us +- 3.3 us: 1.41x faster
```

<!-- issue-number: [bpo-46993](https://bugs.python.org/issue46993) -->
https://bugs.python.org/issue46993
<!-- /issue-number -->
