### PR TITLE
[3.9] Document func parameter of locale.atof (GH-18183)

### DIFF
--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -423,10 +423,10 @@ The :mod:`locale` module defines the following exception and functions:
     .. versionadded:: 3.5
 
 
-.. function:: atof(string)
+.. function:: atof(string, func=float)
 
-   Converts a string to a floating point number, following the :const:`LC_NUMERIC`
-   settings.
+   Converts a string to a number, following the :const:`LC_NUMERIC` settings,
+   by calling *func* on the result of calling :func:`delocalize` on *string*.
 
 
 .. function:: atoi(string)


### PR DESCRIPTION
The second parameter (named `func`) has been present since the `locale`
module was introduced in eef1d4e8b1, but has never been documented.

This commit updates the documentation for `locale.atof` to clarify the
behavior of the function and how the `func` parameter is used.

Signed-off-by: Kevin Locke <kevin@kevinlocke.name>.
(cherry picked from commit 208da6d508bb2683732151f4ae288dfc8001267c)

Co-authored-by: Kevin Locke <kevin@kevinlocke.name>