### PR TITLE
gh-92611: Link to section for PEP 594 modules; mention rm version & alternatives

### DIFF
--- a/Doc/library/aifc.rst
+++ b/Doc/library/aifc.rst
@@ -14,7 +14,8 @@
 
 
 .. deprecated:: 3.11
-   The :mod:`aifc` module is deprecated (see :pep:`594` for details).
+   The :mod:`aifc` module is deprecated
+   (see :pep:`PEP 594 <594#aifc>` for details).
 
 --------------
 

--- a/Doc/library/asynchat.rst
+++ b/Doc/library/asynchat.rst
@@ -11,7 +11,8 @@
 **Source code:** :source:`Lib/asynchat.py`
 
 .. deprecated:: 3.6
-   :mod:`asynchat` will be removed in Python 3.12 (:pep:`594`).
+   :mod:`asynchat` will be removed in Python 3.12
+   (see :pep:`PEP 594 <594#asynchat>` for details).
    Please use :mod:`asyncio` instead.
 
 --------------

--- a/Doc/library/asyncore.rst
+++ b/Doc/library/asyncore.rst
@@ -14,7 +14,8 @@
 **Source code:** :source:`Lib/asyncore.py`
 
 .. deprecated:: 3.6
-   :mod:`asyncore` will be removed in Python 3.12 (:pep:`594`).
+   :mod:`asyncore` will be removed in Python 3.12
+   (see :pep:`PEP 594 <594#asyncore>` for details).
    Please use :mod:`asyncio` instead.
 
 --------------

--- a/Doc/library/audioop.rst
+++ b/Doc/library/audioop.rst
@@ -6,7 +6,8 @@
    :deprecated:
 
 .. deprecated:: 3.11
-   The :mod:`audioop` module is deprecated (see :pep:`594` for details).
+   The :mod:`audioop` module is deprecated
+   (see :pep:`PEP 594 <594#audioop>` for details).
 
 --------------
 

--- a/Doc/library/cgi.rst
+++ b/Doc/library/cgi.rst
@@ -16,7 +16,8 @@
    single: Common Gateway Interface
 
 .. deprecated:: 3.11
-   The :mod:`cgi` module is deprecated (see :pep:`594` for details).
+   The :mod:`cgi` module is deprecated
+   (see :pep:`PEP 594 <594#cgi>` for details and alternatives).
 
 --------------
 

--- a/Doc/library/cgitb.rst
+++ b/Doc/library/cgitb.rst
@@ -17,7 +17,8 @@
    single: tracebacks; in CGI scripts
 
 .. deprecated:: 3.11
-   The :mod:`cgitb` module is deprecated (see :pep:`594` for details).
+   The :mod:`cgitb` module is deprecated
+   (see :pep:`PEP 594 <594#cgitb>` for details).
 
 --------------
 

--- a/Doc/library/chunk.rst
+++ b/Doc/library/chunk.rst
@@ -18,7 +18,8 @@
    single: RMFF
 
 .. deprecated:: 3.11
-   The :mod:`chunk` module is deprecated (see :pep:`594` for details).
+   The :mod:`chunk` module is deprecated
+   (see :pep:`PEP 594 <594#chunk>` for details).
 
 --------------
 

--- a/Doc/library/crypt.rst
+++ b/Doc/library/crypt.rst
@@ -17,7 +17,9 @@
    pair: cipher; DES
 
 .. deprecated:: 3.11
-   The :mod:`crypt` module is deprecated (see :pep:`594` for details).
+   The :mod:`crypt` module is deprecated
+   (see :pep:`PEP 594 <594#crypt>` for details and alternatives).
+   The :mod:`hashlib` module is a potential replacement for certain use cases.
 
 --------------
 

--- a/Doc/library/imghdr.rst
+++ b/Doc/library/imghdr.rst
@@ -8,7 +8,8 @@
 **Source code:** :source:`Lib/imghdr.py`
 
 .. deprecated:: 3.11
-   The :mod:`imghdr` module is deprecated (see :pep:`594` for details).
+   The :mod:`imghdr` module is deprecated
+   (see :pep:`PEP 594 <594#imghdr>` for details and alternatives).
 
 --------------
 

--- a/Doc/library/mailcap.rst
+++ b/Doc/library/mailcap.rst
@@ -8,8 +8,9 @@
 **Source code:** :source:`Lib/mailcap.py`
 
 .. deprecated:: 3.11
-   The :mod:`mailcap` module is deprecated. See :pep:`594` for the rationale
-   and the :mod:`mimetypes` module for an alternative.
+   The :mod:`mailcap` module is deprecated
+   (see :pep:`PEP 594 <594#mailcap>` for details).
+   The :mod:`mimetypes` module provides an alternative.
 
 --------------
 

--- a/Doc/library/msilib.rst
+++ b/Doc/library/msilib.rst
@@ -14,7 +14,8 @@
 .. index:: single: msi
 
 .. deprecated:: 3.11
-   The :mod:`msilib` module is deprecated (see :pep:`594` for details).
+   The :mod:`msilib` module is deprecated
+   (see :pep:`PEP 594 <594#msilib>` for details).
 
 --------------
 

--- a/Doc/library/nis.rst
+++ b/Doc/library/nis.rst
@@ -11,7 +11,8 @@
 .. sectionauthor:: Moshe Zadka <moshez@zadka.site.co.il>
 
 .. deprecated:: 3.11
