### PR TITLE
Support Homebrew libraries on M1 Macs

### DIFF
--- a/Lib/ctypes/macholib/dyld.py
+++ b/Lib/ctypes/macholib/dyld.py
@@ -28,6 +28,7 @@ DEFAULT_FRAMEWORK_FALLBACK = [
 
 DEFAULT_LIBRARY_FALLBACK = [
     os.path.expanduser("~/lib"),
+    "/opt/homebrew/lib",
     "/usr/local/lib",
     "/lib",
     "/usr/lib",


### PR DESCRIPTION
Homebrew installs to `/opt/homebrew/lib` on M1 Macs, instead of `/usr/local/lib` on Intel Macs.
Without disabling SIP (to set DYLD_FALLBACK_LIBRARY_PATH in env) or manually changing the `DEFAULT_LIBRARY_FALLBACK` before loading any third-party libraries (as proposed here: https://github.com/Kozea/CairoSVG/issues/354#issuecomment-1072905204), libraries installed with homebrew can not be loaded.
