### PR TITLE
bpo-47005: Improve performance of bytearray_repeat and bytearray_irepeat

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-13-21-04-20.bpo-47005.OHBfCc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-13-21-04-20.bpo-47005.OHBfCc.rst
@@ -1,0 +1,1 @@
+Improve performance of ``bytearray_repeat`` and ``bytearray_irepeat`` by reducing the number of invocations of ``memcpy``.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -342,8 +342,9 @@ bytearray_repeat(PyByteArrayObject *self, Py_ssize_t count)
                 memcpy(result->ob_bytes, buf, mysize);
                 i = mysize;
             }
+            // repeatedly double the number of bytes copied
             while (i < size) {
-                j = (i <= size - i) ? i : size - i;
+                j = Py_MIN(i, size - i);
                 memcpy(result->ob_bytes + i, result->ob_bytes, j);
                 i += j;
             }
@@ -375,8 +376,9 @@ bytearray_irepeat(PyByteArrayObject *self, Py_ssize_t count)
         Py_ssize_t i, j;
 
         i = mysize;
+        // repeatedly double the number of bytes copied
         while (i < size) {
-            j = (i <= size - i) ? i : size - i;
+            j = Py_MIN(i, size - i);
             memcpy(buf + i, buf, j);
             i += j;
         }

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -335,9 +335,18 @@ bytearray_repeat(PyByteArrayObject *self, Py_ssize_t count)
         if (mysize == 1)
             memset(result->ob_bytes, buf[0], size);
         else {
-            Py_ssize_t i;
-            for (i = 0; i < count; i++)
-                memcpy(result->ob_bytes + i*mysize, buf, mysize);
+            Py_ssize_t i, j;
+
+            i = 0;
+            if (i < size) {
+                memcpy(result->ob_bytes, buf, mysize);
+                i = mysize;
+            }
+            while (i < size) {
+                j = (i <= size - i) ? i : size - i;
+                memcpy(result->ob_bytes + i, result->ob_bytes, j);
+                i += j;
+            }
         }
     }
     return (PyObject *)result;
@@ -363,9 +372,14 @@ bytearray_irepeat(PyByteArrayObject *self, Py_ssize_t count)
     if (mysize == 1)
         memset(buf, buf[0], size);
     else {
-        Py_ssize_t i;
-        for (i = 1; i < count; i++)
-            memcpy(buf + i*mysize, buf, mysize);
+        Py_ssize_t i, j;
+
+        i = mysize;
+        while (i < size) {
+            j = (i <= size - i) ? i : size - i;
+            memcpy(buf + i, buf, j);
+            i += j;
+        }
     }
 
     Py_INCREF(self);


### PR DESCRIPTION
The `bytearray_repeat` and `bytearray_irepeat` are inefficient for small arrays and a high number of repeats.
This can be improved by using the same approach is in the corresponding `bytes_repeat` method.

Microbenchmarks:

```
python -m pyperf timeit "b=bytearray([1,2,])*100" 
python -m pyperf timeit "b=bytearray([1,2,])*1000"
```` 
Results:
```
Mean +- std dev: [base100] 479 ns +- 29 ns -> [patch100] 274 ns +- 18 ns: 1.75x faster
Mean +- std dev: [base1000] 2.58 us +- 0.18 us -> [patch1000] 399 ns +- 26 ns: 6.46x faster
```

https://bugs.python.org/issue47005

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47005](https://bugs.python.org/issue47005) -->
https://bugs.python.org/issue47005
<!-- /issue-number -->
