### PR TITLE
bpo-46541: Add a comment about when to use _Py_DECLARE_STR().

### DIFF
--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -371,6 +371,16 @@ struct _Py_global_strings {
 #define _Py_STR(NAME) \
      (_Py_SINGLETON(strings.literals._ ## NAME._ascii.ob_base))
 
+/* _Py_DECLARE_STR() should precede all uses of _Py_STR() in a function.
+
+   This is true even if the same string has already been declared
+   elsewhere, even in the same file.  Mismatched duplicates are detected
+   by Tools/scripts/generate-global-objects.py.
+
+   Pairing _Py_DECLARE_STR() with every use of _Py_STR() makes sure the
+   string keeps working even if the declaration is removed somewhere
+   else.  It also makes it clear what the actual string is at every
+   place it is being used. */
 #define _Py_DECLARE_STR(name, str)
 
 #ifdef __cplusplus


### PR DESCRIPTION
In https://github.com/python/cpython/pull/32003#discussion_r832548130, I realized it wasn't very clear how `_Py_DECLARE_STR()` should be used.

<!-- issue-number: [bpo-46541](https://bugs.python.org/issue46541) -->
https://bugs.python.org/issue46541
<!-- /issue-number -->
