### PR TITLE
gh-93247: Fix assert function in asyncio locks test

### DIFF
--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -853,7 +853,7 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(t1.result())
         race_tasks = [t2, t3, t4]
         done_tasks = [t for t in race_tasks if t.done() and t.result()]
-        self.assertTrue(2, len(done_tasks))
+        self.assertEqual(2, len(done_tasks))
 
         # cleanup locked semaphore
         sem.release()

--- a/Misc/NEWS.d/next/Tests/2022-05-26-07-59-05.gh-issue-93247.qOdpor.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-26-07-59-05.gh-issue-93247.qOdpor.rst
@@ -1,0 +1,1 @@
+Fix assert function in asyncio locks test.

--- a/Misc/NEWS.d/next/Tests/2022-05-26-07-59-05.gh-issue-93247.qOdpor.rst
+++ b/Misc/NEWS.d/next/Tests/2022-05-26-07-59-05.gh-issue-93247.qOdpor.rst
@@ -1,1 +1,0 @@
-Fix assert function in asyncio locks test.


### PR DESCRIPTION
Fix assert function: change `assertTrue` to `assertEqual`.

#93247