### PR TITLE
gh-91928: Add what's new entry for datetime.UTC alias

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -434,6 +434,8 @@ asyncio
 datetime
 --------
 
+* Add :attr:`datetime.UTC`, a convenience alias for
+  :attr:`datetime.timezone.utc`. (Contributed by Kabir Kwatra in :gh:`91973`.)
 * :meth:`datetime.date.fromisoformat`, :meth:`datetime.time.fromisoformat` and
   :meth:`datetime.datetime.fromisoformat` can now be used to parse most ISO 8601
   formats (barring only those that support fractional hours and minutes).


### PR DESCRIPTION
I merged this without a What's New entry to avoid merge conflicts, so here's the follow-up adding the entry.

@Kab1r do you mind reviewing?

Closes #91928

Automerge-Triggered-By: GH:pganssle