### PR TITLE
[3.10] Fix use of the default role in a news entry.

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2022-04-24-22-09-31.gh-issue-91888.kTjJLx.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-04-24-22-09-31.gh-issue-91888.kTjJLx.rst
@@ -1,1 +1,1 @@
-Add a new `gh` role to the documentation to link to GitHub issues.
+Add a new ``gh`` role to the documentation to link to GitHub issues.


### PR DESCRIPTION
This PR fixes the use of a default role in a news entry, which caused [a build failure](https://dev.azure.com/Python/cpython/_build/results?buildId=103025&view=logs&j=4db1505a-29e5-5cc0-240b-53a8a2681f75&t=a975920c-8356-5388-147c-613d5fab0171).

The news doesn't exist on `3.11`/`main`, only on `3.10`/`3.9`.