### PR TITLE
bpo-46841: remove no-longer-used macro UPDATE_PREV_INSTR_OPARG

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1433,8 +1433,6 @@ eval_frame_handle_pending(PyThreadState *tstate)
 
 #define DEOPT_IF(cond, instname) if (cond) { goto instname ## _miss; }
 
-#define UPDATE_PREV_INSTR_OPARG(instr, oparg) ((uint8_t*)(instr))[-1] = (oparg)
-
 
 #define GLOBALS() frame->f_globals
 #define BUILTINS() frame->f_builtins


### PR DESCRIPTION
This macro is no longer used following the inline-caches changes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46841](https://bugs.python.org/issue46841) -->
https://bugs.python.org/issue46841
<!-- /issue-number -->
