### PR TITLE
[3.9] bpo-47089: Avoid test_compileall failures on Windows (GH-32037).

### DIFF
--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -451,7 +451,7 @@ class CommandLineTestsBase:
 
     def setUp(self):
         self.directory = tempfile.mkdtemp()
-        self.addCleanup(os_helper.rmtree, self.directory)
+        self.addCleanup(shutil.rmtree, self.directory)
         self.pkgdir = os.path.join(self.directory, 'foo')
         os.mkdir(self.pkgdir)
         self.pkgdir_cachedir = os.path.join(self.pkgdir, '__pycache__')

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -449,32 +449,29 @@ class EncodingTest(unittest.TestCase):
 class CommandLineTestsBase:
     """Test compileall's CLI."""
 
-    @classmethod
-    def setUpClass(cls):
-        for path in filter(os.path.isdir, sys.path):
-            directory_created = False
-            directory = pathlib.Path(path) / '__pycache__'
-            path = directory / 'test.try'
-            try:
-                if not directory.is_dir():
-                    directory.mkdir()
-                    directory_created = True
-                with path.open('w') as file:
-                    file.write('# for test_compileall')
-            except OSError:
-                sys_path_writable = False
-                break
-            finally:
-                support.unlink(str(path))
-                if directory_created:
-                    directory.rmdir()
-        else:
-            sys_path_writable = True
-        cls._sys_path_writable = sys_path_writable
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+        self.addCleanup(os_helper.rmtree, self.directory)
+        self.pkgdir = os.path.join(self.directory, 'foo')
+        os.mkdir(self.pkgdir)
+        self.pkgdir_cachedir = os.path.join(self.pkgdir, '__pycache__')
+        # Create the __init__.py and a package module.
+        self.initfn = script_helper.make_script(self.pkgdir, '__init__', '')
+        self.barfn = script_helper.make_script(self.pkgdir, 'bar', '')
 
-    def _skip_if_sys_path_not_writable(self):
-        if not self._sys_path_writable:
-            raise unittest.SkipTest('not all entries on sys.path are writable')
+    @contextlib.contextmanager
+    def temporary_pycache_prefix(self):
+        """Adjust and restore sys.pycache_prefix."""
+        old_prefix = sys.pycache_prefix
+        new_prefix = os.path.join(self.directory, '__testcache__')
+        try:
+            sys.pycache_prefix = new_prefix
+            yield {
+                'PYTHONPATH': self.directory,
+                'PYTHONPYCACHEPREFIX': new_prefix,
+            }
+        finally:
+            sys.pycache_prefix = old_prefix
 
     def _get_run_args(self, args):
         return [*support.optim_args_from_interpreter_flags(),
@@ -502,49 +499,39 @@ class CommandLineTestsBase:
         path = importlib.util.cache_from_source(fn)
         self.assertFalse(os.path.exists(path))
 
-    def setUp(self):
-        self.directory = tempfile.mkdtemp()
-        self.addCleanup(support.rmtree, self.directory)
-        self.pkgdir = os.path.join(self.directory, 'foo')
-        os.mkdir(self.pkgdir)
-        self.pkgdir_cachedir = os.path.join(self.pkgdir, '__pycache__')
-        # Create the __init__.py and a package module.
-        self.initfn = script_helper.make_script(self.pkgdir, '__init__', '')
-        self.barfn = script_helper.make_script(self.pkgdir, 'bar', '')
-
     def test_no_args_compiles_path(self):
         # Note that -l is implied for the no args case.
-        self._skip_if_sys_path_not_writable()
         bazfn = script_helper.make_script(self.directory, 'baz', '')
-        self.assertRunOK(PYTHONPATH=self.directory)
-        self.assertCompiled(bazfn)
-        self.assertNotCompiled(self.initfn)
-        self.assertNotCompiled(self.barfn)
+        with self.temporary_pycache_prefix() as env:
+            self.assertRunOK(**env)
+            self.assertCompiled(bazfn)
+            self.assertNotCompiled(self.initfn)
+            self.assertNotCompiled(self.barfn)
 
     @without_source_date_epoch  # timestamp invalidation test
     def test_no_args_respects_force_flag(self):
-        self._skip_if_sys_path_not_writable()
         bazfn = script_helper.make_script(self.directory, 'baz', '')
-        self.assertRunOK(PYTHONPATH=self.directory)
-        pycpath = importlib.util.cache_from_source(bazfn)
+        with self.temporary_pycache_prefix() as env:
+            self.assertRunOK(**env)
+            pycpath = importlib.util.cache_from_source(bazfn)
         # Set atime/mtime backward to avoid file timestamp resolution issues
         os.utime(pycpath, (time.time()-60,)*2)
         mtime = os.stat(pycpath).st_mtime
         # Without force, no recompilation
-        self.assertRunOK(PYTHONPATH=self.directory)
+        self.assertRunOK(**env)
         mtime2 = os.stat(pycpath).st_mtime
         self.assertEqual(mtime, mtime2)
         # Now force it.
-        self.assertRunOK('-f', PYTHONPATH=self.directory)
+        self.assertRunOK('-f', **env)
         mtime2 = os.stat(pycpath).st_mtime
         self.assertNotEqual(mtime, mtime2)
 
     def test_no_args_respects_quiet_flag(self):
-        self._skip_if_sys_path_not_writable()
         script_helper.make_script(self.directory, 'baz', '')
-        noisy = self.assertRunOK(PYTHONPATH=self.directory)
+        with self.temporary_pycache_prefix() as env:
+            noisy = self.assertRunOK(**env)
         self.assertIn(b'Listing ', noisy)
-        quiet = self.assertRunOK('-q', PYTHONPATH=self.directory)
+        quiet = self.assertRunOK('-q', **env)
         self.assertNotIn(b'Listing ', quiet)
 
     # Ensure that the default behavior of compileall's CLI is to create


### PR DESCRIPTION
(cherry picked from commit 76b8a075b8a79b08468fd0ed06a489a5c815bc11)

Co-authored-by: Jeremy Kloth <jeremy.kloth@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47089](https://bugs.python.org/issue47089) -->
https://bugs.python.org/issue47089
<!-- /issue-number -->
