### PR TITLE
gh-91117: Ensure integer mod and pow operations use cached small ints

### DIFF
--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1024,6 +1024,48 @@ class LongTest(unittest.TestCase):
         self.assertIs(a + b, 1)
         self.assertIs(c - a, 1)
 
+    @support.cpython_only
+    def test_pow_uses_cached_small_ints(self):
+        self.assertIs(pow(10, 3, 998), 2)
+        self.assertIs(10 ** 3 % 998, 2)
+        a, p, m = 10, 3, 998
+        self.assertIs(a ** p % m, 2)
+
+        self.assertIs(pow(2, 31, 2 ** 31 - 1), 1)
+        self.assertIs(2 ** 31 % (2 ** 31 - 1), 1)
+        a, p, m = 2, 31, 2 ** 31 - 1
+        self.assertIs(a ** p % m, 1)
+
+        self.assertIs(pow(2, 100, 2**100 - 3), 3)
+        self.assertIs(2 ** 100 % (2 ** 100 - 3), 3)
+        a, p, m = 2, 100, 2**100 - 3
+        self.assertIs(a ** p % m, 3)
+
+    @support.cpython_only
+    def test_divmod_uses_cached_small_ints(self):
+        big = 10 ** 100
+
+        self.assertIs((big + 1) % big, 1)
+        self.assertIs((big + 1) // big, 1)
+        self.assertIs(big // (big // 2), 2)
+        self.assertIs(big // (big // -4), -4)
+
+        q, r = divmod(2 * big + 3, big)
+        self.assertIs(q, 2)
+        self.assertIs(r, 3)
+
+        q, r = divmod(-4 * big + 100, big)
+        self.assertIs(q, -4)
+        self.assertIs(r, 100)
+
+        q, r = divmod(3 * (-big) - 1, -big)
+        self.assertIs(q, 3)
+        self.assertIs(r, -1)
+
+        q, r = divmod(3 * big - 1, -big)
+        self.assertIs(q, -3)
+        self.assertIs(r, -1)
+
     def test_small_ints(self):
         for i in range(-5, 257):
             self.assertIs(i, i + 0)

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-13-08-23-17.bpo-46961.SgGCkG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-13-08-23-17.bpo-46961.SgGCkG.rst
@@ -1,0 +1,1 @@
+Integer mod/remainder operations, including the three-argument form of :func:`pow`, now consistently return ints from the global small integer cache when applicable.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -2679,6 +2679,7 @@ long_divrem(PyLongObject *a, PyLongObject *b,
     }
     else {
         z = x_divrem(a, b, prem);
+        *prem = maybe_small_long(*prem);
         if (z == NULL)
             return -1;
     }
@@ -2732,6 +2733,7 @@ long_rem(PyLongObject *a, PyLongObject *b, PyLongObject **prem)
     else {
         /* Slow path using divrem. */
         Py_XDECREF(x_divrem(a, b, prem));
+        *prem = maybe_small_long(*prem);
         if (*prem == NULL)
             return -1;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46961](https://bugs.python.org/issue46961) -->
https://bugs.python.org/issue46961
<!-- /issue-number -->
