### PR TITLE
Include freelists in allocation total.

### DIFF
--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -278,7 +278,7 @@ def emit_call_stats(stats):
 def emit_object_stats(stats):
     with Section("Object stats", summary="allocations, frees and dict materializatons"):
         total_materializations = stats.get("Object new values")
-        total_allocations = stats.get("Object allocations")
+        total_allocations = stats.get("Object allocations") + stats.get("Object allocations from freelist")
         total_increfs = stats.get("Object interpreter increfs") + stats.get("Object increfs")
         total_decrefs = stats.get("Object interpreter decrefs") + stats.get("Object decrefs")
         rows = []


### PR DESCRIPTION
Makes sure that percentages in object allocation section make sense.