### PR TITLE
gh-92841: Fix asyncio's RuntimeError: Event loop is closed

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -113,7 +113,7 @@ class _ProactorBasePipeTransport(transports._FlowControlMixin,
     def __del__(self, _warn=warnings.warn):
         if self._sock is not None:
             _warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
-            self.close()
+            self._sock.close()
 
     def _fatal_error(self, exc, message='Fatal error on pipe transport'):
         try:

--- a/Misc/NEWS.d/next/Windows/2022-05-16-11-45-06.gh-issue-92841.NQx107.rst
+++ b/Misc/NEWS.d/next/Windows/2022-05-16-11-45-06.gh-issue-92841.NQx107.rst
@@ -1,0 +1,2 @@
+:meth:`asyncio` no longer throws ``RuntimeError: Event loop is closed`` on
+interpreter exit after asynchronous socket activity. Patch by Oleg Iarygin.

--- a/Misc/NEWS.d/next/Windows/2022-05-16-11-45-06.gh-issue-92841.NQx107.rst
+++ b/Misc/NEWS.d/next/Windows/2022-05-16-11-45-06.gh-issue-92841.NQx107.rst
@@ -1,2 +1,2 @@
-:meth:`asyncio` no longer throws ``RuntimeError: Event loop is closed`` on
+:mod:`asyncio` no longer throws ``RuntimeError: Event loop is closed`` on
 interpreter exit after asynchronous socket activity. Patch by Oleg Iarygin.


### PR DESCRIPTION
Both `asyncio.selector_events._SelectorTransport` and `asyncio.proactor_events._ProactorBasePipeTransport` check if an associated socket is left unclosed and emit a warning on a positive answer.

However, further behavior differs. While `_SelectorTransport` closes the socket:

```python
def __del__(self, _warn=warnings.warn):
    if self._sock is not None:
        _warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
        self._sock.close()
```

the `_ProactorBasePipeTransport` attempts to close itself leaving the socked leaked:

```python
def __del__(self, _warn=warnings.warn):
    if self._sock is not None:
        _warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
        self.close()
```

It looks like there was no plan to close the transport itself causing `<already closed parent loop>.call_soon()`.

The deleters were introduced by 978a9afc6a with no explanatory comment about the implementation difference.

Fixes (no autoclose) gh-92841, gh-91233, and gh-83413. Probably fixes (no autoclose) gh-81562.