### PR TITLE
gh-91611: Use example.com for documentation. Not others' domain.

### DIFF
--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -193,7 +193,7 @@ suitable for password recovery applications:
 .. testcode::
 
    import secrets
-   url = 'https://mydomain.com/reset=' + secrets.token_urlsafe()
+   url = 'https://example.com/reset=' + secrets.token_urlsafe()
 
 
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -2357,7 +2357,7 @@ waiting for clients to connect::
    context.load_cert_chain(certfile="mycertfile", keyfile="mykeyfile")
 
    bindsocket = socket.socket()
-   bindsocket.bind(('myaddr.mydomain.com', 10023))
+   bindsocket.bind(('myaddr.example.com', 10023))
    bindsocket.listen(5)
 
 When a client connects, you'll call :meth:`accept` on the socket to get the


### PR DESCRIPTION
https://github.com/python/cpython/issues/91611

example.com is reserved by the IANA as special-use domain name for documentation
purposes. The domain names are used widely in books, tutorials, sample network
configurations, and generally as examples for the use of domain name.

On the other hand, mydomain.com is real Domain Name Registration service.


