### PR TITLE
gh-69093: Expose sqlite3.Blob as a class

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1055,6 +1055,9 @@ class BlobTests(unittest.TestCase):
         self.blob.close()
         self.cx.close()
 
+    def test_blob_is_a_blob(self):
+        self.assertIsInstance(self.blob, sqlite.Blob)
+
     def test_blob_seek_and_tell(self):
         self.blob.seek(10)
         self.assertEqual(self.blob.tell(), 10)

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -697,6 +697,7 @@ module_exec(PyObject *module)
     }
 
     pysqlite_state *state = pysqlite_get_state(module);
+    ADD_TYPE(module, state->BlobType);
     ADD_TYPE(module, state->ConnectionType);
     ADD_TYPE(module, state->CursorType);
     ADD_TYPE(module, state->PrepareProtocolType);


### PR DESCRIPTION
I noticed this was missing while writing typeshed stubs. It's
useful to expose it for use in annotations.

GH-69093