### PR TITLE
Doc: Fix spurious comma in the author metadata field

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -139,7 +139,7 @@ latex_elements['pointsize'] = '10pt'
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
-_stdauthor = r'Guido van Rossum\\and the Python development team'
+_stdauthor = 'Guido van Rossum and the Python development team'
 latex_documents = [
     ('c-api/index', 'c-api.tex',
      'The Python/C API', _stdauthor, 'manual'),


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Presently, there's a spurious comma in the Author metadata field as discussed in python/docs-community#40 in LaTeX, PDF, etc. docs output and visible in the corresponding BPO-5901 . This PR fixes it.

As a correlate, it might make sense to make the author metadata consistent between output formats (see, e.g. the different one for the `epub` builder); I can make that change here if requested.

I would think it would probably make sense to backport this to the older bugfix branches, but that's not my call.
