### PR TITLE
gh-87389: Fix an open redirection vulnerability in http.server.

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -689,11 +689,8 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             if not parts.path.endswith('/'):
                 # redirect browser - doing basically what apache does
                 self.send_response(HTTPStatus.MOVED_PERMANENTLY)
-                # scheme[0] and netloc[1] are intentionally blanked out as we
-                # are only processing a path. They could allow injection into
-                # the Location header if self.path wound up containing
-                # more than it was supposed to. See gh-87389.
-                new_parts = ('', '', parts[2] + '/', parts[3], parts[4])
+                new_parts = (parts[0], parts[1], parts[2] + '/',
+                             parts[3], parts[4])
                 new_url = urllib.parse.urlunsplit(new_parts)
                 self.send_header("Location", new_url)
                 self.send_header("Content-Length", "0")

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -329,6 +329,13 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
                 return False
         self.command, self.path = command, path
 
+        # gh-87389: The purpose of replacing '//' with '/' is to protect against
+        # open redirect attacks module which could be triggered if the path
+        # starts with '//' because web clients treat //path as an absolute url
+        # without scheme (similar to http://path) rather than a relative path.
+        if self.path.startswith('//'):
+            self.path = '/' + self.path.lstrip('/')  # Reduce to a single /
+
         # Examine the headers and look for a Connection directive.
         try:
             self.headers = http.client.parse_headers(self.rfile,
@@ -682,8 +689,11 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             if not parts.path.endswith('/'):
                 # redirect browser - doing basically what apache does
                 self.send_response(HTTPStatus.MOVED_PERMANENTLY)
-                new_parts = (parts[0], parts[1], parts[2] + '/',
-                             parts[3], parts[4])
+                # scheme[0] and netloc[1] are intentionally blanked out as we
+                # are only processing a path. They could allow injection into
+                # Location header if self.path wound up containing
+                # more than it was supposed to. See gh-87389.
+                new_parts = ('', '', parts[2] + '/', parts[3], parts[4])
                 new_url = urllib.parse.urlunsplit(new_parts)
                 self.send_header("Location", new_url)
                 self.send_header("Content-Length", "0")

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -329,10 +329,10 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
                 return False
         self.command, self.path = command, path
 
-        # gh-87389: The purpose of replacing '//' with '/' is to protect against
-        # open redirect attacks module which could be triggered if the path
-        # starts with '//' because web clients treat //path as an absolute url
-        # without scheme (similar to http://path) rather than a relative path.
+        # gh-87389: The purpose of replacing '//' with '/' is to protect
+        # against open redirect attacks possibly triggered if the path starts
+        # with '//' because http clients treat //path as an absolute URI
+        # without scheme (similar to http://path) rather than a path.
         if self.path.startswith('//'):
             self.path = '/' + self.path.lstrip('/')  # Reduce to a single /
 
@@ -691,7 +691,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
                 self.send_response(HTTPStatus.MOVED_PERMANENTLY)
                 # scheme[0] and netloc[1] are intentionally blanked out as we
                 # are only processing a path. They could allow injection into
-                # Location header if self.path wound up containing
+                # the Location header if self.path wound up containing
                 # more than it was supposed to. See gh-87389.
                 new_parts = ('', '', parts[2] + '/', parts[3], parts[4])
                 new_url = urllib.parse.urlunsplit(new_parts)

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -447,6 +447,17 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         self.check_status_and_reason(response, HTTPStatus.MOVED_PERMANENTLY)
         self.assertEqual(response.getheader('Location'), expected_location)
 
+        # If the second word in the http request (Request-URI for the http
+        # method) is a full URI, we don't worry about it, as that'll be parsed
+        # and reassembled as a full URI within BaseHTTPRequestHandler.send_head
+        # so no errant scheme-less //netloc//evil.co/ domain mixup can happen.
+        attack_scheme_netloc_2slash_url = f'https://pypi.org/{url}'
+        expected_scheme_netloc_location = f'{attack_scheme_netloc_2slash_url}/'
+        response = self.request(attack_scheme_netloc_2slash_url)
+        self.check_status_and_reason(response, HTTPStatus.MOVED_PERMANENTLY)
+        location = response.getheader('Location')
+        self.assertEqual(location, expected_scheme_netloc_location)
+
     def test_get(self):
         #constructs the path relative to the root directory of the HTTPServer
         response = self.request(self.base_url + '/test')

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -434,8 +434,8 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         self.check_status_and_reason(response, HTTPStatus.MOVED_PERMANENTLY)
         location = response.getheader('Location')
         self.assertFalse(location.startswith('//'), msg=location)
-        self.assertEqual(location, attack_url[1:] + '/',
-                msg='Expected Location: to start with a single / and '
+        self.assertEqual(location, f'/{attack_url.lstrip("/")}/',
+                msg='Expected Location header to start with a single / and '
                 'end with a / as this is a directory redirect.')
 
     def test_get(self):

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -429,6 +429,8 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         directory in question exists on the Referrer server.
         """
         os.mkdir(os.path.join(self.tempdir, 'existing_directory'))
+        # Canonicalizes to /tmp/tempdir_name/existing_directory which does
+        # exist and is a dir, triggering the 301 redirect and former bug.
         attack_url = f'//python.org/..%2f..%2f..%2f..%2f..%2f../%0a%0d/../{self.tempdir_name}/existing_directory'
         response = self.request(attack_url)
         self.check_status_and_reason(response, HTTPStatus.MOVED_PERMANENTLY)

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -429,11 +429,16 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         """
         os.mkdir(os.path.join(self.tempdir, 'existing_directory'))
         url = f'/python.org/..%2f..%2f..%2f..%2f..%2f../%0a%0d/../{self.tempdir_name}/existing_directory'
-        # Canonicalizes to /tmp/tempdir_name/existing_directory which does
-        # exist and is a dir, triggering the 301 redirect and former bug.
-        attack_url = f'/{url}'  # //python.org... multi-slash prefix, no trailing slash
         expected_location = f'{url}/'  # /python.org.../ single slash single prefix, trailing slash
+        # Canonicalizes to /tmp/tempdir_name/existing_directory which does
+        # exist and is a dir, triggering the 301 redirect logic.
+        response = self.request(url)
+        self.check_status_and_reason(response, HTTPStatus.MOVED_PERMANENTLY)
+        location = response.getheader('Location')
+        self.assertEqual(location, expected_location, msg='non-attack failed!')
 
+        # //python.org... multi-slash prefix, no trailing slash
+        attack_url = f'/{url}'
         response = self.request(attack_url)
         self.check_status_and_reason(response, HTTPStatus.MOVED_PERMANENTLY)
         location = response.getheader('Location')
@@ -442,7 +447,8 @@ class SimpleHTTPServerTestCase(BaseTestCase):
                 msg='Expected Location header to start with a single / and '
                 'end with a / as this is a directory redirect.')
 
-        attack3_url = f'//{url}'  # ///python.org... triple-slash prefix, no trailing slash
+        # ///python.org... triple-slash prefix, no trailing slash
+        attack3_url = f'//{url}'
         response = self.request(attack3_url)
         self.check_status_and_reason(response, HTTPStatus.MOVED_PERMANENTLY)
         self.assertEqual(response.getheader('Location'), expected_location)
@@ -456,7 +462,10 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         response = self.request(attack_scheme_netloc_2slash_url)
         self.check_status_and_reason(response, HTTPStatus.MOVED_PERMANENTLY)
         location = response.getheader('Location')
-        self.assertEqual(location, expected_scheme_netloc_location)
+        # We're just ensuring that the scheme and domain make it through, if
+        # there are or aren't multiple slashes at the start of the path that
+        # follows that isn't important in this Location: header.
+        self.assertTrue(location.startswith('https://pypi.org/'), msg=location)
 
     def test_get(self):
         #constructs the path relative to the root directory of the HTTPServer

--- a/Misc/NEWS.d/next/Security/2022-06-15-20-09-23.gh-issue-87389.QVaC3f.rst
+++ b/Misc/NEWS.d/next/Security/2022-06-15-20-09-23.gh-issue-87389.QVaC3f.rst
@@ -1,0 +1,3 @@
+:mod:`http.server`: Fix an open redirection vulnerability in the HTTP server
+when an URI path starts with ``//``.  Vulnerability discovered, and initial
+fix proposed, by Hamza Avvan.


### PR DESCRIPTION
Fix an open redirection vulnerability in the `http.server` module when
an URI path starts with `//`.  Vulnerability discovered, and initial fix
proposed, by Hamza Avvan (@hamzaavvan).

Test authored and secondary mitigation by Gregory P. Smith [Google].

This PR takes over and replaces https://github.com/python/cpython/pull/24848.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
