### PR TITLE
gh-92886: fixed tests that were breaking while running with basic optimizations enabled (-O, assertions off)

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5690,21 +5690,22 @@ class TestSyncManagerTypes(unittest.TestCase):
 
     @classmethod
     def _test_list(cls, obj):
-        assert obj[0] == 5
-        assert obj.count(5) == 1
-        assert obj.index(5) == 0
+        case = unittest.TestCase()
+        case.assertEqual(obj[0], 5)
+        case.assertEqual(obj.count(5), 1)
+        case.assertEqual(obj.index(5), 0)
         obj.sort()
         obj.reverse()
         for x in obj:
             pass
-        assert len(obj) == 1
-        assert obj.pop(0) == 5
+        case.assertEqual(len(obj), 1)
+        case.assertEqual(obj.pop(0), 5)
 
     def test_list(self):
         o = self.manager.list()
         o.append(5)
         self.run_worker(self._test_list, o)
-        assert not o
+        self.assertIsNotNone(o)
         self.assertEqual(len(o), 0)
 
     @classmethod

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5710,26 +5710,28 @@ class TestSyncManagerTypes(unittest.TestCase):
 
     @classmethod
     def _test_dict(cls, obj):
-        assert len(obj) == 1
-        assert obj['foo'] == 5
-        assert obj.get('foo') == 5
-        assert list(obj.items()) == [('foo', 5)]
-        assert list(obj.keys()) == ['foo']
-        assert list(obj.values()) == [5]
-        assert obj.copy() == {'foo': 5}
-        assert obj.popitem() == ('foo', 5)
+        case = unittest.TestCase()
+        case.assertEqual(len(obj), 1)
+        case.assertEqual(obj['foo'], 5)
+        case.assertEqual(obj.get('foo'), 5)
+        case.assertListEqual(list(obj.items()), [('foo', 5)])
+        case.assertListEqual(list(obj.keys()), ['foo'])
+        case.assertListEqual(list(obj.values()), [5])
+        case.assertDictEqual(obj.copy(), {'foo': 5})
+        case.assertTupleEqual(obj.popitem(), ('foo', 5))
 
     def test_dict(self):
         o = self.manager.dict()
         o['foo'] = 5
         self.run_worker(self._test_dict, o)
-        assert not o
+        self.assertIsNotNone(o)
         self.assertEqual(len(o), 0)
 
     @classmethod
     def _test_value(cls, obj):
-        assert obj.value == 1
-        assert obj.get() == 1
+        case = unittest.TestCase()
+        case.assertEqual(obj.value, 1)
+        case.assertEqual(obj.get(), 1)
         obj.set(2)
 
     def test_value(self):
@@ -5740,10 +5742,11 @@ class TestSyncManagerTypes(unittest.TestCase):
 
     @classmethod
     def _test_array(cls, obj):
-        assert obj[0] == 0
-        assert obj[1] == 1
-        assert len(obj) == 2
-        assert list(obj) == [0, 1]
+        case = unittest.TestCase()
+        case.assertEqual(obj[0], 0)
+        case.assertEqual(obj[1], 1)
+        case.assertEqual(len(obj), 2)
+        case.assertListEqual(list(obj), [0, 1])
 
     def test_array(self):
         o = self.manager.Array('i', [0, 1])
@@ -5751,8 +5754,9 @@ class TestSyncManagerTypes(unittest.TestCase):
 
     @classmethod
     def _test_namespace(cls, obj):
-        assert obj.x == 0
-        assert obj.y == 1
+        case = unittest.TestCase()
+        case.assertEqual(obj.x, 0)
+        case.assertEqual(obj.y, 1)
 
     def test_namespace(self):
         o = self.manager.Namespace()

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -1279,7 +1279,8 @@ class CoroutineTest(unittest.TestCase):
 
         async def func():
             async with CM():
-                assert (1, ) == 1
+                if (1, ) != 1:
+                    raise AssertionError
 
         with self.assertRaises(AssertionError):
             run_async(func())

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -1279,8 +1279,7 @@ class CoroutineTest(unittest.TestCase):
 
         async def func():
             async with CM():
-                if (1, ) != 1:
-                    raise AssertionError
+                self.assertEqual((1, ), 1)
 
         with self.assertRaises(AssertionError):
             run_async(func())

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1041,11 +1041,6 @@ class DisWithFileTests(DisTests):
         return output.getvalue()
 
 
