### PR TITLE
bpo-27929: resolve names only for AF_INET/AF_INET6 with asyncio

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -620,7 +620,8 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
 
-        if not hasattr(socket, 'AF_UNIX') or sock.family != socket.AF_UNIX:
+        if sock.family == socket.AF_INET or (
+                base_events._HAS_IPv6 and sock.family == socket.AF_INET6):
             resolved = await self._ensure_resolved(
                 address, family=sock.family, type=sock.type, proto=sock.proto,
                 loop=self,

--- a/Misc/NEWS.d/next/Library/2022-03-28-13-35-50.bpo-27929.j5mAmV.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-28-13-35-50.bpo-27929.j5mAmV.rst
@@ -1,0 +1,3 @@
+Fix :func:`asyncio.sock_connect` to only resolve names for ``AF_INET`` or
+``AF_INET6`` families. Resolution may not make sense for other families,
+like ``AF_BLUETOOTH`` and ``AF_UNIX``.

--- a/Misc/NEWS.d/next/Library/2022-03-28-13-35-50.bpo-27929.j5mAmV.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-28-13-35-50.bpo-27929.j5mAmV.rst
@@ -1,3 +1,3 @@
-Fix :func:`asyncio.sock_connect` to only resolve names for ``AF_INET`` or
-``AF_INET6`` families. Resolution may not make sense for other families,
-like ``AF_BLUETOOTH`` and ``AF_UNIX``.
+Fix :meth:`asyncio.loop.sock_connect` to only resolve names for :const:`socket.AF_INET` or
+:const:`socket.AF_INET6` families. Resolution may not make sense for other families,
+like :const:`socket.AF_BLUETOOTH` and :const:`socket.AF_UNIX`.


### PR DESCRIPTION
For other families, it may not make sense to resolve names. For
example, with AF_BLUETOOTH, there is no name resolution and attempting
to do so will trigger a "ai_family not supported".

The bug report contains an example:

```python
import asyncio
import socket
sock = socket.socket(family=socket.AF_BLUETOOTH,
                     type=socket.SOCK_STREAM,
                     proto=socket.BTPROTO_RFCOMM)
sock.setblocking(False)
addr = "00:12:34:56:78:99"
loop = asyncio.get_event_loop()
loop.run_until_complete(loop.sock_connect(sock, (addr, 1)))
```

https://bugs.python.org/issue27929

<!-- issue-number: [bpo-27929](https://bugs.python.org/issue27929) -->
https://bugs.python.org/issue27929
<!-- /issue-number -->
