### PR TITLE
#gh-93409: fix `Tool/redemo`: `event` is not accessed.

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2022-06-01-08-15-45.gh-issue-93409.jxdsUa.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2022-06-01-08-15-45.gh-issue-93409.jxdsUa.rst
@@ -1,0 +1,1 @@
+redemo: params of `event` for `recompile()` and `reevaluate()` are not accessed.

--- a/Tools/demo/redemo.py
+++ b/Tools/demo/redemo.py
@@ -98,7 +98,7 @@ class ReDemo:
             flags = flags | var.get()
         return flags
 
-    def recompile(self, event=None):
+    def recompile(self:
         try:
             self.compiled = re.compile(self.regexdisplay.get(),
                                        self.getflags())
@@ -111,7 +111,7 @@ class ReDemo:
                     background="red")
         self.reevaluate()
 
-    def reevaluate(self, event=None):
+    def reevaluate(self):
         try:
             self.stringdisplay.tag_remove("hit", "1.0", END)
         except TclError:


### PR DESCRIPTION
Both for `recompile()` and `reevaluate()`.