### PR TITLE
gh-76728: Coerce DictReader and DictWriter fieldnames argument to a list

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -153,7 +153,9 @@ The :mod:`csv` module defines the following classes:
    information in each row to a :class:`dict` whose keys are given by the
    optional *fieldnames* parameter.
 
-   The *fieldnames* parameter is a :term:`sequence`.  If *fieldnames* is
+   The *fieldnames* parameter is a :term:`sequence`.  If the argument passed
+   to *fieldnames* is not a :term:`sequence` then a :exc:`TypeError` is
+   raised.  If *fieldnames* is
    omitted, the values in the first row of file *f* will be used as the
    fieldnames.  Regardless of how the fieldnames are determined, the
    dictionary preserves their original ordering.
@@ -195,7 +197,9 @@ The :mod:`csv` module defines the following classes:
    onto output rows.  The *fieldnames* parameter is a :mod:`sequence
    <collections.abc>` of keys that identify the order in which values in the
    dictionary passed to the :meth:`writerow` method are written to file
-   *f*.  The optional *restval* parameter specifies the value to be
+   *f*.  If the argument passed to *fieldnames* is not a
+   :mod:`sequence <collections.abc>`, a :exc:`TypeError` is raised.  The optional
+   *restval* parameter specifies the value to be
    written if the dictionary is missing a key in *fieldnames*.  If the
    dictionary passed to the :meth:`writerow` method contains a key not found in
    *fieldnames*, the optional *extrasaction* parameter indicates what action to

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -153,9 +153,7 @@ The :mod:`csv` module defines the following classes:
    information in each row to a :class:`dict` whose keys are given by the
    optional *fieldnames* parameter.
 
-   The *fieldnames* parameter is a :term:`sequence`.  If the argument passed
-   to *fieldnames* is not a :term:`sequence` then a :exc:`TypeError` is
-   raised.  If *fieldnames* is
+   The *fieldnames* parameter is a :term:`sequence`.  If *fieldnames* is
    omitted, the values in the first row of file *f* will be used as the
    fieldnames.  Regardless of how the fieldnames are determined, the
    dictionary preserves their original ordering.
@@ -168,6 +166,9 @@ The :mod:`csv` module defines the following classes:
 
    All other optional or keyword arguments are passed to the underlying
    :class:`reader` instance.
+
+   If the argument passed to *fieldnames* is not a :term:`sequence`,
+   a :exc:`TypeError` is raised.
 
    .. versionchanged:: 3.6
       Returned rows are now of type :class:`OrderedDict`.
@@ -197,9 +198,7 @@ The :mod:`csv` module defines the following classes:
    onto output rows.  The *fieldnames* parameter is a :mod:`sequence
    <collections.abc>` of keys that identify the order in which values in the
    dictionary passed to the :meth:`writerow` method are written to file
-   *f*.  If the argument passed to *fieldnames* is not a
-   :mod:`sequence <collections.abc>`, a :exc:`TypeError` is raised.  The optional
-   *restval* parameter specifies the value to be
+   *f*.  The optional *restval* parameter specifies the value to be
    written if the dictionary is missing a key in *fieldnames*.  If the
    dictionary passed to the :meth:`writerow` method contains a key not found in
    *fieldnames*, the optional *extrasaction* parameter indicates what action to
@@ -212,6 +211,9 @@ The :mod:`csv` module defines the following classes:
 
    Note that unlike the :class:`DictReader` class, the *fieldnames* parameter
    of the :class:`DictWriter` class is not optional.
+
+   If the argument passed to *fieldnames* is not a
+   :mod:`sequence <collections.abc>`, a :exc:`TypeError` is raised.
 
    A short usage example::
 

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -167,7 +167,7 @@ The :mod:`csv` module defines the following classes:
    All other optional or keyword arguments are passed to the underlying
    :class:`reader` instance.
 
-   The argument passed to *fieldnames* will be coerced to a :class:`list`.
+   If the argument passed to *fieldnames* is an iterator, it will be coerced to a :class:`list`.
 
    .. versionchanged:: 3.6
       Returned rows are now of type :class:`OrderedDict`.
@@ -211,7 +211,7 @@ The :mod:`csv` module defines the following classes:
    Note that unlike the :class:`DictReader` class, the *fieldnames* parameter
    of the :class:`DictWriter` class is not optional.
 
-   The argument passed to *fieldnames* will be coerced to a :class:`list`.
+   If the argument passed to *fieldnames* is an iterator, it will be coerced to a :class:`list`.
 
    A short usage example::
 

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -167,8 +167,7 @@ The :mod:`csv` module defines the following classes:
    All other optional or keyword arguments are passed to the underlying
    :class:`reader` instance.
 
