### PR TITLE
gh-87390: Fix starred tuple equality and pickling

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -399,6 +399,7 @@ class BaseTest(unittest.TestCase):
                     if isinstance(alias, GenericAlias):
                         self.assertEqual(loaded.__unpacked__, alias.__unpacked__)
 
+
     def test_copy(self):
         class X(list):
             def __copy__(self):
@@ -428,7 +429,7 @@ class BaseTest(unittest.TestCase):
         unpacked = (*alias1,)[0]
         self.assertIs(unpacked.__unpacked__, True)
 
-        # The third positional argument should control unpackedness.
+        # The (optional) third positional argument should control unpackedness.
         alias2 = GenericAlias(tuple, int)
         self.assertIs(alias2.__unpacked__, False)
         alias3 = GenericAlias(tuple, int, False)

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -423,6 +423,14 @@ class BaseTest(unittest.TestCase):
                 self.assertEqual(copied.__args__, alias.__args__)
                 self.assertEqual(copied.__parameters__, alias.__parameters__)
 
+    def test_non_bool_to_third_constructor_argument_raises_typeerror(self):
+        with self.assertRaises(TypeError):
+            GenericAlias(tuple, int, 0)
+        with self.assertRaises(TypeError):
+            GenericAlias(tuple, int, 'foo')
+        with self.assertRaises(TypeError):
+            GenericAlias(tuple, int, list)
+
     def test_unpack(self):
         alias1 = tuple[str, ...]
         self.assertIs(alias1.__unpacked__, False)

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-03-20-49-53.gh-issue-87390.QKwANx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-03-20-49-53.gh-issue-87390.QKwANx.rst
@@ -1,0 +1,1 @@
+Give ``types.GenericAlias`` constructor an optional third ``bool`` argument that controls whether it represents an unpacked type (e.g. ``*tuple[int, str]``).

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -730,7 +730,7 @@ ga_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *arguments = PyTuple_GET_ITEM(args, 1);
 
     bool starred;
-    if (PyTuple_Size(args) < 3) {
+    if (PyTuple_GET_SIZE(args) < 3) {
         starred = false;
     } else {
         PyObject *py_starred = PyTuple_GET_ITEM(args, 2);


### PR DESCRIPTION
Hilariously, before this PR, it turned out that `*tuple[int]` was equal to `tuple[int]`. Fixing it, I realised that pickling was also broken: it didn't preserve `gaobject.starred`. This PR fixes both.

I've tested for refleaks with `python3 -m test -v test_genericalias -R 3:3`, and it came back clean, so I think we're good.

@Fidget-Spinner I guess you're the one most familiar with this code? :)