### PR TITLE
Fix whitespace/indentation format in test_sys

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1179,8 +1179,8 @@ class UnraisableHookTest(unittest.TestCase):
                 with test.support.captured_stderr() as stderr, \
                      test.support.swap_attr(sys, 'unraisablehook',
                                             sys.__unraisablehook__):
-                         expected = self.write_unraisable_exc(
-                             A.B.X(), "msg", "obj");
+                    expected = self.write_unraisable_exc(
+                        A.B.X(), "msg", "obj");
                 report = stderr.getvalue()
                 self.assertIn(A.B.X.__qualname__, report)
                 if moduleName in ['builtins', '__main__']:


### PR DESCRIPTION
`make patchcheck` is failing after editing `test_sys` in GH-31936 due to this indent.

Automerge-Triggered-By: GH:Fidget-Spinner