### PR TITLE
gh-83245: Raise BadZipFile instead of ValueError when reading a corrupt file

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1727,6 +1727,17 @@ class OtherTests(unittest.TestCase):
             fp.write("short file")
         self.assertRaises(zipfile.BadZipFile, zipfile.ZipFile, TESTFN)
 
+    def test_negative_central_directory_offset_raises_BadZipFile(self):
+        # Zip file containing an empty EOCD record
+        b = [80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+        # Set the size of the central directory bytes to become 1,
+        # causing the central directory offset to become negative
+        b[12] = 1
+
+        f = io.BytesIO(bytes(b))
+        self.assertRaises(zipfile.BadZipFile, zipfile.ZipFile, f)
+
     def test_closed_zip_raises_ValueError(self):
         """Verify that testzip() doesn't swallow inappropriate exceptions."""
         data = io.BytesIO()

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1729,13 +1729,13 @@ class OtherTests(unittest.TestCase):
 
     def test_negative_central_directory_offset_raises_BadZipFile(self):
         # Zip file containing an empty EOCD record
-        b = [80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        buffer = [80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
         # Set the size of the central directory bytes to become 1,
         # causing the central directory offset to become negative
-        b[12] = 1
+        buffer[12] = 1
 
-        f = io.BytesIO(bytes(b))
+        f = io.BytesIO(bytes(buffer))
         self.assertRaises(zipfile.BadZipFile, zipfile.ZipFile, f)
 
     def test_closed_zip_raises_ValueError(self):

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1729,14 +1729,12 @@ class OtherTests(unittest.TestCase):
 
     def test_negative_central_directory_offset_raises_BadZipFile(self):
         # Zip file containing an empty EOCD record
-        buffer = [80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         buffer = bytearray(b'PK\x05\x06' + b'\0'*18)
 
         # Set the size of the central directory bytes to become 1,
         # causing the central directory offset to become negative
         buffer[12] = 1
 
-        f = io.BytesIO(bytes(buffer))
         f = io.BytesIO(buffer)
         self.assertRaises(zipfile.BadZipFile, zipfile.ZipFile, f)
 

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1730,6 +1730,7 @@ class OtherTests(unittest.TestCase):
     def test_negative_central_directory_offset_raises_BadZipFile(self):
         # Zip file containing an empty EOCD record
         buffer = [80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        buffer = bytearray(b'PK\x05\x06' + b'\0'*18)
 
         # Set the size of the central directory bytes to become 1,
         # causing the central directory offset to become negative

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1733,10 +1733,10 @@ class OtherTests(unittest.TestCase):
 
         # Set the size of the central directory bytes to become 1,
         # causing the central directory offset to become negative
-        buffer[12] = 1
-
-        f = io.BytesIO(buffer)
-        self.assertRaises(zipfile.BadZipFile, zipfile.ZipFile, f)
+        for dirsize in 1, 2**32-1:
+            buffer[12:16] = struct.pack('<L', dirsize)
+            f = io.BytesIO(buffer)
+            self.assertRaises(zipfile.BadZipFile, zipfile.ZipFile, f)
 
     def test_closed_zip_raises_ValueError(self):
         """Verify that testzip() doesn't swallow inappropriate exceptions."""

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1737,6 +1737,7 @@ class OtherTests(unittest.TestCase):
         buffer[12] = 1
 
         f = io.BytesIO(bytes(buffer))
+        f = io.BytesIO(buffer)
         self.assertRaises(zipfile.BadZipFile, zipfile.ZipFile, f)
 
     def test_closed_zip_raises_ValueError(self):

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1369,7 +1369,7 @@ class ZipFile:
         try:
             fp.seek(self.start_dir, 0)
         except ValueError as e:
-            raise BadZipFile("Bad offset for central directory")
+            raise BadZipFile("Bad offset for central directory")  from e
         data = fp.read(size_cd)
         fp = io.BytesIO(data)
         total = 0

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1366,7 +1366,10 @@ class ZipFile:
             print("given, inferred, offset", offset_cd, inferred, concat)
         # self.start_dir:  Position of start of central directory
         self.start_dir = offset_cd + concat
-        fp.seek(self.start_dir, 0)
+        try:
+            fp.seek(self.start_dir, 0)
+        except ValueError as e:
+            raise BadZipFile("Bad offset for central directory")
         data = fp.read(size_cd)
         fp = io.BytesIO(data)
         total = 0

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1366,10 +1366,9 @@ class ZipFile:
             print("given, inferred, offset", offset_cd, inferred, concat)
         # self.start_dir:  Position of start of central directory
         self.start_dir = offset_cd + concat
-        try:
-            fp.seek(self.start_dir, 0)
-        except ValueError as e:
-            raise BadZipFile("Bad offset for central directory")  from e
+        if self.start_dir < 0:
+            raise BadZipFile("Bad offset for central directory")
+        fp.seek(self.start_dir, 0)
         data = fp.read(size_cd)
         fp = io.BytesIO(data)
         total = 0

--- a/Misc/NEWS.d/next/Library/2022-04-03-19-40-09.bpo-39064.76PbIz.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-03-19-40-09.bpo-39064.76PbIz.rst
@@ -1,0 +1,2 @@
+:class:`zipfile.ZipFile` now raises :exc:`zipfile.BadZipFile` when reading a
+corrupt zip file in which the central directory offset is negative.

--- a/Misc/NEWS.d/next/Library/2022-04-03-19-40-09.bpo-39064.76PbIz.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-03-19-40-09.bpo-39064.76PbIz.rst
@@ -1,2 +1,2 @@
-:class:`zipfile.ZipFile` now raises :exc:`zipfile.BadZipFile` when reading a
+:class:`zipfile.ZipFile` now raises :exc:`zipfile.BadZipFile` instead of ``ValueError`` when reading a
 corrupt zip file in which the central directory offset is negative.


### PR DESCRIPTION
Builds on #30863

<!-- issue-number: [bpo-39064](https://bugs.python.org/issue39064) -->
https://bugs.python.org/issue39064
<!-- /issue-number -->
