### PR TITLE
gh-93325: Micro-optimization of small integer lookup

### DIFF
--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -33,6 +33,7 @@ struct _Py_global_objects {
          * -_PY_NSMALLNEGINTS (inclusive) to _PY_NSMALLPOSINTS (exclusive).
          */
         PyLongObject small_ints[_PY_NSMALLNEGINTS + _PY_NSMALLPOSINTS];
+        PyLongObject* small_ints_zero_offset;
 
         PyBytesObject bytes_empty;
         struct {

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -21,6 +21,7 @@ extern void _PyLong_FiniTypes(PyInterpreterState *interp);
 /* other API */
 
 #define _PyLong_SMALL_INTS _Py_SINGLETON(small_ints)
+#define _PyLong_SMALL_INTS_ZERO_OFFSET _Py_SINGLETON(small_ints_zero_offset)
 
 // _PyLong_GetZero() and _PyLong_GetOne() must always be available
 // _PyLong_FromUnsignedChar must always be available
@@ -31,16 +32,16 @@ extern void _PyLong_FiniTypes(PyInterpreterState *interp);
 // Return a borrowed reference to the zero singleton.
 // The function cannot return NULL.
 static inline PyObject* _PyLong_GetZero(void)
-{ return (PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS]; }
+{ return (PyObject *)&_PyLong_SMALL_INTS_ZERO_OFFSET[0]; }
 
 // Return a borrowed reference to the one singleton.
 // The function cannot return NULL.
 static inline PyObject* _PyLong_GetOne(void)
-{ return (PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS+1]; }
+{ return (PyObject *)&_PyLong_SMALL_INTS_ZERO_OFFSET[1]; }
 
 static inline PyObject* _PyLong_FromUnsignedChar(unsigned char i)
 {
-    return Py_NewRef((PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS+i]);
+    return Py_NewRef((PyObject *)&_PyLong_SMALL_INTS_ZERO_OFFSET[i]);
 }
 
 PyObject *_PyLong_Add(PyLongObject *left, PyLongObject *right);

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -388,6 +388,7 @@ extern "C" {
             _PyLong_DIGIT_INIT(255), \
             _PyLong_DIGIT_INIT(256), \
         }, \
+        .small_ints_zero_offset = 0, \
         \
         .bytes_empty = _PyBytes_SIMPLE_INIT(0, 0), \
         .bytes_characters = { \

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -388,8 +388,8 @@ extern "C" {
             _PyLong_DIGIT_INIT(255), \
             _PyLong_DIGIT_INIT(256), \
         }, \
-        .small_ints_zero_offset = 0, \
         \
+        .small_ints_zero_offset = 0, \
         .bytes_empty = _PyBytes_SIMPLE_INIT(0, 0), \
         .bytes_characters = { \
             _PyBytes_CHAR_INIT(0), \

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-28-19-07-26.gh-issue-93325.6HUjfA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-28-19-07-26.gh-issue-93325.6HUjfA.rst
@@ -1,0 +1,1 @@
+Micro optimization of small integer lookup.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -55,7 +55,7 @@ static PyObject *
 get_small_int(sdigit ival)
 {
     assert(IS_SMALL_INT(ival));
-    PyObject *v = (PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS + ival];
+    PyObject *v = (PyObject *)&_PyLong_SMALL_INTS_ZERO_OFFSET[ival];
     Py_INCREF(v);
     return v;
 }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -99,6 +99,9 @@ init_runtime(_PyRuntimeState *runtime,
              PyThread_type_lock interpreters_mutex,
              PyThread_type_lock xidregistry_mutex)
 {
+    // this is a hack to initialize small_ints_zero_offset. should probably be moved somewhere else
+    _Py_SINGLETON(small_ints_zero_offset) = _Py_SINGLETON(small_ints) + _PY_NSMALLNEGINTS;
+
     if (runtime->_initialized) {
         Py_FatalError("runtime already initialized");
     }

--- a/Tools/scripts/generate_global_objects.py
+++ b/Tools/scripts/generate_global_objects.py
@@ -260,6 +260,8 @@ def generate_runtime_init(identifiers, strings):
                     for i in range(-nsmallnegints, nsmallposints):
                         printer.write(f'_PyLong_DIGIT_INIT({i}),')
                 printer.write('')
+                # Small int offset zero
+                printer.write('.small_ints_zero_offset = 0,')
                 # Global bytes objects.
                 printer.write('.bytes_empty = _PyBytes_SIMPLE_INIT(0, 0),')
                 with printer.block('.bytes_characters =', ','):


### PR DESCRIPTION
The small integers are accessed through `_PyLong_SMALL_INTS`. This requires adding the constant `_PY_NSMALLNEGINTS` to the integer desired. This PR adds a new global variable `_PyLong_SMALL_INTS_ZERO_OFFSET` that points to the zero integer.

Advantages:

* Methods like `get_small_int`, `_PyLong_GetZero`, `_PyLong_GetOne` require an addition operation less.
* Since `_PyLong_GetZero` and `_PyLong_GetOne` are inline functions, less code is generated 

Benchmark:
```
Mean +- std dev: [main] 1.79 ms +- 0.10 ms -> [PR] 1.69 ms +- 0.18 ms: 1.06x faster
```

<details>
<summary>Test script</summary>

``` 
import pyperf
import time
runner = pyperf.Runner()

code=""" 
for ii in range(200):
    for jj in range(200):
        a = ii - jj
        b= ii+ jj
"""        

runner.timeit('small int test', stmt=code)
``` 

</details>


Notes:

* This PR adds a new singleton `small_ints_zero_offset`. This extra global can be avoided if we: first allocate `small_ints`, then add `_PY_NSMALLNEGINTS` to the pointer. For deallocating one first has to substract `_PY_NSMALLNEGINTS` again. This is a little more complex, but if preferred I will adapt the PR to this.
* I do not have sufficient knowledge of the Python initialization process to determine the best location to define and initialize the `small_ints_zero_offset` pointer. Suggestions for improvement are welcome.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes #93325.