### PR TITLE
gh-90978: test_ssl of test_asyncio uses LONG_TIMEOUT

### DIFF
--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -62,7 +62,7 @@ class MyBaseProto(asyncio.Protocol):
 class TestSSL(test_utils.TestCase):
 
     PAYLOAD_SIZE = 1024 * 100
-    TIMEOUT = 60
+    TIMEOUT = support.LONG_TIMEOUT
 
     def setUp(self):
         super().setUp()
@@ -179,7 +179,7 @@ class TestSSL(test_utils.TestCase):
     def test_create_server_ssl_1(self):
         CNT = 0           # number of clients that were successful
         TOTAL_CNT = 25    # total number of clients that test will create
-        TIMEOUT = 60.0    # timeout for this test
+        TIMEOUT = support.LONG_TIMEOUT  # timeout for this test
 
         A_DATA = b'A' * 1024 * 1024
         B_DATA = b'B' * 1024 * 1024
@@ -1019,7 +1019,7 @@ class TestSSL(test_utils.TestCase):
     def test_create_server_ssl_over_ssl(self):
         CNT = 0           # number of clients that were successful
         TOTAL_CNT = 25    # total number of clients that test will create
-        TIMEOUT = 30.0    # timeout for this test
+        TIMEOUT = support.LONG_TIMEOUT  # timeout for this test
 
         A_DATA = b'A' * 1024 * 1024
         B_DATA = b'B' * 1024 * 1024


### PR DESCRIPTION
On slow buildbot workers, some test_ssl tests fail randomly because
of short timeout (30 seconds). Use support.LONG_TIMEOUT instead which
is longer and also adjusted (by regrtest --timeout option) on
buildbot workers known to be slow.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
