### PR TITLE
Update Sphinx bpo role to use redirect URI.

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -43,7 +43,7 @@ except ImportError:
 import suspicious
 
 
-ISSUE_URI = 'https://bugs.python.org/issue%s'
+ISSUE_URI = 'https://bugs.python.org/issue?@action=redirect&bpo=%s'
 SOURCE_URI = 'https://github.com/python/cpython/tree/main/%s'
 
 # monkey-patch reST parser to disable alphabetic and roman enumerated lists


### PR DESCRIPTION
This PR updates the `` :bpo:`...` `` role to use the redirect URL instead of the regular one.  This means that when clicking on a `bpo-xxxxx` link in the docs, the user will be redirected to the corresponding GH issue.

This PR should be merged after the migration is completed.