### PR TITLE
gh-89653: PEP 670: Convert tuple macros to functions

### DIFF
--- a/Include/cpython/listobject.h
+++ b/Include/cpython/listobject.h
@@ -24,11 +24,21 @@ typedef struct {
 PyAPI_FUNC(PyObject *) _PyList_Extend(PyListObject *, PyObject *);
 PyAPI_FUNC(void) _PyList_DebugMallocStats(FILE *out);
 
-/* Macro, trading safety for speed */
-
 /* Cast argument to PyListObject* type. */
 #define _PyList_CAST(op) (assert(PyList_Check(op)), (PyListObject *)(op))
 
-#define PyList_GET_ITEM(op, i) (_PyList_CAST(op)->ob_item[i])
-#define PyList_SET_ITEM(op, i, v) _Py_RVALUE(_PyList_CAST(op)->ob_item[i] = (v))
-#define PyList_GET_SIZE(op)    Py_SIZE(_PyList_CAST(op))
+// Macros and static inline functions, trading safety for speed
+
+static inline Py_ssize_t PyList_GET_SIZE(PyListObject *op) {
+    return Py_SIZE(op);
+}
+#define PyList_GET_SIZE(op) PyList_GET_SIZE(_PyList_CAST(op))
+
+#define PyList_GET_ITEM(op, index) (_PyList_CAST(op)->ob_item[index])
+
+static inline void
+PyList_SET_ITEM(PyListObject *op, Py_ssize_t index, PyObject *value) {
+    op->ob_item[index] = value;
+}
+#define PyList_SET_ITEM(op, index, value) \
+    PyList_SET_ITEM(_PyList_CAST(op), index, _PyObject_CAST(value))

--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -13,16 +13,24 @@ typedef struct {
 PyAPI_FUNC(int) _PyTuple_Resize(PyObject **, Py_ssize_t);
 PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 
-/* Macros trading safety for speed */
-
 /* Cast argument to PyTupleObject* type. */
 #define _PyTuple_CAST(op) (assert(PyTuple_Check(op)), (PyTupleObject *)(op))
 
-#define PyTuple_GET_SIZE(op)    Py_SIZE(_PyTuple_CAST(op))
+// Macros and static inline functions, trading safety for speed
 
-#define PyTuple_GET_ITEM(op, i) (_PyTuple_CAST(op)->ob_item[i])
+static inline Py_ssize_t PyTuple_GET_SIZE(PyTupleObject *op) {
+    return Py_SIZE(op);
+}
+#define PyTuple_GET_SIZE(op) PyTuple_GET_SIZE(_PyTuple_CAST(op))
 
-/* Macro, *only* to be used to fill in brand new tuples */
-#define PyTuple_SET_ITEM(op, i, v) _Py_RVALUE(_PyTuple_CAST(op)->ob_item[i] = (v))
+#define PyTuple_GET_ITEM(op, index) (_PyTuple_CAST(op)->ob_item[index])
+
+/* Function *only* to be used to fill in brand new tuples */
+static inline void
+PyTuple_SET_ITEM(PyTupleObject *op, Py_ssize_t index, PyObject *value) {
+    op->ob_item[index] = value;
+}
+#define PyTuple_SET_ITEM(op, index, value) \
+    PyTuple_SET_ITEM(_PyTuple_CAST(op), index, _PyObject_CAST(value))
 
 PyAPI_FUNC(void) _PyTuple_DebugMallocStats(FILE *out);


### PR DESCRIPTION
Convert macros to static inline functions:

* PyTuple_GET_SIZE()
* PyTuple_SET_ITEM()
* PyList_GET_SIZE()
* PyList_SET_ITEM()

Add a macro converting arguments to PyTupleObject*, PyListObject* or
PyObject* to prevent emitting new compiler warnings.

According to PEP 670, PyTuple_GET_ITEM() and PyList_GET_ITEM() are
left as macros.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
