### PR TITLE
Fix `Contributed ... in bpo-bpo-45847` typo

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -779,7 +779,7 @@ Build Changes
   libsqlite3, zlib, bzip2, liblzma, libcrypt, Tcl/Tk libs, and uuid flags
   are detected by ``pkg-config`` (when available).
   (Contributed by Christian Heimes and Erlend Egeberg Aasland in
-  :issue:`bpo-45847`, :issue:`45747`, and :issue:`45763`.)
+  :issue:`45847`, :issue:`45747`, and :issue:`45763`.)
 
   .. note::
      Use the environment variables ``TCLTK_CFLAGS`` and ``TCLTK_LIBS`` to


### PR DESCRIPTION
What's New for 3.11 has an entry with an issue number written as <code>:issue:\`[bpo-45847](https://bugs.python.org/issue45847)\`</code>. As a result, it renders and links incorrectly:

> ![image](https://user-images.githubusercontent.com/4881073/161506919-7828daf7-4f71-4578-a2cf-082214fcebbb.png)

> ![image](https://user-images.githubusercontent.com/4881073/161507191-6a8db78f-a531-45fa-9428-3d4302249635.png)

<!-- issue-number: [bpo-45847](https://bugs.python.org/issue45847) -->
https://bugs.python.org/issue45847
<!-- /issue-number -->