-   If the argument passed to *fieldnames* is not a :term:`sequence`,
-   a :exc:`TypeError` is raised.
+   The argument passed to *fieldnames* will be coerced to a :class:`list`.
 
    .. versionchanged:: 3.6
       Returned rows are now of type :class:`OrderedDict`.
@@ -212,8 +211,7 @@ The :mod:`csv` module defines the following classes:
    Note that unlike the :class:`DictReader` class, the *fieldnames* parameter
    of the :class:`DictWriter` class is not optional.
 
-   If the argument passed to *fieldnames* is not a
-   :mod:`sequence <collections.abc>`, a :exc:`TypeError` is raised.
+   The argument passed to *fieldnames* will be coerced to a :class:`list`.
 
    A short usage example::
 

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -10,6 +10,7 @@ from _csv import Error, __version__, writer, reader, register_dialect, \
                  QUOTE_MINIMAL, QUOTE_ALL, QUOTE_NONNUMERIC, QUOTE_NONE, \
                  __doc__
 from _csv import Dialect as _Dialect
+from _collections_abc import Sequence
 
 from io import StringIO
 
@@ -80,6 +81,8 @@ register_dialect("unix", unix_dialect)
 class DictReader:
     def __init__(self, f, fieldnames=None, restkey=None, restval=None,
                  dialect="excel", *args, **kwds):
+        if not isinstance(fieldnames, Sequence):
+            raise TypeError("fieldnames must be a sequence")
         self._fieldnames = fieldnames   # list of keys for the dict
         self.restkey = restkey          # key to catch long rows
         self.restval = restval          # default value for short rows
@@ -130,6 +133,8 @@ class DictReader:
 class DictWriter:
     def __init__(self, f, fieldnames, restval="", extrasaction="raise",
                  dialect="excel", *args, **kwds):
+        if not isinstance(fieldnames, Sequence):
+            raise TypeError("fieldnames must be a sequence")
         self.fieldnames = fieldnames    # list of keys for the dict
         self.restval = restval          # for writing short dicts
         if extrasaction.lower() not in ("raise", "ignore"):

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -82,7 +82,7 @@ class DictReader:
     def __init__(self, f, fieldnames=None, restkey=None, restval=None,
                  dialect="excel", *args, **kwds):
         if not isinstance(fieldnames, Sequence):
-            raise TypeError("fieldnames must be a sequence")
+            raise TypeError(f"Expected a sequence, got {type(fieldnames)}")
         self._fieldnames = fieldnames   # list of keys for the dict
         self.restkey = restkey          # key to catch long rows
         self.restval = restval          # default value for short rows
@@ -134,7 +134,7 @@ class DictWriter:
     def __init__(self, f, fieldnames, restval="", extrasaction="raise",
                  dialect="excel", *args, **kwds):
         if not isinstance(fieldnames, Sequence):
-            raise TypeError("fieldnames must be a sequence")
+            raise TypeError(f"Expected a sequence, got {type(fieldnames)}")
         self.fieldnames = fieldnames    # list of keys for the dict
         self.restval = restval          # for writing short dicts
         if extrasaction.lower() not in ("raise", "ignore"):

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -81,7 +81,7 @@ register_dialect("unix", unix_dialect)
 class DictReader:
     def __init__(self, f, fieldnames=None, restkey=None, restval=None,
                  dialect="excel", *args, **kwds):
-        if not isinstance(fieldnames, Sequence):
+        if fieldnames is not None and not isinstance(fieldnames, Sequence):
             raise TypeError(f"Expected a sequence, got {type(fieldnames)}")
         self._fieldnames = fieldnames   # list of keys for the dict
         self.restkey = restkey          # key to catch long rows

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -80,7 +80,7 @@ register_dialect("unix", unix_dialect)
 class DictReader:
     def __init__(self, f, fieldnames=None, restkey=None, restval=None,
                  dialect="excel", *args, **kwds):
-        if fieldnames:
+        if fieldnames is not None and iter(fieldnames) is fieldnames:
             fieldnames = list(fieldnames)
         self._fieldnames = fieldnames   # list of keys for the dict
         self.restkey = restkey          # key to catch long rows
@@ -132,7 +132,7 @@ class DictReader:
 class DictWriter:
     def __init__(self, f, fieldnames, restval="", extrasaction="raise",
                  dialect="excel", *args, **kwds):
-        if fieldnames:
+        if fieldnames is not None and iter(fieldnames) is fieldnames:
             fieldnames = list(fieldnames)
         self.fieldnames = fieldnames    # list of keys for the dict
         self.restval = restval          # for writing short dicts

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -10,7 +10,6 @@ from _csv import Error, __version__, writer, reader, register_dialect, \
                  QUOTE_MINIMAL, QUOTE_ALL, QUOTE_NONNUMERIC, QUOTE_NONE, \
                  __doc__
 from _csv import Dialect as _Dialect
