### PR TITLE
gh-92812: Align `ArgumentParser.add_subparsers()` docs with actual argument spec

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1701,7 +1701,7 @@ Sub-commands
 
 .. method:: ArgumentParser.add_subparsers([title], [description], [prog], \
                                           [parser_class], [action], \
-                                          [option_string], [dest], [required], \
+                                          [option_strings], [dest], [required], \
                                           [help], [metavar])
 
    Many programs split up their functionality into a number of sub-commands,


### PR DESCRIPTION
https://github.com/python/cpython/issues/92812