### PR TITLE
gh-66435: Allow nested event loops

### DIFF
--- a/Doc/library/asyncio-runner.rst
+++ b/Doc/library/asyncio-runner.rst
@@ -22,16 +22,20 @@ to simplify async code usage for common wide-spread scenarios.
 Running an asyncio Program
 ==========================
 
-.. function:: run(coro, *, debug=None, loop_factory=None)
+.. function:: run(coro, *, debug=None, loop_factory=None, running_ok=False)
 
    Execute the :term:`coroutine` *coro* and return the result.
 
-   This function runs the passed coroutine, taking care of
+   If *running_ok* is ``False``, this function runs the passed coroutine, taking care of
    managing the asyncio event loop, *finalizing asynchronous
-   generators*, and closing the executor.
+   generators*, and closing the executor. This function cannot be called when another
+   asyncio event loop is running in the same thread.
 
-   This function cannot be called when another asyncio event loop is
-   running in the same thread.
+   If *running_ok* is ``True``, this function allows running the passed coroutine even if
+   this code is already running in an event loop. In other words, it allows re-entering
+   the event loop, while an exception would be raised if *running_ok* were ``False``. If
+   this function is called inside an already running event loop, the same loop is used,
+   and it is not closed at the end.
 
    If *debug* is ``True``, the event loop will be run in debug mode. ``False`` disables
    debug mode explicitly. ``None`` is used to respect the global

--- a/Misc/NEWS.d/next/Library/2022-05-30-09-25-24.gh-issue-66435.E4YBFo.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-30-09-25-24.gh-issue-66435.E4YBFo.rst
@@ -1,0 +1,2 @@
+Allow the event loop to be re-entrant, by making it possible to call
+``asyncio.run(coro, running_ok=True)`` inside an already running event loop.


### PR DESCRIPTION
This PR is basically a copy/paste of @erdewit's [nest_asyncio](https://github.com/erdewit/nest_asyncio) library. It allows the event loop to be re-entrant, by making it possible to call `asyncio.run()` inside an already running event loop.
This feature request was [rejected in the past](https://github.com/python/cpython/issues/73744), but @1st1 recently mentioned that he [could reconsider this decision](https://github.com/python/cpython/issues/66435#issuecomment-1093662839).
Here is an example:
```py
import asyncio

async def task(name):
    for i in range(10):
        await asyncio.sleep(0.1)
        print(f"from {name}: {i}")

async def bar():
    asyncio.create_task(task("bar"))
    await asyncio.sleep(1.1)
    print("bar done")

def foo():
    # asyncio.run inside an already running event loop
    # pre-empts the execution of any other task in the event loop
    asyncio.run(bar())

async def main():
    t = asyncio.create_task(task("main"))  # not executed until foo() is done
    foo()
    await asyncio.sleep(1.1)  # t resumes execution

asyncio.run(main())
```
This will print:
```
from bar: 0
from bar: 1
from bar: 2
from bar: 3
from bar: 4
from bar: 5
from bar: 6
from bar: 7
from bar: 8
from bar: 9
bar done
from main: 0
from main: 1
from main: 2
from main: 3
from main: 4
from main: 5
from main: 6
from main: 7
from main: 8
from main: 9
```

<!-- gh-issue-number: gh-66435 -->
* Issue: gh-66435
<!-- /gh-issue-number -->
