### PR TITLE
bpo-47031: Improve documentation for `math.nan`

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -649,8 +649,8 @@ Constants
    A floating-point "not a number" (NaN) value. Equivalent to the output of
    ``float('nan')``. Due to the requirements of the `IEEE-754 standard
    <https://en.wikipedia.org/wiki/IEEE_754>`_, ``math.nan`` and ``float('nan')`` are
-   not considered to equal to any other numeric value, including themselves. To avoid errors
-   when checking whether a number is a NaN, use the :func:`isnan` function to test
+   not considered to equal to any other numeric value, including themselves. To check
+   whether a number is a NaN, use the :func:`isnan` function to test
    for NaNs instead of ``is`` or ``==``.
    Example::
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -647,7 +647,7 @@ Constants
 .. data:: nan
 
    A floating-point "not a number" (NaN) value. Equivalent to the output of
-   ``float('nan')``. Specifically, due to the requirements of the `IEEE-754 standard
+   ``float('nan')``. Due to the requirements of the `IEEE-754 standard
    <https://en.wikipedia.org/wiki/IEEE_754>`_, ``math.nan`` and ``float('nan')`` are
    not considered to equal to any other numeric value, including themselves. To avoid errors
    when checking whether a number is a NaN, use the :func:`isnan` function to test

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -659,10 +659,6 @@ Constants
       False
       >>> float('nan') == float('nan')
       False
-      >>> math.nan is math.nan
-      True
-      >>> float('nan') is float('nan')
-      False
       >>> math.isnan(math.nan)
       True
       >>> math.isnan(float('nan'))

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -646,8 +646,27 @@ Constants
 
 .. data:: nan
 
-   A floating-point "not a number" (NaN) value.  Equivalent to the output of
-   ``float('nan')``.
+   A floating-point "not a number" (NaN) value. Equivalent to the output of
+   ``float('nan')``. Specifically, due to the requirements of the `IEEE-754 standard
+   <https://en.wikipedia.org/wiki/IEEE_754>`_, ``math.nan`` and ``float('nan')`` are
+   not considered to equal to any other numeric value, including themselves. To avoid errors
+   when checking whether a number is a NaN, use the :func:`isnan` function to test
+   for NaNs instead of ``is`` or ``==``.
+   Example::
+
+      >>> import math
+      >>> math.nan == math.nan
+      False
+      >>> float('nan') == float('nan')
+      False
+      >>> math.nan is math.nan
+      True
+      >>> float('nan') is float('nan')
+      False
+      >>> math.isnan(math.nan)
+      True
+      >>> math.isnan(float('nan'))
+      True
 
    .. versionchanged:: 3.11
       It is now always available.


### PR DESCRIPTION
Documentation improvements for `math.nan` with following points:
* Explain that NANs are never equal to anything, even to themselves.
* Use `math.isnan(x)` to check whether a number is a NaN.
* Add some simple doc examples. 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47031](https://bugs.python.org/issue47031) -->
https://bugs.python.org/issue47031
<!-- /issue-number -->
