### PR TITLE
gh-91401: Add a failsafe way to disable vfork.

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1529,3 +1529,29 @@ runtime):
 
    :mod:`shlex`
       Module which provides function to parse and escape command lines.
+
+
+.. _disable_vfork:
+
+Disabling potential use of ``vfork()``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On Linux, :mod:`subprocess` defaults to using the ``vfork()`` system call
+internally when it is safe to do so rather than ``fork()``. This greatly
+improves performance.
+
+If you ever encounter a presumed highly-unusual situation where you need to
+prevent ``vfork()`` from being used by Python, you can set the
+:attr:`subprocess.disable_vfork_reason` attribute to a non-empty string.
+Ideally one describing why and linking to a bug report explaining how to setup
+an environment with code to reproduce the issue preventing it from working
+properly. Without recording that information, nobody will understand when they
+can unset it in your code in the future.
+
+Setting this has no impact on use of ``posix_spawn()`` which could use
+``vfork()`` within its libc implementation.
+
+It is safe to set this attribute on older Python versions. Do not assume it
+exists to be read until 3.11.
+
+.. versionadded:: 3.11 ``disable_vfork_reason``

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1532,9 +1532,10 @@ runtime):
 
 
 .. _disable_vfork:
+.. _disable_posix_spawn:
 
-Disabling potential use of ``vfork()``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Disabling use of ``vfork()`` or ``posix_spawn()``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On Linux, :mod:`subprocess` defaults to using the ``vfork()`` system call
 internally when it is safe to do so rather than ``fork()``. This greatly
@@ -1542,16 +1543,25 @@ improves performance.
 
 If you ever encounter a presumed highly-unusual situation where you need to
 prevent ``vfork()`` from being used by Python, you can set the
-:attr:`subprocess.disable_vfork_reason` attribute to a non-empty string.
-Ideally one describing why and linking to a bug report explaining how to setup
-an environment with code to reproduce the issue preventing it from working
-properly. Without recording that information, nobody will understand when they
-can unset it in your code in the future.
+:attr:`subprocess._USE_VFORK` attribute to a false value.
+
+   subprocess._USE_VFORK = False  # See CPython issue gh-NNNNNN.
 
 Setting this has no impact on use of ``posix_spawn()`` which could use
-``vfork()`` within its libc implementation.
+``vfork()`` internally within its libc implementation.  There is a similar
+:attr:`subprocess._USE_POSIX_SPAWN` attribute if you need to prevent use of
+that.
 
-It is safe to set this attribute on older Python versions. Do not assume it
-exists to be read until 3.11.
+   subprocess._USE_POSIX_SPAWN = False  # See CPython issue gh-NNNNNN.
 
-.. versionadded:: 3.11 ``disable_vfork_reason``
+It is safe to set these to false on any Python version. They will have no
+effect on older versions when unsupported. Do not assume the attributes are
+available to read. Despite their names, a true value does not indicate that the
+corresponding function will be used, only that that it may be.
+
+Please file issues any time you have to use these private knobs with a way to
+reproduce the issue you were seeing. Link to that issue from a comment in your
+code.
+
+.. versionadded:: 3.8 ``_USE_POSIX_SPAWN``
+.. versionadded:: 3.11 ``_USE_VFORK``

--- a/Lib/multiprocessing/util.py
+++ b/Lib/multiprocessing/util.py
@@ -446,13 +446,15 @@ def _flush_std_streams():
 
 def spawnv_passfds(path, args, passfds):
     import _posixsubprocess
+    import subprocess
     passfds = tuple(sorted(map(int, passfds)))
     errpipe_read, errpipe_write = os.pipe()
     try:
         return _posixsubprocess.fork_exec(
             args, [os.fsencode(path)], True, passfds, None, None,
             -1, -1, -1, -1, -1, -1, errpipe_read, errpipe_write,
-            False, False, None, None, None, -1, None)
+            False, False, None, None, None, -1, None,
+            subprocess.disable_vfork_reason)
     finally:
         os.close(errpipe_read)
         os.close(errpipe_write)

--- a/Lib/multiprocessing/util.py
+++ b/Lib/multiprocessing/util.py
@@ -454,7 +454,7 @@ def spawnv_passfds(path, args, passfds):
             args, [os.fsencode(path)], True, passfds, None, None,
             -1, -1, -1, -1, -1, -1, errpipe_read, errpipe_write,
             False, False, None, None, None, -1, None,
-            subprocess.disable_vfork_reason)
+            subprocess._USE_VFORK)
     finally:
         os.close(errpipe_read)
         os.close(errpipe_write)

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -107,6 +107,14 @@ else:
     import selectors
 
 
