### PR TITLE
gh-91243: Add typing.Required and NotRequired (PEP 655)

### DIFF
--- a/Lib/test/_typed_dict_helper.py
+++ b/Lib/test/_typed_dict_helper.py
@@ -6,13 +6,19 @@ look something like this:
 
     class Bar(_typed_dict_helper.Foo, total=False):
         b: int
+
+In addition, it uses multiple levels of Annotated to test the interaction
+between the __future__ import, Annotated, and Required.
 """
 
 from __future__ import annotations
 
-from typing import Optional, TypedDict
+from typing import Annotated, Optional, Required, TypedDict
 
 OptionalIntType = Optional[int]
 
 class Foo(TypedDict):
     a: OptionalIntType
+
+class VeryAnnotated(TypedDict, total=False):
+    a: Annotated[Annotated[Annotated[Required[int], "a"], "b"], "c"]

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3979,6 +3979,10 @@ class AnnotatedMovie(TypedDict):
     title: Annotated[Required[str], "foobar"]
     year: NotRequired[Annotated[int, 2000]]
 
+class DeeplyAnnotatedMovie(TypedDict):
+    title: Annotated[Annotated[Required[str], "foobar"], "another level"]
+    year: NotRequired[Annotated[int, 2000]]
+
 class HasForeignBaseClass(mod_generics_cache.A):
     some_xrepr: 'XRepr'
     other_a: 'mod_generics_cache.A'
@@ -4276,6 +4280,11 @@ class GetTypeHintTests(BaseTestCase):
         assert get_type_hints(AnnotatedMovie) == {'title': str, 'year': int}
         assert get_type_hints(AnnotatedMovie, include_extras=True) == {
             'title': Annotated[Required[str], "foobar"],
+            'year': NotRequired[Annotated[int, 2000]],
+        }
+        assert get_type_hints(DeeplyAnnotatedMovie) == {'title': str, 'year': int}
+        assert get_type_hints(DeeplyAnnotatedMovie, include_extras=True) == {
+            'title': Annotated[Annotated[Required[str], "foobar"], "another level"],
             'year': NotRequired[Annotated[int, 2000]],
         }
 
@@ -5432,6 +5441,12 @@ class RequiredTests(BaseTestCase):
         with self.assertRaises(TypeError):
             class C(type(Required[int])):
                 pass
+        with self.assertRaises(TypeError):
+            class C(Required):
+                pass
+        with self.assertRaises(TypeError):
+            class C(Required[int]):
+                pass
 
     def test_cannot_init(self):
         with self.assertRaises(TypeError):
@@ -5471,6 +5486,12 @@ class NotRequiredTests(BaseTestCase):
                 pass
         with self.assertRaises(TypeError):
             class C(type(NotRequired[int])):
+                pass
+        with self.assertRaises(TypeError):
+            class C(NotRequired):
+                pass
+        with self.assertRaises(TypeError):
+            class C(NotRequired[int]):
                 pass
 
     def test_cannot_init(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4303,6 +4303,8 @@ class GetUtilitiesTestCase(TestCase):
         self.assertIs(get_origin(list | str), types.UnionType)
         self.assertIs(get_origin(P.args), P)
         self.assertIs(get_origin(P.kwargs), P)
+        self.assertIs(get_origin(Required[int]), Required)
+        self.assertIs(get_origin(NotRequired[int]), NotRequired)
 
     def test_get_args(self):
         T = TypeVar('T')
@@ -4340,6 +4342,8 @@ class GetUtilitiesTestCase(TestCase):
         self.assertEqual(get_args(Callable[Concatenate[int, P], int]),
                          (Concatenate[int, P], int))
         self.assertEqual(get_args(list | str), (list, str))
+        self.assertEqual(get_args(Required[int]), (int,))
+        self.assertEqual(get_args(NotRequired[int]), (int,))
 
 
 class CollectionsAbcTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2906,7 +2906,7 @@ def Required(self, parameters):
     There is no runtime checking that a required key is actually provided
     when instantiating a related TypedDict.
     """
-    item = _type_check(parameters, f'{self._name} accepts only a single type')
+    item = _type_check(parameters, f'{self._name} accepts only a single type.')
     return _GenericAlias(self, (item,))
 
 
@@ -2924,7 +2924,7 @@ def NotRequired(self, parameters):
             year=1999,
         )
     """
-    item = _type_check(parameters, f'{self._name} accepts only a single type')
+    item = _type_check(parameters, f'{self._name} accepts only a single type.')
     return _GenericAlias(self, (item,))
 
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -132,9 +132,11 @@ __all__ = [
     'no_type_check',
     'no_type_check_decorator',
     'NoReturn',
+    'NotRequired',
     'overload',
     'ParamSpecArgs',
     'ParamSpecKwargs',
+    'Required',
     'reveal_type',
     'runtime_checkable',
     'Self',
@@ -2261,6 +2263,8 @@ def _strip_annotations(t):
     """
     if isinstance(t, _AnnotatedAlias):
         return _strip_annotations(t.__origin__)
