### PR TITLE
gh-90284: Restore docstrings in importlib.metadata tests.

### DIFF
--- a/Lib/test/test_importlib/test_main.py
+++ b/Lib/test/test_importlib/test_main.py
@@ -37,10 +37,12 @@ class BasicTests(fixtures.DistInfoPkg, unittest.TestCase):
             Distribution.from_name('does-not-exist')
 
     def test_package_not_found_mentions_metadata(self):
-        # When a package is not found, that could indicate that the
-        # packgae is not installed or that it is installed without
-        # metadata. Ensure the exception mentions metadata to help
-        # guide users toward the cause. See #124.
+        """
+        When a package is not found, that could indicate that the
+        packgae is not installed or that it is installed without
+        metadata. Ensure the exception mentions metadata to help
+        guide users toward the cause. See #124.
+        """
         with self.assertRaises(PackageNotFoundError) as ctx:
             Distribution.from_name('does-not-exist')
 
@@ -89,8 +91,10 @@ class NameNormalizationTests(fixtures.OnSysPath, fixtures.SiteDir, unittest.Test
         return 'my-pkg'
 
     def test_dashes_in_dist_name_found_as_underscores(self):
-        # For a package with a dash in the name, the dist-info metadata
-        # uses underscores in the name. Ensure the metadata loads.
+        """
+        For a package with a dash in the name, the dist-info metadata
+        uses underscores in the name. Ensure the metadata loads.
+        """
         pkg_name = self.pkg_with_dashes(self.site_dir)
         assert version(pkg_name) == '1.0'
 
@@ -108,7 +112,9 @@ class NameNormalizationTests(fixtures.OnSysPath, fixtures.SiteDir, unittest.Test
         return 'CherryPy'
 
     def test_dist_name_found_as_any_case(self):
-        # Ensure the metadata loads when queried with any case.
+        """
+        Ensure the metadata loads when queried with any case.
+        """
         pkg_name = self.pkg_with_mixed_case(self.site_dir)
         assert version(pkg_name) == '1.0'
         assert version(pkg_name.lower()) == '1.0'
@@ -244,11 +250,13 @@ class TestEntryPoints(unittest.TestCase):
         assert "'name'" in repr(self.ep)
 
     def test_hashable(self):
-        # EntryPoints should be hashable.
+        """EntryPoints should be hashable"""
         hash(self.ep)
 
     def test_json_dump(self):
-        # json should not expect to be able to dump an EntryPoint.
+        """
+        json should not expect to be able to dump an EntryPoint
+        """
         with self.assertRaises(Exception):
             with warnings.catch_warnings(record=True):
                 json.dumps(self.ep)
@@ -260,7 +268,9 @@ class TestEntryPoints(unittest.TestCase):
         assert self.ep.attr is None
 
     def test_sortable(self):
-        # EntryPoint objects are sortable, but result is undefined.
+        """
+        EntryPoint objects are sortable, but result is undefined.
+        """
         sorted(
             [
                 EntryPoint(name='b', value='val', group='group'),
@@ -273,8 +283,10 @@ class FileSystem(
     fixtures.OnSysPath, fixtures.SiteDir, fixtures.FileBuilder, unittest.TestCase
 ):
     def test_unicode_dir_on_sys_path(self):
-        # Ensure a Unicode subdirectory of a directory on sys.path
-        # does not crash.
+        """
+        Ensure a Unicode subdirectory of a directory on sys.path
+        does not crash.
+        """
         fixtures.build_files(
             {self.unicode_filename(): {}},
             prefix=self.site_dir,

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -90,8 +90,10 @@ class APITests(
             self.assertEqual(ep.dist.version, "1.0.0")
 
     def test_entry_points_unique_packages(self):
-        # Entry points should only be exposed for the first package
-        # on sys.path with a given name.
+        """
+        Entry points should only be exposed for the first package
+        on sys.path with a given name.
+        """
         alt_site_dir = self.fixtures.enter_context(fixtures.tempdir())
         self.fixtures.enter_context(self.add_sys_path(alt_site_dir))
         alt_pkg = {
@@ -123,9 +125,11 @@ class APITests(
         assert entry_points(group='missing') == ()
 
     def test_entry_points_dict_construction(self):
-        # Prior versions of entry_points() returned simple lists and
-        # allowed casting those lists into maps by name using ``dict()``.
-        # Capture this now deprecated use-case.
+        """
+        Prior versions of entry_points() returned simple lists and
+        allowed casting those lists into maps by name using ``dict()``.
+        Capture this now deprecated use-case.
+        """
         with suppress_known_deprecation() as caught:
             eps = dict(entry_points(group='entries'))
 
@@ -154,9 +158,11 @@ class APITests(
         assert "Accessing entry points by index is deprecated" in str(expected)
 
     def test_entry_points_groups_getitem(self):
-        # Prior versions of entry_points() returned a dict. Ensure
-        # that callers using '.__getitem__()' are supported but warned to
-        # migrate.
+        """
+        Prior versions of entry_points() returned a dict. Ensure
+        that callers using '.__getitem__()' are supported but warned to
+        migrate.
+        """
         with suppress_known_deprecation():
             entry_points()['entries'] == entry_points(group='entries')
 
@@ -164,9 +170,11 @@ class APITests(
                 entry_points()['missing']
 
     def test_entry_points_groups_get(self):
-        # Prior versions of entry_points() returned a dict. Ensure
-        # that callers using '.get()' are supported but warned to
-        # migrate.
+        """
+        Prior versions of entry_points() returned a dict. Ensure
+        that callers using '.get()' are supported but warned to
+        migrate.
+        """
         with suppress_known_deprecation():
             entry_points().get('missing', 'default') == 'default'
             entry_points().get('entries', 'default') == entry_points()['entries']
@@ -313,7 +321,7 @@ class OffSysPathTests(fixtures.DistInfoPkgOffPath, unittest.TestCase):
         assert any(dist.metadata['Name'] == 'distinfo-pkg' for dist in dists)
 
     def test_distribution_at_pathlib(self):
-        # Demonstrate how to load metadata direct from a directory.
+        """Demonstrate how to load metadata direct from a directory."""
         dist_info_path = self.site_dir / 'distinfo_pkg-1.0.0.dist-info'
         dist = Distribution.at(dist_info_path)
         assert dist.version == '1.0.0'


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-46126](https://bugs.python.org/issue46126) -->
https://bugs.python.org/issue46126
<!-- /issue-number -->

Closes #90284.

Reduces divergence from importlib_metadata.