### PR TITLE
gh-91421: Use constant value check during runtime

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-04-10-22-57-27.gh-issue-91421.dHhv6U.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-04-10-22-57-27.gh-issue-91421.dHhv6U.rst
@@ -1,0 +1,1 @@
+Fix a potential integer overflow in _Py_DecodeUTF8Ex.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -5296,7 +5296,7 @@ _Py_DecodeUTF8Ex(const char *s, Py_ssize_t size, wchar_t **wstr, size_t *wlen,
 
     /* Note: size will always be longer than the resulting Unicode
        character count */
-    if (PY_SSIZE_T_MAX / (Py_ssize_t)sizeof(wchar_t) < (size + 1)) {
+    if (PY_SSIZE_T_MAX / (Py_ssize_t)sizeof(wchar_t) - 1 < size) {
         return -1;
     }
 


### PR DESCRIPTION
The left-hand side expression of the if-check can be converted to a
constant by the compiler, but the addition on the right-hand side is
performed during runtime.

Move the addition from the right-hand side to the left-hand side by
turning it into a subtraction there. Since the values are known to
be large enough to not turn negative, this is a safe operation.

Prevents a very unlikely integer overflow on 32 bit systems.

Fixes issue #91421.