### PR TITLE
docs tutorial - specify match cases don't fall through

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -253,8 +253,10 @@ at a more abstract level.  The :keyword:`!pass` is silently ignored::
 A :keyword:`match` statement takes an expression and compares its value to successive
 patterns given as one or more case blocks.  This is superficially
 similar to a switch statement in C, Java or JavaScript (and many
-other languages), but it can also extract components (sequence elements or
-object attributes) from the value into variables.
+other languages), but it's more similar to pattern matching in
+languages like Rust or Haskell. Only the first pattern that matches
+gets executed and it can also extract components (sequence elements
+or object attributes) from the value into variables.
 
 The simplest form compares a subject value against one or more literals::
 


### PR DESCRIPTION
Hello, this is my first contribution here, sorry if I missed something in the contribution guidelines.

I was reading the docs about the for me new `match` control flow and had to dig into the linked PEP to make sure the cases don't fall through like I'd expect because the tutorial compared it to a switch statement but the only difference it pointed out was the pattern matching which confused me. I hope this would make it clearer.