### PR TITLE
gh-80527: Deprecate PEP 623 Unicode functions

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -606,7 +606,7 @@ static inline Py_ssize_t PyUnicode_WSTR_LENGTH(PyObject *op)
    If the Py_UNICODE representation is not available, it will be computed
    on request.  Use PyUnicode_GET_LENGTH() for the length in code points. */
 
-/* Py_DEPRECATED(3.3) */
+Py_DEPRECATED(3.3)
 static inline Py_ssize_t PyUnicode_GET_SIZE(PyObject *op)
 {
     _Py_COMP_DIAG_PUSH
@@ -620,10 +620,13 @@ static inline Py_ssize_t PyUnicode_GET_SIZE(PyObject *op)
 }
 #define PyUnicode_GET_SIZE(op) PyUnicode_GET_SIZE(_PyObject_CAST(op))
 
- /* Py_DEPRECATED(3.3) */
- static inline Py_ssize_t PyUnicode_GET_DATA_SIZE(PyObject *op)
+Py_DEPRECATED(3.3)
+static inline Py_ssize_t PyUnicode_GET_DATA_SIZE(PyObject *op)
 {
+    _Py_COMP_DIAG_PUSH
+    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     return PyUnicode_GET_SIZE(op) * Py_UNICODE_SIZE;
+    _Py_COMP_DIAG_POP
 }
 #define PyUnicode_GET_DATA_SIZE(op) PyUnicode_GET_DATA_SIZE(_PyObject_CAST(op))
 
@@ -632,7 +635,7 @@ static inline Py_ssize_t PyUnicode_GET_SIZE(PyObject *op)
    try to port your code to use the new PyUnicode_*BYTE_DATA() macros or
    use PyUnicode_WRITE() and PyUnicode_READ(). */
 
-/* Py_DEPRECATED(3.3) */
+Py_DEPRECATED(3.3)
 static inline Py_UNICODE* PyUnicode_AS_UNICODE(PyObject *op)
 {
     wchar_t *wstr = _PyASCIIObject_CAST(op)->wstr;
@@ -647,10 +650,13 @@ static inline Py_UNICODE* PyUnicode_AS_UNICODE(PyObject *op)
 }
 #define PyUnicode_AS_UNICODE(op) PyUnicode_AS_UNICODE(_PyObject_CAST(op))
 
-/* Py_DEPRECATED(3.3) */
+Py_DEPRECATED(3.3)
 static inline const char* PyUnicode_AS_DATA(PyObject *op)
 {
+    _Py_COMP_DIAG_PUSH
+    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     return (const char *)PyUnicode_AS_UNICODE(op);
+    _Py_COMP_DIAG_POP
 }
 #define PyUnicode_AS_DATA(op) PyUnicode_AS_DATA(_PyObject_CAST(op))
 

--- a/Misc/NEWS.d/next/C API/2022-04-21-23-11-35.gh-issue-80527.Cx-95G.rst
+++ b/Misc/NEWS.d/next/C API/2022-04-21-23-11-35.gh-issue-80527.Cx-95G.rst
@@ -1,0 +1,3 @@
+Mark functions as deprecated by :pep:`623:`: :c:func:`PyUnicode_AS_DATA`,
+:c:func:`PyUnicode_AS_UNICODE`, :c:func:`PyUnicode_GET_DATA_SIZE`,
+:c:func:`PyUnicode_GET_SIZE`. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2022-04-21-23-11-35.gh-issue-80527.Cx-95G.rst
+++ b/Misc/NEWS.d/next/C API/2022-04-21-23-11-35.gh-issue-80527.Cx-95G.rst
@@ -1,3 +1,3 @@
-Mark functions as deprecated by :pep:`623:`: :c:func:`PyUnicode_AS_DATA`,
+Mark functions as deprecated by :pep:`623`: :c:func:`PyUnicode_AS_DATA`,
 :c:func:`PyUnicode_AS_UNICODE`, :c:func:`PyUnicode_GET_DATA_SIZE`,
 :c:func:`PyUnicode_GET_SIZE`. Patch by Victor Stinner.


### PR DESCRIPTION
Deprecate functions:

* PyUnicode_AS_DATA()
* PyUnicode_AS_UNICODE()
* PyUnicode_GET_DATA_SIZE()
* PyUnicode_GET_SIZE()

Previously, these functions were macros and so it wasn't possible to
decorate them with Py_DEPRECATED().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
