### PR TITLE
bpo-47250: Fix refleak from object.__getstate__()

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5030,7 +5030,6 @@ object_getstate_default(PyObject *obj, int required)
 
             name = PyList_GET_ITEM(slotnames, i);
             Py_INCREF(name);
-            value = PyObject_GetAttr(obj, name);
             if (_PyObject_LookupAttr(obj, name, &value) < 0) {
                 Py_DECREF(name);
                 goto error;


### PR DESCRIPTION
Co-authored-by: Brandt Bucher <brandt@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-47250](https://bugs.python.org/issue47250) -->
https://bugs.python.org/issue47250
<!-- /issue-number -->
