### PR TITLE
Minor optimization for Fractions.limit_denominator

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -245,14 +245,17 @@ class Fraction(numbers.Rational):
                 break
             p0, q0, p1, q1 = p1, q1, p0+a*p1, q2
             n, d = d, n-a*d
-
         k = (max_denominator-q0)//q1
-        bound1 = Fraction(p0+k*p1, q0+k*q1, _normalize=False)
-        bound2 = Fraction(p1, q1, _normalize=False)
-        if abs(bound2 - self) <= abs(bound1-self):
-            return bound2
+
+        # Determine which of the candidate fractions (p0+k*p1)/(q0+k*q1) and
+        # p1/q1 is closer to self. The distance between the two candidates is
+        # 1/(q1*(q0+k*q1)), while the distance from p1/q1 to self is
+        # 1/(q1*(q0+n/d*q1)). So we need to compare q0+k*q1 with 2*(q0+n/d*q1).
+        # That translates to the following comparison in integers.
+        if (q0+2*k*q1)*d <= q1*n:
+            return Fraction(p1, q1, _normalize=False)
         else:
-            return bound1
+            return Fraction(p0+k*p1, q0+k*q1, _normalize=False)
 
     @property
     def numerator(a):

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -247,8 +247,8 @@ class Fraction(numbers.Rational):
             n, d = d, n-a*d
 
         k = (max_denominator-q0)//q1
-        bound1 = Fraction(p0+k*p1, q0+k*q1)
-        bound2 = Fraction(p1, q1)
+        bound1 = Fraction(p0+k*p1, q0+k*q1, _normalize=False)
+        bound2 = Fraction(p1, q1, _normalize=False)
         if abs(bound2 - self) <= abs(bound1-self):
             return bound2
         else:

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -247,12 +247,11 @@ class Fraction(numbers.Rational):
             n, d = d, n-a*d
         k = (max_denominator-q0)//q1
 
-        # Determine which of the candidate fractions (p0+k*p1)/(q0+k*q1) and
-        # p1/q1 is closer to self. The distance between the two candidates is
-        # 1/(q1*(q0+k*q1)), while the distance from p1/q1 to self is
-        # 1/(q1*(q0+n/d*q1)). So we need to compare 2*(q0+k*q1) with q0+n/d*q1.
-        # That translates to the following comparison in integers.
-        if (q0+2*k*q1)*d <= q1*n:
+        # Determine which of the candidates (p0+k*p1)/(q0+k*q1) and p1/q1 is
+        # closer to self. The distance between them is 1/(q1*(q0+k*q1)), while
+        # the distance from p1/q1 to self is d/(q1*self._denominator). So we
+        # need to compare 2*(q0+k*q1) with self._denominator/d.
+        if 2*d*(q0+k*q1) <= self._denominator:
             return Fraction(p1, q1, _normalize=False)
         else:
             return Fraction(p0+k*p1, q0+k*q1, _normalize=False)

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -250,7 +250,7 @@ class Fraction(numbers.Rational):
         # Determine which of the candidate fractions (p0+k*p1)/(q0+k*q1) and
         # p1/q1 is closer to self. The distance between the two candidates is
         # 1/(q1*(q0+k*q1)), while the distance from p1/q1 to self is
-        # 1/(q1*(q0+n/d*q1)). So we need to compare q0+k*q1 with 2*(q0+n/d*q1).
+        # 1/(q1*(q0+n/d*q1)). So we need to compare 2*(q0+k*q1) with q0+n/d*q1.
         # That translates to the following comparison in integers.
         if (q0+2*k*q1)*d <= q1*n:
             return Fraction(p1, q1, _normalize=False)


### PR DESCRIPTION
When we construct the upper and lower candidates in limit_denominator, the numerator and denominator are already relatively prime (and the denominator positive) by construction, so there's no need to go through the usual normalisation in the constructor. This saves a couple of potentially expensive gcd calls.

We also replace the comparison used to determine which bound to pick with a simpler and faster version.

Inspired by Michael Scott Asato Cuthbert in GH-93477.
