### PR TITLE
test_threaded_import: Fix unittest.main spelling

### DIFF
--- a/Lib/test/test_importlib/test_threaded_import.py
+++ b/Lib/test/test_importlib/test_threaded_import.py
@@ -272,4 +272,4 @@ def setUpModule():
 
 
 if __name__ == "__main__":
-    unittets.main()
+    unittest.main()


### PR DESCRIPTION
Regressed in 40348acc180 (GH-28405, v3.11.0a1) - cc @serhiy-storchaka.

(Also regressed in `Lib/test/test_importlib/test_locks.py`, but there it was already fixed in 2b16a08bc77475917dd5c96417aef4c5210b45ac by @tiran)

I believe  this is  simple enough to not need an issue/news-entry, but let me know if you disagree!

(Found by running `flake8` over `Lib/` out of curiosity, see https://github.com/python/cpython/issues/93010#issuecomment-1133402591)
