### PR TITLE
gh-91321: Fix _PyObject_EXTRA_INIT for C++

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -66,7 +66,7 @@ whose size is determined when the object is allocated.
     PyObject *_ob_next;           \
     PyObject *_ob_prev;
 
-#define _PyObject_EXTRA_INIT 0, 0,
+#define _PyObject_EXTRA_INIT _Py_NULL, _Py_NULL,
 
 #else
 #  define _PyObject_HEAD_EXTRA


### PR DESCRIPTION
In C++, the _PyObject_EXTRA_INIT macro now uses nullptr, rather than
0, to initialize the _ob_next and _ob_prev members of the PyObject
structure.

Fix test_cppext failure when Python is built with
./configure --with-trace-refs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
