### PR TITLE
Use static inline function Py_EnterRecursiveCall()

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -91,7 +91,7 @@ extern void _PyEval_DeactivateOpCache(void);
 
 #ifdef USE_STACKCHECK
 /* With USE_STACKCHECK macro defined, trigger stack checks in
-   _Py_CheckRecursiveCall() on every 64th call to Py_EnterRecursiveCall. */
+   _Py_CheckRecursiveCall() on every 64th call to _Py_EnterRecursiveCall. */
 static inline int _Py_MakeRecCheck(PyThreadState *tstate)  {
     return (tstate->recursion_remaining-- <= 0
             || (tstate->recursion_remaining & 63) == 0);
@@ -106,28 +106,24 @@ PyAPI_FUNC(int) _Py_CheckRecursiveCall(
     PyThreadState *tstate,
     const char *where);
 
-static inline int _Py_EnterRecursiveCall(PyThreadState *tstate,
-                                         const char *where) {
+static inline int _Py_EnterRecursiveCallTstate(PyThreadState *tstate,
+                                               const char *where) {
     return (_Py_MakeRecCheck(tstate) && _Py_CheckRecursiveCall(tstate, where));
 }
 
-static inline int _Py_EnterRecursiveCall_inline(const char *where) {
+static inline int _Py_EnterRecursiveCall(const char *where) {
     PyThreadState *tstate = _PyThreadState_GET();
-    return _Py_EnterRecursiveCall(tstate, where);
+    return _Py_EnterRecursiveCallTstate(tstate, where);
 }
 
-#define Py_EnterRecursiveCall(where) _Py_EnterRecursiveCall_inline(where)
-
-static inline void _Py_LeaveRecursiveCall(PyThreadState *tstate)  {
+static inline void _Py_LeaveRecursiveCallTstate(PyThreadState *tstate)  {
     tstate->recursion_remaining++;
 }
 
-static inline void _Py_LeaveRecursiveCall_inline(void)  {
+static inline void _Py_LeaveRecursiveCall(void)  {
     PyThreadState *tstate = _PyThreadState_GET();
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
 }
-
-#define Py_LeaveRecursiveCall() _Py_LeaveRecursiveCall_inline()
 
 extern struct _PyInterpreterFrame* _PyEval_GetFrame(void);
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -112,6 +112,7 @@ bytes(cdata)
 #endif
 
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
 #include "structmember.h"         // PyMemberDef
 
 #include <ffi.h>
@@ -2270,12 +2271,12 @@ PyCSimpleType_from_param(PyObject *type, PyObject *value)
         return NULL;
     }
     if (as_parameter) {
-        if (Py_EnterRecursiveCall("while processing _as_parameter_")) {
+        if (_Py_EnterRecursiveCall("while processing _as_parameter_")) {
             Py_DECREF(as_parameter);
             return NULL;
         }
         value = PyCSimpleType_from_param(type, as_parameter);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         Py_DECREF(as_parameter);
         return value;
     }

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -10,6 +10,7 @@
 #define NEEDS_PY_IDENTIFIER
 
 #include "Python.h"
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
 #include "structmember.h"         // PyMemberDef
 #include "pycore_accu.h"
 
@@ -1059,19 +1060,19 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
             return scanstring_unicode(pystr, idx + 1, s->strict, next_idx_ptr);
         case '{':
             /* object */
-            if (Py_EnterRecursiveCall(" while decoding a JSON object "
-                                      "from a unicode string"))
+            if (_Py_EnterRecursiveCall(" while decoding a JSON object "
+                                       "from a unicode string"))
                 return NULL;
             res = _parse_object_unicode(s, pystr, idx + 1, next_idx_ptr);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             return res;
         case '[':
             /* array */
-            if (Py_EnterRecursiveCall(" while decoding a JSON array "
-                                      "from a unicode string"))
+            if (_Py_EnterRecursiveCall(" while decoding a JSON array "
+                                       "from a unicode string"))
                 return NULL;
             res = _parse_array_unicode(s, pystr, idx + 1, next_idx_ptr);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             return res;
         case 'n':
             /* null */
@@ -1430,17 +1431,17 @@ encoder_listencode_obj(PyEncoderObject *s, _PyAccu *acc,
         return _steal_accumulate(acc, encoded);
     }
     else if (PyList_Check(obj) || PyTuple_Check(obj)) {
-        if (Py_EnterRecursiveCall(" while encoding a JSON object"))
+        if (_Py_EnterRecursiveCall(" while encoding a JSON object"))
             return -1;
         rv = encoder_listencode_list(s, acc, obj, indent_level);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         return rv;
     }
     else if (PyDict_Check(obj)) {
-        if (Py_EnterRecursiveCall(" while encoding a JSON object"))
+        if (_Py_EnterRecursiveCall(" while encoding a JSON object"))
             return -1;
         rv = encoder_listencode_dict(s, acc, obj, indent_level);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         return rv;
     }
     else {
@@ -1468,13 +1469,13 @@ encoder_listencode_obj(PyEncoderObject *s, _PyAccu *acc,
             return -1;
         }
 
-        if (Py_EnterRecursiveCall(" while encoding a JSON object")) {
+        if (_Py_EnterRecursiveCall(" while encoding a JSON object")) {
             Py_DECREF(newobj);
             Py_XDECREF(ident);
             return -1;
         }
         rv = encoder_listencode_obj(s, acc, newobj, indent_level);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
 
         Py_DECREF(newobj);
         if (rv) {

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -9,6 +9,7 @@
 #endif
 
 #include "Python.h"
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "pycore_runtime.h"       // _Py_ID()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
@@ -3068,21 +3069,21 @@ save_list(PicklerObject *self, PyObject *obj)
     if (len != 0) {
         /* Materialize the list elements. */
         if (PyList_CheckExact(obj) && self->proto > 0) {
-            if (Py_EnterRecursiveCall(" while pickling an object"))
+            if (_Py_EnterRecursiveCall(" while pickling an object"))
                 goto error;
             status = batch_list_exact(self, obj);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
         } else {
             PyObject *iter = PyObject_GetIter(obj);
             if (iter == NULL)
                 goto error;
 
-            if (Py_EnterRecursiveCall(" while pickling an object")) {
+            if (_Py_EnterRecursiveCall(" while pickling an object")) {
                 Py_DECREF(iter);
                 goto error;
             }
             status = batch_list(self, iter);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             Py_DECREF(iter);
         }
     }
@@ -3327,10 +3328,10 @@ save_dict(PicklerObject *self, PyObject *obj)
         if (PyDict_CheckExact(obj) && self->proto > 0) {
             /* We can take certain shortcuts if we know this is a dict and
                not a dict subclass. */
-            if (Py_EnterRecursiveCall(" while pickling an object"))
+            if (_Py_EnterRecursiveCall(" while pickling an object"))
                 goto error;
             status = batch_dict_exact(self, obj);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
         } else {
             items = PyObject_CallMethodNoArgs(obj, &_Py_ID(items));
             if (items == NULL)
@@ -3339,12 +3340,12 @@ save_dict(PicklerObject *self, PyObject *obj)
             Py_DECREF(items);
             if (iter == NULL)
                 goto error;
-            if (Py_EnterRecursiveCall(" while pickling an object")) {
+            if (_Py_EnterRecursiveCall(" while pickling an object")) {
                 Py_DECREF(iter);
                 goto error;
             }
             status = batch_dict(self, iter);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             Py_DECREF(iter);
         }
     }
@@ -4300,9 +4301,9 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
         return save_unicode(self, obj);
     }
 
-    /* We're only calling Py_EnterRecursiveCall here so that atomic
+    /* We're only calling _Py_EnterRecursiveCall here so that atomic
        types above are pickled faster. */
-    if (Py_EnterRecursiveCall(" while pickling an object")) {
+    if (_Py_EnterRecursiveCall(" while pickling an object")) {
         return -1;
     }
 
@@ -4460,7 +4461,7 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
     }
   done:
 
-    Py_LeaveRecursiveCall();
+    _Py_LeaveRecursiveCall();
     Py_XDECREF(reduce_func);
     Py_XDECREF(reduce_value);
 

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3489,7 +3489,7 @@ _PyBytesWriter_Alloc(_PyBytesWriter *writer, Py_ssize_t size)
        Don't modify the _PyBytesWriter structure (use a shorter small buffer)
        in debug mode to also be able to detect stack overflow when running
        tests in debug mode. The _PyBytesWriter is large (more than 512 bytes),
-       if Py_EnterRecursiveCall() is not used in deep C callback, we may hit a
+       if _Py_EnterRecursiveCall() is not used in deep C callback, we may hit a
        stack overflow. */
     writer->allocated = Py_MIN(writer->allocated, 10);
     /* _PyBytesWriter_CheckConsistency() requires the last byte to be 0,

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -209,11 +209,11 @@ _PyObject_MakeTpCall(PyThreadState *tstate, PyObject *callable,
     }
 
     PyObject *result = NULL;
-    if (_Py_EnterRecursiveCall(tstate, " while calling a Python object") == 0)
+    if (_Py_EnterRecursiveCallTstate(tstate, " while calling a Python object") == 0)
     {
         result = _PyCFunctionWithKeywords_TrampolineCall(
             (PyCFunctionWithKeywords)call, callable, argstuple, kwdict);
-        _Py_LeaveRecursiveCall(tstate);
+        _Py_LeaveRecursiveCallTstate(tstate);
     }
 
     Py_DECREF(argstuple);
@@ -336,13 +336,13 @@ _PyObject_Call(PyThreadState *tstate, PyObject *callable,
             return NULL;
         }
 
-        if (_Py_EnterRecursiveCall(tstate, " while calling a Python object")) {
+        if (_Py_EnterRecursiveCallTstate(tstate, " while calling a Python object")) {
             return NULL;
         }
 
         result = (*call)(callable, args, kwargs);
 
-        _Py_LeaveRecursiveCall(tstate);
+        _Py_LeaveRecursiveCallTstate(tstate);
 
         return _Py_CheckFunctionResult(tstate, callable, result, NULL);
     }

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1,7 +1,7 @@
 /* Descriptors -- a new, flexible way to describe attributes */
 
 #include "Python.h"
-#include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCallTstate()
 #include "pycore_object.h"        // _PyObject_GC_UNTRACK()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_tuple.h"         // _PyTuple_ITEMS()
@@ -302,7 +302,7 @@ typedef void (*funcptr)(void);
 static inline funcptr
 method_enter_call(PyThreadState *tstate, PyObject *func)
 {
-    if (_Py_EnterRecursiveCall(tstate, " while calling a Python object")) {
+    if (_Py_EnterRecursiveCallTstate(tstate, " while calling a Python object")) {
         return NULL;
     }
     return (funcptr)((PyMethodDescrObject *)func)->d_method->ml_meth;
@@ -330,7 +330,7 @@ method_vectorcall_VARARGS(
     PyObject *result = _PyCFunction_TrampolineCall(
         meth, args[0], argstuple);
     Py_DECREF(argstuple);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     return result;
 }
 
@@ -363,7 +363,7 @@ method_vectorcall_VARARGS_KEYWORDS(
     }
     result = _PyCFunctionWithKeywords_TrampolineCall(
         meth, args[0], argstuple, kwdict);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
 exit:
     Py_DECREF(argstuple);
     Py_XDECREF(kwdict);
@@ -386,7 +386,7 @@ method_vectorcall_FASTCALL_KEYWORDS_METHOD(
     PyObject *result = meth(args[0],
                             ((PyMethodDescrObject *)func)->d_common.d_type,
                             args+1, nargs-1, kwnames);
-    Py_LeaveRecursiveCall();
+    _Py_LeaveRecursiveCall();
     return result;
 }
 
@@ -405,7 +405,7 @@ method_vectorcall_FASTCALL(
         return NULL;
     }
     PyObject *result = meth(args[0], args+1, nargs-1);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     return result;
 }
 
@@ -424,7 +424,7 @@ method_vectorcall_FASTCALL_KEYWORDS(
         return NULL;
     }
     PyObject *result = meth(args[0], args+1, nargs-1, kwnames);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     return result;
 }
 
@@ -451,7 +451,7 @@ method_vectorcall_NOARGS(
         return NULL;
     }
     PyObject *result = _PyCFunction_TrampolineCall(meth, args[0], NULL);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     return result;
 }
 
@@ -479,7 +479,7 @@ method_vectorcall_O(
         return NULL;
     }
     PyObject *result = _PyCFunction_TrampolineCall(meth, args[0], args[1]);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     return result;
 }
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -7,6 +7,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <stdbool.h>
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCall
 #include "pycore_exceptions.h"    // struct _Py_exc_state
 #include "pycore_initconfig.h"
 #include "pycore_object.h"
@@ -1097,7 +1098,7 @@ exceptiongroup_split_recursive(PyObject *exc,
     for (Py_ssize_t i = 0; i < num_excs; i++) {
         PyObject *e = PyTuple_GET_ITEM(eg->excs, i);
         _exceptiongroup_split_result rec_result;
-        if (Py_EnterRecursiveCall(" in exceptiongroup_split_recursive")) {
+        if (_Py_EnterRecursiveCall(" in exceptiongroup_split_recursive")) {
             goto done;
         }
         if (exceptiongroup_split_recursive(
@@ -1105,10 +1106,10 @@ exceptiongroup_split_recursive(PyObject *exc,
                 construct_rest, &rec_result) < 0) {
             assert(!rec_result.match);
             assert(!rec_result.rest);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             goto done;
         }
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (rec_result.match) {
             assert(PyList_CheckExact(match_list));
             if (PyList_Append(match_list, rec_result.match) < 0) {
@@ -1234,11 +1235,11 @@ collect_exception_group_leaves(PyObject *exc, PyObject *leaves)
     /* recursive calls */
     for (Py_ssize_t i = 0; i < num_excs; i++) {
         PyObject *e = PyTuple_GET_ITEM(eg->excs, i);
-        if (Py_EnterRecursiveCall(" in collect_exception_group_leaves")) {
+        if (_Py_EnterRecursiveCall(" in collect_exception_group_leaves")) {
             return -1;
         }
         int res = collect_exception_group_leaves(e, leaves);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res < 0) {
             return -1;
         }

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -2,7 +2,7 @@
 /* Method object implementation */
 
 #include "Python.h"
-#include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCallTstate()
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
@@ -403,7 +403,7 @@ typedef void (*funcptr)(void);
 static inline funcptr
 cfunction_enter_call(PyThreadState *tstate, PyObject *func)
 {
-    if (_Py_EnterRecursiveCall(tstate, " while calling a Python object")) {
+    if (_Py_EnterRecursiveCallTstate(tstate, " while calling a Python object")) {
         return NULL;
     }
     return (funcptr)PyCFunction_GET_FUNCTION(func);
@@ -425,7 +425,7 @@ cfunction_vectorcall_FASTCALL(
         return NULL;
     }
     PyObject *result = meth(PyCFunction_GET_SELF(func), args, nargs);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     return result;
 }
 
@@ -441,7 +441,7 @@ cfunction_vectorcall_FASTCALL_KEYWORDS(
         return NULL;
     }
     PyObject *result = meth(PyCFunction_GET_SELF(func), args, nargs, kwnames);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     return result;
 }
 
@@ -457,7 +457,7 @@ cfunction_vectorcall_FASTCALL_KEYWORDS_METHOD(
         return NULL;
     }
     PyObject *result = meth(PyCFunction_GET_SELF(func), cls, args, nargs, kwnames);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     return result;
 }
 
@@ -485,7 +485,7 @@ cfunction_vectorcall_NOARGS(
     }
     PyObject *result = _PyCFunction_TrampolineCall(
         meth, PyCFunction_GET_SELF(func), NULL);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     return result;
 }
 
@@ -513,7 +513,7 @@ cfunction_vectorcall_O(
     }
     PyObject *result = _PyCFunction_TrampolineCall(
         meth, PyCFunction_GET_SELF(func), args[0]);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     return result;
 }
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -3,7 +3,7 @@
 
 #include "Python.h"
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
-#include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCallTstate()
 #include "pycore_context.h"       // _PyContextTokenMissing_Type
 #include "pycore_dict.h"          // _PyObject_MakeDictFromInstanceAttributes()
 #include "pycore_floatobject.h"   // _PyFloat_DebugMallocStats()
@@ -427,12 +427,12 @@ PyObject_Repr(PyObject *v)
 
     /* It is possible for a type to have a tp_repr representation that loops
        infinitely. */
-    if (_Py_EnterRecursiveCall(tstate,
-                               " while getting the repr of an object")) {
+    if (_Py_EnterRecursiveCallTstate(tstate,
+                                     " while getting the repr of an object")) {
         return NULL;
     }
     res = (*Py_TYPE(v)->tp_repr)(v);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
 
     if (res == NULL) {
         return NULL;
@@ -487,11 +487,11 @@ PyObject_Str(PyObject *v)
 
     /* It is possible for a type to have a tp_str representation that loops
        infinitely. */
-    if (_Py_EnterRecursiveCall(tstate, " while getting the str of an object")) {
+    if (_Py_EnterRecursiveCallTstate(tstate, " while getting the str of an object")) {
         return NULL;
     }
     res = (*Py_TYPE(v)->tp_str)(v);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
 
     if (res == NULL) {
         return NULL;
@@ -724,11 +724,11 @@ PyObject_RichCompare(PyObject *v, PyObject *w, int op)
         }
         return NULL;
     }
-    if (_Py_EnterRecursiveCall(tstate, " in comparison")) {
+    if (_Py_EnterRecursiveCallTstate(tstate, " in comparison")) {
         return NULL;
     }
     PyObject *res = do_richcompare(tstate, v, w, op);
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     return res;
 }
 

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -490,11 +490,11 @@ class Obj2ModPrototypeVisitor(PickleVisitor):
 class Obj2ModVisitor(PickleVisitor):
     @contextmanager
     def recursive_call(self, node, level):
-        self.emit('if (Py_EnterRecursiveCall(" while traversing \'%s\' node")) {' % node, level, reflow=False)
+        self.emit('if (_Py_EnterRecursiveCall(" while traversing \'%s\' node")) {' % node, level, reflow=False)
         self.emit('goto failed;', level + 1)
         self.emit('}', level)
         yield
-        self.emit('Py_LeaveRecursiveCall();', level)
+        self.emit('_Py_LeaveRecursiveCall();', level)
 
     def funcHeader(self, name):
         ctype = get_c_type(name)
@@ -1482,9 +1482,10 @@ def generate_module_def(mod, metadata, f, internal_h):
     print(textwrap.dedent("""
         #include "Python.h"
         #include "pycore_ast.h"
-        #include "pycore_ast_state.h"       // struct ast_state
-        #include "pycore_interp.h"          // _PyInterpreterState.ast
-        #include "pycore_pystate.h"         // _PyInterpreterState_GET()
+        #include "pycore_ast_state.h"     // struct ast_state
+        #include "pycore_ceval.h"         // _Py_EnterRecursiveCall
+        #include "pycore_interp.h"        // _PyInterpreterState.ast
+        #include "pycore_pystate.h"       // _PyInterpreterState_GET()
         #include "structmember.h"
         #include <stddef.h>
 

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -2,9 +2,10 @@
 
 #include "Python.h"
 #include "pycore_ast.h"
-#include "pycore_ast_state.h"       // struct ast_state
-#include "pycore_interp.h"          // _PyInterpreterState.ast
-#include "pycore_pystate.h"         // _PyInterpreterState_GET()
+#include "pycore_ast_state.h"     // struct ast_state
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCall
+#include "pycore_interp.h"        // _PyInterpreterState.ast
+#include "pycore_pystate.h"       // _PyInterpreterState_GET()
 #include "structmember.h"
 #include <stddef.h>
 
@@ -5432,11 +5433,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Module' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Module' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5469,11 +5470,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 type_ignore_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Module' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Module' node")) {
                     goto failed;
                 }
                 res = obj2ast_type_ignore(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5518,11 +5519,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Interactive' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Interactive' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5554,11 +5555,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Expression' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Expression' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &body, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5597,11 +5598,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'FunctionType' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'FunctionType' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5621,11 +5622,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'FunctionType' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'FunctionType' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &returns, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5666,11 +5667,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -5683,11 +5684,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -5700,11 +5701,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -5717,11 +5718,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -5747,11 +5748,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
                 goto failed;
             }
             res = obj2ast_identifier(state, tmp, &name, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5764,11 +5765,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
                 goto failed;
             }
             res = obj2ast_arguments(state, tmp, &args, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5794,11 +5795,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5831,11 +5832,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5855,11 +5856,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &returns, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5872,11 +5873,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
                 goto failed;
             }
             res = obj2ast_string(state, tmp, &type_comment, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5908,11 +5909,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
                 goto failed;
             }
             res = obj2ast_identifier(state, tmp, &name, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5925,11 +5926,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
                 goto failed;
             }
             res = obj2ast_arguments(state, tmp, &args, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5955,11 +5956,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5992,11 +5993,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6016,11 +6017,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &returns, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6033,11 +6034,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
                 goto failed;
             }
             res = obj2ast_string(state, tmp, &type_comment, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6069,11 +6070,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
                 goto failed;
             }
             res = obj2ast_identifier(state, tmp, &name, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6099,11 +6100,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6136,11 +6137,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 keyword_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
                     goto failed;
                 }
                 res = obj2ast_keyword(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6173,11 +6174,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6210,11 +6211,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6248,11 +6249,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Return' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Return' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6291,11 +6292,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Delete' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Delete' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6343,11 +6344,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Assign' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Assign' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6367,11 +6368,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Assign' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Assign' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6384,11 +6385,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Assign' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Assign' node")) {
                 goto failed;
             }
             res = obj2ast_string(state, tmp, &type_comment, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6416,11 +6417,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AugAssign' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AugAssign' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &target, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6433,11 +6434,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AugAssign' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AugAssign' node")) {
                 goto failed;
             }
             res = obj2ast_operator(state, tmp, &op, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6450,11 +6451,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AugAssign' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AugAssign' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6483,11 +6484,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &target, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6500,11 +6501,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &annotation, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6517,11 +6518,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6534,11 +6535,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
                 goto failed;
             }
             res = obj2ast_int(state, tmp, &simple, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6568,11 +6569,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'For' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'For' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &target, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6585,11 +6586,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'For' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'For' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &iter, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6615,11 +6616,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'For' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'For' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6652,11 +6653,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'For' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'For' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6676,11 +6677,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'For' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'For' node")) {
                 goto failed;
             }
             res = obj2ast_string(state, tmp, &type_comment, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6710,11 +6711,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &target, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6727,11 +6728,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &iter, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6757,11 +6758,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6794,11 +6795,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6818,11 +6819,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
                 goto failed;
             }
             res = obj2ast_string(state, tmp, &type_comment, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6851,11 +6852,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'While' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'While' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &test, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6881,11 +6882,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'While' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'While' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6918,11 +6919,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'While' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'While' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6957,11 +6958,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'If' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'If' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &test, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6987,11 +6988,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'If' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'If' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7024,11 +7025,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'If' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'If' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7076,11 +7077,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 withitem_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'With' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'With' node")) {
                     goto failed;
                 }
                 res = obj2ast_withitem(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7113,11 +7114,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'With' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'With' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7137,11 +7138,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'With' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'With' node")) {
                 goto failed;
             }
             res = obj2ast_string(state, tmp, &type_comment, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7182,11 +7183,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 withitem_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'AsyncWith' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'AsyncWith' node")) {
                     goto failed;
                 }
                 res = obj2ast_withitem(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7219,11 +7220,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'AsyncWith' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'AsyncWith' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7243,11 +7244,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'AsyncWith' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'AsyncWith' node")) {
                 goto failed;
             }
             res = obj2ast_string(state, tmp, &type_comment, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7274,11 +7275,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Match' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Match' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &subject, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7304,11 +7305,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 match_case_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Match' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Match' node")) {
                     goto failed;
                 }
                 res = obj2ast_match_case(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7342,11 +7343,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Raise' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Raise' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &exc, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7359,11 +7360,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Raise' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Raise' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &cause, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7405,11 +7406,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Try' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Try' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7442,11 +7443,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 excepthandler_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Try' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Try' node")) {
                     goto failed;
                 }
                 res = obj2ast_excepthandler(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7479,11 +7480,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Try' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Try' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7516,11 +7517,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Try' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Try' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7569,11 +7570,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'TryStar' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'TryStar' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7606,11 +7607,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 excepthandler_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'TryStar' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'TryStar' node")) {
                     goto failed;
                 }
                 res = obj2ast_excepthandler(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7643,11 +7644,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'TryStar' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'TryStar' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7680,11 +7681,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'TryStar' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'TryStar' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7718,11 +7719,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Assert' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Assert' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &test, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7735,11 +7736,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Assert' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Assert' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &msg, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7778,11 +7779,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 alias_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Import' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Import' node")) {
                     goto failed;
                 }
                 res = obj2ast_alias(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7817,11 +7818,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'ImportFrom' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'ImportFrom' node")) {
                 goto failed;
             }
             res = obj2ast_identifier(state, tmp, &module, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7847,11 +7848,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 alias_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'ImportFrom' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'ImportFrom' node")) {
                     goto failed;
                 }
                 res = obj2ast_alias(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7871,11 +7872,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'ImportFrom' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'ImportFrom' node")) {
                 goto failed;
             }
             res = obj2ast_int(state, tmp, &level, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7914,11 +7915,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 identifier val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Global' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Global' node")) {
                     goto failed;
                 }
                 res = obj2ast_identifier(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7964,11 +7965,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 identifier val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Nonlocal' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Nonlocal' node")) {
                     goto failed;
                 }
                 res = obj2ast_identifier(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8001,11 +8002,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Expr' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Expr' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8083,11 +8084,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'expr' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'expr' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -8100,11 +8101,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'expr' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'expr' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -8117,11 +8118,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'expr' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'expr' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -8134,11 +8135,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'expr' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'expr' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -8160,11 +8161,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'BoolOp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'BoolOp' node")) {
                 goto failed;
             }
             res = obj2ast_boolop(state, tmp, &op, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8190,11 +8191,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'BoolOp' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'BoolOp' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8228,11 +8229,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'NamedExpr' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'NamedExpr' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &target, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8245,11 +8246,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'NamedExpr' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'NamedExpr' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8277,11 +8278,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'BinOp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'BinOp' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &left, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8294,11 +8295,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'BinOp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'BinOp' node")) {
                 goto failed;
             }
             res = obj2ast_operator(state, tmp, &op, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8311,11 +8312,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'BinOp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'BinOp' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &right, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8342,11 +8343,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'UnaryOp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'UnaryOp' node")) {
                 goto failed;
             }
             res = obj2ast_unaryop(state, tmp, &op, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8359,11 +8360,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'UnaryOp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'UnaryOp' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &operand, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8390,11 +8391,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Lambda' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Lambda' node")) {
                 goto failed;
             }
             res = obj2ast_arguments(state, tmp, &args, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8407,11 +8408,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Lambda' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Lambda' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &body, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8439,11 +8440,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'IfExp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'IfExp' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &test, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8456,11 +8457,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'IfExp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'IfExp' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &body, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8473,11 +8474,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'IfExp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'IfExp' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &orelse, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8517,11 +8518,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Dict' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Dict' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8554,11 +8555,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Dict' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Dict' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8604,11 +8605,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Set' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Set' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8642,11 +8643,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'ListComp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'ListComp' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &elt, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8672,11 +8673,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'ListComp' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'ListComp' node")) {
                     goto failed;
                 }
                 res = obj2ast_comprehension(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8710,11 +8711,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'SetComp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'SetComp' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &elt, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8740,11 +8741,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'SetComp' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'SetComp' node")) {
                     goto failed;
                 }
                 res = obj2ast_comprehension(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8779,11 +8780,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'DictComp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'DictComp' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &key, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8796,11 +8797,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'DictComp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'DictComp' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8826,11 +8827,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'DictComp' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'DictComp' node")) {
                     goto failed;
                 }
                 res = obj2ast_comprehension(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8864,11 +8865,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'GeneratorExp' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'GeneratorExp' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &elt, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8894,11 +8895,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'GeneratorExp' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'GeneratorExp' node")) {
                     goto failed;
                 }
                 res = obj2ast_comprehension(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8931,11 +8932,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Await' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Await' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8961,11 +8962,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Yield' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Yield' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8991,11 +8992,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'YieldFrom' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'YieldFrom' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9023,11 +9024,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Compare' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Compare' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &left, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9053,11 +9054,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 cmpop_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Compare' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Compare' node")) {
                     goto failed;
                 }
                 res = obj2ast_cmpop(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -9090,11 +9091,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Compare' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Compare' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -9129,11 +9130,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Call' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Call' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &func, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9159,11 +9160,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Call' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Call' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -9196,11 +9197,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 keyword_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Call' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Call' node")) {
                     goto failed;
                 }
                 res = obj2ast_keyword(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -9235,11 +9236,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'FormattedValue' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'FormattedValue' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9252,11 +9253,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'FormattedValue' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'FormattedValue' node")) {
                 goto failed;
             }
             res = obj2ast_int(state, tmp, &conversion, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9269,11 +9270,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'FormattedValue' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'FormattedValue' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &format_spec, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9313,11 +9314,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'JoinedStr' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'JoinedStr' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -9351,11 +9352,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Constant' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Constant' node")) {
                 goto failed;
             }
             res = obj2ast_constant(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9368,11 +9369,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Constant' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Constant' node")) {
                 goto failed;
             }
             res = obj2ast_string(state, tmp, &kind, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9400,11 +9401,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Attribute' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Attribute' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9417,11 +9418,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Attribute' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Attribute' node")) {
                 goto failed;
             }
             res = obj2ast_identifier(state, tmp, &attr, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9434,11 +9435,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Attribute' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Attribute' node")) {
                 goto failed;
             }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9466,11 +9467,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Subscript' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Subscript' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9483,11 +9484,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Subscript' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Subscript' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &slice, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9500,11 +9501,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Subscript' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Subscript' node")) {
                 goto failed;
             }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9531,11 +9532,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Starred' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Starred' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9548,11 +9549,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Starred' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Starred' node")) {
                 goto failed;
             }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9579,11 +9580,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Name' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Name' node")) {
                 goto failed;
             }
             res = obj2ast_identifier(state, tmp, &id, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9596,11 +9597,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Name' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Name' node")) {
                 goto failed;
             }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9640,11 +9641,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'List' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'List' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -9664,11 +9665,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'List' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'List' node")) {
                 goto failed;
             }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9708,11 +9709,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'Tuple' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'Tuple' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -9732,11 +9733,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Tuple' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Tuple' node")) {
                 goto failed;
             }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9764,11 +9765,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Slice' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Slice' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &lower, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9781,11 +9782,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Slice' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Slice' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &upper, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9798,11 +9799,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'Slice' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'Slice' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &step, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -10148,11 +10149,11 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
             goto failed;
         }
         res = obj2ast_expr(state, tmp, &target, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10165,11 +10166,11 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
             goto failed;
         }
         res = obj2ast_expr(state, tmp, &iter, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10195,11 +10196,11 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
             expr_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            if (Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp2, &val, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -10219,11 +10220,11 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &is_async, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10260,11 +10261,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10277,11 +10278,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10294,11 +10295,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10311,11 +10312,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10338,11 +10339,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'ExceptHandler' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'ExceptHandler' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &type, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -10355,11 +10356,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'ExceptHandler' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'ExceptHandler' node")) {
                 goto failed;
             }
             res = obj2ast_identifier(state, tmp, &name, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -10385,11 +10386,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'ExceptHandler' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'ExceptHandler' node")) {
                     goto failed;
                 }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -10447,11 +10448,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
             arg_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
                 goto failed;
             }
             res = obj2ast_arg(state, tmp2, &val, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -10484,11 +10485,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
             arg_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
                 goto failed;
             }
             res = obj2ast_arg(state, tmp2, &val, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -10508,11 +10509,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
             goto failed;
         }
         res = obj2ast_arg(state, tmp, &vararg, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10538,11 +10539,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
             arg_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
                 goto failed;
             }
             res = obj2ast_arg(state, tmp2, &val, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -10575,11 +10576,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
             expr_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp2, &val, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -10599,11 +10600,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
             goto failed;
         }
         res = obj2ast_arg(state, tmp, &kwarg, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10629,11 +10630,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
             expr_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp2, &val, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -10673,11 +10674,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'arg' node")) {
             goto failed;
         }
         res = obj2ast_identifier(state, tmp, &arg, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10690,11 +10691,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'arg' node")) {
             goto failed;
         }
         res = obj2ast_expr(state, tmp, &annotation, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10707,11 +10708,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'arg' node")) {
             goto failed;
         }
         res = obj2ast_string(state, tmp, &type_comment, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10724,11 +10725,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'arg' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10741,11 +10742,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'arg' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10758,11 +10759,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'arg' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10775,11 +10776,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'arg' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10812,11 +10813,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
             goto failed;
         }
         res = obj2ast_identifier(state, tmp, &arg, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10829,11 +10830,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
             goto failed;
         }
         res = obj2ast_expr(state, tmp, &value, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10846,11 +10847,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10863,11 +10864,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10880,11 +10881,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10897,11 +10898,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10934,11 +10935,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'alias' node")) {
             goto failed;
         }
         res = obj2ast_identifier(state, tmp, &name, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10951,11 +10952,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'alias' node")) {
             goto failed;
         }
         res = obj2ast_identifier(state, tmp, &asname, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10968,11 +10969,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'alias' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10985,11 +10986,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'alias' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -11002,11 +11003,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'alias' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -11019,11 +11020,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'alias' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -11052,11 +11053,11 @@ obj2ast_withitem(struct ast_state *state, PyObject* obj, withitem_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'withitem' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'withitem' node")) {
             goto failed;
         }
         res = obj2ast_expr(state, tmp, &context_expr, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -11069,11 +11070,11 @@ obj2ast_withitem(struct ast_state *state, PyObject* obj, withitem_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'withitem' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'withitem' node")) {
             goto failed;
         }
         res = obj2ast_expr(state, tmp, &optional_vars, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -11102,11 +11103,11 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'match_case' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'match_case' node")) {
             goto failed;
         }
         res = obj2ast_pattern(state, tmp, &pattern, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -11119,11 +11120,11 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'match_case' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'match_case' node")) {
             goto failed;
         }
         res = obj2ast_expr(state, tmp, &guard, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -11149,11 +11150,11 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
             stmt_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            if (Py_EnterRecursiveCall(" while traversing 'match_case' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'match_case' node")) {
                 goto failed;
             }
             res = obj2ast_stmt(state, tmp2, &val, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -11197,11 +11198,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -11214,11 +11215,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -11231,11 +11232,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -11248,11 +11249,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     }
     else {
         int res;
-        if (Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
+        if (_Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
             goto failed;
         }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
-        Py_LeaveRecursiveCall();
+        _Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -11273,11 +11274,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'MatchValue' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'MatchValue' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -11303,11 +11304,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'MatchSingleton' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'MatchSingleton' node")) {
                 goto failed;
             }
             res = obj2ast_constant(state, tmp, &value, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -11346,11 +11347,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 pattern_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'MatchSequence' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'MatchSequence' node")) {
                     goto failed;
                 }
                 res = obj2ast_pattern(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -11398,11 +11399,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'MatchMapping' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'MatchMapping' node")) {
                     goto failed;
                 }
                 res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -11435,11 +11436,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 pattern_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'MatchMapping' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'MatchMapping' node")) {
                     goto failed;
                 }
                 res = obj2ast_pattern(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -11459,11 +11460,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'MatchMapping' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'MatchMapping' node")) {
                 goto failed;
             }
             res = obj2ast_identifier(state, tmp, &rest, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -11492,11 +11493,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
                 goto failed;
             }
             res = obj2ast_expr(state, tmp, &cls, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -11522,11 +11523,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 pattern_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
                     goto failed;
                 }
                 res = obj2ast_pattern(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -11559,11 +11560,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 identifier val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
                     goto failed;
                 }
                 res = obj2ast_identifier(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -11596,11 +11597,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 pattern_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
                     goto failed;
                 }
                 res = obj2ast_pattern(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -11634,11 +11635,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'MatchStar' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'MatchStar' node")) {
                 goto failed;
             }
             res = obj2ast_identifier(state, tmp, &name, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -11665,11 +11666,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'MatchAs' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'MatchAs' node")) {
                 goto failed;
             }
             res = obj2ast_pattern(state, tmp, &pattern, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -11682,11 +11683,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'MatchAs' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'MatchAs' node")) {
                 goto failed;
             }
             res = obj2ast_identifier(state, tmp, &name, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -11725,11 +11726,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 pattern_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                if (Py_EnterRecursiveCall(" while traversing 'MatchOr' node")) {
+                if (_Py_EnterRecursiveCall(" while traversing 'MatchOr' node")) {
                     goto failed;
                 }
                 res = obj2ast_pattern(state, tmp2, &val, arena);
-                Py_LeaveRecursiveCall();
+                _Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -11783,11 +11784,11 @@ obj2ast_type_ignore(struct ast_state *state, PyObject* obj, type_ignore_ty*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'TypeIgnore' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'TypeIgnore' node")) {
                 goto failed;
             }
             res = obj2ast_int(state, tmp, &lineno, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -11800,11 +11801,11 @@ obj2ast_type_ignore(struct ast_state *state, PyObject* obj, type_ignore_ty*
         }
         else {
             int res;
-            if (Py_EnterRecursiveCall(" while traversing 'TypeIgnore' node")) {
+            if (_Py_EnterRecursiveCall(" while traversing 'TypeIgnore' node")) {
                 goto failed;
             }
             res = obj2ast_string(state, tmp, &tag, arena);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -880,7 +880,7 @@ Py_SetRecursionLimit(int new_limit)
     }
 }
 
-/* The function _Py_EnterRecursiveCall() only calls _Py_CheckRecursiveCall()
+/* The function _Py_EnterRecursiveCallTstate() only calls _Py_CheckRecursiveCall()
    if the recursion_depth reaches recursion_limit. */
 int
 _Py_CheckRecursiveCall(PyThreadState *tstate, const char *where)
@@ -1736,7 +1736,7 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int 
 
     /* support for generator.throw() */
     if (throwflag) {
-        if (_Py_EnterRecursiveCall(tstate, "")) {
+        if (_Py_EnterRecursiveCallTstate(tstate, "")) {
             tstate->recursion_remaining--;
             goto exit_unwind;
         }
@@ -1776,7 +1776,7 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int 
 
 
 start_frame:
-    if (_Py_EnterRecursiveCall(tstate, "")) {
+    if (_Py_EnterRecursiveCallTstate(tstate, "")) {
         tstate->recursion_remaining--;
         goto exit_unwind;
     }
@@ -2492,7 +2492,7 @@ handle_eval_breaker:
             _PyFrame_SetStackPointer(frame, stack_pointer);
             TRACE_FUNCTION_EXIT();
             DTRACE_FUNCTION_EXIT();
-            _Py_LeaveRecursiveCall(tstate);
+            _Py_LeaveRecursiveCallTstate(tstate);
             if (!frame->is_entry) {
                 frame = cframe.current_frame = pop_frame(tstate, frame);
                 _PyFrame_StackPush(frame, retval);
@@ -2704,7 +2704,7 @@ handle_eval_breaker:
             _PyFrame_SetStackPointer(frame, stack_pointer);
             TRACE_FUNCTION_EXIT();
             DTRACE_FUNCTION_EXIT();
-            _Py_LeaveRecursiveCall(tstate);
+            _Py_LeaveRecursiveCallTstate(tstate);
             /* Restore previous cframe and return. */
             tstate->cframe = cframe.previous;
             tstate->cframe->use_tracing = cframe.use_tracing;
@@ -5066,12 +5066,12 @@ handle_eval_breaker:
             PyCFunction cfunc = PyCFunction_GET_FUNCTION(callable);
             // This is slower but CPython promises to check all non-vectorcall
             // function calls.
-            if (_Py_EnterRecursiveCall(tstate, " while calling a Python object")) {
+            if (_Py_EnterRecursiveCallTstate(tstate, " while calling a Python object")) {
                 goto error;
             }
             PyObject *arg = TOP();
             PyObject *res = cfunc(PyCFunction_GET_SELF(callable), arg);
-            _Py_LeaveRecursiveCall(tstate);
+            _Py_LeaveRecursiveCallTstate(tstate);
             assert((res != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
 
             Py_DECREF(arg);
@@ -5268,11 +5268,11 @@ handle_eval_breaker:
             PyCFunction cfunc = meth->ml_meth;
             // This is slower but CPython promises to check all non-vectorcall
             // function calls.
-            if (_Py_EnterRecursiveCall(tstate, " while calling a Python object")) {
+            if (_Py_EnterRecursiveCallTstate(tstate, " while calling a Python object")) {
                 goto error;
             }
             PyObject *res = cfunc(self, arg);
-            _Py_LeaveRecursiveCall(tstate);
+            _Py_LeaveRecursiveCallTstate(tstate);
             assert((res != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
             Py_DECREF(self);
             Py_DECREF(arg);
@@ -5340,11 +5340,11 @@ handle_eval_breaker:
             PyCFunction cfunc = meth->ml_meth;
             // This is slower but CPython promises to check all non-vectorcall
             // function calls.
-            if (_Py_EnterRecursiveCall(tstate, " while calling a Python object")) {
+            if (_Py_EnterRecursiveCallTstate(tstate, " while calling a Python object")) {
                 goto error;
             }
             PyObject *res = cfunc(self, NULL);
-            _Py_LeaveRecursiveCall(tstate);
+            _Py_LeaveRecursiveCallTstate(tstate);
             assert((res != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
             Py_DECREF(self);
             STACK_SHRINK(oparg + 1);
@@ -5484,7 +5484,7 @@ handle_eval_breaker:
             assert(frame->frame_obj == NULL);
             gen->gi_frame_state = FRAME_CREATED;
             gen_frame->owner = FRAME_OWNED_BY_GENERATOR;
-            _Py_LeaveRecursiveCall(tstate);
+            _Py_LeaveRecursiveCallTstate(tstate);
             if (!frame->is_entry) {
                 _PyInterpreterFrame *prev = frame->previous;
                 _PyThreadState_PopFrame(tstate, frame);
@@ -5850,7 +5850,7 @@ exception_unwind:
 
 exit_unwind:
     assert(_PyErr_Occurred(tstate));
-    _Py_LeaveRecursiveCall(tstate);
+    _Py_LeaveRecursiveCallTstate(tstate);
     if (frame->is_entry) {
         /* Restore previous cframe and exit */
         tstate->cframe = cframe.previous;
@@ -7955,12 +7955,12 @@ maybe_dtrace_line(_PyInterpreterFrame *frame,
 
 int Py_EnterRecursiveCall(const char *where)
 {
-    return _Py_EnterRecursiveCall_inline(where);
+    return _Py_EnterRecursiveCall(where);
 }
 
 #undef Py_LeaveRecursiveCall
 
 void Py_LeaveRecursiveCall(void)
 {
-    _Py_LeaveRecursiveCall_inline();
+    _Py_LeaveRecursiveCall();
 }

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -13,6 +13,7 @@
 #include "Python.h"
 
 #include "pycore_ast.h"           // PyAST_mod2obj
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCall
 #include "pycore_compile.h"       // _PyAST_Compile()
 #include "pycore_interp.h"        // PyInterpreterState.importlib
 #include "pycore_object.h"        // _PyDebug_PrintTotalRefs()
@@ -1268,13 +1269,13 @@ print_chained(struct exception_print_context* ctx, PyObject *value,
 {
     PyObject *f = ctx->file;
 
-    if (Py_EnterRecursiveCall(" in print_chained") < 0) {
+    if (_Py_EnterRecursiveCall(" in print_chained") < 0) {
         return -1;
     }
     bool need_close = ctx->need_close;
     int res = print_exception_recursive(ctx, value);
     ctx->need_close = need_close;
-    Py_LeaveRecursiveCall();
+    _Py_LeaveRecursiveCall();
     if (res < 0) {
         return -1;
     }
@@ -1445,11 +1446,11 @@ print_exception_group(struct exception_print_context *ctx, PyObject *value)
         PyObject *exc = PyTuple_GET_ITEM(excs, i);
 
         if (!truncated) {
-            if (Py_EnterRecursiveCall(" in print_exception_group") != 0) {
+            if (_Py_EnterRecursiveCall(" in print_exception_group") != 0) {
                 return -1;
             }
             int res = print_exception_recursive(ctx, exc);
-            Py_LeaveRecursiveCall();
+            _Py_LeaveRecursiveCall();
             if (res < 0) {
                 return -1;
             }


### PR DESCRIPTION
Currently, calling Py_EnterRecursiveCall() and
Py_LeaveRecursiveCall() may use a function call or a static inline
function call, depending if the internal pycore_ceval.h header file
is included or not. Use a different name for the static inline
function to ensure that the static inline function is always used in
Python internals for best performance. Similar approach than
PyThreadState_GET() (function call) and _PyThreadState_GET() (static
inline function).

* Rename _Py_EnterRecursiveCall() to _Py_EnterRecursiveCallTstate()
* Rename _Py_LeaveRecursiveCall() to _Py_LeaveRecursiveCallTstate()
* pycore_ceval.c: Rename Py_EnterRecursiveCall() to
  _Py_EnterRecursiveCall() and Py_LeaveRecursiveCall() and
  _Py_LeaveRecursiveCall()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
