### PR TITLE
gh-93759: fix python-config.py generation in Makefile.pre.in

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2102,6 +2102,9 @@ python-config: $(srcdir)/Misc/python-config.in Misc/python-config.sh
 	@ # Substitution happens here, as the completely-expanded BINDIR
 	@ # is not available in configure
 	sed -e "s,@EXENAME@,$(BINDIR)/python$(LDVERSION)$(EXE)," < $(srcdir)/Misc/python-config.in >python-config.py
+	@ # BINDIR might be bigger than the max shebang size and lead to failures. Let us assume we have
+	@ # python in the $PATH and let env resolve it
+	sed -i -e '1s|^#!.*|#!/usr/bin/env python3|' python-config.py
 	@ # Replace makefile compat. variable references with shell script compat. ones; $(VAR) -> ${VAR}
 	LC_ALL=C sed -e 's,\$$(\([A-Za-z0-9_]*\)),\$$\{\1\},g' < Misc/python-config.sh >python-config
 	@ # On Darwin, always use the python version of the script, the shell

--- a/Misc/NEWS.d/next/Build/2022-06-13-09-37-08.gh-issue-93759.DVpywt.rst
+++ b/Misc/NEWS.d/next/Build/2022-06-13-09-37-08.gh-issue-93759.DVpywt.rst
@@ -1,0 +1,1 @@
+fix python-config.py generation to allow for arbitrary BINDIR without affecting shebang size compatibility


### PR DESCRIPTION
BINDIR might be bigger than the max shebang size and lead to failures.
Let us assume we have python in the $PATH and let env resolve it.
