### PR TITLE
bpo-43253: don't shutdown invalid socket handles

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -158,7 +158,7 @@ class _ProactorBasePipeTransport(transports._FlowControlMixin,
             # end then it may fail with ERROR_NETNAME_DELETED if we
             # just close our end.  First calling shutdown() seems to
             # cure it, but maybe using DisconnectEx() would be better.
-            if hasattr(self._sock, 'shutdown'):
+            if hasattr(self._sock, 'shutdown') and self._sock.fileno() != -1:
                 self._sock.shutdown(socket.SHUT_RDWR)
             self._sock.close()
             self._sock = None

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -242,6 +242,14 @@ class ProactorSocketTransportTests(test_utils.TestCase):
         test_utils.run_briefly(self.loop)
         self.assertFalse(self.protocol.connection_lost.called)
 
+    def test_close_invalid_sockobj(self):
+        tr = self.socket_transport()
+        self.sock.fileno.return_value = -1
+        tr.close()
+        test_utils.run_briefly(self.loop)
+        self.protocol.connection_lost.assert_called_with(None)
+        self.assertFalse(self.sock.shutdown.called)
+
     @mock.patch('asyncio.base_events.logger')
     def test_fatal_error(self, m_logging):
         tr = self.socket_transport()

--- a/Misc/NEWS.d/next/Library/2022-03-15-07-53-45.bpo-43253.rjdLFj.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-15-07-53-45.bpo-43253.rjdLFj.rst
@@ -1,0 +1,1 @@
+Fix a crash when closing transports where the underlying socket handle is already invalid on the Proactor event loop.


### PR DESCRIPTION
On Windows on the ProactorEventLoop, there are situations where `fileno()` returns -1 during socket close, in which case calling `shutdown()` would raise an OSError. Avoid that by explicitly checking `fileno()`.

<!-- issue-number: [bpo-43253](https://bugs.python.org/issue43253) -->
https://bugs.python.org/issue43253
<!-- /issue-number -->
