### PR TITLE
gh-92412: Clarifying the documentation on library/syslog

### DIFF
--- a/Doc/library/syslog.rst
+++ b/Doc/library/syslog.rst
@@ -29,9 +29,14 @@ The module defines the following functions:
    value given in the :func:`openlog` call is used.
 
    If :func:`openlog` has not been called prior to the call to :func:`syslog`,
-   ``openlog()`` will be called with no arguments.
+   :func:`openlog` will be called with no arguments.
 
    .. audit-event:: syslog.syslog priority,message syslog.syslog
+
+   .. versionchanged:: 3.2
+      In previous versions, :func:`openlog` would not be called automatically if
+      it wasn't called prior to the call to :func:`syslog`, deferring to the syslog
+      implementation to call ``openlog()``.
 
 
 .. function:: openlog([ident[, logoption[, facility]]])
@@ -51,8 +56,7 @@ The module defines the following functions:
 
    .. versionchanged:: 3.2
       In previous versions, keyword arguments were not allowed, and *ident* was
-      required.  The default for *ident* was dependent on the system libraries,
-      and often was ``python`` instead of the name of the Python program file.
+      required.
 
 
 .. function:: closelog()


### PR DESCRIPTION
Clarifying the "Changed in version 3.2" paragraph for syslog.openlog as
the wording could confuse people about *ident* being a mandatory argument
with a default value.