+# This is purely a failsafe. If non-empty the _posixsubprocess code will never
+# consider using vfork(). While any true value will trigger this, set it to a
+# description of why it is being disabled. With a link to a bug report
+# explaining how to setup an environment with code to reproduce the issue this
+# is working around. Otherwise nobody will understand when they can unset it.
+disable_vfork_reason = ""
+
+
 # Exception classes used by this module.
 class SubprocessError(Exception): pass
 
@@ -1792,7 +1800,7 @@ class Popen:
                             errpipe_read, errpipe_write,
                             restore_signals, start_new_session,
                             gid, gids, uid, umask,
-                            preexec_fn)
+                            preexec_fn, disable_vfork_reason)
                     self._child_created = True
                 finally:
                     # be sure the FD is closed no matter what

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -107,14 +107,6 @@ else:
     import selectors
 
 
-# This is purely a failsafe. If non-empty the _posixsubprocess code will never
-# consider using vfork(). While any true value will trigger this, set it to a
-# description of why it is being disabled. With a link to a bug report
-# explaining how to setup an environment with code to reproduce the issue this
-# is working around. Otherwise nobody will understand when they can unset it.
-disable_vfork_reason = ""
-
-
 # Exception classes used by this module.
 class SubprocessError(Exception): pass
 
@@ -711,6 +703,7 @@ def _use_posix_spawn():
 
 
 _USE_POSIX_SPAWN = _use_posix_spawn()
+_USE_VFORK = sys.platform == 'linux'
 
 
 class Popen:
@@ -1800,7 +1793,7 @@ class Popen:
                             errpipe_read, errpipe_write,
                             restore_signals, start_new_session,
                             gid, gids, uid, umask,
-                            preexec_fn, disable_vfork_reason)
+                            preexec_fn, _USE_VFORK)
                     self._child_created = True
                 finally:
                     # be sure the FD is closed no matter what

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -702,8 +702,10 @@ def _use_posix_spawn():
     return False
 
 
+# These are primarily fail-safe knobs for negatives. A True value does not
+# guarantee the given libc/syscall API will be used.
 _USE_POSIX_SPAWN = _use_posix_spawn()
-_USE_VFORK = sys.platform == 'linux'
+_USE_VFORK = True
 
 
 class Popen:

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -118,7 +118,7 @@ class CAPITest(unittest.TestCase):
             def __len__(self):
                 return 1
         self.assertRaises(TypeError, _posixsubprocess.fork_exec,
-                          1,Z(),3,(1, 2),5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21)
+                          1,Z(),3,(1, 2),5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22)
         # Issue #15736: overflow in _PySequence_BytesToCharpArray()
         class Z(object):
             def __len__(self):
@@ -126,7 +126,7 @@ class CAPITest(unittest.TestCase):
             def __getitem__(self, i):
                 return b'x'
         self.assertRaises(MemoryError, _posixsubprocess.fork_exec,
-                          1,Z(),3,(1, 2),5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21)
+                          1,Z(),3,(1, 2),5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22)
 
     @unittest.skipUnless(_posixsubprocess, '_posixsubprocess required for this test.')
     def test_subprocess_fork_exec(self):
@@ -136,7 +136,7 @@ class CAPITest(unittest.TestCase):
 
         # Issue #15738: crash in subprocess_fork_exec()
         self.assertRaises(TypeError, _posixsubprocess.fork_exec,
-                          Z(),[b'1'],3,(1, 2),5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21)
+                          Z(),[b'1'],3,(1, 2),5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22)
 
     @unittest.skipIf(MISSING_C_DOCSTRINGS,
                      "Signature information for builtins requires docstrings")

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -3107,7 +3107,7 @@ class POSIXProcessTestCase(BaseTestCase):
                         1, 2, 3, 4,
                         True, True,
                         False, [], 0, -1,
-                        func)
+                        func, "")
                 # Attempt to prevent
                 # "TypeError: fork_exec() takes exactly N arguments (M given)"
                 # from passing the test.  More refactoring to have us start
@@ -3156,7 +3156,7 @@ class POSIXProcessTestCase(BaseTestCase):
                         1, 2, 3, 4,
                         True, True,
                         None, None, None, -1,
-                        None)
+                        None, "no vfork")
                 self.assertIn('fds_to_keep', str(c.exception))
         finally:
             if not gc_enabled:
@@ -3614,7 +3614,8 @@ class MiscTests(unittest.TestCase):
 
     def test__all__(self):
         """Ensure that __all__ is populated properly."""
