### PR TITLE
ci: add GitHub token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ on:
     - '3.8'
     - '3.7'
 
+permissions:
+  contents: read
+
 jobs:
   check_source:
     name: 'Check for source changes'

--- a/.github/workflows/build_msi.yml
+++ b/.github/workflows/build_msi.yml
@@ -23,6 +23,9 @@ on:
     paths:
     - 'Tools/msi/**'
 
+permissions:
+  contents: read
+
 jobs:
   build_win32:
     name: 'Windows (x86) Installer'

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,6 +24,9 @@ on:
     - 'Doc/**'
     - 'Misc/**'
 
+permissions:
+  contents: read
+
 jobs:
   build_doc:
     name: 'Docs'

--- a/.github/workflows/new-bugs-announce-notifier.yml
+++ b/.github/workflows/new-bugs-announce-notifier.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+permissions:
+  issues: read
+
 jobs:
   notify-new-bugs-announce:
     runs-on: ubuntu-latest
@@ -39,7 +42,7 @@ jobs:
                 assignee : issue.data.assignees.map(assignee => { return assignee.login }),
                 body   : issue.data.body
               };
-            
+
               const data = {
                 from: "CPython Issues <github@mg.python.org>",
                 to: "new-bugs-announce@python.org",


### PR DESCRIPTION
GitHub asks developers to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. 

This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows. 

This project is part of the top 100 critical projects as per OpenSSF (https://github.com/ossf/wg-securing-critical-projects), so fixing the token permissions to improve security. 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
