### PR TITLE
gh-72572: Remove mention of synced None returns for utcoffset() and dst()

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1987,9 +1987,6 @@ Examples of working with a :class:`.time` object::
       return CONSTANT                 # fixed-offset class
       return CONSTANT + self.dst(dt)  # daylight-aware class
 
-   If :meth:`utcoffset` does not return ``None``, :meth:`dst` should not return
-   ``None`` either.
-
    The default implementation of :meth:`utcoffset` raises
    :exc:`NotImplementedError`.
 


### PR DESCRIPTION
#72572

[All methods](https://docs.python.org/3.12/library/datetime.html#tzinfo-objects) of `tzinfo` now already mention the circumstances that they return `None`. [Timezone](https://docs.python.org/3.12/library/datetime.html#timezone-objects) does also appear to violate the removed statement: `timezone.dst` states that it always returns `None`, while that's not the case for `timezone.utcoffset`.