### PR TITLE
gh-90623: signal.raise_signal() calls PyErr_CheckSignals()

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-04-20-18-47-27.gh-issue-90623.5fROpX.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-20-18-47-27.gh-issue-90623.5fROpX.rst
@@ -1,0 +1,2 @@
+:func:`signal.raise_signal` and :func:`os.kill` now check immediately for
+pending signals. Patch by Victor Stinner.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7927,8 +7927,17 @@ os_kill_impl(PyObject *module, pid_t pid, Py_ssize_t signal)
         return NULL;
     }
 #ifndef MS_WINDOWS
-    if (kill(pid, (int)signal) == -1)
+    if (kill(pid, (int)signal) == -1) {
         return posix_error();
+    }
+
+    // Check immediately if the signal was sent to the current process.
+    // Don't micro-optimize pid == getpid(), since PyErr_SetString() check
+    // is cheap.
+    if (PyErr_CheckSignals()) {
+        return NULL;
+    }
+
     Py_RETURN_NONE;
 #else /* !MS_WINDOWS */
     PyObject *result;

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -481,6 +481,13 @@ signal_raise_signal_impl(PyObject *module, int signalnum)
     if (err) {
         return PyErr_SetFromErrno(PyExc_OSError);
     }
+
+    // If the current thread can handle signals, handle immediately
+    // the raised signal.
+    if (PyErr_CheckSignals()) {
+        return NULL;
+    }
+
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
signal.raise_signal() and os.kill() now call PyErr_CheckSignals() to
check immediately for pending signals.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
