### PR TITLE
[3.11] gh-92781: Avoid mixing declarations and code in C API (#92783)

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -111,9 +111,8 @@ static inline PyObject *
 PyObject_CallMethodOneArg(PyObject *self, PyObject *name, PyObject *arg)
 {
     PyObject *args[2] = {self, arg};
-
-    assert(arg != NULL);
     size_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+    assert(arg != NULL);
     return PyObject_VectorcallMethod(name, args, nargsf, _Py_NULL);
 }
 
@@ -160,9 +159,8 @@ static inline PyObject *
 _PyObject_CallMethodIdOneArg(PyObject *self, _Py_Identifier *name, PyObject *arg)
 {
     PyObject *args[2] = {self, arg};
-
-    assert(arg != NULL);
     size_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+    assert(arg != NULL);
     return _PyObject_VectorcallMethodId(name, args, nargsf, _Py_NULL);
 }
 

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -326,8 +326,9 @@ static inline void* _PyUnicode_COMPACT_DATA(PyObject *op) {
 }
 
 static inline void* _PyUnicode_NONCOMPACT_DATA(PyObject *op) {
+    void *data;
     assert(!PyUnicode_IS_COMPACT(op));
-    void *data = _PyUnicodeObject_CAST(op)->data.any;
+    data = _PyUnicodeObject_CAST(op)->data.any;
     assert(data != NULL);
     return data;
 }
@@ -416,8 +417,9 @@ static inline Py_UCS4 PyUnicode_READ(int kind,
    cache kind and use PyUnicode_READ instead. */
 static inline Py_UCS4 PyUnicode_READ_CHAR(PyObject *unicode, Py_ssize_t index)
 {
+    int kind;
     assert(PyUnicode_IS_READY(unicode));
-    int kind = PyUnicode_KIND(unicode);
+    kind = PyUnicode_KIND(unicode);
     if (kind == PyUnicode_1BYTE_KIND) {
         return PyUnicode_1BYTE_DATA(unicode)[index];
     }
@@ -437,12 +439,14 @@ static inline Py_UCS4 PyUnicode_READ_CHAR(PyObject *unicode, Py_ssize_t index)
    than iterating over the string. */
 static inline Py_UCS4 PyUnicode_MAX_CHAR_VALUE(PyObject *op)
 {
+    int kind;
+
     assert(PyUnicode_IS_READY(op));
     if (PyUnicode_IS_ASCII(op)) {
         return 0x7fU;
     }
 
-    int kind = PyUnicode_KIND(op);
+    kind = PyUnicode_KIND(op);
     if (kind == PyUnicode_1BYTE_KIND) {
        return 0xffU;
     }

--- a/Include/cpython/weakrefobject.h
+++ b/Include/cpython/weakrefobject.h
@@ -37,9 +37,11 @@ PyAPI_FUNC(Py_ssize_t) _PyWeakref_GetWeakrefCount(PyWeakReference *head);
 PyAPI_FUNC(void) _PyWeakref_ClearRef(PyWeakReference *self);
 
 static inline PyObject* PyWeakref_GET_OBJECT(PyObject *ref_obj) {
+    PyWeakReference *ref;
+    PyObject *obj;
     assert(PyWeakref_Check(ref_obj));
-    PyWeakReference *ref = _Py_CAST(PyWeakReference*, ref_obj);
-    PyObject *obj = ref->wr_object;
+    ref = _Py_CAST(PyWeakReference*, ref_obj);
+    obj = ref->wr_object;
     // Explanation for the Py_REFCNT() check: when a weakref's target is part
     // of a long chain of deallocations which triggers the trashcan mechanism,
     // clearing the weakrefs can be delayed long after the target's refcount

--- a/Misc/NEWS.d/next/C API/2022-05-13-18-17-48.gh-issue-92781.TVDr3-.rst
+++ b/Misc/NEWS.d/next/C API/2022-05-13-18-17-48.gh-issue-92781.TVDr3-.rst
@@ -1,0 +1,3 @@
+Avoid mixing declarations and code in the C API to fix the compiler warning:
+"ISO C90 forbids mixed declarations and code"
+[-Werror=declaration-after-statement]. Patch by Victor Stinner.


### PR DESCRIPTION
Avoid mixing declarations and code in the C API to fix the compiler
warning: "ISO C90 forbids mixed declarations and code"
[-Werror=declaration-after-statement].

(cherry picked from commit 90e72300730189c4a48529baaad9b0005d40731c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
