### PR TITLE
bpo-46382 dataclass(slots=True) now takes inherited slots into account

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -190,9 +190,12 @@ Module contents
 
     .. versionchanged:: 3.11
        If a field name is already included in the ``__slots__``
-       of a base class, it will not be included in the generated ``__slots__``.
+       of a base class, it will not be included in the generated ``__slots__``
+       to prevent `overriding them <https://docs.python.org/3/reference/datamodel.html#notes-on-using-slots>`_.
        Therefore, do not use ``__slots__`` to retrieve the field names of a
        dataclass. Use :func:`fields` instead.
+       To be able to determine inherited slots,
+       base class ``__slots__`` may be any iterable, but *not* an iterator.
 
 
    ``field``\s may optionally specify a default value, using normal

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -188,6 +188,13 @@ Module contents
 
     .. versionadded:: 3.10
 
+    .. versionchanged:: 3.11
+       If a field name is already included in the ``__slots__``
+       of a base class, it will not be included in the generated ``__slots__``.
+       Therefore, do not use ``__slots__`` to retrieve the field names of a
+       dataclass. Use :func:`fields` instead.
+
+
    ``field``\s may optionally specify a default value, using normal
    Python syntax::
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2926,23 +2926,48 @@ class TestSlots(unittest.TestCase):
                 x: int
 
     def test_generated_slots_value(self):
-        @dataclass(slots=True)
-        class Base:
-            x: int
 
-        self.assertEqual(Base.__slots__, ('x',))
+        class Root:
+            __slots__ = {'x'}
+
+        class Root2(Root):
+            __slots__ = 'aa'
+
+        @dataclass(slots=True)
+        class Base(Root2):
+            y: int
+
+        self.assertEqual(Base.__slots__, ('y', ))
 
         @dataclass(slots=True)
         class Delivered(Base):
-            y: int
+            aa: float
+            x: str
+            z: int
 
-        self.assertEqual(Delivered.__slots__, ('x', 'y'))
+        self.assertEqual(Delivered.__slots__, ('z', ))
 
         @dataclass
         class AnotherDelivered(Base):
             z: int
 
         self.assertTrue('__slots__' not in AnotherDelivered.__dict__)
+
+    def test_cant_inherit_from_iterator_slots(self):
+
+        class Root:
+            __slots__ = iter(['a'])
+
+        class Root2(Root):
+            __slots__ = ('b', )
+
+        with self.assertRaisesRegex(
+           TypeError,
+            "^Slots of 'Root' cannot be determined"
+        ):
+            @dataclass(slots=True)
+            class C(Root2):
+                x: int
 
     def test_returns_new_class(self):
         class A:

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2961,7 +2961,7 @@ class TestSlots(unittest.TestCase):
         class AnotherDerived(Base):
             z: int
 
-        self.assertTrue('__slots__' not in AnotherDerived.__dict__)
+        self.assertNotIn('__slots__', AnotherDerived.__dict__)
 
     def test_cant_inherit_from_iterator_slots(self):
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2942,6 +2942,8 @@ class TestSlots(unittest.TestCase):
         @dataclass(slots=True)
         class Base(Root4):
             y: int
+            j: str
+            h: str
 
         self.assertEqual(Base.__slots__, ('y', ))
 
@@ -2950,6 +2952,8 @@ class TestSlots(unittest.TestCase):
             aa: float
             x: str
             z: int
+            k: str
+            h: str
 
         self.assertEqual(Derived.__slots__, ('z', ))
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2931,27 +2931,33 @@ class TestSlots(unittest.TestCase):
             __slots__ = {'x'}
 
         class Root2(Root):
+            __slots__ = {'k': '...', 'j': ''}
+
+        class Root3(Root2):
+            __slots__ = ['h']
+
+        class Root4(Root3):
             __slots__ = 'aa'
 
         @dataclass(slots=True)
-        class Base(Root2):
+        class Base(Root4):
             y: int
 
         self.assertEqual(Base.__slots__, ('y', ))
 
         @dataclass(slots=True)
-        class Delivered(Base):
+        class Derived(Base):
             aa: float
             x: str
             z: int
 
-        self.assertEqual(Delivered.__slots__, ('z', ))
+        self.assertEqual(Derived.__slots__, ('z', ))
 
         @dataclass
-        class AnotherDelivered(Base):
+        class AnotherDerived(Base):
             z: int
 
-        self.assertTrue('__slots__' not in AnotherDelivered.__dict__)
+        self.assertTrue('__slots__' not in AnotherDerived.__dict__)
 
     def test_cant_inherit_from_iterator_slots(self):
 

--- a/Misc/NEWS.d/next/Library/2022-03-18-17-25-57.bpo-46382.zQUJ66.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-18-17-25-57.bpo-46382.zQUJ66.rst
@@ -1,0 +1,2 @@
+:class:`~dataclasses.dataclass` ``slots=True`` now accounts for slots in base classes.
+Patch by Arie Bovenberg.

--- a/Misc/NEWS.d/next/Library/2022-03-18-17-25-57.bpo-46382.zQUJ66.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-18-17-25-57.bpo-46382.zQUJ66.rst
@@ -1,2 +1,2 @@
-:class:`~dataclasses.dataclass` ``slots=True`` now accounts for slots in base classes.
+:func:`~dataclasses.dataclass` ``slots=True`` now accounts for slots in base classes.
 Patch by Arie Bovenberg.

--- a/Misc/NEWS.d/next/Library/2022-03-18-17-25-57.bpo-46382.zQUJ66.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-18-17-25-57.bpo-46382.zQUJ66.rst
@@ -1,2 +1,2 @@
-:func:`~dataclasses.dataclass` ``slots=True`` now accounts for slots in base classes.
-Patch by Arie Bovenberg.
+:func:`~dataclasses.dataclass` ``slots=True`` now correctly omits slots already
+defined in base classes. Patch by Arie Bovenberg.


### PR DESCRIPTION
see https://bugs.python.org/issue46382

# Questions

- Would we want to backport? I wouldn't recommend as this change may technically be breaking for some rare cases
- I assume we _would_ want to include this fix in the [`dataclasses`](https://github.com/ericvsmith/dataclasses) `add_slots` function?

<!-- issue-number: [bpo-46382](https://bugs.python.org/issue46382) -->
https://bugs.python.org/issue46382
<!-- /issue-number -->
