### PR TITLE
gh-92082: Changed a.closing from a class to a function for consistency with docs

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -181,7 +181,7 @@ Functions and classes provided:
    ``page.close()`` will be called when the :keyword:`with` block is exited.
 
 
-.. class:: aclosing(thing)
+.. function:: aclosing(thing)
 
    Return an async context manager that calls the ``aclose()`` method of *thing*
    upon completion of the block.  This is basically equivalent to::


### PR DESCRIPTION
Signed-off-by: prwatson <prwatson@redhat.com>

# gh-92082: Changed aclosing from a class to a function as closing is listed as a function.

aclosing was originally listed as class, however, this is inconsistent as closing is listed as a function right above it. aclosing has been changed from a class to a function. 