### PR TITLE
bpo-47080: Use atomic groups to simplify fnmatch

### DIFF
--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -124,17 +124,9 @@ class TranslateTestCase(unittest.TestCase):
         self.assertEqual(translate('A*********?[?]?'), r'(?s:A.*.[?].)\Z')
         # fancy translation to prevent exponential-time match failure
         t = translate('**a*a****a')
-        digits = re.findall(r'\d+', t)
-        self.assertEqual(len(digits), 4)
-        self.assertEqual(digits[0], digits[1])
-        self.assertEqual(digits[2], digits[3])
-        g1 = f"g{digits[0]}"  # e.g., group name "g4"
-        g2 = f"g{digits[2]}"  # e.g., group name "g5"
-        self.assertEqual(t,
-         fr'(?s:(?=(?P<{g1}>.*?a))(?P={g1})(?=(?P<{g2}>.*?a))(?P={g2}).*a)\Z')
+        self.assertEqual(t, r'(?s:(?>.*?a)(?>.*?a).*a)\Z')
         # and try pasting multiple translate results - it's an undocumented
-        # feature that this works; all the pain of generating unique group
-        # names across calls exists to support this
+        # feature that this works
         r1 = translate('**a**a**a*')
         r2 = translate('**b**b**b*')
         r3 = translate('*c*c*c*')


### PR DESCRIPTION
Use re's new atomic groups to greatly simplify the
construction of worst-case linear-time patterns.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47080](https://bugs.python.org/issue47080) -->
https://bugs.python.org/issue47080
<!-- /issue-number -->
