### PR TITLE
gh-76773: Update docs mentioning no-longer-supported Windows versions & features

### DIFF
--- a/Doc/extending/windows.rst
+++ b/Doc/extending/windows.rst
@@ -106,8 +106,7 @@ Using DLLs in Practice
 
 
 Windows Python is built in Microsoft Visual C++; using other compilers may or
-may not work (though Borland seems to).  The rest of this section is MSVC++
-specific.
+may not work.  The rest of this section is MSVC++ specific.
 
 When creating DLLs in Windows, you must pass :file:`pythonXY.lib` to the linker.
 To build two DLLs, spam and ni (which uses C functions found in spam), you could
@@ -134,4 +133,3 @@ Developer Studio will throw in a lot of import libraries that you do not really
 need, adding about 100K to your executable.  To get rid of them, use the Project
 Settings dialog, Link tab, to specify *ignore default libraries*.  Add the
 correct :file:`msvcrtxx.lib` to the list of libraries.
-

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -26,8 +26,8 @@ with running programs from the Windows command line then everything will seem
 obvious; otherwise, you might need a little more guidance.
 
 Unless you use some sort of integrated development environment, you will end up
-*typing* Windows commands into what is variously referred to as a "DOS window"
-or "Command prompt window".  Usually you can create such a window from your
+*typing* Windows commands into what is referred to as a
+"Command prompt window".  Usually you can create such a window from your
 search bar by searching for ``cmd``.  You should be able to recognize
 when you have started such a window because you will see a Windows "command
 prompt", which usually looks like this:
@@ -186,9 +186,6 @@ Embedding the Python interpreter in a Windows app can be summarized as follows:
    by the Windows ``GetProcAddress()`` routine.  Macros can make using these
    pointers transparent to any C code that calls routines in Python's C API.
 
-   Borland note: convert :file:`python{NN}.lib` to OMF format using Coff2Omf.exe
-   first.
-
    .. XXX what about static linking?
 
 2. If you use SWIG, it is easy to create a Python "extension module" that will
@@ -279,4 +276,3 @@ How do I check for a keypress without blocking?
 Use the :mod:`msvcrt` module.  This is a standard Windows-specific extension module.
 It defines a function ``kbhit()`` which checks whether a keyboard hit is
 present, and ``getch()`` which gets one character without echoing it.
-

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1360,10 +1360,6 @@ way is to instantiate one of the following classes:
    functions in these libraries use the ``stdcall`` calling convention, and are
    assumed to return :c:type:`int` by default.
 
-   On Windows CE only the standard calling convention is used, for convenience the
-   :class:`WinDLL` and :class:`OleDLL` use the standard calling convention on this
-   platform.
-
 The Python :term:`global interpreter lock` is released before calling any
 function exported by these libraries, and reacquired afterwards.
 
@@ -1664,8 +1660,7 @@ See :ref:`ctypes-callback-functions` for examples.
 .. function:: WINFUNCTYPE(restype, *argtypes, use_errno=False, use_last_error=False)
 
    Windows only: The returned function prototype creates functions that use the
-   ``stdcall`` calling convention, except on Windows CE where
-   :func:`WINFUNCTYPE` is the same as :func:`CFUNCTYPE`.  The function will
+   ``stdcall`` calling convention.  The function will
    release the GIL during the call.  *use_errno* and *use_last_error* have the
    same meaning as above.
 

--- a/Doc/library/optparse.rst
+++ b/Doc/library/optparse.rst
@@ -131,7 +131,7 @@ option
    These option syntaxes are not supported by :mod:`optparse`, and they never
    will be.  This is deliberate: the first three are non-standard on any
    environment, and the last only makes sense if you're exclusively targeting
-   VMS, MS-DOS, and/or Windows.
+   Windows or certain legacy platforms (e.g. VMS, MS-DOS).
 
 option argument
    an argument that follows an option, is closely associated with that option,

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -5,7 +5,7 @@
    :synopsis: Operations on pathnames.
 
 **Source code:** :source:`Lib/posixpath.py` (for POSIX) and
