### PR TITLE
[3.7] bpo-47138: Fix documentation build by pinning Jinja version to 3.0.3

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -127,7 +127,7 @@ clean:
 
 venv:
 	$(PYTHON) -m venv $(VENVDIR)
-	$(VENVDIR)/bin/python3 -m pip install -U Sphinx==2.3.1 blurb docutils==0.17.1
+	$(VENVDIR)/bin/python3 -m pip install -U Sphinx==2.3.1 blurb docutils==0.17.1 Jinja2==3.0.3
 	@echo "The venv has been created in the $(VENVDIR) directory"
 
 dist:

--- a/Misc/NEWS.d/next/Documentation/2022-03-28-12-39-20.bpo-47138.TEZRwC.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-03-28-12-39-20.bpo-47138.TEZRwC.rst
@@ -1,0 +1,1 @@
+Pin Jinja to a version compatible with Sphinx version 2.3.1.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47138](https://bugs.python.org/issue47138) -->
https://bugs.python.org/issue47138
<!-- /issue-number -->
~~https://bugs.python.org/issue45618#msg415979~~