### PR TITLE
bpo-44733: max_tasks_per_child + fork not allowed

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -640,10 +640,6 @@ class ProcessPoolExecutor(_base.Executor):
 
             self._max_workers = max_workers
 
-        if mp_context is None:
-            mp_context = mp.get_context()
-        self._mp_context = mp_context
-
         if initializer is not None and not callable(initializer):
             raise TypeError("initializer must be a callable")
         self._initializer = initializer
@@ -654,7 +650,15 @@ class ProcessPoolExecutor(_base.Executor):
                 raise TypeError("max_tasks_per_child must be an integer")
             elif max_tasks_per_child <= 0:
                 raise ValueError("max_tasks_per_child must be >= 1")
+            if mp_context is None:
+                mp_context = mp.get_context("spawn")
+            if mp_context._name == "fork":
+                raise ValueError("max_tasks_per_child cannot be used with a fork context")
         self._max_tasks_per_child = max_tasks_per_child
+
+        if mp_context is None:
+            mp_context = mp.get_context()
+        self._mp_context = mp_context
 
         # Management thread
         self._executor_manager_thread = None

--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-29-21-33-41.bpo-44733.VbHuf9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-29-21-33-41.bpo-44733.VbHuf9.rst
@@ -1,0 +1,1 @@
+Ensured that ``max_tasks_per_child`` is not used with a fork context.


### PR DESCRIPTION
These changes ensure that if a user specifies `max_tasks_per_child` but no `mp_context`, a usable `mp_context` is generated automatically for them. If the user specified the `fork` context, then an error will be thrown.

For more information please see:

* https://bugs.python.org/issue46464
* https://bugs.python.org/issue44733


<!-- issue-number: [bpo-44733](https://bugs.python.org/issue44733) -->
https://bugs.python.org/issue44733
<!-- /issue-number -->
