### PR TITLE
bpo-46864: Suppress deprecation warnings for ob_shash.

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -47,10 +47,13 @@ extern "C" {
 static PyThreadState *_PyGILState_GetThisThreadState(struct _gilstate_runtime_state *gilstate);
 static void _PyThreadState_Delete(PyThreadState *tstate, int check_current);
 
-
+/* Suppress deprecation warning for PyBytesObject.ob_shash */
+_Py_COMP_DIAG_PUSH
+_Py_COMP_DIAG_IGNORE_DEPR_DECLS
 /* We use "initial" if the runtime gets re-used
    (e.g. Py_Finalize() followed by Py_Initialize(). */
 static const _PyRuntimeState initial = _PyRuntimeState_INIT;
+_Py_COMP_DIAG_POP
 
 static int
 alloc_for_runtime(PyThread_type_lock *plock1, PyThread_type_lock *plock2,


### PR DESCRIPTION


<!-- issue-number: [bpo-46864](https://bugs.python.org/issue46864) -->
https://bugs.python.org/issue46864
<!-- /issue-number -->