-from _collections_abc import Sequence
 
 from io import StringIO
 
@@ -81,8 +80,8 @@ register_dialect("unix", unix_dialect)
 class DictReader:
     def __init__(self, f, fieldnames=None, restkey=None, restval=None,
                  dialect="excel", *args, **kwds):
-        if fieldnames is not None and not isinstance(fieldnames, Sequence):
-            raise TypeError(f"Expected a sequence, got {type(fieldnames)}")
+        if fieldnames:
+            fieldnames = list(fieldnames)
         self._fieldnames = fieldnames   # list of keys for the dict
         self.restkey = restkey          # key to catch long rows
         self.restval = restval          # default value for short rows
@@ -133,8 +132,8 @@ class DictReader:
 class DictWriter:
     def __init__(self, f, fieldnames, restval="", extrasaction="raise",
                  dialect="excel", *args, **kwds):
-        if not isinstance(fieldnames, Sequence):
-            raise TypeError(f"Expected a sequence, got {type(fieldnames)}")
+        if fieldnames:
+            fieldnames = list(fieldnames)
         self.fieldnames = fieldnames    # list of keys for the dict
         self.restval = restval          # for writing short dicts
         if extrasaction.lower() not in ("raise", "ignore"):

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -736,6 +736,36 @@ class TestDictFields(unittest.TestCase):
         csv.DictWriter.writerow(writer, dictrow)
         self.assertEqual(fileobj.getvalue(), "1,2\r\n")
 
+    def test_dict_reader_accepts_only_sequences(self):
+        fieldnames = ["a", "b", "c"]
+        f = StringIO()
+        self.assertRaises(TypeError, csv.DictReader, f, iter(fieldnames))
+
+        try:
+            reader = csv.DictReader(f, fieldnames)
+        except:
+            self.fail("csv.DictReader(f, fieldnames) threw an error")
+
+    def test_dict_writer_accepts_only_sequences(self):
+        fieldnames = ["a", "b", "c"]
+        f = StringIO()
+        self.assertRaises(TypeError, csv.DictWriter, f, iter(fieldnames))
+
+        try:
+            writer = csv.DictWriter(f, fieldnames)
+        except:
+            self.fail("csv.DictWriter(f, fieldnames) threw an error")
+
+
+    def test_dict_reader_fieldnames_is_optional(self):
+        fieldnames = ["a", "b", "c"]
+        f = StringIO()
+
+        try:
+            reader = csv.DictReader(f, fieldnames=None)
+        except:
+            self.fail("csv.DictReader(f, fieldnames=None) threw an error")
+
     def test_read_dict_fields(self):
         with TemporaryFile("w+", encoding="utf-8") as fileobj:
             fileobj.write("1,2,abc\r\n")

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -736,35 +736,29 @@ class TestDictFields(unittest.TestCase):
         csv.DictWriter.writerow(writer, dictrow)
         self.assertEqual(fileobj.getvalue(), "1,2\r\n")
 
-    def test_dict_reader_accepts_only_sequences(self):
+    def test_dict_reader_rejects_iter(self):
         fieldnames = ["a", "b", "c"]
         f = StringIO()
         self.assertRaises(TypeError, csv.DictReader, f, iter(fieldnames))
 
-        try:
-            reader = csv.DictReader(f, fieldnames)
-        except:
-            self.fail("csv.DictReader(f, fieldnames) threw an error")
+    def test_dict_reader_accepts_list(self):
+        fieldnames = ["a", "b", "c"]
+        f = StringIO()
+        reader = csv.DictReader(f, fieldnames)
 
-    def test_dict_writer_accepts_only_sequences(self):
+    def test_dict_writer_rejects_iter(self):
         fieldnames = ["a", "b", "c"]
         f = StringIO()
         self.assertRaises(TypeError, csv.DictWriter, f, iter(fieldnames))
 
-        try:
-            writer = csv.DictWriter(f, fieldnames)
-        except:
-            self.fail("csv.DictWriter(f, fieldnames) threw an error")
-
-
-    def test_dict_reader_fieldnames_is_optional(self):
+    def test_dict_writer_accepts_list(self):
         fieldnames = ["a", "b", "c"]
         f = StringIO()
+        writer = csv.DictWriter(f, fieldnames)
 
-        try:
-            reader = csv.DictReader(f, fieldnames=None)
-        except:
-            self.fail("csv.DictReader(f, fieldnames=None) threw an error")
+    def test_dict_reader_fieldnames_is_optional(self):
+        f = StringIO()
+        reader = csv.DictReader(f, fieldnames=None)
 
     def test_read_dict_fields(self):
         with TemporaryFile("w+", encoding="utf-8") as fileobj:

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -736,25 +736,29 @@ class TestDictFields(unittest.TestCase):
         csv.DictWriter.writerow(writer, dictrow)
         self.assertEqual(fileobj.getvalue(), "1,2\r\n")
 
