### PR TITLE
bpo-47146: Stop Depending On regen-deepfreeze For regen-global-objects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,9 @@ jobs:
         run: make regen-configure
       - name: Build CPython
         run: |
+          # Deepfreeze will usually cause global objects to be added or removed,
+          # so we run it before regen-global-objects gets rum (in regen-all).
+          make regen-deepfreeze
           make -j4 regen-all
           make regen-stdlib-module-names
       - name: Check for changes

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1176,11 +1176,8 @@ regen-importlib: regen-frozen
 .PHONY: regen-global-objects
 regen-global-objects: $(srcdir)/Tools/scripts/generate_global_objects.py
 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/scripts/generate_global_objects.py
-
-# Note that other code generation in our workflow may add or remove
-# global objects.  "make regen-global-objects" should be run after each.
-# This includes when it happens as part of the build process,
-# e.g. deepfreeze, which can cause the build to fail.
+	@echo "Global objects can be added or removed by other tools (e.g. deepfreeze), "
+	@echo "  so be sure to re-run regen-global-objects after those tools."
 
 ############################################################################
 # ABI

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1161,10 +1161,9 @@ Python/deepfreeze/deepfreeze.c: $(DEEPFREEZE_DEPS)
 	Python/frozen_modules/__phello__.spam.h:__phello__.spam \
 	Python/frozen_modules/frozen_only.h:frozen_only \
 	-o Python/deepfreeze/deepfreeze.c
-	@echo "Deepfreeze may have added some global objects,"
-	@echo "  so run 'make regen-global-objects' if necessary."
-
 # END: deepfreeze modules
+	@echo "Note: Deepfreeze may have added some global objects,"
+	@echo "      so run 'make regen-global-objects' if necessary."
 
 # We keep this renamed target around for folks with muscle memory.
 .PHONY: regen-importlib
@@ -1176,8 +1175,8 @@ regen-importlib: regen-frozen
 .PHONY: regen-global-objects
 regen-global-objects: $(srcdir)/Tools/scripts/generate_global_objects.py
 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/scripts/generate_global_objects.py
-	@echo "Global objects can be added or removed by other tools (e.g. deepfreeze), "
-	@echo "  so be sure to re-run regen-global-objects after those tools."
+	@echo "Note: Global objects can be added or removed by other tools (e.g. deepfreeze), "
+	@echo "      so be sure to re-run regen-global-objects after those tools."
 
 ############################################################################
 # ABI

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1161,9 +1161,8 @@ Python/deepfreeze/deepfreeze.c: $(DEEPFREEZE_DEPS)
 	Python/frozen_modules/__phello__.spam.h:__phello__.spam \
 	Python/frozen_modules/frozen_only.h:frozen_only \
 	-o Python/deepfreeze/deepfreeze.c
-	@# The script may have added or removed global object definitions,
-	@# so the global objects must be regenerated.
-	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/scripts/generate_global_objects.py
+	@echo "Deepfreeze may have added some global objects,"
+	@echo "  so run 'make regen-global-objects' if necessary."
 
 # END: deepfreeze modules
 
@@ -1180,10 +1179,8 @@ regen-global-objects: $(srcdir)/Tools/scripts/generate_global_objects.py
 
 # Note that other code generation in our workflow may add or remove
 # global objects.  "make regen-global-objects" should be run after each.
-# In the case where that happens during a build, regen-global-objects
-# should be explicitly run immediately after the code generation
-# completes and before the generated code is used.  For an example, see
-# the Python/deepfreeze/deepfreeze.c target (AKA regen-deepfreeze).
+# This includes when it happens as part of the build process,
+# e.g. deepfreeze, which can cause the build to fail.
 
 ############################################################################
 # ABI

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1161,6 +1161,9 @@ Python/deepfreeze/deepfreeze.c: $(DEEPFREEZE_DEPS)
 	Python/frozen_modules/__phello__.spam.h:__phello__.spam \
 	Python/frozen_modules/frozen_only.h:frozen_only \
 	-o Python/deepfreeze/deepfreeze.c
+	@# The script may have added or removed global object definitions,
+	@# so the global objects must be regenerated.
+	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/scripts/generate_global_objects.py
 
 # END: deepfreeze modules
 
@@ -1171,12 +1174,16 @@ regen-importlib: regen-frozen
 ############################################################################
 # Global objects
 
-# Note that other code generation in our workflow may add or remove
-# global objects.  "make regen-global-objects" should be run after each.
-
 .PHONY: regen-global-objects
 regen-global-objects: $(srcdir)/Tools/scripts/generate_global_objects.py
 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/scripts/generate_global_objects.py
+
+# Note that other code generation in our workflow may add or remove
+# global objects.  "make regen-global-objects" should be run after each.
+# In the case where that happens during a build, regen-global-objects
+# should be explicitly run immediately after the code generation
+# completes and before the generated code is used.  For an example, see
+# the Python/deepfreeze/deepfreeze.c target (AKA regen-deepfreeze).
 
 ############################################################################
 # ABI

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1171,24 +1171,12 @@ regen-importlib: regen-frozen
 ############################################################################
 # Global objects
 
-GLOBAL_OBJECTS_TARGETS = \
-		$(srcdir)/Include/internal/pycore_global_objects.h \
-		$(srcdir)/Include/internal/pycore_global_strings.h
-
-# The global objects will get regenerated as soon these files
-# are required, including as a prerequisite for regen-deepfreeze.
-$(GLOBAL_OBJECTS_TARGETS): generate-global-objects
-
-.PHONY: generate-global-objects
-generate-global-objects: $(srcdir)/Tools/scripts/generate_global_objects.py
-	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/scripts/generate_global_objects.py
-
-.PHONY: generate-global-objects-after-deepfreeze
-generate-global-objects-after-deepfreeze: regen-deepfreeze $(srcdir)/Tools/scripts/generate_global_objects.py
-	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/scripts/generate_global_objects.py
+# Note that other code generation in our workflow may add or remove
+# global objects.  "make regen-global-objects" should be run after each.
 
 .PHONY: regen-global-objects
-regen-global-objects: regen-deepfreeze generate-global-objects-after-deepfreeze
+regen-global-objects: $(srcdir)/Tools/scripts/generate_global_objects.py
+	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/scripts/generate_global_objects.py
 
 ############################################################################
 # ABI

--- a/Tools/scripts/freeze_modules.py
+++ b/Tools/scripts/freeze_modules.py
@@ -606,7 +606,6 @@ def regen_makefile(modules):
         ])
         deepfreezerules.append(f"\t{frozen_header}:{src.frozenid} \\")
     deepfreezerules.append('\t-o Python/deepfreeze/deepfreeze.c')
-    deepfreezerules.append('')
     pyfiles[-1] = pyfiles[-1].rstrip(" \\")
     frozenfiles[-1] = frozenfiles[-1].rstrip(" \\")
 


### PR DESCRIPTION
This effectively reverts the Makefile change in gh-31637.  I've added some notes so it is more clear what is going on.

We also update the "Check if generated files are up to date" job to run "make regen-deepfreeze" to ensure "make regen-global-objects" catches deepfreeze.c.

<!-- issue-number: [bpo-47146](https://bugs.python.org/issue47146) -->
https://bugs.python.org/issue47146
<!-- /issue-number -->
