### PR TITLE
bpo-32642: add support for path-like objects in sys.path

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1157,10 +1157,9 @@ always available.
    To not prepend this potentially unsafe path, use the :option:`-P` command
    line option or the :envvar:`PYTHONSAFEPATH` environment variable?
 
-   A program is free to modify this list for its own purposes.  Only strings
-   should be added to :data:`sys.path`; all other data types are
-   ignored during import.
-
+   A program is free to modify this list for its own purposes.  Only strings,
+   bytes, and :term:`path-like objects <path-like object>` should be added to
+   :data:`sys.path`; all other data types are ignored during import.
 
    .. seealso::
       * Module :mod:`site` This describes how to use .pth files to

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1475,7 +1475,10 @@ class PathFinder:
         #  the list of paths that will become its __path__
         namespace_path = []
         for entry in path:
-            if not isinstance(entry, str):
+            try:
+                # bytes, str and path-like objects will pass fspath
+                entry = _os.fspath(entry)
+            except TypeError:
                 continue
             finder = cls._path_importer_cache(entry)
             if finder is not None:

--- a/Lib/test/test_importlib/test_pkg_import.py
+++ b/Lib/test/test_importlib/test_pkg_import.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import sys
 import shutil
 import string
@@ -24,13 +25,12 @@ class TestImport(unittest.TestCase):
                 del sys.modules[module_name]
 
     def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
+        self.test_dir = pathlib.Path(tempfile.mkdtemp())
         sys.path.append(self.test_dir)
-        self.package_dir = os.path.join(self.test_dir,
-                                        self.package_name)
-        os.mkdir(self.package_dir)
-        create_empty_file(os.path.join(self.package_dir, '__init__.py'))
-        self.module_path = os.path.join(self.package_dir, 'foo.py')
+        self.package_dir = self.test_dir / self.package_name
+        self.package_dir.mkdir()
+        create_empty_file(self.package_dir / '__init__.py')
+        self.module_path = self.package_dir / 'foo.py'
 
     def tearDown(self):
         shutil.rmtree(self.test_dir)

--- a/Misc/NEWS.d/next/Library/2022-03-25-19-51-41.bpo-32642.O-Pr7c.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-25-19-51-41.bpo-32642.O-Pr7c.rst
@@ -1,0 +1,1 @@
+:data:`sys.path` can now accept a :term:`path-like objects <path-like object>`. Patch by ncohen.


### PR DESCRIPTION
The sys.path did only accept `str` or `bytes` object. This change
makes `os.PathLike` object to be accepted as well.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-32642](https://bugs.python.org/issue32642) -->
https://bugs.python.org/issue32642
<!-- /issue-number -->
