### PR TITLE
gh-92231: Prevent `@dataclass` from being used more than once on the same class

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -214,6 +214,10 @@ _FIELDS = '__dataclass_fields__'
 # @dataclass.
 _PARAMS = '__dataclass_params__'
 
+# The name of an attribute on the class that stores if it has been
+# decorated with @dataclass or not.
+_DECORATED = '__dataclass_decorated__'
+
 # The name of the function, that if it exists, is called at the end of
 # __init__.
 _POST_INIT_NAME = '__post_init__'
@@ -1204,6 +1208,9 @@ def dataclass(cls=None, /, *, init=True, repr=True, eq=True, order=False,
     """
 
     def wrap(cls):
+        if getattr(cls, _DECORATED, None):
+            raise TypeError("cannot use this decorator more than once on same class")
+        setattr(cls, _DECORATED, True)
         return _process_class(cls, init, repr, eq, order, unsafe_hash,
                               frozen, match_args, kw_only, slots,
                               weakref_slot)

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -24,6 +24,25 @@ import dataclasses  # Needed for the string "dataclasses.InitVar[int]" to work a
 class CustomError(Exception): pass
 
 class TestCase(unittest.TestCase):
+    def test_decorated_multiple_times(self):
+        with self.assertRaises(TypeError):
+            @dataclass
+            @dataclass
+            class C:
+                pass
+
+        with self.assertRaises(TypeError):
+            @dataclass(repr=False)
+            @dataclass(repr=True)
+            class C:
+                pass
+
+        with self.assertRaises(TypeError):
+            @dataclass()
+            @dataclass()
+            class C:
+                pass
+
     def test_no_fields(self):
         @dataclass
         class C:

--- a/Misc/NEWS.d/next/Library/2022-05-04-00-43-45.gh-issue-92231.cN0A4d.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-04-00-43-45.gh-issue-92231.cN0A4d.rst
@@ -1,0 +1,1 @@
+Prevent @dataclass from being called more than once on the same class


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

#92231 