### PR TITLE
Use support.sleeping_retry() and support.busy_retry()

### DIFF
--- a/Lib/test/_test_eintr.py
+++ b/Lib/test/_test_eintr.py
@@ -403,11 +403,9 @@ class SignalEINTRTest(EINTRBaseTest):
         old_mask = signal.pthread_sigmask(signal.SIG_BLOCK, [signum])
         self.addCleanup(signal.pthread_sigmask, signal.SIG_UNBLOCK, [signum])
 
-        t0 = time.monotonic()
         proc = self.subprocess(code)
         with kill_on_error(proc):
             wait_func(signum)
-            dt = time.monotonic() - t0
 
         self.assertEqual(proc.wait(), 0)
 
@@ -497,16 +495,18 @@ class FNTLEINTRTest(EINTRBaseTest):
         proc = self.subprocess(code)
         with kill_on_error(proc):
             with open(os_helper.TESTFN, 'wb') as f:
-                while True:  # synchronize the subprocess
-                    dt = time.monotonic() - start_time
-                    if dt > 60.0:
-                        raise Exception("failed to sync child in %.1f sec" % dt)
+                # synchronize the subprocess
+                start_time = time.monotonic()
+                for _ in support.sleeping_retry(60.0, error=False):
                     try:
                         lock_func(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
                         lock_func(f, fcntl.LOCK_UN)
-                        time.sleep(0.01)
                     except BlockingIOError:
                         break
+                else:
+                    dt = time.monotonic() - start_time
+                    raise Exception("failed to sync child in %.1f sec" % dt)
+
                 # the child locked the file just a moment ago for 'sleep_time' seconds
                 # that means that the lock below will block for 'sleep_time' minus some
                 # potential context switch delay

--- a/Lib/test/support/threading_helper.py
+++ b/Lib/test/support/threading_helper.py
@@ -88,19 +88,17 @@ def wait_threads_exit(timeout=None):
         yield
     finally:
         start_time = time.monotonic()
-        deadline = start_time + timeout
-        while True:
+        for _ in support.sleeping_retry(timeout, error=False):
+            support.gc_collect()
             count = _thread._count()
             if count <= old_count:
                 break
-            if time.monotonic() > deadline:
-                dt = time.monotonic() - start_time
-                msg = (f"wait_threads() failed to cleanup {count - old_count} "
-                       f"threads after {dt:.1f} seconds "
-                       f"(count: {count}, old count: {old_count})")
-                raise AssertionError(msg)
-            time.sleep(0.010)
-            support.gc_collect()
+        else:
+            dt = time.monotonic() - start_time
+            msg = (f"wait_threads() failed to cleanup {count - old_count} "
+                   f"threads after {dt:.1f} seconds "
+                   f"(count: {count}, old count: {old_count})")
+            raise AssertionError(msg)
 
 
 def join_thread(thread, timeout=None):

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -109,13 +109,12 @@ def run_briefly(loop):
 
 
 def run_until(loop, pred, timeout=support.SHORT_TIMEOUT):
-    deadline = time.monotonic() + timeout
-    while not pred():
-        if timeout is not None:
-            timeout = deadline - time.monotonic()
-            if timeout <= 0:
-                raise futures.TimeoutError()
+    for _ in support.busy_retry(timeout, error=False):
+        if pred():
+            break
         loop.run_until_complete(tasks.sleep(0.001))
+    else:
+        raise futures.TimeoutError()
 
 
 def run_once(loop):

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -76,8 +76,7 @@ def capture_server(evt, buf, serv):
         pass
     else:
         n = 200
-        start = time.monotonic()
-        while n > 0 and time.monotonic() - start < 3.0:
+        for _ in support.busy_retry(3.0, error=False):
             r, w, e = select.select([conn], [], [], 0.1)
             if r:
                 n -= 1
@@ -86,6 +85,8 @@ def capture_server(evt, buf, serv):
                 buf.write(data.replace(b'\n', b''))
                 if b'\n' in data:
                     break
+            if n <= 0:
+                break
             time.sleep(0.01)
 
         conn.close()


### PR DESCRIPTION
* Replace time.sleep() with a constant delay with sleeping_retry() to
  use an exponential sleep.
* _test_eintr: remove unused variables
* support.wait_process(): reuse sleeping_retry()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
