### PR TITLE
bpo-47000: Make `io.text_encoding()` respects UTF-8 mode

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -218,7 +218,7 @@ High-level Module Interface
    See :ref:`io-text-encoding` for more information.
 
    .. versionadded:: 3.10
-   
+
    .. versionchanged:: 3.11
       :func:`text_encoding` returns "utf-8" when UTF-8 mode is enabled and
       *encoding* is ``None``.

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -198,12 +198,13 @@ High-level Module Interface
    This is a helper function for callables that use :func:`open` or
    :class:`TextIOWrapper` and have an ``encoding=None`` parameter.
 
-   This function returns *encoding* if it is not ``None`` and ``"locale"`` if
-   *encoding* is ``None``.
+   This function returns *encoding* if it is not ``None``.
+   Otherwise, it returns ``"locale"`` or ``"utf-8"`` depending on
+   :ref:`UTF-8 Mode <utf8-mode>`.
 
    This function emits an :class:`EncodingWarning` if
    :data:`sys.flags.warn_default_encoding <sys.flags>` is true and *encoding*
-   is None. *stacklevel* specifies where the warning is emitted.
+   is ``None``. *stacklevel* specifies where the warning is emitted.
    For example::
 
       def read_text(path, encoding=None):
@@ -217,6 +218,10 @@ High-level Module Interface
    See :ref:`io-text-encoding` for more information.
 
    .. versionadded:: 3.10
+   
+   .. versionchanged:: 3.11
+      :func:`text_encoding` returns "utf-8" when UTF-8 mode is enabled and
+      *encoding* is ``None``.
 
 
 .. exception:: BlockingIOError

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -48,6 +48,7 @@ struct _Py_global_strings {
         STRUCT_FOR_STR(newline, "\n")
         STRUCT_FOR_STR(open_br, "{")
         STRUCT_FOR_STR(percent, "%")
+        STRUCT_FOR_STR(utf_8, "utf-8")
     } literals;
 
     struct {

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -672,6 +672,7 @@ extern "C" {
                 INIT_STR(newline, "\n"), \
                 INIT_STR(open_br, "{"), \
                 INIT_STR(percent, "%"), \
+                INIT_STR(utf_8, "utf-8"), \
             }, \
             .identifiers = { \
                 INIT_ID(False), \

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -44,9 +44,9 @@ def text_encoding(encoding, stacklevel=2):
     """
     A helper function to choose the text encoding.
 
-    When encoding is not None, just return it.
-    Otherwise, return the default text encoding (i.e. "locale", or "utf-8"
-    if UTF-8 mode is enabled).
+    When encoding is not None, this function returns it.
+    Otherwise, this function returns the default text encoding
+    (i.e. "locale" or "utf-8" depends on UTF-8 mode).
 
     This function emits an EncodingWarning if *encoding* is None and
     sys.flags.warn_default_encoding is true.

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -45,7 +45,8 @@ def text_encoding(encoding, stacklevel=2):
     A helper function to choose the text encoding.
 
     When encoding is not None, just return it.
-    Otherwise, return the default text encoding (i.e. "locale").
+    Otherwise, return the default text encoding (i.e. "locale", or "utf-8"
+    if UTF-8 mode is enabled).
 
     This function emits an EncodingWarning if *encoding* is None and
     sys.flags.warn_default_encoding is true.
@@ -55,7 +56,10 @@ def text_encoding(encoding, stacklevel=2):
     However, please consider using encoding="utf-8" for new APIs.
     """
     if encoding is None:
-        encoding = "locale"
+        if sys.flags.utf8_mode:
+            encoding = "utf-8"
+        else:
+            encoding = "locale"
         if sys.flags.warn_default_encoding:
             import warnings
             warnings.warn("'encoding' argument not specified.",

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4289,6 +4289,17 @@ class MiscIOTest(unittest.TestCase):
         self.assertTrue(
             warnings[1].startswith(b"<string>:8: EncodingWarning: "))
 
+    def test_text_encoding(self):
+        # PEP 597, bpo-47000. io.text_encoding() returns "locale" or "utf-8"
+        # based on sys.flags.utf8_mode
+        code = "import io; print(io.text_encoding(None))"
+
+        proc = assert_python_ok('-X', 'utf8=0', '-c', code)
+        self.assertEqual(b"locale", proc.out.strip())
+
+        proc = assert_python_ok('-X', 'utf8=1', '-c', code)
+        self.assertEqual(b"utf-8", proc.out.strip())
+
     @support.cpython_only
     # Depending if OpenWrapper was already created or not, the warning is
     # emitted or not. For example, the attribute is already created when this

--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -161,7 +161,7 @@ class UTF8ModeTests(unittest.TestCase):
         filename = __file__
 
         out = self.get_output('-c', code, filename, PYTHONUTF8='1')
-        self.assertEqual(out, 'UTF-8/strict')
+        self.assertEqual(out.lower(), 'utf-8/strict')
 
     def _check_io_encoding(self, module, encoding=None, errors=None):
         filename = __file__
@@ -183,10 +183,10 @@ class UTF8ModeTests(unittest.TestCase):
                               PYTHONUTF8='1')
 
         if not encoding:
-            encoding = 'UTF-8'
+            encoding = 'utf-8'
         if not errors:
             errors = 'strict'
-        self.assertEqual(out, f'{encoding}/{errors}')
+        self.assertEqual(out.lower(), f'{encoding}/{errors}')
 
     def check_io_encoding(self, module):
         self._check_io_encoding(module, encoding="latin1")

--- a/Misc/NEWS.d/next/Library/2022-03-20-13-00-08.bpo-47000.p8HpG0.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-20-13-00-08.bpo-47000.p8HpG0.rst
@@ -1,0 +1,1 @@
+Make :func:`io.text_encoding` returns "utf-8" when UTF-8 mode is enabled.

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -458,7 +458,8 @@ _io.text_encoding
 A helper function to choose the text encoding.
 
 When encoding is not None, just return it.
-Otherwise, return the default text encoding (i.e. "locale").
+Otherwise, return the default text encoding (i.e. "locale", or "utf-8"
+if UTF-8 mode is enabled).
 
 This function emits an EncodingWarning if encoding is None and
 sys.flags.warn_default_encoding is true.
@@ -479,7 +480,13 @@ _io_text_encoding_impl(PyObject *module, PyObject *encoding, int stacklevel)
                 return NULL;
             }
         }
