### PR TITLE
bpo-34861: Make cumtime the default sorting key for cProfile

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -66,22 +66,23 @@ your system.)
 The above action would run :func:`re.compile` and print profile results like
 the following::
 
-         197 function calls (192 primitive calls) in 0.002 seconds
+         214 function calls (207 primitive calls) in 0.002 seconds
 
-   Ordered by: standard name
+   Ordered by: cumulative time
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+        1    0.000    0.000    0.002    0.002 {built-in method builtins.exec}
         1    0.000    0.000    0.001    0.001 <string>:1(<module>)
-        1    0.000    0.000    0.001    0.001 re.py:212(compile)
-        1    0.000    0.000    0.001    0.001 re.py:268(_compile)
-        1    0.000    0.000    0.000    0.000 sre_compile.py:172(_compile_charset)
-        1    0.000    0.000    0.000    0.000 sre_compile.py:201(_optimize_charset)
-        4    0.000    0.000    0.000    0.000 sre_compile.py:25(_identityfunction)
-      3/1    0.000    0.000    0.000    0.000 sre_compile.py:33(_compile)
+        1    0.000    0.000    0.001    0.001 re.py:250(compile)
+        1    0.000    0.000    0.001    0.001 re.py:289(_compile)
+        1    0.000    0.000    0.000    0.000 sre_compile.py:759(compile)
+        1    0.000    0.000    0.000    0.000 sre_parse.py:937(parse)
+        1    0.000    0.000    0.000    0.000 sre_compile.py:598(_code)
+        1    0.000    0.000    0.000    0.000 sre_parse.py:435(_parse_sub)
 
-The first line indicates that 197 calls were monitored.  Of those calls, 192
+The first line indicates that 214 calls were monitored.  Of those calls, 207
 were :dfn:`primitive`, meaning that the call was not induced via recursion. The
-next line: ``Ordered by: standard name``, indicates that the text string in the
+next line: ``Ordered by: cumulative name``, indicates that the text string in the
 far right column was used to sort the output. The column headings include:
 
 ncalls

--- a/Lib/cProfile.py
+++ b/Lib/cProfile.py
@@ -140,7 +140,7 @@ def main():
         help="Save stats to <outfile>", default=None)
     parser.add_option('-s', '--sort', dest="sort",
         help="Sort order when printing to stdout, based on pstats.Stats class",
-        default=-1,
+        default=2,
         choices=sorted(pstats.Stats.sort_arg_dict_default))
     parser.add_option('-m', dest="module", action="store_true",
         help="Profile a library module", default=False)

--- a/Misc/NEWS.d/next/Library/2022-03-16-08-49-12.bpo-34861.p8ugVg.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-16-08-49-12.bpo-34861.p8ugVg.rst
@@ -1,0 +1,1 @@
+Made cumtime the default sorting key for cProfile


### PR DESCRIPTION
**Note:** This does not fully resolve [bpo-34861](https://bugs.python.org/issue34861), but only tackles one of the two issues identified.

This is a resubmit of https://github.com/python/cpython/pull/9655 and some of the changes that were discussed there.

@pablogsal I'm tagging you since you basically asked for the PR to be split and said that this change looked good. Sorry if the ping is uncalled for.

I have also updated the documentation to better reflect what a new call to `cProfile.run('re.compile("foo|bar")')` would look like. This also shows that we no longer sort on standard name.

<!-- issue-number: [bpo-34861](https://bugs.python.org/issue34861) -->
https://bugs.python.org/issue34861
<!-- /issue-number -->
