### PR TITLE
gh-90765: Catch LegacyInterpolation deprecation warning

### DIFF
--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -1028,7 +1028,9 @@ class ConfigParserTestCaseNoInterpolation(BasicTestCase, unittest.TestCase):
 
 class ConfigParserTestCaseLegacyInterpolation(ConfigParserTestCase):
     config_class = configparser.ConfigParser
-    interpolation = configparser.LegacyInterpolation()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        interpolation = configparser.LegacyInterpolation()
 
     def test_set_malformatted_interpolation(self):
         cf = self.fromstring("[sect]\n"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Follow on from gh-90765, see https://github.com/python/cpython/pull/30927#issuecomment-1096491343.

# Before

```console
$ PYTHONWARNINGS=always ./python.exe -Wall -m test test_configparser
Raised RLIMIT_NOFILE: 256 -> 1024
0:00:00 load avg: 5.65 Run tests sequentially
0:00:00 load avg: 5.65 [1/1] test_configparser
/Users/huvankem/github/cpython/Lib/test/test_configparser.py:1031: DeprecationWarning: LegacyInterpolation has been deprecated since Python 3.2 and will be removed from the configparser module in Python 3.13. Use BasicInterpolation or ExtendedInterpolation instead.
  interpolation = configparser.LegacyInterpolation()

== Tests result: SUCCESS ==

1 test OK.

Total duration: 476 ms
Tests result: SUCCESS
```

# After

```console
$ PYTHONWARNINGS=always ./python.exe -Wall -m test test_configparser
Raised RLIMIT_NOFILE: 256 -> 1024
0:00:00 load avg: 5.67 Run tests sequentially
0:00:00 load avg: 5.67 [1/1] test_configparser

== Tests result: SUCCESS ==

1 test OK.

Total duration: 468 ms
Tests result: SUCCESS
```
