### PR TITLE
gh-91320: Add _Py_reinterpret_cast() macro

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -50,7 +50,8 @@ PyAPI_FUNC(PyObject *) _PyObject_MakeTpCall(
     PyObject *const *args, Py_ssize_t nargs,
     PyObject *keywords);
 
-#define PY_VECTORCALL_ARGUMENTS_OFFSET ((size_t)1 << (8 * sizeof(size_t) - 1))
+#define PY_VECTORCALL_ARGUMENTS_OFFSET \
+    (_Py_static_cast(size_t, 1) << (8 * sizeof(size_t) - 1))
 
 static inline Py_ssize_t
 PyVectorcall_NARGS(size_t n)

--- a/Include/cpython/listobject.h
+++ b/Include/cpython/listobject.h
@@ -25,7 +25,8 @@ PyAPI_FUNC(PyObject *) _PyList_Extend(PyListObject *, PyObject *);
 PyAPI_FUNC(void) _PyList_DebugMallocStats(FILE *out);
 
 /* Cast argument to PyListObject* type. */
-#define _PyList_CAST(op) (assert(PyList_Check(op)), (PyListObject *)(op))
+#define _PyList_CAST(op) \
+    (assert(PyList_Check(op)), _Py_reinterpret_cast(PyListObject*, (op)))
 
 // Macros and static inline functions, trading safety for speed
 

--- a/Include/cpython/methodobject.h
+++ b/Include/cpython/methodobject.h
@@ -8,9 +8,11 @@ PyAPI_DATA(PyTypeObject) PyCMethod_Type;
 #define PyCMethod_Check(op) PyObject_TypeCheck(op, &PyCMethod_Type)
 
 #define _PyCFunctionObject_CAST(func) \
-    (assert(PyCFunction_Check(func)), (PyCFunctionObject *)(func))
+    (assert(PyCFunction_Check(func)), \
+     _Py_reinterpret_cast(PyCFunctionObject*, (func)))
 #define _PyCMethodObject_CAST(func) \
-    (assert(PyCMethod_Check(func)), (PyCMethodObject *)(func))
+    (assert(PyCMethod_Check(func)), \
+     _Py_reinterpret_cast((PyCMethodObject*, (func)))
 
 /* Macros for direct access to these values. Type checks are *not*
    done, so use with care. */

--- a/Include/cpython/methodobject.h
+++ b/Include/cpython/methodobject.h
@@ -12,7 +12,7 @@ PyAPI_DATA(PyTypeObject) PyCMethod_Type;
      _Py_reinterpret_cast(PyCFunctionObject*, (func)))
 #define _PyCMethodObject_CAST(func) \
     (assert(PyCMethod_Check(func)), \
-     _Py_reinterpret_cast((PyCMethodObject*, (func)))
+     _Py_reinterpret_cast(PyCMethodObject*, (func)))
 
 /* Macros for direct access to these values. Type checks are *not*
    done, so use with care. */

--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -14,7 +14,8 @@ PyAPI_FUNC(int) _PyTuple_Resize(PyObject **, Py_ssize_t);
 PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 
 /* Cast argument to PyTupleObject* type. */
