### PR TITLE
gh-90473: WASI: skip gethostname tests

### DIFF
--- a/Lib/test/support/socket_helper.py
+++ b/Lib/test/support/socket_helper.py
@@ -11,6 +11,9 @@ HOST = "localhost"
 HOSTv4 = "127.0.0.1"
 HOSTv6 = "::1"
 
+# WASI SDK 15.0 does not provide gethostname, stub raises OSError ENOTSUP.
+has_gethostname = not support.is_wasi
+
 
 def find_unused_port(family=socket.AF_INET, socktype=socket.SOCK_STREAM):
     """Returns an unused port that should be suitable for binding.  This is

--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -10,10 +10,15 @@ import io
 import tempfile
 from test import support
 from test.support import os_helper
+from test.support import socket_helper
 import unittest
 import textwrap
 import mailbox
 import glob
+
+
+if not socket_helper.has_gethostname:
+    raise unittest.SkipTest("test requires gethostname()")
 
 
 class TestBase:

--- a/Lib/test/test_mailcap.py
+++ b/Lib/test/test_mailcap.py
@@ -221,6 +221,10 @@ class FindmatchTest(unittest.TestCase):
 
     @unittest.skipUnless(os.name == "posix", "Requires 'test' command on system")
     @unittest.skipIf(sys.platform == "vxworks", "'test' command is not supported on VxWorks")
+    @unittest.skipUnless(
+        test.support.has_subprocess_support,
+        "'test' command needs process support."
+    )
     def test_test(self):
         # findmatch() will automatically check any "test" conditions and skip
         # the entry if the check fails.

--- a/Lib/test/test_smtpd.py
+++ b/Lib/test/test_smtpd.py
@@ -10,6 +10,9 @@ import io
 smtpd = warnings_helper.import_deprecated('smtpd')
 asyncore = warnings_helper.import_deprecated('asyncore')
 
+if not socket_helper.has_gethostname:
+    raise unittest.SkipTest("test requires gethostname()")
+
 
 class DummyServer(smtpd.SMTPServer):
     def __init__(self, *args, **kwargs):

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -664,6 +664,7 @@ class TestSupport(unittest.TestCase):
             self.assertTrue(support.match_test(test_chdir))
 
     @unittest.skipIf(support.is_emscripten, "Unstable in Emscripten")
+    @unittest.skipIf(support.is_wasi, "Unavailable on WASI")
     def test_fd_count(self):
         # We cannot test the absolute value of fd_count(): on old Linux
         # kernel or glibc versions, os.urandom() keeps a FD open on

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -489,6 +489,9 @@ class TimeTestCase(unittest.TestCase):
     def test_perf_counter(self):
         time.perf_counter()
 
+    @unittest.skipIf(
+        support.is_wasi, "process_time not available on WASI"
+    )
     def test_process_time(self):
         # process_time() should not include time spend during a sleep
         start = time.process_time()

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -10,6 +10,7 @@ import unittest
 from unittest.mock import patch
 from test import support
 from test.support import os_helper
+from test.support import socket_helper
 from test.support import warnings_helper
 import os
 try:
@@ -22,6 +23,10 @@ from nturl2path import url2pathname, pathname2url
 
 from base64 import b64encode
 import collections
+
+
+if not socket_helper.has_gethostname:
+    raise unittest.SkipTest("test requires gethostname()")
 
 
 def hexescape(char):

--- a/Lib/test/test_urllib_response.py
+++ b/Lib/test/test_urllib_response.py
@@ -4,6 +4,11 @@ import socket
 import tempfile
 import urllib.response
 import unittest
+from test import support
+
+if support.is_wasi:
+    raise unittest.SkipTest("Cannot create socket on WASI")
+
 
 class TestResponse(unittest.TestCase):
 

--- a/Tools/wasm/README.md
+++ b/Tools/wasm/README.md
@@ -239,6 +239,7 @@ are:
   yet. A future version of WASI may provide a limited ``set_permissions`` API.
 - File locking (``fcntl``) is not available.
 - ``os.pipe()``, ``os.mkfifo()``, and ``os.mknod()`` are not supported.
+- ``process_time`` clock does not work.
 
 
 # Detect WebAssembly builds


### PR DESCRIPTION
- WASI's ``gethostname()`` is a stub that always fails with OSError
  ``ENOTSUP``
- skip mailcap ``test`` if subprocess is not available
- WASI process_time clock does not work.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
