### PR TITLE
gh-76948: Expand on mutating list while iterating

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1235,6 +1235,9 @@ application).
    ``list( (1, 2, 3) )`` returns ``[1, 2, 3]``.
    If no argument is given, the constructor creates a new empty list, ``[]``.
 
+   An iteration of a list is terminated when its index matches its length. However,
+   its length is calculated on each iteration of the loop, which allows the list to
+   be mutated while being iterated over (see :ref:`tut-loopidioms` for an example).
 
    Many other operations also produce lists, including the :func:`sorted`
    built-in.

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -650,6 +650,21 @@ however, it is often simpler and safer to create a new list instead. ::
    >>> filtered_data
    [56.2, 51.7, 55.3, 52.5, 47.8]
 
+Nonetheless, mutating a list while it's being iterated can be done, as
+the list length is calculated on each iteration. This can be useful, for
+example, when doing a breadth-first search. ::
+
+   >>> L = [1, 2, 3]
+   >>> for l in L:
+   ...     print(l)
+   ...     if l == 1:
+   ...         L.append("New node")
+   ...
+   1
+   2
+   3
+   New node
+
 
 .. _tut-conditions:
 


### PR DESCRIPTION
#76948

https://docs.python.org/3/library/stdtypes.html#list

https://docs.python.org/3/tutorial/datastructures.html#looping-techniques

See also #90253, which moved the original note from the compound statements page to stdtypes