### PR TITLE
gh-92658: Add Hyper-V socket support

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -236,7 +236,7 @@ created.  Socket addresses are represented as follows:
 
   - ``HV_GUID_ZERO``
   - ``HV_GUID_BROADCAST``
-  - ``HV_GUID_WILDCARD `` - Used to bind on itself and accept connections from
+  - ``HV_GUID_WILDCARD`` - Used to bind on itself and accept connections from
     all partitions.
   - ``HV_GUID_CHILDREN`` - Used to bind on itself and accept connection from
     child partitions.

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -231,7 +231,7 @@ created.  Socket addresses are represented as follows:
   UUID strings.
 
   The ``vm_id`` is the virtual machine identifier or a set of known VMID values
-  if the target is not a specific virtual machine. Known VMID constants are
+  if the target is not a specific virtual machine. Known VMID constants
   defined on ``socket`` are:
 
   - ``HV_GUID_ZERO``

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -614,8 +614,17 @@ Constants
 
 .. data:: AF_HYPERV
           HV_PROTOCOL_RAW
-          HVSOCKET_*
-          HV_GUID_*
+          HVSOCKET_CONNECT_TIMEOUT
+          HVSOCKET_CONNECT_TIMEOUT_MAX
+          HVSOCKET_CONTAINER_PASSTHRU
+          HVSOCKET_CONNECTED_SUSPEND
+          HVSOCKET_ADDRESS_FLAG_PASSTHRU
+          HV_GUID_ZERO
+          HV_GUID_WILDCARD
+          HV_GUID_BROADCAST
+          HV_GUID_CHILDREN
+          HV_GUID_LOOPBACK
+          HV_GUID_LOOPBACK
 
    Constants for Windows Hyper-V sockets for host/guest communications.
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -227,28 +227,24 @@ created.  Socket addresses are represented as follows:
 
 - :const:`AF_HYPERV` is a Windows-only socket based interface for communicating
   with Hyper-V hosts and guests. The address family is represented as a
-  ``(vm_id, service_id)`` tuple where the ``vm_id`` and ``service_id`` are the
-  little endian byte representation of a ``uuid.UUID`` object.
+  ``(vm_id, service_id)`` tuple where the ``vm_id`` and ``service_id`` are
+  UUID strings.
 
   The ``vm_id`` is the virtual machine identifier or a set of known VMID values
-  if the target is not a specific virtual machine. Known VMID values are:
+  if the target is not a specific virtual machine. Known VMID constants are
+  defined on ``socket`` are:
 
-  - ``HV_GUID_ZERO 00000000-0000-0000-0000-000000000000`` - Used to bind on
-    itself and accept connections from all partitions.
-  - ``HV_GUID_BROADCAST FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF``
-  - ``HV_GUID_CHILDREN 90db8b89-0d35-4f79-8ce9-49ea0ac8b7cd`` - Used to bind on
-    itself and accept connection from child partitions.
-  - ``HV_GUID_LOOPBACK e0e16197-dd56-4a10-9195-5ee7a155a838`` - Used as a
-    target to itself.
-  - ``HV_GUID_PARENT a42e7cda-d03f-480c-9cc2-a4de20abb878`` - When used as a
-    bind accepts connection from the parent partition. When used as an address
-    target it will connect to the parent parition.
+  - ``HV_GUID_ZERO``
+  - ``HV_GUID_BROADCAST``
+  - ``HV_GUID_WILDCARD `` - Used to bind on itself and accept connections from
+    all partitions.
+  - ``HV_GUID_CHILDREN`` - Used to bind on itself and accept connection from
+    child partitions.
+  - ``HV_GUID_LOOPBACK`` - Used as a target to itself.
+  - ``HV_GUID_PARENT`` - When used as a bind accepts connection from the parent
+    partition. When used as an address target it will connect to the parent parition.
 
-  The ``service_id`` is the registered service identifier of the registered
-  service.
-
-  The easily get the byte value do
-  ``uuid.UUID("eee5f691-5210-47e8-bbc9-7198bed79b77").bytes_le``.
+  The ``service_id`` is the service identifier of the registered service.
 
   .. versionadded:: 3.12
 
