### PR TITLE
Remove dead "Check PRs with 'CLA not signed' label"

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,27 +14,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: "Check PRs with 'CLA signed' label"
+    - name: "Check PRs"
       uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        only-pr-labels: 'CLA signed'
         stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity.'
         stale-pr-label: 'stale'
         days-before-stale: 30
         days-before-close: -1
-        ascending: true
-        operations-per-run: 120
-
-    - name: "Check PRs with 'CLA not signed' label"
-      uses: actions/stale@v4
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        only-pr-labels: 'CLA not signed'
-        stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. If the CLA is not signed within 14 days, it will be closed. See also https://devguide.python.org/pullrequest/#licensing'
-        stale-pr-label: 'stale'
-        close-pr-message: 'Closing this stale PR because the CLA is still not signed.'
-        days-before-stale: 30
-        days-before-close: 14
         ascending: true
         operations-per-run: 120


### PR DESCRIPTION
Since cpython-cla-bot doesn't add `CLA not signed` label, "Check PRs with 'CLA not signed' label" action will never trigger any warning.

This PR effectively reverts gh-30500.