### PR TITLE
gh-74166: break cycle by clearing the list instead of dropping its reference

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -851,7 +851,7 @@ def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT,
             raise ExceptionGroup("create_connection failed", exceptions)
         finally:
             # Break explicitly a reference cycle
-            exceptions = None
+            exceptions.clear()
     else:
         raise error("getaddrinfo returns an empty list")
 


### PR DESCRIPTION
This is a more robust way to drop references to the individual exceptions, and it is consistent with how we do it in line 837.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
