### PR TITLE
gh-89253: Add 3.10 whatsnew section for itertools.pairwise

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1223,6 +1223,12 @@ now call :func:`inspect.get_annotations` to retrieve annotations. This means
 also now un-stringize stringized annotations.
 (Contributed by Larry Hastings in :issue:`43817`.)
 
+itertools
+---------
+
+Add :func:`itertools.pairwise()`.
+(Contributed by Brett Cannon in :issue:`38200`.)
+
 linecache
 ---------
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1227,7 +1227,7 @@ itertools
 ---------
 
 Add :func:`itertools.pairwise()`.
-(Contributed by Brett Cannon in :issue:`38200`.)
+(Contributed by Raymond Hettinger in :issue:`38200`.)
 
 linecache
 ---------


### PR DESCRIPTION
#89253

[`pairwise()`](https://docs.python.org/3/library/itertools.html#itertools.pairwise) already has the 'new in python3.10'

Automerge-Triggered-By: GH:rhettinger