### PR TITLE
bpo-46850: Move _PyEval_EvalFrameDefault() to internal C API

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1097,6 +1097,11 @@ Porting to Python 3.11
 * Distributors are encouraged to build Python with the optimized Blake2
   library `libb2`_.
 
+* Move the private undocumented ``_PyEval_EvalFrameDefault()`` function to the
+  internal C API. The function now uses the ``_PyInterpreterFrame`` type which
+  is part of the internal C API.
+  (Contributed by Victor Stinner in :issue:`46850`.)
+
 
 Deprecated
 ----------

--- a/Include/cpython/ceval.h
+++ b/Include/cpython/ceval.h
@@ -15,8 +15,6 @@ PyAPI_FUNC(PyObject *) _PyEval_GetBuiltinId(_Py_Identifier *);
    flag was set, else return 0. */
 PyAPI_FUNC(int) PyEval_MergeCompilerFlags(PyCompilerFlags *cf);
 
-PyAPI_FUNC(PyObject *) _PyEval_EvalFrameDefault(PyThreadState *tstate, struct _PyInterpreterFrame *f, int exc);
-
 PyAPI_FUNC(void) _PyEval_SetSwitchInterval(unsigned long microseconds);
 PyAPI_FUNC(unsigned long) _PyEval_GetSwitchInterval(void);
 

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -59,6 +59,11 @@ extern PyObject* _PyEval_BuiltinsFromGlobals(
     PyObject *globals);
 
 
+PyAPI_FUNC(PyObject *) _PyEval_EvalFrameDefault(
+    PyThreadState *tstate,
+    struct _PyInterpreterFrame *frame,
+    int throwflag);
+
 static inline PyObject*
 _PyEval_EvalFrame(PyThreadState *tstate, struct _PyInterpreterFrame *frame, int throwflag)
 {

--- a/Misc/NEWS.d/next/C API/2022-03-22-16-48-02.bpo-46850.7M5dO7.rst
+++ b/Misc/NEWS.d/next/C API/2022-03-22-16-48-02.bpo-46850.7M5dO7.rst
@@ -1,0 +1,3 @@
+Move the private undocumented ``_PyEval_EvalFrameDefault()`` function to the
+internal C API. The function now uses the ``_PyInterpreterFrame`` type which is
+part of the internal C API. Patch by Victor Stinner.


### PR DESCRIPTION
Move the private undocumented _PyEval_EvalFrameDefault() function to
the internal C API. The function now uses the _PyInterpreterFrame
type which is part of the internal C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46850](https://bugs.python.org/issue46850) -->
https://bugs.python.org/issue46850
<!-- /issue-number -->
