### PR TITLE
[3.10] gh-91401: Conservative backport of `subprocess._USE_VFORK`

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -691,7 +691,10 @@ def _use_posix_spawn():
     return False
 
 
+# These are primarily fail-safe knobs for negatives. A True value does not
+# guarantee the given libc/syscall API will be used.
 _USE_POSIX_SPAWN = _use_posix_spawn()
+_USE_VFORK = True
 
 
 class Popen:

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1709,7 +1709,6 @@ class RunFuncTestCase(BaseTestCase):
         # probes the subprocess module for the existence and value of this
         # attribute in 3.10.5.
         self.assertTrue(subprocess._USE_VFORK)  # The default value regardless.
-        self.assertEqual(self.run_python("pass").returncode, 0)
         with mock.patch.object(subprocess, "_USE_VFORK", False):
             self.assertEqual(self.run_python("pass").returncode, 0,
                              msg="False _USE_VFORK failed")

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1528,6 +1528,7 @@ class ProcessTestCase(BaseTestCase):
         self.assertIsInstance(subprocess.Popen[bytes], types.GenericAlias)
         self.assertIsInstance(subprocess.CompletedProcess[str], types.GenericAlias)
 
+
 class RunFuncTestCase(BaseTestCase):
     def run_python(self, code, **kwargs):
         """Run Python code in a subprocess using subprocess.run"""
@@ -1701,6 +1702,29 @@ class RunFuncTestCase(BaseTestCase):
         self.assertLess(after_secs - before_secs, 1.5,
                         msg="TimeoutExpired was delayed! Bad traceback:\n```\n"
                         f"{stacks}```")
+
+    @unittest.skipIf(not sysconfig.get_config_var("HAVE_VFORK"),
+                     "vfork() not enabled by configure.")
+    def test__use_vfork(self):
+        # Attempts code coverage within _posixsubprocess.c on the code that
+        # probes the subprocess module for the existence and value of this
+        # attribute in 3.10.5.
+        self.assertTrue(subprocess._USE_VFORK)  # The default value regardless.
+        self.assertEqual(self.run_python("pass").returncode, 0)
+        with mock.patch.object(subprocess, "_USE_VFORK", False):
+            self.assertEqual(self.run_python("pass").returncode, 0,
+                             msg="False _USE_VFORK failed")
+
+        class RaisingBool:
+            def __bool__(self):
+                raise RuntimeError("force PyObject_IsTrue to return -1")
+
+        with mock.patch.object(subprocess, "_USE_VFORK", RaisingBool()):
+            self.assertEqual(self.run_python("pass").returncode, 0,
+                             msg="odd bool()-error _USE_VFORK failed")
+            del subprocess._USE_VFORK
+            self.assertEqual(self.run_python("pass").returncode, 0,
+                             msg="lack of a _USE_VFORK attribute failed")
 
 
 def _get_test_grp_name():

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1528,7 +1528,6 @@ class ProcessTestCase(BaseTestCase):
         self.assertIsInstance(subprocess.Popen[bytes], types.GenericAlias)
         self.assertIsInstance(subprocess.CompletedProcess[str], types.GenericAlias)
 
-
 class RunFuncTestCase(BaseTestCase):
     def run_python(self, code, **kwargs):
         """Run Python code in a subprocess using subprocess.run"""

--- a/Misc/NEWS.d/next/Library/2022-04-26-00-10-06.gh-issue-91401.mddRC8.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-26-00-10-06.gh-issue-91401.mddRC8.rst
@@ -1,5 +1,5 @@
 Provide a fail-safe way to disable :mod:`subprocess` use of ``vfork()`` via
-a private ``subprocess._USE_VFORK`` attribute. There is currently no known
-need for this. If you find a need, please only set it to ``False`` and file
-an issue as to why and leaving a comment in your code pointing to the issue.
-This attribute is documented in 3.11.
+a private ``subprocess._USE_VFORK`` attribute. While there is currently no
+known need for this, if you find a need please only set it to ``False``.
+File a CPython issue as to why you needed it and link to that from a
+comment in your code. This attribute is documented as a footnote in 3.11.

--- a/Misc/NEWS.d/next/Library/2022-04-26-00-10-06.gh-issue-91401.mddRC8.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-26-00-10-06.gh-issue-91401.mddRC8.rst
@@ -1,0 +1,5 @@
+Provide a fail-safe way to disable :mod:`subprocess` use of ``vfork()`` via
+a private ``subprocess._USE_VFORK`` attribute. There is currently no known
+need for this. If you find a need, please only set it to ``False`` and file
+an issue as to why and leaving a comment in your code pointing to the issue.
+This attribute is documented in 3.11.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -944,7 +944,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
             PyObject *allow_vfork_obj = PyObject_GetAttrString(
                 subprocess_module, "_USE_VFORK");
             Py_DECREF(subprocess_module);
