### PR TITLE
bpo-43224: Add tests for pickling and copying of unpacked native tuple

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -47,11 +47,43 @@ from unittest.case import _AssertRaisesContext
 from queue import Queue, SimpleQueue
 from weakref import WeakSet, ReferenceType, ref
 import typing
+from typing import Unpack
 
 from typing import TypeVar
 T = TypeVar('T')
 K = TypeVar('K')
 V = TypeVar('V')
+
+_UNPACKED_TUPLES = [
+    # Unpacked tuple using `*`
+    (*tuple[int],)[0],
+    (*tuple[T],)[0],
+    (*tuple[int, str],)[0],
+    (*tuple[int, ...],)[0],
+    (*tuple[T, ...],)[0],
+    tuple[*tuple[int, ...]],
+    tuple[*tuple[T, ...]],
+    tuple[str, *tuple[int, ...]],
+    tuple[*tuple[int, ...], str],
+    tuple[float, *tuple[int, ...], str],
+    tuple[*tuple[*tuple[int, ...]]],
+    # Unpacked tuple using `Unpack`
+    Unpack[tuple[int]],
+    Unpack[tuple[T]],
+    Unpack[tuple[int, str]],
+    Unpack[tuple[int, ...]],
+    Unpack[tuple[T, ...]],
+    tuple[Unpack[tuple[int, ...]]],
+    tuple[Unpack[tuple[T, ...]]],
+    tuple[str, Unpack[tuple[int, ...]]],
+    tuple[Unpack[tuple[int, ...]], str],
+    tuple[float, Unpack[tuple[int, ...]], str],
+    tuple[Unpack[tuple[Unpack[tuple[int, ...]]]]],
+    # Unpacked tuple using `*` AND `Unpack`
+    tuple[Unpack[tuple[*tuple[int, ...]]]],
+    tuple[*tuple[Unpack[tuple[int, ...]]]],
+]
+
 
 class BaseTest(unittest.TestCase):
     """Test basics."""
@@ -351,13 +383,14 @@ class BaseTest(unittest.TestCase):
             MyType[int]
 
     def test_pickle(self):
-        alias = GenericAlias(list, T)
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            s = pickle.dumps(alias, proto)
-            loaded = pickle.loads(s)
-            self.assertEqual(loaded.__origin__, alias.__origin__)
-            self.assertEqual(loaded.__args__, alias.__args__)
-            self.assertEqual(loaded.__parameters__, alias.__parameters__)
+        aliases = [GenericAlias(list, T)] + _UNPACKED_TUPLES
+        for alias in aliases:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                s = pickle.dumps(alias, proto)
+                loaded = pickle.loads(s)
+                self.assertEqual(loaded.__origin__, alias.__origin__)
+                self.assertEqual(loaded.__args__, alias.__args__)
+                self.assertEqual(loaded.__parameters__, alias.__parameters__)
 
     def test_copy(self):
         class X(list):
@@ -366,8 +399,12 @@ class BaseTest(unittest.TestCase):
             def __deepcopy__(self, memo):
                 return self
 
-        for origin in list, deque, X:
-            alias = GenericAlias(origin, T)
+        aliases = [
+            GenericAlias(list, T),
+            GenericAlias(deque, T),
+            GenericAlias(X, T)
+        ] + _UNPACKED_TUPLES
+        for alias in aliases:
             copied = copy.copy(alias)
             self.assertEqual(copied.__origin__, alias.__origin__)
             self.assertEqual(copied.__args__, alias.__args__)

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -385,12 +385,13 @@ class BaseTest(unittest.TestCase):
     def test_pickle(self):
         aliases = [GenericAlias(list, T)] + _UNPACKED_TUPLES
         for alias in aliases:
-            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                s = pickle.dumps(alias, proto)
-                loaded = pickle.loads(s)
-                self.assertEqual(loaded.__origin__, alias.__origin__)
-                self.assertEqual(loaded.__args__, alias.__args__)
-                self.assertEqual(loaded.__parameters__, alias.__parameters__)
+            with self.subTest(alias=alias):
+                for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                    s = pickle.dumps(alias, proto)
+                    loaded = pickle.loads(s)
+                    self.assertEqual(loaded.__origin__, alias.__origin__)
+                    self.assertEqual(loaded.__args__, alias.__args__)
+                    self.assertEqual(loaded.__parameters__, alias.__parameters__)
 
     def test_copy(self):
         class X(list):
@@ -405,14 +406,15 @@ class BaseTest(unittest.TestCase):
             GenericAlias(X, T)
         ] + _UNPACKED_TUPLES
         for alias in aliases:
-            copied = copy.copy(alias)
-            self.assertEqual(copied.__origin__, alias.__origin__)
-            self.assertEqual(copied.__args__, alias.__args__)
-            self.assertEqual(copied.__parameters__, alias.__parameters__)
-            copied = copy.deepcopy(alias)
-            self.assertEqual(copied.__origin__, alias.__origin__)
-            self.assertEqual(copied.__args__, alias.__args__)
-            self.assertEqual(copied.__parameters__, alias.__parameters__)
+            with self.subTest(alias=alias):
+                copied = copy.copy(alias)
+                self.assertEqual(copied.__origin__, alias.__origin__)
+                self.assertEqual(copied.__args__, alias.__args__)
+                self.assertEqual(copied.__parameters__, alias.__parameters__)
+                copied = copy.deepcopy(alias)
+                self.assertEqual(copied.__origin__, alias.__origin__)
+                self.assertEqual(copied.__args__, alias.__args__)
+                self.assertEqual(copied.__parameters__, alias.__parameters__)
 
     def test_union(self):
         a = typing.Union[list[int], list[str]]

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -385,8 +385,8 @@ class BaseTest(unittest.TestCase):
     def test_pickle(self):
         aliases = [GenericAlias(list, T)] + _UNPACKED_TUPLES
         for alias in aliases:
-            with self.subTest(alias=alias):
-                for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                with self.subTest(alias=alias, proto=proto):
                     s = pickle.dumps(alias, proto)
                     loaded = pickle.loads(s)
                     self.assertEqual(loaded.__origin__, alias.__origin__)


### PR DESCRIPTION


<!-- issue-number: [bpo-43224](https://bugs.python.org/issue43224) -->
https://bugs.python.org/issue43224
<!-- /issue-number -->
