### PR TITLE
gh-91320: Fix more old-style cast warnings in C++

### DIFF
--- a/Include/boolobject.h
+++ b/Include/boolobject.h
@@ -19,8 +19,8 @@ PyAPI_DATA(PyLongObject) _Py_FalseStruct;
 PyAPI_DATA(PyLongObject) _Py_TrueStruct;
 
 /* Use these macros */
-#define Py_False ((PyObject *) &_Py_FalseStruct)
-#define Py_True ((PyObject *) &_Py_TrueStruct)
+#define Py_False _PyObject_CAST(&_Py_FalseStruct)
+#define Py_True _PyObject_CAST(&_Py_TrueStruct)
 
 // Test if an object is the True singleton, the same as "x is True" in Python.
 PyAPI_FUNC(int) Py_IsTrue(PyObject *x);

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -31,7 +31,7 @@ Py_DEPRECATED(3.9) PyAPI_FUNC(PyObject *) PyEval_CallObjectWithKeywords(
 
 /* Deprecated since PyEval_CallObjectWithKeywords is deprecated */
 #define PyEval_CallObject(callable, arg) \
-    PyEval_CallObjectWithKeywords(callable, arg, (PyObject *)NULL)
+    PyEval_CallObjectWithKeywords(callable, arg, _PyObject_CAST(_Py_NULL))
 
 Py_DEPRECATED(3.9) PyAPI_FUNC(PyObject *) PyEval_CallFunction(
     PyObject *callable, const char *format, ...);

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -62,7 +62,7 @@ PyAPI_FUNC(void) PyException_SetContext(PyObject *, PyObject *);
 
 PyAPI_FUNC(const char *) PyExceptionClass_Name(PyObject *);
 
-#define PyExceptionInstance_Class(x) ((PyObject*)Py_TYPE(x))
+#define PyExceptionInstance_Class(x) _PyObject_CAST(Py_TYPE(x))
 
 #define _PyBaseExceptionGroup_Check(x)                   \
     PyObject_TypeCheck(x, (PyTypeObject *)PyExc_BaseExceptionGroup)


### PR DESCRIPTION
Use _Py_CAST() and _PyObject_CAST() in the public C API to fix C++
compiler warnings: "use of old-style cast" (clang -Wold-style-cast).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
