### PR TITLE
Speedup: build docs in parallel

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -43,12 +43,12 @@ jobs:
     # Run "check doctest html" as 3 steps to get a more readable output
     # in the web UI
     - name: 'Check documentation'
-      run: make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going -j4" check
+      run: make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going" check
     # Use "xvfb-run" since some doctest tests open GUI windows
     - name: 'Run documentation doctest'
-      run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going -j4" doctest
+      run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going" doctest
     - name: 'Build HTML documentation'
-      run: make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going -j4" html
+      run: make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going" html
     - name: 'Upload'
       uses: actions/upload-artifact@v3
       with:

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -18,7 +18,7 @@ SPHINXERRORHANDLING = -W
 PAPEROPT_a4     = -D latex_elements.papersize=a4paper
 PAPEROPT_letter = -D latex_elements.papersize=letterpaper
 
-ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees $(PAPEROPT_$(PAPER)) \
+ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees $(PAPEROPT_$(PAPER)) -j auto \
                 $(SPHINXOPTS) $(SPHINXERRORHANDLING) . build/$(BUILDER) $(SOURCES)
 
 .PHONY: help build html htmlhelp latex text texinfo changes linkcheck \


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

`sphinx-build` has a `-j N` option:

> Distribute the build over _N_ processes in parallel, to make building on multiprocessor machines more effective. Note that not all parts and not all builders of Sphinx can be parallelized. If `auto` argument is given, Sphinx uses the number of CPUs as _N_.

https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-j

# Test on a new 10-core Mac

```sh
make -C Doc clean venv; time make -C Doc html
```

## Results of two runs before

```
make -C Doc html  64.83s user 0.84s system 98% cpu 1:06.79 total
make -C Doc html  64.61s user 0.84s system 99% cpu 1:06.04 total
```

## Results of two runs after

```
make -C Doc html  73.28s user 3.09s system 219% cpu 34.826 total
make -C Doc html  74.05s user 3.09s system 221% cpu 34.791 total
```

That's nearly twice as fast: 1m06s -> 35s

# Test on an old dual-core Mac

## Results of one run before

```
make -C Doc html  204.87s user 5.07s system 94% cpu 3:41.28 total
```

## Results of one runs before

```
make -C Doc html  278.01s user 13.18s system 196% cpu 2:28.38 total
```

That's about 1.5x faster: 3m42s -> 2m29s
