### PR TITLE
GH-93112: Fix missing ResourceDenied import in test_urllib2net

### DIFF
--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -3,6 +3,7 @@ import unittest
 from test import support
 from test.support import os_helper
 from test.support import socket_helper
+from test.support import ResourceDenied
 from test.test_urllib2 import sanepathname2url
 
 import os


### PR DESCRIPTION
The code was moved out of test.support in
311110abcd8ab648dbf1803e36a8ba5d93fa019b (GH-20812), thus making
ResourceDenied undefined.

Closes #93112.