### PR TITLE
bpo-46850: Remove _PyEval_GetCoroutineOriginTrackingDepth()

### DIFF
--- a/Include/cpython/ceval.h
+++ b/Include/cpython/ceval.h
@@ -8,7 +8,6 @@ PyAPI_FUNC(void) PyEval_SetProfile(Py_tracefunc, PyObject *);
 PyAPI_DATA(int) _PyEval_SetProfile(PyThreadState *tstate, Py_tracefunc func, PyObject *arg);
 PyAPI_FUNC(void) PyEval_SetTrace(Py_tracefunc, PyObject *);
 PyAPI_FUNC(int) _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg);
-PyAPI_FUNC(int) _PyEval_GetCoroutineOriginTrackingDepth(void);
 
 /* Helper to look up a builtin object */
 PyAPI_FUNC(PyObject *) _PyEval_GetBuiltin(PyObject *);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -33,9 +33,6 @@ PyAPI_FUNC(void) _PyEval_SignalAsyncExc(PyInterpreterState *interp);
 #ifdef HAVE_FORK
 extern PyStatus _PyEval_ReInitThreads(PyThreadState *tstate);
 #endif
-PyAPI_FUNC(void) _PyEval_SetCoroutineOriginTrackingDepth(
-    PyThreadState *tstate,
-    int new_depth);
 
 // Used by sys.get_asyncgen_hooks()
 extern PyObject* _PyEval_GetAsyncGenFirstiter(void);
@@ -45,11 +42,16 @@ extern PyObject* _PyEval_GetAsyncGenFinalizer(void);
 extern int _PyEval_SetAsyncGenFirstiter(PyObject *);
 extern int _PyEval_SetAsyncGenFinalizer(PyObject *);
 
-void _PyEval_Fini(void);
+// Used by sys.get_coroutine_origin_tracking_depth()
+// and sys.set_coroutine_origin_tracking_depth()
+extern int _PyEval_GetCoroutineOriginTrackingDepth(void);
+extern int _PyEval_SetCoroutineOriginTrackingDepth(int depth);
+
+extern void _PyEval_Fini(void);
 
 
 extern PyObject* _PyEval_GetBuiltins(PyThreadState *tstate);
-extern PyObject *_PyEval_BuiltinsFromGlobals(
+extern PyObject* _PyEval_BuiltinsFromGlobals(
     PyThreadState *tstate,
     PyObject *globals);
 
@@ -63,7 +65,7 @@ _PyEval_EvalFrame(PyThreadState *tstate, struct _PyInterpreterFrame *frame, int 
     return tstate->interp->eval_frame(tstate, frame, throwflag);
 }
 
-extern PyObject *
+extern PyObject*
 _PyEval_Vector(PyThreadState *tstate,
             PyFunctionObject *func, PyObject *locals,
             PyObject* const* args, size_t argcount,
@@ -124,9 +126,9 @@ static inline void _Py_LeaveRecursiveCall_inline(void)  {
 
 #define Py_LeaveRecursiveCall() _Py_LeaveRecursiveCall_inline()
 
-struct _PyInterpreterFrame *_PyEval_GetFrame(void);
+extern struct _PyInterpreterFrame* _PyEval_GetFrame(void);
 
-PyObject *_Py_MakeCoro(PyFunctionObject *func);
+extern PyObject* _Py_MakeCoro(PyFunctionObject *func);
 
 #ifdef __cplusplus
 }

--- a/Misc/NEWS.d/next/C API/2022-03-21-01-30-14.bpo-46850.Tfxde5.rst
+++ b/Misc/NEWS.d/next/C API/2022-03-21-01-30-14.bpo-46850.Tfxde5.rst
@@ -1,0 +1,4 @@
+Remove the private undocumented function
+``_PyEval_GetCoroutineOriginTrackingDepth()`` from the C API. Call the
+public :func:`sys.get_coroutine_origin_tracking_depth` function instead.
+Patch by Victor Stinner.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -6852,12 +6852,18 @@ PyEval_SetTrace(Py_tracefunc func, PyObject *arg)
 }
 
 
-void
-_PyEval_SetCoroutineOriginTrackingDepth(PyThreadState *tstate, int new_depth)
+int
+_PyEval_SetCoroutineOriginTrackingDepth(int depth)
 {
-    assert(new_depth >= 0);
-    tstate->coroutine_origin_tracking_depth = new_depth;
+    PyThreadState *tstate = _PyThreadState_GET();
+    if (depth < 0) {
+        _PyErr_SetString(tstate, PyExc_ValueError, "depth must be >= 0");
+        return -1;
+    }
+    tstate->coroutine_origin_tracking_depth = depth;
+    return 0;
 }
+
 
 int
 _PyEval_GetCoroutineOriginTrackingDepth(void)

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1186,12 +1186,9 @@ static PyObject *
 sys_set_coroutine_origin_tracking_depth_impl(PyObject *module, int depth)
 /*[clinic end generated code: output=0a2123c1cc6759c5 input=a1d0a05f89d2c426]*/
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-    if (depth < 0) {
-        _PyErr_SetString(tstate, PyExc_ValueError, "depth must be >= 0");
+    if (_PyEval_SetCoroutineOriginTrackingDepth(depth) < 0) {
         return NULL;
     }
-    _PyEval_SetCoroutineOriginTrackingDepth(tstate, depth);
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Remove the private undocumented function
_PyEval_GetCoroutineOriginTrackingDepth() from the C API. Call the
public sys.get_coroutine_origin_tracking_depth() function
instead.

Change the internal function
_PyEval_SetCoroutineOriginTrackingDepth():

* Remove the 'tstate' parameter;
* Add return value and raises an exception if depth is negative;
* No longer export the function: call the public
  sys.set_coroutine_origin_tracking_depth() function instead.

Uniformize also function declarations in pycore_ceval.h.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46850](https://bugs.python.org/issue46850) -->
https://bugs.python.org/issue46850
<!-- /issue-number -->
