### PR TITLE
gh-92888: memory_ass_sub() calls CHECK_RELEASED_INT() twice

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-23-17-53-54.gh-issue-92888.aLR9yl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-23-17-53-54.gh-issue-92888.aLR9yl.rst
@@ -1,0 +1,3 @@
+If a memoryview is released while setting an item, raise an exception. For
+example, converting an object to an index in C can execute arbitrary Python
+code which can indirectly release the memoryview. Patch by Victor Stinner.


### PR DESCRIPTION
If a memoryview is released while setting an item, raise an
exception. For example, converting an object to an index in C can
execute arbitrary Python code which can indirectly release the
memoryview.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
