### PR TITLE
gh-85567: Register a cleanup function to close files for FileType objects in argparse

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -84,7 +84,7 @@ __all__ = [
     'ZERO_OR_MORE',
 ]
 
-
+import atexit as _atexit
 import os as _os
 import re as _re
 import sys as _sys
@@ -1268,14 +1268,12 @@ class FileType(object):
 
         # all other arguments are used as file names
         try:
-            file = open(string, self._mode, self._bufsize, self._encoding,
-                        self._errors)
+            fh = open(string, self._mode, self._bufsize, self._encoding, self._errors)
 
             # Register cleanup function to close file
-            import atexit
-            atexit.register(file.close)
+            _atexit.register(fh.close)
 
-            return file
+            return fh
         except OSError as e:
             args = {'filename': string, 'error': e}
             message = _("can't open '%(filename)s': %(error)s")

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1268,8 +1268,14 @@ class FileType(object):
 
         # all other arguments are used as file names
         try:
-            return open(string, self._mode, self._bufsize, self._encoding,
+            file = open(string, self._mode, self._bufsize, self._encoding,
                         self._errors)
+
+            # Register cleanup function to close file
+            import atexit
+            atexit.register(file.close)
+
+            return file
         except OSError as e:
             args = {'filename': string, 'error': e}
             message = _("can't open '%(filename)s': %(error)s")

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -312,6 +312,7 @@ Nicolas Chauvat
 Jerry Chen
 Michael Chermside
 Ingrid Cheung
+Adam Chhina
 Terry Chia
 Albert Chin-A-Young
 Adal Chiriliuc

--- a/Misc/NEWS.d/next/Library/2022-04-02-14-40-53.bpo-41395.Y1ZVvT.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-02-14-40-53.bpo-41395.Y1ZVvT.rst
@@ -1,0 +1,3 @@
+FileType objects from argparse may not be closed and lead to
+ResourceWarning. Register a file.close function with atexit for FileType
+objects to ensure they are closed. Patch Contributed by Adam Chhina.


### PR DESCRIPTION

[BPO-41395](https://bugs.python.org/issue41395)

- [x] Signed CLA
- [x] Ran tests and `make patchcheck`
- [x] Added News Entry

Hello! First-time contribution, I've read through what I believe to be the relevant sections in the Python Developer's Guide, however, feel free to let me know if there is something I missed.

This is a follow-up to [PR-21702](https://github.com/python/cpython/pull/21702), where it was suggested to address the `ResourceWarning` issue directly in `argparse` itself. However, as that was discussed back in 2020, I've attempted to take a stab at it myself! After reading a suggestion from @facundobatista, I have added a `file.close` cleanup function with `atexit` for files opened with `FileType` objects, to ensure they are always closed.

<ins>Previously:</ins>
```python
❯ ./python.exe -Wall -m pickle p1              
{'a': 1}
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name='p1'>

❯ ./python.exe -Wall -m pickle p1 p2
/user: ResourceWarning: unclosed file <_io.BufferedReader name='p1'>
  value = [self._get_value(action, v) for v in arg_strings]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
usage: pickle.py [-h] [-t] [-v] [pickle_file ...]
pickle.py: error: argument pickle_file: can't open 'p2': [Errno 2] No such file or directory: 'p2'
```

<ins>With Patch:</ins>
```python
❯ ./python.exe -Wall -m pickle p1   
{'a': 1}

❯ ./python.exe -Wall -m pickle p1 p2
usage: pickle.py [-h] [-t] [-v] [pickle_file ...]
pickle.py: error: argument pickle_file: can't open 'p2': [Errno 2] No such file or directory: 'p2'
```

<!-- issue-number: [bpo-41395](https://bugs.python.org/issue41395) -->
https://bugs.python.org/issue41395
<!-- /issue-number -->
