### PR TITLE
gh-86986: bump min sphinx version to 3.2

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -45,7 +45,7 @@ today_fmt = '%B %d, %Y'
 highlight_language = 'python3'
 
 # Minimum version of sphinx required
-needs_sphinx = '1.8'
+needs_sphinx = '3.2'
 
 # Ignore any .rst files in the venv/ directory.
 exclude_patterns = ['venv/*', 'README.rst']

--- a/Misc/NEWS.d/next/Documentation/2022-05-29-21-22-54.gh-issue-86986.lFXw8j.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-05-29-21-22-54.gh-issue-86986.lFXw8j.rst
@@ -1,0 +1,1 @@
+The minimum Sphinx version required to build the documentation is now 3.2.


### PR DESCRIPTION
https://github.com/python/cpython/pull/92318 introduced changes that require a minimum Sphinx version of 3.2, so `needs_sphinx` needs to be updated accordingly. The change was backported to 3.11 and 3.10 so the same should apply for this PR (see also discussion in the issue https://github.com/python/cpython/issues/86986#issuecomment-1140493331). 