### PR TITLE
bpo-47129: Add more informative messages to f-string syntax errors

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -637,7 +637,7 @@ x = (
                              ])
 
         # Different error messeges are raised when a specfier ('!', ':' or '=') is used after an empty expression
-        self.assertAllRaise(SyntaxError, "f-string: optional specifier '!' must follow a non-empty expression",
+        self.assertAllRaise(SyntaxError, "f-string: expression required before '!'",
                             ["f'{!r}'",
                              "f'{ !r}'",
                              "f'{!}'",
@@ -658,7 +658,7 @@ x = (
                              "f'{ !xr:a}'",
                              ])
 
-        self.assertAllRaise(SyntaxError, "f-string: optional specifier ':' must follow a non-empty expression",
+        self.assertAllRaise(SyntaxError, "f-string: expression required before ':'",
                             ["f'{:}'",
                              "f'{ :!}'",
                              "f'{:2}'",
@@ -666,7 +666,7 @@ x = (
                              "f'{:'",
                              ])
 
-        self.assertAllRaise(SyntaxError, "f-string: optional specifier '=' must follow a non-empty expression",
+        self.assertAllRaise(SyntaxError, "f-string: expression required before '='",
                             ["f'{=}'",
                              "f'{ =}'",
                              "f'{ =:}'",

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -628,16 +628,27 @@ x = (
                             ["f'{}'",
                              "f'{ }'"
                              "f' {} '",
-                             "f'{!r}'",
-                             "f'{ !r}'",
                              "f'{10:{ }}'",
                              "f' { } '",
 
                              # The Python parser ignores also the following
                              # whitespace characters in additional to a space.
-                             "f'''{\t\f\r\n}'''",
+                             "f'''{\t\f\r\n}'''",                            
+                             ])
+                             
+        # Different error messeges are raised when a specfier ('!', ':' or '=') is used after an empty expression
+        self.assertAllRaise(SyntaxError, "f-string: optional specifier '!' must follow a non-empty expression", 
+                            ["f'{!r}'",
+                             "f'{ !r}'",
+                             "f'{!}'",
+                             "f'''{\t\f\r\n!a}'''",
 
-                             # Catch the empty expression before the
+                             # Catch empty expression before the
+                             #  missing closing brace.
+                             "f'{!'",
+                             "f'{!s:'",
+                             
+                             # Catch empty expression before the
                              #  invalid conversion.
                              "f'{!x}'",
                              "f'{ !xr}'",
@@ -645,16 +656,23 @@ x = (
                              "f'{!x:a}'",
                              "f'{ !xr:}'",
                              "f'{ !xr:a}'",
+                             ])
 
-                             "f'{!}'",
-                             "f'{:}'",
-
-                             # We find the empty expression before the
-                             #  missing closing brace.
-                             "f'{!'",
-                             "f'{!s:'",
+        self.assertAllRaise(SyntaxError, "f-string: optional specifier ':' must follow a non-empty expression", 
+                            ["f'{:}'",
+                             "f'{ :!}'",
+                             "f'{:2}'",
+                             "f'''{\t\f\r\n:a}'''",
                              "f'{:'",
-                             "f'{:x'",
+                             ])
+
+        self.assertAllRaise(SyntaxError, "f-string: optional specifier '=' must follow a non-empty expression", 
+                            ["f'{=}'",
+                             "f'{ =}'",
+                             "f'{ =:}'",
+                             "f'{   =!}'",
+                             "f'''{\t\f\r\n=}'''",
+                             "f'{='",
                              ])
 
         # Different error message is raised for other whitespace characters.

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -633,11 +633,11 @@ x = (
 
                              # The Python parser ignores also the following
                              # whitespace characters in additional to a space.
-                             "f'''{\t\f\r\n}'''",                            
+                             "f'''{\t\f\r\n}'''",
                              ])
-                             
+
         # Different error messeges are raised when a specfier ('!', ':' or '=') is used after an empty expression
-        self.assertAllRaise(SyntaxError, "f-string: optional specifier '!' must follow a non-empty expression", 
+        self.assertAllRaise(SyntaxError, "f-string: optional specifier '!' must follow a non-empty expression",
                             ["f'{!r}'",
                              "f'{ !r}'",
                              "f'{!}'",
@@ -647,7 +647,7 @@ x = (
                              #  missing closing brace.
                              "f'{!'",
                              "f'{!s:'",
-                             
+
                              # Catch empty expression before the
                              #  invalid conversion.
                              "f'{!x}'",
@@ -658,7 +658,7 @@ x = (
                              "f'{ !xr:a}'",
                              ])
 
-        self.assertAllRaise(SyntaxError, "f-string: optional specifier ':' must follow a non-empty expression", 
+        self.assertAllRaise(SyntaxError, "f-string: optional specifier ':' must follow a non-empty expression",
                             ["f'{:}'",
                              "f'{ :!}'",
                              "f'{:2}'",
@@ -666,7 +666,7 @@ x = (
                              "f'{:'",
                              ])
 
-        self.assertAllRaise(SyntaxError, "f-string: optional specifier '=' must follow a non-empty expression", 
+        self.assertAllRaise(SyntaxError, "f-string: optional specifier '=' must follow a non-empty expression",
                             ["f'{=}'",
                              "f'{ =}'",
                              "f'{ =:}'",

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-26-16-35-57.bpo-47129.hDg2Vt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-26-16-35-57.bpo-47129.hDg2Vt.rst
@@ -1,0 +1,1 @@
+Improve error messages in f-string syntax errors concerning empty expressions.

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -357,9 +357,15 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
             break;
         }
     }
+    
     if (s == expr_end) {
-        RAISE_SYNTAX_ERROR("f-string: empty expression not allowed");
-        return NULL;
+        if (*expr_end == '!' || *expr_end == ':' || *expr_end == '=') {
+            RAISE_SYNTAX_ERROR("f-string: optional specifier '%c' must follow a non-empty expression", *expr_end);
+            return NULL;
+        } else {
+            RAISE_SYNTAX_ERROR("f-string: empty expression not allowed");
+            return NULL;
+        }
     }
 
     len = expr_end - expr_start;

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -362,10 +362,9 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
         if (*expr_end == '!' || *expr_end == ':' || *expr_end == '=') {
             RAISE_SYNTAX_ERROR("f-string: expression required before '%c'", *expr_end);
             return NULL;
-        } else {
-            RAISE_SYNTAX_ERROR("f-string: empty expression not allowed");
-            return NULL;
         }
+        RAISE_SYNTAX_ERROR("f-string: empty expression not allowed");
+        return NULL;
     }
 
     len = expr_end - expr_start;

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -360,7 +360,7 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
     
     if (s == expr_end) {
         if (*expr_end == '!' || *expr_end == ':' || *expr_end == '=') {
-            RAISE_SYNTAX_ERROR("f-string: optional specifier '%c' must follow a non-empty expression", *expr_end);
+            RAISE_SYNTAX_ERROR("f-string: expression required before '%c'", *expr_end);
             return NULL;
         } else {
             RAISE_SYNTAX_ERROR("f-string: empty expression not allowed");


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47129](https://bugs.python.org/issue47129) -->
https://bugs.python.org/issue47129
<!-- /issue-number -->

Automerge-Triggered-By: GH:lysnikolaou