### PR TITLE
bpo-34790: Remove passing coroutine objects to asyncio.wait()

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -534,7 +534,7 @@ Waiting Primitives
 
 .. coroutinefunction:: wait(aws, *, timeout=None, return_when=ALL_COMPLETED)
 
-   Run :ref:`awaitable objects <asyncio-awaitables>` in the *aws*
+   Run :class:`~asyncio.Future` and :class:`~asyncioTask` instances in the *aws*
    iterable concurrently and block until the condition specified
    by *return_when*.
 
@@ -577,51 +577,11 @@ Waiting Primitives
    Unlike :func:`~asyncio.wait_for`, ``wait()`` does not cancel the
    futures when a timeout occurs.
 
-   .. deprecated:: 3.8
-
-      If any awaitable in *aws* is a coroutine, it is automatically
-      scheduled as a Task.  Passing coroutines objects to
-      ``wait()`` directly is deprecated as it leads to
-      :ref:`confusing behavior <asyncio_example_wait_coroutine>`.
-
    .. versionchanged:: 3.10
       Removed the *loop* parameter.
 
-   .. _asyncio_example_wait_coroutine:
-   .. note::
-
-      ``wait()`` schedules coroutines as Tasks automatically and later
-      returns those implicitly created Task objects in ``(done, pending)``
-      sets.  Therefore the following code won't work as expected::
-
-          async def foo():
-              return 42
-
-          coro = foo()
-          done, pending = await asyncio.wait({coro})
-
-          if coro in done:
-              # This branch will never be run!
-
-      Here is how the above snippet can be fixed::
-
-          async def foo():
-              return 42
-
-          task = asyncio.create_task(foo())
-          done, pending = await asyncio.wait({task})
-
-          if task in done:
-              # Everything will work as expected now.
-
-   .. deprecated-removed:: 3.8 3.11
-
-      Passing coroutine objects to ``wait()`` directly is
-      deprecated.
-
-   .. versionchanged:: 3.10
-      Removed the *loop* parameter.
-
+   .. versionchanged:: 3.11
+      Passing coroutine objects to ``wait()`` directly is forbidden.
 
 .. function:: as_completed(aws, *, timeout=None)
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -534,7 +534,7 @@ Waiting Primitives
 
 .. coroutinefunction:: wait(aws, *, timeout=None, return_when=ALL_COMPLETED)
 
-   Run :class:`~asyncio.Future` and :class:`~asyncioTask` instances in the *aws*
+   Run :class:`~asyncio.Future` and :class:`~asyncio.Task` instances in the *aws*
    iterable concurrently and block until the condition specified
    by *return_when*.
 

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -387,7 +387,7 @@ ALL_COMPLETED = concurrent.futures.ALL_COMPLETED
 
 
 async def wait(fs, *, timeout=None, return_when=ALL_COMPLETED):
-    """Wait for the Futures and coroutines given by fs to complete.
+    """Wait for the Futures or Tasks given by fs to complete.
 
     The fs iterable must not be empty.
 
@@ -405,22 +405,16 @@ async def wait(fs, *, timeout=None, return_when=ALL_COMPLETED):
     if futures.isfuture(fs) or coroutines.iscoroutine(fs):
         raise TypeError(f"expect a list of futures, not {type(fs).__name__}")
     if not fs:
-        raise ValueError('Set of coroutines/Futures is empty.')
+        raise ValueError('Set of Futures is empty.')
     if return_when not in (FIRST_COMPLETED, FIRST_EXCEPTION, ALL_COMPLETED):
         raise ValueError(f'Invalid return_when value: {return_when}')
-
-    loop = events.get_running_loop()
 
     fs = set(fs)
 
     if any(coroutines.iscoroutine(f) for f in fs):
-        warnings.warn("The explicit passing of coroutine objects to "
-                      "asyncio.wait() is deprecated since Python 3.8, and "
-                      "scheduled for removal in Python 3.11.",
-                      DeprecationWarning, stacklevel=2)
+        raise TypeError("Passing coroutines is forbidden, use tasks explicitly.")
 
-    fs = {ensure_future(f, loop=loop) for f in fs}
-
+    loop = events.get_running_loop()
     return await _wait(fs, timeout, return_when, loop)
 
 

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -405,7 +405,7 @@ async def wait(fs, *, timeout=None, return_when=ALL_COMPLETED):
     if futures.isfuture(fs) or coroutines.iscoroutine(fs):
         raise TypeError(f"expect a list of futures, not {type(fs).__name__}")
     if not fs:
-        raise ValueError('Set of Futures is empty.')
+        raise ValueError('Set of Tasks/Futures is empty.')
     if return_when not in (FIRST_COMPLETED, FIRST_EXCEPTION, ALL_COMPLETED):
         raise ValueError(f'Invalid return_when value: {return_when}')
 

--- a/Misc/NEWS.d/next/Library/2022-03-17-19-38-40.bpo-34790.zQIiVJ.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-17-19-38-40.bpo-34790.zQIiVJ.rst
@@ -1,0 +1,1 @@
+Remove passing coroutine objects to :func:`asyncio.wait`.


### PR DESCRIPTION


<!-- issue-number: [bpo-34790](https://bugs.python.org/issue34790) -->
https://bugs.python.org/issue34790
<!-- /issue-number -->
