### PR TITLE
bpo-47061: document module deprecations due to PEP 594

### DIFF
--- a/Doc/library/aifc.rst
+++ b/Doc/library/aifc.rst
@@ -3,6 +3,7 @@
 
 .. module:: aifc
    :synopsis: Read and write audio files in AIFF or AIFC format.
+   :deprecated:
 
 **Source code:** :source:`Lib/aifc.py`
 
@@ -10,6 +11,10 @@
    single: Audio Interchange File Format
    single: AIFF
    single: AIFF-C
+
+
+.. deprecated:: 3.11
+   The :mod:`aifc` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/audioop.rst
+++ b/Doc/library/audioop.rst
@@ -3,6 +3,10 @@
 
 .. module:: audioop
    :synopsis: Manipulate raw audio data.
+   :deprecated:
+
+.. deprecated:: 3.11
+   The :mod:`audioop` is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/audioop.rst
+++ b/Doc/library/audioop.rst
@@ -6,7 +6,7 @@
    :deprecated:
 
 .. deprecated:: 3.11
-   The :mod:`audioop` is deprecated (see :pep:`594` for details).
+   The :mod:`audioop` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/cgi.rst
+++ b/Doc/library/cgi.rst
@@ -3,6 +3,7 @@
 
 .. module:: cgi
    :synopsis: Helpers for running Python scripts via the Common Gateway Interface.
+   :deprecated:
 
 **Source code:** :source:`Lib/cgi.py`
 
@@ -13,6 +14,9 @@
    pair: MIME; headers
    single: URL
    single: Common Gateway Interface
+
+.. deprecated:: 3.11
+   The :mod:`cgi` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/cgitb.rst
+++ b/Doc/library/cgitb.rst
@@ -3,6 +3,7 @@
 
 .. module:: cgitb
    :synopsis: Configurable traceback handler for CGI scripts.
+   :deprecated:
 
 .. moduleauthor:: Ka-Ping Yee <ping@lfw.org>
 .. sectionauthor:: Fred L. Drake, Jr. <fdrake@acm.org>
@@ -14,6 +15,9 @@
    single: CGI; tracebacks
    single: exceptions; in CGI scripts
    single: tracebacks; in CGI scripts
+
+.. deprecated:: 3.11
+   The :mod:`cgitb` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/chunk.rst
+++ b/Doc/library/chunk.rst
@@ -18,7 +18,7 @@
    single: RMFF
 
 .. deprecated:: 3.11
-   The :mod:`chunk` module is deprecated (see :pep`594` for details).
+   The :mod:`chunk` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/chunk.rst
+++ b/Doc/library/chunk.rst
@@ -3,6 +3,7 @@
 
 .. module:: chunk
    :synopsis: Module to read IFF chunks.
+   :deprecated:
 
 .. moduleauthor:: Sjoerd Mullender <sjoerd@acm.org>
 .. sectionauthor:: Sjoerd Mullender <sjoerd@acm.org>
@@ -15,6 +16,9 @@
    single: AIFF-C
    single: Real Media File Format
    single: RMFF
+
+.. deprecated:: 3.11
+   The :mod:`chunk` module is deprecated (see :pep`594` for details).
 
 --------------
 

--- a/Doc/library/crypt.rst
+++ b/Doc/library/crypt.rst
@@ -4,6 +4,7 @@
 .. module:: crypt
    :platform: Unix
    :synopsis: The crypt() function used to check Unix passwords.
+   :deprecated:
 
 .. moduleauthor:: Steven D. Majewski <sdm7g@virginia.edu>
 .. sectionauthor:: Steven D. Majewski <sdm7g@virginia.edu>
@@ -14,6 +15,9 @@
 .. index::
    single: crypt(3)
    pair: cipher; DES
+
+.. deprecated:: 3.11
+   The :mod:`crypt` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/fileformats.rst
+++ b/Doc/library/fileformats.rst
@@ -14,5 +14,4 @@ that aren't markup languages and are not related to e-mail.
    configparser.rst
    tomllib.rst
    netrc.rst
-   xdrlib.rst
    plistlib.rst

--- a/Doc/library/imghdr.rst
+++ b/Doc/library/imghdr.rst
@@ -3,8 +3,12 @@
 
 .. module:: imghdr
    :synopsis: Determine the type of image contained in a file or byte stream.
+   :deprecated:
 
 **Source code:** :source:`Lib/imghdr.py`
+
+.. deprecated:: 3.11
+   The :mod:`imghdr` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/internet.rst
+++ b/Doc/library/internet.rst
@@ -20,8 +20,6 @@ is currently supported on most popular platforms.  Here is an overview:
 .. toctree::
 
    webbrowser.rst
-   cgi.rst
-   cgitb.rst
    wsgiref.rst
    urllib.rst
    urllib.request.rst
