### PR TITLE
Use percentage over factor for whatsnew in 3.11 performance claim

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -840,7 +840,7 @@ Optimizations
 Faster CPython
 ==============
 
-CPython 3.11 is on average `1.25x faster <https://github.com/faster-cpython/ideas/blob/main/main-vs-310.rst>`_
+CPython 3.11 is on average `25% faster <https://github.com/faster-cpython/ideas/blob/main/main-vs-310.rst>`_
 than CPython 3.10 when measured with the
 `pyperformance <https://github.com/python/pyperformance>`_ benchmark suite,
 and compiled with GCC on Ubuntu Linux. Depending on your workload, the speedup


### PR DESCRIPTION
I just realised that "1.25x faster" might confuse casual readers. IMO to make things as clear as possible, it should either be a "1.25x speedup" (this term is [well established](https://en.wikipedia.org/wiki/Speedup) in computer science literature) or "25% faster".

In contrast, the summary at the top of What's New uses "1.25x speedup":
> Python 3.11 is up to 10-60% faster than Python 3.10. On average, we measured a 1.22x speedup on the standard benchmark suite. See [Faster CPython](https://docs.python.org/3.11/whatsnew/3.11.html#faster-cpython) for details.