### PR TITLE
Fix typo in turtle deprecation warning and use warnings._deprecated

### DIFF
--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -2863,10 +2863,10 @@ class RawTurtle(TPen, TNavigator):
         >>> turtle.stamp()
         >>> turtle.fd(50)
         """
-        warnings.warn("turtle.RawTurtle.settiltangle() is deprecated since "
-                      "Python 3.1 and scheduled for removal in Python 3.13."
-                      "Use tiltangle() instead.",
-                       DeprecationWarning)
+        warnings._deprecated("turtle.RawTurtle.settiltangle()",
+                             "{name} is deprecated since Python 3.1 and scheduled for "
+                             "removal in Python {remove}. Use tiltangle() instead.",
+                             remove=(3, 13))
         self.tiltangle(angle)
 
     def tiltangle(self, angle=None):

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -2864,8 +2864,8 @@ class RawTurtle(TPen, TNavigator):
         >>> turtle.fd(50)
         """
         warnings._deprecated("turtle.RawTurtle.settiltangle()",
-                             "{name} is deprecated since Python 3.1 and scheduled for "
-                             "removal in Python {remove}. Use tiltangle() instead.",
+                             "{name!r} is deprecated since Python 3.1 and scheduled "
+                             "for removal in Python {remove}. Use tiltangle() instead.",
                              remove=(3, 13))
         self.tiltangle(angle)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

In GH-29618, I missed the space after "...Python 3.13."

Whilst fixing it, let's also use the [new `warnings._deprecated()`](https://discuss.python.org/t/introducing-warnings-deprecated/14856?u=hugovk).
