### PR TITLE
gh-91821: Make decimal test succeed consistently

### DIFF
--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -5520,6 +5520,7 @@ class CWhitebox(unittest.TestCase):
 
         with localcontext() as c:
 
+            c.prec = 9
             c.traps[InvalidOperation] = True
             c.traps[Overflow] = True
             c.traps[Underflow] = True

--- a/Misc/NEWS.d/next/Library/2022-04-22-08-25-18.gh-issue-91821.XwMkj0.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-22-08-25-18.gh-issue-91821.XwMkj0.rst
@@ -1,0 +1,1 @@
+Fix unstable ``test_from_tuple`` test in ``test_decimal.py``.


### PR DESCRIPTION
The test relies on precision being set to 9, but some ways of
invoking this test leave it set to 28 instead. I don't know
exactly how it happens, but setting the precision directly should
make the behavior consistent.

#91821
