### PR TITLE
[3.9] bpo-45790: List macros in same order in which fields are described (GH-29529)

### DIFF
--- a/Doc/extending/newtypes_tutorial.rst
+++ b/Doc/extending/newtypes_tutorial.rst
@@ -67,8 +67,8 @@ The first bit is::
 This is what a Custom object will contain.  ``PyObject_HEAD`` is mandatory
 at the start of each object struct and defines a field called ``ob_base``
 of type :c:type:`PyObject`, containing a pointer to a type object and a
-reference count (these can be accessed using the macros :c:macro:`Py_REFCNT`
-and :c:macro:`Py_TYPE` respectively).  The reason for the macro is to
+reference count (these can be accessed using the macros :c:macro:`Py_TYPE`
+and :c:macro:`Py_REFCNT` respectively).  The reason for the macro is to
 abstract away the layout and to enable additional fields in debug builds.
 
 .. note::

--- a/Misc/NEWS.d/next/Documentation/2021-11-12-11-03-55.bpo-45790.6yuhe8.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-11-12-11-03-55.bpo-45790.6yuhe8.rst
@@ -1,0 +1,2 @@
+Adjust inaccurate phrasing in :doc:`../extending/newtypes_tutorial` about the
+``ob_base`` field and the macros used to access its contents.


### PR DESCRIPTION
Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>

Co-authored-by: Jelle Zijlstra <jelle.zijlstra@gmail.com>.
(cherry picked from commit b275267aa7d44ec90fa435c9cb1610c549da745a)

Co-authored-by: rtobar <rtobar@icrar.org>


<!-- issue-number: [bpo-45790](https://bugs.python.org/issue45790) -->
https://bugs.python.org/issue45790
<!-- /issue-number -->
