### PR TITLE
bpo-to-github-migration replace roundup summary script

### DIFF
--- a/.github/actions/roundup_summary.py
+++ b/.github/actions/roundup_summary.py
@@ -1,0 +1,108 @@
+import json
+import os
+from datetime import date, timedelta
+from typing import Iterable
+
+import requests
+
+ISSUE_ENDPOINT = "https://github.com/python/cpython/issues"
+SEARCH_ENDPOINT = "https://api.github.com/search/issues"
+GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
+MAILGUN_ENDPOINT = "https://api.mailgun.net/v3/mg.python.org"
+
+
+def get_issue_counts(token: str) -> tuple[int, int]:
+    """use the GraphQL API to get the number of opened and closed issues
+    without having to query every single issue and count them."""
+    data = {
+        "query": """
+        {
+            repository(owner: "python", name: "cpython") {
+                open: issues(states: OPEN) { totalCount }
+                closed: issues(states: CLOSED) { totalCount }
+            }
+        }
+        """
+    }
+    response = requests.post(GRAPHQL_ENDPOINT, json=data, headers={
+        "Authorization": f"Bearer {token}",
+        "accept": "application/vnd.github.v3+json"
+    })
+    repo = response.json()["data"]["repository"]
+    open = repo["open"]["totalCount"]
+    closed = repo["closed"]["totalCount"]
+    return open, closed
+
+def get_issues(filters: Iterable[str], token: str, all_: bool = True):
+    """return a list of results from the Github search API"""
+    # TODO: if there are more than 100 issues, we need to include pagination
+    # this doesn't occur very often, but it should still be included just incase.
+    search = " ".join(filters)
+    data = {"query": """
+        {{
+            search(query:"{}" type: ISSUE first: 100)
+            {{
+                pageInfo {{ hasNextPage endCursor startCursor }}
+                nodes {{
+                    ... on Issue {{
+                        title number author {{ login }} closedAt createdAt
+                    }}
+                }}
+            }}
+        }}
+    """.format(search)}
+    response = requests.post(GRAPHQL_ENDPOINT, json=data, headers={
+        "Authorization": f"Bearer {token}",
+        "accept": "application/vnd.github.v3+json"
+    })
+    return response.json()["data"]["search"]["nodes"]
+
+def send_report(payload: str, token: str) -> int:
+    """send the report using the Mailgun API"""
+    params = {
+        "from": "Cpython Issues <github@mg.python.org>",
+        "to": "",
+        "subject": "Summary of Python tracker Issues",
+        "template": "issue-tracker-template",
+        "o:tracking-clicks": "no",
+        "h:X-Mailgun-Variables": payload,
+    }
+    response = requests.post(
+        MAILGUN_ENDPOINT,
+        auth=("api", token),
+        json=params)
+    return response.status_code
+
+if __name__ == '__main__':
+    date_from = date.today() - timedelta(days=7)
+    github_token = os.environ.get("github_api_token")
+    mailgun_token = os.environ.get("mailgun_api_key")
+
+    total_open, total_closed = get_issue_counts(github_token)
+    closed = get_issues(("repo:python/cpython", f"closed:>{date_from}", "type:issue"), github_token)
+    opened = get_issues(("repo:python/cpython", "state:open", f"created:>{date_from}", "type:issue"), github_token)
+    most_discussed = get_issues(
+        ("repo:python/cpython", "state:open", "type:issue", "sort:comments"),
+        github_token,
+        False)
+    no_comments = get_issues(
+        ("repo:python/cpython", "state:open", "type:issue", "comments:0", "sort:updated"),
+        github_token,
+        False)
+
+    payload = {
+        "opened_issues": opened,
+        "closed_issues": closed,
+        "most_discussed": most_discussed[:10],
+        "no_comments": no_comments[:15],
+        "total_open": total_open,
+        "total_closed": total_closed,
+        "week_delta": len(opened) - len(closed),
+    }
+    status_code = send_report(json.dumps(payload), mailgun_token)
+    if status_code == 200:
+        print("successfully sent email")
+    else:
+        # in this case, fail the GitHub action
+        print("failed to send email", status_code)
+        exit(1)

--- a/.github/actions/roundup_summary.py
+++ b/.github/actions/roundup_summary.py
@@ -37,10 +37,9 @@ def get_issues(filters: Iterable[str], token: str, all_: bool = True):
     """return a list of results from the Github search API"""
     # TODO: if there are more than 100 issues, we need to include pagination
     # this doesn't occur very often, but it should still be included just incase.
