### PR TITLE
bpo-47057: Use FASTCALL convention for FutureIter.throw()

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-03-18-14-22-38.bpo-47057.n-IHbt.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-18-14-22-38.bpo-47057.n-IHbt.rst
@@ -1,0 +1,1 @@
+Use FASTCALL convention for ``FutureIter.throw()``

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1713,7 +1713,7 @@ FutureIter_traverse(futureiterobject *it, visitproc visit, void *arg)
 
 static PyMethodDef FutureIter_methods[] = {
     {"send",  (PyCFunction)FutureIter_send, METH_O, NULL},
-    {"throw", (PyCFunction)FutureIter_throw, METH_FASTCALL, NULL},
+    {"throw", (PyCFunction)(void(*)(void))FutureIter_throw, METH_FASTCALL, NULL},
     {"close", (PyCFunction)FutureIter_close, METH_NOARGS, NULL},
     {NULL, NULL}        /* Sentinel */
 };

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1637,18 +1637,23 @@ FutureIter_send(futureiterobject *self, PyObject *unused)
 }
 
 static PyObject *
-FutureIter_throw(futureiterobject *self, PyObject *args)
+FutureIter_throw(futureiterobject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *type, *val = NULL, *tb = NULL;
-    if (!PyArg_ParseTuple(args, "O|OO", &type, &val, &tb))
+    if (!_PyArg_CheckPositional("throw", nargs, 1, 3)) {
         return NULL;
-
-    if (val == Py_None) {
-        val = NULL;
     }
-    if (tb == Py_None) {
-        tb = NULL;
-    } else if (tb != NULL && !PyTraceBack_Check(tb)) {
+
+    type = args[0];
+    if (nargs == 3) {
+        val = args[1];
+        tb = args[2];
+    }
+    else if (nargs == 2) {
+        val = args[1];
+    }
+
+    if (tb != NULL && !PyTraceBack_Check(tb)) {
         PyErr_SetString(PyExc_TypeError, "throw() third argument must be a traceback");
         return NULL;
     }
@@ -1708,7 +1713,7 @@ FutureIter_traverse(futureiterobject *it, visitproc visit, void *arg)
 
 static PyMethodDef FutureIter_methods[] = {
     {"send",  (PyCFunction)FutureIter_send, METH_O, NULL},
-    {"throw", (PyCFunction)FutureIter_throw, METH_VARARGS, NULL},
+    {"throw", (PyCFunction)FutureIter_throw, METH_FASTCALL, NULL},
     {"close", (PyCFunction)FutureIter_close, METH_NOARGS, NULL},
     {NULL, NULL}        /* Sentinel */
 };


### PR DESCRIPTION


<!-- issue-number: [bpo-47057](https://bugs.python.org/issue47057) -->
https://bugs.python.org/issue47057
<!-- /issue-number -->
