### PR TITLE
gh-93626: Set the release for `__future__.annotations` to `None`

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -336,6 +336,14 @@ See :pep:`681` for more details.
 (Contributed by Jelle Zijlstra in :gh:`91860`. PEP written by
 Erik De Bonte and Eric Traut.)
 
+Non-futures Related to Type Hints
+---------------------------------
+
+* :pep:`563` Postponed Evaluation of Annotations, ``__future__.annotations``
+  that was planned for this release has been indefinitely postponed.
+  See `this message <https://mail.python.org/archives/list/python-dev@python.
+  org/message/VIZEBX5EYMSYIJNDBF6DMUMZOCWHARSO/>`_ for more information.
+
 Other Language Changes
 ======================
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -336,8 +336,8 @@ See :pep:`681` for more details.
 (Contributed by Jelle Zijlstra in :gh:`91860`. PEP written by
 Erik De Bonte and Eric Traut.)
 
-Non-futures Related to Type Hints
----------------------------------
+PEP 563 May Not Be the Future
+-----------------------------
 
 * :pep:`563` Postponed Evaluation of Annotations, ``__future__.annotations``
   that was planned for this release has been indefinitely postponed.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -341,8 +341,7 @@ PEP 563 May Not Be the Future
 
 * :pep:`563` Postponed Evaluation of Annotations, ``__future__.annotations``
   that was planned for this release has been indefinitely postponed.
-  See `this message <https://mail.python.org/archives/list/python-dev@python.
-  org/message/VIZEBX5EYMSYIJNDBF6DMUMZOCWHARSO/>`_ for more information.
+  See `this message <https://mail.python.org/archives/list/python-dev@python.org/message/VIZEBX5EYMSYIJNDBF6DMUMZOCWHARSO/>`_ for more information.
 
 Other Language Changes
 ======================

--- a/Lib/__future__.py
+++ b/Lib/__future__.py
@@ -33,7 +33,7 @@ in releases at or after that, modules no longer need
 to use the feature in question, but may continue to use such imports.
 
 MandatoryRelease may also be None, meaning that a planned feature got
-dropped.
+dropped or that the release version is undetermined.
 
 Instances of class _Feature have two corresponding methods,
 .getOptionalRelease() and .getMandatoryRelease().
@@ -96,7 +96,7 @@ class _Feature:
         """Return release in which this feature will become mandatory.
 
         This is a 5-tuple, of the same form as sys.version_info, or, if
-        the feature was dropped, is None.
+        the feature was dropped, or the release date is undetermined, is None.
         """
         return self.mandatory
 
@@ -143,5 +143,5 @@ generator_stop = _Feature((3, 5, 0, "beta", 1),
                           CO_FUTURE_GENERATOR_STOP)
 
 annotations = _Feature((3, 7, 0, "beta", 1),
-                       (3, 11, 0, "alpha", 0),
+                       None,
                        CO_FUTURE_ANNOTATIONS)

--- a/Misc/NEWS.d/next/Library/2022-06-09-14-44-21.gh-issue-93626.sfghs46.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-09-14-44-21.gh-issue-93626.sfghs46.rst
@@ -1,0 +1,1 @@
+Set ``__future__.annotations`` to have a ``None`` mandatoryRelease to indicate that it is currently 'TBD'.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Hi everyone, I noticed that `__future__.annotations` was turned **on** in the 3.11 betas 😳😳😳😳😳😳.

This is highly sus as it should be turned off till further notice ~~(3.12 :trollface:)~~ (`None` kinda means 'tbd' I think).

This is my first cpython contrib, I tried to follow the contributing process, but maybe I missed something, sorry!


This PR also needs to be backported to the 3.11 branch


resolves: #93626

<!-- gh-issue-number: gh-93626 -->
* Issue: gh-93626
<!-- /gh-issue-number -->


Corresponding typeshed PR https://github.com/python/typeshed/pull/8232