### PR TITLE
bpo-47079: return a correct type from the Integral.denominator

### DIFF
--- a/Lib/numbers.py
+++ b/Lib/numbers.py
@@ -388,6 +388,6 @@ class Integral(Rational):
     @property
     def denominator(self):
         """Integers have a denominator of 1."""
-        return 1
+        return type(self)(1)
 
 Integral.register(int)

--- a/Lib/test/test_abstract_numbers.py
+++ b/Lib/test/test_abstract_numbers.py
@@ -5,6 +5,61 @@ import operator
 import unittest
 from numbers import Complex, Real, Rational, Integral
 
+
+class DummyIntegral(Integral):
+    """Dummy Integral class to test default implementations of methods."""
+
+    def __init__(self, val=0):
+        self._val = int(val)
+
+    def __int__(self):
+        return self._val
+
+    def __pow__(self, exponent, modulus=None):
+        return NotImplemented
+    __rpow__ = __pow__
+
+    def __lshift__(self, other):
+        return NotImplemented
+    __rlshift__ = __lshift__
+    __rshift__ = __lshift__
+    __rrshift__ = __lshift__
+    __and__ = __lshift__
+    __rand__ = __lshift__
+    __xor__ = __lshift__
+    __rxor__ = __lshift__
+    __or__ = __lshift__
+    __ror__ = __lshift__
+    __add__ = __lshift__
+    __radd__ = __lshift__
+    __mul__ = __lshift__
+    __rmul__ = __lshift__
+    __mod__ = __lshift__
+    __rmod__ = __lshift__
+    __floordiv__ = __lshift__
+    __rfloordiv__ = __lshift__
+    __truediv__ = __lshift__
+    __rtruediv__ = __lshift__
+    __lt__ = __lshift__
+    __le__ = __lshift__
+
+    def __eq__(self, other):
+        return all(isinstance(_, DummyIntegral)
+                   for _ in [self, other]) and self._val == other._val
+
+    def __invert__(self):
+        return NotImplemented
+    __abs__ = __invert__
+    __neg__ = __invert__
+    __trunc__ = __invert__
+    __ceil__ = __invert__
+    __floor__ = __invert__
+    __round__ = __invert__
+
+    def __pos__(self):
+        return self
+
+
 class TestNumbers(unittest.TestCase):
     def test_int(self):
         self.assertTrue(issubclass(int, Integral))
@@ -16,6 +71,14 @@ class TestNumbers(unittest.TestCase):
         self.assertEqual(-7, int(-7).conjugate())
         self.assertEqual(7, int(7).numerator)
         self.assertEqual(1, int(7).denominator)
+
+    def test_DummyIntegral(self):
+        seven = DummyIntegral(7)
+        one = DummyIntegral(1)
+        self.assertEqual(float(seven), 7.0)
+        self.assertEqual(float(one), 1.0)
+        self.assertEqual(seven.numerator, seven)
+        self.assertEqual(seven.denominator, one)
 
     def test_float(self):
         self.assertFalse(issubclass(float, Rational))

--- a/Misc/NEWS.d/next/Library/2022-03-21-07-33-45.bpo-47079.CmpCm3.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-21-07-33-45.bpo-47079.CmpCm3.rst
@@ -1,0 +1,1 @@
+Correct the implementation of :attr:`Integral.denominator`.


### PR DESCRIPTION
Also this adds tests for default methods of the Integral class.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47079](https://bugs.python.org/issue47079) -->
https://bugs.python.org/issue47079
<!-- /issue-number -->
