### PR TITLE
gh-92332: Docs-only deprecation of `typing.Text`

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1977,8 +1977,8 @@ Other concrete types
    .. versionadded:: 3.5.2
 
    .. deprecated:: 3.11
-      Python 2 is no longer supported at runtime, and is also no longer
-      supported by most type checkers. Users should therefore now use
+      Python 2 is no longer supported and most type checkers no longer
+      support type checking Python 2 code either. Users should now use
       :class:`str` instead of ``Text`` wherever possible.
 
 Abstract Base Classes

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1976,6 +1976,11 @@ Other concrete types
 
    .. versionadded:: 3.5.2
 
+   .. deprecated:: 3.11
+      Python 2 is no longer supported at runtime, and is also no longer
+      supported by most type checkers. Users should therefore now use
+      :class:`str` instead of ``Text`` wherever possible.
+
 Abstract Base Classes
 ---------------------
 
@@ -2686,4 +2691,6 @@ convenience. This is subject to change, and not all deprecations are listed.
 +----------------------------------+---------------+-------------------+----------------+
 |  ``typing`` versions of standard | 3.9           | Undecided         | :pep:`585`     |
 |  collections                     |               |                   |                |
++----------------------------------+---------------+-------------------+----------------+
+|  ``typing.Text``                 | 3.11          | Undecided         | :gh:`92332`    |
 +----------------------------------+---------------+-------------------+----------------+

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1977,8 +1977,8 @@ Other concrete types
    .. versionadded:: 3.5.2
 
    .. deprecated:: 3.11
-      Python 2 is no longer supported and most type checkers no longer
-      support type checking Python 2 code either. Users should now use
+      Python 2 is no longer supported, and most type checkers also no longer
+      support type checking Python 2 code. Users should now use
       :class:`str` instead of ``Text`` wherever possible.
 
 Abstract Base Classes

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1202,6 +1202,12 @@ Deprecated
   For now, a deprecation warning is raised for such syntax.
   (Contributed by Serhiy Storchaka in :gh:`91760`.)
 
+* :class:`typing.Text`, which exists solely to provide compatibility support
+  between Python 2 and Python 3 code, is now deprecated. Its removal is
+  currently unplanned, but users are encouraged to use :class:`str` instead
+  wherever possible.
+  (Contributed by Alex Waygood in :gh:`92332`.)
+
 
 Removed
 =======

--- a/Misc/NEWS.d/next/Library/2022-05-05-22-46-52.gh-issue-92332.Fv9CJx.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-05-22-46-52.gh-issue-92332.Fv9CJx.rst
@@ -1,0 +1,2 @@
+Deprecate :class:`typing.Text` (removal of the class is currently not
+planned). Patch by Alex Waygood.


### PR DESCRIPTION
Closes #92332