### PR TITLE
gh-85757: Change wording from nested to inner

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -303,7 +303,7 @@ The following list comprehension will transpose rows and columns::
    >>> [[row[i] for row in matrix] for i in range(4)]
    [[1, 5, 9], [2, 6, 10], [3, 7, 11], [4, 8, 12]]
 
-As we saw in the previous section, the nested listcomp is evaluated in
+As we saw in the previous section, the inner listcomp is evaluated in
 the context of the :keyword:`for` that follows it, so this example is
 equivalent to::
 

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -303,7 +303,7 @@ The following list comprehension will transpose rows and columns::
    >>> [[row[i] for row in matrix] for i in range(4)]
    [[1, 5, 9], [2, 6, 10], [3, 7, 11], [4, 8, 12]]
 
-As we saw in the previous section, the inner listcomp is evaluated in
+As we saw in the previous section, the inner list comprehension is evaluated in
 the context of the :keyword:`for` that follows it, so this example is
 equivalent to::
 


### PR DESCRIPTION
#85757

https://docs.python.org/3/tutorial/datastructures.html#nested-list-comprehensions

I do think this is clearer, but I wonder if 'nested' should be kept though to get the terminology out there more often. So perhaps it could be something like 'inner (nested) listcomp' or 'nested (inner) listcomp' despite sounding a bit redundant

Automerge-Triggered-By: GH:rhettinger