### PR TITLE
gh-93858: Prevent error when activating venv in nested fish instances (GH-93931)

### DIFF
--- a/Lib/venv/scripts/posix/activate.fish
+++ b/Lib/venv/scripts/posix/activate.fish
@@ -13,10 +13,13 @@ function deactivate  -d "Exit virtual environment and return to normal shell env
     end
 
     if test -n "$_OLD_FISH_PROMPT_OVERRIDE"
-        functions -e fish_prompt
         set -e _OLD_FISH_PROMPT_OVERRIDE
-        functions -c _old_fish_prompt fish_prompt
-        functions -e _old_fish_prompt
+        # prevents error when using nested fish instances (Issue #93858)
+        if functions -q _old_fish_prompt
+            functions -e fish_prompt
+            functions -c _old_fish_prompt fish_prompt
+            functions -e _old_fish_prompt
+        end
     end
 
     set -e VIRTUAL_ENV

--- a/Misc/NEWS.d/next/Library/2022-06-17-12-02-30.gh-issue-93858.R49ARc.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-17-12-02-30.gh-issue-93858.R49ARc.rst
@@ -1,0 +1,1 @@
+Prevent error when activating venv in nested fish instances.


### PR DESCRIPTION
Fixes #93858

<!-- gh-issue-number: gh-93858 -->
* Issue: gh-93858
<!-- /gh-issue-number -->
