### PR TITLE
Doc: Update references and examples of old, unsupported OSes and uarches

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -735,9 +735,8 @@ PyConfig
 
       * ``"utf-8"`` if :c:member:`PyPreConfig.utf8_mode` is non-zero.
       * ``"ascii"`` if Python detects that ``nl_langinfo(CODESET)`` announces
-        the ASCII encoding (or Roman8 encoding on HP-UX), whereas the
-        ``mbstowcs()`` function decodes from a different encoding (usually
-        Latin1).
+        the ASCII encoding, whereas the ``mbstowcs()`` function
+        decodes from a different encoding (usually Latin1).
       * ``"utf-8"`` if ``nl_langinfo(CODESET)`` returns an empty string.
       * Otherwise, use the :term:`locale encoding`:
         ``nl_langinfo(CODESET)`` result.

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -483,8 +483,7 @@ including :func:`~shutil.copyfile`, :func:`~shutil.copytree`, and
 How do I copy a file?
 ---------------------
 
-The :mod:`shutil` module contains a :func:`~shutil.copyfile` function.  Note
-that on MacOS 9 it doesn't copy the resource fork and Finder info.
+The :mod:`shutil` module contains a :func:`~shutil.copyfile` function.
 
 
 How do I read (or write) binary data?

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -484,6 +484,13 @@ How do I copy a file?
 ---------------------
 
 The :mod:`shutil` module contains a :func:`~shutil.copyfile` function.
+Note that on Windows NTFS volumes, it does not copy
+`alternate data streams
+<https://en.wikipedia.org/wiki/NTFS#Alternate_data_stream_(ADS)>`_
+nor `resource forks <https://en.wikipedia.org/wiki/Resource_fork>`__
+on macOS HFS+ volumes, though both are now rarely used.
+It also doesn't copy file permissions and metadata, though using
+:func:`shutil.copy2` instead will preserve most (though not all) of it.
 
 
 How do I read (or write) binary data?

--- a/Doc/howto/sockets.rst
+++ b/Doc/howto/sockets.rst
@@ -253,10 +253,12 @@ Binary Data
 
 It is perfectly possible to send binary data over a socket. The major problem is
 that not all machines use the same formats for binary data. For example,
-network byte order is big-endian, with the most significant byte first,
+`network byte order <https://en.wikipedia.org/wiki/Endianness#Networking>`_
+is big-endian, with the most significant byte first,
 so a 16 bit integer with the value ``1`` would be the two hex bytes ``00 01``.
 However, most common processors (x86/AMD64, ARM, RISC-V), are little-endian,
 with the least significant byte first - that same ``1`` would be ``01 00``.
+
 Socket libraries have calls for converting 16 and 32 bit integers - ``ntohl,
 htonl, ntohs, htons`` where "n" means *network* and "h" means *host*, "s" means
 *short* and "l" means *long*. Where network order is host order, these do
@@ -265,8 +267,8 @@ appropriately.
 
 In these days of 64-bit machines, the ASCII representation of binary data is
 frequently smaller than the binary representation. That's because a surprising
-amount of the time, all those integers have the value 0, or maybe 1.
-The string ``"0"`` would be two bytes, while a full 64-bit word would be 8.
+amount of the time, most integers have the value 0, or maybe 1.
+The string ``"0"`` would be two bytes, while a full 64-bit integer would be 8.
 Of course, this doesn't fit well with fixed-length messages.
 Decisions, decisions.
 

--- a/Doc/howto/sockets.rst
+++ b/Doc/howto/sockets.rst
@@ -252,20 +252,23 @@ Binary Data
 -----------
 
 It is perfectly possible to send binary data over a socket. The major problem is
-that not all machines use the same formats for binary data. For example, a
-Motorola chip will represent a 16 bit integer with the value 1 as the two hex
-bytes 00 01. Intel and DEC, however, are byte-reversed - that same 1 is 01 00.
+that not all machines use the same formats for binary data. For example,
+network byte order is big-endian, with the most significant byte first,
+so a 16 bit integer with the value ``1`` would be the two hex bytes ``00 01``.
+However, most common processors (x86/AMD64, ARM, RISC-V), are little-endian,
+with the least significant byte first - that same ``1`` would be ``01 00``.
 Socket libraries have calls for converting 16 and 32 bit integers - ``ntohl,
 htonl, ntohs, htons`` where "n" means *network* and "h" means *host*, "s" means
 *short* and "l" means *long*. Where network order is host order, these do
 nothing, but where the machine is byte-reversed, these swap the bytes around
 appropriately.
 
-In these days of 32 bit machines, the ascii representation of binary data is
+In these days of 64-bit machines, the ASCII representation of binary data is
 frequently smaller than the binary representation. That's because a surprising
-amount of the time, all those longs have the value 0, or maybe 1. The string "0"
-would be two bytes, while binary is four. Of course, this doesn't fit well with
-fixed-length messages. Decisions, decisions.
+amount of the time, all those integers have the value 0, or maybe 1.
+The string ``"0"`` would be two bytes, while a full 64-bit word would be 8.
+Of course, this doesn't fit well with fixed-length messages.
+Decisions, decisions.
 
 
 Disconnecting

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -102,7 +102,7 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
 
    To ensure validity of the created memory mapping the file specified
    by the descriptor *fileno* is internally automatically synchronized
-   with physical backing store on macOS and OpenVMS.
+   with the physical backing store on macOS.
 
    This example shows a simple way of using :class:`~mmap.mmap`::
 

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -53,7 +53,7 @@ Cross Platform
 
 .. function:: machine()
 
-   Returns the machine type, e.g. ``'i386'``. An empty string is returned if the
+   Returns the machine type, e.g. ``'AMD64'``. An empty string is returned if the
    value cannot be determined.
 
 

--- a/Doc/library/posix.rst
+++ b/Doc/library/posix.rst
@@ -37,7 +37,7 @@ Large File Support
 
 .. sectionauthor:: Steve Clift <clift@mail.anacapa.net>
 
-Several operating systems (including AIX, HP-UX and Solaris) provide
+Several operating systems (including AIX and Solaris) provide
 support for files that are larger than 2 GiB from a C programming model where
 :c:type:`int` and :c:type:`long` are 32-bit values. This is typically accomplished
 by defining the relevant size and offset types as 64-bit values. Such files are

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -146,9 +146,10 @@ If the first character is not one of these, ``'@'`` is assumed.
 
 Native byte order is big-endian or little-endian, depending on the host
 system. For example, Intel x86 and AMD64 (x86-64) are little-endian;
-Motorola 68000 and PowerPC G5 are big-endian; ARM and Intel Itanium feature
-switchable endianness (bi-endian). Use ``sys.byteorder`` to check the
-endianness of your system.
+IBM z and most legacy architectures are big-endian;
+and ARM, RISC-V and IBM Power feature switchable endianness
+(bi-endian, though the former two are nearly always little-endian in practice).
+Use ``sys.byteorder`` to check the endianness of your system.
 
 Native size and alignment are determined using the C compiler's
 ``sizeof`` expression.  This is always combined with native byte order.


### PR DESCRIPTION
As a followup to PR #92529 resolving issue #76773 , I also noticed a few other references to legacy OSes that are no longer supported by Python (or their own developers) per PEP 11 (PEP-11) that I elided or updated. More impactfully, I rewrote several descriptions and examples (e.g. in `socket` and `struct`) that were very out of date with modern 64-bit architectures. To keep this narrowly scoped and backportable, I avoided changes that were too broad or could potentially affect references that were still of some modern value.