### PR TITLE
gh-91927: Add helpers for obtaining new references to various singletons

### DIFF
--- a/Doc/c-api/bool.rst
+++ b/Doc/c-api/bool.rst
@@ -29,6 +29,20 @@ are available, however.
    just like any other object with respect to reference counts.
 
 
+.. c:function:: void Py_RefFalse(void)
+
+   Return a new reference to :const:`False`.
+
+   This function never returns ``NULL``.
+
+
+.. c:function:: void Py_RefTrue(void)
+
+   Return a new reference to :const:`True`.
+
+   This function never returns ``NULL``.
+
+
 .. c:macro:: Py_RETURN_FALSE
 
    Return :const:`Py_False` from a function, properly incrementing its reference
@@ -45,3 +59,5 @@ are available, however.
 
    Return a new reference to :const:`Py_True` or :const:`Py_False` depending on the
    truth value of *v*.
+
+   This function never returns ``NULL``.

--- a/Doc/c-api/none.rst
+++ b/Doc/c-api/none.rst
@@ -20,7 +20,16 @@ same reason.
    counts.
 
 
+.. c:function:: void Py_RefNone(void)
+
+   Return a new reference to :const:`None`.
+
+   This function never returns ``NULL``.
+
+
 .. c:macro:: Py_RETURN_NONE
 
-   Properly handle returning :c:data:`Py_None` from within a C function (that is,
-   increment the reference count of ``None`` and return it.)
+   Properly handle returning :c:data:`Py_None` from within a C function.
+   Equivalent to::
+
+       return Py_RefNone()

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -12,6 +12,13 @@ Object Protocol
    not implemented for the given type combination.
 
 
+.. c:function:: void Py_RefNotImplemented(void)
+
+   Return a new reference to :const:`NotImplemented`.
+
+   This function never returns ``NULL``.
+
+
 .. c:macro:: Py_RETURN_NOTIMPLEMENTED
 
    Properly handle returning :c:data:`Py_NotImplemented` from within a C

--- a/Doc/c-api/slice.rst
+++ b/Doc/c-api/slice.rst
@@ -121,3 +121,10 @@ Ellipsis Object
    The Python ``Ellipsis`` object.  This object has no methods.  It needs to be
    treated just like any other object with respect to reference counts.  Like
    :c:data:`Py_None` it is a singleton object.
+
+
+.. c:function:: void Py_RefEllipsis(void)
+
+   Return a new reference to :const:`Ellipsis`.
+
+   This function never returns ``NULL``.

--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -406,7 +406,6 @@ size of an internal pointer is equal::
    static PyObject *
    newdatatype_richcmp(PyObject *obj1, PyObject *obj2, int op)
    {
-       PyObject *result;
        int c, size1, size2;
 
        /* code to make sure that both arguments are of type
@@ -423,9 +422,7 @@ size of an internal pointer is equal::
        case Py_GT: c = size1 >  size2; break;
        case Py_GE: c = size1 >= size2; break;
        }
-       result = c ? Py_True : Py_False;
-       Py_INCREF(result);
-       return result;
+       return PyBool_FromLong(c);
     }
 
 

--- a/Include/boolobject.h
+++ b/Include/boolobject.h
@@ -22,6 +22,20 @@ PyAPI_DATA(PyLongObject) _Py_TrueStruct;
 #define Py_False ((PyObject *) &_Py_FalseStruct)
 #define Py_True ((PyObject *) &_Py_TrueStruct)
 
+// Return a new reference to the False singleton.
+// The function cannot return NULL.
+static inline PyObject *Py_RefFalse(void)
+{
+    return Py_NewRef(Py_False);
+}
+
+// Return a new reference to the True singleton.
+// The function cannot return NULL.
+static inline PyObject *Py_RefTrue(void)
+{
+    return Py_NewRef(Py_True);
+}
+
 // Test if an object is the True singleton, the same as "x is True" in Python.
 PyAPI_FUNC(int) Py_IsTrue(PyObject *x);
 #define Py_IsTrue(x) Py_Is((x), Py_True)
@@ -31,8 +45,8 @@ PyAPI_FUNC(int) Py_IsFalse(PyObject *x);
 #define Py_IsFalse(x) Py_Is((x), Py_False)
 
 /* Macros for returning Py_True or Py_False, respectively */
-#define Py_RETURN_TRUE return Py_NewRef(Py_True)
-#define Py_RETURN_FALSE return Py_NewRef(Py_False)
+#define Py_RETURN_TRUE return Py_RefTrue()
+#define Py_RETURN_FALSE return Py_RefFalse()
 
 /* Function to return a bool from a C long */
 PyAPI_FUNC(PyObject *) PyBool_FromLong(long);

--- a/Include/boolobject.h
+++ b/Include/boolobject.h
@@ -48,8 +48,15 @@ PyAPI_FUNC(int) Py_IsFalse(PyObject *x);
 #define Py_RETURN_TRUE return Py_RefTrue()
 #define Py_RETURN_FALSE return Py_RefFalse()
 
-/* Function to return a bool from a C long */
+// Function to return a bool from a C long
+// The function cannot return NULL.
 PyAPI_FUNC(PyObject *) PyBool_FromLong(long);
+
+static inline PyObject *_PyBool_FromLong(long ok)
+{
+    return Py_NewRef(ok ? Py_True : Py_False);
+}
+#define PyBool_FromLong(ok) _PyBool_FromLong(ok)
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -370,8 +370,10 @@ struct _Py_global_strings {
 
 #define _Py_ID(NAME) \
      (_Py_SINGLETON(strings.identifiers._ ## NAME._ascii.ob_base))
+#define _Py_RefID(NAME) Py_NewRef(&_Py_ID(NAME))
 #define _Py_STR(NAME) \
      (_Py_SINGLETON(strings.literals._ ## NAME._ascii.ob_base))
+#define _Py_RefSTR(NAME) Py_NewRef(&_Py_STR(NAME))
 
 /* _Py_DECLARE_STR() should precede all uses of _Py_STR() in a function.
 

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 #include "pycore_global_objects.h"  // _PY_NSMALLNEGINTS
-#include "pycore_runtime.h"       // _PyRuntime
+#include "pycore_runtime.h"         // _PyRuntime
 
 
 /* runtime lifecycle */
@@ -33,10 +33,24 @@ extern void _PyLong_FiniTypes(PyInterpreterState *interp);
 static inline PyObject* _PyLong_GetZero(void)
 { return (PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS]; }
 
+// Return a new reference to the zero singleton.
+// The function cannot return NULL.
+static inline PyObject* _PyLong_RefZero(void)
+{
+    return Py_NewRef(_PyLong_GetZero());
+}
+
 // Return a borrowed reference to the one singleton.
 // The function cannot return NULL.
 static inline PyObject* _PyLong_GetOne(void)
 { return (PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS+1]; }
+
+// Return a new reference to the one singleton.
+// The function cannot return NULL.
+static inline PyObject* _PyLong_RefOne(void)
+{
+    return Py_NewRef(_PyLong_GetOne());
+}
 
 static inline PyObject* _PyLong_FromUnsignedChar(unsigned char i)
 {

--- a/Include/object.h
+++ b/Include/object.h
@@ -622,8 +622,15 @@ PyAPI_DATA(PyObject) _Py_NoneStruct; /* Don't use this directly */
 PyAPI_FUNC(int) Py_IsNone(PyObject *x);
 #define Py_IsNone(x) Py_Is((x), Py_None)
 
+// Return a new reference to the None singleton.
+// The function cannot return NULL.
+static inline PyObject *Py_RefNone(void)
+{
+    return Py_NewRef(Py_None);
+}
+
 /* Macro for returning Py_None from a function */
-#define Py_RETURN_NONE return Py_NewRef(Py_None)
+#define Py_RETURN_NONE return Py_RefNone()
 
 /*
 Py_NotImplemented is a singleton used to signal that an operation is
@@ -632,8 +639,15 @@ not implemented for a given type combination.
 PyAPI_DATA(PyObject) _Py_NotImplementedStruct; /* Don't use this directly */
 #define Py_NotImplemented (&_Py_NotImplementedStruct)
 
+// Return a new reference to the NotImplemented singleton.
+// The function cannot return NULL.
+static inline PyObject *Py_RefNotImplemented(void)
+{
+    return Py_NewRef(Py_NotImplemented);
+}
+
 /* Macro for returning Py_NotImplemented from a function */
-#define Py_RETURN_NOTIMPLEMENTED return Py_NewRef(Py_NotImplemented)
+#define Py_RETURN_NOTIMPLEMENTED return Py_RefNotImplemented()
 
 /* Rich comparison opcodes */
 #define Py_LT 0

--- a/Include/sliceobject.h
+++ b/Include/sliceobject.h
@@ -10,6 +10,13 @@ PyAPI_DATA(PyObject) _Py_EllipsisObject; /* Don't use this directly */
 
 #define Py_Ellipsis (&_Py_EllipsisObject)
 
+// Return a new reference to the Ellipsis singleton.
+// The function cannot return NULL.
+static inline PyObject *Py_RefEllipsis(void)
+{
+    return Py_NewRef(Py_Ellipsis);
+}
+
 /* Slice object interface */
 
 /*

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -597,8 +597,7 @@ _abc__abc_instancecheck_impl(PyObject *module, PyObject *self,
         goto end;
     }
     if (incache > 0) {
-        result = Py_True;
-        Py_INCREF(result);
+        result = Py_RefTrue();
         goto end;
     }
     subtype = (PyObject *)Py_TYPE(instance);
@@ -609,8 +608,7 @@ _abc__abc_instancecheck_impl(PyObject *module, PyObject *self,
                 goto end;
             }
             if (incache > 0) {
-                result = Py_False;
-                Py_INCREF(result);
+                result = Py_RefFalse();
                 goto end;
             }
         }

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2640,8 +2640,7 @@ PyCData_GetContainer(CDataObject *self)
             if (self->b_objects == NULL)
                 return NULL;
         } else {
-            Py_INCREF(Py_None);
-            self->b_objects = Py_None;
+            self->b_objects = Py_RefNone();
         }
     }
     return self;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5399,9 +5399,8 @@ datetime_subtract(PyObject *left, PyObject *right)
             int delta_d, delta_s, delta_us;
 
             if (GET_DT_TZINFO(left) == GET_DT_TZINFO(right)) {
-                offset2 = offset1 = Py_None;
-                Py_INCREF(offset1);
-                Py_INCREF(offset2);
+                offset1 = Py_RefNone();
+                offset2 = Py_RefNone();
             }
             else {
                 offset1 = datetime_utcoffset(left, NULL);

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1324,8 +1324,7 @@ tzinfo_from_isoformat_results(int rv, int tzoffset, int tz_useconds)
         Py_DECREF(delta);
     }
     else {
-        tzinfo = Py_None;
-        Py_INCREF(Py_None);
+        tzinfo = Py_RefNone();
     }
 
     return tzinfo;
@@ -4442,12 +4441,10 @@ time_richcompare(PyObject *self, PyObject *other, int op)
         result = diff_to_bool(diff, op);
     }
     else if (op == Py_EQ) {
-        result = Py_False;
-        Py_INCREF(result);
+        result = Py_RefFalse();
     }
     else if (op == Py_NE) {
-        result = Py_True;
-        Py_INCREF(result);
+        result = Py_RefTrue();
     }
     else {
         PyErr_SetString(PyExc_TypeError,
@@ -5742,12 +5739,10 @@ datetime_richcompare(PyObject *self, PyObject *other, int op)
         result = diff_to_bool(diff, op);
     }
     else if (op == Py_EQ) {
-        result = Py_False;
-        Py_INCREF(result);
+        result = Py_RefFalse();
     }
     else if (op == Py_NE) {
-        result = Py_True;
-        Py_INCREF(result);
+        result = Py_RefTrue();
     }
     else {
         PyErr_SetString(PyExc_TypeError,

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -116,15 +116,13 @@ static PyTypeObject PyDecContextManager_Type;
 Py_LOCAL_INLINE(PyObject *)
 incr_true(void)
 {
-    Py_INCREF(Py_True);
-    return Py_True;
+    return Py_RefTrue();
 }
 
 Py_LOCAL_INLINE(PyObject *)
 incr_false(void)
 {
-    Py_INCREF(Py_False);
-    return Py_False;
+    return Py_RefFalse();
 }
 
 
@@ -2881,8 +2879,7 @@ convert_op(int type_err, PyObject **conv, PyObject *v, PyObject *context)
             Py_TYPE(v)->tp_name);
     }
     else {
-        Py_INCREF(Py_NotImplemented);
-        *conv = Py_NotImplemented;
+        *conv = Py_RefNotImplemented();
     }
     return 0;
 }
@@ -3074,8 +3071,7 @@ convert_op_cmp(PyObject **vcmp, PyObject **wcmp, PyObject *v, PyObject *w,
             }
         }
         else {
-            Py_INCREF(Py_NotImplemented);
-            *wcmp = Py_NotImplemented;
+            *wcmp = Py_RefNotImplemented();
         }
     }
     else {
@@ -3093,8 +3089,7 @@ convert_op_cmp(PyObject **vcmp, PyObject **wcmp, PyObject *v, PyObject *w,
             }
         }
         else {
-            Py_INCREF(Py_NotImplemented);
-            *wcmp = Py_NotImplemented;
+            *wcmp = Py_RefNotImplemented();
         }
     }
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -113,19 +113,6 @@ static PyTypeObject PyDecContextManager_Type;
 #define CtxCaps(v) (((PyDecContextObject *)v)->capitals)
 
 
-Py_LOCAL_INLINE(PyObject *)
-incr_true(void)
-{
-    return Py_RefTrue();
-}
-
-Py_LOCAL_INLINE(PyObject *)
-incr_false(void)
-{
-    return Py_RefFalse();
-}
-
-
 #ifndef WITH_DECIMAL_CONTEXTVAR
 /* Key for thread state dictionary */
 static PyObject *tls_context_key = NULL;
@@ -569,7 +556,7 @@ signaldict_getitem(PyObject *self, PyObject *key)
         return NULL;
     }
 
-    return SdFlags(self)&flag ? incr_true() : incr_false();
+    return SdFlags(self)&flag ? Py_RefTrue() : Py_RefFalse();
 }
 
 static int
@@ -3990,7 +3977,7 @@ nm_##MPDFUNC(PyObject *self, PyObject *other)                    \
 static PyObject *                                           \
 dec_##MPDFUNC(PyObject *self, PyObject *dummy UNUSED)       \
 {                                                           \
-    return MPDFUNC(MPD(self)) ? incr_true() : incr_false(); \
+    return MPDFUNC(MPD(self)) ? Py_RefTrue() : Py_RefFalse(); \
 }
 
 /* Boolean function with an optional context arg. */
@@ -4007,7 +3994,7 @@ dec_##MPDFUNC(PyObject *self, PyObject *args, PyObject *kwds)             \
     }                                                                     \
     CONTEXT_CHECK_VA(context);                                            \
                                                                           \
-    return MPDFUNC(MPD(self), CTX(context)) ? incr_true() : incr_false(); \
+    return MPDFUNC(MPD(self), CTX(context)) ? Py_RefTrue() : Py_RefFalse(); \
 }
 
 /* Unary function with an optional context arg. */
@@ -4492,7 +4479,7 @@ dec_mpd_same_quantum(PyObject *self, PyObject *args, PyObject *kwds)
     CONTEXT_CHECK_VA(context);
     CONVERT_BINOP_RAISE(&a, &b, self, other, context);
 
-    result = mpd_same_quantum(MPD(a), MPD(b)) ? incr_true() : incr_false();
+    result = mpd_same_quantum(MPD(a), MPD(b)) ? Py_RefTrue() : Py_RefFalse();
     Py_DECREF(a);
     Py_DECREF(b);
 
@@ -4587,7 +4574,7 @@ dec_richcompare(PyObject *v, PyObject *w, int op)
         }
         /* qNaN comparison with op={eq,ne} or comparison
          * with InvalidOperation disabled. */
-        return (op == Py_NE) ? incr_true() : incr_false();
+        return (op == Py_NE) ? Py_RefTrue() : Py_RefFalse();
     }
 
     switch (op) {
@@ -5052,7 +5039,7 @@ ctx_##MPDFUNC(PyObject *context, PyObject *v)                         \
                                                                       \
     CONVERT_OP_RAISE(&a, v, context);                                 \
                                                                       \
-    ret = MPDFUNC(MPD(a), CTX(context)) ? incr_true() : incr_false(); \
+    ret = MPDFUNC(MPD(a), CTX(context)) ? Py_RefTrue() : Py_RefFalse(); \
     Py_DECREF(a);                                                     \
     return ret;                                                       \
 }
@@ -5067,7 +5054,7 @@ ctx_##MPDFUNC(PyObject *context, PyObject *v)           \
                                                         \
     CONVERT_OP_RAISE(&a, v, context);                   \
                                                         \
-    ret = MPDFUNC(MPD(a)) ? incr_true() : incr_false(); \
+    ret = MPDFUNC(MPD(a)) ? Py_RefTrue() : Py_RefFalse(); \
     Py_DECREF(a);                                       \
     return ret;                                         \
 }
