### PR TITLE
GH-74460: Renamed name argument to fullname for importlib.machinery.ExtensionFileLoader

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1062,6 +1062,12 @@ CPython bytecode changes
 Deprecated
 ==========
 
+* The parameter ``name`` in :class:`importlib.machinery.ExtensionFileLoader` is
+  now deprecated, use ``fullname`` instead. This brings the name in line with
+  the rest of :mod:`importlib` and what the documentation has always said the
+  name of the parameter was.
+  (Contributed by Sayan Chowdhury and Adam Chhina in :issue:`74460`.)
+
 * Octal escapes with value larger than ``0o377`` now produce
   a :exc:`DeprecationWarning`.
   In a future Python version they will be a :exc:`SyntaxWarning` and

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1066,7 +1066,7 @@ Deprecated
   now deprecated, use ``fullname`` instead. This brings the name in line with
   the rest of :mod:`importlib` and what the documentation has always said the
   name of the parameter was.
-  (Contributed by Sayan Chowdhury and Adam Chhina in :issue:`74460`.)
+  (Contributed by Sayan Chowdhury and Adam Chhina in :gh:`74460`.)
 
 * Octal escapes with value larger than ``0o377`` now produce
   a :exc:`DeprecationWarning`.

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1216,8 +1216,17 @@ class ExtensionFileLoader(FileLoader, _LoaderBasics):
 
     """
 
-    def __init__(self, name, path):
-        self.name = name
+    def __init__(self, fullname=None, path=None, *, name=None):
+        if name is not None:
+            _warnings.warn("the 'name' parameter is deprecated; use "
+                           "'fullname' instead", DeprecationWarning,
+                           stacklevel=2)
+            if fullname is not None:
+                raise TypeError("'name' and 'fullname' cannot be used "
+                                "simultaneously")
+            self.name = name
+        else:
+            self.name = fullname
         self.path = path
 
     def __eq__(self, other):

--- a/Lib/test/test_importlib/extension/test_loader.py
+++ b/Lib/test/test_importlib/extension/test_loader.py
@@ -37,6 +37,24 @@ class LoaderTests(abc.LoaderTests):
             with self.assertRaises(ImportError):
                 self.load_module('XXX')
 
+    def test_deprecation_warning_argument_name_and_fullname_use(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            self.machinery.ExtensionFileLoader(
+                name=util.EXTENSIONS.name,
+                path=util.EXTENSIONS.file_path)
+
+        self.assertIn("fullname", str(cm.warning))
+
+    def test_argument_name_and_fullname_use(self):
+        with self.assertWarns(DeprecationWarning) as warning_cm:
+            with self.assertRaises(TypeError) as exception_cm:
+                self.machinery.ExtensionFileLoader(
+                    fullname=util.EXTENSIONS.name,
+                    name=util.EXTENSIONS.name,
+                    path=util.EXTENSIONS.file_path)
+
+        self.assertIn("fullname", str(exception_cm.exception))
+
     def test_equality(self):
         other = self.machinery.ExtensionFileLoader(util.EXTENSIONS.name,
                                                    util.EXTENSIONS.file_path)

--- a/Misc/NEWS.d/next/Library/2022-05-04-04-52-28.gh-issue-74460.1SxyxH.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-04-04-52-28.gh-issue-74460.1SxyxH.rst
@@ -1,0 +1,3 @@
+Rename *name* argument to *fullname* to
+:class:`importlib.machinery.ExtensionFileLoader`. Patch by Sayan Chowdhury
+and Adam Chhina.


### PR DESCRIPTION
Corresponds to issue [GH-74460](https://github.com/python/cpython/issues/74460). Fixed merge conflicts in [PR-1735](https://github.com/python/cpython/pull/1735) as it has been reviewed successfully but has now been stale for over two years; thanks to @sayanchowdhury for the original code. 

- [x] Tests passed locally
- [x] CLA signed 
- [x] Blurb added
- [x] Deprecation notice added in 3.11 what's new  
