### PR TITLE
GH-93897: Streamline `_PyFrame_InitializeSpecials` a bit.

### DIFF
--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -94,18 +94,18 @@ static inline void _PyFrame_StackPush(_PyInterpreterFrame *f, PyObject *value) {
 
 void _PyFrame_Copy(_PyInterpreterFrame *src, _PyInterpreterFrame *dest);
 
-/* Consumes reference to func */
+/* Consumes reference to func and locals (if not NULL) */
 static inline void
 _PyFrame_InitializeSpecials(
-    _PyInterpreterFrame *frame, PyFunctionObject *func,
-    PyObject *locals, int nlocalsplus)
+    _PyInterpreterFrame *frame, PyFunctionObject *func, PyObject *locals)
 {
     frame->f_func = func;
-    frame->f_code = (PyCodeObject *)Py_NewRef(func->func_code);
+    PyCodeObject *code = (PyCodeObject *)func->func_code;
+    frame->f_code = (PyCodeObject *)Py_NewRef(code);
     frame->f_builtins = func->func_builtins;
     frame->f_globals = func->func_globals;
-    frame->f_locals = Py_XNewRef(locals);
-    frame->stacktop = nlocalsplus;
+    frame->f_locals = locals;
+    frame->stacktop = code->co_nlocalsplus;
     frame->frame_obj = NULL;
     frame->prev_instr = _PyCode_CODE(frame->f_code) - 1;
     frame->is_entry = false;

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -859,7 +859,8 @@ init_frame(_PyInterpreterFrame *frame, PyFunctionObject *func, PyObject *locals)
     /* _PyFrame_InitializeSpecials consumes reference to func */
     Py_INCREF(func);
     PyCodeObject *code = (PyCodeObject *)func->func_code;
-    _PyFrame_InitializeSpecials(frame, func, locals, code->co_nlocalsplus);
+    Py_XINCREF(locals);
+    _PyFrame_InitializeSpecials(frame, func, locals);
     for (Py_ssize_t i = 0; i < code->co_nlocalsplus; i++) {
         frame->localsplus[i] = NULL;
     }

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -126,7 +126,7 @@ _PyFrame_Push(PyThreadState *tstate, PyFunctionObject *func)
         Py_DECREF(func);
         return NULL;
     }
-    _PyFrame_InitializeSpecials(new_frame, func, NULL, code->co_nlocalsplus);
+    _PyFrame_InitializeSpecials(new_frame, func, NULL);
     return new_frame;
 }
 


### PR DESCRIPTION
Moves test for `locals == NULL` off the fast path. Also removes the `co_nlocalsplus` parameter.