### PR TITLE
Implement callable_iterator in _collections_abc

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -41,7 +41,7 @@ __name__ = "collections.abc"
 # are not included on this list.
 bytes_iterator = type(iter(b''))
 bytearray_iterator = type(iter(bytearray()))
-callable_iterator = type(iter(lambda: None, None))
+callable_iterator = type(iter(len, None))
 dict_keyiterator = type(iter({}.keys()))
 dict_valueiterator = type(iter({}.values()))
 dict_itemiterator = type(iter({}.items()))

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -41,7 +41,7 @@ __name__ = "collections.abc"
 # are not included on this list.
 bytes_iterator = type(iter(b''))
 bytearray_iterator = type(iter(bytearray()))
-#callable_iterator = ???
+callable_iterator = type(iter(lambda: None, None))
 dict_keyiterator = type(iter({}.keys()))
 dict_valueiterator = type(iter({}.values()))
 dict_itemiterator = type(iter({}.items()))
@@ -289,7 +289,7 @@ class Iterator(Iterable):
 
 Iterator.register(bytes_iterator)
 Iterator.register(bytearray_iterator)
-#Iterator.register(callable_iterator)
+Iterator.register(callable_iterator)
 Iterator.register(dict_keyiterator)
 Iterator.register(dict_valueiterator)
 Iterator.register(dict_itemiterator)

--- a/Misc/NEWS.d/next/Library/2022-05-08-20-53-48.gh-issue-
+++ b/Misc/NEWS.d/next/Library/2022-05-08-20-53-48.gh-issue-
@@ -1,0 +1,1 @@
+I just implement callable_iterator and nothing else

--- a/Misc/NEWS.d/next/Library/2022-05-08-20-53-48.gh-issue-
+++ b/Misc/NEWS.d/next/Library/2022-05-08-20-53-48.gh-issue-
@@ -1,1 +1,1 @@
-I just implement callable_iterator and nothing else
+callable_itarator in Lib/_collections_abc.py was implemented.


### PR DESCRIPTION
In current implementation callable_iterator private type was not daclared in this file. So I do this :)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
