### PR TITLE
bpo-42197: Don't create `f_locals` dictionary unless we actually need it.

### DIFF
--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -41,6 +41,17 @@ See also :ref:`Reflection <reflection>`.
    .. versionadded:: 3.9
 
 
+.. c:function:: PyCodeObject* PyFrame_GetLocals(PyFrameObject *frame)
+
+   Get the *frame*'s ``f_locals`` attribute.
+
+   Return a :term:`strong reference`.
+
+   *frame* must not be ``NULL``.
+
+   .. versionadded:: 3.11
+
+
 .. c:function:: int PyFrame_GetLineNumber(PyFrameObject *frame)
 
    Return the line number that *frame* is currently executing.

--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -41,9 +41,9 @@ See also :ref:`Reflection <reflection>`.
    .. versionadded:: 3.9
 
 
-.. c:function:: PyCodeObject* PyFrame_GetLocals(PyFrameObject *frame)
+.. c:function:: PyObject* PyFrame_GetLocals(PyFrameObject *frame)
 
-   Get the *frame*'s ``f_locals`` attribute.
+   Get the *frame*'s ``f_locals`` attribute (:class:`dict`).
 
    Return a :term:`strong reference`.
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -978,6 +978,12 @@ Porting to Python 3.11
   computed lazily. The :c:func:`PyFrame_GetBack` function must be called
   instead.
 
+  Debuggers that accessed the ``f_locals`` directly *must* call
+  `:c:func:`PyFrame_GetLocals` instead. They no longer need to call
+  `:c:func:`PyFrame_FastToLocalsWithError` or :c:func:`PyFrame_LocalsToFast`,
+  in fact they should not call those functions. The necessary updating of the
+  frame is now managed by the virtual machine.
+
   Code defining ``PyFrame_GetCode()`` on Python 3.8 and older::
 
       #if PY_VERSION_HEX < 0x030900B1

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -964,7 +964,7 @@ Porting to Python 3.11
     Code using ``f_lasti`` with ``PyCode_Addr2Line()`` must use
     :c:func:`PyFrame_GetLineNumber` instead.
   * ``f_lineno``: use :c:func:`PyFrame_GetLineNumber`
-  * ``f_locals``: use ``PyFrame_GetLocals(frame)``.
+  * ``f_locals``: use :c:func:`PyFrame_GetLocals(frame)`.
   * ``f_stackdepth``: removed.
   * ``f_state``: no public API (renamed to ``f_frame.f_state``).
   * ``f_trace``: no public API.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -964,7 +964,7 @@ Porting to Python 3.11
     Code using ``f_lasti`` with ``PyCode_Addr2Line()`` must use
     :c:func:`PyFrame_GetLineNumber` instead.
   * ``f_lineno``: use :c:func:`PyFrame_GetLineNumber`
-  * ``f_locals``: use ``PyObject_GetAttrString((PyObject*)frame, "f_locals")``.
+  * ``f_locals``: use ``PyFrame_GetLocals(frame)``.
   * ``f_stackdepth``: removed.
   * ``f_state``: no public API (renamed to ``f_frame.f_state``).
   * ``f_trace``: no public API.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -964,7 +964,7 @@ Porting to Python 3.11
     Code using ``f_lasti`` with ``PyCode_Addr2Line()`` must use
     :c:func:`PyFrame_GetLineNumber` instead.
   * ``f_lineno``: use :c:func:`PyFrame_GetLineNumber`
-  * ``f_locals``: use :c:func:`PyFrame_GetLocals(frame)`.
+  * ``f_locals``: use :c:func:`PyFrame_GetLocals`.
   * ``f_stackdepth``: removed.
   * ``f_state``: no public API (renamed to ``f_frame.f_state``).
   * ``f_trace``: no public API.

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -23,3 +23,4 @@ PyAPI_FUNC(int) PyFrame_FastToLocalsWithError(PyFrameObject *f);
 PyAPI_FUNC(void) PyFrame_FastToLocals(PyFrameObject *);
 
 PyAPI_FUNC(PyFrameObject *) PyFrame_GetBack(PyFrameObject *frame);
