### PR TITLE
gh-92584: test_decimal uses shutil.which()

### DIFF
--- a/Modules/_decimal/tests/formathelper.py
+++ b/Modules/_decimal/tests/formathelper.py
@@ -32,7 +32,7 @@
 import os, sys, locale, random
 import platform, subprocess
 from test.support.import_helper import import_fresh_module
-from distutils.spawn import find_executable
+from shutil import which
 
 C = import_fresh_module('decimal', fresh=['_decimal'])
 P = import_fresh_module('decimal', blocked=['_decimal'])
@@ -139,7 +139,7 @@ else:
         with open("/var/lib/locales/supported.d/local") as f:
             locale_list = [loc.split()[0] for loc in f.readlines() \
                            if not loc.startswith('#')]
-    elif find_executable('locale'):
+    elif which('locale'):
         locale_list = subprocess.Popen(["locale", "-a"],
                           stdout=subprocess.PIPE).communicate()[0]
         try:


### PR DESCRIPTION
test_decimal now uses shutil.which() rather than deprecated
distutils.spawn.find_executable().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
