### PR TITLE
bpo-47196: Fix one more PyInit function signature

### DIFF
--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -796,7 +796,7 @@ static PyModuleDef def_exec_raise = TEST_MODULE_DEF(
     "_testmultiphase_exec_raise", slots_exec_raise, NULL);
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_exec_raise(PyObject *mod)
+PyInit__testmultiphase_exec_raise(void)
 {
     return PyModuleDef_Init(&def_exec_raise);
 }


### PR DESCRIPTION
I missed one PyInit function in #32244.

<!-- issue-number: [bpo-47196](https://bugs.python.org/issue47196) -->
https://bugs.python.org/issue47196
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran