### PR TITLE
bpo-4833: Add ZipFile.mkdir

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -478,6 +478,18 @@ ZipFile Objects
       a closed ZipFile will raise a :exc:`ValueError`.  Previously,
       a :exc:`RuntimeError` was raised.
 
+.. method:: ZipFile.mkdir(zinfo_or_directory, mode=511)
+
+   .. versionadded:: 3.11
+
+   Create a directory inside the archive.  If *zinfo_or_directory* is a string,
+   a directory is created inside the archive with the mode that is specified in
+   the *mode* argument. If, however, *zinfo_or_directory* is
+   a :class:`ZipInfo` instance then the *mode* argument is ignored.
+
+   The archive must be opened with mode ``'w'``, ``'x'`` or ``'a'``.
+
+
 
 The following data attributes are also available:
 

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -480,8 +480,6 @@ ZipFile Objects
 
 .. method:: ZipFile.mkdir(zinfo_or_directory, mode=511)
 
-   .. versionadded:: 3.11
-
    Create a directory inside the archive.  If *zinfo_or_directory* is a string,
    a directory is created inside the archive with the mode that is specified in
    the *mode* argument. If, however, *zinfo_or_directory* is
@@ -489,6 +487,7 @@ ZipFile Objects
 
    The archive must be opened with mode ``'w'``, ``'x'`` or ``'a'``.
 
+   .. versionadded:: 3.11
 
 
 The following data attributes are also available:

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -2667,7 +2667,7 @@ class TestWithDirectory(unittest.TestCase):
             target = os.path.join(TESTFN2, "target")
             os.mkdir(target)
             zf.extractall(target)
-            self.assertEqual(os.listdir(target), ["directory", "directory2", "directory3", "directory4"])
+            self.assertEqual(set(os.listdir(target)), {"directory", "directory2", "directory3", "directory4"})
 
     def tearDown(self):
         rmtree(TESTFN2)

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -2682,7 +2682,7 @@ class TestWithDirectory(unittest.TestCase):
             zf.write(directory, arcname="directory2/")
             zinfo = zf.filelist[1]
             self.assertEqual(zinfo.filename, "directory2/")
-            self.assertEqual(zinfo.external_attr, ((0o40000 | mode) << 16) | 0x10)
+            self.assertEqual(zinfo.external_attr, (mode << 16) | 0x10)
 
             target = os.path.join(TESTFN2, "target")
             os.mkdir(target)

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1841,7 +1841,7 @@ class ZipFile:
             zinfo = ZipInfo(directory_name)
             zinfo.compress_size = 0
             zinfo.CRC = 0
-            zinfo.external_attr = (mode & 0xFFFF) << 16
+            zinfo.external_attr = ((0o40000 | mode) & 0xFFFF) << 16
             zinfo.file_size = 0
             zinfo.external_attr |= 0x10
         else:

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1772,6 +1772,7 @@ class ZipFile:
         if zinfo.is_dir():
             zinfo.compress_size = 0
             zinfo.CRC = 0
+            self.mkdir(zinfo)
         else:
             if compress_type is not None:
                 zinfo.compress_type = compress_type
@@ -1783,23 +1784,6 @@ class ZipFile:
             else:
                 zinfo._compresslevel = self.compresslevel
 
-        if zinfo.is_dir():
-            with self._lock:
-                if self._seekable:
-                    self.fp.seek(self.start_dir)
-                zinfo.header_offset = self.fp.tell()  # Start of header bytes
-                if zinfo.compress_type == ZIP_LZMA:
-                # Compressed data includes an end-of-stream (EOS) marker
-                    zinfo.flag_bits |= _MASK_COMPRESS_OPTION_1
-
-                self._writecheck(zinfo)
-                self._didModify = True
-
-                self.filelist.append(zinfo)
-                self.NameToInfo[zinfo.filename] = zinfo
-                self.fp.write(zinfo.FileHeader(False))
-                self.start_dir = self.fp.tell()
-        else:
             with open(filename, "rb") as src, self.open(zinfo, 'w') as dest:
                 shutil.copyfileobj(src, dest, 1024*8)
 
@@ -1843,6 +1827,41 @@ class ZipFile:
         with self._lock:
             with self.open(zinfo, mode='w') as dest:
                 dest.write(data)
+
+    def mkdir(self, zinfo_or_directory_name, mode=511):
+        """Creates a directory inside the zip archive."""
+        if isinstance(zinfo_or_directory_name, ZipInfo):
+            zinfo = zinfo_or_directory_name
+            if not zinfo.is_dir():
+                raise ValueError("The given ZipInfo does not describe a directory")
+        elif isinstance(zinfo_or_directory_name, str):
+            directory_name = zinfo_or_directory_name
+            if not directory_name.endswith("/"):
+                directory_name += "/"
+            zinfo = ZipInfo(directory_name)
+            zinfo.compress_size = 0
+            zinfo.CRC = 0
+            zinfo.external_attr = (mode & 0xFFFF) << 16
+            zinfo.file_size = 0
+            zinfo.external_attr |= 0x10
+        else:
+            raise TypeError("Expected type str or ZipInfo")
+
+        with self._lock:
+            if self._seekable:
+                self.fp.seek(self.start_dir)
+            zinfo.header_offset = self.fp.tell()  # Start of header bytes
+            if zinfo.compress_type == ZIP_LZMA:
+            # Compressed data includes an end-of-stream (EOS) marker
+                zinfo.flag_bits |= _MASK_COMPRESS_OPTION_1
+
+            self._writecheck(zinfo)
+            self._didModify = True
+
+            self.filelist.append(zinfo)
+            self.NameToInfo[zinfo.filename] = zinfo
+            self.fp.write(zinfo.FileHeader(False))
+            self.start_dir = self.fp.tell()
 
     def __del__(self):
         """Call the "close()" method in case the user forgot."""

--- a/Misc/NEWS.d/next/Library/2022-03-28-20-16-37.bpo-4833.2vSUE5.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-28-20-16-37.bpo-4833.2vSUE5.rst
@@ -1,1 +1,1 @@
-Add ZipFile.mkdir
+Add :meth:`ZipFile.mkdir`

--- a/Misc/NEWS.d/next/Library/2022-03-28-20-16-37.bpo-4833.2vSUE5.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-28-20-16-37.bpo-4833.2vSUE5.rst
@@ -1,0 +1,1 @@
+Add ZipFile.mkdir


### PR DESCRIPTION
Add `ZipFile.mkdir` method to create directories inside zip archives.

<!-- issue-number: [bpo-4833](https://bugs.python.org/issue4833) -->
https://bugs.python.org/issue4833
<!-- /issue-number -->
