### PR TITLE
gh-92611: Clarify planned removal version in PEP 594-deprecated modules

### DIFF
--- a/Doc/library/aifc.rst
+++ b/Doc/library/aifc.rst
@@ -13,7 +13,7 @@
    single: AIFF-C
 
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`aifc` module is deprecated
    (see :pep:`PEP 594 <594#aifc>` for details).
 

--- a/Doc/library/asynchat.rst
+++ b/Doc/library/asynchat.rst
@@ -10,8 +10,8 @@
 
 **Source code:** :source:`Lib/asynchat.py`
 
-.. deprecated:: 3.6
-   :mod:`asynchat` will be removed in Python 3.12
+.. deprecated-removed:: 3.6 3.12
+   The :mod:`asynchat` module is deprecated
    (see :pep:`PEP 594 <594#asynchat>` for details).
    Please use :mod:`asyncio` instead.
 

--- a/Doc/library/asyncore.rst
+++ b/Doc/library/asyncore.rst
@@ -13,8 +13,8 @@
 
 **Source code:** :source:`Lib/asyncore.py`
 
-.. deprecated:: 3.6
-   :mod:`asyncore` will be removed in Python 3.12
+.. deprecated-removed:: 3.6 3.12
+   The :mod:`asyncore` module is deprecated
    (see :pep:`PEP 594 <594#asyncore>` for details).
    Please use :mod:`asyncio` instead.
 

--- a/Doc/library/audioop.rst
+++ b/Doc/library/audioop.rst
@@ -5,7 +5,7 @@
    :synopsis: Manipulate raw audio data.
    :deprecated:
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`audioop` module is deprecated
    (see :pep:`PEP 594 <594#audioop>` for details).
 

--- a/Doc/library/cgi.rst
+++ b/Doc/library/cgi.rst
@@ -15,7 +15,7 @@
    single: URL
    single: Common Gateway Interface
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`cgi` module is deprecated
    (see :pep:`PEP 594 <594#cgi>` for details and alternatives).
 

--- a/Doc/library/cgitb.rst
+++ b/Doc/library/cgitb.rst
@@ -16,7 +16,7 @@
    single: exceptions; in CGI scripts
    single: tracebacks; in CGI scripts
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`cgitb` module is deprecated
    (see :pep:`PEP 594 <594#cgitb>` for details).
 

--- a/Doc/library/chunk.rst
+++ b/Doc/library/chunk.rst
@@ -17,7 +17,7 @@
    single: Real Media File Format
    single: RMFF
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`chunk` module is deprecated
    (see :pep:`PEP 594 <594#chunk>` for details).
 

--- a/Doc/library/crypt.rst
+++ b/Doc/library/crypt.rst
@@ -16,7 +16,7 @@
    single: crypt(3)
    pair: cipher; DES
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`crypt` module is deprecated
    (see :pep:`PEP 594 <594#crypt>` for details and alternatives).
    The :mod:`hashlib` module is a potential replacement for certain use cases.

--- a/Doc/library/imghdr.rst
+++ b/Doc/library/imghdr.rst
@@ -7,7 +7,7 @@
 
 **Source code:** :source:`Lib/imghdr.py`
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`imghdr` module is deprecated
    (see :pep:`PEP 594 <594#imghdr>` for details and alternatives).
 

--- a/Doc/library/imp.rst
+++ b/Doc/library/imp.rst
@@ -7,7 +7,7 @@
 
 **Source code:** :source:`Lib/imp.py`
 
-.. deprecated:: 3.4
+.. deprecated-removed:: 3.4 3.12
    The :mod:`imp` module is deprecated in favor of :mod:`importlib`.
 
 .. index:: statement: import

--- a/Doc/library/mailcap.rst
+++ b/Doc/library/mailcap.rst
@@ -7,7 +7,7 @@
 
 **Source code:** :source:`Lib/mailcap.py`
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`mailcap` module is deprecated
    (see :pep:`PEP 594 <594#mailcap>` for details).
    The :mod:`mimetypes` module provides an alternative.

--- a/Doc/library/msilib.rst
+++ b/Doc/library/msilib.rst
@@ -13,7 +13,7 @@
 
 .. index:: single: msi
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`msilib` module is deprecated
    (see :pep:`PEP 594 <594#msilib>` for details).
 

