### PR TITLE
bpo-47037: Don't test for strftime('%4Y') on Windows

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -521,10 +521,13 @@ def requires_subprocess():
     return unittest.skipUnless(has_subprocess_support, "requires subprocess support")
 
 # Does strftime() support glibc extension like '%4Y'?
-try:
-    has_strftime_extensions = time.strftime("%4Y") != "%4Y"
-except ValueError:
-    has_strftime_extensions = False
+has_strftime_extensions = False
+if sys.platform != "win32":
+    # bpo-47037: Windows debug builds crash with "Debug Assertion Failed"
+    try:
+        has_strftime_extensions = time.strftime("%4Y") != "%4Y"
+    except ValueError:
+        pass
 
 # Define the URL of a dedicated HTTP server for the network tests.
 # The URL must use clear-text HTTP: no redirection to encrypted HTTPS.

--- a/Misc/NEWS.d/next/Tests/2022-03-16-21-29-30.bpo-47037.xcrLpJ.rst
+++ b/Misc/NEWS.d/next/Tests/2022-03-16-21-29-30.bpo-47037.xcrLpJ.rst
@@ -1,0 +1,2 @@
+Skip ``strftime("%4Y")`` feature test on Windows. It can cause an assertion
+error in debug builds.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47037](https://bugs.python.org/issue47037) -->
https://bugs.python.org/issue47037
<!-- /issue-number -->
