### PR TITLE
gh-93585: Set PyCode_Type.tp_basicsize to sizeof(PyCodeObject)

### DIFF
--- a/Misc/NEWS.d/next/C API/2022-06-07-17-08-35.gh-issue-93585.EfIKlx.rst
+++ b/Misc/NEWS.d/next/C API/2022-06-07-17-08-35.gh-issue-93585.EfIKlx.rst
@@ -1,0 +1,6 @@
+Set ``PyCode_Type.tp_basicsize`` to ``sizeof(PyCodeObject)``. Cython makes the
+assumption that ``PyCode_Type.tp_basicsize`` equals to
+``sizeof(PyCodeObject)``. This assumption is no longer true since the commit
+2bde6827ea4f136297b2d882480b981ff26262b6. Restore ``tp_basicsize`` until the
+PyCodeObject structure can use a C99 flexible array of size zero with the
+syntax ``char co_code_adaptive[]``. Patch by Victor Stinner.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1910,7 +1910,7 @@ static struct PyMethodDef code_methods[] = {
 PyTypeObject PyCode_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "code",
-    offsetof(PyCodeObject, co_code_adaptive),
+    sizeof(PyCodeObject),
     sizeof(_Py_CODEUNIT),
     (destructor)code_dealloc,           /* tp_dealloc */
     0,                                  /* tp_vectorcall_offset */


### PR DESCRIPTION
Cython makes the assumption that PyCode_Type.tp_basicsize equals to
sizeof(PyCodeObject). This assumption is no longer true since the
commit 2bde6827ea4f136297b2d882480b981ff26262b6. Restore tp_basicsize
until the PyCodeObject structure can use a C99 flexible array of size
zero with the syntax "char co_code_adaptive[]".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
