### PR TITLE
Update What's New in 3.11 faster cpython figures and contributors

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -63,7 +63,7 @@ Summary -- Release highlights
    Brevity is key.
 
 - Python 3.11 is up to 10-60% faster than Python 3.10. On average, we measured a
-  1.22x speedup on the standard benchmark suite. See `Faster CPython`_ for details.
+  1.25x speedup on the standard benchmark suite. See `Faster CPython`_ for details.
 
 .. PEP-sized items next.
 
@@ -828,7 +828,7 @@ Optimizations
 Faster CPython
 ==============
 
-CPython 3.11 is on average `1.22x faster <https://github.com/faster-cpython/ideas/blob/main/main-vs-310.rst>`_
+CPython 3.11 is on average `1.25x faster <https://github.com/faster-cpython/ideas/blob/main/main-vs-310.rst>`_
 than CPython 3.10 when measured with the
 `pyperformance <https://github.com/python/pyperformance>`_ benchmark suite,
 and compiled with GCC on Ubuntu Linux. Depending on your workload, the speedup
@@ -930,8 +930,8 @@ and specialization attempts are not too expensive. This allows specialization
 to adapt to new circumstances.
 
 (PEP written by Mark Shannon, with ideas inspired by Stefan Brunthaler.
-See :pep:`659` for more information.)
-
+See :pep:`659` for more information. Implementation by Mark Shannon and Brandt
+Bucher, with additional help from Irit Katriel and Dennis Sweeney.)
 ..
    If I missed out anyone, please add them.
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -932,6 +932,7 @@ to adapt to new circumstances.
 (PEP written by Mark Shannon, with ideas inspired by Stefan Brunthaler.
 See :pep:`659` for more information. Implementation by Mark Shannon and Brandt
 Bucher, with additional help from Irit Katriel and Dennis Sweeney.)
+
 ..
    If I missed out anyone, please add them.
 


### PR DESCRIPTION
This should be the final figure now that 3.11 is in beta freeze mode.

I think we can merge this before or after the beta freeze. But it would be nice to get it done before so that the numbers are accurate when people read them.