### PR TITLE
gh-91832: Fix 'required' attribute not showing up in repr of argparse…

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -850,6 +850,7 @@ class Action(_AttributeHolder):
             'default',
             'type',
             'choices',
+            'required',
             'help',
             'metavar',
         ]

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4902,12 +4902,13 @@ class TestStrings(TestCase):
             nargs='+',
             default=42,
             choices=[1, 2, 3],
+            required = True,
             help='HELP',
             metavar='METAVAR')
         string = (
             "Action(option_strings=['--foo', '-a', '-b'], dest='b', "
             "nargs='+', const=None, default=42, type='int', "
-            "choices=[1, 2, 3], help='HELP', metavar='METAVAR')")
+            "choices=[1, 2, 3], required=True, help='HELP', metavar='METAVAR')")
         self.assertStringEqual(option, string)
 
     def test_argument(self):
@@ -4918,12 +4919,13 @@ class TestStrings(TestCase):
             nargs='?',
             default=2.5,
             choices=[0.5, 1.5, 2.5],
+            required=False,
             help='H HH H',
             metavar='MV MV MV')
         string = (
             "Action(option_strings=[], dest='x', nargs='?', "
             "const=None, default=2.5, type=%r, choices=[0.5, 1.5, 2.5], "
-            "help='H HH H', metavar='MV MV MV')" % float)
+            "required=False, help='H HH H', metavar='MV MV MV')" % float)
         self.assertStringEqual(argument, string)
 
     def test_namespace(self):

--- a/Misc/NEWS.d/next/Library/2022-04-22-21-59-10.gh-issue-91832.HJEpLk.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-22-21-59-10.gh-issue-91832.HJEpLk.rst
@@ -1,0 +1,2 @@
+Solved the problem of the 'required' keyword not being visible in the repr of the argparser's argument.
+Added the 'required' keyword to the 'names' list.


### PR DESCRIPTION
Closes #91832 
Also there is another solution to just use `self.__dict__` and ignore `container`, it gives the same list and seems to be better than creating and updating the list manually.
If `self.__dict__` usage would be approved, I am volunteer to do the necessary change(s).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
