### PR TITLE
gh-93476: Fraction.limit_denominator speed increase

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -260,7 +260,7 @@ class Fraction(numbers.Rational):
         bound2_n = p1
         bound2_d = q1
 
-        # diff1_n = numerator of (bound1 minus self) as a Fraction; 
+        # diff1_n = numerator of (bound1 minus self) as a Fraction;
         # etc. for diff1_d, diff2_n, diff2_d
         diff1_n = abs(bound1_n*d_original - n_original*bound1_d)
         diff1_d = d_original * bound1_d

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -234,7 +234,7 @@ class Fraction(numbers.Rational):
         if max_denominator < 1:
             raise ValueError("max_denominator should be at least 1")
         if self._denominator <= max_denominator:
-            return Fraction(self._numerator, self._denominator)
+            return Fraction(self._numerator, self._denominator, _normalize=False)
 
         p0, q0, p1, q1 = 0, 1, 1, 0
         n, d = self._numerator, self._denominator
@@ -261,7 +261,7 @@ class Fraction(numbers.Rational):
 
         difference = ((bound1_minus_self_n * bound2_minus_self_d)
                       - (bound2_minus_self_n * bound1_minus_self_d))
-        if difference > 0:
+        if difference >= 0:
             return Fraction(bound2_n, bound2_d)
         else:
             return Fraction(bound1_n, bound1_d)

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -234,10 +234,11 @@ class Fraction(numbers.Rational):
         if max_denominator < 1:
             raise ValueError("max_denominator should be at least 1")
         if self._denominator <= max_denominator:
-            return Fraction(self)
+            return Fraction(self._numerator, self._denominator)
 
         p0, q0, p1, q1 = 0, 1, 1, 0
         n, d = self._numerator, self._denominator
+        n_original, d_original = n, d
         while True:
             a = n//d
             q2 = q0+a*q1
@@ -247,12 +248,23 @@ class Fraction(numbers.Rational):
             n, d = d, n-a*d
 
         k = (max_denominator-q0)//q1
-        bound1 = Fraction(p0+k*p1, q0+k*q1)
-        bound2 = Fraction(p1, q1)
-        if abs(bound2 - self) <= abs(bound1-self):
-            return bound2
+        bound1_n = p0 + k*p1
+        bound1_d = q0 + k*q1
+        bound2_n = p1
+        bound2_d = q1
+        bound1_minus_self_n = abs((bound1_n * d_original)
+                                  - (n_original * bound1_d))
+        bound1_minus_self_d = d_original * bound1_d
+        bound2_minus_self_n = abs((bound2_n * d_original)
+                                  - (n_original * bound2_d))
+        bound2_minus_self_d = d_original * bound2_d
+
+        difference = ((bound1_minus_self_n * bound2_minus_self_d)
+                      - (bound2_minus_self_n * bound1_minus_self_d))
+        if difference > 0:
+            return Fraction(bound2_n, bound2_d)
         else:
-            return bound1
+            return Fraction(bound1_n, bound1_d)
 
     @property
     def numerator(a):

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -241,7 +241,7 @@ class Fraction(numbers.Rational):
         if max_denominator < 1:
             raise ValueError("max_denominator should be at least 1")
         if self._denominator <= max_denominator:
-            return Fraction(self._numerator, self._denominator, _normalize=False)
+            return Fraction(self)
 
         p0, q0, p1, q1 = 0, 1, 1, 0
         n, d = self._numerator, self._denominator

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -90,13 +90,6 @@ class Fraction(numbers.Rational):
         Fraction(147, 100)
 
         """
-        # private _normalize=False should only be set if the Fraction is
-        # already asserted to be normalized.
-        # (see discussion: at https://github.com/python/cpython/pull/93477)
-        # if a non-normalized Fraction is passed in with _normalize=False
-        # then API calls may give inconsistent results on equivalent
-        # Fraction objects.
-
         self = super(Fraction, cls).__new__(cls)
 
         if denominator is None:

--- a/Misc/NEWS.d/next/Library/2022-06-03-11-17-49.gh-issue-93476.vvjcGL.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-03-11-17-49.gh-issue-93476.vvjcGL.rst
@@ -1,0 +1,2 @@
+:meth:`fractions.Fraction.limit_denominator()` performance enhancements.
+Patch by Michael Scott Asato Cuthbert.


### PR DESCRIPTION
Create only one new Fraction object during `limit_denominator()` instead of the four previously made.

Fixes #93476

I believe that each of the calls to `Fraction()` can be called with `_normalize=False` but I have not included that in this PR to limit the scope of changes to the minimum to verify no change in implementation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
