### PR TITLE
gh-90772: Allow datetime.isoformat to use "Z" UTC designator

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1409,7 +1409,7 @@ Instance methods:
    and ``weekday``. The same as ``self.date().isocalendar()``.
 
 
-.. method:: datetime.isoformat(sep='T', timespec='auto')
+.. method:: datetime.isoformat(sep='T', timespec='auto', use_utc_designator=False)
 
    Return a string representing the date and time in ISO 8601 format:
 
@@ -1473,9 +1473,22 @@ Instance methods:
       >>> dt.isoformat(timespec='microseconds')
       '2015-01-01T12:30:59.000000'
 
+   If the optional argument *use_utc_designator* is set to :const:`True` and
+   :meth:`tzname` returns exactly ``"UTC"``, then "Z" will be given as the UTC
+   offset in the formatted string::
+
+      >>> from datetime import datetime, timezone
+      >>> dt = datetime(2022, 3, 21, 12, 30, 59, tzinfo=timezone.utc)
+      >>> dt.isoformat()
+      '2022-03-21T12:30:59+00:00'
+      >>> dt.isoformat(use_utc_designator=True)
+      '2022-03-21T12:30:59Z'
+
    .. versionadded:: 3.6
       Added the *timespec* argument.
 
+   .. versionadded:: 3.11
+      Added the *use_utc_designator* argument.
 
 .. method:: datetime.__str__()
 
@@ -1797,7 +1810,7 @@ Instance methods:
       Added the ``fold`` argument.
 
 
-.. method:: time.isoformat(timespec='auto')
+.. method:: time.isoformat(timespec='auto', use_utc_designator=False)
 
    Return a string representing the time in ISO 8601 format, one of:
 
@@ -1826,9 +1839,13 @@ Instance methods:
 
    :exc:`ValueError` will be raised on an invalid *timespec* argument.
 
+   If the optional argument *use_utc_designator* is set to :const:`True` and
+   :meth:`tzname` returns exactly ``"UTC"``, then "Z" will be given as the UTC
+   offset in the formatted string.
+
    Example::
 
-      >>> from datetime import time
+      >>> from datetime import time, timezone
       >>> time(hour=12, minute=34, second=56, microsecond=123456).isoformat(timespec='minutes')
       '12:34'
       >>> dt = time(hour=12, minute=34, second=56, microsecond=0)
@@ -1836,9 +1853,17 @@ Instance methods:
       '12:34:56.000000'
       >>> dt.isoformat(timespec='auto')
       '12:34:56'
+      >>> dt = time(12, 30, 59, tzinfo=timezone.utc)
+      >>> dt.isoformat()
+      '12:30:59+00:00'
+      >>> dt.isoformat(use_utc_designator=True)
+      '12:30:59Z'
 
    .. versionadded:: 3.6
       Added the *timespec* argument.
+
+   .. versionadded:: 3.11
+      Added the *use_utc_designator* argument.
 
 
 .. method:: time.__str__()

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1414,11 +1414,13 @@ class time:
             s = s[:-1] + ", fold=1)"
         return s
 
-    def isoformat(self, timespec='auto'):
+    def isoformat(self, timespec='auto', use_utc_designator=False):
         """Return the time formatted according to ISO.
 
         The full format is 'HH:MM:SS.mmmmmm+zz:zz'. By default, the fractional
-        part is omitted if self.microsecond == 0.
+        part is omitted if self.microsecond == 0. The UTC offset will be
+        replaced with a single "Z" if use_utc_designator is True and
+        self.tzname() is exactly "UTC"
 
         The optional argument timespec specifies the number of additional
         terms of the time to include. Valid options are 'auto', 'hours',
@@ -1426,9 +1428,12 @@ class time:
         """
         s = _format_time(self._hour, self._minute, self._second,
                           self._microsecond, timespec)
-        tz = self._tzstr()
-        if tz:
-            s += tz
+        if use_utc_designator and "UTC" == self.tzname():
+            s += "Z"
+        else:
+            tz = self._tzstr()
+            if tz:
+                s += tz
         return s
 
     __str__ = isoformat
@@ -1894,14 +1899,16 @@ class datetime(date):
             self._hour, self._minute, self._second,
             self._year)
 
-    def isoformat(self, sep='T', timespec='auto'):
+    def isoformat(self, sep='T', timespec='auto', use_utc_designator=False):
         """Return the time formatted according to ISO.
 
         The full format looks like 'YYYY-MM-DD HH:MM:SS.mmmmmm'.
         By default, the fractional part is omitted if self.microsecond == 0.
 
-        If self.tzinfo is not None, the UTC offset is also attached, giving
-        giving a full format of 'YYYY-MM-DD HH:MM:SS.mmmmmm+HH:MM'.
+        If self.tzinfo is not None, the UTC offset is also attached. If the
+        optional argument use_utc_designator is True and the timezone name is
+        "UTC", a Z is appended: 'YYYY-MM-DD HH:MM:SS.mmmmmmZ'.
+        Otherwise the format is 'YYYY-MM-DD HH:MM:SS.mmmmmm+HH:MM'.
 
         Optional argument sep specifies the separator between date and
         time, default 'T'.
@@ -1915,9 +1922,12 @@ class datetime(date):
                           self._microsecond, timespec))
 
         off = self.utcoffset()
-        tz = _format_offset(off)
-        if tz:
-            s += tz
+        if use_utc_designator and "UTC" == self.tzname():
+            s += "Z"
+        else:
+            tz = _format_offset(off)
+            if tz:
+                s += tz
 
         return s
 

--- a/Misc/NEWS.d/next/Library/2022-03-22-00-27-11.bpo-46614.Rgt_1Y.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-22-00-27-11.bpo-46614.Rgt_1Y.rst
@@ -1,0 +1,4 @@
+Add *use_utc_designator* as an optional parameter to
+:meth:`datetime.datetime.isoformat` and :meth:`datetime.time.isoformat`. If
+it's set to true, the UTC offset will be formatted as "Z" rather than "+00:00"
+if the object is associated with a timezone named exactly ``"UTC"``.


### PR DESCRIPTION
Add an optional parameter to datetime.isoformat() and time.isoformat()
called use_utc_designator. If provided and True and the object is
associated with a tzinfo and its tzname is exactly "UTC", the formatted
UTC offset will be "Z" rather than an offset from UTC.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46614](https://bugs.python.org/issue46614) -->
https://bugs.python.org/issue46614
<!-- /issue-number -->

<!-- gh-issue-number: gh-90772 -->
* Issue: gh-90772
<!-- /gh-issue-number -->
