### PR TITLE
[3.10] bpo-47032: Ensure Windows install builds fail correctly with a non-zero exit code when part of the build fails (GH-31921)

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-03-16-00-37-40.bpo-47032.tsS9KE.rst
+++ b/Misc/NEWS.d/next/Build/2022-03-16-00-37-40.bpo-47032.tsS9KE.rst
@@ -1,0 +1,2 @@
+Ensure Windows install builds fail correctly with a non-zero exit code when
+part of the build fails.

--- a/Tools/msi/build.bat
+++ b/Tools/msi/build.bat
@@ -27,25 +27,26 @@ call "%PCBUILD%find_msbuild.bat" %MSBUILD%
 if ERRORLEVEL 1 (echo Cannot locate MSBuild.exe on PATH or as MSBUILD variable & exit /b 2)
 
 if defined BUILDX86 (
-    call "%PCBUILD%build.bat" -d -e %REBUILD% %BUILDTEST%
-    if errorlevel 1 goto :eof
-    call "%PCBUILD%build.bat" -e %REBUILD% %BUILDTEST%
-    if errorlevel 1 goto :eof
+    call "%PCBUILD%build.bat" -p Win32 -d -e %REBUILD% %BUILDTEST%
+    if errorlevel 1 exit /B %ERRORLEVEL%
+    call "%PCBUILD%build.bat" -p Win32 -e %REBUILD% %BUILDTEST%
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 if defined BUILDX64 (
     call "%PCBUILD%build.bat" -p x64 -d -e %REBUILD% %BUILDTEST%
-    if errorlevel 1 goto :eof
+    if errorlevel 1 exit /B %ERRORLEVEL%
     call "%PCBUILD%build.bat" -p x64 -e %REBUILD% %BUILDTEST%
-    if errorlevel 1 goto :eof
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 if defined BUILDDOC (
     call "%PCBUILD%..\Doc\make.bat" htmlhelp
-    if errorlevel 1 goto :eof
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 rem Build the launcher MSI separately
 %MSBUILD% "%D%launcher\launcher.wixproj" /p:Platform=x86
+if errorlevel 1 exit /B %ERRORLEVEL%
 
 set BUILD_CMD="%D%bundle\snapshot.wixproj"
 if defined BUILDTEST (
@@ -59,12 +60,12 @@ if defined REBUILD (
 )
 
 if defined BUILDX86 (
-    %MSBUILD% %BUILD_CMD%
-    if errorlevel 1 goto :eof
+    %MSBUILD% /p:Platform=x86 %BUILD_CMD%
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 if defined BUILDX64 (
     %MSBUILD% /p:Platform=x64 %BUILD_CMD%
-    if errorlevel 1 goto :eof
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 exit /B 0

--- a/Tools/msi/buildrelease.bat
+++ b/Tools/msi/buildrelease.bat
@@ -80,7 +80,7 @@ if "%SKIPBUILD%" EQU "1" goto skipdoc
 if "%SKIPDOC%" EQU "1" goto skipdoc
 
 call "%D%..\..\doc\make.bat" htmlhelp
-if errorlevel 1 goto :eof
+if errorlevel 1 exit /B %ERRORLEVEL%
 :skipdoc
 
 where dlltool /q && goto skipdlltoolsearch
@@ -93,16 +93,17 @@ set _DLLTOOL_PATH=
 
 if defined BUILDX86 (
     call :build x86
-    if errorlevel 1 exit /B
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 if defined BUILDX64 (
     call :build x64 "%PGO%"
-    if errorlevel 1 exit /B
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 if defined TESTTARGETDIR (
     call "%D%testrelease.bat" -t "%TESTTARGETDIR%"
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 exit /B 0
@@ -128,19 +129,19 @@ if "%1" EQU "x86" (
 if exist "%BUILD%en-us" (
     echo Deleting %BUILD%en-us
     rmdir /q/s "%BUILD%en-us"
-    if errorlevel 1 exit /B
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 if exist "%D%obj\Debug_%OBJDIR_PLAT%" (
     echo Deleting "%D%obj\Debug_%OBJDIR_PLAT%"
     rmdir /q/s "%D%obj\Debug_%OBJDIR_PLAT%"
-    if errorlevel 1 exit /B
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 if exist "%D%obj\Release_%OBJDIR_PLAT%" (
     echo Deleting "%D%obj\Release_%OBJDIR_PLAT%"
     rmdir /q/s "%D%obj\Release_%OBJDIR_PLAT%"
-    if errorlevel 1 exit /B
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 if not "%CERTNAME%" EQU "" (
@@ -156,41 +157,41 @@ if not "%PGO%" EQU "" (
 if not "%SKIPBUILD%" EQU "1" (
     @echo call "%PCBUILD%build.bat" -e -p %BUILD_PLAT% -t %TARGET% %PGOOPTS% %CERTOPTS%
     @call "%PCBUILD%build.bat" -e -p %BUILD_PLAT% -t %TARGET% %PGOOPTS% %CERTOPTS%
-    @if errorlevel 1 exit /B
+    @if errorlevel 1 exit /B %ERRORLEVEL%
     @rem build.bat turns echo back on, so we disable it again
     @echo off
 
     @echo call "%PCBUILD%build.bat" -d -e -p %BUILD_PLAT% -t %TARGET%
     @call "%PCBUILD%build.bat" -d -e -p %BUILD_PLAT% -t %TARGET%
-    @if errorlevel 1 exit /B
+    @if errorlevel 1 exit /B %ERRORLEVEL%
     @rem build.bat turns echo back on, so we disable it again
     @echo off
 )
 
 if "%OUTDIR_PLAT%" EQU "win32" (
     %MSBUILD% "%D%launcher\launcher.wixproj" /p:Platform=x86 %CERTOPTS% /p:ReleaseUri=%RELEASE_URI%
-    if errorlevel 1 exit /B
+    if errorlevel 1 exit /B %ERRORLEVEL%
 ) else if not exist "%Py_OutDir%win32\en-us\launcher.msi" (
     %MSBUILD% "%D%launcher\launcher.wixproj" /p:Platform=x86 %CERTOPTS% /p:ReleaseUri=%RELEASE_URI%
-    if errorlevel 1 exit /B
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 set BUILDOPTS=/p:Platform=%1 /p:BuildForRelease=true /p:DownloadUrl=%DOWNLOAD_URL% /p:DownloadUrlBase=%DOWNLOAD_URL_BASE% /p:ReleaseUri=%RELEASE_URI%
 if defined BUILDMSI (
     %MSBUILD% "%D%bundle\releaselocal.wixproj" /t:Rebuild %BUILDOPTS% %CERTOPTS% /p:RebuildAll=true
-    if errorlevel 1 exit /B
+    if errorlevel 1 exit /B %ERRORLEVEL%
     %MSBUILD% "%D%bundle\releaseweb.wixproj" /t:Rebuild %BUILDOPTS% %CERTOPTS% /p:RebuildAll=false
-    if errorlevel 1 exit /B
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 if defined BUILDZIP (
     %MSBUILD% "%D%make_zip.proj" /t:Build %BUILDOPTS% %CERTOPTS% /p:OutputPath="%BUILD%en-us"
-    if errorlevel 1 exit /B
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 if defined BUILDNUGET (
     %MSBUILD% "%D%..\nuget\make_pkg.proj" /t:Build /p:Configuration=Release /p:Platform=%1 /p:OutputPath="%BUILD%en-us"
-    if errorlevel 1 exit /B
+    if errorlevel 1 exit /B %ERRORLEVEL%
 )
 
 if not "%OUTDIR%" EQU "" (


### PR DESCRIPTION


<!-- issue-number: [bpo-47032](https://bugs.python.org/issue47032) -->
https://bugs.python.org/issue47032
<!-- /issue-number -->

Automerge-Triggered-By: GH:zooba