### PR TITLE
gh-92546: Fix invalid call in pprint executed as a script

### DIFF
--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -643,7 +643,7 @@ def _perfcheck(object=None):
         object = [("string", (1, 2), [3, 4], {5: 6, 7: 8})] * 100000
     p = PrettyPrinter()
     t1 = time.perf_counter()
-    p._safe_repr(object, {}, None, 0, True)
+    p._safe_repr(object, {}, None, 0)
     t2 = time.perf_counter()
     p.pformat(object)
     t3 = time.perf_counter()

--- a/Misc/NEWS.d/next/Library/2022-05-09-17-31-30.gh-issue-92546.1hbeQQ.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-09-17-31-30.gh-issue-92546.1hbeQQ.rst
@@ -1,2 +1,2 @@
-Fix invalid :meth:`PrettyPrinter._safe_repr` call when :module:`pprint` is
+Fix invalid :meth:`PrettyPrinter._safe_repr` call when :mod:`pprint` is
 runned as a script.

--- a/Misc/NEWS.d/next/Library/2022-05-09-17-31-30.gh-issue-92546.1hbeQQ.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-09-17-31-30.gh-issue-92546.1hbeQQ.rst
@@ -1,0 +1,2 @@
+Fix invalid :meth:`PrettyPrinter._safe_repr` call when :module:`pprint` is
+runned as a script.

--- a/Misc/NEWS.d/next/Library/2022-05-09-17-31-30.gh-issue-92546.1hbeQQ.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-09-17-31-30.gh-issue-92546.1hbeQQ.rst
@@ -1,2 +1,2 @@
 Fix invalid :meth:`PrettyPrinter._safe_repr` call when :mod:`pprint` is
-runned as a script.
+executed as a script.


### PR DESCRIPTION
Before the fix:

```plain
C:\Users\oleg\Documents\dev\notmine\cpython>python -m pprint
Running Release|x64 interpreter...
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\oleg\Documents\dev\notmine\cpython\Lib\pprint.py", line 671, in <module>
    _perfcheck()
    ^^^^^^^^^^^^
  File "C:\Users\oleg\Documents\dev\notmine\cpython\Lib\pprint.py", line 646, in _perfcheck
    p._safe_repr(object, {}, None, 0, True)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: PrettyPrinter._safe_repr() takes 5 positional arguments but 6 were given
```

After the fix:

```plain
C:\Users\oleg\Documents\dev\notmine\cpython>python -m pprint
Running Release|x64 interpreter...
_safe_repr: 1.7387325000017881
pformat: 3.657650000001013
```

Issue: gh-92546.