### PR TITLE
Remove ANY_VARARGS() macro from the C API

### DIFF
--- a/Include/cpython/modsupport.h
+++ b/Include/cpython/modsupport.h
@@ -34,11 +34,13 @@ PyAPI_FUNC(int) _PyArg_NoPositional(const char *funcname, PyObject *args);
 #define _PyArg_NoPositional(funcname, args) \
     ((args) == NULL || _PyArg_NoPositional((funcname), (args)))
 
+#define _Py_ANY_VARARGS(n) (n == PY_SSIZE_T_MAX)
+
 PyAPI_FUNC(void) _PyArg_BadArgument(const char *, const char *, const char *, PyObject *);
 PyAPI_FUNC(int) _PyArg_CheckPositional(const char *, Py_ssize_t,
                                        Py_ssize_t, Py_ssize_t);
 #define _PyArg_CheckPositional(funcname, nargs, min, max) \
-    ((!ANY_VARARGS(max) && (min) <= (nargs) && (nargs) <= (max)) \
+    ((!_Py_ANY_VARARGS(max) && (min) <= (nargs) && (nargs) <= (max)) \
      || _PyArg_CheckPositional((funcname), (nargs), (min), (max)))
 
 PyAPI_FUNC(PyObject **) _Py_VaBuildStack(

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -37,8 +37,6 @@ PyAPI_FUNC(PyObject *) Py_BuildValue(const char *, ...);
 PyAPI_FUNC(PyObject *) _Py_BuildValue_SizeT(const char *, ...);
 
 
-#define ANY_VARARGS(n) (n == PY_SSIZE_T_MAX)
-
 PyAPI_FUNC(PyObject *) Py_VaBuildValue(const char *, va_list);
 
 // Add an attribute with name 'name' and value 'obj' to the module 'mod.


### PR DESCRIPTION
The macro was exposed by mistake.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