-:source:`Lib/ntpath.py` (for Windows NT).
+:source:`Lib/ntpath.py` (for Windows).
 
 .. index:: single: path; operations
 

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -84,7 +84,7 @@ The module defines the following user-callable items:
    file-like object.  Whether the name can be
    used to open the file a second time, while the named temporary file is
    still open, varies across platforms (it can be so used on Unix; it cannot
-   on Windows NT or later).  If *delete* is true (the default), the file is
+   on Windows).  If *delete* is true (the default), the file is
    deleted as soon as it is closed.
    The returned object is always a file-like object whose :attr:`!file`
    attribute is the underlying true file object. This file-like object can

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -425,7 +425,7 @@ dependants, such as Idle), pip and the Python documentation are not included.
 .. note::
 
     The embedded distribution does not include the `Microsoft C Runtime
-    <https://www.microsoft.com/en-us/download/details.aspx?id=48145>`_ and it is
+    <https://docs.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist#visual-studio-2015-2017-2019-and-2022>`_ and it is
     the responsibility of the application installer to provide this. The
     runtime may have already been installed on a user's system previously or
     automatically via Windows Update, and can be detected by finding
@@ -569,11 +569,11 @@ System variables, you need non-restricted access to your machine
     https://docs.microsoft.com/en-us/windows/win32/procthread/environment-variables
       Overview of environment variables on Windows
 
-    https://technet.microsoft.com/en-us/library/cc754250.aspx
-      The SET command, for temporarily modifying environment variables
+    https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1
+      The ``set`` command, for temporarily modifying environment variables
 
-    https://technet.microsoft.com/en-us/library/cc755104.aspx
-      The SETX command, for permanently modifying environment variables
+    https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx
+      The ``setx`` command, for permanently modifying environment variables
 
 
 .. _windows-path-mod:
@@ -1127,13 +1127,14 @@ is a collection of modules for advanced Windows-specific support.  This includes
 utilities for:
 
 * `Component Object Model
-  <https://docs.microsoft.com/en-us/windows/desktop/com/component-object-model--com--portal>`_
+  <https://docs.microsoft.com/en-us/windows/win32/com/component-object-model--com--portal>`_
   (COM)
 * Win32 API calls
 * Registry
 * Event log
-* `Microsoft Foundation Classes <https://msdn.microsoft.com/en-us/library/fe1cf721%28VS.80%29.aspx>`_ (MFC)
-  user interfaces
+* `Microsoft Foundation Classes
+  <https://docs.microsoft.com/en-us/cpp/mfc/mfc-desktop-applications>`_
+  (MFC) user interfaces
 
 `PythonWin <https://web.archive.org/web/20060524042422/
 https://www.python.org/windows/pythonwin/>`_ is a sample MFC application
@@ -1144,7 +1145,7 @@ shipped with PyWin32.  It is an embeddable IDE with a built-in debugger.
    `Win32 How Do I...? <http://timgolden.me.uk/python/win32_how_do_i.html>`_
       by Tim Golden
 
-   `Python and COM <http://www.boddie.org.uk/python/COM.html>`_
+   `Python and COM <https://www.boddie.org.uk/python/COM.html>`_
       by David and Paul Boddie
 
 

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -559,9 +559,9 @@ System variables, you need non-restricted access to your machine
     Windows will concatenate User variables *after* System variables, which may
     cause unexpected results when modifying :envvar:`PATH`.
 
-    The :envvar:`PYTHONPATH` variable is used by all versions of Python 2 and
-    Python 3, so you should not permanently configure this variable unless it
-    only includes code that is compatible with all of your installed Python
+    The :envvar:`PYTHONPATH` variable is used by all versions of Python,
+    so you should not permanently configure it unless the listed paths
+    only include code that is compatible with all of your installed Python
     versions.
 
 .. seealso::
