### PR TITLE
gh-92193: Check for overridden vectorcall field on PyFunctionObject

### DIFF
--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -134,6 +134,9 @@ uint32_t _PyFunction_GetVersionForCurrentState(PyFunctionObject *func)
     if (func->func_version != 0) {
         return func->func_version;
     }
+    if (func->vectorcall != _PyFunction_Vectorcall) {
+        return 0;
+    }
     if (next_func_version == 0) {
         return 0;
     }


### PR DESCRIPTION
# gh-92193: Check for overridden vectorcall field on PyFunctionObject

avoid specializing functions with overridden vectorcall field