-    search = " ".join(filters)
-    data = {"query": """
+    data = {"query": f"""
         {{
-            search(query:"{}" type: ISSUE first: 100)
+            search(query:"{' '.join(filters)}" type: ISSUE first: 100)
             {{
                 pageInfo {{ hasNextPage endCursor startCursor }}
                 nodes {{
@@ -50,7 +49,7 @@ def get_issues(filters: Iterable[str], token: str, all_: bool = True):
                 }}
             }}
         }}
-    """.format(search)}
+    """}
     response = requests.post(GRAPHQL_ENDPOINT, json=data, headers={
         "Authorization": f"Bearer {token}",
         "accept": "application/vnd.github.v3+json"

--- a/.github/workflows/roundup.yml
+++ b/.github/workflows/roundup.yml
@@ -1,0 +1,26 @@
+name: weekly-summary
+
+on: 
+  schedule:
+   - cron: "15 19 * * FRI"
+
+jobs:
+  roundup-summary:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.10.1
+      - name: install deps
+        run: pip install requests
+      - name: execute script
+        run: |
+          python -u ./.github/actions/roundup_summary.py
+        env:
+          github_api_token: ${{ secrets.GITHUB_TOKEN }}
+          mailgun_api_key: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/roundup.yml
+++ b/.github/workflows/roundup.yml
@@ -23,4 +23,4 @@ jobs:
           python -u ./.github/actions/roundup_summary.py
         env:
           github_api_token: ${{ secrets.GITHUB_TOKEN }}
-          mailgun_api_key: ${{ secrets.GITHUB_TOKEN }}
+          mailgun_api_key: ${{ secrets.PSF_MAILGUN_KEY }}

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1029,6 +1029,7 @@ James Lee
 John J. Lee
 Thomas Lee
 Robert Leenders
+Harry Lees
 Cooper Ry Lees
 Yaron de Leeuw
 Tennessee Leeuwenburg


### PR DESCRIPTION
References: https://github.com/psf/gh-migration/issues/6

Currently, this script requires the following template in MailGun:

```handlebars
<h1>ACTIVITY SUMMARY</h1>
<p>({{ timespan }})</p>
<p>Python issue tracker at <a href="https://github.com/python/cpython/issues">https://github.com/python/cpython/issues</a></p>

<p>To view or respond to any of the issues listed below, click on the issue. Do NOT respond to this message.</p>

<br>

<p>Issues stats:</p>
<table border="1">
    <tr>
        <th>open</th>
        <td>{{ total_open }} ({{len opened_issues }})</td>
    </tr>
    <tr>
        <th>closed</th>
        <td>{{ total_closed }} ({{len closed_issues }})</td>
    </tr>
    <tr>
        <th>total</th>
        <td>{{sum total_open total_closed }} ({{ total_diff }})</td>
    </tr>
</table>

<br>

<p>Issues Opened ({{len opened_issues }})</p>
=======================================
{{#each opened_issues}}
<p>#{{ this.number }}: {{ this.title }}<br>
<a href="https://github.com/python/cpython/issues/{{ this.number }}">https://github.com/python/cpython/issues/{{ this.number }}</a> opened by {{ this.author.login }}</p>
{{/each}}

<br>

<p>Top 10 most discussed issues ({{len most_discussed }})</p>
=======================================
{{#each most_discussed }}
<p>#{{ this.number }}: {{ this.title }}<br>
<a href="https://github.com/python/cpython/issues/{{ this.number }}">https://github.com/python/cpython/issues/{{ this.number }}</a> opened by {{ this.author.login }}</p>
{{/each}}

<br>

<p>Most recent 15 issues with no replies ({{len no_comments }})</p>
=======================================
{{#each no_comments }}
<p>#{{ this.number }}: {{ this.title }}<br>
<a href="https://github.com/python/cpython/issues/{{ this.number }}">https://github.com/python/cpython/issues/{{ this.number }}</a> opened by {{ this.author.login }}</p>
{{/each}}

<br>

<p>Issues Closed ({{len closed_issues }})</p>
=======================================
{{#each closed_issues}}
<p>#{{ this.number }}: {{ this.title }}<br>
<a href="https://github.com/python/cpython/issues/{{ this.number }}">https://github.com/python/cpython/issues/{{ this.number }}</a> opened by {{ this.author.login }}</p>
{{/each}}
```

Furthermore, the following helpers were used to calculate number of issues etc.
```javascript
Handlebars.registerHelper('sum', function (a, b) {
    return a + b
})

Handlebars.registerHelper('len', function(arr) {
    return arr.length
})
```