### PR TITLE
bpo-46850: Remove _PyEval_SetAsyncGenFinalizer()

### DIFF
--- a/Include/cpython/ceval.h
+++ b/Include/cpython/ceval.h
@@ -9,10 +9,6 @@ PyAPI_DATA(int) _PyEval_SetProfile(PyThreadState *tstate, Py_tracefunc func, PyO
 PyAPI_FUNC(void) PyEval_SetTrace(Py_tracefunc, PyObject *);
 PyAPI_FUNC(int) _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg);
 PyAPI_FUNC(int) _PyEval_GetCoroutineOriginTrackingDepth(void);
-PyAPI_FUNC(int) _PyEval_SetAsyncGenFirstiter(PyObject *);
-PyAPI_FUNC(PyObject *) _PyEval_GetAsyncGenFirstiter(void);
-PyAPI_FUNC(int) _PyEval_SetAsyncGenFinalizer(PyObject *);
-PyAPI_FUNC(PyObject *) _PyEval_GetAsyncGenFinalizer(void);
 
 /* Helper to look up a builtin object */
 PyAPI_FUNC(PyObject *) _PyEval_GetBuiltin(PyObject *);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -37,6 +37,14 @@ PyAPI_FUNC(void) _PyEval_SetCoroutineOriginTrackingDepth(
     PyThreadState *tstate,
     int new_depth);
 
+// Used by sys.get_asyncgen_hooks()
+extern PyObject* _PyEval_GetAsyncGenFirstiter(void);
+extern PyObject* _PyEval_GetAsyncGenFinalizer(void);
+
+// Used by sys.set_asyncgen_hooks()
+extern int _PyEval_SetAsyncGenFirstiter(PyObject *);
+extern int _PyEval_SetAsyncGenFinalizer(PyObject *);
+
 void _PyEval_Fini(void);
 
 

--- a/Misc/NEWS.d/next/C API/2022-03-21-00-41-29.bpo-46850.rOt771.rst
+++ b/Misc/NEWS.d/next/C API/2022-03-21-00-41-29.bpo-46850.rOt771.rst
@@ -1,0 +1,9 @@
+Remove the following private undocumented functions from the C API:
+
+* ``_PyEval_GetAsyncGenFirstiter()``
+* ``_PyEval_GetAsyncGenFinalizer()``
+* ``_PyEval_SetAsyncGenFirstiter()``
+* ``_PyEval_SetAsyncGenFinalizer()``
+
+Call the public :func:`sys.get_asyncgen_hooks` and
+:func:`sys.set_asyncgen_hooks` functions instead. Patch by Victor Stinner.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -16,7 +16,7 @@ Data members:
 
 #include "Python.h"
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
-#include "pycore_ceval.h"         // _Py_RecursionLimitLowerWaterMark()
+#include "pycore_ceval.h"         // _PyEval_SetAsyncGenFinalizer()
 #include "pycore_code.h"          // _Py_QuickenedCount
 #include "pycore_frame.h"         // _PyInterpreterFrame
 #include "pycore_initconfig.h"    // _PyStatus_EXCEPTION()


### PR DESCRIPTION
Remove the following private undocumented functions from the C API:

* _PyEval_GetAsyncGenFirstiter()
* _PyEval_GetAsyncGenFinalizer()
* _PyEval_SetAsyncGenFirstiter()
* _PyEval_SetAsyncGenFinalizer()

Call the public sys.get_asyncgen_hooks() and sys.set_asyncgen_hooks()
functions instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46850](https://bugs.python.org/issue46850) -->
https://bugs.python.org/issue46850
<!-- /issue-number -->