@@ -5354,7 +5341,7 @@ ctx_iscanonical(PyObject *context UNUSED, PyObject *v)
         return NULL;
     }
 
-    return mpd_iscanonical(MPD(v)) ? incr_true() : incr_false();
+    return mpd_iscanonical(MPD(v)) ? Py_RefTrue() : Py_RefFalse();
 }
 
 /* Functions with a single decimal argument */
@@ -5560,7 +5547,7 @@ ctx_mpd_same_quantum(PyObject *context, PyObject *args)
 
     CONVERT_BINOP_RAISE(&a, &b, v, w, context);
 
-    result = mpd_same_quantum(MPD(a), MPD(b)) ? incr_true() : incr_false();
+    result = mpd_same_quantum(MPD(a), MPD(b)) ? Py_RefTrue() : Py_RefFalse();
     Py_DECREF(a);
     Py_DECREF(b);
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -556,7 +556,7 @@ signaldict_getitem(PyObject *self, PyObject *key)
         return NULL;
     }
 
-    return SdFlags(self)&flag ? Py_RefTrue() : Py_RefFalse();
+    return PyBool_FromLong(SdFlags(self) & flag);
 }
 
 static int
@@ -3977,7 +3977,7 @@ nm_##MPDFUNC(PyObject *self, PyObject *other)                    \
 static PyObject *                                           \
 dec_##MPDFUNC(PyObject *self, PyObject *dummy UNUSED)       \
 {                                                           \
-    return MPDFUNC(MPD(self)) ? Py_RefTrue() : Py_RefFalse(); \
+    return PyBool_FromLong(MPDFUNC(MPD(self)));             \
 }
 
 /* Boolean function with an optional context arg. */
@@ -3994,7 +3994,7 @@ dec_##MPDFUNC(PyObject *self, PyObject *args, PyObject *kwds)             \
     }                                                                     \
     CONTEXT_CHECK_VA(context);                                            \
                                                                           \
-    return MPDFUNC(MPD(self), CTX(context)) ? Py_RefTrue() : Py_RefFalse(); \
+    return PyBool_FromLong(MPDFUNC(MPD(self), CTX(context)));             \
 }
 
 /* Unary function with an optional context arg. */
@@ -4479,7 +4479,7 @@ dec_mpd_same_quantum(PyObject *self, PyObject *args, PyObject *kwds)
     CONTEXT_CHECK_VA(context);
     CONVERT_BINOP_RAISE(&a, &b, self, other, context);
 
-    result = mpd_same_quantum(MPD(a), MPD(b)) ? Py_RefTrue() : Py_RefFalse();
+    result = PyBool_FromLong(mpd_same_quantum(MPD(a), MPD(b)));
     Py_DECREF(a);
     Py_DECREF(b);
 
@@ -4574,7 +4574,7 @@ dec_richcompare(PyObject *v, PyObject *w, int op)
         }
         /* qNaN comparison with op={eq,ne} or comparison
          * with InvalidOperation disabled. */
-        return (op == Py_NE) ? Py_RefTrue() : Py_RefFalse();
+        return PyBool_FromLong(op == Py_NE);
     }
 
     switch (op) {
@@ -5039,7 +5039,7 @@ ctx_##MPDFUNC(PyObject *context, PyObject *v)                         \
                                                                       \
     CONVERT_OP_RAISE(&a, v, context);                                 \
                                                                       \
-    ret = MPDFUNC(MPD(a), CTX(context)) ? Py_RefTrue() : Py_RefFalse(); \
+    ret = PyBool_FromLong(MPDFUNC(MPD(a), CTX(context)));             \
     Py_DECREF(a);                                                     \
     return ret;                                                       \
 }
@@ -5054,7 +5054,7 @@ ctx_##MPDFUNC(PyObject *context, PyObject *v)           \
                                                         \
     CONVERT_OP_RAISE(&a, v, context);                   \
                                                         \
-    ret = MPDFUNC(MPD(a)) ? Py_RefTrue() : Py_RefFalse(); \
+    ret = PyBool_FromLong(MPDFUNC(MPD(a)));             \
     Py_DECREF(a);                                       \
     return ret;                                         \
 }
@@ -5341,7 +5341,7 @@ ctx_iscanonical(PyObject *context UNUSED, PyObject *v)
         return NULL;
     }
 
-    return mpd_iscanonical(MPD(v)) ? Py_RefTrue() : Py_RefFalse();
+    return PyBool_FromLong(mpd_iscanonical(MPD(v)));
 }
 
 /* Functions with a single decimal argument */
@@ -5547,7 +5547,7 @@ ctx_mpd_same_quantum(PyObject *context, PyObject *args)
 
     CONVERT_BINOP_RAISE(&a, &b, v, w, context);
 
-    result = mpd_same_quantum(MPD(a), MPD(b)) ? Py_RefTrue() : Py_RefFalse();
+    result = PyBool_FromLong(mpd_same_quantum(MPD(a), MPD(b)));
     Py_DECREF(a);
     Py_DECREF(b);
 
@@ -5999,15 +5999,12 @@ PyInit__decimal(void)
 
 #ifndef WITH_DECIMAL_CONTEXTVAR
     ASSIGN_PTR(tls_context_key, PyUnicode_FromString("___DECIMAL_CTX__"));
-    Py_INCREF(Py_False);
-    CHECK_INT(PyModule_AddObject(m, "HAVE_CONTEXTVAR", Py_False));
+    CHECK_INT(PyModule_AddObject(m, "HAVE_CONTEXTVAR", Py_RefFalse()));
 #else
     ASSIGN_PTR(current_context_var, PyContextVar_New("decimal_context", NULL));
-    Py_INCREF(Py_True);
-    CHECK_INT(PyModule_AddObject(m, "HAVE_CONTEXTVAR", Py_True));
+    CHECK_INT(PyModule_AddObject(m, "HAVE_CONTEXTVAR", Py_RefTrue()));
 #endif
-    Py_INCREF(Py_True);
-    CHECK_INT(PyModule_AddObject(m, "HAVE_THREADS", Py_True));
+    CHECK_INT(PyModule_AddObject(m, "HAVE_THREADS", Py_RefTrue()));
 
     /* Init basic context template */
     ASSIGN_PTR(basic_context_template,

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -415,11 +415,9 @@ element_init(PyObject *self, PyObject *args, PyObject *kwds)
     Py_INCREF(tag);
     Py_XSETREF(self_elem->tag, tag);
 
-    Py_INCREF(Py_None);
-    _set_joined_ptr(&self_elem->text, Py_None);
+    _set_joined_ptr(&self_elem->text, Py_RefNone());
 
-    Py_INCREF(Py_None);
-    _set_joined_ptr(&self_elem->tail, Py_None);
+    _set_joined_ptr(&self_elem->tail, Py_RefNone());
 
     return 0;
 }
@@ -694,11 +692,9 @@ _elementtree_Element_clear_impl(ElementObject *self)
 {
     clear_extra(self);
 
-    Py_INCREF(Py_None);
-    _set_joined_ptr(&self->text, Py_None);
+    _set_joined_ptr(&self->text, Py_RefNone());
 
-    Py_INCREF(Py_None);
-    _set_joined_ptr(&self->tail, Py_None);
+    _set_joined_ptr(&self->tail, Py_RefNone());
 
     Py_RETURN_NONE;
 }

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -282,11 +282,9 @@ create_new_element(PyObject* tag, PyObject* attrib)
     Py_INCREF(tag);
     self->tag = tag;
 
-    Py_INCREF(Py_None);
-    self->text = Py_None;
+    self->text = Py_RefNone();
 
-    Py_INCREF(Py_None);
-    self->tail = Py_None;
+    self->tail = Py_RefNone();
 
     self->weakreflist = NULL;
 
