### PR TITLE
📝 Make sure the phrase "constant-time compare" actually appears in the docs

### DIFF
--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -129,7 +129,7 @@ Other functions
 .. function:: compare_digest(a, b)
 
    Return ``True`` if strings *a* and *b* are equal, otherwise ``False``,
-   in such a way as to reduce the risk of
+   using a "constant-time compare" to reduce the risk of
    `timing attacks <https://codahale.com/a-lesson-in-timing-attacks/>`_.
    See :func:`hmac.compare_digest` for additional details.
 


### PR DESCRIPTION
This is purely for SEO as this is the actual generic name for this kind of method and it currently does not appear in a Google search for "python constant time compare". Not creating an issue or setting this up for backports as its trivial (I think) and not a functional change.

Automerge-Triggered-By: GH:rhettinger