### PR TITLE
gh-69093: Disallow instantiation of sqlite3.Blob objects

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -356,6 +356,7 @@ class ModuleTests(unittest.TestCase):
     def test_disallow_instantiation(self):
         cx = sqlite.connect(":memory:")
         check_disallow_instantiation(self, type(cx("select 1")))
+        check_disallow_instantiation(self, sqlite.Blob)
 
     def test_complete_statement(self):
         self.assertFalse(sqlite.complete_statement("select t"))

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -334,7 +334,7 @@ static PyType_Spec blob_spec = {
     .name = MODULE_NAME ".Blob",
     .basicsize = sizeof(pysqlite_Blob),
     .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-              Py_TPFLAGS_IMMUTABLETYPE),
+              Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION),
     .slots = blob_slots,
 };
 


### PR DESCRIPTION
Objects of this type should only be instantiated from an SQLite connection object, using `blobopen()`.

gh-69093