### PR TITLE
gh-82678: Fix parameter name for pipes

### DIFF
--- a/Doc/library/pipes.rst
+++ b/Doc/library/pipes.rst
@@ -89,7 +89,7 @@ Template objects following methods:
    arguments.
 
 
-.. method:: Template.open(file, mode)
+.. method:: Template.open(file, rw)
 
    Return a file-like object, open to *file*, but read from or written to by the
    pipeline.  Note that only one of ``'r'``, ``'w'`` may be given.

--- a/Lib/pipes.py
+++ b/Lib/pipes.py
@@ -48,8 +48,8 @@ standard output is written, respectively.  The return value is the
 exit status of the conversion pipeline.
 
 To open a file for reading or writing through a conversion pipeline:
-   fp = t.open(file, mode)
-where mode is 'r' to read the file, or 'w' to write it -- just like
+   fp = t.open(file, rw)
+where rw is 'r' to read the file, or 'w' to write it -- just like
 for the built-in function open() or for os.popen().
 
 To create a new template object initialized to a given one:


### PR DESCRIPTION
#82678

https://github.com/python/cpython/blob/main/Lib/pipes.py#L145

(Also a random `# '` [here](https://github.com/python/cpython/blob/main/Lib/pipes.py#L57) that could optionally be removed)