### PR TITLE
bpo-40280: Add debug Emscripten flavors (GH-32233)

### DIFF
--- a/configure
+++ b/configure
@@ -6262,6 +6262,10 @@ if test "${with_emscripten_target+set}" = set; then :
     ac_sys_emscripten_target=browser ;; #(
   node) :
     ac_sys_emscripten_target=node ;; #(
+        browser-debug) :
+    ac_sys_emscripten_target=browser-debug ;; #(
+  node-debug) :
+    ac_sys_emscripten_target=node-debug ;; #(
   *) :
     as_fn_error $? "Invalid argument: --with-emscripten-target=browser|node" "$LINENO" 5
      ;;
@@ -6303,9 +6307,9 @@ esac
 else
 
   case $ac_sys_system/$ac_sys_emscripten_target in #(
-  Emscripten/browser) :
+  Emscripten/browser*) :
     EXEEXT=.html ;; #(
-  Emscripten/node) :
+  Emscripten/node*) :
     EXEEXT=.js ;; #(
   WASI/*) :
     EXEEXT=.wasm ;; #(
@@ -6615,7 +6619,7 @@ $as_echo "$LDLIBRARY" >&6; }
 
 # LIBRARY_DEPS, LINK_PYTHON_OBJS and LINK_PYTHON_DEPS variable
 case $ac_sys_system/$ac_sys_emscripten_target in #(
-  Emscripten/browser) :
+  Emscripten/browser*) :
     LIBRARY_DEPS='$(PY3LIBRARY) $(WASM_STDLIB)' ;; #(
   *) :
     LIBRARY_DEPS='$(PY3LIBRARY) $(EXPORTSYMS)'
@@ -7758,29 +7762,29 @@ fi
 # The option disables code elimination, which increases code size of main
 # binary. All objects must be built with -fPIC.
 case $ac_sys_system/$ac_sys_emscripten_target in #(
-  Emscripten/browser) :
+  Emscripten/browser*) :
 
     LDFLAGS_NODIST="$LDFLAGS_NODIST -s ALLOW_MEMORY_GROWTH=1"
     LINKFORSHARED="--preload-file \$(WASM_ASSETS_DIR)"
     WASM_ASSETS_DIR=".\$(prefix)"
     WASM_STDLIB="\$(WASM_ASSETS_DIR)/local/lib/python\$(VERSION)/os.py"
-        if test "$Py_DEBUG" = 'true'; then
+        if test "$Py_DEBUG" = 'true' -o "$ac_sys_emscripten_target" = "browser-debug"; then
       LDFLAGS_NODIST="$LDFLAGS_NODIST -s ASSERTIONS=1"
       LINKFORSHARED="$LINKFORSHARED -gsource-map --emit-symbol-map"
     else
       LINKFORSHARED="$LINKFORSHARED -O2 -g0"
     fi
    ;; #(
-  Emscripten/node) :
+  Emscripten/node*) :
 
     LDFLAGS_NODIST="$LDFLAGS_NODIST -s ALLOW_MEMORY_GROWTH=1 -s NODERAWFS=1 -s USE_PTHREADS=1"
     LINKFORSHARED="-s PROXY_TO_PTHREAD=1 -s EXIT_RUNTIME=1"
     CFLAGS_NODIST="$CFLAGS_NODIST -pthread"
-    if test "$Py_DEBUG" = 'true'; then
+    if test "$Py_DEBUG" = 'true' -o "$ac_sys_emscripten_target" = "node-debug"; then
       LDFLAGS_NODIST="$LDFLAGS_NODIST -s ASSERTIONS=1"
       LINKFORSHARED="$LINKFORSHARED -gseparate-dwarf --emit-symbol-map"
     else
-      LINKFORSHARED="$LINKFORSHARED -O2 -gseparate-dwarf"
+      LINKFORSHARED="$LINKFORSHARED -O2 -g0"
     fi
    ;; #(
   WASI/*) :
@@ -21672,7 +21676,7 @@ if test "$enable_test_modules" = no; then
     TEST_MODULES=no
 else
     case $ac_sys_system/$ac_sys_emscripten_target in #(
-  Emscripten/browser) :
+  Emscripten/browser*) :
     TEST_MODULES=no ;; #(
   *) :
     TEST_MODULES=yes
@@ -21731,7 +21735,7 @@ case $ac_sys_system/$ac_sys_emscripten_target in #(
     py_cv_module__scproxy=n/a
     py_cv_module_spwd=n/a
  ;; #(
-  Emscripten/browser) :
+  Emscripten/browser*) :
 
 
 
@@ -21759,7 +21763,7 @@ case $ac_sys_system/$ac_sys_emscripten_target in #(
     py_cv_module_=n/a
 
    ;; #(
-      Emscripten/node) :
+      Emscripten/node*) :
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1091,6 +1091,12 @@ AC_ARG_WITH([emscripten-target],
     AS_CASE([$with_emscripten_target],
       [browser], [ac_sys_emscripten_target=browser],
       [node], [ac_sys_emscripten_target=node],
+dnl Debug builds with source map / dwarf symbols. Py_DEBUG builds easily
+dnl run out of stack space. Detached sybmols and map prohibit some
+dnl optimizations and increase file size. Options are undocumented so we
+dnl are free to remove them in the future.
+      [browser-debug], [ac_sys_emscripten_target=browser-debug],
+      [node-debug], [ac_sys_emscripten_target=node-debug],
       [AC_MSG_ERROR([Invalid argument: --with-emscripten-target=browser|node])]
     )
   ], [
@@ -1112,8 +1118,8 @@ AC_ARG_WITH([suffix],
   )
 ], [
   AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
-    [Emscripten/browser], [EXEEXT=.html],
-    [Emscripten/node], [EXEEXT=.js],
+    [Emscripten/browser*], [EXEEXT=.html],
+    [Emscripten/node*], [EXEEXT=.js],
     [WASI/*], [EXEEXT=.wasm],
     [EXEEXT=]
   )
@@ -1376,7 +1382,7 @@ AC_MSG_RESULT($LDLIBRARY)
 
 # LIBRARY_DEPS, LINK_PYTHON_OBJS and LINK_PYTHON_DEPS variable
 AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
-  [Emscripten/browser], [LIBRARY_DEPS='$(PY3LIBRARY) $(WASM_STDLIB)'],
+  [Emscripten/browser*], [LIBRARY_DEPS='$(PY3LIBRARY) $(WASM_STDLIB)'],
   [LIBRARY_DEPS='$(PY3LIBRARY) $(EXPORTSYMS)']
 )
 LINK_PYTHON_DEPS='$(LIBRARY_DEPS)'
@@ -1888,28 +1894,28 @@ fi
 # The option disables code elimination, which increases code size of main
 # binary. All objects must be built with -fPIC.
 AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
-  [Emscripten/browser], [
+  [Emscripten/browser*], [
     LDFLAGS_NODIST="$LDFLAGS_NODIST -s ALLOW_MEMORY_GROWTH=1"
     LINKFORSHARED="--preload-file \$(WASM_ASSETS_DIR)"
     WASM_ASSETS_DIR=".\$(prefix)"
     WASM_STDLIB="\$(WASM_ASSETS_DIR)/local/lib/python\$(VERSION)/os.py"
     dnl separate-dwarf does not seem to work in Chrome DevTools Support.
-    if test "$Py_DEBUG" = 'true'; then
+    if test "$Py_DEBUG" = 'true' -o "$ac_sys_emscripten_target" = "browser-debug"; then
       LDFLAGS_NODIST="$LDFLAGS_NODIST -s ASSERTIONS=1"
       LINKFORSHARED="$LINKFORSHARED -gsource-map --emit-symbol-map"
     else
       LINKFORSHARED="$LINKFORSHARED -O2 -g0"
     fi
   ],
-  [Emscripten/node], [
+  [Emscripten/node*], [
     LDFLAGS_NODIST="$LDFLAGS_NODIST -s ALLOW_MEMORY_GROWTH=1 -s NODERAWFS=1 -s USE_PTHREADS=1"
     LINKFORSHARED="-s PROXY_TO_PTHREAD=1 -s EXIT_RUNTIME=1"
     CFLAGS_NODIST="$CFLAGS_NODIST -pthread"
-    if test "$Py_DEBUG" = 'true'; then
+    if test "$Py_DEBUG" = 'true' -o "$ac_sys_emscripten_target" = "node-debug"; then
       LDFLAGS_NODIST="$LDFLAGS_NODIST -s ASSERTIONS=1"
       LINKFORSHARED="$LINKFORSHARED -gseparate-dwarf --emit-symbol-map"
     else
-      LINKFORSHARED="$LINKFORSHARED -O2 -gseparate-dwarf"
+      LINKFORSHARED="$LINKFORSHARED -O2 -g0"
     fi
   ],
   [WASI/*], [
@@ -6453,7 +6459,7 @@ if test "$enable_test_modules" = no; then
     TEST_MODULES=no
 else
     AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
-      [Emscripten/browser], [TEST_MODULES=no],
+      [Emscripten/browser*], [TEST_MODULES=no],
       [TEST_MODULES=yes]
     )
 fi
@@ -6478,7 +6484,7 @@ AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
   [CYGWIN*/*], [PY_STDLIB_MOD_SET_NA([_scproxy], [nis])],
   [QNX*/*], [PY_STDLIB_MOD_SET_NA([_scproxy], [nis])],
   [FreeBSD*/*], [PY_STDLIB_MOD_SET_NA([_scproxy], [spwd])],
-  [Emscripten/browser], [
+  [Emscripten/browser*], [
     PY_STDLIB_MOD_SET_NA(
       [_ctypes],
       [_curses],
@@ -6505,7 +6511,7 @@ AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
   ],
   dnl Some modules like _posixsubprocess do not work. We build them anyway
   dnl so imports in tests do not fail.
-  [Emscripten/node], [
+  [Emscripten/node*], [
     PY_STDLIB_MOD_SET_NA(
       [_ctypes],
       [_curses],


### PR DESCRIPTION
Debug builds with source map / dwarf symbols. Py_DEBUG builds easily
run out of stack space. Detached sybmols and map prohibit some
optimizations and increase file size. Options are undocumented so we
are free to remove them in the future.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40280](https://bugs.python.org/issue40280) -->
https://bugs.python.org/issue40280
<!-- /issue-number -->