--- a/Doc/library/nis.rst
+++ b/Doc/library/nis.rst
@@ -10,7 +10,7 @@
 .. moduleauthor:: Fred Gansevles <Fred.Gansevles@cs.utwente.nl>
 .. sectionauthor:: Moshe Zadka <moshez@zadka.site.co.il>
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`nis` module is deprecated
    (see :pep:`PEP 594 <594#nis>` for details).
 

--- a/Doc/library/ossaudiodev.rst
+++ b/Doc/library/ossaudiodev.rst
@@ -6,7 +6,7 @@
    :synopsis: Access to OSS-compatible audio devices.
    :deprecated:
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`ossaudiodev` module is deprecated
    (see :pep:`PEP 594 <594#ossaudiodev>` for details).
 

--- a/Doc/library/pipes.rst
+++ b/Doc/library/pipes.rst
@@ -10,7 +10,7 @@
 
 **Source code:** :source:`Lib/pipes.py`
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`pipes` module is deprecated
    (see :pep:`PEP 594 <594#pipes>` for details).
    Please use the :mod:`subprocess` module instead.

--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -14,8 +14,8 @@
 
 This module offers several classes to implement SMTP (email) servers.
 
-.. deprecated:: 3.6
-   :mod:`smtpd` will be removed in Python 3.12
+.. deprecated-removed:: 3.6 3.12
+   The :mod:`smtpd` module is deprecated
    (see :pep:`PEP 594 <594#smtpd>` for details).
    The `aiosmtpd <https://aiosmtpd.readthedocs.io/>`_ package is a recommended
    replacement for this module.  It is based on :mod:`asyncio` and provides a

--- a/Doc/library/sndhdr.rst
+++ b/Doc/library/sndhdr.rst
@@ -14,7 +14,7 @@
    single: A-LAW
    single: u-LAW
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`sndhdr` module is deprecated
    (see :pep:`PEP 594 <594#sndhdr>` for details and alternatives).
 

--- a/Doc/library/spwd.rst
+++ b/Doc/library/spwd.rst
@@ -6,7 +6,7 @@
    :synopsis: The shadow password database (getspnam() and friends).
    :deprecated:
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`spwd` module is deprecated
    (see :pep:`PEP 594 <594#spwd>` for details and alternatives).
 

--- a/Doc/library/sunau.rst
+++ b/Doc/library/sunau.rst
@@ -9,7 +9,7 @@
 
 **Source code:** :source:`Lib/sunau.py`
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`sunau` module is deprecated
    (see :pep:`PEP 594 <594#sunau>` for details).
 

--- a/Doc/library/telnetlib.rst
+++ b/Doc/library/telnetlib.rst
@@ -11,7 +11,7 @@
 
 .. index:: single: protocol; Telnet
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`telnetlib` module is deprecated
    (see :pep:`PEP 594 <594#telnetlib>` for details and alternatives).
 

--- a/Doc/library/uu.rst
+++ b/Doc/library/uu.rst
@@ -9,7 +9,7 @@
 
 **Source code:** :source:`Lib/uu.py`
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`uu` module is deprecated
    (see :pep:`PEP 594 <594#uu-and-the-uu-encoding>` for details).
    :mod:`base64` is a modern alternative.

--- a/Doc/library/xdrlib.rst
+++ b/Doc/library/xdrlib.rst
@@ -11,7 +11,7 @@
    single: XDR
    single: External Data Representation
 
-.. deprecated:: 3.11
+.. deprecated-removed:: 3.11 3.13
    The :mod:`xdrlib` module is deprecated
    (see :pep:`PEP 594 <594#xdrlib>` for details).
 


### PR DESCRIPTION
As discussed in #92611 and #92564 and as a followup to PR #92612 , this 3.11+ only PR uses the proper `deprecated-removed` role for the modules deprecated by PEP 593 (PEP-594) to clearly indicate to users that a removal version is planned and what it is, so they can prepare accordingly or voice any unanticipated impacts.

Related to #92792 ; if we decide to backport that PR, the upgrade to using `deprecated-removed` on those functions can be moved to this one.

Automerge-Triggered-By: GH:brettcannon