### PR TITLE
bpo-to-github-migration notify new-bugs-announce on new issue open

### DIFF
--- a/.github/workflows/new-bugs-announce-notifier.yml
+++ b/.github/workflows/new-bugs-announce-notifier.yml
@@ -1,0 +1,53 @@
+name: new-bugs-announce notifier
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  notify-new-bugs-announce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: npm install mailgun.js form-data
+      - name: Send notification
+        uses: actions/github-script@v5
+        env:
+          MAILGUN_API_KEY: ${{ secrets.PSF_MAILGUN_KEY }}
+        with:
+          script: |
+            const Mailgun = require("mailgun.js");
+            const formData = require('form-data');
+            const mailgun = new Mailgun(formData);
+            const DOMAIN = "mg.python.org";
+            const mg = mailgun.client({username: 'api', key: process.env.MAILGUN_API_KEY});
+            github.rest.issues.get({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            .then(function(issue) {
+              const payload = {
+                author : issue.data.user.login,
+                issue  : issue.data.number,
+                title  : issue.data.title,
+                url    : issue.data.html_url,
+                labels : issue.data.labels.map(label => { return label.name }).join(", "),
+                assignee : issue.data.assignees.map(assignee => { return assignee.login }),
+                body   : issue.data.body
+              };
+            
+              const data = {
+                from: "CPython Issues <github@mg.python.org>",
+                to: "new-bugs-announce@python.org",
+                subject: `[Issue ${issue.data.number}] ${issue.data.title}`,
+                template: "new-github-issue",
+                'o:tracking-clicks': 'no',
+                'h:X-Mailgun-Variables': JSON.stringify(payload)
+              };
+              return mg.messages.create(DOMAIN, data)
+            })
+            .then(msg => console.log(msg));


### PR DESCRIPTION
ref https://github.com/psf/gh-migration/issues/7

Unfortunately this quick and dirty one relies on a template that lives in MailGun.

If someone is interested in considering a way to manage formatting from the action, please do!

```
New GitHub issue #{{ issue }} from {{author}}:<br>

<hr>

<pre>
{{body}}
</pre>

<hr>

<a href="{{url}}">View on GitHub</a>
<p>Labels: {{ labels }}</p>
<p>Assignee: {{ assignee }}</p>
```
