### PR TITLE
bpo-46850: Remove _PyEval_CallTracing() function

### DIFF
--- a/Include/cpython/ceval.h
+++ b/Include/cpython/ceval.h
@@ -2,8 +2,6 @@
 #  error "this header file must not be included directly"
 #endif
 
-PyAPI_FUNC(PyObject *) _PyEval_CallTracing(PyObject *func, PyObject *args);
-
 PyAPI_FUNC(void) PyEval_SetProfile(Py_tracefunc, PyObject *);
 PyAPI_DATA(int) _PyEval_SetProfile(PyThreadState *tstate, Py_tracefunc func, PyObject *arg);
 PyAPI_FUNC(void) PyEval_SetTrace(Py_tracefunc, PyObject *);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -34,6 +34,9 @@ PyAPI_FUNC(void) _PyEval_SignalAsyncExc(PyInterpreterState *interp);
 extern PyStatus _PyEval_ReInitThreads(PyThreadState *tstate);
 #endif
 
+// Used by sys.call_tracing()
+extern PyObject* _PyEval_CallTracing(PyObject *func, PyObject *args);
+
 // Used by sys.get_asyncgen_hooks()
 extern PyObject* _PyEval_GetAsyncGenFirstiter(void);
 extern PyObject* _PyEval_GetAsyncGenFinalizer(void);

--- a/Misc/NEWS.d/next/C API/2022-03-21-02-26-27.bpo-46850.hU3c-O.rst
+++ b/Misc/NEWS.d/next/C API/2022-03-21-02-26-27.bpo-46850.hU3c-O.rst
@@ -1,0 +1,3 @@
+Remove the private undocumented function ``_PyEval_CallTracing()`` from the
+C API. Call the public :func:`sys.call_tracing` function instead. Patch by
+Victor Stinner.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -6708,16 +6708,19 @@ call_trace(Py_tracefunc func, PyObject *obj,
     return result;
 }
 
-PyObject *
+PyObject*
 _PyEval_CallTracing(PyObject *func, PyObject *args)
 {
+    // Save and disable tracing
     PyThreadState *tstate = _PyThreadState_GET();
     int save_tracing = tstate->tracing;
     int save_use_tracing = tstate->cframe->use_tracing;
-    PyObject *result;
-
     tstate->tracing = 0;
-    result = PyObject_Call(func, args, NULL);
+
+    // Call the tracing function
+    PyObject *result = PyObject_Call(func, args, NULL);
+
+    // Restore tracing
     tstate->tracing = save_tracing;
     tstate->cframe->use_tracing = save_use_tracing;
     return result;


### PR DESCRIPTION
Remove the private undocumented function _PyEval_CallTracing() from
the C API. Call the public sys.call_tracing() function instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46850](https://bugs.python.org/issue46850) -->
https://bugs.python.org/issue46850
<!-- /issue-number -->
