### PR TITLE
gh-89653: PEP 670: Functions don't cast pointers

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -256,14 +256,18 @@ PyAPI_FUNC(int) _PyUnicode_CheckConsistency(
 static inline unsigned int PyUnicode_CHECK_INTERNED(PyObject *op) {
     return _PyASCIIObject_CAST(op)->state.interned;
 }
-#define PyUnicode_CHECK_INTERNED(op) PyUnicode_CHECK_INTERNED(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_CHECK_INTERNED(op) PyUnicode_CHECK_INTERNED(_PyObject_CAST(op))
+#endif
 
 /* Fast check to determine whether an object is ready. Equivalent to:
    PyUnicode_IS_COMPACT(op) || _PyUnicodeObject_CAST(op)->data.any */
 static inline unsigned int PyUnicode_IS_READY(PyObject *op) {
     return _PyASCIIObject_CAST(op)->state.ready;
 }
-#define PyUnicode_IS_READY(op) PyUnicode_IS_READY(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_IS_READY(op) PyUnicode_IS_READY(_PyObject_CAST(op))
+#endif
 
 /* Return true if the string contains only ASCII characters, or 0 if not. The
    string may be compact (PyUnicode_IS_COMPACT_ASCII) or not, but must be
@@ -272,21 +276,27 @@ static inline unsigned int PyUnicode_IS_ASCII(PyObject *op) {
     assert(PyUnicode_IS_READY(op));
     return _PyASCIIObject_CAST(op)->state.ascii;
 }
-#define PyUnicode_IS_ASCII(op) PyUnicode_IS_ASCII(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_IS_ASCII(op) PyUnicode_IS_ASCII(_PyObject_CAST(op))
+#endif
 
 /* Return true if the string is compact or 0 if not.
    No type checks or Ready calls are performed. */
 static inline unsigned int PyUnicode_IS_COMPACT(PyObject *op) {
     return _PyASCIIObject_CAST(op)->state.compact;
 }
-#define PyUnicode_IS_COMPACT(op) PyUnicode_IS_COMPACT(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_IS_COMPACT(op) PyUnicode_IS_COMPACT(_PyObject_CAST(op))
+#endif
 
 /* Return true if the string is a compact ASCII string (use PyASCIIObject
    structure), or 0 if not.  No type checks or Ready calls are performed. */
 static inline int PyUnicode_IS_COMPACT_ASCII(PyObject *op) {
     return (_PyASCIIObject_CAST(op)->state.ascii && PyUnicode_IS_COMPACT(op));
 }
-#define PyUnicode_IS_COMPACT_ASCII(op) PyUnicode_IS_COMPACT_ASCII(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_IS_COMPACT_ASCII(op) PyUnicode_IS_COMPACT_ASCII(_PyObject_CAST(op))
+#endif
 
 enum PyUnicode_Kind {
 /* String contains only wstr byte characters.  This is only possible
@@ -325,7 +335,9 @@ static inline void* PyUnicode_DATA(PyObject *op) {
     }
     return _PyUnicode_NONCOMPACT_DATA(op);
 }
-#define PyUnicode_DATA(op) PyUnicode_DATA(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_DATA(op) PyUnicode_DATA(_PyObject_CAST(op))
+#endif
 
 /* Return pointers to the canonical representation cast to unsigned char,
    Py_UCS2, or Py_UCS4 for direct character access.
@@ -343,7 +355,9 @@ static inline Py_ssize_t PyUnicode_GET_LENGTH(PyObject *op) {
     assert(PyUnicode_IS_READY(op));
     return _PyASCIIObject_CAST(op)->length;
 }
-#define PyUnicode_GET_LENGTH(op) PyUnicode_GET_LENGTH(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_GET_LENGTH(op) PyUnicode_GET_LENGTH(_PyObject_CAST(op))
+#endif
 
 /* Write into the canonical representation, this function does not do any sanity
    checks and is intended for usage in loops.  The caller should cache the
@@ -399,8 +413,10 @@ static inline Py_UCS4 PyUnicode_READ_CHAR(PyObject *unicode, Py_ssize_t index)
     }
     return PyUnicode_4BYTE_DATA(unicode)[index];
 }
-#define PyUnicode_READ_CHAR(unicode, index) \
-    PyUnicode_READ_CHAR(_PyObject_CAST(unicode), (index))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_READ_CHAR(unicode, index) \
+       PyUnicode_READ_CHAR(_PyObject_CAST(unicode), (index))
+#endif
 
 /* Return a maximum character value which is suitable for creating another
    string based on op.  This is always an approximation but more efficient
@@ -421,8 +437,10 @@ static inline Py_UCS4 PyUnicode_MAX_CHAR_VALUE(PyObject *op)
     }
     return 0x10ffffU;
 }
-#define PyUnicode_MAX_CHAR_VALUE(op) \
-    PyUnicode_MAX_CHAR_VALUE(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_MAX_CHAR_VALUE(op) \
+       PyUnicode_MAX_CHAR_VALUE(_PyObject_CAST(op))
+#endif
 
 /* === Public API ========================================================= */
 
@@ -458,7 +476,9 @@ static inline int PyUnicode_READY(PyObject *op)
     }
     return _PyUnicode_Ready(op);
 }
