### PR TITLE
bpo-47038: Increase a test timeout for slow CI machines

### DIFF
--- a/Lib/test/test_asyncio/test_waitfor.py
+++ b/Lib/test/test_asyncio/test_waitfor.py
@@ -144,7 +144,7 @@ class AsyncioWaitForTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(fut.done())
         # it should have been cancelled due to the timeout
         self.assertTrue(fut.cancelled())
-        self.assertLess(t1 - t0, 0.2)
+        self.assertLess(t1 - t0, 0.5)
         self.assertEqual(foo_running, False)
 
     async def test_wait_for_blocking(self):


### PR DESCRIPTION


<!-- issue-number: [bpo-47038](https://bugs.python.org/issue47038) -->
https://bugs.python.org/issue47038
<!-- /issue-number -->
