### PR TITLE
gh-57684: Add the -p command line option

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -560,6 +560,10 @@ PyConfig
       Set to ``1`` by the :option:`-P` command line option and the
       :envvar:`PYTHONSAFEPATH` environment variable.
 
+      Set to 0 by the :option:`-p` command line option, which takes precedence
+      over the :option:`-P` option and the :envvar:`PYTHONSAFEPATH` environment
+      variable (and the :option:`-P` option implied by the :option:`-I` option).
+
       Default: ``0`` in Python config, ``1`` in isolated config.
 
       .. versionadded:: 3.11

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1142,9 +1142,9 @@ always available.
    the environment variable :envvar:`PYTHONPATH`, plus an installation-dependent
    default.
 
-   By default, as initialized upon program startup, a potentially unsafe path
-   is prepended to :data:`sys.path` (*before* the entries inserted as a result
-   of :envvar:`PYTHONPATH`):
+   By default, as initialized upon program startup, the following path is
+   prepended to :data:`sys.path` (*before* the entries inserted as a result of
+   :envvar:`PYTHONPATH`):
 
    * ``python -m module`` command line: prepend the current working
      directory.
@@ -1154,7 +1154,9 @@ always available.
      string, which means the current working directory.
 
    To not prepend this potentially unsafe path, use the :option:`-P` command
-   line option or the :envvar:`PYTHONSAFEPATH` environment variable?
+   line option or the :envvar:`PYTHONSAFEPATH` environment variable. The
+   :option:`-p` option causes the :option:`-P` option and the
+   :envvar:`PYTHONSAFEPATH` environment variable to be ignored.
 
    A program is free to modify this list for its own purposes.  Only strings
    and bytes should be added to :data:`sys.path`; all other data types are

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -284,6 +284,11 @@ Miscellaneous options
    variables are ignored, too. Further restrictions may be imposed to prevent
    the user from injecting malicious code.
 
+   The :option:`-p` option can be used with the :option:`-I` option to ignore
+   the :option:`-P` implied by the :option:`-I` option: prepend a potentially
+   unsafe path to :data:`sys.path` such as the current directory, the script's
+   directory or an empty string.
+
    .. versionadded:: 3.4
 
 
@@ -319,10 +324,28 @@ Miscellaneous options
    * ``python -c code`` and ``python`` (REPL) command lines: Don't prepend an
      empty string, which means the current working directory.
 
-   See also the :envvar:`PYTHONSAFEPATH` environment variable, and :option:`-E`
+   See also the :envvar:`PYTHONSAFEPATH` environment variable, and :option:`-p`
    and :option:`-I` (isolated) options.
 
    .. versionadded:: 3.11
+
+
+.. cmdoption:: -p
+
+   Prepend a potentially unsafe path to :data:`sys.path` such as the current
+   directory, the script's directory or an empty string; opposite of the
+   :option:`-P` option.
+
+   This is the default Python behavior. This option can be used to ignore the
+   :option:`-P` command line option and the :envvar:`PYTHONSAFEPATH`
+   environment variable.
+
+   The :option:`-p` option takes precedence over the :option:`-P` option and
+   the :envvar:`PYTHONSAFEPATH` environment variable. It also takes precedence
+   over the :option:`-P` option implied by the :option:`-I` option (isolated
+   mode).
+
+   .. versionadded:: 3.12
 
 
 .. cmdoption:: -q
@@ -606,11 +629,18 @@ conflict.
    :ref:`using-on-interface-options`. The search path can be manipulated from
    within a Python program as the variable :data:`sys.path`.
 
+   See also the :option:`-p` and :option:`-P` options and the
+   :envvar:`PYTHONSAFEPATH` environment variable.
+
 
 .. envvar:: PYTHONSAFEPATH
 
    If this is set to a non-empty string, don't prepend a potentially unsafe
-   path to :data:`sys.path`: see the :option:`-P` option for details.
+   path to :data:`sys.path` such as the current directory, the script's
+   directory or an empty string; same effect as the :option:`-P` option.
+
+   See also the :option:`-P` and :option:`-p` option and the
+   :envvar:`PYTHONPATH` environment variable.
 
    .. versionadded:: 3.11
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -79,6 +79,12 @@ New Features
 Other Language Changes
 ======================
 