-        intentionally_excluded = {"list2cmdline", "Handle", "pwd", "grp", "fcntl"}
+        intentionally_excluded = {"list2cmdline", "Handle", "pwd", "grp",
+                                  "fcntl", "disable_vfork_reason"}
         exported = set(subprocess.__all__)
         possible_exports = set()
         import types

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -3107,7 +3107,7 @@ class POSIXProcessTestCase(BaseTestCase):
                         1, 2, 3, 4,
                         True, True,
                         False, [], 0, -1,
-                        func, "")
+                        func, False)
                 # Attempt to prevent
                 # "TypeError: fork_exec() takes exactly N arguments (M given)"
                 # from passing the test.  More refactoring to have us start
@@ -3614,8 +3614,7 @@ class MiscTests(unittest.TestCase):
 
     def test__all__(self):
         """Ensure that __all__ is populated properly."""
-        intentionally_excluded = {"list2cmdline", "Handle", "pwd", "grp",
-                                  "fcntl", "disable_vfork_reason"}
+        intentionally_excluded = {"list2cmdline", "Handle", "pwd", "grp", "fcntl"}
         exported = set(subprocess.__all__)
         possible_exports = set()
         import types

--- a/Misc/NEWS.d/next/Library/2022-04-25-21-33-48.gh-issue-91401._Jo4Bu.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-25-21-33-48.gh-issue-91401._Jo4Bu.rst
@@ -1,0 +1,2 @@
+Provide a way to disable :mod:`subprocess` use of ``vfork()`` just in case
+it is ever needed and document the existing mechanism for ``posix_spawn()``.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -751,9 +751,10 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
     Py_ssize_t arg_num, num_groups = 0;
     int need_after_fork = 0;
     int saved_errno = 0;
+    int disable_vfork;
 
     if (!PyArg_ParseTuple(
-            args, "OOpO!OOiiiiiiiiiiOOOiO:fork_exec",
+            args, "OOpO!OOiiiiiiiiiiOOOiOp:fork_exec",
             &process_args, &executable_list,
             &close_fds, &PyTuple_Type, &py_fds_to_keep,
             &cwd_obj, &env_list,
@@ -761,7 +762,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
             &errread, &errwrite, &errpipe_read, &errpipe_write,
             &restore_signals, &call_setsid,
             &gid_object, &groups_list, &uid_object, &child_umask,
-            &preexec_fn))
+            &preexec_fn, &disable_vfork))
         return NULL;
 
     if ((preexec_fn != Py_None) &&
@@ -940,7 +941,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
 #ifdef VFORK_USABLE
     /* Use vfork() only if it's safe. See the comment above child_exec(). */
     sigset_t old_sigs;
-    if (preexec_fn == Py_None &&
+    if (preexec_fn == Py_None && !disable_vfork &&
         !call_setuid && !call_setgid && !call_setgroups) {
         /* Block all signals to ensure that no signal handlers are run in the
          * child process while it shares memory with us. Note that signals

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -751,7 +751,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
     Py_ssize_t arg_num, num_groups = 0;
     int need_after_fork = 0;
     int saved_errno = 0;
-    int disable_vfork;
+    int allow_vfork;
 
     if (!PyArg_ParseTuple(
             args, "OOpO!OOiiiiiiiiiiOOOiOp:fork_exec",
@@ -762,7 +762,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
             &errread, &errwrite, &errpipe_read, &errpipe_write,
             &restore_signals, &call_setsid,
             &gid_object, &groups_list, &uid_object, &child_umask,
-            &preexec_fn, &disable_vfork))
+            &preexec_fn, &allow_vfork))
         return NULL;
 
     if ((preexec_fn != Py_None) &&
@@ -941,7 +941,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
 #ifdef VFORK_USABLE
     /* Use vfork() only if it's safe. See the comment above child_exec(). */
     sigset_t old_sigs;
-    if (preexec_fn == Py_None && !disable_vfork &&
+    if (preexec_fn == Py_None && allow_vfork &&
         !call_setuid && !call_setgid && !call_setgroups) {
         /* Block all signals to ensure that no signal handlers are run in the
          * child process while it shares memory with us. Note that signals


### PR DESCRIPTION
Just in case there is ever an issue with `_posixsubprocess`'s use of
`vfork()` due to the complexity of using it properly and potential
directions that Linux platforms where it defaults to on could take, this
adds a failsafe so that users can disable its use entirely by setting
a global flag.

No known reason to disable it exists. But it'd be a shame to encounter
one and not be able to use CPython without patching and rebuilding it.

See the linked issue for some discussion on reasoning.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
