### PR TITLE
[3.10] gh-93735: Split Docs CI to speed-up the build (GH-93736).

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,6 +28,38 @@ jobs:
     - uses: actions/checkout@v3
     - name: Register Sphinx problem matcher
       run: echo "::add-matcher::.github/problem-matchers/sphinx.json"
+    - name: 'Set up Python'
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3'
+        cache: 'pip'
+        cache-dependency-path: 'Doc/requirements.txt'
+    - name: 'Install build dependencies'
+      run: make -C Doc/ venv
+    - name: 'Check documentation'
+      run: make -C Doc/ suspicious
+    - name: 'Build HTML documentation'
+      run: make -C Doc/ SPHINXOPTS="-q" SPHINXERRORHANDLING="-W --keep-going" html
+    - name: 'Upload'
+      uses: actions/upload-artifact@v3
+      with:
+        name: doc-html
+        path: Doc/build/html
+
+  # Run "doctest" on HEAD as new syntax doesn't exist in the latest stable release
+  doctest:
+    name: 'Doctest'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Register Sphinx problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/sphinx.json"
+    - uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ubuntu-doc-${{ hashFiles('Doc/requirements.txt') }}
+        restore-keys: |
+          ubuntu-doc-
     - name: 'Install Dependencies'
       run: sudo ./.github/workflows/posix-deps-apt.sh && sudo apt-get install wamerican
     - name: 'Configure CPython'
@@ -36,10 +68,6 @@ jobs:
       run: make -j4
     - name: 'Install build dependencies'
       run: make -C Doc/ PYTHON=../python venv
-    - name: 'Build documentation'
-      run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going" doctest html suspicious
-    - name: 'Upload'
-      uses: actions/upload-artifact@v3
-      with:
-        name: doc-html
-        path: Doc/build/html
+    # Use "xvfb-run" since some doctest tests open GUI windows
+    - name: 'Run documentation doctest'
+      run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q" SPHINXERRORHANDLING="-W --keep-going" doctest


### PR DESCRIPTION
(cherry picked from commit 4f26963526f386bba84de8e14962163bfd5da955)

Co-authored-by: Adam Turner <9087854+AA-Turner@users.noreply.github.com>

Note the 3.10 branch uses `make suspicious` as `make check` wasn't backported.