### PR TITLE
gh-91577: SharedMemory move imports out of methods

### DIFF
--- a/Lib/multiprocessing/shared_memory.py
+++ b/Lib/multiprocessing/shared_memory.py
@@ -23,6 +23,7 @@ else:
     import _posixshmem
     _USE_POSIX = True
 
+from . import resource_tracker
 
 _O_CREX = os.O_CREAT | os.O_EXCL
 
@@ -116,8 +117,7 @@ class SharedMemory:
                 self.unlink()
                 raise
 
-            from .resource_tracker import register
-            register(self._name, "shared_memory")
+            resource_tracker.register(self._name, "shared_memory")
 
         else:
 
@@ -237,9 +237,8 @@ class SharedMemory:
         called once (and only once) across all processes which have access
         to the shared memory block."""
         if _USE_POSIX and self._name:
-            from .resource_tracker import unregister
             _posixshmem.shm_unlink(self._name)
-            unregister(self._name, "shared_memory")
+            resource_tracker.unregister(self._name, "shared_memory")
 
 
 _encoding = "utf8"

--- a/Misc/NEWS.d/next/Library/2022-04-15-17-38-55.gh-issue-91577.Ah7cLL.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-15-17-38-55.gh-issue-91577.Ah7cLL.rst
@@ -1,0 +1,1 @@
+Move imports in :class:`~multiprocessing.SharedMemory` methods to module level so that they can be executed late in python finalization.


### PR DESCRIPTION
`SharedMemory.unlink()` uses the `unregister()` function from resource_tracker. Previously it was imported in the method, but this can fail if the method is called during interpreter shutdown, for example when `unlink()` is part of a `__del__()` method.

Moving the import to the top of the file, means that the `unregister()` method is available during interpreter shutdown.

The register call in `SharedMemory.__init__()` can also use this imported resource_tracker.

closes gh-91577 