### PR TITLE
gh-89653: PEP 670: Convert PyCFunction macros to functions

### DIFF
--- a/Include/cpython/methodobject.h
+++ b/Include/cpython/methodobject.h
@@ -2,30 +2,7 @@
 #  error "this header file must not be included directly"
 #endif
 
-PyAPI_DATA(PyTypeObject) PyCMethod_Type;
-
-#define PyCMethod_CheckExact(op) Py_IS_TYPE(op, &PyCMethod_Type)
-#define PyCMethod_Check(op) PyObject_TypeCheck(op, &PyCMethod_Type)
-
-#define _PyCFunctionObject_CAST(func) \
-    (assert(PyCFunction_Check(func)), \
-     _Py_CAST(PyCFunctionObject*, (func)))
-#define _PyCMethodObject_CAST(func) \
-    (assert(PyCMethod_Check(func)), \
-     _Py_CAST(PyCMethodObject*, (func)))
-
-/* Macros for direct access to these values. Type checks are *not*
-   done, so use with care. */
-#define PyCFunction_GET_FUNCTION(func) \
-    (_PyCFunctionObject_CAST(func)->m_ml->ml_meth)
-#define PyCFunction_GET_SELF(func) \
-    (_PyCFunctionObject_CAST(func)->m_ml->ml_flags & METH_STATIC ? \
-     NULL : _PyCFunctionObject_CAST(func)->m_self)
-#define PyCFunction_GET_FLAGS(func) \
-    (_PyCFunctionObject_CAST(func)->m_ml->ml_flags)
-#define PyCFunction_GET_CLASS(func) \
-    (_PyCFunctionObject_CAST(func)->m_ml->ml_flags & METH_METHOD ? \
-     _PyCMethodObject_CAST(func)->mm_class : NULL)
+// PyCFunctionObject structure
 
 typedef struct {
     PyObject_HEAD
@@ -36,7 +13,62 @@ typedef struct {
     vectorcallfunc vectorcall;
 } PyCFunctionObject;
 
+#define _PyCFunctionObject_CAST(func) \
+    (assert(PyCFunction_Check(func)), \
+     _Py_CAST(PyCFunctionObject*, (func)))
+
+
+// PyCMethodObject structure
+
 typedef struct {
     PyCFunctionObject func;
     PyTypeObject *mm_class; /* Class that defines this method */
 } PyCMethodObject;
+
+#define _PyCMethodObject_CAST(func) \
+    (assert(PyCMethod_Check(func)), \
+     _Py_CAST(PyCMethodObject*, (func)))
+
+PyAPI_DATA(PyTypeObject) PyCMethod_Type;
+
+#define PyCMethod_CheckExact(op) Py_IS_TYPE(op, &PyCMethod_Type)
+#define PyCMethod_Check(op) PyObject_TypeCheck(op, &PyCMethod_Type)
+
+
+/* Static inline functions for direct access to these values.
+   Type checks are *not* done, so use with care. */
+static inline PyCFunction PyCFunction_GET_FUNCTION(PyObject *func) {
+    return _PyCFunctionObject_CAST(func)->m_ml->ml_meth;
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyCFunction_GET_FUNCTION(func) PyCFunction_GET_FUNCTION(_PyObject_CAST(func))
+#endif
+
+static inline PyObject* PyCFunction_GET_SELF(PyObject *func_obj) {
+    PyCFunctionObject *func = _PyCFunctionObject_CAST(func_obj);
+    if (func->m_ml->ml_flags & METH_STATIC) {
+        return _Py_NULL;
+    }
+    return func->m_self;
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyCFunction_GET_SELF(func) PyCFunction_GET_SELF(_PyObject_CAST(func))
+#endif
+
+static inline int PyCFunction_GET_FLAGS(PyObject *func) {
+    return _PyCFunctionObject_CAST(func)->m_ml->ml_flags;
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyCFunction_GET_FLAGS(func) PyCFunction_GET_FLAGS(_PyObject_CAST(func))
+#endif
+
+static inline PyTypeObject* PyCFunction_GET_CLASS(PyObject *func_obj) {
+    PyCFunctionObject *func = _PyCFunctionObject_CAST(func_obj);
+    if (func->m_ml->ml_flags & METH_METHOD) {
+        return _PyCMethodObject_CAST(func)->mm_class;
+    }
+    return _Py_NULL;
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyCFunction_GET_CLASS(func) PyCFunction_GET_CLASS(_PyObject_CAST(func))
+#endif


### PR DESCRIPTION
Convert the following macros to static inline functions:

* PyCFunction_GET_CLASS()
* PyCFunction_GET_FLAGS()
* PyCFunction_GET_FUNCTION()
* PyCFunction_GET_SELF()

Limited C API version 3.11 no longer casts arguments.

Export the PyCMethod_GetClass() function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
