### PR TITLE
gh-92859: Doc: add info about logging.debug() calling basicConfig() (GH-93063)

### DIFF
--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -178,10 +178,11 @@ following example::
        raise ValueError('Invalid log level: %s' % loglevel)
    logging.basicConfig(level=numeric_level, ...)
 
-The call to :func:`basicConfig` should come *before* any calls to :func:`debug`,
-:func:`info` etc. As it's intended as a one-off simple configuration facility,
-only the first call will actually do anything: subsequent calls are effectively
-no-ops.
+The call to :func:`basicConfig` should come *before* any calls to
+:func:`debug`, :func:`info`, etc. Otherwise, those functions will call
+:func:`basicConfig` for you with the default options. As it's intended as a
+one-off simple configuration facility, only the first call will actually do
+anything: subsequent calls are effectively no-ops.
 
 If you run the above script several times, the messages from successive runs
 are appended to the file *example.log*. If you want each run to start afresh,

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -242,9 +242,9 @@ is the module's name in the Python package namespace.
       above example). In such circumstances, it is likely that specialized
       :class:`Formatter`\ s would be used with particular :class:`Handler`\ s.
 
-      If no handler is attached to this logger (or its parents if
-      :attr:`Logger.propagate` evaluates to true), the message will be sent to
-      the handler set on :attr:`lastResort`.
+      If no handler is attached to this logger (or any of its ancestors,
+      taking into account the relevant :attr:`Logger.propagate` attributes),
+      the message will be sent to the handler set on :attr:`lastResort`.
 
       .. versionchanged:: 3.2
          The *stack_info* parameter was added.
@@ -1042,8 +1042,9 @@ functions.
    above example). In such circumstances, it is likely that specialized
    :class:`Formatter`\ s would be used with particular :class:`Handler`\ s.
 
-   The function will call :func:`basicConfig` if the root logger doesn't have
-   any handler attached.
+   This function (as well as :func:`info`, :func:`warning`, :func:`error` and
+   :func:`critical`) will call :func:`basicConfig` if the root logger doesn't
+   have any handler attached.
 
    .. versionchanged:: 3.2
       The *stack_info* parameter was added.

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -242,6 +242,10 @@ is the module's name in the Python package namespace.
       above example). In such circumstances, it is likely that specialized
       :class:`Formatter`\ s would be used with particular :class:`Handler`\ s.
 
+      If no handler is attached to this logger (or its parents if
+      :attr:`Logger.propagate` evaluates to true), the message will be sent to
+      the handler set on :attr:`lastResort`.
+
       .. versionchanged:: 3.2
          The *stack_info* parameter was added.
 
@@ -1037,6 +1041,9 @@ functions.
    context (such as remote client IP address and authenticated user name, in the
    above example). In such circumstances, it is likely that specialized
    :class:`Formatter`\ s would be used with particular :class:`Handler`\ s.
+
+   The function will call :func:`basicConfig` if the root logger doesn't have
+   any handler attached.
 
    .. versionchanged:: 3.2
       The *stack_info* parameter was added.


### PR DESCRIPTION
This adds some info about logging.debug() (and other level functions)
calling basicConfig() on behalf of the user if logging wasn't configured
beforehand.

#92859 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
