### PR TITLE
bpo-47126: Update to canonical PEP URLs

### DIFF
--- a/Doc/c-api/code.rst
+++ b/Doc/c-api/code.rst
@@ -58,7 +58,7 @@ bound into a function.
     If you just need the line number of a frame, use :c:func:`PyFrame_GetLineNumber` instead.
 
     For efficiently iterating over the line numbers in a code object, use `the API described in PEP 626
-    <https://www.python.org/dev/peps/pep-0626/#out-of-process-debuggers-and-profilers>`_.
+    <https://peps.python.org/pep-0626/#out-of-process-debuggers-and-profilers>`_.
 
 .. c:function:: int PyCode_Addr2Location(PyObject *co, int byte_offset, int *start_line, int *start_column, int *end_line, int *end_column)
 

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -218,9 +218,7 @@ coverage_ignore_c_items = {
 # ----------------------------
 
 # Ignore certain URLs.
-linkcheck_ignore = [r'https://bugs.python.org/(issue)?\d+',
-                    # Ignore PEPs for now, they all have permanent redirects.
-                    r'http://www.python.org/dev/peps/pep-\d+']
+linkcheck_ignore = [r'https://bugs.python.org/(issue)?\d+']
 
 
 # Options for extensions

--- a/Doc/distutils/sourcedist.rst
+++ b/Doc/distutils/sourcedist.rst
@@ -62,7 +62,7 @@ Notes:
    requires the :program:`compress` program. Notice that this format is now
    pending for deprecation and will be removed in the future versions of Python.
 (5)
-  deprecated by `PEP 527 <https://www.python.org/dev/peps/pep-0527/>`_;
+  deprecated by `PEP 527 <https://peps.python.org/pep-0527/>`_;
   `PyPI <https://pypi.org>`_ only accepts ``.zip`` and ``.tar.gz`` files.
 
 When using any ``tar`` format (``gztar``, ``bztar``, ``xztar``, ``ztar`` or

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -310,7 +310,7 @@ The latest stable releases can always be found on the `Python download page
 <https://www.python.org/downloads/>`_.  There are two production-ready versions
 of Python: 2.x and 3.x. The recommended version is 3.x, which is supported by
 most widely used libraries.  Although 2.x is still widely used, `it is not
-maintained anymore <https://www.python.org/dev/peps/pep-0373/>`_.
+maintained anymore <https://peps.python.org/pep-0373/>`_.
 
 How many people are using Python?
 ---------------------------------
@@ -345,7 +345,7 @@ include Google, Yahoo, and Lucasfilm Ltd.
 What new developments are expected for Python in the future?
 ------------------------------------------------------------
 
-See https://www.python.org/dev/peps/ for the Python Enhancement Proposals
+See https://peps.python.org/ for the Python Enhancement Proposals
 (PEPs). PEPs are design documents describing a suggested new feature for Python,
 providing a concise technical specification and a rationale.  Look for a PEP
 titled "Python X.Y Release Schedule", where X.Y is a version that hasn't been

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1826,7 +1826,7 @@ Function and class definitions
    * ``bases`` is a list of nodes for explicitly specified base classes.
    * ``keywords`` is a list of :class:`keyword` nodes, principally for 'metaclass'.
      Other keywords will be passed to the metaclass, as per `PEP-3115
-     <https://www.python.org/dev/peps/pep-3115/>`_.
+     <https://peps.python.org/pep-3115/>`_.
    * ``starargs`` and ``kwargs`` are each a single node, as in a function call.
      starargs will be expanded to join the list of base classes, and kwargs will
      be passed to the metaclass.

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -208,7 +208,7 @@ The :mod:`functools` module defines the following functions:
         @lru_cache(maxsize=32)
         def get_pep(num):
             'Retrieve text of a Python Enhancement Proposal'
-            resource = 'https://www.python.org/dev/peps/pep-%04d/' % num
+            resource = 'https://peps.python.org/pep-%04d/' % num
             try:
                 with urllib.request.urlopen(resource) as s:
                     return s.read()

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -191,7 +191,7 @@ Module functions and constants
    |                  |                 |                      | connections and cursors       |
    +------------------+-----------------+----------------------+-------------------------------+
 
-   .. _threadsafety: https://www.python.org/dev/peps/pep-0249/#threadsafety
+   .. _threadsafety: https://peps.python.org/pep-0249/#threadsafety
    .. _SQLITE_THREADSAFE: https://sqlite.org/compile.html#threadsafe
 
    .. versionchanged:: 3.11

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -3,7 +3,7 @@
 # Sphinx version is pinned so that new versions that introduce new warnings
 # won't suddenly cause build failures. Updating the version is fine as long
 # as no warnings are raised by doing so.
-sphinx==4.2.0
+sphinx==4.5.0
 
 blurb
 

--- a/Doc/tools/templates/indexsidebar.html
+++ b/Doc/tools/templates/indexsidebar.html
@@ -10,7 +10,7 @@
 <h3>{% trans %}Other resources{% endtrans %}</h3>
 <ul>
   {# XXX: many of these should probably be merged in the main docs #}
-  <li><a href="https://www.python.org/dev/peps/">{% trans %}PEP Index{% endtrans %}</a></li>
+  <li><a href="https://peps.python.org/">{% trans %}PEP Index{% endtrans %}</a></li>
   <li><a href="https://wiki.python.org/moin/BeginnersGuide">{% trans %}Beginner's Guide{% endtrans %}</a></li>
   <li><a href="https://wiki.python.org/moin/PythonBooks">{% trans %}Book List{% endtrans %}</a></li>
   <li><a href="https://www.python.org/doc/av/">{% trans %}Audio/Visual Talks{% endtrans %}</a></li>

--- a/Doc/whatsnew/2.0.rst
+++ b/Doc/whatsnew/2.0.rst
@@ -130,7 +130,7 @@ Guidelines":
 Read the rest of :pep:`1` for the details of the PEP editorial process, style, and
 format.  PEPs are kept in the Python CVS tree on SourceForge, though they're not
 part of the Python 2.0 distribution, and are also available in HTML form from
-https://www.python.org/dev/peps/.  As of September 2000, there are 25 PEPS, ranging
+https://peps.python.org/.  As of September 2000, there are 25 PEPS, ranging
 from :pep:`201`, "Lockstep Iteration", to PEP 225, "Elementwise/Objectwise
 Operators".
 

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -2681,7 +2681,7 @@ these commands by default, as long as, when invoked, they provide clear and
 simple directions on how to install them on that platform (usually using
 the system package manager).
 
-__ https://www.python.org/dev/peps/pep-0477/#disabling-ensurepip-by-downstream-distributors
+__ https://peps.python.org/pep-0477/#disabling-ensurepip-by-downstream-distributors
 
 
 Documentation Changes

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -220,7 +220,7 @@ these commands by default, as long as, when invoked, they provide clear and
 simple directions on how to install them on that platform (usually using
 the system package manager).
 
-__ https://www.python.org/dev/peps/pep-0453/#recommendations-for-downstream-distributors
+__ https://peps.python.org/pep-0453/#recommendations-for-downstream-distributors
 
 .. note::
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -353,7 +353,7 @@ module:
 
 The new functions return the number of nanoseconds as an integer value.
 
-`Measurements <https://www.python.org/dev/peps/pep-0564/#annex-clocks-resolution-in-python>`_
+`Measurements <https://peps.python.org/pep-0564/#annex-clocks-resolution-in-python>`_
 show that on Linux and Windows the resolution of :func:`time.time_ns` is
 approximately 3 times better than that of :func:`time.time`.
 

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -298,7 +298,7 @@ class Field:
     # This is used to support the PEP 487 __set_name__ protocol in the
     # case where we're using a field that contains a descriptor as a
     # default value.  For details on __set_name__, see
-    # https://www.python.org/dev/peps/pep-0487/#implementation-details.
+    # https://peps.python.org/pep-0487/#implementation-details.
     #
     # Note that in _process_class, this Field object is overwritten
     # with the default value, so the end result is a descriptor that

--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -692,7 +692,7 @@ class build_ext(Command):
         suffix = '_' + ext.name.split('.')[-1]
         try:
             # Unicode module name support as defined in PEP-489
-            # https://www.python.org/dev/peps/pep-0489/#export-hook-name
+            # https://peps.python.org/pep-0489/#export-hook-name
             suffix.encode('ascii')
         except UnicodeEncodeError:
             suffix = 'U' + suffix.encode('punycode').replace(b'-', b'_').decode('ascii')

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -697,7 +697,7 @@ class HTMLDoc(Doc):
                 url = 'http://www.rfc-editor.org/rfc/rfc%d.txt' % int(rfc)
                 results.append('<a href="%s">%s</a>' % (url, escape(all)))
             elif pep:
-                url = 'https://www.python.org/dev/peps/pep-%04d/' % int(pep)
+                url = 'https://peps.python.org/pep-%04d/' % int(pep)
                 results.append('<a href="%s">%s</a>' % (url, escape(all)))
             elif selfdot:
                 # Create a link for methods like 'self.method(...)'

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -694,7 +694,7 @@ class HTMLDoc(Doc):
                 url = escape(all).replace('"', '&quot;')
                 results.append('<a href="%s">%s</a>' % (url, url))
             elif rfc:
-                url = 'http://www.rfc-editor.org/rfc/rfc%d.txt' % int(rfc)
+                url = 'https://www.rfc-editor.org/rfc/rfc%d.txt' % int(rfc)
                 results.append('<a href="%s">%s</a>' % (url, escape(all)))
             elif pep:
                 url = 'https://peps.python.org/pep-%04d/' % int(pep)

--- a/Lib/secrets.py
+++ b/Lib/secrets.py
@@ -2,7 +2,7 @@
 managing secrets such as account authentication, tokens, and similar.
 
 See PEP 506 for more information.
-https://www.python.org/dev/peps/pep-0506/
+https://peps.python.org/pep-0506/
 
 """
 

--- a/Lib/test/test_docxmlrpc.py
+++ b/Lib/test/test_docxmlrpc.py
@@ -148,7 +148,7 @@ class DocXMLRPCHTTPGETServer(unittest.TestCase):
              b'<tt>Add&nbsp;two&nbsp;instances&nbsp;together.&nbsp;This&nbsp;'
              b'follows&nbsp;<a href="https://peps.python.org/pep-0008/">'
              b'PEP008</a>,&nbsp;but&nbsp;has&nbsp;nothing<br>\nto&nbsp;do&nbsp;'
-             b'with&nbsp;<a href="http://www.rfc-editor.org/rfc/rfc1952.txt">'
+             b'with&nbsp;<a href="https://www.rfc-editor.org/rfc/rfc1952.txt">'
              b'RFC1952</a>.&nbsp;Case&nbsp;should&nbsp;matter:&nbsp;pEp008&nbsp;'
              b'and&nbsp;rFC1952.&nbsp;&nbsp;Things<br>\nthat&nbsp;start&nbsp;'
              b'with&nbsp;http&nbsp;and&nbsp;ftp&nbsp;should&nbsp;be&nbsp;'

--- a/Lib/test/test_docxmlrpc.py
+++ b/Lib/test/test_docxmlrpc.py
@@ -146,7 +146,7 @@ class DocXMLRPCHTTPGETServer(unittest.TestCase):
         self.assertIn(
             (b'<dl><dt><a name="-add"><strong>add</strong></a>(x, y)</dt><dd>'
              b'<tt>Add&nbsp;two&nbsp;instances&nbsp;together.&nbsp;This&nbsp;'
-             b'follows&nbsp;<a href="https://www.python.org/dev/peps/pep-0008/">'
+             b'follows&nbsp;<a href="https://peps.python.org/pep-0008/">'
              b'PEP008</a>,&nbsp;but&nbsp;has&nbsp;nothing<br>\nto&nbsp;do&nbsp;'
              b'with&nbsp;<a href="http://www.rfc-editor.org/rfc/rfc1952.txt">'
              b'RFC1952</a>.&nbsp;Case&nbsp;should&nbsp;matter:&nbsp;pEp008&nbsp;'

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -2,7 +2,7 @@
 
 This module is an implementation of PEP 205:
 
-https://www.python.org/dev/peps/pep-0205/
+https://peps.python.org/pep-0205/
 """
 
 # Naming convention: Variables named "wr" are weak reference objects;

--- a/Lib/xmlrpc/server.py
+++ b/Lib/xmlrpc/server.py
@@ -734,7 +734,7 @@ class ServerHTMLDoc(pydoc.HTMLDoc):
                 url = 'http://www.rfc-editor.org/rfc/rfc%d.txt' % int(rfc)
                 results.append('<a href="%s">%s</a>' % (url, escape(all)))
             elif pep:
-                url = 'https://www.python.org/dev/peps/pep-%04d/' % int(pep)
+                url = 'https://peps.python.org/pep-%04d/' % int(pep)
                 results.append('<a href="%s">%s</a>' % (url, escape(all)))
             elif text[end:end+1] == '(':
                 results.append(self.namelink(name, methods, funcs, classes))

--- a/Lib/xmlrpc/server.py
+++ b/Lib/xmlrpc/server.py
@@ -731,7 +731,7 @@ class ServerHTMLDoc(pydoc.HTMLDoc):
                 url = escape(all).replace('"', '&quot;')
                 results.append('<a href="%s">%s</a>' % (url, url))
             elif rfc:
-                url = 'http://www.rfc-editor.org/rfc/rfc%d.txt' % int(rfc)
+                url = 'https://www.rfc-editor.org/rfc/rfc%d.txt' % int(rfc)
                 results.append('<a href="%s">%s</a>' % (url, escape(all)))
             elif pep:
                 url = 'https://peps.python.org/pep-%04d/' % int(pep)

--- a/Misc/NEWS.d/next/Documentation/2022-03-26-12-20-16.bpo-47126.p6_Ovm.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-03-26-12-20-16.bpo-47126.p6_Ovm.rst
@@ -1,0 +1,1 @@
+Update PEP URLs to :pep:`676`'s new canonical form.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -523,7 +523,7 @@ ensure_utf8(char *line, struct tok_state *tok)
                      "Non-UTF-8 code starting with '\\x%.2x' "
                      "in file %U on line %i, "
                      "but no encoding declared; "
-                     "see https://python.org/dev/peps/pep-0263/ for details",
+                     "see https://peps.python.org/pep-0263/ for details",
                      badchar, tok->filename, tok->lineno + 1);
         return 0;
     }

--- a/README.rst
+++ b/README.rst
@@ -228,7 +228,7 @@ If you have a proposal to change Python, you may want to send an email to the
 `comp.lang.python`_ or `python-ideas`_ mailing lists for initial feedback.  A
 Python Enhancement Proposal (PEP) may be submitted if your idea gains ground.
 All current PEPs, as well as guidelines for submitting a new PEP, are listed at
-`python.org/dev/peps/ <https://www.python.org/dev/peps/>`_.
+`peps.python.org <https://peps.python.org/>`_.
 
 .. _python-ideas: https://mail.python.org/mailman/listinfo/python-ideas/
 .. _comp.lang.python: https://mail.python.org/mailman/listinfo/python-list

--- a/Tools/scripts/stable_abi.py
+++ b/Tools/scripts/stable_abi.py
@@ -656,7 +656,7 @@ def main():
 
         And in PEP 384:
 
-        https://www.python.org/dev/peps/pep-0384/
+        https://peps.python.org/pep-0384/
         """)
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
With the recent implementation of [PEP 676](https://peps.python.org/pep-0676/) the canonical URL for PEPs has changed from, for example:

https://www.python.org/dev/peps/pep-0008/

to:

https://peps.python.org/pep-0008/

Redirects are in place so the old links still work, but let's update the docs and docstrings to use the new canonical form. There's also a couple of places in code.

Also removed `r'http://www.python.org/dev/peps/pep-\d+'` from the docs linkcheck. There are no URLs of that form in `main`, they're all `https`, so this isn't needed.

Also updated RFC link generator to use `https` instead of `http`, because it was right next to the PEP link generator being changed. I can drop this change if necessary.


<!-- issue-number: [bpo-47126](https://bugs.python.org/issue47126) -->
https://bugs.python.org/issue47126
<!-- /issue-number -->
