### PR TITLE
[3.7] gh-92448: Update the documentation builder to render the GitHub issue

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -309,7 +309,8 @@ class DeprecatedRemoved(Directive):
 
 # Support for including Misc/NEWS
 
-issue_re = re.compile('(?:[Ii]ssue #|bpo-)([0-9]+)')
+issue_re = re.compile('(?:[Ii]ssue #|bpo-)([0-9]+)', re.I)
+gh_issue_re = re.compile('(?:gh-issue-|gh-)([0-9]+)', re.I)
 whatsnew_re = re.compile(r"(?im)^what's new in (.*?)\??$")
 
 
@@ -336,9 +337,9 @@ class MiscNews(Directive):
             text = 'The NEWS file is not available.'
             node = nodes.strong(text, text)
             return [node]
-        content = issue_re.sub(r'`bpo-\1 <https://bugs.python.org/'
-                               r'issue?@action=redirect&bpo=\1>`__',
-                               content)
+        content = issue_re.sub(r':issue:`\1`', content)
+        # Fallback handling for the GitHub issue
+        content = gh_issue_re.sub(r':gh:`\1`', content)
         content = whatsnew_re.sub(r'\1', content)
         # remove first 3 lines as they are the main heading
         lines = ['.. default-role:: obj', ''] + content.splitlines()[3:]

--- a/Misc/NEWS.d/3.7.0a3.rst
+++ b/Misc/NEWS.d/3.7.0a3.rst
@@ -289,7 +289,7 @@ by Nir Soffer.
 
 ..
 
-.. bpo: 321010
+.. bpo: 32101
 .. date: 2017-11-29-00-42-47
 .. nonce: -axD5l
 .. section: Library

--- a/Misc/NEWS.d/3.7.5.rst
+++ b/Misc/NEWS.d/3.7.5.rst
@@ -13,7 +13,7 @@ Prevent ctypes crash when handling arrays in structs/unions.
 .. nonce: 9TWMlz
 .. section: Library
 
-Revert GH-15522, which introduces a regression in
+Revert PR 15522, which introduces a regression in
 :meth:`mimetypes.guess_type` due to improper handling of filenames as urls.
 
 ..

--- a/Misc/NEWS.d/3.7.7rc1.rst
+++ b/Misc/NEWS.d/3.7.7rc1.rst
@@ -180,7 +180,7 @@ Remove obsolete check for `__args__` in bdb.Bdb.format_stack_entry.
 .. section: Library
 
 The original fix for bpo-27657, "Fix urlparse() with numeric paths"
-(GH-16839) included in 3.7.6, inadvertently introduced a behavior change
+(PR 16839) included in 3.7.6, inadvertently introduced a behavior change
 that broke several third-party packages relying on the original undefined
 parsing behavior. The change is reverted in 3.7.7, restoring the behavior of
 3.7.5 and earlier releases.


### PR DESCRIPTION
Backported from #92449 