### PR TITLE
bpo-47097: Add documentation for TypeVarTuple

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1256,8 +1256,10 @@ These are not used in annotations. They are building blocks for creating generic
     tuple and into the square brackets directly.
 
     (In older versions of Python, where ``*`` was less flexible, you might see
-    this written as ``Unpack[Shape]`` instead. This means the same thing as
-    ``*Shape`` - ``Unpack`` and ``*`` can be used interchangeably.)
+    this written using :data:`Unpack <Unpack>` instead, as
+    ``Unpack[Shape]``. This means the same thing as ``*Shape`` - ``Unpack`` and
+    ``*`` can be used interchangeably in the context of types.)
+
 
     Type variable tuples must *always* be used in combination with the unpacking
     operator. This helps distinguish type variable types from normal type
@@ -1310,6 +1312,22 @@ These are not used in annotations. They are building blocks for creating generic
     For more details on type variable tuples, see :pep:`646`.
 
     .. versionadded:: 3.11
+
+.. data:: Unpack
+
+    A typing operator that conceptually marks an object as having been
+    unpacked. For example, using the unpack operator ``*`` on a
+    :class:`type variable tuple <TypeVarTuple>` internally uses ``Unpack``
+    to mark the type variable tuple as having been unpacked::
+
+        Ts = TypeVarTuple('Ts')
+        array: tuple[*Ts]
+        # Effectively does:
+        array: tuple[Unpack[Ts]]
+
+    In fact, ``Unpack`` can be used interchangeably with ``*`` in the context
+    of types. You might see ``Unpack`` being used explicitly in older versions
+    of Python, where ``*`` couldn't be used in certain places.
 
 .. class:: ParamSpec(name, *, bound=None, covariant=False, contravariant=False)
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1248,17 +1248,17 @@ These are not used in annotations. They are building blocks for creating generic
         def remove_first_element(xs: tuple[T, *Ts]) -> tuple[*Ts]:
             return xs[1:]
 
-        remove_first_element(xs=(1,))
         # T is bound to int, Ts is bound to ()
         # Return value is (), which has type tuple[()]
+        remove_first_element(xs=(1,))
 
-        remove_first_element(xs=(1, 'spam'))
         # T is bound to int, Ts is bound to (str,)
         # Return value is ('foo',), which has type tuple[str]
+        remove_first_element(xs=(1, 'spam'))
 
-        remove_first_element(xs=(1, 'spam', 3.0))
         # T is bound to int, Ts is bound to (str, float)
         # Return value is ('spam', 3.0), which has type tuple[str, float]
+        remove_first_element(xs=(1, 'spam', 3.0))
 
     Note the use of the unpacking operator ``*`` in ``tuple[T, *Ts]``.
     Conceptually, you can think of ``Ts`` as a tuple of type variables

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1242,33 +1242,37 @@ These are not used in annotations. They are building blocks for creating generic
     *arbitrary* number of types by acting like an *arbitrary* number of type
     variables wrapped in a tuple. For example::
 
-        Shape = TypeVarTuple('Shape')
+        T = TypeVar('T')
+        Ts = TypeVarTuple('Ts')
 
-        class Array(Generic[*Shape]): ...
+        def remove_first_element(xs: tuple[T, *Ts]) -> tuple[*Ts]: ...
 
-        array_1d: Array[int] = Array()       # 1 type parameter: fine
-        array_2d: Array[int, int] = Array()  # 2 type parameters: also fine
-        array_0d: Array[()] = Array()        # 0 type parameters: also fine
+        remove_first_element(xs=(1,))
+        # T is bound to int, Ts is bound to ()
+        # Return type is tuple[()]
 
-    Note the use of the unpacking operator ``*`` in ``Generic[*Shape]``.
-    Conceptually, you can think of ``Shape`` as a tuple of type variables
-    ``(T1, T2, ...)``. ``Generic[*Shape]`` would then become
-    ``Generic[*(T1, T2, ...)]``, which is equivalent to
-    ``Generic[T1, T2, ...]``. (Note that in older versions of Python, you might
+        remove_first_element(xs=(1, '2'))
+        # T is bound to int, Ts is bound to (str,)
+        # Return type is tuple[str]
+
+        remove_first_element(xs=(1, '2', 3.0))
+        # T is bound to int, Ts is bound to (str, float)
+        # Return type is tuple[str, float]
+
+    Note the use of the unpacking operator ``*`` in ``tuple[T, *Ts]``.
+    Conceptually, you can think of ``Ts`` as a tuple of type variables
+    ``(T1, T2, ...)``. ``tuple[T, *Ts]`` would then become
+    ``tuple[T, *(T1, T2, ...)]``, which is equivalent to
+    ``tuple[T, T1, T2, ...]``. (Note that in older versions of Python, you might
     see this written using :data:`Unpack <Unpack>` instead, as
-    ``Unpack[Shape]``.)
+    ``Unpack[Ts]``.)
 
     Type variable tuples must *always* be unpacked. This helps distinguish type
     variable types from normal type variables::
 
-        class C(Generic[Shape]): ...  # Not valid (should be Generic[*Shape])
-
-    In cases where you really do just want a tuple of types, make this explicit
-    by wrapping the type variable tuple in ``tuple[]``::
-
-        shape: Shape          # Not valid
-        shape: tuple[Shape]   # Also not valid
-        shape: tuple[*Shape]  # The correct way to do it
+        x: Ts          # Not valid
+        x: tuple[Ts]   # Not valid
+        x: tuple[*Ts]  # The correct way to to do it
 
     Type variable tuples can be used in the same contexts as normal type
     variables. For example, in class definitions, arguments, and return types::

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1299,6 +1299,7 @@ These are not used in annotations. They are building blocks for creating generic
     However, note that at most one type variable tuple may appear in a single
     list of type arguments or type parameters::
 
+        x: tuple[*Ts, *Ts]                     # Not valid
         class Array(Generic[*Shape, *Shape]):  # Not valid
             pass
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1234,7 +1234,7 @@ These are not used in annotations. They are building blocks for creating generic
 
 .. class:: TypeVarTuple
 
-    Type variable tuple. A specialised form of :class:`Type variable <TypeVar>`
+    Type variable tuple. A specialized form of :class:`Type variable <TypeVar>`
     that enables *variadic* generics.
 
     A normal type variable enables parameterization with a single type. A type
@@ -1329,7 +1329,7 @@ These are not used in annotations. They are building blocks for creating generic
 
     A typing operator that conceptually marks an object as having been
     unpacked. For example, using the unpack operator ``*`` on a
-    :class:`type variable tuple <TypeVarTuple>` internally uses ``Unpack``
+    :class:`type variable tuple <TypeVarTuple>` is equivalent to using ``Unpack``
     to mark the type variable tuple as having been unpacked::
 
         Ts = TypeVarTuple('Ts')

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1277,6 +1277,7 @@ These are not used in annotations. They are building blocks for creating generic
     Type variable tuples can be used in the same contexts as normal type
     variables. For example, in class definitions, arguments, and return types::
 
+        Shape = TypeVarTuple('Shape')
         class Array(Generic[*Shape]):
             def __getitem__(self, key: tuple[*Shape]) -> float: ...
             def __abs__(self) -> Array[*Shape]: ...
@@ -1304,13 +1305,19 @@ These are not used in annotations. They are building blocks for creating generic
     Finally, an unpacked type variable tuple can be used as the type annotation
     of ``*args``::
 
-        def args_to_tuple(*args: *Ts) -> tuple[*Ts]:
-            return tuple(args)
+        def call_soon(
+                callback: Callable[[*Ts], None],
+                *args: *Ts
+        ) -> None:
+            ...
+            callback(*args)
 
     In contrast to non-unpacked annotations of ``*args`` - e.g. ``*args: int``,
     which would specify that *all* arguments are ``int`` - ``*args: *Ts``
     enables reference to the types of the *individual* arguments in ``*args``.
-    In this case, it binds those types to ``Ts``.
+    Here, this allows us to ensure the types of the ``*args`` passed
+    to ``call_soon`` match the types of the (positional) arguments of
+    ``callback``.
 
     For more details on type variable tuples, see :pep:`646`.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1289,6 +1289,9 @@ These are not used in annotations. They are building blocks for creating generic
         class Array(Generic[DType, *Shape]):  # This is fine
             pass
 
