### PR TITLE
gh-91731: Build Python with -std=c11

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-04-20-11-14-51.gh-issue-91731.zRoPcJ.rst
+++ b/Misc/NEWS.d/next/Build/2022-04-20-11-14-51.gh-issue-91731.zRoPcJ.rst
@@ -1,0 +1,2 @@
+Python is now built with ``-std=c11`` compiler option, rather than
+``-std=c99``. Patch by Victor Stinner.

--- a/configure
+++ b/configure
@@ -7871,7 +7871,7 @@ UNIVERSAL_ARCH_FLAGS=
 # tweak BASECFLAGS based on compiler and platform
 case $GCC in
 yes)
-    CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
+    CFLAGS_NODIST="$CFLAGS_NODIST -std=c11"
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1983,7 +1983,7 @@ AC_DEFUN([PY_CHECK_CC_WARNING], [
 # tweak BASECFLAGS based on compiler and platform
 case $GCC in
 yes)
-    CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
+    CFLAGS_NODIST="$CFLAGS_NODIST -std=c11"
 
     PY_CHECK_CC_WARNING([enable], [extra], [if we can add -Wextra])
     AS_VAR_IF([ac_cv_enable_extra_warning], [yes],


### PR DESCRIPTION
Python is now built with "-std=c11" compiler option, rather than
"-std=c99".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
