### PR TITLE
gh-91162: Disallow tuple[T][*anything]

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -399,6 +399,7 @@ class BaseTest(unittest.TestCase):
                     if isinstance(alias, GenericAlias):
                         self.assertEqual(loaded.__unpacked__, alias.__unpacked__)
 
+
     def test_copy(self):
         class X(list):
             def __copy__(self):
@@ -428,7 +429,7 @@ class BaseTest(unittest.TestCase):
         unpacked = (*alias1,)[0]
         self.assertIs(unpacked.__unpacked__, True)
 
-        # The third positional argument should control unpackedness.
+        # The (optional) third positional argument should control unpackedness.
         alias2 = GenericAlias(tuple, int)
         self.assertIs(alias2.__unpacked__, False)
         alias3 = GenericAlias(tuple, int, False)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -581,11 +581,25 @@ class TemplateReplacementTests(BaseTestCase):
 class GenericAliasSubstitutionTests(BaseTestCase):
     """Tests for type variable substitution in generic aliases.
 
-    Note that the expected results here are tentative, based on a
-    still-being-worked-out spec for what we allow at runtime (given that
-    implementation of *full* substitution logic at runtime would add too much
-    complexity to typing.py). This spec is currently being discussed at
-    https://github.com/python/cpython/issues/91162.
+    Note that not all the rules governing substitution behavior at runtime
+    is codified in PEPs; the source of truth for these tests is the tests
+    themselves.
+
+    Informally, the specification is as follows:
+    * In general, we aim to support as many valid substitutions (as specified
+      by the PEPs themselves) as possible at runtme.
+    * Leniency: In some cases, we also choose to allow some substitutions that
+      the PEPs themselves might forbid. This is partly for simplicity - we want
+      to minimise complexity in the runtime - and partly to enable users to
+      experiment with new ways to use types.
+    * Exceptions:
+      * PEP 646 Exception 1: Unpacked types (e.g. *tuple[int], *tuple[int, ...],
+        *Ts where Ts is a TypeVarTuple) cannot be used as arguments to generic
+        aliases which expect a fixed number of arguments. See the tests
+        themselves for examples.
+      * PEP 646 Exception 2: Unpacked TypeVarTuples can only be used as
+        arguments to generic aliases whose sole parameter is also an unpacked
+        TypeVarTuple.
     """
 
     def test_one_parameter(self):
@@ -603,22 +617,16 @@ class GenericAliasSubstitutionTests(BaseTestCase):
             ('generic[T]',                        '[int]',                   'generic[int]'),
             ('generic[T]',                        '[int, str]',              'TypeError'),
             ('generic[T]',                        '[tuple_type[int, ...]]',  'generic[tuple_type[int, ...]]'),
-            # Should raise TypeError: a) according to the tentative spec,
-            # unpacked types cannot be used as arguments to aliases that expect
-            # a fixed number of arguments; b) it's equivalent to generic[()].
-            ('generic[T]',                        '[*tuple[()]]',            'generic[*tuple[()]]'),
+            # See PEP 646 Exception 1 in docstring.
+            ('generic[T]',                        '[*tuple[()]]',            'TypeError'),
             ('generic[T]',                        '[*Tuple[()]]',            'TypeError'),
-            # Should raise TypeError according to the tentative spec: unpacked
-            # types cannot be used as arguments to aliases that expect a fixed
-            # number of arguments.
-            ('generic[T]',                        '[*tuple[int]]',           'generic[*tuple[int]]'),
+            ('generic[T]',                        '[*tuple[int]]',           'TypeError'),
             ('generic[T]',                        '[*Tuple[int]]',           'TypeError'),
-            # Ditto.
-            ('generic[T]',                        '[*tuple[int, str]]',      'generic[*tuple[int, str]]'),
+            ('generic[T]',                        '[*tuple[int, str]]',      'TypeError'),
             ('generic[T]',                        '[*Tuple[int, str]]',      'TypeError'),
-            # Ditto.
-            ('generic[T]',                        '[*tuple[int, ...]]',      'generic[*tuple[int, ...]]'),
+            ('generic[T]',                        '[*tuple[int, ...]]',      'TypeError'),
             ('generic[T]',                        '[*Tuple[int, ...]]',      'TypeError'),
+            # See PEP 646 Exception 2 in docstring.
             ('generic[T]',                        '[*Ts]',                   'TypeError'),
             ('generic[T]',                        '[T, *Ts]',                'TypeError'),
             ('generic[T]',                        '[*Ts, T]',                'TypeError'),
@@ -663,30 +671,19 @@ class GenericAliasSubstitutionTests(BaseTestCase):
             ('generic[T1, T2]',                        '[int]',                                             'TypeError'),
             ('generic[T1, T2]',                        '[int, str]',                                        'generic[int, str]'),
             ('generic[T1, T2]',                        '[int, str, bool]',                                  'TypeError'),
+            ('generic[T1, T2]',                        '[tuple_type[int, ...], tuple_type[str, ...]]',      'generic[tuple_type[int, ...], tuple_type[str, ...]]'),
+            # See PEP 646 Exception 1 in docstring.
             ('generic[T1, T2]',                        '[*tuple_type[int]]',                                'TypeError'),
             ('generic[T1, T2]',                        '[*tuple_type[int, str]]',                           'TypeError'),
             ('generic[T1, T2]',                        '[*tuple_type[int, str, bool]]',                     'TypeError'),
