### PR TITLE
gh-92033: Remove usage of first person narration

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2522,7 +2522,7 @@ the attributes of the spec. In addition mocked functions / methods have the
 same call signature as the original so they raise a :exc:`TypeError` if they are
 called incorrectly.
 
-Before I explain how auto-speccing works, here's why it is needed.
+Before explaining how auto-speccing works, it is important to understand why it is needed.
 
 :class:`Mock` is a very powerful and flexible object, but it suffers from two flaws
 when used to mock out objects from a system under test. One of these flaws is


### PR DESCRIPTION
Remove the literal only usage of first person narration in the entire documentation. 
Update single sentence to be more readable without the use of first-person pronouns.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
