### PR TITLE
bpo-40280: Add wasm32-emscripten and wasm32-wasi SOABI

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-03-24-12-12-35.bpo-40280.eAQWrM.rst
+++ b/Misc/NEWS.d/next/Build/2022-03-24-12-12-35.bpo-40280.eAQWrM.rst
@@ -1,0 +1,2 @@
+Add SOABI ``wasm32-emscripten`` for Emscripten and ``wasm32-wasi`` for WASI
+on 32bit WASM as well as ``wasm64`` counter parts.

--- a/configure
+++ b/configure
@@ -6084,6 +6084,22 @@ cat > conftest.c <<EOF
         darwin
 #elif defined(__VXWORKS__)
         vxworks
+#elif defined(__wasm32__)
+#  if defined(__EMSCRIPTEN__)
+	wasm32-emscripten
+#  elif defined(__wasi__)
+	wasm32-wasi
+#  else
+#    error unknown wasm32 platform
+#  endif
+#elif defined(__wasm64__)
+#  if defined(__EMSCRIPTEN)
+	wasm64-emscripten
+#  elif defined(__wasi__)
+	wasm64-wasi
+#  else
+#    error unknown wasm64 platform
+#  endif
 #else
 # error unknown platform triplet
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -973,6 +973,22 @@ cat > conftest.c <<EOF
         darwin
 #elif defined(__VXWORKS__)
         vxworks
+#elif defined(__wasm32__)
+#  if defined(__EMSCRIPTEN__)
+	wasm32-emscripten
+#  elif defined(__wasi__)
+	wasm32-wasi
+#  else
+#    error unknown wasm32 platform
+#  endif
+#elif defined(__wasm64__)
+#  if defined(__EMSCRIPTEN)
+	wasm64-emscripten
+#  elif defined(__wasi__)
+	wasm64-wasi
+#  else
+#    error unknown wasm64 platform
+#  endif
 #else
 # error unknown platform triplet
 #endif


### PR DESCRIPTION
Shared extension on Emscripten now have suffix
``.cpython-311-wasm32-emscripten.so`` (JS loader) and
``.cpython-311-wasm32-emscripten.wasm`` (WebAssembly code).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran