### PR TITLE
bpo-39394: Improve warning message in the re module

### DIFF
--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -807,9 +807,11 @@ def _parse(source, state, verbose, nested, first=False):
                         if not first or subpattern:
                             import warnings
                             warnings.warn(
-                                'Flags not at the start of the expression %r%s' % (
+                                'Flags not at the start of the expression %r%s'
+                                ' but at position %d' % (
                                     source.string[:20],  # truncate long regexes
                                     ' (truncated)' if len(source.string) > 20 else '',
+                                    start,
                                 ),
                                 DeprecationWarning, stacklevel=nested + 6
                             )

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1444,7 +1444,8 @@ class ReTests(unittest.TestCase):
             self.assertTrue(re.match(p, lower_char))
         self.assertEqual(
             str(warns.warnings[0].message),
-            'Flags not at the start of the expression %r' % p
+            'Flags not at the start of the expression %r'
+            ' but at position 1' % p
         )
         self.assertEqual(warns.warnings[0].filename, __file__)
 
@@ -1453,7 +1454,8 @@ class ReTests(unittest.TestCase):
             self.assertTrue(re.match(p, lower_char))
         self.assertEqual(
             str(warns.warnings[0].message),
-            'Flags not at the start of the expression %r (truncated)' % p[:20]
+            'Flags not at the start of the expression %r (truncated)'
+            ' but at position 1' % p[:20]
         )
         self.assertEqual(warns.warnings[0].filename, __file__)
 
@@ -1465,7 +1467,8 @@ class ReTests(unittest.TestCase):
                 self.assertTrue(re.match(p, b'a'))
             self.assertEqual(
                 str(warns.warnings[0].message),
-                'Flags not at the start of the expression %r' % p
+                'Flags not at the start of the expression %r'
+                ' but at position 1' % p
             )
             self.assertEqual(warns.warnings[0].filename, __file__)
 

--- a/Misc/NEWS.d/next/Library/2022-03-19-13-38-29.bpo-39394.7j6WL6.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-19-13-38-29.bpo-39394.7j6WL6.rst
@@ -1,0 +1,2 @@
+A warning about inline flags not at the start of the regular expression now
+contains the position of the flag.


### PR DESCRIPTION
A warning about inline flags not at the start of the regular
expression now contains the position of the flag.


<!-- issue-number: [bpo-39394](https://bugs.python.org/issue39394) -->
https://bugs.python.org/issue39394
<!-- /issue-number -->
