### PR TITLE
Add redirects to Misc/NEWS bpo links

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -433,7 +433,8 @@ class MiscNews(Directive):
             text = 'The NEWS file is not available.'
             node = nodes.strong(text, text)
             return [node]
-        content = issue_re.sub(r'`bpo-\1 <https://bugs.python.org/issue\1>`__',
+        content = issue_re.sub(r'`bpo-\1 <https://bugs.python.org/'
+                               r'issue?@action=redirect&bpo=\1>`__',
                                content)
         content = whatsnew_re.sub(r'\1', content)
         # remove first 3 lines as they are the main heading


### PR DESCRIPTION
This PR updates `bpo-*` links in Misc/NEWS with the redirect URL that points to GitHub issues.