### PR TITLE
docs: fix link

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -7,7 +7,7 @@
 .. moduleauthor:: Fredrik Lundh <fredrik@pythonware.com>
 .. sectionauthor:: Andrew M. Kuchling <amk@amk.ca>
 
-**Source code:** :source:`Lib/re.py`
+**Source code:** :source:`Lib/re/`
 
 --------------
 


### PR DESCRIPTION
Trivial. No news or issue needed.

Related to https://github.com/python/cpython/issues/91308

Needs backport to 3.11