### PR TITLE
bpo-46480: rephrase typing.assert_type docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2150,7 +2150,7 @@ Functions and decorators
 
 .. function:: assert_type(val, typ, /)
 
-   Assert (to the type checker) that *val* has an inferred type of *typ*.
+   Ask a static type checker to confirm that *val* has an inferred type of *typ*.
 
    When the type checker encounters a call to ``assert_type()``, it
    emits an error if the value is not of the specified type::

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2085,7 +2085,7 @@ def cast(typ, val):
 
 
 def assert_type(val, typ, /):
-    """Assert (to the type checker) that the value is of the given type.
+    """Ask a static type checker to confirm that the value is of the given type.
 
     When the type checker encounters a call to assert_type(), it
     emits an error if the value is not of the specified type::


### PR DESCRIPTION
The goal here is to reduce potential confusion between
`assert_type(val, typ)` and `assert isinstance(val, typ)`.

The former is meant to ask a type checker to confirm a fact, the latter
is meant to tell a type checker a fact. The behaviour of the latter more
closely resembles what I'd expect from the previous phrasing of
"assert [something] to the type checker".

<!-- issue-number: [bpo-46480](https://bugs.python.org/issue46480) -->
https://bugs.python.org/issue46480
<!-- /issue-number -->
