### PR TITLE
gh-92417: `importlib` docs: remove references to unsupported Python versions

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -17,9 +17,9 @@
 package metadata.  Built in part on Python's import system, this library
 intends to replace similar functionality in the `entry point
 API`_ and `metadata API`_ of ``pkg_resources``.  Along with
-:mod:`importlib.resources` in Python 3.7
-and newer (backported as `importlib_resources`_ for older versions of
-Python), this can eliminate the need to use the older and less efficient
+:mod:`importlib.resources` (with new features backported to the
+`importlib_resources`_ package), this can eliminate the need to use the older
+and less efficient
 ``pkg_resources`` package.
 
 By "installed package" we generally mean a third-party package installed into

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1354,8 +1354,7 @@ Import itself is implemented in Python code, making it possible to
 expose most of the import machinery through importlib. The following
 helps illustrate the various APIs that importlib exposes by providing an
 approximate implementation of
-:func:`importlib.import_module`.
-::
+:func:`importlib.import_module`::
 
   import importlib.util
   import sys

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -414,8 +414,8 @@ ABC hierarchy::
 
        .. versionadded:: 3.4
 
-       .. versionchanged:: 3.5
-          Starting in Python 3.6, this method will not be optional when
+       .. versionchanged:: 3.6
+          This method is no longer optional when
           :meth:`exec_module` is defined.
 
     .. method:: exec_module(module)
@@ -1273,8 +1273,7 @@ import, then you should use :func:`importlib.util.find_spec`.
 Importing a source file directly
 ''''''''''''''''''''''''''''''''
 
-To import a Python source file directly, use the following recipe
-(Python 3.5 and newer only)::
+To import a Python source file directly, use the following recipe::
 
   import importlib.util
   import sys
@@ -1355,8 +1354,7 @@ Import itself is implemented in Python code, making it possible to
 expose most of the import machinery through importlib. The following
 helps illustrate the various APIs that importlib exposes by providing an
 approximate implementation of
-:func:`importlib.import_module` (Python 3.4 and newer for the importlib usage,
-Python 3.6 and newer for other parts of the code).
+:func:`importlib.import_module`.
 ::
 
   import importlib.util


### PR DESCRIPTION
#92417