### PR TITLE
bpo-45171: Remove tests of deprecated logger.warn(). (GH-32139)

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1568,7 +1568,7 @@ class Logger(Filterer):
         while stacklevel > 0:
             next_f = f.f_back
             if next_f is None:
-                ##TODO: We've got options here
+                ## We've got options here.
                 ## If we want to use the last (deepest) frame:
                 break
                 ## If we want to mimic the warnings module:

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5075,9 +5075,6 @@ class LoggerTest(BaseTest, AssertErrorMessage):
         self.assertEqual(records[-1].funcName, 'outer')
         self.assertGreater(records[-1].lineno, lineno)
         lineno = records[-1].lineno
-        trigger = self.logger.warn
-        outer()
-        self.assertEqual(records[-1].funcName, 'outer')
         root_logger = logging.getLogger()
         root_logger.addHandler(self.recording)
         trigger = logging.warning


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This is a follow-up to #28287. @tirkarthi observed that a deprecation message was emitted by the tests. Rather than catch and ignore this deprecation warning, we might as well forego testing deprecated methods.
In addition, I reworded a comment ever so slightly, as discussed briefly with @vsajip in #28287.

<!-- issue-number: [bpo-45171](https://bugs.python.org/issue45171) -->
https://bugs.python.org/issue45171
<!-- /issue-number -->
