### PR TITLE
Minor: fix unicode-related inline function warnings

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -193,7 +193,7 @@ static inline unsigned int PyUnicode_CHECK_INTERNED(PyObject *op) {
 #endif
 
 /* For backward compatibility */
-static inline unsigned int PyUnicode_IS_READY(PyObject *op) {
+static inline unsigned int PyUnicode_IS_READY(PyObject* Py_UNUSED(op)) {
     return 1;
 }
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
@@ -413,7 +413,7 @@ PyAPI_FUNC(PyObject*) PyUnicode_New(
     );
 
 /* For backward compatibility */
-static inline int PyUnicode_READY(PyObject *op)
+static inline int PyUnicode_READY(PyObject* Py_UNUSED(op))
 {
     return 0;
 }


### PR DESCRIPTION
When compiling my extension module against latest `main` version of CPython, I get many warnings related to unused parameters in `unicodeobject.h`. Example:

```
In file included from /Users/wjakob/nanobind/src/tensor.cpp:1:
In file included from /Users/wjakob/nanobind/include/nanobind/tensor.h:14:
In file included from /Users/wjakob/nanobind/include/nanobind/nanobind.h:37:
In file included from /Users/wjakob/nanobind/include/nanobind/nb_python.h:22:
In file included from /Users/wjakob/cpython-dist/include/python3.12/Python.h:51:
In file included from /Users/wjakob/cpython-dist/include/python3.12/unicodeobject.h:1029:
/Users/wjakob/cpython-dist/include/python3.12/cpython/unicodeobject.h:196:57: warning: unused parameter 'op' [-Wunused-parameter]
static inline unsigned int PyUnicode_IS_READY(PyObject *op) {
                                                        ^
/Users/wjakob/cpython-dist/include/python3.12/cpython/unicodeobject.h:416:45: warning: unused parameter 'op' [-Wunused-parameter]
static inline int PyUnicode_READY(PyObject *op)
                                            ^
```                                           

This PR fixes those warnings. This isn't really a bug in Python, so I did not create a corresponding issue tracker ticket.