### PR TITLE
bpo-26120: do not exclude __future__ Features in pydoc of the __future__ module itself

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -292,7 +292,7 @@ def visiblename(name, all=None, obj=None):
     if name.startswith('_') and hasattr(obj, '_fields'):
         return True
     # Ignore __future__ imports.
-    if name in _future_feature_names:
+    if obj is not __future__ and name in _future_feature_names:
         if isinstance(getattr(obj, name, None), __future__._Feature):
             return False
     if all is not None:

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -850,6 +850,23 @@ class B(A)
         for expected_line in expected_lines:
             self.assertIn(expected_line, as_text)
 
+    def test__future__imports(self):
+        # __future__ features are excluded from module help,
+        # except when it's the __future__ module itself
+        import __future__
+        future_text, _ = get_pydoc_text(__future__)
+        future_html, _ = get_pydoc_html(__future__)
+        pydoc_mod_text, _ = get_pydoc_text(pydoc_mod)
+        pydoc_mod_html, _ = get_pydoc_html(pydoc_mod)
+
+        for feature in __future__.all_feature_names:
+            txt = f"{feature} = _Feature"
+            html = f"<strong>{feature}</strong> = _Feature"
+            self.assertIn(txt, future_text)
+            self.assertIn(html, future_html)
+            self.assertNotIn(txt, pydoc_mod_text)
+            self.assertNotIn(html, pydoc_mod_html)
+
 
 class PydocImportTest(PydocBaseTest):
 


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-26120](https://bugs.python.org/issue26120) -->
https://bugs.python.org/issue26120
<!-- /issue-number -->
