### PR TITLE
gh-76075: Remove mentions of C's mktime in datetime.timestamp()

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1364,7 +1364,8 @@ Instance methods:
 
    Return POSIX timestamp corresponding to the :class:`.datetime`
    instance. The return value is a :class:`float` similar to that
-   returned by :func:`time.time`.
+   returned by :func:`time.time`. Raises :exc:`OSError` for times far in the
+   past or far in the future.
 
    For aware :class:`.datetime` instances, the return value is computed
    as::

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1366,13 +1366,6 @@ Instance methods:
    instance. The return value is a :class:`float` similar to that
    returned by :func:`time.time`.
 
-   Naive :class:`.datetime` instances are assumed to represent local
-   time and this method relies on the platform C :c:func:`mktime`
-   function to perform the conversion. Since :class:`.datetime`
-   supports wider range of values than :c:func:`mktime` on many
-   platforms, this method may raise :exc:`OverflowError` for times far
-   in the past or far in the future.
-
    For aware :class:`.datetime` instances, the return value is computed
    as::
 


### PR DESCRIPTION
#76075

https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp

https://github.com/python/cpython/blob/main/Modules/_datetimemodule.c#L6378

```
>>> from datetime import datetime
>>> datetime(year=1900, month=1, day=1).timestamp()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: [Errno 22] Invalid argument
```