### PR TITLE
[3.7] bpo-47138: Ensure Windows docs build uses the same pinned version as other platforms

### DIFF
--- a/Doc/make.bat
+++ b/Doc/make.bat
@@ -13,7 +13,7 @@ if not defined SPHINXBUILD (
     %PYTHON% -c "import sphinx" > nul 2> nul
     if errorlevel 1 (
         echo Installing sphinx with %PYTHON%
-        %PYTHON% -m pip install sphinx==2.2.0
+        %PYTHON% -m pip install sphinx==2.3.1 blurb docutils==0.17.1 Jinja2==3.0.3
         if errorlevel 1 exit /B
     )
     set SPHINXBUILD=%PYTHON% -c "import sphinx.cmd.build, sys; sys.exit(sphinx.cmd.build.main())"


### PR DESCRIPTION


<!-- issue-number: [bpo-47138](https://bugs.python.org/issue47138) -->
https://bugs.python.org/issue47138
<!-- /issue-number -->