@@ -307,14 +305,11 @@ element_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     ElementObject *e = (ElementObject *)type->tp_alloc(type, 0);
     if (e != NULL) {
-        Py_INCREF(Py_None);
-        e->tag = Py_None;
+        e->tag = Py_RefNone();
 
-        Py_INCREF(Py_None);
-        e->text = Py_None;
+        e->text = Py_RefNone();
 
-        Py_INCREF(Py_None);
-        e->tail = Py_None;
+        e->tail = Py_RefNone();
 
         e->extra = NULL;
         e->weakreflist = NULL;
@@ -2354,10 +2349,8 @@ treebuilder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (t != NULL) {
         t->root = NULL;
 
-        Py_INCREF(Py_None);
-        t->this = Py_None;
-        Py_INCREF(Py_None);
-        t->last = Py_None;
+        t->this = Py_RefNone();
+        t->last = Py_RefNone();
 
         t->data = NULL;
         t->element_factory = NULL;
@@ -3504,8 +3497,7 @@ expat_start_doctype_handler(XMLParserObject *self,
             return;
         }
     } else {
-        Py_INCREF(Py_None);
-        sysid_obj = Py_None;
+        sysid_obj = Py_RefNone();
     }
 
     if (pubid) {
@@ -3516,8 +3508,7 @@ expat_start_doctype_handler(XMLParserObject *self,
             return;
         }
     } else {
-        Py_INCREF(Py_None);
-        pubid_obj = Py_None;
+        pubid_obj = Py_RefNone();
     }
 
     /* If the target has a handler for doctype, call it. */

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -481,8 +481,7 @@ buffered_close(buffered *self, PyObject *args)
     if (r < 0)
         goto end;
     if (r > 0) {
-        res = Py_None;
-        Py_INCREF(res);
+        res = Py_RefNone();
         goto end;
     }
 
@@ -1007,8 +1006,7 @@ _buffered_readinto_generic(buffered *self, Py_buffer *buffer, char readinto1)
             break;
         if (n < 0) {
             if (n == -2) {
-                Py_INCREF(Py_None);
-                res = Py_None;
+                res = Py_RefNone();
             }
             goto end;
         }

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -791,8 +791,7 @@ bytesio_getstate(bytesio *self, PyObject *Py_UNUSED(ignored))
     if (initvalue == NULL)
         return NULL;
     if (self->dict == NULL) {
-        Py_INCREF(Py_None);
-        dict = Py_None;
+        dict = Py_RefNone();
     }
     else {
         dict = PyDict_Copy(self->dict);

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -822,8 +822,7 @@ stringio_getstate(stringio *self, PyObject *Py_UNUSED(ignored))
     if (initvalue == NULL)
         return NULL;
     if (self->dict == NULL) {
-        Py_INCREF(Py_None);
-        dict = Py_None;
+        dict = Py_RefNone();
     }
     else {
         dict = PyDict_Copy(self->dict);

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1111,7 +1111,7 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
 
     if (encoding == NULL && _PyRuntime.preconfig.utf8_mode) {
         _Py_DECLARE_STR(utf_8, "utf-8");
-        self->encoding = Py_NewRef(&_Py_STR(utf_8));
+        self->encoding = _Py_RefSTR(utf_8);
     }
     else if (encoding == NULL || (strcmp(encoding, "locale") == 0)) {
         self->encoding = _Py_GetLocaleEncodingObject();
@@ -2231,7 +2231,7 @@ _textiowrapper_readline(textio *self, Py_ssize_t limit)
         Py_CLEAR(chunks);
     }
     if (line == NULL) {
-        line = &_Py_STR(empty);
+        line = _Py_RefSTR(empty);
     }
 
     return line;

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -480,8 +480,7 @@ _locale__getdefaultlocale_impl(PyObject *module)
     }
 
     /* cannot determine the language code (very unlikely) */
-    Py_INCREF(Py_None);
-    return Py_BuildValue("Os", Py_None, encoding);
+    return Py_BuildValue("Os", Py_RefNone(), encoding);
 }
 #endif
 

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -555,8 +555,7 @@ static int statsForEntry(rotating_node_t *node, void *arg)
         }
     }
     else {
-        Py_INCREF(Py_None);
-        collect->sublist = Py_None;
+        collect->sublist = Py_RefNone();
     }
 
     info = PyObject_CallFunction((PyObject*) collect->state->stats_entry_type,

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -706,8 +706,7 @@ static PyObject *
 _operator_is__impl(PyObject *module, PyObject *a, PyObject *b)
 /*[clinic end generated code: output=bcd47a402e482e1d input=5fa9b97df03c427f]*/
 {
-    PyObject *result = Py_Is(a, b) ? Py_True : Py_False;
-    return Py_NewRef(result);
+    return PyBool_FromLong(Py_Is(a, b));
 }
 
 /*[clinic input]
@@ -720,10 +719,7 @@ static PyObject *
 _operator_is_not_impl(PyObject *module, PyObject *a, PyObject *b)
 /*[clinic end generated code: output=491a1f2f81f6c7f9 input=5a93f7e1a93535f1]*/
 {
-    PyObject *result;
-    result = (a != b) ? Py_True : Py_False;
-    Py_INCREF(result);
-    return result;
+    return PyBool_FromLong(a != b);
 }
 
 /* compare_digest **********************************************************/

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1975,9 +1975,7 @@ whichmodule(PyObject *global, PyObject *dotted_path)
     }
 
     /* If no module is found, use __main__. */
-    module_name = &_Py_ID(__main__);
-    Py_INCREF(module_name);
-    return module_name;
+    return _Py_RefID(__main__);
 }
 
 /* fast_save_enter() and fast_save_leave() are guards against recursive

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -163,8 +163,7 @@ simplequeue_pop_item(simplequeueobject *self)
     assert(self->lst_pos < n);
 
     item = PyList_GET_ITEM(self->lst, self->lst_pos);
-    Py_INCREF(Py_None);
-    PyList_SET_ITEM(self->lst, self->lst_pos, Py_None);
+    PyList_SET_ITEM(self->lst, self->lst_pos, Py_RefNone());
     self->lst_pos += 1;
     count = n - self->lst_pos;
     if (self->lst_pos > count) {

--- a/Modules/_scproxy.c
+++ b/Modules/_scproxy.c
@@ -104,13 +104,11 @@ get_proxy_settings(PyObject* Py_UNUSED(mod), PyObject *Py_UNUSED(ignored))
 
             aString = CFArrayGetValueAtIndex(anArray, i);
             if (aString == NULL) {
-                PyTuple_SetItem(v, i, Py_None);
-                Py_INCREF(Py_None);
+                PyTuple_SetItem(v, i, Py_RefNone());
             } else {
                 PyObject* t = cfstring_to_pystring(aString);
                 if (!t) {
-                    PyTuple_SetItem(v, i, Py_None);
-                    Py_INCREF(Py_None);
+                    PyTuple_SetItem(v, i, Py_RefNone());
                 } else {
                     PyTuple_SetItem(v, i, t);
                 }

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -260,7 +260,7 @@ pysqlite_connection_init_impl(pysqlite_Connection *self,
     self->cursors = cursors;
     self->blobs = blobs;
     self->created_cursors = 0;
-    self->row_factory = Py_NewRef(Py_None);
+    self->row_factory = Py_RefNone();
     self->text_factory = Py_NewRef(&PyUnicode_Type);
     self->trace_ctx = NULL;
     self->progress_ctx = NULL;
@@ -740,7 +740,7 @@ _pysqlite_build_py_params(sqlite3_context *context, int argc,
             }
             case SQLITE_NULL:
             default:
-                cur_py_value = Py_NewRef(Py_None);
+                cur_py_value = Py_RefNone();
         }
 
         if (!cur_py_value) {
@@ -1842,7 +1842,7 @@ pysqlite_connection_interrupt_impl(pysqlite_Connection *self)
 
     sqlite3_interrupt(self->db);
 
-    retval = Py_NewRef(Py_None);
+    retval = Py_RefNone();
 
 finally:
     return retval;

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -301,7 +301,7 @@ _pysqlite_fetch_one_row(pysqlite_Cursor* self)
                     PyErr_NoMemory();
                     goto error;
                 }
-                converted = Py_NewRef(Py_None);
+                converted = Py_RefNone();
             }
             else {
                 nbytes = sqlite3_column_bytes(self->statement->st, i);
@@ -317,7 +317,7 @@ _pysqlite_fetch_one_row(pysqlite_Cursor* self)
             coltype = sqlite3_column_type(self->statement->st, i);
             Py_END_ALLOW_THREADS
             if (coltype == SQLITE_NULL) {
-                converted = Py_NewRef(Py_None);
+                converted = Py_RefNone();
             } else if (coltype == SQLITE_INTEGER) {
                 converted = PyLong_FromLongLong(sqlite3_column_int64(self->statement->st, i));
             } else if (coltype == SQLITE_FLOAT) {

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -53,18 +53,15 @@ pysqlite_cursor_init_impl(pysqlite_Cursor *self,
     Py_CLEAR(self->statement);
     Py_CLEAR(self->row_cast_map);
 
-    Py_INCREF(Py_None);
-    Py_XSETREF(self->description, Py_None);
+    Py_XSETREF(self->description, Py_RefNone());
 
-    Py_INCREF(Py_None);
-    Py_XSETREF(self->lastrowid, Py_None);
+    Py_XSETREF(self->lastrowid, Py_RefNone());
 
     self->arraysize = 1;
     self->closed = 0;
     self->rowcount = -1L;
 
-    Py_INCREF(Py_None);
-    Py_XSETREF(self->row_factory, Py_None);
+    Py_XSETREF(self->row_factory, Py_RefNone());
 
     if (!pysqlite_check_thread(self->connection)) {
         return -1;
@@ -514,8 +511,7 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* operation
     }
 
     /* reset description and rowcount */
