### PR TITLE
bpo-43224: Add TypeVarTuple.__name__

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -415,6 +415,12 @@ class TypeVarTupleTests(BaseTestCase):
         if not string.endswith(tail):
             self.fail(f"String {string!r} does not end with {tail!r}")
 
+    def test_name(self):
+        Ts = TypeVarTuple('Ts')
+        self.assertEqual(Ts.__name__, 'Ts')
+        Ts2 = TypeVarTuple('Ts2')
+        self.assertEqual(Ts2.__name__, 'Ts2')
+
     def test_instance_is_equal_to_itself(self):
         Ts = TypeVarTuple('Ts')
         self.assertEqual(Ts, Ts)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -517,15 +517,6 @@ class TypeVarTupleTests(BaseTestCase):
         self.assertEqual(repr(Unpack[tuple[Unpack[Ts]]]), '*tuple[*Ts]')
         self.assertEqual(repr(Unpack[Tuple[Unpack[Ts]]]), '*typing.Tuple[*Ts]')
 
-    def test_repr_is_correct(self):
-        Ts = TypeVarTuple('Ts')
-        self.assertEqual(repr(Ts), 'Ts')
-        self.assertEqual(repr(Unpack[Ts]), '*Ts')
-        self.assertEqual(repr(tuple[Unpack[Ts]]), 'tuple[*Ts]')
-        self.assertEqual(repr(Tuple[Unpack[Ts]]), 'typing.Tuple[*Ts]')
-        self.assertEqual(repr(Unpack[tuple[Unpack[Ts]]]), '*tuple[*Ts]')
-        self.assertEqual(repr(Unpack[Tuple[Unpack[Ts]]]), '*typing.Tuple[*Ts]')
-
     def test_variadic_class_repr_is_correct(self):
         Ts = TypeVarTuple('Ts')
         class A(Generic[Unpack[Ts]]): pass

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -939,13 +939,13 @@ class TypeVarTuple(_Final, _Immutable, _root=True):
     """
 
     def __init__(self, name):
-        self._name = name
+        self.__name__ = name
 
     def __iter__(self):
         yield Unpack[self]
 
     def __repr__(self):
-        return self._name
+        return self.__name__
 
     def __typing_subst__(self, arg):
         raise AssertionError


### PR DESCRIPTION
I noticed that TypeVar and ParamSpec put their name in a `__name__`
attribute, but TypeVarTuple doesn't. Let's be consistent.

<!-- issue-number: [bpo-43224](https://bugs.python.org/issue43224) -->
https://bugs.python.org/issue43224
<!-- /issue-number -->
