### PR TITLE
test_concurrent_futures: Remove unneeded/confusing format call

### DIFF
--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -484,7 +484,7 @@ class ThreadPoolShutdownTest(ThreadPoolMixin, ExecutorShutdownTest, BaseTestCase
                 t = ThreadPoolExecutor()
                 t.submit(sleep_and_print, .1, "apple")
                 t.shutdown(wait=False, cancel_futures=True)
-            """.format(executor_type=self.executor_type.__name__))
+            """)
         # Errors in atexit hooks don't change the process exit code, check
         # stderr manually.
         self.assertFalse(err)


### PR DESCRIPTION
Added in 339fd46cb764277cbbdc3e78dcc5b45b156bb6ae (GH-18057) by @aeros - but as noted in a comment, the test only tests ThreadPoolExecutor. Thus, I'm assuming that was a copy-paste mistake.

I believe this is simple enough to not need an issue/news entry.

(Found by running `flake8` over `Lib/` out of curiosity, see https://github.com/python/cpython/issues/93010#issuecomment-1133402591)