-        return &_Py_ID(locale);
+        const PyPreConfig *preconfig = &_PyRuntime.preconfig;
+        if (preconfig->utf8_mode) {
+            return &_Py_STR(utf_8);
+        }
+        else {
+            return &_Py_ID(locale);
+        }
     }
     Py_INCREF(encoding);
     return encoding;

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -470,7 +470,7 @@ However, please consider using encoding="utf-8" for new APIs.
 
 static PyObject *
 _io_text_encoding_impl(PyObject *module, PyObject *encoding, int stacklevel)
-/*[clinic end generated code: output=91b2cfea6934cc0c input=bf70231213e2a7b4]*/
+/*[clinic end generated code: output=91b2cfea6934cc0c input=350c198cb6b0d25e]*/
 {
     if (encoding == NULL || encoding == Py_None) {
         PyInterpreterState *interp = _PyInterpreterState_GET();

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -482,6 +482,7 @@ _io_text_encoding_impl(PyObject *module, PyObject *encoding, int stacklevel)
         }
         const PyPreConfig *preconfig = &_PyRuntime.preconfig;
         if (preconfig->utf8_mode) {
+            _Py_DECLARE_STR(utf_8, "utf-8");
             encoding = &_Py_STR(utf_8);
         }
         else {

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -457,9 +457,9 @@ _io.text_encoding
 
 A helper function to choose the text encoding.
 
-When encoding is not None, just return it.
-Otherwise, return the default text encoding (i.e. "locale", or "utf-8"
-if UTF-8 mode is enabled).
+When encoding is not None, this function returns it.
+Otherwise, this function returns the default text encoding
+(i.e. "locale" or "utf-8" depends on UTF-8 mode).
 
 This function emits an EncodingWarning if encoding is None and
 sys.flags.warn_default_encoding is true.

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -483,7 +483,6 @@ _io_text_encoding_impl(PyObject *module, PyObject *encoding, int stacklevel)
         const PyPreConfig *preconfig = &_PyRuntime.preconfig;
         if (preconfig->utf8_mode) {
             _Py_DECLARE_STR(utf_8, "utf-8");
-            _Py_DECLARE_STR(utf_8, "utf-8");
             encoding = &_Py_STR(utf_8);
         }
         else {

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -483,6 +483,7 @@ _io_text_encoding_impl(PyObject *module, PyObject *encoding, int stacklevel)
         const PyPreConfig *preconfig = &_PyRuntime.preconfig;
         if (preconfig->utf8_mode) {
             _Py_DECLARE_STR(utf_8, "utf-8");
+            _Py_DECLARE_STR(utf_8, "utf-8");
             encoding = &_Py_STR(utf_8);
         }
         else {

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -470,7 +470,7 @@ However, please consider using encoding="utf-8" for new APIs.
 
 static PyObject *
 _io_text_encoding_impl(PyObject *module, PyObject *encoding, int stacklevel)
-/*[clinic end generated code: output=91b2cfea6934cc0c input=350c198cb6b0d25e]*/
+/*[clinic end generated code: output=91b2cfea6934cc0c input=4999aa8b3d90f3d4]*/
 {
     if (encoding == NULL || encoding == Py_None) {
         PyInterpreterState *interp = _PyInterpreterState_GET();

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -482,10 +482,10 @@ _io_text_encoding_impl(PyObject *module, PyObject *encoding, int stacklevel)
         }
         const PyPreConfig *preconfig = &_PyRuntime.preconfig;
         if (preconfig->utf8_mode) {
-            return &_Py_STR(utf_8);
+            encoding = &_Py_STR(utf_8);
         }
         else {
-            return &_Py_ID(locale);
+            encoding = &_Py_ID(locale);
         }
     }
     Py_INCREF(encoding);

--- a/Modules/_io/clinic/_iomodule.c.h
+++ b/Modules/_io/clinic/_iomodule.c.h
@@ -274,7 +274,8 @@ PyDoc_STRVAR(_io_text_encoding__doc__,
 "A helper function to choose the text encoding.\n"
 "\n"
 "When encoding is not None, just return it.\n"
-"Otherwise, return the default text encoding (i.e. \"locale\").\n"
+"Otherwise, return the default text encoding (i.e. \"locale\", or \"utf-8\"\n"
+"if UTF-8 mode is enabled).\n"
 "\n"
 "This function emits an EncodingWarning if encoding is None and\n"
 "sys.flags.warn_default_encoding is true.\n"
@@ -354,4 +355,4 @@ _io_open_code(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6ea315343f6a94ba input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5492a6512a3d7db0 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/_iomodule.c.h
+++ b/Modules/_io/clinic/_iomodule.c.h
@@ -273,9 +273,9 @@ PyDoc_STRVAR(_io_text_encoding__doc__,
 "\n"
 "A helper function to choose the text encoding.\n"
 "\n"
-"When encoding is not None, just return it.\n"
-"Otherwise, return the default text encoding (i.e. \"locale\", or \"utf-8\"\n"
-"if UTF-8 mode is enabled).\n"
+"When encoding is not None, this function returns it.\n"
+"Otherwise, this function returns the default text encoding\n"
+"(i.e. \"locale\" or \"utf-8\" depends on UTF-8 mode).\n"
 "\n"
 "This function emits an EncodingWarning if encoding is None and\n"
 "sys.flags.warn_default_encoding is true.\n"
@@ -355,4 +355,4 @@ _io_open_code(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5492a6512a3d7db0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1a7fd7755c9a9609 input=a9049054013a1b77]*/

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -841,7 +841,8 @@ static PyObject *
 sys_getdefaultencoding_impl(PyObject *module)
 /*[clinic end generated code: output=256d19dfcc0711e6 input=d416856ddbef6909]*/
 {
-    return PyUnicode_FromString(PyUnicode_GetDefaultEncoding());
+    _Py_DECLARE_STR(utf_8, "utf-8");
+    return &_Py_STR(utf_8);
 }
 
 /*[clinic input]

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -842,7 +842,9 @@ sys_getdefaultencoding_impl(PyObject *module)
 /*[clinic end generated code: output=256d19dfcc0711e6 input=d416856ddbef6909]*/
 {
     _Py_DECLARE_STR(utf_8, "utf-8");
-    return &_Py_STR(utf_8);
+    PyObject *ret = &_Py_STR(utf_8);
+    Py_INCREF(ret);
+    return ret;
 }
 
 /*[clinic input]


### PR DESCRIPTION


<!-- issue-number: [bpo-47000](https://bugs.python.org/issue47000) -->
https://bugs.python.org/issue47000
<!-- /issue-number -->
