### PR TITLE
gh-93244: Py_PRINT_RAW was incorrectly spelled as Py_Print_RAW.

### DIFF
--- a/Include/abstract.h
+++ b/Include/abstract.h
@@ -14,12 +14,9 @@ extern "C" {
 
    Print an object 'o' on file 'fp'.  Returns -1 on error. The flags argument
    is used to enable certain printing options. The only option currently
-   supported is Py_PRINT_RAW. 
-   
-   By default, PyObject_Print stringifies 'o' by calling its __repr__ method. 
-   However, if Py_PRINT_RAW is specified in 'flags' the object's __str__  method
-   is used for conversion to a string, falling back on __repr__ if no 
-   __str__ method exists. */
+   supported is Py_PRINT_RAW. By default (flags=0), PyObject_Print() formats
+   the object by calling PyObject_Repr(). If flags equals to Py_PRINT_RAW, it
+   formats the object by calling PyObject_Str(). */
 
 
 /* Implemented elsewhere:

--- a/Include/abstract.h
+++ b/Include/abstract.h
@@ -14,12 +14,12 @@ extern "C" {
 
    Print an object 'o' on file 'fp'.  Returns -1 on error. The flags argument
    is used to enable certain printing options. The only option currently
-   supported is Py_PRINT_RAW. By default, PyObject_Print "stringifies" 'o' by
-   calling its __repr__ method. However, if Py_PRINT_RAW is specified
-   in 'flags' the object is "stringified" for printing by invoking its __str__
-   method. If Py_PRINT_RAW is specified and the object does not have a
-   __str__ method, only then will it's __repr__ method be called to perform
-   "stringification". */
+   supported is Py_PRINT_RAW. 
+   
+   By default, PyObject_Print stringifies 'o' by calling its __repr__ method. 
+   However, if Py_PRINT_RAW is specified in 'flags' the object's __str__  method
+   is used for conversion to a string, falling back on __repr__ if no 
+   __str__ method exists. */
 
 
 /* Implemented elsewhere:

--- a/Include/abstract.h
+++ b/Include/abstract.h
@@ -14,9 +14,11 @@ extern "C" {
 
    Print an object 'o' on file 'fp'.  Returns -1 on error. The flags argument
    is used to enable certain printing options. The only option currently
-   supported is Py_Print_RAW.
-
-   (What should be said about Py_Print_RAW?). */
+   supported is Py_PRINT_RAW. By default, PyObject_Print "renders" 'o' by
+   calling its __repr__ method. However, if Py_PRINT_RAW is specified
+   in 'flags' the object is "rendered" for printing by invoking its __str__
+   method. If Py_PRINT_RAW is specified and the object does not have a
+   __str__ method, only then will it's __repr__ method be called. */
 
 
 /* Implemented elsewhere:

--- a/Include/abstract.h
+++ b/Include/abstract.h
@@ -14,11 +14,12 @@ extern "C" {
 
    Print an object 'o' on file 'fp'.  Returns -1 on error. The flags argument
    is used to enable certain printing options. The only option currently
-   supported is Py_PRINT_RAW. By default, PyObject_Print "renders" 'o' by
+   supported is Py_PRINT_RAW. By default, PyObject_Print "stringifies" 'o' by
    calling its __repr__ method. However, if Py_PRINT_RAW is specified
-   in 'flags' the object is "rendered" for printing by invoking its __str__
+   in 'flags' the object is "stringified" for printing by invoking its __str__
    method. If Py_PRINT_RAW is specified and the object does not have a
-   __str__ method, only then will it's __repr__ method be called. */
+   __str__ method, only then will it's __repr__ method be called to perform
+   "stringification". */
 
 
 /* Implemented elsewhere:


### PR DESCRIPTION
Py_PRINT_RAW was incorrectly spelled as Py_Print_RAW in Include/Abstract.h