### PR TITLE
gh-91447: Fix findtext to only give an empty string on None

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2735,6 +2735,22 @@ class BadElementPathTest(ElementTestCase, unittest.TestCase):
         except ZeroDivisionError:
             pass
 
+    def test_findtext_with_falsey_text_attribute(self):
+        root_elem = ET.Element('foo')
+        sub_elem = ET.SubElement(root_elem, 'bar')
+        falsey = ["", 0, False, [], (), {}]
+
+        for val in falsey:
+            sub_elem.text = val
+            self.assertEqual(root_elem.findtext('./bar'), val)
+
+    def test_findtext_with_none_text_attribute(self):
+        root_elem = ET.Element('foo')
+        sub_elem = ET.SubElement(root_elem, 'bar')
+        sub_elem.text = None
+
+        self.assertEqual(root_elem.findtext('./bar'), '')
+
     def test_findall_with_mutating(self):
         e = ET.Element('foo')
         e.extend([ET.Element('bar')])

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2739,7 +2739,6 @@ class BadElementPathTest(ElementTestCase, unittest.TestCase):
         root_elem = ET.Element('foo')
         sub_elem = ET.SubElement(root_elem, 'bar')
         falsey = ["", 0, False, [], (), {}]
-
         for val in falsey:
             sub_elem.text = val
             self.assertEqual(root_elem.findtext('./bar'), val)
@@ -2748,7 +2747,6 @@ class BadElementPathTest(ElementTestCase, unittest.TestCase):
         root_elem = ET.Element('foo')
         sub_elem = ET.SubElement(root_elem, 'bar')
         sub_elem.text = None
-
         self.assertEqual(root_elem.findtext('./bar'), '')
 
     def test_findall_with_mutating(self):

--- a/Lib/xml/etree/ElementPath.py
+++ b/Lib/xml/etree/ElementPath.py
@@ -416,6 +416,10 @@ def findall(elem, path, namespaces=None):
 def findtext(elem, path, default=None, namespaces=None):
     try:
         elem = next(iterfind(elem, path, namespaces))
-        return elem.text or ""
+
+        if elem.text is None:
+            return ""
+
+        return elem.text
     except StopIteration:
         return default

--- a/Lib/xml/etree/ElementPath.py
+++ b/Lib/xml/etree/ElementPath.py
@@ -416,10 +416,8 @@ def findall(elem, path, namespaces=None):
 def findtext(elem, path, default=None, namespaces=None):
     try:
         elem = next(iterfind(elem, path, namespaces))
-
         if elem.text is None:
             return ""
-
         return elem.text
     except StopIteration:
         return default

--- a/Misc/NEWS.d/next/Library/2022-04-12-18-05-40.gh-issue-91447.N_Fs4H.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-12-18-05-40.gh-issue-91447.N_Fs4H.rst
@@ -1,0 +1,2 @@
+Fix findtext in the xml module to only give an empty string when the text
+attribute is set to None.


### PR DESCRIPTION
The API documentation for [findtext](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.findtext) states that this function gives back an empty string on "no text content." With the previous implementation, this would give back a empty string even on text content values such as 0 or False. This patch attempts to resolve that by only giving back an empty string if the text attribute is set to `None`. Resolves #91447.

<!-- gh-issue-number: gh-91447 -->
* Issue: gh-91447
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:gvanrossum