### PR TITLE
gh-92114: Improve error message for types with __class_getitem__ = None

### DIFF
--- a/Lib/test/test_genericclass.py
+++ b/Lib/test/test_genericclass.py
@@ -220,6 +220,7 @@ class TestClassGetitem(unittest.TestCase):
                 return None
         with self.assertRaises(TypeError):
             C_too_few[int]
+
         class C_too_many:
             def __class_getitem__(cls, one, two):
                 return None
@@ -232,15 +233,22 @@ class TestClassGetitem(unittest.TestCase):
                 return None
         with self.assertRaises(TypeError):
             C()[int]
+
         class E: ...
         e = E()
         e.__class_getitem__ = lambda cls, item: 'This will not work'
         with self.assertRaises(TypeError):
             e[int]
+
         class C_not_callable:
             __class_getitem__ = "Surprise!"
         with self.assertRaises(TypeError):
             C_not_callable[int]
+
+        class C_is_none(tuple):
+            __class_getitem__ = None
+        with self.assertRaisesRegex(TypeError, "C_is_none"):
+            C_is_none[int]
 
     def test_class_getitem_metaclass(self):
         class Meta(type):

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-01-16-40-07.gh-issue-92114.5xTlLt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-01-16-40-07.gh-issue-92114.5xTlLt.rst
@@ -1,0 +1,2 @@
+Improve error message when subscript a type with ``__class_getitem__`` set
+to ``None``.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -185,11 +185,12 @@ PyObject_GetItem(PyObject *o, PyObject *key)
         if (_PyObject_LookupAttr(o, &_Py_ID(__class_getitem__), &meth) < 0) {
             return NULL;
         }
-        if (meth) {
+        if (meth && meth != Py_None) {
             result = PyObject_CallOneArg(meth, key);
             Py_DECREF(meth);
             return result;
         }
+        Py_XDECREF(meth);
         PyErr_Format(PyExc_TypeError, "type '%.200s' is not subscriptable",
                      ((PyTypeObject *)o)->tp_name);
         return NULL;


### PR DESCRIPTION
Closes #92114.