### PR TITLE
[3.8] bpo-47138: Ensure Windows docs build uses the same pinned version as other platforms (GH-32161)

### DIFF
--- a/Doc/make.bat
+++ b/Doc/make.bat
@@ -13,7 +13,7 @@ if not defined SPHINXBUILD (
     %PYTHON% -c "import sphinx" > nul 2> nul
     if errorlevel 1 (
         echo Installing sphinx with %PYTHON%
-        %PYTHON% -m pip install sphinx==2.2.0
+        %PYTHON% -m pip install -r requirements.txt
         if errorlevel 1 exit /B
     )
     set SPHINXBUILD=%PYTHON% -c "import sphinx.cmd.build, sys; sys.exit(sphinx.cmd.build.main())"
@@ -30,6 +30,7 @@ if not defined BLURB (
     %PYTHON% -c "import blurb" > nul 2> nul
     if errorlevel 1 (
         echo Installing blurb with %PYTHON%
+        rem Should have been installed with Sphinx earlier
         %PYTHON% -m pip install blurb
         if errorlevel 1 exit /B
     )


### PR DESCRIPTION


<!-- issue-number: [bpo-47138](https://bugs.python.org/issue47138) -->
https://bugs.python.org/issue47138
<!-- /issue-number -->
