### PR TITLE
Update documentation to note dangers of shared state in `random` module

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -33,7 +33,7 @@ The functions supplied by this module are actually bound methods of a hidden
 instance of the :class:`random.Random` class, and thus share state – in 
 particular, calls to :meth:`random.set_seed` anywhere in application code 
 or any libraries will affect the sequence of random values produced by calls 
-to `random.*` methods in the same process, which can lead to unexpected results 
+to `random.*` methods in the same process, which can lead to unexpected results.
 You should consider instantiating your own instance or instances of :class:`Random` 
 to get generators that don't share state. 
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -30,8 +30,12 @@ deterministic, it is not suitable for all purposes, and is completely unsuitable
 for cryptographic purposes.
 
 The functions supplied by this module are actually bound methods of a hidden
-instance of the :class:`random.Random` class.  You can instantiate your own
-instances of :class:`Random` to get generators that don't share state.
+instance of the :class:`random.Random` class, and thus share state – in 
+particular, calls to :meth:`random.set_seed` anywhere in application code 
+or any libraries will affect the sequence of random values produced by calls 
+to `random.*` methods in the same process, which can lead to unexpected results 
+You should consider instantiating your own instance or instances of :class:`Random` 
+to get generators that don't share state. 
 
 Class :class:`Random` can also be subclassed if you want to use a different
 basic generator of your own devising: in that case, override the :meth:`~Random.random`,


### PR DESCRIPTION
Context: I've been bitten recently by a call to a third-party library function indirectly calling `random.seed` and changing the behaviour of my own code. I think it's worth adding bit of extra warning about the dangers of shared state since this can lead to subtle, hard-to-detect and hard-to-explain bugs.

I thought this was small enough that it didn't need an issue (clarifying existing docs) but happy to be corrected.