### PR TITLE
Fix issues 86199 86795

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -215,6 +215,32 @@ class TestCallingConventions(unittest.TestCase):
             (self.expected_self, (1, 2), {'a': 3, 'b': 4})
         )
 
+    def test_keywords_copied_python(self):
+        d = {}
+        self.assertIsNot(
+            self.obj.meth_varargs_keywords(**d)[2],
+            d
+        )
+
+        d = {'a': 1}
+        self.assertIsNot(
+            self.obj.meth_varargs_keywords(**d)[2],
+            d
+        )
+
+    def test_keywords_copied_capi(self):
+        d = {}
+        self.assertIsNot(
+            self.obj.object_call(self.obj.meth_varargs_keywords, (), d)[2],
+            d
+        )
+
+        d = {'a': 1}
+        self.assertIsNot(
+            self.obj.object_call(self.obj.meth_varargs_keywords, (), d)[2],
+            d
+        )
+
     def test_o(self):
         self.assertEqual(self.obj.meth_o(1), (self.expected_self, 1))
 

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-02-20-19-06.gh-issue-86199.IZbF0m.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-02-20-19-06.gh-issue-86199.IZbF0m.rst
@@ -1,0 +1,6 @@
+`PyObject_Call` now guarantees any kwargs `dict` passed is shallow-copied
+before being passed to the callee, matching the documented equivalence with
+`callable(*args, **kwargs)`, fixing #86795.     When a function call's sole source of
+keyword arguments is a single `**`     unpacked `dict`, no copy is performed
+when the callable uses the vectorcall     protocol and no copy is needed to
+protect the caller's `dict` from mutation.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -5508,6 +5508,25 @@ _null_to_none(PyObject* obj)
     return obj;
 }
 
