### PR TITLE
gh-91353: Fix void return type handling in ctypes (GH-32246)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-04-03-17-21-04.bpo-47197.Ji_c30.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-04-03-17-21-04.bpo-47197.Ji_c30.rst
@@ -1,0 +1,5 @@
+ctypes used to mishandle ``void`` return types, so that for instance a
+function declared like ``ctypes.CFUNCTYPE(None, ctypes.c_int)`` would be
+called with signature ``int f(int)`` instead of ``void f(int)``. Wasm
+targets require function pointers to be called with the correct signatures
+so this led to crashes. The problem is now fixed.

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -399,7 +399,7 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
 #endif
     result = ffi_prep_cif(&p->cif, cc,
                           Py_SAFE_DOWNCAST(nargs, Py_ssize_t, int),
-                          p->restype,
+                          p->ffi_restype,
                           &p->atypes[0]);
     if (result != FFI_OK) {
         PyErr_Format(PyExc_RuntimeError,

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -399,7 +399,7 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
 #endif
     result = ffi_prep_cif(&p->cif, cc,
                           Py_SAFE_DOWNCAST(nargs, Py_ssize_t, int),
-                          &p->restype,
+                          p->restype,
                           &p->atypes[0]);
     if (result != FFI_OK) {
         PyErr_Format(PyExc_RuntimeError,

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -399,7 +399,7 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
 #endif
     result = ffi_prep_cif(&p->cif, cc,
                           Py_SAFE_DOWNCAST(nargs, Py_ssize_t, int),
-                          _ctypes_get_ffi_type(restype),
+                          &p->restype,
                           &p->atypes[0]);
     if (result != FFI_OK) {
         PyErr_Format(PyExc_RuntimeError,

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1209,7 +1209,12 @@ PyObject *_ctypes_callproc(PPROC pProc,
         }
     }
 
-    rtype = _ctypes_get_ffi_type(restype);
+    if (restype == Py_None) {
+        rtype = &ffi_type_void;
+    } else {
+        rtype = _ctypes_get_ffi_type(restype);
+    }
+
     resbuf = alloca(max(rtype->size, sizeof(ffi_arg)));
 
 #ifdef _Py_MEMORY_SANITIZER


### PR DESCRIPTION
_ctypes_get_ffi_type never returns ffi_type_void. If the
return type is specified as None, we need set the libffi
return type to void, but just taking the output from
_ctypes_get_ffi_type will make the return type be sint.

This fixes two spots where ctypes accidentally converts
None return type to sint rather than void, causing crashes
on Emscripten targets.

I tested this patch against Pyodide and it fixes `test_code`.

<!-- issue-number: [bpo-47197](https://bugs.python.org/issue47197) -->
https://bugs.python.org/issue47197
<!-- /issue-number -->
