### PR TITLE
Remove the issue template config after the migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: ⚠ GitHub Issues Migration in progress ⚠
-    url: https://discuss.python.org/t/github-issues-migration-status-update/14573
-    about: Check status updates on the migration


### PR DESCRIPTION
This is a follow-up of #32101 to remove the template after the migration is completed.  It should only be merged after the migration.