### PR TITLE
gh-91960: Add FreeBSD build and test using Cirrus-CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,23 @@
+freebsd_task:
+  freebsd_instance:
+    matrix:
+    - image: freebsd-13-2-release-amd64
+  # Turn off TCP and UDP blackhole.  It is not enabled by default in FreeBSD,
+  # but it is in the FreeBSD GCE images as used by Cirrus-CI.  It causes even
+  # local local connections to fail with ETIMEDOUT instead of ECONNREFUSED.
+  # For more information see https://reviews.freebsd.org/D41751 and
+  # https://github.com/cirruslabs/cirrus-ci-docs/issues/483.
+  sysctl_script:
+    - sysctl net.inet.tcp.blackhole=0
+    - sysctl net.inet.udp.blackhole=0
+  build_script:
+    - mkdir build
+    - cd build
+    - ../configure
+    - make -j$(sysctl -n hw.ncpu)
+  pythoninfo_script:
+    - cd build && make pythoninfo
+  test_script:
+    - cd build
+    # dtrace fails to build on FreeBSD - see gh-73263
+    - make buildbottest TESTOPTS="-j0 -x test_dtrace"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,4 +20,4 @@ freebsd_task:
   test_script:
     - cd build
     # dtrace fails to build on FreeBSD - see gh-73263
-    - make buildbottest TESTOPTS="-j0 -x test_dtrace"
+    - make buildbottest TESTOPTS="-j0 -x test_dtrace --timeout=600"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ freebsd_task:
   build_script:
     - mkdir build
     - cd build
-    - ../configure
+    - ../configure --with-pydebug
     - make -j$(sysctl -n hw.ncpu)
   pythoninfo_script:
     - cd build && make pythoninfo

--- a/Misc/NEWS.d/next/Tests/2023-09-05-21-42-54.gh-issue-91960.abClTs.rst
+++ b/Misc/NEWS.d/next/Tests/2023-09-05-21-42-54.gh-issue-91960.abClTs.rst
@@ -1,0 +1,1 @@
+FreeBSD 13.2 CI coverage for pull requests is now provided by Cirrus-CI (a hosted CI service that supports Linux, macOS, Windows, and FreeBSD).


### PR DESCRIPTION
Cirrus-CI is a hosted CI service that supports FreeBSD, Linux, macOS,
and Winodws.  Add a .cirrus.yml to provide CI coverage on pull requests
for FreeBSD 12.3 and 13.0.

<!-- gh-issue-number: gh-91960 -->
* Issue: gh-91960
<!-- /gh-issue-number -->
