### PR TITLE
bpo-44800: rename _PyInterpreterFrame to _Py_frame

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -949,13 +949,13 @@ Porting to Python 3.11
   * ``f_lineno``: use :c:func:`PyFrame_GetLineNumber`
   * ``f_locals``: use ``PyObject_GetAttrString((PyObject*)frame, "f_locals")``.
   * ``f_stackdepth``: removed.
-  * ``f_state``: no public API (renamed to ``f_frame.f_state``).
+  * ``f_state``: no public API.
   * ``f_trace``: no public API.
   * ``f_trace_lines``: use ``PyObject_GetAttrString((PyObject*)frame, "f_trace_lines")``
     (it also be modified).
   * ``f_trace_opcodes``: use ``PyObject_GetAttrString((PyObject*)frame, "f_trace_opcodes")``
     (it also be modified).
-  * ``f_localsplus``: no public API (renamed to ``f_frame.localsplus``).
+  * ``f_localsplus``: no public API.
   * ``f_valuestack``: removed.
 
   The Python frame object is now created lazily. A side effect is that the

--- a/Include/cpython/ceval.h
+++ b/Include/cpython/ceval.h
@@ -22,7 +22,7 @@ PyAPI_FUNC(PyObject *) _PyEval_GetBuiltinId(_Py_Identifier *);
    flag was set, else return 0. */
 PyAPI_FUNC(int) PyEval_MergeCompilerFlags(PyCompilerFlags *cf);
 
-PyAPI_FUNC(PyObject *) _PyEval_EvalFrameDefault(PyThreadState *tstate, struct _PyInterpreterFrame *f, int exc);
+PyAPI_FUNC(PyObject *) _PyEval_EvalFrameDefault(PyThreadState *tstate, struct _Py_frame *f, int exc);
 
 PyAPI_FUNC(void) _PyEval_SetSwitchInterval(unsigned long microseconds);
 PyAPI_FUNC(unsigned long) _PyEval_GetSwitchInterval(void);

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -48,7 +48,7 @@ typedef struct _PyCFrame {
      */
     int use_tracing;
     /* Pointer to the currently executing frame (it can be NULL) */
-    struct _PyInterpreterFrame *current_frame;
+    struct _Py_frame *current_frame;
     struct _PyCFrame *previous;
 } _PyCFrame;
 
@@ -260,7 +260,7 @@ PyAPI_FUNC(void) PyThreadState_DeleteCurrent(void);
 
 /* Frame evaluation API */
 
