### PR TITLE
Remove extra spaces in custom openSSL documentation.

### DIFF
--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -158,16 +158,16 @@ Custom OpenSSL
    .. code-block:: shell-session
 
       $ curl -O https://www.openssl.org/source/openssl-VERSION.tar.gz
-         $ tar xzf openssl-VERSION
-         $ pushd openssl-VERSION
-         $ ./config \
-              --prefix=/usr/local/custom-openssl \
-              --libdir=lib \
-              --openssldir=/etc/ssl
-         $ make -j1 depend
-         $ make -j8
-         $ make install_sw
-         $ popd
+      $ tar xzf openssl-VERSION
+      $ pushd openssl-VERSION
+      $ ./config \
+          --prefix=/usr/local/custom-openssl \
+          --libdir=lib \
+          --openssldir=/etc/ssl
+      $ make -j1 depend
+      $ make -j8
+      $ make install_sw
+      $ popd
 
 3. Build Python with custom OpenSSL
    (see the configure `--with-openssl` and `--with-openssl-rpath` options)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Format the [custom openSSL documentation](https://docs.python.org/3.10/using/unix.html#custom-openssl), removing extra spaces in the following code block
```shell
$ curl -O https://www.openssl.org/source/openssl-VERSION.tar.gz
   $ tar xzf openssl-VERSION
   $ pushd openssl-VERSION
   $ ./config \
        --prefix=/usr/local/custom-openssl \
        --libdir=lib \
        --openssldir=/etc/ssl
   $ make -j1 depend
   $ make -j8
   $ make install_sw
   $ popd
```