### PR TITLE
gh-89455: Fix an uninitialized bool in exception print context.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-04-11-18-44-19.gh-issue-89455.d0qMYd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-04-11-18-44-19.gh-issue-89455.d0qMYd.rst
@@ -1,2 +1,2 @@
 Fixed an uninitialized bool value in the traceback printing code path that
-was introduced by the initial bpo-45292 work.
+was introduced by the initial bpo-45292 exception groups work.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-04-11-18-44-19.gh-issue-89455.d0qMYd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-04-11-18-44-19.gh-issue-89455.d0qMYd.rst
@@ -1,0 +1,2 @@
+Fixed an uninitialized bool value in the traceback printing code path that
+was introduced by the initial bpo-45292 work.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1504,6 +1504,7 @@ _PyErr_Display(PyObject *file, PyObject *exception, PyObject *value, PyObject *t
     struct exception_print_context ctx;
     ctx.file = file;
     ctx.exception_group_depth = 0;
+    ctx.need_close = false;
     ctx.max_group_width = PyErr_MAX_GROUP_WIDTH;
     ctx.max_group_depth = PyErr_MAX_GROUP_DEPTH;
 


### PR DESCRIPTION
Fix an uninitialized bool in exception print context.
    
`struct exception_print_context.need_close` was uninitialized.
    
Found by oss-fuzz in a test case running under the undefined behavior sanitizer.
    
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46618
https://oss-fuzz.com/testcase-detail/6217746058182656
    
```
Python/pythonrun.c:1241:28: runtime error: load of value 253, which is not a valid value for type 'bool'
    #0 0xbf2203 in print_chained cpython3/Python/pythonrun.c:1241:28
    #1 0xbea4bb in print_exception_cause_and_context cpython3/Python/pythonrun.c:1320:19
    #2 0xbea4bb in print_exception_recursive cpython3/Python/pythonrun.c:1470:13
    #3 0xbe9e39 in _PyErr_Display cpython3/Python/pythonrun.c:1517:9
```
    
Pretty obvious what the ommission was upon code inspection.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
