### PR TITLE
gh-92984 The Windows build of Python does not need incremental linker support for release and PGO builds

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-05-19-14-01-30.gh-issue-92984.Dsxnlr.rst
+++ b/Misc/NEWS.d/next/Windows/2022-05-19-14-01-30.gh-issue-92984.Dsxnlr.rst
@@ -1,0 +1,1 @@
+Explicitly disable incremental linking for non-Debug builds

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -18,7 +18,7 @@
     <SupportSigning Condition="'$(SupportSigning)' == ''">true</SupportSigning>
     <SupportSigning Condition="'$(Configuration)' == 'Debug'">false</SupportSigning>
     <SupportSigning Condition="'$(ConfigurationType)' == 'StaticLibrary'">false</SupportSigning>
-    <LinkIncremental Condition="$(Configuration) == 'Release' or $(Configuration) == 'PGInstrument' or $(Configuration) == 'PGUpdate'">false</LinkIncremental>
+    <LinkIncremental Condition="$(Configuration) != 'Debug'">false</LinkIncremental>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -18,6 +18,7 @@
     <SupportSigning Condition="'$(SupportSigning)' == ''">true</SupportSigning>
     <SupportSigning Condition="'$(Configuration)' == 'Debug'">false</SupportSigning>
     <SupportSigning Condition="'$(ConfigurationType)' == 'StaticLibrary'">false</SupportSigning>
+    <LinkIncremental Condition="$(Configuration) == 'Release' or $(Configuration) == 'PGInstrument' or $(Configuration) == 'PGUpdate'">false</LinkIncremental>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Closes #92984 

This PR disables the incremental linker option for Windows builds when compiling Release or PGO.  This configuration change equates to the [/INCREMENTAL:NO](https://docs.microsoft.com/en-us/cpp/build/reference/incremental-link-incrementally?view=msvc-170) linker option.  

Debug builds were not changed.  Incremental linking is more likely to be useful there.

This change was tested by compiling the project using `pcbuild/build.bat --pgo`.  When run on the `main` branch with no changes the resulting binaries could not be analyzed in some tools because of incremental linking (even though it wasn't actually incremental).  After this change and a recompile of everything the resulting binary could be analyzed.
