### PR TITLE
gh-91985: Ensure in-tree builds override platstdlib_dir in every path calculation

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1334,12 +1334,12 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         }
         env = {'TESTHOME': home, 'PYTHONPATH': paths_str}
 
-        env['INVALID_ISPYTHONBUILD'] = '1'
+        env['NEGATIVE_ISPYTHONBUILD'] = '1'
         config['_is_python_build'] = 0
         self.check_all_configs("test_init_is_python_build", config,
                                api=API_COMPAT, env=env)
 
-        env['INVALID_ISPYTHONBUILD'] = '0'
+        env['NEGATIVE_ISPYTHONBUILD'] = '0'
         config['_is_python_build'] = 1
         config['module_search_paths'][-1] = os.path.dirname(self.test_exe)
         self.check_all_configs("test_init_is_python_build", config,

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1358,10 +1358,10 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             expected_paths = [paths[0], stdlib, platstdlib]
         else:
             prefix = exec_prefix = sys.prefix
-            expected_paths = [self.module_search_paths(prefix=prefix)[0],
-                              stdlib, platstdlib]
             # stdlib calculation (/Lib) is not yet supported.
             stdlib = os.path.join(home, sys.platlibdir, f'python{version}')
+            expected_paths = [self.module_search_paths(prefix=prefix)[0],
+                              stdlib, platstdlib]
 
         config.update(module_search_paths=expected_paths,
                       prefix=prefix, base_prefix=prefix,

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1304,7 +1304,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                                api=API_COMPAT, env=env)
 
     def test_init_is_python_build_with_home(self):
-        # Test _Py_path_config._is_python_build field (gh-91985)
+        # Test _Py_path_config._is_python_build configuration (gh-91985)
         config = self._get_expected_config()
         paths = config['config']['module_search_paths']
         paths_str = os.path.pathsep.join(paths)
@@ -1348,24 +1348,20 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
         env['NEGATIVE_ISPYTHONBUILD'] = '0'
         config['_is_python_build'] = 1
-
         exedir = os.path.dirname(sys.executable)
         with open(os.path.join(exedir, 'pybuilddir.txt'), encoding='utf8') as f:
-            platstdlib = os.path.join(exedir, f'{f.read()}\n$'.splitlines()[0])
-        platstdlib = os.path.normpath(platstdlib)
-
+            platstdlib = os.path.normpath(os.path.join(exedir,
+                                          f'{f.read()}\n$'.splitlines()[0]))
         if MS_WINDOWS:
-            expected_paths = [paths[0], stdlib, platstdlib]
+            expected_paths[2] = platstdlib
         else:
+            # PREFIX (default) is set when running in build directory
             prefix = exec_prefix = sys.prefix
-            # stdlib calculation (/Lib) is not yet supported.
-            stdlib = os.path.join(home, sys.platlibdir, f'python{version}')
-            expected_paths = [self.module_search_paths(prefix=prefix)[0],
-                              stdlib, platstdlib]
-
-        config.update(module_search_paths=expected_paths,
-                      prefix=prefix, base_prefix=prefix,
-                      exec_prefix=exec_prefix, base_exec_prefix=exec_prefix)
+            # stdlib calculation (/Lib) is not yet supported
+            expected_paths[0] = self.module_search_paths(prefix=prefix)[0]
+            expected_paths[2] = platstdlib
+            config.update(prefix=prefix, base_prefix=prefix,
+                          exec_prefix=exec_prefix, base_exec_prefix=exec_prefix)
         self.check_all_configs("test_init_is_python_build", config,
                                api=API_COMPAT, env=env)
 

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1339,6 +1339,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'pythonpath_env': paths_str,
             'stdlib_dir': stdlib,
         }
