### PR TITLE
Add link to sys.path in os lib

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3556,8 +3556,8 @@ to be ignored.
    Add a path to the DLL search path.
 
    This search path is used when resolving dependencies for imported
-   extension modules (the module itself is resolved through sys.path),
-   and also by :mod:`ctypes`.
+   extension modules (the module itself is resolved through
+   :data:`sys.path`), and also by :mod:`ctypes`.
 
    Remove the directory by calling **close()** on the returned object
    or using it in a :keyword:`with` statement.


### PR DESCRIPTION
It was the first and only entry on the page, and also looked a bit off without any formatting:

https://docs.python.org/3/library/os.html#os.add_dll_directory