### PR TITLE
Fixup 'LOAD_METHOD' specialization stats so that they display properly.

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -358,16 +358,13 @@ miss_counter_start(void) {
 #define SPEC_FAIL_ATTR_NON_STRING_OR_SPLIT 18
 #define SPEC_FAIL_ATTR_MODULE_ATTR_NOT_FOUND 19
 
-/* Methods */
-
-#define SPEC_FAIL_LOAD_METHOD_METHOD 20
-#define SPEC_FAIL_LOAD_METHOD_IS_ATTR 21
-#define SPEC_FAIL_LOAD_METHOD_BUILTIN_CLASS_METHOD 22
-#define SPEC_FAIL_LOAD_METHOD_CLASS_METHOD_OBJ 23
-#define SPEC_FAIL_LOAD_METHOD_OBJECT_SLOT 24
-#define SPEC_FAIL_LOAD_METHOD_HAS_MANAGED_DICT 25
-#define SPEC_FAIL_LOAD_METHOD_INSTANCE_ATTRIBUTE 26
-#define SPEC_FAIL_LOAD_METHOD_METACLASS_ATTRIBUTE 27
+#define SPEC_FAIL_ATTR_SHADOWED 21
+#define SPEC_FAIL_ATTR_BUILTIN_CLASS_METHOD 22
+#define SPEC_FAIL_ATTR_CLASS_METHOD_OBJ 23
+#define SPEC_FAIL_ATTR_OBJECT_SLOT 24
+#define SPEC_FAIL_ATTR_HAS_MANAGED_DICT 25
+#define SPEC_FAIL_ATTR_INSTANCE_ATTRIBUTE 26
+#define SPEC_FAIL_ATTR_METACLASS_ATTRIBUTE 27
 
 /* Binary subscr and store subscr */
 
@@ -863,7 +860,7 @@ load_attr_fail_kind(DescriptorClassification kind)
         case PROPERTY:
             return SPEC_FAIL_ATTR_PROPERTY;
         case OBJECT_SLOT:
-            return SPEC_FAIL_LOAD_METHOD_OBJECT_SLOT;
+            return SPEC_FAIL_ATTR_OBJECT_SLOT;
         case OTHER_SLOT:
             return SPEC_FAIL_ATTR_NON_OBJECT_SLOT;
         case DUNDER_CLASS:
@@ -873,15 +870,15 @@ load_attr_fail_kind(DescriptorClassification kind)
         case GETSET_OVERRIDDEN:
             return SPEC_FAIL_OVERRIDDEN;
         case BUILTIN_CLASSMETHOD:
-            return SPEC_FAIL_LOAD_METHOD_BUILTIN_CLASS_METHOD;
+            return SPEC_FAIL_ATTR_BUILTIN_CLASS_METHOD;
         case PYTHON_CLASSMETHOD:
-            return SPEC_FAIL_LOAD_METHOD_CLASS_METHOD_OBJ;
+            return SPEC_FAIL_ATTR_CLASS_METHOD_OBJ;
         case NON_OVERRIDING:
             return SPEC_FAIL_ATTR_NON_OVERRIDING_DESCRIPTOR;
         case NON_DESCRIPTOR:
             return SPEC_FAIL_ATTR_NOT_DESCRIPTOR;
         case ABSENT:
-            return SPEC_FAIL_LOAD_METHOD_INSTANCE_ATTRIBUTE;
+            return SPEC_FAIL_ATTR_INSTANCE_ATTRIBUTE;
     }
     Py_UNREACHABLE();
 }
@@ -905,7 +902,7 @@ specialize_class_load_attr(PyObject *owner, _Py_CODEUNIT *instr,
 #ifdef Py_STATS
         case ABSENT:
             if (_PyType_Lookup(Py_TYPE(owner), name) != NULL) {
-                SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_LOAD_METHOD_METACLASS_ATTRIBUTE);
+                SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_METACLASS_ATTRIBUTE);
             }
             else {
                 SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_EXPECTED_ERROR);
@@ -975,7 +972,7 @@ PyObject *descr, DescriptorClassification kind)
     if (dictkind == MANAGED_VALUES || dictkind == OFFSET_DICT) {
         Py_ssize_t index = _PyDictKeys_StringLookup(keys, name);
         if (index != DKIX_EMPTY) {
-            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_LOAD_METHOD_IS_ATTR);
+            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_SHADOWED);
             goto fail;
         }
         uint32_t keys_version = _PyDictKeys_GetVersionForCurrentState(keys);
@@ -993,7 +990,7 @@ PyObject *descr, DescriptorClassification kind)
             _Py_SET_OPCODE(*instr, LOAD_ATTR_METHOD_WITH_VALUES);
             break;
         case MANAGED_DICT:
-            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_LOAD_METHOD_HAS_MANAGED_DICT);
+            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_HAS_MANAGED_DICT);
             goto fail;
         case OFFSET_DICT:
             assert(owner_cls->tp_dictoffset > 0 && owner_cls->tp_dictoffset <= INT16_MAX);


### PR DESCRIPTION
With this PR, the specialization stats for `LOAD_ATTR` now display properly.

------------------------------------------

### LOAD_ATTR

<details>
<summary> specialization stats for LOAD_ATTR family </summary>

|Kind | Count | Ratio | 
|---|---|---|
|  unquickened |    234936676 | 3.8% |
| specialization.deferred |    701617362 | 11.3% |
| specialization.deopt |      2817399 | 0.0% |
|          hit |   5144908243 | 82.5% |
|         miss |    153019671 | 2.5% |

#### Specialization attempts

| | Count | Ratio | 
|---|---:|---:|
| Success | 5166904 | 65.2% |
| Failure | 2751896 | 34.8% |

|Failure kind | Count | Ratio | 
|---|---:|---:|
| property | 380454 | 13.8% |
| overridden | 350626 | 12.7% |
| not managed dict | 324824 | 11.8% |
| method | 319486 | 11.6% |
| overriding descriptor | 256699 | 9.3% |
| out of range | 232721 | 8.5% |
| non object slot | 216423 | 7.9% |
| metaclass attribute | 189030 | 6.9% |
| class method obj | 171201 | 6.2% |
| mutable class | 156896 | 5.7% |
| non overriding descriptor | 117729 | 4.3% |
| has managed dict | 96775 | 3.5% |
| builtin class method | 46116 | 1.7% |
| shadowed | 4951 | 0.2% |
| module attr not found | 4901 | 0.2% |
| other | 1562 | 0.1% |


</details>
