### PR TITLE
gh-91782: Define static_assert() macro on FreeBSD

### DIFF
--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -1,6 +1,15 @@
 #ifndef Py_PYMACRO_H
 #define Py_PYMACRO_H
 
+// gh-91782: On FreeBSD 12, if the _POSIX_C_SOURCE and _XOPEN_SOURCE macros are
+// defined, <sys/cdefs.h> disables C11 support and <assert.h> does not define
+// the static_assert() macro. Define the static_assert() macro in Python until
+// <sys/cdefs.h> suports C11:
+// https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255290
+#if defined(__FreeBSD__) && !defined(static_assert)
+#  define static_assert _Static_assert
+#endif
+
 /* Minimum value between x and y */
 #define Py_MIN(x, y) (((x) > (y)) ? (y) : (x))
 


### PR DESCRIPTION
On FreeBSD, if the static_assert() macro is not defined, define it in
Python until <sys/cdefs.h> supports C11:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255290

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
