### PR TITLE
gh-92352 optimize Condition.notify()

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -369,15 +369,13 @@ class Condition:
         if not self._is_owned():
             raise RuntimeError("cannot notify on un-acquired lock")
         all_waiters = self._waiters
-        waiters_to_notify = _deque(_islice(all_waiters, n))
-        if not waiters_to_notify:
+
+        if not all_waiters:
             return
-        for waiter in waiters_to_notify:
+        num_to_notify = min(n, len(all_waiters))
+        for i in range(num_to_notify):
+            waiter = all_waiters.popleft()
             waiter.release()
-            try:
-                all_waiters.remove(waiter)
-            except ValueError:
-                pass
 
     def notify_all(self):
         """Wake up all threads waiting on this condition.

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -368,13 +368,13 @@ class Condition:
         """
         if not self._is_owned():
             raise RuntimeError("cannot notify on un-acquired lock")
-        all_waiters = self._waiters
+        waiters = self._waiters
 
-        if not all_waiters:
+        if not waiters:
             return
-        num_to_notify = min(n, len(all_waiters))
+        num_to_notify = min(n, len(waiters))
         for i in range(num_to_notify):
-            waiter = all_waiters.popleft()
+            waiter = waiters.popleft()
             waiter.release()
 
     def notify_all(self):

--- a/Misc/NEWS.d/next/Library/2022-05-06-03-27-58.gh-issue-92352.Tv7wYm.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-06-03-27-58.gh-issue-92352.Tv7wYm.rst
@@ -1,0 +1,1 @@
+Optimizes ``Condition.notify()`` by removing unneeded construction of a ``_deque``


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Closes https://github.com/python/cpython/issues/92352

This speeds up `Condition.notify()`.  I benchmarked it with this command:
`./python -m timeit -s 'import queue; q = queue.Queue()' 'for i in range(10 ** 6): q.put(42)'`

Here are the timings with and without this PR:
```
1 loop, best of 5: 1.93 sec per loop  # original version
1 loop, best of 5: 1.37 sec per loop  # with this PR
```

With this change, `notify()` no longer creates a new `_deque` every time.  I think the speedup tends to be most noticeable when there aren't any threads waiting.  