@@ -33,10 +31,7 @@ is currently supported on most popular platforms.  Here is an overview:
    ftplib.rst
    poplib.rst
    imaplib.rst
-   nntplib.rst
    smtplib.rst
-   smtpd.rst
-   telnetlib.rst
    uuid.rst
    socketserver.rst
    http.server.rst

--- a/Doc/library/ipc.rst
+++ b/Doc/library/ipc.rst
@@ -22,7 +22,5 @@ The list of modules described in this chapter is:
    ssl.rst
    select.rst
    selectors.rst
-   asyncore.rst
-   asynchat.rst
    signal.rst
    mmap.rst

--- a/Doc/library/mm.rst
+++ b/Doc/library/mm.rst
@@ -11,12 +11,5 @@ discretion of the installation.  Here's an overview:
 
 .. toctree::
 
-   audioop.rst
-   aifc.rst
-   sunau.rst
    wave.rst
-   chunk.rst
    colorsys.rst
-   imghdr.rst
-   sndhdr.rst
-   ossaudiodev.rst

--- a/Doc/library/msilib.rst
+++ b/Doc/library/msilib.rst
@@ -4,6 +4,7 @@
 .. module:: msilib
    :platform: Windows
    :synopsis: Creation of Microsoft Installer files, and CAB files.
+   :deprecated:
 
 .. moduleauthor:: Martin v. Löwis <martin@v.loewis.de>
 .. sectionauthor:: Martin v. Löwis <martin@v.loewis.de>
@@ -11,6 +12,9 @@
 **Source code:** :source:`Lib/msilib/__init__.py`
 
 .. index:: single: msi
+
+.. deprecated:: 3.11
+   The :mod:`msilib` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/netdata.rst
+++ b/Doc/library/netdata.rst
@@ -19,4 +19,3 @@ on the internet.
    base64.rst
    binascii.rst
    quopri.rst
-   uu.rst

--- a/Doc/library/nis.rst
+++ b/Doc/library/nis.rst
@@ -5,9 +5,13 @@
 .. module:: nis
    :platform: Unix
    :synopsis: Interface to Sun's NIS (Yellow Pages) library.
+   :deprecated:
 
 .. moduleauthor:: Fred Gansevles <Fred.Gansevles@cs.utwente.nl>
 .. sectionauthor:: Moshe Zadka <moshez@zadka.site.co.il>
+
+.. deprecated:: 3.11
+   The :mod:`nis` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/nntplib.rst
+++ b/Doc/library/nntplib.rst
@@ -3,12 +3,16 @@
 
 .. module:: nntplib
    :synopsis: NNTP protocol client (requires sockets).
+   :deprecated:
 
 **Source code:** :source:`Lib/nntplib.py`
 
 .. index::
    pair: NNTP; protocol
    single: Network News Transfer Protocol
+
+.. deprecated:: 3.11
+   The :mod:`nntplib` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/ossaudiodev.rst
+++ b/Doc/library/ossaudiodev.rst
@@ -4,6 +4,10 @@
 .. module:: ossaudiodev
    :platform: Linux, FreeBSD
    :synopsis: Access to OSS-compatible audio devices.
+   :deprecated:
+
+.. deprecated:: 3.11
+   The :mod:`ossaudiodev` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/pipes.rst
+++ b/Doc/library/pipes.rst
@@ -4,10 +4,14 @@
 .. module:: pipes
    :platform: Unix
    :synopsis: A Python interface to Unix shell pipelines.
+   :deprecated:
 
 .. sectionauthor:: Moshe Zadka <moshez@zadka.site.co.il>
 
 **Source code:** :source:`Lib/pipes.py`
+
+.. deprecated:: 3.11
+   The :mod:`pipes` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/sndhdr.rst
+++ b/Doc/library/sndhdr.rst
@@ -3,6 +3,7 @@
 
 .. module:: sndhdr
    :synopsis: Determine type of a sound file.
+   :deprecated:
 
 .. sectionauthor:: Fred L. Drake, Jr. <fdrake@acm.org>
 .. Based on comments in the module source file.
@@ -12,6 +13,9 @@
 .. index::
    single: A-LAW
    single: u-LAW
+
+.. deprecated:: 3.11
+   The :mod:`sndhdr` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/spwd.rst
+++ b/Doc/library/spwd.rst
@@ -4,6 +4,10 @@
 .. module:: spwd
    :platform: Unix
    :synopsis: The shadow password database (getspnam() and friends).
+   :deprecated:
+
+.. deprecated:: 3.11
+   The :mod:`spwd` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/sunau.rst
+++ b/Doc/library/sunau.rst
@@ -3,10 +3,14 @@
 
 .. module:: sunau
    :synopsis: Provide an interface to the Sun AU sound format.
+   :deprecated:
 
 .. sectionauthor:: Moshe Zadka <moshez@zadka.site.co.il>
 
 **Source code:** :source:`Lib/sunau.py`
