### PR TITLE
Improve efficiency of lehvenshtein_distance method

### DIFF
--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -78,9 +78,10 @@ levenshtein_distance(const char *a, size_t a_size,
     // Instead of producing the whole traditional len(a)-by-len(b)
     // matrix, we can update just one row in place.
     // Initialize the buffer row
-    for (size_t i = 0; i < a_size; i++) {
+    buffer[0] = MOVE_COST;
+    for (size_t i = 1; i < a_size; i++) {
         // cost from b[:0] to a[:i+1]
-        buffer[i] = (i + 1) * MOVE_COST;
+        buffer[i] = buffer[i-1] + MOVE_COST;
     }
 
     size_t result = 0;

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -78,10 +78,11 @@ levenshtein_distance(const char *a, size_t a_size,
     // Instead of producing the whole traditional len(a)-by-len(b)
     // matrix, we can update just one row in place.
     // Initialize the buffer row
-    buffer[0] = MOVE_COST;
-    for (size_t i = 1; i < a_size; i++) {
+    size_t tmp = MOVE_COST;
+    for (size_t i = 0; i < a_size; i++) {
         // cost from b[:0] to a[:i+1]
-        buffer[i] = buffer[i-1] + MOVE_COST;
+        buffer[i] = tmp;
+        tmp += MOVE_COST;
     }
 
     size_t result = 0;


### PR DESCRIPTION
The `buffer` initialization (which happens many times) is improved by replacing the multiplication with a sum.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
