### PR TITLE
[3.10] gh-91676 gh-91260 unittest.IsolatedAsyncioTestCase no longer leaks its executor

### DIFF
--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -148,6 +148,8 @@ class IsolatedAsyncioTestCase(TestCase):
             # shutdown asyncgens
             loop.run_until_complete(loop.shutdown_asyncgens())
         finally:
+            # Prevent our executor environment from leaking to future tests.
+            loop.run_until_complete(loop.shutdown_default_executor())
             asyncio.set_event_loop(None)
             loop.close()
 

--- a/Misc/NEWS.d/next/Library/2022-04-19-04-33-39.gh-issue-91676.ceQBwh.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-19-04-33-39.gh-issue-91676.ceQBwh.rst
@@ -1,0 +1,4 @@
+Fix :class:`unittest.IsolatedAsyncioTestCase` to shutdown the per test event
+loop executor before returning from its ``run`` method so that a not yet
+stopped or garbage collected executor state does not persist beyond the
+test.


### PR DESCRIPTION
For things like `test_asyncio.test_thread` this was causing frequent
"environment modified by test" errors as the executor threads had not
always stopped running after the test was over.

issues #91676 and #91260 alternate fix to #91667.

This only happened in 3.10 and 3.9 after #32086 as the main 3.11 branch has a completely rewritten `unittest.IsolatedAsyncioTestCase` that uses asyncio APIs itself that do not appear to leak the executor.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
