### PR TITLE
gh-47937: Note that Popen attributes are read-only

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -839,7 +839,8 @@ Instances of the :class:`Popen` class have the following methods:
    On Windows :meth:`kill` is an alias for :meth:`terminate`.
 
 
-The following read-only attributes are also available:
+The following attributes are also set by the class for you to access.
+Reassigning them to new values is unsupported:
 
 .. attribute:: Popen.args
 
@@ -852,9 +853,9 @@ The following read-only attributes are also available:
 
    If the *stdin* argument was :data:`PIPE`, this attribute is a writeable
    stream object as returned by :func:`open`. If the *encoding* or *errors*
-   arguments were specified or the *universal_newlines* argument was ``True``,
-   the stream is a text stream, otherwise it is a byte stream. If the *stdin*
-   argument was not :data:`PIPE`, this attribute is ``None``.
+   arguments were specified or the *text* or *universal_newlines* argument
+   was ``True``, the stream is a text stream, otherwise it is a byte stream.
+   If the *stdin* argument was not :data:`PIPE`, this attribute is ``None``.
 
 
 .. attribute:: Popen.stdout
@@ -862,9 +863,9 @@ The following read-only attributes are also available:
    If the *stdout* argument was :data:`PIPE`, this attribute is a readable
    stream object as returned by :func:`open`. Reading from the stream provides
    output from the child process. If the *encoding* or *errors* arguments were
-   specified or the *universal_newlines* argument was ``True``, the stream is a
-   text stream, otherwise it is a byte stream. If the *stdout* argument was not
-   :data:`PIPE`, this attribute is ``None``.
+   specified or the *text* or *universal_newlines* argument was ``True``, the
+   stream is a text stream, otherwise it is a byte stream. If the *stdout*
+   argument was not :data:`PIPE`, this attribute is ``None``.
 
 
 .. attribute:: Popen.stderr
@@ -872,9 +873,9 @@ The following read-only attributes are also available:
    If the *stderr* argument was :data:`PIPE`, this attribute is a readable
    stream object as returned by :func:`open`. Reading from the stream provides
    error output from the child process. If the *encoding* or *errors* arguments
-   were specified or the *universal_newlines* argument was ``True``, the stream
-   is a text stream, otherwise it is a byte stream. If the *stderr* argument was
-   not :data:`PIPE`, this attribute is ``None``.
+   were specified or the *text* or *universal_newlines* argument was ``True``, the
+   stream is a text stream, otherwise it is a byte stream. If the *stderr* argument
+   was not :data:`PIPE`, this attribute is ``None``.
 
 .. warning::
 

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -450,7 +450,7 @@ functions.
    - :const:`0` means unbuffered (read and write are one
      system call and can return short)
    - :const:`1` means line buffered
-     (only usable if ``universal_newlines=True`` i.e., in a text mode)
+     (only usable if ``text=True`` or ``universal_newlines=True``)
    - any other positive value means use a buffer of approximately that
      size
    - negative bufsize (the default) means the system default of

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -839,7 +839,7 @@ Instances of the :class:`Popen` class have the following methods:
    On Windows :meth:`kill` is an alias for :meth:`terminate`.
 
 
-The following attributes are also available:
+The following read-only attributes are also available:
 
 .. attribute:: Popen.args
 


### PR DESCRIPTION
#47937

https://docs.python.org/3/library/subprocess.html#subprocess.Popen.args

Couldn't find the mentioned `__setattr__`, but for example, Popen's stdin is set by [`p2cwrite`](https://github.com/python/cpython/blob/e5d8dbdd304935dbd0631ee9605efb501332f792/Lib/subprocess.py#L995), which is given by the [argument's `stdin`](https://github.com/python/cpython/blob/e5d8dbdd304935dbd0631ee9605efb501332f792/Lib/subprocess.py#L877), which gets set by `_get_handles` by platform. All this seems to imply that the attributes are not intended to be set other than from the constructor.