### PR TITLE
gh-91544: Better stringification of Parameter defaults

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2719,10 +2719,23 @@ class Parameter:
                                        formatannotation(self._annotation))
 
         if self._default is not _empty:
-            if self._annotation is not _empty:
-                formatted = '{} = {}'.format(formatted, repr(self._default))
+            if hasattr(self._default, '__qualname__') or hasattr(self._default, '__name__'):
+                if hasattr(self._default, '__qualname__'):
+                    val = self._default.__qualname__
+                else:
+                    val = self._default.__name__
+                if (not ismodule(self._default)
+                    and (mod := getmodule(self._default))
+                    and hasattr(mod, '__name__')
+                    and mod.__name__ != 'builtins'
+                ):
+                    val = '{}.{}'.format(mod.__name__, val)
             else:
-                formatted = '{}={}'.format(formatted, repr(self._default))
+                val = repr(self._default)
+            if self._annotation is not _empty:
+                formatted = '{} = {}'.format(formatted, val)
+            else:
+                formatted = '{}={}'.format(formatted, val)
 
         if kind == _VAR_POSITIONAL:
             formatted = '*' + formatted

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -3708,6 +3708,17 @@ class TestParameterObject(unittest.TestCase):
         with self.assertRaises(AttributeError):
             p.kind = 123
 
+    def test_stringified_defaults(self):
+        for d, s in (
+            (12, 'spam=12'),
+            (int, 'spam=int'),
+            (inspect, 'spam=inspect'),
+            (inspect.Parameter, 'spam=inspect.Parameter'),
+        ):
+            with self.subTest(d=d, s=s):
+                p = inspect.Parameter('spam', kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, default=d)
+                self.assertEqual(str(p), s)
+
 
 class TestSignatureBind(unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
Examples from the issue, redone under this commit:
```python
>>> import inspect
>>> def a_test(a=str, b=inspect, c=inspect.Signature, d=inspect.signature, e=inspect.Signature.replace, f=(i for i in range(3))):
...    """lots of objects with awkward reprs"""
...
>>> print(inspect.signature(a_test))
(a=str, b=inspect, c=inspect.Signature, d=inspect.signature, e=inspect.Signature.replace, f=<genexpr>)
>>>
>>> def b_test(a: str = str):
...    """annotations seem to get this right"""
...
>>> print(inspect.signature(b_test))
(a: str = str)
```

```python
>>> help(locale.atof)
Help on function atof in module locale:

atof(string, func=float)
    Parses a string as a float according to the locale settings.
```