### PR TITLE
CI: Don't apply 'stale' label to issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity.'
         stale-pr-label: 'stale'
-        days-before-stale: 30
+        days-before-issue-stale: -1
+        days-before-pr-stale: 30
         days-before-close: -1
         ascending: true
         operations-per-run: 120


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Fixes https://github.com/python/core-workflow/issues/439.

Currently we only want this GitHub action to only process old PRs.

It may be useful to also do so for issues, but following the BPO->GH migration, let's discuss that separately and first make sure this doesn't do issues.