+    if hasattr(t, "__origin__") and t.__origin__ in (Required, NotRequired):
+        return _strip_annotations(t.__args__[0])
     if isinstance(t, _GenericAlias):
         stripped_args = tuple(_strip_annotations(a) for a in t.__args__)
         if stripped_args == t.__args__:
@@ -2785,10 +2789,22 @@ class _TypedDictMeta(type):
             optional_keys.update(base.__dict__.get('__optional_keys__', ()))
 
         annotations.update(own_annotations)
-        if total:
-            required_keys.update(own_annotation_keys)
-        else:
-            optional_keys.update(own_annotation_keys)
+        for annotation_key, annotation_type in own_annotations.items():
+            annotation_origin = get_origin(annotation_type)
+            if annotation_origin is Annotated:
+                annotation_args = get_args(annotation_type)
+                if annotation_args:
+                    annotation_type = annotation_args[0]
+                    annotation_origin = get_origin(annotation_type)
+
+            if annotation_origin is Required:
+                required_keys.add(annotation_key)
+            elif annotation_origin is NotRequired:
+                optional_keys.add(annotation_key)
+            elif total:
+                required_keys.add(annotation_key)
+            else:
+                optional_keys.add(annotation_key)
 
         tp_dict.__annotations__ = annotations
         tp_dict.__required_keys__ = frozenset(required_keys)
@@ -2871,6 +2887,45 @@ def TypedDict(typename, fields=None, /, *, total=True, **kwargs):
 
 _TypedDict = type.__new__(_TypedDictMeta, 'TypedDict', (), {})
 TypedDict.__mro_entries__ = lambda bases: (_TypedDict,)
+
+
+@_SpecialForm
+def Required(self, parameters):
+    """A special typing construct to mark a key of a total=False TypedDict
+    as required. For example:
+
+        class Movie(TypedDict, total=False):
+            title: Required[str]
+            year: int
+
+        m = Movie(
+            title='The Matrix',  # typechecker error if key is omitted
+            year=1999,
+        )
+
+    There is no runtime checking that a required key is actually provided
+    when instantiating a related TypedDict.
+    """
+    item = _type_check(parameters, f'{self._name} accepts only single type')
+    return _GenericAlias(self, (item,))
+
+
+@_SpecialForm
+def NotRequired(self, parameters):
+    """A special typing construct to mark a key of a TypedDict as
+    potentially missing. For example:
+
+        class Movie(TypedDict):
+            title: str
+            year: NotRequired[int]
+
+        m = Movie(
+            title='The Matrix',  # typechecker error if key is omitted
+            year=1999,
+        )
+    """
+    item =_type_check(parameters, f'{self._name} accepts only single type')
+    return _GenericAlias(self, (item,))
 
 
 class NewType:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2906,7 +2906,7 @@ def Required(self, parameters):
     There is no runtime checking that a required key is actually provided
     when instantiating a related TypedDict.
     """
-    item = _type_check(parameters, f'{self._name} accepts only single type')
+    item = _type_check(parameters, f'{self._name} accepts only a single type')
     return _GenericAlias(self, (item,))
 
 
@@ -2924,7 +2924,7 @@ def NotRequired(self, parameters):
             year=1999,
         )
     """
-    item =_type_check(parameters, f'{self._name} accepts only single type')
+    item = _type_check(parameters, f'{self._name} accepts only a single type')
     return _GenericAlias(self, (item,))
 
 

--- a/Misc/NEWS.d/next/Library/2022-04-08-08-55-36.bpo-47087.Q5C3EI.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-08-08-55-36.bpo-47087.Q5C3EI.rst
@@ -1,0 +1,2 @@
+Implement ``typing.Required`` and ``typing.NotRequired`` (:pep:`655`). Patch
+by Jelle Zijlstra.


### PR DESCRIPTION
I talked to @davidfstr and I offered to implement the runtime part of PEP 655
to make sure we can get it in before the feature freeze. We're going to defer
the documentation to a separate PR, because it can wait until after the feature
freeze.

The runtime implementation conveniently already exists in typing-extensions,
so I largely copied that.

Co-authored-by: David Foster <david@dafoster.net>

<!-- issue-number: [bpo-47087](https://bugs.python.org/issue47087) -->
https://bugs.python.org/issue47087
<!-- /issue-number -->
