### PR TITLE
gh-84461: Fix parallel testing on WebAssembly (GH-93768)

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -629,15 +629,15 @@ class Regrtest:
         # the tests. The name of the dir includes the pid to allow parallel
         # testing (see the -j option).
         # Emscripten and WASI have stubbed getpid(), Emscripten has only
-        # milisecond clock resolution. Use time_ns() + randint() instead.
+        # milisecond clock resolution. Use randint() instead.
         if sys.platform in {"emscripten", "wasi"}:
-            pid = time.time_ns() + random.randint(0, 1000000)
+            nounce = random.randint(0, 1_000_000)
         else:
-            pid = os.getpid()
+            nounce = os.getpid()
         if self.worker_test_name is not None:
-            test_cwd = 'test_python_worker_{}'.format(pid)
+            test_cwd = 'test_python_worker_{}'.format(nounce)
         else:
-            test_cwd = 'test_python_{}'.format(pid)
+            test_cwd = 'test_python_{}'.format(nounce)
         test_cwd += os_helper.FS_NONASCII
         test_cwd = os.path.join(self.tmp_dir, test_cwd)
         return test_cwd

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -628,7 +628,12 @@ class Regrtest:
         # Define a writable temp dir that will be used as cwd while running
         # the tests. The name of the dir includes the pid to allow parallel
         # testing (see the -j option).
-        pid = os.getpid()
+        # Emscripten and WASI have stubbed getpid(), Emscripten has only
+        # milisecond clock resolution. Use time_ns() + randint() instead.
+        if sys.platform in {"emscripten", "wasi"}:
+            pid = time.time_ns() + random.randint(0, 1000000)
+        else:
+            pid = os.getpid()
         if self.worker_test_name is not None:
             test_cwd = 'test_python_worker_{}'.format(pid)
         else:

--- a/Tools/scripts/run_tests.py
+++ b/Tools/scripts/run_tests.py
@@ -63,9 +63,9 @@ def main(regrtest_args):
         args.append('-n')         # Silence alerts under Windows
     if not any(is_multiprocess_flag(arg) for arg in regrtest_args):
         if cross_compile and hostrunner:
-            # For now use only one core for cross-compiled builds;
+            # For now use only two cores for cross-compiled builds;
             # hostrunner can be expensive.
-            args.extend(['-j', '1'])
+            args.extend(['-j', '2'])
         else:
             args.extend(['-j', '0'])  # Use all CPU cores
     if not any(is_resource_use_flag(arg) for arg in regrtest_args):


### PR DESCRIPTION
Emscripten and WASI have stubbed getpid() syscall that always returns
the same value. Use time and random value instead of pid to create a
unique working directory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
