### PR TITLE
gh-91595: fix the comparison of character and integer by using ord()

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-04-16-05-12-13.gh-issue-91595.CocJBv.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-16-05-12-13.gh-issue-91595.CocJBv.rst
@@ -1,0 +1,1 @@
+Fix the comparison of character and integer inside :func:`Tools.gdb.libpython.write_repr`. Patch by Yu Liu.

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1418,7 +1418,7 @@ class PyUnicodeObjectPtr(PyObjectPtr):
                 out.write('\\r')
 
             # Map non-printable US ASCII to '\xhh' */
-            elif ch < ' ' or ch == 0x7F:
+            elif ch < ' ' or ord(ch) == 0x7F:
                 out.write('\\x')
                 out.write(hexdigits[(ord(ch) >> 4) & 0x000F])
                 out.write(hexdigits[ord(ch) & 0x000F])


### PR DESCRIPTION
Fix #91597 