### PR TITLE
gh-91888: add a `:gh:` role to the documentation

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -44,6 +44,7 @@ import suspicious
 
 
 ISSUE_URI = 'https://bugs.python.org/issue?@action=redirect&bpo=%s'
+GH_ISSUE_URI = 'https://github.com/python/cpython/issues/%s'
 SOURCE_URI = 'https://github.com/python/cpython/tree/main/%s'
 
 # monkey-patch reST parser to disable alphabetic and roman enumerated lists
@@ -58,8 +59,30 @@ Body.enum.converters['loweralpha'] = \
 
 def issue_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     issue = utils.unescape(text)
+    # sanity check: there are no bpo issues within these two values
+    if int(issue) > 47261 and int(issue) < 400000:
+        msg = inliner.reporter.error(f'The bpo id {text!r} seems too high -- '
+                                     f'use :gh:`...` for GitHub ids.', line=lineno)
+        prb = inliner.problematic(rawtext, rawtext, msg)
+        return [prb], [msg]
     text = 'bpo-' + issue
     refnode = nodes.reference(text, text, refuri=ISSUE_URI % issue)
+    return [refnode], []
+
+
+# Support for marking up and linking to GitHub issues
+
+def gh_issue_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
+    issue = utils.unescape(text)
+    # sanity check: all GitHub issues have highest ID
+    # note that there is some overlapping with bpo ids
+    if int(issue) < 32427:
+        msg = inliner.reporter.error(f'The GitHub id {text!r} seems too low -- '
+                                     f'use :issue:`...` for bpo ids.', line=lineno)
+        prb = inliner.problematic(rawtext, rawtext, msg)
+        return [prb], [msg]
+    text = 'gh-' + issue
+    refnode = nodes.reference(text, text, refuri=GH_ISSUE_URI % issue)
     return [refnode], []
 
 
@@ -615,6 +638,7 @@ def process_audit_events(app, doctree, fromdocname):
 
 def setup(app):
     app.add_role('issue', issue_role)
+    app.add_role('gh', gh_issue_role)
     app.add_role('source', source_role)
     app.add_directive('impl-detail', ImplementationDetail)
     app.add_directive('availability', Availability)

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -60,9 +60,9 @@ Body.enum.converters['loweralpha'] = \
 def issue_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     issue = utils.unescape(text)
     # sanity check: there are no bpo issues within these two values
-    if int(issue) > 47261 and int(issue) < 400000:
-        msg = inliner.reporter.error(f'The bpo id {text!r} seems too high -- '
-                                     f'use :gh:`...` for GitHub ids.', line=lineno)
+    if 47261 < int(issue) < 400000:
+        msg = inliner.reporter.error(f'The BPO ID {text!r} seems too high -- '
+                                     'use :gh:`...` for GitHub IDs', line=lineno)
         prb = inliner.problematic(rawtext, rawtext, msg)
         return [prb], [msg]
     text = 'bpo-' + issue
@@ -74,11 +74,11 @@ def issue_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
 
 def gh_issue_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     issue = utils.unescape(text)
-    # sanity check: all GitHub issues have highest ID
-    # note that there is some overlapping with bpo ids
-    if int(issue) < 32427:
-        msg = inliner.reporter.error(f'The GitHub id {text!r} seems too low -- '
-                                     f'use :issue:`...` for bpo ids.', line=lineno)
+    # sanity check: all GitHub issues have ID >= 32426
+    # even though some of them are also valid BPO IDs
+    if int(issue) < 32426:
+        msg = inliner.reporter.error(f'The GitHub ID {text!r} seems too low -- '
+                                     'use :issue:`...` for BPO IDs', line=lineno)
         prb = inliner.problematic(rawtext, rawtext, msg)
         return [prb], [msg]
     text = 'gh-' + issue

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -332,7 +332,7 @@ inspect
   line number, column and end column). The affected functions are:
   :func:`inspect.getframeinfo`, :func:`inspect.getouterframes`, :func:`inspect.getinnerframes`,
   :func:`inspect.stack` and :func:`inspect.trace`. (Contributed by Pablo Galindo in
-  :issue:`88116`)
+  :gh:`88116`)
 
 locale
 ------

--- a/Misc/NEWS.d/next/Documentation/2022-04-24-22-09-31.gh-issue-91888.kTjJLx.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-04-24-22-09-31.gh-issue-91888.kTjJLx.rst
@@ -1,0 +1,1 @@
+Add a new `gh` role to the documentation to link to GitHub issues.


### PR DESCRIPTION
This PR adds the `` :gh:`...` `` role proposed in GH-91888.

Some comments about the PR:
* A `` :pr:`...` `` (or `:gh-pr:`) role could be added too
* To be more explicit, we could also use `` :gh-issue:`...` `` instead of `` :gh:`...` ``
* A `` :bpo:`...` `` alias to the `:issue:` role could be added, and `:issue:` deprecated