### PR TITLE
[3.9] bpo-47230: Silence compiler warnings on Windows from zlib 1.2.12 (GH-32337)

### DIFF
--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -500,7 +500,9 @@
     <ClCompile Include="$(zlibDir)\adler32.c" />
     <ClCompile Include="$(zlibDir)\compress.c" />
     <ClCompile Include="$(zlibDir)\crc32.c" />
-    <ClCompile Include="$(zlibDir)\deflate.c" />
+    <ClCompile Include="$(zlibDir)\deflate.c">
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+    </ClCompile>
     <ClCompile Include="$(zlibDir)\infback.c" />
     <ClCompile Include="$(zlibDir)\inffast.c" />
     <ClCompile Include="$(zlibDir)\inflate.c" />


### PR DESCRIPTION
…2 (GH-32337).

(cherry picked from commit 944f09adfcc59f54432ac2947cf95f3465d90e1e)

Co-authored-by: Jeremy Kloth <jeremy.kloth@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47230](https://bugs.python.org/issue47230) -->
https://bugs.python.org/issue47230
<!-- /issue-number -->
