### PR TITLE
bpo-40280: select: Use NULL for empty fdset (GH-31865)

### DIFF
--- a/Lib/test/test_select.py
+++ b/Lib/test/test_select.py
@@ -46,7 +46,7 @@ class SelectTestCase(unittest.TestCase):
         self.assertIsNot(r, x)
         self.assertIsNot(w, x)
 
-    @unittest.skipUnless(hasattr(os, 'popen'), "need os.popen()")
+    @support.requires_fork()
     def test_select(self):
         code = textwrap.dedent('''
             import time

--- a/Misc/NEWS.d/next/Library/2022-03-14-09-26-42.bpo-40280.2-k8TV.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-14-09-26-42.bpo-40280.2-k8TV.rst
@@ -1,0 +1,1 @@
+:func:`select.select` now passes ``NULL`` to ``select`` for each empty fdset.

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -330,7 +330,12 @@ select_select_impl(PyObject *module, PyObject *rlist, PyObject *wlist,
     do {
         Py_BEGIN_ALLOW_THREADS
         errno = 0;
-        n = select(max, &ifdset, &ofdset, &efdset, tvp);
+        n = select(
+            max,
+            imax ? &ifdset : NULL,
+            omax ? &ofdset : NULL,
+            emax ? &efdset : NULL,
+            tvp);
         Py_END_ALLOW_THREADS
 
         if (errno != EINTR)


### PR DESCRIPTION
wasm32-emscripten does not support exceptfds and requires NULL. Python
now passes NULL instead of a fdset pointer when the input list is empty.
This works fine on all platforms and might even be a tiny bit faster.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
