### PR TITLE
gh-92739: Warn on code like `if x == 1 or 2`

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -1272,6 +1272,25 @@ class GrammarTests(unittest.TestCase):
             compile('assert x, "msg"', '<testcase>', 'exec')
             compile('assert False, "msg"', '<testcase>', 'exec')
 
+    def test_syntax_warnings_if_x_equals_1_or_2(self):
+        self.check_syntax_warning("""if x == 1 or 2: pass""",
+                                  """2 is always true""")
+        self.check_syntax_warning("""if x in "abc" and "bcd": pass""",
+                                  """'bcd' is always true""")
+        self.check_syntax_warning("""if sqrt(x) < 3 and 4: pass""",
+                                  """4 is always true""")
+        self.check_syntax_warning("""if sqrt(x) < 3 or 0: pass""",
+                                  """0 is always false""")
+        self.check_syntax_warning("""if 'a' or 'b' in my_set: pass""",
+                                  """'a' is always true""")
+        self.check_syntax_warning("""if x == 1 or True: print(True)""",
+                                  """True is always true""")
+        with self.check_no_warnings(category=SyntaxWarning):
+            compile("""if 0 and 3 in x: pass""", '<testcase>', 'exec')
+            compile("""if 1 or 3 in x: pass""", '<testcase>', 'exec')
+            compile("""if True and 3 == x: pass""", '<testcase>', 'exec')
+            compile("""if False or 3 == x: pass""", '<testcase>', 'exec')
+
     def test_assert_warning_promotes_to_syntax_error(self):
         # If SyntaxWarning is configured to be an error, it actually raises a
         # SyntaxError.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-12-21-07-58.gh-issue-92739.tF2XmG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-12-21-07-58.gh-issue-92739.tF2XmG.rst
@@ -1,0 +1,1 @@
+Emit ``SyntaxWarning`` on if-statements containing boolean and/or expressions in which one sub-expression is always true or always false.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3061,8 +3061,7 @@ warn_constant_true_or_false(struct compiler *c, PyObject *constant)
     }
     const char *msg = istrue ? "%R is always true"
                              : "%R is always false";
-    compiler_warn(c, msg, constant);
-    return 1;
+    return compiler_warn(c, msg, constant);
 }
 
 // Warn on `if condition == 1 or 2`.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3059,8 +3059,8 @@ warn_constant_true_or_false(struct compiler *c, PyObject *constant)
     if (istrue < 0) {
         return 0;
     }
-    const char *msg = istrue ? "'%R' is always true"
-                        : "'%R' is always false";
+    const char *msg = istrue ? "%R is always true"
+                             : "%R is always false";
     compiler_warn(c, msg, constant);
     return 1;
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Example:
```python
>>> x = 42
>>> if x == 0 or 1 or 2 or 3:
...     pass
...
<stdin>:1: SyntaxWarning: 1 is always true
<stdin>:1: SyntaxWarning: 2 is always true
<stdin>:1: SyntaxWarning: 3 is always true

>>> if "A" or "B" or "C" in my_list:
...     pass
...
<stdin>:1: SyntaxWarning: 'A' is always true
<stdin>:1: SyntaxWarning: 'B' is always true
```