### PR TITLE
[3.9] More minor fixes to C API docs (GH-31714)

### DIFF
--- a/Doc/c-api/bytearray.rst
+++ b/Doc/c-api/bytearray.rst
@@ -42,8 +42,6 @@ Direct API functions
    Return a new bytearray object from any object, *o*, that implements the
    :ref:`buffer protocol <bufferobjects>`.
 
-   .. XXX expand about the buffer protocol, at least somewhere
-
 
 .. c:function:: PyObject* PyByteArray_FromStringAndSize(const char *string, Py_ssize_t len)
 

--- a/Doc/c-api/bytes.rst
+++ b/Doc/c-api/bytes.rst
@@ -5,7 +5,7 @@
 Bytes Objects
 -------------
 
-These functions raise :exc:`TypeError` when expecting a bytes parameter and are
+These functions raise :exc:`TypeError` when expecting a bytes parameter and
 called with a non-bytes parameter.
 
 .. index:: object: bytes

--- a/Doc/c-api/call.rst
+++ b/Doc/c-api/call.rst
@@ -26,7 +26,7 @@ This convention is not only used by *tp_call*:
 :c:member:`~PyTypeObject.tp_new` and :c:member:`~PyTypeObject.tp_init`
 also pass arguments this way.
 
-To call an object, use :c:func:`PyObject_Call` or other
+To call an object, use :c:func:`PyObject_Call` or another
 :ref:`call API <capi-call>`.
 
 

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -281,7 +281,7 @@ For convenience, some of these functions will always return a
 
 .. c:function:: void PyErr_SyntaxLocation(const char *filename, int lineno)
 
-   Like :c:func:`PyErr_SyntaxLocationEx`, but the col_offset parameter is
+   Like :c:func:`PyErr_SyntaxLocationEx`, but the *col_offset* parameter is
    omitted.
 
 
@@ -333,7 +333,7 @@ an error value).
 
    Issue a warning message with explicit control over all warning attributes.  This
    is a straightforward wrapper around the Python function
-   :func:`warnings.warn_explicit`, see there for more information.  The *module*
+   :func:`warnings.warn_explicit`; see there for more information.  The *module*
    and *registry* arguments may be set to ``NULL`` to get the default effect
    described there.
 
@@ -441,7 +441,7 @@ Querying the error indicator
       error indicator.
 
 
-.. c:function:: void PyErr_NormalizeException(PyObject**exc, PyObject**val, PyObject**tb)
+.. c:function:: void PyErr_NormalizeException(PyObject **exc, PyObject **val, PyObject **tb)
 
    Under certain circumstances, the values returned by :c:func:`PyErr_Fetch` below
    can be "unnormalized", meaning that ``*exc`` is a class object but ``*val`` is

--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -823,7 +823,7 @@ Isolated Configuration
 isolate Python from the system. For example, to embed Python into an
 application.
 
-This configuration ignores global configuration variables, environments
+This configuration ignores global configuration variables, environment
 variables, command line arguments (:c:member:`PyConfig.argv` is not parsed)
 and user site directory. The C standard streams (ex: ``stdout``) and the
 LC_CTYPE locale are left unchanged. Signal handlers are not installed.
@@ -1000,7 +1000,7 @@ Multi-Phase Initialization Private Provisional API
 --------------------------------------------------
 
 This section is a private provisional API introducing multi-phase
-initialization, the core feature of the :pep:`432`:
+initialization, the core feature of :pep:`432`:
 
 * "Core" initialization phase, "bare minimum Python":
 


### PR DESCRIPTION
* init_config: wording fixes

* bytearray: remove XXX, there is a good link to the buffer docs

* bytes, call, exceptions: minor wording fixes.
(cherry picked from commit 677a87946630c5fbd9998969669b4dd4f4b32545)

Co-authored-by: Jelle Zijlstra <jelle.zijlstra@gmail.com>