### PR TITLE
gh-92670: Skip test_copyfile_nonexistent_dir test on AIX

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1294,10 +1294,10 @@ class TestCopy(BaseTest, unittest.TestCase):
         self.assertEqual(read_file(src_file), 'foo')
 
     @unittest.skipIf(MACOS or SOLARIS or _winapi, 'On MACOS, Solaris and Windows the errors are not confusing (though different)')
-    # Issue 92670: The test uses a trailing slash to force the OS consider
+    # gh-92670: The test uses a trailing slash to force the OS consider
     # the path as a directory, but on AIX the trailing slash has no effect
     # and is considered as a file.
-    @unittest.skipIf(AIX, 'Not valid on AIX, see issue #92670')
+    @unittest.skipIf(AIX, 'Not valid on AIX, see gh-92670')
     def test_copyfile_nonexistent_dir(self):
         # Issue 43219
         src_dir = self.mkdtemp()

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1294,6 +1294,7 @@ class TestCopy(BaseTest, unittest.TestCase):
         self.assertEqual(read_file(src_file), 'foo')
 
     @unittest.skipIf(MACOS or SOLARIS or _winapi, 'On MACOS, Solaris and Windows the errors are not confusing (though different)')
+    @unittest.skipIf(AIX, 'Not valid on AIX, see issue #92670')
     def test_copyfile_nonexistent_dir(self):
         # Issue 43219
         src_dir = self.mkdtemp()

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1294,6 +1294,9 @@ class TestCopy(BaseTest, unittest.TestCase):
         self.assertEqual(read_file(src_file), 'foo')
 
     @unittest.skipIf(MACOS or SOLARIS or _winapi, 'On MACOS, Solaris and Windows the errors are not confusing (though different)')
+    # Issue 92670: The test uses a trailing slash to force the OS consider
+    # the path as a directory, but on AIX the trailing slash has no effect
+    # and is considered as a file.
     @unittest.skipIf(AIX, 'Not valid on AIX, see issue #92670')
     def test_copyfile_nonexistent_dir(self):
         # Issue 43219

--- a/Misc/NEWS.d/next/Tests/2022-05-12-05-51-06.gh-issue-92670.7L43Z_.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-12-05-51-06.gh-issue-92670.7L43Z_.rst
@@ -1,0 +1,3 @@
+Skip test_copyfile_nonexistent_dir test on AIX  as the test uses a trailing
+slash to force the OS consider the path as a directory, but on AIX the
+trailing slash has no effect and is considered as a file.

--- a/Misc/NEWS.d/next/Tests/2022-05-12-05-51-06.gh-issue-92670.7L43Z_.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-12-05-51-06.gh-issue-92670.7L43Z_.rst
@@ -1,3 +1,3 @@
-Skip ``test_copyfile_nonexistent_dir`` test on AIX as the test uses a trailing
+Skip ``test_shutil.TestCopy.test_copyfile_nonexistent_dir`` test on AIX as the test uses a trailing
 slash to force the OS consider the path as a directory, but on AIX the
 trailing slash has no effect and is considered as a file.

--- a/Misc/NEWS.d/next/Tests/2022-05-12-05-51-06.gh-issue-92670.7L43Z_.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-12-05-51-06.gh-issue-92670.7L43Z_.rst
@@ -1,3 +1,3 @@
-Skip test_copyfile_nonexistent_dir test on AIX  as the test uses a trailing
+Skip ``test_copyfile_nonexistent_dir`` test on AIX as the test uses a trailing
 slash to force the OS consider the path as a directory, but on AIX the
 trailing slash has no effect and is considered as a file.


### PR DESCRIPTION
The test uses a trailing slash to force the OS consider
the path as a directory, but on AIX the trailing slash has
no effect and is considered as a file.

```
gh-92670: Skip test_copyfile_nonexistent_dir test on AIX
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-92670: Skip test_copyfile_nonexistent_dir test on AIX
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
