### PR TITLE
Grammar fix to socket error string

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -123,7 +123,7 @@ if sys.platform.lower().startswith("win"):
     errorTab[10014] = "A fault occurred on the network??"  # WSAEFAULT
     errorTab[10022] = "An invalid operation was attempted."
     errorTab[10024] = "Too many open files."
-    errorTab[10035] = "The socket operation would block"
+    errorTab[10035] = "The socket operation would block."
     errorTab[10036] = "A blocking operation is already in progress."
     errorTab[10037] = "Operation already in progress."
     errorTab[10038] = "Socket operation on nonsocket."


### PR DESCRIPTION
All similar error strings end in punctuation that finishes the sentence (full stop, question mark) however this string seems to have escaped the notice of the developers.

As this is a trivial change, an issue has not been raised. Requires the `skip issue` label as well as the `skip news` label.