### PR TITLE
gh-86019: Add table for Windows installer options

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -127,7 +127,7 @@ machines without user interaction.  These options may also be set without
 suppressing the UI in order to change some of the defaults.
 
 The following options (found by executing the installer with ``/?``) can be
-passed into Python:
+passed into the installer:
 
 +---------------------+--------------------------------------------------------+
 | Name                | Description                                            |

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -126,11 +126,24 @@ command line, allowing scripted installers to replicate an installation on many
 machines without user interaction.  These options may also be set without
 suppressing the UI in order to change some of the defaults.
 
-To completely hide the installer UI and install Python silently, pass the
-``/quiet`` option. To skip past the user interaction but still display
-progress and errors, pass the ``/passive`` option. The ``/uninstall``
-option may be passed to immediately begin removing Python - no confirmation
-prompt will be displayed.
+The following options (found by executing the installer with ``/?``) can be
+passed into Python:
+
++---------------------+--------------------------------------------------------+
+| Name                | Description                                            |
++=====================+========================================================+
+| /passive            | to display progress without requiring user interaction |
++---------------------+--------------------------------------------------------+
+| /quiet              | to install/uninstall without displaying any UI         |
++---------------------+--------------------------------------------------------+
+| /simple             | to prevent user customization                          |
++---------------------+--------------------------------------------------------+
+| /uninstall          | to remove Python (without confirmation)                |
++---------------------+--------------------------------------------------------+
+| /layout [directory] | to pre-download all components                         |
++---------------------+--------------------------------------------------------+
+| /log [filename]     | to specify log files location                          |
++---------------------+--------------------------------------------------------+
 
 All other options are passed as ``name=value``, where the value is usually
 ``0`` to disable a feature, ``1`` to enable a feature, or a path. The full list


### PR DESCRIPTION
#86019

Text copied from [Tools/msi/bundle/Default.wxl](https://github.com/python/cpython/blob/main/Tools/msi/bundle/Default.wxl#L30)

Table generated by https://www.tablesgenerator.com/text_tables#

Current:
https://docs.python.org/3/using/windows.html#installing-without-ui

After:
![image](https://user-images.githubusercontent.com/46876382/164625274-ec47d354-dbb7-4751-bdb8-205759bd8fb1.png)
