### PR TITLE
gh-92886: Remove `assert` in clinic.permute_optional_groups so that it works when running with optimizations

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-05-25-21-23-37.gh-issue-92886.i5gbQo.rst
+++ b/Misc/NEWS.d/next/Build/2022-05-25-21-23-37.gh-issue-92886.i5gbQo.rst
@@ -1,0 +1,1 @@
+Remove assert in :func:`clinic.permute_optional_groups` so that it works as intended, and tests pass, when running with optimizations (``-O``).

--- a/Misc/NEWS.d/next/Build/2022-05-25-22-09-19.gh-issue-92886.i5gbQo.rst
+++ b/Misc/NEWS.d/next/Build/2022-05-25-22-09-19.gh-issue-92886.i5gbQo.rst
@@ -1,0 +1,1 @@
+Remove assert in :func:`clinic.permute_optional_groups` so that it works as intended, and tests pass, when running with optimizations (``-O``).

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -495,8 +495,8 @@ def permute_optional_groups(left, required, right):
     required = tuple(required)
     result = []
 
-    if not required:
-        assert not left
+    if not required and left:
+        raise AssertionError('If required is empty, left must also be empty.')
 
     accumulator = []
     counts = set()


### PR DESCRIPTION
Replacing assert statement with `raise AssertionError()`. This also fixes a test in test_clinic.py which fails when ran with `-O`.

#92886

Before:

```sh
$ ./python.exe -Om unittest test.test_clinic
.....F.................................................
======================================================================
FAIL: test_have_left_options_but_required_is_empty (test.test_clinic.ClinicGroupPermuterTest.test_have_left_options_but_required_is_empty)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/.../dev/cpython/Lib/test/test_clinic.py", line 156, in test_have_left_options_but_required_is_empty
    self.assertRaises(AssertionError, fn)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: AssertionError not raised by fn

----------------------------------------------------------------------
Ran 55 tests in 0.098s

FAILED (failures=1)
```

After:

```sh
./python.exe -Om unittest test.test_clinic
.......................................................
----------------------------------------------------------------------
Ran 55 tests in 0.098s

OK
```