### PR TITLE
gh-88279: Fix compiler warning for using deprecated PySys_SetArgvEx

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3302,7 +3302,10 @@ PySys_SetArgvEx(int argc, wchar_t **argv, int updatepath)
 void
 PySys_SetArgv(int argc, wchar_t **argv)
 {
+_Py_COMP_DIAG_PUSH
+_Py_COMP_DIAG_IGNORE_DEPR_DECLS
     PySys_SetArgvEx(argc, argv, Py_IsolatedFlag == 0);
+_Py_COMP_DIAG_POP
 }
 
 /* Reimplementation of PyFile_WriteString() no calling indirectly


### PR DESCRIPTION
#88279
@pablogsal 