### PR TITLE
gh-93573: Replace wrong example domains in configparser doc

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -65,7 +65,7 @@ Let's take a very basic configuration file that looks like this:
    CompressionLevel = 9
    ForwardX11 = yes
 
-   [bitbucket.org]
+   [forge.example]
    User = hg
 
    [topsecret.server.example]
@@ -85,8 +85,8 @@ creating the above configuration file programmatically.
    >>> config['DEFAULT'] = {'ServerAliveInterval': '45',
    ...                      'Compression': 'yes',
    ...                      'CompressionLevel': '9'}
-   >>> config['bitbucket.org'] = {}
-   >>> config['bitbucket.org']['User'] = 'hg'
+   >>> config['forge.example'] = {}
+   >>> config['forge.example']['User'] = 'hg'
    >>> config['topsecret.server.example'] = {}
    >>> topsecret = config['topsecret.server.example']
    >>> topsecret['Port'] = '50022'     # mutates the parser
@@ -111,12 +111,12 @@ back and explore the data it holds.
    >>> config.read('example.ini')
    ['example.ini']
    >>> config.sections()
-   ['bitbucket.org', 'topsecret.server.example']
-   >>> 'bitbucket.org' in config
+   ['forge.example', 'topsecret.server.example']
+   >>> 'forge.example' in config
    True
    >>> 'python.org' in config
    False
-   >>> config['bitbucket.org']['User']
+   >>> config['forge.example']['User']
    'hg'
    >>> config['DEFAULT']['Compression']
    'yes'
@@ -125,14 +125,14 @@ back and explore the data it holds.
    'no'
    >>> topsecret['Port']
    '50022'
-   >>> for key in config['bitbucket.org']:  # doctest: +SKIP
+   >>> for key in config['forge.example']:  # doctest: +SKIP
    ...     print(key)
    user
    compressionlevel
    serveraliveinterval
    compression
    forwardx11
-   >>> config['bitbucket.org']['ForwardX11']
+   >>> config['forge.example']['ForwardX11']
    'yes'
 
 As we can see above, the API is pretty straightforward.  The only bit of magic
@@ -191,9 +191,9 @@ recognizes Boolean values from ``'yes'``/``'no'``, ``'on'``/``'off'``,
 
    >>> topsecret.getboolean('ForwardX11')
    False
-   >>> config['bitbucket.org'].getboolean('ForwardX11')
+   >>> config['forge.example'].getboolean('ForwardX11')
    True
-   >>> config.getboolean('bitbucket.org', 'Compression')
+   >>> config.getboolean('forge.example', 'Compression')
    True
 
 Apart from :meth:`~ConfigParser.getboolean`, config parsers also
@@ -235,7 +235,7 @@ the ``fallback`` keyword-only argument:
 
 .. doctest::
 
-   >>> config.get('bitbucket.org', 'monster',
+   >>> config.get('forge.example', 'monster',
    ...            fallback='No such things as monsters')
    'No such things as monsters'
 

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -68,7 +68,7 @@ Let's take a very basic configuration file that looks like this:
    [bitbucket.org]
    User = hg
 
-   [topsecret.server.com]
+   [topsecret.server.example]
    Port = 50022
    ForwardX11 = no
 
@@ -87,8 +87,8 @@ creating the above configuration file programmatically.
    ...                      'CompressionLevel': '9'}
    >>> config['bitbucket.org'] = {}
    >>> config['bitbucket.org']['User'] = 'hg'
-   >>> config['topsecret.server.com'] = {}
-   >>> topsecret = config['topsecret.server.com']
+   >>> config['topsecret.server.example'] = {}
+   >>> topsecret = config['topsecret.server.example']
    >>> topsecret['Port'] = '50022'     # mutates the parser
    >>> topsecret['ForwardX11'] = 'no'  # same here
    >>> config['DEFAULT']['ForwardX11'] = 'yes'
@@ -111,7 +111,7 @@ back and explore the data it holds.
    >>> config.read('example.ini')
    ['example.ini']
    >>> config.sections()
-   ['bitbucket.org', 'topsecret.server.com']
+   ['bitbucket.org', 'topsecret.server.example']
    >>> 'bitbucket.org' in config
    True
    >>> 'python.org' in config
@@ -120,7 +120,7 @@ back and explore the data it holds.
    'hg'
    >>> config['DEFAULT']['Compression']
    'yes'
-   >>> topsecret = config['topsecret.server.com']
+   >>> topsecret = config['topsecret.server.example']
    >>> topsecret['ForwardX11']
    'no'
    >>> topsecret['Port']
@@ -150,15 +150,15 @@ configuration while the previously existing keys are retained.
    >>> another_config = configparser.ConfigParser()
    >>> another_config.read('example.ini')
    ['example.ini']
-   >>> another_config['topsecret.server.com']['Port']
+   >>> another_config['topsecret.server.example']['Port']
    '50022'
-   >>> another_config.read_string("[topsecret.server.com]\nPort=48484")
-   >>> another_config['topsecret.server.com']['Port']
+   >>> another_config.read_string("[topsecret.server.example]\nPort=48484")
+   >>> another_config['topsecret.server.example']['Port']
    '48484'
-   >>> another_config.read_dict({"topsecret.server.com": {"Port": 21212}})
-   >>> another_config['topsecret.server.com']['Port']
+   >>> another_config.read_dict({"topsecret.server.example": {"Port": 21212}})
+   >>> another_config['topsecret.server.example']['Port']
    '21212'
-   >>> another_config['topsecret.server.com']['ForwardX11']
+   >>> another_config['topsecret.server.example']['ForwardX11']
    'no'
 
 This behaviour is equivalent to a :meth:`ConfigParser.read` call with several
@@ -220,7 +220,7 @@ provide fallback values:
 Please note that default values have precedence over fallback values.
 For instance, in our example the ``'CompressionLevel'`` key was
 specified only in the ``'DEFAULT'`` section.  If we try to get it from
-the section ``'topsecret.server.com'``, we will always get the default,
+the section ``'topsecret.server.example'``, we will always get the default,
 even if we specify a fallback:
 
 .. doctest::

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -114,7 +114,7 @@ back and explore the data it holds.
    ['bitbucket.org', 'topsecret.server.com']
    >>> 'bitbucket.org' in config
    True
-   >>> 'bytebong.com' in config
+   >>> 'python.org' in config
    False
    >>> config['bitbucket.org']['User']
    'hg'


### PR DESCRIPTION
This minor PR replaces bytebong.com to python.org in configparser example in order to use a domain the PSF controls.


`topsecret.server.com` is obviously an example and I don't think `bitbucket.org` is a risk currently so they are not modified.


<!-- gh-issue-number: gh-93573 -->
* Issue: gh-93573
<!-- /gh-issue-number -->
