### PR TITLE
Use `localcontext()` in decimal pi recipe

### DIFF
--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -1902,17 +1902,17 @@ to work with the :class:`Decimal` class::
        3.141592653589793238462643383
 
        """
-       getcontext().prec += 2  # extra digits for intermediate steps
-       three = Decimal(3)      # substitute "three=3.0" for regular floats
-       lasts, t, s, n, na, d, da = 0, three, 3, 1, 0, 0, 24
-       while s != lasts:
-           lasts = s
-           n, na = n+na, na+8
-           d, da = d+da, da+32
-           t = (t * n) / d
-           s += t
-       getcontext().prec -= 2
-       return +s               # unary plus applies the new precision
+       with localcontext() as ctx:
+           ctx.prec += 2       # extra digits for intermediate steps
+           three = Decimal(3)  # substitute "three=3.0" for regular floats
+           lasts, t, s, n, na, d, da = 0, three, 3, 1, 0, 0, 24
+           while s != lasts:
+               lasts = s
+               n, na = n+na, na+8
+               d, da = d+da, da+32
+               t = (t * n) / d
+               s += t
+       return +s               # unary plus applies the default precision
 
    def exp(x):
        """Return e raised to the power of x.  Result type matches input type.


### PR DESCRIPTION
I thought this would be a nice update to demonstrate use of `localcontext()` (possibly [decimal.html#decimal.localcontext](https://docs.python.org/3/library/decimal.html#decimal.localcontext) could be linked to this example) and avoid mutating the global context.

This was small enough I didn't start a issue but I'm happy to do that if this the first reviewer considers this non-trivial.

Thanks