### PR TITLE
[3.11] bpo-14916: interactive fd is not tied to stdin [type-bug]

### DIFF
--- a/Misc/NEWS.d/next/C API/2022-04-13-16-10-55.gh-issue-59121.-B7mKp.rst
+++ b/Misc/NEWS.d/next/C API/2022-04-13-16-10-55.gh-issue-59121.-B7mKp.rst
@@ -1,0 +1,1 @@
+Fixed an assert that prevented ``PyRun_InteractiveOne`` from providing tracebacks when parsing from the provided FD.

--- a/Parser/pegen_errors.c
+++ b/Parser/pegen_errors.c
@@ -245,7 +245,7 @@ get_error_line_from_tokenizer_buffers(Parser *p, Py_ssize_t lineno)
      * (multi-line) statement are stored in p->tok->interactive_src_start.
      * If not, we're parsing from a string, which means that the whole source
      * is stored in p->tok->str. */
-    assert((p->tok->fp == NULL && p->tok->str != NULL) || p->tok->fp == stdin);
+    assert((p->tok->fp == NULL && p->tok->str != NULL) || p->tok->fp != NULL);
 
     char *cur_line = p->tok->fp_interactive ? p->tok->interactive_src_start : p->tok->str;
     if (cur_line == NULL) {


### PR DESCRIPTION
related to https://github.com/python/cpython/pull/31006 merged bugfix.

following https://bugs.python.org/issue14916 or https://github.com/python/cpython/issues/59121