+* Add the :option:`-p` command line option to prepend the potentially unsafe
+  path to :data:`sys.path`. It causes the :option:`-P` option and the
+  :envvar:`PYTHONSAFEPATH` environment variable to be ignored. It also causes
+  the :option:`-P` option implied by the :option:`-I` option (isolated mode) to
+  be ignored.
+  (Contributed by Victor Stinner in :gh:`57684`.)
 
 
 New Modules

--- a/Lib/distutils/tests/test_bdist_rpm.py
+++ b/Lib/distutils/tests/test_bdist_rpm.py
@@ -49,10 +49,9 @@ class BuildRpmTestCase(support.TempdirManager,
                      'the rpm command is not found')
     @unittest.skipIf(find_executable('rpmbuild') is None,
                      'the rpmbuild command is not found')
-    # import foo fails with safe path
-    @unittest.skipIf(sys.flags.safe_path,
-                     'PYTHONSAFEPATH changes default sys.path')
     def test_quiet(self):
+        os.environ.pop('PYTHONSAFEPATH', '')
+
         # let's create a package
         tmp_dir = self.mkdtemp()
         os.environ['HOME'] = tmp_dir   # to confine dir '.rpmdb' creation
@@ -96,10 +95,9 @@ class BuildRpmTestCase(support.TempdirManager,
                      'the rpm command is not found')
     @unittest.skipIf(find_executable('rpmbuild') is None,
                      'the rpmbuild command is not found')
-    # import foo fails with safe path
-    @unittest.skipIf(sys.flags.safe_path,
-                     'PYTHONSAFEPATH changes default sys.path')
     def test_no_optimize_flag(self):
+        os.environ.pop('PYTHONSAFEPATH', '')
+
         # let's create a package that breaks bdist_rpm
         tmp_dir = self.mkdtemp()
         os.environ['HOME'] = tmp_dir   # to confine dir '.rpmdb' creation

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -116,9 +116,7 @@ class CmdLineTest(unittest.TestCase):
         self.assertIn(printed_file.encode('utf-8'), data)
         self.assertIn(printed_package.encode('utf-8'), data)
         self.assertIn(printed_argv0.encode('utf-8'), data)
-        # PYTHONSAFEPATH=1 changes the default sys.path[0]
-        if not sys.flags.safe_path:
-            self.assertIn(printed_path0.encode('utf-8'), data)
+        self.assertIn(printed_path0.encode('utf-8'), data)
         self.assertIn(printed_cwd.encode('utf-8'), data)
 
     def _check_script(self, script_exec_args, expected_file,
@@ -127,7 +125,7 @@ class CmdLineTest(unittest.TestCase):
                             *cmd_line_switches, cwd=None, **env_vars):
         if isinstance(script_exec_args, str):
             script_exec_args = [script_exec_args]
