### PR TITLE
gh-92886: Fixing test that fails when running with optimizations (`-O`) in `test_imaplib.py`

### DIFF
--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -939,6 +939,7 @@ class ThreadedNetworkedTests(unittest.TestCase):
 
     @threading_helper.reap_threads
     @cpython_only
+    @unittest.skipUnless(__debug__, "Won't work if __debug__ is False")
     def test_dump_ur(self):
         # See: http://bugs.python.org/issue26543
         untagged_resp_dict = {'READ-WRITE': [b'']}

--- a/Misc/NEWS.d/next/Tests/2022-05-25-23-07-15.gh-issue-92886.Aki63_.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-25-23-07-15.gh-issue-92886.Aki63_.rst
@@ -1,0 +1,1 @@
+Fixing tests that fail when running with optimizations (``-O``) in ``test_imaplib.py``.


### PR DESCRIPTION
#92886

Before:

```sh
$ ./python.exe -Om unittest test.test_imaplib
...
======================================================================
ERROR: test_dump_ur (test.test_imaplib.ThreadedNetworkedTests.test_dump_ur)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/.../dev/cpython/Lib/test/support/threading_helper.py", line 63, in decorator
    return func(*args)
           ^^^^^^^^^^^
  File "/Users/.../dev/cpython/Lib/test/test_imaplib.py", line 948, in test_dump_ur
    with mock.patch.object(imap, '_mesg') as mock_mesg:
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/.../dev/cpython/Lib/unittest/mock.py", line 1427, in __enter__
    original, local = self.get_original()
                      ^^^^^^^^^^^^^^^^^^^
  File "/Users/.../dev/cpython/Lib/unittest/mock.py", line 1400, in get_original
    raise AttributeError(
    ^^^^^^^^^^^^^^^^^^^^^
AttributeError: <imaplib.IMAP4 object at 0x1032a3bc0> does not have the attribute '_mesg'

----------------------------------------------------------------------
Ran 103 tests in 6.203s

FAILED (errors=1, skipped=55)
```

After:

```sh
./python.exe -Om unittest test.test_zipimport
...
----------------------------------------------------------------------
Ran 103 tests in 6.156s

OK (skipped=56)
```