### PR TITLE
gh-91998: 'WebAssemby' to 'WebAssembly'

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -144,7 +144,7 @@ General Options
    .. versionadded:: 3.11
 
 WebAssembly Options
-------------------
+-------------------
 
 .. cmdoption:: --with-emscripten-target=[browser|node]
 

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -143,7 +143,7 @@ General Options
 
    .. versionadded:: 3.11
 
-WebAssemby Options
+WebAssembly Options
 ------------------
 
 .. cmdoption:: --with-emscripten-target=[browser|node]

--- a/Misc/NEWS.d/next/Documentation/2022-04-29-02-57-54.gh-issue-91998.c7v2Bq.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-04-29-02-57-54.gh-issue-91998.c7v2Bq.rst
@@ -1,0 +1,1 @@
+spelling corrected for 'WebAssembly' (previously 'WebAssemby')

--- a/Misc/NEWS.d/next/Documentation/2022-04-29-02-57-54.gh-issue-91998.c7v2Bq.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-04-29-02-57-54.gh-issue-91998.c7v2Bq.rst
@@ -1,1 +1,0 @@
-spelling corrected for 'WebAssembly' (previously 'WebAssemby')


### PR DESCRIPTION
it appears that in the documentation it is 'Tools/scripts/summarize_stats.py', but here,
https://docs.python.org/3.11/using/configure.html#cmdoption-enable-pystats
it shows `Tools//summarize_stats.py`

found another typo, so, created this pr.