### PR TITLE
Doc: amend ssl.PROTOCOL_SSLv2 and ssl.PROTOCOL_SSLv3 wording

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -714,7 +714,7 @@ Constants
    Selects SSL version 2 as the channel encryption protocol.
 
    This protocol is not available if OpenSSL is compiled with the
-   ``OPENSSL_NO_SSL2`` flag.
+   ``OPENSSL_NO_SSLv2`` flag.
 
    .. warning::
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -714,7 +714,7 @@ Constants
    Selects SSL version 2 as the channel encryption protocol.
 
    This protocol is not available if OpenSSL is compiled with the
-   ``no-ssl2`` option (``OPENSSL_NO_SSL2`` flag defined).
+   ``no-ssl2`` option.
 
    .. warning::
 
@@ -729,7 +729,7 @@ Constants
    Selects SSL version 3 as the channel encryption protocol.
 
    This protocol is not available if OpenSSL is compiled with the
-   ``no-ssl3`` option (``OPENSSL_NO_SSL3`` flag defined).
+   ``no-ssl3`` option.
 
    .. warning::
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -714,7 +714,7 @@ Constants
    Selects SSL version 2 as the channel encryption protocol.
 
    This protocol is not available if OpenSSL is compiled with the
-   ``OPENSSL_NO_SSLv2`` flag.
+   ``no-ssl2`` option (``OPENSSL_NO_SSL2`` flag defined).
 
    .. warning::
 
@@ -729,7 +729,7 @@ Constants
    Selects SSL version 3 as the channel encryption protocol.
 
    This protocol is not available if OpenSSL is compiled with the
-   ``OPENSSL_NO_SSLv3`` flag.
+   ``no-ssl3`` option (``OPENSSL_NO_SSL3`` flag defined).
 
    .. warning::
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -728,7 +728,7 @@ Constants
 
    Selects SSL version 3 as the channel encryption protocol.
 
-   This protocol is not be available if OpenSSL is compiled with the
+   This protocol is not available if OpenSSL is compiled with the
    ``OPENSSL_NO_SSLv3`` flag.
 
    .. warning::


### PR DESCRIPTION
1. Trivial typo in SSLv3 support wording.
2. I'd also fixup the preceding SSLv2 OpenSSL flag ~from `SSL_OP_NO_SSL2` to `SSL_OP_NO_SSLv2` as per [@openssl/openssl(master): ssl/ssl_conf.c](https://github.com/openssl/openssl/blob/master/ssl/ssl_conf.c#L281) that seems to have been so like forever however don't have enough historical context to propose such change myself — but just nod and I'll fix that as well.~ _nevermind, it was the `no-ssl3` option that had incorrect flag, fixed now too…_