### PR TITLE
gh-93103: Py_DecodeLocale() uses _PyRuntime.preconfig

### DIFF
--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -603,9 +603,9 @@ _Py_DecodeLocaleEx(const char* arg, wchar_t **wstr, size_t *wlen,
     return _Py_DecodeUTF8Ex(arg, strlen(arg), wstr, wlen, reason,
                             errors);
 #else
-    int use_utf8 = (Py_UTF8Mode == 1);
+    int use_utf8 = (_PyRuntime.preconfig.utf8_mode >= 1);
 #ifdef MS_WINDOWS
-    use_utf8 |= !Py_LegacyWindowsFSEncodingFlag;
+    use_utf8 |= (_PyRuntime.preconfig.legacy_windows_fs_encoding == 0);
 #endif
     if (use_utf8) {
         return _Py_DecodeUTF8Ex(arg, strlen(arg), wstr, wlen, reason,
@@ -795,9 +795,9 @@ encode_locale_ex(const wchar_t *text, char **str, size_t *error_pos,
     return _Py_EncodeUTF8Ex(text, str, error_pos, reason,
                             raw_malloc, errors);
 #else
-    int use_utf8 = (Py_UTF8Mode == 1);
+    int use_utf8 = (_PyRuntime.preconfig.utf8_mode >= 1);
 #ifdef MS_WINDOWS
-    use_utf8 |= !Py_LegacyWindowsFSEncodingFlag;
+    use_utf8 |= (_PyRuntime.preconfig.legacy_windows_fs_encoding == 0);
 #endif
     if (use_utf8) {
         return _Py_EncodeUTF8Ex(text, str, error_pos, reason,

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -826,12 +826,10 @@ _PyPreConfig_Read(PyPreConfig *config, const _PyArgv *args)
         _Py_SetLocaleFromEnv(LC_CTYPE);
     }
 
-    _PyPreCmdline cmdline = _PyPreCmdline_INIT;
-    int init_utf8_mode = Py_UTF8Mode;
-#ifdef MS_WINDOWS
-    int init_legacy_encoding = Py_LegacyWindowsFSEncodingFlag;
-#endif
+    PyPreConfig save_runtime_config;
+    preconfig_copy(&save_runtime_config, &_PyRuntime.preconfig);
 
+    _PyPreCmdline cmdline = _PyPreCmdline_INIT;
     int locale_coerced = 0;
     int loops = 0;
 
@@ -847,11 +845,9 @@ _PyPreConfig_Read(PyPreConfig *config, const _PyArgv *args)
         }
 
         /* bpo-34207: Py_DecodeLocale() and Py_EncodeLocale() depend
-           on Py_UTF8Mode and Py_LegacyWindowsFSEncodingFlag. */
-        Py_UTF8Mode = config->utf8_mode;
-#ifdef MS_WINDOWS
-        Py_LegacyWindowsFSEncodingFlag = config->legacy_windows_fs_encoding;
-#endif
+           on the utf8_mode and legacy_windows_fs_encoding members
+           of _PyRuntime.preconfig. */
+        preconfig_copy(&_PyRuntime.preconfig, config);
 
         if (args) {
             // Set command line arguments at each iteration. If they are bytes
@@ -914,14 +910,10 @@ _PyPreConfig_Read(PyPreConfig *config, const _PyArgv *args)
     status = _PyStatus_OK();
 
 done:
-    if (init_ctype_locale != NULL) {
-        setlocale(LC_CTYPE, init_ctype_locale);
-        PyMem_RawFree(init_ctype_locale);
-    }
-    Py_UTF8Mode = init_utf8_mode ;
-#ifdef MS_WINDOWS
-    Py_LegacyWindowsFSEncodingFlag = init_legacy_encoding;
-#endif
+    // Revert side effects
+    setlocale(LC_CTYPE, init_ctype_locale);
+    PyMem_RawFree(init_ctype_locale);
+    preconfig_copy(&_PyRuntime.preconfig, &save_runtime_config);
     _PyPreCmdline_Clear(&cmdline);
     return status;
 }


### PR DESCRIPTION
The Py_DecodeLocale() and Py_EncodeLocale() now use
_PyRuntime.preconfig, rather than Py_UTF8Mode and
Py_LegacyWindowsFSEncodingFlag global configuration varibles, to
decide if the UTF-8 encoding is used or not.

As documented, these functions must not be called before Python is
preinitialized. The new PyConfig API should now be used, rather than
using deprecated functions like Py_SetPath() or PySys_SetArgv().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
