### PR TITLE
gh-89898: Fix test_threading.test_args_argument()

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -149,6 +149,7 @@ class ThreadTests(BaseTestCase):
             with self.subTest(target=target, args=args):
                 t = threading.Thread(target=target, args=args)
                 t.start()
+                t.join()
 
     @cpython_only
     def test_disallow_instantiation(self):


### PR DESCRIPTION
Join the thread to not leak threads running in the background to the
next test.

Fix the following warning on the "AMD64 FreeBSD Shared 3.11"
buildbot:

test_args_argument (test.test_threading.ThreadTests.test_args_argument) ...
Warning -- threading_cleanup() failed to cleanup 1 threads (count: 1, dangling: 2)
Warning -- Dangling thread: <_MainThread(MainThread, started 35026161664)>
Warning -- Dangling thread: <Thread(Thread-134 (<lambda>), started 35314998016)>
ok

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
