### PR TITLE
[3.10] gh-89896: `importlib.abc.Traversable.name` is an attribute, not a method

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -814,9 +814,9 @@ ABC hierarchy::
 
     .. versionadded:: 3.9
 
-    .. abstractmethod:: name()
+    .. attribute:: name
 
-       The base name of this object without any parent references.
+       Abstract. The base name of this object without any parent references.
 
     .. abstractmethod:: iterdir()
 
@@ -930,7 +930,7 @@ The following functions are available.
 
 .. function:: files(package)
 
-    Returns an :class:`importlib.resources.abc.Traversable` object
+    Returns an :class:`importlib.abc.Traversable` object
     representing the resource container for the package (think directory)
     and its resources (think files). A Traversable may contain other
     containers (think subdirectories).
@@ -942,7 +942,7 @@ The following functions are available.
 
 .. function:: as_file(traversable)
 
-    Given a :class:`importlib.resources.abc.Traversable` object representing
+    Given a :class:`importlib.abc.Traversable` object representing
     a file, typically from :func:`importlib.resources.files`, return
     a context manager for use in a :keyword:`with` statement.
     The context manager provides a :class:`pathlib.Path` object.

--- a/Misc/NEWS.d/next/Documentation/2022-06-10-15-45-41.gh-issue-93610.wSHRJg.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-10-15-45-41.gh-issue-93610.wSHRJg.rst
@@ -1,0 +1,1 @@
+``importlib.abc.Traversable.name`` is an attribute, not a method.


### PR DESCRIPTION
Closes #89896

This also addresses #93610 in that it fixes the link to
`importlib.abc.Traversable` too, for Python 3.10 and earlier.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
