### PR TITLE
gh-93103: Parser uses PyConfig.parser_debug instead of Py_DebugFlag

### DIFF
--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -2,7 +2,7 @@
 #include "pegen.h"
 
 #if defined(Py_DEBUG) && defined(Py_BUILD_CORE)
-#  define D(x) if (Py_DebugFlag) x;
+#  define D(x) if (p->debug) { x; }
 #else
 #  define D(x)
 #endif

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -774,6 +774,9 @@ _PyPegen_Parser_New(struct tok_state *tok, int start_rule, int flags,
     p->known_err_token = NULL;
     p->level = 0;
     p->call_invalid_rules = 0;
+#ifdef Py_DEBUG
+    p->debug = _Py_GetConfig()->parser_debug;
+#endif
     return p;
 }
 

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -78,6 +78,7 @@ typedef struct {
     Token *known_err_token;
     int level;
     int call_invalid_rules;
+    int debug;
 } Parser;
 
 typedef struct {

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -88,6 +88,9 @@ tok_new(void)
     tok->async_def_nl = 0;
     tok->interactive_underflow = IUNDERFLOW_NORMAL;
     tok->str = NULL;
+#ifdef Py_DEBUG
+    tok->debug = _Py_GetConfig()->parser_debug;
+#endif
     return tok;
 }
 
@@ -1021,7 +1024,7 @@ tok_nextc(struct tok_state *tok)
             rc = tok_underflow_file(tok);
         }
 #if defined(Py_DEBUG)
-        if (Py_DebugFlag) {
+        if (tok->debug) {
             fprintf(stderr, "line[%d] = ", tok->lineno);
             print_escape(stderr, tok->cur, tok->inp - tok->cur);
             fprintf(stderr, "  tok->done = %d\n", tok->done);

--- a/Parser/tokenizer.h
+++ b/Parser/tokenizer.h
@@ -84,6 +84,9 @@ struct tok_state {
                              NEWLINE token after it. */
     /* How to proceed when asked for a new token in interactive mode */
     enum interactive_underflow_t interactive_underflow;
+#ifdef Py_DEBUG
+    int debug;
+#endif
 };
 
 extern struct tok_state *_PyTokenizer_FromString(const char *, int);

--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -53,7 +53,7 @@ Py_FrozenMain(int argc, char **argv)
     PyWinFreeze_ExeInit();
 #endif
 
-    if (Py_VerboseFlag) {
+    if (_Py_GetConfig()->verbose) {
         fprintf(stderr, "Python %s\n%s\n",
                 Py_GetVersion(), Py_GetCopyright());
     }

--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -32,7 +32,7 @@ EXTENSION_PREFIX = """\
 #include "pegen.h"
 
 #if defined(Py_DEBUG) && defined(Py_BUILD_CORE)
-#  define D(x) if (Py_DebugFlag) x;
+#  define D(x) if (p->debug) { x; }
 #else
 #  define D(x)
 #endif


### PR DESCRIPTION
Replace deprecated Py_DebugFlag with PyConfig.parser_debug in the
parser.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