+        class Array2(Generic[*Shape, DType]):  # This would also be fine
+            pass
+
         float_array_1d: Array[float, Height] = Array()     # Totally fine
         int_array_2d: Array[int, Height, Width] = Array()  # Yup, fine too
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1245,19 +1245,20 @@ These are not used in annotations. They are building blocks for creating generic
         T = TypeVar('T')
         Ts = TypeVarTuple('Ts')
 
-        def remove_first_element(xs: tuple[T, *Ts]) -> tuple[*Ts]: ...
+        def remove_first_element(xs: tuple[T, *Ts]) -> tuple[*Ts]:
+            return xs[1:]
 
         remove_first_element(xs=(1,))
         # T is bound to int, Ts is bound to ()
-        # Return type is tuple[()]
+        # Return value is (), which has type tuple[()]
 
-        remove_first_element(xs=(1, '2'))
+        remove_first_element(xs=(1, 'spam'))
         # T is bound to int, Ts is bound to (str,)
-        # Return type is tuple[str]
+        # Return value is ('foo',), which has type tuple[str]
 
-        remove_first_element(xs=(1, '2', 3.0))
+        remove_first_element(xs=(1, 'spam', 3.0))
         # T is bound to int, Ts is bound to (str, float)
-        # Return type is tuple[str, float]
+        # Return value is ('spam', 3.0), which has type tuple[str, float]
 
     Note the use of the unpacking operator ``*`` in ``tuple[T, *Ts]``.
     Conceptually, you can think of ``Ts`` as a tuple of type variables

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1245,20 +1245,20 @@ These are not used in annotations. They are building blocks for creating generic
         T = TypeVar('T')
         Ts = TypeVarTuple('Ts')
 
-        def remove_first_element(xs: tuple[T, *Ts]) -> tuple[*Ts]:
-            return xs[1:]
+        def remove_first_element(tup: tuple[T, *Ts]) -> tuple[*Ts]:
+            return tup[1:]
 
         # T is bound to int, Ts is bound to ()
         # Return value is (), which has type tuple[()]
-        remove_first_element(xs=(1,))
+        remove_first_element(tup=(1,))
 
         # T is bound to int, Ts is bound to (str,)
         # Return value is ('spam',), which has type tuple[str]
-        remove_first_element(xs=(1, 'spam'))
+        remove_first_element(tup=(1, 'spam'))
 
         # T is bound to int, Ts is bound to (str, float)
         # Return value is ('spam', 3.0), which has type tuple[str, float]
-        remove_first_element(xs=(1, 'spam', 3.0))
+        remove_first_element(tup=(1, 'spam', 3.0))
 
     Note the use of the unpacking operator ``*`` in ``tuple[T, *Ts]``.
     Conceptually, you can think of ``Ts`` as a tuple of type variables

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1253,7 +1253,7 @@ These are not used in annotations. They are building blocks for creating generic
         remove_first_element(xs=(1,))
 
         # T is bound to int, Ts is bound to (str,)
-        # Return value is ('foo',), which has type tuple[str]
+        # Return value is ('spam',), which has type tuple[str]
         remove_first_element(xs=(1, 'spam'))
 
         # T is bound to int, Ts is bound to (str, float)

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1341,6 +1341,8 @@ These are not used in annotations. They are building blocks for creating generic
     of types. You might see ``Unpack`` being used explicitly in older versions
     of Python, where ``*`` couldn't be used in certain places::
 
+        # In older versions of Python, TypeVarTuple and Unpack
+        # are located in the `typing_extensions` backports package.
         from typing_extensions import TypeVarTuple, Unpack
 
         Ts = TypeVarTuple('Ts')

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1234,9 +1234,10 @@ These are not used in annotations. They are building blocks for creating generic
 
 .. class:: TypeVarTuple
 
-    :class:`Type variable <TypeVar>` tuple.
+    Type variable tuple. A specialised form of :class:`Type variable <TypeVar>`
+    that enables *variadic* generics.
 
-    A vanilla type variable enables parameterization with a single type. A type
+    A normal type variable enables parameterization with a single type. A type
     variable tuple, in contrast, allows parameterization with an
     *arbitrary* number of types by acting like an *arbitrary* number of type
     variables wrapped in a tuple. For example::
@@ -1252,20 +1253,15 @@ These are not used in annotations. They are building blocks for creating generic
     Note the use of the unpacking operator ``*`` in ``Generic[*Shape]``.
     Conceptually, you can think of ``Shape`` as a tuple of type variables
     ``(T1, T2, ...)``. ``Generic[*Shape]`` would then become