-    Py_INCREF(Py_None);
-    Py_SETREF(self->description, Py_None);
+    Py_SETREF(self->description, Py_RefNone());
     self->rowcount = 0L;
 
     if (self->statement) {

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -98,11 +98,7 @@ static PyObject *
 pysqlite_complete_statement_impl(PyObject *module, const char *statement)
 /*[clinic end generated code: output=e55f1ff1952df558 input=ac45d257375bb828]*/
 {
-    if (sqlite3_complete(statement)) {
-        return Py_RefTrue();
-    } else {
-        return Py_RefFalse();
-    }
+    return PyBool_FromLong(sqlite3_complete(statement));
 }
 
 /*[clinic input]

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -99,9 +99,9 @@ pysqlite_complete_statement_impl(PyObject *module, const char *statement)
 /*[clinic end generated code: output=e55f1ff1952df558 input=ac45d257375bb828]*/
 {
     if (sqlite3_complete(statement)) {
-        return Py_NewRef(Py_True);
+        return Py_RefTrue();
     } else {
-        return Py_NewRef(Py_False);
+        return Py_RefFalse();
     }
 }
 
@@ -199,7 +199,7 @@ pysqlite_register_converter_impl(PyObject *module, PyObject *orig_name,
         goto error;
     }
 
-    retval = Py_NewRef(Py_None);
+    retval = Py_RefNone();
 error:
     Py_XDECREF(name);
     return retval;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5940,9 +5940,7 @@ sslmodule_init_constants(PyObject *m)
 
 #define addbool(m, key, value) \
     do { \
-        PyObject *bool_obj = (value) ? Py_True : Py_False; \
-        Py_INCREF(bool_obj); \
-        PyModule_AddObject((m), (key), bool_obj); \
+        PyModule_AddObject((m), (key), PyBool_FromLong(value)); \
     } while (0)
 
     addbool(m, "HAS_SNI", 1);

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1907,8 +1907,7 @@ cipher_to_tuple(const SSL_CIPHER *cipher)
 
     cipher_name = SSL_CIPHER_get_name(cipher);
     if (cipher_name == NULL) {
-        Py_INCREF(Py_None);
-        PyTuple_SET_ITEM(retval, 0, Py_None);
+        PyTuple_SET_ITEM(retval, 0, Py_RefNone());
     } else {
         v = PyUnicode_FromString(cipher_name);
         if (v == NULL)
@@ -1918,8 +1917,7 @@ cipher_to_tuple(const SSL_CIPHER *cipher)
 
     cipher_protocol = SSL_CIPHER_get_version(cipher);
     if (cipher_protocol == NULL) {
-        Py_INCREF(Py_None);
-        PyTuple_SET_ITEM(retval, 1, Py_None);
+        PyTuple_SET_ITEM(retval, 1, Py_RefNone());
     } else {
         v = PyUnicode_FromString(cipher_protocol);
         if (v == NULL)
@@ -5209,7 +5207,7 @@ _ssl_get_default_verify_paths_impl(PyObject *module)
 #define CONVERT(info, target) { \
         const char *tmp = (info); \
         target = NULL; \
-        if (!tmp) { Py_INCREF(Py_None); target = Py_None; } \
+        if (!tmp) { target = Py_RefNone(); } \
         else if ((target = PyUnicode_DecodeFSDefault(tmp)) == NULL) { \
             target = PyBytes_FromString(tmp); } \
         if (!target) goto error; \

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -503,8 +503,7 @@ fill_and_set_sslerror(_sslmodulestate *state,
             if (verify_str != NULL) {
                 verify_obj = PyUnicode_FromString(verify_str);
             } else {
-                verify_obj = Py_None;
-                Py_INCREF(verify_obj);
+                verify_obj = Py_RefNone();
             }
             break;
         }
@@ -1029,8 +1028,7 @@ _asn1obj2py(_sslmodulestate *state, const ASN1_OBJECT *name, int no_name)
         }
     }
     if (!buflen && no_name) {
-        Py_INCREF(Py_None);
-        name_obj = Py_None;
+        name_obj = Py_RefNone();
     }
     else {
         name_obj = PyUnicode_FromStringAndSize(namebuf, buflen);
@@ -1879,8 +1877,7 @@ _ssl__SSLSocket_get_unverified_chain_impl(PySSLSocket *self)
         X509 *peer = SSL_get_peer_certificate(self->ssl);
 
         if (peer == NULL) {
-            peerobj = Py_None;
-            Py_INCREF(peerobj);
+            peerobj = Py_RefNone();
         } else {
             /* consume X509 reference on success */
             peerobj = _PySSL_CertificateFromX509(self->ctx->state, peer, 0);

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1445,7 +1445,7 @@ s_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self = alloc_func(type, 0);
     if (self != NULL) {
         PyStructObject *s = (PyStructObject*)self;
-        s->s_format = Py_NewRef(Py_None);
+        s->s_format = Py_RefNone();
         s->s_codes = NULL;
         s->s_size = -1;
         s->s_len = -1;

--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -2504,7 +2504,6 @@ cmp_contig(PyObject *self, PyObject *args)
 {
     PyObject *b1, *b2; /* buffer objects */
     Py_buffer v1, v2;
-    PyObject *ret;
     int equal = 0;
 
     if (!PyArg_ParseTuple(args, "OO", &b1, &b2)) {
@@ -2558,9 +2557,7 @@ result:
     PyBuffer_Release(&v1);
     PyBuffer_Release(&v2);
 
-    ret = equal ? Py_True : Py_False;
-    Py_INCREF(ret);
-    return ret;
+    return PyBool_FromLong(equal);
 }
 
 static PyObject *

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2055,8 +2055,7 @@ test_Z_code(PyObject *self, PyObject *Py_UNUSED(ignored))
 
     obj = PyUnicode_FromString("test");
     PyTuple_SET_ITEM(tuple, 0, obj);
-    Py_INCREF(Py_None);
-    PyTuple_SET_ITEM(tuple, 1, Py_None);
+    PyTuple_SET_ITEM(tuple, 1, Py_RefNone());
 
     /* swap values on purpose */
     value1 = NULL;

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1289,7 +1289,7 @@ test_type_from_ephemeral_spec(PyObject *self, PyObject *Py_UNUSED(ignored))
     assert(strcmp(PyUnicode_AsUTF8(obj), "<test>") == 0);
     Py_CLEAR(obj);
 
-    result = Py_NewRef(Py_None);
+    result = Py_RefNone();
   finally:
     PyMem_Del(spec);
     PyMem_Del(name);
@@ -1715,8 +1715,7 @@ getargs_z_star(PyObject *self, PyObject *args)
     if (buffer.buf != NULL)
         bytes = PyBytes_FromStringAndSize(buffer.buf, buffer.len);
     else {
-        Py_INCREF(Py_None);
-        bytes = Py_None;
+        bytes = Py_RefNone();
     }
     PyBuffer_Release(&buffer);
     return bytes;
@@ -1979,8 +1978,7 @@ parse_tuple_and_keywords(PyObject *self, PyObject *args)
         buffers + 4, buffers + 5, buffers + 6, buffers + 7);
 
     if (result) {
-        return_value = Py_None;
-        Py_INCREF(Py_None);
+        return_value = Py_RefNone();
     }
 
 exit:
@@ -4280,8 +4278,7 @@ test_setallocators(PyMemAllocatorDomain domain)
         goto fail;
     }
 
-    Py_INCREF(Py_None);
-    res = Py_None;
+    res = Py_RefNone();
     goto finally;
 
 fail:
@@ -4563,8 +4560,7 @@ call_in_temporary_c_thread(PyObject *self, PyObject *callback)
         PyThread_release_lock(test_c_thread.exit_event);
     Py_END_ALLOW_THREADS
 
-    Py_INCREF(Py_None);
-    res = Py_None;
+    res = Py_RefNone();
 
 exit:
     Py_CLEAR(test_c_thread.callback);

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -1736,8 +1736,7 @@ SetVar(TkappObject *self, PyObject *args, int flags)
         if (!ok)
             Tkinter_Error(self);
         else {
-            res = Py_None;
-            Py_INCREF(res);
+            res = Py_RefNone();
         }
         LEAVE_OVERLAP_TCL
         break;
@@ -1755,8 +1754,7 @@ SetVar(TkappObject *self, PyObject *args, int flags)
         if (!ok)
             Tkinter_Error(self);
         else {
-            res = Py_None;
-            Py_INCREF(res);
+            res = Py_RefNone();
         }
         LEAVE_OVERLAP_TCL
         break;
@@ -1842,8 +1840,7 @@ UnsetVar(TkappObject *self, PyObject *args, int flags)
     if (code == TCL_ERROR)
         res = Tkinter_Error(self);
     else {
-        Py_INCREF(Py_None);
-        res = Py_None;
+        res = Py_RefNone();
     }
     LEAVE_OVERLAP_TCL
     return res;

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -2685,13 +2685,9 @@ zoneinfomodule_exec(PyObject *m)
     }
 
     if (NO_TTINFO.utcoff == NULL) {
-        NO_TTINFO.utcoff = Py_None;
-        NO_TTINFO.dstoff = Py_None;
-        NO_TTINFO.tzname = Py_None;
-
-        for (size_t i = 0; i < 3; ++i) {
-            Py_INCREF(Py_None);
-        }
+        NO_TTINFO.utcoff = Py_RefNone();
+        NO_TTINFO.dstoff = Py_RefNone();
+        NO_TTINFO.tzname = Py_RefNone();
     }
 
     if (initialize_caches()) {

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -704,12 +704,7 @@ array_richcompare(PyObject *v, PyObject *w, int op)
 
     if (Py_SIZE(va) != Py_SIZE(wa) && (op == Py_EQ || op == Py_NE)) {
         /* Shortcut: if the lengths differ, the arrays differ */
-        if (op == Py_EQ)
-            res = Py_False;
-        else
-            res = Py_True;
-        Py_INCREF(res);
-        return res;
+        return PyBool_FromLong(op != Py_EQ);
     }
 
     if (va->ob_descr == wa->ob_descr && va->ob_descr->compareitems != NULL) {
@@ -731,9 +726,7 @@ array_richcompare(PyObject *v, PyObject *w, int op)
         case Py_GE: cmp = result >= 0; break;
         default: return NULL; /* cannot happen */
         }
-        PyObject *res = cmp ? Py_True : Py_False;
-        Py_INCREF(res);
-        return res;
+        return PyBool_FromLong(cmp);
     }
 
 
@@ -773,12 +766,7 @@ array_richcompare(PyObject *v, PyObject *w, int op)
         case Py_GE: cmp = vs >= ws; break;
         default: return NULL; /* cannot happen */
         }
-        if (cmp)
-            res = Py_True;
-        else
-            res = Py_False;
-        Py_INCREF(res);
-        return res;
+        return PyBool_FromLong(cmp);
     }
 
     /* We have an item that differs.  First, shortcuts for EQ/NE */

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -783,12 +783,10 @@ array_richcompare(PyObject *v, PyObject *w, int op)
 
     /* We have an item that differs.  First, shortcuts for EQ/NE */
     if (op == Py_EQ) {
-        Py_INCREF(Py_False);
-        res = Py_False;
+        res = Py_RefFalse();
     }
     else if (op == Py_NE) {
-        Py_INCREF(Py_True);
-        res = Py_True;
+        res = Py_RefTrue();
     }
     else {
         /* Compare the final item again using the proper operator */
@@ -2223,8 +2221,7 @@ array_array___reduce_ex___impl(arrayobject *self, PyTypeObject *cls,
         return NULL;
     }
     if (dict == NULL) {
-        dict = Py_None;
-        Py_INCREF(dict);
+        dict = Py_RefNone();
     }
 
     mformat_code = typecode_to_mformat_code(typecode);

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1869,14 +1869,7 @@ static PyObject *
 gc_is_tracked(PyObject *module, PyObject *obj)
 /*[clinic end generated code: output=14f0103423b28e31 input=d83057f170ea2723]*/
 {
-    PyObject *result;
-
-    if (_PyObject_IS_GC(obj) && _PyObject_GC_IS_TRACKED(obj))
-        result = Py_True;
-    else
-        result = Py_False;
-    Py_INCREF(result);
-    return result;
+    return PyBool_FromLong(_PyObject_IS_GC(obj) && _PyObject_GC_IS_TRACKED(obj));
 }
 
 /*[clinic input]

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -586,8 +586,7 @@ wchar_to_dict(PyObject *dict, const char *key, const wchar_t *s)
             return 0;
         }
     } else {
-        u = Py_None;
-        Py_INCREF(u);
+        u = Py_RefNone();
     }
     r = PyDict_SetItemString(dict, key, u) == 0;
     Py_DECREF(u);
@@ -612,8 +611,7 @@ decode_to_dict(PyObject *dict, const char *key, const char *s)
             return 0;
         }
     } else {
-        u = Py_None;
-        Py_INCREF(u);
+        u = Py_RefNone();
     }
     r = PyDict_SetItemString(dict, key, u) == 0;
     Py_DECREF(u);

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -81,8 +81,7 @@ mkgrent(PyObject *module, struct group *p)
     if (p->gr_passwd)
             SET(setIndex++, PyUnicode_DecodeFSDefault(p->gr_passwd));
     else {
-            SET(setIndex++, Py_None);
-            Py_INCREF(Py_None);
+            SET(setIndex++, Py_RefNone());
     }
     SET(setIndex++, _PyLong_FromGid(p->gr_gid));
     SET(setIndex++, w);

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -4586,8 +4586,7 @@ zip_longest_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
     for (i=0 ; i < tuplesize ; i++) {
-        Py_INCREF(Py_None);
-        PyTuple_SET_ITEM(result, i, Py_None);
+        PyTuple_SET_ITEM(result, i, Py_RefNone());
     }
 
     /* create ziplongestobject structure */

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -1761,8 +1761,7 @@ islice_reduce(isliceobject *lz, PyObject *Py_UNUSED(ignored))
         return Py_BuildValue("O(Nn)n", Py_TYPE(lz), empty_it, 0, 0);
     }
     if (lz->stop == -1) {
-        stop = Py_None;
-        Py_INCREF(stop);
+        stop = Py_RefNone();
     } else {
         stop = PyLong_FromSsize_t(lz->stop);
         if (stop == NULL)
@@ -3678,8 +3677,7 @@ accumulate_next(accumulateobject *lz)
 
     if (lz->initial != Py_None) {
         lz->total = lz->initial;
-        Py_INCREF(Py_None);
-        lz->initial = Py_None;
+        lz->initial = Py_RefNone();
         Py_INCREF(lz->total);
         return lz->total;
     }

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -845,7 +845,7 @@ math_gcd(PyObject *module, PyObject * const *args, Py_ssize_t nargs)
     Py_ssize_t i;
 
     if (nargs == 0) {
-        return PyLong_FromLong(0);
+        return _PyLong_RefZero();
     }
     res = PyNumber_Index(args[0]);
     if (res == NULL) {
@@ -891,7 +891,7 @@ long_lcm(PyObject *a, PyObject *b)
     PyObject *g, *m, *f, *ab;
 
     if (Py_SIZE(a) == 0 || Py_SIZE(b) == 0) {
-        return PyLong_FromLong(0);
+        return _PyLong_RefZero();
     }
     g = _PyLong_GCD(a, b);
     if (g == NULL) {
@@ -920,7 +920,7 @@ math_lcm(PyObject *module, PyObject * const *args, Py_ssize_t nargs)
     Py_ssize_t i;
 
     if (nargs == 0) {
-        return PyLong_FromLong(1);
+        return _PyLong_RefOne();
     }
     res = PyNumber_Index(args[0]);
     if (res == NULL) {
@@ -1797,7 +1797,7 @@ math_isqrt(PyObject *module, PyObject *n)
     }
     if (_PyLong_Sign(n) == 0) {
         Py_DECREF(n);
-        return PyLong_FromLong(0);
+        return _PyLong_RefZero();
     }
 
     /* c = (n.bit_length() - 1) // 2 */
@@ -2031,9 +2031,7 @@ factorial_odd_part(unsigned long n)
     unsigned long v, lower, upper;
     PyObject *partial, *tmp, *inner, *outer;
 
-    inner = PyLong_FromLong(1);
-    if (inner == NULL)
-        return NULL;
+    inner = _PyLong_RefOne();
     outer = inner;
     Py_INCREF(outer);
 
@@ -3383,7 +3381,7 @@ static PyObject *
 perm_comb_small(unsigned long long n, unsigned long long k, int iscomb)
 {
     if (k == 0) {
-        return PyLong_FromLong(1);
+        return _PyLong_RefOne();
     }
 
     /* For small enough n and k the result fits in the 64-bit range and can
@@ -3504,7 +3502,7 @@ static PyObject *
 perm_comb(PyObject *n, unsigned long long k, int iscomb)
 {
     if (k == 0) {
-        return PyLong_FromLong(1);
+        return _PyLong_RefOne();
     }
     if (k == 1) {
         Py_INCREF(n);
@@ -3605,7 +3603,7 @@ math_perm_impl(PyObject *module, PyObject *n, PyObject *k)
     cmp = PyObject_RichCompareBool(n, k, Py_LT);
     if (cmp != 0) {
         if (cmp > 0) {
-            result = PyLong_FromLong(0);
+            result = _PyLong_RefZero();
             goto done;
         }
         goto error;
@@ -3701,7 +3699,7 @@ math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
         ki = PyLong_AsLongLongAndOverflow(k, &overflow);
         assert(overflow >= 0 && !PyErr_Occurred());
         if (overflow || ki > ni) {
-            result = PyLong_FromLong(0);
+            result = _PyLong_RefZero();
             goto done;
         }
         assert(ki >= 0);
@@ -3722,7 +3720,7 @@ math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
         }
         if (Py_SIZE(temp) < 0) {
             Py_DECREF(temp);
-            result = PyLong_FromLong(0);
+            result = _PyLong_RefZero();
             goto done;
         }
         cmp = PyObject_RichCompareBool(temp, k, Py_LT);

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7970,8 +7970,7 @@ os_kill_impl(PyObject *module, pid_t pid, Py_ssize_t signal)
         err = GetLastError();
         result = PyErr_SetFromWindowsErr(err);
     } else {
-        Py_INCREF(Py_None);
-        result = Py_None;
+        result = Py_RefNone();
     }
 
     CloseHandle(handle);

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -71,8 +71,7 @@ sets(PyObject *v, int i, const char* val)
       PyStructSequence_SET_ITEM(v, i, o);
   }
   else {
-      PyStructSequence_SET_ITEM(v, i, Py_None);
-      Py_INCREF(Py_None);
+      PyStructSequence_SET_ITEM(v, i, Py_RefNone());
   }
 }
 

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -4241,8 +4241,7 @@ sock_sendall(PySocketSockObject *s, PyObject *args)
     } while (len > 0);
     PyBuffer_Release(&pbuf);
 
-    Py_INCREF(Py_None);
-    res = Py_None;
+    res = Py_RefNone();
 
 done:
     PyBuffer_Release(&pbuf);

--- a/Modules/spwdmodule.c
+++ b/Modules/spwdmodule.c
@@ -80,8 +80,7 @@ sets(PyObject *v, int i, const char* val)
       PyObject *o = PyUnicode_DecodeFSDefault(val);
       PyStructSequence_SET_ITEM(v, i, o);
   } else {
-      PyStructSequence_SET_ITEM(v, i, Py_None);
-      Py_INCREF(Py_None);
+      PyStructSequence_SET_ITEM(v, i, Py_RefNone());
   }
 }
 

--- a/Modules/testcapi_long.h
+++ b/Modules/testcapi_long.h
@@ -202,6 +202,5 @@ TESTNAME(PyObject *error(const char*))
         Py_DECREF(Py_None);
     }
 
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }

--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -217,8 +217,7 @@ Xxo_demo(XxoObject *self, PyTypeObject *defining_class,
         return o;
     }
 
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyMethodDef Xxo_methods[] = {

--- a/Modules/xxlimited_35.c
+++ b/Modules/xxlimited_35.c
@@ -67,8 +67,7 @@ Xxo_demo(XxoObject *self, PyObject *args)
         Py_INCREF(o);
         return o;
     }
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyMethodDef Xxo_methods[] = {
@@ -176,8 +175,7 @@ xx_roj(PyObject *self, PyObject *args)
     long b;
     if (!PyArg_ParseTuple(args, "O#:roj", &a, &b))
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 

--- a/Modules/xxmodule.c
+++ b/Modules/xxmodule.c
@@ -52,8 +52,7 @@ Xxo_demo(XxoObject *self, PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ":demo"))
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyMethodDef Xxo_methods[] = {
@@ -195,8 +194,7 @@ xx_bug(PyObject *self, PyObject *args)
     printf("\n");
     /* Py_DECREF(item); */
 
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 /* Test bad format character */
@@ -208,8 +206,7 @@ xx_roj(PyObject *self, PyObject *args)
     long b;
     if (!PyArg_ParseTuple(args, "O#:roj", &a, &b))
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 
@@ -266,8 +263,7 @@ static PyTypeObject Str_Type = {
 static PyObject *
 null_richcompare(PyObject *self, PyObject *other, int op)
 {
-    Py_INCREF(Py_NotImplemented);
-    return Py_NotImplemented;
+    Py_RETURN_NOTIMPLEMENTED;
 }
 
 static PyTypeObject Null_Type = {

--- a/Modules/xxsubtype.c
+++ b/Modules/xxsubtype.c
@@ -39,8 +39,7 @@ spamlist_setstate(spamlistobject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "i:setstate", &state))
         return NULL;
     self->state = state;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -164,8 +163,7 @@ spamdict_setstate(spamdictobject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "i:setstate", &state))
         return NULL;
     self->state = state;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyMethodDef spamdict_methods[] = {

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -14,17 +14,12 @@ bool_repr(PyObject *self)
 
 /* Function to return a bool from a C long */
 
+#undef PyBool_FromLong
 PyObject *PyBool_FromLong(long ok)
 {
-    PyObject *result;
-
-    if (ok)
-        result = Py_True;
-    else
-        result = Py_False;
-    Py_INCREF(result);
-    return result;
+    return _PyBool_FromLong(ok);
 }
+#define PyBool_FromLong(ok) _PyBool_FromLong(ok)
 
 /* We define bool_new to always return either Py_True or Py_False */
 

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -9,7 +9,7 @@
 static PyObject *
 bool_repr(PyObject *self)
 {
-    return self == Py_True ? &_Py_ID(True) : &_Py_ID(False);
+    return self == Py_True ? _Py_RefID(True) : _Py_RefID(False);
 }
 
 /* Function to return a bool from a C long */

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -246,7 +246,6 @@ static PyObject *
 method_richcompare(PyObject *self, PyObject *other, int op)
 {
     PyMethodObject *a, *b;
-    PyObject *res;
     int eq;
 
     if ((op != Py_EQ && op != Py_NE) ||
@@ -263,12 +262,7 @@ method_richcompare(PyObject *self, PyObject *other, int op)
     }
     else if (eq < 0)
         return NULL;
-    if (op == Py_EQ)
-        res = eq ? Py_True : Py_False;
-    else
-        res = eq ? Py_False : Py_True;
-    Py_INCREF(res);
-    return res;
+    return PyBool_FromLong(eq == (op == Py_EQ));
 }
 
 static PyObject *
@@ -462,7 +456,6 @@ static PyObject *
 instancemethod_richcompare(PyObject *self, PyObject *other, int op)
 {
     PyInstanceMethodObject *a, *b;
-    PyObject *res;
     int eq;
 
     if ((op != Py_EQ && op != Py_NE) ||
@@ -476,12 +469,7 @@ instancemethod_richcompare(PyObject *self, PyObject *other, int op)
     eq = PyObject_RichCompareBool(a->func, b->func, Py_EQ);
     if (eq < 0)
         return NULL;
-    if (op == Py_EQ)
-        res = eq ? Py_True : Py_False;
-    else
-        res = eq ? Py_False : Py_True;
-    Py_INCREF(res);
-    return res;
+    return PyBool_FromLong(eq == (op == Py_EQ));
 }
 
 static PyObject *

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1074,8 +1074,7 @@ lineiter_next(lineiterator *li)
     start = PyLong_FromLong(bounds->ar_start);
     end = PyLong_FromLong(bounds->ar_end);
     if (bounds->ar_line < 0) {
-        Py_INCREF(Py_None);
-        line = Py_None;
+        line = Py_RefNone();
     }
     else {
         line = PyLong_FromLong(bounds->ar_line);

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -449,8 +449,7 @@ to_complex(PyObject **pobj, Py_complex *pc)
         pc->real = PyFloat_AsDouble(obj);
         return 0;
     }
-    Py_INCREF(Py_NotImplemented);
-    *pobj = Py_NotImplemented;
+    *pobj = Py_RefNotImplemented();
     return -1;
 }
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3206,21 +3206,15 @@ static PyObject *
 dict_richcompare(PyObject *v, PyObject *w, int op)
 {
     int cmp;
-    PyObject *res;
 
-    if (!PyDict_Check(v) || !PyDict_Check(w)) {
-        res = Py_NotImplemented;
+    if (!PyDict_Check(v) || !PyDict_Check(w) || (op != Py_EQ && op != Py_NE)) {
+        Py_RETURN_NOTIMPLEMENTED;
     }
-    else if (op == Py_EQ || op == Py_NE) {
-        cmp = dict_equal((PyDictObject *)v, (PyDictObject *)w);
-        if (cmp < 0)
-            return NULL;
-        res = (cmp == (op == Py_EQ)) ? Py_True : Py_False;
-    }
-    else
-        res = Py_NotImplemented;
-    Py_INCREF(res);
-    return res;
+
+    cmp = dict_equal((PyDictObject *)v, (PyDictObject *)w);
+    if (cmp < 0)
+        return NULL;
+    return PyBool_FromLong(cmp == (op == Py_EQ));
 }
 
 /*[clinic input]
@@ -4643,7 +4637,6 @@ dictview_richcompare(PyObject *self, PyObject *other, int op)
 {
     Py_ssize_t len_self, len_other;
     int ok;
-    PyObject *result;
 
     assert(self != NULL);
     assert(PyDictViewSet_Check(self));
@@ -4693,9 +4686,7 @@ dictview_richcompare(PyObject *self, PyObject *other, int op)
     }
     if (ok < 0)
         return NULL;
-    result = ok ? Py_True : Py_False;
-    Py_INCREF(result);
-    return result;
+    return PyBool_FromLong(ok);
 }
 
 static PyObject *

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1285,7 +1285,7 @@ exception_group_projection(PyObject *eg, PyObject *keep)
     }
 
     PyObject *result = split_result.match ?
-        split_result.match : Py_NewRef(Py_None);
+        split_result.match : Py_RefNone();
     assert(split_result.rest == NULL);
     return result;
 }
@@ -1330,7 +1330,7 @@ _PyExc_PrepReraiseStar(PyObject *orig, PyObject *excs)
     Py_ssize_t numexcs = PyList_GET_SIZE(excs);
 
     if (numexcs == 0) {
-        return Py_NewRef(Py_None);
+        Py_RETURN_NONE;
     }
 
     if (!_PyBaseExceptionGroup_Check(orig)) {

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1998,8 +1998,7 @@ OSError_reduce(PyOSErrorObject *self, PyObject *Py_UNUSED(ignored))
              * So, to recreate filename2, we need to pass in
              * winerror as well.
              */
-            Py_INCREF(Py_None);
-            PyTuple_SET_ITEM(args, 3, Py_None);
+            PyTuple_SET_ITEM(args, 3, Py_RefNone());
 
             /* filename2 */
             Py_INCREF(self->filename2);

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -362,8 +362,7 @@ convert_to_double(PyObject **v, double *dbl)
         }
     }
     else {
-        Py_INCREF(Py_NotImplemented);
-        *v = Py_NotImplemented;
+        *v = Py_RefNotImplemented();
         return -1;
     }
     return 0;

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1596,9 +1596,7 @@ float_as_integer_ratio_impl(PyObject *self)
     numerator = PyLong_FromDouble(float_part);
     if (numerator == NULL)
         goto error;
-    denominator = PyLong_FromLong(1);
-    if (denominator == NULL)
-        goto error;
+    denominator = _PyLong_RefOne();
     py_exponent = PyLong_FromLong(Py_ABS(exponent));
     if (py_exponent == NULL)
         goto error;

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -30,8 +30,7 @@ _PyFunction_FromConstructor(PyFrameConstructor *constr)
     op->func_defaults = NULL;
     op->func_kwdefaults = NULL;
     op->func_closure = NULL;
-    Py_INCREF(Py_None);
-    op->func_doc = Py_None;
+    op->func_doc = Py_RefNone();
     op->func_dict = NULL;
     op->func_weakreflist = NULL;
     op->func_module = NULL;

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -692,8 +692,8 @@ func_clear(PyFunctionObject *op)
     // However, name and qualname could be str subclasses, so they
     // could have reference cycles. The solution is to replace them
     // with a genuinely immutable string.
-    Py_SETREF(op->func_name, Py_NewRef(&_Py_STR(empty)));
-    Py_SETREF(op->func_qualname, Py_NewRef(&_Py_STR(empty)));
+    Py_SETREF(op->func_name, _Py_RefSTR(empty));
+    Py_SETREF(op->func_qualname, _Py_RefSTR(empty));
     return 0;
 }
 

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -192,8 +192,7 @@ gen_send_ex2(PyGenObject *gen, PyObject *arg, PyObject **presult,
         else if (arg && !exc) {
             /* `gen` is an exhausted generator:
                only return value if called from send(). */
-            *presult = Py_None;
-            Py_INCREF(*presult);
+            *presult = Py_RefNone();
             return PYGEN_RETURN;
         }
         return PYGEN_ERROR;
@@ -687,8 +686,7 @@ _PyGen_FetchStopIterationValue(PyObject **pvalue)
         return -1;
     }
     if (value == NULL) {
-        value = Py_None;
-        Py_INCREF(value);
+        value = Py_RefNone();
     }
     *pvalue = value;
     return 0;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -821,7 +821,7 @@ _PyLong_FromByteArray(const unsigned char* bytes, size_t n,
     Py_ssize_t idigit = 0;              /* next free index in v->ob_digit */
 
     if (n == 0)
-        return PyLong_FromLong(0L);
+        return _PyLong_RefZero();
 
     if (little_endian) {
         pstartbyte = bytes;
@@ -2672,9 +2672,7 @@ long_divrem(PyLongObject *a, PyLongObject *b,
         if (*prem == NULL) {
             return -1;
         }
-        PyObject *zero = _PyLong_GetZero();
-        Py_INCREF(zero);
-        *pdiv = (PyLongObject*)zero;
+        *pdiv = (PyLongObject*)_PyLong_RefZero();
         return 0;
     }
     if (size_b == 1) {
@@ -3202,7 +3200,7 @@ x_sub(PyLongObject *a, PyLongObject *b)
         while (--i >= 0 && a->ob_digit[i] == b->ob_digit[i])
             ;
         if (i < 0)
-            return (PyLongObject *)PyLong_FromLong(0);
+            return (PyLongObject *)_PyLong_RefZero();
         if (a->ob_digit[i] < b->ob_digit[i]) {
             sign = -1;
             { PyLongObject *temp = a; a = b; b = temp; }
@@ -3489,7 +3487,7 @@ k_mul(PyLongObject *a, PyLongObject *b)
     i = a == b ? KARATSUBA_SQUARE_CUTOFF : KARATSUBA_CUTOFF;
     if (asize <= i) {
         if (asize == 0)
-            return (PyLongObject *)PyLong_FromLong(0);
+            return (PyLongObject *)_PyLong_RefZero();
         else
             return x_mul(a, b);
     }
@@ -4258,15 +4256,8 @@ long_invmod(PyLongObject *a, PyLongObject *n)
     /* Should only ever be called for positive n */
     assert(Py_SIZE(n) > 0);
 
-    b = (PyLongObject *)PyLong_FromLong(1L);
-    if (b == NULL) {
-        return NULL;
-    }
-    c = (PyLongObject *)PyLong_FromLong(0L);
-    if (c == NULL) {
-        Py_DECREF(b);
-        return NULL;
-    }
+    b = (PyLongObject *)_PyLong_RefOne();
+    c = (PyLongObject *)_PyLong_RefZero();
     Py_INCREF(a);
     Py_INCREF(n);
 
@@ -4398,7 +4389,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
         /* if modulus == 1:
                return 0 */
         if ((Py_SIZE(c) == 1) && (c->ob_digit[0] == 1)) {
-            z = (PyLongObject *)PyLong_FromLong(0L);
+            z = (PyLongObject *)_PyLong_RefZero();
             goto Done;
         }
 
@@ -4444,7 +4435,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
     /* At this point a, b, and c are guaranteed non-negative UNLESS
        c is NULL, in which case a may be negative. */
 
-    z = (PyLongObject *)PyLong_FromLong(1L);
+    z = (PyLongObject *)_PyLong_RefOne();
     if (z == NULL)
         goto Error;
 
@@ -4720,7 +4711,7 @@ long_rshift1(PyLongObject *a, Py_ssize_t wordshift, digit remshift)
     else {
         newsize = Py_SIZE(a) - wordshift;
         if (newsize <= 0)
-            return PyLong_FromLong(0);
+            return _PyLong_RefZero();
         hishift = PyLong_SHIFT - remshift;
         z = _PyLong_New(newsize);
         if (z == NULL)
@@ -4751,7 +4742,7 @@ long_rshift(PyObject *a, PyObject *b)
         return NULL;
     }
     if (Py_SIZE(a) == 0) {
-        return PyLong_FromLong(0);
+        return _PyLong_RefZero();
     }
     if (divmod_shift(b, &wordshift, &remshift) < 0)
         return NULL;
@@ -4767,7 +4758,7 @@ _PyLong_Rshift(PyObject *a, size_t shiftby)
 
     assert(PyLong_Check(a));
     if (Py_SIZE(a) == 0) {
-        return PyLong_FromLong(0);
+        return _PyLong_RefZero();
     }
     wordshift = shiftby / PyLong_SHIFT;
     remshift = shiftby % PyLong_SHIFT;
@@ -4828,7 +4819,7 @@ long_lshift(PyObject *a, PyObject *b)
         return NULL;
     }
     if (Py_SIZE(a) == 0) {
-        return PyLong_FromLong(0);
+        return _PyLong_RefZero();
     }
     if (divmod_shift(b, &wordshift, &remshift) < 0)
         return NULL;
@@ -4844,7 +4835,7 @@ _PyLong_Lshift(PyObject *a, size_t shiftby)
 
     assert(PyLong_Check(a));
     if (Py_SIZE(a) == 0) {
-        return PyLong_FromLong(0);
+        return _PyLong_RefZero();
     }
     wordshift = shiftby / PyLong_SHIFT;
     remshift = shiftby % PyLong_SHIFT;
@@ -5281,7 +5272,7 @@ long_new_impl(PyTypeObject *type, PyObject *x, PyObject *obase)
                             "int() missing string argument");
             return NULL;
         }
-        return PyLong_FromLong(0L);
+        return _PyLong_RefZero();
     }
     if (obase == NULL)
         return PyNumber_Long(x);
@@ -5359,13 +5350,13 @@ int___getnewargs___impl(PyObject *self)
 static PyObject *
 long_get0(PyObject *Py_UNUSED(self), void *Py_UNUSED(context))
 {
-    return PyLong_FromLong(0L);
+    return _PyLong_RefZero();
 }
 
 static PyObject *
 long_get1(PyObject *Py_UNUSED(self), void *Py_UNUSED(ignored))
 {
-    return PyLong_FromLong(1L);
+    return _PyLong_RefOne();
 }
 
 /*[clinic input]
@@ -5606,7 +5597,7 @@ int_bit_length_impl(PyObject *self)
 
     ndigits = Py_ABS(Py_SIZE(self));
     if (ndigits == 0)
-        return PyLong_FromLong(0);
+        return _PyLong_RefZero();
 
     msd = ((PyLongObject *)self)->ob_digit[ndigits-1];
     msd_bits = bit_length_digit(msd);

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -296,7 +296,6 @@ static PyObject *
 meth_richcompare(PyObject *self, PyObject *other, int op)
 {
     PyCFunctionObject *a, *b;
-    PyObject *res;
     int eq;
 
     if ((op != Py_EQ && op != Py_NE) ||
@@ -310,12 +309,7 @@ meth_richcompare(PyObject *self, PyObject *other, int op)
     eq = a->m_self == b->m_self;
     if (eq)
         eq = a->m_ml->ml_meth == b->m_ml->ml_meth;
-    if (op == Py_EQ)
-        res = eq ? Py_True : Py_False;
-    else
-        res = eq ? Py_False : Py_True;
-    Py_INCREF(res);
-    return res;
+    return PyBool_FromLong(eq == (op == Py_EQ));
 }
 
 static Py_hash_t

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1477,7 +1477,7 @@ odict_richcompare(PyObject *v, PyObject *w, int op)
     }
 
     if (op == Py_EQ || op == Py_NE) {
-        PyObject *res, *cmp;
+        PyObject *cmp;
         int eq;
 
         cmp = PyDict_Type.tp_richcompare(v, w, op);
@@ -1496,9 +1496,7 @@ odict_richcompare(PyObject *v, PyObject *w, int op)
         if (eq < 0)
             return NULL;
 
-        res = (eq == (op == Py_EQ)) ? Py_True : Py_False;
-        Py_INCREF(res);
-        return res;
+        return PyBool_FromLong(eq == (op == Py_EQ));
     } else {
         Py_RETURN_NOTIMPLEMENTED;
     }

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -527,10 +527,8 @@ range_hash(rangeobject *r)
     if (cmp_result == -1)
         goto end;
     if (cmp_result == 1) {
-        Py_INCREF(Py_None);
-        Py_INCREF(Py_None);
-        PyTuple_SET_ITEM(t, 1, Py_None);
-        PyTuple_SET_ITEM(t, 2, Py_None);
+        PyTuple_SET_ITEM(t, 1, Py_RefNone());
+        PyTuple_SET_ITEM(t, 2, Py_RefNone());
     }
     else {
         Py_INCREF(r->start);
@@ -539,8 +537,7 @@ range_hash(rangeobject *r)
         if (cmp_result == -1)
             goto end;
         if (cmp_result == 1) {
-            Py_INCREF(Py_None);
-            PyTuple_SET_ITEM(t, 2, Py_None);
+            PyTuple_SET_ITEM(t, 2, Py_RefNone());
         }
         else {
             Py_INCREF(r->step);

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -29,7 +29,7 @@ validate_step(PyObject *step)
 {
     /* No step specified, use a step of 1. */
     if (!step)
-        return PyLong_FromLong(1);
+        return _PyLong_RefOne();
 
     step = PyNumber_Index(step);
     if (step && _PyLong_Sign(step) == 0) {
@@ -104,10 +104,8 @@ range_from_array(PyTypeObject *type, PyObject *const *args, Py_ssize_t num_args)
             if (!stop) {
                 return NULL;
             }
-            start = _PyLong_GetZero();
-            Py_INCREF(start);
-            step = _PyLong_GetOne();
-            Py_INCREF(step);
+            start = _PyLong_RefZero();
+            step = _PyLong_RefOne();
             break;
         case 0:
             PyErr_SetString(PyExc_TypeError,
@@ -1125,11 +1123,10 @@ range_iter(PyObject *seq)
     it->start = r->start;
     it->step = r->step;
     it->len = r->length;
-    it->index = _PyLong_GetZero();
     Py_INCREF(it->start);
     Py_INCREF(it->step);
     Py_INCREF(it->len);
-    Py_INCREF(it->index);
+    it->index = _PyLong_RefZero();
     return (PyObject *)it;
 }
 
@@ -1232,8 +1229,7 @@ long_range:
     if (!it->step)
         goto create_failure;
 
-    it->index = _PyLong_GetZero();
-    Py_INCREF(it->index);
+    it->index = _PyLong_RefZero();
     return (PyObject *)it;
 
 create_failure:

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -15,7 +15,7 @@ this type and there is exactly one in existence.
 
 #include "Python.h"
 #include "pycore_abstract.h"      // _PyIndex_Check()
-#include "pycore_long.h"          // _PyLong_GetZero()
+#include "pycore_long.h"          // _PyLong_RefZero()
 #include "pycore_object.h"        // _PyObject_GC_TRACK()
 #include "structmember.h"         // PyMemberDef
 
@@ -388,8 +388,7 @@ _PySlice_GetLongIndices(PySliceObject *self, PyObject *length,
 
     /* Convert step to an integer; raise for zero step. */
     if (self->step == Py_None) {
-        step = _PyLong_GetOne();
-        Py_INCREF(step);
+        step = _PyLong_RefOne();
         step_is_negative = 0;
     }
     else {
@@ -417,8 +416,7 @@ _PySlice_GetLongIndices(PySliceObject *self, PyObject *length,
             goto error;
     }
     else {
-        lower = _PyLong_GetZero();
-        Py_INCREF(lower);
+        lower = _PyLong_RefZero();
         upper = length;
         Py_INCREF(upper);
     }

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -26,8 +26,7 @@ ellipsis_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         PyErr_SetString(PyExc_TypeError, "EllipsisType takes no arguments");
         return NULL;
     }
-    Py_INCREF(Py_Ellipsis);
-    return Py_Ellipsis;
+    return Py_RefEllipsis();
 }
 
 static PyObject *

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -1042,8 +1042,7 @@ formatteriter_next(formatteriterobject *it)
            otherwise create a one length string with the conversion
            character */
         if (conversion == '\0') {
-            conversion_str = Py_None;
-            Py_INCREF(conversion_str);
+            conversion_str = Py_RefNone();
         }
         else
             conversion_str = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND,

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4647,13 +4647,8 @@ object_richcompare(PyObject *self, PyObject *other, int op)
             Py_DECREF(res);
             if (ok < 0)
                 res = NULL;
-            else {
-                if (ok)
-                    res = Py_False;
-                else
-                    res = Py_True;
-                Py_INCREF(res);
-            }
+            else
+                res = PyBool_FromLong(!ok);
         }
         break;
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -566,8 +566,7 @@ type_module(PyTypeObject *type, void *context)
                 PyUnicode_InternInPlace(&mod);
         }
         else {
-            mod = &_Py_ID(builtins);
-            Py_INCREF(mod);
+            mod = _Py_RefID(builtins);
         }
     }
     return mod;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -237,7 +237,7 @@ _PyType_InitCache(PyInterpreterState *interp)
         entry->version = 0;
         // Set to None so _PyType_Lookup() can use Py_SETREF(),
         // rather than using slower Py_XSETREF().
-        entry->name = Py_NewRef(Py_None);
+        entry->name = Py_RefNone();
         entry->value = NULL;
     }
 }
