### PR TITLE
gh-93660: Change list to view object in SymbolTable docstring

### DIFF
--- a/Doc/library/symtable.rst
+++ b/Doc/library/symtable.rst
@@ -69,7 +69,8 @@ Examining Symbol Tables
 
    .. method:: get_identifiers()
 
-      Return a list of names of symbols in this table.
+      Return a view object containing the names of symbols in the table.
+      See the :ref:`documentation of view objects <dict-views>`.
 
    .. method:: lookup(name)
 

--- a/Lib/symtable.py
+++ b/Lib/symtable.py
@@ -111,7 +111,7 @@ class SymbolTable:
         return bool(self._table.children)
 
     def get_identifiers(self):
-        """Return a list of names of symbols in the table.
+        """Return a view object containing the names of symbols in the table.
         """
         return self._table.symbols.keys()
 


### PR DESCRIPTION
This PR changes the docstring and RST to accurately describe the return value. I included a link to the dictionary views reference since that's what dict.keys() does. I could not find any other examples of stdlib functions/methods that return dictionary view objects (outside of dict) so I'm not sure if there's a clearer way to describe them.

