### PR TITLE
Docs: replace 'currying' by 'partial function'.

### DIFF
--- a/Doc/howto/functional.rst
+++ b/Doc/howto/functional.rst
@@ -1218,6 +1218,8 @@ https://en.wikipedia.org/wiki/Coroutine: Entry for coroutines.
 
 https://en.wikipedia.org/wiki/Partial_application: Entry for the concept of partial function application.
 
+https://en.wikipedia.org/wiki/Currying: Entry for the concept of currying.
+
 Python-specific
 ---------------
 

--- a/Doc/howto/functional.rst
+++ b/Doc/howto/functional.rst
@@ -1216,7 +1216,7 @@ describing functional programming.
 
 https://en.wikipedia.org/wiki/Coroutine: Entry for coroutines.
 
-https://en.wikipedia.org/wiki/Currying: Entry for the concept of currying.
+https://en.wikipedia.org/wiki/Partial_application: Entry for the concept of partial function application.
 
 Python-specific
 ---------------


### PR DESCRIPTION
Currying is not mentioned in the text so the reference is a little pointless.

> Currying is related to, but not the same as, partial application.

From https://en.wikipedia.org/wiki/Currying.

It is better to replace this with link to https://en.wikipedia.org/wiki/Partial_application as that is used in https://docs.python.org/3.8/howto/functional.html#the-functools-module

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
