### PR TITLE
gh-90829: Changing error message in builtins.min/max

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-04-15-06-01-50.gh-issue-90829.kAWvLz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-04-15-06-01-50.gh-issue-90829.kAWvLz.rst
@@ -1,0 +1,6 @@
+When passing an empty iterable to min/max function, such
+as min(set()), it returns the error 'arg is an empty sequence'.
+'arg' does not match any argument of the functions signature.
+Also, the iterable argument does not need to be a sequence.
+This commit changes that error message to:
+'iterable argument is an empty sequence'.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1772,7 +1772,7 @@ min_max(PyObject *args, PyObject *kwds, int op)
             maxitem = defaultval;
         } else {
             PyErr_Format(PyExc_ValueError,
-                         "%s() arg is an empty sequence", name);
+                         "%s() iterable argument is empty", name);
         }
     }
     else


### PR DESCRIPTION
gh-90829: Fixed builtin.min/max error messages when iterable is empty

When passing an empty iterable to min function, such as
min(set()), it returns the error 'arg is an empty sequence'.
'arg' does not match any argument of the function signature.
Also, the iterable argument does not need to be a sequence.
This commit changes it to 'iterable argument is an empty sequence'.