### PR TITLE
gh-93240: clarify wording in IO tutorial

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -179,7 +179,8 @@ square brackets ``'[]'`` to access the keys. ::
    ...       'Dcab: {0[Dcab]:d}'.format(table))
    Jack: 4098; Sjoerd: 4127; Dcab: 8637678
 
-This could also be done by passing the ``table`` dictionary as keyword arguments with the ``**`` notation. ::
+This could also be done by passing the ``table`` dictionary as keyword arguments with the ``**``
+notation. ::
 
    >>> table = {'Sjoerd': 4127, 'Jack': 4098, 'Dcab': 8637678}
    >>> print('Jack: {Jack:d}; Sjoerd: {Sjoerd:d}; Dcab: {Dcab:d}'.format(**table))

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -179,8 +179,7 @@ square brackets ``'[]'`` to access the keys. ::
    ...       'Dcab: {0[Dcab]:d}'.format(table))
    Jack: 4098; Sjoerd: 4127; Dcab: 8637678
 
-This could also be done by passing the table as keyword arguments with the '**'
-notation. ::
+This could also be done by passing the ``table`` dictionary as keyword arguments with the ``**`` notation. ::
 
    >>> table = {'Sjoerd': 4127, 'Jack': 4098, 'Dcab': 8637678}
    >>> print('Jack: {Jack:d}; Sjoerd: {Sjoerd:d}; Dcab: {Dcab:d}'.format(**table))


### PR DESCRIPTION
Changed the wording of the Docs to "This could also be done by passing the ``table`` dictionary as keyword arguments with the ``**`` notation. " on line 182 of the inputoutpout.rst file.
