### PR TITLE
gh-93391: fix typo in `array` docs

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -52,7 +52,7 @@ Notes:
 
    .. versionchanged:: 3.9
       ``array('u')`` now uses ``wchar_t`` as C type instead of deprecated
-      ``Py_UNICODE``. This change doesn't affect to its behavior because
+      ``Py_UNICODE``. This change doesn't affect its behavior because
       ``Py_UNICODE`` is alias of ``wchar_t`` since Python 3.3.
 
    .. deprecated-removed:: 3.3 4.0

--- a/Misc/NEWS.d/next/Documentation/2022-05-31-21-06-59.gh-issue-93391.2HcnhF.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-05-31-21-06-59.gh-issue-93391.2HcnhF.rst
@@ -1,0 +1,1 @@
+Fix typo in ``array`` module documentation

--- a/Misc/NEWS.d/next/Documentation/2022-05-31-21-06-59.gh-issue-93391.2HcnhF.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-05-31-21-06-59.gh-issue-93391.2HcnhF.rst
@@ -1,1 +1,0 @@
-Fix typo in ``array`` module documentation


### PR DESCRIPTION
Fixes #93391

Automerge-Triggered-By: GH:rhettinger