### PR TITLE
bpo-46841: Avoid unnecessary allocations in code object comparisons

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-31-15-57-42.bpo-46841.U-25Z6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-31-15-57-42.bpo-46841.U-25Z6.rst
@@ -1,0 +1,1 @@
+Avoid unnecessary allocations when comparing code objects.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1398,20 +1398,20 @@ code_richcompare(PyObject *self, PyObject *other, int op)
     if (!eq) goto unequal;
     eq = co->co_firstlineno == cp->co_firstlineno;
     if (!eq) goto unequal;
-    PyObject *co_code = _PyCode_GetCode(co);
-    if (co_code == NULL) {
-        return NULL;
-    }
-    PyObject *cp_code = _PyCode_GetCode(cp);
-    if (cp_code == NULL) {
-        Py_DECREF(co_code);
-        return NULL;
-    }
-    eq = PyObject_RichCompareBool(co_code, cp_code, Py_EQ);
-    Py_DECREF(co_code);
-    Py_DECREF(cp_code);
-    if (eq <= 0) {
+    eq = Py_SIZE(co) == Py_SIZE(cp);
+    if (!eq) {
         goto unequal;
+    }
+    for (int i = 0; i < Py_SIZE(co); i++) {
+        _Py_CODEUNIT co_instr = _PyCode_CODE(co)[i];
+        _Py_CODEUNIT cp_instr = _PyCode_CODE(cp)[i];
+        _Py_SET_OPCODE(co_instr, _PyOpcode_Deopt[_Py_OPCODE(co_instr)]);
+        _Py_SET_OPCODE(cp_instr, _PyOpcode_Deopt[_Py_OPCODE(cp_instr)]);
+        eq = co_instr == cp_instr;
+        if (!eq) {
+            goto unequal;
+        }
+        i += _PyOpcode_Caches[_Py_OPCODE(co_instr)];
     }
 
     /* compare constants */


### PR DESCRIPTION


<!-- issue-number: [bpo-46841](https://bugs.python.org/issue46841) -->
https://bugs.python.org/issue46841
<!-- /issue-number -->