@@ -877,8 +877,7 @@ type_get_doc(PyTypeObject *type, void *context)
     result = PyDict_GetItemWithError(type->tp_dict, &_Py_ID(__doc__));
     if (result == NULL) {
         if (!PyErr_Occurred()) {
-            result = Py_None;
-            Py_INCREF(result);
+            result = Py_RefNone();
         }
     }
     else if (Py_TYPE(result)->tp_descr_get) {
@@ -4639,8 +4638,7 @@ object_richcompare(PyObject *self, PyObject *other, int op)
         /* By default, __ne__() delegates to __eq__() and inverts the result,
            unless the latter returns NotImplemented. */
         if (Py_TYPE(self)->tp_richcompare == NULL) {
-            res = Py_NotImplemented;
-            Py_INCREF(res);
+            res = Py_RefNotImplemented();
             break;
         }
         res = (*Py_TYPE(self)->tp_richcompare)(self, other, Py_EQ);
@@ -4660,8 +4658,7 @@ object_richcompare(PyObject *self, PyObject *other, int op)
         break;
 
     default:
-        res = Py_NotImplemented;
-        Py_INCREF(res);
+        res = Py_RefNotImplemented();
         break;
     }
 
@@ -4972,8 +4969,7 @@ object_getstate_default(PyObject *obj, int required)
     }
 
     if (_PyObject_IsInstanceDictEmpty(obj)) {
-        state = Py_None;
-        Py_INCREF(state);
+        state = Py_RefNone();
     }
     else {
         state = PyObject_GenericGetDict(obj, NULL);
@@ -5231,8 +5227,7 @@ _PyObject_GetItemsIter(PyObject *obj, PyObject **listitems,
     }
 
     if (!PyList_Check(obj)) {
-        *listitems = Py_None;
-        Py_INCREF(*listitems);
+        *listitems = Py_RefNone();
     }
     else {
         *listitems = PyObject_GetIter(obj);
@@ -5241,8 +5236,7 @@ _PyObject_GetItemsIter(PyObject *obj, PyObject **listitems,
     }
 
     if (!PyDict_Check(obj)) {
-        *dictitems = Py_None;
-        Py_INCREF(*dictitems);
+        *dictitems = Py_RefNone();
     }
     else {
         PyObject *items = PyObject_CallMethodNoArgs(obj, &_Py_ID(items));

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -11580,13 +11580,13 @@ unicode_count(PyObject *self, PyObject *args)
     kind1 = PyUnicode_KIND(self);
     kind2 = PyUnicode_KIND(substring);
     if (kind1 < kind2)
-        return PyLong_FromLong(0);
+        return _PyLong_RefZero();
 
     len1 = PyUnicode_GET_LENGTH(self);
     len2 = PyUnicode_GET_LENGTH(substring);
     ADJUST_INDICES(start, end, len1);
     if (end - start < len2)
-        return PyLong_FromLong(0);
+        return _PyLong_RefZero();
 
     buf1 = PyUnicode_DATA(self);
     buf2 = PyUnicode_DATA(substring);

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -705,8 +705,7 @@ _msi_SummaryInformation_GetProperty_impl(msiobj *self, int field)
             result = PyBytes_FromStringAndSize(sval, ssize);
             break;
         case VT_EMPTY:
-            Py_INCREF(Py_None);
-            result = Py_None;
+            result = Py_RefNone();
             break;
         default:
             PyErr_Format(PyExc_NotImplementedError, "result of type %d", type);

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -796,8 +796,7 @@ Reg2Py(BYTE *retDataBuf, DWORD retDataSize, DWORD typ)
            support it natively, we should handle the bits. */
         default:
             if (retDataSize == 0) {
-                Py_INCREF(Py_None);
-                obData = Py_None;
+                obData = Py_RefNone();
             }
             else
                 obData = PyBytes_FromStringAndSize(

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -78,7 +78,7 @@ create_filter(PyObject *category, PyObject *action_str, const char *modname)
             return NULL;
         }
     } else {
-        modname_obj = Py_NewRef(Py_None);
+        modname_obj = Py_RefNone();
     }
 
     /* This assumes the line number is zero for now. */
@@ -383,8 +383,7 @@ get_filter(PyInterpreterState *interp, PyObject *category,
 
     action = get_default_action(interp);
     if (action != NULL) {
-        Py_INCREF(Py_None);
-        *item = Py_None;
+        *item = Py_RefNone();
         return action;
     }
 
@@ -752,8 +751,7 @@ warn_explicit(PyThreadState *tstate, PyObject *category, PyObject *message,
         goto cleanup;
 
  return_none:
-    result = Py_None;
-    Py_INCREF(result);
+    result = Py_RefNone();
 
  cleanup:
     Py_XDECREF(item);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -10,6 +10,7 @@
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_tuple.h"         // _PyTuple_FromArray()
 #include "pycore_ceval.h"         // _PyEval_Vector()
+#include "pycore_long.h"          // _PyLong_RefZero()
 
 #include "clinic/bltinmodule.c.h"
 
@@ -2410,11 +2411,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
         return NULL;
 
     if (result == NULL) {
-        result = PyLong_FromLong(0);
-        if (result == NULL) {
-            Py_DECREF(iter);
-            return NULL;
-        }
+        result = _PyLong_RefZero();
     } else {
         /* reject string values for 'start' parameter */
         if (PyUnicode_Check(result)) {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2689,8 +2689,7 @@ zip_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
     for (i=0 ; i < tuplesize ; i++) {
-        Py_INCREF(Py_None);
-        PyTuple_SET_ITEM(result, i, Py_None);
+        PyTuple_SET_ITEM(result, i, Py_RefNone());
     }
 
     /* create zipobject structure */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3912,10 +3912,7 @@ handle_eval_breaker:
         TARGET(IS_OP) {
             PyObject *right = POP();
             PyObject *left = TOP();
-            int res = Py_Is(left, right) ^ oparg;
-            PyObject *b = res ? Py_True : Py_False;
-            Py_INCREF(b);
-            SET_TOP(b);
+            SET_TOP(PyBool_FromLong(Py_Is(left, right) ^ oparg));
             Py_DECREF(left);
             Py_DECREF(right);
             DISPATCH();
@@ -3930,9 +3927,7 @@ handle_eval_breaker:
             if (res < 0) {
                 goto error;
             }
-            PyObject *b = (res^oparg) ? Py_True : Py_False;
-            Py_INCREF(b);
-            PUSH(b);
+            PUSH(PyBool_FromLong(res^oparg));
             DISPATCH();
         }
 
@@ -3988,7 +3983,7 @@ handle_eval_breaker:
 
             int res = PyErr_GivenExceptionMatches(left, right);
             Py_DECREF(right);
-            PUSH(Py_NewRef(res ? Py_True : Py_False));
+            PUSH(PyBool_FromLong(res));
             DISPATCH();
         }
 
@@ -4305,9 +4300,7 @@ handle_eval_breaker:
         TARGET(MATCH_MAPPING) {
             PyObject *subject = TOP();
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
-            PyObject *res = match ? Py_True : Py_False;
-            Py_INCREF(res);
-            PUSH(res);
+            PUSH(PyBool_FromLong(match));
             PREDICT(POP_JUMP_FORWARD_IF_FALSE);
             PREDICT(POP_JUMP_BACKWARD_IF_FALSE);
             DISPATCH();
@@ -4316,9 +4309,7 @@ handle_eval_breaker:
         TARGET(MATCH_SEQUENCE) {
             PyObject *subject = TOP();
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
-            PyObject *res = match ? Py_True : Py_False;
-            Py_INCREF(res);
-            PUSH(res);
+            PUSH(PyBool_FromLong(match));
             PREDICT(POP_JUMP_FORWARD_IF_FALSE);
             PREDICT(POP_JUMP_BACKWARD_IF_FALSE);
             DISPATCH();
@@ -5207,17 +5198,12 @@ handle_eval_breaker:
                 Py_DECREF(cls);
                 goto error;
             }
-            PyObject *res = PyBool_FromLong(retval);
-            assert((res != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
 
             STACK_SHRINK(2-is_meth);
-            SET_TOP(res);
+            SET_TOP(PyBool_FromLong(retval));
             Py_DECREF(inst);
             Py_DECREF(cls);
             Py_DECREF(callable);
-            if (res == NULL) {
-                goto error;
-            }
             DISPATCH();
         }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1015,8 +1015,7 @@ match_keys(PyThreadState *tstate, PyObject *map, PyObject *keys)
             Py_DECREF(value);
             Py_DECREF(values);
             // Return None:
-            Py_INCREF(Py_None);
-            values = Py_None;
+            values = Py_RefNone();
             goto done;
         }
         PyTuple_SET_ITEM(values, i, value);
@@ -1994,13 +1993,11 @@ handle_eval_breaker:
             int err = PyObject_IsTrue(value);
             Py_DECREF(value);
             if (err == 0) {
-                Py_INCREF(Py_True);
-                SET_TOP(Py_True);
+                SET_TOP(Py_RefTrue());
                 DISPATCH();
             }
             else if (err > 0) {
-                Py_INCREF(Py_False);
-                SET_TOP(Py_False);
+                SET_TOP(Py_RefFalse());
                 DISPATCH();
             }
             STACK_SHRINK(1);
@@ -4299,8 +4296,7 @@ handle_eval_breaker:
             }
             else {
                 // Failure!
-                Py_INCREF(Py_None);
-                SET_TOP(Py_None);
+                SET_TOP(Py_RefNone());
             }
             Py_DECREF(subject);
             DISPATCH();
@@ -4522,8 +4518,7 @@ handle_eval_breaker:
                 SET_TOP(exc_info->exc_value);
             }
             else {
-                Py_INCREF(Py_None);
-                SET_TOP(Py_None);
+                SET_TOP(Py_RefNone());
             }
 
             Py_INCREF(value);
@@ -6635,8 +6630,8 @@ exception_group_match(PyObject* exc_value, PyObject *match_type,
                       PyObject **match, PyObject **rest)
 {
     if (Py_IsNone(exc_value)) {
-        *match = Py_NewRef(Py_None);
-        *rest = Py_NewRef(Py_None);
+        *match = Py_RefNone();
+        *rest = Py_RefNone();
         return 0;
     }
     assert(PyExceptionInstance_Check(exc_value));
@@ -6660,7 +6655,7 @@ exception_group_match(PyObject* exc_value, PyObject *match_type,
             }
             *match = wrapped;
         }
-        *rest = Py_NewRef(Py_None);
+        *rest = Py_RefNone();
         return 0;
     }
 
@@ -6681,8 +6676,8 @@ exception_group_match(PyObject* exc_value, PyObject *match_type,
         return 0;
     }
     /* no match */
-    *match = Py_NewRef(Py_None);
-    *rest = Py_NewRef(Py_None);
+    *match = Py_RefNone();
+    *rest = Py_RefNone();
     return 0;
 }
 
@@ -6795,8 +6790,7 @@ call_exc_trace(Py_tracefunc func, PyObject *self,
     int err;
     _PyErr_Fetch(tstate, &type, &value, &orig_traceback);
     if (value == NULL) {
-        value = Py_None;
-        Py_INCREF(value);
+        value = Py_RefNone();
     }
     _PyErr_NormalizeException(tstate, &type, &value, &orig_traceback);
     traceback = (orig_traceback != NULL) ? orig_traceback : Py_None;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6111,8 +6111,7 @@ compiler_error(struct compiler *c, const char *format, ...)
     }
     PyObject *loc = PyErr_ProgramTextObject(c->c_filename, c->u->u_lineno);
     if (loc == NULL) {
-        Py_INCREF(Py_None);
-        loc = Py_None;
+        loc = Py_RefNone();
     }
     PyObject *args = Py_BuildValue("O(OiiOii)", msg, c->c_filename,
                                    c->u->u_lineno, c->u->u_col_offset + 1, loc,

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -326,8 +326,7 @@ _PyErr_NormalizeException(PyThreadState *tstate, PyObject **exc,
        set to NULL.
     */
     if (!value) {
-        value = Py_None;
-        Py_INCREF(value);
+        value = Py_RefNone();
     }
 
     /* Normalize the exception so that if the type is a class, the

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -95,7 +95,7 @@ _Py_device_encoding(int fd)
 #else
     if (_PyRuntime.preconfig.utf8_mode) {
         _Py_DECLARE_STR(utf_8, "utf-8");
-        return Py_NewRef(&_Py_STR(utf_8));
+        return _Py_RefSTR(utf_8);
     }
     return _Py_GetLocaleEncodingObject();
 #endif

--- a/Python/import.c
+++ b/Python/import.c
@@ -1405,8 +1405,7 @@ PyImport_ImportFrozenModuleObject(PyObject *name)
         }
     }
     else {
-        Py_INCREF(Py_None);
-        origname = Py_None;
+        origname = Py_RefNone();
     }
     err = PyDict_SetItemString(d, "__origname__", origname);
     Py_DECREF(origname);

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -202,7 +202,7 @@ _Py_GetGlobalVariablesAsDict(void)
 #define FROM_STRING(STR) \
     ((STR != NULL) ? \
         PyUnicode_FromString(STR) \
-        : (Py_INCREF(Py_None), Py_None))
+        : Py_RefNone())
 #define SET_ITEM_STR(VAR) \
     SET_ITEM(#VAR, FROM_STRING(VAR))
 
@@ -992,7 +992,7 @@ _PyConfig_AsDict(const PyConfig *config)
 #define FROM_WSTRING(STR) \
     ((STR != NULL) ? \
         PyUnicode_FromWideChar(STR, -1) \
-        : (Py_INCREF(Py_None), Py_None))
+        : Py_RefNone())
 #define SET_ITEM_WSTR(ATTR) \
     SET_ITEM(#ATTR, FROM_WSTRING(config->ATTR))
 #define SET_ITEM_WSTRLIST(LIST) \

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1008,8 +1008,7 @@ r_object(RFILE *p)
         break;
 
     case TYPE_NONE:
-        Py_INCREF(Py_None);
-        retval = Py_None;
+        retval = Py_RefNone();
         break;
 
     case TYPE_STOPITER:
@@ -1018,18 +1017,15 @@ r_object(RFILE *p)
         break;
 
     case TYPE_ELLIPSIS:
-        Py_INCREF(Py_Ellipsis);
-        retval = Py_Ellipsis;
+        retval = Py_RefEllipsis();
         break;
 
     case TYPE_FALSE:
-        Py_INCREF(Py_False);
-        retval = Py_False;
+        retval = Py_RefFalse();
         break;
 
     case TYPE_TRUE:
-        Py_INCREF(Py_True);
-        retval = Py_True;
+        retval = Py_RefTrue();
         break;
 
     case TYPE_INT:

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -359,8 +359,7 @@ do_mkvalue(const char **p_format, va_list *p_va, int flags)
             else
                 n = -1;
             if (u == NULL) {
-                v = Py_None;
-                Py_INCREF(v);
+                v = Py_RefNone();
             }
             else {
                 if (n < 0)
@@ -410,8 +409,7 @@ do_mkvalue(const char **p_format, va_list *p_va, int flags)
             else
                 n = -1;
             if (str == NULL) {
-                v = Py_None;
-                Py_INCREF(v);
+                v = Py_RefNone();
             }
             else {
                 if (n < 0) {
@@ -446,8 +444,7 @@ do_mkvalue(const char **p_format, va_list *p_va, int flags)
             else
                 n = -1;
             if (str == NULL) {
-                v = Py_None;
-                Py_INCREF(v);
+                v = Py_RefNone();
             }
             else {
                 if (n < 0) {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2522,8 +2522,7 @@ _Py_FatalError_PrintExc(PyThreadState *tstate)
 
     _PyErr_NormalizeException(tstate, &exception, &v, &tb);
     if (tb == NULL) {
-        tb = Py_None;
-        Py_INCREF(tb);
+        tb = Py_RefNone();
     }
     PyException_SetTraceback(v, tb);
     if (exception == NULL) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -961,8 +961,7 @@ PyState_RemoveModule(PyModuleDef* def)
         Py_FatalError("Module index out of bounds.");
     }
 
-    Py_INCREF(Py_None);
-    return PyList_SetItem(interp->modules_by_index, index, Py_None);
+    return PyList_SetItem(interp->modules_by_index, index, Py_RefNone());
 }
 
 // Used by finalize_modules()

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2065,8 +2065,7 @@ static PyObject *
 _new_none_object(_PyCrossInterpreterData *data)
 {
     // XXX Singleton refcounts are problematic across interpreters...
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static int

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -515,8 +515,7 @@ parse_syntax_error(PyObject *err, PyObject **message, PyObject **filename,
     if (v == Py_None) {
         Py_DECREF(v);
         _Py_DECLARE_STR(anon_string, "<string>");
-        *filename = &_Py_STR(anon_string);
-        Py_INCREF(*filename);
+        *filename = _Py_RefSTR(anon_string);
     }
     else {
         *filename = v;

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -785,8 +785,7 @@ _PyErr_PrintEx(PyThreadState *tstate, int set_sys_last_vars)
 
     _PyErr_NormalizeException(tstate, &exception, &v, &tb);
     if (tb == NULL) {
-        tb = Py_None;
-        Py_INCREF(tb);
+        tb = Py_RefNone();
     }
     PyException_SetTraceback(v, tb);
     if (exception == NULL) {
@@ -832,12 +831,10 @@ _PyErr_PrintEx(PyThreadState *tstate, int set_sys_last_vars)
                to be NULL. However PyErr_Display() can't
                tolerate NULLs, so just be safe. */
             if (exception2 == NULL) {
-                exception2 = Py_None;
-                Py_INCREF(exception2);
+                exception2 = Py_RefNone();
             }
             if (v2 == NULL) {
-                v2 = Py_None;
-                Py_INCREF(v2);
+                v2 = Py_RefNone();
             }
             fflush(stdout);
             PySys_WriteStderr("Error in sys.excepthook:\n");

--- a/Python/structmember.c
+++ b/Python/structmember.c
@@ -49,8 +49,7 @@ PyMember_GetOne(const char *obj_addr, PyMemberDef *l)
         break;
     case T_STRING:
         if (*(char**)addr == NULL) {
-            Py_INCREF(Py_None);
-            v = Py_None;
+            v = Py_RefNone();
         }
         else
             v = PyUnicode_FromString(*(char**)addr);
@@ -85,8 +84,7 @@ PyMember_GetOne(const char *obj_addr, PyMemberDef *l)
         v = PyLong_FromUnsignedLongLong(*(unsigned long long *)addr);
         break;
     case T_NONE:
-        v = Py_None;
-        Py_INCREF(v);
+        v = Py_RefNone();
         break;
     default:
         PyErr_SetString(PyExc_SystemError, "bad memberdescr type");

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2308,8 +2308,7 @@ _PySys_AddXOptionWithError(const wchar_t *s)
     const wchar_t *name_end = wcschr(s, L'=');
     if (!name_end) {
         name = PyUnicode_FromWideChar(s, -1);
-        value = Py_True;
-        Py_INCREF(value);
+        value = Py_RefTrue();
     }
     else {
         name = PyUnicode_FromWideChar(s, name_end - s);
@@ -2959,8 +2958,7 @@ sys_add_xoption(PyObject *opts, const wchar_t *s)
     const wchar_t *name_end = wcschr(s, L'=');
     if (!name_end) {
         name = PyUnicode_FromWideChar(s, -1);
-        value = Py_True;
-        Py_INCREF(value);
+        value = Py_RefTrue();
     }
     else {
         name = PyUnicode_FromWideChar(s, name_end - s);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -845,9 +845,7 @@ sys_getdefaultencoding_impl(PyObject *module)
 /*[clinic end generated code: output=256d19dfcc0711e6 input=d416856ddbef6909]*/
 {
     _Py_DECLARE_STR(utf_8, "utf-8");
-    PyObject *ret = &_Py_STR(utf_8);
-    Py_INCREF(ret);
-    return ret;
+    return _Py_RefSTR(utf_8);
 }
 
 /*[clinic input]

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -219,8 +219,7 @@ PyThread_GetInfo(void)
         return NULL;
     }
 #else
-    Py_INCREF(Py_None);
-    value = Py_None;
+    value = Py_RefNone();
 #endif
     PyStructSequence_SET_ITEM(threadinfo, pos++, value);
 
@@ -236,8 +235,7 @@ PyThread_GetInfo(void)
     if (value == NULL)
 #endif
     {
-        Py_INCREF(Py_None);
-        value = Py_None;
+        value = Py_RefNone();
     }
     PyStructSequence_SET_ITEM(threadinfo, pos++, value);
     return threadinfo;

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -3816,8 +3816,7 @@ class NoneType_return_converter(CReturnConverter):
 if (_return_value != Py_None) {
     goto exit;
 }
-return_value = Py_None;
-Py_INCREF(Py_None);
+return_value = Py_RefNone();
 '''.strip())
 
 class bool_return_converter(CReturnConverter):

--- a/Tools/peg_generator/peg_extension/peg_extension.c
+++ b/Tools/peg_generator/peg_extension/peg_extension.c
@@ -12,8 +12,7 @@ _build_return_object(mod_ty module, int mode, PyObject *filename_ob, PyArena *ar
     } else if (mode == 1) {
         result = PyAST_mod2obj(module);
     } else {
-        result = Py_None;
-        Py_INCREF(result);
+        result = Py_RefNone();
     }
 
     return result;

--- a/Tools/scripts/generate_global_objects.py
+++ b/Tools/scripts/generate_global_objects.py
@@ -105,7 +105,7 @@ def iter_files():
 
 
 def iter_global_strings():
-    id_regex = re.compile(r'\b_Py_ID\((\w+)\)')
+    id_regex = re.compile(r'\b_Py_(?:Ref)?ID\((\w+)\)')
     str_regex = re.compile(r'\b_Py_DECLARE_STR\((\w+), "(.*?)"\)')
     for filename in iter_files():
         try:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

There are lots of places where a new reference to a singleton is needed. This is done in a variety of ways:

1.
```
obj = Py_NewRef(Py_None);
```

2.
```
obj = Py_None;
Py_INCREF(obj);
```

3.
```
Py_INCREF(Py_None);
obj = Py_None;
```

4.
```
obj = Py_None;
Py_INCREF(Py_None);
```

5.
```
obj = (Py_INCREF(Py_None), Py_None);
```

The helpers implemented here add another way that can hopefully become more idiomatic:

6.
```
obj = Py_RefNone();
```

One advantage of using the new helpers is that it abstracts away the necessity to increment the reference count if [immortal instances](https://github.com/python/cpython/pull/19474) are implemented.

Alternatively, if immortal instances aren't implemented and all singletons are made per-interpreter, it will slightly reduce the performance overhead by making sure that the singletons are only obtained once (compared to patterns 3, 4, and 5, where the singetons are obtained twice).