### PR TITLE
gh-91880: add try/except around `signal.signal`

### DIFF
--- a/Lib/asyncio/runners.py
+++ b/Lib/asyncio/runners.py
@@ -100,7 +100,10 @@ class Runner:
             and signal.getsignal(signal.SIGINT) is signal.default_int_handler
         ):
             sigint_handler = functools.partial(self._on_sigint, main_task=task)
-            signal.signal(signal.SIGINT, sigint_handler)
+            try:
+                signal.signal(signal.SIGINT, sigint_handler)
+            except ValueError:
+                pass
         else:
             sigint_handler = None
 

--- a/Lib/asyncio/runners.py
+++ b/Lib/asyncio/runners.py
@@ -103,7 +103,10 @@ class Runner:
             try:
                 signal.signal(signal.SIGINT, sigint_handler)
             except ValueError:
-                pass
+                # `signal.signal` may throw if `threading.main_thread` does
+                # not support signals (e.g. embedded interpreter with signals
+                # not registered - see gh-91880)
+                signal_handler = None
         else:
             sigint_handler = None
 

--- a/Lib/test/test_asyncio/test_runners.py
+++ b/Lib/test/test_asyncio/test_runners.py
@@ -3,10 +3,12 @@ import asyncio
 import contextvars
 import gc
 import re
+import signal
 import threading
 import unittest
 
 from unittest import mock
+from unittest.mock import patch
 from test.test_asyncio import utils as test_utils
 
 
@@ -373,6 +375,23 @@ class RunnerTests(BaseTest):
 
         with asyncio.Runner() as runner:
             with self.assertRaises(asyncio.CancelledError):
+                runner.run(coro())
+    
+    def test_signal_install_not_supported_ok(self):
+        # signal.signal() can throw if the "main thread" doensn't have signals enabled
+        assert threading.current_thread() is threading.main_thread()
+
+        async def coro():
+            pass
+
+        with asyncio.Runner() as runner:
+            with patch.object(
+                signal,
+                "signal",
+                side_effect=ValueError(
+                    "signal only works in main thread of the main interpreter"
+                )
+            ):
                 runner.run(coro())
 
 


### PR DESCRIPTION
As suggested in https://github.com/python/cpython/pull/32105#issuecomment-1104360465 by @gvanrossum, add a `try/except` around use of `signal.signal` to protect against possible exceptions.