+        # The code above is taken from test_init_setpythonhome()
         env = {'TESTHOME': home, 'PYTHONPATH': paths_str}
 
         env['NEGATIVE_ISPYTHONBUILD'] = '1'

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1350,16 +1350,13 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         config['_is_python_build'] = 1
         exedir = os.path.dirname(sys.executable)
         with open(os.path.join(exedir, 'pybuilddir.txt'), encoding='utf8') as f:
-            platstdlib = os.path.normpath(os.path.join(exedir,
-                                          f'{f.read()}\n$'.splitlines()[0]))
-        if MS_WINDOWS:
-            expected_paths[2] = platstdlib
-        else:
+            expected_paths[2] = os.path.normpath(
+                os.path.join(exedir, f'{f.read()}\n$'.splitlines()[0]))
+        if not MS_WINDOWS:
             # PREFIX (default) is set when running in build directory
             prefix = exec_prefix = sys.prefix
             # stdlib calculation (/Lib) is not yet supported
             expected_paths[0] = self.module_search_paths(prefix=prefix)[0]
-            expected_paths[2] = platstdlib
             config.update(prefix=prefix, base_prefix=prefix,
                           exec_prefix=exec_prefix, base_exec_prefix=exec_prefix)
         self.check_all_configs("test_init_is_python_build", config,

--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -239,48 +239,6 @@ class MockGetPathTests(unittest.TestCase):
         actual = getpath(ns, expected)
         self.assertEqual(expected, actual)
 
-    def test_run_in_tree_build_win32(self):
-        "Test _is_python_build fields with invalid cases.(gh-91985)"
-        def read_pathconfig(config, attr):
-            if _Py_path_config[attr] >= 0 and config[attr] <= 0:
-                config[attr] = _Py_path_config[attr]
-
-        def update_pathconfig(config, attr):
-            if config[attr] > 0:
-                _Py_path_config[attr] = config[attr]
-
-        for flags in [(0,-1), (-1, 0), (-1,-1), (-10, 0), [-10, 5], [5,-10]]:
-            _Py_path_config = dict(
-                _is_python_build=flags[0],
-            )
-            ns = MockNTNamespace(
-                argv0=r"C:\CPython\PCbuild\amd64\python.exe",
-            )
-            ns.add_known_file(r"C:\CPython\PCbuild\amd64\pybuilddir.txt", [""])
-            ns['config'].update(
-                home=r"C:\CPython",  # turn on 'home_was_set'
-                _is_python_build=flags[1],
-            )
-            # _PyConfig_InitPathConfig emulation
-            read_pathconfig(ns['config'], '_is_python_build')
-            if isinstance(flags, tuple):
-                expected = dict(
-                    _is_python_build=ns['config']['_is_python_build'],
-                    build_prefix=None,
-                    platstdlib_dir=r"C:\CPython\DLLs",
-                )
-            else:
-                flags = (1, 1)
-                expected = dict(
-                    _is_python_build=flags[1],
-                    build_prefix=r"C:\CPython",
-                    platstdlib_dir=r"C:\CPython\PCbuild\amd64",
-                )
-            actual = getpath(ns, expected)
-            self.assertEqual(actual, expected)
-            update_pathconfig(actual, '_is_python_build')
-            self.assertEqual(_Py_path_config['_is_python_build'], flags[0])
-
     def test_normal_posix(self):
         "Test a 'standard' install layout on *nix"
         ns = MockPosixNamespace(

--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -249,21 +249,15 @@ class MockGetPathTests(unittest.TestCase):
             if config[attr] > 0:
                 _Py_path_config[attr] = config[attr]
 
-        edges = {
-            ( 0, -1) :  0,
-            (-1,  0) : -1,
-            (-1, -1) : -1,
-            ( 1,  0) :  1,
-        }
-        for key in edges:
+        for edges in [(0,-1), (-1, 0), (-1,-1), (1, 0)]:
             _Py_path_config = dict(
-                _is_python_build=key[0],
+                _is_python_build=edges[0],
             )
             ns = MockNTNamespace(
                 argv0=r"C:\CPython\PCbuild\amd64\python.exe",
             )
             ns['config'].update(
-                _is_python_build=key[1],
+                _is_python_build=edges[1],
             )
             # _PyConfig_InitPathConfig emulation
             read_pathconfig(ns['config'], '_is_python_build')
@@ -274,7 +268,7 @@ class MockGetPathTests(unittest.TestCase):
             actual = getpath(ns, expected)
             self.assertEqual(actual, expected)
             update_pathconfig(actual, '_is_python_build')
-            self.assertEqual(_Py_path_config['_is_python_build'], edges[key])
+            self.assertEqual(_Py_path_config['_is_python_build'], edges[0])
 
     def test_normal_posix(self):
         "Test a 'standard' install layout on *nix"

--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -249,7 +249,7 @@ class MockGetPathTests(unittest.TestCase):
             if config[attr] > 0:
                 _Py_path_config[attr] = config[attr]
 
-        for edges in [(0,-1), (-1, 0), (-1,-1)]:
+        for edges in [(0,-1), (-1, 0), (-1,-1), (-10, 0), [-10, 5], [5, -10]]:
             _Py_path_config = dict(
                 _is_python_build=edges[0],
             )
@@ -263,10 +263,17 @@ class MockGetPathTests(unittest.TestCase):
             )
             # _PyConfig_InitPathConfig emulation
             read_pathconfig(ns['config'], '_is_python_build')
-            expected = dict(
-                _is_python_build=ns['config']['_is_python_build'],
-                build_prefix=None,        # landmarks must not be checked for
-            )
+            if isinstance(edges, tuple):
+                expected = dict(
+                    _is_python_build=ns['config']['_is_python_build'],
+                    build_prefix=None,
+                )
+            else:
+                edges = (1, 1)
+                expected = dict(
+                    _is_python_build=edges[1],
+                    build_prefix=r"C:\CPython",
+                )
             actual = getpath(ns, expected)
             self.assertEqual(actual, expected)
             update_pathconfig(actual, '_is_python_build')

--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -265,7 +265,7 @@ class MockGetPathTests(unittest.TestCase):
             read_pathconfig(ns['config'], '_is_python_build')
             expected = dict(
                 _is_python_build=ns['config']['_is_python_build'],
-                build_prefix=None,        # landmarks must not be checked
+                build_prefix=None,        # landmarks must not be checked for
             )
             actual = getpath(ns, expected)
             self.assertEqual(actual, expected)

--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -240,7 +240,7 @@ class MockGetPathTests(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_run_in_tree_build_win32(self):
-        "Test _is_python_build fields with edge cases.(gh-91985)"
+        "Test _is_python_build fields with invalid cases.(gh-91985)"
         def read_pathconfig(config, attr):
             if _Py_path_config[attr] >= 0 and config[attr] <= 0:
                 config[attr] = _Py_path_config[attr]
@@ -249,9 +249,9 @@ class MockGetPathTests(unittest.TestCase):
             if config[attr] > 0:
                 _Py_path_config[attr] = config[attr]
 
-        for edges in [(0,-1), (-1, 0), (-1,-1), (-10, 0), [-10, 5], [5,-10]]:
+        for flags in [(0,-1), (-1, 0), (-1,-1), (-10, 0), [-10, 5], [5,-10]]:
             _Py_path_config = dict(
-                _is_python_build=edges[0],
+                _is_python_build=flags[0],
             )
             ns = MockNTNamespace(
                 argv0=r"C:\CPython\PCbuild\amd64\python.exe",
@@ -259,27 +259,27 @@ class MockGetPathTests(unittest.TestCase):
             ns.add_known_file(r"C:\CPython\PCbuild\amd64\pybuilddir.txt", [""])
             ns['config'].update(
                 home=r"C:\CPython",  # turn on 'home_was_set'
-                _is_python_build=edges[1],
+                _is_python_build=flags[1],
             )
             # _PyConfig_InitPathConfig emulation
             read_pathconfig(ns['config'], '_is_python_build')
-            if isinstance(edges, tuple):
+            if isinstance(flags, tuple):
                 expected = dict(
                     _is_python_build=ns['config']['_is_python_build'],
                     build_prefix=None,
                     platstdlib_dir=r"C:\CPython\DLLs",
                 )
             else:
-                edges = (1, 1)
+                flags = (1, 1)
                 expected = dict(
-                    _is_python_build=edges[1],
+                    _is_python_build=flags[1],
                     build_prefix=r"C:\CPython",
                     platstdlib_dir=r"C:\CPython\PCbuild\amd64",
                 )
             actual = getpath(ns, expected)
             self.assertEqual(actual, expected)
             update_pathconfig(actual, '_is_python_build')
-            self.assertEqual(_Py_path_config['_is_python_build'], edges[0])
+            self.assertEqual(_Py_path_config['_is_python_build'], flags[0])
 
     def test_normal_posix(self):
         "Test a 'standard' install layout on *nix"

--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -249,7 +249,7 @@ class MockGetPathTests(unittest.TestCase):
             if config[attr] > 0:
                 _Py_path_config[attr] = config[attr]
 
-        for edges in [(0,-1), (-1, 0), (-1,-1), (-10, 0), [-10, 5], [5, -10]]:
+        for edges in [(0,-1), (-1, 0), (-1,-1), (-10, 0), [-10, 5], [5,-10]]:
             _Py_path_config = dict(
                 _is_python_build=edges[0],
             )
@@ -258,7 +258,7 @@ class MockGetPathTests(unittest.TestCase):
             )
             ns.add_known_file(r"C:\CPython\PCbuild\amd64\pybuilddir.txt", [""])
             ns['config'].update(
-                home=r"C:\CPython",       # turn on 'home_was_set'
+                home=r"C:\CPython",  # turn on 'home_was_set'
                 _is_python_build=edges[1],
             )
             # _PyConfig_InitPathConfig emulation
@@ -267,12 +267,14 @@ class MockGetPathTests(unittest.TestCase):
                 expected = dict(
                     _is_python_build=ns['config']['_is_python_build'],
                     build_prefix=None,
+                    platstdlib_dir=r"C:\CPython\DLLs",
                 )
             else:
                 edges = (1, 1)
                 expected = dict(
                     _is_python_build=edges[1],
                     build_prefix=r"C:\CPython",
+                    platstdlib_dir=r"C:\CPython\PCbuild\amd64",
                 )
             actual = getpath(ns, expected)
             self.assertEqual(actual, expected)

--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -249,21 +249,23 @@ class MockGetPathTests(unittest.TestCase):
             if config[attr] > 0:
                 _Py_path_config[attr] = config[attr]
 
-        for edges in [(0,-1), (-1, 0), (-1,-1), (1, 0)]:
+        for edges in [(0,-1), (-1, 0), (-1,-1)]:
             _Py_path_config = dict(
                 _is_python_build=edges[0],
             )
             ns = MockNTNamespace(
                 argv0=r"C:\CPython\PCbuild\amd64\python.exe",
             )
+            ns.add_known_file(r"C:\CPython\PCbuild\amd64\pybuilddir.txt", [""])
             ns['config'].update(
+                home=r"C:\CPython",       # turn on 'home_was_set'
                 _is_python_build=edges[1],
             )
             # _PyConfig_InitPathConfig emulation
             read_pathconfig(ns['config'], '_is_python_build')
             expected = dict(
                 _is_python_build=ns['config']['_is_python_build'],
-                build_prefix=None,  # no build-landmark
+                build_prefix=None,        # landmarks must not be checked
             )
             actual = getpath(ns, expected)
             self.assertEqual(actual, expected)

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -462,7 +462,7 @@ if not py_setpath and not home_was_set:
 build_prefix = None
 
 if ((not home_was_set and real_executable_dir and not py_setpath)
-        or config.get('_is_python_build')):
+        or config.get('_is_python_build', 0) > 0):
     # Detect a build marker and use it to infer prefix, exec_prefix,
     # stdlib_dir and the platstdlib_dir directories.
     try:

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -461,7 +461,8 @@ if not py_setpath and not home_was_set:
 
 build_prefix = None
 
-if not home_was_set and real_executable_dir and not py_setpath:
+if ((not home_was_set and real_executable_dir and not py_setpath)
+        or config.get('_is_python_build')):
     # Detect a build marker and use it to infer prefix, exec_prefix,
     # stdlib_dir and the platstdlib_dir directories.
     try:

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1570,6 +1570,7 @@ static int test_init_is_python_build(void)
     // under the effect of 'home' or PYTHONHOME environment variable.
     config_set_string(&config, &config.home, home);
     PyMem_RawFree(home);
+    putenv("TESTHOME=");
 
     // Use an impossible value so we can detect whether it isn't updated
     // during initialization.

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1574,7 +1574,7 @@ static int test_init_is_python_build(void)
     config._is_python_build = INT_MAX;
     env = getenv("NEGATIVE_ISPYTHONBUILD");
     if (env) {
-        if (strcmp(env, "1") == 0) {
+        if (strcmp(env, "0") != 0) {
             config._is_python_build++;
         }
         putenv("NEGATIVE_ISPYTHONBUILD=");

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1552,6 +1552,8 @@ static int test_init_setpythonhome(void)
 
 static int test_init_is_python_build(void)
 {
+    // gh-91985: in-tree builds fail to check for build directory landmarks
+    // under the effect of 'home' or PYTHONHOME environment variable.
     char *env = getenv("TESTHOME");
     if (!env) {
         error("missing TESTHOME env var");
@@ -1566,8 +1568,6 @@ static int test_init_is_python_build(void)
     PyConfig config;
     _PyConfig_InitCompatConfig(&config);
     config_set_program_name(&config);
-    // gh-91985: in-tree builds fail to check for build directory landmarks
-    // under the effect of 'home' or PYTHONHOME environment variable.
     config_set_string(&config, &config.home, home);
     PyMem_RawFree(home);
     putenv("TESTHOME=");

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1572,12 +1572,12 @@ static int test_init_is_python_build(void)
     putenv("TESTHOME=");
 
     config._is_python_build = INT_MAX;
-    env = getenv("INVALID_ISPYTHONBUILD");
+    env = getenv("NEGATIVE_ISPYTHONBUILD");
     if (env) {
         if (strcmp(env, "1") == 0) {
             config._is_python_build++;
         }
-        putenv("INVALID_ISPYTHONBUILD=");
+        putenv("NEGATIVE_ISPYTHONBUILD=");
     }
     init_from_config_clear(&config);
     Py_Finalize();

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1566,25 +1566,24 @@ static int test_init_is_python_build(void)
     PyConfig config;
     _PyConfig_InitCompatConfig(&config);
     config_set_program_name(&config);
-    // Ensure 'home_was_set' is turned on in getpath.py
+    // gh-91985: in-tree builds fail to check for build directory landmarks
+    // under the effect of 'home' or PYTHONHOME environment variable.
     config_set_string(&config, &config.home, home);
     PyMem_RawFree(home);
-    putenv("TESTHOME=");
 
+    // Use an impossible value so we can detect whether it isn't updated
+    // during initialization.
     config._is_python_build = INT_MAX;
     env = getenv("NEGATIVE_ISPYTHONBUILD");
-    if (env) {
-        if (strcmp(env, "0") != 0) {
-            config._is_python_build++;
-        }
-        putenv("NEGATIVE_ISPYTHONBUILD=");
+    if (env && strcmp(env, "0") != 0) {
+        config._is_python_build++;
     }
     init_from_config_clear(&config);
     Py_Finalize();
     // Second initialization
     config._is_python_build = -1;
     init_from_config_clear(&config);
-    dump_config();  // home and _is_python_build are from _Py_path_config
+    dump_config();  // home and _is_python_build are cached in _Py_path_config
     Py_Finalize();
     return 0;
 }

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -103,6 +103,7 @@ _PyPathConfig_ReadGlobal(PyConfig *config)
 
 #define COPY_INT(ATTR) \
     do { \
+        assert(_Py_path_config.ATTR >= 0); \
         if ((_Py_path_config.ATTR >= 0) && (config->ATTR <= 0)) { \
             config->ATTR = _Py_path_config.ATTR; \
         } \

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -103,7 +103,7 @@ _PyPathConfig_ReadGlobal(PyConfig *config)
 
 #define COPY_INT(ATTR) \
     do { \
-        if ((_Py_path_config.ATTR > 0) && (config->ATTR <= 0)) { \
+        if ((_Py_path_config.ATTR >= 0) && (config->ATTR <= 0)) { \
             config->ATTR = _Py_path_config.ATTR; \
         } \
     } while (0)

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -36,10 +36,11 @@ typedef struct _PyPathConfig {
     wchar_t *program_name;
     /* Set by Py_SetPythonHome() or PYTHONHOME environment variable */
     wchar_t *home;
+    int _is_python_build;
 } _PyPathConfig;
 
 #  define _PyPathConfig_INIT \
-      {.module_search_path = NULL}
+      {.module_search_path = NULL, ._is_python_build = 0}
 
 
 _PyPathConfig _Py_path_config = _PyPathConfig_INIT;
@@ -72,6 +73,7 @@ _PyPathConfig_ClearGlobal(void)
     CLEAR(calculated_module_search_path);
     CLEAR(program_name);
     CLEAR(home);
+    _Py_path_config._is_python_build = 0;
 
 #undef CLEAR
 
@@ -99,15 +101,24 @@ _PyPathConfig_ReadGlobal(PyConfig *config)
         } \
     } while (0)
 
+#define COPY_INT(ATTR) \
+    do { \
+        if ((_Py_path_config.ATTR > 0) && (config->ATTR <= 0)) { \
+            config->ATTR = _Py_path_config.ATTR; \
+        } \
+    } while (0)
+
     COPY(prefix);
     COPY(exec_prefix);
     COPY(stdlib_dir);
     COPY(program_name);
     COPY(home);
     COPY2(executable, program_full_path);
+    COPY_INT(_is_python_build);
     // module_search_path must be initialised - not read
 #undef COPY
 #undef COPY2
+#undef COPY_INT
 
 done:
     return status;
@@ -137,14 +148,23 @@ _PyPathConfig_UpdateGlobal(const PyConfig *config)
         } \
     } while (0)
 
+#define COPY_INT(ATTR) \
+    do { \
+        if (config->ATTR > 0) { \
+            _Py_path_config.ATTR = config->ATTR; \
+        } \
+    } while (0)
+
     COPY(prefix);
     COPY(exec_prefix);
     COPY(stdlib_dir);
     COPY(program_name);
     COPY(home);
     COPY2(program_full_path, executable);
+    COPY_INT(_is_python_build);
 #undef COPY
 #undef COPY2
+#undef COPY_INT
 
     PyMem_RawFree(_Py_path_config.module_search_path);
     _Py_path_config.module_search_path = NULL;


### PR DESCRIPTION
This adds `_is_python_build` field to `_PyPathConfig` structure, where `getpath.py` saves and restores the value via `PyInterpreterState.config._is_python_build`, so that in-tree builds can detect build directory landmarks every time `Py_Initialize*()` is called.

The source configuration data which we pass to `Py_Initialize*()` is supposed to be left as-is.

#91985