### PR TITLE
gh-91378: Allow subprocess pass-thru with stdout/stderr capture

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -699,6 +699,13 @@ functions.
       The ``read_stdout_callback`` and ``read_stderr_callback`` parameters
       were added.
 
+   Add a tee'ing handler that may be accessed by calling
+   ``tee_pipe_to(handle)``. It takes the handle of the file to clone to
+   as an argument, such as *sys.stdout* or *sys.stderr*.
+
+   .. versionadded: 3.11
+      The ``tee_pipe_to()`` method was added.
+
    Popen objects are supported as context managers via the :keyword:`with` statement:
    on exit, standard file descriptors are closed, and the process is waited for.
    ::

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -357,7 +357,8 @@ functions.
                  start_new_session=False, pass_fds=(), *, group=None, \
                  extra_groups=None, user=None, umask=-1, \
                  encoding=None, errors=None, text=None, pipesize=-1, \
-                 process_group=None)
+                 process_group=None, read_stdout_callback=None, \
+                 read_stderr_callback=None)
 
    Execute a child program in a new process.  On POSIX, the class uses
    :meth:`os.execvpe`-like behavior to execute the child program.  On Windows,
@@ -683,6 +684,20 @@ functions.
 
    .. versionadded:: 3.10
       The ``pipesize`` parameter was added.
+
+   *read_stdout_callback*, if supplied, is called upon :data:`PIPE` data
+   being read for *stdout* of the child process. It must expect four
+   args: The :class:`Popen` instance, an ``output_buffer`` list of bytes
+   to append accumulated data to, and the ``data`` (bytes) just read from
+   the pipe. In order to maintain standard Popen behavior of collecting pipe
+   data to be available at the finish in the *stdout* attribute,
+   ``output_buffer.append(data)`` must be called within the callback.
+
+   *read_stderr_callback*, as above, but for *stderr*.
+
+   .. versionadded: 3.11
+      The ``read_stdout_callback`` and ``read_stderr_callback`` parameters
+      were added.
 
    Popen objects are supported as context managers via the :keyword:`with` statement:
    on exit, standard file descriptors are closed, and the process is waited for.

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1325,6 +1325,12 @@ class Popen:
         # Prevent a double close of these handles/fds from __init__ on error.
         self._closed_child_pipe_fds = True
 
+    def tee_pipe_to(output_fh):
+        def _tee_handler(self, buffer, data):
+            buffer.append(data)
+            output_fh.write(data)
+        return _tee_handler
+
     def _read_common_handler(self, buffer, data):
         """Default handler for read_stdout_callback and read_stderr_callback."""
         buffer.append(data)

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -53,6 +53,8 @@ if not support.has_subprocess_support:
 
 mswindows = (sys.platform == "win32")
 
+NEWLINE = b'\r\n' if mswindows else b'\n'
+
 #
 # Depends on the following external programs: Python
 #
@@ -335,7 +337,7 @@ class ProcessTestCase(BaseTestCase):
             self.addCleanup(p.stderr.close)
             out, err = p.communicate()
             self.assertEqual(p.returncode, 0, err)
-            self.assertEqual(out.rstrip(), b'test_stdout_none')
+            self.assertEqual(out, b'test_stdout_none' + NEWLINE)
             self.assertEqual(err, b'')
 
     def test_stderr_none(self):
@@ -684,7 +686,7 @@ class ProcessTestCase(BaseTestCase):
         self.addCleanup(p.stderr.close)
         out, err = p.communicate()
         self.assertEqual(p.returncode, 0, err)
-        self.assertEqual(out.rstrip(), b'test with stdout=1')
+        self.assertEqual(out, b'test with stdout=1')
 
     def test_stdout_devnull(self):
         p = subprocess.Popen([sys.executable, "-c",
@@ -2683,8 +2685,7 @@ class POSIXProcessTestCase(BaseTestCase):
             stdout = subprocess.check_output(
                 [sys.executable, "-c", script],
                 env=env)
-            stdout = stdout.rstrip(b'\n\r')
-            self.assertEqual(stdout.decode('ascii'), ascii(decoded_value))
+            self.assertEqual(stdout.decode('ascii'), ascii(decoded_value) + NEWLINE.decode())
 
             # test bytes
             key = key.encode("ascii", "surrogateescape")
@@ -2694,8 +2695,7 @@ class POSIXProcessTestCase(BaseTestCase):
             stdout = subprocess.check_output(
                 [sys.executable, "-c", script],
                 env=env)
-            stdout = stdout.rstrip(b'\n\r')
-            self.assertEqual(stdout.decode('ascii'), ascii(encoded_value))
+            self.assertEqual(stdout.decode('ascii'), ascii(encoded_value) + NEWLINE.decode())
 
     def test_bytes_program(self):
         abs_program = os.fsencode(ZERO_RETURN_CMD[0])

--- a/Misc/NEWS.d/next/Library/2022-04-05-22-15-55.bpo-47222.I5CLHq.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-05-22-15-55.bpo-47222.I5CLHq.rst
@@ -1,0 +1,1 @@
+In the :mod:`subprocess` :class:`Popen`, factor the read callback handler for the ``PIPE`` file descriptors into its own function.  Also add class variables pointing to the *stdout* and *stderr* read handlers.  Lastly, add constructor variable ``read_stdout_callback`` and ``read_stderr_callback`` to allow overriding the handler with a user-supplied function.

--- a/Misc/NEWS.d/next/Library/2022-04-05-22-15-55.bpo-47222.I5CLHq.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-05-22-15-55.bpo-47222.I5CLHq.rst
@@ -1,1 +1,3 @@
 In the :mod:`subprocess` :class:`Popen`, factor the read callback handler for the ``PIPE`` file descriptors into its own function.  Also add class variables pointing to the *stdout* and *stderr* read handlers.  Lastly, add constructor variable ``read_stdout_callback`` and ``read_stderr_callback`` to allow overriding the handler with a user-supplied function.
+
+Also add the method ``tee_pipe_to(handle)`` to this class, which indicates that output on the pipes should be copied to the parent's buffers, as well as being cloned onto the named *handle*.


### PR DESCRIPTION
# Allow pass-thru of subprocess output even when capturing to buffers

I maintain some build wrappers that both pass the output (both `stdout` and `stderr`) through when being run interactively, but also capture logs into artifacts when being run through a CI/CD pipeline.

Being able to call `proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, tee=True)` would allow harvesting results as `output, errors = subprocess.communicate()` as well as permitting the results of the running process to be seen in real-time (some `make` recipes invoke `docker` and can take a while to complete... buffering until completion would confuse users as it might appear that the recipe has hung). 

https://github.com/python/cpython/issues/91378, formerly:
<!-- issue-number: [bpo-47222](https://bugs.python.org/issue47222) -->
https://bugs.python.org/issue47222
<!-- /issue-number -->


<!-- gh-issue-number: gh-91378 -->
* Issue: gh-91378
<!-- /gh-issue-number -->
