### PR TITLE
gh-92417: Update docs and examples of doctest.IGNORE_EXCEPTION_DETAIL for Py>=3

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -574,16 +574,15 @@ doctest decides whether actual output matches an example's expected output:
 
       >>> raise CustomError('message')
       Traceback (most recent call last):
-      CustomError: message
+      my_module.CustomError: message
 
       >>> raise CustomError('message')
       Traceback (most recent call last):
-      my_module.CustomError: message
+      my_other_module.CustomError: message
 
    Note that :const:`ELLIPSIS` can also be used to ignore the
    details of the exception message, but such a test may still fail based
-   on whether or not the module details are printed as part of the
-   exception name.
+   on whether the module matches exactly in the exception name.
 
    .. versionchanged:: 3.2
       :const:`IGNORE_EXCEPTION_DETAIL` now also ignores any information relating

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -563,26 +563,35 @@ doctest decides whether actual output matches an example's expected output:
 
 .. data:: IGNORE_EXCEPTION_DETAIL
 
-   When specified, an example that expects an exception passes if an exception of
-   the expected type is raised, even if the exception detail does not match.  For
-   example, an example expecting ``ValueError: 42`` will pass if the actual
-   exception raised is ``ValueError: 3*14``, but will fail, e.g., if
-   :exc:`TypeError` is raised.
+   When specified, doctests expecting exceptions pass so long as an exception
+   of the expected type is raised, even if the details
+   (message and fully-qualified exception name) don't match.
 
-   It will also ignore the module name used in doctest reports;
-   hence, both of these variations will work with the flag specified::
+   For example, an example expecting ``ValueError: 42`` will pass if the actual
+   exception raised is ``ValueError: 3*14``, but will fail if, say, a
+   :exc:`TypeError` is raised instead.
+   It will also ignore any fully-qualified name included before the
+   exception class, which can vary between implementations and versions
+   of Python and the code/libraries in use.
+   Hence, all three of these variations will work with the flag specified:
 
-      >>> raise CustomError('message')
+   .. code-block:: pycon
+
+      >>> raise Exception('message')
       Traceback (most recent call last):
-      my_module.CustomError: message
+      Exception: message
 
-      >>> raise CustomError('message')
+      >>> raise Exception('message')
       Traceback (most recent call last):
-      my_other_module.CustomError: message
+      builtins.Exception: message
+
+      >>> raise Exception('message')
+      Traceback (most recent call last):
+      __main__.Exception: message
 
    Note that :const:`ELLIPSIS` can also be used to ignore the
    details of the exception message, but such a test may still fail based
-   on whether the module matches exactly in the exception name.
+   on whether the module name is present or matches exactly.
 
    .. versionchanged:: 3.2
       :const:`IGNORE_EXCEPTION_DETAIL` now also ignores any information relating

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -569,9 +569,8 @@ doctest decides whether actual output matches an example's expected output:
    exception raised is ``ValueError: 3*14``, but will fail, e.g., if
    :exc:`TypeError` is raised.
 
-   It will also ignore the module name used in Python 3 doctest reports. Hence
-   both of these variations will work with the flag specified, regardless of
-   whether the test is run under Python 2.7 or Python 3.2 (or later versions)::
+   It will also ignore the module name used in doctest reports;
+   hence, both of these variations will work with the flag specified::
 
       >>> raise CustomError('message')
       Traceback (most recent call last):
@@ -584,20 +583,7 @@ doctest decides whether actual output matches an example's expected output:
    Note that :const:`ELLIPSIS` can also be used to ignore the
    details of the exception message, but such a test may still fail based
    on whether or not the module details are printed as part of the
-   exception name. Using :const:`IGNORE_EXCEPTION_DETAIL` and the details
-   from Python 2.3 is also the only clear way to write a doctest that doesn't
-   care about the exception detail yet continues to pass under Python 2.3 or
-   earlier (those releases do not support :ref:`doctest directives
-   <doctest-directives>` and ignore them as irrelevant comments). For example::
-
-      >>> (1, 2)[3] = 'moo'
-      Traceback (most recent call last):
-        File "<stdin>", line 1, in <module>
-      TypeError: object doesn't support item assignment
-
-   passes under Python 2.3 and later Python versions with the flag specified,
-   even though the detail
-   changed in Python 2.4 to say "does not" instead of "doesn't".
+   exception name.
 
    .. versionchanged:: 3.2
       :const:`IGNORE_EXCEPTION_DETAIL` now also ignores any information relating


### PR DESCRIPTION
Part of issue #92417 and followup to @AlexWaygood 's PR #92420 .

Following #92420 , there's still a chunk of text in the `doctest` library docs referring to compatibility with Python <3.2, and workarounds to support Python <2.4, in the [description of doctest.EXCEPTION_DETAIL](https://docs.python.org/3/library/doctest.html#doctest.IGNORE_EXCEPTION_DETAIL) which it seems should be elided as well.

It substantially complicates the description of `doctest.IGNORE_EXCEPTION_DETAIL` and doesn't seem to be of any use for modern Python, beyond what is already noted in the `versionchanged` notice. Furthermore, it made the section pretty difficult to understand and parse for me even as a native English speaker, technical writer/copyeditor and reasonably experianced Python developer; I had to re-read it several times to fully grasp the intended meaning.

Therefore, I simplified the section to remove the outdated material and focus on the functionality relevant to modern Python, while retaining the existing `versionchanged` note that already captured the key version differences clearly.

Sidenote, I'm a triager now, so I'm not sure why I still can't set the PR tags and such when creating the PR, but can perfectly fine after it is created (causing the `skip-news` check to initially fail and resulting in additional noise on the PR).