### PR TITLE
gh-89479: Export _Py_GetSpecializationStats() internal function

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -139,7 +139,7 @@ General Options
    The statistics will be dumped to a arbitrary (probably unique) file in
    ``/tmp/py_stats/``, or ``C:\temp\py_stats\`` on Windows.
 
-   Use ``Tools//summarize_stats.py`` to read the stats.
+   Use ``Tools/scripts/summarize_stats.py`` to read the stats.
 
    .. versionadded:: 3.11
 

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -316,7 +316,8 @@ extern PyStats _py_stats;
 
 extern void _Py_PrintSpecializationStats(int to_file);
 
-extern PyObject* _Py_GetSpecializationStats(void);
+// Used by the _opcode extension which is built as a shared library
+PyAPI_FUNC(PyObject*) _Py_GetSpecializationStats(void);
 
 #else
 #define STAT_INC(opname, name) ((void)0)
@@ -324,7 +325,7 @@ extern PyObject* _Py_GetSpecializationStats(void);
 #define OPCODE_EXE_INC(opname) ((void)0)
 #define CALL_STAT_INC(name) ((void)0)
 #define OBJECT_STAT_INC(name) ((void)0)
-#endif
+#endif  // !Py_STATS
 
 // Cache values are only valid in memory, so use native endianness.
 #ifdef WORDS_BIGENDIAN


### PR DESCRIPTION
When Python is built with "./configure --enable-pystats" (if the
Py_STATS macro is defined), the _Py_GetSpecializationStats() function
must be exported, since it's used by the _opcode extension which is
built as a shared library.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
