### PR TITLE
gh-92356: Fix regression in ctypes function call overhead

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-05-05-19-25-09.gh-issue-92356.uvxWdu.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-05-19-25-09.gh-issue-92356.uvxWdu.rst
@@ -1,0 +1,1 @@
+Fixed a performance regression in ctypes function calls.

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -1602,6 +1602,7 @@ _ctypes_get_fielddesc(const char *fmt)
     struct fielddesc *table = formattable;
 
     if (!initialized) {
+        initialized = 1;
         _ctypes_init_fielddesc();
     }
 


### PR DESCRIPTION
38f331d introduced a delayed initialization routine to set up
ctypes formattable (`_ctypes_init_fielddesc`), but inadvertently
removed setting the `initialization` flag to 1 to avoid initting
each time.

Cc: @tiran 

#92356