### PR TITLE
gh-75372: Specify major version in README for installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,7 +201,7 @@ script) you must take care that your primary python executable is not
 overwritten by the installation of a different version.  All files and
 directories installed using ``make altinstall`` contain the major and minor
 version and can thus live side-by-side.  ``make install`` also creates
-``${prefix}/bin/python3`` which refers to ``${prefix}/bin/pythonX.Y``.  If you
+``${prefix}/bin/python3`` which refers to ``${prefix}/bin/python3.X``.  If you
 intend to install multiple versions using the same prefix you must decide which
 version (if any) is your "primary" version.  Install that version using ``make
 install``.  Install all other versions using ``make altinstall``.


### PR DESCRIPTION
#75372

Minor change, but maybe some people could think that `pythonX.Y` refers to `python2.Y`