### PR TITLE
gh-92119: Make _ctypes_extend_error print exception class name instead of exception class string repr

### DIFF
--- a/Lib/ctypes/test/test_structures.py
+++ b/Lib/ctypes/test/test_structures.py
@@ -332,13 +332,13 @@ class StructureTestCase(unittest.TestCase):
         cls, msg = self.get_except(Person, b"Someone", (1, 2))
         self.assertEqual(cls, RuntimeError)
         self.assertEqual(msg,
-                             "(Phone) <class 'TypeError'>: "
+                             "(Phone) TypeError: "
                              "expected bytes, int found")
 
         cls, msg = self.get_except(Person, b"Someone", (b"a", b"b", b"c"))
         self.assertEqual(cls, RuntimeError)
         self.assertEqual(msg,
-                             "(Phone) <class 'TypeError'>: too many initializers")
+                             "(Phone) TypeError: too many initializers")
 
     def test_huge_field_name(self):
         # issue12881: segfault with large structure field names

--- a/Misc/NEWS.d/next/Library/2022-05-04-20-48-51.gh-issue-92119.52jeKL.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-04-20-48-51.gh-issue-92119.52jeKL.rst
@@ -1,0 +1,1 @@
+Change the way :c:func:`_ctypes_extend_error` prints the type of raised exception: use :c:func:`PyType_GetQualName` instead of :c:func:`PyObject_Str`.

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1016,7 +1016,7 @@ void _ctypes_extend_error(PyObject *exc_class, const char *fmt, ...)
 
     PyErr_Fetch(&tp, &v, &tb);
     PyErr_NormalizeException(&tp, &v, &tb);
-    cls_str = PyObject_Str(tp);
+    cls_str = PyType_GetQualName((PyTypeObject *)tp);
     if (cls_str) {
         PyUnicode_AppendAndDel(&s, cls_str);
         PyUnicode_AppendAndDel(&s, PyUnicode_FromString(": "));


### PR DESCRIPTION
When making a call of C function with argument of wrong type (with function's argtypes attribute set) ctypes raises ArgumentError with error message containing exception class string representation (e. g. "<class 'TypeError'>"). This change makes it to use exception class qualified name instead, which is better matches the behavior described in ctypes documentation.