### PR TITLE
Specify which square root is returned in the docs.

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -436,7 +436,7 @@ Power and logarithmic functions
 
 .. function:: sqrt(x)
 
-   Return the square root of *x*.
+   Return the principal (nonnegative) square root of *x*.
 
 
 Trigonometric functions


### PR DESCRIPTION
By formal definition, the square roots of x are the values of y such that y^2 = x.

For example, -3 and 3 are the square roots of 9, and we say that the **principal** square root of 9 is 3 (the positive one). This
nomenclature is valid even when we are working only with real numbers.

I know, although, that in several countries, to avoid repeatedly saying that √x is the principal square root of x, usually omit the term "principal", particularly in school. But I think it is best to be clear in the docs of this function.

As a reference, please look at [https://en.wikipedia.org/wiki/Square_root](https://en.wikipedia.org/wiki/Square_root).

I added a parenthesis explanation, taking into account the problem mentioned by @AA-Turner in the [discussion](https://github.com/python/cpython/pull/93361) of the Pull Request I incorrectly made on the wrong branch, some minutes ago. If there is a better way to add this information, please let me know.