-#define _PyTuple_CAST(op) (assert(PyTuple_Check(op)), (PyTupleObject *)(op))
+#define _PyTuple_CAST(op) \
+    (assert(PyTuple_Check(op)), _Py_reinterpret_cast(PyTupleObject*, (op)))
 
 // Macros and static inline functions, trading safety for speed
 

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -236,11 +236,14 @@ PyAPI_FUNC(int) _PyUnicode_CheckConsistency(
 
 
 #define _PyASCIIObject_CAST(op) \
-    (assert(PyUnicode_Check(op)), (PyASCIIObject*)(op))
+    (assert(PyUnicode_Check(op)), \
+     _Py_reinterpret_cast(PyASCIIObject*, (op)))
 #define _PyCompactUnicodeObject_CAST(op) \
-    (assert(PyUnicode_Check(op)), (PyCompactUnicodeObject*)(op))
+    (assert(PyUnicode_Check(op)), \
+     _Py_reinterpret_cast(PyCompactUnicodeObject*, (op)))
 #define _PyUnicodeObject_CAST(op) \
-    (assert(PyUnicode_Check(op)), (PyUnicodeObject*)(op))
+    (assert(PyUnicode_Check(op)), \
+     _Py_reinterpret_cast(PyUnicodeObject*, (op)))
 
 
 /* --- Flexible String Representation Helper Macros (PEP 393) -------------- */

--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -42,7 +42,9 @@ typedef PyObject *(*PyCMethod)(PyObject *, PyTypeObject *, PyObject *const *,
 // used to prevent a compiler warning. If the function has a single parameter,
 // it triggers an undefined behavior when Python calls it with 2 parameters
 // (bpo-33012).
-#define _PyCFunction_CAST(func) ((PyCFunction)(void(*)(void))(func))
+#define _PyCFunction_CAST(func) \
+    _Py_reinterpret_cast(PyCFunction, \
+        _Py_reinterpret_cast(void(*)(void), (func)))
 
 PyAPI_FUNC(PyCFunction) PyCFunction_GetFunction(PyObject *);
 PyAPI_FUNC(PyObject *) PyCFunction_GetSelf(PyObject *);

--- a/Include/object.h
+++ b/Include/object.h
@@ -104,7 +104,7 @@ struct _object {
 };
 
 /* Cast argument to PyObject* type. */
-#define _PyObject_CAST(op) ((PyObject*)(op))
+#define _PyObject_CAST(op) _Py_reinterpret_cast(PyObject*, (op))
 
 typedef struct {
     PyObject ob_base;
@@ -112,7 +112,7 @@ typedef struct {
 } PyVarObject;
 
 /* Cast argument to PyVarObject* type. */
-#define _PyVarObject_CAST(op) ((PyVarObject*)(op))
+#define _PyVarObject_CAST(op) _Py_reinterpret_cast(PyVarObject*, (op))
 
 
 // Test if the 'x' object is the 'y' object, the same as "x is y" in Python.
@@ -780,7 +780,8 @@ static inline int PyType_Check(PyObject *op) {
 #  define PyType_Check(op) PyType_Check(_PyObject_CAST(op))
 #endif
 
-#define _PyType_CAST(op) (assert(PyType_Check(op)), (PyTypeObject*)(op))
+#define _PyType_CAST(op) \
+    (assert(PyType_Check(op)), _Py_reinterpret_cast(PyTypeObject*, (op)))
 
 static inline int PyType_CheckExact(PyObject *op) {
     return Py_IS_TYPE(op, &PyType_Type);

--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -182,9 +182,9 @@ PyAPI_FUNC(void) PyObject_GC_UnTrack(void *);
 PyAPI_FUNC(void) PyObject_GC_Del(void *);
 
 #define PyObject_GC_New(type, typeobj) \
-                ( (type *) _PyObject_GC_New(typeobj) )
+                _Py_reinterpret_cast(type*, _PyObject_GC_New(typeobj))
 #define PyObject_GC_NewVar(type, typeobj, n) \
-                ( (type *) _PyObject_GC_NewVar((typeobj), (n)) )
+                _Py_reinterpret_cast(type*, _PyObject_GC_NewVar((typeobj), (n)))
 
 PyAPI_FUNC(int) PyObject_GC_IsTracked(PyObject *);
 PyAPI_FUNC(int) PyObject_GC_IsFinalized(PyObject *);

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -14,6 +14,16 @@
 #endif
 
 
+// Macro to use C++ static_cast<> and reinterpret_cast<> in the Python C API
+#ifdef __cplusplus
+#  define _Py_static_cast(type, expr) static_cast<type>(expr)
+#  define _Py_reinterpret_cast(type, expr) reinterpret_cast<type>(expr)
+#else
+#  define _Py_static_cast(type, expr) ((type)(expr))
+#  define _Py_reinterpret_cast(type, expr) ((type)(expr))
+#endif
+
+
 /* Defines to build Python and its standard library:
  *
  * - Py_BUILD_CORE: Build Python core. Give access to Python internals, but
@@ -295,10 +305,11 @@ extern "C" {
  *    VALUE may be evaluated more than once.
  */
 #ifdef Py_DEBUG
-#define Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW) \
-    (assert((WIDE)(NARROW)(VALUE) == (VALUE)), (NARROW)(VALUE))
+#  define Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW) \
+       (assert((WIDE)(NARROW)(VALUE) == (VALUE)), (NARROW)(VALUE))
 #else
-#define Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW) (NARROW)(VALUE)
+#  define Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW) \
+       _Py_reinterpret_cast(NARROW, (VALUE))
 #endif
 
 

--- a/Misc/NEWS.d/next/C API/2022-04-26-16-51-31.gh-issue-91320.QDHmTv.rst
+++ b/Misc/NEWS.d/next/C API/2022-04-26-16-51-31.gh-issue-91320.QDHmTv.rst
@@ -1,0 +1,3 @@
+Fix C++ compiler warnings about "old-style cast" (``g++ -Wold-style-cast``) in
+the Python C API. Use C++ ``reinterpret_cast<>`` and ``static_cast<>`` casts
+when the Python C API is used in C++. Patch by Victor Stinner.


### PR DESCRIPTION
Fix C++ compiler warnings about "old-style cast"
(g++ -Wold-style-cast) in the Python C API.  Use C++
reinterpret_cast<> and static_cast<> casts when the Python C API is
used in C++.

Example of fixed warning:

    Include/object.h:107:43: error: use of old-style cast to
    ‘PyObject*’ {aka ‘struct _object*’} [-Werror=old-style-cast]
    #define _PyObject_CAST(op) ((PyObject*)(op))

Add _Py_reinterpret_cast() and _Py_static_cast() macros.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
