### PR TITLE
gh-92062: `inspect.Parameter` checks whether `name` is a keyword

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2708,7 +2708,10 @@ class Parameter:
             self._kind = _POSITIONAL_ONLY
             name = 'implicit{}'.format(name[1:])
 
-        if iskeyword(name) or not name.isidentifier():
+        # It's possible for C functions to have a positional-only parameter
+        # where the name is a keyword, so for compatibility we'll allow it.
+        is_keyword = iskeyword(name) and self._kind is not _POSITIONAL_ONLY
+        if is_keyword or not name.isidentifier():
             raise ValueError('{!r} is not a valid parameter name'.format(name))
 
         self._name = name

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -149,6 +149,7 @@ import token
 import types
 import functools
 import builtins
+from keyword import iskeyword
 from operator import attrgetter
 from collections import namedtuple, OrderedDict
 
@@ -2707,7 +2708,7 @@ class Parameter:
             self._kind = _POSITIONAL_ONLY
             name = 'implicit{}'.format(name[1:])
 
-        if not name.isidentifier():
+        if iskeyword(name) or not name.isidentifier():
             raise ValueError('{!r} is not a valid parameter name'.format(name))
 
         self._name = name

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1646,7 +1646,7 @@ class Traceback(_Traceback):
         instance = super().__new__(cls, filename, lineno, function, code_context, index)
         instance.positions = positions
         return instance
-    
+
     def __repr__(self):
         return ('Traceback(filename={!r}, lineno={!r}, function={!r}, '
                'code_context={!r}, index={!r}, positions={!r})'.format(
@@ -1684,7 +1684,7 @@ def getframeinfo(frame, context=1):
         frame, *positions = (frame, lineno, *positions[1:])
     else:
         frame, *positions = (frame, *positions)
-    
+
     lineno = positions[0]
 
     if not isframe(frame):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -3604,6 +3604,9 @@ class TestParameterObject(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'not a valid parameter name'):
             inspect.Parameter('1', kind=inspect.Parameter.VAR_KEYWORD)
 
+        with self.assertRaisesRegex(ValueError, 'not a valid parameter name'):
+            inspect.Parameter('from', kind=inspect.Parameter.VAR_KEYWORD)
+
         with self.assertRaisesRegex(TypeError, 'name must be a str'):
             inspect.Parameter(None, kind=inspect.Parameter.VAR_KEYWORD)
 

--- a/Misc/NEWS.d/next/Library/2022-04-29-18-15-23.gh-issue-92062.X2c_Rj.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-29-18-15-23.gh-issue-92062.X2c_Rj.rst
@@ -1,0 +1,2 @@
+:class:`inspect.Parameter` now raises :exc:`ValueError` if ``name`` is
+a keyword, in addition to the existing check that it is an identifier.


### PR DESCRIPTION
Fixes #92062.

Automerge-Triggered-By: GH:pganssle