### PR TITLE
bpo-46841: Don't scan backwards in bytecode.

### DIFF
--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -359,9 +359,12 @@ _PyGen_yf(PyGenObject *gen)
             assert(code[0] != SEND);
             return NULL;
         }
-
-        if (code[(frame->f_lasti-1)*sizeof(_Py_CODEUNIT)] != SEND || frame->stacktop < 0)
+        int opcode = code[(frame->f_lasti+1)*sizeof(_Py_CODEUNIT)];
+        int oparg = code[(frame->f_lasti+1)*sizeof(_Py_CODEUNIT)+1];
+        if (opcode != RESUME || oparg < 2) {
+            /* Not in a yield from */
             return NULL;
+        }
         yf = _PyFrame_StackPeek(frame);
         Py_INCREF(yf);
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1565,16 +1565,6 @@ trace_function_exit(PyThreadState *tstate, _PyInterpreterFrame *frame, PyObject 
     return 0;
 }
 
-static int
-skip_backwards_over_extended_args(PyCodeObject *code, int offset)
-{
-    _Py_CODEUNIT *instrs = (_Py_CODEUNIT *)PyBytes_AS_STRING(code->co_code);
-    while (offset > 0 && _Py_OPCODE(instrs[offset-1]) == EXTENDED_ARG) {
-        offset--;
-    }
-    return offset;
-}
-
 static _PyInterpreterFrame *
 pop_frame(PyThreadState *tstate, _PyInterpreterFrame *frame)
 {
@@ -5443,7 +5433,7 @@ handle_eval_breaker:
 #else
         case DO_TRACING: {
 #endif
-            int instr_prev = skip_backwards_over_extended_args(frame->f_code, frame->f_lasti);
+            int instr_prev = frame->f_lasti;
             frame->f_lasti = INSTR_OFFSET();
             TRACING_NEXTOPARG();
             if (opcode == RESUME) {
@@ -6725,9 +6715,13 @@ maybe_call_line_trace(Py_tracefunc func, PyObject *obj,
        then call the trace function if we're tracing source lines.
     */
     initialize_trace_info(&tstate->trace_info, frame);
-    _Py_CODEUNIT prev = ((_Py_CODEUNIT *)PyBytes_AS_STRING(frame->f_code->co_code))[instr_prev];
+    int entry_point = 0;
+    _Py_CODEUNIT *code = (_Py_CODEUNIT *)PyBytes_AS_STRING(frame->f_code->co_code);
+    while (_Py_OPCODE(code[entry_point]) != RESUME) {
+        entry_point++;
+    }
     int lastline;
-    if (_Py_OPCODE(prev) == RESUME && _Py_OPARG(prev) == 0) {
+    if (instr_prev <= entry_point) {
         lastline = -1;
     }
     else {


### PR DESCRIPTION
Avoid scanning backwards when working out whether to trace a line, or whether we are in a `yield from`.

This should help with https://github.com/python/cpython/pull/31888.

<!-- issue-number: [bpo-46841](https://bugs.python.org/issue46841) -->
https://bugs.python.org/issue46841
<!-- /issue-number -->
