### PR TITLE
Tests call sleeping_retry() with SHORT_TIMEOUT

### DIFF
--- a/Lib/test/_test_eintr.py
+++ b/Lib/test/_test_eintr.py
@@ -497,7 +497,7 @@ class FNTLEINTRTest(EINTRBaseTest):
             with open(os_helper.TESTFN, 'wb') as f:
                 # synchronize the subprocess
                 start_time = time.monotonic()
-                for _ in support.sleeping_retry(60.0, error=False):
+                for _ in support.sleeping_retry(support.LONG_TIMEOUT, error=False):
                     try:
                         lock_func(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
                         lock_func(f, fcntl.LOCK_UN)

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -124,6 +124,8 @@ else:
 # BaseManager.shutdown_timeout
 SHUTDOWN_TIMEOUT = support.SHORT_TIMEOUT
 
+WAIT_ACTIVE_CHILDREN_TIMEOUT = 5.0
+
 HAVE_GETVALUE = not getattr(_multiprocessing,
                             'HAVE_BROKEN_SEM_GETVALUE', False)
 
@@ -5569,8 +5571,9 @@ class TestSyncManagerTypes(unittest.TestCase):
         # if there are other children too (see #17395).
         join_process(self.proc)
 
+        timeout = WAIT_ACTIVE_CHILDREN_TIMEOUT
         start_time = time.monotonic()
-        for _ in support.sleeping_retry(5.0, error=False):
+        for _ in support.sleeping_retry(timeout, error=False):
             if len(multiprocessing.active_children()) <= 1:
                 break
         else:
@@ -5875,8 +5878,9 @@ class ManagerMixin(BaseMixin):
         # only the manager process should be returned by active_children()
         # but this can take a bit on slow machines, so wait a few seconds
         # if there are other children too (see #17395)
+        timeout = WAIT_ACTIVE_CHILDREN_TIMEOUT
         start_time = time.monotonic()
-        for _ in support.sleeping_retry(5.0, error=False):
+        for _ in support.sleeping_retry(timeout, error=False):
             if len(multiprocessing.active_children()) <= 1:
                 break
         else:

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -76,7 +76,7 @@ def capture_server(evt, buf, serv):
         pass
     else:
         n = 200
-        for _ in support.busy_retry(3.0, error=False):
+        for _ in support.busy_retry(support.SHORT_TIMEOUT, error=False):
             r, w, e = select.select([conn], [], [], 0.1)
             if r:
                 n -= 1

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -258,7 +258,8 @@ class FailingInitializerMixin(ExecutorMixin):
                     future.result()
 
             # At some point, the executor should break
-            for _ in support.sleeping_retry(5, "executor not broken"):
+            for _ in support.sleeping_retry(support.SHORT_TIMEOUT,
+                                            "executor not broken"):
                 if self.executor._broken:
                     break
 

--- a/Lib/test/test_multiprocessing_main_handling.py
+++ b/Lib/test/test_multiprocessing_main_handling.py
@@ -62,7 +62,8 @@ if __name__ == '__main__':
         pool.map_async(f, [1, 2, 3], callback=results.extend)
 
         # up to 1 min to report the results
-        for _ in support.sleeping_retry(60, "Timed out waiting for results"):
+        for _ in support.sleeping_retry(support.LONG_TIMEOUT,
+                                        "Timed out waiting for results"):
             if results:
                 break
 
@@ -93,7 +94,8 @@ results = []
 with Pool(5) as pool:
     pool.map_async(int, [1, 4, 9], callback=results.extend)
     # up to 1 min to report the results
-    for _ in support.sleeping_retry(60, "Timed out waiting for results"):
+    for _ in support.sleeping_retry(support.LONG_TIMEOUT,
+                                    "Timed out waiting for results"):
         if results:
             break
 

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -812,7 +812,7 @@ class ItimerTest(unittest.TestCase):
         signal.signal(signal.SIGVTALRM, self.sig_vtalrm)
         signal.setitimer(self.itimer, 0.3, 0.2)
 
-        for _ in support.busy_retry(60.0, error=False):
+        for _ in support.busy_retry(support.LONG_TIMEOUT, error=False):
             # use up some virtual time by doing real work
             _ = pow(12345, 67890, 10000019)
             if signal.getitimer(self.itimer) == (0.0, 0.0):
@@ -833,7 +833,7 @@ class ItimerTest(unittest.TestCase):
         signal.signal(signal.SIGPROF, self.sig_prof)
         signal.setitimer(self.itimer, 0.2, 0.2)
 
-        for _ in support.busy_retry(60.0, error=False):
+        for _ in support.busy_retry(support.LONG_TIMEOUT, error=False):
             # do some work
             _ = pow(12345, 67890, 10000019)
             if signal.getitimer(self.itimer) == (0.0, 0.0):


### PR DESCRIPTION
Tests now call sleeping_retry() with SHORT_TIMEOUT or LONG_TIMEOUT
(of test.support), rather than hardcoded constants.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
