### PR TITLE
bpo-43224: Fix Tuple[()].__args__

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4232,7 +4232,7 @@ class GetUtilitiesTestCase(TestCase):
         self.assertEqual(get_args(Union[int, Callable[[Tuple[T, ...]], str]]),
                          (int, Callable[[Tuple[T, ...]], str]))
         self.assertEqual(get_args(Tuple[int, ...]), (int, ...))
-        self.assertEqual(get_args(Tuple[()]), ((),))
+        self.assertEqual(get_args(Tuple[()]), ())
         self.assertEqual(get_args(Annotated[T, 'one', 2, ['three']]), (T, 'one', 2, ['three']))
         self.assertEqual(get_args(List), ())
         self.assertEqual(get_args(Tuple), ())

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1218,9 +1218,11 @@ class _GenericAlias(_BaseGenericAlias, _root=True):
         super().__init__(origin, inst=inst, name=name)
         if not isinstance(args, tuple):
             args = (args,)
-        self.__args__ = tuple(... if a is _TypingEllipsis else
-                              () if a is _TypingEmpty else
-                              a for a in args)
+        if args == (_TypingEmpty,):
+            self.__args__ = ()
+        else:
+            self.__args__ = tuple(... if a is _TypingEllipsis else
+                                  a for a in args)
         self.__parameters__ = _collect_parameters(args)
         self._paramspec_tvars = _paramspec_tvars
         if not name:


### PR DESCRIPTION
Here's a fun inconsistency:

```python
>>> Tuple[()].__args__
((),)
>>> tuple[()].__args__
()
```

Even though there's an explicit test for the former behaviour, I don't think it's right:
* Argument 1: If `foo.__args__` is `(bar,)`, that says that `foo` is being parameterised by `bar`. When we do `Tuple[()]`, it's really just to get around the fact that `Tuple[]` is invalid syntax - what we're really meaning to say is that we're not parameterising it with _anything_. `Tuple[()].__args__` should therefore be empty.
* Argument 2: Everything in `Tuple[...].__args__` should be a type. `()` is _not_ a type.

This matters for PEP 646, where we were expecting that a `TypeVarTuple` with no arguments would expand to nothing rather than `()`. If we were to change things so it was consistent with the current behaviour of `Tuple[()]`, we'd have

```python
T = TypeVar('T')
Ts = TypeVarTuple('Ts')
class C(Generic[T, *Ts]): pass
Alias = C[int, *Ts]
Alias[()]  # C[int, ()]
```

which definitely isn't what we want.

@ilevkivskyi who added the test for the former behaviour, according to the git blame. Is there something I'm missing here?

<!-- issue-number: [bpo-43224](https://bugs.python.org/issue43224) -->
https://bugs.python.org/issue43224
<!-- /issue-number -->
