### PR TITLE
gh-91928: Add `datetime.UTC` alias for `datetime.timezone.utc`

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -86,7 +86,7 @@ The :mod:`datetime` module exports the following constants:
 
 .. attribute:: UTC
 
-   alias for the UTC timezone, ``datetime.utc``.
+   Alias for the UTC timezone singleton :attr:`datetime.timezone.utc`.
 
 Available Types
 ---------------

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -84,6 +84,7 @@ The :mod:`datetime` module exports the following constants:
    The largest year number allowed in a :class:`date` or :class:`.datetime` object.
    :const:`MAXYEAR` is ``9999``.
 
+.. versionadded:: 3.11
 .. attribute:: UTC
 
    Alias for the UTC timezone singleton :attr:`datetime.timezone.utc`.

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -84,6 +84,11 @@ The :mod:`datetime` module exports the following constants:
    The largest year number allowed in a :class:`date` or :class:`.datetime` object.
    :const:`MAXYEAR` is ``9999``.
 
+.. attribute:: UTC
+
+   alias for the UTC timezone, ``datetime.utc``.
+
+
 Available Types
 ---------------
 

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -88,7 +88,6 @@ The :mod:`datetime` module exports the following constants:
 
    alias for the UTC timezone, ``datetime.utc``.
 
-
 Available Types
 ---------------
 

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -84,10 +84,11 @@ The :mod:`datetime` module exports the following constants:
    The largest year number allowed in a :class:`date` or :class:`.datetime` object.
    :const:`MAXYEAR` is ``9999``.
 
-.. versionadded:: 3.11
 .. attribute:: UTC
 
    Alias for the UTC timezone singleton :attr:`datetime.timezone.utc`.
+
+   .. versionadded:: 3.11
 
 Available Types
 ---------------

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -2290,7 +2290,8 @@ class timezone(tzinfo):
             return f'UTC{sign}{hours:02d}:{minutes:02d}:{seconds:02d}'
         return f'UTC{sign}{hours:02d}:{minutes:02d}'
 
-UTC = timezone.utc = timezone._create(timedelta(0))
+timezone.utc = timezone._create(timedelta(0))
+
 # bpo-37642: These attributes are rounded to the nearest minute for backwards
 # compatibility, even though the constructor will accept a wider range of
 # values. This may change in the future.
@@ -2514,3 +2515,5 @@ else:
     # appropriate to maintain a single module level docstring and
     # remove the following line.
     from _datetime import __doc__
+
+UTC = timezone.utc

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -2290,7 +2290,7 @@ class timezone(tzinfo):
             return f'UTC{sign}{hours:02d}:{minutes:02d}:{seconds:02d}'
         return f'UTC{sign}{hours:02d}:{minutes:02d}'
 
-timezone.utc = timezone._create(timedelta(0))
+UTC = timezone.utc = timezone._create(timedelta(0))
 
 # bpo-37642: These attributes are rounded to the nearest minute for backwards
 # compatibility, even though the constructor will accept a wider range of
@@ -2515,5 +2515,3 @@ else:
     # appropriate to maintain a single module level docstring and
     # remove the following line.
     from _datetime import __doc__
-
-UTC = timezone.utc

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -5,7 +5,7 @@ time zone and DST data sources.
 """
 
 __all__ = ("date", "datetime", "time", "timedelta", "timezone", "tzinfo",
-           "MINYEAR", "MAXYEAR")
+           "MINYEAR", "MAXYEAR", "UTC")
 
 
 import time as _time
@@ -2290,7 +2290,7 @@ class timezone(tzinfo):
             return f'UTC{sign}{hours:02d}:{minutes:02d}:{seconds:02d}'
         return f'UTC{sign}{hours:02d}:{minutes:02d}'
 
-timezone.utc = timezone._create(timedelta(0))
+UTC = timezone.utc = timezone._create(timedelta(0))
 # bpo-37642: These attributes are rounded to the nearest minute for backwards
 # compatibility, even though the constructor will accept a wider range of
 # values. This may change in the future.

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -28,6 +28,7 @@ from datetime import timedelta
 from datetime import tzinfo
 from datetime import time
 from datetime import timezone
+from datetime import UTC
 from datetime import date, datetime
 import time as _time
 
@@ -81,7 +82,7 @@ class TestModule(unittest.TestCase):
                     if not name.startswith('__') and not name.endswith('__'))
         allowed = set(['MAXYEAR', 'MINYEAR', 'date', 'datetime',
                        'datetime_CAPI', 'time', 'timedelta', 'timezone',
-                       'tzinfo', 'sys'])
+                       'tzinfo', 'UTC', 'sys'])
         self.assertEqual(names - allowed, set([]))
 
     def test_divide_and_round(self):
@@ -310,6 +311,7 @@ class TestTimeZone(unittest.TestCase):
 
     def test_tzname(self):
         self.assertEqual('UTC', timezone.utc.tzname(None))
+        self.assertEqual('UTC', UTC.tzname(None))
         self.assertEqual('UTC', timezone(ZERO).tzname(None))
         self.assertEqual('UTC-05:00', timezone(-5 * HOUR).tzname(None))
         self.assertEqual('UTC+09:30', timezone(9.5 * HOUR).tzname(None))

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -67,6 +67,9 @@ class TestModule(unittest.TestCase):
         self.assertEqual(datetime.MINYEAR, 1)
         self.assertEqual(datetime.MAXYEAR, 9999)
 
+    def test_utc_alias(self):
+        self.assertIs(UTC, timezone.utc)
+
     def test_all(self):
         """Test that __all__ only points to valid attributes."""
         all_attrs = dir(datetime_module)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -987,6 +987,7 @@ Toshio Kuratomi
 Ilia Kurenkov
 Vladimir Kushnir
 Erno Kuusela
+Kabir Kwatra
 Ross Lagerwall
 Cameron Laird
 Loïc Lajeanne

--- a/Misc/NEWS.d/next/Library/2022-04-26-18-02-44.gh-issue-91928.V0YveU.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-26-18-02-44.gh-issue-91928.V0YveU.rst
@@ -1,0 +1,1 @@
+Add `datetime.UTC` alias for `datetime.timezone.utc`.

--- a/Misc/NEWS.d/next/Library/2022-04-26-18-02-44.gh-issue-91928.V0YveU.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-26-18-02-44.gh-issue-91928.V0YveU.rst
@@ -1,1 +1,3 @@
 Add `datetime.UTC` alias for `datetime.timezone.utc`.
+
+Patch by Kabir Kwatra.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6634,6 +6634,10 @@ _datetime_exec(PyObject *module)
         return -1;
     }
 
+    if (PyModule_AddObjectRef(module, "UTC", PyDateTime_TimeZone_UTC) < 0) {
+        return -1;
+    }
+
     /* A 4-year cycle has an extra leap day over what we'd get from
      * pasting together 4 single years.
      */


### PR DESCRIPTION
### fixes #91928

`UTC` is now module attribute aliased to `datetime.timezone.utc`.
You can now do the following:
```python
from datetime import UTC
```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:pganssle