@@ -619,6 +615,7 @@ Constants
 .. data:: AF_HYPERV
           HV_PROTOCOL_RAW
           HVSOCKET_*
+          HV_GUID_*
 
    Constants for Windows Hyper-V sockets for host/guest communications.
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -225,6 +225,33 @@ created.  Socket addresses are represented as follows:
 
   .. versionadded:: 3.9
 
+- :const:`AF_HYPERV` is a Windows-only socket based interface for communicating
+  with Hyper-V hosts and guests. The address family is represented as a
+  ``(vm_id, service_id)`` tuple where the ``vm_id`` and ``service_id`` are the
+  little endian byte representation of a ``uuid.UUID`` object.
+
+  The ``vm_id`` is the virtual machine identifier or a set of known VMID values
+  if the target is not a specific virtual machine. Known VMID values are:
+
+  - ``HV_GUID_ZERO 00000000-0000-0000-0000-000000000000`` - Used to bind on
+    itself and accept connections from all partitions.
+  - ``HV_GUID_BROADCAST FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF``
+  - ``HV_GUID_CHILDREN 90db8b89-0d35-4f79-8ce9-49ea0ac8b7cd`` - Used to bind on
+    itself and accept connection from child partitions.
+  - ``HV_GUID_LOOPBACK e0e16197-dd56-4a10-9195-5ee7a155a838`` - Used as a
+    target to itself.
+  - ``HV_GUID_PARENT a42e7cda-d03f-480c-9cc2-a4de20abb878`` - When used as a
+    bind accepts connection from the parent partition. When used as an address
+    target it will connect to the parent parition.
+
+  The ``service_id`` is the registered service identifier of the registered
+  service.
+
+  The easily get the byte value do
+  ``uuid.UUID("eee5f691-5210-47e8-bbc9-7198bed79b77").bytes_le``.
+
+  .. versionadded:: 3.12
+
 If you use a hostname in the *host* portion of IPv4/v6 socket address, the
 program may show a nondeterministic behavior, as Python uses the first address
 returned from the DNS resolution.  The socket address will be resolved
@@ -588,6 +615,16 @@ Constants
   .. versionadded:: 3.11
 
   .. availability:: Linux >= 3.9
+
+.. data:: AF_HYPERV
+          HV_PROTOCOL_RAW
+          HVSOCKET_*
+
+   Constants for Windows Hyper-V sockets for host/guest communications.
+
+   .. availability:: Windows.
+
+   .. versionadded:: 3.12
 
 Functions
 ^^^^^^^^^

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -2482,29 +2482,41 @@ class BasicHyperVTest(unittest.TestCase):
         socket.HVSOCKET_CONTAINER_PASSTHRU
         socket.HVSOCKET_CONNECTED_SUSPEND
         socket.HVSOCKET_ADDRESS_FLAG_PASSTHRU
+        socket.HV_GUID_ZERO
+        socket.HV_GUID_WILDCARD
+        socket.HV_GUID_BROADCAST
+        socket.HV_GUID_CHILDREN
+        socket.HV_GUID_LOOPBACK
+        socket.HV_GUID_LOOPBACK
 
     def testCreateHyperVSocketWithUnknownProtoFailure(self):
-        self.assertRaises(OSError, socket.socket, socket.AF_HYPERV, socket.SOCK_STREAM)
+        with self.assertRaises(OSError):
+            socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM)
 
     def testCreateHyperVSocketAddrNotTupleFailure(self):
         with socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM, socket.HV_PROTOCOL_RAW) as s:
-            self.assertRaises(TypeError, s.connect, b"\x00" * 16)
+            with self.assertRaises(TypeError):
+                s.connect(socket.HV_GUID_ZERO)
 
-    def testCreateHyperVSocketAddrNotTupleOf2BytesFailure(self):
+    def testCreateHyperVSocketAddrNotTupleOf2StrsFailure(self):
         with socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM, socket.HV_PROTOCOL_RAW) as s:
-            self.assertRaises(TypeError, s.connect, (b"\x00" * 16,))
+            with self.assertRaises(TypeError):
+                s.connect((socket.HV_GUID_ZERO,))
 
