### PR TITLE
gh-91985: Introduce _is_python_build member to struct _PyPathConfig for getpath

### DIFF
--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -460,7 +460,8 @@ if not py_setpath and not home_was_set:
 
 build_prefix = None
 
-if not home_was_set and real_executable_dir and not py_setpath:
+if (not home_was_set and real_executable_dir and not py_setpath) or \
+        config.get('_is_python_build'):
     # Detect a build marker and use it to infer prefix, exec_prefix,
     # stdlib_dir and the platstdlib_dir directories.
     try:

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -73,6 +73,7 @@ _PyPathConfig_ClearGlobal(void)
     CLEAR(calculated_module_search_path);
     CLEAR(program_name);
     CLEAR(home);
+    _Py_path_config._is_python_build = 0;
 
 #undef CLEAR
 

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -36,6 +36,7 @@ typedef struct _PyPathConfig {
     wchar_t *program_name;
     /* Set by Py_SetPythonHome() or PYTHONHOME environment variable */
     wchar_t *home;
+    int _is_python_build;
 } _PyPathConfig;
 
 #  define _PyPathConfig_INIT \
@@ -105,6 +106,7 @@ _PyPathConfig_ReadGlobal(PyConfig *config)
     COPY(program_name);
     COPY(home);
     COPY2(executable, program_full_path);
+    config->_is_python_build = _Py_path_config._is_python_build;
     // module_search_path must be initialised - not read
 #undef COPY
 #undef COPY2
@@ -143,6 +145,7 @@ _PyPathConfig_UpdateGlobal(const PyConfig *config)
     COPY(program_name);
     COPY(home);
     COPY2(program_full_path, executable);
+    _Py_path_config._is_python_build = config->_is_python_build;
 #undef COPY
 #undef COPY2
 


### PR DESCRIPTION
This ensures that `sys.path` has a build path (on Windows), when testing repeated initialization with `PYTHONHOME`. The behavior of `Py_SetPythonHome()` is left as is, which is distinguished from other ways of setting home.

#91985