### PR TITLE
gh-92886: Fixing tests that fail when running with optimizations (`-O`) in `test_dis.py`

### DIFF
--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1041,11 +1041,6 @@ class DisWithFileTests(DisTests):
         return output.getvalue()
 
 
-if sys.flags.optimize:
-    code_info_consts = "0: None"
-else:
-    code_info_consts = "0: 'Formatted details of methods, functions, or code.'"
-
 code_info_code_info = f"""\
 Name:              code_info
 Filename:          (.*)
@@ -1056,7 +1051,7 @@ Number of locals:  1
 Stack size:        \\d+
 Flags:             OPTIMIZED, NEWLOCALS
 Constants:
-   {code_info_consts}
+   0: 'Formatted details of methods, functions, or code.'
 Names:
    0: _format_code_info
    1: _get_code_object

--- a/Misc/NEWS.d/next/Tests/2022-05-25-23-14-09.gh-issue-92886.z99rtj.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-25-23-14-09.gh-issue-92886.z99rtj.rst
@@ -1,0 +1,1 @@
+Fixing tests that fail when running with optimizations (``-O``) in ``test_dis.py``.


### PR DESCRIPTION
#92886

Before:

```sh
$ ./python.exe -Om unittest test.test_dis    

.....F...F..F....s.................................s.................................................
======================================================================
FAIL: test_info (test.test_dis.BytecodeTests.test_info)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/.../dev/cpython/Lib/test/test_dis.py", line 1623, in test_info
    self.assertRegex(b.info(), expected)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Regex didn't match: 'Name:              code_info\nFilename:          (.*)\nArgument count:    1\nPositional-only arguments: 0\nKw-only arguments: 0\nNumber of locals:  1\nStack size:        \\d+\nFlags:             OPTIMIZED, NEWLOCALS\nConstants:\n   0: None\nNames:\n   0: _format_code_info\n   1: _get_code_object\nVariable names:\n   0: x' not found in "Name:              code_info\nFilename:          /Users/.../dev/cpython/Lib/dis.py\nArgument count:    1\nPositional-only arguments: 0\nKw-only arguments: 0\nNumber of locals:  1\nStack size:        5\nFlags:             OPTIMIZED, NEWLOCALS\nConstants:\n   0: 'Formatted details of methods, functions, or code.'\nNames:\n   0: _format_code_info\n   1: _get_code_object\nVariable names:\n   0: x"

======================================================================
FAIL: test_code_info (test.test_dis.CodeInfoTests.test_code_info)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/.../dev/cpython/Lib/test/test_dis.py", line 1212, in test_code_info
    self.assertRegex(dis.code_info(x), expected)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Regex didn't match: 'Name:              code_info\nFilename:          (.*)\nArgument count:    1\nPositional-only arguments: 0\nKw-only arguments: 0\nNumber of locals:  1\nStack size:        \\d+\nFlags:             OPTIMIZED, NEWLOCALS\nConstants:\n   0: None\nNames:\n   0: _format_code_info\n   1: _get_code_object\nVariable names:\n   0: x' not found in "Name:              code_info\nFilename:          /Users/.../dev/cpython/Lib/dis.py\nArgument count:    1\nPositional-only arguments: 0\nKw-only arguments: 0\nNumber of locals:  1\nStack size:        5\nFlags:             OPTIMIZED, NEWLOCALS\nConstants:\n   0: 'Formatted details of methods, functions, or code.'\nNames:\n   0: _format_code_info\n   1: _get_code_object\nVariable names:\n   0: x"

======================================================================
FAIL: test_show_code (test.test_dis.CodeInfoTests.test_show_code)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/.../dev/cpython/Lib/test/test_dis.py", line 1219, in test_show_code
    self.assertRegex(output.getvalue(), expected+"\n")
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Regex didn't match: 'Name:              code_info\nFilename:          (.*)\nArgument count:    1\nPositional-only arguments: 0\nKw-only arguments: 0\nNumber of locals:  1\nStack size:        \\d+\nFlags:             OPTIMIZED, NEWLOCALS\nConstants:\n   0: None\nNames:\n   0: _format_code_info\n   1: _get_code_object\nVariable names:\n   0: x\n' not found in "Name:              code_info\nFilename:          /Users/.../dev/cpython/Lib/dis.py\nArgument count:    1\nPositional-only arguments: 0\nKw-only arguments: 0\nNumber of locals:  1\nStack size:        5\nFlags:             OPTIMIZED, NEWLOCALS\nConstants:\n   0: 'Formatted details of methods, functions, or code.'\nNames:\n   0: _format_code_info\n   1: _get_code_object\nVariable names:\n   0: x\n"

----------------------------------------------------------------------
Ran 101 tests in 0.618s

FAILED (failures=3, skipped=2)
```

After:

```sh
./python.exe -Om unittest test.test_dis

.................s.................................s.................................................
----------------------------------------------------------------------
Ran 101 tests in 0.624s

OK (skipped=2)
```