### PR TITLE
gh-91985: Ensure the same path calculations when repeated with PYTHONHOME

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1389,7 +1389,8 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
     @unittest.skipUnless(MS_WINDOWS, 'Windows only')
     def test_repeated_init_pybuilddir_pythonhome_win32(self):
         # Test an out-of-build-tree layout with PYTHONHOME override,
-        # repeating path calculation.
+        # repeating path calculation (gh-91985). This layout is cited
+        # from test_buildtree_pythonhome_win32 in test_getpath.
         config = self._get_expected_config()
         paths = config['config']['module_search_paths']
 

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -481,6 +481,27 @@ static int test_init_compat_config(void)
 }
 
 
+static int test_repeated_init_compat_config(void)
+{
+    PyConfig config;
+    _PyConfig_InitCompatConfig(&config);
+    config_set_program_name(&config);
+
+    for (int i=0; i<3; i++) {
+        PyStatus status = Py_InitializeFromConfig(&config);
+        if (PyStatus_Exception(status)) {
+            Py_ExitStatusException(status);
+        }
+        Py_Finalize();
+    }
+    init_from_config_clear(&config);
+
+    dump_config();
+    Py_Finalize();
+    return 0;
+}
+
+
 static int test_init_global_config(void)
 {
     /* FIXME: test Py_IgnoreEnvironmentFlag */
@@ -1939,6 +1960,7 @@ static struct TestCase TestCases[] = {
     {"test_init_initialize_config", test_init_initialize_config},
     {"test_preinit_compat_config", test_preinit_compat_config},
     {"test_init_compat_config", test_init_compat_config},
+    {"test_repeated_init_compat_config", test_repeated_init_compat_config},
     {"test_init_global_config", test_init_global_config},
     {"test_init_from_config", test_init_from_config},
     {"test_init_parse_argv", test_init_parse_argv},


### PR DESCRIPTION
When an embedded Python is initialized multiple times, getpath.py requires `home` with the same value, for the consistent path configuration.

Roughly, the transition of `home` (`PyInterpreterState.config.home`) is as below:

1. `home` = `config.home`(original, local) or `_Py_path_config.home`(global)
2. `home`, `paths` = `getpath(home, PYTHONHOME, *._pth)`
3. `_Py_path_config.home` = `home` (the original `config.home` is left as-is)

**1st initialization with PYTHONHOME:**
1. `home` gets `NULL`.
2. getpath receives `None` as `home` and returns the value of `PYTHONHOME`.

**2nd:**
1. `home` starts with `PYTHONHOME` from `_Py_path_config.home`.
2. getpath keeps the existing `home` unchanged. The returned `paths`, which are less flexible than 1st, can cause import errors.

In this cycle, the value from `_Py_path_config.home` at step1 needs to be discarded unless the global value was set by `Py_SetPythonHome()`.

#91985