### PR TITLE
bpo-47164: Add _PyCFunctionObject_CAST() macro

### DIFF
--- a/Include/cpython/methodobject.h
+++ b/Include/cpython/methodobject.h
@@ -7,18 +7,23 @@ PyAPI_DATA(PyTypeObject) PyCMethod_Type;
 #define PyCMethod_CheckExact(op) Py_IS_TYPE(op, &PyCMethod_Type)
 #define PyCMethod_Check(op) PyObject_TypeCheck(op, &PyCMethod_Type)
 
+#define _PyCFunctionObject_CAST(func) \
+    (assert(PyCFunction_Check(func)), (PyCFunctionObject *)(func))
+#define _PyCMethodObject_CAST(func) \
+    (assert(PyCMethod_Check(func)), (PyCMethodObject *)(func))
+
 /* Macros for direct access to these values. Type checks are *not*
    done, so use with care. */
 #define PyCFunction_GET_FUNCTION(func) \
-        (((PyCFunctionObject *)func) -> m_ml -> ml_meth)
+    (_PyCFunctionObject_CAST(func)->m_ml->ml_meth)
 #define PyCFunction_GET_SELF(func) \
-        (((PyCFunctionObject *)func) -> m_ml -> ml_flags & METH_STATIC ? \
-         NULL : ((PyCFunctionObject *)func) -> m_self)
+    (_PyCFunctionObject_CAST(func)->m_ml->ml_flags & METH_STATIC ? \
+     NULL : _PyCFunctionObject_CAST(func)->m_self)
 #define PyCFunction_GET_FLAGS(func) \
-        (((PyCFunctionObject *)func) -> m_ml -> ml_flags)
+    (_PyCFunctionObject_CAST(func)->m_ml->ml_flags)
 #define PyCFunction_GET_CLASS(func) \
-    (((PyCFunctionObject *)func) -> m_ml -> ml_flags & METH_METHOD ? \
-         ((PyCMethodObject *)func) -> mm_class : NULL)
+    (_PyCFunctionObject_CAST(func)->m_ml->ml_flags & METH_METHOD ? \
+     _PyCMethodObject_CAST(func)->mm_class : NULL)
 
 typedef struct {
     PyObject_HEAD


### PR DESCRIPTION
Add _PyCFunctionObject_CAST() and _PyCMethodObject_CAST() macros to
make macros casting their argument easier to read, but also to check
the type of their input in debug mode: assert(PyCFunction_Check(func)
and assert(PyCMethod_Check(func).

Reformat also PyCFunction_XXX() macros for readability.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47164](https://bugs.python.org/issue47164) -->
https://bugs.python.org/issue47164
<!-- /issue-number -->
