### PR TITLE
gh-44123: Add note on relative path for os.exec*

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3653,7 +3653,8 @@ to be ignored.
    the :envvar:`PATH` variable. The other variants, :func:`execl`, :func:`execle`,
    :func:`execv`, and :func:`execve`, will not use the :envvar:`PATH` variable to
    locate the executable; *path* must contain an appropriate absolute or relative
-   path.
+   path. Note that even on Windows, the relative path in this case will follow the
+   Unix model, requiring ``./`` prepended to the executable.
 
    For :func:`execle`, :func:`execlpe`, :func:`execve`, and :func:`execvpe` (note
    that these all end in "e"), the *env* parameter must be a mapping which is

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3653,8 +3653,8 @@ to be ignored.
    the :envvar:`PATH` variable. The other variants, :func:`execl`, :func:`execle`,
    :func:`execv`, and :func:`execve`, will not use the :envvar:`PATH` variable to
    locate the executable; *path* must contain an appropriate absolute or relative
-   path. Note that even on Windows, the relative path in this case will follow the
-   Unix model, requiring ``./`` prepended to the executable.
+   path. Relative paths must include at least one slash, even on Windows, as
+   plain names will not be resolved.
 
    For :func:`execle`, :func:`execlpe`, :func:`execve`, and :func:`execvpe` (note
    that these all end in "e"), the *env* parameter must be a mapping which is


### PR DESCRIPTION
#44123

https://docs.python.org/3/library/os.html#os.execl