### PR TITLE
gh-92106: Forbid specialization of TypedDict types

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5812,6 +5812,8 @@ class TypedDictTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(dict, Emp)
         with self.assertRaises(TypeError):
+            Emp[int, str]
+        with self.assertRaises(TypeError):
             TypedDict('Hi', [('x', int)], y=int)
 
     def test_py36_class_syntax_usage(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2883,6 +2883,7 @@ class _TypedDictMeta(type):
         tp_dict.__optional_keys__ = frozenset(optional_keys)
         if not hasattr(tp_dict, '__total__'):
             tp_dict.__total__ = total
+        tp_dict.__class_getitem__ = None
         return tp_dict
 
     __call__ = dict  # static method

--- a/Misc/NEWS.d/next/Library/2022-05-01-16-58-31.gh-issue-92106.qjt1Gq.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-01-16-58-31.gh-issue-92106.qjt1Gq.rst
@@ -1,0 +1,2 @@
+:class:`typing.TypedDict` types are non-generic by default. Subscripting
+them raises now TypeError.


### PR DESCRIPTION
Closes #92106.