### PR TITLE
gh-74668: Fix encoded unicode in url byte string

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -36,6 +36,7 @@ parse_qsl_test_cases = [
     ("a=a+b;b=b+c", [('a', 'a b;b=b c')]),
     (b";a=b", [(b';a', b'b')]),
     (b"a=a+b;b=b+c", [(b'a', b'a b;b=b c')]),
+    (b"a=a\xe2\x80\x99b", [(b'a', b'a\xe2\x80\x99b')]),
 ]
 
 # Each parse_qs testcase is a two-tuple that contains
@@ -66,6 +67,7 @@ parse_qs_test_cases = [
     ("a=a+b;b=b+c", {'a': ['a b;b=b c']}),
     (b";a=b", {b';a': [b'b']}),
     (b"a=a+b;b=b+c", {b'a':[ b'a b;b=b c']}),
+    (b"a=a\xe2\x80\x99b", {b'a': [b'a\xe2\x80\x99b']}),
 ]
 
 class UrlParseTestCase(unittest.TestCase):

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -107,7 +107,7 @@ def _decode_args(args, encoding=_implicit_encoding,
                        errors=_implicit_errors):
     return tuple(x.decode(encoding, errors) if x else '' for x in args)
 
-def _coerce_args(*args):
+def _coerce_args(*args, encoding=_implicit_encoding):
     # Invokes decode if necessary to create str args
     # and returns the coerced inputs along with
     # an appropriate result coercion function
@@ -121,7 +121,7 @@ def _coerce_args(*args):
             raise TypeError("Cannot mix str and non-str arguments")
     if str_input:
         return args + (_noop,)
-    return _decode_args(args) + (_encode_result,)
+    return _decode_args(args, encoding=encoding) + (functools.partial(_encode_result, encoding=encoding),)
 
 # Result objects are more helpful than simple tuples
 class _ResultMixinStr(object):
@@ -730,8 +730,8 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
 
         Returns a list, as G-d intended.
     """
-    qs, _coerce_result = _coerce_args(qs)
-    separator, _ = _coerce_args(separator)
+    qs, _coerce_result = _coerce_args(qs, encoding=encoding)
+    separator, _ = _coerce_args(separator, encoding=encoding)
 
     if not separator or (not isinstance(separator, (str, bytes))):
         raise ValueError("Separator must be of type string or bytes.")


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

When `urllib.parse.parse_qs` is called with a byte string, an encoding can be provided which is used to decode the byte string. However, when parsing, `parse.py` uses 'ascii' encoding to re-encode the parsed data. This breaks utf-8 encoded URLs received as byte strings.

This change uses the encoding passed to `parse_qs` to re-encode the parsed data.