+PyAPI_FUNC(PyObject *) PyFrame_GetLocals(PyFrameObject *frame);

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -15,6 +15,7 @@ struct _frame {
     int f_lineno;               /* Current line number. Only valid if non-zero */
     char f_trace_lines;         /* Emit per-line trace events? */
     char f_trace_opcodes;       /* Emit per-opcode trace events? */
+    char f_fast_as_locals;      /* Have the fast locals of this frame been converted to a dict? */
     /* The frame data, if this frame object owns the frame */
     PyObject *_f_frame_data[1];
 };

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-22-15-12-28.bpo-42197.SwrrFO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-22-15-12-28.bpo-42197.SwrrFO.rst
@@ -1,5 +1,5 @@
-`PyFrame_FastToLocalsWithError` and `PyFrame_LocalsToFast` are no longer
-called during profile nor tracing. C code that accesses the `f_locals` directly
-(which is not recommended) must now call
-`PyFrame_FastToLocalsWithError` to update locals and `PyFrame_LocalsToFast`
-after `PyFrameObject.f_locals` are updated.
+``PyFrame_FastToLocalsWithError`` and ``PyFrame_LocalsToFast`` are no longer
+called during profile nor tracing. C code that accesses the ``f_locals`` attribute
+ directly (which is not recommended) must now call
+``PyFrame_FastToLocalsWithError`` to update locals and ``PyFrame_LocalsToFast``
+after ``f_locals`` are updated.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-22-15-12-28.bpo-42197.SwrrFO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-22-15-12-28.bpo-42197.SwrrFO.rst
@@ -1,0 +1,5 @@
+`PyFrame_FastToLocalsWithError` and `PyFrame_LocalsToFast` are no longer
+called during profile nor tracing. C code that accesses the `f_locals` directly
+(which is not recommended) must now call
+`PyFrame_FastToLocalsWithError` to update locals and `PyFrame_LocalsToFast`
+after `PyFrameObject.f_locals` are updated.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-22-15-12-28.bpo-42197.SwrrFO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-22-15-12-28.bpo-42197.SwrrFO.rst
@@ -1,5 +1,3 @@
 ``PyFrame_FastToLocalsWithError`` and ``PyFrame_LocalsToFast`` are no longer
 called during profile nor tracing. C code that accesses the ``f_locals`` attribute
- directly (which is not recommended) must now call
-``PyFrame_FastToLocalsWithError`` to update locals and ``PyFrame_LocalsToFast``
-after ``f_locals`` are updated.
+ directly must do so by calling ``PyFrame_GetLocals``.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-22-15-12-28.bpo-42197.SwrrFO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-22-15-12-28.bpo-42197.SwrrFO.rst
@@ -1,3 +1,2 @@
-``PyFrame_FastToLocalsWithError`` and ``PyFrame_LocalsToFast`` are no longer
-called during profile nor tracing. C code that accesses the ``f_locals`` attribute
- directly must do so by calling ``PyFrame_GetLocals``.
+:c:func:`PyFrame_FastToLocalsWithError` and :c:func:`PyFrame_LocalsToFast` are no longer
+called during profiling nor tracing. C code can access the ``f_locals`` attribute of :c:type:`PyFrameObject` by calling :c:func:`PyFrame_GetLocals`.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -912,9 +912,6 @@ _PyFrame_FastToLocalsWithError(_PyInterpreterFrame *frame) {
     PyObject **fast;
     PyCodeObject *co;
     locals = frame->f_locals;
-    if ((frame->f_code->co_flags & CO_NEWLOCALS) == 0) {
-        return 0;
-    }
     if (locals == NULL) {
         locals = frame->f_locals = PyDict_New();
         if (locals == NULL)
@@ -1036,9 +1033,6 @@ _PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear)
     PyObject *error_type, *error_value, *error_traceback;
     PyCodeObject *co;
     locals = frame->f_locals;
-    if ((frame->f_code->co_flags & CO_NEWLOCALS) == 0) {
-        return;
-    }
     if (locals == NULL) {
         return;
     }

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -840,6 +840,7 @@ _PyFrame_New_NoTrack(PyCodeObject *code)
     f->f_trace = NULL;
     f->f_trace_lines = 1;
     f->f_trace_opcodes = 0;
+    f->f_fast_as_locals = 0;
     f->f_lineno = 0;
     return f;
 }
@@ -911,6 +912,9 @@ _PyFrame_FastToLocalsWithError(_PyInterpreterFrame *frame) {
     PyObject **fast;
     PyCodeObject *co;
     locals = frame->f_locals;
+    if ((frame->f_code->co_flags & CO_NEWLOCALS) == 0) {
+        return 0;
+    }
     if (locals == NULL) {
         locals = frame->f_locals = PyDict_New();
         if (locals == NULL)
@@ -1004,7 +1008,11 @@ PyFrame_FastToLocalsWithError(PyFrameObject *f)
         PyErr_BadInternalCall();
         return -1;
     }
-    return _PyFrame_FastToLocalsWithError(f->f_frame);
+    int err = _PyFrame_FastToLocalsWithError(f->f_frame);
+    if (err == 0) {
+        f->f_fast_as_locals = 1;
+    }
+    return err;
 }
 
 void
