### PR TITLE
gh-93610: Fix links to importlib.abc.Traversable

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -219,7 +219,7 @@ check:
 	$(SPHINXLINT) --enable default-role ../Misc/NEWS.d/next/
 
 serve:
-	@echo "The serve target was removed, use htmlview instead (see bpo-36329)"
+	@echo "The serve target was removed, use `make htmlview` instead (see bpo-36329)"
 
 # Targets for daily automated doc build
 # By default, Sphinx only rebuilds pages where the page content has changed.

--- a/Doc/library/importlib.resources.rst
+++ b/Doc/library/importlib.resources.rst
@@ -61,7 +61,7 @@ The following functions are available.
 
 .. function:: files(package)
 
-    Returns an :class:`importlib.resources.abc.Traversable` object
+    Returns an :class:`importlib.abc.Traversable` object
     representing the resource container for the package (think directory)
     and its resources (think files). A Traversable may contain other
     containers (think subdirectories).
@@ -73,7 +73,7 @@ The following functions are available.
 
 .. function:: as_file(traversable)
 
-    Given a :class:`importlib.resources.abc.Traversable` object representing
+    Given a :class:`importlib.abc.Traversable` object representing
     a file, typically from :func:`importlib.resources.files`, return
     a context manager for use in a :keyword:`with` statement.
     The context manager provides a :class:`pathlib.Path` object.

--- a/Misc/NEWS.d/next/Documentation/2022-06-10-15-13-55.gh-issue-93699.SsifdG.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-10-15-13-55.gh-issue-93699.SsifdG.rst
@@ -1,0 +1,1 @@
+Fix documentation links to ``importlib.abc.Traversable``.


### PR DESCRIPTION
Closes #93610

This also improves the error message when someone uses the older `make serve`
command of `Docs/Makefile`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
