### PR TITLE
Call busy_retry() and sleeping_retry() with error=True

### DIFF
--- a/Lib/test/fork_wait.py
+++ b/Lib/test/fork_wait.py
@@ -54,7 +54,7 @@ class ForkWait(unittest.TestCase):
             self.threads.append(thread)
 
         # busy-loop to wait for threads
-        for _ in support.sleeping_retry(support.SHORT_TIMEOUT, error=False):
+        for _ in support.sleeping_retry(support.SHORT_TIMEOUT):
             if len(self.alive) >= NUM_THREADS:
                 break
 

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -76,7 +76,7 @@ def capture_server(evt, buf, serv):
         pass
     else:
         n = 200
-        for _ in support.busy_retry(support.SHORT_TIMEOUT, error=False):
+        for _ in support.busy_retry(support.SHORT_TIMEOUT):
             r, w, e = select.select([conn], [], [], 0.1)
             if r:
                 n -= 1

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3613,11 +3613,10 @@ class ConfigDictTest(BaseTest):
             logging.warning('baz')
 
             # Need to let the listener thread finish its work
-            while support.sleeping_retry(support.LONG_TIMEOUT, error=False):
+            while support.sleeping_retry(support.LONG_TIMEOUT,
+                                         "queue not empty"):
                 if qh.listener.queue.empty():
                     break
-            else:
-                self.fail("queue not empty")
 
             with open(fn, encoding='utf-8') as f:
                 data = f.read().splitlines()

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -812,16 +812,12 @@ class ItimerTest(unittest.TestCase):
         signal.signal(signal.SIGVTALRM, self.sig_vtalrm)
         signal.setitimer(self.itimer, 0.3, 0.2)
 
-        for _ in support.busy_retry(support.LONG_TIMEOUT, error=False):
+        for _ in support.busy_retry(support.LONG_TIMEOUT):
             # use up some virtual time by doing real work
             _ = pow(12345, 67890, 10000019)
             if signal.getitimer(self.itimer) == (0.0, 0.0):
                 # sig_vtalrm handler stopped this itimer
                 break
-        else:
-            # bpo-8424
-            self.skipTest("timeout: likely cause: machine too slow or load too "
-                          "high")
 
         # virtual itimer should be (0.0, 0.0) now
         self.assertEqual(signal.getitimer(self.itimer), (0.0, 0.0))
@@ -833,16 +829,12 @@ class ItimerTest(unittest.TestCase):
         signal.signal(signal.SIGPROF, self.sig_prof)
         signal.setitimer(self.itimer, 0.2, 0.2)
 
-        for _ in support.busy_retry(support.LONG_TIMEOUT, error=False):
+        for _ in support.busy_retry(support.LONG_TIMEOUT):
             # do some work
             _ = pow(12345, 67890, 10000019)
             if signal.getitimer(self.itimer) == (0.0, 0.0):
                 # sig_prof handler stopped this itimer
                 break
-        else:
-            # bpo-8424
-            self.skipTest("timeout: likely cause: machine too slow or load too "
-                          "high")
 
         # profiling itimer should be (0.0, 0.0) now
         self.assertEqual(signal.getitimer(self.itimer), (0.0, 0.0))
@@ -1317,7 +1309,7 @@ class StressTest(unittest.TestCase):
 
             expected_sigs += 2
             # Wait for handlers to run to avoid signal coalescing
-            for _ in support.sleeping_retry(support.SHORT_TIMEOUT, error=False):
+            for _ in support.sleeping_retry(support.SHORT_TIMEOUT):
                 if len(sigs) >= expected_sigs:
                     break
 

--- a/Lib/test/test_wait3.py
+++ b/Lib/test/test_wait3.py
@@ -19,7 +19,7 @@ class Wait3Test(ForkWait):
         # This many iterations can be required, since some previously run
         # tests (e.g. test_ctypes) could have spawned a lot of children
         # very quickly.
-        for _ in support.sleeping_retry(support.SHORT_TIMEOUT, error=False):
+        for _ in support.sleeping_retry(support.SHORT_TIMEOUT):
             # wait3() shouldn't hang, but some of the buildbots seem to hang
             # in the forking tests.  This is an attempt to fix the problem.
             spid, status, rusage = os.wait3(os.WNOHANG)

--- a/Lib/test/test_wait4.py
+++ b/Lib/test/test_wait4.py
@@ -21,7 +21,7 @@ class Wait4Test(ForkWait):
             # Issue #11185: wait4 is broken on AIX and will always return 0
             # with WNOHANG.
             option = 0
-        for _ in support.sleeping_retry(support.SHORT_TIMEOUT, error=False):
+        for _ in support.sleeping_retry(support.SHORT_TIMEOUT):
             # wait4() shouldn't hang, but some of the buildbots seem to hang
             # in the forking tests.  This is an attempt to fix the problem.
             spid, status, rusage = os.wait4(cpid, option)


### PR DESCRIPTION
Tests no longer call busy_retry() and sleeping_retry() with
error=False: raise an exception if the loop times out.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
