### PR TITLE
gh-88831: In docs for asyncio.create_task, explain why strong references to tasks are needed

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -227,24 +227,23 @@ Creating Tasks
 
       Save a reference to the result of this function, to avoid
       a task disappearing mid execution. The event loop only keeps
-      weak references to all task. Without a strong reference, the
-      task may get garbage-collected at any time. If you want to have
-      "fire-and-forget" background tasks you can do something like this::
+      weak references to tasks. A task that isn't referenced elsewhere
+      may get garbage-collected at any time, even before it's done.
+      For reliable "fire-and-forget" background tasks, gather them in
+      a collection::
 
-          # create an empty set to store references to background tasks
           background_tasks = set()
 
-          # start 10 background tasks
           for i in range(10):
               task = asyncio.create_task(some_coro(param=i))
 
-              # Add task to set. This creates a strong reference.
+              # Add task to the set. This creates a strong reference.
               background_tasks.add(task)
 
-              # To prevent accumulation of references to already finished
-              # tasks, make each task remove its own reference from set after
+              # To prevent keeping references to finished tasks forever,
+              # make each task remove its own reference from the set after
               # completion:
-              task.add_done_callback(lambda t: background_tasks.discard(t))
+              task.add_done_callback(background_tasks.discard)
 
    .. versionadded:: 3.7
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -228,7 +228,23 @@ Creating Tasks
       Save a reference to the result of this function, to avoid
       a task disappearing mid execution. The event loop only keeps
       weak references to all task. Without a strong reference, the
-      task may get garbage-collected at any time.
+      task may get garbage-collected at any time. If you want to have
+      "fire-and-forget" background tasks you can do something like this::
+
+          # create an empty set to store references to background tasks
+          background_tasks = set()
+
+          # start 10 background tasks
+          for i in range(10):
+              task = asyncio.create_task(some_coro(param=i))
+
+              # Add task to set. This creates a strong reference.
+              background_tasks.add(task)
+
+              # To prevent accumulation of references to already finished
+              # tasks, make each task remove its own reference from set after
+              # completion:
+              task.add_done_callback(lambda t: background_tasks.discard(t))
 
    .. versionadded:: 3.7
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -226,7 +226,9 @@ Creating Tasks
    .. important::
 
       Save a reference to the result of this function, to avoid
-      a task disappearing mid execution.
+      a task disappearing mid execution. The event loop only keeps
+      weak references to all task. Without a strong reference, the
+      task may get garbage-collected at any time.
 
    .. versionadded:: 3.7
 

--- a/Misc/NEWS.d/next/Documentation/2022-05-26-14-51-25.gh-issue-88831.5Cccr5.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-05-26-14-51-25.gh-issue-88831.5Cccr5.rst
@@ -1,0 +1,1 @@
+Augmented documentation of asyncio.create_task(). Clarified the need to keep strong references to tasks and added a code snippet detailing how to to this.


### PR DESCRIPTION
Hello everybody,

this is a small PR augmenting the documentation of `asyncio.create_task()`. The documentation states that one has to keep a reference to all running tasks, but most of the time it also works when you don't. This led to a bit of head-scratching on my part (see https://stackoverflow.com/questions/71938799/python-asyncio-create-task-really-need-to-keep-a-reference) until I discovered https://github.com/python/cpython/issues/88831 (which led me to create this PR to solve this issue).

If accepted, this PR should probably be backported to versions starting from 3.7, i.e. all versions having `asyncio.create_task()`.

This PR might have relevance for issue https://github.com/python/cpython/issues/91887: If the `asyncio` event loop keeps strong references itself one day, the information added with this PR can be removed again.
