### PR TITLE
gh-91904: Fix setting envvar PYTHONREGRTEST_UNICODE_GUARD

### DIFF
--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -105,7 +105,7 @@ def setup_tests(ns):
 
     # Ensure there's a non-ASCII character in env vars at all times to force
     # tests consider this case. See BPO-44647 for details.
-    if TESTFN_UNDECODABLE and hasattr(os, 'environb'):
+    if TESTFN_UNDECODABLE and os.supports_bytes_environ:
         os.environb.setdefault(UNICODE_GUARD_ENV.encode(), TESTFN_UNDECODABLE)
     elif FS_NONASCII:
         os.environ.setdefault(UNICODE_GUARD_ENV, FS_NONASCII)

--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -5,6 +5,7 @@ import signal
 import sys
 import unittest
 from test import support
+from test.support.os_helper import TESTFN_UNDECODABLE, FS_NONASCII
 try:
     import gc
 except ImportError:
@@ -104,10 +105,10 @@ def setup_tests(ns):
 
     # Ensure there's a non-ASCII character in env vars at all times to force
     # tests consider this case. See BPO-44647 for details.
-    os.environ.setdefault(
-        UNICODE_GUARD_ENV,
-        "\N{SMILING FACE WITH SUNGLASSES}",
-    )
+    if TESTFN_UNDECODABLE and hasattr(os, 'environb'):
+        os.environb.setdefault(UNICODE_GUARD_ENV.encode(), TESTFN_UNDECODABLE)
+    elif FS_NONASCII:
+        os.environ.setdefault(UNICODE_GUARD_ENV, FS_NONASCII)
 
 
 def replace_stdout():

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1339,7 +1339,7 @@ class ArgsTestCase(BaseTestCase):
     def test_unicode_guard_env(self):
         guard = os.environ.get(setup.UNICODE_GUARD_ENV)
         self.assertIsNotNone(guard, f"{setup.UNICODE_GUARD_ENV} not set")
-        if guard != "\N{SMILING FACE WITH SUNGLASSES}":
+        if guard.isascii():
             # Skip to signify that the env var value was changed by the user;
             # possibly to something ASCII to work around Unicode issues.
             self.skipTest("Modified guard")

--- a/Misc/NEWS.d/next/Tests/2022-04-25-11-16-36.gh-issue-91904.13Uvrz.rst
+++ b/Misc/NEWS.d/next/Tests/2022-04-25-11-16-36.gh-issue-91904.13Uvrz.rst
@@ -1,2 +1,2 @@
-Fix initialization of :env:`PYTHONREGRTEST_UNICODE_GUARD` which prevented
+Fix initialization of :envvar:`PYTHONREGRTEST_UNICODE_GUARD` which prevented
 running regression tests on non-UTF-8 locale.

--- a/Misc/NEWS.d/next/Tests/2022-04-25-11-16-36.gh-issue-91904.13Uvrz.rst
+++ b/Misc/NEWS.d/next/Tests/2022-04-25-11-16-36.gh-issue-91904.13Uvrz.rst
@@ -1,0 +1,2 @@
+Fix initialization of :env:`PYTHONREGRTEST_UNICODE_GUARD` which prevented
+running regression tests on non-UTF-8 locale.


### PR DESCRIPTION
It always failed on non-UTF-8 locale and prevented running regrtests.

Closes #91904.