### PR TITLE
gh-66571: Expand matches for %Z in strptime

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2566,10 +2566,19 @@ Notes:
 
       1. any value in ``time.tzname`` for your machine's locale
       2. the hard-coded values ``UTC`` and ``GMT``
+      3. any two to five character abbreviation
 
-      So someone living in Japan may have ``JST``, ``UTC``, and ``GMT`` as
-      valid values, but probably not ``EST``. It will raise ``ValueError`` for
-      invalid values.
+      If none of criteria above are met, it will raise a ``ValueError``.
+
+      The string in ``%Z`` cannot be reliably used as an indicator of the timezone
+      because timezone abbreviations are inherently ambiguous. It must be accompanied
+      by ``%z`` to produce a TZ-aware datetime object. Because of this, the validation
+      is fairly lax. If you'd like to be stricter about the validation for ``%Z``, you
+      may check the ``tzname`` property on the datetime object to do so.
+
+   .. versionchanged:: 3.12
+      ``%Z`` accepts a wider range of inputs by matching on any string
+      that is two to five characters.
 
    .. versionchanged:: 3.2
       When the ``%z`` directive is provided to the :meth:`strptime` method, an

--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -209,8 +209,7 @@ class TimeRE(dict):
             'p': self.__seqToRE(self.locale_time.am_pm, 'p'),
             'Z': self.__seqToRE((tz for tz_names in self.locale_time.timezone
                                         for tz in tz_names),
-                                'Z',
-                                fallback='[a-z]{2,5}'),
+                                'Z', fallback='[a-z]{2,5}'),
             '%': '%'})
         base.__setitem__('W', base.__getitem__('U').replace('U', 'W'))
         base.__setitem__('c', self.pattern(self.locale_time.LC_date_time))
@@ -232,12 +231,9 @@ class TimeRE(dict):
                 break
         else:
             return ''
-
         regex = '|'.join(re_escape(stuff) for stuff in to_convert)
-
         if fallback is not None:
             regex = f'({regex})|({fallback})'
-
         return f'(?P<{directive}>{regex})'
 
     def pattern(self, format):

--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -209,14 +209,15 @@ class TimeRE(dict):
             'p': self.__seqToRE(self.locale_time.am_pm, 'p'),
             'Z': self.__seqToRE((tz for tz_names in self.locale_time.timezone
                                         for tz in tz_names),
-                                'Z'),
+                                'Z',
+                                fallback='[a-z]{2,5}'),
             '%': '%'})
         base.__setitem__('W', base.__getitem__('U').replace('U', 'W'))
         base.__setitem__('c', self.pattern(self.locale_time.LC_date_time))
         base.__setitem__('x', self.pattern(self.locale_time.LC_date))
         base.__setitem__('X', self.pattern(self.locale_time.LC_time))
 
-    def __seqToRE(self, to_convert, directive):
+    def __seqToRE(self, to_convert, directive, fallback=None):
         """Convert a list to a regex string for matching a directive.
 
         Want possible matching values to be from longest to shortest.  This
@@ -231,9 +232,13 @@ class TimeRE(dict):
                 break
         else:
             return ''
+
         regex = '|'.join(re_escape(stuff) for stuff in to_convert)
-        regex = '(?P<%s>%s' % (directive, regex)
-        return '%s)' % regex
+
+        if fallback is not None:
+            regex = f'({regex})|({fallback})'
+
+        return f'(?P<{directive}>{regex})'
 
     def pattern(self, format):
         """Return regex pattern for the format string.

--- a/Lib/test/test_strptime.py
+++ b/Lib/test/test_strptime.py
@@ -370,6 +370,25 @@ class StrptimeTests(unittest.TestCase):
             _strptime._strptime("-01:3030", "%z")
         self.assertEqual("Inconsistent use of : in -01:3030", str(err.exception))
 
