### PR TITLE
gh-48496: Added example and link to faq for UnboundLocalError in reference

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -111,6 +111,8 @@ Yes.  The coding style required for standard library modules is documented as
 Core Language
 =============
 
+.. _faq-unboundlocalerror:
+
 Why am I getting an UnboundLocalError when the variable has a value?
 --------------------------------------------------------------------
 

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -128,8 +128,8 @@ lead to errors when a name is used within a block before it is bound.  This rule
 is subtle.  Python lacks declarations and allows name binding operations to
 occur anywhere within a code block.  The local variables of a code block can be
 determined by scanning the entire text of the block for name binding operations.
-See :ref:`the FAQ entry on UnboundLocalError <faq-unboundlocalerror>` for some
-examples.
+See :ref:`the FAQ entry on UnboundLocalError <faq-unboundlocalerror>`
+for examples.
 
 If the :keyword:`global` statement occurs within a block, all uses of the names
 specified in the statement refer to the bindings of those names in the top-level

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -125,7 +125,7 @@ used, an :exc:`UnboundLocalError` exception is raised.
 If a name binding operation occurs anywhere within a code block, all uses of the
 name within the block are treated as references to the current block.  This can
 lead to errors when a name is used within a block before it is bound.  This rule
-is subtle. Python lacks declarations and allows name binding operations to
+is subtle.  Python lacks declarations and allows name binding operations to
 occur anywhere within a code block.  The local variables of a code block can be
 determined by scanning the entire text of the block for name binding operations.
 See :ref:`the FAQ entry on UnboundLocalError <faq-unboundlocalerror>` for some

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -125,23 +125,11 @@ used, an :exc:`UnboundLocalError` exception is raised.
 If a name binding operation occurs anywhere within a code block, all uses of the
 name within the block are treated as references to the current block.  This can
 lead to errors when a name is used within a block before it is bound.  This rule
-is subtle::
-
-   >>> x = 1
-   >>> def new_scope():
-   ...     print(x)
-   ...     x = 2
-   ...
-   >>> new_scope()
-   Traceback (most recent call last):
-     File "<stdin>", line 1, in <module>
-     File "<stdin>", line 2, in new_scope
-   UnboundLocalError: local variable 'x' referenced before assignment
-
-Python lacks declarations and allows name binding operations to
+is subtle. Python lacks declarations and allows name binding operations to
 occur anywhere within a code block.  The local variables of a code block can be
 determined by scanning the entire text of the block for name binding operations.
-See also :ref:`the FAQ entry on UnboundLocalError <faq-unboundlocalerror>`.
+See :ref:`the FAQ entry on UnboundLocalError <faq-unboundlocalerror>` for some
+examples.
 
 If the :keyword:`global` statement occurs within a block, all uses of the names
 specified in the statement refer to the bindings of those names in the top-level

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -125,9 +125,23 @@ used, an :exc:`UnboundLocalError` exception is raised.
 If a name binding operation occurs anywhere within a code block, all uses of the
 name within the block are treated as references to the current block.  This can
 lead to errors when a name is used within a block before it is bound.  This rule
-is subtle.  Python lacks declarations and allows name binding operations to
+is subtle::
+
+   >>> x = 1
+   >>> def new_scope():
+   ...     print(x)
+   ...     x = 2
+   ...
+   >>> new_scope()
+   Traceback (most recent call last):
+     File "<stdin>", line 1, in <module>
+     File "<stdin>", line 2, in new_scope
+   UnboundLocalError: local variable 'x' referenced before assignment
+
+Python lacks declarations and allows name binding operations to
 occur anywhere within a code block.  The local variables of a code block can be
 determined by scanning the entire text of the block for name binding operations.
+See also :ref:`the FAQ entry on UnboundLocalError <faq-unboundlocalerror>`.
 
 If the :keyword:`global` statement occurs within a block, all uses of the names
 specified in the statement refer to the bindings of those names in the top-level


### PR DESCRIPTION
#48496

https://docs.python.org/3/faq/programming.html#why-am-i-getting-an-unboundlocalerror-when-the-variable-has-a-value

https://docs.python.org/3/reference/executionmodel.html#resolution-of-names

A comment on the issue mentioned putting an example in the tutorial, but skipped it since it's already got an FAQ entry, and that the [scopes](https://docs.python.org/3/tutorial/classes.html#python-scopes-and-namespaces) tutorial makes no mention of NameError/UnboundLocalError.