### PR TITLE
gh-91709: gmtoff is not set for %Z directive

### DIFF
--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -481,6 +481,7 @@ def _strptime(data_string, format="%a %b %d %H:%M:%S %Y"):
                        time.daylight and found_zone not in ("utc", "gmt")):
                         break
                     else:
+                        gmtoff = 0
                         tz = value
                         break
     # Deal with the cases where ambiguities arize

--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -481,7 +481,8 @@ def _strptime(data_string, format="%a %b %d %H:%M:%S %Y"):
                        time.daylight and found_zone not in ("utc", "gmt")):
                         break
                     else:
-                        gmtoff = 0
+                        if gmtoff is None:
+                            gmtoff = 0
                         tz = value
                         break
     # Deal with the cases where ambiguities arize

--- a/Misc/NEWS.d/next/Library/2022-04-19-21-58-50.gh-issue-91709.7HOPI3.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-19-21-58-50.gh-issue-91709.7HOPI3.rst
@@ -1,0 +1,1 @@
+Fixed: gmtoff is not set for %Z directive


### PR DESCRIPTION
```from datetime import datetime
d = datetime.strptime('2018-04-18-17-04-30-UTC', '%Y-%m-%d-%H-%M-%S-%Z')
print(d) # previously it will return naive object
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Does this need an issue?