### PR TITLE
gh-92417: `json` docs: `dict` is ordered on all supported Python versions

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -125,13 +125,6 @@ See :ref:`json-commandline` for detailed documentation.
    This module's encoders and decoders preserve input and output order by
    default.  Order is only lost if the underlying containers are unordered.
 
-   Prior to Python 3.7, :class:`dict` was not guaranteed to be ordered, so
-   inputs and outputs were typically scrambled unless
-   :class:`collections.OrderedDict` was specifically requested.  Starting
-   with Python 3.7, the regular :class:`dict` became order preserving, so
-   it is no longer necessary to specify :class:`collections.OrderedDict` for
-   JSON generation and parsing.
-
 
 Basic Usage
 -----------


### PR DESCRIPTION
#92417