### PR TITLE
bpo-46126: Restore 'descriptions' when running tests internally.

### DIFF
--- a/Lib/test/support/testresult.py
+++ b/Lib/test/support/testresult.py
@@ -145,11 +145,7 @@ def get_test_runner_class(verbosity, buffer=False):
         return functools.partial(unittest.TextTestRunner,
                                  resultclass=RegressionTestResult,
                                  buffer=buffer,
-                                 verbosity=verbosity,
-                                 # disable descriptions so errors are
-                                 # readily traceable. bpo-46126
-                                 descriptions=False,
-                                 )
+                                 verbosity=verbosity)
     return functools.partial(QuietRegressionTestRunner, buffer=buffer)
 
 def get_test_runner(stream, verbosity, capture_output=False):

--- a/Misc/NEWS.d/next/Tests/2022-03-26-11-41-19.bpo-46126.q14Ioy.rst
+++ b/Misc/NEWS.d/next/Tests/2022-03-26-11-41-19.bpo-46126.q14Ioy.rst
@@ -1,0 +1,1 @@
+Restore 'descriptions' when running tests internally.


### PR DESCRIPTION
This reverts commit a941e5927f7f2540946813606c61c6aea38db426 (GH-30194).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46126](https://bugs.python.org/issue46126) -->
https://bugs.python.org/issue46126
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco