### PR TITLE
gh-91321: Fix PyModuleDef_HEAD_INIT on C++

### DIFF
--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -48,11 +48,11 @@ typedef struct PyModuleDef_Base {
   PyObject* m_copy;
 } PyModuleDef_Base;
 
-#define PyModuleDef_HEAD_INIT { \
-    PyObject_HEAD_INIT(NULL)    \
-    NULL, /* m_init */          \
-    0,    /* m_index */         \
-    NULL, /* m_copy */          \
+#define PyModuleDef_HEAD_INIT {  \
+    PyObject_HEAD_INIT(_Py_NULL) \
+    _Py_NULL, /* m_init */       \
+    0,        /* m_index */      \
+    _Py_NULL, /* m_copy */       \
   }
 
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03050000


### PR DESCRIPTION
The PyModuleDef_HEAD_INIT macro now uses _Py_NULL to fix C++ compiler
warnings when using it in C++.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
