### PR TITLE
gh-92886: Fix tests that fail when running with optimizations (`-O`) in `test_py_compile.py`

### DIFF
--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -235,11 +235,12 @@ class PyCompileCLITestCase(unittest.TestCase):
         # assert_python_* helpers don't return proc object. We'll just use
         # subprocess.run() instead of spawn_python() and its friends to test
         # stdin support of the CLI.
+        opts = '-m' if __debug__ else '-Om'
         if args and args[0] == '-' and 'input' in kwargs:
-            return subprocess.run([sys.executable, '-m', 'py_compile', '-'],
+            return subprocess.run([sys.executable, opts, 'py_compile', '-'],
                                   input=kwargs['input'].encode(),
                                   capture_output=True)
-        return script_helper.assert_python_ok('-m', 'py_compile', *args, **kwargs)
+        return script_helper.assert_python_ok(opts, 'py_compile', *args, **kwargs)
 
     def pycompilecmd_failure(self, *args):
         return script_helper.assert_python_failure('-m', 'py_compile', *args)

--- a/Misc/NEWS.d/next/Tests/2022-05-25-22-53-30.gh-issue-92886.mIfdtz.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-25-22-53-30.gh-issue-92886.mIfdtz.rst
@@ -1,0 +1,1 @@
+Fixing tests that fail when running with optimizations (``-O``) in ``test_py_compile.py``


### PR DESCRIPTION
#92886

Before:

```sh
$ ./python.exe -Om unittest test.test_py_compile

....FF......s............s......
======================================================================
FAIL: test_stdin (test.test_py_compile.PyCompileCLITestCase.test_stdin)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/.../dev/cpython/Lib/test/test_py_compile.py", line 252, in test_stdin
    self.assertTrue(os.path.exists(self.cache_path))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: False is not true

======================================================================
FAIL: test_with_files (test.test_py_compile.PyCompileCLITestCase.test_with_files)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/.../dev/cpython/Lib/test/test_py_compile.py", line 259, in test_with_files
    self.assertTrue(os.path.exists(self.cache_path))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: False is not true

----------------------------------------------------------------------
Ran 32 tests in 0.322s

FAILED (failures=2, skipped=2)
```

After:

```sh
./python.exe -Om unittest test.test_py_compile

............s............s......
----------------------------------------------------------------------
Ran 32 tests in 0.307s

OK (skipped=2)
```