### PR TITLE
[3.9] gh-92049: Forbid pickling constants re._constants.SUCCES…

### DIFF
--- a/Lib/sre_constants.py
+++ b/Lib/sre_constants.py
@@ -62,6 +62,8 @@ class _NamedIntConstant(int):
     def __repr__(self):
         return self.name
 
+    __reduce__ = None
+
 MAXREPEAT = _NamedIntConstant(MAXREPEAT, 'MAXREPEAT')
 
 def _makecodes(names):

--- a/Misc/NEWS.d/next/Library/2022-04-30-10-53-10.gh-issue-92049.5SEKoh.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-30-10-53-10.gh-issue-92049.5SEKoh.rst
@@ -1,0 +1,2 @@
+Forbid pickling constants ``re._constants.SUCCESS`` etc. Previously,
+pickling did not fail, but the result could not be unpickled.


### PR DESCRIPTION
…S etc (GH-92070) (GH-92073)

Previously, pickling did not fail, but the result could not be unpickled.
(cherry picked from commit 6d0d547033e295f91f05030322acfbb0e280fc1f)
(cherry picked from commit e8ff3c92f69b475aa20ba7c08efccbc329f9b42e)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
