### PR TITLE
gh-92052: Make dataclass function idempotent

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -27,6 +27,7 @@ __all__ = ['dataclass',
            'make_dataclass',
            'replace',
            'is_dataclass',
+           'is_direct_dataclass'
            ]
 
 # Conditions for adding methods.  The boxes indicate what action the
@@ -209,6 +210,9 @@ _FIELD_INITVAR = _FIELD_BASE('_FIELD_INITVAR')
 # The name of an attribute on the class where we store the Field
 # objects.  Also used to check if a class is a Data Class.
 _FIELDS = '__dataclass_fields__'
+
+# The set of classes and ancestors that have been directly declared as dataclasses (vs. inherited)
+_DECLARED_DATA_CLASSES = '__declared_dataclasses__'
 
 # The name of an attribute on the class that stores the parameters to
 # @dataclass.
@@ -1204,9 +1208,15 @@ def dataclass(cls=None, /, *, init=True, repr=True, eq=True, order=False,
     """
 
     def wrap(cls):
+        seen = getattr(cls, _DECLARED_DATA_CLASSES, None)
+        if seen is None:
+            seen = set()
+            setattr(cls, _DECLARED_DATA_CLASSES, seen)
+        elif id(cls) in seen:
+            return cls
+        seen.add(id(cls))
         return _process_class(cls, init, repr, eq, order, unsafe_hash,
-                              frozen, match_args, kw_only, slots,
-                              weakref_slot)
+                              frozen, match_args, kw_only, slots)
 
     # See if we're being called as @dataclass or @dataclass().
     if cls is None:
@@ -1245,6 +1255,11 @@ def is_dataclass(obj):
     dataclass."""
     cls = obj if isinstance(obj, type) and not isinstance(obj, GenericAlias) else type(obj)
     return hasattr(cls, _FIELDS)
+
+
+def is_direct_dataclass(cls: type):
+    """ Returns True if cls is declared as a dataclass (vs. inherits from) """
+    return id(cls) in getattr(cls, _DECLARED_DATA_CLASSES, set())
 
 
 def asdict(obj, *, dict_factory=dict):


### PR DESCRIPTION
While it is already possible to determine whether a class
or one of its ancestors has been processed by the `dataclass`
function, there is no way to determine whether the first
argument, `_cls`, has.  Because of this, `dataclass(dataclass(C))` is not valid.  Third party libraries
(e.g. pydantic) need invoke the dataclass wrapper _if it
has not already been invoked_ before adding their on functions.  This patch:
a) Provides a mechanism, `is_direct_datacclass`, to determine whether
`dataclass` has been applied to a given class
b) Uses this mechanism to make dataclass idempotent.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-92052 -->
* Issue: gh-92052
<!-- /gh-issue-number -->
