### PR TITLE
gh-92417: `typing` docs: `from __future__ import annotations` can be used in all supported Python versions

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2668,7 +2668,7 @@ Constant
 
    .. note::
 
-      If ``from __future__ import annotations`` is used in Python 3.7 or later,
+      If ``from __future__ import annotations`` is used,
       annotations are not evaluated at function definition time.
       Instead, they are stored as strings in ``__annotations__``.
       This makes it unnecessary to use quotes around the annotation


### PR DESCRIPTION
#92417