### PR TITLE
[3.7] bpo-45405: Prevent internal configure error when running configure with recent versions of clang. (GH-28845)

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
@@ -1,0 +1,2 @@
+Prevent ``internal configure error`` when running ``configure``
+with recent versions of clang.  Patch by David Bohman.

--- a/configure
+++ b/configure
@@ -5183,9 +5183,6 @@ $as_echo "$as_me:
 fi
 
 
-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
-
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
 $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
 cat >> conftest.c <<EOF
@@ -5341,6 +5338,11 @@ else
 $as_echo "none" >&6; }
 fi
 rm -f conftest.c conftest.out
+
+if test x$PLATFORM_TRIPLET != xdarwin; then
+  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+fi
+
 
 if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then

--- a/configure.ac
+++ b/configure.ac
@@ -724,9 +724,6 @@ then
 fi
 
 
-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
-AC_SUBST(MULTIARCH)
-
 AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
 cat >> conftest.c <<EOF
 #undef bfin
@@ -879,6 +876,11 @@ else
   AC_MSG_RESULT([none])
 fi
 rm -f conftest.c conftest.out
+
+if test x$PLATFORM_TRIPLET != xdarwin; then
+  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+fi
+AC_SUBST(MULTIARCH)
 
 if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then


### PR DESCRIPTION
Change the configure logic to function properly on macOS when the compiler
outputs a platform triplet for option --print-multiarch.
The Apple Clang included with Xcode 13.3 now supports --print-multiarch
causing configure to fail without this change.

Co-authored-by: Ned Deily <nad@python.org>
(cherry picked from commit 9c4766772cda67648184f8ddba546a5fc0167f91)

Co-authored-by: David Bohman <debohman@gmail.com>

<!-- issue-number: [bpo-45405](https://bugs.python.org/issue45405) -->
https://bugs.python.org/issue45405
<!-- /issue-number -->
