### PR TITLE
bpo-40421: test_capi uses assertEqual(), not assertEquals()

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -1097,7 +1097,7 @@ class Test_FrameAPI(unittest.TestCase):
 
     def test_frame_getters(self):
         frame = self.getframe()
-        self.assertEquals(frame.f_locals, _testcapi.frame_getlocals(frame))
+        self.assertEqual(frame.f_locals, _testcapi.frame_getlocals(frame))
         self.assertIs(frame.f_globals, _testcapi.frame_getglobals(frame))
         self.assertIs(frame.f_builtins, _testcapi.frame_getbuiltins(frame))
 


### PR DESCRIPTION
unittest.TestCase.assertEquals() alias is depracated. Fix the
warning:

Lib/test/test_capi.py:1100: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(frame.f_locals, _testcapi.frame_getlocals(frame))

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40421](https://bugs.python.org/issue40421) -->
https://bugs.python.org/issue40421
<!-- /issue-number -->
