### PR TITLE
gh-90763: Modernise xx template module initialisation

### DIFF
--- a/Modules/xxlimited_35.c
+++ b/Modules/xxlimited_35.c
@@ -243,8 +243,7 @@ create_and_add_type(PyObject *module, const char *name, PyType_Spec *spec)
     if (type == NULL) {
         return NULL;
     }
-    int rc = PyModule_AddObject(module, name, type);
-    if (rc < 0) {
+    if (PyModule_AddObject(module, name, type) < 0) {
         Py_DECREF(type);
         return NULL;
     }
@@ -269,8 +268,7 @@ xx_modexec(PyObject *m)
         }
     }
     Py_INCREF(ErrorObject);
-    int rc = PyModule_AddObject(m, "error", ErrorObject);
-    if (rc < 0) {
+    if (PyModule_AddObject(m, "error", ErrorObject) < 0) {
         Py_DECREF(ErrorObject);
         return -1;
     }

--- a/Modules/xxlimited_35.c
+++ b/Modules/xxlimited_35.c
@@ -236,23 +236,11 @@ static PyMethodDef xx_methods[] = {
 PyDoc_STRVAR(module_doc,
 "This is a module for testing limited API from Python 3.5.");
 
-static PyObject *
-create_and_add_type(PyObject *module, const char *name, PyType_Spec *spec)
-{
-    PyObject *type = PyType_FromSpec(spec);
-    if (type == NULL) {
-        return NULL;
-    }
-    if (PyModule_AddObject(module, name, type) < 0) {
-        Py_DECREF(type);
-        return NULL;
-    }
-    return type;
-}
-
 static int
 xx_modexec(PyObject *m)
 {
+    PyObject *o;
+
     /* Due to cross platform compiler issues the slots must be filled
      * here. It's required for portability to Windows without requiring
      * C++. */
@@ -273,15 +261,33 @@ xx_modexec(PyObject *m)
         return -1;
     }
 
-    /* Add Xxo, Str, and Null types */
-    Xxo_Type = create_and_add_type(m, "Xxo", &Xxo_Type_spec);
+    /* Add Xxo */
+    Xxo_Type = PyType_FromSpec(&Xxo_Type_spec);
     if (Xxo_Type == NULL) {
         return -1;
     }
-    if (create_and_add_type(m, "Str", &Str_Type_spec) == NULL) {
+    if (PyModule_AddObject(m, "Xxo", Xxo_Type) < 0) {
+        Py_DECREF(Xxo_Type);
         return -1;
     }
-    if (create_and_add_type(m, "Null", &Null_Type_spec) == NULL) {
+
+    /* Add Str */
+    o = PyType_FromSpec(&Str_Type_spec);
+    if (o == NULL) {
+        return -1;
+    }
+    if (PyModule_AddObject(m, "Str", o) < 0) {
+        Py_DECREF(o);
+        return -1;
+    }
+
+    /* Add Null */
+    o = PyType_FromSpec(&Null_Type_spec);
+    if (o == NULL) {
+        return -1;
+    }
+    if (PyModule_AddObject(m, "Null", o) < 0) {
+        Py_DECREF(o);
         return -1;
     }
 

--- a/Modules/xxmodule.c
+++ b/Modules/xxmodule.c
@@ -358,31 +358,32 @@ xx_exec(PyObject *m)
 
     /* Finalize the type object including setting type of the new type
      * object; doing it here is required for portability, too. */
-    if (PyType_Ready(&Xxo_Type) < 0)
-        goto fail;
+    if (PyType_Ready(&Xxo_Type) < 0) {
+        return -1;
+    }
 
     /* Add some symbolic constants to the module */
     if (ErrorObject == NULL) {
         ErrorObject = PyErr_NewException("xx.error", NULL, NULL);
-        if (ErrorObject == NULL)
-            goto fail;
+        if (ErrorObject == NULL) {
+            return -1;
+        }
     }
-    Py_INCREF(ErrorObject);
-    PyModule_AddObject(m, "error", ErrorObject);
+    int rc = PyModule_AddType(m, (PyTypeObject *)ErrorObject);
+    Py_DECREF(ErrorObject);
+    if (rc < 0) {
+        return -1;
+    }
 
-    /* Add Str */
-    if (PyType_Ready(&Str_Type) < 0)
-        goto fail;
-    PyModule_AddObject(m, "Str", (PyObject *)&Str_Type);
+    /* Add Str and Null types */
+    if (PyModule_AddType(m, &Str_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddType(m, &Null_Type) < 0) {
+        return -1;
+    }
 
-    /* Add Null */
-    if (PyType_Ready(&Null_Type) < 0)
-        goto fail;
-    PyModule_AddObject(m, "Null", (PyObject *)&Null_Type);
     return 0;
- fail:
-    Py_XDECREF(m);
-    return -1;
 }
 
 static struct PyModuleDef_Slot xx_slots[] = {


### PR DESCRIPTION
xxmodule:
- remove incorrect decref of module object if module init fails
- modernise API usage; use PyModule_AddType iso. PyModule_AddObject

xxlimited_35:
- remove incorrect decref of module object if module init fails
- check return of PyModule_AddObject
- fix module name in type objects


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
