### PR TITLE
Rename random module's distribution functions

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -86,7 +86,7 @@ __all__ = [
     "seed",
     "setstate",
     "shuffle",
-    "triangular",
+    "triangularvariate",
     "uniform",
     "vonmisesvariate",
     "weibullvariate",
@@ -485,7 +485,7 @@ class Random(_random.Random):
         "Get a random number in the range [a, b) or [a, b] depending on rounding."
         return a + (b - a) * self.random()
 
-    def triangular(self, low=0.0, high=1.0, mode=None):
+    def triangularvariate(self, low=0.0, high=1.0, mode=None):
         """Triangular distribution.
 
         Continuous distribution bounded by given lower and upper limits,
@@ -796,7 +796,7 @@ _inst = Random()
 seed = _inst.seed
 random = _inst.random
 uniform = _inst.uniform
-triangular = _inst.triangular
+triangular = _inst.triangularvariate
 randint = _inst.randint
 choice = _inst.choice
 randrange = _inst.randrange
@@ -854,7 +854,7 @@ def _test(N=2000):
     _test_generator(N, gammavariate, (200.0, 1.0))
     _test_generator(N, gaussvariate, (0.0, 1.0))
     _test_generator(N, betavariate, (3.0, 3.0))
-    _test_generator(N, triangular, (0.0, 1.0, 1.0 / 3.0))
+    _test_generator(N, triangularvariate, (0.0, 1.0, 1.0 / 3.0))
 
 
 ## ------------------------------------------------------

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -72,7 +72,7 @@ __all__ = [
     "choices",
     "expovariate",
     "gammavariate",
-    "gauss",
+    "gaussvariate",
     "getrandbits",
     "getstate",
     "lognormvariate",
@@ -526,7 +526,7 @@ class Random(_random.Random):
                 break
         return mu + z * sigma
 
-    def gauss(self, mu=0.0, sigma=1.0):
+    def gaussvariate(self, mu=0.0, sigma=1.0):
         """Gaussian distribution.
 
         mu is the mean, and sigma is the standard deviation.  This is
@@ -808,7 +808,7 @@ lognormvariate = _inst.lognormvariate
 expovariate = _inst.expovariate
 vonmisesvariate = _inst.vonmisesvariate
 gammavariate = _inst.gammavariate
-gauss = _inst.gauss
+gaussvariate = _inst.gaussvariate
 betavariate = _inst.betavariate
 paretovariate = _inst.paretovariate
 weibullvariate = _inst.weibullvariate
@@ -852,7 +852,7 @@ def _test(N=2000):
     _test_generator(N, gammavariate, (2.0, 1.0))
     _test_generator(N, gammavariate, (20.0, 1.0))
     _test_generator(N, gammavariate, (200.0, 1.0))
-    _test_generator(N, gauss, (0.0, 1.0))
+    _test_generator(N, gaussvariate, (0.0, 1.0))
     _test_generator(N, betavariate, (3.0, 3.0))
     _test_generator(N, triangular, (0.0, 1.0, 1.0 / 3.0))
 


### PR DESCRIPTION
# Rename random module's distribution functions
The random module's function `gauss()` is the Gaussian distribution function. I think it should be renamed to `gaussvariate()`, because it's the Gauss distribution, and to keep the format. The function `triangular()` I also think should be renamed, to `triangularvariate()`.
These are the names of the other distributions:
|   Function name   | Ends in "variate"  | 
|-------------------|:------------------:|
| betavariate()     | :heavy_check_mark: |
| expovariate()     | :heavy_check_mark: |
| gammavariate()    | :heavy_check_mark: |
| gauss()           |        :x:         |
| lognormvariate()  | :heavy_check_mark: |
| normalvariate()   | :heavy_check_mark: |
| paretovariate()   | :heavy_check_mark: |
| triangular()      |        :x:         |
| vonmisesvariate() | :heavy_check_mark: |
| weibullvariate()  | :heavy_check_mark: |

All of them, except `gauss()` and `triangular()` end in "variate".