### PR TITLE
gh-92178: Add redirect_stdin context manager

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -355,6 +355,16 @@ Functions and classes provided:
    .. versionadded:: 3.5
 
 
+.. function:: redirect_stdin(new_target)
+
+   Similar to :func:`~contextlib.redirect_stdout` but redirecting
+   :data:`sys.stdin` to another file or file-like object.
+
+   This context manager is :ref:`reentrant <reentrant-cms>`.
+
+   .. versionadded:: 3.11
+
+
 .. function:: chdir(path)
 
    Non parallel-safe context manager to change the current working directory.

--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -10,8 +10,8 @@ from types import MethodType, GenericAlias
 __all__ = ["asynccontextmanager", "contextmanager", "closing", "nullcontext",
            "AbstractContextManager", "AbstractAsyncContextManager",
            "AsyncExitStack", "ContextDecorator", "ExitStack",
-           "redirect_stdout", "redirect_stderr", "suppress", "aclosing",
-           "chdir"]
+           "redirect_stdin", "redirect_stdout", "redirect_stderr",
+           "suppress", "aclosing", "chdir"]
 
 
 class AbstractContextManager(abc.ABC):
@@ -401,6 +401,10 @@ class redirect_stdout(_RedirectStream):
 
     _stream = "stdout"
 
+class redirect_stdin(_RedirectStream):
+    """Context manager for temporarily redirecting stdin to another file."""
+
+    _stream = "stdin"
 
 class redirect_stderr(_RedirectStream):
     """Context manager for temporarily redirecting stderr to another file."""

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -1009,6 +1009,15 @@ class TestRedirectStream:
         self.redirect_stream(None)
         self.assertIs(getattr(sys, self.orig_stream), orig_stdout)
 
+
+    def test_enter_result_is_target(self):
+        f = io.StringIO()
+        with self.redirect_stream(f) as enter_result:
+            self.assertIs(enter_result, f)
+
+
+
+class TestRedirectOutputStream(TestRedirectStream):
     def test_redirect_to_string_io(self):
         f = io.StringIO()
         msg = "Consider an API like help(), which prints directly to stdout"
@@ -1018,11 +1027,6 @@ class TestRedirectStream:
         self.assertIs(getattr(sys, self.orig_stream), orig_stdout)
         s = f.getvalue().strip()
         self.assertEqual(s, msg)
-
-    def test_enter_result_is_target(self):
-        f = io.StringIO()
-        with self.redirect_stream(f) as enter_result:
-            self.assertIs(enter_result, f)
 
     def test_cm_is_reusable(self):
         f = io.StringIO()
@@ -1048,24 +1052,20 @@ class TestRedirectStream:
         s = f.getvalue()
         self.assertEqual(s, "Hello World!\n")
 
-
-class TestRedirectStdout(TestRedirectStream, unittest.TestCase):
+class TestRedirectStdout(TestRedirectOutputStream, unittest.TestCase):
 
     redirect_stream = redirect_stdout
     orig_stream = "stdout"
 
-class TestRedirectStdout(TestRedirectStream, unittest.TestCase):
-
-    redirect_stream = redirect_stdin
-    orig_stream = "stdin"
-
-
-
-class TestRedirectStderr(TestRedirectStream, unittest.TestCase):
+class TestRedirectStderr(TestRedirectOutputStream, unittest.TestCase):
 
     redirect_stream = redirect_stderr
     orig_stream = "stderr"
 
+class TestRedirectStdin(TestRedirectOutputStream, unittest.TestCase):
+
+    redirect_stream = redirect_stdin
+    orig_stream = "stdin"
 
 class TestSuppress(unittest.TestCase):
 

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -1054,6 +1054,12 @@ class TestRedirectStdout(TestRedirectStream, unittest.TestCase):
     redirect_stream = redirect_stdout
     orig_stream = "stdout"
 
+class TestRedirectStdout(TestRedirectStream, unittest.TestCase):
+
+    redirect_stream = redirect_stdin
+    orig_stream = "stdin"
+
+
 
 class TestRedirectStderr(TestRedirectStream, unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2022-05-02-20-15-48.gh-issue-92178.bXIDXh.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-02-20-15-48.gh-issue-92178.bXIDXh.rst
@@ -1,0 +1,2 @@
+Adds a new :meth:`contextlib.redirect_stdin` context manager to redirect
+``sys.stdin`` to another file.


### PR DESCRIPTION
Adds a `redirect_stdin` context manager for redirecting `sys.stdin` to another stream.

Resolves #92178 

# TODO
- [ ] Add more tests that specifically test the input capabilities of `redirect_stdin`