+
+.. deprecated:: 3.11
+   The :mod:`sunau` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/superseded.rst
+++ b/Doc/library/superseded.rst
@@ -10,8 +10,26 @@ backwards compatibility. They have been superseded by other modules.
 
 .. toctree::
 
+   aifc.rst
    asynchat.rst
    asyncore.rst
-   smtpd.rst
+   audioop.rst
+   cgi.rst
+   cgitb.rst
+   chunk.rst
+   crypt.rst
+   imghdr.rst
    imp.rst
+   msilib.rst
+   nntplib.rst
+   nis.rst
    optparse.rst
+   ossaudiodev.rst
+   pipes.rst
+   smtpd.rst
+   sndhdr.rst
+   spwd.rst
+   sunau.rst
+   telnetlib.rst
+   uu.rst
+   xdrlib.rst

--- a/Doc/library/telnetlib.rst
+++ b/Doc/library/telnetlib.rst
@@ -3,12 +3,16 @@
 
 .. module:: telnetlib
    :synopsis: Telnet client class.
+   :deprecated:
 
 .. sectionauthor:: Skip Montanaro <skip@pobox.com>
 
 **Source code:** :source:`Lib/telnetlib.py`
 
 .. index:: single: protocol; Telnet
+
+.. deprecated:: 3.11
+   The :mod:`telnetlib` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/unix.rst
+++ b/Doc/library/unix.rst
@@ -13,14 +13,10 @@ of it.  Here's an overview:
 
    posix.rst
    pwd.rst
-   spwd.rst
    grp.rst
-   crypt.rst
    termios.rst
    tty.rst
    pty.rst
    fcntl.rst
-   pipes.rst
    resource.rst
-   nis.rst
    syslog.rst

--- a/Doc/library/uu.rst
+++ b/Doc/library/uu.rst
@@ -3,10 +3,14 @@
 
 .. module:: uu
    :synopsis: Encode and decode files in uuencode format.
+   :deprecated:
 
 .. moduleauthor:: Lance Ellinghouse
 
 **Source code:** :source:`Lib/uu.py`
+
+.. deprecated:: 3.11
+   The :mod:`uu` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Doc/library/windows.rst
+++ b/Doc/library/windows.rst
@@ -9,7 +9,6 @@ This chapter describes modules that are only available on MS Windows platforms.
 
 .. toctree::
 
-   msilib.rst
    msvcrt.rst
    winreg.rst
    winsound.rst

--- a/Doc/library/xdrlib.rst
+++ b/Doc/library/xdrlib.rst
@@ -3,12 +3,16 @@
 
 .. module:: xdrlib
    :synopsis: Encoders and decoders for the External Data Representation (XDR).
+   :deprecated:
 
 **Source code:** :source:`Lib/xdrlib.py`
 
 .. index::
    single: XDR
    single: External Data Representation
+
+.. deprecated:: 3.11
+   The :mod:`xdrlib` module is deprecated (see :pep:`594` for details).
 
 --------------
 

--- a/Misc/NEWS.d/next/Library/2022-03-18-13-30-40.bpo-47061.etLHK5.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-18-13-30-40.bpo-47061.etLHK5.rst
@@ -1,7 +1,5 @@
 Deprecate the various modules listed by :pep:`594`:
 
-- aifc - asynchat: https://bugs.python.org/issue47022 - asyncore:
-https://bugs.python.org/issue47022 - audioop - cgi - cgitb - chunk - crypt -
-imghdr - msilib - nntplib - nis - ossaudiodev - pipes - smtpd:
-https://bugs.python.org/issue47022 - sndhdr - spwd - sunau - telnetlib - uu
-- xdrlib
+aifc, asynchat, asyncore, audioop, cgi, cgitb, chunk, crypt,
+imghdr, msilib, nntplib, nis, ossaudiodev, pipes, smtpd,
+sndhdr, spwd, sunau, telnetlib, uu, xdrlib

--- a/Misc/NEWS.d/next/Library/2022-03-18-13-30-40.bpo-47061.etLHK5.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-18-13-30-40.bpo-47061.etLHK5.rst
@@ -1,0 +1,7 @@
+Deprecate the various modules listed by :pep:`594`:
+
+- aifc - asynchat: https://bugs.python.org/issue47022 - asyncore:
+https://bugs.python.org/issue47022 - audioop - cgi - cgitb - chunk - crypt -
+imghdr - msilib - nntplib - nis - ossaudiodev - pipes - smtpd:
+https://bugs.python.org/issue47022 - sndhdr - spwd - sunau - telnetlib - uu
+- xdrlib


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Also removed asynchat, asyncore, and smtpd from their respective toctree entries so they are only  in the superceded subtree.

<!-- issue-number: [bpo-47061](https://bugs.python.org/issue47061) -->
https://bugs.python.org/issue47061
<!-- /issue-number -->

Automerge-Triggered-By: GH:brettcannon