### PR TITLE
gh-91622: Deprecated _AttributeHolder._get_args().

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -119,7 +119,15 @@ class _AttributeHolder(object):
         type_name = type(self).__name__
         arg_strings = []
         star_args = {}
-        for arg in self._get_args():
+
+        get_args = self._get_args()
+        if get_args:
+            warnings.warn("_AttributeHolder()._get_args() is deprecated as of "
+                          "Python 3.11.",
+                          DeprecationWarning,
+                          stacklevel=2)
+
+        for arg in get_args:
             arg_strings.append(repr(arg))
         for name, value in self._get_kwargs():
             if name.isidentifier():
@@ -134,6 +142,7 @@ class _AttributeHolder(object):
         return list(self.__dict__.items())
 
     def _get_args(self):
+        """This method is deprecated."""
         return []
 
 

--- a/Misc/NEWS.d/next/Library/2022-04-16-20-21-35.gh-issue-91622.UWj91T.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-16-20-21-35.gh-issue-91622.UWj91T.rst
@@ -1,0 +1,1 @@
+argparse._AttributeHolder()._get_args() method is deprecated.


### PR DESCRIPTION
[GH-91622](https://github.com/python/cpython/issues/91622)

If `self._get_args()` is overridden and returns a nonempty list then display a `DeprecationWarning`.

- [x] Signed CLA
- [x] Ran tests and `make patchcheck`
- [x] Added News Entry