### PR TITLE
gh-92886: Fixing tests that fail when running with optimizations (`-O`) in `test_zipimport.py`

### DIFF
--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -656,6 +656,8 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         self.assertEqual(mod.test(1), 1)
         if __debug__:
             self.assertRaises(AssertionError, mod.test, False)
+        else:
+            self.assertEqual(mod.test(0), 0)
 
     def testImport_WithStuff(self):
         # try importing from a zipfile which contains additional

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -654,7 +654,8 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         sys.path.insert(0, TEMP_ZIP)
         mod = importlib.import_module(TESTMOD)
         self.assertEqual(mod.test(1), 1)
-        self.assertRaises(AssertionError, mod.test, False)
+        if __debug__:
+            self.assertRaises(AssertionError, mod.test, False)
 
     def testImport_WithStuff(self):
         # try importing from a zipfile which contains additional

--- a/Misc/NEWS.d/next/Tests/2022-05-25-23-00-35.gh-issue-92886.Y-vrWj.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-25-23-00-35.gh-issue-92886.Y-vrWj.rst
@@ -1,0 +1,1 @@
+Fixing tests that fail when running with optimizations (``-O``) in ``test_zipimport.py``


### PR DESCRIPTION
#92886

Before:

```sh
$ ./python.exe -Om unittest test.test_zipimport 

................F...................s............F...................s...
======================================================================
FAIL: testDefaultOptimizationLevel (test.test_zipimport.CompressedZipImportTestCase.testDefaultOptimizationLevel)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/.../dev/cpython/Lib/test/test_zipimport.py", line 657, in testDefaultOptimizationLevel
    self.assertRaises(AssertionError, mod.test, False)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: AssertionError not raised by test

======================================================================
FAIL: testDefaultOptimizationLevel (test.test_zipimport.UncompressedZipImportTestCase.testDefaultOptimizationLevel)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/.../dev/cpython/Lib/test/test_zipimport.py", line 657, in testDefaultOptimizationLevel
    self.assertRaises(AssertionError, mod.test, False)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: AssertionError not raised by test

----------------------------------------------------------------------
Ran 73 tests in 0.073s

FAILED (failures=2, skipped=2)
```

After:

```sh
./python.exe -Om unittest test.test_zipimport

....................................s................................s...
----------------------------------------------------------------------
Ran 73 tests in 0.065s

OK (skipped=2)
```