### PR TITLE
gh-92445 Fix incorrect interaction between nargs="*" and choices()

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2477,7 +2477,10 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
               not action.option_strings):
             if action.default is not None:
                 value = action.default
+                self._check_value(action, value)
             else:
+                # since arg_strings is always [] at this point
+                # there is no need to use self._check_value(action, value)
                 value = arg_strings
 
         # single argument or optional argument produces a single value

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2479,7 +2479,6 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 value = action.default
             else:
                 value = arg_strings
-            self._check_value(action, value)
 
         # single argument or optional argument produces a single value
         elif len(arg_strings) == 1 and action.nargs in [None, OPTIONAL]:

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5236,11 +5236,6 @@ class TestParseKnownArgs(TestCase):
         args = parser.parse_args([])
         self.assertEqual(NS(x=[]), args)
 
-    def test_zero_or_more_default(self):
-        parser = argparse.ArgumentParser()
-        parser.add_argument('x', nargs='*', default=['x'], choices=('x', 'y'))
-        args = parser.parse_args([])
-        self.assertEqual(NS(x=['x']), args)
 
 # ===========================
 # parse_intermixed_args tests

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5230,6 +5230,18 @@ class TestParseKnownArgs(TestCase):
         self.assertEqual(NS(v=3, spam=True, badger="B"), args)
         self.assertEqual(["C", "--foo", "4"], extras)
 
+    def test_zero_or_more_optional(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('x', nargs='*', choices=('x', 'y'))
+        args = parser.parse_args([])
+        self.assertEqual(NS(x=[]), args)
+
+    def test_zero_or_more_default(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('x', nargs='*', default=['x'], choices=('x', 'y'))
+        args = parser.parse_args([])
+        self.assertEqual(NS(x=['x']), args)
+
 # ===========================
 # parse_intermixed_args tests
 # ===========================

--- a/Misc/NEWS.d/next/Library/2022-05-09-21-31-41.gh-issue-92445.tJosdm.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-09-21-31-41.gh-issue-92445.tJosdm.rst
@@ -1,0 +1,3 @@
+Fixed broken interaction where nargs="*" would raise an error instead of returning
+an empty list when 0 arguments were supplied if choice was also defined in
+argparser.add_argument().

--- a/Misc/NEWS.d/next/Library/2022-05-09-21-31-41.gh-issue-92445.tJosdm.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-09-21-31-41.gh-issue-92445.tJosdm.rst
@@ -1,3 +1,3 @@
 Fix a bug in :mod:`argparse` where `nargs="*"` would raise an error instead of returning
 an empty list when 0 arguments were supplied if choice was also defined in
-argparser.add_argument().
+``parser.add_argument``.

--- a/Misc/NEWS.d/next/Library/2022-05-09-21-31-41.gh-issue-92445.tJosdm.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-09-21-31-41.gh-issue-92445.tJosdm.rst
@@ -1,3 +1,3 @@
-Fixed broken interaction where nargs="*" would raise an error instead of returning
+Fix a bug in :mod:`argparse` where `nargs="*"` would raise an error instead of returning
 an empty list when 0 arguments were supplied if choice was also defined in
 argparser.add_argument().


### PR DESCRIPTION
gh-92445: Fixed issue where using nargs="*" with choices caused an error to be incorrectly raised.

The example

```python
from argparse import ArgumentParser

p = ArgumentParser()
p.add_argument('dessert', nargs='*', choices=('cake', 'pie'))
p.parse_args([])
```

now returns 
```
Namespace(dessert=[])
```