### PR TITLE
gh-74953: PyThread_acquire_lock_timed() recomputes timeout

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-06-20-17-52-34.gh-issue-74953.FqQInl.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-20-17-52-34.gh-issue-74953.FqQInl.rst
@@ -1,0 +1,4 @@
+The mutex with conditional variable implementation of
+:class:`threading.Lock` now recomputes the timeout if
+``acquire(timeout=timeout)`` is interrupted by a signal. Patch by Victor
+Stinner.


### PR DESCRIPTION
The mutex with conditional variable implementation of lock now
recomputes the timeout if acquire(timeout=timeout) is interrupted by
a signal.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
