### PR TITLE
gh-60856: Be explicit about localhost for socket.getfqdn

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -827,8 +827,8 @@ The following functions all create :ref:`socket objects <socket-objects>`.
    ``(host, port)``) and returns the socket object.
 
    *family* should be either :data:`AF_INET` or :data:`AF_INET6`.
-   *backlog* is the queue size passed to :meth:`socket.listen`; if not specified
-   , a default reasonable value is chosen.
+   *backlog* is the queue size passed to :meth:`socket.listen`; if not
+   specified, a default reasonable value is chosen.
    *reuse_port* dictates whether to set the :data:`SO_REUSEPORT` socket option.
 
    If *dualstack_ipv6* is true and the platform supports it the socket will
@@ -963,15 +963,15 @@ The :mod:`socket` module also offers various network-related services:
       for IPv6 multicast addresses, string representing an address will not
       contain ``%scope_id`` part.
 
-.. function:: getfqdn([name])
+.. function:: getfqdn(name='')
 
-   Return a fully qualified domain name for *name*. If *name* is empty or equal to
-   ``'0.0.0.0'``, the hostname from :func:`gethostname` is returned.
+   Return a fully qualified domain name for *name*.
    To find the fully qualified name, the
    hostname returned by :func:`gethostbyaddr` is checked, followed by aliases for the
    host, if available.  The first name which includes a period is selected.  In
    case no fully qualified domain name is available and *name* was provided,
-   it is returned unchanged.
+   it is returned unchanged. If *name* is empty, or equal to "0.0.0.0", "::", or "",
+   the hostname from :func:`gethostname` is returned.
 
 
 .. function:: gethostbyname(hostname)

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -965,14 +965,13 @@ The :mod:`socket` module also offers various network-related services:
 
 .. function:: getfqdn([name])
 
-   Return a fully qualified domain name for *name*. If *name* is omitted or empty,
-   it is interpreted as the local host (as returned by :func:`gethostname`).
+   Return a fully qualified domain name for *name*. If *name* is empty or equal to
+   ``'0.0.0.0'``, the hostname from :func:`gethostname` is returned.
    To find the fully qualified name, the
    hostname returned by :func:`gethostbyaddr` is checked, followed by aliases for the
    host, if available.  The first name which includes a period is selected.  In
    case no fully qualified domain name is available and *name* was provided,
-   it is returned unchanged.  If *name* was empty or equal to ``'0.0.0.0'``,
-   the hostname from :func:`gethostname` is returned.
+   it is returned unchanged.
 
 
 .. function:: gethostbyname(hostname)

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -970,8 +970,8 @@ The :mod:`socket` module also offers various network-related services:
    hostname returned by :func:`gethostbyaddr` is checked, followed by aliases for the
    host, if available.  The first name which includes a period is selected.  In
    case no fully qualified domain name is available and *name* was provided,
-   it is returned unchanged. If *name* is empty, or equal to ``'0.0.0.0'``, ``'::'``,
-   or ``''``, the hostname from :func:`gethostname` is returned.
+   it is returned unchanged. If *name* is omitted, or equal to ``'0.0.0.0'``,
+   ``'::'``, or ``''``, the hostname from :func:`gethostname` is returned.
 
 
 .. function:: gethostbyname(hostname)

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -970,8 +970,8 @@ The :mod:`socket` module also offers various network-related services:
    hostname returned by :func:`gethostbyaddr` is checked, followed by aliases for the
    host, if available.  The first name which includes a period is selected.  In
    case no fully qualified domain name is available and *name* was provided,
-   it is returned unchanged. If *name* is empty, or equal to "0.0.0.0", "::", or "",
-   the hostname from :func:`gethostname` is returned.
+   it is returned unchanged. If *name* is empty, or equal to ``'0.0.0.0'``, ``'::'``,
+   or ``''``, the hostname from :func:`gethostname` is returned.
 
 
 .. function:: gethostbyname(hostname)

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -966,7 +966,8 @@ The :mod:`socket` module also offers various network-related services:
 .. function:: getfqdn([name])
 
    Return a fully qualified domain name for *name*. If *name* is omitted or empty,
-   it is interpreted as the local host.  To find the fully qualified name, the
+   it is interpreted as the local host (as returned by :func:`gethostname`).
+   To find the fully qualified name, the
    hostname returned by :func:`gethostbyaddr` is checked, followed by aliases for the
    host, if available.  The first name which includes a period is selected.  In
    case no fully qualified domain name is available and *name* was provided,


### PR DESCRIPTION
#60856

This moves the wording from #27971 to the front to reduce the duplicated wording

https://docs.python.org/3/library/socket.html#socket.getfqdn

https://github.com/python/cpython/blob/main/Lib/socket.py#L792