### PR TITLE
Doc: Add an empty line as secondary prompt

### DIFF
--- a/Doc/tutorial/stdlib2.rst
+++ b/Doc/tutorial/stdlib2.rst
@@ -108,6 +108,7 @@ placeholders such as the current date, image sequence number, or file format::
    >>> photofiles = ['img_1074.jpg', 'img_1076.jpg', 'img_1077.jpg']
    >>> class BatchRename(Template):
    ...     delimiter = '%'
+   ...
    >>> fmt = input('Enter rename style (%d-date %n-seqnum %f-format):  ')
    Enter rename style (%d-date %n-seqnum %f-format):  Ashley_%n%f
 


### PR DESCRIPTION
There should be an empty line before the secondary prompt return to primary prompt.
If this empty line is absent, the code to copy will arise error since the next line will still in secondary prompt.

**Before change**
Code to show:
<img width="817" alt="Before change (code to show)" src="https://user-images.githubusercontent.com/18076739/171519686-4ead6e72-fd3b-40e7-9395-4d0f7b9d5413.png">
Code to copy:
<img width="818" alt="Before change (code to copy)" src="https://user-images.githubusercontent.com/18076739/171518615-f65a13ec-1654-4014-966a-9160af86e493.png">
Run the code:
<img width="497" alt="Before change (run the code)" src="https://user-images.githubusercontent.com/18076739/171518621-15702b32-b7b6-48e5-9f19-807540b04c41.png">

**After change**
Code to show:
<img width="816" alt="After change (code to show)" src="https://user-images.githubusercontent.com/18076739/171519765-b3532543-cf30-4a31-a50d-4a3c7f23ee7d.png">
Code to copy:
<img width="818" alt="After change (code to copy)" src="https://user-images.githubusercontent.com/18076739/171518644-9d05d8b3-09cf-483c-92d3-dd8f8afc3bbe.png">
Run the code:
<img width="501" alt="After change (run the code)" src="https://user-images.githubusercontent.com/18076739/171518651-a6044c3d-13bd-43f1-aee9-ba28a6b0f534.png">



