### PR TITLE
gh-92107: Forbid specialization of namedtuple types

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -493,6 +493,7 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
         '_asdict': _asdict,
         '__getnewargs__': __getnewargs__,
         '__match_args__': field_names,
+        '__class_getitem__': None,
     }
     for index, name in enumerate(field_names):
         doc = _sys.intern(f'Alias for field number {index}')

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -520,6 +520,11 @@ class TestNamedTuple(unittest.TestCase):
         with self.assertRaises(AttributeError):
             p.z
 
+    def test_non_generic(self):
+        Point = namedtuple('Point', 'x y')
+        with self.assertRaises(TypeError):
+            Point[int, str]
+
     def test_odd_sizes(self):
         Zero = namedtuple('Zero', '')
         self.assertEqual(Zero(), ())

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -116,7 +116,6 @@ class BaseTest(unittest.TestCase):
                      TemporaryDirectory, SpooledTemporaryFile,
                      Queue, SimpleQueue,
                      _AssertRaisesContext,
-                     SplitResult, ParseResult,
                      WeakSet, ReferenceType, ref,
                      ShareableList,
                      Future, _WorkItem,
@@ -138,7 +137,7 @@ class BaseTest(unittest.TestCase):
                 self.assertEqual(alias.__parameters__, ())
 
     def test_unsubscriptable(self):
-        for t in int, str, float, Sized, Hashable:
+        for t in int, str, float, Sized, Hashable, SplitResult, ParseResult:
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):
                 with self.assertRaisesRegex(TypeError, tname):

--- a/Misc/NEWS.d/next/Library/2022-05-01-17-10-36.gh-issue-92107.RmsD1n.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-01-17-10-36.gh-issue-92107.RmsD1n.rst
@@ -1,0 +1,2 @@
+:class:`collections.namedtuple` types are non-generic by default.
+Subscripting them now raises TypeError.


### PR DESCRIPTION
Closes #92107.