### PR TITLE
Rephrase typing.assert_never docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2358,7 +2358,7 @@ Functions and decorators
    reachable, it will emit an error. For example, if the type annotation
    for ``arg`` was instead ``int | str | float``, the type checker would
    emit an error pointing out that ``unreachable`` is of type :class:`float`.
-   For a call to ``assert_never`` to succeed, the inferred type of
+   For a call to ``assert_never`` to pass type checking, the inferred type of
    the argument passed in must be the bottom type, :data:`Never`, and nothing
    else.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2337,7 +2337,7 @@ Functions and decorators
 
 .. function:: assert_never(arg, /)
 
-   Assert to the type checker that a line of code is unreachable.
+   Ask a static type checker to confirm that a line of code is unreachable.
 
    Example::
 


### PR DESCRIPTION
This change is similar to that in #32069

The goal here is to reduce potential confusion between
`assert_never(val)` and `assert False`