### PR TITLE
gh-93061: Mark as artificial: backwards jump after async for

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-22-02-37-50.gh-issue-93061.r70Imp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-22-02-37-50.gh-issue-93061.r70Imp.rst
@@ -1,0 +1,1 @@
+Backward jumps after ``async for`` loops are no longer given dubious line numbers.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3148,6 +3148,8 @@ compiler_async_for(struct compiler *c, stmt_ty s)
     /* Success block for __anext__ */
     VISIT(c, expr, s->v.AsyncFor.target);
     VISIT_SEQ(c, stmt, s->v.AsyncFor.body);
+    /* Mark jump as artificial */
+    UNSET_LOC(c);
     ADDOP_JUMP(c, JUMP, start);
 
     compiler_pop_fblock(c, FOR_LOOP, start);


### PR DESCRIPTION
This updates `compiler_async_for` to match `compiler_for`.

https://github.com/python/cpython/issues/93061

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
