### PR TITLE
[3.10] gh-91877: Fix WriteTransport.get_write_buffer_{limits,size} docs (#92338)

### DIFF
--- a/Doc/library/asyncio-llapi-index.rst
+++ b/Doc/library/asyncio-llapi-index.rst
@@ -349,6 +349,10 @@ pipes, etc).  Returned from methods like
 
     * - :meth:`transport.get_write_buffer_size()
         <WriteTransport.get_write_buffer_size>`
+      - Return the current size of the output buffer.
+
+    * - :meth:`transport.get_write_buffer_limits()
+        <WriteTransport.get_write_buffer_limits>`
       - Return high and low water marks for write flow control.
 
     * - :meth:`transport.set_write_buffer_limits()


### PR DESCRIPTION
- Add docs for WriteTransport.get_write_buffer_limits
- Amend docs for WriteTransport.get_write_buffer_size

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
