### PR TITLE
Add `__slots__` to `typing._NotIterable`

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -427,6 +427,7 @@ class _NotIterable:
     is treated specially.
     """
 
+    __slots__ = ()
     __iter__ = None
 
 


### PR DESCRIPTION
4739997e141c4c84bd2241d4d887c3c658d92700 added `typing._NotIterable` as a mixin to `typing._SpecialForm`, which defines `__slots__` as an optimisation technique. However, `typing._NotIterable` does not define `__slots__`, meaning the the `__slots__` declaration on `typing._SpecialForm` is now meaningless, since all base classes must define `__slots__` in order for a `__slots__` declaration on a subclass to have any effect.

This PR adds `__slots__ = ()` to `typing._NotIterable`.