### PR TITLE
[3.10] bpo-47138: Fix documentation build by pinning Jinja version to 3.0.3

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -8,6 +8,8 @@ sphinx==3.2.1
 # version 3.2.1. It can be removed after bumping Sphinx version to at
 # least 3.5.4.
 docutils==0.17.1
+# Jinja version is pinned to a version compatible with Sphinx version 2.4.4.
+jinja2==3.0.3
 
 blurb
 

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -8,7 +8,7 @@ sphinx==3.2.1
 # version 3.2.1. It can be removed after bumping Sphinx version to at
 # least 3.5.4.
 docutils==0.17.1
-# Jinja version is pinned to a version compatible with Sphinx version 2.4.4.
+# Jinja version is pinned to a version compatible with Sphinx version 3.2.1.
 jinja2==3.0.3
 
 blurb

--- a/Misc/NEWS.d/next/Documentation/2022-03-28-12-29-42.bpo-47138.2B4N-k.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-03-28-12-29-42.bpo-47138.2B4N-k.rst
@@ -1,0 +1,1 @@
+Pin Jinja to a version compatible with Sphinx version 3.2.1.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Cherry-picked from https://github.com/python/cpython/pull/32109, thanks @m-aciek!

<!-- issue-number: [bpo-47138](https://bugs.python.org/issue47138) -->
https://bugs.python.org/issue47138
<!-- /issue-number -->
