### PR TITLE
bpo-47208: Allow vendors to override CTYPES_MAX_ARGCOUNT (GH-32297)

### DIFF
--- a/Lib/ctypes/test/test_callbacks.py
+++ b/Lib/ctypes/test/test_callbacks.py
@@ -4,6 +4,7 @@ from test import support
 
 from ctypes import *
 from ctypes.test import need_symbol
+from _ctypes import CTYPES_MAX_ARGCOUNT
 import _ctypes_test
 
 class Callbacks(unittest.TestCase):
@@ -292,8 +293,6 @@ class SampleCallbacksTestCase(unittest.TestCase):
     def test_callback_too_many_args(self):
         def func(*args):
             return len(args)
-
-        CTYPES_MAX_ARGCOUNT = 1024
 
         # valid call with nargs <= CTYPES_MAX_ARGCOUNT
         proto = CFUNCTYPE(c_int, *(c_int,) * CTYPES_MAX_ARGCOUNT)

--- a/Misc/NEWS.d/next/Library/2022-04-04-08-54-31.bpo-47208.cOh9xZ.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-04-08-54-31.bpo-47208.cOh9xZ.rst
@@ -1,0 +1,1 @@
+Allow vendors to override :const:`CTYPES_MAX_ARGCOUNT`.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5781,6 +5781,7 @@ _ctypes_add_objects(PyObject *mod)
 #endif
     MOD_ADD("RTLD_LOCAL", PyLong_FromLong(RTLD_LOCAL));
     MOD_ADD("RTLD_GLOBAL", PyLong_FromLong(RTLD_GLOBAL));
+    MOD_ADD("CTYPES_MAX_ARGCOUNT", PyLong_FromLong(CTYPES_MAX_ARGCOUNT));
     MOD_ADD("ArgumentError", Py_NewRef(PyExc_ArgError));
     return 0;
 #undef MOD_ADD

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -18,7 +18,9 @@
  * This limit is enforced for the `alloca()` call in `_ctypes_callproc`,
  * to avoid allocating a massive buffer on the stack.
  */
-#define CTYPES_MAX_ARGCOUNT 1024
+#ifndef CTYPES_MAX_ARGCOUNT
+  #define CTYPES_MAX_ARGCOUNT 1024
+#endif
 
 typedef struct tagPyCArgObject PyCArgObject;
 typedef struct tagCDataObject CDataObject;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47208](https://bugs.python.org/issue47208) -->
https://bugs.python.org/issue47208
<!-- /issue-number -->
