### PR TITLE
gh-91916: Fix test_runpy on non-UTF-8 locale

### DIFF
--- a/Lib/test/test_runpy.py
+++ b/Lib/test/test_runpy.py
@@ -740,8 +740,7 @@ class RunPathTestCase(unittest.TestCase, CodeExecutionMixin):
                       "runpy.run_path(%r)\n") % dummy_dir
             script_name = self._make_test_script(script_dir, mod_name, source)
             zip_name, fname = make_zip_script(script_dir, 'test_zip', script_name)
-            msg = "recursion depth exceeded"
-            self.assertRaisesRegex(RecursionError, msg, run_path, zip_name)
+            self.assertRaises(RecursionError, run_path, zip_name)
 
     def test_encoding(self):
         with temp_dir() as script_dir:


### PR DESCRIPTION
If use a non-builtin codec, partially implemented in Python
(e.g. ISO-8859-15), a new RecursionError (with empty error message)
can be raised while handle a RecursionError.

Testing for error message was needed to distinguish
a recursion error from arbitrary RuntimeError. After introducing
RecursionError, it became unnecessary.

Closes #91916.
