### PR TITLE
gh-91731: Add macro compatibility for static_assert for old libcs

### DIFF
--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -12,7 +12,9 @@
 
 // static_assert is defined in GLIB from version 2.16. Before it requires
 // compiler support (gcc >= 4.6) and is called _Static_assert.
-#if defined(__GLIBC__) && (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ <= 16)) && !defined(static_assert)
+#if (defined(__GLIBC__) \
+     && (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ <= 16)) \
+     && !defined(static_assert))
 #  define static_assert _Static_assert
 #endif
 

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -10,7 +10,7 @@
 #  define static_assert _Static_assert
 #endif
 
-// static_assert isd efined in GLIB from version 2.16. Before it requires
+// static_assert is defined in GLIB from version 2.16. Before it requires
 // compiler support (gcc >= 4.6) and is called _Static_assert.
 #if defined(__GLIBC__) && (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ <= 16)) && !defined(static_assert)
 #  define static_assert _Static_assert

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -12,7 +12,7 @@
 
 // static_assert isd efined in GLIB from version 2.16. Before it requires
 // compiler support (gcc >= 4.6) and is called _Static_assert.
-#if defined(__GLIBC__) && (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ <= 16) && !defined(static_assert)
+#if defined(__GLIBC__) && (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ <= 16)) && !defined(static_assert)
 #  define static_assert _Static_assert
 #endif
 

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -12,7 +12,7 @@
 
 // static_assert isd efined in GLIB from version 2.16. Before it requires
 // compiler support (gcc >= 4.6) and is called _Static_assert.
-#if defined(__GLIBC__) && __GLIBC__ <= 2 && __GLIBC_MINOR__ <= 16
+#if defined(__GLIBC__) && (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ <= 16) && !defined(static_assert)
 #  define static_assert _Static_assert
 #endif
 

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -10,6 +10,13 @@
 #  define static_assert _Static_assert
 #endif
 
+// static_assert isd efined in GLIB from version 2.16. Before it requires
+// compiler support (gcc >= 4.6) and is called _Static_assert.
+#if defined(__GLIBC__) && __GLIBC__ <= 2 && __GLIBC_MINOR__ <= 16
+#  define static_assert _Static_assert
+#endif
++
+
 /* Minimum value between x and y */
 #define Py_MIN(x, y) (((x) > (y)) ? (y) : (x))
 

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -15,7 +15,6 @@
 #if defined(__GLIBC__) && __GLIBC__ <= 2 && __GLIBC_MINOR__ <= 16
 #  define static_assert _Static_assert
 #endif
-+
 
 /* Minimum value between x and y */
 #define Py_MIN(x, y) (((x) > (y)) ? (y) : (x))


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
