### PR TITLE
bpo-47037: Test debug builds on Windows in CI so that native assertions are noticed sooner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build CPython
-      run: .\PCbuild\build.bat -e -p Win32
+      run: .\PCbuild\build.bat -e -d -p Win32
       timeout-minutes: 30
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
@@ -132,7 +132,7 @@ jobs:
     - name: Register MSVC problem matcher
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
-      run: .\PCbuild\build.bat -e -p x64
+      run: .\PCbuild\build.bat -e -d -p x64
       timeout-minutes: 30
     - name: Display build info
       run: .\python.bat -m test.pythoninfo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests
-      run: .\PCbuild\rt.bat -p Win32 -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0
+      run: .\PCbuild\rt.bat -p Win32 -d -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0
 
   build_win_amd64:
     name: 'Windows (x64)'
@@ -137,7 +137,7 @@ jobs:
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests
-      run: .\PCbuild\rt.bat -p x64 -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0
+      run: .\PCbuild\rt.bat -p x64 -d -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0
 
   build_macos:
     name: 'macOS'


### PR DESCRIPTION


<!-- issue-number: [bpo-47037](https://bugs.python.org/issue47037) -->
https://bugs.python.org/issue47037
<!-- /issue-number -->
