### PR TITLE
gh-89452: Prefer gdbm-compat over ndbm

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-05-03-03-36-47.gh-issue-89452.NIY0fF.rst
+++ b/Misc/NEWS.d/next/Build/2022-05-03-03-36-47.gh-issue-89452.NIY0fF.rst
@@ -1,0 +1,2 @@
+gdbm-compat is now preferred over ndbm if both are available on the system.
+This allows avoiding the problematic ndbm.h on macOS.

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -12,10 +12,7 @@
 /* Some Linux systems install gdbm/ndbm.h, but not ndbm.h.  This supports
  * whichever configure was able to locate.
  */
-#if defined(USE_NDBM)
-  #include <ndbm.h>
-  static const char which_dbm[] = "GNU gdbm";  /* EMX port of GDBM */
-#elif defined(USE_GDBM_COMPAT)
+#if defined(USE_GDBM_COMPAT)
   #ifdef HAVE_GDBM_NDBM_H
     #include <gdbm/ndbm.h>
   #elif HAVE_GDBM_DASH_NDBM_H
@@ -23,6 +20,9 @@
   #else
     #error "No gdbm/ndbm.h or gdbm-ndbm.h available"
   #endif
+  static const char which_dbm[] = "GNU gdbm";
+#elif defined(USE_NDBM)
+  #include <ndbm.h>
   static const char which_dbm[] = "GNU gdbm";
 #elif defined(USE_BERKDB)
   #ifndef DB_DBM_HSEARCH

--- a/configure
+++ b/configure
@@ -13726,7 +13726,7 @@ $as_echo_n "checking for --with-dbmliborder... " >&6; }
 if test "${with_dbmliborder+set}" = set; then :
   withval=$with_dbmliborder;
 else
-  with_dbmliborder=ndbm:gdbm:bdb
+  with_dbmliborder=gdbm:ndbm:bdb
 fi
 
 
@@ -13749,7 +13749,7 @@ done
 IFS=$as_save_IFS
 if test "x$with_dbmliborder" = xerror; then :
 
-  as_fn_error $? "proper usage is --with-dbmliborder=db1:db2:... (ndbm:gdbm:bdb)" "$LINENO" 5
+  as_fn_error $? "proper usage is --with-dbmliborder=db1:db2:... (gdbm:ndbm:bdb)" "$LINENO" 5
 
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_dbmliborder" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -3850,7 +3850,7 @@ AC_CHECK_HEADERS([db.h], [
 AC_MSG_CHECKING(for --with-dbmliborder)
 AC_ARG_WITH(dbmliborder,
             AS_HELP_STRING([--with-dbmliborder=db1:db2:...], [override order to check db backends for dbm; a valid value is a colon separated string with the backend names `ndbm', `gdbm' and `bdb'.]),
-[], [with_dbmliborder=ndbm:gdbm:bdb])
+[], [with_dbmliborder=gdbm:ndbm:bdb])
 
 have_gdbm_dbmliborder=no
 as_save_IFS=$IFS
@@ -3865,7 +3865,7 @@ for db in $with_dbmliborder; do
 done
 IFS=$as_save_IFS
 AS_VAR_IF([with_dbmliborder], [error], [
-  AC_MSG_ERROR([proper usage is --with-dbmliborder=db1:db2:... (ndbm:gdbm:bdb)])
+  AC_MSG_ERROR([proper usage is --with-dbmliborder=db1:db2:... (gdbm:ndbm:bdb)])
 ])
 AC_MSG_RESULT($with_dbmliborder)
 

--- a/setup.py
+++ b/setup.py
@@ -1207,7 +1207,7 @@ class PyBuildExt(build_ext):
             if dbm_args:
                 dbm_order = [arg.split('=')[-1] for arg in dbm_args][-1].split(":")
             else:
-                dbm_order = "ndbm:gdbm:bdb".split(":")
+                dbm_order = "gdbm:ndbm:bdb".split(":")
             dbmext = None
             for cand in dbm_order:
                 if cand == "ndbm":


### PR DESCRIPTION
This makes macOS gdbm provided by Homebrew not segfault through correct
selection of the linked library (`-lgdbm_compat`) *AND* the correct ndbm-style
header (`gdbm-ndbm.h` instead of the invalid `ndbm.h`).

Addresses #89452.