### PR TITLE
gh-89653: PEP 670: Use PyObject* type for parameters

### DIFF
--- a/Include/cpython/listobject.h
+++ b/Include/cpython/listobject.h
@@ -30,20 +30,22 @@ PyAPI_FUNC(void) _PyList_DebugMallocStats(FILE *out);
 
 // Macros and static inline functions, trading safety for speed
 
-static inline Py_ssize_t PyList_GET_SIZE(PyListObject *op) {
-    return Py_SIZE(op);
+static inline Py_ssize_t PyList_GET_SIZE(PyObject *op) {
+    PyListObject *list = _PyList_CAST(op);
+    return Py_SIZE(list);
 }
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
-#  define PyList_GET_SIZE(op) PyList_GET_SIZE(_PyList_CAST(op))
+#  define PyList_GET_SIZE(op) PyList_GET_SIZE(_PyObject_CAST(op))
 #endif
 
 #define PyList_GET_ITEM(op, index) (_PyList_CAST(op)->ob_item[index])
 
 static inline void
-PyList_SET_ITEM(PyListObject *op, Py_ssize_t index, PyObject *value) {
-    op->ob_item[index] = value;
+PyList_SET_ITEM(PyObject *op, Py_ssize_t index, PyObject *value) {
+    PyListObject *list = _PyList_CAST(op);
+    list->ob_item[index] = value;
 }
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #define PyList_SET_ITEM(op, index, value) \
-    PyList_SET_ITEM(_PyList_CAST(op), index, _PyObject_CAST(value))
+    PyList_SET_ITEM(_PyObject_CAST(op), index, _PyObject_CAST(value))
 #endif

--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -19,23 +19,25 @@ PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 
 // Macros and static inline functions, trading safety for speed
 
-static inline Py_ssize_t PyTuple_GET_SIZE(PyTupleObject *op) {
-    return Py_SIZE(op);
+static inline Py_ssize_t PyTuple_GET_SIZE(PyObject *op) {
+    PyTupleObject *tuple = _PyTuple_CAST(op);
+    return Py_SIZE(tuple);
 }
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
-#  define PyTuple_GET_SIZE(op) PyTuple_GET_SIZE(_PyTuple_CAST(op))
+#  define PyTuple_GET_SIZE(op) PyTuple_GET_SIZE(_PyObject_CAST(op))
 #endif
 
 #define PyTuple_GET_ITEM(op, index) (_PyTuple_CAST(op)->ob_item[index])
 
 /* Function *only* to be used to fill in brand new tuples */
 static inline void
-PyTuple_SET_ITEM(PyTupleObject *op, Py_ssize_t index, PyObject *value) {
-    op->ob_item[index] = value;
+PyTuple_SET_ITEM(PyObject *op, Py_ssize_t index, PyObject *value) {
+    PyTupleObject *tuple = _PyTuple_CAST(op);
+    tuple->ob_item[index] = value;
 }
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #define PyTuple_SET_ITEM(op, index, value) \
-    PyTuple_SET_ITEM(_PyTuple_CAST(op), index, _PyObject_CAST(value))
+    PyTuple_SET_ITEM(_PyObject_CAST(op), index, _PyObject_CAST(value))
 #endif
 
 PyAPI_FUNC(void) _PyTuple_DebugMallocStats(FILE *out);

--- a/Include/object.h
+++ b/Include/object.h
@@ -137,11 +137,12 @@ static inline PyTypeObject* Py_TYPE(PyObject *ob) {
 #endif
 
 // bpo-39573: The Py_SET_SIZE() function must be used to set an object size.
-static inline Py_ssize_t Py_SIZE(PyVarObject *ob) {
-    return ob->ob_size;
+static inline Py_ssize_t Py_SIZE(PyObject *ob) {
+    PyVarObject *var_ob = _PyVarObject_CAST(ob);
+    return var_ob->ob_size;
 }
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
-#  define Py_SIZE(ob) Py_SIZE(_PyVarObject_CAST(ob))
+#  define Py_SIZE(ob) Py_SIZE(_PyObject_CAST(ob))
 #endif
 
 


### PR DESCRIPTION
Use the PyObject* type for parameters of static inline functions:

* Py_SIZE(): same parameter type than PyObject_Size()
* PyList_GET_SIZE(), PyList_SET_ITEM(): same parameter type than
  PyList_Size() and PyList_SetItem()
* PyTuple_GET_SIZE(), PyTuple_SET_ITEM(): same parameter type than
  PyTuple_Size() and PyTuple_SetItem().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
