### PR TITLE
gh-91952: Make TextIOWrapper.reconfigure() supports "locale" encoding

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -1038,6 +1038,9 @@ Text I/O
 
       .. versionadded:: 3.7
 
+      .. versionchanged:: 3.11
+         The method supports ``encoding="locale"`` option.
+
 
 .. class:: StringIO(initial_value='', newline='\\n')
 

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2161,6 +2161,8 @@ class TextIOWrapper(TextIOBase):
         else:
             if not isinstance(encoding, str):
                 raise TypeError("invalid encoding: %r" % encoding)
+            if encoding == "locale":
+                encoding = locale.getencoding()
 
         if newline is Ellipsis:
             newline = self._readnl

--- a/Misc/NEWS.d/next/Library/2022-04-27-18-04-24.gh-issue-91952.9A4RXx.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-27-18-04-24.gh-issue-91952.9A4RXx.rst
@@ -1,0 +1,1 @@
+Add ``encoding="locale"`` support to :meth:`TextIOWrapper.reconfigure`.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1248,8 +1248,16 @@ textiowrapper_change_encoding(textio *self, PyObject *encoding,
             errors = self->errors;
         }
     }
-    else if (errors == Py_None) {
-        errors = &_Py_ID(strict);
+    else {
+        if (_PyUnicode_EqualToASCIIString(encoding, "locale")) {
+            encoding = _Py_GetLocaleEncodingObject();
+            if (encoding == NULL) {
+                return -1;
+            }
+        }
+        if (errors == Py_None) {
+            errors = &_Py_ID(strict);
+        }
     }
 
     const char *c_errors = PyUnicode_AsUTF8(errors);


### PR DESCRIPTION
Fix #91952

```
$ LANG=ja_JP.eucJP
$ export PYTHONUTF8=1
$ ./python.exe
Python 3.11.0a7+ (heads/main-dirty:29e2245ad5, Apr 27 2022, 17:57:13) [Clang 12.0.0 (clang-1200.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.stdin.encoding
'utf-8'
>>> sys.stdin.reconfigure(encoding="locale")
>>> sys.stdin.encoding
'eucJP'
```