### PR TITLE
[3.10] bpo-43504: Remove effbot urls (GH-26308)

### DIFF
--- a/Doc/about.rst
+++ b/Doc/about.rst
@@ -23,9 +23,8 @@ Many thanks go to:
   and writer of much of the content;
 * the `Docutils <http://docutils.sourceforge.net/>`_ project for creating
   reStructuredText and the Docutils suite;
-* Fredrik Lundh for his `Alternative Python Reference
-  <http://effbot.org/zone/pyref.htm>`_ project from which Sphinx got many good
-  ideas.
+* Fredrik Lundh for his Alternative Python Reference project from which Sphinx
+  got many good ideas.
 
 
 Contributors to the Python Documentation

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -106,9 +106,6 @@ support, pads, and mouse support. This means the module isn't compatible with
 operating systems that only have BSD curses, but there don't seem to be any
 currently maintained OSes that fall into this category.
 
-For Windows: use `the consolelib module
-<http://effbot.org/zone/console-index.htm>`_.
-
 
 Is there an equivalent to C's onexit() in Python?
 -------------------------------------------------

--- a/Doc/howto/curses.rst
+++ b/Doc/howto/curses.rst
@@ -55,11 +55,7 @@ everything, though.
 
 The Windows version of Python doesn't include the :mod:`curses`
 module.  A ported version called `UniCurses
-<https://pypi.org/project/UniCurses>`_ is available.  You could
-also try `the Console module <http://effbot.org/zone/console-index.htm>`_
-written by Fredrik Lundh, which doesn't
-use the same API as curses but provides cursor-addressable text output
-and full support for mouse and keyboard input.
+<https://pypi.org/project/UniCurses>`_ is available.
 
 
 The Python curses module

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -55,6 +55,9 @@ details that are unchanged.
 
    Books:
 
+   `Programming Python <http://learning-python.com/about-pp4e.html>`_
+      Book by Mark Lutz, has excellent coverage of Tkinter.
+
    * `Modern Tkinter for Busy Python Developers <https://tkdocs.com/book.html>`_
       By Mark Roseman. (ISBN 978-1999149567)
 

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -55,9 +55,6 @@ details that are unchanged.
 
    Books:
 
-   `Programming Python <http://learning-python.com/about-pp4e.html>`_
-      Book by Mark Lutz, has excellent coverage of Tkinter.
-
    * `Modern Tkinter for Busy Python Developers <https://tkdocs.com/book.html>`_
       By Mark Roseman. (ISBN 978-1999149567)
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -363,13 +363,6 @@ These two approaches both output::
      |--> Commander Clement
 
 
-Additional resources
-^^^^^^^^^^^^^^^^^^^^
-
-See http://effbot.org/zone/element-index.htm for tutorials and links to other
-docs.
-
-
 .. _elementtree-xpath:
 
 XPath support

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -169,12 +169,6 @@ between conformable Python objects and XML on the wire.
    `XML-RPC Specification <http://xmlrpc.scripting.com/spec.html>`_
       The official specification.
 
-   `Unofficial XML-RPC Errata <http://effbot.org/zone/xmlrpc-errata.htm>`_
-      Fredrik Lundh's "unofficial errata, intended to clarify certain
-      details in the XML-RPC specification, as well as hint at
-      'best practices' to use when designing your own XML-RPC
-      implementations."
-
 .. _serverproxy-objects:
 
 ServerProxy Objects

--- a/Lib/xml/etree/ElementPath.py
+++ b/Lib/xml/etree/ElementPath.py
@@ -226,7 +226,6 @@ def prepare_parent(next, token):
 
 def prepare_predicate(next, token):
     # FIXME: replace with real parser!!! refs:
-    # http://effbot.org/zone/simple-iterator-parser.htm
     # http://javascript.crockford.com/tdop/tdop.html
     signature = []
     predicate = []

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -4,7 +4,8 @@
 
 /* fast search/count implementation, based on a mix between boyer-
    moore and horspool, with a few more bells and whistles on the top.
-   for some more background, see: http://effbot.org/zone/stringlib.htm */
+   for some more background, see:
+   https://web.archive.org/web/20201107074620/http://effbot.org/zone/stringlib.htm */
 
 /* note: fastsearch may access s[n], which isn't a problem when using
    Python's ordinary string types, but may cause problems if you're


### PR DESCRIPTION
(cherry picked from commit e9f66aedf44ccc3be27975cfb070a44ce6a6bd13)

Co-authored-by: E-Paine <63801254+E-Paine@users.noreply.github.com>

# [3.10] Remove effbot urls (GH-26308).

Back-porting change to remove old effbot urls and update with current urls