-typedef PyObject* (*_PyFrameEvalFunction)(PyThreadState *tstate, struct _PyInterpreterFrame *, int);
+typedef PyObject* (*_PyFrameEvalFunction)(PyThreadState *tstate, struct _Py_frame *, int);
 
 PyAPI_FUNC(_PyFrameEvalFunction) _PyInterpreterState_GetEvalFrameFunc(
     PyInterpreterState *interp);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -47,7 +47,7 @@ extern PyObject *_PyEval_BuiltinsFromGlobals(
 
 
 static inline PyObject*
-_PyEval_EvalFrame(PyThreadState *tstate, struct _PyInterpreterFrame *frame, int throwflag)
+_PyEval_EvalFrame(PyThreadState *tstate, struct _Py_frame *frame, int throwflag)
 {
     if (tstate->interp->eval_frame == NULL) {
         return _PyEval_EvalFrameDefault(tstate, frame, throwflag);
@@ -116,7 +116,7 @@ static inline void _Py_LeaveRecursiveCall_inline(void)  {
 
 #define Py_LeaveRecursiveCall() _Py_LeaveRecursiveCall_inline()
 
-struct _PyInterpreterFrame *_PyEval_GetFrame(void);
+struct _Py_frame *_PyEval_GetFrame(void);
 
 PyObject *_Py_MakeCoro(PyFunctionObject *func);
 

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -97,7 +97,7 @@ typedef struct _Py_frame {
     PyFunctionObject *func; /* Strong reference */
     PyObject *globals; /* Borrowed reference */
     PyObject *builtins; /* Borrowed reference */
-    PyObject *f_locals; /* Strong reference, may be NULL */
+    PyObject *locals; /* Strong reference, may be NULL */
     PyCodeObject *f_code; /* Strong reference */
     PyFrameObject *frame_obj; /* Strong reference, may be NULL */
     struct _Py_frame *previous;
@@ -156,7 +156,7 @@ _PyFrame_InitializeSpecials(
     frame->f_code = (PyCodeObject *)Py_NewRef(func->func_code);
     frame->builtins = func->func_builtins;
     frame->globals = func->func_globals;
-    frame->f_locals = Py_XNewRef(locals);
+    frame->locals = Py_XNewRef(locals);
     frame->stacktop = nlocalsplus;
     frame->frame_obj = NULL;
     frame->f_lasti = -1;

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -96,7 +96,7 @@ typedef signed char PyFrameState;
 typedef struct _Py_frame {
     PyFunctionObject *func; /* Strong reference */
     PyObject *globals; /* Borrowed reference */
-    PyObject *f_builtins; /* Borrowed reference */
+    PyObject *builtins; /* Borrowed reference */
     PyObject *f_locals; /* Strong reference, may be NULL */
     PyCodeObject *f_code; /* Strong reference */
     PyFrameObject *frame_obj; /* Strong reference, may be NULL */
@@ -154,7 +154,7 @@ _PyFrame_InitializeSpecials(
 {
     frame->func = func;
     frame->f_code = (PyCodeObject *)Py_NewRef(func->func_code);
-    frame->f_builtins = func->func_builtins;
+    frame->builtins = func->func_builtins;
     frame->globals = func->func_globals;
     frame->f_locals = Py_XNewRef(locals);
     frame->stacktop = nlocalsplus;

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -89,7 +89,7 @@ enum _framestate {
 typedef signed char PyFrameState;
 
 /*
-    frame->f_lasti refers to the index of the last instruction,
+    frame->lasti refers to the index of the last instruction,
     unless it's -1 in which case next_instr should be first_instr.
 */
 
@@ -101,7 +101,7 @@ typedef struct _Py_frame {
     PyCodeObject *code; /* Strong reference */
     PyFrameObject *frame_obj; /* Strong reference, may be NULL */
     struct _Py_frame *previous;
-    int f_lasti;       /* Last instruction if called */
+    int lasti;       /* Last instruction if called */
     int stacktop;     /* Offset of TOS from localsplus  */
     PyFrameState f_state;  /* What state the frame is in */
     bool is_entry;  // Whether this is the "root" frame for the current _PyCFrame.
@@ -159,7 +159,7 @@ _PyFrame_InitializeSpecials(
     frame->locals = Py_XNewRef(locals);
     frame->stacktop = nlocalsplus;
     frame->frame_obj = NULL;
-    frame->f_lasti = -1;
+    frame->lasti = -1;
     frame->f_state = FRAME_CREATED;
     frame->is_entry = false;
     frame->is_generator = false;

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -65,7 +65,7 @@ struct _frame {
     char f_trace_opcodes;       /* Emit per-opcode trace events? */
     char f_owns_frame;          /* This frame owns the frame */
     /* The frame data, if this frame object owns the frame */
-    PyObject *_f_frame_data[1];
+    PyObject *_f_owned_fdata[1];
 };
 
 extern PyFrameObject* _PyFrame_New_NoTrack(PyCodeObject *code);

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -95,7 +95,7 @@ typedef signed char PyFrameState;
 
 typedef struct _Py_frame {
     PyFunctionObject *func; /* Strong reference */
-    PyObject *f_globals; /* Borrowed reference */
+    PyObject *globals; /* Borrowed reference */
     PyObject *f_builtins; /* Borrowed reference */
     PyObject *f_locals; /* Strong reference, may be NULL */
     PyCodeObject *f_code; /* Strong reference */
@@ -155,7 +155,7 @@ _PyFrame_InitializeSpecials(
     frame->func = func;
     frame->f_code = (PyCodeObject *)Py_NewRef(func->func_code);
     frame->f_builtins = func->func_builtins;
-    frame->f_globals = func->func_globals;
+    frame->globals = func->func_globals;
     frame->f_locals = Py_XNewRef(locals);
     frame->stacktop = nlocalsplus;
     frame->frame_obj = NULL;

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -58,7 +58,7 @@ extern "C" {
 struct _frame {
     PyObject_HEAD
     PyFrameObject *f_back;      /* previous frame, or NULL */
-    struct _Py_frame *f_frame; /* points to the frame data */
+    struct _Py_frame *f_fdata; /* points to the frame data */
     PyObject *f_trace;          /* Trace function */
     int f_lineno;               /* Current line number. Only valid if non-zero */
     char f_trace_lines;         /* Emit per-line trace events? */

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -94,7 +94,7 @@ typedef signed char PyFrameState;
 */
 
 typedef struct _Py_frame {
-    PyFunctionObject *f_func; /* Strong reference */
+    PyFunctionObject *func; /* Strong reference */
     PyObject *f_globals; /* Borrowed reference */
     PyObject *f_builtins; /* Borrowed reference */
     PyObject *f_locals; /* Strong reference, may be NULL */
@@ -152,7 +152,7 @@ _PyFrame_InitializeSpecials(
     _Py_frame *frame, PyFunctionObject *func,
     PyObject *locals, int nlocalsplus)
 {
-    frame->f_func = func;
+    frame->func = func;
     frame->f_code = (PyCodeObject *)Py_NewRef(func->func_code);
     frame->f_builtins = func->func_builtins;
     frame->f_globals = func->func_globals;

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -109,6 +109,36 @@ typedef struct _Py_frame {
     PyObject *localsplus[1];
 } _Py_frame;
 
+#if !defined(_PY_FRAME_API_DISABLE_INTERIM_COMPAT_3_11a6)
+/* Interim compatibility for the internal frame API as shipped in 3.11a6
+ * Some projects (Cython, gevent, greenlet) are known to access the private
+ * frame API in CPython. This API has already changed twice for 3.11 (first
+ * with the structural split, then with the full object structure becoming
+ * opaque and internal struct gaining the `_Py` prefix). The recommended
+ * resolution is expected to change again once a proper public API for the
+ * required frame operations is defined (as discussed in
+ * https://github.com/faster-cpython/ideas/issues/309).
+ *
+ * This interim compatibility workaround enables the bpo-44800 struct and field
+ * name changes for CPython maintainability without forcing yet another interim
+ * code update on the affected projects. Since the workaround affects symbols
+ * without the `Py` or `_Py` prefix, a preprocessor symbol can be declared to
+ * disable the workaround: _PY_FRAME_API_DISABLE_INTERIM_COMPAT_3_11a6
+ */
+// Renamed frame data struct and fields
+typedef _Py_frame _PyInterpreterFrame;
+#define f_func func
+#define f_globals globals
+#define f_builtins builtins
+#define f_locals locals
+#define f_code code
+#define f_lasti lasti
+#define f_state state
+// Renamed frame object fields
+#define f_frame f_fdata
+#define _f_frame_data _f_owned_fdata
+#endif // End internal frame API compatibilty workaround
+
 static inline int _PyFrame_IsRunnable(_Py_frame *f) {
     return f->state < FRAME_EXECUTING;
 }

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -74,7 +74,7 @@ extern PyFrameObject* _PyFrame_New_NoTrack(PyCodeObject *code);
 /* other API */
 
 /* These values are chosen so that the inline functions below all
- * compare f_state to zero.
+ * compare the current frame state to zero.
  */
 enum _framestate {
     FRAME_CREATED = -2,
@@ -103,22 +103,22 @@ typedef struct _Py_frame {
     struct _Py_frame *previous;
     int lasti;       /* Last instruction if called */
     int stacktop;     /* Offset of TOS from localsplus  */
-    PyFrameState f_state;  /* What state the frame is in */
+    PyFrameState state;  /* What state the frame is in */
     bool is_entry;  // Whether this is the "root" frame for the current _PyCFrame.
     bool is_generator;
     PyObject *localsplus[1];
 } _Py_frame;
 
 static inline int _PyFrame_IsRunnable(_Py_frame *f) {
-    return f->f_state < FRAME_EXECUTING;
+    return f->state < FRAME_EXECUTING;
 }
 
 static inline int _PyFrame_IsExecuting(_Py_frame *f) {
-    return f->f_state == FRAME_EXECUTING;
+    return f->state == FRAME_EXECUTING;
 }
 
 static inline int _PyFrameHasCompleted(_Py_frame *f) {
-    return f->f_state > FRAME_EXECUTING;
+    return f->state > FRAME_EXECUTING;
 }
 
 static inline PyObject **_PyFrame_Stackbase(_Py_frame *f) {
@@ -160,7 +160,7 @@ _PyFrame_InitializeSpecials(
     frame->stacktop = nlocalsplus;
     frame->frame_obj = NULL;
     frame->lasti = -1;
-    frame->f_state = FRAME_CREATED;
+    frame->state = FRAME_CREATED;
     frame->is_entry = false;
     frame->is_generator = false;
 }

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -98,7 +98,7 @@ typedef struct _Py_frame {
     PyObject *globals; /* Borrowed reference */
     PyObject *builtins; /* Borrowed reference */
     PyObject *locals; /* Strong reference, may be NULL */
-    PyCodeObject *f_code; /* Strong reference */
+    PyCodeObject *code; /* Strong reference */
     PyFrameObject *frame_obj; /* Strong reference, may be NULL */
     struct _Py_frame *previous;
     int f_lasti;       /* Last instruction if called */
@@ -122,17 +122,17 @@ static inline int _PyFrameHasCompleted(_Py_frame *f) {
 }
 
 static inline PyObject **_PyFrame_Stackbase(_Py_frame *f) {
-    return f->localsplus + f->f_code->co_nlocalsplus;
+    return f->localsplus + f->code->co_nlocalsplus;
 }
 
 static inline PyObject *_PyFrame_StackPeek(_Py_frame *f) {
-    assert(f->stacktop > f->f_code->co_nlocalsplus);
+    assert(f->stacktop > f->code->co_nlocalsplus);
     assert(f->localsplus[f->stacktop-1] != NULL);
     return f->localsplus[f->stacktop-1];
 }
 
 static inline PyObject *_PyFrame_StackPop(_Py_frame *f) {
-    assert(f->stacktop > f->f_code->co_nlocalsplus);
+    assert(f->stacktop > f->code->co_nlocalsplus);
     f->stacktop--;
     return f->localsplus[f->stacktop];
 }
@@ -153,7 +153,7 @@ _PyFrame_InitializeSpecials(
     PyObject *locals, int nlocalsplus)
 {
     frame->func = func;
-    frame->f_code = (PyCodeObject *)Py_NewRef(func->func_code);
+    frame->code = (PyCodeObject *)Py_NewRef(func->func_code);
     frame->builtins = func->func_builtins;
     frame->globals = func->func_globals;
     frame->locals = Py_XNewRef(locals);

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -6,10 +6,59 @@ extern "C" {
 
 #include <stdbool.h>
 
+/* Starting in CPython 3.11, CPython separates the frame state between the
+ * full frame objects exposed by the Python and C runtime state introspection
+ * APIs, and internal lighter weight frame data structs, which are simple C
+ * structures owned by either the interpreter eval loop (while executing
+ * ordinary functions), by a generator or coroutine object (for frames that
+ * are able to be suspended), or by their corresponding full frame object (if
+ * a state instrospection API has been invoked and the full frame object has
+ * taken responsibility for the lifecycle of the frame data storage).
+ *
+ * This split storage eliminates a lot of allocation and deallocation of full
+ * Python objects during code execution, providing a significant speed gain
+ * over the previous approach of using full Python objects for both
+ * introspection and code execution.
+ *
+ * Field naming conventions:
+ *
+ *   * full frame object fields have an "f_*" prefix
+ *   * frame data struct fields have no prefix
+ *
+ * Naming conventions for local variables, function parameters and fields in other structs:
+ *
+ *   * "frame", and "f" may refer to either full frame objects or frame data structs
+ *     * the field naming convention usually makes the type unambiguous in code reviews
+ *   * the following alternative names are used when more clarity is needed:
+ *     * full frame objects: "frame_obj" (and variants like "frameobj" or "fobj")
+ *     * frame data structs: "fdata"
+ *   * the "iframe" name is still used in the generator & coroutine structs. It
+ *     comes from a period where frame data structs were called "interpreter frames"
+ *     (which implied a larger distinction between full frame objects and their
+ *     associated lightweight frame data structs than is actually the case).
+ *   * "current frame" should NOT be abbreviated as "cframe", as the latter typically
+ *     refers to the C stack frame data that is used to separate Python level recursion
+ *     from C level recursive calls to the eval loop function
+ *
+ * Function/macro parameter types:
+ *
+ *   * "PyFrame_*" functions and other public C API functions that relate to
+ *     frames accept full frame objects
+ *   * "_PyFrame_*" functions and other private C API functions that relate to
+ *     frames accept either full frame objecst or frame data structs. Check
+ *     the specific function signatures for details.
+ *
+ * Function return types:
+ *
+ *   * Public C API functions will only ever return full frame objects
+ *   * Private C API functions with an underscore prefix may return frame
+ *     data structs instead. Check the specific function signatures for details.
+ */
+
 struct _frame {
     PyObject_HEAD
     PyFrameObject *f_back;      /* previous frame, or NULL */
-    struct _PyInterpreterFrame *f_frame; /* points to the frame data */
+    struct _Py_frame *f_frame; /* points to the frame data */
     PyObject *f_trace;          /* Trace function */
     int f_lineno;               /* Current line number. Only valid if non-zero */
     char f_trace_lines;         /* Emit per-line trace events? */
@@ -44,63 +93,63 @@ typedef signed char PyFrameState;
     unless it's -1 in which case next_instr should be first_instr.
 */
 
-typedef struct _PyInterpreterFrame {
+typedef struct _Py_frame {
     PyFunctionObject *f_func; /* Strong reference */
     PyObject *f_globals; /* Borrowed reference */
     PyObject *f_builtins; /* Borrowed reference */
     PyObject *f_locals; /* Strong reference, may be NULL */
     PyCodeObject *f_code; /* Strong reference */
     PyFrameObject *frame_obj; /* Strong reference, may be NULL */
-    struct _PyInterpreterFrame *previous;
+    struct _Py_frame *previous;
     int f_lasti;       /* Last instruction if called */
     int stacktop;     /* Offset of TOS from localsplus  */
     PyFrameState f_state;  /* What state the frame is in */
     bool is_entry;  // Whether this is the "root" frame for the current _PyCFrame.
     bool is_generator;
     PyObject *localsplus[1];
-} _PyInterpreterFrame;
+} _Py_frame;
 
-static inline int _PyFrame_IsRunnable(_PyInterpreterFrame *f) {
+static inline int _PyFrame_IsRunnable(_Py_frame *f) {
     return f->f_state < FRAME_EXECUTING;
 }
 
-static inline int _PyFrame_IsExecuting(_PyInterpreterFrame *f) {
+static inline int _PyFrame_IsExecuting(_Py_frame *f) {
     return f->f_state == FRAME_EXECUTING;
 }
 
-static inline int _PyFrameHasCompleted(_PyInterpreterFrame *f) {
+static inline int _PyFrameHasCompleted(_Py_frame *f) {
     return f->f_state > FRAME_EXECUTING;
 }
 
-static inline PyObject **_PyFrame_Stackbase(_PyInterpreterFrame *f) {
+static inline PyObject **_PyFrame_Stackbase(_Py_frame *f) {
     return f->localsplus + f->f_code->co_nlocalsplus;
 }
 
-static inline PyObject *_PyFrame_StackPeek(_PyInterpreterFrame *f) {
+static inline PyObject *_PyFrame_StackPeek(_Py_frame *f) {
     assert(f->stacktop > f->f_code->co_nlocalsplus);
     assert(f->localsplus[f->stacktop-1] != NULL);
     return f->localsplus[f->stacktop-1];
 }
 
-static inline PyObject *_PyFrame_StackPop(_PyInterpreterFrame *f) {
+static inline PyObject *_PyFrame_StackPop(_Py_frame *f) {
     assert(f->stacktop > f->f_code->co_nlocalsplus);
     f->stacktop--;
     return f->localsplus[f->stacktop];
 }
 
-static inline void _PyFrame_StackPush(_PyInterpreterFrame *f, PyObject *value) {
+static inline void _PyFrame_StackPush(_Py_frame *f, PyObject *value) {
     f->localsplus[f->stacktop] = value;
     f->stacktop++;
 }
 
-#define FRAME_SPECIALS_SIZE ((sizeof(_PyInterpreterFrame)-1)/sizeof(PyObject *))
+#define FRAME_SPECIALS_SIZE ((sizeof(_Py_frame)-1)/sizeof(PyObject *))
 
-void _PyFrame_Copy(_PyInterpreterFrame *src, _PyInterpreterFrame *dest);
+void _PyFrame_Copy(_Py_frame *src, _Py_frame *dest);
 
 /* Consumes reference to func */
 static inline void
 _PyFrame_InitializeSpecials(
-    _PyInterpreterFrame *frame, PyFunctionObject *func,
+    _Py_frame *frame, PyFunctionObject *func,
     PyObject *locals, int nlocalsplus)
 {
     frame->f_func = func;
@@ -120,19 +169,19 @@ _PyFrame_InitializeSpecials(
  * that precedes this frame.
  */
 static inline PyObject**
-_PyFrame_GetLocalsArray(_PyInterpreterFrame *frame)
+_PyFrame_GetLocalsArray(_Py_frame *frame)
 {
     return frame->localsplus;
 }
 
 static inline PyObject**
-_PyFrame_GetStackPointer(_PyInterpreterFrame *frame)
+_PyFrame_GetStackPointer(_Py_frame *frame)
 {
     return frame->localsplus+frame->stacktop;
 }
 
 static inline void
-_PyFrame_SetStackPointer(_PyInterpreterFrame *frame, PyObject **stack_pointer)
+_PyFrame_SetStackPointer(_Py_frame *frame, PyObject **stack_pointer)
 {
     frame->stacktop = (int)(stack_pointer - frame->localsplus);
 }
@@ -140,13 +189,13 @@ _PyFrame_SetStackPointer(_PyInterpreterFrame *frame, PyObject **stack_pointer)
 /* For use by _PyFrame_GetFrameObject
   Do not call directly. */
 PyFrameObject *
-_PyFrame_MakeAndSetFrameObject(_PyInterpreterFrame *frame);
+_PyFrame_MakeAndSetFrameObject(_Py_frame *frame);
 
 /* Gets the PyFrameObject for this frame, lazily
  * creating it if necessary.
  * Returns a borrowed referennce */
 static inline PyFrameObject *
-_PyFrame_GetFrameObject(_PyInterpreterFrame *frame)
+_PyFrame_GetFrameObject(_Py_frame *frame)
 {
     PyFrameObject *res =  frame->frame_obj;
     if (res != NULL) {
@@ -156,7 +205,7 @@ _PyFrame_GetFrameObject(_PyInterpreterFrame *frame)
 }
 
 /* Clears all references in the frame.
- * If take is non-zero, then the _PyInterpreterFrame frame
+ * If take is non-zero, then the _Py_frame frame
  * may be transferred to the frame object it references
  * instead of being cleared. Either way
  * the caller no longer owns the references
@@ -165,21 +214,21 @@ _PyFrame_GetFrameObject(_PyInterpreterFrame *frame)
  * frames like the ones in generators and coroutines.
  */
 void
-_PyFrame_Clear(_PyInterpreterFrame * frame);
+_PyFrame_Clear(_Py_frame * frame);
 
 int
-_PyFrame_Traverse(_PyInterpreterFrame *frame, visitproc visit, void *arg);
+_PyFrame_Traverse(_Py_frame *frame, visitproc visit, void *arg);
 
 int
-_PyFrame_FastToLocalsWithError(_PyInterpreterFrame *frame);
+_PyFrame_FastToLocalsWithError(_Py_frame *frame);
 
 void
-_PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear);
+_PyFrame_LocalsToFast(_Py_frame *frame, int clear);
 
-extern _PyInterpreterFrame *
+extern _Py_frame *
 _PyThreadState_BumpFramePointerSlow(PyThreadState *tstate, size_t size);
 
-static inline _PyInterpreterFrame *
+static inline _Py_frame *
 _PyThreadState_BumpFramePointer(PyThreadState *tstate, size_t size)
 {
     PyObject **base = tstate->datastack_top;
@@ -188,16 +237,16 @@ _PyThreadState_BumpFramePointer(PyThreadState *tstate, size_t size)
         assert(tstate->datastack_limit);
         if (top < tstate->datastack_limit) {
             tstate->datastack_top = top;
-            return (_PyInterpreterFrame *)base;
+            return (_Py_frame *)base;
         }
     }
     return _PyThreadState_BumpFramePointerSlow(tstate, size);
 }
 
-void _PyThreadState_PopFrame(PyThreadState *tstate, _PyInterpreterFrame *frame);
+void _PyThreadState_PopFrame(PyThreadState *tstate, _Py_frame *frame);
 
 /* Consume reference to func */
-_PyInterpreterFrame *
+_Py_frame *
 _PyFrame_Push(PyThreadState *tstate, PyFunctionObject *func);
 
 #ifdef __cplusplus

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-19-21-47-36.bpo-44800.XnGKoD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-19-21-47-36.bpo-44800.XnGKoD.rst
@@ -1,0 +1,9 @@
+Renamed `_PyInterpreterFrame` as `_Py_frame` to emphasise its close
+association with `PyFrameObject` (they're conceptually the same thing, but
+split into a Python object struct and a C data struct as a performance
+optimisation).
+
+The `f_` prefix has been removed from all `_Py_frame` fields that previously
+used it, so the presence or absence of the prefix provides a way to infer
+the exact type of a frame pointer when reading an isolated snippet in a code
+diff.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-19-21-47-36.bpo-44800.XnGKoD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-19-21-47-36.bpo-44800.XnGKoD.rst
@@ -1,9 +1,9 @@
-Renamed `_PyInterpreterFrame` as `_Py_frame` to emphasise its close
-association with `PyFrameObject` (they're conceptually the same thing, but
+Renamed ``_PyInterpreterFrame`` as ``_Py_frame`` to emphasise its close
+association with ``PyFrameObject`` (they're conceptually the same thing, but
 split into a Python object struct and a C data struct as a performance
 optimisation).
 
-The `f_` prefix has been removed from all `_Py_frame` fields that previously
+The ``f_`` prefix has been removed from all ``_Py_frame`` fields that previously
 used it, so the presence or absence of the prefix provides a way to infer
 the exact type of a frame pointer when reading an isolated snippet in a code
 diff.

--- a/Misc/gdbinit
+++ b/Misc/gdbinit
@@ -56,7 +56,7 @@ end
 define lineno
     set $__continue = 1
     set $__co = f->code
-    set $__lasti = f->f_lasti
+    set $__lasti = f->lasti
     set $__sz = ((PyVarObject *)$__co->co_lnotab)->ob_size/2
     set $__p = (unsigned char *)((PyBytesObject *)$__co->co_lnotab)->ob_sval
     set $__li = $__co->co_firstlineno

--- a/Misc/gdbinit
+++ b/Misc/gdbinit
@@ -37,9 +37,9 @@ end
 
 define pylocals
     set $_i = 0
-    while $_i < f->f_code->co_nlocals
+    while $_i < f->code->co_nlocals
 	if f->f_localsplus + $_i != 0
-	    set $_names = f->f_code->co_varnames
+	    set $_names = f->code->co_varnames
 	    set $_name = PyUnicode_AsUTF8(PyTuple_GetItem($_names, $_i))
 	    printf "%s:\n", $_name
             pyo f->f_localsplus[$_i]
@@ -55,7 +55,7 @@ end
 # command language
 define lineno
     set $__continue = 1
-    set $__co = f->f_code
+    set $__co = f->code
     set $__lasti = f->f_lasti
     set $__sz = ((PyVarObject *)$__co->co_lnotab)->ob_size/2
     set $__p = (unsigned char *)((PyBytesObject *)$__co->co_lnotab)->ob_sval
@@ -84,8 +84,8 @@ document pyframev
 end
 
 define pyframe
-    set $__fn = PyUnicode_AsUTF8(f->f_code->co_filename)
-    set $__n = PyUnicode_AsUTF8(f->f_code->co_name)
+    set $__fn = PyUnicode_AsUTF8(f->code->co_filename)
+    set $__n = PyUnicode_AsUTF8(f->code->co_name)
     printf "%s (", $__fn
     lineno
     printf "): %s\n", $__n

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -308,7 +308,7 @@ static void
 tracemalloc_get_frame(_Py_frame *pyframe, frame_t *frame)
 {
     frame->filename = &_Py_STR(anon_unknown);
-    int lineno = PyCode_Addr2Line(pyframe->code, pyframe->f_lasti*sizeof(_Py_CODEUNIT));
+    int lineno = PyCode_Addr2Line(pyframe->code, pyframe->lasti*sizeof(_Py_CODEUNIT));
     if (lineno < 0) {
         lineno = 0;
     }

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -305,7 +305,7 @@ hashtable_compare_traceback(const void *key1, const void *key2)
 
 
 static void
-tracemalloc_get_frame(_PyInterpreterFrame *pyframe, frame_t *frame)
+tracemalloc_get_frame(_Py_frame *pyframe, frame_t *frame)
 {
     frame->filename = &_Py_STR(anon_unknown);
     int lineno = PyCode_Addr2Line(pyframe->f_code, pyframe->f_lasti*sizeof(_Py_CODEUNIT));
@@ -399,7 +399,7 @@ traceback_get_frames(traceback_t *traceback)
         return;
     }
 
-    _PyInterpreterFrame *pyframe = tstate->cframe->current_frame;
+    _Py_frame *pyframe = tstate->cframe->current_frame;
     for (; pyframe != NULL;) {
         if (traceback->nframe < _Py_tracemalloc_config.max_nframe) {
             tracemalloc_get_frame(pyframe, &traceback->frames[traceback->nframe]);
@@ -410,7 +410,7 @@ traceback_get_frames(traceback_t *traceback)
             traceback->total_nframe++;
         }
 
-        _PyInterpreterFrame *back = pyframe->previous;
+        _Py_frame *back = pyframe->previous;
         pyframe = back;
     }
 }

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -308,13 +308,13 @@ static void
 tracemalloc_get_frame(_Py_frame *pyframe, frame_t *frame)
 {
     frame->filename = &_Py_STR(anon_unknown);
-    int lineno = PyCode_Addr2Line(pyframe->f_code, pyframe->f_lasti*sizeof(_Py_CODEUNIT));
+    int lineno = PyCode_Addr2Line(pyframe->code, pyframe->f_lasti*sizeof(_Py_CODEUNIT));
     if (lineno < 0) {
         lineno = 0;
     }
     frame->lineno = (unsigned int)lineno;
 
-    PyObject *filename = pyframe->f_code->co_filename;
+    PyObject *filename = pyframe->code->co_filename;
 
     if (filename == NULL) {
 #ifdef TRACE_DEBUG

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1839,7 +1839,7 @@ _is_running(PyInterpreterState *interp)
     }
 
     assert(!PyErr_Occurred());
-    _PyInterpreterFrame *frame = tstate->cframe->current_frame;
+    _Py_frame *frame = tstate->cframe->current_frame;
     if (frame == NULL) {
         return 0;
     }

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -8,7 +8,7 @@
 #include "pycore_call.h"          // _PyObject_Call()
 #include "pycore_ceval.h"         // _PyEval_SignalReceived()
 #include "pycore_fileutils.h"     // _Py_BEGIN_SUPPRESS_IPH
-#include "pycore_frame.h"         // _PyInterpreterFrame
+#include "pycore_frame.h"         // _Py_frame
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "pycore_pyerrors.h"      // _PyErr_SetString()
 #include "pycore_pylifecycle.h"   // NSIG
@@ -1817,7 +1817,7 @@ _PyErr_CheckSignalsTstate(PyThreadState *tstate)
      */
     _Py_atomic_store(&is_tripped, 0);
 
-    _PyInterpreterFrame *frame = tstate->cframe->current_frame;
+    _Py_frame *frame = tstate->cframe->current_frame;
     signal_state_t *state = &signal_global_state;
     for (int i = 1; i < NSIG; i++) {
         if (!_Py_atomic_load_relaxed(&Handlers[i].tripped)) {

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -78,7 +78,7 @@ frame_getglobals(PyFrameObject *f, void *closure)
 static PyObject *
 frame_getbuiltins(PyFrameObject *f, void *closure)
 {
-    PyObject *builtins = f->f_frame->f_builtins;
+    PyObject *builtins = f->f_frame->builtins;
     if (builtins == NULL) {
         builtins = Py_None;
     }

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -26,7 +26,7 @@ frame_getlocals(PyFrameObject *f, void *closure)
 {
     if (PyFrame_FastToLocalsWithError(f) < 0)
         return NULL;
-    PyObject *locals = f->f_frame->f_locals;
+    PyObject *locals = f->f_frame->locals;
     Py_INCREF(locals);
     return locals;
 }
@@ -635,7 +635,7 @@ frame_dealloc(PyFrameObject *f)
         co = frame->f_code;
         frame->f_code = NULL;
         Py_CLEAR(frame->func);
-        Py_CLEAR(frame->f_locals);
+        Py_CLEAR(frame->locals);
         PyObject **locals = _PyFrame_GetLocalsArray(frame);
         for (int i = 0; i < frame->stacktop; i++) {
             Py_CLEAR(locals[i]);
@@ -850,13 +850,13 @@ _PyFrame_OpAlreadyRan(_Py_frame *frame, int opcode, int oparg)
 
 int
 _PyFrame_FastToLocalsWithError(_Py_frame *frame) {
-    /* Merge fast locals into f->f_locals */
+    /* Merge fast locals into f->locals */
     PyObject *locals;
     PyObject **fast;
     PyCodeObject *co;
-    locals = frame->f_locals;
+    locals = frame->locals;
     if (locals == NULL) {
-        locals = frame->f_locals = PyDict_New();
+        locals = frame->locals = PyDict_New();
         if (locals == NULL)
             return -1;
     }
@@ -967,7 +967,7 @@ _PyFrame_LocalsToFast(_Py_frame *frame, int clear)
     PyObject **fast;
     PyObject *error_type, *error_value, *error_traceback;
     PyCodeObject *co;
-    locals = frame->f_locals;
+    locals = frame->locals;
     if (locals == NULL)
         return;
     fast = _PyFrame_GetLocalsArray(frame);

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -39,7 +39,7 @@ PyFrame_GetLineNumber(PyFrameObject *f)
         return f->f_lineno;
     }
     else {
-        return PyCode_Addr2Line(f->f_frame->code, f->f_frame->f_lasti*sizeof(_Py_CODEUNIT));
+        return PyCode_Addr2Line(f->f_frame->code, f->f_frame->lasti*sizeof(_Py_CODEUNIT));
     }
 }
 
@@ -58,10 +58,10 @@ frame_getlineno(PyFrameObject *f, void *closure)
 static PyObject *
 frame_getlasti(PyFrameObject *f, void *closure)
 {
-    if (f->f_frame->f_lasti < 0) {
+    if (f->f_frame->lasti < 0) {
         return PyLong_FromLong(-1);
     }
-    return PyLong_FromLong(f->f_frame->f_lasti*sizeof(_Py_CODEUNIT));
+    return PyLong_FromLong(f->f_frame->lasti*sizeof(_Py_CODEUNIT));
 }
 
 static PyObject *
@@ -516,7 +516,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
 
     int64_t best_stack = OVERFLOWED;
     int best_addr = -1;
-    int64_t start_stack = stacks[f->f_frame->f_lasti];
+    int64_t start_stack = stacks[f->f_frame->lasti];
     int err = -1;
     const char *msg = "cannot find bytecode for specified line";
     for (int i = 0; i < len; i++) {
@@ -560,7 +560,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
     }
     /* Finally set the new lasti and return OK. */
     f->f_lineno = 0;
-    f->f_frame->f_lasti = best_addr;
+    f->f_frame->lasti = best_addr;
     return 0;
 }
 
@@ -840,7 +840,7 @@ _PyFrame_OpAlreadyRan(_Py_frame *frame, int opcode, int oparg)
 {
     const _Py_CODEUNIT *code =
         (const _Py_CODEUNIT *)PyBytes_AS_STRING(frame->code->co_code);
-    for (int i = 0; i < frame->f_lasti; i++) {
+    for (int i = 0; i < frame->lasti; i++) {
         if (_Py_OPCODE(code[i]) == opcode && _Py_OPARG(code[i]) == oparg) {
             return 1;
         }
@@ -862,7 +862,7 @@ _PyFrame_FastToLocalsWithError(_Py_frame *frame) {
     }
     co = frame->code;
     fast = _PyFrame_GetLocalsArray(frame);
-    if (frame->f_lasti < 0 && _Py_OPCODE(co->co_firstinstr[0]) == COPY_FREE_VARS) {
+    if (frame->lasti < 0 && _Py_OPCODE(co->co_firstinstr[0]) == COPY_FREE_VARS) {
         /* Free vars have not been initialized -- Do that */
         PyCodeObject *co = frame->code;
         PyObject *closure = frame->func->func_closure;
@@ -872,7 +872,7 @@ _PyFrame_FastToLocalsWithError(_Py_frame *frame) {
             Py_INCREF(o);
             frame->localsplus[offset + i] = o;
         }
-        frame->f_lasti = 0;
+        frame->lasti = 0;
     }
     for (int i = 0; i < co->co_nlocalsplus; i++) {
         _PyLocals_Kind kind = _PyLocals_GetKind(co->co_localspluskinds, i);

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -629,8 +629,8 @@ frame_dealloc(PyFrameObject *f)
     /* Kill all local variables including specials, if we own them */
     if (f->f_owns_frame) {
         f->f_owns_frame = 0;
-        assert(f->f_frame == (_PyInterpreterFrame *)f->_f_frame_data);
-        _PyInterpreterFrame *frame = (_PyInterpreterFrame *)f->_f_frame_data;
+        assert(f->f_frame == (_Py_frame *)f->_f_frame_data);
+        _Py_frame *frame = (_Py_frame *)f->_f_frame_data;
         /* Don't clear code object until the end */
         co = frame->f_code;
         frame->f_code = NULL;
@@ -707,7 +707,7 @@ static PyObject *
 frame_sizeof(PyFrameObject *f, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t res;
-    res = offsetof(PyFrameObject, _f_frame_data) + offsetof(_PyInterpreterFrame, localsplus);
+    res = offsetof(PyFrameObject, _f_frame_data) + offsetof(_Py_frame, localsplus);
     PyCodeObject *code = f->f_frame->f_code;
     res += (code->co_nlocalsplus+code->co_stacksize) * sizeof(PyObject *);
     return PyLong_FromSsize_t(res);
@@ -738,7 +738,7 @@ PyTypeObject PyFrame_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "frame",
     offsetof(PyFrameObject, _f_frame_data) +
-    offsetof(_PyInterpreterFrame, localsplus),
+    offsetof(_Py_frame, localsplus),
     sizeof(PyObject *),
     (destructor)frame_dealloc,                  /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
@@ -771,7 +771,7 @@ PyTypeObject PyFrame_Type = {
 };
 
 static void
-init_frame(_PyInterpreterFrame *frame, PyFunctionObject *func, PyObject *locals)
+init_frame(_Py_frame *frame, PyFunctionObject *func, PyObject *locals)
 {
     /* _PyFrame_InitializeSpecials consumes reference to func */
     Py_INCREF(func);
@@ -827,8 +827,8 @@ PyFrame_New(PyThreadState *tstate, PyCodeObject *code,
         Py_DECREF(func);
         return NULL;
     }
-    init_frame((_PyInterpreterFrame *)f->_f_frame_data, func, locals);
-    f->f_frame = (_PyInterpreterFrame *)f->_f_frame_data;
+    init_frame((_Py_frame *)f->_f_frame_data, func, locals);
+    f->f_frame = (_Py_frame *)f->_f_frame_data;
     f->f_owns_frame = 1;
     Py_DECREF(func);
     _PyObject_GC_TRACK(f);
@@ -836,7 +836,7 @@ PyFrame_New(PyThreadState *tstate, PyCodeObject *code,
 }
 
 static int
-_PyFrame_OpAlreadyRan(_PyInterpreterFrame *frame, int opcode, int oparg)
+_PyFrame_OpAlreadyRan(_Py_frame *frame, int opcode, int oparg)
 {
     const _Py_CODEUNIT *code =
         (const _Py_CODEUNIT *)PyBytes_AS_STRING(frame->f_code->co_code);
@@ -849,7 +849,7 @@ _PyFrame_OpAlreadyRan(_PyInterpreterFrame *frame, int opcode, int oparg)
 }
 
 int
-_PyFrame_FastToLocalsWithError(_PyInterpreterFrame *frame) {
+_PyFrame_FastToLocalsWithError(_Py_frame *frame) {
     /* Merge fast locals into f->f_locals */
     PyObject *locals;
     PyObject **fast;
@@ -960,7 +960,7 @@ PyFrame_FastToLocals(PyFrameObject *f)
 }
 
 void
-_PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear)
+_PyFrame_LocalsToFast(_Py_frame *frame, int clear)
 {
     /* Merge locals into fast locals */
     PyObject *locals;

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -20,6 +20,23 @@ static PyMemberDef frame_memberlist[] = {
     {NULL}      /* Sentinel */
 };
 
+// Compile time check of interim Python 3.11a6 API compatibility aliases
+// Can be removed once the aliases are removed
+static_assert(OFF(f_fdata) == OFF(f_frame), "Incorrect alias for f_frame");
+static_assert(OFF(_f_owned_fdata) == OFF(_f_frame_data), "Incorrect alias for _f_frame_data");
+
+#define INTERIM_FRAME_DATA_ALIAS_CHECK(new_field) \
+    static_assert(offsetof(_Py_frame, new_field) == offsetof(_PyInterpreterFrame, f_##new_field), \
+                  "Incorrect alias for f_" #new_field )
+
+INTERIM_FRAME_DATA_ALIAS_CHECK(func);
+INTERIM_FRAME_DATA_ALIAS_CHECK(builtins);
+INTERIM_FRAME_DATA_ALIAS_CHECK(globals);
+INTERIM_FRAME_DATA_ALIAS_CHECK(locals);
+INTERIM_FRAME_DATA_ALIAS_CHECK(code);
+INTERIM_FRAME_DATA_ALIAS_CHECK(lasti);
+INTERIM_FRAME_DATA_ALIAS_CHECK(state);
+// End compatiblity alias check
 
 static PyObject *
 frame_getlocals(PyFrameObject *f, void *closure)

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -634,7 +634,7 @@ frame_dealloc(PyFrameObject *f)
         /* Don't clear code object until the end */
         co = frame->f_code;
         frame->f_code = NULL;
-        Py_CLEAR(frame->f_func);
+        Py_CLEAR(frame->func);
         Py_CLEAR(frame->f_locals);
         PyObject **locals = _PyFrame_GetLocalsArray(frame);
         for (int i = 0; i < frame->stacktop; i++) {
@@ -865,7 +865,7 @@ _PyFrame_FastToLocalsWithError(_Py_frame *frame) {
     if (frame->f_lasti < 0 && _Py_OPCODE(co->co_firstinstr[0]) == COPY_FREE_VARS) {
         /* Free vars have not been initialized -- Do that */
         PyCodeObject *co = frame->f_code;
-        PyObject *closure = frame->f_func->func_closure;
+        PyObject *closure = frame->func->func_closure;
         int offset = co->co_nlocals + co->co_nplaincellvars;
         for (int i = 0; i < co->co_nfreevars; ++i) {
             PyObject *o = PyTuple_GET_ITEM(closure, i);

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -67,7 +67,7 @@ frame_getlasti(PyFrameObject *f, void *closure)
 static PyObject *
 frame_getglobals(PyFrameObject *f, void *closure)
 {
-    PyObject *globals = f->f_frame->f_globals;
+    PyObject *globals = f->f_frame->globals;
     if (globals == NULL) {
         globals = Py_None;
     }

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -442,7 +442,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
      * In addition, jumps are forbidden when not tracing,
      * as this is a debugging feature.
      */
-    switch(f->f_frame->f_state) {
+    switch(f->f_frame->state) {
         case FRAME_CREATED:
             PyErr_Format(PyExc_ValueError,
                      "can't jump from the 'call' trace event of a new frame");
@@ -550,7 +550,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
         return -1;
     }
     /* Unwind block stack. */
-    if (f->f_frame->f_state == FRAME_SUSPENDED) {
+    if (f->f_frame->state == FRAME_SUSPENDED) {
         /* Account for value popped by yield */
         start_stack = pop_value(start_stack);
     }
@@ -668,7 +668,7 @@ frame_tp_clear(PyFrameObject *f)
      * frame may also point to this frame, believe itself to still be
      * active, and try cleaning up this frame again.
      */
-    f->f_frame->f_state = FRAME_CLEARED;
+    f->f_frame->state = FRAME_CLEARED;
 
     Py_CLEAR(f->f_trace);
 
@@ -891,7 +891,7 @@ _PyFrame_FastToLocalsWithError(_Py_frame *frame) {
 
         PyObject *name = PyTuple_GET_ITEM(co->co_localsplusnames, i);
         PyObject *value = fast[i];
-        if (frame->f_state != FRAME_CLEARED) {
+        if (frame->state != FRAME_CLEARED) {
             if (kind & CO_FAST_FREE) {
                 // The cell was set by COPY_FREE_VARS.
                 assert(value != NULL && PyCell_Check(value));
@@ -1028,7 +1028,7 @@ _PyFrame_LocalsToFast(_Py_frame *frame, int clear)
 void
 PyFrame_LocalsToFast(PyFrameObject *f, int clear)
 {
-    if (f == NULL || f->f_frame->f_state == FRAME_CLEARED) {
+    if (f == NULL || f->f_frame->state == FRAME_CLEARED) {
         return;
     }
     _PyFrame_LocalsToFast(f->f_frame, clear);

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -7,7 +7,7 @@
 #include "pycore_object.h"        // _PyObject_GC_UNTRACK()
 #include "pycore_pyerrors.h"      // _PyErr_ClearExcState()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "pycore_frame.h"         // _PyInterpreterFrame
+#include "pycore_frame.h"         // _Py_frame
 #include "frameobject.h"          // PyFrameObject
 #include "structmember.h"         // PyMemberDef
 #include "opcode.h"               // SEND
@@ -36,7 +36,7 @@ gen_traverse(PyGenObject *gen, visitproc visit, void *arg)
     Py_VISIT(gen->gi_name);
     Py_VISIT(gen->gi_qualname);
     if (gen->gi_frame_valid) {
-        _PyInterpreterFrame *frame = (_PyInterpreterFrame *)(gen->gi_iframe);
+        _Py_frame *frame = (_Py_frame *)(gen->gi_iframe);
         assert(frame->frame_obj == NULL || frame->frame_obj->f_owns_frame == 0);
         int err = _PyFrame_Traverse(frame, visit, arg);
         if (err) {
@@ -55,7 +55,7 @@ _PyGen_Finalize(PyObject *self)
     PyObject *res = NULL;
     PyObject *error_type, *error_value, *error_traceback;
 
-    if (gen->gi_frame_valid == 0 || _PyFrameHasCompleted((_PyInterpreterFrame *)gen->gi_iframe)) {
+    if (gen->gi_frame_valid == 0 || _PyFrameHasCompleted((_Py_frame *)gen->gi_iframe)) {
         /* Generator isn't paused, so no need to close */
         return;
     }
@@ -87,7 +87,7 @@ _PyGen_Finalize(PyObject *self)
        issue a RuntimeWarning. */
     if (gen->gi_code != NULL &&
         ((PyCodeObject *)gen->gi_code)->co_flags & CO_COROUTINE &&
-        ((_PyInterpreterFrame *)gen->gi_iframe)->f_state == FRAME_CREATED)
+        ((_Py_frame *)gen->gi_iframe)->f_state == FRAME_CREATED)
     {
         _PyErr_WarnUnawaitedCoroutine((PyObject *)gen);
     }
@@ -131,7 +131,7 @@ gen_dealloc(PyGenObject *gen)
         Py_CLEAR(((PyAsyncGenObject*)gen)->ag_origin_or_finalizer);
     }
     if (gen->gi_frame_valid) {
-        _PyInterpreterFrame *frame = (_PyInterpreterFrame *)gen->gi_iframe;
+        _Py_frame *frame = (_Py_frame *)gen->gi_iframe;
         gen->gi_frame_valid = 0;
         frame->is_generator = false;
         frame->previous = NULL;
@@ -152,7 +152,7 @@ gen_send_ex2(PyGenObject *gen, PyObject *arg, PyObject **presult,
              int exc, int closing)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    _PyInterpreterFrame *frame = (_PyInterpreterFrame *)gen->gi_iframe;
+    _Py_frame *frame = (_Py_frame *)gen->gi_iframe;
     PyObject *result;
 
     *presult = NULL;
@@ -348,7 +348,7 @@ _PyGen_yf(PyGenObject *gen)
     PyObject *yf = NULL;
 
     if (gen->gi_frame_valid) {
-        _PyInterpreterFrame *frame = (_PyInterpreterFrame *)gen->gi_iframe;
+        _Py_frame *frame = (_Py_frame *)gen->gi_iframe;
         PyObject *bytecode = gen->gi_code->co_code;
         unsigned char *code = (unsigned char *)PyBytes_AS_STRING(bytecode);
 
@@ -380,7 +380,7 @@ gen_close(PyGenObject *gen, PyObject *args)
     int err = 0;
 
     if (yf) {
-        _PyInterpreterFrame *frame = (_PyInterpreterFrame *)gen->gi_iframe;
+        _Py_frame *frame = (_Py_frame *)gen->gi_iframe;
         PyFrameState state = frame->f_state;
         frame->f_state = FRAME_EXECUTING;
         err = gen_close_iter(yf);
@@ -421,7 +421,7 @@ _gen_throw(PyGenObject *gen, int close_on_genexit,
     PyObject *yf = _PyGen_yf(gen);
 
     if (yf) {
-        _PyInterpreterFrame *frame = (_PyInterpreterFrame *)gen->gi_iframe;
+        _Py_frame *frame = (_Py_frame *)gen->gi_iframe;
         PyObject *ret;
         int err;
         if (PyErr_GivenExceptionMatches(typ, PyExc_GeneratorExit) &&
@@ -448,7 +448,7 @@ _gen_throw(PyGenObject *gen, int close_on_genexit,
                will be reported correctly to the user. */
             /* XXX We should probably be updating the current frame
                somewhere in ceval.c. */
-            _PyInterpreterFrame *prev = tstate->cframe->current_frame;
+            _Py_frame *prev = tstate->cframe->current_frame;
             frame->previous = prev;
             tstate->cframe->current_frame = frame;
             /* Close the generator that we are currently iterating with
@@ -482,7 +482,7 @@ _gen_throw(PyGenObject *gen, int close_on_genexit,
             PyObject *val;
             /* Pop subiterator from stack */
             assert(gen->gi_frame_valid);
-            ret = _PyFrame_StackPop((_PyInterpreterFrame *)gen->gi_iframe);
+            ret = _PyFrame_StackPop((_Py_frame *)gen->gi_iframe);
             assert(ret == yf);
             Py_DECREF(ret);
             /* Termination repetition of SEND loop */
@@ -760,7 +760,7 @@ gen_getrunning(PyGenObject *gen, void *Py_UNUSED(ignored))
     if (gen->gi_frame_valid == 0) {
         Py_RETURN_FALSE;
     }
-    return PyBool_FromLong(_PyFrame_IsExecuting((_PyInterpreterFrame *)gen->gi_iframe));
+    return PyBool_FromLong(_PyFrame_IsExecuting((_Py_frame *)gen->gi_iframe));
 }
 
 static PyObject *
@@ -769,7 +769,7 @@ gen_getsuspended(PyGenObject *gen, void *Py_UNUSED(ignored))
     if (gen->gi_frame_valid == 0) {
         Py_RETURN_FALSE;
     }
-    return PyBool_FromLong(((_PyInterpreterFrame *)gen->gi_iframe)->f_state == FRAME_SUSPENDED);
+    return PyBool_FromLong(((_Py_frame *)gen->gi_iframe)->f_state == FRAME_SUSPENDED);
 }
 
 static PyObject *
@@ -781,7 +781,7 @@ _gen_getframe(PyGenObject *gen, const char *const name)
     if (gen->gi_frame_valid == 0) {
         Py_RETURN_NONE;
     }
-    return _Py_XNewRef((PyObject *)_PyFrame_GetFrameObject((_PyInterpreterFrame *)gen->gi_iframe));
+    return _Py_XNewRef((PyObject *)_PyFrame_GetFrameObject((_Py_frame *)gen->gi_iframe));
 }
 
 static PyObject *
@@ -812,7 +812,7 @@ static PyObject *
 gen_sizeof(PyGenObject *gen, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t res;
-    res = offsetof(PyGenObject, gi_iframe) + offsetof(_PyInterpreterFrame, localsplus);
+    res = offsetof(PyGenObject, gi_iframe) + offsetof(_Py_frame, localsplus);
     PyCodeObject *code = gen->gi_code;
     res += (code->co_nlocalsplus+code->co_stacksize) * sizeof(PyObject *);
     return PyLong_FromSsize_t(res);
@@ -841,7 +841,7 @@ PyTypeObject PyGen_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "generator",                                /* tp_name */
     offsetof(PyGenObject, gi_iframe) +
-    offsetof(_PyInterpreterFrame, localsplus),       /* tp_basicsize */
+    offsetof(_Py_frame, localsplus),       /* tp_basicsize */
     sizeof(PyObject *),                         /* tp_itemsize */
     /* methods */
     (destructor)gen_dealloc,                    /* tp_dealloc */
@@ -915,7 +915,7 @@ make_gen(PyTypeObject *type, PyFunctionObject *func)
 }
 
 static PyObject *
-compute_cr_origin(int origin_depth, _PyInterpreterFrame *current_frame);
+compute_cr_origin(int origin_depth, _Py_frame *current_frame);
 
 PyObject *
 _Py_MakeCoro(PyFunctionObject *func)
@@ -974,8 +974,8 @@ gen_new_with_qualname(PyTypeObject *type, PyFrameObject *f,
     /* Copy the frame */
     assert(f->f_frame->frame_obj == NULL);
     assert(f->f_owns_frame);
-    _PyInterpreterFrame *frame = (_PyInterpreterFrame *)gen->gi_iframe;
-    _PyFrame_Copy((_PyInterpreterFrame *)f->_f_frame_data, frame);
+    _Py_frame *frame = (_Py_frame *)gen->gi_iframe;
+    _PyFrame_Copy((_Py_frame *)f->_f_frame_data, frame);
     gen->gi_frame_valid = 1;
     assert(frame->frame_obj == f);
     f->f_owns_frame = 0;
@@ -1118,7 +1118,7 @@ cr_getsuspended(PyCoroObject *coro, void *Py_UNUSED(ignored))
     if (coro->cr_frame_valid == 0) {
         Py_RETURN_FALSE;
     }
-    return PyBool_FromLong(((_PyInterpreterFrame *)coro->cr_iframe)->f_state == FRAME_SUSPENDED);
+    return PyBool_FromLong(((_Py_frame *)coro->cr_iframe)->f_state == FRAME_SUSPENDED);
 }
 
 static PyObject *
@@ -1127,7 +1127,7 @@ cr_getrunning(PyCoroObject *coro, void *Py_UNUSED(ignored))
     if (coro->cr_frame_valid == 0) {
         Py_RETURN_FALSE;
     }
-    return PyBool_FromLong(_PyFrame_IsExecuting((_PyInterpreterFrame *)coro->cr_iframe));
+    return PyBool_FromLong(_PyFrame_IsExecuting((_Py_frame *)coro->cr_iframe));
 }
 
 static PyObject *
@@ -1186,7 +1186,7 @@ PyTypeObject PyCoro_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "coroutine",                                /* tp_name */
     offsetof(PyCoroObject, cr_iframe) +
-    offsetof(_PyInterpreterFrame, localsplus),       /* tp_basicsize */
+    offsetof(_Py_frame, localsplus),       /* tp_basicsize */
     sizeof(PyObject *),                         /* tp_itemsize */
     /* methods */
     (destructor)gen_dealloc,                    /* tp_dealloc */
@@ -1325,9 +1325,9 @@ PyTypeObject _PyCoroWrapper_Type = {
 };
 
 static PyObject *
-compute_cr_origin(int origin_depth, _PyInterpreterFrame *current_frame)
+compute_cr_origin(int origin_depth, _Py_frame *current_frame)
 {
-    _PyInterpreterFrame *frame = current_frame;
+    _Py_frame *frame = current_frame;
     /* First count how many frames we have */
     int frame_count = 0;
     for (; frame && frame_count < origin_depth; ++frame_count) {
@@ -1578,7 +1578,7 @@ PyTypeObject PyAsyncGen_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "async_generator",                          /* tp_name */
     offsetof(PyAsyncGenObject, ag_iframe) +
-    offsetof(_PyInterpreterFrame, localsplus),       /* tp_basicsize */
+    offsetof(_Py_frame, localsplus),       /* tp_basicsize */
     sizeof(PyObject *),                         /* tp_itemsize */
     /* methods */
     (destructor)gen_dealloc,                    /* tp_dealloc */
@@ -2064,7 +2064,7 @@ static PyObject *
 async_gen_athrow_send(PyAsyncGenAThrow *o, PyObject *arg)
 {
     PyGenObject *gen = (PyGenObject*)o->agt_gen;
-    _PyInterpreterFrame *frame = (_PyInterpreterFrame *)gen->gi_iframe;
+    _Py_frame *frame = (_Py_frame *)gen->gi_iframe;
     PyObject *retval;
 
     if (o->agt_state == AWAITABLE_STATE_CLOSED) {

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -975,7 +975,7 @@ gen_new_with_qualname(PyTypeObject *type, PyFrameObject *f,
     assert(f->f_fdata->frame_obj == NULL);
     assert(f->f_owns_frame);
     _Py_frame *frame = (_Py_frame *)gen->gi_iframe;
-    _PyFrame_Copy((_Py_frame *)f->_f_frame_data, frame);
+    _PyFrame_Copy((_Py_frame *)f->_f_owned_fdata, frame);
     gen->gi_frame_valid = 1;
     assert(frame->frame_obj == f);
     f->f_owns_frame = 0;

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -964,7 +964,7 @@ static PyObject *
 gen_new_with_qualname(PyTypeObject *type, PyFrameObject *f,
                       PyObject *name, PyObject *qualname)
 {
-    PyCodeObject *code = f->f_frame->f_code;
+    PyCodeObject *code = f->f_frame->code;
     int size = code->co_nlocalsplus + code->co_stacksize;
     PyGenObject *gen = PyObject_GC_NewVar(PyGenObject, type, size);
     if (gen == NULL) {
@@ -1341,10 +1341,10 @@ compute_cr_origin(int origin_depth, _Py_frame *current_frame)
     }
     frame = current_frame;
     for (int i = 0; i < frame_count; ++i) {
-        PyCodeObject *code = frame->f_code;
+        PyCodeObject *code = frame->code;
         PyObject *frameinfo = Py_BuildValue("OiO",
                                             code->co_filename,
-                                            PyCode_Addr2Line(frame->f_code, frame->f_lasti*sizeof(_Py_CODEUNIT)),
+                                            PyCode_Addr2Line(frame->code, frame->f_lasti*sizeof(_Py_CODEUNIT)),
                                             code->co_name);
         if (!frameinfo) {
             Py_DECREF(cr_origin);

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -352,15 +352,15 @@ _PyGen_yf(PyGenObject *gen)
         PyObject *bytecode = gen->gi_code->co_code;
         unsigned char *code = (unsigned char *)PyBytes_AS_STRING(bytecode);
 
-        if (frame->f_lasti < 1) {
+        if (frame->lasti < 1) {
             /* Return immediately if the frame didn't start yet. SEND
                always come after LOAD_CONST: a code object should not start
                with SEND */
             assert(code[0] != SEND);
             return NULL;
         }
-        int opcode = code[(frame->f_lasti+1)*sizeof(_Py_CODEUNIT)];
-        int oparg = code[(frame->f_lasti+1)*sizeof(_Py_CODEUNIT)+1];
+        int opcode = code[(frame->lasti+1)*sizeof(_Py_CODEUNIT)];
+        int oparg = code[(frame->lasti+1)*sizeof(_Py_CODEUNIT)+1];
         if (opcode != RESUME || oparg < 2) {
             /* Not in a yield from */
             return NULL;
@@ -486,14 +486,14 @@ _gen_throw(PyGenObject *gen, int close_on_genexit,
             assert(ret == yf);
             Py_DECREF(ret);
             /* Termination repetition of SEND loop */
-            assert(frame->f_lasti >= 0);
+            assert(frame->lasti >= 0);
             PyObject *bytecode = gen->gi_code->co_code;
             unsigned char *code = (unsigned char *)PyBytes_AS_STRING(bytecode);
             /* Backup to SEND */
-            frame->f_lasti--;
-            assert(code[frame->f_lasti*sizeof(_Py_CODEUNIT)] == SEND);
-            int jump = code[frame->f_lasti*sizeof(_Py_CODEUNIT)+1];
-            frame->f_lasti += jump;
+            frame->lasti--;
+            assert(code[frame->lasti*sizeof(_Py_CODEUNIT)] == SEND);
+            int jump = code[frame->lasti*sizeof(_Py_CODEUNIT)+1];
+            frame->lasti += jump;
             if (_PyGen_FetchStopIterationValue(&val) == 0) {
                 ret = gen_send(gen, val);
                 Py_DECREF(val);
@@ -1344,7 +1344,7 @@ compute_cr_origin(int origin_depth, _Py_frame *current_frame)
         PyCodeObject *code = frame->code;
         PyObject *frameinfo = Py_BuildValue("OiO",
                                             code->co_filename,
-                                            PyCode_Addr2Line(frame->code, frame->f_lasti*sizeof(_Py_CODEUNIT)),
+                                            PyCode_Addr2Line(frame->code, frame->lasti*sizeof(_Py_CODEUNIT)),
                                             code->co_name);
         if (!frameinfo) {
             Py_DECREF(cr_origin);

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -964,7 +964,7 @@ static PyObject *
 gen_new_with_qualname(PyTypeObject *type, PyFrameObject *f,
                       PyObject *name, PyObject *qualname)
 {
-    PyCodeObject *code = f->f_frame->code;
+    PyCodeObject *code = f->f_fdata->code;
     int size = code->co_nlocalsplus + code->co_stacksize;
     PyGenObject *gen = PyObject_GC_NewVar(PyGenObject, type, size);
     if (gen == NULL) {
@@ -972,14 +972,14 @@ gen_new_with_qualname(PyTypeObject *type, PyFrameObject *f,
         return NULL;
     }
     /* Copy the frame */
-    assert(f->f_frame->frame_obj == NULL);
+    assert(f->f_fdata->frame_obj == NULL);
     assert(f->f_owns_frame);
     _Py_frame *frame = (_Py_frame *)gen->gi_iframe;
     _PyFrame_Copy((_Py_frame *)f->_f_frame_data, frame);
     gen->gi_frame_valid = 1;
     assert(frame->frame_obj == f);
     f->f_owns_frame = 0;
-    f->f_frame = frame;
+    f->f_fdata = frame;
     frame->is_generator = true;
     assert(PyObject_GC_IsTracked((PyObject *)f));
     gen->gi_code = PyFrame_GetCode(f);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -12,7 +12,7 @@
 #include "pycore_typeobject.h"    // struct type_cache
 #include "pycore_unionobject.h"   // _Py_union_type_or
 #include "frameobject.h"          // PyFrameObject
-#include "pycore_frame.h"         // _PyInterpreterFrame
+#include "pycore_frame.h"         // _Py_frame
 #include "opcode.h"               // MAKE_CELL
 #include "structmember.h"         // PyMemberDef
 
@@ -8933,7 +8933,7 @@ super_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 }
 
 static int
-super_init_without_args(_PyInterpreterFrame *cframe, PyCodeObject *co,
+super_init_without_args(_Py_frame *cframe, PyCodeObject *co,
                         PyTypeObject **type_p, PyObject **obj_p)
 {
     if (co->co_argcount == 0) {
@@ -9026,7 +9026,7 @@ super_init_impl(PyObject *self, PyTypeObject *type, PyObject *obj) {
         /* Call super(), without args -- fill in from __class__
            and first local variable on the stack. */
         PyThreadState *tstate = _PyThreadState_GET();
-        _PyInterpreterFrame *cframe = tstate->cframe->current_frame;
+        _Py_frame *cframe = tstate->cframe->current_frame;
         if (cframe == NULL) {
             PyErr_SetString(PyExc_RuntimeError,
                             "super(): no current frame");

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8942,7 +8942,7 @@ super_init_without_args(_Py_frame *cframe, PyCodeObject *co,
         return -1;
     }
 
-    assert(cframe->f_code->co_nlocalsplus > 0);
+    assert(cframe->code->co_nlocalsplus > 0);
     PyObject *firstarg = _PyFrame_GetLocalsArray(cframe)[0];
     // The first argument might be a cell.
     if (firstarg != NULL && (_PyLocals_GetKind(co->co_localspluskinds, 0) & CO_FAST_CELL)) {
@@ -9032,7 +9032,7 @@ super_init_impl(PyObject *self, PyTypeObject *type, PyObject *obj) {
                             "super(): no current frame");
             return -1;
         }
-        int res = super_init_without_args(cframe, cframe->f_code, &type, &obj);
+        int res = super_init_without_args(cframe, cframe->code, &type, &obj);
 
         if (res < 0) {
             return -1;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -9026,13 +9026,13 @@ super_init_impl(PyObject *self, PyTypeObject *type, PyObject *obj) {
         /* Call super(), without args -- fill in from __class__
            and first local variable on the stack. */
         PyThreadState *tstate = _PyThreadState_GET();
-        _Py_frame *cframe = tstate->cframe->current_frame;
-        if (cframe == NULL) {
+        _Py_frame *frame = tstate->cframe->current_frame;
+        if (frame == NULL) {
             PyErr_SetString(PyExc_RuntimeError,
                             "super(): no current frame");
             return -1;
         }
-        int res = super_init_without_args(cframe, cframe->code, &type, &obj);
+        int res = super_init_without_args(frame, frame->code, &type, &obj);
 
         if (res < 0) {
             return -1;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8933,7 +8933,7 @@ super_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 }
 
 static int
-super_init_without_args(_Py_frame *cframe, PyCodeObject *co,
+super_init_without_args(_Py_frame *frame, PyCodeObject *co,
                         PyTypeObject **type_p, PyObject **obj_p)
 {
     if (co->co_argcount == 0) {
@@ -8942,13 +8942,13 @@ super_init_without_args(_Py_frame *cframe, PyCodeObject *co,
         return -1;
     }
 
-    assert(cframe->code->co_nlocalsplus > 0);
-    PyObject *firstarg = _PyFrame_GetLocalsArray(cframe)[0];
+    assert(frame->code->co_nlocalsplus > 0);
+    PyObject *firstarg = _PyFrame_GetLocalsArray(frame)[0];
     // The first argument might be a cell.
     if (firstarg != NULL && (_PyLocals_GetKind(co->co_localspluskinds, 0) & CO_FAST_CELL)) {
         // "firstarg" is a cell here unless (very unlikely) super()
         // was called from the C-API before the first MAKE_CELL op.
-        if (cframe->lasti >= 0) {
+        if (frame->lasti >= 0) {
             assert(_Py_OPCODE(*co->co_firstinstr) == MAKE_CELL || _Py_OPCODE(*co->co_firstinstr) == COPY_FREE_VARS);
             assert(PyCell_Check(firstarg));
             firstarg = PyCell_GET(firstarg);
@@ -8968,7 +8968,7 @@ super_init_without_args(_Py_frame *cframe, PyCodeObject *co,
         PyObject *name = PyTuple_GET_ITEM(co->co_localsplusnames, i);
         assert(PyUnicode_Check(name));
         if (_PyUnicode_Equal(name, &_Py_ID(__class__))) {
-            PyObject *cell = _PyFrame_GetLocalsArray(cframe)[i];
+            PyObject *cell = _PyFrame_GetLocalsArray(frame)[i];
             if (cell == NULL || !PyCell_Check(cell)) {
                 PyErr_SetString(PyExc_RuntimeError,
                   "super(): bad __class__ cell");

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8948,7 +8948,7 @@ super_init_without_args(_Py_frame *cframe, PyCodeObject *co,
     if (firstarg != NULL && (_PyLocals_GetKind(co->co_localspluskinds, 0) & CO_FAST_CELL)) {
         // "firstarg" is a cell here unless (very unlikely) super()
         // was called from the C-API before the first MAKE_CELL op.
-        if (cframe->f_lasti >= 0) {
+        if (cframe->lasti >= 0) {
             assert(_Py_OPCODE(*co->co_firstinstr) == MAKE_CELL || _Py_OPCODE(*co->co_firstinstr) == COPY_FREE_VARS);
             assert(PyCell_Check(firstarg));
             firstarg = PyCell_GET(firstarg);

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -849,7 +849,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
     }
     else {
         globals = f->f_frame->globals;
-        *filename = f->f_frame->f_code->co_filename;
+        *filename = f->f_frame->code->co_filename;
         Py_INCREF(*filename);
         *lineno = PyFrame_GetLineNumber(f);
         Py_DECREF(f);

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -848,8 +848,8 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
         *lineno = 1;
     }
     else {
-        globals = f->f_frame->globals;
-        *filename = f->f_frame->code->co_filename;
+        globals = f->f_fdata->globals;
+        *filename = f->f_fdata->code->co_filename;
         Py_INCREF(*filename);
         *lineno = PyFrame_GetLineNumber(f);
         Py_DECREF(f);

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -848,7 +848,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
         *lineno = 1;
     }
     else {
-        globals = f->f_frame->f_globals;
+        globals = f->f_frame->globals;
         *filename = f->f_frame->f_code->co_filename;
         Py_INCREF(*filename);
         *lineno = PyFrame_GetLineNumber(f);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1442,7 +1442,7 @@ eval_frame_handle_pending(PyThreadState *tstate)
 
 
 #define GLOBALS() frame->globals
-#define BUILTINS() frame->f_builtins
+#define BUILTINS() frame->builtins
 #define LOCALS() frame->f_locals
 
 /* Shared opcode macros */
@@ -6934,7 +6934,7 @@ _PyEval_GetBuiltins(PyThreadState *tstate)
 {
     _Py_frame *frame = tstate->cframe->current_frame;
     if (frame != NULL) {
-        return frame->f_builtins;
+        return frame->builtins;
     }
     return tstate->interp->builtins;
 }
@@ -7205,7 +7205,7 @@ import_name(PyThreadState *tstate, _Py_frame *frame,
     PyObject *import_func, *res;
     PyObject* stack[5];
 
-    import_func = _PyDict_GetItemWithError(frame->f_builtins, &_Py_ID(__import__));
+    import_func = _PyDict_GetItemWithError(frame->builtins, &_Py_ID(__import__));
     if (import_func == NULL) {
         if (!_PyErr_Occurred(tstate)) {
             _PyErr_SetString(tstate, PyExc_ImportError, "__import__ not found");

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1443,7 +1443,7 @@ eval_frame_handle_pending(PyThreadState *tstate)
 
 #define GLOBALS() frame->globals
 #define BUILTINS() frame->builtins
-#define LOCALS() frame->f_locals
+#define LOCALS() frame->locals
 
 /* Shared opcode macros */
 
@@ -5284,7 +5284,7 @@ handle_eval_breaker:
             }
             /* Make sure that frame is in a valid state */
             frame->stacktop = 0;
-            frame->f_locals = NULL;
+            frame->locals = NULL;
             Py_INCREF(frame->func);
             Py_INCREF(frame->f_code);
             /* Restore previous cframe and return. */
@@ -6981,7 +6981,7 @@ PyEval_GetLocals(void)
         return NULL;
     }
 
-    PyObject *locals = current_frame->f_locals;
+    PyObject *locals = current_frame->locals;
     assert(locals != NULL);
     return locals;
 }
@@ -7212,7 +7212,7 @@ import_name(PyThreadState *tstate, _Py_frame *frame,
         }
         return NULL;
     }
-    PyObject *locals = frame->f_locals;
+    PyObject *locals = frame->locals;
     /* Fast path for not overloaded __import__. */
     if (import_func == tstate->interp->import_func) {
         int ilevel = _PyLong_AsInt(level);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1739,7 +1739,7 @@ handle_eval_breaker:
             PREDICTED(RESUME_QUICK);
             assert(tstate->cframe == &cframe);
             assert(frame == cframe.current_frame);
-            frame->f_state = FRAME_EXECUTING;
+            frame->state = FRAME_EXECUTING;
             if (_Py_atomic_load_relaxed(eval_breaker) && oparg < 2) {
                 goto handle_eval_breaker;
             }
@@ -2382,7 +2382,7 @@ handle_eval_breaker:
         TARGET(RETURN_VALUE) {
             PyObject *retval = POP();
             assert(EMPTY());
-            frame->f_state = FRAME_RETURNED;
+            frame->state = FRAME_RETURNED;
             _PyFrame_SetStackPointer(frame, stack_pointer);
             TRACE_FUNCTION_EXIT();
             DTRACE_FUNCTION_EXIT();
@@ -2594,7 +2594,7 @@ handle_eval_breaker:
         TARGET(YIELD_VALUE) {
             assert(frame->is_entry);
             PyObject *retval = POP();
-            frame->f_state = FRAME_SUSPENDED;
+            frame->state = FRAME_SUSPENDED;
             _PyFrame_SetStackPointer(frame, stack_pointer);
             TRACE_FUNCTION_EXIT();
             DTRACE_FUNCTION_EXIT();
@@ -4086,7 +4086,7 @@ handle_eval_breaker:
              * generator or coroutine, so we deliberately do not check it here.
              * (see bpo-30039).
              */
-            frame->f_state = FRAME_EXECUTING;
+            frame->state = FRAME_EXECUTING;
             JUMPTO(oparg);
             DISPATCH();
         }
@@ -5273,7 +5273,7 @@ handle_eval_breaker:
             assert(frame->frame_obj == NULL);
             gen->gi_frame_valid = 1;
             gen_frame->is_generator = true;
-            gen_frame->f_state = FRAME_CREATED;
+            gen_frame->state = FRAME_CREATED;
             _Py_LeaveRecursiveCall(tstate);
             if (!frame->is_entry) {
                 _Py_frame *prev = frame->previous;
@@ -5454,7 +5454,7 @@ handle_eval_breaker:
                 TRACE_FUNCTION_ENTRY();
                 DTRACE_FUNCTION_ENTRY();
             }
-            else if (frame->f_state > FRAME_CREATED) {
+            else if (frame->state > FRAME_CREATED) {
                 /* line-by-line tracing support */
                 if (PyDTrace_LINE_ENABLED()) {
                     maybe_dtrace_line(frame, &tstate->trace_info, instr_prev);
@@ -5575,13 +5575,13 @@ error:
 
         if (tstate->c_tracefunc != NULL) {
             /* Make sure state is set to FRAME_UNWINDING for tracing */
-            frame->f_state = FRAME_UNWINDING;
+            frame->state = FRAME_UNWINDING;
             call_exc_trace(tstate->c_tracefunc, tstate->c_traceobj,
                            tstate, frame);
         }
 
 exception_unwind:
-        frame->f_state = FRAME_UNWINDING;
+        frame->state = FRAME_UNWINDING;
         /* We can't use frame->lasti here, as RERAISE may have set it */
         int offset = INSTR_OFFSET()-1;
         int level, handler, lasti;
@@ -5597,7 +5597,7 @@ exception_unwind:
             }
             assert(STACK_LEVEL() == 0);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            frame->f_state = FRAME_RAISED;
+            frame->state = FRAME_RAISED;
             TRACE_FUNCTION_UNWIND();
             DTRACE_FUNCTION_EXIT();
             goto exit_unwind;
@@ -5632,7 +5632,7 @@ exception_unwind:
         PUSH(val);
         JUMPTO(handler);
         /* Resume normal execution */
-        frame->f_state = FRAME_EXECUTING;
+        frame->state = FRAME_EXECUTING;
         DISPATCH();
     }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3155,7 +3155,7 @@ handle_eval_breaker:
         TARGET(COPY_FREE_VARS) {
             /* Copy closure variables to free variables */
             PyCodeObject *co = frame->f_code;
-            PyObject *closure = frame->f_func->func_closure;
+            PyObject *closure = frame->func->func_closure;
             int offset = co->co_nlocals + co->co_nplaincellvars;
             assert(oparg == co->co_nfreevars);
             for (int i = 0; i < oparg; ++i) {
@@ -5262,7 +5262,7 @@ handle_eval_breaker:
         }
 
         TARGET(RETURN_GENERATOR) {
-            PyGenObject *gen = (PyGenObject *)_Py_MakeCoro(frame->f_func);
+            PyGenObject *gen = (PyGenObject *)_Py_MakeCoro(frame->func);
             if (gen == NULL) {
                 goto error;
             }
@@ -5285,7 +5285,7 @@ handle_eval_breaker:
             /* Make sure that frame is in a valid state */
             frame->stacktop = 0;
             frame->f_locals = NULL;
-            Py_INCREF(frame->f_func);
+            Py_INCREF(frame->func);
             Py_INCREF(frame->f_code);
             /* Restore previous cframe and return. */
             tstate->cframe = cframe.previous;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1111,14 +1111,14 @@ PyEval_EvalFrame(PyFrameObject *f)
 {
     /* Function kept for backward compatibility */
     PyThreadState *tstate = _PyThreadState_GET();
-    return _PyEval_EvalFrame(tstate, f->f_frame, 0);
+    return _PyEval_EvalFrame(tstate, f->f_fdata, 0);
 }
 
 PyObject *
 PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    return _PyEval_EvalFrame(tstate, f->f_frame, throwflag);
+    return _PyEval_EvalFrame(tstate, f->f_fdata, throwflag);
 }
 
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1441,7 +1441,7 @@ eval_frame_handle_pending(PyThreadState *tstate)
 #define UPDATE_PREV_INSTR_OPARG(instr, oparg) ((uint8_t*)(instr))[-1] = (oparg)
 
 
-#define GLOBALS() frame->f_globals
+#define GLOBALS() frame->globals
 #define BUILTINS() frame->f_builtins
 #define LOCALS() frame->f_locals
 
@@ -6994,7 +6994,7 @@ PyEval_GetGlobals(void)
     if (current_frame == NULL) {
         return NULL;
     }
-    return current_frame->f_globals;
+    return current_frame->globals;
 }
 
 int
@@ -7221,7 +7221,7 @@ import_name(PyThreadState *tstate, _Py_frame *frame,
         }
         res = PyImport_ImportModuleLevelObject(
                         name,
-                        frame->f_globals,
+                        frame->globals,
                         locals == NULL ? Py_None :locals,
                         fromlist,
                         ilevel);
@@ -7231,7 +7231,7 @@ import_name(PyThreadState *tstate, _Py_frame *frame,
     Py_INCREF(import_func);
 
     stack[0] = name;
-    stack[1] = frame->f_globals;
+    stack[1] = frame->globals;
     stack[2] = locals == NULL ? Py_None : locals;
     stack[3] = fromlist;
     stack[4] = level;

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -10,7 +10,7 @@ int
 _PyFrame_Traverse(_Py_frame *frame, visitproc visit, void *arg)
 {
     Py_VISIT(frame->frame_obj);
-    Py_VISIT(frame->f_locals);
+    Py_VISIT(frame->locals);
     Py_VISIT(frame->func);
     Py_VISIT(frame->f_code);
    /* locals */
@@ -104,7 +104,7 @@ _PyFrame_Clear(_Py_frame *frame)
         Py_XDECREF(frame->localsplus[i]);
     }
     Py_XDECREF(frame->frame_obj);
-    Py_XDECREF(frame->f_locals);
+    Py_XDECREF(frame->locals);
     Py_DECREF(frame->func);
     Py_DECREF(frame->f_code);
 }

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -59,8 +59,8 @@ take_ownership(PyFrameObject *f, _Py_frame *frame)
 {
     assert(f->f_owns_frame == 0);
     Py_ssize_t size = ((char*)&frame->localsplus[frame->stacktop]) - (char *)frame;
-    memcpy((_Py_frame *)f->_f_frame_data, frame, size);
-    frame = (_Py_frame *)f->_f_frame_data;
+    memcpy((_Py_frame *)f->_f_owned_fdata, frame, size);
+    frame = (_Py_frame *)f->_f_owned_fdata;
     f->f_owns_frame = 1;
     f->f_fdata = frame;
     assert(f->f_back == NULL);

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -12,7 +12,7 @@ _PyFrame_Traverse(_Py_frame *frame, visitproc visit, void *arg)
     Py_VISIT(frame->frame_obj);
     Py_VISIT(frame->locals);
     Py_VISIT(frame->func);
-    Py_VISIT(frame->f_code);
+    Py_VISIT(frame->code);
    /* locals */
     PyObject **locals = _PyFrame_GetLocalsArray(frame);
     int i = 0;
@@ -30,7 +30,7 @@ _PyFrame_MakeAndSetFrameObject(_Py_frame *frame)
     PyObject *error_type, *error_value, *error_traceback;
     PyErr_Fetch(&error_type, &error_value, &error_traceback);
 
-    PyFrameObject *f = _PyFrame_New_NoTrack(frame->f_code);
+    PyFrameObject *f = _PyFrame_New_NoTrack(frame->code);
     if (f == NULL) {
         Py_XDECREF(error_type);
         Py_XDECREF(error_value);
@@ -48,7 +48,7 @@ _PyFrame_MakeAndSetFrameObject(_Py_frame *frame)
 void
 _PyFrame_Copy(_Py_frame *src, _Py_frame *dest)
 {
-    assert(src->stacktop >= src->f_code->co_nlocalsplus);
+    assert(src->stacktop >= src->code->co_nlocalsplus);
     Py_ssize_t size = ((char*)&src->localsplus[src->stacktop]) - (char *)src;
     memcpy(dest, src, size);
 }
@@ -106,7 +106,7 @@ _PyFrame_Clear(_Py_frame *frame)
     Py_XDECREF(frame->frame_obj);
     Py_XDECREF(frame->locals);
     Py_DECREF(frame->func);
-    Py_DECREF(frame->f_code);
+    Py_DECREF(frame->code);
 }
 
 /* Consumes reference to func */

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -38,7 +38,7 @@ _PyFrame_MakeAndSetFrameObject(_Py_frame *frame)
     }
     else {
         f->f_owns_frame = 0;
-        f->f_frame = frame;
+        f->f_fdata = frame;
         frame->frame_obj = f;
         PyErr_Restore(error_type, error_value, error_traceback);
     }
@@ -62,7 +62,7 @@ take_ownership(PyFrameObject *f, _Py_frame *frame)
     memcpy((_Py_frame *)f->_f_frame_data, frame, size);
     frame = (_Py_frame *)f->_f_frame_data;
     f->f_owns_frame = 1;
-    f->f_frame = frame;
+    f->f_fdata = frame;
     assert(f->f_back == NULL);
     if (frame->previous != NULL) {
         /* Link PyFrameObjects.f_back and remove link through _Py_frame.previous */

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -11,7 +11,7 @@ _PyFrame_Traverse(_Py_frame *frame, visitproc visit, void *arg)
 {
     Py_VISIT(frame->frame_obj);
     Py_VISIT(frame->f_locals);
-    Py_VISIT(frame->f_func);
+    Py_VISIT(frame->func);
     Py_VISIT(frame->f_code);
    /* locals */
     PyObject **locals = _PyFrame_GetLocalsArray(frame);
@@ -105,7 +105,7 @@ _PyFrame_Clear(_Py_frame *frame)
     }
     Py_XDECREF(frame->frame_obj);
     Py_XDECREF(frame->f_locals);
-    Py_DECREF(frame->f_func);
+    Py_DECREF(frame->func);
     Py_DECREF(frame->f_code);
 }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1393,7 +1393,7 @@ _PyThread_CurrentFrames(void)
     for (i = runtime->interpreters.head; i != NULL; i = i->next) {
         PyThreadState *t;
         for (t = i->threads.head; t != NULL; t = t->next) {
-            _PyInterpreterFrame *frame = t->cframe->current_frame;
+            _Py_frame *frame = t->cframe->current_frame;
             if (frame == NULL) {
                 continue;
             }
@@ -2180,7 +2180,7 @@ push_chunk(PyThreadState *tstate, int size)
     return res;
 }
 
-_PyInterpreterFrame *
+_Py_frame *
 _PyThreadState_BumpFramePointerSlow(PyThreadState *tstate, size_t size)
 {
     assert(size < INT_MAX/sizeof(PyObject *));
@@ -2192,11 +2192,11 @@ _PyThreadState_BumpFramePointerSlow(PyThreadState *tstate, size_t size)
     else {
         tstate->datastack_top = top;
     }
-    return (_PyInterpreterFrame *)base;
+    return (_Py_frame *)base;
 }
 
 void
-_PyThreadState_PopFrame(PyThreadState *tstate, _PyInterpreterFrame * frame)
+_PyThreadState_PopFrame(PyThreadState *tstate, _Py_frame * frame)
 {
     assert(tstate->datastack_chunk);
     PyObject **base = (PyObject **)frame;

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -240,7 +240,7 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
         return suggestions;
     }
 
-    dir = PySequence_List(frame->f_frame->globals);
+    dir = PySequence_List(frame->f_fdata->globals);
     if (dir == NULL) {
         return NULL;
     }
@@ -250,7 +250,7 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
         return suggestions;
     }
 
-    dir = PySequence_List(frame->f_frame->builtins);
+    dir = PySequence_List(frame->f_fdata->builtins);
     if (dir == NULL) {
         return NULL;
     }

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -250,7 +250,7 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
         return suggestions;
     }
 
-    dir = PySequence_List(frame->f_frame->f_builtins);
+    dir = PySequence_List(frame->f_frame->builtins);
     if (dir == NULL) {
         return NULL;
     }

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -240,7 +240,7 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
         return suggestions;
     }
 
-    dir = PySequence_List(frame->f_frame->f_globals);
+    dir = PySequence_List(frame->f_frame->globals);
     if (dir == NULL) {
         return NULL;
     }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -18,7 +18,7 @@ Data members:
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_ceval.h"         // _Py_RecursionLimitLowerWaterMark()
 #include "pycore_code.h"          // _Py_QuickenedCount
-#include "pycore_frame.h"         // _PyInterpreterFrame
+#include "pycore_frame.h"         // _Py_frame
 #include "pycore_initconfig.h"    // _PyStatus_EXCEPTION()
 #include "pycore_namespace.h"     // _PyNamespace_New()
 #include "pycore_object.h"        // _PyObject_IS_GC()
@@ -1771,7 +1771,7 @@ sys__getframe_impl(PyObject *module, int depth)
 /*[clinic end generated code: output=d438776c04d59804 input=c1be8a6464b11ee5]*/
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    _PyInterpreterFrame *frame = tstate->cframe->current_frame;
+    _Py_frame *frame = tstate->cframe->current_frame;
 
     if (_PySys_Audit(tstate, "sys._getframe", NULL) < 0) {
         return NULL;

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -791,7 +791,7 @@ tb_displayline(PyTracebackObject* tb, PyObject *f, PyObject *filename, int linen
     }
 
     int code_offset = tb->tb_lasti;
-    PyCodeObject* code = frame->f_frame->f_code;
+    PyCodeObject* code = frame->f_frame->code;
 
     int start_line;
     int end_line;
@@ -1169,7 +1169,7 @@ done:
 static void
 dump_frame(int fd, _Py_frame *frame)
 {
-    PyCodeObject *code = frame->f_code;
+    PyCodeObject *code = frame->code;
     PUTS(fd, "  File ");
     if (code->co_filename != NULL
         && PyUnicode_Check(code->co_filename))

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -240,7 +240,7 @@ _PyTraceBack_FromFrame(PyObject *tb_next, PyFrameObject *frame)
     assert(tb_next == NULL || PyTraceBack_Check(tb_next));
     assert(frame != NULL);
 
-    return tb_create_raw((PyTracebackObject *)tb_next, frame, frame->f_frame->f_lasti*sizeof(_Py_CODEUNIT),
+    return tb_create_raw((PyTracebackObject *)tb_next, frame, frame->f_frame->lasti*sizeof(_Py_CODEUNIT),
                          PyFrame_GetLineNumber(frame));
 }
 
@@ -1181,7 +1181,7 @@ dump_frame(int fd, _Py_frame *frame)
         PUTS(fd, "???");
     }
 
-    int lineno = PyCode_Addr2Line(code, frame->f_lasti*sizeof(_Py_CODEUNIT));
+    int lineno = PyCode_Addr2Line(code, frame->lasti*sizeof(_Py_CODEUNIT));
     PUTS(fd, ", line ");
     if (lineno >= 0) {
         _Py_DumpDecimal(fd, (size_t)lineno);

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -240,7 +240,7 @@ _PyTraceBack_FromFrame(PyObject *tb_next, PyFrameObject *frame)
     assert(tb_next == NULL || PyTraceBack_Check(tb_next));
     assert(frame != NULL);
 
-    return tb_create_raw((PyTracebackObject *)tb_next, frame, frame->f_frame->lasti*sizeof(_Py_CODEUNIT),
+    return tb_create_raw((PyTracebackObject *)tb_next, frame, frame->f_fdata->lasti*sizeof(_Py_CODEUNIT),
                          PyFrame_GetLineNumber(frame));
 }
 
@@ -791,7 +791,7 @@ tb_displayline(PyTracebackObject* tb, PyObject *f, PyObject *filename, int linen
     }
 
     int code_offset = tb->tb_lasti;
-    PyCodeObject* code = frame->f_frame->code;
+    PyCodeObject* code = frame->f_fdata->code;
 
     int start_line;
     int end_line;

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -1167,7 +1167,7 @@ done:
    This function is signal safe. */
 
 static void
-dump_frame(int fd, _PyInterpreterFrame *frame)
+dump_frame(int fd, _Py_frame *frame)
 {
     PyCodeObject *code = frame->f_code;
     PUTS(fd, "  File ");
@@ -1205,7 +1205,7 @@ dump_frame(int fd, _PyInterpreterFrame *frame)
 static void
 dump_traceback(int fd, PyThreadState *tstate, int write_header)
 {
-    _PyInterpreterFrame *frame;
+    _Py_frame *frame;
     unsigned int depth;
 
     if (write_header) {

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1003,7 +1003,7 @@ class PyFramePtr:
         return convert(self._gdbval[name])
 
     def _f_globals(self):
-        return self._f_special("f_globals")
+        return self._f_special("globals")
 
     def _f_builtins(self):
         return self._f_special("f_builtins")

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1006,7 +1006,7 @@ class PyFramePtr:
         return self._f_special("globals")
 
     def _f_builtins(self):
-        return self._f_special("f_builtins")
+        return self._f_special("builtins")
 
     def _f_code(self):
         return self._f_special("f_code", PyCodeObjectPtr.from_pyobject_ptr)

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -971,7 +971,7 @@ class PyFramePtr:
             self.co_name = self.co.pyop_field('co_name')
             self.co_filename = self.co.pyop_field('co_filename')
 
-            self.f_lasti = self._f_lasti()
+            self.lasti = self._f_lasti()
             self.co_nlocals = int_from_int(self.co.field('co_nlocals'))
             pnames = self.co.field('co_localsplusnames')
             self.co_localsplusnames = PyTupleObjectPtr.from_pyobject_ptr(pnames)
@@ -1015,7 +1015,7 @@ class PyFramePtr:
         return self._f_special("nlocalsplus", int_from_int)
 
     def _f_lasti(self):
-        return self._f_special("f_lasti", int_from_int)
+        return self._f_special("lasti", int_from_int)
 
     def is_entry(self):
         return self._f_special("is_entry", bool)
@@ -1079,7 +1079,7 @@ class PyFramePtr:
         if self.is_optimized_out():
             return None
         try:
-            return self.co.addr2line(self.f_lasti*2)
+            return self.co.addr2line(self.lasti*2)
         except Exception:
             # bpo-34989: addr2line() is a complex function, it can fail in many
             # ways. For example, it fails with a TypeError on "FakeRepr" if

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1009,7 +1009,7 @@ class PyFramePtr:
         return self._f_special("builtins")
 
     def _f_code(self):
-        return self._f_special("f_code", PyCodeObjectPtr.from_pyobject_ptr)
+        return self._f_special("code", PyCodeObjectPtr.from_pyobject_ptr)
 
     def _f_nlocalsplus(self):
         return self._f_special("nlocalsplus", int_from_int)

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -890,7 +890,7 @@ class PyFrameObjectPtr(PyObjectPtr):
         PyObjectPtr.__init__(self, gdbval, cast_to)
 
         if not self.is_optimized_out():
-            self._frame = PyFramePtr(self.field('f_frame'))
+            self._frame = PyFramePtr(self.field('f_fdata'))
 
     def iter_locals(self):
         '''


### PR DESCRIPTION
* rename `_PyInterpreterFrame` to `_Py_frame` to help indicate that `_Py_frame`
  is an implementation optimisation for frame objects rather than a distinct concept
* remove `f_` prefix from `_Py_frame` fields that currently have it so presence or
  absence of the prefix disambiguates `PyFrameObject` and `_Py_frame` pointers
  when reading code snippets without their type declarations in code diffs
* rename `f_frame` to `f_fdata` to avoid the odd `frame->f_frame` construct
* rename `_f_frame_data` to `_f_owned_fdata` to avoid confusion with `f_fdata`
* convert a potentially confusing use of `cframe` as a variable name to just `frame`
* add a block comment to `pycore_frame.h` covering the naming conventions

<!-- issue-number: [bpo-44800](https://bugs.python.org/issue44800) -->
https://bugs.python.org/issue44800
<!-- /issue-number -->