+    def test_tz_abbreviations_with_Z(self):
+        create_time_struct = lambda tz_abbr: (
+            (1900, 1, 1, 0, 0, 0, 0, 1, -1, tz_abbr, None), 0, 0
+        )
+
+        accepted_abbrs = ['CT', 'BST', 'CHST', 'CHADT']
+        for abbr in accepted_abbrs:
+            with self.subTest(f'%Z should match {abbr}'):
+                self.assertEqual(
+                    _strptime._strptime(abbr, "%Z"),
+                    create_time_struct(abbr),
+                )
+
+        rejected_abbrs = ['', 'A', 'ABCDEF']
+        for abbr in rejected_abbrs:
+            with self.subTest(f'%Z should raise ValueError with {abbr}'):
+                with self.assertRaises(ValueError):
+                    _strptime._strptime(abbr, "%Z")
+
     @skip_if_buggy_ucrt_strfptime
     @unittest.skipIf(
         support.is_emscripten, "musl libc issue on Emscripten, bpo-46390"
@@ -728,11 +747,6 @@ class CacheTests(unittest.TestCase):
         second_time_re = _strptime._TimeRE_cache
         # They should not be equal.
         self.assertIsNot(first_time_re, second_time_re)
-        # Make sure old names no longer accepted.
-        with self.assertRaises(ValueError):
-            _strptime._strptime_time(oldtzname[0], '%Z')
-        with self.assertRaises(ValueError):
-            _strptime._strptime_time(oldtzname[1], '%Z')
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_strptime.py
+++ b/Lib/test/test_strptime.py
@@ -374,7 +374,6 @@ class StrptimeTests(unittest.TestCase):
         create_time_struct = lambda tz_abbr: (
             (1900, 1, 1, 0, 0, 0, 0, 1, -1, tz_abbr, None), 0, 0
         )
-
         accepted_abbrs = ['CT', 'BST', 'CHST', 'CHADT']
         for abbr in accepted_abbrs:
             with self.subTest(f'%Z should match {abbr}'):
@@ -382,7 +381,6 @@ class StrptimeTests(unittest.TestCase):
                     _strptime._strptime(abbr, "%Z"),
                     create_time_struct(abbr),
                 )
-
         rejected_abbrs = ['', 'A', 'ABCDEF']
         for abbr in rejected_abbrs:
             with self.subTest(f'%Z should raise ValueError with {abbr}'):

--- a/Misc/NEWS.d/next/Library/2022-06-03-21-53-30.gh-issue-66571.6AnlQ2.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-03-21-53-30.gh-issue-66571.6AnlQ2.rst
@@ -1,0 +1,2 @@
+Expand range of matches for ``%Z`` with :meth:`datetime.datetime.strptime`
+to additionally include any two to five character abbreviations.


### PR DESCRIPTION
I had sent a message a while back to the datetime-sig mailing list in regard to this issue and got some more direction from there. That also prompted a brief discussion with @pganssle on the original ticket.

In particular, @pganssle had suggested simply expanding the range of inputs that %Z will accept. Paul had mentioned any 3-4 characters, but I had noticed there was some timezone abbreviations with 2 characters (such as CT) and some with as many as 5 (such as CHADT) so I made that the max here.

The PR tries to take a more conservative approach by simply adding on the 2-5 character match if the machine's locale and UTC/GMT check first fail. 

  - If we wanted to, I would assume this 2-5 character match _should_ encompass the set of values that the machine's locale timezones may have and UTC/GMT. So we could possibly just have `(?P<Z>[a-z]{2,5})`.
  - Furthermore, does 2 to 5 characters make sense? Or, at this point, would it make more sense to simply match on any word given for %Z rather than have this middle ground where there are some values that are matched on that the caller could expect to be valid but some that the caller would need to check because of this more lax 2-5 character match. In reality, I would assume that simply means if the caller wants to be strict here, they need to get the full range of possible abbreviations and validate them all against tzname. And at that point, is there a point in us matching on utc/gmt/machine's locale timezones as well instead of simply accepting whatever word is giving for %Z? 

Closes #66571

<!-- gh-issue-number: gh-66571 -->
* Issue: gh-66571
<!-- /gh-issue-number -->
