### PR TITLE
gh-93785: Update includes in call.c

### DIFF
--- a/Objects/call.c
+++ b/Objects/call.c
@@ -1,11 +1,10 @@
 #include "Python.h"
 #include "pycore_call.h"          // _PyObject_CallNoArgsTstate()
-#include "pycore_ceval.h"         // _PyEval_EvalFrame()
-#include "pycore_object.h"        // _PyObject_GC_TRACK()
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCallTstate()
+#include "pycore_object.h"        // _PyCFunctionWithKeywords_TrampolineCall()
 #include "pycore_pyerrors.h"      // _PyErr_Occurred()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_tuple.h"         // _PyTuple_ITEMS()
-#include "frameobject.h"          // _PyFrame_New_NoTrack()
 
 
 static PyObject *const *


### PR DESCRIPTION
Fix for https://github.com/python/cpython/issues/93785

This PR removes the unneeded include and updates comments for 2 other includes to accurately reflect what function they use from those files (currently they reference no-longer used functions).
