### PR TITLE
gh-84461: Fix pydebug Emscripten browser builds

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -247,8 +247,8 @@ SRCDIRS= 	@SRCDIRS@
 SUBDIRSTOO=	Include Lib Misc
 
 # assets for Emscripten browser builds
-WASM_ASSETS_DIR=".$(prefix)"
-WASM_STDLIB="$(WASM_ASSETS_DIR)/local/lib/python$(VERSION)/os.py"
+WASM_ASSETS_DIR=.$(prefix)
+WASM_STDLIB=$(WASM_ASSETS_DIR)/lib/python$(VERSION)/os.py
 
 # Files and directories to be distributed
 CONFIGFILES=	configure configure.ac acconfig.h pyconfig.h.in Makefile.pre.in
@@ -821,7 +821,7 @@ $(WASM_STDLIB): $(srcdir)/Lib/*.py $(srcdir)/Lib/*/*.py \
 	    Makefile pybuilddir.txt Modules/Setup.local \
 	    python.html python.worker.js
 	$(PYTHON_FOR_BUILD) $(srcdir)/Tools/wasm/wasm_assets.py \
-	    --builddir . --prefix $(prefix)
+	    --buildroot . --prefix $(prefix)
 
 python.html: $(srcdir)/Tools/wasm/python.html python.worker.js
 	@cp $(srcdir)/Tools/wasm/python.html $@
@@ -2391,7 +2391,7 @@ clean-retain-profile: pycremoval
 	-rm -f Lib/lib2to3/*Grammar*.pickle
 	-rm -f _bootstrap_python
 	-rm -f python.html python*.js python.data python*.symbols python*.map
-	-rm -rf $(WASM_STDLIB)
+	-rm -f $(WASM_STDLIB)
 	-rm -f Programs/_testembed Programs/_freeze_module
 	-rm -f Python/deepfreeze/*.[co]
 	-rm -f Python/frozen_modules/*.h

--- a/Tools/wasm/wasm_assets.py
+++ b/Tools/wasm/wasm_assets.py
@@ -13,18 +13,13 @@ import argparse
 import pathlib
 import shutil
 import sys
+import sysconfig
 import zipfile
 
 # source directory
 SRCDIR = pathlib.Path(__file__).parent.parent.parent.absolute()
 SRCDIR_LIB = SRCDIR / "Lib"
 
-# sysconfig data relative to build dir.
-SYSCONFIGDATA = pathlib.PurePath(
-    "build",
-    f"lib.emscripten-wasm32-{sys.version_info.major}.{sys.version_info.minor}",
-    "_sysconfigdata__emscripten_wasm32-emscripten.py",
-)
 
 # Library directory relative to $(prefix).
 WASM_LIB = pathlib.PurePath("lib")
@@ -121,6 +116,22 @@ OMIT_SUBDIRS = (
     "unittest/test/",
 )
 
+def get_builddir(args: argparse.Namespace) -> pathlib.Path:
+    """Get builddir path from pybuilddir.txt
+    """
+    with open("pybuilddir.txt", encoding="utf-8") as f:
+        builddir = f.read()
+    return pathlib.Path(builddir)
+
+
+def get_sysconfigdata(args: argparse.Namespace) -> pathlib.Path:
+    """Get path to sysconfigdata relative to build root
+    """
+    data_name = sysconfig._get_sysconfigdata_name()
+    assert "emscripten_wasm32" in data_name
+    filename = data_name + ".py"
+    return args.builddir / filename
+
 
 def create_stdlib_zip(
     args: argparse.Namespace,
@@ -150,7 +161,7 @@ def detect_extension_modules(args: argparse.Namespace):
     modules = {}
 
     # disabled by Modules/Setup.local ?
-    with open(args.builddir / "Makefile") as f:
+    with open(args.buildroot / "Makefile") as f:
         for line in f:
             if line.startswith("MODDISABLED_NAMES="):
                 disabled = line.split("=", 1)[1].strip().split()
@@ -183,8 +194,8 @@ def path(val: str) -> pathlib.Path:
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    "--builddir",
-    help="absolute build directory",
+    "--buildroot",
+    help="absolute path to build root",
     default=pathlib.Path(".").absolute(),
     type=path,
 )
@@ -202,7 +213,7 @@ def main():
     relative_prefix = args.prefix.relative_to(pathlib.Path("/"))
     args.srcdir = SRCDIR
     args.srcdir_lib = SRCDIR_LIB
-    args.wasm_root = args.builddir / relative_prefix
+    args.wasm_root = args.buildroot / relative_prefix
     args.wasm_stdlib_zip = args.wasm_root / WASM_STDLIB_ZIP
     args.wasm_stdlib = args.wasm_root / WASM_STDLIB
     args.wasm_dynload = args.wasm_root / WASM_DYNLOAD
@@ -212,9 +223,10 @@ def main():
     args.compression = zipfile.ZIP_DEFLATED
     args.compresslevel = 9
 
-    args.sysconfig_data = args.builddir / SYSCONFIGDATA
+    args.builddir = get_builddir(args)
+    args.sysconfig_data = get_sysconfigdata(args)
     if not args.sysconfig_data.is_file():
-        raise ValueError(f"sysconfigdata file {SYSCONFIGDATA} missing.")
+        raise ValueError(f"sysconfigdata file {args.sysconfig_data} missing.")
 
     extmods = detect_extension_modules(args)
     omit_files = list(OMIT_FILES)


### PR DESCRIPTION
wasm_assets script did not take the ABIFLAG flag of sysconfigdata into
account.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
