### PR TITLE
gh-89653: PEP 670: Limited API doesn't cast arguments

### DIFF
--- a/Include/cpython/listobject.h
+++ b/Include/cpython/listobject.h
@@ -33,7 +33,9 @@ PyAPI_FUNC(void) _PyList_DebugMallocStats(FILE *out);
 static inline Py_ssize_t PyList_GET_SIZE(PyListObject *op) {
     return Py_SIZE(op);
 }
-#define PyList_GET_SIZE(op) PyList_GET_SIZE(_PyList_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyList_GET_SIZE(op) PyList_GET_SIZE(_PyList_CAST(op))
+#endif
 
 #define PyList_GET_ITEM(op, index) (_PyList_CAST(op)->ob_item[index])
 
@@ -41,5 +43,7 @@ static inline void
 PyList_SET_ITEM(PyListObject *op, Py_ssize_t index, PyObject *value) {
     op->ob_item[index] = value;
 }
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #define PyList_SET_ITEM(op, index, value) \
     PyList_SET_ITEM(_PyList_CAST(op), index, _PyObject_CAST(value))
+#endif

--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -22,7 +22,9 @@ PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 static inline Py_ssize_t PyTuple_GET_SIZE(PyTupleObject *op) {
     return Py_SIZE(op);
 }
-#define PyTuple_GET_SIZE(op) PyTuple_GET_SIZE(_PyTuple_CAST(op))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyTuple_GET_SIZE(op) PyTuple_GET_SIZE(_PyTuple_CAST(op))
+#endif
 
 #define PyTuple_GET_ITEM(op, index) (_PyTuple_CAST(op)->ob_item[index])
 
@@ -31,7 +33,9 @@ static inline void
 PyTuple_SET_ITEM(PyTupleObject *op, Py_ssize_t index, PyObject *value) {
     op->ob_item[index] = value;
 }
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #define PyTuple_SET_ITEM(op, index, value) \
     PyTuple_SET_ITEM(_PyTuple_CAST(op), index, _PyObject_CAST(value))
+#endif
 
 PyAPI_FUNC(void) _PyTuple_DebugMallocStats(FILE *out);

--- a/Include/cpython/weakrefobject.h
+++ b/Include/cpython/weakrefobject.h
@@ -51,4 +51,6 @@ static inline PyObject* PyWeakref_GET_OBJECT(PyObject *ref_obj) {
     }
     return Py_None;
 }
-#define PyWeakref_GET_OBJECT(ref) PyWeakref_GET_OBJECT(_PyObject_CAST(ref))
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define PyWeakref_GET_OBJECT(ref) PyWeakref_GET_OBJECT(_PyObject_CAST(ref))
+#endif


### PR DESCRIPTION
The limited API version 3.12 no longer casts arguments to expected
types of functions of functions:

* PyList_GET_SIZE(), PyList_SET_ITEM()
* PyTuple_GET_SIZE(), PyTuple_SET_ITEM()
* PyWeakref_GET_OBJECT()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
