### PR TITLE
gh-92932: dis._unpack_opargs should handle EXTENDED_ARG_QUICK

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -592,7 +592,7 @@ def _unpack_opargs(code):
         caches = _inline_cache_entries[deop]
         if deop >= HAVE_ARGUMENT:
             arg = code[i+1] | extended_arg
-            extended_arg = (arg << 8) if op == EXTENDED_ARG else 0
+            extended_arg = (arg << 8) if EXTENDED_ARG in (op, deop) else 0
             # The oparg is stored as a signed integer
             # If the value exceeds its upper limit, it will overflow and wrap
             # to a negative integer

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -592,7 +592,7 @@ def _unpack_opargs(code):
         caches = _inline_cache_entries[deop]
         if deop >= HAVE_ARGUMENT:
             arg = code[i+1] | extended_arg
-            extended_arg = (arg << 8) if EXTENDED_ARG in (op, deop) else 0
+            extended_arg = (arg << 8) if deop == EXTENDED_ARG else 0
             # The oparg is stored as a signed integer
             # If the value exceeds its upper limit, it will overflow and wrap
             # to a negative integer

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -620,6 +620,22 @@ dis_loop_test_quickened_code = """\
        loop_test.__code__.co_firstlineno + 2,
        loop_test.__code__.co_firstlineno + 1,)
 
+def extend_arg_quick():
+    *_, _ = ...
+
+dis_extended_arg_quick_code = """\
+%3d           0 RESUME                   0
+
+%3d           2 LOAD_CONST               1 (Ellipsis)
+              4 EXTENDED_ARG_QUICK       1
+              6 UNPACK_EX              256
+              8 STORE_FAST               0 (_)
+             10 STORE_FAST               0 (_)
+             12 LOAD_CONST               0 (None)
+             14 RETURN_VALUE
+"""% (extend_arg_quick.__code__.co_firstlineno,
+      extend_arg_quick.__code__.co_firstlineno + 1,)
+
 QUICKENING_WARMUP_DELAY = 8
 
 class DisTestBase(unittest.TestCase):
@@ -996,6 +1012,11 @@ class DisTests(DisTestBase):
         self.code_quicken(loop_test, 1)
         got = self.get_disassembly(loop_test, adaptive=True)
         self.do_disassembly_compare(got, dis_loop_test_quickened_code)
+
+    @cpython_only
+    def test_extenaded_arg_quick(self):
+        got = self.get_disassembly(extend_arg_quick)
+        self.do_disassembly_compare(got, dis_extended_arg_quick_code, True)
 
     def get_cached_values(self, quickened, adaptive):
         def f():

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -620,7 +620,7 @@ dis_loop_test_quickened_code = """\
        loop_test.__code__.co_firstlineno + 2,
        loop_test.__code__.co_firstlineno + 1,)
 
-def extend_arg_quick():
+def extended_arg_quick():
     *_, _ = ...
 
 dis_extended_arg_quick_code = """\
@@ -633,8 +633,8 @@ dis_extended_arg_quick_code = """\
              10 STORE_FAST               0 (_)
              12 LOAD_CONST               0 (None)
              14 RETURN_VALUE
-"""% (extend_arg_quick.__code__.co_firstlineno,
-      extend_arg_quick.__code__.co_firstlineno + 1,)
+"""% (extended_arg_quick.__code__.co_firstlineno,
+      extended_arg_quick.__code__.co_firstlineno + 1,)
 
 QUICKENING_WARMUP_DELAY = 8
 
@@ -1014,8 +1014,8 @@ class DisTests(DisTestBase):
         self.do_disassembly_compare(got, dis_loop_test_quickened_code)
 
     @cpython_only
-    def test_extenaded_arg_quick(self):
-        got = self.get_disassembly(extend_arg_quick)
+    def test_extended_arg_quick(self):
+        got = self.get_disassembly(extended_arg_quick)
         self.do_disassembly_compare(got, dis_extended_arg_quick_code, True)
 
     def get_cached_values(self, quickened, adaptive):

--- a/Misc/NEWS.d/next/Library/2022-05-19-17-49-58.gh-issue-92932.o2peTh.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-19-17-49-58.gh-issue-92932.o2peTh.rst
@@ -1,0 +1,3 @@
+Now :func:`~dis.dis` and :func:`~dis.get_instructions` handle operand values
+for instructions prefixed by ``EXTENDED_ARG_QUICK``.
+Patch by Sam Gross and Dong-hee Na.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

closes: gh-92932