### PR TITLE
gh-89885: Add example for spam.Bar

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -497,14 +497,16 @@ and ``spam/__init__.py`` has the following lines in it::
     from .foo import Foo
     from .bar import Bar
 
-then executing the following puts a name binding to ``foo`` and ``bar`` in the
-``spam`` module::
+then executing the following puts a name binding to ``foo`` and ``bar`` (as well
+as ``Foo`` and ``Bar``) in the ``spam`` module::
 
     >>> import spam
     >>> spam.foo
     <module 'spam.foo' from '/tmp/imports/spam/foo.py'>
-    >>> spam.bar
-    <module 'spam.bar' from '/tmp/imports/spam/bar.py'>
+    >>> spam.Bar
+    <class 'spam.bar.Bar'>
+
+
 
 Given Python's familiar name binding rules this might seem surprising, but
 it's actually a fundamental feature of the import system.  The invariant

--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -491,11 +491,11 @@ submodule.  Let's say you have the following directory structure::
         __init__.py
         foo.py
 
-and ``spam/__init__.py`` has the following lines in it::
+and ``spam/__init__.py`` has the following line in it::
 
     from .foo import Foo
 
-then executing the following puts a name binding to ``foo`` and ``Foo`` in the
+then executing the following puts name bindings for ``foo`` and ``Foo`` in the
 ``spam`` module::
 
     >>> import spam
@@ -503,8 +503,6 @@ then executing the following puts a name binding to ``foo`` and ``Foo`` in the
     <module 'spam.foo' from '/tmp/imports/spam/foo.py'>
     >>> spam.Foo
     <class 'spam.foo.Foo'>
-
-
 
 Given Python's familiar name binding rules this might seem surprising, but
 it's actually a fundamental feature of the import system.  The invariant

--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -490,21 +490,18 @@ submodule.  Let's say you have the following directory structure::
     spam/
         __init__.py
         foo.py
-        bar.py
 
 and ``spam/__init__.py`` has the following lines in it::
 
     from .foo import Foo
-    from .bar import Bar
 
-then executing the following puts a name binding to ``foo`` and ``bar`` (as well
-as ``Foo`` and ``Bar``) in the ``spam`` module::
+then executing the following puts a name binding to ``foo`` and ``Foo`` in the ``spam`` module::
 
     >>> import spam
     >>> spam.foo
     <module 'spam.foo' from '/tmp/imports/spam/foo.py'>
-    >>> spam.Bar
-    <class 'spam.bar.Bar'>
+    >>> spam.Foo
+    <class 'spam.foo.Foo'>
 
 
 

--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -495,7 +495,8 @@ and ``spam/__init__.py`` has the following lines in it::
 
     from .foo import Foo
 
-then executing the following puts a name binding to ``foo`` and ``Foo`` in the ``spam`` module::
+then executing the following puts a name binding to ``foo`` and ``Foo`` in the
+``spam`` module::
 
     >>> import spam
     >>> spam.foo


### PR DESCRIPTION
https://github.com/python/cpython/issues/89885

Instead of showing `foo` and `Foo`, I opted to change it slightly and show `foo` and `Bar` (deleting `bar`)