### PR TITLE
gh-93713: LogRecord.getMessage() cashes itself and returns cash if present

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -387,9 +387,12 @@ class LogRecord(object):
         Return the message for this LogRecord after merging any user-supplied
         arguments with the message.
         """
+        if hasattr(self, "message"):
+            return str(self.message)
         msg = str(self.msg)
         if self.args:
             msg = msg % self.args
+        self.message = msg
         return msg
 
 #
@@ -700,7 +703,7 @@ class Formatter(object):
         called to format the event time. If there is exception information,
         it is formatted using formatException() and appended to the message.
         """
-        record.message = record.getMessage()
+        record.getMessage()
         if self.usesTime():
             record.asctime = self.formatTime(record, self.datefmt)
         s = self.formatMessage(record)


### PR DESCRIPTION
Optionally, we could add some flag to `getMessage()`, something like `reformat=False` for "hard refresh", but I don't know any scenario, it would be appropriate.