@@ -682,22 +682,22 @@ You should find that the latest version of Python you have installed is
 started - it can be exited as normal, and any additional command-line
 arguments specified will be sent directly to Python.
 
-If you have multiple versions of Python installed (e.g., 2.7 and |version|) you
-will have noticed that Python |version| was started - to launch Python 2.7, try
+If you have multiple versions of Python installed (e.g., 3.7 and |version|) you
+will have noticed that Python |version| was started - to launch Python 3.7, try
 the command:
 
 ::
 
-  py -2.7
+  py -3.7
 
-If you want the latest version of Python 2.x you have installed, try the
+If you want the latest version of Python 3 you have installed, try the
 command:
 
 ::
 
-  py -2
+  py -3
 
-You should find the latest version of Python 2.x starts.
+You should find the latest version of Python 3.x starts.
 
 If you see the following error, you do not have the launcher installed:
 
@@ -754,9 +754,9 @@ is printed.  Now try changing the first line to be:
 
 Re-executing the command should now print the latest Python 3.x information.
 As with the above command-line examples, you can specify a more explicit
-version qualifier.  Assuming you have Python 2.6 installed, try changing the
-first line to ``#! python2.6`` and you should find the 2.6 version
-information printed.
+version qualifier.  Assuming you have Python |version| installed, try changing
+the first line to "#! python|version|" and you should find the |version|
+version information printed.
 
 Note that unlike interactive use, a bare "python" will use the latest
 version of Python 2.x that you have installed.  This is for backward
@@ -809,8 +809,8 @@ shebang lines starting with ``/usr``.
 Any of the above virtual commands can be suffixed with an explicit version
 (either just the major version, or the major and minor version).
 Furthermore the 32-bit version can be requested by adding "-32" after the
-minor version. I.e. ``/usr/bin/python2.7-32`` will request usage of the
-32-bit python 2.7.
+minor version. I.e. ``/usr/bin/python3.7-32`` will request usage of the
+32-bit python 3.7.
 
 .. versionadded:: 3.7
 
@@ -903,19 +903,19 @@ Examples:
   ``python2`` will use the latest Python 2.x version installed and
   the command ``python3`` will use the latest Python 3.x installed.
 
-* The commands ``python3.1`` and ``python2.7`` will not consult any
+* The commands ``python3.11`` and ``python3.7`` will not consult any
   options at all as the versions are fully specified.
 
 * If ``PY_PYTHON=3``, the commands ``python`` and ``python3`` will both use
   the latest installed Python 3 version.
 
-* If ``PY_PYTHON=3.1-32``, the command ``python`` will use the 32-bit
-  implementation of 3.1 whereas the command ``python3`` will use the latest
+* If ``PY_PYTHON=3.11-32``, the command ``python`` will use the 32-bit
+  implementation of 3.11 whereas the command ``python3`` will use the latest
   installed Python (PY_PYTHON was not considered at all as a major
   version was specified.)
 
-* If ``PY_PYTHON=3`` and ``PY_PYTHON3=3.1``, the commands
-  ``python`` and ``python3`` will both use specifically 3.1
+* If ``PY_PYTHON=3`` and ``PY_PYTHON3=3.11``, the commands
+  ``python`` and ``python3`` will both use specifically 3.11
 
 In addition to environment variables, the same settings can be configured
 in the .INI file used by the launcher.  The section in the INI file is
@@ -926,21 +926,21 @@ an environment variable will override things specified in the INI file.
 
 For example:
 
-* Setting ``PY_PYTHON=3.1`` is equivalent to the INI file containing:
+* Setting ``PY_PYTHON=3.11`` is equivalent to the INI file containing:
 
 .. code-block:: ini
 
   [defaults]
-  python=3.1
+  python=3.11
 