-    def test_dict_reader_rejects_iter(self):
+    def test_dict_reader_fieldnames_accepts_iter(self):
         fieldnames = ["a", "b", "c"]
         f = StringIO()
-        self.assertRaises(TypeError, csv.DictReader, f, iter(fieldnames))
+        reader = csv.DictReader(f, iter(fieldnames))
+        self.assertEqual(reader.fieldnames, fieldnames)
 
-    def test_dict_reader_accepts_list(self):
+    def test_dict_reader_fieldnames_accepts_list(self):
         fieldnames = ["a", "b", "c"]
         f = StringIO()
         reader = csv.DictReader(f, fieldnames)
+        self.assertEqual(reader.fieldnames, fieldnames)
 
-    def test_dict_writer_rejects_iter(self):
+    def test_dict_writer_fieldnames_rejects_iter(self):
         fieldnames = ["a", "b", "c"]
         f = StringIO()
-        self.assertRaises(TypeError, csv.DictWriter, f, iter(fieldnames))
+        writer = csv.DictWriter(f, iter(fieldnames))
+        self.assertEqual(writer.fieldnames, fieldnames)
 
-    def test_dict_writer_accepts_list(self):
+    def test_dict_writer_fieldnames_accepts_list(self):
         fieldnames = ["a", "b", "c"]
         f = StringIO()
         writer = csv.DictWriter(f, fieldnames)
+        self.assertEqual(writer.fieldnames, fieldnames)
 
     def test_dict_reader_fieldnames_is_optional(self):
         f = StringIO()

--- a/Misc/NEWS.d/next/Library/2022-04-01-09-43-54.bpo-32547.NIUiNC.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-01-09-43-54.bpo-32547.NIUiNC.rst
@@ -1,0 +1,2 @@
+The constructors for csv.DictWriter and csv.DictReader raise TypeError when
+the fieldnames argument is not a sequence.

--- a/Misc/NEWS.d/next/Library/2022-04-01-09-43-54.bpo-32547.NIUiNC.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-01-09-43-54.bpo-32547.NIUiNC.rst
@@ -1,2 +1,2 @@
-The constructors for csv.DictWriter and csv.DictReader raise TypeError when
-the fieldnames argument is not a sequence.
+The constructors for :class:`~csv.DictWriter` and :class:`~csv.DictReader` raise :exc:`TypeError` when
+the ``fieldnames`` argument is not a sequence.

--- a/Misc/NEWS.d/next/Library/2022-04-01-09-43-54.bpo-32547.NIUiNC.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-01-09-43-54.bpo-32547.NIUiNC.rst
@@ -1,1 +1,1 @@
-The constructors for :class:`~csv.DictWriter` and :class:`~csv.DictReader` now coerce the ``fieldnames`` argument to a :class:`list`.
+The constructors for :class:`~csv.DictWriter` and :class:`~csv.DictReader` now coerce the ``fieldnames`` argument to a :class:`list` if it is an iterator.

--- a/Misc/NEWS.d/next/Library/2022-04-01-09-43-54.bpo-32547.NIUiNC.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-01-09-43-54.bpo-32547.NIUiNC.rst
@@ -1,1 +1,1 @@
-The constructors for :class:`~csv.DictWriter` and :class:`~csv.DictReader` now coerce the ``fieldnames`` argument to a `list`.
+The constructors for :class:`~csv.DictWriter` and :class:`~csv.DictReader` now coerce the ``fieldnames`` argument to a :class:`list`.

--- a/Misc/NEWS.d/next/Library/2022-04-01-09-43-54.bpo-32547.NIUiNC.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-01-09-43-54.bpo-32547.NIUiNC.rst
@@ -1,2 +1,1 @@
-The constructors for :class:`~csv.DictWriter` and :class:`~csv.DictReader` raise :exc:`TypeError` when
-the ``fieldnames`` argument is not a sequence.
+The constructors for :class:`~csv.DictWriter` and :class:`~csv.DictReader` now coerce the ``fieldnames`` argument to a `list`.


### PR DESCRIPTION
Raises a TypeError when the given argument to the `fieldnames` parameter is not a sequence in `csv.DictWriter` and `csv.DictReader`

<!-- issue-number: [bpo-32547](https://bugs.python.org/issue32547) -->
https://bugs.python.org/issue32547
<!-- /issue-number -->


<!-- gh-issue-number: gh-76728 -->
* Issue: gh-76728
<!-- /gh-issue-number -->
