### PR TITLE
Comment nit: fix comment reference in pycore_interp.h

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -76,7 +76,7 @@ struct atexit_state {
 /* PyInterpreterState holds the global state for one of the runtime's
    interpreters.  Typically the initial (main) interpreter is the only one.
 
-   The PyInterpreterState typedef is in Include/pystate.h.
+   The PyInterpreterState typedef is in Include/pytypedefs.h.
    */
 struct _is {
 


### PR DESCRIPTION
GH-31527 moved this typedef to `Include/pytypedefs.h`, so this comment should point at the correct location