### PR TITLE
gh-91873: Summarise deprecations in typing at the top level

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -49,9 +49,6 @@ convenience. This is subject to change, and not all deprecations are listed.
 |  ``typing.io`` and ``typing.re`` | 3.8           | 3.12              | :issue:`38291` |
 |  submodules                      |               |                   |                |
 +----------------------------------+---------------+-------------------+----------------+
-|  ``typing`` versions of standard | 3.9           | 3.14              | :pep:`585`     |
-|  collections                     |               |                   |                |
-+----------------------------------+---------------+-------------------+----------------+
 
 
 .. _relevant-peps:

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -49,6 +49,9 @@ convenience. This is subject to change, and not all deprecations are listed.
 |  ``typing.io`` and ``typing.re`` | 3.8           | 3.12              | :issue:`38291` |
 |  submodules                      |               |                   |                |
 +----------------------------------+---------------+-------------------+----------------+
+|  ``typing`` versions of standard | 3.9           | not planned       | :pep:`585`     |
+|  collections                     |               |                   |                |
++----------------------------------+---------------+-------------------+----------------+
 
 
 .. _relevant-peps:

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -36,22 +36,8 @@ New features are frequently added to the ``typing`` module.
 The `typing_extensions <https://pypi.org/project/typing-extensions/>`_ package
 provides backports of these new features to older versions of Python.
 
-Deprecation Timeline of Major Features
-======================================
-
-Certain features in ``typing`` are deprecated and may be removed in a future
-version of Python. The following table summarizes major deprecations for your
-convenience. This is subject to change, and not all deprecations are listed.
-
-+----------------------------------+---------------+-------------------+----------------+
-|  Feature                         | Deprecated in | Projected removal | PEP/issue      |
-+==================================+===============+===================+================+
-|  ``typing.io`` and ``typing.re`` | 3.8           | 3.12              | :issue:`38291` |
-|  submodules                      |               |                   |                |
-+----------------------------------+---------------+-------------------+----------------+
-|  ``typing`` versions of standard | 3.9           | not planned       | :pep:`585`     |
-|  collections                     |               |                   |                |
-+----------------------------------+---------------+-------------------+----------------+
+For a summary of deprecated features and a deprecation timeline, please see
+`Deprecation Timeline of Major Features`_.
 
 
 .. _relevant-peps:
@@ -2648,3 +2634,20 @@ Constant
       (see :pep:`563`).
 
    .. versionadded:: 3.5.2
+
+Deprecation Timeline of Major Features
+======================================
+
+Certain features in ``typing`` are deprecated and may be removed in a future
+version of Python. The following table summarizes major deprecations for your
+convenience. This is subject to change, and not all deprecations are listed.
+
++----------------------------------+---------------+-------------------+----------------+
+|  Feature                         | Deprecated in | Projected removal | PEP/issue      |
++==================================+===============+===================+================+
+|  ``typing.io`` and ``typing.re`` | 3.8           | 3.12              | :issue:`38291` |
+|  submodules                      |               |                   |                |
++----------------------------------+---------------+-------------------+----------------+
+|  ``typing`` versions of standard | 3.9           | Undecided         | :pep:`585`     |
+|  collections                     |               |                   |                |
++----------------------------------+---------------+-------------------+----------------+

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -36,6 +36,24 @@ New features are frequently added to the ``typing`` module.
 The `typing_extensions <https://pypi.org/project/typing-extensions/>`_ package
 provides backports of these new features to older versions of Python.
 
+Deprecation Timeline of Major Features
+======================================
+
+Certain features in ``typing`` are deprecated and may be removed in a future
+version of Python. The following table summarizes major deprecations for your
+convenience. This is subject to change, and not all deprecations are listed.
+
++----------------------------------+---------------+-------------------+----------------+
+|  Feature                         | Deprecated in | Projected removal | PEP/issue      |
++==================================+===============+===================+================+
+|  ``typing.io`` and ``typing.re`` | 3.8           | 3.12              | :issue:`38291` |
+|  submodules                      |               |                   |                |
++----------------------------------+---------------+-------------------+----------------+
+|  ``typing`` versions of standard | 3.9           | 3.14              | :pep:`585`     |
+|  collections                     |               |                   |                |
++----------------------------------+---------------+-------------------+----------------+
+
+
 .. _relevant-peps:
 
 Relevant PEPs


### PR DESCRIPTION
The rationale behind this is that certain deprecations may cause major disruptions in Python's ecosystem. It's better to give an obvious heads up rather than hide those deprecations behind walls of text.