### PR TITLE
gh-92914: Round the allocated size for lists up to the even number

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1432,9 +1432,10 @@ class SizeofTest(unittest.TestCase):
         import re
         check(re.finditer('',''), size('2P'))
         # list
-        samples = [[], [1,2,3], ['1', '2', '3']]
-        for sample in samples:
-            check(list(sample), vsize('Pn') + len(sample)*self.P)
+        check(list([]), vsize('Pn'))
+        check(list([1]), vsize('Pn') + 2*self.P)
+        check(list([1, 2]), vsize('Pn') + 2*self.P)
+        check(list([1, 2, 3]), vsize('Pn') + 4*self.P)
         # sortwrapper (list)
         # XXX
         # cmpwrapper (list)

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-18-08-32-33.gh-issue-92914.tJUeTD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-18-08-32-33.gh-issue-92914.tJUeTD.rst
@@ -1,1 +1,1 @@
-Always round up the size allocated for lists up to 16 bytes.
+Always round up the allocated size for lists to the nearest even number.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-18-08-32-33.gh-issue-92914.tJUeTD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-18-08-32-33.gh-issue-92914.tJUeTD.rst
@@ -1,0 +1,1 @@
+Always round up the size allocated for lists up to 16 bytes.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-18-08-32-33.gh-issue-92914.tJUeTD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-18-08-32-33.gh-issue-92914.tJUeTD.rst
@@ -1,1 +1,1 @@
-Always round up the allocated size for lists to the nearest even number.
+Always round the allocated size for lists up to the nearest even number.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -94,6 +94,16 @@ list_preallocate_exact(PyListObject *self, Py_ssize_t size)
     assert(self->ob_item == NULL);
     assert(size > 0);
 
+    /* Since the Python memory allocator has granularity of 16 bytes,
+     * there is no benefit of allocating space for the odd number of items,
+     * and there is no drawback of rounding it up.
+     */
+    if (sizeof(PyObject*) > 4) {
+        size = (size + 1) & ~(size_t)1;
+    }
+    else {
+        size = (size + 3) & ~(size_t)3;
+    }
     PyObject **items = PyMem_New(PyObject*, size);
     if (items == NULL) {
         PyErr_NoMemory();

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -94,16 +94,12 @@ list_preallocate_exact(PyListObject *self, Py_ssize_t size)
     assert(self->ob_item == NULL);
     assert(size > 0);
 
-    /* Since the Python memory allocator has granularity of 16 bytes,
-     * there is no benefit of allocating space for the odd number of items,
-     * and there is no drawback of rounding it up.
+    /* Since the Python memory allocator has granularity of 16 bytes on 64-bit
+     * platforms (8 on 32-bit), there is no benefit of allocating space for
+     * the odd number of items, and there is no drawback of rounding the
+     * allocated size up to the nearest even number.
      */
-    if (sizeof(PyObject*) > 4) {
-        size = (size + 1) & ~(size_t)1;
-    }
-    else {
-        size = (size + 3) & ~(size_t)3;
-    }
+    size = (size + 1) & ~(size_t)1;
     PyObject **items = PyMem_New(PyObject*, size);
     if (items == NULL) {
         PyErr_NoMemory();


### PR DESCRIPTION
Closes #92914.