### PR TITLE
gh-89653: PEP 670: Convert unicodeobject.h macros to functions

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -45,7 +45,7 @@
 #define Py_UNICODE_ISALPHA(ch) _PyUnicode_IsAlpha(ch)
 
 #define Py_UNICODE_ISALNUM(ch) \
-       (Py_UNICODE_ISALPHA(ch) || \
+   (Py_UNICODE_ISALPHA(ch) || \
     Py_UNICODE_ISDECIMAL(ch) || \
     Py_UNICODE_ISDIGIT(ch) || \
     Py_UNICODE_ISNUMERIC(ch))
@@ -243,38 +243,90 @@ PyAPI_FUNC(int) _PyUnicode_CheckConsistency(
     (assert(PyUnicode_Check(op)), (PyUnicodeObject*)(op))
 
 
-/* Fast access macros */
+/* Fast access functions */
+
+/* Return true if the string is compact or 0 if not.
+   No type checks or Ready calls are performed. */
+static inline unsigned int PyUnicode_IS_COMPACT(PyObject *op) {
+    return _PyASCIIObject_CAST(op)->state.compact;
+}
+#define PyUnicode_IS_COMPACT(op) PyUnicode_IS_COMPACT(_PyObject_CAST(op))
+
+/* Return true if the string is a compact ASCII string (use PyASCIIObject
+   structure), or 0 if not.  No type checks or Ready calls are performed. */
+static inline int PyUnicode_IS_COMPACT_ASCII(PyObject *op) {
+    return (_PyASCIIObject_CAST(op)->state.ascii && PyUnicode_IS_COMPACT(op));
+}
+#define PyUnicode_IS_COMPACT_ASCII(op) PyUnicode_IS_COMPACT_ASCII(_PyObject_CAST(op))
+
+Py_DEPRECATED(3.3) static inline Py_ssize_t PyUnicode_WSTR_LENGTH(PyObject *op)
+{
+    if (PyUnicode_IS_COMPACT_ASCII(op)) {
+        return _PyASCIIObject_CAST(op)->length;
+    }
+    else {
+        return _PyCompactUnicodeObject_CAST(op)->wstr_length;
+    }
+}
+#define PyUnicode_WSTR_LENGTH(op) PyUnicode_WSTR_LENGTH(_PyObject_CAST(op))
+
+
+/* Return a read-only pointer to the Unicode object's internal
+   Py_UNICODE buffer.
+   If the wchar_t/Py_UNICODE representation is not yet available, this
+   function will calculate it. */
+Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
+    PyObject *unicode           /* Unicode object */
+    );
 
 /* Returns the deprecated Py_UNICODE representation's size in code units
    (this includes surrogate pairs as 2 units).
    If the Py_UNICODE representation is not available, it will be computed
    on request.  Use PyUnicode_GET_LENGTH() for the length in code points. */
 
-/* Py_DEPRECATED(3.3) */
-#define PyUnicode_GET_SIZE(op)                       \
-    (_PyASCIIObject_CAST(op)->wstr ?                 \
-      PyUnicode_WSTR_LENGTH(op) :                    \
-      ((void)PyUnicode_AsUnicode(_PyObject_CAST(op)),\
-       assert(_PyASCIIObject_CAST(op)->wstr),        \
-       PyUnicode_WSTR_LENGTH(op)))
+/* Py_DEPRECATED(3.3) */ static inline Py_ssize_t PyUnicode_GET_SIZE(PyObject *op)
+{
+    _Py_COMP_DIAG_PUSH
+    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
+    if (_PyASCIIObject_CAST(op)->wstr == NULL) {
+        (void)PyUnicode_AsUnicode(op);
+        assert(_PyASCIIObject_CAST(op)->wstr != NULL);
+    }
+    return PyUnicode_WSTR_LENGTH(op);
+    _Py_COMP_DIAG_POP
+}
+#define PyUnicode_GET_SIZE(op) PyUnicode_GET_SIZE(_PyObject_CAST(op))
 
-/* Py_DEPRECATED(3.3) */
-#define PyUnicode_GET_DATA_SIZE(op) \
-    (PyUnicode_GET_SIZE(op) * Py_UNICODE_SIZE)
+ /* Py_DEPRECATED(3.3) */ static inline Py_ssize_t PyUnicode_GET_DATA_SIZE(PyObject *op)
+{
+    return PyUnicode_GET_SIZE(op) * Py_UNICODE_SIZE;
+}
+#define PyUnicode_GET_DATA_SIZE(op) PyUnicode_GET_DATA_SIZE(_PyObject_CAST(op))
 
 /* Alias for PyUnicode_AsUnicode().  This will create a wchar_t/Py_UNICODE
-   representation on demand.  Using this macro is very inefficient now,
-   try to port your code to use the new PyUnicode_*BYTE_DATA() macros or
+   representation on demand.  Using this function is very inefficient now,
+   try to port your code to use the new PyUnicode_*BYTE_DATA() functions or
    use PyUnicode_WRITE() and PyUnicode_READ(). */
 
-/* Py_DEPRECATED(3.3) */
-#define PyUnicode_AS_UNICODE(op) \
-    (_PyASCIIObject_CAST(op)->wstr ? _PyASCIIObject_CAST(op)->wstr : \
-     PyUnicode_AsUnicode(_PyObject_CAST(op)))
+/* Py_DEPRECATED(3.3) */ static inline Py_UNICODE* PyUnicode_AS_UNICODE(PyObject *op)
+{
+    wchar_t *wstr = _PyASCIIObject_CAST(op)->wstr;
+    if (wstr != NULL) {
+        return wstr;
+    }
 
-/* Py_DEPRECATED(3.3) */
-#define PyUnicode_AS_DATA(op) \
-    ((const char *)(PyUnicode_AS_UNICODE(op)))
+    _Py_COMP_DIAG_PUSH
+    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
+    return PyUnicode_AsUnicode(op);
+    _Py_COMP_DIAG_POP
+}
+#define PyUnicode_AS_UNICODE(op) PyUnicode_AS_UNICODE(_PyObject_CAST(op))
+
+/* Py_DEPRECATED(3.3) */ static inline const char* PyUnicode_AS_DATA(PyObject *op)
+{
+    return (const char *)PyUnicode_AS_UNICODE(op);
+}
+#define PyUnicode_AS_DATA(op) PyUnicode_AS_DATA(_PyObject_CAST(op))
 
 
 /* --- Flexible String Representation Helper Macros (PEP 393) -------------- */
@@ -287,160 +339,172 @@ PyAPI_FUNC(int) _PyUnicode_CheckConsistency(
 #define SSTATE_INTERNED_IMMORTAL 2
 
 /* Use only if you know it's a string */
-#define PyUnicode_CHECK_INTERNED(op) \
-    (_PyASCIIObject_CAST(op)->state.interned)
+static inline unsigned int PyUnicode_CHECK_INTERNED(PyObject *op) {
+    return _PyASCIIObject_CAST(op)->state.interned;
+}
+#define PyUnicode_CHECK_INTERNED(op) PyUnicode_CHECK_INTERNED(_PyObject_CAST(op))
+
+/* Fast check to determine whether an object is ready. Equivalent to:
+   PyUnicode_IS_COMPACT(op) || _PyUnicodeObject_CAST(op)->data.any */
+static inline unsigned int PyUnicode_IS_READY(PyObject *op) {
+    return _PyASCIIObject_CAST(op)->state.ready;
+}
+#define PyUnicode_IS_READY(op) PyUnicode_IS_READY(_PyObject_CAST(op))
 
 /* Return true if the string contains only ASCII characters, or 0 if not. The
    string may be compact (PyUnicode_IS_COMPACT_ASCII) or not, but must be
    ready. */
-#define PyUnicode_IS_ASCII(op)                   \
-    (assert(PyUnicode_IS_READY(op)),             \
-     _PyASCIIObject_CAST(op)->state.ascii)
-
-/* Return true if the string is compact or 0 if not.
-   No type checks or Ready calls are performed. */
-#define PyUnicode_IS_COMPACT(op) \
-    (_PyASCIIObject_CAST(op)->state.compact)
-
-/* Return true if the string is a compact ASCII string (use PyASCIIObject
-   structure), or 0 if not.  No type checks or Ready calls are performed. */
-#define PyUnicode_IS_COMPACT_ASCII(op)                 \
-    (_PyASCIIObject_CAST(op)->state.ascii && PyUnicode_IS_COMPACT(op))
+static inline unsigned int PyUnicode_IS_ASCII(PyObject *op) {
+    assert(PyUnicode_IS_READY(op));
+    return _PyASCIIObject_CAST(op)->state.ascii;
+}
+#define PyUnicode_IS_ASCII(op) PyUnicode_IS_ASCII(_PyObject_CAST(op))
 
 enum PyUnicode_Kind {
 /* String contains only wstr byte characters.  This is only possible
    when the string was created with a legacy API and _PyUnicode_Ready()
    has not been called yet.  */
     PyUnicode_WCHAR_KIND = 0,
-/* Return values of the PyUnicode_KIND() macro: */
+/* Return values of the PyUnicode_KIND() function: */
     PyUnicode_1BYTE_KIND = 1,
     PyUnicode_2BYTE_KIND = 2,
     PyUnicode_4BYTE_KIND = 4
 };
 
+/* Return one of the PyUnicode_*_KIND values defined above. */
+static inline unsigned int PyUnicode_KIND(PyObject *op) {
+    return _PyASCIIObject_CAST(op)->state.kind;
+}
+#define PyUnicode_KIND(op) PyUnicode_KIND(_PyObject_CAST(op))
+
+/* Return a void pointer to the raw unicode buffer. */
+static inline void* _PyUnicode_COMPACT_DATA(PyObject *op) {
+    if (PyUnicode_IS_ASCII(op)) {
+        return (void*)(_PyASCIIObject_CAST(op) + 1);
+    }
+    else {
+        return (void*)(_PyCompactUnicodeObject_CAST(op) + 1);
+    }
+}
+
+static inline void* _PyUnicode_NONCOMPACT_DATA(PyObject *op) {
+    void *data = _PyUnicodeObject_CAST(op)->data.any;
+    assert(data != NULL);
+    return data;
+}
+
+static inline void* PyUnicode_DATA(PyObject *op) {
+    if (PyUnicode_IS_COMPACT(op)) {
+        return _PyUnicode_COMPACT_DATA(op);
+    }
+    else {
+        return _PyUnicode_NONCOMPACT_DATA(op);
+    }
+}
+#define PyUnicode_DATA(op) PyUnicode_DATA(_PyObject_CAST(op))
+
 /* Return pointers to the canonical representation cast to unsigned char,
    Py_UCS2, or Py_UCS4 for direct character access.
    No checks are performed, use PyUnicode_KIND() before to ensure
    these will work correctly. */
-
 #define PyUnicode_1BYTE_DATA(op) ((Py_UCS1*)PyUnicode_DATA(op))
 #define PyUnicode_2BYTE_DATA(op) ((Py_UCS2*)PyUnicode_DATA(op))
 #define PyUnicode_4BYTE_DATA(op) ((Py_UCS4*)PyUnicode_DATA(op))
 
-/* Return one of the PyUnicode_*_KIND values defined above. */
-#define PyUnicode_KIND(op) \
-    (assert(PyUnicode_IS_READY(op)),            \
-     _PyASCIIObject_CAST(op)->state.kind)
+/* Returns the length of the unicode string. The caller has to make sure that
+   the string has it's canonical representation set before calling
+   this function.  Call PyUnicode_(FAST_)Ready to ensure that. */
+static inline Py_ssize_t PyUnicode_GET_LENGTH(PyObject *op) {
+    assert(PyUnicode_IS_READY(op));
+    return _PyASCIIObject_CAST(op)->length;
+}
+#define PyUnicode_GET_LENGTH(op) PyUnicode_GET_LENGTH(_PyObject_CAST(op))
 
-/* Return a void pointer to the raw unicode buffer. */
-#define _PyUnicode_COMPACT_DATA(op)                     \
-    (PyUnicode_IS_ASCII(op) ?                           \
-     ((void*)(_PyASCIIObject_CAST(op) + 1)) :           \
-     ((void*)(_PyCompactUnicodeObject_CAST(op) + 1)))
-
-#define _PyUnicode_NONCOMPACT_DATA(op)                  \
-    (assert(_PyUnicodeObject_CAST(op)->data.any),       \
-     (_PyUnicodeObject_CAST(op)->data.any))
-
-#define PyUnicode_DATA(op) \
-    (PyUnicode_IS_COMPACT(op) ? _PyUnicode_COMPACT_DATA(op) :   \
-     _PyUnicode_NONCOMPACT_DATA(op))
-
-/* In the access macros below, "kind" may be evaluated more than once.
-   All other macro parameters are evaluated exactly once, so it is safe
-   to put side effects into them (such as increasing the index). */
-
-/* Write into the canonical representation, this macro does not do any sanity
+/* Write into the canonical representation, this function does not do any sanity
    checks and is intended for usage in loops.  The caller should cache the
-   kind and data pointers obtained from other macro calls.
+   kind and data pointers obtained from other function calls.
    index is the index in the string (starts at 0) and value is the new
    code point value which should be written to that location. */
+static inline void PyUnicode_WRITE(unsigned int kind, void *data,
+                                   Py_ssize_t index, Py_UCS4 value)
+{
+    switch (kind) {
+    case PyUnicode_1BYTE_KIND:
+        ((Py_UCS1 *)data)[index] = (Py_UCS1)value;
+        break;
+    case PyUnicode_2BYTE_KIND:
+        ((Py_UCS2 *)data)[index] = (Py_UCS2)value;
+        break;
+    default:
+        assert(kind == PyUnicode_4BYTE_KIND);
+        ((Py_UCS4 *)data)[index] = value;
+    }
+}
 #define PyUnicode_WRITE(kind, data, index, value) \
-    do { \
-        switch ((kind)) { \
-        case PyUnicode_1BYTE_KIND: { \
-            ((Py_UCS1 *)(data))[(index)] = (Py_UCS1)(value); \
-            break; \
-        } \
-        case PyUnicode_2BYTE_KIND: { \
-            ((Py_UCS2 *)(data))[(index)] = (Py_UCS2)(value); \
-            break; \
-        } \
-        default: { \
-            assert((kind) == PyUnicode_4BYTE_KIND); \
-            ((Py_UCS4 *)(data))[(index)] = (Py_UCS4)(value); \
-        } \
-        } \
-    } while (0)
+    PyUnicode_WRITE((kind), (void*)(data), (index), (Py_UCS4)(value))
 
 /* Read a code point from the string's canonical representation.  No checks
    or ready calls are performed. */
+static inline Py_UCS4 PyUnicode_READ(unsigned int kind,
+                                     const void *data, Py_ssize_t index)
+{
+    if (kind == PyUnicode_1BYTE_KIND) {
+        return ((const Py_UCS1 *)data)[index];
+    }
+    else if (kind == PyUnicode_2BYTE_KIND) {
+        return ((const Py_UCS2 *)data)[index];
+    }
+    else {
+        return ((const Py_UCS4 *)data)[index];
+    }
+}
 #define PyUnicode_READ(kind, data, index) \
-    ((Py_UCS4) \
-    ((kind) == PyUnicode_1BYTE_KIND ? \
-        ((const Py_UCS1 *)(data))[(index)] : \
-        ((kind) == PyUnicode_2BYTE_KIND ? \
-            ((const Py_UCS2 *)(data))[(index)] : \
-            ((const Py_UCS4 *)(data))[(index)] \
-        ) \
-    ))
+    PyUnicode_READ((kind), (const void*)(data), (index))
 
 /* PyUnicode_READ_CHAR() is less efficient than PyUnicode_READ() because it
    calls PyUnicode_KIND() and might call it twice.  For single reads, use
    PyUnicode_READ_CHAR, for multiple consecutive reads callers should
    cache kind and use PyUnicode_READ instead. */
+static inline Py_UCS4 PyUnicode_READ_CHAR(PyObject *unicode, Py_ssize_t index)
+{
+    assert(PyUnicode_IS_READY(unicode));
+    unsigned int kind = PyUnicode_KIND(unicode);
+    if (kind == PyUnicode_1BYTE_KIND) {
+        return PyUnicode_1BYTE_DATA(unicode)[index];
+    }
+    else if (kind == PyUnicode_2BYTE_KIND) {
+        return PyUnicode_2BYTE_DATA(unicode)[index];
+    }
+    else {
+        return PyUnicode_4BYTE_DATA(unicode)[index];
+    }
+}
 #define PyUnicode_READ_CHAR(unicode, index) \
-    (assert(PyUnicode_IS_READY(unicode)),       \
-     (Py_UCS4)                                  \
-        (PyUnicode_KIND((unicode)) == PyUnicode_1BYTE_KIND ? \
-            ((const Py_UCS1 *)(PyUnicode_DATA((unicode))))[(index)] : \
-            (PyUnicode_KIND((unicode)) == PyUnicode_2BYTE_KIND ? \
-                ((const Py_UCS2 *)(PyUnicode_DATA((unicode))))[(index)] : \
-                ((const Py_UCS4 *)(PyUnicode_DATA((unicode))))[(index)] \
-            ) \
-        ))
-
-/* Returns the length of the unicode string. The caller has to make sure that
-   the string has it's canonical representation set before calling
-   this macro.  Call PyUnicode_(FAST_)Ready to ensure that. */
-#define PyUnicode_GET_LENGTH(op)                \
-    (assert(PyUnicode_IS_READY(op)),            \
-     _PyASCIIObject_CAST(op)->length)
-
-
-/* Fast check to determine whether an object is ready. Equivalent to
-   PyUnicode_IS_COMPACT(op) || _PyUnicodeObject_CAST(op)->data.any */
-
-#define PyUnicode_IS_READY(op) (_PyASCIIObject_CAST(op)->state.ready)
-
-/* PyUnicode_READY() does less work than _PyUnicode_Ready() in the best
-   case.  If the canonical representation is not yet set, it will still call
-   _PyUnicode_Ready().
-   Returns 0 on success and -1 on errors. */
-#define PyUnicode_READY(op)                        \
-    ((PyUnicode_IS_READY(op) ?                     \
-      0 : _PyUnicode_Ready(_PyObject_CAST(op))))
+    PyUnicode_READ_CHAR(_PyObject_CAST(unicode), (index))
 
 /* Return a maximum character value which is suitable for creating another
    string based on op.  This is always an approximation but more efficient
    than iterating over the string. */
-#define PyUnicode_MAX_CHAR_VALUE(op) \
-    (assert(PyUnicode_IS_READY(op)),                                    \
-     (PyUnicode_IS_ASCII(op) ?                                          \
-      (0x7f) :                                                          \
-      (PyUnicode_KIND(op) == PyUnicode_1BYTE_KIND ?                     \
-       (0xffU) :                                                        \
-       (PyUnicode_KIND(op) == PyUnicode_2BYTE_KIND ?                    \
-        (0xffffU) :                                                     \
-        (0x10ffffU)))))
+static inline Py_UCS4 PyUnicode_MAX_CHAR_VALUE(PyObject *op)
+{
+    assert(PyUnicode_IS_READY(op));
+    if (PyUnicode_IS_ASCII(op)) {
+        return 0x7fU;
+    }
 
-Py_DEPRECATED(3.3)
-static inline Py_ssize_t PyUnicode_WSTR_LENGTH(PyObject *op) {
-    return PyUnicode_IS_COMPACT_ASCII(op) ?
-            _PyASCIIObject_CAST(op)->length :
-            _PyCompactUnicodeObject_CAST(op)->wstr_length;
+    unsigned int kind = PyUnicode_KIND(op);
+    if (kind == PyUnicode_1BYTE_KIND) {
+       return 0xffU;
+    }
+    else if (kind == PyUnicode_2BYTE_KIND) {
+        return 0xffffU;
+    }
+    else {
+        return 0x10ffffU;
+    }
 }
-#define PyUnicode_WSTR_LENGTH(op) PyUnicode_WSTR_LENGTH(_PyObject_CAST(op))
+#define PyUnicode_MAX_CHAR_VALUE(op) \
+    PyUnicode_MAX_CHAR_VALUE(_PyObject_CAST(op))
 
 /* === Public API ========================================================= */
 
@@ -459,11 +523,26 @@ PyAPI_FUNC(PyObject*) PyUnicode_New(
    objects which were created using the old API to the new flexible format
    introduced with PEP 393.
 
-   Don't call this function directly, use the public PyUnicode_READY() macro
+   Don't call this function directly, use the public PyUnicode_READY() function
    instead. */
 PyAPI_FUNC(int) _PyUnicode_Ready(
     PyObject *unicode           /* Unicode object */
     );
+
+/* PyUnicode_READY() does less work than _PyUnicode_Ready() in the best
+   case.  If the canonical representation is not yet set, it will still call
+   _PyUnicode_Ready().
+   Returns 0 on success and -1 on errors. */
+static inline int PyUnicode_READY(PyObject *op)
+{
+    if (PyUnicode_IS_READY(op)) {
+        return 0;
+    }
+    else {
+        return _PyUnicode_Ready(_PyObject_CAST(op));
+    }
+}
+#define PyUnicode_READY(op) PyUnicode_READY(_PyObject_CAST(op))
 
 /* Get a copy of a Unicode string. */
 PyAPI_FUNC(PyObject*) _PyUnicode_Copy(
@@ -564,14 +643,6 @@ PyAPI_FUNC(Py_UCS4) _PyUnicode_FindMaxChar (
     PyObject *unicode,
     Py_ssize_t start,
     Py_ssize_t end);
-
-/* Return a read-only pointer to the Unicode object's internal
-   Py_UNICODE buffer.
-   If the wchar_t/Py_UNICODE representation is not yet available, this
-   function will calculate it. */
-Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
-    PyObject *unicode           /* Unicode object */
-    );
 
 /* Similar to PyUnicode_AsUnicode(), but raises a ValueError if the string
    contains null characters. */

--- a/Include/unicodeobject.h
+++ b/Include/unicodeobject.h
@@ -112,7 +112,7 @@ PyAPI_DATA(PyTypeObject) PyUnicode_Type;
 PyAPI_DATA(PyTypeObject) PyUnicodeIter_Type;
 
 #define PyUnicode_Check(op) \
-    PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_UNICODE_SUBCLASS)
+                 PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_UNICODE_SUBCLASS)
 #define PyUnicode_CheckExact(op) Py_IS_TYPE(op, &PyUnicode_Type)
 
 /* --- Constants ---------------------------------------------------------- */


### PR DESCRIPTION
Convert unicodeobject.h macros to static inline functions:

* Reorder functions to declare functions before their first usage.
* PyUnicode_READ_CHAR() and PyUnicode_MAX_CHAR_VALUE() now only call
  PyUnicode_KIND() once.
* Simplify PyUnicode_GET_SIZE().
* PyUnicode_READ_CHAR() now uses PyUnicode_1BYTE_DATA(),
  PyUnicode_2BYTE_DATA() and PyUnicode_4BYTE_DATA().
* Remove redundant PyUnicode_Check() assertions.

Static inline functions are wrapped into macros which casts pointer
types (PyObject*, void*) to prevent introducing new compiler warnings
when passing const pointers (ex: PyUnicode_WRITE).

PyUnicode_KIND() return type is "unsigned int" rather than "enum
PyUnicode_Kind" to prevent introducing new compiler warnings.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
