### PR TITLE
bpo-35134: Add Include/cpython/complexobject.h header

### DIFF
--- a/Include/complexobject.h
+++ b/Include/complexobject.h
@@ -6,61 +6,22 @@
 extern "C" {
 #endif
 
-#ifndef Py_LIMITED_API
-typedef struct {
-    double real;
-    double imag;
-} Py_complex;
-
-/* Operations on complex numbers from complexmodule.c */
-
-PyAPI_FUNC(Py_complex) _Py_c_sum(Py_complex, Py_complex);
-PyAPI_FUNC(Py_complex) _Py_c_diff(Py_complex, Py_complex);
-PyAPI_FUNC(Py_complex) _Py_c_neg(Py_complex);
-PyAPI_FUNC(Py_complex) _Py_c_prod(Py_complex, Py_complex);
-PyAPI_FUNC(Py_complex) _Py_c_quot(Py_complex, Py_complex);
-PyAPI_FUNC(Py_complex) _Py_c_pow(Py_complex, Py_complex);
-PyAPI_FUNC(double) _Py_c_abs(Py_complex);
-#endif
-
 /* Complex object interface */
-
-/*
-PyComplexObject represents a complex number with double-precision
-real and imaginary parts.
-*/
-#ifndef Py_LIMITED_API
-typedef struct {
-    PyObject_HEAD
-    Py_complex cval;
-} PyComplexObject;
-#endif
 
 PyAPI_DATA(PyTypeObject) PyComplex_Type;
 
 #define PyComplex_Check(op) PyObject_TypeCheck(op, &PyComplex_Type)
 #define PyComplex_CheckExact(op) Py_IS_TYPE(op, &PyComplex_Type)
 
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) PyComplex_FromCComplex(Py_complex);
-#endif
 PyAPI_FUNC(PyObject *) PyComplex_FromDoubles(double real, double imag);
 
 PyAPI_FUNC(double) PyComplex_RealAsDouble(PyObject *op);
 PyAPI_FUNC(double) PyComplex_ImagAsDouble(PyObject *op);
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(Py_complex) PyComplex_AsCComplex(PyObject *op);
-#endif
 
-/* Format the object based on the format_spec, as defined in PEP 3101
-   (Advanced String Formatting). */
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(int) _PyComplex_FormatAdvancedWriter(
-    _PyUnicodeWriter *writer,
-    PyObject *obj,
-    PyObject *format_spec,
-    Py_ssize_t start,
-    Py_ssize_t end);
+#  define Py_CPYTHON_COMPLEXOBJECT_H
+#  include "cpython/complexobject.h"
+#  undef Py_CPYTHON_COMPLEXOBJECT_H
 #endif
 
 #ifdef __cplusplus

--- a/Include/cpython/complexobject.h
+++ b/Include/cpython/complexobject.h
@@ -1,0 +1,44 @@
+#ifndef Py_CPYTHON_COMPLEXOBJECT_H
+#  error "this header file must not be included directly"
+#endif
+
+typedef struct {
+    double real;
+    double imag;
+} Py_complex;
+
+/* Operations on complex numbers from complexmodule.c */
+
+PyAPI_FUNC(Py_complex) _Py_c_sum(Py_complex, Py_complex);
+PyAPI_FUNC(Py_complex) _Py_c_diff(Py_complex, Py_complex);
+PyAPI_FUNC(Py_complex) _Py_c_neg(Py_complex);
+PyAPI_FUNC(Py_complex) _Py_c_prod(Py_complex, Py_complex);
+PyAPI_FUNC(Py_complex) _Py_c_quot(Py_complex, Py_complex);
+PyAPI_FUNC(Py_complex) _Py_c_pow(Py_complex, Py_complex);
+PyAPI_FUNC(double) _Py_c_abs(Py_complex);
+
+/* Complex object interface */
+
+/*
+PyComplexObject represents a complex number with double-precision
+real and imaginary parts.
+*/
+typedef struct {
+    PyObject_HEAD
+    Py_complex cval;
+} PyComplexObject;
+
+PyAPI_FUNC(PyObject *) PyComplex_FromCComplex(Py_complex);
+
+PyAPI_FUNC(Py_complex) PyComplex_AsCComplex(PyObject *op);
+
+#ifdef Py_BUILD_CORE
+/* Format the object based on the format_spec, as defined in PEP 3101
+   (Advanced String Formatting). */
+extern int _PyComplex_FormatAdvancedWriter(
+    _PyUnicodeWriter *writer,
+    PyObject *obj,
+    PyObject *format_spec,
+    Py_ssize_t start,
+    Py_ssize_t end);
+#endif  // Py_BUILD_CORE

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1522,6 +1522,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/cpython/classobject.h \
 		$(srcdir)/Include/cpython/code.h \
 		$(srcdir)/Include/cpython/compile.h \
+		$(srcdir)/Include/cpython/complexobject.h \
 		$(srcdir)/Include/cpython/context.h \
 		$(srcdir)/Include/cpython/descrobject.h \
 		$(srcdir)/Include/cpython/dictobject.h \

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -141,6 +141,7 @@
     <ClInclude Include="..\Include\cpython\classobject.h" />
     <ClInclude Include="..\Include\cpython\code.h" />
     <ClInclude Include="..\Include\cpython\compile.h" />
+    <ClInclude Include="..\Include\cpython\complexobject.h" />
     <ClInclude Include="..\Include\cpython\context.h" />
     <ClInclude Include="..\Include\cpython\descrobject.h" />
     <ClInclude Include="..\Include\cpython\dictobject.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -357,6 +357,9 @@
     <ClInclude Include="..\Include\cpython\compile.h">
       <Filter>Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\cpython\complexobject.h">
+      <Filter>Include</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\cpython\context.h">
       <Filter>Include\cpython</Filter>
     </ClInclude>


### PR DESCRIPTION
Move the private _PyComplex_FormatAdvancedWriter() function to the
internal C API. No longer export the function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-35134](https://bugs.python.org/issue35134) -->
https://bugs.python.org/issue35134
<!-- /issue-number -->