-* Setting ``PY_PYTHON=3`` and ``PY_PYTHON3=3.1`` is equivalent to the INI file
+* Setting ``PY_PYTHON=3`` and ``PY_PYTHON3=3.11`` is equivalent to the INI file
   containing:
 
 .. code-block:: ini
 
   [defaults]
   python=3
-  python3=3.1
+  python3=3.11
 
 Diagnostics
 -----------

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -754,8 +754,8 @@ is printed.  Now try changing the first line to be:
 
 Re-executing the command should now print the latest Python 3.x information.
 As with the above command-line examples, you can specify a more explicit
-version qualifier.  Assuming you have Python |version| installed, try changing
-the first line to "#! python|version|" and you should find the |version|
+version qualifier.  Assuming you have Python 3.7 installed, try changing
+the first line to ``#! python3.7`` and you should find the |version|
 version information printed.
 
 Note that unlike interactive use, a bare "python" will use the latest
@@ -903,19 +903,19 @@ Examples:
   ``python2`` will use the latest Python 2.x version installed and
   the command ``python3`` will use the latest Python 3.x installed.
 
-* The commands ``python3.11`` and ``python3.7`` will not consult any
+* The command ``python3.7`` will not consult any
   options at all as the versions are fully specified.
 
 * If ``PY_PYTHON=3``, the commands ``python`` and ``python3`` will both use
   the latest installed Python 3 version.
 
-* If ``PY_PYTHON=3.11-32``, the command ``python`` will use the 32-bit
-  implementation of 3.11 whereas the command ``python3`` will use the latest
+* If ``PY_PYTHON=3.7-32``, the command ``python`` will use the 32-bit
+  implementation of 3.7 whereas the command ``python3`` will use the latest
   installed Python (PY_PYTHON was not considered at all as a major
   version was specified.)
 
-* If ``PY_PYTHON=3`` and ``PY_PYTHON3=3.11``, the commands
-  ``python`` and ``python3`` will both use specifically 3.11
+* If ``PY_PYTHON=3`` and ``PY_PYTHON3=3.7``, the commands
+  ``python`` and ``python3`` will both use specifically 3.7
 
 In addition to environment variables, the same settings can be configured
 in the .INI file used by the launcher.  The section in the INI file is
@@ -926,21 +926,21 @@ an environment variable will override things specified in the INI file.
 
 For example:
 
-* Setting ``PY_PYTHON=3.11`` is equivalent to the INI file containing:
+* Setting ``PY_PYTHON=3.7`` is equivalent to the INI file containing:
 
 .. code-block:: ini
 
   [defaults]
-  python=3.11
+  python=3.7
 
-* Setting ``PY_PYTHON=3`` and ``PY_PYTHON3=3.11`` is equivalent to the INI file
+* Setting ``PY_PYTHON=3`` and ``PY_PYTHON3=3.7`` is equivalent to the INI file
   containing:
 
 .. code-block:: ini
 
   [defaults]
   python=3
-  python3=3.11
+  python3=3.7
 
 Diagnostics
 -----------
@@ -1168,7 +1168,7 @@ latest release's source or just grab a fresh `checkout
 <https://devguide.python.org/setup/#getting-the-source-code>`_.
 
 The source tree contains a build solution and project files for Microsoft
-Visual Studio 2017, which is the compiler used to build the official Python
+Visual Studio, which is the compiler used to build the official Python
 releases. These files are in the :file:`PCbuild` directory.
 
 Check :file:`PCbuild/readme.txt` for general information on the build process.

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -566,8 +566,8 @@ System variables, you need non-restricted access to your machine
 
 .. seealso::
 
-    https://www.microsoft.com/en-us/wdsi/help/folder-variables
-      Environment variables in Windows NT
+    https://docs.microsoft.com/en-us/windows/win32/procthread/environment-variables
+      Overview of environment variables on Windows
 
     https://technet.microsoft.com/en-us/library/cc754250.aspx
       The SET command, for temporarily modifying environment variables
