### PR TITLE
GH-92184: Convert os.altsep to '/' in filenames when creating ZipInfo objects

### DIFF
--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -352,6 +352,8 @@ def _sanitize_filename(filename):
     # ZIP format specification.
     if os.sep != "/" and os.sep in filename:
         filename = filename.replace(os.sep, "/")
+    if os.altsep and os.altsep != "/" and os.altsep in filename:
+        filename = filename.replace(os.altsep, "/")
     return filename
 
 

--- a/Misc/NEWS.d/next/Library/2022-05-02-16-21-05.gh-issue-92184.hneGVW.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-02-16-21-05.gh-issue-92184.hneGVW.rst
@@ -1,0 +1,2 @@
+When creating zip files using the ``zipfile`` module, ``os.altsep`` will always
+be treated as a path separator. Patch by Carey Metcalfe.

--- a/Misc/NEWS.d/next/Library/2022-05-02-16-21-05.gh-issue-92184.hneGVW.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-02-16-21-05.gh-issue-92184.hneGVW.rst
@@ -1,2 +1,3 @@
-When creating zip files using the ``zipfile`` module, ``os.altsep`` will always
-be treated as a path separator. Patch by Carey Metcalfe.
+When creating zip files using :mod:`zipfile`, ``os.altsep``, if not ``None``,
+will always be treated as a path separator even when it is not ``/``.
+Patch by Carey Metcalfe.


### PR DESCRIPTION
This causes the zipfile module to also consider the character defined by `os.altsep` (if there is one) to be a path separator and convert it to a forward slash, as defined by the zip specification.

Fixes #92184

<!-- gh-issue-number: gh-92184 -->
* Issue: gh-92184
<!-- /gh-issue-number -->
