### PR TITLE
gh-89745: Avoid exact match when comparing program_name in test_embed on Windows

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -629,7 +629,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         return configs
 
     def get_expected_config(self, expected_preconfig, expected,
-                            env, api, modify_path_cb=None, cwd=None):
+                            env, api, modify_path_cb=None):
         configs = self._get_expected_config()
 
         pre_config = configs['pre_config']
@@ -672,14 +672,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             expected['base_executable'] = default_executable
         if expected['program_name'] is self.GET_DEFAULT_CONFIG:
             expected['program_name'] = './_testembed'
-            if MS_WINDOWS:
-                # follow the calculation in getpath.py
-                tmpname = expected['program_name'] + '.exe'
-                if cwd:
-                    tmpname = os.path.join(cwd, tmpname)
-                if os.path.isfile(tmpname):
-                    expected['program_name'] += '.exe'
-                del tmpname
 
         config = configs['config']
         for key, value in expected.items():
@@ -709,6 +701,9 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
     def check_config(self, configs, expected):
         config = dict(configs['config'])
+        if MS_WINDOWS and (value := config.get('program_name')):
+            ptn = '_d.exe$' if debug_build(sys.executable) else '.exe$'
+            config['program_name'] = re.sub(ptn, '', value, 1, re.I)
         for key, value in list(expected.items()):
             if value is self.IGNORE_CONFIG:
                 config.pop(key, None)
@@ -773,7 +768,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         self.get_expected_config(expected_preconfig,
                                  expected_config,
                                  env,
-                                 api, modify_path_cb, cwd)
+                                 api, modify_path_cb)
 
         out, err = self.run_embedded_interpreter(testname,
                                                  env=env, cwd=cwd)

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -704,7 +704,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         if MS_WINDOWS:
             value = config.get('program_name')
             if value and isinstance(value, str):
-                ptn = '_d.exe$' if debug_build(sys.executable) else '.exe$'
+                ptn = r'_d\.exe$' if debug_build(sys.executable) else r'\.exe$'
                 config['program_name'] = re.sub(ptn, '', value, 1, re.IGNORECASE)
         for key, value in list(expected.items()):
             if value is self.IGNORE_CONFIG:

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -701,9 +701,11 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
     def check_config(self, configs, expected):
         config = dict(configs['config'])
-        if MS_WINDOWS and (value := config.get('program_name')):
-            ptn = r'_d\.exe$' if debug_build(sys.executable) else r'\.exe$'
-            config['program_name'] = re.sub(ptn, '', value, 1, re.I)
+        if MS_WINDOWS:
+            value = config.get('program_name')
+            if value and isinstance(value, str):
+                ptn = '_d.exe$' if debug_build(sys.executable) else '.exe$'
+                config['program_name'] = re.sub(ptn, '', value, 1, re.IGNORECASE)
         for key, value in list(expected.items()):
             if value is self.IGNORE_CONFIG:
                 config.pop(key, None)

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -702,10 +702,10 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
     def check_config(self, configs, expected):
         config = dict(configs['config'])
         if MS_WINDOWS:
-            value = config.get('program_name')
+            value = config.get(key := 'program_name')
             if value and isinstance(value, str):
-                ptn = r'_d\.exe$' if debug_build(sys.executable) else r'\.exe$'
-                config['program_name'] = re.sub(ptn, '', value, 1, re.IGNORECASE)
+                ext = '_d.exe' if debug_build(sys.executable) else '.exe'
+                config[key] = value[:len(value.lower().removesuffix(ext))]
         for key, value in list(expected.items()):
             if value is self.IGNORE_CONFIG:
                 config.pop(key, None)

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -702,7 +702,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
     def check_config(self, configs, expected):
         config = dict(configs['config'])
         if MS_WINDOWS and (value := config.get('program_name')):
-            ptn = '_d.exe$' if debug_build(sys.executable) else '.exe$'
+            ptn = r'_d\.exe$' if debug_build(sys.executable) else r'\.exe$'
             config['program_name'] = re.sub(ptn, '', value, 1, re.I)
         for key, value in list(expected.items()):
             if value is self.IGNORE_CONFIG:


### PR DESCRIPTION
**Python version: `3.11`, `3.12`**

When initializing on Windows, the `program_name` config field can have an extension (`[_d].exe`) to configure the `executable`. However, `test_embed` basically expects the name with no extension, which has caused inconsistent comparisons on the test machines.

With this patch, `test_embed` allows partial matching for `program_name` on Windows, and the previous workaround only for release builds (#29930) can be removed.

#89745