### PR TITLE
bpo-46995: Deprecate missing asyncio.Task.set_name() for third-party task implementations

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -67,7 +67,7 @@ def _set_task_name(task, name):
         try:
             set_name = task.set_name
         except AttributeError:
-            warnings.warn("Task.set_name() was added by Python 3.8, "
+            warnings.warn("Task.set_name() was added in Python 3.8, "
                       "the method support will be mandatory for third-party "
                       "task implementations since 3.13.",
                       DeprecationWarning, stacklevel=2)

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -70,7 +70,7 @@ def _set_task_name(task, name):
             warnings.warn("Task.set_name() was added in Python 3.8, "
                       "the method support will be mandatory for third-party "
                       "task implementations since 3.13.",
-                      DeprecationWarning, stacklevel=2)
+                      DeprecationWarning, stacklevel=3)
         else:
             set_name(name)
 

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -67,7 +67,10 @@ def _set_task_name(task, name):
         try:
             set_name = task.set_name
         except AttributeError:
-            pass
+            warnings.warn("Task.set_name() was added by Python 3.8, "
+                      "the method support will be mandatory for third-party "
+                      "task implementations since 3.13.",
+                      DeprecationWarning, stacklevel=2)
         else:
             set_name(name)
 

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -12,7 +12,6 @@ import sys
 import textwrap
 import traceback
 import unittest
-import weakref
 from unittest import mock
 from types import GenericAlias
 

--- a/Misc/NEWS.d/next/Library/2022-03-12-13-50-42.bpo-46995.2kdNDg.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-12-13-50-42.bpo-46995.2kdNDg.rst
@@ -1,2 +1,2 @@
 Deprecate missing :meth:`asyncio.Task.set_name` for third-party task
-implementations, schedule the making it mandatory in Python 3.13.
+implementations, schedule making it mandatory in Python 3.13.

--- a/Misc/NEWS.d/next/Library/2022-03-12-13-50-42.bpo-46995.2kdNDg.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-12-13-50-42.bpo-46995.2kdNDg.rst
@@ -1,0 +1,2 @@
+Deprecate missing :meth:`asyncio.Task.set_name` for third-party task
+implementations, schedule the making it mandatory in Python 3.13.


### PR DESCRIPTION


<!-- issue-number: [bpo-46995](https://bugs.python.org/issue46995) -->
https://bugs.python.org/issue46995
<!-- /issue-number -->
