### PR TITLE
Fix array-lengh reference to "non-negative" from "positive"

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -2512,7 +2512,7 @@ Arrays and pointers
    Abstract base class for arrays.
 
    The recommended way to create concrete array types is by multiplying any
-   :mod:`ctypes` data type with a positive integer.  Alternatively, you can subclass
+   :mod:`ctypes` data type with a non-negative integer.  Alternatively, you can subclass
    this type and define :attr:`_length_` and :attr:`_type_` class variables.
    Array elements can be read and written using standard
    subscript and slice accesses; for slice reads, the resulting object is


### PR DESCRIPTION
I was looking in the docs for how to create zero-length arrays, and found this reference which was misleading because you can create zero-length arrays (which serve only for taking their offsets in that case) with e.g `(c_char * 0)`. Only `c_char * -1` fails (as with any other negative).

I suppose this is a small change so I didn't create a bpo, lmk if you think it's needed...