### PR TITLE
gh-59150: Add table of runnable modules

### DIFF
--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -1,7 +1,9 @@
 .. _idle:
 
-IDLE
-====
+:mod:`idlelib` --- IDLE
+=======================
+
+.. module:: idlelib
 
 .. moduleauthor:: Guido van Rossum <guido@python.org>
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -112,6 +112,34 @@ source.
        python -m timeit -s 'setup here' 'benchmarked code here'
        python -m timeit -h # for details
 
+   Other modules include
+
+   .. list-table::
+
+      * - :mod:`compileall`
+        - Precompiling Python source modules to bytecode
+
+      * - :mod:`pickle`
+        - Display the contents of pickles saved as files
+
+      * - :mod:`pickletools`
+        - Analyse the contents of pickles saved as files
+
+      * - :mod:`site`
+        - Display details of Python's configuration
+
+      * - :mod:`sysconfig`
+        - Display additional details of Python's configuration
+
+      * - :mod:`test`
+        - Execute Python's own regression test suite
+
+      * - :mod:`timeit`
+        - Microbenchmarking for small Python snippets
+
+      * - :mod:`unittest`
+        - Find and execute unit tests
+
    .. audit-event:: cpython.run_module module-name cmdoption-m
 
    .. seealso::

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -116,8 +116,26 @@ source.
 
    .. list-table::
 
+      * - :mod:`ast`
+        - Process Python Abstract Syntax Trees
+
+      * - :mod:`asyncio`
+        - Launch a natively async REPL
+
       * - :mod:`compileall`
-        - Precompiling Python source modules to bytecode
+        - Precompile Python source modules to bytecode
+
+      * - :mod:`doctest`
+        - Run :func:`doctest.testmod` on a module
+
+      * - :mod:`http.server`
+        - Create a server that serves files in the current directory
+
+      * - :mod:`idlelib`
+        - Open IDLE
+
+      * - :mod:`json.tool`
+        - Validate and pretty-print JSON objects
 
       * - :mod:`pickle`
         - Display the contents of pickles saved as files
@@ -125,20 +143,47 @@ source.
       * - :mod:`pickletools`
         - Analyse the contents of pickles saved as files
 
+      * - :mod:`profile`
+        - Profile Python programs
+
       * - :mod:`site`
         - Display details of Python's configuration
 
       * - :mod:`sysconfig`
         - Display additional details of Python's configuration
 
+      * - :mod:`tarfile`
+        - Interact with tar archives
+
       * - :mod:`test`
         - Execute Python's own regression test suite
 
       * - :mod:`timeit`
-        - Microbenchmarking for small Python snippets
+        - Microbenchmark small Python snippets
+
+      * - :mod:`tkinter`
+        - Open a Tk interface to verify proper installation
+
+      * - :mod:`tokenize`
+        - Tokenize Python source code
+
+      * - :mod:`trace`
+        - Trace program execution
 
       * - :mod:`unittest`
         - Find and execute unit tests
+
+      * - :mod:`webbrowser`
+        - Open a page in a new browser window or tab
+
+      * - :mod:`xmlrpc.client`
+        - Launch demo XMLRPC client
+
+      * - :mod:`xmlrpc.server`
+        - Launch demo XMLRPC server
+
+      * - :mod:`zipapp`
+        - Manage Python zip files
 
    .. audit-event:: cpython.run_module module-name cmdoption-m
 


### PR DESCRIPTION
#59150

https://docs.python.org/dev/using/cmdline.html#cmdoption-m

Looks roughly like

![image](https://user-images.githubusercontent.com/46876382/171362501-827f143e-3271-4717-8480-3a20181de09a.png)

but much longer. For checking that the docs mention `-m`:

Skipped [`py_compile`](https://docs.python.org/3/library/py_compile) as I couldn't find documentation; `asyncio`'s documentation is only on the [3.8 what's new](https://docs.python.org/3/whatsnew/3.8.html#asyncio); `xmlrpc.client` documentation is in `xmlrpc.server`; `pickle` documentation is in `pickletool`