### PR TITLE
Add an issue template config for the migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ⚠ GitHub Issues Migration in progress ⚠
+    url: https://discuss.python.org/t/github-issues-migration-status-update/14573
+    about: Check status updates on the migration


### PR DESCRIPTION
This PR adds an issue template config file that adds a link to the [Discourse post with status updates about the migration](https://discuss.python.org/t/github-issues-migration-status-update/14573).  This will be used for the duration of the migration, and will be removed afterwards.