### PR TITLE
gh-93035: Fix IntFlag crash with no single bit members

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -537,7 +537,7 @@ class EnumType(type):
         #
         # create a default docstring if one has not been provided
         if enum_class.__doc__ is None:
-            if not member_names:
+            if not member_names or not list(enum_class):
                 enum_class.__doc__ = classdict['__doc__'] = _dedent("""\
                         Create a collection of name/value pairs.
 


### PR DESCRIPTION
Fixes #93035 by changing automatic docstring generation of enums to include aliases in examples.