### PR TITLE
gh-93955: Use unbound methods for slot `__getattr__` and `__getattribute__`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-17-16-30-24.gh-issue-93955.LmiAe9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-17-16-30-24.gh-issue-93955.LmiAe9.rst
@@ -1,0 +1,1 @@
+Improve performance of attribute lookups on objects with custom ``__getattribute__`` and ``__getattr__``. Patch by Ken Jin.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7827,9 +7827,9 @@ slot_tp_getattr_hook(PyObject *self, PyObject *name)
     Py_INCREF(getattr);
     /* speed hack: we could use lookup_maybe, but that would resolve the
        method fully for each attribute lookup for classes with
-       __getattr__, even when the attribute is present. So we use
-       _PyType_Lookup and create the method only when needed, with
-       call_attribute. */
+       __getattr__, even when self has the default __getattribute__
+       method. So we use _PyType_Lookup and create the method only when
+       needed, with call_attribute. */
     getattribute = _PyType_Lookup(tp, &_Py_ID(__getattribute__));
     if (getattribute == NULL ||
         (Py_IS_TYPE(getattribute, &PyWrapperDescr_Type) &&

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7827,8 +7827,8 @@ slot_tp_getattr_hook(PyObject *self, PyObject *name)
     else {
         res = vectorcall_unbound(tstate, unbound_getattribute, getattribute,
             args, 2);
-        Py_DECREF(getattribute);
     }
+    Py_XDECREF(getattribute);
     if (res == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
         PyErr_Clear();
         res = vectorcall_unbound(tstate, unbound_getattr, getattr, args, 2);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7783,24 +7783,6 @@ slot_tp_getattro(PyObject *self, PyObject *name)
 }
 
 static PyObject *
-call_attribute(PyObject *self, PyObject *attr, PyObject *name)
-{
-    PyObject *res, *descr = NULL;
-    descrgetfunc f = Py_TYPE(attr)->tp_descr_get;
-
-    if (f != NULL) {
-        descr = f(attr, self, (PyObject *)(Py_TYPE(self)));
-        if (descr == NULL)
-            return NULL;
-        else
-            attr = descr;
-    }
-    res = PyObject_CallOneArg(attr, name);
-    Py_XDECREF(descr);
-    return res;
-}
-
-static PyObject *
 slot_tp_getattr_hook(PyObject *self, PyObject *name)
 {
     PyTypeObject *tp = Py_TYPE(self);


### PR DESCRIPTION
Closes #93955. 