-
-            # Should raise TypeError according to the tentative spec: unpacked
-            # types cannot be used as arguments to aliases that expect a fixed
-            # number of arguments.
-            ('generic[T1, T2]',                        '[*tuple[int, str], *tuple[float, bool]]',           'generic[*tuple[int, str], *tuple[float, bool]]'),
-            ('generic[T1, T2]',                        '[*Tuple[int, str], *Tuple[float, bool]]',           'TypeError'),
-
+            ('generic[T1, T2]',                        '[*tuple_type[int, str], *tuple_type[float, bool]]', 'TypeError'),
             ('generic[T1, T2]',                        '[tuple_type[int, ...]]',                            'TypeError'),
-            ('generic[T1, T2]',                        '[tuple_type[int, ...], tuple_type[str, ...]]',      'generic[tuple_type[int, ...], tuple_type[str, ...]]'),
             ('generic[T1, T2]',                        '[*tuple_type[int, ...]]',                           'TypeError'),
-
-            # Ditto.
-            ('generic[T1, T2]',                        '[*tuple[int, ...], *tuple[str, ...]]',              'generic[*tuple[int, ...], *tuple[str, ...]]'),
-            ('generic[T1, T2]',                        '[*Tuple[int, ...], *Tuple[str, ...]]',              'TypeError'),
-
+            ('generic[T1, T2]',                        '[*tuple_type[int, ...], *tuple_type[str, ...]]',    'TypeError'),
             ('generic[T1, T2]',                        '[*Ts]',                                             'TypeError'),
             ('generic[T1, T2]',                        '[T, *Ts]',                                          'TypeError'),
             ('generic[T1, T2]',                        '[*Ts, T]',                                          'TypeError'),
-            # Should raise TypeError according to the tentative spec: unpacked
-            # types cannot be used as arguments to generics that expect a fixed
-            # number of arguments.
+            # Should raise TypeError - see PEP 646 Exception 1 in docstring.
             # (None of the things in `generics` were defined using *Ts.)
             ('generic[T1, *tuple_type[int, ...]]',     '[str]',                                             'generic[str, *tuple_type[int, ...]]'),
         ]
@@ -820,12 +817,7 @@ class GenericAliasSubstitutionTests(BaseTestCase):
             ('tuple[T, *Ts]',                          '[int, str, bool]',                               'tuple[int, str, bool]'),
             ('Tuple[T, *Ts]',                          '[int, str, bool]',                               'Tuple[int, str, bool]'),
 
-            ('C[T, *Ts]',                              '[*tuple[int, ...]]',                             'C[*tuple[int, ...]]'),  # Should be C[int, *tuple[int, ...]]
-            ('C[T, *Ts]',                              '[*Tuple[int, ...]]',                             'TypeError'),  # Ditto
-            ('tuple[T, *Ts]',                          '[*tuple[int, ...]]',                             'tuple[*tuple[int, ...]]'),  # Should be tuple[int, *tuple[int, ...]]
-            ('tuple[T, *Ts]',                          '[*Tuple[int, ...]]',                             'TypeError'),  # Should be tuple[int, *Tuple[int, ...]]
-            ('Tuple[T, *Ts]',                          '[*tuple[int, ...]]',                             'Tuple[*tuple[int, ...]]'),  # Should be Tuple[int, *tuple[int, ...]]
-            ('Tuple[T, *Ts]',                          '[*Tuple[int, ...]]',                             'TypeError'),  # Should be Tuple[int, *Tuple[int, ...]]
+            ('generic[T, *Ts]',                        '[*tuple_type[int, ...]]',                        'TypeError'),  # Should be generic[int, *tuple_type[int, ...]]
 
             ('C[*Ts, T]',                              '[int]',                                          'C[int]'),
             ('tuple[*Ts, T]',                          '[int]',                                          'tuple[int]'),

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -876,6 +876,15 @@ class ForwardRef(_Final, _root=True):
         return f'ForwardRef({self.__forward_arg__!r}{module_repr})'
 
 
+def _is_unpacked_type(x: Any) -> bool:
+    return (
+        # E.g. *tuple[int]
+        (isinstance(x, GenericAlias) and x.__unpacked__)
+        or
+        # E.g. Unpack[tuple[int]]
+        (isinstance(x, _GenericAlias) and x.__origin__ is Unpack)
+    )
+
 def _is_unpacked_typevartuple(x: Any) -> bool:
     return (
             isinstance(x, _UnpackGenericAlias)
@@ -995,7 +1004,7 @@ class TypeVar(_Final, _Immutable, _BoundVarianceMixin, _PickleUsingNameMixin,
     def __typing_subst__(self, arg):
         msg = "Parameters to generic types must be types."
         arg = _type_check(arg, msg, is_argument=True)
-        if (isinstance(arg, _GenericAlias) and arg.__origin__ is Unpack):
+        if _is_unpacked_type(arg):
             raise TypeError(f"{arg} is not valid as type argument")
         return arg
 


### PR DESCRIPTION
We agreed in https://github.com/python/cpython/issues/91162 that unpacked type arguments should only be valid to generic aliases that can accept a variable number of arguments - that is, unpacked type arguments should only be valid to generic aliases with a TypeVarTuple in the type parameters.

@JelleZijlstra Could I ask you for review on this?

(This PR is based on https://github.com/python/cpython/pull/92249, so there are a couple of extra commits. See the latest commit for the one that's actually part of this PR. I _think_ I should be able to effectively hide the changes from the extra commits once https://github.com/python/cpython/pull/92249 is merged - so we _can_ start review on this PR now?)