### PR TITLE
[3.10] gh-91915: Fix test_netrc on non-UTF-8 locale (GH-91918).

### DIFF
--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -11,7 +11,7 @@ class NetrcTestCase(unittest.TestCase):
         if sys.platform != 'cygwin':
             mode += 't'
         temp_fd, temp_filename = tempfile.mkstemp()
-        with os.fdopen(temp_fd, mode=mode) as fp:
+        with os.fdopen(temp_fd, mode=mode, encoding="utf-8") as fp:
             fp.write(test_data)
         self.addCleanup(os.unlink, temp_filename)
         return netrc.netrc(temp_filename)


### PR DESCRIPTION
(cherry picked from commit 36306cf7862097318a3fef74224075cc4cf37229)
