### PR TITLE
gh-93253: Add an explicit message for when there is not enough disk space to create new semaphores 

### DIFF
--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 import _multiprocessing
 import time
+import errno
 
 from . import context
 from . import process
@@ -59,6 +60,10 @@ class SemLock(object):
                     unlink_now)
             except FileExistsError:
                 pass
+            except OSError as e:
+                if e.errno == errno.ENOSPC:
+                    raise Exception("There is not enough space in the"
+                                    " file system(tmpfs) to create a semaphore") from e
             else:
                 break
         else:

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-26-11-44-51.gh-issue-93253.egSDbi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-26-11-44-51.gh-issue-93253.egSDbi.rst
@@ -1,4 +1,1 @@
-Added clear message
-
-When there is not enough disk space to create new semaphores, a confusing error occurs.
-This fix adds a clearer message.
+Add an explicit message for when there is not enough disk space to create new semaphores.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-26-11-44-51.gh-issue-93253.egSDbi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-26-11-44-51.gh-issue-93253.egSDbi.rst
@@ -1,0 +1,4 @@
+Added clear message
+
+When there is not enough disk space to create new semaphores, a confusing error occurs.
+This fix adds a clearer message.


### PR DESCRIPTION
When there is not enough disk space to create new semaphores, a confusing error occurs.
This fix adds a clearer message.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
