### PR TITLE
gh-92417: `zlib` docs, `binascii` docs: remove Python 2 compatibility notes

### DIFF
--- a/Doc/library/binascii.rst
+++ b/Doc/library/binascii.rst
@@ -121,8 +121,6 @@ The :mod:`binascii` module defines the following functions:
 
    .. versionchanged:: 3.0
       The result is always unsigned.
-      To generate the same numeric value when using Python 2 or earlier,
-      use ``crc32(data) & 0xffffffff``.
 
 .. function:: b2a_hex(data[, sep[, bytes_per_sep=1]])
               hexlify(data[, sep[, bytes_per_sep=1]])

--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -43,8 +43,6 @@ The available exception and functions in this module are:
 
    .. versionchanged:: 3.0
       The result is always unsigned.
-      To generate the same numeric value when using Python 2 or earlier,
-      use ``adler32(data) & 0xffffffff``.
 
 .. function:: compress(data, /, level=-1, wbits=MAX_WBITS)
 
@@ -137,8 +135,6 @@ The available exception and functions in this module are:
 
    .. versionchanged:: 3.0
       The result is always unsigned.
-      To generate the same numeric value when using Python 2 or earlier,
-      use ``crc32(data) & 0xffffffff``.
 
 .. function:: decompress(data, /, wbits=MAX_WBITS, bufsize=DEF_BUF_SIZE)
 


### PR DESCRIPTION
#92417