### PR TITLE
[3.10] Fix typo in argparse docs. (GH-92691)

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -502,7 +502,7 @@ disallowed.
 fromfile_prefix_chars
 ^^^^^^^^^^^^^^^^^^^^^
 
-Sometimes, for example when dealing with a particularly long argument lists, it
+Sometimes, for example when dealing with a particularly long argument list, it
 may make sense to keep the list of arguments in a file rather than typing it out
 at the command line.  If the ``fromfile_prefix_chars=`` argument is given to the
 :class:`ArgumentParser` constructor, then arguments that start with any of the


### PR DESCRIPTION
# [3.10] Fix typo in argparse docs. (GH-92691)
> Sometimes,  for example when dealing with **a** particularly long argument list**s**, [...]

Mixture between plural and singular forms is incorrect. Use singular consistently since typically only a single argument list is employed. Change to:

> Sometimes,  for example when dealing with a particularly long argument list, [...]

No issue was opened, since this is a trivial change.

Automerge-Triggered-By: GH:rhettinger
(cherry picked from commit f67d71b431af064409c1f41f6d73becee01882ae)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
