### PR TITLE
[3.10] bpo-28516: document contextlib.ExitStack.__enter__ behavior (GH-31636)

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -485,6 +485,9 @@ Functions and classes provided:
           # the with statement, even if attempts to open files later
           # in the list raise an exception
 
+   The :meth:`__enter__` method returns the :class:`ExitStack` instance, and
+   performs no additional operations.
+
    Each instance maintains a stack of registered callbacks that are called in
    reverse order when the instance is closed (either explicitly or implicitly
    at the end of a :keyword:`with` statement). Note that callbacks are *not*


### PR DESCRIPTION
The enter_context is updated with following information: 'The :meth:`__enter__` method
      returns the ExitStack instance, and performs no additional operations.'

Co-authored-by: Jelle Zijlstra <jelle.zijlstra@gmail.com>
(cherry picked from commit 86384cf83f96fcaec03e2ad6516e2e24f20d3b92)

Co-authored-by: vidhya <96202776+Vidhyavinu@users.noreply.github.com>

<!-- issue-number: [bpo-28516](https://bugs.python.org/issue28516) -->
https://bugs.python.org/issue28516
<!-- /issue-number -->
