### PR TITLE
gh-90155: Fix broken `asyncio.Semaphore` and strengthen FIFO guarantee.

### DIFF
--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -367,7 +367,7 @@ class Semaphore(_ContextManagerMixin, mixins._LoopBoundMixin):
 
     def locked(self):
         """Returns True if semaphore can not be acquired immediately."""
-        return self._value == 0
+        return self._value <= 0 or self._wakeup_scheduled
 
     async def acquire(self):
         """Acquire a semaphore.

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -357,8 +357,8 @@ class Semaphore(_ContextManagerMixin, mixins._LoopBoundMixin):
         return f'<{res[1:-1]} [{extra}]>'
 
     def locked(self):
-        """Returns True if semaphore can not be acquired immediately."""
-        return self._value <= 0
+        """Returns True if semaphore counter is zero."""
+        return self._value == 0
 
     async def acquire(self):
         """Acquire a semaphore.

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -367,7 +367,7 @@ class Semaphore(_ContextManagerMixin, mixins._LoopBoundMixin):
 
     def locked(self):
         """Returns True if semaphore can not be acquired immediately."""
-        return self._value <= 0 or self._wakeup_scheduled
+        return self._value <= 0 or bool(self._wakeup_scheduled)
 
     async def acquire(self):
         """Acquire a semaphore.
@@ -378,9 +378,9 @@ class Semaphore(_ContextManagerMixin, mixins._LoopBoundMixin):
         called release() to make it larger than 0, and then return
         True.
         """
-        freshman = True
-        while self._value <= 0 or (freshman and self._wakeup_scheduled):
-            freshman = False
+        first = True
+        while self._value <= 0 or (first and self._wakeup_scheduled):
+            first = False
             fut = self._get_loop().create_future()
             self._waiters.append(fut)
             try:

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -362,6 +362,7 @@ class Semaphore(_ContextManagerMixin, mixins._LoopBoundMixin):
 
     async def acquire(self):
         """Acquire a semaphore.
+
         If the internal counter is larger than zero on entry,
         decrement it by one and return True immediately.  If it is
         zero on entry, block, waiting until some other coroutine has
@@ -398,6 +399,7 @@ class Semaphore(_ContextManagerMixin, mixins._LoopBoundMixin):
 
     def release(self):
         """Release a semaphore, incrementing the internal counter by one.
+
         When it was zero on entry and another coroutine is waiting for it to
         become larger than zero again, wake up that coroutine.
         """

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -922,7 +922,7 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
 
         async def c2():
             async with sem:
-                await asyncio.sleep(0)
+                self.assertFalse(True)
 
         t1 = asyncio.create_task(c1())
         t2 = asyncio.create_task(c2())

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -934,7 +934,7 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(r1 is None)
         self.assertTrue(isinstance(r2, asyncio.CancelledError))
 
-        await asyncio.wait_for(sem.acquire(), timeout=0.01)
+        await asyncio.wait_for(sem.acquire(), timeout=1.0)
 
     def test_release_not_acquired(self):
         sem = asyncio.BoundedSemaphore()

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -846,7 +846,8 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
         sem.release()
         self.assertEqual(2, sem._value)
 
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
         self.assertEqual(0, sem._value)
         self.assertEqual(3, len(result))
         self.assertTrue(sem.locked())

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -883,13 +883,14 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
         t3 = asyncio.create_task(sem.acquire())
         t4 = asyncio.create_task(sem.acquire())
 
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0)
 
         t1.cancel()
         t2.cancel()
         sem.release()
 
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
         num_done = sum(t.done() for t in [t3, t4])
         self.assertEqual(num_done, 1)
         self.assertTrue(t3.done())
@@ -908,7 +909,8 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
 
         t1.cancel()
         sem.release()
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
         self.assertTrue(sem.locked())
         self.assertTrue(t2.done())
 
@@ -1034,7 +1036,7 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
 
         t1.cancel()
 
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0)
 
         sem.release()
         sem.release()

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -834,7 +834,7 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
         t2 = asyncio.create_task(c2(result))
         t3 = asyncio.create_task(c3(result))
 
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0)
         self.assertEqual([1], result)
         self.assertTrue(sem.locked())
         self.assertEqual(2, len(sem._waiters))

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -830,7 +830,7 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
         t2 = asyncio.create_task(c2(result))
         t3 = asyncio.create_task(c3(result))
 
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
         self.assertEqual([1], result)
         self.assertTrue(sem.locked())
         self.assertEqual(2, len(sem._waiters))
@@ -842,7 +842,7 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
         sem.release()
         self.assertEqual(2, sem._value)
 
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
         self.assertEqual(0, sem._value)
         self.assertEqual(3, len(result))
         self.assertTrue(sem.locked())
@@ -878,13 +878,13 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
         t3 = asyncio.create_task(sem.acquire())
         t4 = asyncio.create_task(sem.acquire())
 
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
 
         t1.cancel()
         t2.cancel()
         sem.release()
 
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
         num_done = sum(t.done() for t in [t3, t4])
         self.assertEqual(num_done, 1)
         self.assertTrue(t3.done())
@@ -903,7 +903,7 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
 
         t1.cancel()
         sem.release()
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
         self.assertTrue(sem.locked())
         self.assertTrue(t2.done())
 

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -5,6 +5,7 @@ from unittest import mock
 import re
 
 import asyncio
+import collections
 
 STR_RGX_REPR = (
     r'^<(?P<class>.*?) object at (?P<address>.*?)'
@@ -773,6 +774,9 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(repr(sem).endswith('[locked]>'))
         self.assertTrue('waiters' not in repr(sem))
         self.assertTrue(RGX_REPR.match(repr(sem)))
+
+        if sem._waiters is None:
+            sem._waiters = collections.deque()
 
         sem._waiters.append(mock.Mock())
         self.assertTrue('waiters:1' in repr(sem))

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -927,9 +927,9 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
         t1 = asyncio.create_task(c1())
         t2 = asyncio.create_task(c2())
 
-        result = await asyncio.gather(t1, t2, return_exceptions=True)
-        self.assertTrue(result[0] is None)
-        self.assertTrue(isinstance(result[1], asyncio.CancelledError))
+        r1, r2 = await asyncio.gather(t1, t2, return_exceptions=True)
+        self.assertTrue(r1 is None)
+        self.assertTrue(isinstance(r2, asyncio.CancelledError))
 
         await asyncio.wait_for(sem.acquire(), timeout=0.01)
 

--- a/Misc/NEWS.d/next/Library/2022-05-25-15-57-39.gh-issue-90155.YMstB5.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-25-15-57-39.gh-issue-90155.YMstB5.rst
@@ -1,1 +1,1 @@
-Fix broken :class:`asyncio.Semaphore` and strengthen FIFO guarantee.
+Fix broken :class:`asyncio.Semaphore` when acquire is cancelled.

--- a/Misc/NEWS.d/next/Library/2022-05-25-15-57-39.gh-issue-90155.YMstB5.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-25-15-57-39.gh-issue-90155.YMstB5.rst
@@ -1,0 +1,1 @@
+Fix broken :class:`asyncio.Semaphore` and strengthen FIFO guarantee.


### PR DESCRIPTION
# gh-90155: Fix broken :class:`asyncio.Semaphore` and strengthen FIFO guarantee.

Current `asyncio.Semaphore` may become broken on certain workflow. Tasks waiting on a broken `Semaphore` can hang forever. This PR not only fixes this problem but also strengthens the FIFO guarantee on `Semaphore` waiters. Test cases show details.