### PR TITLE
bpo-46775: OSError should call winerror_to_errno unconditionally

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-30-02-36-25.bpo-46775.e3Oxqf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-30-02-36-25.bpo-46775.e3Oxqf.rst
@@ -1,4 +1,3 @@
-Update the constructor of :exc:`OSError` to use winerror_to_errno()
-unconditionally. Some :exc:`OSError` now be raised as a subclass and the
-:attr:`OSError.errno` follows the mapping policy of winerror_to_errno().
+Some Windows system error codes(>= 10000) are now mapped into
+the correct errno while :exc:`OSError` is raised as a subclass.
 Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-30-02-36-25.bpo-46775.e3Oxqf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-30-02-36-25.bpo-46775.e3Oxqf.rst
@@ -1,3 +1,3 @@
 Some Windows system error codes(>= 10000) are now mapped into
-the correct errno while :exc:`OSError` is raised as a subclass.
+the correct errno and may now raise a subclass of :exc:`OSError`.
 Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-30-02-36-25.bpo-46775.e3Oxqf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-30-02-36-25.bpo-46775.e3Oxqf.rst
@@ -1,2 +1,4 @@
 Update the constructor of :exc:`OSError` to use winerror_to_errno()
-unconditionally. Patch by Dong-hee Na.
+unconditionally. Some :exc:`OSError` now be raised as a subclass and the
+:attr:`OSError.errno` follows the mapping policy of winerror_to_errno().
+Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-30-02-36-25.bpo-46775.e3Oxqf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-30-02-36-25.bpo-46775.e3Oxqf.rst
@@ -1,0 +1,2 @@
+Update the constructor of :exc:`OSError` to use winerror_to_errno()
+unconditionally. Patch by Dong-hee Na.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1634,14 +1634,7 @@ oserror_parse_args(PyObject **p_args,
             winerrcode = PyLong_AsLong(*winerror);
             if (winerrcode == -1 && PyErr_Occurred())
                 return -1;
-            /* Set errno to the corresponding POSIX errno (overriding
-               first argument).  Windows Socket error codes (>= 10000)
-               have the same value as their POSIX counterparts.
-            */
-            if (winerrcode < 10000)
-                errcode = winerror_to_errno(winerrcode);
-            else
-                errcode = winerrcode;
+            errcode = winerror_to_errno(winerrcode);
             *myerrno = PyLong_FromLong(errcode);
             if (!*myerrno)
                 return -1;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46775](https://bugs.python.org/issue46775) -->
https://bugs.python.org/issue46775
<!-- /issue-number -->
