### PR TITLE
Revert "bpo-46850: Move _PyEval_EvalFrameDefault() to internal C API (GH-32052)"

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1228,24 +1228,17 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
 
    .. versionadded:: 3.8
 
-.. c:type:: PyObject* (*_PyFrameEvalFunction)(PyThreadState *tstate, _PyInterpreterFrame *frame, int throwflag)
-
-   Internal C API.
+.. c:type:: PyObject* (*_PyFrameEvalFunction)(PyThreadState *tstate, PyFrameObject *frame, int throwflag)
 
    Type of a frame evaluation function.
 
    The *throwflag* parameter is used by the ``throw()`` method of generators:
    if non-zero, handle the current exception.
 
-   .. versionchanged:: 3.11
-      The second parameter type becomes ``_PyInterpreterFrame``.
-
    .. versionchanged:: 3.9
       The function now takes a *tstate* parameter.
 
 .. c:function:: _PyFrameEvalFunction _PyInterpreterState_GetEvalFrameFunc(PyInterpreterState *interp)
-
-   Internal C API.
 
    Get the frame evaluation function.
 
@@ -1254,8 +1247,6 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    .. versionadded:: 3.9
 
 .. c:function:: void _PyInterpreterState_SetEvalFrameFunc(PyInterpreterState *interp, _PyFrameEvalFunction eval_frame)
-
-   Internal C API.
 
    Set the frame evaluation function.
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1126,11 +1126,6 @@ Porting to Python 3.11
 * Distributors are encouraged to build Python with the optimized Blake2
   library `libb2`_.
 
-* Move the private undocumented ``_PyEval_EvalFrameDefault()`` function to the
-  internal C API. The function now uses the ``_PyInterpreterFrame`` type which
-  is part of the internal C API.
-  (Contributed by Victor Stinner in :issue:`46850`.)
-
 
 Deprecated
 ----------

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1131,12 +1131,6 @@ Porting to Python 3.11
   is part of the internal C API.
   (Contributed by Victor Stinner in :issue:`46850`.)
 
-* Move the private ``_PyFrameEvalFunction`` type, and private
-  ``_PyInterpreterState_GetEvalFrameFunc()`` and
-  ``_PyInterpreterState_SetEvalFrameFunc()`` functions to the internal C API.
-  The ``_PyFrameEvalFunction`` callback function type now uses the
-  ``_PyInterpreterFrame`` type which is part of the internal C API.
-  (Contributed by Victor Stinner in :issue:`46850`.)
 
 Deprecated
 ----------

--- a/Include/cpython/ceval.h
+++ b/Include/cpython/ceval.h
@@ -15,6 +15,8 @@ PyAPI_FUNC(PyObject *) _PyEval_GetBuiltinId(_Py_Identifier *);
    flag was set, else return 0. */
 PyAPI_FUNC(int) PyEval_MergeCompilerFlags(PyCompilerFlags *cf);
 
+PyAPI_FUNC(PyObject *) _PyEval_EvalFrameDefault(PyThreadState *tstate, struct _PyInterpreterFrame *f, int exc);
+
 PyAPI_FUNC(void) _PyEval_SetSwitchInterval(unsigned long microseconds);
 PyAPI_FUNC(unsigned long) _PyEval_GetSwitchInterval(void);
 

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -259,6 +259,16 @@ PyAPI_FUNC(PyThreadState *) PyInterpreterState_ThreadHead(PyInterpreterState *);
 PyAPI_FUNC(PyThreadState *) PyThreadState_Next(PyThreadState *);
 PyAPI_FUNC(void) PyThreadState_DeleteCurrent(void);
 
