### PR TITLE
gh-92345: Import rlcompleter before sys.path is extended

### DIFF
--- a/Lib/rlcompleter.py
+++ b/Lib/rlcompleter.py
@@ -32,6 +32,8 @@ Notes:
 import atexit
 import builtins
 import inspect
+import keyword
+import re
 import __main__
 
 __all__ = ["Completer"]
@@ -113,7 +115,6 @@ class Completer:
         defined in self.namespace that match.
 
         """
-        import keyword
         matches = []
         seen = {"__builtins__"}
         n = len(text)
@@ -146,7 +147,6 @@ class Completer:
         with a __getattr__ hook is evaluated.
 
         """
-        import re
         m = re.match(r"(\w+(\.\w+)*)\.(\w*)", text)
         if not m:
             return []

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-05-20-05-41.gh-issue-92345.lnN_RA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-05-20-05-41.gh-issue-92345.lnN_RA.rst
@@ -1,0 +1,3 @@
+``pymain_run_python()`` now imports ``readline`` and ``rlcompleter`` before
+sys.path is extended to include the current working directory of an
+interactive interpreter. Non-interactive interpreters are not affected.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -219,6 +219,13 @@ pymain_import_readline(const PyConfig *config)
     else {
         Py_DECREF(mod);
     }
+    mod = PyImport_ImportModule("rlcompleter");
+    if (mod == NULL) {
+        PyErr_Clear();
+    }
+    else {
+        Py_DECREF(mod);
+    }
 }
 
 
@@ -555,6 +562,9 @@ pymain_run_python(int *exitcode)
         }
     }
 
+    // import readline and rlcompleter before script dir is added to sys.path
+    pymain_import_readline(config);
+
     if (main_importer_path != NULL) {
         if (pymain_sys_path_add_path0(interp, main_importer_path) < 0) {
             goto error;
@@ -577,7 +587,6 @@ pymain_run_python(int *exitcode)
     }
 
     pymain_header(config);
-    pymain_import_readline(config);
 
     if (config->run_command) {
         *exitcode = pymain_run_command(config->run_command);


### PR DESCRIPTION
``pymain_run_python()`` now imports ``readline`` and ``rlcompleter``
before sys.path is extended to include the current working directory of
an interactive interpreter. Non-interactive interpreters are not
affected.

Also move imports of ``re`` and ``keyword`` module to top level so they
are materialized early, too. The ``keyword`` module is trivial and the
``re`` is already imported via ``inspect`` -> ``linecache``.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