-   The :mod:`nis` module is deprecated (see :pep:`594` for details).
+   The :mod:`nis` module is deprecated
+   (see :pep:`PEP 594 <594#nis>` for details).
 
 --------------
 

--- a/Doc/library/ossaudiodev.rst
+++ b/Doc/library/ossaudiodev.rst
@@ -7,7 +7,8 @@
    :deprecated:
 
 .. deprecated:: 3.11
-   The :mod:`ossaudiodev` module is deprecated (see :pep:`594` for details).
+   The :mod:`ossaudiodev` module is deprecated
+   (see :pep:`PEP 594 <594#ossaudiodev>` for details).
 
 --------------
 

--- a/Doc/library/pipes.rst
+++ b/Doc/library/pipes.rst
@@ -11,7 +11,9 @@
 **Source code:** :source:`Lib/pipes.py`
 
 .. deprecated:: 3.11
-   The :mod:`pipes` module is deprecated (see :pep:`594` for details).
+   The :mod:`pipes` module is deprecated
+   (see :pep:`PEP 594 <594#pipes>` for details).
+   Please use the :mod:`subprocess` module instead.
 
 --------------
 

--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -15,7 +15,8 @@
 This module offers several classes to implement SMTP (email) servers.
 
 .. deprecated:: 3.6
-   :mod:`smtpd` will be removed in Python 3.12 (:pep:`594`).
+   :mod:`smtpd` will be removed in Python 3.12
+   (see :pep:`PEP 594 <594#smtpd>` for details).
    The `aiosmtpd <https://aiosmtpd.readthedocs.io/>`_ package is a recommended
    replacement for this module.  It is based on :mod:`asyncio` and provides a
    more straightforward API.

--- a/Doc/library/sndhdr.rst
+++ b/Doc/library/sndhdr.rst
@@ -15,7 +15,8 @@
    single: u-LAW
 
 .. deprecated:: 3.11
-   The :mod:`sndhdr` module is deprecated (see :pep:`594` for details).
+   The :mod:`sndhdr` module is deprecated
+   (see :pep:`PEP 594 <594#sndhdr>` for details and alternatives).
 
 --------------
 

--- a/Doc/library/spwd.rst
+++ b/Doc/library/spwd.rst
@@ -7,7 +7,8 @@
    :deprecated:
 
 .. deprecated:: 3.11
-   The :mod:`spwd` module is deprecated (see :pep:`594` for details).
+   The :mod:`spwd` module is deprecated
+   (see :pep:`PEP 594 <594#spwd>` for details and alternatives).
 
 --------------
 

--- a/Doc/library/sunau.rst
+++ b/Doc/library/sunau.rst
@@ -10,7 +10,8 @@
 **Source code:** :source:`Lib/sunau.py`
 
 .. deprecated:: 3.11
-   The :mod:`sunau` module is deprecated (see :pep:`594` for details).
+   The :mod:`sunau` module is deprecated
+   (see :pep:`PEP 594 <594#sunau>` for details).
 
 --------------
 

--- a/Doc/library/telnetlib.rst
+++ b/Doc/library/telnetlib.rst
@@ -12,7 +12,8 @@
 .. index:: single: protocol; Telnet
 
 .. deprecated:: 3.11
-   The :mod:`telnetlib` module is deprecated (see :pep:`594` for details).
+   The :mod:`telnetlib` module is deprecated
+   (see :pep:`PEP 594 <594#telnetlib>` for details and alternatives).
 
 --------------
 

--- a/Doc/library/uu.rst
+++ b/Doc/library/uu.rst
@@ -10,7 +10,9 @@
 **Source code:** :source:`Lib/uu.py`
 
 .. deprecated:: 3.11
-   The :mod:`uu` module is deprecated (see :pep:`594` for details).
+   The :mod:`uu` module is deprecated
+   (see :pep:`PEP 594 <594#uu-and-the-uu-encoding>` for details).
+   :mod:`base64` is a modern alternative.
 
 --------------
 

--- a/Doc/library/xdrlib.rst
+++ b/Doc/library/xdrlib.rst
@@ -12,7 +12,8 @@
    single: External Data Representation
 
 .. deprecated:: 3.11
-   The :mod:`xdrlib` module is deprecated (see :pep:`594` for details).
+   The :mod:`xdrlib` module is deprecated
+   (see :pep:`PEP 594 <594#xdrlib>` for details).
 
 --------------
 


### PR DESCRIPTION
As discussed in #92611 , currently the experience is pretty subpar for users trying to get even basic information about the deprecations from PEP 594 in the relevant modules' docs. To improve this and increase the visibility of the pending removal, this PR

* [x] Links directly to each module's section in the PEP (so users can easily access the relevant information)
* [x] For those with direct replacements with other stdlib modules, directly internal-links such as well (so users don't have to click through to the PEPs and then back to the docs first, which also won't preserve the version and translation they are on)
* [x] ~Uses the proper `deprecated-removed` to clearly indicate to users that a removal version is planned and what it is, so they can prepare accordingly or voice any unanticipated impacts (as discussed in #92564)~ Deferred to a 3.11+ PR for now.
* [x] ~Add additional replacement information for functions in the `cgi` module, per requests~ Deferred to a 3.11+ PR

Also, despite having been deprecated for many versions without any mention of imminent removal, the `imp` module is due to be removed in Python 3.12, but no indication of that is given in the documentation, which this also resolves.

Fixes #92611 