### PR TITLE
[3.9] bpo-47004: Sync with importlib_metadata 4.11.3. (GH-31854).

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -199,6 +199,8 @@ function::
     ["pytest (>=3.0.0) ; extra == 'test'", "pytest-cov ; extra == 'test'"]
 
 
+.. _distributions:
+
 Distributions
 =============
 

--- a/Lib/importlib/metadata.py
+++ b/Lib/importlib/metadata.py
@@ -45,6 +45,15 @@ class EntryPoint(
     See `the packaging docs on entry points
     <https://packaging.python.org/specifications/entry-points/>`_
     for more information.
+
+    >>> ep = EntryPoint(
+    ...     name=None, group=None, value='package.module:attr [extra1, extra2]')
+    >>> ep.module
+    'package.module'
+    >>> ep.attr
+    'attr'
+    >>> ep.extras
+    ['extra1', 'extra2']
     """
 
     pattern = re.compile(
@@ -91,7 +100,7 @@ class EntryPoint(
     @property
     def extras(self):
         match = self.pattern.match(self.value)
-        return list(re.finditer(r'\w+', match.group('extras') or ''))
+        return re.findall(r'\w+', match.group('extras') or '')
 
     @classmethod
     def _from_config(cls, config):
@@ -308,7 +317,7 @@ class Distribution:
 
     def _read_egg_info_reqs(self):
         source = self.read_text('requires.txt')
-        return source and self._deps_from_requires_text(source)
+        return None if source is None else self._deps_from_requires_text(source)
 
     @classmethod
     def _deps_from_requires_text(cls, source):

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -104,6 +104,16 @@ class APITests(
             for dep in deps
             )
 
+    def test_requires_egg_info_empty(self):
+        fixtures.build_files(
+            {
+                'requires.txt': '',
+            },
+            self.site_dir.joinpath('egginfo_pkg.egg-info'),
+        )
+        deps = requires('egginfo-pkg')
+        assert deps == []
+
     def test_requires_dist_info(self):
         deps = requires('distinfo-pkg')
         assert len(deps) == 2

--- a/Misc/NEWS.d/next/Library/2022-03-13-15-04-05.bpo-47004.SyYpxd.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-13-15-04-05.bpo-47004.SyYpxd.rst
@@ -1,0 +1,3 @@
+Apply bugfixes from importlib_metadata 4.11.3, including bugfix for
+EntryPoint.extras, which was returning match objects and not the extras
+strings.


### PR DESCRIPTION
(cherry picked from commit b1e286860742e7ba6fadc75e3ddb6c2899a56919)

Co-authored-by: Jason R. Coombs <jaraco@jaraco.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47004](https://bugs.python.org/issue47004) -->
https://bugs.python.org/issue47004
<!-- /issue-number -->
