### PR TITLE
gh-92128: Add `__class_getitem__` to `logging.LoggerAdapter` and `logging.StreamHandler`

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -25,6 +25,7 @@ To use, simply 'import logging' and log away!
 
 import sys, os, time, io, re, traceback, warnings, weakref, collections.abc
 
+from types import GenericAlias
 from string import Template
 from string import Formatter as StrFormatter
 
@@ -1145,6 +1146,8 @@ class StreamHandler(Handler):
             name += ' '
         return '<%s %s(%s)>' % (self.__class__.__name__, name, level)
 
+    __class_getitem__ = classmethod(GenericAlias)
+
 
 class FileHandler(StreamHandler):
     """
@@ -1938,6 +1941,8 @@ class LoggerAdapter(object):
         logger = self.logger
         level = getLevelName(logger.getEffectiveLevel())
         return '<%s %s (%s)>' % (self.__class__.__name__, logger.name, level)
+
+    __class_getitem__ = classmethod(GenericAlias)
 
 root = RootLogger(WARNING)
 Logger.root = root

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -14,6 +14,7 @@ from contextvars import ContextVar, Token
 from dataclasses import Field
 from functools import partial, partialmethod, cached_property
 from graphlib import TopologicalSorter
+from logging import LoggerAdapter, StreamHandler
 from mailbox import Mailbox, _PartialFile
 try:
     import ctypes
@@ -113,6 +114,7 @@ class BaseTest(unittest.TestCase):
                      MappingProxyType, AsyncGeneratorType,
                      DirEntry,
                      chain,
+                     LoggerAdapter, StreamHandler,
                      TemporaryDirectory, SpooledTemporaryFile,
                      Queue, SimpleQueue,
                      _AssertRaisesContext,

--- a/Misc/NEWS.d/next/Library/2022-05-01-21-45-41.gh-issue-92128.Di7VbE.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-01-21-45-41.gh-issue-92128.Di7VbE.rst
@@ -1,0 +1,2 @@
+Add :meth:`~object.__class_getitem__` to :class:`logging.LoggerAdapter` and
+:class:`logging.StreamHandler`. Patch by Alex Waygood.

--- a/Misc/NEWS.d/next/Library/2022-05-01-21-45-41.gh-issue-92128.Di7VbE.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-01-21-45-41.gh-issue-92128.Di7VbE.rst
@@ -1,2 +1,3 @@
 Add :meth:`~object.__class_getitem__` to :class:`logging.LoggerAdapter` and
-:class:`logging.StreamHandler`. Patch by Alex Waygood.
+:class:`logging.StreamHandler`, allowing them to be parameterized at runtime.
+Patch by Alex Waygood.


### PR DESCRIPTION
Closes #92128
