### PR TITLE
bpo-47022: Document asynchat, asyncore and smtpd removals in 3.12

### DIFF
--- a/Doc/library/asynchat.rst
+++ b/Doc/library/asynchat.rst
@@ -3,6 +3,7 @@
 
 .. module:: asynchat
    :synopsis: Support for asynchronous command/response protocols.
+   :deprecated:
 
 .. moduleauthor:: Sam Rushing <rushing@nightmare.com>
 .. sectionauthor:: Steve Holden <sholden@holdenweb.com>

--- a/Doc/library/asynchat.rst
+++ b/Doc/library/asynchat.rst
@@ -10,6 +10,7 @@
 **Source code:** :source:`Lib/asynchat.py`
 
 .. deprecated:: 3.6
+   :mod:`asynchat` will be removed in Python 3.12 (:pep:`594`).
    Please use :mod:`asyncio` instead.
 
 --------------

--- a/Doc/library/asyncore.rst
+++ b/Doc/library/asyncore.rst
@@ -4,6 +4,7 @@
 .. module:: asyncore
    :synopsis: A base class for developing asynchronous socket handling
               services.
+   :deprecated:
 
 .. moduleauthor:: Sam Rushing <rushing@nightmare.com>
 .. sectionauthor:: Christopher Petrilli <petrilli@amber.org>

--- a/Doc/library/asyncore.rst
+++ b/Doc/library/asyncore.rst
@@ -13,6 +13,7 @@
 **Source code:** :source:`Lib/asyncore.py`
 
 .. deprecated:: 3.6
+   :mod:`asyncore` will be removed in Python 3.12 (:pep:`594`).
    Please use :mod:`asyncio` instead.
 
 --------------

--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -3,6 +3,7 @@
 
 .. module:: smtpd
    :synopsis: A SMTP server implementation in Python.
+   :deprecated:
 
 .. moduleauthor:: Barry Warsaw <barry@python.org>
 .. sectionauthor:: Moshe Zadka <moshez@moshez.org>

--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -14,6 +14,7 @@
 This module offers several classes to implement SMTP (email) servers.
 
 .. deprecated:: 3.6
+   :mod:`smtpd` will be removed in Python 3.12 (:pep:`594`).
    The `aiosmtpd <https://aiosmtpd.readthedocs.io/>`_ package is a recommended
    replacement for this module.  It is based on :mod:`asyncio` and provides a
    more straightforward API.

--- a/Doc/library/superseded.rst
+++ b/Doc/library/superseded.rst
@@ -10,5 +10,8 @@ backwards compatibility. They have been superseded by other modules.
 
 .. toctree::
 
-   optparse.rst
+   asynchat.rst
+   asyncore.rst
+   smtpd.rst
    imp.rst
+   optparse.rst

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -523,6 +523,11 @@ Deprecated
   :func:`locale.getlocale` functions instead.
   (Contributed by Victor Stinner in :issue:`46659`.)
 
+* The :mod:`asynchat`, :mod:`asyncore` and  :mod:`smtpd` modules have been
+  deprecated since at least Python 3.6. Their documentation and deprecation
+  warnings have now been updated to note they will removed in Python 3.12
+  (:pep:`594`).
+  (Contributed by Hugo van Kemenade in :issue:`47022`.)
 
 Removed
 =======

--- a/Lib/asynchat.py
+++ b/Lib/asynchat.py
@@ -50,7 +50,7 @@ from collections import deque
 
 from warnings import warn
 warn(
-    'The asynchat module is deprecated. '
+    'The asynchat module is deprecated and will be removed in Python 3.12. '
     'The recommended replacement is asyncio',
     DeprecationWarning,
     stacklevel=2)

--- a/Lib/asyncore.py
+++ b/Lib/asyncore.py
@@ -58,7 +58,7 @@ from errno import EALREADY, EINPROGRESS, EWOULDBLOCK, ECONNRESET, EINVAL, \
      errorcode
 
 warnings.warn(
-    'The asyncore module is deprecated. '
+    'The asyncore module is deprecated and will be removed in Python 3.12. '
     'The recommended replacement is asyncio',
     DeprecationWarning,
     stacklevel=2)

--- a/Lib/smtpd.py
+++ b/Lib/smtpd.py
@@ -85,7 +85,8 @@ __all__ = [
 ]
 
 warn(
-    'The smtpd module is deprecated and unmaintained.  Please see aiosmtpd '
+    'The smtpd module is deprecated and unmaintained and will be removed '
+    'in Python 3.12.  Please see aiosmtpd '
     '(https://aiosmtpd.readthedocs.io/) for the recommended replacement.',
     DeprecationWarning,
     stacklevel=2)

--- a/Misc/NEWS.d/next/Library/2022-03-15-09-29-52.bpo-47022.uaEDcI.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-15-09-29-52.bpo-47022.uaEDcI.rst
@@ -1,0 +1,4 @@
+The :mod:`asynchat`, :mod:`asyncore` and  :mod:`smtpd` modules have been
+deprecated since at least Python 3.6. Their documentation and deprecation
+warnings and have now been updated to note they will removed in Python 3.12
+(:pep:`594`).


### PR DESCRIPTION
Document the deprecation of asyncore, asynchat, and smtpd with a slated removal in Python 3.12 thanks to PEP 594.

Automerge-Triggered-By: GH:brettcannon