### PR TITLE
bpo-43224: Forbid TypeVar substitution with Unpack

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -506,6 +506,20 @@ class TypeVarTupleTests(BaseTestCase):
             self.assertEqual(E[float, str, int, bytes],
                              Tuple[List[float], A[str, int], List[bytes]])
 
+    def test_bad_var_substitution(self):
+        Ts = TypeVarTuple('Ts')
+        T = TypeVar('T')
+        T2 = TypeVar('T2')
+        class G(Generic[Unpack[Ts]]): pass
+
+        for A in G, Tuple:
+            B = A[T, Unpack[Ts], str, T2]
+            with self.assertRaises(TypeError):
+                B[int, Unpack[Ts]]
+            C = A[T, Unpack[Ts], str, T2]
+            with self.assertRaises(TypeError):
+                C[int, Unpack[Ts], Unpack[Ts]]
+
     def test_repr_is_correct(self):
         Ts = TypeVarTuple('Ts')
         self.assertEqual(repr(Ts), 'Ts')

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -912,6 +912,8 @@ class TypeVar(_Final, _Immutable, _BoundVarianceMixin, _root=True):
     def __typing_subst__(self, arg):
         msg = "Parameters to generic types must be types."
         arg = _type_check(arg, msg, is_argument=True)
+        if (isinstance(arg, _GenericAlias) and arg.__origin__ is Unpack):
+            raise TypeError(f"{arg} is not valid as type argument")
         return arg
 
 


### PR DESCRIPTION


<!-- issue-number: [bpo-43224](https://bugs.python.org/issue43224) -->
https://bugs.python.org/issue43224
<!-- /issue-number -->
