### PR TITLE
gh-87961: Remove outdated notes from functions that aren't in the Limited API

### DIFF
--- a/Doc/c-api/call.rst
+++ b/Doc/c-api/call.rst
@@ -144,8 +144,6 @@ Vectorcall Support API
    However, the function ``PyVectorcall_NARGS`` should be used to allow
    for future extensions.
 
-   This function is not part of the :ref:`limited API <stable>`.
-
    .. versionadded:: 3.8
 
 .. c:function:: vectorcallfunc PyVectorcall_Function(PyObject *op)
@@ -158,8 +156,6 @@ Vectorcall Support API
    This is mostly useful to check whether or not *op* supports vectorcall,
    which can be done by checking ``PyVectorcall_Function(op) != NULL``.
 
-   This function is not part of the :ref:`limited API <stable>`.
-
    .. versionadded:: 3.8
 
 .. c:function:: PyObject* PyVectorcall_Call(PyObject *callable, PyObject *tuple, PyObject *dict)
@@ -171,8 +167,6 @@ Vectorcall Support API
    :c:member:`~PyTypeObject.tp_call` slot or be used in an implementation of ``tp_call``.
    It does not check the :const:`Py_TPFLAGS_HAVE_VECTORCALL` flag
    and it does not fall back to ``tp_call``.
-
-   This function is not part of the :ref:`limited API <stable>`.
 
    .. versionadded:: 3.8
 
@@ -255,8 +249,6 @@ please see individual documentation for details.
 
    Return the result of the call on success, or raise an exception and return
    *NULL* on failure.
-
-   This function is not part of the :ref:`limited API <stable>`.
 
    .. versionadded:: 3.9
 
@@ -343,8 +335,6 @@ please see individual documentation for details.
    Return the result of the call on success, or raise an exception and return
    *NULL* on failure.
 
-   This function is not part of the :ref:`limited API <stable>`.
-
    .. versionadded:: 3.9
 
 
@@ -356,8 +346,6 @@ please see individual documentation for details.
 
    Return the result of the call on success, or raise an exception and return
    *NULL* on failure.
-
-   This function is not part of the :ref:`limited API <stable>`.
 
    .. versionadded:: 3.9
 
@@ -372,8 +360,6 @@ please see individual documentation for details.
    Return the result of the call on success, or raise an exception and return
    *NULL* on failure.
 
-   This function is not part of the :ref:`limited API <stable>`.
-
    .. versionadded:: 3.9
 
 .. c:function:: PyObject* PyObject_VectorcallDict(PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwdict)
@@ -387,8 +373,6 @@ please see individual documentation for details.
    Therefore, this function should only be used if the caller
    already has a dictionary ready to use for the keyword arguments,
    but not a tuple for the positional arguments.
-
-   This function is not part of the :ref:`limited API <stable>`.
 
    .. versionadded:: 3.9
 
@@ -409,8 +393,6 @@ please see individual documentation for details.
 
    Return the result of the call on success, or raise an exception and return
    *NULL* on failure.
-
-   This function is not part of the :ref:`limited API <stable>`.
 
    .. versionadded:: 3.9
 

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -321,8 +321,6 @@ There are these calling conventions:
    or possibly ``NULL`` if there are no keywords.  The values of the keyword
    arguments are stored in the *args* array, after the positional arguments.
 
-   This is not part of the :ref:`limited API <stable>`.
-
    .. versionadded:: 3.7
 
 

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -727,12 +727,6 @@ and :c:type:`PyType_Type` effectively act as defaults.)
       When a user sets :attr:`__call__` in Python code, only *tp_call* is updated,
       likely making it inconsistent with the vectorcall function.
 
-   .. note::
-
-      The semantics of the ``tp_vectorcall_offset`` slot are provisional and
-      expected to be finalized in Python 3.9.
-      If you use vectorcall, plan for updating your code for Python 3.9.
-
    .. versionchanged:: 3.8
 
       Before version 3.8, this slot was named ``tp_print``.


### PR DESCRIPTION
Nowadays everything that *is* in the Limited API has a note added automatically.
Notes sayitng "this is not part of the limited API" could mislead people to think that these functions could never be added to the limited API. Remove them.

The note about tp_vectorcall_offset being provisional is outdated.