@@ -575,11 +575,6 @@ System variables, you need non-restricted access to your machine
     https://technet.microsoft.com/en-us/library/cc755104.aspx
       The SETX command, for permanently modifying environment variables
 
-    https://support.microsoft.com/en-us/help/310519/how-to-manage-environment-variables-in-windows-xp
-      How To Manage Environment Variables in Windows XP
-
-    https://www.chem.gla.ac.uk/~louis/software/faq/q1.html
-      Setting Environment variables, Louis J. Farrugia
 
 .. _windows-path-mod:
 
@@ -1163,18 +1158,6 @@ you can distribute your application without requiring your users to install
 Python.
 
 
-WConio
-------
-
-Since Python's advanced terminal handling layer, :mod:`curses`, is restricted to
-Unix-like systems, there is a library exclusive to Windows as well: Windows
-Console I/O for Python.
-
-`WConio <http://newcenturycomputers.net/projects/wconio.html>`_ is a wrapper for
-Turbo-C's :file:`CONIO.H`, used to create text user interfaces.
-
-
-
 Compiling Python on Windows
 ===========================
 
@@ -1184,20 +1167,12 @@ latest release's source or just grab a fresh `checkout
 <https://devguide.python.org/setup/#getting-the-source-code>`_.
 
 The source tree contains a build solution and project files for Microsoft
-Visual Studio 2015, which is the compiler used to build the official Python
+Visual Studio 2017, which is the compiler used to build the official Python
 releases. These files are in the :file:`PCbuild` directory.
 
 Check :file:`PCbuild/readme.txt` for general information on the build process.
 
-
 For extension modules, consult :ref:`building-on-windows`.
-
-.. seealso::
-
-   `Python + Windows + distutils + SWIG + gcc MinGW <http://sebsauvage.net/python/mingw.html>`_
-      or "Creating Python extensions in C/C++ with SWIG and compiling them with
-      MinGW gcc under Windows" or "Installing Python extension with distutils
-      and without Microsoft Visual C++" by Sébastien Sauvage, 2003
 
 
 Other Platforms
@@ -1207,12 +1182,12 @@ With ongoing development of Python, some platforms that used to be supported
 earlier are no longer supported (due to the lack of users or developers).
 Check :pep:`11` for details on all unsupported platforms.
 
-* `Windows CE <http://pythonce.sourceforge.net/>`_ is still supported.
-* The `Cygwin <https://cygwin.com/>`_ installer offers to install the Python
-  interpreter as well (cf. `Cygwin package source
-  <ftp://ftp.uni-erlangen.de/pub/pc/gnuwin32/cygwin/mirrors/cygnus/
-  release/python>`_, `Maintainer releases
-  <http://www.tishler.net/jason/software/python/>`_)
+* `Windows CE <http://pythonce.sourceforge.net/>`_ is
+  `no longer supported <https://github.com/python/cpython/issues/71542>`__
+  since Python 3 (if it ever was).
+* The `Cygwin <https://cygwin.com/>`_ installer offers to install the
+  `Python interpreter <https://cygwin.com/packages/summary/python3.html>`__
+  as well
 
 See `Python for Windows <https://www.python.org/downloads/windows/>`_
 for detailed information about platforms with pre-compiled installers.

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -378,7 +378,9 @@ may be changed from ``.``, and the package will be installed into a
 subdirectory. By default, the subdirectory is named the same as the package,
 and without the ``-ExcludeVersion`` option this name will include the specific
 version installed. Inside the subdirectory is a ``tools`` directory that
-contains the Python installation::
+contains the Python installation:
+
+.. code-block:: doscon
 
    # Without -ExcludeVersion
    > .\python.3.5.2\tools\python.exe -V
