### PR TITLE
gh-89653: PEP 670: Convert PyDict_GET_SIZE() macro to function

### DIFF
--- a/Include/cpython/dictobject.h
+++ b/Include/cpython/dictobject.h
@@ -46,7 +46,15 @@ PyAPI_FUNC(int) _PyDict_Next(
     PyObject *mp, Py_ssize_t *pos, PyObject **key, PyObject **value, Py_hash_t *hash);
 
 /* Get the number of items of a dictionary. */
-#define PyDict_GET_SIZE(mp)  (assert(PyDict_Check(mp)),((PyDictObject *)mp)->ma_used)
+static inline Py_ssize_t PyDict_GET_SIZE(PyObject *op) {
+    assert(PyDict_Check(op));
+    PyDictObject *mp = _Py_CAST(PyDictObject*, op);
+    return mp->ma_used;
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDict_GET_SIZE(op) PyDict_GET_SIZE(_PyObject_CAST(op))
+#endif
+
 PyAPI_FUNC(int) _PyDict_Contains_KnownHash(PyObject *, PyObject *, Py_hash_t);
 PyAPI_FUNC(int) _PyDict_ContainsId(PyObject *, _Py_Identifier *);
 PyAPI_FUNC(PyObject *) _PyDict_NewPresized(Py_ssize_t minused);


### PR DESCRIPTION
The limited C API version 3.12 no longer casts the argument.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