-            if (allow_vfork_obj) {
+            if (allow_vfork_obj != NULL) {
                 allow_vfork = PyObject_IsTrue(allow_vfork_obj);
                 Py_DECREF(allow_vfork_obj);
                 if (allow_vfork < 0) {

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -936,10 +936,10 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
 #ifdef VFORK_USABLE
     /* Use vfork() only if it's safe. See the comment above child_exec(). */
     sigset_t old_sigs;
+    int allow_vfork = 1;  /* 3.10.0 behavior */
     if (preexec_fn == Py_None) {
         PyObject *subprocess_module = PyImport_ImportModule("subprocess");
         if (subprocess_module != NULL) {
-            int allow_vfork;
             PyObject *allow_vfork_obj = PyObject_GetAttrString(
                 subprocess_module, "_USE_VFORK");
             Py_DECREF(subprocess_module);
@@ -952,29 +952,30 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
                 }
             } else {
                 PyErr_Clear();  /* No _USE_VFORK attribute. */
-                allow_vfork = 1;  /* 3.10.0 behavior */
-            }
-            if (allow_vfork && !call_setuid && !call_setgid && !call_setgroups) {
-                /* Block all signals to ensure that no signal handlers are run in the
-                 * child process while it shares memory with us. Note that signals
-                 * used internally by C libraries won't be blocked by
-                 * pthread_sigmask(), but signal handlers installed by C libraries
-                 * normally service only signals originating from *within the process*,
-                 * so it should be sufficient to consider any library function that
-                 * might send such a signal to be vfork-unsafe and do not call it in
-                 * the child.
-                 */
-                sigset_t all_sigs;
-                sigfillset(&all_sigs);
-                if ((saved_errno = pthread_sigmask(SIG_BLOCK, &all_sigs, &old_sigs))) {
-                    goto cleanup;
-                }
-                old_sigmask = &old_sigs;
             }
         } else {
             PyErr_Clear();  /* no subprocess module? suspicious; don't care. */
         }
-    }  /* no preexec_fn */
+    } else {
+        allow_vfork = 0;
+    }
+    if (allow_vfork && !call_setuid && !call_setgid && !call_setgroups) {
+        /* Block all signals to ensure that no signal handlers are run in the
+         * child process while it shares memory with us. Note that signals
+         * used internally by C libraries won't be blocked by
+         * pthread_sigmask(), but signal handlers installed by C libraries
+         * normally service only signals originating from *within the process*,
+         * so it should be sufficient to consider any library function that
+         * might send such a signal to be vfork-unsafe and do not call it in
+         * the child.
+         */
+        sigset_t all_sigs;
+        sigfillset(&all_sigs);
+        if ((saved_errno = pthread_sigmask(SIG_BLOCK, &all_sigs, &old_sigs))) {
+            goto cleanup;
+        }
+        old_sigmask = &old_sigs;
+    }
 #endif
 
     pid = do_fork_exec(exec_array, argv, envp, cwd,

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -936,8 +936,9 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
 #ifdef VFORK_USABLE
     /* Use vfork() only if it's safe. See the comment above child_exec(). */
     sigset_t old_sigs;
-    int allow_vfork = 1;  /* 3.10.0 behavior */
+    int allow_vfork;
     if (preexec_fn == Py_None) {
+        allow_vfork = 1;  /* 3.10.0 behavior */
         PyObject *subprocess_module = PyImport_ImportModule("subprocess");
         if (subprocess_module != NULL) {
             PyObject *allow_vfork_obj = PyObject_GetAttrString(


### PR DESCRIPTION
This does not alter the `_posixsubprocess.fork_exec()` private API to
avoid issues for anyone relying on that (bad idea) or for anyone who's
`subprocess.py` and `_posixsubprocess.so` upgrades may not become
visible to existing Python 3.10 processes at the same time.

Backports the concept of cd5726fe674eaff442510eeb6c75628858be9e9f.

Provides a fail-safe way to disable vfork for #91401.

I didn't backport the documentation as I don't actually expect this to be used and versionadded 3.10.5 always looks weird in docs. It's being done more to have a fail-safe in place for people just in case.