### PR TITLE
gh-91984: Appended '\n' to test strings in test_argparse.py(#91984)

### DIFF
--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2265,8 +2265,7 @@ class TestAddSubparsers(TestCase):
             main description
 
             positional arguments:
-              foo         
-
+              foo         \n
             options:
               -h, --help  show this help message and exit
         '''))
@@ -2282,8 +2281,7 @@ class TestAddSubparsers(TestCase):
             main description
 
             positional arguments:
-              {}          
-
+              {}          \n
             options:
               -h, --help  show this help message and exit
         '''))

--- a/Misc/NEWS.d/next/Library/2022-04-27-18-30-00.gh-issue-91984.LxAB11.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-27-18-30-00.gh-issue-91984.LxAB11.rst
@@ -1,0 +1,1 @@
+Modified test strings in test_argparse.py to not contain trailing spaces before end of line.


### PR DESCRIPTION
#gh-91984: Appended '\n' to test strings in test_argparse.py(#91984)

Implementing the fix proposed in the issue description in https://github.com/python/cpython/issues/91984

Adding '\n' to the end of:

https://github.com/python/cpython/blob/b733708ca32afb5742d921f0b2cad39f4741af50/Lib/test/test_argparse.py#L2268
and 
https://github.com/python/cpython/blob/b733708ca32afb5742d921f0b2cad39f4741af50/Lib/test/test_argparse.py#L2285

Closes #91984.