### PR TITLE
GH-89914: Remove f_globals and f_builtins fields from _PyInterpreterFrame.

### DIFF
--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -47,8 +47,6 @@ enum _frameowner {
 typedef struct _PyInterpreterFrame {
     /* "Specials" section */
     PyFunctionObject *f_func; /* Strong reference */
-    PyObject *f_globals; /* Borrowed reference */
-    PyObject *f_builtins; /* Borrowed reference */
     PyObject *f_locals; /* Strong reference, may be NULL */
     PyCodeObject *f_code; /* Strong reference */
     PyFrameObject *frame_obj; /* Strong reference, may be NULL */
@@ -102,8 +100,6 @@ _PyFrame_InitializeSpecials(
 {
     frame->f_func = func;
     frame->f_code = (PyCodeObject *)Py_NewRef(func->func_code);
-    frame->f_builtins = func->func_builtins;
-    frame->f_globals = func->func_globals;
     frame->f_locals = Py_XNewRef(locals);
     frame->stacktop = nlocalsplus;
     frame->frame_obj = NULL;

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1408,7 +1408,7 @@ class SizeofTest(unittest.TestCase):
         def func():
             return sys._getframe()
         x = func()
-        check(x, size('3Pi3c7P2ic??2P'))
+        check(x, size('3Pi3c5P2ic??2P'))
         # function
         def func(): pass
         check(func, size('14Pi'))
@@ -1425,7 +1425,7 @@ class SizeofTest(unittest.TestCase):
             check(bar, size('PP'))
         # generator
         def get_gen(): yield 1
-        check(get_gen(), size('P2P4P4c7P2ic??P'))
+        check(get_gen(), size('P2P4P4c5P2ic??P'))
         # iterator
         check(iter('abc'), size('lP'))
         # callable-iterator

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -69,7 +69,7 @@ frame_getlasti(PyFrameObject *f, void *closure)
 static PyObject *
 frame_getglobals(PyFrameObject *f, void *closure)
 {
-    PyObject *globals = f->f_frame->f_globals;
+    PyObject *globals = f->f_frame->f_func->func_globals;
     if (globals == NULL) {
         globals = Py_None;
     }
@@ -80,7 +80,7 @@ frame_getglobals(PyFrameObject *f, void *closure)
 static PyObject *
 frame_getbuiltins(PyFrameObject *f, void *closure)
 {
-    PyObject *builtins = f->f_frame->f_builtins;
+    PyObject *builtins = f->f_frame->f_func->func_builtins;
     if (builtins == NULL) {
         builtins = Py_None;
     }

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -848,7 +848,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
         *lineno = 1;
     }
     else {
-        globals = f->f_frame->f_globals;
+        globals = f->f_frame->f_func->func_globals;
         *filename = f->f_frame->f_code->co_filename;
         Py_INCREF(*filename);
         *lineno = PyFrame_GetLineNumber(f);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1551,8 +1551,8 @@ eval_frame_handle_pending(PyThreadState *tstate)
 #define DEOPT_IF(cond, instname) if (cond) { goto miss; }
 
 
-#define GLOBALS() frame->f_globals
-#define BUILTINS() frame->f_builtins
+#define GLOBALS() frame->f_func->func_globals
+#define BUILTINS() frame->f_func->func_builtins
 #define LOCALS() frame->f_locals
 
 /* Shared opcode macros */
@@ -7090,7 +7090,7 @@ _PyEval_GetBuiltins(PyThreadState *tstate)
 {
     _PyInterpreterFrame *frame = tstate->cframe->current_frame;
     if (frame != NULL) {
-        return frame->f_builtins;
+        return frame->f_func->func_builtins;
     }
     return tstate->interp->builtins;
 }
@@ -7150,7 +7150,7 @@ PyEval_GetGlobals(void)
     if (current_frame == NULL) {
         return NULL;
     }
-    return current_frame->f_globals;
+    return current_frame->f_func->func_globals;
 }
 
 int
@@ -7361,7 +7361,7 @@ import_name(PyThreadState *tstate, _PyInterpreterFrame *frame,
     PyObject *import_func, *res;
     PyObject* stack[5];
 
-    import_func = _PyDict_GetItemWithError(frame->f_builtins, &_Py_ID(__import__));
+    import_func = _PyDict_GetItemWithError(frame->f_func->func_builtins, &_Py_ID(__import__));
     if (import_func == NULL) {
         if (!_PyErr_Occurred(tstate)) {
             _PyErr_SetString(tstate, PyExc_ImportError, "__import__ not found");
@@ -7377,7 +7377,7 @@ import_name(PyThreadState *tstate, _PyInterpreterFrame *frame,
         }
         res = PyImport_ImportModuleLevelObject(
                         name,
-                        frame->f_globals,
+                        frame->f_func->func_globals,
                         locals == NULL ? Py_None :locals,
                         fromlist,
                         ilevel);
@@ -7387,7 +7387,7 @@ import_name(PyThreadState *tstate, _PyInterpreterFrame *frame,
     Py_INCREF(import_func);
 
     stack[0] = name;
-    stack[1] = frame->f_globals;
+    stack[1] = frame->f_func->func_globals;
     stack[2] = locals == NULL ? Py_None : locals;
     stack[3] = fromlist;
     stack[4] = level;

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -242,7 +242,7 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
         return suggestions;
     }
 
-    dir = PySequence_List(frame->f_frame->f_globals);
+    dir = PySequence_List(frame->f_frame->f_func->func_globals);
     if (dir == NULL) {
         return NULL;
     }
@@ -252,7 +252,7 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
         return suggestions;
     }
 
-    dir = PySequence_List(frame->f_frame->f_builtins);
+    dir = PySequence_List(frame->f_frame->f_func->func_builtins);
     if (dir == NULL) {
         return NULL;
     }

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -721,6 +721,11 @@ class PyCodeObjectPtr(PyObjectPtr):
         assert False, "Unreachable"
 
 
+class PyFunctionObjectPtr(PyObjectPtr):
+
+    _typename = 'PyFunctionObject'
+
+
 def items_from_keys_and_values(keys, values):
     entries, nentries = PyDictObjectPtr._get_entries(keys)
     for i in safe_range(nentries):
@@ -1050,11 +1055,14 @@ class PyFramePtr:
     def _f_special(self, name, convert=PyObjectPtr.from_pyobject_ptr):
         return convert(self._gdbval[name])
 
+    def _f_func(self):
+        return self._f_special("f_func", PyFunctionObjectPtr.from_pyobject_ptr)
+
     def _f_globals(self):
-        return self._f_special("f_globals")
+        return self._f_func().pyop_field("func_globals")
 
     def _f_builtins(self):
-        return self._f_special("f_builtins")
+        return self._f_func().pyop_field("func_builtins")
 
     def _f_code(self):
         return self._f_special("f_code", PyCodeObjectPtr.from_pyobject_ptr)


### PR DESCRIPTION
This PR removes the `f_globals` and `f_builitns` from the `_PyInterpreterFrame` struct.
It is the first part of https://github.com/faster-cpython/ideas/issues/111#issuecomment-1100903897

It is the simplest part of that idea, and the part that could potentially cause a slowdown, so I though it best to do in its own PR.

Benchmarking shows a  [1% slowdown](https://gist.github.com/markshannon/ebaa2159fe69bcd4e9a22d0f42ab9c2a), so it is probably best not to merge this until we can demonstrate a speedup with the rest of https://github.com/faster-cpython/ideas/issues/111#issuecomment-1100903897




