### PR TITLE
[3.10] gh-93108: Bump sphinx to fix rendering issue.

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -3,7 +3,7 @@
 # Sphinx version is pinned so that new versions that introduce new warnings
 # won't suddenly cause build failures. Updating the version is fine as long
 # as no warnings are raised by doing so.
-sphinx==3.2.1
+sphinx==3.4.3
 # Docutils version is pinned to a version compatible with Sphinx
 # version 3.2.1. It can be removed after bumping Sphinx version to at
 # least 3.5.4.

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -5,10 +5,10 @@
 # as no warnings are raised by doing so.
 sphinx==3.4.3
 # Docutils version is pinned to a version compatible with Sphinx
-# version 3.2.1. It can be removed after bumping Sphinx version to at
+# version <3.5.4. It can be removed after bumping Sphinx version to at
 # least 3.5.4.
 docutils==0.17.1
-# Jinja version is pinned to a version compatible with Sphinx version 3.2.1.
+# Jinja version is pinned to a version compatible with Sphinx version <4.5.
 jinja2==3.0.3
 
 blurb


### PR DESCRIPTION
Bug was visible on [SysLogHandler](https://docs.python.org/3.10/library/logging.handlers.html#sysloghandler) in Python 3.10 only (3.9 uses an older Sphinx version without the issue, 3.11 uses a newer Sphinx version without the issue).

bad: `SysLogHandler(address='localhost', SYSLOG_UDP_PORT, ...`
good: `SysLogHandler(address=('localhost', SYSLOG_UDP_PORT), ...`

So this commit only lives on 3.10, hope that's ok! @pablogsal what do you think?

