### PR TITLE
gh-91815: Clarify availability of PyOS_CheckStack

### DIFF
--- a/Doc/c-api/sys.rst
+++ b/Doc/c-api/sys.rst
@@ -96,9 +96,9 @@ Operating System Utilities
 
    Return true when the interpreter runs out of stack space.  This is a reliable
    check, but is only available when :const:`USE_STACKCHECK` is defined (currently
-   on Windows using the Microsoft Visual C++ compiler).  :const:`USE_STACKCHECK`
-   will be defined automatically; you should never change the definition in your
-   own code.
+   on certain versions of Windows using the Microsoft Visual C++ compiler).
+   :const:`USE_STACKCHECK` will be defined automatically; you should never
+   change the definition in your own code.
 
 
 .. c:function:: PyOS_sighandler_t PyOS_getsig(int i)

--- a/Include/pythonrun.h
+++ b/Include/pythonrun.h
@@ -24,6 +24,7 @@ PyAPI_DATA(int) (*PyOS_InputHook)(void);
 
 #if defined(WIN32) && !defined(MS_WIN64) && !defined(_M_ARM) && defined(_MSC_VER) && _MSC_VER >= 1300
 /* Enable stack checking under Microsoft C */
+// When changing the platforms, ensure PyOS_CheckStack() docs are still correct
 #define USE_STACKCHECK
 #endif
 


### PR DESCRIPTION
The function is only available on *some* variants of Windows-MSVC.
I don't think it's important to document exactly which ones those are, just don't suggest it's all of them.

Could a Windows expert check this wording?