### PR TITLE
bpo-47151: Fallback to fork when vfork fails in subprocess.

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-03-30-01-17-43.bpo-47151.z-nQkR.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-30-01-17-43.bpo-47151.z-nQkR.rst
@@ -1,0 +1,3 @@
+When subprocess tries to use vfork, it now falls back to fork if vfork
+returns an error. This allows use in situations where vfork isn't allowed.
+Such as the pid 1 init process.

--- a/Misc/NEWS.d/next/Library/2022-03-30-01-17-43.bpo-47151.z-nQkR.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-30-01-17-43.bpo-47151.z-nQkR.rst
@@ -1,3 +1,3 @@
 When subprocess tries to use vfork, it now falls back to fork if vfork
-returns an error. This allows use in situations where vfork isn't allowed.
-Such as the pid 1 init process.
+returns an error. This allows use in situations where vfork isn't allowed
+by the OS kernel.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -687,8 +687,8 @@ do_fork_exec(char *const exec_array[],
         pid = vfork();
         if (pid == -1) {
             /* If vfork() fails, fall back to using fork(). When it isn't
-             * allowed from a process (such as pid==1 init), vfork can return
-             * -1 with errno EINVAL. https://bugs.python.org/issue47151. */
+             * allowed in a process by the kernel, vfork can return -1
+             * with errno EINVAL. https://bugs.python.org/issue47151. */
             pid = fork();
         }
     } else

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -685,9 +685,16 @@ do_fork_exec(char *const exec_array[],
         assert(preexec_fn == Py_None);
 
         pid = vfork();
+        if (pid == -1) {
+            /* If vfork() fails, fall back to using fork(). When it isn't
+             * allowed from a process (such as pid==1 init), vfork can return
+             * -1 with errno EINVAL. https://bugs.python.org/issue47151. */
+            goto fallback_to_fork;
+        }
     } else
 #endif
     {
+fallback_to_fork:
         pid = fork();
     }
 

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -689,12 +689,11 @@ do_fork_exec(char *const exec_array[],
             /* If vfork() fails, fall back to using fork(). When it isn't
              * allowed from a process (such as pid==1 init), vfork can return
              * -1 with errno EINVAL. https://bugs.python.org/issue47151. */
-            goto fallback_to_fork;
+            pid = fork();
         }
     } else
 #endif
     {
-fallback_to_fork:
         pid = fork();
     }
 


### PR DESCRIPTION
`vfork()` can return -1 and set `errno`. We now fall back to `fork()` in that situation as one possible error is `EINVAL` indicating that the kernel doesn't permit vfork from the current process. See the bug.

<!-- issue-number: [bpo-47151](https://bugs.python.org/issue47151) -->
https://bugs.python.org/issue47151
<!-- /issue-number -->
