### PR TITLE
fnmatch should use re.search()

### DIFF
--- a/Lib/fnmatch.py
+++ b/Lib/fnmatch.py
@@ -43,7 +43,7 @@ def _compile_pattern(pat):
         res = bytes(res_str, 'ISO-8859-1')
     else:
         res = translate(pat)
-    return re.compile(res).match
+    return re.compile(res).search
 
 def filter(names, pat):
     """Construct a list from those elements of the iterable NAMES that match PAT."""

--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -42,7 +42,7 @@ class FnmatchTestCase(unittest.TestCase):
         # http://bugs.python.org/issue6665
         check('foo\nbar', 'foo*')
         check('foo\nbar\n', 'foo*')
-        check('\nfoo', 'foo*', False)
+        check('\nfoo\n', 'foo*')
         check('\n', '*')
 
     def test_slow_fnmatch(self):

--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -32,6 +32,11 @@ class FnmatchTestCase(unittest.TestCase):
         check('a', '??', False)
         check('a', 'b', False)
 
+        check('/tmp/file.txt', 'file.txt')
+        check('/tmp/file.txt', '.txt')
+        check('/tmp/file.txt', 'file', False)
+        check('/tmp/file.txt', 'file*')
+
         # these test that '\' is handled correctly in character sets;
         # see SF bug #409651
         check('\\', r'[\]')


### PR DESCRIPTION
`re.match` does not work with the end of a string (`\Z` or `$`).
```python
import fnmatch, re

fnmatch.translate("busybox")
Out[2]: '(?s:busybox)\\Z'

re.compile(fnmatch.translate("busybox")).match("/bin/busybox")

re.compile(fnmatch.translate("busybox")).search("/bin/busybox")
Out[4]: <re.Match object; span=(5, 12), match='busybox'>
```

