### PR TITLE
gh-91783: Document security considerations for shutil.unpack_archive

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -635,9 +635,14 @@ provided.  They rely on the :mod:`zipfile` and :mod:`tarfile` modules.
 
    .. audit-event:: shutil.unpack_archive filename,extract_dir,format shutil.unpack_archive
 
+   .. warning::
+
+      Never extract archives from untrusted sources without prior inspection.
+      It is possible that files are created outside of path, e.g. members that have
+      absolute filenames starting with "/" or filenames with two dots "..".
+
    .. versionchanged:: 3.7
       Accepts a :term:`path-like object` for *filename* and *extract_dir*.
-
 
 .. function:: register_unpack_format(name, extensions, function[, extra_args[, description]])
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -638,8 +638,9 @@ provided.  They rely on the :mod:`zipfile` and :mod:`tarfile` modules.
    .. warning::
 
       Never extract archives from untrusted sources without prior inspection.
-      It is possible that files are created outside of path, e.g. members that have
-      absolute filenames starting with "/" or filenames with two dots "..".
+      It is possible that files are created outside of the path specified in
+      the *extract_dir* argument, e.g. members that have absolute filenames
+      starting with "/" or filenames with two dots "..".
 
    .. versionchanged:: 3.7
       Accepts a :term:`path-like object` for *filename* and *extract_dir*.

--- a/Misc/NEWS.d/next/Documentation/2022-04-23-00-22-54.gh-issue-91783.N09dRR.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-04-23-00-22-54.gh-issue-91783.N09dRR.rst
@@ -1,0 +1,2 @@
+Document security issues concerning the use of the function
+:meth:`shutil.unpack_archive`


### PR DESCRIPTION
Adds a warning to the documentation for [`shutil.unpack_archive`](https://docs.python.org/3/library/shutil.html#shutil.unpack_archive) noting that it is unsafe to unpack archives from untrusted sources. This is done in line with the documentation from [`Zipfile.extractall`](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.extractall) and [`TarFile.extractall`](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.extractall).

Resolves #91783 