### PR TITLE
gh-92434: Silence a compiler warning in _sqlite/connection.c for 32bit version

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-05-25-04-48-30.gh-issue-92434.ZCv8o0.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-25-04-48-30.gh-issue-92434.ZCv8o0.rst
@@ -1,2 +1,2 @@
 :meth:`sqlite3.Connection.serialize` now raises :exc:`OverflowError` on 32-bit
-platforms if the serialized database exceeds ``Py_SSIZE_T_MAX`` bytes.
+platforms if the serialized database exceeds ``INT_MAX`` bytes.

--- a/Misc/NEWS.d/next/Library/2022-05-25-04-48-30.gh-issue-92434.ZCv8o0.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-25-04-48-30.gh-issue-92434.ZCv8o0.rst
@@ -1,2 +1,0 @@
-:meth:`sqlite3.Connection.serialize` now raises :exc:`OverflowError` on 32-bit
-platforms if the serialized database exceeds ``INT_MAX`` bytes.

--- a/Misc/NEWS.d/next/Library/2022-05-25-04-48-30.gh-issue-92434.ZCv8o0.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-25-04-48-30.gh-issue-92434.ZCv8o0.rst
@@ -1,2 +1,2 @@
-:meth:`~sqlite3.Connection.serialize` raises :exc:`OverflowError` on 32bit Python
-when more than ``Py_SSIZE_T_MAX`` bytes of serialization occurs.
+:meth:`sqlite3.Connection.serialize` now raises :exc:`OverflowError` on 32-bit
+platforms if the serialized database exceeds ``Py_SSIZE_T_MAX`` bytes.

--- a/Misc/NEWS.d/next/Library/2022-05-25-04-48-30.gh-issue-92434.ZCv8o0.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-25-04-48-30.gh-issue-92434.ZCv8o0.rst
@@ -1,0 +1,2 @@
+:meth:`~sqlite3.Connection.serialize` raises :exc:`OverflowError` on 32bit Python
+when more than ``Py_SSIZE_T_MAX`` bytes of serialization occurs.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -2092,7 +2092,7 @@ serialize_impl(pysqlite_Connection *self, const char *name)
         return NULL;
     }
 #if PY_SSIZE_T_MAX < 9223372036854775807
-    if (size > PY_SSIZE_T_MAX) {
+    if (size > INT_MAX) {
         PyErr_Format(PyExc_OverflowError,
                      "serialized '%s' too large to convert to bytes", name);
         return NULL;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -2091,7 +2091,7 @@ serialize_impl(pysqlite_Connection *self, const char *name)
                      name);
         return NULL;
     }
-    PyObject *res = PyBytes_FromStringAndSize(data, size);
+    PyObject *res = PyBytes_FromStringAndSize(data, (Py_ssize_t)size);
     if (!(flags & SQLITE_SERIALIZE_NOCOPY)) {
         sqlite3_free((void *)data);
     }

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -2092,11 +2092,7 @@ serialize_impl(pysqlite_Connection *self, const char *name)
         return NULL;
     }
 #if PY_SSIZE_T_MAX < 9223372036854775807
-    if (size > INT_MAX) {
-        PyErr_Format(PyExc_OverflowError,
-                     "serialized '%s' too large to convert to bytes", name);
-        return NULL;
-    }
+    size = Py_MIN(size, INT_MAX);
 #endif
     PyObject *res = PyBytes_FromStringAndSize(data, (Py_ssize_t)size);
     if (!(flags & SQLITE_SERIALIZE_NOCOPY)) {

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -2091,9 +2091,6 @@ serialize_impl(pysqlite_Connection *self, const char *name)
                      name);
         return NULL;
     }
-#if PY_SSIZE_T_MAX < 9223372036854775807
-    size = Py_MIN(size, INT_MAX);
-#endif
     PyObject *res = PyBytes_FromStringAndSize(data, (Py_ssize_t)size);
     if (!(flags & SQLITE_SERIALIZE_NOCOPY)) {
         sqlite3_free((void *)data);

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -2091,6 +2091,13 @@ serialize_impl(pysqlite_Connection *self, const char *name)
                      name);
         return NULL;
     }
+#if PY_SSIZE_T_MAX < 9223372036854775807
+    if (size > PY_SSIZE_T_MAX) {
+        PyErr_Format(PyExc_OverflowError,
+                     "serialized '%s' too large to convert to bytes", name);
+        return NULL;
+    }
+#endif
     PyObject *res = PyBytes_FromStringAndSize(data, (Py_ssize_t)size);
     if (!(flags & SQLITE_SERIALIZE_NOCOPY)) {
         sqlite3_free((void *)data);


### PR DESCRIPTION
MSVC emits a `possible loss of data` warning when building 32bit version of `_sqlite3.Connection.serialize()`, whose data size ~is~ should be limited to `0x7fffffff` in `sqlite-3.38.4.0/sqlite3.c`, ~even on 64bit python~ (EDIT: Sorry, I missed the pages):
```
SQLITE_PRIVATE void *sqlite3Malloc(u64 n){
  void *p;
  if( n==0 || n>=0x7fffff00 ){
    /* A memory allocation of a number of bytes which is near the maximum
    ** signed integer value might cause an integer overflow inside of the
    ** xMalloc().  Hence we limit the maximum size to 0x7fffff00, giving
    ** 255 bytes of overhead.  SQLite itself will never use anything near
    ** this amount.  The only way to reach the limit is with sqlite3_malloc() */
    p = 0;
  }else if( sqlite3GlobalConfig.bMemstat ){
    ...
```
#92434