### PR TITLE
add mapping & sequence type flags to the stable api

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -334,12 +334,12 @@ given type object has a specified feature.
  * classes, such as classes that extend tuple.
  */
 #define Py_TPFLAGS_MANAGED_DICT (1 << 4)
+#endif
 
 /* Set if instances of the type object are treated as sequences for pattern matching */
 #define Py_TPFLAGS_SEQUENCE (1 << 5)
 /* Set if instances of the type object are treated as mappings for pattern matching */
 #define Py_TPFLAGS_MAPPING (1 << 6)
-#endif
 
 /* Disallow creating instances of the type: set tp_new to NULL and don't create
  * the "__new__" key in the type dictionary. */


### PR DESCRIPTION
In https://github.com/python/cpython/pull/25723#discussion_r623362248 it was implied that these flags should be "internal", but it's not entirely clear to me why. PEP 634 doesn't make a clear indication whether they should be in the stable API or not.

These flags are already readily available when compiling C extensions with the full API and can be used in two ways:
 - to implement native classes which can be used as mappings in `match` cases 
 - to test for sequence / mapping types in the same way that the `match` keyword would

It would be nice to have them available in the stable ABI, if that's deemed reasonable. 