-#define PyUnicode_READY(op) PyUnicode_READY(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_READY(op) PyUnicode_READY(_PyObject_CAST(op))
+#endif
 
 /* Get a copy of a Unicode string. */
 PyAPI_FUNC(PyObject*) _PyUnicode_Copy(
@@ -599,7 +619,9 @@ static inline Py_ssize_t PyUnicode_WSTR_LENGTH(PyObject *op)
         return _PyCompactUnicodeObject_CAST(op)->wstr_length;
     }
 }
-#define PyUnicode_WSTR_LENGTH(op) PyUnicode_WSTR_LENGTH(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_WSTR_LENGTH(op) PyUnicode_WSTR_LENGTH(_PyObject_CAST(op))
+#endif
 
 /* Returns the deprecated Py_UNICODE representation's size in code units
    (this includes surrogate pairs as 2 units).
@@ -618,14 +640,18 @@ static inline Py_ssize_t PyUnicode_GET_SIZE(PyObject *op)
     return PyUnicode_WSTR_LENGTH(op);
     _Py_COMP_DIAG_POP
 }
-#define PyUnicode_GET_SIZE(op) PyUnicode_GET_SIZE(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_GET_SIZE(op) PyUnicode_GET_SIZE(_PyObject_CAST(op))
+#endif
 
  /* Py_DEPRECATED(3.3) */
  static inline Py_ssize_t PyUnicode_GET_DATA_SIZE(PyObject *op)
 {
     return PyUnicode_GET_SIZE(op) * Py_UNICODE_SIZE;
 }
-#define PyUnicode_GET_DATA_SIZE(op) PyUnicode_GET_DATA_SIZE(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_GET_DATA_SIZE(op) PyUnicode_GET_DATA_SIZE(_PyObject_CAST(op))
+#endif
 
 /* Alias for PyUnicode_AsUnicode().  This will create a wchar_t/Py_UNICODE
    representation on demand.  Using this macro is very inefficient now,
@@ -645,14 +671,18 @@ static inline Py_UNICODE* PyUnicode_AS_UNICODE(PyObject *op)
     return PyUnicode_AsUnicode(op);
     _Py_COMP_DIAG_POP
 }
-#define PyUnicode_AS_UNICODE(op) PyUnicode_AS_UNICODE(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_AS_UNICODE(op) PyUnicode_AS_UNICODE(_PyObject_CAST(op))
+#endif
 
 /* Py_DEPRECATED(3.3) */
 static inline const char* PyUnicode_AS_DATA(PyObject *op)
 {
     return (const char *)PyUnicode_AS_UNICODE(op);
 }
-#define PyUnicode_AS_DATA(op) PyUnicode_AS_DATA(_PyObject_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyUnicode_AS_DATA(op) PyUnicode_AS_DATA(_PyObject_CAST(op))
+#endif
 
 
 /* --- _PyUnicodeWriter API ----------------------------------------------- */

--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -110,12 +110,13 @@ newXxoObject(PyObject *module)
 /* Xxo finalization */
 
 static int
-Xxo_traverse(XxoObject *self, visitproc visit, void *arg)
+Xxo_traverse(PyObject *self_obj, visitproc visit, void *arg)
 {
     // Visit the type
-    Py_VISIT(Py_TYPE(self));
+    Py_VISIT(Py_TYPE(self_obj));
 
     // Visit the attribute dict
+    XxoObject *self = (XxoObject *)self_obj;
     Py_VISIT(self->x_attr);
     return 0;
 }
@@ -128,13 +129,14 @@ Xxo_clear(XxoObject *self)
 }
 
 static void
-Xxo_finalize(XxoObject *self)
+Xxo_finalize(PyObject *self_obj)
 {
+    XxoObject *self = (XxoObject *)self_obj;
     Py_CLEAR(self->x_attr);
 }
 
 static void
-Xxo_dealloc(XxoObject *self)
+Xxo_dealloc(PyObject *self)
 {
     Xxo_finalize(self);
     PyTypeObject *tp = Py_TYPE(self);


### PR DESCRIPTION
In the limited C API version 3.11 and newer, the following functions
no longer cast their object pointer argument with _PyObject_CAST() or
_PyObject_CAST_CONST():

* Py_REFCNT(), Py_TYPE(), Py_SIZE()
* Py_SET_REFCNT(), Py_SET_TYPE(), Py_SET_SIZE()
* Py_IS_TYPE()
* Py_INCREF(), Py_DECREF()
* Py_XINCREF(), Py_XDECREF()
* Py_NewRef(), Py_XNewRef()
* PyObject_TypeCheck()
* PyType_Check()
* PyType_CheckExact()

Split Py_DECREF() implementation in 3 versions to make the code more
readable.

Update the xxlimited.c extension, which uses the limited C API
version 3.11, to pass PyObject* to these functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
