### PR TITLE
gh-91914: Fix test_curses on non-UTF-8 locale

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -268,7 +268,12 @@ class TestCurses(unittest.TestCase):
         stdscr.echochar(b'A')
         stdscr.echochar(65)
         with self.assertRaises((UnicodeEncodeError, OverflowError)):
-            stdscr.echochar('\u20ac')
+            # Unicode is not fully supported yet, but at least it does
+            # not crash.
+            # It is supposed to fail because either the character is
+            # not encodable with the current encoding, or it is encoded to
+            # a multibyte sequence.
+            stdscr.echochar('\u0114')
         stdscr.echochar('A', curses.A_BOLD)
         self.assertIs(stdscr.is_wintouched(), False)
 


### PR DESCRIPTION
Closes #91914.