### PR TITLE
gh-57348: Add that multiprocessing.map() can raise exception on fail

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2240,8 +2240,9 @@ with the :class:`Pool` class.
    .. method:: map(func, iterable[, chunksize])
 
       A parallel equivalent of the :func:`map` built-in function (it supports only
-      one *iterable* argument though, for multiple iterables see :meth:`starmap`).
-      It blocks until the result is ready.
+      one *iterable* argument though; for multiple iterables see :meth:`starmap`).
+      It blocks until the result is ready. If any of its results fail, then an
+      exception is raised.
 
       This method chops the iterable into a number of chunks which it submits to
       the process pool as separate tasks.  The (approximate) size of these


### PR DESCRIPTION
#57348

https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.map

(also snuck in a semicolon change)