### PR TITLE
GH-74866: Fix utils.parsedate_to_datetime raising exception on None

### DIFF
--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -195,6 +195,8 @@ def make_msgid(idstring=None, domain=None):
 
 
 def parsedate_to_datetime(data):
+    if data is None:
+        return None
     parsed_date_tz = _parsedate_tz(data)
     if parsed_date_tz is None:
         raise ValueError('Invalid date value or format "%s"' % str(data))

--- a/Lib/test/test_email/test_utils.py
+++ b/Lib/test/test_email/test_utils.py
@@ -59,6 +59,9 @@ class DateTimeTests(unittest.TestCase):
             with self.subTest(dtstr=dtstr):
                 self.assertRaises(ValueError, utils.parsedate_to_datetime, dtstr)
 
+    def test_parsedate_to_datetime_with_None_returns_None(self):
+        self.assertIsNone(utils.parsedate_to_datetime(None))
+
 class LocaltimeTests(unittest.TestCase):
 
     def test_localtime_is_tz_aware_daylight_true(self):

--- a/Misc/NEWS.d/next/Library/2022-06-17-14-23-16.gh-issue-74866.WS__3i.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-17-14-23-16.gh-issue-74866.WS__3i.rst
@@ -1,0 +1,1 @@
+Fix :meth:`utils.parsedate_to_datetime` raising exception on ``None``. It now returns ``None`` instead.


### PR DESCRIPTION

Closes  #74866.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
