### PR TITLE
gh-93714 Create fast version of match_keys for exact dict

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-12-15-32-55.gh-issue-93714.bW84XJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-12-15-32-55.gh-issue-93714.bW84XJ.rst
@@ -1,0 +1,1 @@
+Optimize pattern matching of mappings when the mapping is a builtin dictionary.


### PR DESCRIPTION
When the type is an exact dict, there's a real speed-up to be gained by skipping the call to "get" and using PyDict_GetItemWithError instead. The implementation is just a slightly modified copy of the existing `match_keys` function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
