### PR TITLE
[3.9] bpo-46769: Fix backticks in typing.rst to appease rstlint

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -930,7 +930,7 @@ These are not used in annotations. They are building blocks for creating generic
                self.radius = radius
 
            # Use a type variable to show that the return type
-           # will always be an instance of whatever `cls` is
+           # will always be an instance of whatever ``cls`` is
            @classmethod
            def with_circumference(cls: type[C], circumference: float) -> C:
                """Create a circle with the specified circumference"""

--- a/Doc/tools/susp-ignored.csv
+++ b/Doc/tools/susp-ignored.csv
@@ -370,4 +370,4 @@ whatsnew/changelog,,::,default::DeprecationWarning
 library/importlib.metadata,,:main,"EntryPoint(name='wheel', value='wheel.cli:main', group='console_scripts')"
 library/importlib.metadata,,`,loading the metadata for packages for the indicated ``context``.
 library/re,,`,"`"
-library/typing,,`,    # will always be an instance of whatever `cls` is
+library/typing,,`,    # will always be an instance of whatever ``cls`` is


### PR DESCRIPTION
See https://dev.azure.com/Python/cpython/_build/results?buildId=100322&view=logs&j=4db1505a-29e5-5cc0-240b-53a8a2681f75&t=a975920c-8356-5388-147c-613d5fab0171 for an example test failure in 3.9.

<!-- issue-number: [bpo-46769](https://bugs.python.org/issue46769) -->
https://bugs.python.org/issue46769
<!-- /issue-number -->