-if sys.flags.optimize:
-    code_info_consts = "0: None"
-else:
-    code_info_consts = "0: 'Formatted details of methods, functions, or code.'"
-
 code_info_code_info = f"""\
 Name:              code_info
 Filename:          (.*)
@@ -1056,7 +1051,7 @@ Number of locals:  1
 Stack size:        \\d+
 Flags:             OPTIMIZED, NEWLOCALS
 Constants:
-   {code_info_consts}
+   0: 'Formatted details of methods, functions, or code.'
 Names:
    0: _format_code_info
    1: _get_code_object

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -939,6 +939,7 @@ class ThreadedNetworkedTests(unittest.TestCase):
 
     @threading_helper.reap_threads
     @cpython_only
+    @unittest.skipUnless(__debug__, "Won't work if __debug__ is False")
     def test_dump_ur(self):
         # See: http://bugs.python.org/issue26543
         untagged_resp_dict = {'READ-WRITE': [b'']}

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -235,12 +235,12 @@ class PyCompileCLITestCase(unittest.TestCase):
         # assert_python_* helpers don't return proc object. We'll just use
         # subprocess.run() instead of spawn_python() and its friends to test
         # stdin support of the CLI.
+        opts = '-m' if __debug__ else '-Om'
         if args and args[0] == '-' and 'input' in kwargs:
-            opts = '-m' if __debug__ else '-Om'
             return subprocess.run([sys.executable, opts, 'py_compile', '-'],
                                   input=kwargs['input'].encode(),
                                   capture_output=True)
-        return script_helper.assert_python_ok('-m', 'py_compile', *args, **kwargs)
+        return script_helper.assert_python_ok(opts, 'py_compile', *args, **kwargs)
 
     def pycompilecmd_failure(self, *args):
         return script_helper.assert_python_failure('-m', 'py_compile', *args)

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -236,7 +236,8 @@ class PyCompileCLITestCase(unittest.TestCase):
         # subprocess.run() instead of spawn_python() and its friends to test
         # stdin support of the CLI.
         if args and args[0] == '-' and 'input' in kwargs:
-            return subprocess.run([sys.executable, '-m', 'py_compile', '-'],
+            opts = '-m' if __debug__ else '-Om'
+            return subprocess.run([sys.executable, opts, 'py_compile', '-'],
                                   input=kwargs['input'].encode(),
                                   capture_output=True)
         return script_helper.assert_python_ok('-m', 'py_compile', *args, **kwargs)

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -833,9 +833,8 @@ class TraceTestCase(unittest.TestCase):
              (5, 'line'),
              (6, 'line'),
              (7, 'line'),
-             (10, 'line'),
-             (13, 'line'),
-             (13, 'return')])
+             (10, 'line')] +
+             ([(13, 'line'), (13, 'return')] if __debug__ else [(10, 'return')]))
 
     def test_continue_through_finally(self):
 
@@ -870,9 +869,8 @@ class TraceTestCase(unittest.TestCase):
              (6, 'line'),
              (7, 'line'),
              (10, 'line'),
-             (3, 'line'),
-             (13, 'line'),
-             (13, 'return')])
+             (3, 'line')] +
+             ([(13, 'line'), (13, 'return')] if __debug__ else [(3, 'return')]))
 
     def test_return_through_finally(self):
 

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -654,7 +654,8 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         sys.path.insert(0, TEMP_ZIP)
         mod = importlib.import_module(TESTMOD)
         self.assertEqual(mod.test(1), 1)
-        self.assertRaises(AssertionError, mod.test, False)
+        if __debug__:
+            self.assertRaises(AssertionError, mod.test, False)
 
     def testImport_WithStuff(self):
         # try importing from a zipfile which contains additional

--- a/Lib/wsgiref/handlers.py
+++ b/Lib/wsgiref/handlers.py
@@ -237,9 +237,12 @@ class BaseHandler:
         self.status = status
         self.headers = self.headers_class(headers)
         status = self._convert_string_type(status, "Status")
-        assert len(status)>=4,"Status must be at least 4 characters"
-        assert status[:3].isdigit(), "Status message must begin w/3-digit code"
-        assert status[3]==" ", "Status message must have a space after code"
+        if not len(status) >= 4:
+            raise AssertionError("Status must be at least 4 characters")
+        if not status[:3].isdigit():
+            raise AssertionError("Status message must begin w/3-digit code")
+        if status[3] != " ":
+            raise AssertionError("Status message must have a space after code")
 
         if __debug__:
             for name, val in headers:

--- a/Lib/wsgiref/handlers.py
+++ b/Lib/wsgiref/handlers.py
@@ -237,7 +237,7 @@ class BaseHandler:
         self.status = status
         self.headers = self.headers_class(headers)
         status = self._convert_string_type(status, "Status")
-        if not len(status) >= 4:
+        if len(status) < 4:
             raise AssertionError("Status must be at least 4 characters")
         if not status[:3].isdigit():
             raise AssertionError("Status message must begin w/3-digit code")

--- a/Misc/NEWS.d/next/Tests/2022-05-24-14-24-39.gh-issue-92886.8FvvAB.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-24-14-24-39.gh-issue-92886.8FvvAB.rst
@@ -1,0 +1,1 @@
+Fixed tests that were breaking while running with basic optimizations enabled (-O, assertions off).

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -495,8 +495,8 @@ def permute_optional_groups(left, required, right):
     required = tuple(required)
     result = []
 
-    if not required:
-        assert not left
+    if not required and left:
+        raise AssertionError('If required is empty, left must also be empty.')
 
     accumulator = []
     counts = set()


### PR DESCRIPTION
Resolves #92886 

```
$ uname -a
Darwin ... 21.4.0 Darwin Kernel Version 21.4.0: Fri Mar 18 00:47:26 PDT 2022; root:xnu-8020.101.4~15/RELEASE_ARM64_T8101 arm64

$ ./python.exe -Om test -j8
...
== Tests result: SUCCESS ==

407 tests OK.

29 tests skipped:
    test_curses test_dbm_gnu test_devpoll test_epoll test_gdb
    test_idle test_ioctl test_launcher test_msilib
    test_multiprocessing_fork test_ossaudiodev test_smtpnet
    test_socketserver test_spwd test_ssl test_startfile test_tcl
    test_tix test_tk test_ttk_guionly test_ttk_textonly test_turtle
    test_urllib2net test_urllibnet test_winconsoleio test_winreg
    test_winsound test_xmlrpc_net test_zipfile64

Total duration: 3 min 49 sec
Tests result: SUCCESS
```