### PR TITLE
Fix awkward sentence in signal docs

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -712,7 +712,7 @@ case, wrap your entry point to catch this exception as follows::
         main()
 
 Do not set :const:`SIGPIPE`'s disposition to :const:`SIG_DFL` in
-order to avoid :exc:`BrokenPipeError`.  Doing that causes
+order to avoid :exc:`BrokenPipeError`.  Doing that would cause
 your program to exit unexpectedly whenever any socket
 connection is interrupted while your program is still writing to
 it.

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -711,10 +711,11 @@ case, wrap your entry point to catch this exception as follows::
     if __name__ == '__main__':
         main()
 
-Do not set :const:`SIGPIPE`'s disposition to :const:`SIG_DFL`
-in order to avoid :exc:`BrokenPipeError`.  Doing that would cause
-your program to exit unexpectedly also whenever any socket connection
-is interrupted while your program is still writing to it.
+Do not set :const:`SIGPIPE`'s disposition to :const:`SIG_DFL` in
+order to avoid :exc:`BrokenPipeError`.  Doing that would also
+cause your program to exit unexpectedly whenever any socket
+connection is interrupted while your program is still writing to
+it.
 
 .. _handlers-and-exceptions:
 

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -712,8 +712,8 @@ case, wrap your entry point to catch this exception as follows::
         main()
 
 Do not set :const:`SIGPIPE`'s disposition to :const:`SIG_DFL` in
-order to avoid :exc:`BrokenPipeError`.  Doing that would also
-cause your program to exit unexpectedly whenever any socket
+order to avoid :exc:`BrokenPipeError`.  Doing that causes
+your program to exit unexpectedly whenever any socket
 connection is interrupted while your program is still writing to
 it.
 


### PR DESCRIPTION
The diff is kind of hard to read because I reformatted where the paragraph breaks, but all I did was move the position of `also` in the sentence.