### PR TITLE
gh-93820: Fix copy() regression in enum.Flag

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1369,6 +1369,9 @@ class Flag(Enum, boundary=STRICT):
     Support for flags
     """
 
+    def __reduce_ex__(self, proto):
+        return self.__class__, (self._value_, )
+
     _numeric_repr_ = repr
 
     def _generate_next_value_(name, start, count, last_values):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1,3 +1,4 @@
+import copy
 import enum
 import doctest
 import inspect
@@ -733,6 +734,13 @@ class _MinimalOutputTests:
             self.assertFormatIsValue('{:n}', TE.third)
             self.assertFormatIsValue('{:5.2}', TE.third)
             self.assertFormatIsValue('{:f}', TE.third)
+
+    def test_copy(self):
+        TE = self.MainEnum
+        copied = copy.copy(TE)
+        self.assertEqual(copied, TE)
+        deep = copy.deepcopy(TE)
+        self.assertEqual(deep, TE)
 
 
 class _FlagTests:
@@ -2653,6 +2661,26 @@ class TestSpecial(unittest.TestCase):
             FOUR = 4
         self.assertTrue(isinstance(MyIntFlag.ONE | MyIntFlag.TWO, MyIntFlag), MyIntFlag.ONE | MyIntFlag.TWO)
         self.assertTrue(isinstance(MyIntFlag.ONE | 2, MyIntFlag))
+
+    def test_int_flags_copy(self):
+        class MyIntFlag(IntFlag):
+            ONE = 1
+            TWO = 2
+            FOUR = 4
+
+        flags = MyIntFlag.ONE | MyIntFlag.TWO
+        copied = copy.copy(flags)
+        deep = copy.deepcopy(flags)
+        self.assertEqual(copied, flags)
+        self.assertEqual(deep, flags)
+
+        flags = MyIntFlag.ONE | MyIntFlag.TWO | 8
+        copied = copy.copy(flags)
+        deep = copy.deepcopy(flags)
+        self.assertEqual(copied, flags)
+        self.assertEqual(deep, flags)
+        self.assertEqual(copied.value, 1 | 2 | 8)
+
 
 class TestOrder(unittest.TestCase):
     "test usage of the `_order_` attribute"

--- a/Misc/NEWS.d/next/Library/2022-06-15-21-20-02.gh-issue-93820.FAMLY8.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-15-21-20-02.gh-issue-93820.FAMLY8.rst
@@ -1,0 +1,2 @@
+Fixed a regression when :func:`copy.copy`-ing :class:`enum.Flag` with
+multiple flag members.


### PR DESCRIPTION
GH-26658 introduced a regression in copy / pickle protocol for combined
`enum.Flag`s. `copy.copy(re.A | re.I)` would fail with
`AttributeError: ASCII|IGNORECASE`.

`enum.Flag` now has a `__reduce_ex__()` method that reduces flags by
combined value, not by combined name.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:tiran