### PR TITLE
gh-91321: Fix test_cppext for C++03

### DIFF
--- a/Lib/test/setup_testcppext.py
+++ b/Lib/test/setup_testcppext.py
@@ -19,8 +19,6 @@ if not MS_WINDOWS:
         '-Werror',
         # Warn on old-style cast (C cast) like: (PyObject*)op
         '-Wold-style-cast',
-        # Warn when using NULL rather than _Py_NULL in static inline functions
-        '-Wzero-as-null-pointer-constant',
     ]
 else:
     # Don't pass any compiler flag to MSVC
@@ -39,6 +37,10 @@ def main():
         name = '_testcpp11ext'
 
     cppflags = [*CPPFLAGS, f'-std={std}']
+    if std == 'c++11':
+        # Warn when using NULL rather than _Py_NULL in static inline functions
+        cppflags.append('-Wzero-as-null-pointer-constant')
+
     cpp_ext = Extension(
         name,
         sources=[SOURCE],


### PR DESCRIPTION
Don't build _testcppext.cpp with -Wzero-as-null-pointer-constant when
testing C++03: only use this compiler flag with C++11.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
