### PR TITLE
[3.10] Revert "[3.10] bpo-47104: Rewrite asyncio.to_thread tests to use IsolatedAsyncioTestCase (GH-32086)"

### DIFF
--- a/Misc/NEWS.d/next/Tests/2022-03-23-22-45-51.bpo-47104._esUq8.rst
+++ b/Misc/NEWS.d/next/Tests/2022-03-23-22-45-51.bpo-47104._esUq8.rst
@@ -1,2 +1,0 @@
-Rewrite :func:`asyncio.to_thread` tests to use
-:class:`unittest.IsolatedAsyncioTestCase`.


### PR DESCRIPTION
Reverts python/cpython#32087

See https://github.com/python/cpython/issues/91260