### PR TITLE
[3.11] Restore default role check in `make check`. (GH-92290)

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -213,8 +213,10 @@ dist:
 	rm dist/python-$(DISTVERSION)-docs-texinfo.tar
 
 check:
-	$(SPHINXLINT) -i tools -i $(VENVDIR) -i README.rst
-	$(SPHINXLINT) ../Misc/NEWS.d/next/
+	# Check the docs and NEWS files with sphinx-lint.
+	# Ignore the tools and venv dirs and check that the default role is not used.
+	$(SPHINXLINT) -i tools -i $(VENVDIR) --enable default-role
+	$(SPHINXLINT) --enable default-role ../Misc/NEWS.d/next/
 
 serve:
 	@echo "The serve target was removed, use htmlview instead (see bpo-36329)"

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -998,7 +998,7 @@ Other constructors, all class methods:
    ISO 8601 format, with the following exceptions:
 
    1. Time zone offsets may have fractional seconds.
-   2. The `T` separator may be replaced by any single unicode character.
+   2. The ``T`` separator may be replaced by any single unicode character.
    3. Ordinal dates are not currently supported.
    4. Fractional hours and minutes are not supported.
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -126,11 +126,11 @@ Module Contents
 
    :func:`member`
 
-      Make `obj` a member.  Can be used as a decorator.
+      Make ``obj`` a member.  Can be used as a decorator.
 
    :func:`nonmember`
 
-      Do not make `obj` a member.  Can be used as a decorator.
+      Do not make ``obj`` a member.  Can be used as a decorator.
 
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``

--- a/Doc/make.bat
+++ b/Doc/make.bat
@@ -180,7 +180,10 @@ if EXIST "%BUILDDIR%\html\index.html" (
 goto end
 
 :check
-cmd /S /C "%SPHINXLINT% -i tools"
+rem Check the docs and NEWS files with sphinx-lint.
+rem Ignore the tools dir and check that the default role is not used.
+cmd /S /C "%SPHINXLINT% -i tools --enable default-role"
+cmd /S /C "%SPHINXLINT% --enable default-role ..\Misc\NEWS.d\next\ "
 goto end
 
 :serve


### PR DESCRIPTION
* Restore default role check in `make check`.

* Options first, then files.

* Update `make.bat` too.

* Add a comment explaining the extra options.

* No reason to ignore the README.rst.

* Enable default-role check in sphinx-lint.

Co-authored-by: Julien Palard <julien@palard.fr>

* Update sphinx-lint default-role check.

* Fix use of the default role in the docs.

* Update make.bat to check for the default role too.

* Fix comment in make.bat.

Co-authored-by: Julien Palard <julien@palard.fr>
(cherry picked from commit 953ab0795243900ccccaaca069d932730a86fc20)

Co-authored-by: Ezio Melotti <ezio.melotti@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
