### PR TITLE
gh-92031: Improve test for unquickening static code

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -345,10 +345,15 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
 
     def test_quickened_static_code_gets_unquickened_at_Py_FINALIZE(self):
         # https://github.com/python/cpython/issues/92031
+
+        # Do these imports outside of the code string to avoid using
+        # importlib too much from within the code string, so that
+        # _handle_fromlist doesn't get quickened until we intend it to.
         from dis import _all_opmap
         resume = _all_opmap["RESUME"]
         resume_quick = _all_opmap["RESUME_QUICK"]
         from test.test_dis import QUICKENING_WARMUP_DELAY
+
         code = textwrap.dedent(f"""\
             import importlib._bootstrap
             func = importlib._bootstrap._handle_fromlist

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -343,19 +343,34 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
         out, err = self.run_embedded_interpreter("test_repeated_init_exec", code)
         self.assertEqual(out, 'Tests passed\n' * INIT_LOOPS)
 
-    @support.skip_if_pgo_task
     def test_quickened_static_code_gets_unquickened_at_Py_FINALIZE(self):
         # https://github.com/python/cpython/issues/92031
-        code = """if 1:
-            from importlib._bootstrap import _handle_fromlist
-            import dis
-            for name in dis.opmap:
-                # quicken this frozen code object.
-                _handle_fromlist(dis, [name], lambda *args: None)
+        from dis import _all_opmap
+        resume = _all_opmap["RESUME"]
+        resume_quick = _all_opmap["RESUME_QUICK"]
+        code = f"""if 1:
+            import importlib._bootstrap
+            func = importlib._bootstrap._handle_fromlist
+            code = func.__code__
+
+            # Assert initially unquickened.
+            # Use sets to account for byte order.
+            if set(code._co_code_adaptive[:2]) != set([{resume}, 0]):
+                raise AssertionError()
+
+            # Warmup
+            for i in range(30):
+                func(importlib._bootstrap, ["x"], lambda *args: None)
+
+            # Assert quickening worked
+            if set(code._co_code_adaptive[:2]) != set([{resume_quick}, 0]):
+                raise AssertionError()
+
+            print("Tests passed")
         """
         run = self.run_embedded_interpreter
-        for i in range(50):
-            out, err = run("test_repeated_init_exec", code, timeout=60)
+        out, err = run("test_repeated_init_exec", code)
+        self.assertEqual(out, 'Tests passed\n' * INIT_LOOPS)
 
     def test_ucnhash_capi_reset(self):
         # bpo-47182: unicodeobject.c:ucnhash_capi was not reset on shutdown.

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -348,7 +348,8 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
         from dis import _all_opmap
         resume = _all_opmap["RESUME"]
         resume_quick = _all_opmap["RESUME_QUICK"]
-        code = f"""if 1:
+        from test.test_dis import QUICKENING_WARMUP_DELAY
+        code = textwrap.dedent(f"""\
             import importlib._bootstrap
             func = importlib._bootstrap._handle_fromlist
             code = func.__code__
@@ -358,8 +359,7 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
             if set(code._co_code_adaptive[:2]) != set([{resume}, 0]):
                 raise AssertionError()
 
-            # Warmup
-            for i in range(30):
+            for i in range({QUICKENING_WARMUP_DELAY}):
                 func(importlib._bootstrap, ["x"], lambda *args: None)
 
             # Assert quickening worked
@@ -367,7 +367,7 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
                 raise AssertionError()
 
             print("Tests passed")
-        """
+        """)
         run = self.run_embedded_interpreter
         out, err = run("test_repeated_init_exec", code)
         self.assertEqual(out, 'Tests passed\n' * INIT_LOOPS)


### PR DESCRIPTION
This test is deterministic, faster, and directly tests the behavior it's supposed to be testing, rather than relying on some C-level assertion to fail.

I checked that commenting out `deopt_code(...)` in `_PyStaticCode_Dealloc` causes the test to fail reliably.

cc @vstinner @markshannon 