### PR TITLE
gh-92135: Fix _Py_reinterpret_cast() for const

### DIFF
--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -43,8 +43,7 @@ typedef PyObject *(*PyCMethod)(PyObject *, PyTypeObject *, PyObject *const *,
 // it triggers an undefined behavior when Python calls it with 2 parameters
 // (bpo-33012).
 #define _PyCFunction_CAST(func) \
-    _Py_reinterpret_cast(PyCFunction, \
-        _Py_reinterpret_cast(void(*)(void), (func)))
+    _Py_reinterpret_cast(PyCFunction, _Py_reinterpret_cast(void(*)(void), (func)))
 
 PyAPI_FUNC(PyCFunction) PyCFunction_GetFunction(PyObject *);
 PyAPI_FUNC(PyObject *) PyCFunction_GetSelf(PyObject *);

--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -182,9 +182,9 @@ PyAPI_FUNC(void) PyObject_GC_UnTrack(void *);
 PyAPI_FUNC(void) PyObject_GC_Del(void *);
 
 #define PyObject_GC_New(type, typeobj) \
-                _Py_reinterpret_cast(type*, _PyObject_GC_New(typeobj))
+    _Py_reinterpret_cast(type*, _PyObject_GC_New(typeobj))
 #define PyObject_GC_NewVar(type, typeobj, n) \
-                _Py_reinterpret_cast(type*, _PyObject_GC_NewVar((typeobj), (n)))
+    _Py_reinterpret_cast(type*, _PyObject_GC_NewVar((typeobj), (n)))
 
 PyAPI_FUNC(int) PyObject_GC_IsTracked(PyObject *);
 PyAPI_FUNC(int) PyObject_GC_IsFinalized(PyObject *);

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -14,10 +14,20 @@
 #endif
 
 
-// Macro to use C++ static_cast<> and reinterpret_cast<> in the Python C API
+// Macro to use C++ static_cast<>, reinterpret_cast<> and const_cast<>
+// in the Python C API.
+//
+// In C++, _Py_reinterpret_cast(type, expr) converts a constant expression to a
+// non constant type using const_cast<type>. For example,
+// _Py_reinterpret_cast(PyObject*, op) can convert a "const PyObject*" to
+// "PyObject*".
+//
+// The type argument must not be constant. For example, in C++,
+// _Py_reinterpret_cast(const PyObject*, expr) fails with a compiler error.
 #ifdef __cplusplus
 #  define _Py_static_cast(type, expr) static_cast<type>(expr)
-#  define _Py_reinterpret_cast(type, expr) reinterpret_cast<type>(expr)
+#  define _Py_reinterpret_cast(type, expr) \
+       const_cast<type>(reinterpret_cast<const type>(expr))
 #else
 #  define _Py_static_cast(type, expr) ((type)(expr))
 #  define _Py_reinterpret_cast(type, expr) ((type)(expr))
@@ -307,10 +317,10 @@ extern "C" {
  */
 #ifdef Py_DEBUG
 #  define Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW) \
-       (assert((WIDE)(NARROW)(VALUE) == (VALUE)), (NARROW)(VALUE))
+       (assert(_Py_static_cast(WIDE, _Py_static_cast(NARROW, (VALUE))) == (VALUE)), \
+        _Py_static_cast(NARROW, (VALUE)))
 #else
-#  define Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW) \
-       _Py_reinterpret_cast(NARROW, (VALUE))
+#  define Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW) _Py_static_cast(NARROW, (VALUE))
 #endif
 
 


### PR DESCRIPTION
Fix C++ compiler warnings on cast macros, like _PyObject_CAST(), when
casting a constant expression to a non constant type: use
const_cast<> in C++.

* In C++, Py_SAFE_DOWNCAST() now uses static_cast<> rather than
  reinterpret_cast<>.
* Add tests to the _testcppext C++ extension.
* test_cppext no longer captures stdout in verbose mode.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
