### PR TITLE
gh-92049: Forbid pickling constants re._constants.SUCCESS etc

### DIFF
--- a/Lib/re/_constants.py
+++ b/Lib/re/_constants.py
@@ -62,6 +62,8 @@ class _NamedIntConstant(int):
     def __repr__(self):
         return self.name
 
+    __reduce__ = None
+
 MAXREPEAT = _NamedIntConstant(MAXREPEAT, 'MAXREPEAT')
 
 def _makecodes(*names):

--- a/Misc/NEWS.d/next/Library/2022-04-30-10-53-10.gh-issue-92049.5SEKoh.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-30-10-53-10.gh-issue-92049.5SEKoh.rst
@@ -1,0 +1,2 @@
+Forbid pickling constants ``re._constants.SUCCESS`` etc. Previously,
+pickling did not fail, but the result could not be unpickled.


### PR DESCRIPTION
Previously, pickling did not fail, but the result could not be unpickled.
