### PR TITLE
gh-71616: Add note to warn against general translation of saxutils.escape()

### DIFF
--- a/Doc/library/xml.sax.utils.rst
+++ b/Doc/library/xml.sax.utils.rst
@@ -25,6 +25,11 @@ or as base classes.
    replaced with its corresponding value.  The characters ``'&'``, ``'<'`` and
    ``'>'`` are always escaped, even if *entities* is provided.
 
+   .. note::
+
+      This function should only be used to escape characters that are
+      problematic to include directly in XML. Do not use this function as a general
+      string translation function.
 
 .. function:: unescape(data, entities={})
 

--- a/Doc/library/xml.sax.utils.rst
+++ b/Doc/library/xml.sax.utils.rst
@@ -27,8 +27,8 @@ or as base classes.
 
    .. note::
 
-      This function should only be used to escape characters that are
-      problematic to include directly in XML. Do not use this function as a general
+      This function should only be used to escape characters that
+      can't be used directly in XML. Do not use this function as a general
       string translation function.
 
 .. function:: unescape(data, entities={})


### PR DESCRIPTION
#71616

Co-authored-by: Xiang Zhang <angwerzx@126.com>

https://docs.python.org/3/library/xml.sax.utils.html