### PR TITLE
gh-92019: Make sqlite3.Blob indexing conform with the norm

### DIFF
--- a/Doc/includes/sqlite3/blob.py
+++ b/Doc/includes/sqlite3/blob.py
@@ -9,8 +9,8 @@ with con.blobopen("test", "blob_col", 1) as blob:
     blob.write(b"hello, ")
     blob.write(b"world.")
     # Modify the first and last bytes of our blob
-    blob[0] = b"H"
-    blob[-1] = b"!"
+    blob[0] = ord("H")
+    blob[-1] = ord("!")
 
 # Read the contents of our blob
 with con.blobopen("test", "blob_col", 1) as blob:

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -120,7 +120,25 @@ blob_seterror(pysqlite_Blob *self, int rc)
 }
 
 static PyObject *
-inner_read(pysqlite_Blob *self, Py_ssize_t length, Py_ssize_t offset)
+read_single(pysqlite_Blob *self, Py_ssize_t offset)
+{
+    assert(offset <= sqlite3_blob_bytes(self->blob));
+
+    unsigned long buf;
+    int rc;
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_blob_read(self->blob, (void *)&buf, 1, (int)offset);
+    Py_END_ALLOW_THREADS
+
+    if (rc != SQLITE_OK) {
+        blob_seterror(self, rc);
+        return NULL;
+    }
+    return PyLong_FromUnsignedLong(buf);
+}
+
+static PyObject *
+read_multiple(pysqlite_Blob *self, Py_ssize_t length, Py_ssize_t offset)
 {
     assert(length <= sqlite3_blob_bytes(self->blob));
     assert(offset <= sqlite3_blob_bytes(self->blob));
@@ -175,7 +193,7 @@ blob_read_impl(pysqlite_Blob *self, int length)
         length = max_read_len;
     }
 
-    PyObject *buffer = inner_read(self, length, self->offset);
+    PyObject *buffer = read_multiple(self, length, self->offset);
     if (buffer == NULL) {
         return NULL;
     }
@@ -387,7 +405,7 @@ subscript_index(pysqlite_Blob *self, PyObject *item)
     if (i < 0) {
         return NULL;
     }
-    return inner_read(self, 1, i);
+    return read_single(self, i);
 }
 
 static int
@@ -411,9 +429,9 @@ subscript_slice(pysqlite_Blob *self, PyObject *item)
     }
 
     if (step == 1) {
-        return inner_read(self, len, start);
+        return read_multiple(self, len, start);
     }
-    PyObject *blob = inner_read(self, stop - start, start);
+    PyObject *blob = read_multiple(self, stop - start, start);
     if (blob == NULL) {
         return NULL;
     }
@@ -455,24 +473,27 @@ ass_subscript_index(pysqlite_Blob *self, PyObject *item, PyObject *value)
                         "Blob doesn't support item deletion");
         return -1;
     }
+    if (!PyLong_Check(value)) {
+        PyErr_Format(PyExc_TypeError,
+                     "'%s' object cannot be interpreted as an integer",
+                     Py_TYPE(value)->tp_name);
+        return -1;
+    }
     Py_ssize_t i = get_subscript_index(self, item);
     if (i < 0) {
         return -1;
     }
 
-    Py_buffer vbuf;
-    if (PyObject_GetBuffer(value, &vbuf, PyBUF_SIMPLE) < 0) {
+    long val = PyLong_AsLong(value);
+    if (val == -1 && PyErr_Occurred()) {
+        PyErr_Clear();
+        val = -1;
+    }
+    if (val < 0 || val > 255) {
+        PyErr_SetString(PyExc_ValueError, "byte must be in range(0, 256)");
         return -1;
     }
-    int rc = -1;
-    if (vbuf.len != 1) {
-        PyErr_SetString(PyExc_ValueError, "Blob assignment must be a single byte");
-    }
-    else {
-        rc = inner_write(self, (const char *)vbuf.buf, 1, i);
-    }
-    PyBuffer_Release(&vbuf);
-    return rc;
+    return inner_write(self, (const void *)&val, 1, i);
 }
 
 static int
@@ -507,7 +528,7 @@ ass_subscript_slice(pysqlite_Blob *self, PyObject *item, PyObject *value)
         rc = inner_write(self, vbuf.buf, len, start);
     }
     else {
-        PyObject *blob_bytes = inner_read(self, stop - start, start);
+        PyObject *blob_bytes = read_multiple(self, stop - start, start);
         if (blob_bytes != NULL) {
             char *blob_buf = PyBytes_AS_STRING(blob_bytes);
             for (Py_ssize_t i = 0, j = 0; i < len; i++, j += step) {

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -496,7 +496,9 @@ ass_subscript_index(pysqlite_Blob *self, PyObject *item, PyObject *value)
         PyErr_SetString(PyExc_ValueError, "byte must be in range(0, 256)");
         return -1;
     }
-    return inner_write(self, (const void *)&val, 1, i);
+    // Downcast to avoid endianness problems.
+    unsigned char byte = (unsigned char)val;
+    return inner_write(self, (const void *)&byte, 1, i);
 }
 
 static int

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -139,7 +139,7 @@ static PyObject *
 read_multiple(pysqlite_Blob *self, Py_ssize_t length, Py_ssize_t offset)
 {
     assert(length <= sqlite3_blob_bytes(self->blob));
-    assert(offset <= sqlite3_blob_bytes(self->blob));
+    assert(offset < sqlite3_blob_bytes(self->blob));
 
     PyObject *buffer = PyBytes_FromStringAndSize(NULL, length);
     if (buffer == NULL) {
@@ -189,6 +189,11 @@ blob_read_impl(pysqlite_Blob *self, int length)
     int max_read_len = blob_len - self->offset;
     if (length < 0 || length > max_read_len) {
         length = max_read_len;
+    }
+
+    assert(length >= 0);
+    if (length == 0) {
+        return PyBytes_FromStringAndSize(NULL, 0);
     }
 
     PyObject *buffer = read_multiple(self, length, self->offset);

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -122,7 +122,7 @@ blob_seterror(pysqlite_Blob *self, int rc)
 static PyObject *
 read_single(pysqlite_Blob *self, Py_ssize_t offset)
 {
-    unsigned long buf = 0;
+    unsigned char buf = 0;
     int rc;
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_blob_read(self->blob, (void *)&buf, 1, (int)offset);
@@ -132,7 +132,7 @@ read_single(pysqlite_Blob *self, Py_ssize_t offset)
         blob_seterror(self, rc);
         return NULL;
     }
-    return PyLong_FromUnsignedLong(buf);
+    return PyLong_FromUnsignedLong((unsigned long)buf);
 }
 
 static PyObject *

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -122,8 +122,6 @@ blob_seterror(pysqlite_Blob *self, int rc)
 static PyObject *
 read_single(pysqlite_Blob *self, Py_ssize_t offset)
 {
-    assert(offset <= sqlite3_blob_bytes(self->blob));
-
     unsigned long buf = 0;
     int rc;
     Py_BEGIN_ALLOW_THREADS

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -124,7 +124,7 @@ read_single(pysqlite_Blob *self, Py_ssize_t offset)
 {
     assert(offset <= sqlite3_blob_bytes(self->blob));
 
-    unsigned long buf;
+    unsigned long buf = 0;
     int rc;
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_blob_read(self->blob, (void *)&buf, 1, (int)offset);


### PR DESCRIPTION
- get index now returns an int
- set index now requires an int in range(0, 256)

Resolves #92019

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