-    def testCreateHyperVSocketAddrNotTupleOfBytesFailure(self):
+    def testCreateHyperVSocketAddrNotTupleOfStrsFailure(self):
         with socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM, socket.HV_PROTOCOL_RAW) as s:
-            self.assertRaises(TypeError, s.connect, (1, 2))
+            with self.assertRaises(TypeError):
+                s.connect((1, 2))
 
-    def testCreateHyperVSocketAddrVmIdNotCorrectLengthFailure(self):
+    def testCreateHyperVSocketAddrVmIdNotValidUUIDFailure(self):
         with socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM, socket.HV_PROTOCOL_RAW) as s:
-            self.assertRaises(TypeError, s.connect, (b"\x00", b"\x00" * 16))
+            with self.assertRaises(ValueError):
+                s.connect(("00", socket.HV_GUID_ZERO))
 
-    def testCreateHyperVSocketAddrServiceIdNotCorrectLengthFailure(self):
+    def testCreateHyperVSocketAddrServiceIdNotValidUUIDFailure(self):
         with socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM, socket.HV_PROTOCOL_RAW) as s:
-            self.assertRaises(TypeError, s.connect, (b"\x00" * 16, b"\x00"))
+            with self.assertRaises(ValueError):
+                s.connect((socket.HV_GUID_ZERO, "00"))
 
 
 class BasicTCPTest(SocketConnectedTest):

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -22,6 +22,7 @@ from weakref import proxy
 import signal
 import math
 import pickle
+import re
 import struct
 import random
 import shutil
@@ -2490,32 +2491,39 @@ class BasicHyperVTest(unittest.TestCase):
         socket.HV_GUID_LOOPBACK
 
     def testCreateHyperVSocketWithUnknownProtoFailure(self):
-        with self.assertRaises(OSError):
+        expected = "A protocol was specified in the socket function call " \
+            "that does not support the semantics of the socket type requested"
+        with self.assertRaisesRegex(OSError, expected):
             socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM)
 
     def testCreateHyperVSocketAddrNotTupleFailure(self):
+        expected = "connect(): AF_HYPERV address must be tuple, not str"
         with socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM, socket.HV_PROTOCOL_RAW) as s:
-            with self.assertRaises(TypeError):
+            with self.assertRaisesRegex(TypeError, re.escape(expected)):
                 s.connect(socket.HV_GUID_ZERO)
 
     def testCreateHyperVSocketAddrNotTupleOf2StrsFailure(self):
+        expected = "AF_HYPERV address must be a str tuple (vm_id, service_id)"
         with socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM, socket.HV_PROTOCOL_RAW) as s:
-            with self.assertRaises(TypeError):
+            with self.assertRaisesRegex(TypeError, re.escape(expected)):
                 s.connect((socket.HV_GUID_ZERO,))
 
     def testCreateHyperVSocketAddrNotTupleOfStrsFailure(self):
+        expected = "AF_HYPERV address must be a str tuple (vm_id, service_id)"
         with socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM, socket.HV_PROTOCOL_RAW) as s:
-            with self.assertRaises(TypeError):
+            with self.assertRaisesRegex(TypeError, re.escape(expected)):
                 s.connect((1, 2))
 
     def testCreateHyperVSocketAddrVmIdNotValidUUIDFailure(self):
+        expected = "connect(): AF_HYPERV address vm_id is not a valid UUID string"
         with socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM, socket.HV_PROTOCOL_RAW) as s:
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, re.escape(expected)):
                 s.connect(("00", socket.HV_GUID_ZERO))
 
     def testCreateHyperVSocketAddrServiceIdNotValidUUIDFailure(self):
+        expected = "connect(): AF_HYPERV address service_id is not a valid UUID string"
         with socket.socket(socket.AF_HYPERV, socket.SOCK_STREAM, socket.HV_PROTOCOL_RAW) as s:
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, re.escape(expected)):
                 s.connect((socket.HV_GUID_ZERO, "00"))
 
 

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-13-00-57-18.gh-issue-92658.YdhFE2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-13-00-57-18.gh-issue-92658.YdhFE2.rst
@@ -1,0 +1,1 @@
+Add support for connecting and binding to Hyper-V sockets on Windows Hyper-V hosts and guests.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1588,16 +1588,20 @@ makesockaddr(SOCKET_T sockfd, struct sockaddr *addr, size_t addrlen, int proto)
         SOCKADDR_HV *a = (SOCKADDR_HV *) addr;
 
         wchar_t *guidStr;
