### PR TITLE
gh-92632: Make function starunpack_helper run faster when processing starred argument

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4375,6 +4375,7 @@ starunpack_helper(struct compiler *c, asdl_expr_seq *elts, int pushed,
         expr_ty elt = asdl_seq_GET(elts, i);
         if (elt->kind == Starred_kind) {
             seen_star = 1;
+            break;
         }
     }
     if (!seen_star && !big) {


### PR DESCRIPTION
Make function starunpack_helper run faster when processing starred argument

In function starunpack_helper, there is a loop to figure out where there is a starred argument.
When a starred argument found, the loop does not stop. We can add a break statement to stop the
loop as early as possible.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

closes: gh-92632