### PR TITLE
gh-91249: Remove .bat extension in documentation for when activating venv on Windows. (GH-92770)

### DIFF
--- a/Doc/tutorial/venv.rst
+++ b/Doc/tutorial/venv.rst
@@ -60,7 +60,7 @@ Once you've created a virtual environment, you may activate it.
 
 On Windows, run::
 
-  tutorial-env\Scripts\activate.bat
+  tutorial-env\Scripts\activate
 
 On Unix or MacOS, run::
 


### PR DESCRIPTION
#gh-91249: Removed .bat when activating venv on windows https://github.com/python/cpython/issues/91249

I have replaced
```
 tutorial-env\Scripts\activate.bat -> tutorial-env\Scripts\activate 
Basically removed .bat from script.
```

Please let me know if this is as expected. Thank you