### PR TITLE
gh-91670: Removes `SO` config variable in `sysconfig.py`

### DIFF
--- a/Lib/distutils/tests/test_sysconfig.py
+++ b/Lib/distutils/tests/test_sysconfig.py
@@ -227,26 +227,6 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
         self.assertEqual(global_sysconfig.get_config_var('CC'),
                          sysconfig.get_config_var('CC'))
 
-    @unittest.skipIf(sysconfig.get_config_var('EXT_SUFFIX') is None,
-                     'EXT_SUFFIX required for this test')
-    def test_SO_deprecation(self):
-        self.assertWarns(DeprecationWarning,
-                         sysconfig.get_config_var, 'SO')
-
-    @unittest.skipIf(sysconfig.get_config_var('EXT_SUFFIX') is None,
-                     'EXT_SUFFIX required for this test')
-    def test_SO_value(self):
-        with check_warnings(('', DeprecationWarning)):
-            self.assertEqual(sysconfig.get_config_var('SO'),
-                             sysconfig.get_config_var('EXT_SUFFIX'))
-
-    @unittest.skipIf(sysconfig.get_config_var('EXT_SUFFIX') is None,
-                     'EXT_SUFFIX required for this test')
-    def test_SO_in_vars(self):
-        vars = sysconfig.get_config_vars()
-        self.assertIsNotNone(vars['SO'])
-        self.assertEqual(vars['SO'], vars['EXT_SUFFIX'])
-
     @requires_subprocess()
     def test_customize_compiler_before_get_config_vars(self):
         # Issue #21923: test that a Distribution compiler

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -667,10 +667,6 @@ def get_config_vars(*args):
             _CONFIG_VARS['VPATH'] = sys._vpath
         if os.name == 'posix':
             _init_posix(_CONFIG_VARS)
-        # For backward compatibility, see issue19555
-        SO = _CONFIG_VARS.get('EXT_SUFFIX')
-        if SO is not None:
-            _CONFIG_VARS['SO'] = SO
         if _HAS_USER_BASE:
             # Setting 'userbase' is done below the call to the
             # init function to enable using 'get_config_var' in
@@ -715,9 +711,6 @@ def get_config_var(name):
 
     Equivalent to get_config_vars().get(name)
     """
-    if name == 'SO':
-        import warnings
-        warnings.warn('SO is deprecated, use EXT_SUFFIX', DeprecationWarning, 2)
     return get_config_vars().get(name)
 
 

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -465,26 +465,11 @@ class TestSysConfig(unittest.TestCase):
 
     @unittest.skipIf(sysconfig.get_config_var('EXT_SUFFIX') is None,
                      'EXT_SUFFIX required for this test')
-    def test_SO_deprecation(self):
-        self.assertWarns(DeprecationWarning,
-                         sysconfig.get_config_var, 'SO')
-
-    @unittest.skipIf(sysconfig.get_config_var('EXT_SUFFIX') is None,
-                     'EXT_SUFFIX required for this test')
-    def test_SO_value(self):
-        with check_warnings(('', DeprecationWarning)):
-            self.assertEqual(sysconfig.get_config_var('SO'),
-                             sysconfig.get_config_var('EXT_SUFFIX'))
-
-    @unittest.skipIf(sysconfig.get_config_var('EXT_SUFFIX') is None,
-                     'EXT_SUFFIX required for this test')
     def test_EXT_SUFFIX_in_vars(self):
         import _imp
         if not _imp.extension_suffixes():
             self.skipTest("stub loader has no suffixes")
         vars = sysconfig.get_config_vars()
-        self.assertIsNotNone(vars['SO'])
-        self.assertEqual(vars['SO'], vars['EXT_SUFFIX'])
         self.assertEqual(vars['EXT_SUFFIX'], _imp.extension_suffixes()[0])
 
     @unittest.skipUnless(sys.platform == 'linux' and

--- a/Misc/NEWS.d/next/Library/2022-04-18-15-23-24.gh-issue-91670.6eyChw.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-18-15-23-24.gh-issue-91670.6eyChw.rst
@@ -1,0 +1,1 @@
+Removes deprecated ``SO`` config variable in ``sysconfig.py``

--- a/Misc/NEWS.d/next/Library/2022-04-18-15-23-24.gh-issue-91670.6eyChw.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-18-15-23-24.gh-issue-91670.6eyChw.rst
@@ -1,1 +1,1 @@
-Removes deprecated ``SO`` config variable in ``sysconfig.py``
+Remove deprecated ``SO`` config variable in :mod:`sysconfig`.


### PR DESCRIPTION
Per @warsaw in https://github.com/python/cpython/issues/63754, this was
deprecated in Python 3.4 and was suggested for removal in Python 3.5.

Discussion in https://github.com/python/cpython/issues/91670 and https://discuss.python.org/t/remove-so-config-variable-in-sysconfig-py/15142. Closes #91670