@@ -672,9 +674,7 @@ From the command-line
 System-wide installations of Python 3.3 and later will put the launcher on your
 :envvar:`PATH`. The launcher is compatible with all available versions of
 Python, so it does not matter which version is installed. To check that the
-launcher is available, execute the following command in Command Prompt:
-
-::
+launcher is available, execute the following command in Command Prompt::
 
   py
 
@@ -684,24 +684,18 @@ arguments specified will be sent directly to Python.
 
 If you have multiple versions of Python installed (e.g., 3.7 and |version|) you
 will have noticed that Python |version| was started - to launch Python 3.7, try
-the command:
-
-::
+the command::
 
   py -3.7
 
-If you want the latest version of Python 3 you have installed, try the
-command:
+If you want the latest version of Python 2 you have installed, try the
+command::
 
-::
-
-  py -3
+  py -2
 
 You should find the latest version of Python 3.x starts.
 
-If you see the following error, you do not have the launcher installed:
-
-::
+If you see the following error, you do not have the launcher installed::
 
   'py' is not recognized as an internal or external command,
   operable program or batch file.
@@ -709,11 +703,11 @@ If you see the following error, you do not have the launcher installed:
 Per-user installations of Python do not add the launcher to :envvar:`PATH`
 unless the option was selected on installation.
 
-::
+The command::
 
   py --list
 
-You should see the currently installed versions of Python.
+displays the currently installed version(s) of Python.
 
 Virtual environments
 ^^^^^^^^^^^^^^^^^^^^
@@ -739,9 +733,7 @@ following contents
     import sys
     sys.stdout.write("hello from Python %s\n" % (sys.version,))
 
-From the directory in which hello.py lives, execute the command:
-
-::
+From the directory in which hello.py lives, execute the command::
 
    py hello.py
 

--- a/PC/readme.txt
+++ b/PC/readme.txt
@@ -18,7 +18,7 @@ All PC ports use this scheme to try to set up a module search path:
 
   1) The script location; the current directory without script.
   2) The PYTHONPATH variable, if set.
-  3) For Win32 platforms (NT/95), paths specified in the Registry.
+  3) Paths specified in the Registry.
   4) Default directories lib, lib/win, lib/test, lib/tkinter;
      these are searched relative to the environment variable
      PYTHONHOME, if set, or relative to the executable and its
@@ -26,8 +26,8 @@ All PC ports use this scheme to try to set up a module search path:
      or the current directory (not useful).
   5) The directory containing the executable.
 
-The best installation strategy is to put the Python executable (and
-DLL, for Win32 platforms) in some convenient directory such as
+The best installation strategy is to put the Python executable and
+DLL in some convenient directory such as
 C:/python, and copy all library files and subdirectories (using XCOPY)
 to C:/python/lib.  Then you don't need to set PYTHONPATH.  Otherwise,
 set the environment variable PYTHONPATH to your Python search path.

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -14,7 +14,7 @@ Building Python using Microsoft Visual C++
 ------------------------------------------
 
 This directory is used to build CPython for Microsoft Windows NT version
