### PR TITLE
[3.7 - 3.11] removing unused import from Lib/netrc.py 

### DIFF
--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -2,7 +2,7 @@
 
 # Module and documentation by Eric S. Raymond, 21 Dec 1998
 
-import os, shlex, stat
+import os, stat
 
 __all__ = ["netrc", "NetrcParseError"]
 


### PR DESCRIPTION
Removing shlex import in netrc module