### PR TITLE
gh-91673: Missing import in dataclasses documentation

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -700,6 +700,8 @@ variable ``x``, as expected.
 
 Using dataclasses, *if* this code was valid::
 
+  from typing import List
+  
   @dataclass
   class D:
       x: List = []

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -699,12 +699,10 @@ Note that the two instances of class ``C`` share the same class
 variable ``x``, as expected.
 
 Using dataclasses, *if* this code was valid::
-
-  from typing import List
   
   @dataclass
   class D:
-      x: List = []
+      x: list = field(default_factory=list)
       def add(self, element):
           self.x += element
 


### PR DESCRIPTION
As reported in #91673, the import is missed for the typing  ```List``` at dataclasses.rst file.

In this example:

```
  @dataclass
  class D:
      x: List = []
      def add(self, element):
          self.x += element
```
the import ```from typing import List``` is missing

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
