### PR TITLE
What's New 3.12: PyFrame_BlockSetup() was removed in 3.11

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -139,5 +139,3 @@ Deprecated
 
 Removed
 -------
-
-* :c:func:`PyFrame_BlockSetup` and :c:func:`PyFrame_BlockPop` have been removed.


### PR DESCRIPTION
What's New in Python 3.11: "PyFrame_BlockSetup() and
PyFrame_BlockPop() have been removed.  (Contributed by Mark Shannon
in bpo-40222.)"
https://docs.python.org/dev/whatsnew/3.11.html#id8

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
