### PR TITLE
test_asyncore: Optimize capture_server()

### DIFF
--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -87,7 +87,6 @@ def capture_server(evt, buf, serv):
                     break
             if n <= 0:
                 break
-            time.sleep(0.01)
 
         conn.close()
     finally:


### PR DESCRIPTION
Remove time.sleep(0.01) in test_asyncore capture_server(). The sleep
was redundant and inefficient, since the loop starts with
select.select() which also implements a sleep (poll for socket data
with a timeout).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
