### PR TITLE
gh-93951: In test_bdb.StateTestCase.test_skip, avoid including auxiliary importers.

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1768,6 +1768,18 @@ def patch(test_instance, object_to_patch, attr_name, new_value):
     setattr(object_to_patch, attr_name, new_value)
 
 
+@contextlib.contextmanager
+def patch_list(orig):
+    """
+    Like unittest.mock.patch.dict, but for lists.
+    """
+    try:
+        saved = orig[:]
+        yield
+    finally:
+        orig[:] = saved
+
+
 def run_in_subinterp(code):
     """
     Run code in a subinterpreter. Raise unittest.SkipTest if the tracemalloc

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1770,9 +1770,7 @@ def patch(test_instance, object_to_patch, attr_name, new_value):
 
 @contextlib.contextmanager
 def patch_list(orig):
-    """
-    Like unittest.mock.patch.dict, but for lists.
-    """
+    """Like unittest.mock.patch.dict, but for lists."""
     try:
         saved = orig[:]
         yield

--- a/Lib/test/test_bdb.py
+++ b/Lib/test/test_bdb.py
@@ -59,6 +59,7 @@ from contextlib import contextmanager
 from itertools import islice, repeat
 from test.support import import_helper
 from test.support import os_helper
+from test.support import patch_list
 
 
 class BdbException(Exception): pass
@@ -713,9 +714,18 @@ class StateTestCase(BaseTestCase):
         with TracerRun(self) as tracer:
             tracer.runcall(tfunc_main)
 
+    @patch_list(sys.meta_path)
     def test_skip(self):
         # Check that tracing is skipped over the import statement in
         # 'tfunc_import()'.
+
+        # Remove all but the standard importers.
+        sys.meta_path[:] = (
+            item
+            for item in sys.meta_path
+            if item.__module__.startswith('_frozen_importlib')
+        )
+
         code = """
             def main():
                 lno = 3

--- a/Misc/NEWS.d/next/Tests/2022-06-17-15-20-09.gh-issue-93951.CW1Vv4.rst
+++ b/Misc/NEWS.d/next/Tests/2022-06-17-15-20-09.gh-issue-93951.CW1Vv4.rst
@@ -1,0 +1,1 @@
+In test_bdb.StateTestCase.test_skip, avoid including auxiliary importers.


### PR DESCRIPTION
Fixes gh-93951