### PR TITLE
bpo-47180: Remove unnecessary registration of weakref.WeakSet as a subtype of _collections_abc.Set

### DIFF
--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -33,7 +33,6 @@ __all__ = ["ref", "proxy", "getweakrefcount", "getweakrefs",
            "WeakSet", "WeakMethod", "finalize"]
 
 
-_collections_abc.Set.register(WeakSet)
 _collections_abc.MutableSet.register(WeakSet)
 
 class WeakMethod(ref):


### PR DESCRIPTION
Registering `weakref.WeakSet` as a subtype of `_collections_abc.MutableSet` implies that it is also a subtype of `_collections_abc.Set` since `_collections_abc.MutableSet` is a subtype of `_collections_abc.Set` and the subtype relation is transitive.

<!-- issue-number: [bpo-47180](https://bugs.python.org/issue47180) -->
https://bugs.python.org/issue47180
<!-- /issue-number -->
