### PR TITLE
gh-82616: Add Py_IS_TYPE_SIGNED() macro

### DIFF
--- a/Include/internal/pycore_pymath.h
+++ b/Include/internal/pycore_pymath.h
@@ -56,17 +56,13 @@ static inline void _Py_ADJUST_ERANGE2(double x, double y)
     }
 }
 
-// Return whether integral type *type* is signed or not.
-#define _Py_IntegralTypeSigned(type) \
-    ((type)(-1) < 0)
-
 // Return the maximum value of integral type *type*.
 #define _Py_IntegralTypeMax(type) \
-    ((_Py_IntegralTypeSigned(type)) ? (((((type)1 << (sizeof(type)*CHAR_BIT - 2)) - 1) << 1) + 1) : ~(type)0)
+    (_Py_IS_TYPE_SIGNED(type) ? (((((type)1 << (sizeof(type)*CHAR_BIT - 2)) - 1) << 1) + 1) : ~(type)0)
 
 // Return the minimum value of integral type *type*.
 #define _Py_IntegralTypeMin(type) \
-    ((_Py_IntegralTypeSigned(type)) ? -_Py_IntegralTypeMax(type) - 1 : 0)
+    (_Py_IS_TYPE_SIGNED(type) ? -_Py_IntegralTypeMax(type) - 1 : 0)
 
 // Check whether *v* is in the range of integral type *type*. This is most
 // useful if *v* is floating-point, since demoting a floating-point *v* to an

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -150,4 +150,7 @@
 // For example, "int x; _Py_RVALUE(x) = 1;" fails with a compiler error.
 #define _Py_RVALUE(EXPR) ((void)0, (EXPR))
 
+// Return non-zero if the type is signed, return zero if it's unsigned.
+#define _Py_IS_TYPE_SIGNED(type) ((type)(-1) < 0)
+
 #endif /* Py_PYMACRO_H */

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -151,6 +151,8 @@
 #define _Py_RVALUE(EXPR) ((void)0, (EXPR))
 
 // Return non-zero if the type is signed, return zero if it's unsigned.
-#define _Py_IS_TYPE_SIGNED(type) ((type)(-1) < 0)
+// Use "<= 0" rather than "< 0" to prevent the compiler warning:
+// "comparison of unsigned expression in '< 0' is always false".
+#define _Py_IS_TYPE_SIGNED(type) ((type)(-1) <= 0)
 
 #endif /* Py_PYMACRO_H */

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -612,8 +612,10 @@ child_exec(char *const exec_array[],
 #endif
 
 #ifdef HAVE_SETPGID
-    if (pgid_to_set >= 0)
+    static_assert(_Py_IS_TYPE_SIGNED(pid_t), "pid_t is unsigned");
+    if (pgid_to_set >= 0) {
         POSIX_CALL(setpgid(0, pgid_to_set));
+    }
 #endif
 
 #ifdef HAVE_SETGROUPS

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -5832,6 +5832,20 @@ settrace_to_record(PyObject *self, PyObject *list)
     Py_RETURN_NONE;
 }
 
+static PyObject *
+test_macros(PyObject *self, PyObject *Py_UNUSED(args))
+{
+    // Py_MIN(), Py_MAX()
+    assert(Py_MIN(5, 11) == 5);
+    assert(Py_MAX(5, 11) == 11);
+
+    // _Py_IS_TYPE_SIGNED()
+    assert(_Py_IS_TYPE_SIGNED(int));
+    assert(!_Py_IS_TYPE_SIGNED(unsigned int));
+
+    Py_RETURN_NONE;
+}
+
 static PyObject *negative_dictoffset(PyObject *, PyObject *);
 static PyObject *test_buildvalue_issue38913(PyObject *, PyObject *);
 static PyObject *getargs_s_hash_int(PyObject *, PyObject *, PyObject*);
@@ -6122,6 +6136,7 @@ static PyMethodDef TestMethods[] = {
     {"get_feature_macros", get_feature_macros, METH_NOARGS, NULL},
     {"test_code_api", test_code_api, METH_NOARGS, NULL},
     {"settrace_to_record", settrace_to_record, METH_O, NULL},
+    {"test_macros", test_macros, METH_NOARGS, NULL},
     {NULL, NULL} /* sentinel */
 };
 


### PR DESCRIPTION
_posixsubprocess: add a static assertion to ensure that the pid_t
type is signed.

Replace _Py_IntegralTypeSigned() with Py_IS_TYPE_SIGNED().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
