### PR TITLE
gh-89828: Do not relay the __class__ attribute in GenericAlias

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -230,7 +230,7 @@ class InitVar:
         self.type = type
 
     def __repr__(self):
-        if isinstance(self.type, type) and not isinstance(self.type, GenericAlias):
+        if isinstance(self.type, type):
             type_name = self.type.__name__
         else:
             # typing objects, e.g. List[int]
@@ -1248,7 +1248,7 @@ def _is_dataclass_instance(obj):
 def is_dataclass(obj):
     """Returns True if obj is a dataclass or an instance of a
     dataclass."""
-    cls = obj if isinstance(obj, type) and not isinstance(obj, GenericAlias) else type(obj)
+    cls = obj if isinstance(obj, type) else type(obj)
     return hasattr(cls, _FIELDS)
 
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -843,12 +843,11 @@ def singledispatch(func):
         return get_origin(cls) in {Union, types.UnionType}
 
     def _is_valid_dispatch_type(cls):
-        if isinstance(cls, type) and not isinstance(cls, GenericAlias):
+        if isinstance(cls, type):
             return True
         from typing import get_args
         return (_is_union_type(cls) and
-                all(isinstance(arg, type) and not isinstance(arg, GenericAlias)
-                    for arg in get_args(cls)))
+                all(isinstance(arg, type) for arg in get_args(cls)))
 
     def register(cls, func=None):
         """generic_func.register(cls, func) -> func

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -80,7 +80,7 @@ def resolve_bases(bases):
     updated = False
     shift = 0
     for i, base in enumerate(bases):
-        if isinstance(base, type) and not isinstance(base, GenericAlias):
+        if isinstance(base, type):
             continue
         if not hasattr(base, "__mro_entries__"):
             continue

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1079,7 +1079,7 @@ class TypeVarTuple(_Final, _Immutable, _PickleUsingNameMixin, _root=True):
         var_tuple_index = None
         fillarg = None
         for k, arg in enumerate(args):
-            if not (isinstance(arg, type) and not isinstance(arg, GenericAlias)):
+            if not isinstance(arg, type):
                 subargs = getattr(arg, '__typing_unpacked_tuple_args__', None)
                 if subargs and len(subargs) == 2 and subargs[-1] is ...:
                     if var_tuple_index is not None:

--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-12-19-31-56.gh-issue-89828.bq02M7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-12-19-31-56.gh-issue-89828.bq02M7.rst
@@ -1,1 +1,2 @@
-:class:`types.GenericAlias` no longer relay the ``__class__`` attribute.
+:class:`types.GenericAlias` no longer relays the ``__class__`` attribute.
+For example, ``isinstance(list[int], type)`` no longer returns ``True``.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-12-19-31-56.gh-issue-89828.bq02M7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-12-19-31-56.gh-issue-89828.bq02M7.rst
@@ -1,0 +1,1 @@
+:class:`types.GenericAlias` no longer relay the ``__class__`` attribute.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -583,6 +583,7 @@ ga_vectorcall(PyObject *self, PyObject *const *args,
 }
 
 static const char* const attr_exceptions[] = {
+    "__class__",
     "__origin__",
     "__args__",
     "__unpacked__",


### PR DESCRIPTION
`list[int].__class__` returned `type`, and `isinstance(list[int], type)`
returned `True`. It caused numerous problems in code that checks
`isinstance(x, type)`.

#89828