### PR TITLE
gh-79512: Fixed names and __module__ value of weakref classes

### DIFF
--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -2154,6 +2154,17 @@ class FinalizeTestCase(unittest.TestCase):
         self.assertTrue(b'ZeroDivisionError' in err)
 
 
+class ModuleTestCase(unittest.TestCase):
+    def test_names(self):
+        for name in ('ReferenceType', 'ProxyType', 'CallableProxyType',
+                     'WeakMethod', 'WeakSet', 'WeakKeyDictionary', 'WeakValueDictionary'):
+            obj = getattr(weakref, name)
+            if name != 'WeakSet':
+                self.assertEqual(obj.__module__, 'weakref')
+            self.assertEqual(obj.__name__, name)
+            self.assertEqual(obj.__qualname__, name)
+
+
 libreftest = """ Doctest for examples in the library reference: weakref.rst
 
 >>> from test.support import gc_collect

--- a/Misc/NEWS.d/next/Library/2022-06-11-13-32-17.gh-issue-79512.A1KTDr.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-11-13-32-17.gh-issue-79512.A1KTDr.rst
@@ -1,0 +1,3 @@
+Fixed names and ``__module__`` value of :mod:`weakref` classes
+:class:`~weakref.ReferenceType`, :class:`~weakref.ProxyType`,
+:class:`~weakref.CallableProxyType`. It makes them pickleable.

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -371,7 +371,7 @@ static PyMethodDef weakref_methods[] = {
 PyTypeObject
 _PyWeakref_RefType = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    .tp_name = "weakref",
+    .tp_name = "weakref.ReferenceType",
     .tp_basicsize = sizeof(PyWeakReference),
     .tp_dealloc = weakref_dealloc,
     .tp_vectorcall_offset = offsetof(PyWeakReference, vectorcall),
@@ -719,7 +719,7 @@ static PyMappingMethods proxy_as_mapping = {
 PyTypeObject
 _PyWeakref_ProxyType = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "weakproxy",
+    "weakref.ProxyType",
     sizeof(PyWeakReference),
     0,
     /* methods */
@@ -754,7 +754,7 @@ _PyWeakref_ProxyType = {
 PyTypeObject
 _PyWeakref_CallableProxyType = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "weakcallableproxy",
+    "weakref.CallableProxyType",
     sizeof(PyWeakReference),
     0,
     /* methods */


### PR DESCRIPTION
Classes ReferenceType, ProxyType and CallableProxyType have now correct
attributes `__module__`, `__name__` and `__qualname__`. It makes them pickleable.

#79512