### PR TITLE
gh-92265: set meta_path and path_hooks correctly in test_reload_namespace_changed

### DIFF
--- a/Lib/test/test_importlib/test_api.py
+++ b/Lib/test/test_importlib/test_api.py
@@ -301,7 +301,8 @@ class ReloadTests:
         name = 'spam'
         with os_helper.temp_cwd(None) as cwd:
             with test_util.uncache('spam'):
-                with import_helper.DirsOnSysPath(cwd):
+                with test_util.import_state(path=[cwd]):
+                    self.init._bootstrap_external._install(self.init._bootstrap)
                     # Start as a namespace package.
                     self.init.invalidate_caches()
                     bad_path = os.path.join(cwd, name, '__init.py')


### PR DESCRIPTION
Previously, we were blocking the frozen imports and forcing the source
version to be used, but we did not fix up sys.meta_path or
sys.path_hooks, causing the frozen importers to leak into the source
version of the test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:ericsnowcurrently