### PR TITLE
gh-89653: PEP 670: unicodeobject.h uses _Py_CAST()

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -149,7 +149,7 @@ access to internal read-only data of Unicode objects:
       ``PyUnicode_WCHAR_KIND`` is deprecated.
 
 
-.. c:function:: unsigned int PyUnicode_KIND(PyObject *o)
+.. c:function:: int PyUnicode_KIND(PyObject *o)
 
    Return one of the PyUnicode kind constants (see above) that indicate how many
    bytes per character this Unicode object uses to store its data.  *o* has to
@@ -168,7 +168,7 @@ access to internal read-only data of Unicode objects:
    .. versionadded:: 3.3
 
 
-.. c:function:: void PyUnicode_WRITE(unsigned int kind, void *data, \
+.. c:function:: void PyUnicode_WRITE(int kind, void *data, \
                                      Py_ssize_t index, Py_UCS4 value)
 
    Write into a canonical representation *data* (as obtained with
@@ -181,7 +181,7 @@ access to internal read-only data of Unicode objects:
    .. versionadded:: 3.3
 
 
-.. c:function:: Py_UCS4 PyUnicode_READ(unsigned int kind, void *data, \
+.. c:function:: Py_UCS4 PyUnicode_READ(int kind, void *data, \
                                        Py_ssize_t index)
 
    Read a code point from a canonical representation *data* (as obtained with

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -351,7 +351,7 @@ static inline Py_ssize_t PyUnicode_GET_LENGTH(PyObject *op) {
    kind and data pointers obtained from other function calls.
    index is the index in the string (starts at 0) and value is the new
    code point value which should be written to that location. */
-static inline void PyUnicode_WRITE(unsigned int kind, void *data,
+static inline void PyUnicode_WRITE(int kind, void *data,
                                    Py_ssize_t index, Py_UCS4 value)
 {
     if (kind == PyUnicode_1BYTE_KIND) {
@@ -368,12 +368,15 @@ static inline void PyUnicode_WRITE(unsigned int kind, void *data,
         _Py_STATIC_CAST(Py_UCS4*, data)[index] = value;
     }
 }
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #define PyUnicode_WRITE(kind, data, index, value) \
-    PyUnicode_WRITE((unsigned int)(kind), (void*)(data), (index), (Py_UCS4)(value))
+    PyUnicode_WRITE(_Py_STATIC_CAST(int, kind), _Py_CAST(void*, data), \
+                    (index), _Py_STATIC_CAST(Py_UCS4, value))
+#endif
 
 /* Read a code point from the string's canonical representation.  No checks
    or ready calls are performed. */
-static inline Py_UCS4 PyUnicode_READ(unsigned int kind,
+static inline Py_UCS4 PyUnicode_READ(int kind,
                                      const void *data, Py_ssize_t index)
 {
     if (kind == PyUnicode_1BYTE_KIND) {
@@ -385,8 +388,11 @@ static inline Py_UCS4 PyUnicode_READ(unsigned int kind,
     assert(kind == PyUnicode_4BYTE_KIND);
     return _Py_STATIC_CAST(const Py_UCS4*, data)[index];
 }
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #define PyUnicode_READ(kind, data, index) \
-    PyUnicode_READ((unsigned int)(kind), (const void*)(data), (index))
+    PyUnicode_READ(_Py_STATIC_CAST(int, kind), _Py_CAST(const void*, data), \
+                   (index))
+#endif
 
 /* PyUnicode_READ_CHAR() is less efficient than PyUnicode_READ() because it
    calls PyUnicode_KIND() and might call it twice.  For single reads, use
@@ -395,7 +401,7 @@ static inline Py_UCS4 PyUnicode_READ(unsigned int kind,
 static inline Py_UCS4 PyUnicode_READ_CHAR(PyObject *unicode, Py_ssize_t index)
 {
     assert(PyUnicode_IS_READY(unicode));
-    unsigned int kind = PyUnicode_KIND(unicode);
+    int kind = PyUnicode_KIND(unicode);
     if (kind == PyUnicode_1BYTE_KIND) {
         return PyUnicode_1BYTE_DATA(unicode)[index];
     }
@@ -420,7 +426,7 @@ static inline Py_UCS4 PyUnicode_MAX_CHAR_VALUE(PyObject *op)
         return 0x7fU;
     }
 
-    unsigned int kind = PyUnicode_KIND(op);
+    int kind = PyUnicode_KIND(op);
     if (kind == PyUnicode_1BYTE_KIND) {
        return 0xffU;
     }


### PR DESCRIPTION
Use _Py_CAST() and _Py_STATIC_CAST() in macros wrapping static inline
functions of unicodeobject.h.

Change also the kind type from unsigned int to int: same parameter
type than PyUnicode_FromKindAndData().

The limited API version 3.11 no longer casts arguments to expected
types.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
