### PR TITLE
`random`: note that shared global state includes seed value

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -31,7 +31,8 @@ for cryptographic purposes.
 
 The functions supplied by this module are actually bound methods of a hidden
 instance of the :class:`random.Random` class.  You can instantiate your own
-instances of :class:`Random` to get generators that don't share state.
+instances of :class:`Random` to get generators that don't share global state
+(which includes the seed value).
 
 Class :class:`Random` can also be subclassed if you want to use a different
 basic generator of your own devising: in that case, override the :meth:`~Random.random`,


### PR DESCRIPTION
Implementing @AA-Turner 's [suggestion](https://github.com/python/cpython/pull/93743#issuecomment-1153236443) from #93743 

notes that random `seed` is part of shared state.
