### PR TITLE
gh-91985: Fix sys.path calculation with PYTHONHOME on Windows (alt)

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1258,7 +1258,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             # gh-91985 Replace the DLLs path according to pybuilddir.txt
             p = os.path.dirname(self.test_exe)
             try:
-                with open(os.path.join(p, 'pybuilddir.txt'), encoding="utf8") as f:
+                with open(os.path.join(p, 'pybuilddir.txt'), encoding='utf8') as f:
                     expected_paths[-1] = os.path.normpath(
                         os.path.join(p, f'{f.read()}\n$'.splitlines()[0])
                     )
@@ -1301,15 +1301,14 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             self.fail(f"Unable to find home in {paths!r}")
 
         pyddir = os.path.dirname(
-            import_helper.import_module('_testinternalcapi').__file__
-        )
+            import_helper.import_module('_testinternalcapi').__file__)
         with self.tmpdir_with_python() as tmpdir:
             config = {
                 'home': home,
                 'pythonpath_env': pyddir,
                 'module_search_paths': [
                     os.path.join(tmpdir, os.path.basename(paths[0])),  # zip
-                    os.path.join(home, "Lib"),
+                    os.path.join(home, 'Lib'),
                     os.path.join(home, 'DLLs'),
                 ],
             }

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1269,8 +1269,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 exedir = os.path.dirname(self.test_exe)
                 with open(os.path.join(exedir, 'pybuilddir.txt'), encoding='utf8') as f:
                     expected_paths[-1] = os.path.normpath(
-                        os.path.join(exedir, f'{f.read()}\n$'.splitlines()[0])
-                    )
+                        os.path.join(exedir, f'{f.read()}\n$'.splitlines()[0]))
             except FileNotFoundError:
                 pass
         else:

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1300,7 +1300,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         else:
             self.fail(f"Unable to find home in {paths!r}")
 
-        ziplib = os.path.basename(self.module_search_paths()[-3])
         pyddir = os.path.dirname(
             import_helper.import_module('_testinternalcapi').__file__
         )
@@ -1309,7 +1308,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 'home': home,
                 'pythonpath_env': pyddir,
                 'module_search_paths': [
-                    os.path.join(tmpdir, ziplib),
+                    os.path.join(tmpdir, os.path.basename(paths[0])),  # zip
                     os.path.join(home, "Lib"),
                     os.path.join(home, 'DLLs'),
                 ],

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1255,12 +1255,12 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             # Because we are specifying 'home', module search paths
             # are fairly static
             expected_paths = [paths[0], stdlib, os.path.join(home, 'DLLs')]
-            # gh-91985 Replace the DLLs path according to pybuilddir.txt
-            p = os.path.dirname(self.test_exe)
             try:
-                with open(os.path.join(p, 'pybuilddir.txt'), encoding='utf8') as f:
+                # gh-91985 Replace the DLLs path according to pybuilddir.txt
+                exedir = os.path.dirname(self.test_exe)
+                with open(os.path.join(exedir, 'pybuilddir.txt'), encoding='utf8') as f:
                     expected_paths[-1] = os.path.normpath(
-                        os.path.join(p, f'{f.read()}\n$'.splitlines()[0])
+                        os.path.join(exedir, f'{f.read()}\n$'.splitlines()[0])
                     )
             except FileNotFoundError:
                 pass

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -603,6 +603,17 @@ if not stdlib_dir:
         stdlib_dir = ''
 
 if not platstdlib_dir:
+    if os_name == 'nt' and real_executable_dir and \
+            isfile(joinpath(real_executable_dir, BUILDDIR_TXT)):
+        try:
+            platstdlib_dir = joinpath(
+                real_executable_dir,
+                readlines(joinpath(real_executable_dir, BUILDDIR_TXT))[0],
+            )
+        except IndexError:
+            platstdlib_dir = real_executable_dir
+
+if not platstdlib_dir:
     if exec_prefix:
         platstdlib_dir = joinpath(exec_prefix, PLATSTDLIB_LANDMARK)
     else:

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -612,9 +612,7 @@ if not platstdlib_dir:
             )
         except IndexError:
             platstdlib_dir = real_executable_dir
-
-if not platstdlib_dir:
-    if exec_prefix:
+    elif exec_prefix:
         platstdlib_dir = joinpath(exec_prefix, PLATSTDLIB_LANDMARK)
     else:
         platstdlib_dir = ''


### PR DESCRIPTION
Alternative PR to #92288.
A build path overrides `f'{PYTHONHOME}/DLLs'` in sys.path, when `pybuilddir.txt` is found. And a new test runs in a temp directory where `pybuilddir.txt` doesn't exist.

Here is an output of C code in the description of #91985:
```
PYTHONHOME: C:\cpython-main

0
C:\cpython-main\PCbuild\amd64\python311.zip
C:\cpython-main\Lib
C:\cpython-main\PCbuild\amd64
C:\cpython-main
C:\cpython-main\Lib\site-packages

1
C:\cpython-main\PCbuild\amd64\python311.zip
C:\cpython-main\Lib
C:\cpython-main\PCbuild\amd64
C:\cpython-main
C:\cpython-main\Lib\site-packages

2
C:\cpython-main\PCbuild\amd64\python311.zip
C:\cpython-main\Lib
C:\cpython-main\PCbuild\amd64
C:\cpython-main
C:\cpython-main\Lib\site-packages
```