@@ -1028,8 +1036,12 @@ _PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear)
     PyObject *error_type, *error_value, *error_traceback;
     PyCodeObject *co;
     locals = frame->f_locals;
-    if (locals == NULL)
+    if ((frame->f_code->co_flags & CO_NEWLOCALS) == 0) {
         return;
+    }
+    if (locals == NULL) {
+        return;
+    }
     fast = _PyFrame_GetLocalsArray(frame);
     co = frame->f_code;
 
@@ -1088,12 +1100,11 @@ _PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear)
 void
 PyFrame_LocalsToFast(PyFrameObject *f, int clear)
 {
-    if (f == NULL || _PyFrame_GetState(f) == FRAME_CLEARED) {
-        return;
+    if (f && f->f_fast_as_locals && _PyFrame_GetState(f) != FRAME_CLEARED) {
+        _PyFrame_LocalsToFast(f->f_frame, clear);
+        f->f_fast_as_locals = 0;
     }
-    _PyFrame_LocalsToFast(f->f_frame, clear);
 }
-
 
 PyCodeObject *
 PyFrame_GetCode(PyFrameObject *frame)
@@ -1116,6 +1127,12 @@ PyFrame_GetBack(PyFrameObject *frame)
     }
     Py_XINCREF(back);
     return back;
+}
+
+PyObject*
+PyFrame_GetLocals(PyFrameObject *frame)
+{
+    return frame_getlocals(frame, NULL);
 }
 
 PyObject*

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -933,6 +933,11 @@ call_trampoline(PyThreadState *tstate, PyObject* callback,
     /* call the Python-level function */
     PyObject *result = _PyObject_FastCallTstate(tstate, callback, stack, 3);
 
+    PyFrame_LocalsToFast(frame, 1);
+
+    if (result == NULL) {
+        PyTraceBack_Here(frame);
+    }
 
     return result;
 }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -924,9 +924,6 @@ static PyObject *
 call_trampoline(PyThreadState *tstate, PyObject* callback,
                 PyFrameObject *frame, int what, PyObject *arg)
 {
-    if (PyFrame_FastToLocalsWithError(frame) < 0) {
-        return NULL;
-    }
 
     PyObject *stack[3];
     stack[0] = (PyObject *)frame;
@@ -936,10 +933,6 @@ call_trampoline(PyThreadState *tstate, PyObject* callback,
     /* call the Python-level function */
     PyObject *result = _PyObject_FastCallTstate(tstate, callback, stack, 3);
 
-    PyFrame_LocalsToFast(frame, 1);
-    if (result == NULL) {
-        PyTraceBack_Here(frame);
-    }
 
     return result;
 }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -934,7 +934,6 @@ call_trampoline(PyThreadState *tstate, PyObject* callback,
     PyObject *result = _PyObject_FastCallTstate(tstate, callback, stack, 3);
 
     PyFrame_LocalsToFast(frame, 1);
-
     if (result == NULL) {
         PyTraceBack_Here(frame);
     }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -930,6 +930,13 @@ call_trampoline(PyThreadState *tstate, PyObject* callback,
     stack[1] = whatstrings[what];
     stack[2] = (arg != NULL) ? arg : Py_None;
 
+    /* Discard any previous modifications the frame's fast locals */
+    if (frame->f_fast_as_locals) {
+        if (PyFrame_FastToLocalsWithError(frame) < 0) {
+            return NULL;
+        }
+    }
+
     /* call the Python-level function */
     PyObject *result = _PyObject_FastCallTstate(tstate, callback, stack, 3);
 


### PR DESCRIPTION
This tiny change seems to double the speed of coverage.py https://bugs.python.org/issue42197#msg411210

Original implementation by @fabioz. I've dropped his modifications to the `sys` docs, as the `f_locals` field is now internal, so should not be accessed directly: https://github.com/python/cpython/blob/main/Doc/whatsnew/3.11.rst

<!-- issue-number: [bpo-42197](https://bugs.python.org/issue42197) -->
https://bugs.python.org/issue42197
<!-- /issue-number -->
