### PR TITLE
gh-91321: Fix compatibility with C++ older than C++11

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -36,10 +36,12 @@ extern "C++" {
         inline type _Py_CAST_impl(int ptr) {
             return reinterpret_cast<type>(ptr);
         }
+#if __cplusplus >= 201103
         template <typename type>
         inline type _Py_CAST_impl(std::nullptr_t) {
             return static_cast<type>(nullptr);
         }
+#endif
 
         template <typename type, typename expr_type>
             inline type _Py_CAST_impl(expr_type *expr) {
@@ -70,8 +72,9 @@ extern "C++" {
 #endif
 
 // Static inline functions should use _Py_NULL rather than using directly NULL
-// to prevent C++ compiler warnings. In C++, _Py_NULL uses nullptr.
-#ifdef __cplusplus
+// to prevent C++ compiler warnings. On C++11 and newer, _Py_NULL is defined as
+// nullptr.
+#if defined(__cplusplus) && __cplusplus >= 201103
 #  define _Py_NULL nullptr
 #else
 #  define _Py_NULL NULL

--- a/Lib/test/setup_testcppext.py
+++ b/Lib/test/setup_testcppext.py
@@ -13,8 +13,6 @@ SOURCE = support.findfile('_testcppext.cpp')
 if not MS_WINDOWS:
     # C++ compiler flags for GCC and clang
     CPPFLAGS = [
-        # Python currently targets C++11
-        '-std=c++11',
         # gh-91321: The purpose of _testcppext extension is to check that building
         # a C++ extension using the Python C API does not emit C++ compiler
         # warnings
@@ -30,12 +28,23 @@ else:
 
 
 def main():
+    cppflags = list(CPPFLAGS)
+    if '-std=c++03' in sys.argv:
+        sys.argv.remove('-std=c++03')
+        std = 'c++03'
+        name = '_testcpp03ext'
+    else:
+        # Python currently targets C++11
+        std = 'c++11'
+        name = '_testcpp11ext'
+
+    cppflags = [*CPPFLAGS, f'-std={std}']
     cpp_ext = Extension(
-        '_testcppext',
+        name,
         sources=[SOURCE],
         language='c++',
-        extra_compile_args=CPPFLAGS)
-    setup(name="_testcppext", ext_modules=[cpp_ext])
+        extra_compile_args=cppflags)
+    setup(name=name, ext_modules=[cpp_ext])
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_cppext.py
+++ b/Lib/test/test_cppext.py
@@ -16,22 +16,29 @@ SETUP_TESTCPPEXT = support.findfile('setup_testcppext.py')
 
 @support.requires_subprocess()
 class TestCPPExt(unittest.TestCase):
+    def test_build_cpp11(self):
+        self.check_build(False)
+
+    def test_build_cpp03(self):
+        self.check_build(True)
+
     # With MSVC, the linker fails with: cannot open file 'python311.lib'
     # https://github.com/python/cpython/pull/32175#issuecomment-1111175897
     @unittest.skipIf(MS_WINDOWS, 'test fails on Windows')
     # the test uses venv+pip: skip if it's not available
     @support.requires_venv_with_pip()
-    def test_build(self):
+    def check_build(self, std_cpp03):
         # Build in a temporary directory
         with os_helper.temp_cwd():
-            self._test_build()
+            self._check_build(std_cpp03)
 
-    def _test_build(self):
+    def _check_build(self, std_cpp03):
         venv_dir = 'env'
+        verbose = support.verbose
 
         # Create virtual environment to get setuptools
         cmd = [sys.executable, '-X', 'dev', '-m', 'venv', venv_dir]
-        if support.verbose:
+        if verbose:
             print()
             print('Run:', ' '.join(cmd))
         subprocess.run(cmd, check=True)
@@ -46,16 +53,21 @@ class TestCPPExt(unittest.TestCase):
             python = os.path.join(venv_dir, 'bin', python_exe)
 
         # Build the C++ extension
-        cmd = [python, '-X', 'dev', SETUP_TESTCPPEXT, 'build_ext', '--verbose']
-        if support.verbose:
+        cmd = [python, '-X', 'dev',
+               SETUP_TESTCPPEXT, 'build_ext', '--verbose']
+        if std_cpp03:
+            cmd.append('-std=c++03')
+        if verbose:
             print('Run:', ' '.join(cmd))
-        proc = subprocess.run(cmd,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.STDOUT,
-                              text=True)
-        if proc.returncode:
-            print(proc.stdout, end='')
-            self.fail(f"Build failed with exit code {proc.returncode}")
+            subprocess.run(cmd, check=True)
+        else:
+            proc = subprocess.run(cmd,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT,
+                                  text=True)
+            if proc.returncode:
+                print(proc.stdout, end='')
+                self.fail(f"Build failed with exit code {proc.returncode}")
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/C API/2022-06-13-21-37-31.gh-issue-91321.DgJFvS.rst
+++ b/Misc/NEWS.d/next/C API/2022-06-13-21-37-31.gh-issue-91321.DgJFvS.rst
@@ -1,0 +1,2 @@
+Fix the compatibility of the Python C API with C++ older than C++11. Patch by
+Victor Stinner.


### PR DESCRIPTION
Fix the compatibility of the Python C API with C++ older than C++11.

_Py_NULL is only defined as nullptr on C++11 and newer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