+/* For testing unpacking behaviors in C API without eval loop
+ * changing behavior by potentially copying structures dict implicitly
+ */
+static PyObject*
+object_call(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *func, *posargs, *kwargs;
+
+    if (!_PyArg_CheckPositional("object_call", nargs, 2, 3)) {
+        return NULL;
+    }
+
+    func = args[0];
+    posargs = args[1];
+    kwargs = PyVectorcall_NARGS(nargs) == 3 ? args[2] : NULL;
+
+    return PyObject_Call(func, posargs, kwargs);
+}
+
 static PyObject*
 meth_varargs(PyObject* self, PyObject* args)
 {
@@ -6202,6 +6221,7 @@ static PyMethodDef TestMethods[] = {
 #endif
     {"write_unraisable_exc", test_write_unraisable_exc, METH_VARARGS},
     {"sequence_getitem", sequence_getitem, METH_VARARGS},
+    {"object_call", (PyCFunction)(void(*)(void))object_call, METH_FASTCALL},
     {"meth_varargs", meth_varargs, METH_VARARGS},
     {"meth_varargs_keywords", (PyCFunction)(void(*)(void))meth_varargs_keywords, METH_VARARGS|METH_KEYWORDS},
     {"meth_o", meth_o, METH_O},
@@ -7358,6 +7378,7 @@ static PyType_Spec HeapCTypeSetattr_spec = {
 };
 
 static PyMethodDef meth_instance_methods[] = {
+    {"object_call", (PyCFunction)(void(*)(void))object_call, METH_FASTCALL},
     {"meth_varargs", meth_varargs, METH_VARARGS},
     {"meth_varargs_keywords", (PyCFunction)(void(*)(void))meth_varargs_keywords, METH_VARARGS|METH_KEYWORDS},
     {"meth_o", meth_o, METH_O},
@@ -7380,6 +7401,7 @@ static PyTypeObject MethInstance_Type = {
 };
 
 static PyMethodDef meth_class_methods[] = {
+    {"object_call", (PyCFunction)(void(*)(void))object_call, METH_FASTCALL|METH_CLASS},
     {"meth_varargs", meth_varargs, METH_VARARGS|METH_CLASS},
     {"meth_varargs_keywords", (PyCFunction)(void(*)(void))meth_varargs_keywords, METH_VARARGS|METH_KEYWORDS|METH_CLASS},
     {"meth_o", meth_o, METH_O|METH_CLASS},
@@ -7402,6 +7424,7 @@ static PyTypeObject MethClass_Type = {
 };
 
 static PyMethodDef meth_static_methods[] = {
+    {"object_call", (PyCFunction)(void(*)(void))object_call, METH_FASTCALL|METH_STATIC},
     {"meth_varargs", meth_varargs, METH_VARARGS|METH_STATIC},
     {"meth_varargs_keywords", (PyCFunction)(void(*)(void))meth_varargs_keywords, METH_VARARGS|METH_KEYWORDS|METH_STATIC},
     {"meth_o", meth_o, METH_O|METH_STATIC},

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -309,6 +309,30 @@ _PyObject_FastCall(PyObject *func, PyObject *const *args, Py_ssize_t nargs)
 }
 
 
+static PyObject*
+_new_dict_if_nonempty(PyObject *mapping)
+{
+    PyObject *newdict = NULL;
+
+    if (mapping != NULL) {
+        Py_ssize_t kwlen = PyDict_Size(mapping);
+        if (kwlen < 0) {
+            return NULL;
+        } else if (kwlen > 0) {
+            newdict = _PyDict_NewPresized(kwlen);
+            if (newdict == NULL) {
+                return NULL;
+            }
+            if (_PyDict_MergeEx(newdict, mapping, 2) < 0) {
+                Py_DECREF(newdict);
+                return NULL;
+            }
+        }
+    }
+
+    return newdict;
+}
+
 PyObject *
 _PyObject_Call(PyThreadState *tstate, PyObject *callable,
                PyObject *args, PyObject *kwargs)
@@ -328,6 +352,7 @@ _PyObject_Call(PyThreadState *tstate, PyObject *callable,
         return _PyVectorcall_Call(tstate, vector_func, callable, args, kwargs);
     }
     else {
+        PyObject *kwcopy;
         call = Py_TYPE(callable)->tp_call;
         if (call == NULL) {
             _PyErr_Format(tstate, PyExc_TypeError,
@@ -336,13 +361,26 @@ _PyObject_Call(PyThreadState *tstate, PyObject *callable,
             return NULL;
         }
 
+        /* Adhere to documented equivalence:
+           callable(*args, **kwargs) == PyObject_Call(callable, args, kwargs)
+
+           The dict must be copied to ensure the caller's copy isn't modified.
+           Not needed when following vectorcall paths that don't use the dict.
+           */
+        kwcopy = _new_dict_if_nonempty(kwargs);
+        if (kwcopy == NULL && _PyErr_Occurred(tstate)) {
+            return NULL;
+        }
+
         if (_Py_EnterRecursiveCall(tstate, " while calling a Python object")) {
             return NULL;
         }
 
-        result = (*call)(callable, args, kwargs);
+        result = (*call)(callable, args, kwcopy);
 
         _Py_LeaveRecursiveCall(tstate);
+
+        Py_XDECREF(kwcopy);
 
         return _Py_CheckFunctionResult(tstate, callable, result, NULL);
     }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5094,6 +5094,15 @@ ex_call:
             keyword_ty kw = asdl_seq_GET(keywords, i);
             if (kw->arg == NULL) {
                 /* A keyword argument unpacking. */
+                if (nkwelts == 1) {
+                    /* Only one **kwargs passed, with no individual
+                       keyword arguments; no need to make new dict and merge
+                       as this will be done for us if needed
+                     */
+                    VISIT(c, expr, kw->value);
+                    have_dict = 1;
+                    break;
+                }
                 if (nseen) {
                     if (!compiler_subkwargs(c, keywords, i - nseen, i)) {
                         return 0;


### PR DESCRIPTION
# Fix issues #86199 and #86795 by centralizing copying of keyword arguments in `PyObject_Copy` only when needed

```
gh-86199: `**kwargs` are not copied by the compiler when they are the only source of keyword arguments for a call. -

gh-86795: `PyObject_Call` makes copies of the keyword arguments dictionary when calling non-vectorcall functions to consistently ensure the caller's `dict` is not modified, whether the `dict` comes from the eval loop or a direct C extension call to `PyObject_Call`, matching the documented equivalence with `callable(*args, **kwargs)`. Reduces overhead of `callable(**kwargs)` ~30%.
```

