### PR TITLE
gh-81548: Clarify the deprecation of octal sequences affect byte strings

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1100,8 +1100,8 @@ Deprecated
   that was added in Python 3.10.
   (Contributed by Raymond Hettinger in :gh:`89519`.)
 
-* Octal escapes with value larger than ``0o377`` now produce
-  a :exc:`DeprecationWarning`.
+* Octal escapes in :class:`bytes` objects with value larger than ``0o377`` now
+  produce a :exc:`DeprecationWarning`.
   In a future Python version they will be a :exc:`SyntaxWarning` and
   eventually a :exc:`SyntaxError`.
   (Contributed by Serhiy Storchaka in :gh:`81548`.)

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1101,7 +1101,7 @@ Deprecated
   (Contributed by Raymond Hettinger in :gh:`89519`.)
 
 * Octal escapes in string and bytes literals with value larger than ``0o377`` now
-  produce a :exc:`DeprecationWarning`.
+  produce :exc:`DeprecationWarning`.
   In a future Python version they will be a :exc:`SyntaxWarning` and
   eventually a :exc:`SyntaxError`.
   (Contributed by Serhiy Storchaka in :gh:`81548`.)

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1100,7 +1100,7 @@ Deprecated
   that was added in Python 3.10.
   (Contributed by Raymond Hettinger in :gh:`89519`.)
 
-* Octal escapes in :class:`bytes` objects with value larger than ``0o377`` now
+* Octal escapes in string and bytes literals with value larger than ``0o377`` now
   produce a :exc:`DeprecationWarning`.
   In a future Python version they will be a :exc:`SyntaxWarning` and
   eventually a :exc:`SyntaxError`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:pablogsal