### PR TITLE
GH-93249: relax overly strict assertion on bounds->ar_start

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from io import StringIO
 import linecache
 import sys
+import types
 import inspect
 import unittest
 import re
@@ -1128,7 +1129,7 @@ boundaries = re.compile(
 class BaseExceptionReportingTests:
 
     def get_exception(self, exception_or_callable):
-        if isinstance(exception_or_callable, Exception):
+        if isinstance(exception_or_callable, BaseException):
             return exception_or_callable
         try:
             exception_or_callable()
@@ -1848,6 +1849,31 @@ class BaseExceptionReportingTests:
                     f'    +------------------------------------\n')
 
         report = self.get_report(exc)
+        self.assertEqual(report, expected)
+
+    def test_KeyboardInterrupt_at_first_line_of_frame(self):
+        # see GH-93249
+        def f():
+            return sys._getframe()
+
+        tb_next = None
+        frame = f()
+        lasti = 0
+        lineno = f.__code__.co_firstlineno
+        tb = types.TracebackType(tb_next, frame, lasti, lineno)
+
+        exc = KeyboardInterrupt()
+        exc.__traceback__ = tb
+
+        expected = (f'Traceback (most recent call last):\n'
+                    f'  File "{__file__}", line {lineno}, in f\n'
+                    f'    def f():\n'
+                    f'\n'
+                    f'KeyboardInterrupt\n')
+
+        report = self.get_report(exc)
+        # remove trailing writespace:
+        report = '\n'.join([l.rstrip() for l in report.split('\n')])
         self.assertEqual(report, expected)
 
 

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -818,7 +818,7 @@ static void
 retreat(PyCodeAddressRange *bounds)
 {
     ASSERT_VALID_BOUNDS(bounds);
-    assert(bounds->ar_start > 0);
+    assert(bounds->ar_start >= 0);
     do {
         bounds->opaque.lo_next--;
     } while (((*bounds->opaque.lo_next) & 128) == 0);

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -775,6 +775,11 @@ next_code_delta(PyCodeAddressRange *bounds)
 static int
 previous_code_delta(PyCodeAddressRange *bounds)
 {
+    if (bounds->ar_start == 0) {
+        // If we looking at the first entry, the
+        // "previous" entry has an implicit length of 1.
+        return 1;
+    }
     const uint8_t *ptr = bounds->opaque.lo_next-1;
     while (((*ptr) & 128) == 0) {
         ptr--;


### PR DESCRIPTION
Closes #93249.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
