### PR TITLE
use crc32_z and adler32_z if available at compile time

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-06-14-57-17.gh-issue-92369.g5mxMm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-06-14-57-17.gh-issue-92369.g5mxMm.rst
@@ -1,0 +1,2 @@
+Use ``adler32_z`` and ``crc32_z`` in binascii and zlib modules, if available
+at compile time.

--- a/Modules/clinic/binascii.c.h
+++ b/Modules/clinic/binascii.c.h
@@ -244,7 +244,7 @@ PyDoc_STRVAR(binascii_crc32__doc__,
 #define BINASCII_CRC32_METHODDEF    \
     {"crc32", _PyCFunction_CAST(binascii_crc32), METH_FASTCALL, binascii_crc32__doc__},
 
-static unsigned int
+static PyObject *
 binascii_crc32_impl(PyObject *module, Py_buffer *data, unsigned int crc);
 
 static PyObject *
@@ -253,7 +253,6 @@ binascii_crc32(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     unsigned int crc = 0;
-    unsigned int _return_value;
 
     if (!_PyArg_CheckPositional("crc32", nargs, 1, 2)) {
         goto exit;
@@ -273,11 +272,7 @@ binascii_crc32(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
 skip_optional:
-    _return_value = binascii_crc32_impl(module, &data, crc);
-    if ((_return_value == (unsigned int)-1) && PyErr_Occurred()) {
-        goto exit;
-    }
-    return_value = PyLong_FromUnsignedLong((unsigned long)_return_value);
+    return_value = binascii_crc32_impl(module, &data, crc);
 
 exit:
     /* Cleanup for data */
@@ -628,4 +623,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=ba9ed7b810b8762d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2d0e3108e2f4980e input=a9049054013a1b77]*/

--- a/Modules/clinic/zlibmodule.c.h
+++ b/Modules/clinic/zlibmodule.c.h
@@ -788,7 +788,7 @@ PyDoc_STRVAR(zlib_crc32__doc__,
 #define ZLIB_CRC32_METHODDEF    \
     {"crc32", _PyCFunction_CAST(zlib_crc32), METH_FASTCALL, zlib_crc32__doc__},
 
-static unsigned int
+static PyObject *
 zlib_crc32_impl(PyObject *module, Py_buffer *data, unsigned int value);
 
 static PyObject *
@@ -797,7 +797,6 @@ zlib_crc32(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     unsigned int value = 0;
-    unsigned int _return_value;
 
     if (!_PyArg_CheckPositional("crc32", nargs, 1, 2)) {
         goto exit;
@@ -817,11 +816,7 @@ zlib_crc32(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
 skip_optional:
-    _return_value = zlib_crc32_impl(module, &data, value);
-    if ((_return_value == (unsigned int)-1) && PyErr_Occurred()) {
-        goto exit;
-    }
-    return_value = PyLong_FromUnsignedLong((unsigned long)_return_value);
+    return_value = zlib_crc32_impl(module, &data, value);
 
 exit:
     /* Cleanup for data */
@@ -855,4 +850,4 @@ exit:
 #ifndef ZLIB_DECOMPRESS___DEEPCOPY___METHODDEF
     #define ZLIB_DECOMPRESS___DEEPCOPY___METHODDEF
 #endif /* !defined(ZLIB_DECOMPRESS___DEEPCOPY___METHODDEF) */
-/*[clinic end generated code: output=757804b3ad33454f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7a90d2086f4717d7 input=a9049054013a1b77]*/

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -1399,20 +1399,14 @@ zlib_adler32_impl(PyObject *module, Py_buffer *data, unsigned int value)
 {
     /* Releasing the GIL for very small buffers is inefficient
        and may lower performance */
-#if ZLIB_VERNUM >= 0x1290
-    if (data->len > 1024*5) {
-        Py_BEGIN_ALLOW_THREADS
-        value = adler32_z(value, data->buf, data->len);
-        Py_END_ALLOW_THREADS
-    } else {
-        value = adler32_z(value, data->buf, data->len);
-    }
-#else
     if (data->len > 1024*5) {
         unsigned char *buf = data->buf;
         Py_ssize_t len = data->len;
 
         Py_BEGIN_ALLOW_THREADS
+#if ZLIB_VERNUM >= 0x1290
+        value = adler32_z(value, buf, len);
+#else
         /* Avoid truncation of length for very large buffers. adler32() takes
            length as an unsigned int, which may be narrower than Py_ssize_t. */
         while ((size_t)len > UINT_MAX) {
@@ -1421,11 +1415,15 @@ zlib_adler32_impl(PyObject *module, Py_buffer *data, unsigned int value)
             len -= (size_t) UINT_MAX;
         }
         value = adler32(value, buf, (unsigned int)len);
+#endif
         Py_END_ALLOW_THREADS
     } else {
+#if ZLIB_VERNUM >= 0x1290
+        value = adler32_z(value, data->buf, data->len);
+#else
         value = adler32(value, data->buf, (unsigned int)data->len);
-    }
 #endif
+    }
     return PyLong_FromUnsignedLong(value & 0xffffffffU);
 }
 
@@ -1448,20 +1446,14 @@ zlib_crc32_impl(PyObject *module, Py_buffer *data, unsigned int value)
 {
     /* Releasing the GIL for very small buffers is inefficient
        and may lower performance */
-#if ZLIB_VERNUM >= 0x1290
-    if (data->len > 1024*5) {
-        Py_BEGIN_ALLOW_THREADS
-        value = crc32_z(value, data->buf, data->len);
-        Py_END_ALLOW_THREADS
-    } else {
-        value = crc32_z(value, data->buf, data->len);
-    }
-#else
     if (data->len > 1024*5) {
         unsigned char *buf = data->buf;
         Py_ssize_t len = data->len;
 
         Py_BEGIN_ALLOW_THREADS
+#if ZLIB_VERNUM >= 0x1290
+        value = crc32_z(value, buf, len);
+#else
         /* Avoid truncation of length for very large buffers. crc32() takes
            length as an unsigned int, which may be narrower than Py_ssize_t. */
         while ((size_t)len > UINT_MAX) {
@@ -1470,11 +1462,15 @@ zlib_crc32_impl(PyObject *module, Py_buffer *data, unsigned int value)
             len -= (size_t) UINT_MAX;
         }
         value = crc32(value, buf, (unsigned int)len);
+#endif
         Py_END_ALLOW_THREADS
     } else {
+#if ZLIB_VERNUM >= 0x1290
+        value = crc32_z(value, data->buf, data->len);
+#else
         value = crc32(value, data->buf, (unsigned int)data->len);
-    }
 #endif
+    }
     return PyLong_FromUnsignedLong(value & 0xffffffffU);
 }
 

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -1399,6 +1399,15 @@ zlib_adler32_impl(PyObject *module, Py_buffer *data, unsigned int value)
 {
     /* Releasing the GIL for very small buffers is inefficient
        and may lower performance */
+#if ZLIB_VERNUM >= 0x1290
+    if (data->len > 1024*5) {
+        Py_BEGIN_ALLOW_THREADS
+        value = adler32_z(value, data->buf, data->len);
+        Py_END_ALLOW_THREADS
+    } else {
+        value = adler32_z(value, data->buf, data->len);
+    }
+#else
     if (data->len > 1024*5) {
         unsigned char *buf = data->buf;
         Py_ssize_t len = data->len;
@@ -1416,11 +1425,12 @@ zlib_adler32_impl(PyObject *module, Py_buffer *data, unsigned int value)
     } else {
         value = adler32(value, data->buf, (unsigned int)data->len);
     }
+#endif
     return PyLong_FromUnsignedLong(value & 0xffffffffU);
 }
 
 /*[clinic input]
-zlib.crc32 -> unsigned_int
+zlib.crc32
 
     data: Py_buffer
     value: unsigned_int(bitwise=True) = 0
@@ -1432,12 +1442,21 @@ Compute a CRC-32 checksum of data.
 The returned checksum is an integer.
 [clinic start generated code]*/
 
-static unsigned int
+static PyObject *
 zlib_crc32_impl(PyObject *module, Py_buffer *data, unsigned int value)
-/*[clinic end generated code: output=b217562e4fe6d6a6 input=1229cb2fb5ea948a]*/
+/*[clinic end generated code: output=63499fa20af7ea25 input=26c3ed430fa00b4c]*/
 {
     /* Releasing the GIL for very small buffers is inefficient
        and may lower performance */
+#if ZLIB_VERNUM >= 0x1290
+    if (data->len > 1024*5) {
+        Py_BEGIN_ALLOW_THREADS
+        value = crc32_z(value, data->buf, data->len);
+        Py_END_ALLOW_THREADS
+    } else {
+        value = crc32_z(value, data->buf, data->len);
+    }
+#else
     if (data->len > 1024*5) {
         unsigned char *buf = data->buf;
         Py_ssize_t len = data->len;
@@ -1455,7 +1474,8 @@ zlib_crc32_impl(PyObject *module, Py_buffer *data, unsigned int value)
     } else {
         value = crc32(value, data->buf, (unsigned int)data->len);
     }
-    return value;
+#endif
+    return PyLong_FromUnsignedLong(value & 0xffffffffU);
 }
 
 


### PR DESCRIPTION
they've been in zlib since v1.2.9, so why not use them? also use PyLong_FromUnsignedLong directly to avoid useless clinic error checks
feel free to squash this with an edited commit message