### PR TITLE
gh-93372: Fix typo in os.rename documentation

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2328,7 +2328,7 @@ features:
    :exc:`IsADirectoryError` or a :exc:`NotADirectoryError` will be raised
    respectively.  If both are directories and *dst* is empty, *dst* will be
    silently replaced.  If *dst* is a non-empty directory, an :exc:`OSError`
-   is raised. If both are files, *dst* it will be replaced silently if the user
+   is raised. If both are files, *dst* will be replaced silently if the user
    has permission.  The operation may fail on some Unix flavors if *src* and
    *dst* are on different filesystems.  If successful, the renaming will be an
    atomic operation (this is a POSIX requirement).

--- a/Misc/NEWS.d/next/Documentation/2022-06-01-04-54-33.gh-issue-93372.SCa_tP.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-01-04-54-33.gh-issue-93372.SCa_tP.rst
@@ -1,0 +1,1 @@
+Fix typo in ``os.rename`` documentation.

--- a/Misc/NEWS.d/next/Documentation/2022-06-01-04-54-33.gh-issue-93372.SCa_tP.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-01-04-54-33.gh-issue-93372.SCa_tP.rst
@@ -1,1 +1,0 @@
-Fix typo in ``os.rename`` documentation.


### PR DESCRIPTION
Fixes #93372