### PR TITLE
gh-85984: Remove legacy Lib/pty.py code.

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -512,6 +512,10 @@ Pending Removal in Python 3.14
   :func:`~multiprocessing.set_start_method` APIs to explicitly specify when
   your code *requires* ``'fork'``.  See :ref:`multiprocessing-start-methods`.
 
+* :mod:`pty` has two undocumented ``master_open()`` and ``slave_open()``
+  functions that have been deprecated since Python 2 but only gained a
+  proper :exc:`DeprecationWarning` in 3.12. Remove them in 3.14.
+
 Pending Removal in Future Versions
 ----------------------------------
 

--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -39,7 +39,7 @@ def master_open():
     """master_open() -> (master_fd, slave_name)
     Open a pty master and return the fd, and the filename of the slave end.
     Deprecated, use openpty() instead."""
-    
+
     import warnings
     warnings.warn("Use pty.openpty() instead.", DeprecationWarning, stacklevel=2)  # Remove API in 3.14
 

--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -39,6 +39,9 @@ def master_open():
     """master_open() -> (master_fd, slave_name)
     Open a pty master and return the fd, and the filename of the slave end.
     Deprecated, use openpty() instead."""
+    
+    import warnings
+    warnings.warn("Use pty.openpty() instead.", DeprecationWarning, stacklevel=2)  # Remove API in 3.14
 
     try:
         master_fd, slave_fd = os.openpty()
@@ -68,6 +71,9 @@ def slave_open(tty_name):
     Open the pty slave and acquire the controlling terminal, returning
     opened filedescriptor.
     Deprecated, use openpty() instead."""
+
+    import warnings
+    warnings.warn("Use pty.openpty() instead.", DeprecationWarning, stacklevel=2)  # Remove API in 3.14
 
     result = os.open(tty_name, os.O_RDWR)
     try:

--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -101,20 +101,8 @@ def fork():
     master_fd, slave_fd = openpty()
     pid = os.fork()
     if pid == CHILD:
-        # Establish a new session.
-        os.setsid()
         os.close(master_fd)
-
-        # Slave becomes stdin/stdout/stderr of child.
-        os.dup2(slave_fd, STDIN_FILENO)
-        os.dup2(slave_fd, STDOUT_FILENO)
-        os.dup2(slave_fd, STDERR_FILENO)
-        if slave_fd > STDERR_FILENO:
-            os.close(slave_fd)
-
-        # Explicitly open the tty to make it become a controlling tty.
-        tmp_fd = os.open(os.ttyname(STDOUT_FILENO), os.O_RDWR)
-        os.close(tmp_fd)
+        os.login_tty(slave_fd)
     else:
         os.close(slave_fd)
 

--- a/Misc/NEWS.d/next/Library/2023-02-05-21-40-15.gh-issue-85984.Kfzbb2.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-05-21-40-15.gh-issue-85984.Kfzbb2.rst
@@ -1,4 +1,4 @@
-Changes the implementation of :func:`pty.fork` to use :func:`os.login_tty` on systems lacking :func:`os.forkpty`.
+Refactored the implementation of :func:`pty.fork` to use :func:`os.login_tty`.
 
 A :exc:`DeprecationWarning` is now raised by ``pty.master_open()`` and ``pty.slave_open()``. They were
 undocumented and deprecated long long ago in the docstring in favor of :func:`pty.openpty`.

--- a/Misc/NEWS.d/next/Library/2023-02-05-21-40-15.gh-issue-85984.Kfzbb2.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-05-21-40-15.gh-issue-85984.Kfzbb2.rst
@@ -1,0 +1,1 @@
+Changes the implementation of :func:`pty.fork` to use :func:`os.login_tty` on systems lacking :func:`os.forkpty`.

--- a/Misc/NEWS.d/next/Library/2023-02-05-21-40-15.gh-issue-85984.Kfzbb2.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-05-21-40-15.gh-issue-85984.Kfzbb2.rst
@@ -1,1 +1,4 @@
 Changes the implementation of :func:`pty.fork` to use :func:`os.login_tty` on systems lacking :func:`os.forkpty`.
+
+A :exc:`DeprecationWarning` is now raised by ``pty.master_open()`` and ``pty.slave_open()``. They were
+undocumented and deprecated long long ago in the docstring in favor of :func:`pty.openpty`.


### PR DESCRIPTION
This follows #29658. This is one in a series of PRs aimed at cleaning-up, fixing bugs in, introducing new features in, and updating the code in "Lib/pty.py".

Signed-off-by: Soumendra Ganguly <soumendraganguly@gmail.com>

<!-- gh-issue-number: gh-85984 -->
* Issue: gh-85984
<!-- /gh-issue-number -->
