### PR TITLE
gh-92897: Ensure `venv --copies` respects source build property of the creating interpreter (GH-92899)

### DIFF
--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -30,8 +30,6 @@ from sysconfig import (
     parse_config_h as sysconfig_parse_config_h,
 
     _init_non_posix,
-    _is_python_source_dir,
-    _sys_home,
 
     _variable_rx,
     _findvar1_rx,
@@ -51,9 +49,6 @@ from sysconfig import (
 # because it makes sure that the global dictionary is initialized
 # which might not be true in the time of import.
 _config_vars = get_config_vars()
-
-if os.name == "nt":
-    from sysconfig import _fix_pcbuild
 
 warnings.warn(
     'The distutils.sysconfig module is deprecated, use sysconfig instead',
@@ -287,7 +282,7 @@ def get_python_inc(plat_specific=0, prefix=None):
             # must use "srcdir" from the makefile to find the "Include"
             # directory.
             if plat_specific:
-                return _sys_home or project_base
+                return project_base
             else:
                 incdir = os.path.join(get_config_var('srcdir'), 'Include')
                 return os.path.normpath(incdir)

--- a/Lib/distutils/tests/test_sysconfig.py
+++ b/Lib/distutils/tests/test_sysconfig.py
@@ -60,7 +60,11 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
             # should be a full source checkout.
             Python_h = os.path.join(srcdir, 'Include', 'Python.h')
             self.assertTrue(os.path.exists(Python_h), Python_h)
-            self.assertTrue(sysconfig._is_python_source_dir(srcdir))
+            # <srcdir>/PC/pyconfig.h always exists even if unused on POSIX.
+            pyconfig_h = os.path.join(srcdir, 'PC', 'pyconfig.h')
+            self.assertTrue(os.path.exists(pyconfig_h), pyconfig_h)
+            pyconfig_h_in = os.path.join(srcdir, 'pyconfig.h.in')
+            self.assertTrue(os.path.exists(pyconfig_h_in), pyconfig_h_in)
         elif os.name == 'posix':
             self.assertEqual(
                 os.path.dirname(sysconfig.get_makefile_filename()),

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -448,7 +448,13 @@ class TestSysConfig(unittest.TestCase):
             # should be a full source checkout.
             Python_h = os.path.join(srcdir, 'Include', 'Python.h')
             self.assertTrue(os.path.exists(Python_h), Python_h)
-            self.assertTrue(sysconfig._is_python_source_dir(srcdir))
+            # <srcdir>/PC/pyconfig.h always exists even if unused on POSIX.
+            pyconfig_h = os.path.join(srcdir, 'PC', 'pyconfig.h')
+            self.assertTrue(os.path.exists(pyconfig_h), pyconfig_h)
+            # <srcdir>/pyconfig.h is generated but must exist by virtue
+            # of running the built executable.
+            pyconfig_h = os.path.join(srcdir, 'pyconfig.h')
+            self.assertTrue(os.path.exists(pyconfig_h), pyconfig_h)
         elif os.name == 'posix':
             makefile_dir = os.path.dirname(sysconfig.get_makefile_filename())
             # Issue #19340: srcdir has been realpath'ed already

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -451,10 +451,8 @@ class TestSysConfig(unittest.TestCase):
             # <srcdir>/PC/pyconfig.h always exists even if unused on POSIX.
             pyconfig_h = os.path.join(srcdir, 'PC', 'pyconfig.h')
             self.assertTrue(os.path.exists(pyconfig_h), pyconfig_h)
-            # <srcdir>/pyconfig.h is generated but must exist by virtue
-            # of running the built executable.
-            pyconfig_h = os.path.join(srcdir, 'pyconfig.h')
-            self.assertTrue(os.path.exists(pyconfig_h), pyconfig_h)
+            pyconfig_h_in = os.path.join(srcdir, 'pyconfig.h.in')
+            self.assertTrue(os.path.exists(pyconfig_h_in), pyconfig_h_in)
         elif os.name == 'posix':
             makefile_dir = os.path.dirname(sysconfig.get_makefile_filename())
             # Issue #19340: srcdir has been realpath'ed already

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -13,6 +13,7 @@ import shutil
 import struct
 import subprocess
 import sys
+import sysconfig
 import tempfile
 from test.support import (captured_stdout, captured_stderr, requires_zlib,
                           skip_if_broken_multiprocessing_synchronize, verbose,
@@ -240,18 +241,49 @@ class BasicTest(BaseTest):
             self.assertEqual(out.strip(), expected.encode(), prefix)
 
     @requireVenvCreate
-    def test_sysconfig_preferred_and_default_scheme(self):
+    def test_sysconfig(self):
         """
-        Test that the sysconfig preferred(prefix) and default scheme is venv.
+        Test that the sysconfig functions work in a virtual environment.
         """
         rmtree(self.env_dir)
-        self.run_with_capture(venv.create, self.env_dir)
+        self.run_with_capture(venv.create, self.env_dir, symlinks=False)
         envpy = os.path.join(self.env_dir, self.bindir, self.exe)
         cmd = [envpy, '-c', None]
-        for call in ('get_preferred_scheme("prefix")', 'get_default_scheme()'):
-            cmd[2] = 'import sysconfig; print(sysconfig.%s)' % call
-            out, err = check_output(cmd)
-            self.assertEqual(out.strip(), b'venv', err)
+        for call, expected in (
+            # installation scheme
+            ('get_preferred_scheme("prefix")', 'venv'),
+            ('get_default_scheme()', 'venv'),
+            # build environment
+            ('is_python_build()', str(sysconfig.is_python_build())),
+            ('get_makefile_filename()', sysconfig.get_makefile_filename()),
+            ('get_config_h_filename()', sysconfig.get_config_h_filename())):
+            with self.subTest(call):
+                cmd[2] = 'import sysconfig; print(sysconfig.%s)' % call
+                out, err = check_output(cmd)
+                self.assertEqual(out.strip(), expected.encode(), err)
+
+    @requireVenvCreate
+    @unittest.skipUnless(can_symlink(), 'Needs symlinks')
+    def test_sysconfig_symlinks(self):
+        """
+        Test that the sysconfig functions work in a virtual environment.
+        """
+        rmtree(self.env_dir)
+        self.run_with_capture(venv.create, self.env_dir, symlinks=True)
+        envpy = os.path.join(self.env_dir, self.bindir, self.exe)
+        cmd = [envpy, '-c', None]
+        for call, expected in (
+            # installation scheme
+            ('get_preferred_scheme("prefix")', 'venv'),
+            ('get_default_scheme()', 'venv'),
+            # build environment
+            ('is_python_build()', str(sysconfig.is_python_build())),
+            ('get_makefile_filename()', sysconfig.get_makefile_filename()),
+            ('get_config_h_filename()', sysconfig.get_config_h_filename())):
+            with self.subTest(call):
+                cmd[2] = 'import sysconfig; print(sysconfig.%s)' % call
+                out, err = check_output(cmd)
+                self.assertEqual(out.strip(), expected.encode(), err)
 
     if sys.platform == 'win32':
         ENV_SUBDIRS = (


### PR DESCRIPTION
There is a discrepancy between a symlink venv and a copied venv when determining whether the interpreter is considered to be from a source build.  A symlink venv indicates `True` for `sysconfig.is_python_build()` whereas a copied venv returns `False`.

Since symlink venvs are the default for POSIX (where the majority of source builds would be used/tested), I have opted to use that behavior as correct.  Windows users are far more likely to use the binary installer so odds of venvs being created from source builds are quite low.  Likewise with `venv --copies` on POSIX.

These changes will allow for building extensions out of venvs created from source builds without any pre-configuration steps (see [this](https://pyperformance.readthedocs.io/usage.html#windows-notes) section from pyperformance documentation).

Adding @zooba for Windows and @vsajip for venv

<!-- gh-issue-number: gh-92897 -->
* Issue: gh-92897
<!-- /gh-issue-number -->
