### PR TITLE
[3.11] GH-93662: Make sure that column offsets are correct in multi-line method calls. (GH-93673)

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -574,6 +574,15 @@ def positions_from_location_table(code):
         for _ in range(length):
             yield (line, end_line, col, end_col)
 
+def dedup(lst, prev=object()):
+    for item in lst:
+        if item != prev:
+            yield item
+            prev = item
+
+def lines_from_postions(positions):
+    return dedup(l for (l, _, _, _) in positions)
+
 def misshappen():
     """
 
@@ -606,6 +615,13 @@ def misshappen():
 
         ) else p
 
+def bug93662():
+    example_report_generation_message= (
+            """
+            """
+    ).strip()
+    raise ValueError()
+
 
 class CodeLocationTest(unittest.TestCase):
 
@@ -616,10 +632,23 @@ class CodeLocationTest(unittest.TestCase):
             self.assertEqual(l1, l2)
         self.assertEqual(len(pos1), len(pos2))
 
-
     def test_positions(self):
         self.check_positions(parse_location_table)
         self.check_positions(misshappen)
+        self.check_positions(bug93662)
+
+    def check_lines(self, func):
+        co = func.__code__
+        lines1 = list(dedup(l for (_, _, l) in co.co_lines()))
+        lines2 = list(lines_from_postions(positions_from_location_table(co)))
+        for l1, l2 in zip(lines1, lines2):
+            self.assertEqual(l1, l2)
+        self.assertEqual(len(lines1), len(lines2))
+
+    def test_lines(self):
+        self.check_lines(parse_location_table)
+        self.check_lines(misshappen)
+        self.check_lines(bug93662)
 
 
 if check_impl_detail(cpython=True) and ctypes is not None:

--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-10-10-31-18.gh-issue-93662.-7RSC1.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-10-10-31-18.gh-issue-93662.-7RSC1.rst
@@ -1,0 +1,2 @@
+Make sure that the end column offsets are correct in multi-line method
+calls. Previously, the end column could precede the column offset.


### PR DESCRIPTION

(Manually cherry-picked from commit 2bf74753c14e5360e04930b478703f4e2618f4a3, and resolved conflict in Python/compile.c, function maybe_optimize_method_call).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
