### PR TITLE
gh-69093: improve sqlite3.Connection.blobopen() error handling

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -475,7 +475,11 @@ blobopen_impl(pysqlite_Connection *self, const char *table, const char *col,
     rc = sqlite3_blob_open(self->db, name, table, col, row, !readonly, &blob);
     Py_END_ALLOW_THREADS
 
-    if (rc != SQLITE_OK) {
+    if (rc == SQLITE_MISUSE) {
+        PyErr_Format(self->state->InterfaceError, sqlite3_errstr(rc));
+        return NULL;
+    }
+    else if (rc != SQLITE_OK) {
         _pysqlite_seterror(self->state, self->db);
         return NULL;
     }


### PR DESCRIPTION
Unless sqlite3_blob_open() returns SQLITE_MISUSE, the error code and
message are available on the connection object. This means we have to
handle SQLITE_MISUSE error messages explicitly.

gh-69093

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
