### PR TITLE
[3.10] gh-68966: Document mailcap deprecation in Python 3.11

### DIFF
--- a/Doc/library/mailcap.rst
+++ b/Doc/library/mailcap.rst
@@ -3,8 +3,13 @@
 
 .. module:: mailcap
    :synopsis: Mailcap file handling.
+   :deprecated:
 
 **Source code:** :source:`Lib/mailcap.py`
+
+.. deprecated:: 3.11
+   The :mod:`mailcap` module is deprecated. See :pep:`594` for the rationale
+   and the :mod:`mimetypes` module for an alternative.
 
 --------------
 

--- a/Doc/library/netdata.rst
+++ b/Doc/library/netdata.rst
@@ -13,7 +13,6 @@ on the internet.
 
    email.rst
    json.rst
-   mailcap.rst
    mailbox.rst
    mimetypes.rst
    base64.rst

--- a/Doc/library/superseded.rst
+++ b/Doc/library/superseded.rst
@@ -20,9 +20,10 @@ backwards compatibility. They have been superseded by other modules.
    crypt.rst
    imghdr.rst
    imp.rst
+   mailcap.rst
    msilib.rst
-   nntplib.rst
    nis.rst
+   nntplib.rst
    optparse.rst
    ossaudiodev.rst
    pipes.rst


### PR DESCRIPTION
(cherry picked from commit 80de0273c0caf8bae19787bb00255eb3fb2a2d0c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
