### PR TITLE
[3.7] bpo-47024: Update Windows builds and macOS installer build to use OpenSSL 1.1.1n.

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -61,7 +61,7 @@ jobs:
   variables:
     testRunTitle: '$(build.sourceBranchName)-linux'
     testRunPlatform: linux
-    openssl_version: 1.1.1g
+    openssl_version: 1.1.1n
 
   steps:
   - template: ./posix-steps.yml
@@ -118,7 +118,7 @@ jobs:
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
     testRunPlatform: linux-coverage
-    openssl_version: 1.1.1g
+    openssl_version: 1.1.1n
 
   steps:
   - template: ./posix-steps.yml

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -61,7 +61,7 @@ jobs:
   variables:
     testRunTitle: '$(system.pullRequest.TargetBranch)-linux'
     testRunPlatform: linux
-    openssl_version: 1.1.1g
+    openssl_version: 1.1.1n
 
   steps:
   - template: ./posix-steps.yml
@@ -118,7 +118,7 @@ jobs:
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
     testRunPlatform: linux-coverage
-    openssl_version: 1.1.1g
+    openssl_version: 1.1.1n
 
   steps:
   - template: ./posix-steps.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
-      OPENSSL_VER: 1.1.1f
+      OPENSSL_VER: 1.1.1n
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
     name: 'Ubuntu (Coverage)'
     runs-on: ubuntu-latest
     env:
-      OPENSSL_VER: 1.1.1f
+      OPENSSL_VER: 1.1.1n
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -209,9 +209,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.1.1g",
-              url="https://www.openssl.org/source/openssl-1.1.1g.tar.gz",
-              checksum='76766e98997660138cdaf13a187bd234',
+              name="OpenSSL 1.1.1n",
+              url="https://www.openssl.org/source/openssl-1.1.1n.tar.gz",
+              checksum='2aad5635f9bb338bc2c6b7d19cbc9676',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/Build/2022-03-15-11-53-10.bpo-47024.p3PjRy.rst
+++ b/Misc/NEWS.d/next/Build/2022-03-15-11-53-10.bpo-47024.p3PjRy.rst
@@ -1,0 +1,1 @@
+Update Windows builds and macOS installer build to use OpenSSL 1.1.1n.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -49,7 +49,7 @@ echo.Fetching external libraries...
 
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.8
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1g
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1n
 set libraries=%libraries%                                       sqlite-3.31.1.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.9.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.9.0
@@ -72,7 +72,7 @@ for %%e in (%libraries%) do (
 echo.Fetching external binaries...
 
 set binaries=
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1g
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1n
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.9.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -49,8 +49,8 @@
     <sqlite3Dir>$(ExternalsDir)sqlite-3.31.1.0\</sqlite3Dir>
     <bz2Dir>$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-    <opensslDir>$(ExternalsDir)openssl-1.1.1g\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1g\$(ArchName)\</opensslOutDir>
+    <opensslDir>$(ExternalsDir)openssl-1.1.1n\</opensslDir>
+    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1n\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir>$(ExternalsDir)\zlib-1.2.11\</zlibDir>

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -48,7 +48,7 @@ OPENSSL_OLD_VERSIONS = [
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "1.1.1g",
+    "1.1.1n",
     # "3.0.0-alpha2"
 ]
 


### PR DESCRIPTION


<!-- issue-number: [bpo-47024](https://bugs.python.org/issue47024) -->
https://bugs.python.org/issue47024
<!-- /issue-number -->