-        if (UuidToStringW(&a->VmId, &guidStr) == RPC_S_OUT_OF_MEMORY) {
-            return PyErr_NoMemory();
+        RPC_STATUS res = UuidToStringW(&a->VmId, &guidStr);
+        if (res != RPC_S_OK) {
+            PyErr_SetFromWindowsErr(res);
+            return 0;
         }
         PyObject *vmId = PyUnicode_FromWideChar(guidStr, -1);
-        RPC_STATUS res = RpcStringFreeW(&guidStr);
+        res = RpcStringFreeW(&guidStr);
         assert(res == RPC_S_OK);
 
-        if (UuidToStringW(&a->ServiceId, &guidStr) == RPC_S_OUT_OF_MEMORY) {
+        res = UuidToStringW(&a->ServiceId, &guidStr);
+        if (res != RPC_S_OK) {
             Py_DECREF(vmId);
-            return PyErr_NoMemory();
+            PyErr_SetFromWindowsErr(res);
+            return 0;
         }
         PyObject *serviceId = PyUnicode_FromWideChar(guidStr, -1);
         res = RpcStringFreeW(&guidStr);

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -77,7 +77,10 @@ struct SOCKADDR_BTH_REDEF {
 typedef int socklen_t;
 # endif /* IPPROTO_IPV6 */
 
-/* Future remove once Py_WINVER has been bumped to >=0x0604 */
+/* Remove ifdef once Py_WINVER >= 0x0604
+ * socket.h only defines AF_HYPERV if _WIN32_WINNT is at that level or higher
+ * so for now it's just manually defined.
+ */
 # ifndef AF_HYPERV
 #  define AF_HYPERV 34
 # endif

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -76,6 +76,14 @@ struct SOCKADDR_BTH_REDEF {
 # else
 typedef int socklen_t;
 # endif /* IPPROTO_IPV6 */
+
+/* Future remove once Py_WINVER has been bumped to >=0x0604 */
+# ifndef AF_HYPERV
+#  define AF_HYPERV 34
+# endif
+
+/* FIXME: Should this have some sort of safe guard? */
+# include <hvsocket.h>
 #endif /* MS_WINDOWS */
 
 #ifdef HAVE_SYS_UN_H
@@ -287,6 +295,9 @@ typedef union sock_addr {
 #endif
 #ifdef HAVE_LINUX_TIPC_H
     struct sockaddr_tipc tipc;
+#endif
+#ifdef AF_HYPERV
+    SOCKADDR_HV hv;
 #endif
 } sock_addr_t;
 

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -81,8 +81,6 @@ typedef int socklen_t;
 # ifndef AF_HYPERV
 #  define AF_HYPERV 34
 # endif
-
-/* FIXME: Should this have some sort of safe guard? */
 # include <hvsocket.h>
 #endif /* MS_WINDOWS */
 

--- a/PCbuild/_socket.vcxproj
+++ b/PCbuild/_socket.vcxproj
@@ -93,7 +93,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Partially fixes https://github.com/python/cpython/issues/92658.

There are 2 outstanding questions I have for the PR:

* What should `connect` and `bind` accept as the addr

Currently the code accepts a tuple of 2 16 byte strings only. This could potentially be changed to somehow accept a `uuid.UUID` or even potentially a string of a UUID. My C skills are rusty so I just went with the simpler solution but if it is desired to change this or add support for other types I'm happy to do so at someones direction.

* How should I define/guard `AF_HYPERV` and `# include <hvsocket.h>`

Currently `AF_HYPERV` is defined at https://github.com/tpn/winsdk-10/blob/9b69fd26ac0c7d0b83d378dba01080e93349c2ed/Include/10.0.16299.0/shared/ws2def.h#L145-L148 and is only included if `_WIN32_WINNT > 0x0604`. Currently Python sets that at `0x0602` for Windows 8 compatibility which is why the PR manually defines it. The header also imports `hvsocket.h` for some other definitions used in the code but I'm unsure if this should be done conditionally somehow. Any suggestions or improvements would be great.