### PR TITLE
gh-93747: Fix Refleak when handling multiple Py_tp_doc slots

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3569,7 +3569,7 @@ PyType_FromMetaclass(PyTypeObject *metaclass, PyObject *module,
                 PyErr_SetString(
                     PyExc_SystemError,
                     "Multiple Py_tp_doc slots are not supported.");
-                return NULL;
+                goto finally;
             }
             if (slot->pfunc == NULL) {
                 type->tp_doc = NULL;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
