### PR TITLE
bpo-47099: Replace with_traceback() with exception chaining and reraising

### DIFF
--- a/Lib/test/support/socket_helper.py
+++ b/Lib/test/support/socket_helper.py
@@ -256,7 +256,7 @@ def transient_internet(resource_name, *, timeout=_NOT_SET, errnos=()):
                 err = a[0]
             # The error can also be wrapped as args[1]:
             #    except socket.error as msg:
-            #        raise OSError('socket error', msg).with_traceback(sys.exc_info()[2])
+            #        raise OSError('socket error', msg) from msg
             elif len(a) >= 2 and isinstance(a[1], OSError):
                 err = a[1]
             else:

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -940,10 +940,9 @@ def urlencode(query, doseq=False, safe='', encoding=None, errors=None,
             # but that's a minor nit.  Since the original implementation
             # allowed empty dicts that type of behavior probably should be
             # preserved for consistency
-        except TypeError:
-            ty, va, tb = sys.exc_info()
+        except TypeError as err:
             raise TypeError("not a valid non-string sequence "
-                            "or mapping object").with_traceback(tb)
+                            "or mapping object") from err
 
     l = []
     if not doseq:

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1579,8 +1579,7 @@ class FTPHandler(BaseHandler):
             headers = email.message_from_string(headers)
             return addinfourl(fp, headers, req.full_url)
         except ftplib.all_errors as exp:
-            exc = URLError('ftp error: %r' % exp)
-            raise exc.with_traceback(sys.exc_info()[2])
+            raise URLError(f'ftp error: {exp}') from exp
 
     def connect_ftp(self, user, passwd, host, port, dirs, timeout):
         return ftpwrapper(user, passwd, host, port, dirs, timeout,
@@ -1791,7 +1790,7 @@ class URLopener:
         except (HTTPError, URLError):
             raise
         except OSError as msg:
-            raise OSError('socket error', msg).with_traceback(sys.exc_info()[2])
+            raise OSError('socket error', msg) from msg
 
     def open_unknown(self, fullurl, data=None):
         """Overridable interface to open unknown URL type."""
@@ -2093,7 +2092,7 @@ class URLopener:
             headers = email.message_from_string(headers)
             return addinfourl(fp, headers, "ftp:" + url)
         except ftperrors() as exp:
-            raise URLError('ftp error %r' % exp).with_traceback(sys.exc_info()[2])
+            raise URLError(f'ftp error: {exp}') from exp
 
     def open_data(self, url, data=None):
         """Use "data" URL."""
@@ -2443,8 +2442,7 @@ class ftpwrapper:
                 conn, retrlen = self.ftp.ntransfercmd(cmd)
             except ftplib.error_perm as reason:
                 if str(reason)[:3] != '550':
-                    raise URLError('ftp error: %r' % reason).with_traceback(
-                        sys.exc_info()[2])
+                    raise URLError(f'ftp error: {reason}') from reason
         if not conn:
             # Set transfer mode to ASCII!
             self.ftp.voidcmd('TYPE A')

--- a/Lib/wsgiref/handlers.py
+++ b/Lib/wsgiref/handlers.py
@@ -228,8 +228,7 @@ class BaseHandler:
         if exc_info:
             try:
                 if self.headers_sent:
-                    # Re-raise original exception if headers sent
-                    raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
+                    raise
             finally:
                 exc_info = None        # avoid dangling circular ref
         elif self.headers is not None:

--- a/Misc/NEWS.d/next/Library/2022-03-23-13-55-41.bpo-47099.P6quRP.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-23-13-55-41.bpo-47099.P6quRP.rst
@@ -1,0 +1,3 @@
+Exception chaining is changed from
+:func:`Exception.with_traceback`/:func:`sys.exc_info` to :pep:`3134`.
+Patch by Oleg Iarygin.

--- a/Misc/NEWS.d/next/Library/2022-03-23-14-16-38.bpo-47099.2raait.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-23-14-16-38.bpo-47099.2raait.rst
@@ -1,0 +1,5 @@
+All :exc:`URLError` exception messages raised in
+:class:`urllib.request.URLopener` now contain a colon between ``ftp error``
+and the rest of the message. Previously,
+:func:`~urllib.request.URLopener.open_ftp` missed the colon. Patch by Oleg
+Iarygin.


### PR DESCRIPTION
This PR changes exception chaining used in the library from `Exception.with_traceback`/`sys.exc_info` to [PEP 3134](https://www.python.org/dev/peps/pep-3134/).

There are minor user-visible changes in the exception report:

- the line *During handling of the above exception, another exception occurred* is replaced with *The above exception was the direct cause of the following exception*

    <details><summary>Comparison of the full console output</summary>
    Before:

    ```plain
    Python 3.11.0a6 (main, Mar  7 2022, 16:46:19) [MSC v.1929 64 bit (AMD64)] on win32
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import urllib.parse
    >>> urllib.parse.urlencode(None)
    Traceback (most recent call last):
      File "C:\Program Files\Python311\Lib\urllib\parse.py", line 937, in urlencode
        if len(query) and not isinstance(query[0], tuple):
           ^^^^^^^^^^
    TypeError: object of type 'NoneType' has no len()

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "C:\Program Files\Python311\Lib\urllib\parse.py", line 945, in urlencode
        raise TypeError("not a valid non-string sequence "
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Program Files\Python311\Lib\urllib\parse.py", line 937, in urlencode
        if len(query) and not isinstance(query[0], tuple):
           ^^^^^^^^^^
    TypeError: not a valid non-string sequence or mapping object
    ```

    After:

    ```plain
    Python 3.11.0a6+ (main, Mar 23 2022, 12:00:42) [MSC v.1929 64 bit (AMD64)] on win32
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import urllib.parse
    >>> urllib.parse.urlencode(None)
    Traceback (most recent call last):
      File "C:\Users\oleg\Documents\dev\cpython\Lib\urllib\parse.py", line 937, in urlencode
        if len(query) and not isinstance(query[0], tuple):
           ^^^^^^^^^^
    TypeError: object of type 'NoneType' has no len()

    The above exception was the direct cause of the following exception:

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "C:\Users\oleg\Documents\dev\cpython\Lib\urllib\parse.py", line 944, in urlencode
        raise TypeError("not a valid non-string sequence "
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: not a valid non-string sequence or mapping object
    ```
    </details>
- all `URLError` exception messages raised in `urllib.request.URLopener` now contain a colon between `ftp error` and the rest of the message. Previously, `URLopener.open_ftp()` missed the colon.

<!-- issue-number: [bpo-47099](https://bugs.python.org/issue47099) -->
https://bugs.python.org/issue47099
<!-- /issue-number -->
