### PR TITLE
Adding clarification that poll is better to get the return code status.

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -897,6 +897,8 @@ The following attributes are also available:
    A negative value ``-N`` indicates that the child was terminated by signal
    ``N`` (POSIX only).
 
+   Note: The value stored in returncode may be out-of-date. Use poll() to reliably find the current return code.
+
 
 Windows Popen Helpers
 ---------------------


### PR DESCRIPTION
# Adding clarification that poll is better to get the return code status.

```
gh-87452: This change fixes a possible implication that to get the best return code for a subprocess is to use returncode. Instead I added the suggested new wording to the bottom of the section to say that using poll() is the best way to perform that change.

```


