### PR TITLE
gh-81039: Add small description of f-string's "=}" to tutorial

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -133,11 +133,14 @@ applies :func:`repr`::
    >>> print(f'My hovercraft is full of {animals!r}.')
    My hovercraft is full of 'eels'.
 
-The ``=`` specifier can be used to expand an expression and its evaluation:
+The ``=`` specifier can be used to expand an expression to the text of the
+expression, an equal sign, then the representation of the evaluated expression:
 
-   >>> fruit = 'durians'
-   >>> print(f'This pie is filled with {fruit=}.')
-   This pie is filled with fruit='durians'.
+   >>> bugs = 'roaches'
+   >>> count = 13
+   >>> area = 'living room'
+   >>> print(f'Debugging {bugs=} {count=} {area=}')
+   Debugging bugs='roaches' count=13 area='living room'
 
 See :ref:`self-documenting expressions <bpo-36817-whatsnew>` for more information
 on the ``=`` specifier. For a reference on these format specifications, see

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -133,7 +133,14 @@ applies :func:`repr`::
    >>> print(f'My hovercraft is full of {animals!r}.')
    My hovercraft is full of 'eels'.
 
-For a reference on these format specifications, see
+The ``=`` specifier can be used to expand an expression and its evaluation:
+
+   >>> fruit = 'durians'
+   >>> print(f'This pie is filled with {fruit=}.')
+   This pie is filled with fruit='durians'.
+
+See :ref:`self-documenting expressions <bpo-36817-whatsnew>` for more information
+on the ``=`` specifier. For a reference on these format specifications, see
 the reference guide for the :ref:`formatspec`.
 
 .. _tut-string-format:

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -249,6 +249,7 @@ Android and Cygwin, whose cases are handled by the script);
 this change is backward incompatible on purpose.
 (Contributed by Victor Stinner in :issue:`36721`.)
 
+.. _bpo-36817-whatsnew:
 
 f-strings support ``=`` for self-documenting expressions and debugging
 ----------------------------------------------------------------------


### PR DESCRIPTION
#81039

https://docs.python.org/3/tutorial/inputoutput.html#formatted-string-literals

https://docs.python.org/3/whatsnew/3.8.html#f-strings-support-for-self-documenting-expressions-and-debugging