### PR TITLE
Document that MozillaCookieJar works for curl's cookie files

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -321,8 +321,8 @@ writing.
 .. class:: MozillaCookieJar(filename, delayload=None, policy=None)
 
    A :class:`FileCookieJar` that can load from and save cookies to disk in the
-   Mozilla ``cookies.txt`` file format (which is also used by the Lynx and Netscape
-   browsers).
+   Mozilla ``cookies.txt`` file format (which is also used by curl and the Lynx
+   and Netscape browsers).
 
    .. note::
 

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -1985,7 +1985,7 @@ class MozillaCookieJar(FileCookieJar):
 
     This class differs from CookieJar only in the format it uses to save and
     load cookies to and from a file.  This class uses the Mozilla/Netscape
-    `cookies.txt' format.  lynx uses this file format, too.
+    `cookies.txt' format.  curl and lynx use this file format, too.
 
     Don't expect cookies saved while the browser is running to be noticed by
     the browser (in fact, Mozilla on unix will overwrite your saved cookies if


### PR DESCRIPTION
I came to the documentation because I wanted to know how to parse [cookie files](https://curl.se/docs/http-cookies.html) generated by 

```sh
curl -b cookie.txt -c cookie.txt www.google.com
```

and it seems like `MozillaCookieJar` is exactly what I need. It would be helpful for the documentation to mention this explicitly because curl is probably the most common reason developers these days are encountering this file format.