### PR TITLE
gh-92782: unify the style of CFG traversal algorithms in the compiler

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7088,11 +7088,6 @@ make_cfg_traversal_stack(basicblock *entry) {
     return stack;
 }
 
-static void
-free_cfg_traversal_stack(basicblock **stack) {
-    PyMem_Free(stack);
-}
-
 Py_LOCAL_INLINE(void)
 stackdepth_push(basicblock ***sp, basicblock *b, int depth)
 {
@@ -7173,7 +7168,7 @@ stackdepth(struct compiler *c, basicblock *entry)
             stackdepth_push(&sp, next, depth);
         }
     }
-    free_cfg_traversal_stack(stack);
+    PyMem_Free(stack);
     return maxdepth;
 }
 
@@ -7363,7 +7358,7 @@ label_exception_targets(basicblock *entry) {
     PyMem_Free(todo_stack);
     return 0;
 error:
-    free_cfg_traversal_stack(todo_stack);
+    PyMem_Free(todo_stack);
     PyMem_Free(except_stack);
     return -1;
 }
@@ -9119,7 +9114,7 @@ mark_reachable(struct assembler *a) {
             }
         }
     }
-    free_cfg_traversal_stack(stack);
+    PyMem_Free(stack);
     return 0;
 }
 

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -8053,7 +8053,7 @@ static int
 optimize_cfg(struct compiler *c, struct assembler *a, PyObject *consts);
 
 static int
-trim_unused_consts(struct compiler *c, struct assembler *a, PyObject *consts);
+trim_unused_consts(struct assembler *a, PyObject *consts);
 
 /* Duplicates exit BBs, so that line numbers can be propagated to them */
 static int
@@ -8369,7 +8369,7 @@ assemble(struct compiler *c, int addNone)
     if (duplicate_exits_without_lineno(c)) {
         return NULL;
     }
-    if (trim_unused_consts(c, &a, consts)) {
+    if (trim_unused_consts(&a, consts)) {
         goto error;
     }
     propagate_line_numbers(&a);
@@ -9257,7 +9257,7 @@ optimize_cfg(struct compiler *c, struct assembler *a, PyObject *consts)
 
 // Remove trailing unused constants.
 static int
-trim_unused_consts(struct compiler *c, struct assembler *a, PyObject *consts)
+trim_unused_consts(struct assembler *a, PyObject *consts)
 {
     assert(PyList_CheckExact(consts));
 

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7061,7 +7061,6 @@ struct assembler {
     PyObject *a_except_table;  /* bytes containing exception table */
     basicblock *a_entry;
     int a_offset;              /* offset into bytecode */
-    int a_nblocks;             /* number of reachable blocks */
     int a_except_table_off;    /* offset into exception table */
     int a_prevlineno;     /* lineno of last emitted line in line table */
     int a_prev_end_lineno; /* end_lineno of last emitted line in line table */
@@ -8350,7 +8349,6 @@ assemble(struct compiler *c, int addNone)
     if (!assemble_init(&a, nblocks, c->u->u_firstlineno))
         goto error;
     a.a_entry = entryblock;
-    a.a_nblocks = nblocks;
 
     int numdropped = fix_cell_offsets(c, entryblock, cellfixedoffsets);
     PyMem_Free(cellfixedoffsets);  // At this point we're done with it.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -9129,12 +9129,15 @@ eliminate_empty_basic_blocks(basicblock *entry) {
         if (b->b_iused == 0) {
             continue;
         }
-        if (is_jump(&b->b_instr[b->b_iused-1])) {
-            basicblock *target = b->b_instr[b->b_iused-1].i_target;
-            while (target->b_iused == 0) {
-                target = target->b_next;
+        for (int i = 0; i < b->b_iused; i++) {
+            struct instr *instr = &b->b_instr[i];
+            if (is_jump(instr) || is_block_push(instr)) {
+                basicblock *target = instr->i_target;
+                while (target->b_iused == 0) {
+                    target = target->b_next;
+                }
+                instr->i_target = target;
             }
-            b->b_instr[b->b_iused-1].i_target = target;
         }
     }
 }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -9091,10 +9091,8 @@ mark_reachable(struct assembler *a) {
     *sp++ = a->a_entry;
     while (sp > stack) {
         basicblock *b = *(--sp);
-        b->b_visited = 1;
         if (b->b_next && !b->b_nofallthrough) {
-            if (!b->b_next->b_visited) {
-                assert(b->b_next->b_predecessors == 0);
+            if (b->b_next->b_predecessors == 0) {
                 *sp++ = b->b_next;
             }
             b->b_next->b_predecessors++;
@@ -9104,8 +9102,7 @@ mark_reachable(struct assembler *a) {
             struct instr *instr = &b->b_instr[i];
             if (is_jump(instr) || is_block_push(instr)) {
                 target = instr->i_target;
-                if (!target->b_visited) {
-                    assert(target->b_predecessors == 0);
+                if (target->b_predecessors == 0) {
                     *sp++ = target;
                 }
                 target->b_predecessors++;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -9091,8 +9091,10 @@ mark_reachable(struct assembler *a) {
     *sp++ = a->a_entry;
     while (sp > stack) {
         basicblock *b = *(--sp);
+        b->b_visited = 1;
         if (b->b_next && !b->b_nofallthrough) {
-            if (b->b_next->b_predecessors == 0) {
+            if (!b->b_next->b_visited) {
+                assert(b->b_next->b_predecessors == 0);
                 *sp++ = b->b_next;
             }
             b->b_next->b_predecessors++;
@@ -9102,7 +9104,8 @@ mark_reachable(struct assembler *a) {
             struct instr *instr = &b->b_instr[i];
             if (is_jump(instr) || is_block_push(instr)) {
                 target = instr->i_target;
-                if (target->b_predecessors == 0) {
+                if (!target->b_visited) {
+                    assert(target->b_predecessors == 0 || target == b->b_next);
                     *sp++ = target;
                 }
                 target->b_predecessors++;


### PR DESCRIPTION
This makes the traversals more consistent:

* reduces repetition of stack allocation code
* makes them all use PyMem_Malloc (currently there are two that use PyObject_Malloc)
* always counts the blocks (a.a_nblocks can be stale) and uses the b_next list, which excludes unreachable (empty) blocks
* always initialises b_visited before a traversal
* mark_reachable uses b_visited
* eliminate_empty_basic_blocks fixes except targets like jump targets (see [discussion below](https://github.com/python/cpython/pull/92784#issuecomment-1126702342))
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
