### PR TITLE
Fix missing word in sys.float_info docstring

### DIFF
--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -71,7 +71,7 @@ static PyStructSequence_Field floatinfo_fields[] = {
     {"min_exp",         "DBL_MIN_EXP -- minimum int e such that radix**(e-1) "
                     "is a normalized float"},
     {"min_10_exp",      "DBL_MIN_10_EXP -- minimum int e such that 10**e is "
-                    "a normalized"},
+                    "a normalized float"},
     {"dig",             "DBL_DIG -- maximum number of decimal digits that "
                     "can be faithfully represented in a float"},
     {"mant_dig",        "DBL_MANT_DIG -- mantissa digits"},


### PR DESCRIPTION
The `sys.float_info` docstring entry for `min_10_exp` was missing a word: it should say `such that 10**e is a normalized float` instead of `such that 10**e is a normalized`. This PR fixes that.