### PR TITLE
gh-61162: Clarify sqlite3 connection context manager docs

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1442,7 +1442,7 @@ context manager.
 If the body of the :keyword:`with` statement finishes without exceptions,
 the transaction is committed.
 If this commit fails,
-or the body of the ``with`` statement raise an exception which is not caught,
+or if the body of the ``with`` statement raises an uncaught exception,
 the transaction is rolled back.
 
 If there is no open transaction upon leaving the body of the ``with`` statement,

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1440,8 +1440,8 @@ Connection objects can be used as context managers that automatically commit or
 rollback open transactions when leaving the body of the context manager.
 If the body of the :keyword:`with` statement finishes without exceptions,
 the transaction is committed.
-If this commit fails, the transaction is rolled back.
-If the body of the ``with`` statement raise an exception which is not caught,
+If this commit fails,
+or the body of the ``with`` statement raise an exception which is not caught,
 the transaction is rolled back.
 
 If there is no open transaction upon leaving the body of the ``with`` statement,

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1449,8 +1449,8 @@ the context manager is a no-op.
 
 .. note::
 
-   The context manager does not implicitly open a new transaction.
-   The context manager does not implicitly close the connection.
+   The context manager does not implicitly open a new transaction
+   or close the connection.
 
 .. literalinclude:: ../includes/sqlite3/ctx_manager.py
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1443,7 +1443,7 @@ otherwise, the transaction is committed:
 
 .. note::
 
-    The context manager does not implicitly start a new transaction.
+    The context manager does not implicitly open a new transaction.
 
 .. literalinclude:: ../includes/sqlite3/ctx_manager.py
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1435,9 +1435,15 @@ Using the connection as a context manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Connection objects can be used as context managers
-that automatically commit or rollback transactions.  In the event of an
-exception, the transaction is rolled back; otherwise, the transaction is
-committed:
+that automatically commit or rollback transactions,
+*if* there is an open transaction.
+If there is no open transaction, the context manager is a no-op.
+In the event of an exception, the transaction is rolled back;
+otherwise, the transaction is committed:
+
+.. note::
+
+    The context manager does not implicitly start a new transaction.
 
 .. literalinclude:: ../includes/sqlite3/ctx_manager.py
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1434,12 +1434,13 @@ case-insensitively by name:
 Using the connection as a context manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Connection objects can be used as context managers
-that automatically commit or rollback transactions,
-*if* there is an open transaction.
+With an open transaction, connection objects can be used as context managers
+that automatically commit or rollback transactions.
+If the body of the ``with`` statement finishes without exceptions,
+the transaction is committed.
+If an exception is raised and not caught, the transaction is rolled back.
+
 If there is no open transaction, the context manager is a no-op.
-In the event of an exception, the transaction is rolled back;
-otherwise, the transaction is committed:
 
 .. note::
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1450,8 +1450,8 @@ the context manager is a no-op.
 
 .. note::
 
-   The context manager does not implicitly open a new transaction
-   or close the connection.
+   The context manager neither implicitly opens a new transaction
+   nor closes the connection.
 
 .. literalinclude:: ../includes/sqlite3/ctx_manager.py
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1437,8 +1437,8 @@ Using the connection as a context manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A :class:`Connection` object can be used as a context manager that
-automatically commits or rolls back open transactions when leaving the body of the
-context manager.
+automatically commits or rolls back open transactions when leaving the body of
+the context manager.
 If the body of the :keyword:`with` statement finishes without exceptions,
 the transaction is committed.
 If this commit fails,

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1436,8 +1436,9 @@ case-insensitively by name:
 Using the connection as a context manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:class:`Connection` objects can be used as context managers that automatically commit or
-rollback open transactions when leaving the body of the context manager.
+A :class:`Connection` object can be used as a context manager that
+automatically commit or rollback open transactions when leaving the body of the
+context manager.
 If the body of the :keyword:`with` statement finishes without exceptions,
 the transaction is committed.
 If this commit fails,

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1437,7 +1437,7 @@ Using the connection as a context manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A :class:`Connection` object can be used as a context manager that
-automatically commit or rollback open transactions when leaving the body of the
+automatically commits or rolls back open transactions when leaving the body of the
 context manager.
 If the body of the :keyword:`with` statement finishes without exceptions,
 the transaction is committed.

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1436,7 +1436,7 @@ case-insensitively by name:
 Using the connection as a context manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Connection objects can be used as context managers that automatically commit or
+:class:`Connection` objects can be used as context managers that automatically commit or
 rollback open transactions when leaving the body of the context manager.
 If the body of the :keyword:`with` statement finishes without exceptions,
 the transaction is committed.

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1431,6 +1431,8 @@ case-insensitively by name:
 .. literalinclude:: ../includes/sqlite3/rowclass.py
 
 
+.. _sqlite3-connection-context-manager:
+
 Using the connection as a context manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1448,7 +1448,7 @@ the context manager is a no-op.
 .. note::
 
    The context manager does not implicitly open a new transaction.
-   The context manager does not close the connection.
+   The context manager does not implicitly close the connection.
 
 .. literalinclude:: ../includes/sqlite3/ctx_manager.py
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1442,10 +1442,6 @@ If an exception is raised and not caught, the transaction is rolled back.
 
 If there is no open transaction, the context manager is a no-op.
 
-.. note::
-
-    The context manager does not implicitly open a new transaction.
-
 .. literalinclude:: ../includes/sqlite3/ctx_manager.py
 
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1434,13 +1434,21 @@ case-insensitively by name:
 Using the connection as a context manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-With an open transaction, connection objects can be used as context managers
-that automatically commit or rollback transactions.
-If the body of the ``with`` statement finishes without exceptions,
+Connection objects can be used as context managers that automatically commit or
+rollback open transactions when leaving the body of the context manager.
+If the body of the :keyword:`with` statement finishes without exceptions,
 the transaction is committed.
-If an exception is raised and not caught, the transaction is rolled back.
+If this commit fails, the transaction is rolled back.
+If the body of the ``with`` statement raise an exception which is not caught,
+the transaction is rolled back.
 
-If there is no open transaction, the context manager is a no-op.
+If there is no open transaction upon leaving the body of the ``with`` statement,
+the context manager is a no-op.
+
+.. note::
+
+   The context manager does not implicitly open a new transaction.
+   The context manager does not close the connection.
 
 .. literalinclude:: ../includes/sqlite3/ctx_manager.py
 

--- a/Misc/NEWS.d/next/Documentation/2022-06-16-10-10-59.gh-issue-61162.1ypkG8.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-16-10-10-59.gh-issue-61162.1ypkG8.rst
@@ -1,1 +1,1 @@
-Clarify :mod:`sqlite3` connection context manager behaviour.
+Clarify :mod:`sqlite3` behavior when :ref:`sqlite3-connection-context-manager`.

--- a/Misc/NEWS.d/next/Documentation/2022-06-16-10-10-59.gh-issue-61162.1ypkG8.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-16-10-10-59.gh-issue-61162.1ypkG8.rst
@@ -1,0 +1,1 @@
+Clarify :mod:`sqlite3` connection context manager behaviour.


### PR DESCRIPTION
Explicitly note that transactions are only closed if there is an open
transation at `__exit__`, and that transactions are not implicitly
opened during `__enter__`.

Co-authored-by: CAM Gerlach <CAM.Gerlach@Gerlach.CAM>
Co-authored-by: Stanley <46876382+slateny@users.noreply.github.com>

Automerge-Triggered-By: GH:erlend-aasland