-6.0 or higher (Windows Vista, Windows Server 2008, or later) on 32 and 64
+6.3 or higher (Windows 8.1/Windows Server 2012 or later) on 32- and 64-
 bit platforms.  Using this directory requires an installation of
 Microsoft Visual Studio 2017 (MSVC 14.1) with the *Python workload* and
 its optional *Python native development* component selected. (For

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -13,12 +13,10 @@ Quick Start Guide
 Building Python using Microsoft Visual C++
 ------------------------------------------
 
-This directory is used to build CPython for Microsoft Windows NT version
-6.3 or higher (Windows 8.1/Windows Server 2012 or later) on 32- and 64-
+This directory is used to build CPython for Microsoft Windows on 32- and 64-
 bit platforms.  Using this directory requires an installation of
-Microsoft Visual Studio 2017 (MSVC 14.1) with the *Python workload* and
-its optional *Python native development* component selected. (For
-command-line builds, Visual Studio 2015 may also be used.)
+Microsoft Visual Studio (MSVC) with the *Python workload* and
+its optional *Python native development* component selected.
 
 Building from the command line is recommended in order to obtain any
 external dependencies. To build, simply run the "build.bat" script without

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -105,7 +105,7 @@ pythonw
     Prompt window
 pylauncher
     py.exe, the Python Launcher for Windows, see
-        http://docs.python.org/3/using/windows.html#launcher
+        https://docs.python.org/3/using/windows.html#launcher
 pywlauncher
     pyw.exe, a variant of py.exe that doesn't open a Command Prompt
     window
@@ -168,14 +168,14 @@ _bz2
 _lzma
     Python wrapper for version 5.2.2 of the liblzma compression library
     Homepage:
-        http://tukaani.org/xz/
+        https://tukaani.org/xz/
 _ssl
     Python wrapper for version 1.1.1k of the OpenSSL secure sockets
     library, which is downloaded from our binaries repository at
     https://github.com/python/cpython-bin-deps.
 
     Homepage:
-        http://www.openssl.org/
+        https://www.openssl.org/
 
     Building OpenSSL requires Perl on your path, and can be performed by
     running PCbuild\prepare_ssl.bat. This will retrieve the version of
@@ -191,14 +191,14 @@ _ssl
 _sqlite3
     Wraps SQLite 3.38.3, which is itself built by sqlite3.vcxproj
     Homepage:
-        http://www.sqlite.org/
+        https://www.sqlite.org/
 _tkinter
     Wraps version 8.6.6 of the Tk windowing system, which is downloaded
     from our binaries repository at
     https://github.com/python/cpython-bin-deps.
 
     Homepage:
-        http://www.tcl.tk/
+        https://www.tcl.tk/
 
     Building Tcl and Tk can be performed by running
     PCbuild\prepare_tcltk.bat. This will retrieve the version of the
@@ -257,7 +257,7 @@ It creates the PGI files, runs the unit test suite or PyBench with the
 PGI python, and finally creates the optimized files.
 
 See
-    http://msdn.microsoft.com/en-us/library/e7k32f4k(VS.140).aspx
+    https://docs.microsoft.com/en-us/cpp/build/profile-guided-optimizations
 for more on this topic.
 
 


### PR DESCRIPTION
In #76773 , I compiled a [detailed list](https://github.com/python/cpython/issues/76773#issuecomment-1093773607) of places where currently or (then-)to-be-unsupported Windows versions were referred to in the context of being current, with a focus on documentation. Unfortunately, as the issue became mired for a time in debates about whether and when it was necessary to drop Windows <8.1 support, I was never able to follow up and update them.

Support for Windows <8.1 was broken in PR #18231 to fix issue #83582 (CVE-2020-8315), dropped officially (albeit rather unceremoniously, with only a short news entry and without documentation updates) in @zooba 's PR #21656 to resolve issue #85584 and clarified a bit at least in the "Using Python on Windows" document in PR #23603 addressing issue #42523 . However, it appears that besides that, few of the others enumerated there were actually updated.

Therefore, this PR updates them, as well as a handful of other mentions I found in the process. In particular, it:

* [x] Corrects statements of the supported Windows and MSVC versions to accurately reflect this
* [x] Elides mentions of long-obsolete/unsupported Windows versions, compilers and distributions
* [x] Revises a few other related bits in the documentation that had drifted out of date.
* [x] Fixes numerous broken and out of date links in the above Windows-related sections
* [x] Opportunistically updates references to long-EoL Python versions where already modifying nearby content

All of the changes should be backport-safe since the removed/updated portions are mostly long-obsolete and support for Windows <8.1 was dropped in Python 3.9, the earliest version still accepting bugfix PRs; I avoided any changes that were potentially version-specific or referred to anything 3.9 or later.