### PR TITLE
[3.10] bpo-46769: Fix backticks in typing.rst to appease rstlint

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1158,7 +1158,7 @@ These are not used in annotations. They are building blocks for creating generic
                self.radius = radius
 
            # Use a type variable to show that the return type
-           # will always be an instance of whatever `cls` is
+           # will always be an instance of whatever ``cls`` is
            @classmethod
            def with_circumference(cls: type[C], circumference: float) -> C:
                """Create a circle with the specified circumference"""

--- a/Doc/tools/susp-ignored.csv
+++ b/Doc/tools/susp-ignored.csv
@@ -384,4 +384,4 @@ library/typing,,`,# Type of ``val`` is narrowed to ``str``
 library/typing,,`,"# Else, type of ``val`` is narrowed to ``float``."
 library/typing,,`,# Type of ``val`` is narrowed to ``List[str]``.
 library/typing,,`,# Type of ``val`` remains as ``List[object]``.
-library/typing,,`,    # will always be an instance of whatever `cls` is
+library/typing,,`,    # will always be an instance of whatever ``cls`` is


### PR DESCRIPTION
See https://dev.azure.com/Python/cpython/_build/results?buildId=100170&view=logs&j=4db1505a-29e5-5cc0-240b-53a8a2681f75&t=a975920c-8356-5388-147c-613d5fab0171 for an example test failure for rstlint.

<!-- issue-number: [bpo-46769](https://bugs.python.org/issue46769) -->
https://bugs.python.org/issue46769
<!-- /issue-number -->
