### PR TITLE
gh-93018: Fix for the compatibility problems with expat

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -1149,14 +1149,10 @@ class MinidomTest(unittest.TestCase):
 
         # Verify that character decoding errors raise exceptions instead
         # of crashing
-        if pyexpat.version_info >= (2, 4, 5):
-            self.assertRaises(ExpatError, parseString,
-                    b'<fran\xe7ais></fran\xe7ais>')
-            self.assertRaises(ExpatError, parseString,
-                    b'<franais>Comment \xe7a va ? Tr\xe8s bien ?</franais>')
-        else:
-            self.assertRaises(UnicodeDecodeError, parseString,
-                b'<fran\xe7ais>Comment \xe7a va ? Tr\xe8s bien ?</fran\xe7ais>')
+        with self.assertRaises((UnicodeDecodeError, ExpatError)):
+            parseString(
+                b'<fran\xe7ais>Comment \xe7a va ? Tr\xe8s bien ?</fran\xe7ais>'
+            )
 
         doc.unlink()
 
@@ -1617,13 +1613,11 @@ class MinidomTest(unittest.TestCase):
         self.confirm(doc2.namespaceURI == xml.dom.EMPTY_NAMESPACE)
 
     def testExceptionOnSpacesInXMLNSValue(self):
-        if pyexpat.version_info >= (2, 4, 5):
-            context = self.assertRaisesRegex(ExpatError, 'syntax error')
-        else:
-            context = self.assertRaisesRegex(ValueError, 'Unsupported syntax')
-
-        with context:
-            parseString('<element xmlns:abc="http:abc.com/de f g/hi/j k"><abc:foo /></element>')
+        with self.assertRaises((ValueError, ExpatError)):
+            parseString(
+                '<element xmlns:abc="http:abc.com/de f g/hi/j k">' +
+                '<abc:foo /></element>'
+            )
 
     def testDocRemoveChild(self):
         doc = parse(tstfile)

--- a/Misc/NEWS.d/next/Tests/2022-06-16-13-26-31.gh-issue-93018.wvNx76.rst
+++ b/Misc/NEWS.d/next/Tests/2022-06-16-13-26-31.gh-issue-93018.wvNx76.rst
@@ -1,0 +1,1 @@
+Fix for the compatibility problems with expat made more robust.

--- a/Misc/NEWS.d/next/Tests/2022-06-16-13-26-31.gh-issue-93018.wvNx76.rst
+++ b/Misc/NEWS.d/next/Tests/2022-06-16-13-26-31.gh-issue-93018.wvNx76.rst
@@ -1,1 +1,1 @@
-Fix for the compatibility problems with expat made more robust.
+Make two tests forgiving towards host system libexpat with backported security fixes applied.


### PR DESCRIPTION
This is another take on #93022, fixes #93018.

1. I believe it is inappropriate to assert on the error message for the external API. Error messages are not part of the provided contract with its users.
2. I don't think we really care what exact exception is thrown, it is much more important that non-well-formed XML is discovered.
3. Changing tests based on the version of library seems as a code smell to me, but that's a personal opinion.

Cc: @corona10 @hartwork 

<!-- gh-issue-number: gh-93018 -->
* Issue: gh-93018
<!-- /gh-issue-number -->
