### PR TITLE
bpo-47128: Enhance Argument Clinic's NoneType return converter to give `void`

### DIFF
--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1055,6 +1055,7 @@ Currently Argument Clinic supports only a few return converters:
 
 .. code-block:: none
 
+    NoneType
     bool
     int
     unsigned int

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1046,10 +1046,12 @@ There's one additional complication when using return converters: how do you
 indicate an error has occurred?  Normally, a function returns a valid (non-``NULL``)
 pointer for success, and ``NULL`` for failure.  But if you use an integer return converter,
 all integers are valid.  How can Argument Clinic detect an error?  Its solution: each return
-converter implicitly looks for a special value that indicates an error.  If you return
+converter except ``NoneType`` implicitly looks for a special value that indicates an error.  If you return
 that value, and an error has been set (``PyErr_Occurred()`` returns a true
 value), then the generated code will propagate the error.  Otherwise it will
-encode the value you return like normal.
+encode the value you return like normal. For ``NoneType``,
+``PyErr_Occurred()`` only is checked because the ``void`` type cannot have a
+special value.
 
 Currently Argument Clinic supports only a few return converters:
 

--- a/Misc/NEWS.d/next/Tools-Demos/2022-03-26-15-29-25.bpo-47128.-48DIT.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2022-03-26-15-29-25.bpo-47128.-48DIT.rst
@@ -1,0 +1,5 @@
+Argument Clinic got enhanced :data:`NoneType` return converter. With it, a
+generated impl header gets :c:type:`void` return type and the corresponding
+generated wrapper returns :const:`NULL` on :c:func:`PyErr_Occurred` or
+:c:macro:`Py_None` otherwise. Previously, the return type was
+:c:type:`PyObject *`. Patch by Oleg Iarygin.

--- a/Modules/_io/clinic/iobase.c.h
+++ b/Modules/_io/clinic/iobase.c.h
@@ -251,6 +251,25 @@ PyDoc_STRVAR(_io__IOBase_writelines__doc__,
 #define _IO__IOBASE_WRITELINES_METHODDEF    \
     {"writelines", (PyCFunction)_io__IOBase_writelines, METH_O, _io__IOBase_writelines__doc__},
 
+static void
+_io__IOBase_writelines_impl(PyObject *self, PyObject *lines);
+
+static PyObject *
+_io__IOBase_writelines(PyObject *self, PyObject *lines)
+{
+    PyObject *return_value = NULL;
+
+    _io__IOBase_writelines_impl(self, lines);
+    if (PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = Py_None;
+    Py_INCREF(Py_None);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_io__RawIOBase_read__doc__,
 "read($self, size=-1, /)\n"
 "--\n"
@@ -310,4 +329,4 @@ _io__RawIOBase_readall(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__RawIOBase_readall_impl(self);
 }
-/*[clinic end generated code: output=83c1361a7a51ca84 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=93ac28e60a088847 input=a9049054013a1b77]*/

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -739,7 +739,7 @@ _io__IOBase_readlines_impl(PyObject *self, Py_ssize_t hint)
 }
 
 /*[clinic input]
-_io._IOBase.writelines
+_io._IOBase.writelines -> NoneType
     lines: object
     /
 
@@ -749,25 +749,25 @@ Line separators are not added, so it is usual for each of the
 lines provided to have a line separator at the end.
 [clinic start generated code]*/
 
-static PyObject *
-_io__IOBase_writelines(PyObject *self, PyObject *lines)
-/*[clinic end generated code: output=976eb0a9b60a6628 input=cac3fc8864183359]*/
+static void
+_io__IOBase_writelines_impl(PyObject *self, PyObject *lines)
+/*[clinic end generated code: output=f3feca36db72dbd1 input=286ba711cb7291ad]*/
 {
     PyObject *iter, *res;
 
     if (iobase_check_closed(self))
-        return NULL;
+        return;
 
     iter = PyObject_GetIter(lines);
     if (iter == NULL)
-        return NULL;
+        return;
 
     while (1) {
         PyObject *line = PyIter_Next(iter);
         if (line == NULL) {
             if (PyErr_Occurred()) {
                 Py_DECREF(iter);
-                return NULL;
+                return;
             }
             else
                 break; /* Stop Iteration */
@@ -780,12 +780,11 @@ _io__IOBase_writelines(PyObject *self, PyObject *lines)
         Py_DECREF(line);
         if (res == NULL) {
             Py_DECREF(iter);
-            return NULL;
+            return;
         }
         Py_DECREF(res);
     }
     Py_DECREF(iter);
-    Py_RETURN_NONE;
 }
 
 #include "clinic/iobase.c.h"


### PR DESCRIPTION
This PR makes the following possible (note that the impl has a void return type):

```c
/*[clinic input]
_io._IOBase.writelines -> NoneType
    lines: object
    /
[clinic start generated code]*/

static void
_io__IOBase_writelines_impl(PyObject *self, PyObject *lines)
/*[clinic end generated code: output=f3feca36db72dbd1 input=286ba711cb7291ad]*/
```

Previously, the return type would be `Object *` and a caller would replace non-`Py_None` values with NULL.

So now there is no need to track whether `NULL` or `Py_None` should be returned. Or should it be `Py_RETURN_NONE`? Argument Clinic does it by itself returning NULL on errors and Py_None otherwise:

```c
static PyObject *
_io__IOBase_writelines(PyObject *self, PyObject *lines)
{
    PyObject *return_value = NULL;

    _io__IOBase_writelines_impl(self, lines);
    if (PyErr_Occurred()) {
        goto exit;
    }
    return_value = Py_None;
    Py_INCREF(Py_None);

exit:
    return return_value;
}
```

<!-- issue-number: [bpo-47128](https://bugs.python.org/issue47128) -->
https://bugs.python.org/issue47128
<!-- /issue-number -->
