### PR TITLE
gh-51574: Return the absolute path in `tempfile.mkdtemp()`

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -376,7 +376,7 @@ def mkdtemp(suffix=None, prefix=None, dir=None):
                 continue
             else:
                 raise
-        return file
+        return _os.path.abspath(file)
 
     raise FileExistsError(_errno.EEXIST,
                           "No usable temporary directory name found")

--- a/Misc/NEWS.d/next/Library/2022-05-04-23-49-20.gh-issue-51574.8zvexM.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-04-23-49-20.gh-issue-51574.8zvexM.rst
@@ -1,0 +1,1 @@
+The absolute path is returned, just like [mkdtemp()](https://docs.python.org/3/library/tempfile.html#tempfile.mkdtemp)


### PR DESCRIPTION
This is a fix for old problems (gh-51574, gh-64466) where `tempfile.mkdtemp()` would not return an absolute path if a relative directory was specified.

This doesn't solve any global problem, but it does make the result consistent
Judging by [grep.app](https://grep.app/search?q=%28TemporaryDirectory%5C%28dir%3D%5C%22%5C.%5C%22%5C%29%29%7C%28mkdtemp%5C%28dir%3D%5C%22%5C.%5C%22%5C%29%29&regexp=true&filter[lang][0]=Python) this case occurred in a small number of projects and shouldn't break everything after the upgrade

As @serhiy-storchaka mentioned https://github.com/python/cpython/issues/64466#issuecomment-1093642375
the temporary directory will not be deleted if you rename the parent directory

```
Python 3.8.12 (default, Nov 23 2021, 17:00:15)
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import os, tempfile
>>> os.mkdir('parent')
>>> os.chdir('parent')
>>> t = tempfile.TemporaryDirectory(dir=".")
>>> os.rename('../parent', '../parent2')
>>> t.cleanup()
>>> os.path.exists("../parent2/" + t.name.split("/")[-1])
False
```

```
Python 3.11.0a7+ (heads/main-dirty:e61330b44f, May  4 2022, 23:41:57) [Clang 13.1.6 (clang-1316.0.21.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import os, tempfile
>>> os.mkdir('parent')
>>> os.chdir('parent')
>>> t = tempfile.TemporaryDirectory(dir=".")
>>> os.rename('../parent', '../parent2')
>>> t.cleanup()
>>> os.path.exists("../parent2/" + t.name.split("/")[-1])
True
```

But it seems normal - now the behavior of TemporaryDirectory and NamedTemporaryFile is the same, in the sense that both classes do not delete the temporary directory/file if it no longer exists in the old path

```
Python 3.8.12 (default, Nov 23 2021, 17:00:15)
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
>>> import os, tempfile
>>> os.mkdir('parent')
>>> os.chdir('parent')
>>> t = tempfile.TemporaryDirectory(dir=".")
>>> os.rename('../parent', '../parent2')
>>> t.__exit__(None, None, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/marat/.pyenv/versions/3.8.12/lib/python3.8/tempfile.py", line 492, in __exit__
    self.close()
  File "/Users/marat/.pyenv/versions/3.8.12/lib/python3.8/tempfile.py", line 499, in close
    self._closer.close()
  File "/Users/marat/.pyenv/versions/3.8.12/lib/python3.8/tempfile.py", line 436, in close
    unlink(self.name)
FileNotFoundError: [Errno 2] No such file or directory: '/private/tmp/parent/tmp4ztw557q'
```

(It might be worth adding the same error for TemporaryDirectory, that the directory does not exist)
