### PR TITLE
Reduce branches in PyUnicode_MAX_CHAR_VALUE

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -436,7 +436,7 @@ static inline Py_UCS4 PyUnicode_MAX_CHAR_VALUE(PyObject *op)
     if (PyUnicode_IS_ASCII(op)) {
         return 0x7fU;
     }
-    static Py_UCS4 max_char_values[] = {
+    static const Py_UCS4 max_char_values[] = {
         0, /* PyUnicode_WCHAR_KIND */
         0xffU, /* PyUnicode_1BYTE_KIND */
         0xffffU, /* PyUnicode_2BYTE_KIND */

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -436,10 +436,12 @@ static inline Py_UCS4 PyUnicode_MAX_CHAR_VALUE(PyObject *op)
     if (PyUnicode_IS_ASCII(op)) {
         return 0x7fU;
     }
-    static const Py_UCS4 max_char_values[] = {
-        [PyUnicode_1BYTE_KIND] = 0xffU,
-        [PyUnicode_2BYTE_KIND] = 0xffffU,
-        [PyUnicode_4BYTE_KIND] = 0x10ffffU,
+    static Py_UCS4 max_char_values[] = {
+        0, /* PyUnicode_WCHAR_KIND */
+        0xffU, /* PyUnicode_1BYTE_KIND */
+        0xffffU, /* PyUnicode_2BYTE_KIND */
+        0,
+        0x10ffffU, /* PyUnicode_4BYTE_KIND */
     };
     unsigned int kind = PyUnicode_KIND(op);
     const Py_UCS4 value = max_char_values[kind];

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -436,17 +436,17 @@ static inline Py_UCS4 PyUnicode_MAX_CHAR_VALUE(PyObject *op)
     if (PyUnicode_IS_ASCII(op)) {
         return 0x7fU;
     }
-
+    static const Py_UCS4 max_char_values[] = {
+        [PyUnicode_1BYTE_KIND] = 0xffU,
+        [PyUnicode_2BYTE_KIND] = 0xffffU,
+        [PyUnicode_4BYTE_KIND] = 0x10ffffU,
+    };
     unsigned int kind = PyUnicode_KIND(op);
-    if (kind == PyUnicode_1BYTE_KIND) {
-       return 0xffU;
-    }
-    if (kind == PyUnicode_2BYTE_KIND) {
-        return 0xffffU;
-    }
-    assert(kind == PyUnicode_4BYTE_KIND);
-    return 0x10ffffU;
+    const Py_UCS4 value = max_char_values[kind];
+    assert(value);
+    return value;
 }
+
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #  define PyUnicode_MAX_CHAR_VALUE(op) \
        PyUnicode_MAX_CHAR_VALUE(_PyObject_CAST(op))


### PR DESCRIPTION
Offers a minor 5.5 % speed improvement in microbenchmark but less branches are better especially when it can be done with a small lookup table.

Benchmark:

```console
./python -m timeit -s "a='🚀'" "a*1000"
```

```console
# Before
2000000 loops, best of 5: 182 nsec per loop
# After
2000000 loops, best of 5: 172 nsec per loop
```