### PR TITLE
bpo-46841: Use a `bytes` object for `_co_code_adaptive`

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1523,7 +1523,7 @@ code_getfreevars(PyCodeObject *code, void *closure)
 static PyObject *
 code_getcodeadaptive(PyCodeObject *code, void *closure)
 {
-    return PyBytes_FromStringAndSize(code->co_code_adaptive, 
+    return PyBytes_FromStringAndSize(code->co_code_adaptive,
                                      _PyCode_NBYTES(code));
 }
 

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1523,8 +1523,8 @@ code_getfreevars(PyCodeObject *code, void *closure)
 static PyObject *
 code_getcodeadaptive(PyCodeObject *code, void *closure)
 {
-    return PyMemoryView_FromMemory(code->co_code_adaptive, _PyCode_NBYTES(code),
-                                   PyBUF_READ);
+    return PyBytes_FromStringAndSize(code->co_code_adaptive, 
+                                     _PyCode_NBYTES(code));
 }
 
 static PyObject *


### PR DESCRIPTION
The `memoryview` was a fun idea, but it actually creates some subtle memory management issues (since it can possibly outlive the code object it references).

While we *could* fix this by hacking around inside of the returned `memoryview` or giving code objects full buffer protocol support, a `bytes` object is totally fine here (and it even makes disassembly a bit easier).

<!-- issue-number: [bpo-46841](https://bugs.python.org/issue46841) -->
https://bugs.python.org/issue46841
<!-- /issue-number -->
