### PR TITLE
gh-92800: Fix C++ _Py_CAST with constant types

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -29,6 +29,10 @@ template <typename T>
 struct _Py_add_const {
     typedef const T type;
 };
+template <typename T>
+struct _Py_add_const<T*> { // specialization for pointer
+    typedef const T* type;
+};
 #  define _Py_CAST(tp, expr) \
        const_cast<tp>(reinterpret_cast<_Py_add_const<tp>::type>(expr))
 #else

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -21,13 +21,16 @@
 // non constant type using const_cast<type>. For example,
 // _Py_CAST(PyObject*, op) can convert a "const PyObject*" to
 // "PyObject*".
-//
-// The type argument must not be constant. For example, in C++,
-// _Py_CAST(const PyObject*, expr) fails with a compiler error.
 #ifdef __cplusplus
 #  define _Py_STATIC_CAST(type, expr) static_cast<type>(expr)
-#  define _Py_CAST(type, expr) \
-       const_cast<type>(reinterpret_cast<const type>(expr))
+// _Py_add_const is purely for the implementation of the C++ cast
+// It isn't intended as public interface
+template <typename T>
+struct _Py_add_const {
+    typedef const T type;
+};
+#  define _Py_CAST(tp, expr) \
+       const_cast<tp>(reinterpret_cast<_Py_add_const<tp>::type>(expr))
 #else
 #  define _Py_STATIC_CAST(type, expr) ((type)(expr))
 #  define _Py_CAST(type, expr) ((type)(expr))

--- a/Lib/test/_testcppext.cpp
+++ b/Lib/test/_testcppext.cpp
@@ -49,10 +49,23 @@ test_api_casts(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
     Py_RETURN_NONE;
 }
 
+static PyObject *
+test_unicode_read(PyObject *Py_UNUSED(module), PyObject *arg) {
+    // PyUnicode_READ contains a cast to a const and failed to compile (gh-92800)
+    if (!PyUnicode_Check(arg) || PyUnicode_GET_LENGTH(arg) > 0) {
+        Py_RETURN_NONE;  // not a suitable unicode object
+    }
+    void* data = PyUnicode_DATA(arg);
+    unsigned int kind = PyUnicode_KIND(arg);
+    Py_UCS4 chr0 = PyUnicode_READ(kind, data, 0);
+    return PyLong_FromUnsignedLong(chr0);
+}
+
 
 static PyMethodDef _testcppext_methods[] = {
     {"add", _testcppext_add, METH_VARARGS, _testcppext_add_doc},
     {"test_api_casts", test_api_casts, METH_NOARGS, nullptr},
+    {"test_unicode_read", test_unicode_read, METH_O, nullptr},
     {nullptr, nullptr, 0, nullptr}  /* sentinel */
 };
 


### PR DESCRIPTION
Thus fixing PyUnicode_READ in C++.
Fixes https://github.com/python/cpython/issues/92800

I've created a C++ helper struct definition to work out the
type with constant added (it's OK to add const to a constant
type in typedefs in C++).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
