### PR TITLE
[3.9] gh-81488: Add recursive wording for issubclass docs (GH-92087).

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -862,7 +862,8 @@ are always available.  They are listed here in alphabetical order.
    Return ``True`` if *class* is a subclass (direct, indirect or :term:`virtual
    <abstract base class>`) of *classinfo*.  A
    class is considered a subclass of itself. *classinfo* may be a tuple of class
-   objects, in which case return ``True`` if *class* is a subclass of any entry
+   objects (or recursively, other such tuples),
+   in which case return ``True`` if *class* is a subclass of any entry
    in *classinfo*.  In any other case, a :exc:`TypeError` exception is raised.
 
 


### PR DESCRIPTION
(cherry picked from commit 1066ecb97042b8e89de554e6f9dc2e3d634208c0)