### PR TITLE
bpo-47196: Fix function pointer cast in test_imp

### DIFF
--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -450,7 +450,7 @@ static PyModuleDef_Slot main_slots[] = {
 static PyModuleDef main_def = TEST_MODULE_DEF("main", main_slots, testexport_methods);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase(PyObject *spec)
+PyInit__testmultiphase(void)
 {
     return PyModuleDef_Init(&main_def);
 }
@@ -495,7 +495,7 @@ static PyModuleDef def_nonmodule = TEST_MODULE_DEF(
     "_testmultiphase_nonmodule", slots_create_nonmodule, NULL);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_nonmodule(PyObject *spec)
+PyInit__testmultiphase_nonmodule(void)
 {
     return PyModuleDef_Init(&def_nonmodule);
 }
@@ -525,7 +525,7 @@ static PyModuleDef def_nonmodule_with_methods = TEST_MODULE_DEF(
     "_testmultiphase_nonmodule_with_methods", slots_create_nonmodule, nonmodule_methods);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_nonmodule_with_methods(PyObject *spec)
+PyInit__testmultiphase_nonmodule_with_methods(void)
 {
     return PyModuleDef_Init(&def_nonmodule_with_methods);
 }
@@ -545,7 +545,7 @@ static PyModuleDef def_nonascii_latin = { \
 };
 
 PyMODINIT_FUNC
-PyInitU__testmultiphase_zkouka_naten_evc07gi8e(PyObject *spec)
+PyInitU__testmultiphase_zkouka_naten_evc07gi8e(void)
 {
     return PyModuleDef_Init(&def_nonascii_latin);
 }
@@ -563,7 +563,7 @@ static PyModuleDef def_nonascii_kana = { \
 };
 
 PyMODINIT_FUNC
-PyInitU_eckzbwbhc6jpgzcx415x(PyObject *spec)
+PyInitU_eckzbwbhc6jpgzcx415x(void)
 {
     return PyModuleDef_Init(&def_nonascii_kana);
 }
@@ -571,7 +571,7 @@ PyInitU_eckzbwbhc6jpgzcx415x(PyObject *spec)
 /*** Module with a single-character name ***/
 
 PyMODINIT_FUNC
-PyInit_x(PyObject *spec)
+PyInit_x(void)
 {
     return PyModuleDef_Init(&main_def);
 }
@@ -582,7 +582,7 @@ static PyModuleDef null_slots_def = TEST_MODULE_DEF(
     "_testmultiphase_null_slots", NULL, NULL);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_null_slots(PyObject *spec)
+PyInit__testmultiphase_null_slots(void)
 {
     return PyModuleDef_Init(&null_slots_def);
 }
@@ -598,7 +598,7 @@ static PyModuleDef def_bad_large = TEST_MODULE_DEF(
     "_testmultiphase_bad_slot_large", slots_bad_large, NULL);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_bad_slot_large(PyObject *spec)
+PyInit__testmultiphase_bad_slot_large(void)
 {
     return PyModuleDef_Init(&def_bad_large);
 }
@@ -612,7 +612,7 @@ static PyModuleDef def_bad_negative = TEST_MODULE_DEF(
     "_testmultiphase_bad_slot_negative", slots_bad_negative, NULL);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_bad_slot_negative(PyObject *spec)
+PyInit__testmultiphase_bad_slot_negative(void)
 {
     return PyModuleDef_Init(&def_bad_negative);
 }
@@ -630,7 +630,7 @@ static PyModuleDef def_create_int_with_state = { \
 };
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_create_int_with_state(PyObject *spec)
+PyInit__testmultiphase_create_int_with_state(void)
 {
     return PyModuleDef_Init(&def_create_int_with_state);
 }
@@ -649,7 +649,7 @@ static PyModuleDef def_negative_size = { \
 };
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_negative_size(PyObject *spec)
+PyInit__testmultiphase_negative_size(void)
 {
     return PyModuleDef_Init(&def_negative_size);
 }
@@ -658,26 +658,26 @@ PyInit__testmultiphase_negative_size(PyObject *spec)
 static PyModuleDef uninitialized_def = TEST_MODULE_DEF("main", main_slots, testexport_methods);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_export_uninitialized(PyObject *spec)
+PyInit__testmultiphase_export_uninitialized(void)
 {
     return (PyObject*) &uninitialized_def;
 }
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_export_null(PyObject *spec)
+PyInit__testmultiphase_export_null(void)
 {
     return NULL;
 }
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_export_raise(PyObject *spec)
+PyInit__testmultiphase_export_raise(void)
 {
     PyErr_SetString(PyExc_SystemError, "bad export function");
     return NULL;
 }
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_export_unreported_exception(PyObject *spec)
+PyInit__testmultiphase_export_unreported_exception(void)
 {
     PyErr_SetString(PyExc_SystemError, "bad export function");
     return PyModuleDef_Init(&main_def);
@@ -698,7 +698,7 @@ static PyModuleDef def_create_null = TEST_MODULE_DEF(
     "_testmultiphase_create_null", slots_create_null, NULL);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_create_null(PyObject *spec)
+PyInit__testmultiphase_create_null(void)
 {
     return PyModuleDef_Init(&def_create_null);
 }
@@ -719,7 +719,7 @@ static PyModuleDef def_create_raise = TEST_MODULE_DEF(
     "_testmultiphase_create_null", slots_create_raise, NULL);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_create_raise(PyObject *spec)
+PyInit__testmultiphase_create_raise(void)
 {
     return PyModuleDef_Init(&def_create_raise);
 }
@@ -740,7 +740,7 @@ static PyModuleDef def_create_unreported_exception = TEST_MODULE_DEF(
     "_testmultiphase_create_unreported_exception", slots_create_unreported_exception, NULL);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_create_unreported_exception(PyObject *spec)
+PyInit__testmultiphase_create_unreported_exception(void)
 {
     return PyModuleDef_Init(&def_create_unreported_exception);
 }
@@ -755,7 +755,7 @@ static PyModuleDef def_nonmodule_with_exec_slots = TEST_MODULE_DEF(
     "_testmultiphase_nonmodule_with_exec_slots", slots_nonmodule_with_exec_slots, NULL);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_nonmodule_with_exec_slots(PyObject *spec)
+PyInit__testmultiphase_nonmodule_with_exec_slots(void)
 {
     return PyModuleDef_Init(&def_nonmodule_with_exec_slots);
 }
@@ -775,7 +775,7 @@ static PyModuleDef def_exec_err = TEST_MODULE_DEF(
     "_testmultiphase_exec_err", slots_exec_err, NULL);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_exec_err(PyObject *spec)
+PyInit__testmultiphase_exec_err(void)
 {
     return PyModuleDef_Init(&def_exec_err);
 }
@@ -817,7 +817,7 @@ static PyModuleDef def_exec_unreported_exception = TEST_MODULE_DEF(
     "_testmultiphase_exec_unreported_exception", slots_exec_unreported_exception, NULL);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_exec_unreported_exception(PyObject *spec)
+PyInit__testmultiphase_exec_unreported_exception(void)
 {
     return PyModuleDef_Init(&def_exec_unreported_exception);
 }
@@ -861,7 +861,7 @@ static PyModuleDef def_meth_state_access = {
 };
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_meth_state_access(PyObject *spec)
+PyInit__testmultiphase_meth_state_access(void)
 {
     return PyModuleDef_Init(&def_meth_state_access);
 }
@@ -874,7 +874,7 @@ static PyModuleDef def_module_state_shared = {
 };
 
 PyMODINIT_FUNC
-PyInit__test_module_state_shared(PyObject *spec)
+PyInit__test_module_state_shared(void)
 {
     PyObject *module = PyModule_Create(&def_module_state_shared);
     if (module == NULL) {

--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -894,7 +894,7 @@ PyInit__test_module_state_shared(PyObject *spec)
 static PyModuleDef imp_dummy_def = TEST_MODULE_DEF("imp_dummy", main_slots, testexport_methods);
 
 PyMODINIT_FUNC
-PyInit_imp_dummy(PyObject *spec)
+PyInit_imp_dummy(void)
 {
     return PyModuleDef_Init(&imp_dummy_def);
 }


### PR DESCRIPTION
The function PyInit_imp_dummy is declared as void f(PyObject* spec)
but called as void f(void). On wasm targets without the call
trampolines this causes a fatal error.

<!-- issue-number: [bpo-47196](https://bugs.python.org/issue47196) -->
https://bugs.python.org/issue47196
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran