### PR TITLE
Add notes maintaining ABCs

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -6,6 +6,32 @@
 Unit tests are in test_collections.
 """
 
+############ Maintenance notes #########################################
+#
+# ABCs are different from other standard library modules in that they
+# specify compliance tests.  In general, once an ABC has been published,
+# new methods (either abstract or concrete) cannot be added.
+#
+# Though classes that inherit from an ABC would automatically receive a
+# new mixin method, registered classes would become non-compliant and
+# violate the contract promised by ``isinstance(someobj, SomeABC)``.
+#
+# Though irritating, the correct procedure for adding a new abstract or
+# mixin methods is to create a new class as a subclass of the previous
+# class.  For example, union(), intersection(), and difference() cannot
+# be added to Set but could a new ABC that extends Set.
+#
+# Because they are so hard to change, new ABCs should have their APIs
+# carefully thought through prior to publication.
+#
+# Since ABCMeta only checks for the presence of methods, it is possible
+# to alter the signature of a method by adding optional arguments
+# or changing parameters names.  This is still a bit dubious but at
+# least it won't cause isinstance() to return an incorrect result.
+#
+#
+#######################################################################
+
 from abc import ABCMeta, abstractmethod
 import sys
 

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -17,8 +17,8 @@ Unit tests are in test_collections.
 # violate the contract promised by ``isinstance(someobj, SomeABC)``.
 #
 # Though irritating, the correct procedure for adding new abstract or
-# mixin methods is to create a new class as a subclass of the previous
-# class.  For example, union(), intersection(), and difference() cannot
+# mixin methods is to create a new ABC as a subclass of the previous
+# ABC.  For example, union(), intersection(), and difference() cannot
 # be added to Set but could go into a new ABC that extends Set.
 #
 # Because they are so hard to change, new ABCs should have their APIs

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -16,10 +16,10 @@ Unit tests are in test_collections.
 # new mixin method, registered classes would become non-compliant and
 # violate the contract promised by ``isinstance(someobj, SomeABC)``.
 #
-# Though irritating, the correct procedure for adding a new abstract or
+# Though irritating, the correct procedure for adding new abstract or
 # mixin methods is to create a new class as a subclass of the previous
 # class.  For example, union(), intersection(), and difference() cannot
-# be added to Set but could a new ABC that extends Set.
+# be added to Set but could go into a new ABC that extends Set.
 #
 # Because they are so hard to change, new ABCs should have their APIs
 # carefully thought through prior to publication.

--- a/Lib/numbers.py
+++ b/Lib/numbers.py
@@ -5,6 +5,31 @@
 
 TODO: Fill out more detailed documentation on the operators."""
 
+############ Maintenance notes #########################################
+#
+# ABCs are different from other standard library modules in that they
+# specify compliance tests.  In general, once an ABC has been published,
+# new methods (either abstract or concrete) cannot be added.
+#
+# Though classes that inherit from an ABC would automatically receive a
+# new mixin method, registered classes would become non-compliant and
+# violate the contract promised by ``isinstance(someobj, SomeABC)``.
+#
+# Though irritating, the correct procedure for adding a new abstract or
+# mixin methods is to create a new class as a subclass of the previous
+# class.
+#
+# Because they are so hard to change, new ABCs should have their APIs
+# carefully thought through prior to publication.
+#
+# Since ABCMeta only checks for the presence of methods, it is possible
+# to alter the signature of a method by adding optional arguments
+# or changing parameters names.  This is still a bit dubious but at
+# least it won't cause isinstance() to return an incorrect result.
+#
+#
+#######################################################################
+
 from abc import ABCMeta, abstractmethod
 
 __all__ = ["Number", "Complex", "Real", "Rational", "Integral"]

--- a/Lib/numbers.py
+++ b/Lib/numbers.py
@@ -15,7 +15,7 @@ TODO: Fill out more detailed documentation on the operators."""
 # new mixin method, registered classes would become non-compliant and
 # violate the contract promised by ``isinstance(someobj, SomeABC)``.
 #
-# Though irritating, the correct procedure for adding a new abstract or
+# Though irritating, the correct procedure for adding new abstract or
 # mixin methods is to create a new class as a subclass of the previous
 # class.
 #

--- a/Lib/numbers.py
+++ b/Lib/numbers.py
@@ -16,8 +16,8 @@ TODO: Fill out more detailed documentation on the operators."""
 # violate the contract promised by ``isinstance(someobj, SomeABC)``.
 #
 # Though irritating, the correct procedure for adding new abstract or
-# mixin methods is to create a new class as a subclass of the previous
-# class.
+# mixin methods is to create a new ABC as a subclass of the previous
+# ABC.
 #
 # Because they are so hard to change, new ABCs should have their APIs
 # carefully thought through prior to publication.

--- a/Lib/numbers.py
+++ b/Lib/numbers.py
@@ -24,7 +24,7 @@ TODO: Fill out more detailed documentation on the operators."""
 #
 # Since ABCMeta only checks for the presence of methods, it is possible
 # to alter the signature of a method by adding optional arguments
-# or changing parameters names.  This is still a bit dubious but at
+# or changing parameter names.  This is still a bit dubious but at
 # least it won't cause isinstance() to return an incorrect result.
 #
 #


### PR DESCRIPTION
We have a recurring issue where new maintainers aspire to modify the ABCs without understanding the implications.   Adding some notes for the ABC maintenance facts-of-life.