### PR TITLE
gh-93973: Add all_errors to asyncio.create_connection

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -377,7 +377,8 @@ Opening network connections
                           local_addr=None, server_hostname=None, \
                           ssl_handshake_timeout=None, \
                           ssl_shutdown_timeout=None, \
-                          happy_eyeballs_delay=None, interleave=None)
+                          happy_eyeballs_delay=None, interleave=None \
+                          all_errors=False)
 
    Open a streaming transport connection to a given
    address specified by *host* and *port*.
@@ -468,6 +469,14 @@ Opening network connections
      to complete before aborting the connection. ``30.0`` seconds if ``None``
      (default).
 
+   * *all_errors* determines what exceptions are raised when a connection cannot
+   be created. By default, only a single `Exception`` is raised: the first
+   exception if there is only one or all errors have same message, or a single
+   `OSError` with the error messages combined. When `all_errors`is `True`,
+   an `ExceptionGroup` will be raised containing all exceptions (even if there
+   is only one).
+
+
    .. versionchanged:: 3.5
 
       Added support for SSL/TLS in :class:`ProactorEventLoop`.
@@ -499,6 +508,9 @@ Opening network connections
    .. versionchanged:: 3.11
 
       Added the *ssl_shutdown_timeout* parameter.
+
+   .. versionchanged:: 3.12
+      *all_errors* was added.
 
    .. seealso::
 

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -470,11 +470,11 @@ Opening network connections
      (default).
 
    * *all_errors* determines what exceptions are raised when a connection cannot
-   be created. By default, only a single `Exception`` is raised: the first
-   exception if there is only one or all errors have same message, or a single
-   `OSError` with the error messages combined. When `all_errors`is `True`,
-   an `ExceptionGroup` will be raised containing all exceptions (even if there
-   is only one).
+     be created. By default, only a single ``Exception`` is raised: the first
+     exception if there is only one or all errors have same message, or a single
+     ``OSError`` with the error messages combined. When ``all_errors`` is ``True``,
+     an ``ExceptionGroup`` will be raised containing all exceptions (even if there
+     is only one).
 
 
    .. versionchanged:: 3.5

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -377,7 +377,7 @@ Opening network connections
                           local_addr=None, server_hostname=None, \
                           ssl_handshake_timeout=None, \
                           ssl_shutdown_timeout=None, \
-                          happy_eyeballs_delay=None, interleave=None \
+                          happy_eyeballs_delay=None, interleave=None, \
                           all_errors=False)
 
    Open a streaming transport connection to a given

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -980,7 +980,8 @@ class BaseEventLoop(events.AbstractEventLoop):
             local_addr=None, server_hostname=None,
             ssl_handshake_timeout=None,
             ssl_shutdown_timeout=None,
-            happy_eyeballs_delay=None, interleave=None):
+            happy_eyeballs_delay=None, interleave=None,
+            all_errors=False):
         """Connect to a TCP server.
 
         Create a streaming transport connection to a given internet host and
@@ -1069,6 +1070,8 @@ class BaseEventLoop(events.AbstractEventLoop):
 
             if sock is None:
                 exceptions = [exc for sub in exceptions for exc in sub]
+                if all_errors:
+                    raise ExceptionGroup("create_connection failed", exceptions)
                 if len(exceptions) == 1:
                     raise exceptions[0]
                 else:

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1110,6 +1110,15 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
 
         self.assertEqual(str(cm.exception), 'Multiple exceptions: err1, err2')
 
+        idx = -1
+        coro = self.loop.create_connection(MyProto, 'example.com', 80, all_errors=True)
+        with self.assertRaises(ExceptionGroup) as cm:
+            self.loop.run_until_complete(coro)
+
+        self.assertIsInstance(cm.exception, ExceptionGroup)
+        for e in cm.exception.exceptions:
+            self.assertIsInstance(e, OSError)
+
     @patch_socket
     def test_create_connection_timeout(self, m_socket):
         # Ensure that the socket is closed on timeout
@@ -1229,6 +1238,14 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.assertRaises(
             OSError, self.loop.run_until_complete, coro)
 
+        coro = self.loop.create_connection(MyProto, 'example.com', 80, all_errors=True)
+        with self.assertRaises(ExceptionGroup) as cm:
+            self.loop.run_until_complete(coro)
+
+        self.assertIsInstance(cm.exception, ExceptionGroup)
+        self.assertEqual(len(cm.exception.exceptions), 1)
+        self.assertIsInstance(cm.exception.exceptions[0], OSError)
+
     def test_create_connection_multiple(self):
         async def getaddrinfo(*args, **kw):
             return [(2, 1, 6, '', ('0.0.0.1', 80)),
@@ -1245,6 +1262,15 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
             MyProto, 'example.com', 80, family=socket.AF_INET)
         with self.assertRaises(OSError):
             self.loop.run_until_complete(coro)
+
+        coro = self.loop.create_connection(
+            MyProto, 'example.com', 80, family=socket.AF_INET, all_errors=True)
+        with self.assertRaises(ExceptionGroup) as cm:
+            self.loop.run_until_complete(coro)
+
+        self.assertIsInstance(cm.exception, ExceptionGroup)
+        for e in cm.exception.exceptions:
+            self.assertIsInstance(e, OSError)
 
     @patch_socket
     def test_create_connection_multiple_errors_local_addr(self, m_socket):
@@ -1276,6 +1302,16 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
 
         self.assertTrue(str(cm.exception).startswith('Multiple exceptions: '))
         self.assertTrue(m_socket.socket.return_value.close.called)
+
+        coro = self.loop.create_connection(
+            MyProto, 'example.com', 80, family=socket.AF_INET,
+            local_addr=(None, 8080), all_errors=True)
+        with self.assertRaises(ExceptionGroup) as cm:
+            self.loop.run_until_complete(coro)
+
+        self.assertIsInstance(cm.exception, ExceptionGroup)
+        for e in cm.exception.exceptions:
+            self.assertIsInstance(e, OSError)
 
     def _test_create_connection_ip_addr(self, m_socket, allow_inet_pton):
         # Test the fallback code, even if this system has inet_pton.

--- a/Misc/NEWS.d/next/Library/2022-06-18-15-06-54.gh-issue-93973.4y6UQT.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-18-15-06-54.gh-issue-93973.4y6UQT.rst
@@ -1,0 +1,1 @@
+Add keyword argument ``all_errors`` to ``asyncio.create_connection`` so that multiple connection errors can be raised as an ``ExceptionGroup``.


### PR DESCRIPTION
Adds `all_errors` to `asyncio.create_connection`, related documentation, and tests. See https://github.com/python/cpython/issues/93973 for background.