### PR TITLE
[3.9] bpo-42782: fix broken shutil test

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2154,7 +2154,7 @@ class TestMove(BaseTest, unittest.TestCase):
 
             # Create a file and keep the directory immutable
             os.lchflags(TESTFN_SRC, stat.UF_OPAQUE)
-            os_helper.create_empty_file(os.path.join(TESTFN_SRC, 'child'))
+            support.create_empty_file(os.path.join(TESTFN_SRC, 'child'))
             os.lchflags(TESTFN_SRC, stat.SF_IMMUTABLE)
 
             # Testing on a non-empty immutable directory
@@ -2164,10 +2164,10 @@ class TestMove(BaseTest, unittest.TestCase):
         finally:
             if os.path.exists(TESTFN_SRC):
                 os.lchflags(TESTFN_SRC, stat.UF_OPAQUE)
-                os_helper.rmtree(TESTFN_SRC)
+                support.rmtree(TESTFN_SRC)
             if os.path.exists(TESTFN_DST):
                 os.lchflags(TESTFN_DST, stat.UF_OPAQUE)
-                os_helper.rmtree(TESTFN_DST)
+                support.rmtree(TESTFN_DST)
 
 
 class TestCopyFile(unittest.TestCase):


### PR DESCRIPTION
We were using os_helper, which doesn't exist on 3.9. This wasn't
caught because the test is only run as root. I confirmed that when
run as root, the test previously failed and now passes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-42782](https://bugs.python.org/issue42782) -->
https://bugs.python.org/issue42782
<!-- /issue-number -->
