### PR TITLE
bpo-47105: Cite grp.h instead of pwd.h in grp docs

### DIFF
--- a/Doc/library/grp.rst
+++ b/Doc/library/grp.rst
@@ -12,7 +12,7 @@ Unix versions.
 
 Group database entries are reported as a tuple-like object, whose attributes
 correspond to the members of the ``group`` structure (Attribute field below, see
-``<pwd.h>``):
+``<grp.h>``):
 
 +-------+-----------+---------------------------------+
 | Index | Attribute | Meaning                         |


### PR DESCRIPTION
<!-- issue-number: [bpo-47105](https://bugs.python.org/issue47105) -->
https://bugs.python.org/issue47105
<!-- /issue-number -->
