### PR TITLE
gh-92417: `socket` docs: remove references to Python <3.3

### DIFF
--- a/Doc/library/chunk.rst
+++ b/Doc/library/chunk.rst
@@ -94,7 +94,8 @@ instance will fail with an :exc:`EOFError` exception.
       underlying file.
 
    The remaining methods will raise :exc:`OSError` if called after the
-   :meth:`close` method has been called.
+   :meth:`close` method has been called.  Before Python 3.3, they used to
+   raise :exc:`IOError`, now an alias of :exc:`OSError`.
 
 
    .. method:: isatty()

--- a/Doc/library/chunk.rst
+++ b/Doc/library/chunk.rst
@@ -94,8 +94,7 @@ instance will fail with an :exc:`EOFError` exception.
       underlying file.
 
    The remaining methods will raise :exc:`OSError` if called after the
-   :meth:`close` method has been called.  Before Python 3.3, they used to
-   raise :exc:`IOError`, now an alias of :exc:`OSError`.
+   :meth:`close` method has been called.
 
 
    .. method:: isatty()

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -233,9 +233,9 @@ resolution and/or the host configuration.  For deterministic behavior use a
 numeric address in *host* portion.
 
 All errors raise exceptions.  The normal exceptions for invalid argument types
-and out-of-memory conditions can be raised; starting from Python 3.3, errors
+and out-of-memory conditions can be raised. Errors
 related to socket or address semantics raise :exc:`OSError` or one of its
-subclasses (they used to raise :exc:`socket.error`).
+subclasses.
 
 Non-blocking mode is supported through :meth:`~socket.setblocking`.  A
 generalization of this based on timeouts is supported through


### PR DESCRIPTION
#92417