### PR TITLE
gh-90172: add test for functools.singledispatch on Union types with None type

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2793,39 +2793,39 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(f(1.0), "types.UnionType")
 
     def test_union_None(self):
-         @functools.singledispatch
-         def f(arg):
-             return "default"
+        @functools.singledispatch
+        def f(arg):
+            return "default"
 
-         @f.register
-         def _(arg: typing.Union[str, None]):
-             return "typing.Union"
+        @f.register
+        def _(arg: typing.Union[str, None]):
+            return "typing.Union"
 
-         @f.register
-         def _(arg: int):
-             return "types.UnionType"
+        @f.register
+        def _(arg: int):
+            return "types.UnionType"
 
-         self.assertEqual(f([]), "default")
-         self.assertEqual(f(""), "typing.Union")
-         self.assertEqual(f(None), "typing.Union")
-         self.assertEqual(f(1), "types.UnionType")
+        self.assertEqual(f([]), "default")
+        self.assertEqual(f(""), "typing.Union")
+        self.assertEqual(f(None), "typing.Union")
+        self.assertEqual(f(1), "types.UnionType")
 
-         @functools.singledispatch
-         def f(arg):
-             return "default"
+        @functools.singledispatch
+        def f(arg):
+            return "default"
 
-         @f.register
-         def _(arg: str):
-             return "typing.Union"
+        @f.register
+        def _(arg: str):
+            return "typing.Union"
 
-         @f.register
-         def _(arg: int | None):
-             return "types.UnionType"
+        @f.register
+        def _(arg: int | None):
+            return "types.UnionType"
 
-         self.assertEqual(f([]), "default")
-         self.assertEqual(f(""), "typing.Union")
-         self.assertEqual(f(1), "types.UnionType")
-         self.assertEqual(f(None), "types.UnionType")
+        self.assertEqual(f([]), "default")
+        self.assertEqual(f(""), "typing.Union")
+        self.assertEqual(f(1), "types.UnionType")
+        self.assertEqual(f(None), "types.UnionType")
 
     def test_register_genericalias(self):
         @functools.singledispatch

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2792,6 +2792,42 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(f(1), "types.UnionType")
         self.assertEqual(f(1.0), "types.UnionType")
 
+    def test_union_None(self):
+         @functools.singledispatch
+         def f(arg):
+             return "default"
+
+         @f.register
+         def _(arg: typing.Union[str, None]):
+             return "typing.Union"
+
+         @f.register
+         def _(arg: int):
+             return "types.UnionType"
+
+         self.assertEqual(f([]), "default")
+         self.assertEqual(f(""), "typing.Union")
+         self.assertEqual(f(None), "typing.Union")
+         self.assertEqual(f(1), "types.UnionType")
+
+         @functools.singledispatch
+         def f(arg):
+             return "default"
+
+         @f.register
+         def _(arg: str):
+             return "typing.Union"
+
+         @f.register
+         def _(arg: int | None):
+             return "types.UnionType"
+
+         self.assertEqual(f([]), "default")
+         self.assertEqual(f(""), "typing.Union")
+         self.assertEqual(f(1), "types.UnionType")
+         self.assertEqual(f(None), "types.UnionType")
+
+
     def test_register_genericalias(self):
         @functools.singledispatch
         def f(arg):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2827,7 +2827,6 @@ class TestSingleDispatch(unittest.TestCase):
          self.assertEqual(f(1), "types.UnionType")
          self.assertEqual(f(None), "types.UnionType")
 
-
     def test_register_genericalias(self):
         @functools.singledispatch
         def f(arg):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2792,40 +2792,48 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(f(1), "types.UnionType")
         self.assertEqual(f(1.0), "types.UnionType")
 
-    def test_union_None(self):
+    def test_union_conflict(self):
         @functools.singledispatch
         def f(arg):
             return "default"
 
         @f.register
+        def _(arg: typing.Union[str, bytes]):
+            return "typing.Union"
+
+        @f.register
+        def _(arg: int | str):
+            return "types.UnionType"
+
+        self.assertEqual(f([]), "default")
+        self.assertEqual(f(""), "types.UnionType")  # last one wins
+        self.assertEqual(f(b""), "typing.Union")
+        self.assertEqual(f(1), "types.UnionType")
+
+    def test_union_None(self):
+        @functools.singledispatch
+        def typing_union(arg):
+            return "default"
+
+        @typing_union.register
         def _(arg: typing.Union[str, None]):
             return "typing.Union"
 
-        @f.register
-        def _(arg: int):
-            return "types.UnionType"
-
-        self.assertEqual(f([]), "default")
-        self.assertEqual(f(""), "typing.Union")
-        self.assertEqual(f(None), "typing.Union")
-        self.assertEqual(f(1), "types.UnionType")
+        self.assertEqual(typing_union(1), "default")
+        self.assertEqual(typing_union(""), "typing.Union")
+        self.assertEqual(typing_union(None), "typing.Union")
 
         @functools.singledispatch
-        def f(arg):
+        def types_union(arg):
             return "default"
 
-        @f.register
-        def _(arg: str):
-            return "typing.Union"
-
-        @f.register
+        @types_union.register
         def _(arg: int | None):
             return "types.UnionType"
 
-        self.assertEqual(f([]), "default")
-        self.assertEqual(f(""), "typing.Union")
-        self.assertEqual(f(1), "types.UnionType")
-        self.assertEqual(f(None), "types.UnionType")
+        self.assertEqual(types_union(""), "default")
+        self.assertEqual(types_union(1), "types.UnionType")
+        self.assertEqual(types_union(None), "types.UnionType")
 
     def test_register_genericalias(self):
         @functools.singledispatch


### PR DESCRIPTION
Signed-off-by: prwatson <prwatson@redhat.com>

# gh-90172 added test for functools.singledispatch on Union types with None type

functools.singledispatch needed a test to see if Union types can accept None type as an argument. Tests were added for types.UnionType and typing.Union. 
