### PR TITLE
gh-84461: Add ability for multiprocessed libregrtest to use a different Python executable

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -206,6 +206,8 @@ def _create_parser():
     group.add_argument('-S', '--start', metavar='START',
                        help='the name of the test at which to start.' +
                             more_details)
+    group.add_argument('-p', '--python', metavar='PYTHON',
+                       help='Command to run Python test subprocesses with.')
 
     group = parser.add_argument_group('Verbosity')
     group.add_argument('-v', '--verbose', action='count',
@@ -370,6 +372,8 @@ def _parse_args(args, **kwargs):
         parser.error("-s and -f don't go together!")
     if ns.use_mp is not None and ns.trace:
         parser.error("-T and -j don't go together!")
+    if ns.python is not None and ns.use_mp is None:
+        parser.error("-p requires -j!")
     if ns.failfast and not (ns.verbose or ns.verbose3):
         parser.error("-G/--failfast needs either -v or -W")
     if ns.pgo and (ns.verbose or ns.verbose2 or ns.verbose3):

--- a/Lib/test/libregrtest/runtest_mp.py
+++ b/Lib/test/libregrtest/runtest_mp.py
@@ -2,6 +2,7 @@ import faulthandler
 import json
 import os
 import queue
+import shlex
 import signal
 import subprocess
 import sys
@@ -55,8 +56,12 @@ def run_test_in_subprocess(testname: str, ns: Namespace) -> subprocess.Popen:
     ns_dict = vars(ns)
     worker_args = (ns_dict, testname)
     worker_args = json.dumps(worker_args)
-
-    cmd = [sys.executable, *support.args_from_interpreter_flags(),
+    if ns.python is not None:
+        # The "executable" may be two or more parts, e.g. "node python.js"
+        executable = shlex.split(ns.python)
+    else:
+        executable = [sys.executable]
+    cmd = [*executable, *support.args_from_interpreter_flags(),
            '-u',    # Unbuffered stdout and stderr
            '-m', 'test.regrtest',
            '--worker-args', worker_args]

--- a/Misc/NEWS.d/next/Tests/2022-05-02-20-15-54.gh-issue-84461.DhxllI.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-02-20-15-54.gh-issue-84461.DhxllI.rst
@@ -1,1 +1,1 @@
-When multiprocessing is enabled, libregrtest can now use a Python executable other than :code:`sys.executable`
+When multiprocessing is enabled, libregrtest can now use a Python executable other than :code:`sys.executable` via the ``--python`` flag.

--- a/Misc/NEWS.d/next/Tests/2022-05-02-20-15-54.gh-issue-84461.DhxllI.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-02-20-15-54.gh-issue-84461.DhxllI.rst
@@ -1,0 +1,1 @@
+When multiprocessing is enabled, libregrtest can now use a Python executable other than :code:`sys.executable`


### PR DESCRIPTION
wasm32-emscripten does not support subprocesses. As a workaround, we can run the regression test suite with e.g. the system-native Python used for cross building, then execute the actual subprocess workers with the emscripten/target runtime.

For example, consider a setup where you have two folders: `linux`, which includes a build of CPython for linux and the native architecture of the machine. You also have `wasm`, which is the cross compiled Python for emscripten/node.

This PR would enable you to do `linux/python -m test -j1 -p "node wasm/python.js"`, to run the test suite workers in nodejs.