-    ``Generic[*(T1, T2, ...)]``. The ``*`` brings the type variables out of the
-    tuple and into the square brackets directly.
+    ``Generic[*(T1, T2, ...)]``, which is equivalent to
+    ``Generic[T1, T2, ...]``. (Note that in older versions of Python, you might
+    see this written using :data:`Unpack <Unpack>` instead, as
+    ``Unpack[Shape]``.)
 
-    (In older versions of Python, where ``*`` was less flexible, you might see
-    this written using :data:`Unpack <Unpack>` instead, as
-    ``Unpack[Shape]``. This means the same thing as ``*Shape`` - ``Unpack`` and
-    ``*`` can be used interchangeably in the context of types.)
+    Type variable tuples must *always* be unpacked. This helps distinguish type
+    variable types from normal type variables::
 
-
-    Type variable tuples must *always* be used in combination with the unpacking
-    operator. This helps distinguish type variable types from normal type
-    variables::
-
-        class Array(Generic[Shape]): ...  # Not valid
+        class C(Generic[Shape]): ...  # Not valid (should be Generic[*Shape])
 
     In cases where you really do just want a tuple of types, make this explicit
     by wrapping the type variable tuple in ``tuple[]``::
@@ -1274,7 +1270,7 @@ These are not used in annotations. They are building blocks for creating generic
         shape: tuple[Shape]   # Also not valid
         shape: tuple[*Shape]  # The correct way to do it
 
-    Type variable tuples can be used in the same contexts as vanilla type
+    Type variable tuples can be used in the same contexts as normal type
     variables. For example, in class definitions, arguments, and return types::
 
         class Array(Generic[*Shape]):
@@ -1282,7 +1278,7 @@ These are not used in annotations. They are building blocks for creating generic
             def __abs__(self) -> Array[*Shape]: ...
             def get_shape(self) -> tuple[*Shape]: ...
 
-    Type variable tuples can be happily combined with vanilla type variables::
+    Type variable tuples can be happily combined with normal type variables::
 
         DType = TypeVar('DType')
 
@@ -1324,13 +1320,19 @@ These are not used in annotations. They are building blocks for creating generic
     to mark the type variable tuple as having been unpacked::
 
         Ts = TypeVarTuple('Ts')
-        array: tuple[*Ts]
+        tup: tuple[*Ts]
         # Effectively does:
-        array: tuple[Unpack[Ts]]
+        tup: tuple[Unpack[Ts]]
 
     In fact, ``Unpack`` can be used interchangeably with ``*`` in the context
     of types. You might see ``Unpack`` being used explicitly in older versions
-    of Python, where ``*`` couldn't be used in certain places.
+    of Python, where ``*`` couldn't be used in certain places::
+
+        from typing_extensions import TypeVarTuple, Unpack
+
+        Ts = TypeVarTuple('Ts')
+        tup: tuple[*Ts]         # Syntax error on Python <= 3.10!
+        tup: tuple[Unpack[Ts]]  # Semantically equivalent, and backwards-compatible
 
 .. class:: ParamSpec(name, *, bound=None, covariant=False, contravariant=False)
 


### PR DESCRIPTION
Here's the first part of the documentation for PEP 646: documentation of `TypeVarTuple` in https://docs.python.org/3.11/library/typing.html.

I've kept this information self-contained in the section on `TypeVarTuple` rather than e.g. also writing about `TypeVarTuple` in the section on `Generic` because, let's face it, user-defined generics are kinda tricky, and if a user is reading about `Generic` for the first time, we don't want to overload them.

There are many other things from the PEP we could write about here, but I'm assuming that best practice is to keep the docs accessible by only including the key bits of info, and linking to the PEP itself for more details?

I'm also unsure about whether we should add something about `Unpack` here. On one hand, it's only relevant for older versions of Python, so I lean towards thinking we should only write about it when we get to backporting? On the other hand, it's still going to be a public member of `typing.py`, so maybe it would be better to say at least something?

Pedagogical feedback also appreciated :) I wouldn't be surprised if there's an easier way to explain this.

@JelleZijlstra @pradeep90

<!-- issue-number: [bpo-47097](https://bugs.python.org/issue47097) -->
https://bugs.python.org/issue47097
<!-- /issue-number -->
