### PR TITLE
bpo-2604: Make DocTestCase reset globs in teardown

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -2171,6 +2171,7 @@ class DocTestCase(unittest.TestCase):
         unittest.TestCase.__init__(self)
         self._dt_optionflags = optionflags
         self._dt_checker = checker
+        self._dt_globs = test.globs.copy()
         self._dt_test = test
         self._dt_setUp = setUp
         self._dt_tearDown = tearDown
@@ -2187,7 +2188,9 @@ class DocTestCase(unittest.TestCase):
         if self._dt_tearDown is not None:
             self._dt_tearDown(test)
 
+        # restore the original globs
         test.globs.clear()
+        test.globs.update(self._dt_globs)
 
     def runTest(self):
         test = self._dt_test

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -3130,6 +3130,22 @@ def test_no_trailing_whitespace_stripping():
     """
 
 
+def test_run_doctestsuite_multiple_times():
+    """
+    It was not possible to run the same DocTestSuite multiple times
+    http://bugs.python.org/issue2604
+    http://bugs.python.org/issue9736
+
+    >>> import unittest
+    >>> import test.sample_doctest
+    >>> suite = doctest.DocTestSuite(test.sample_doctest)
+    >>> suite.run(unittest.TestResult())
+    <unittest.result.TestResult run=9 errors=0 failures=4>
+    >>> suite.run(unittest.TestResult())
+    <unittest.result.TestResult run=9 errors=0 failures=4>
+    """
+
+
 def load_tests(loader, tests, pattern):
     tests.addTest(doctest.DocTestSuite(doctest))
     tests.addTest(doctest.DocTestSuite())

--- a/Misc/NEWS.d/next/Library/2022-03-16-18-25-19.bpo-2604.jeopdL.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-16-18-25-19.bpo-2604.jeopdL.rst
@@ -1,1 +1,1 @@
-Fixed DocTestCase not resetting globs in teardown
+Fix bug where doctests using globals would fail when run multiple times.

--- a/Misc/NEWS.d/next/Library/2022-03-16-18-25-19.bpo-2604.jeopdL.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-16-18-25-19.bpo-2604.jeopdL.rst
@@ -1,0 +1,1 @@
+Fixed DocTestCase not resetting globs in teardown


### PR DESCRIPTION
Targets [bpo-2604](https://bugs.python.org/issue2604) and [bpo-9736](https://bugs.python.org/issue9736).

Combination of both patches as suggested by Irit Katriel on [bpo-2604](https://bugs.python.org/issue2604).

I didn't include a news entry as I didn't think it was necessary for test changes. Let me know if I should add one!

<!-- issue-number: [bpo-2604](https://bugs.python.org/issue2604) -->
https://bugs.python.org/issue2604
<!-- /issue-number -->
