### PR TITLE
gh-90817: Deprecate explicitly locale.resetlocale()

### DIFF
--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -375,6 +375,8 @@ The :mod:`locale` module defines the following exception and functions:
    The default setting is determined by calling :func:`getdefaultlocale`.
    *category* defaults to :const:`LC_ALL`.
 
+   .. deprecated:: 3.11 3.13
+
 
 .. function:: strcoll(string1, string2)
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1221,7 +1221,11 @@ Deprecated
   removed in Python 3.13. Use :func:`locale.setlocale`,
   :func:`locale.getpreferredencoding(False) <locale.getpreferredencoding>` and
   :func:`locale.getlocale` functions instead.
-  (Contributed by Victor Stinner in :issue:`46659`.)
+  (Contributed by Victor Stinner in :gh:`90817`.)
+
+* The :func:`locale.resetlocale` function is deprecated and will be
+  removed in Python 3.13. Use ``locale.setlocale(locale.LC_ALL, "")`` instead.
+  (Contributed by Victor Stinner in :gh:`90817`.)
 
 * The :mod:`asynchat`, :mod:`asyncore` and  :mod:`smtpd` modules have been
   deprecated since at least Python 3.6. Their documentation and deprecation

--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -633,7 +633,17 @@ def resetlocale(category=LC_ALL):
         getdefaultlocale(). category defaults to LC_ALL.
 
     """
-    _setlocale(category, _build_localename(getdefaultlocale()))
+    import warnings
+    warnings.warn(
+        'Use locale.setlocale(locale.LC_ALL, "") instead',
+        DeprecationWarning, stacklevel=2
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=DeprecationWarning)
+        loc = getdefaultlocale()
+
+    _setlocale(category, _build_localename(loc))
 
 
 try:

--- a/Misc/NEWS.d/next/Library/2022-05-25-02-45-41.gh-issue-90817.yxANgU.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-25-02-45-41.gh-issue-90817.yxANgU.rst
@@ -1,0 +1,3 @@
+The :func:`locale.resetlocale` function is deprecated and will be removed in
+Python 3.13. Use ``locale.setlocale(locale.LC_ALL, "")`` instead. Patch by
+Victor Stinner.


### PR DESCRIPTION
The function was already deprecated in Python 3.11 since it calls
locale.getdefaultlocale() which was deprecated in Python 3.11.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
