### PR TITLE
gh-89158: Add some REPL secondary prompt markers

### DIFF
--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -479,9 +479,9 @@ If the same attribute name occurs in both an instance and in a class,
 then attribute lookup prioritizes the instance::
 
     >>> class Warehouse:
-            purpose = 'storage'
-            region = 'west'
-
+    ...    purpose = 'storage'
+    ...    region = 'west'
+    ...
     >>> w1 = Warehouse()
     >>> print(w1.purpose, w1.region)
     storage west


### PR DESCRIPTION
This fixes an issue on tutorial/classes.rst section 9.4 where the example "class Warehouse"
was truncated when pressing the >>> button to hide the prompts and output.

#89158