### PR TITLE
[3.11] gh-92434: Silence a compiler warning in _xxsubinterpretersmodule.c for 32bit version

### DIFF
--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2338,7 +2338,7 @@ channel_list_all(PyObject *self, PyObject *Py_UNUSED(ignored))
             ids = NULL;
             break;
         }
-        PyList_SET_ITEM(ids, i, id);
+        PyList_SET_ITEM(ids, (Py_ssize_t)i, id);
     }
 
 finally:


### PR DESCRIPTION
Manual backport of gh-93091. 

@corona10 Could you please check again?