+/* Frame evaluation API */
+
+typedef PyObject* (*_PyFrameEvalFunction)(PyThreadState *tstate, struct _PyInterpreterFrame *, int);
+
+PyAPI_FUNC(_PyFrameEvalFunction) _PyInterpreterState_GetEvalFrameFunc(
+    PyInterpreterState *interp);
+PyAPI_FUNC(void) _PyInterpreterState_SetEvalFrameFunc(
+    PyInterpreterState *interp,
+    _PyFrameEvalFunction eval_frame);
+
 PyAPI_FUNC(const PyConfig*) _PyInterpreterState_GetConfig(PyInterpreterState *interp);
 
 /* Get a copy of the current interpreter configuration.

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -59,11 +59,6 @@ extern PyObject* _PyEval_BuiltinsFromGlobals(
     PyObject *globals);
 
 
-PyAPI_FUNC(PyObject *) _PyEval_EvalFrameDefault(
-    PyThreadState *tstate,
-    struct _PyInterpreterFrame *frame,
-    int throwflag);
-
 static inline PyObject*
 _PyEval_EvalFrame(PyThreadState *tstate, struct _PyInterpreterFrame *frame, int throwflag)
 {

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -17,9 +17,9 @@ extern "C" {
 #include "pycore_dict.h"          // struct _Py_dict_state
 #include "pycore_exceptions.h"    // struct _Py_exc_state
 #include "pycore_floatobject.h"   // struct _Py_float_state
-#include "pycore_gc.h"            // struct _gc_runtime_state
 #include "pycore_genobject.h"     // struct _Py_async_gen_state
 #include "pycore_gil.h"           // struct _gil_runtime_state
+#include "pycore_gc.h"            // struct _gc_runtime_state
 #include "pycore_list.h"          // struct _Py_list_state
 #include "pycore_tuple.h"         // struct _Py_tuple_state
 #include "pycore_typeobject.h"    // struct type_cache
@@ -69,20 +69,6 @@ struct atexit_state {
     int ncallbacks;
     int callback_len;
 };
-
-
-/* Frame evaluation API (PEP 523) */
-
-typedef PyObject* (*_PyFrameEvalFunction) (
-    PyThreadState *tstate,
-    struct _PyInterpreterFrame *frame,
-    int throwflag);
-
-PyAPI_FUNC(_PyFrameEvalFunction) _PyInterpreterState_GetEvalFrameFunc(
-    PyInterpreterState *interp);
-PyAPI_FUNC(void) _PyInterpreterState_SetEvalFrameFunc(
-    PyInterpreterState *interp,
-    _PyFrameEvalFunction eval_frame);
 
 
 /* interpreter state */

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -8,7 +8,7 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "pycore_runtime.h"       // _PyRuntime
+#include "pycore_runtime.h"   /* PyRuntimeState */
 
 
 /* Check if the current thread is the main thread.

--- a/Misc/NEWS.d/next/C API/2022-03-22-16-48-02.bpo-46850.7M5dO7.rst
+++ b/Misc/NEWS.d/next/C API/2022-03-22-16-48-02.bpo-46850.7M5dO7.rst
@@ -1,3 +1,0 @@
-Move the private undocumented ``_PyEval_EvalFrameDefault()`` function to the
-internal C API. The function now uses the ``_PyInterpreterFrame`` type which is
-part of the internal C API. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2022-03-22-16-59-34.bpo-46850.lmEKLy.rst
+++ b/Misc/NEWS.d/next/C API/2022-03-22-16-59-34.bpo-46850.lmEKLy.rst
@@ -1,6 +1,0 @@
-Move the private ``_PyFrameEvalFunction`` type, and private
-``_PyInterpreterState_GetEvalFrameFunc()`` and
-``_PyInterpreterState_SetEvalFrameFunc()`` functions to the internal C API. The
-``_PyFrameEvalFunction`` callback function type now uses the
-``_PyInterpreterFrame`` type which is part of the internal C API. Patch by
-Victor Stinner.


### PR DESCRIPTION
* Revert "[bpo-46850](https://bugs.python.org/issue46850): Move _PyEval_EvalFrameDefault() to internal C API (GH-32052)"
* Revert "[bpo-46850](https://bugs.python.org/issue46850): Move _PyInterpreterState_SetEvalFrameFunc() to internal C API (GH-32054)"


<!-- issue-number: [bpo-46850](https://bugs.python.org/issue46850) -->
https://bugs.python.org/issue46850
<!-- /issue-number -->
