### PR TITLE
gh-92889: Fix declarations after statements in public headers

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -111,9 +111,9 @@ static inline PyObject *
 PyObject_CallMethodOneArg(PyObject *self, PyObject *name, PyObject *arg)
 {
     PyObject *args[2] = {self, arg};
+    size_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
 
     assert(arg != NULL);
-    size_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
     return PyObject_VectorcallMethod(name, args, nargsf, _Py_NULL);
 }
 
@@ -160,9 +160,9 @@ static inline PyObject *
 _PyObject_CallMethodIdOneArg(PyObject *self, _Py_Identifier *name, PyObject *arg)
 {
     PyObject *args[2] = {self, arg};
+    size_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
 
     assert(arg != NULL);
-    size_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
     return _PyObject_VectorcallMethodId(name, args, nargsf, _Py_NULL);
 }
 

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -326,8 +326,10 @@ static inline void* _PyUnicode_COMPACT_DATA(PyObject *op) {
 }
 
 static inline void* _PyUnicode_NONCOMPACT_DATA(PyObject *op) {
+    void *data;
+
     assert(!PyUnicode_IS_COMPACT(op));
-    void *data = _PyUnicodeObject_CAST(op)->data.any;
+    data = _PyUnicodeObject_CAST(op)->data.any;
     assert(data != NULL);
     return data;
 }
@@ -410,8 +412,10 @@ static inline Py_UCS4 PyUnicode_READ(unsigned int kind,
    cache kind and use PyUnicode_READ instead. */
 static inline Py_UCS4 PyUnicode_READ_CHAR(PyObject *unicode, Py_ssize_t index)
 {
+    unsigned int kind;
+
     assert(PyUnicode_IS_READY(unicode));
-    unsigned int kind = PyUnicode_KIND(unicode);
+    kind = PyUnicode_KIND(unicode);
     if (kind == PyUnicode_1BYTE_KIND) {
         return PyUnicode_1BYTE_DATA(unicode)[index];
     }
@@ -431,12 +435,14 @@ static inline Py_UCS4 PyUnicode_READ_CHAR(PyObject *unicode, Py_ssize_t index)
    than iterating over the string. */
 static inline Py_UCS4 PyUnicode_MAX_CHAR_VALUE(PyObject *op)
 {
+    unsigned int kind;
+
     assert(PyUnicode_IS_READY(op));
     if (PyUnicode_IS_ASCII(op)) {
         return 0x7fU;
     }
 
-    unsigned int kind = PyUnicode_KIND(op);
+    kind = PyUnicode_KIND(op);
     if (kind == PyUnicode_1BYTE_KIND) {
        return 0xffU;
     }

--- a/Include/cpython/weakrefobject.h
+++ b/Include/cpython/weakrefobject.h
@@ -37,9 +37,12 @@ PyAPI_FUNC(Py_ssize_t) _PyWeakref_GetWeakrefCount(PyWeakReference *head);
 PyAPI_FUNC(void) _PyWeakref_ClearRef(PyWeakReference *self);
 
 static inline PyObject* PyWeakref_GET_OBJECT(PyObject *ref_obj) {
+    PyWeakReference *ref;
+    PyObject *obj;
+
     assert(PyWeakref_Check(ref_obj));
-    PyWeakReference *ref = _Py_CAST(PyWeakReference*, ref_obj);
-    PyObject *obj = ref->wr_object;
+    ref = _Py_CAST(PyWeakReference*, ref_obj);
+    obj = ref->wr_object;
     // Explanation for the Py_REFCNT() check: when a weakref's target is part
     // of a long chain of deallocations which triggers the trashcan mechanism,
     // clearing the weakrefs can be delayed long after the target's refcount


### PR DESCRIPTION
This makes these headers more usable with pre-C99 compilers.

fixes #92889