-        run_args = [*support.optim_args_from_interpreter_flags(),
+        run_args = [*support.optim_args_from_interpreter_flags(), '-p',
                     *cmd_line_switches, *script_exec_args, *example_args]
         rc, out, err = assert_python_ok(
             *run_args, __isolated=False, __cwd=cwd, **env_vars

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1143,10 +1143,11 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         pre_config = {
             'parse_argv': 0,
         }
+        argv = ['./argv0', '-E', '-c', 'pass', 'arg1', '-v', 'arg3']
         config = {
             'parse_argv': 0,
-            'argv': ['./argv0', '-E', '-c', 'pass', 'arg1', '-v', 'arg3'],
-            'orig_argv': ['./argv0', '-E', '-c', 'pass', 'arg1', '-v', 'arg3'],
+            'argv': argv,
+            'orig_argv': argv,
             'program_name': './argv0',
         }
         self.check_all_configs("test_init_dont_parse_argv", config, pre_config,

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1369,11 +1369,9 @@ class PdbTestCase(unittest.TestCase):
     def tearDown(self):
         os_helper.unlink(os_helper.TESTFN)
 
-    @unittest.skipIf(sys.flags.safe_path,
-                     'PYTHONSAFEPATH changes default sys.path')
     def _run_pdb(self, pdb_args, commands):
         self.addCleanup(os_helper.rmtree, '__pycache__')
-        cmd = [sys.executable, '-m', 'pdb'] + pdb_args
+        cmd = [sys.executable, '-p', '-m', 'pdb'] + pdb_args
         with subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,

--- a/Lib/test/test_runpy.py
+++ b/Lib/test/test_runpy.py
@@ -782,8 +782,7 @@ class TestExit(unittest.TestCase):
 
     @requires_subprocess()
     def assertSigInt(self, cmd, *args, **kwargs):
-        # Use -E to ignore PYTHONSAFEPATH
-        cmd = [sys.executable, '-E', *cmd]
+        cmd = [sys.executable, '-p', *cmd]
         proc = subprocess.run(cmd, *args, **kwargs, text=True, stderr=subprocess.PIPE)
         self.assertTrue(proc.stderr.endswith("\nKeyboardInterrupt\n"), proc.stderr)
         self.assertEqual(proc.returncode, self.EXPECTED_CODE)

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-06-03-53-47.gh-issue-57684.ITjOhD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-06-03-53-47.gh-issue-57684.ITjOhD.rst
@@ -1,0 +1,4 @@
+Add the :option:`-p` option to ignore the :option:`-P` option and the
+:envvar:`PYTHONSAFEPATH` environment variable. It also causes the :option:`-P`
+option implied by the :option:`-I` option (isolated mode) to be ignored. Patch
+by Victor Stinner.

--- a/Misc/python.man
+++ b/Misc/python.man
@@ -46,6 +46,9 @@ python \- an interpreted, interactive, object-oriented programming language
 .B \-P
 ]
 [
+.B \-p
+]
+[
 .B \-s
 ]
 [
@@ -184,6 +187,9 @@ compiled (bytecode) files by adding .opt-2 before the .pyc extension.
 Don't automatically prepend a potentially unsafe path to \fBsys.path\fP such
 as the current directory, the script's directory or an empty string. See also the
 \fBPYTHONSAFEPATH\fP environment variable.
+.TP
+.B \-p
+Ignore the \fB\-P\fP option and the \fBPYTHONSAFEPATH\fP environment variable.
 .TP
 .B \-q
 Do not print the version and copyright messages. These messages are
@@ -409,7 +415,7 @@ interpreter.
 .IP PYTHONSAFEPATH
 If this is set to a non-empty string, don't automatically prepend a potentially
 unsafe path to \fBsys.path\fP such as the current directory, the script's
-directory or an empty string. See also the \fB\-P\fP option.
+directory or an empty string. See also \fB\-P\fP and\fB\-p\fP options.
 .IP PYTHONHOME
 Change the location of the standard Python libraries.  By default, the
 libraries are searched in ${prefix}/lib/python<version> and

--- a/Python/getopt.c
+++ b/Python/getopt.c
@@ -41,7 +41,7 @@ static const wchar_t *opt_ptr = L"";
 
 /* Python command line short and long options */
 
-#define SHORT_OPTS L"bBc:dEhiIJm:OPqRsStuvVW:xX:?"
+#define SHORT_OPTS L"bBc:dEhiIJm:OpPqRsStuvVW:xX:?"
 
 static const _PyOS_LongOption longopts[] = {
     {L"check-hash-based-pycs", 1, 0},

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -172,8 +172,7 @@ def freeze(python, scriptfile, outdir):
 
     print(f'freezing {scriptfile}...')
     os.makedirs(outdir, exist_ok=True)
-    # Use -E to ignore PYTHONSAFEPATH
-    _run_quiet([python, '-E', FREEZE, '-o', outdir, scriptfile], outdir)
+    _run_quiet([python, '-p', FREEZE, '-o', outdir, scriptfile], outdir)
     _run_quiet([MAKE, '-C', os.path.dirname(scriptfile)])
 
     name = os.path.basename(scriptfile).rpartition('.')[0]


### PR DESCRIPTION
Add the -p option to ignore the -P option and the PYTHONSAFEPATH
environment variable. The -p option takes precedence over -P and -I
options and the PYTHONSAFEPATH environment variable.

test_cmd_line, test_cmd_line_script, test_pdb, test_runpy and
test_tools now use the -p option to ignore the PYTHONSAFEPATH
environment variable.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
