### PR TITLE
gh-91791: Add docstrings to keyword module functions

### DIFF
--- a/Lib/keyword.py
+++ b/Lib/keyword.py
@@ -59,5 +59,12 @@ softkwlist = [
     'match'
 ]
 
-iskeyword = frozenset(kwlist).__contains__
-issoftkeyword = frozenset(softkwlist).__contains__
+_kwset = frozenset(kwlist)
+def iskeyword(word, /):
+    """Return True if the string is a Python keyword, False otherwise."""
+    return word in _kwset
+
+_softkwset = frozenset(softkwlist)
+def issoftkeyword(word, /):
+    """Return True if the string is a Python soft keyword, False otherwise."""
+    return word in _softkwset

--- a/Tools/peg_generator/pegen/keywordgen.py
+++ b/Tools/peg_generator/pegen/keywordgen.py
@@ -31,8 +31,15 @@ softkwlist = [
 {soft_keywords}
 ]
 
-iskeyword = frozenset(kwlist).__contains__
-issoftkeyword = frozenset(softkwlist).__contains__
+_kwset = frozenset(kwlist)
+def iskeyword(word, /):
+    """Return True if the string is a Python keyword, False otherwise."""
+    return word in _kwset
+
+_softkwset = frozenset(softkwlist)
+def issoftkeyword(word, /):
+    """Return True if the string is a Python soft keyword, False otherwise."""
+    return word in _softkwset
 '''.lstrip()
 
 EXTRA_KEYWORDS = ["async", "await"]


### PR DESCRIPTION

```
FUNCTIONS
    iskeyword(word, /)
        Return True if the string is a Python keyword, False otherwise.
    
    issoftkeyword(word, /)
        Return True if the string is a Python soft keyword, False otherwise.
```

Resolves #91791