### PR TITLE
[3.9] bpo-46785: Fix race condition between os.stat() and unlink on Windows (GH-31858)

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2715,10 +2715,6 @@ class Win32NtTests(unittest.TestCase):
 
         self.assertEqual(0, handle_delta)
 
-<<<<<<< HEAD
-@support.skip_unless_symlink
-=======
-    @support.requires_subprocess()
     def test_stat_unlink_race(self):
         # bpo-46785: the implementation of os.stat() falls back to reading
         # the parent directory if CreateFileW() fails with a permission
@@ -2726,8 +2722,8 @@ class Win32NtTests(unittest.TestCase):
         # directory are subsequently unlinked, or because the volume or
         # share are no longer available, then the original permission error
         # should not be restored.
-        filename =  os_helper.TESTFN
-        self.addCleanup(os_helper.unlink, filename)
+        filename =  support.TESTFN
+        self.addCleanup(support.unlink, filename)
         deadline = time.time() + 5
         command = textwrap.dedent("""\
             import os
@@ -2761,8 +2757,7 @@ class Win32NtTests(unittest.TestCase):
                 proc.terminate()
 
 
-@os_helper.skip_unless_symlink
->>>>>>> 39e6b8ae6a (bpo-46785: Fix race condition between os.stat() and unlink on Windows (GH-31858))
+@support.skip_unless_symlink
 class NonLocalSymlinkTests(unittest.TestCase):
 
     def setUp(self):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1664,6 +1664,7 @@ Anthony Starks
 David Steele
 Oliver Steele
 Greg Stein
+Itai Steinherz
 Marek Stepniowski
 Baruch Sterin
 Chris Stern

--- a/Misc/NEWS.d/next/Windows/2022-03-13-20-35-41.bpo-46785.Pnknyl.rst
+++ b/Misc/NEWS.d/next/Windows/2022-03-13-20-35-41.bpo-46785.Pnknyl.rst
@@ -1,0 +1,1 @@
+Fix race condition between :func:`os.stat` and unlinking a file on Windows, by using errors codes returned by ``FindFirstFileW()`` when appropriate in ``win32_xstat_impl``.


### PR DESCRIPTION
(cherry picked from commit 39e6b8ae6a5b49bb23746fdcc354d148ff2d98e3)