### PR TITLE
gh-91639: import Mapping from collections.abc into collections

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -37,6 +37,7 @@ from operator import eq as _eq
 from operator import itemgetter as _itemgetter
 from reprlib import recursive_repr as _recursive_repr
 from _weakref import proxy as _proxy
+from collections.abc import Mapping
 
 try:
     from _collections import deque


### PR DESCRIPTION
Concerning python 3.10, the following error occurs for scripts trying to import `Mapping` from `collections`

### Error:
`
ImportError: cannot import name 'Mapping' from 'collections' (/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/collections/__init__.py
`
### Proposed Solution:
add the following line to the `collections/__init__.py`
**Line :** `from collections.abc import Mapping`

### Reason:
Python scripts using the `collections` library form older versions would face problems when updating to **python 3.10**
