### PR TITLE
[3.11] gh-93937, C API: Move PyFrame_GetBack() to Python.h (#93938)

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1757,6 +1757,21 @@ Porting to Python 3.11
   which are not available in the limited C API.
   (Contributed by Victor Stinner in :issue:`46007`.)
 
+* The following frame functions and type are now directly available with
+  ``#include <Python.h>``, it's no longer needed to add
+  ``#include <frameobject.h>``:
+
+  * :c:func:`PyFrame_Check`
+  * :c:func:`PyFrame_GetBack`
+  * :c:func:`PyFrame_GetBuiltins`
+  * :c:func:`PyFrame_GetGenerator`
+  * :c:func:`PyFrame_GetGlobals`
+  * :c:func:`PyFrame_GetLasti`
+  * :c:func:`PyFrame_GetLocals`
+  * :c:type:`PyFrame_Type`
+
+  (Contributed by Victor Stinner in :gh:`93937`.)
+
 .. _pyframeobject-3.11-hiding:
 
 * The :c:type:`PyFrameObject` structure members have been removed from the
@@ -1892,7 +1907,6 @@ Porting to Python 3.11
   fill any values into :c:member:`PyConfig.module_search_paths`. To calculate default
   paths and then modify them, finish initialization and use :c:func:`PySys_GetObject`
   to retrieve :data:`sys.path` as a Python list object and modify it directly.
-
 
 Deprecated
 ----------

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -6,10 +6,6 @@
 
 /* Standard object interface */
 
-PyAPI_DATA(PyTypeObject) PyFrame_Type;
-
-#define PyFrame_Check(op) Py_IS_TYPE(op, &PyFrame_Type)
-
 PyAPI_FUNC(PyFrameObject *) PyFrame_New(PyThreadState *, PyCodeObject *,
                                         PyObject *, PyObject *);
 
@@ -31,12 +27,3 @@ PyAPI_FUNC(int) _PyFrame_IsEntryFrame(PyFrameObject *frame);
 
 PyAPI_FUNC(int) PyFrame_FastToLocalsWithError(PyFrameObject *f);
 PyAPI_FUNC(void) PyFrame_FastToLocals(PyFrameObject *);
-
-PyAPI_FUNC(PyFrameObject *) PyFrame_GetBack(PyFrameObject *frame);
-PyAPI_FUNC(PyObject *) PyFrame_GetLocals(PyFrameObject *frame);
-
-PyAPI_FUNC(PyObject *) PyFrame_GetGlobals(PyFrameObject *frame);
-PyAPI_FUNC(PyObject *) PyFrame_GetBuiltins(PyFrameObject *frame);
-
-PyAPI_FUNC(PyObject *) PyFrame_GetGenerator(PyFrameObject *frame);
-PyAPI_FUNC(int) PyFrame_GetLasti(PyFrameObject *frame);

--- a/Include/cpython/pyframe.h
+++ b/Include/cpython/pyframe.h
@@ -1,0 +1,17 @@
+#ifndef Py_CPYTHON_PYFRAME_H
+#  error "this header file must not be included directly"
+#endif
+
+PyAPI_DATA(PyTypeObject) PyFrame_Type;
+
+#define PyFrame_Check(op) Py_IS_TYPE((op), &PyFrame_Type)
+
+PyAPI_FUNC(PyFrameObject *) PyFrame_GetBack(PyFrameObject *frame);
+PyAPI_FUNC(PyObject *) PyFrame_GetLocals(PyFrameObject *frame);
+
+PyAPI_FUNC(PyObject *) PyFrame_GetGlobals(PyFrameObject *frame);
+PyAPI_FUNC(PyObject *) PyFrame_GetBuiltins(PyFrameObject *frame);
+
+PyAPI_FUNC(PyObject *) PyFrame_GetGenerator(PyFrameObject *frame);
+PyAPI_FUNC(int) PyFrame_GetLasti(PyFrameObject *frame);
+

--- a/Include/pyframe.h
+++ b/Include/pyframe.h
@@ -14,6 +14,12 @@ PyAPI_FUNC(int) PyFrame_GetLineNumber(PyFrameObject *);
 
 PyAPI_FUNC(PyCodeObject *) PyFrame_GetCode(PyFrameObject *frame);
 
+#ifndef Py_LIMITED_API
+#  define Py_CPYTHON_PYFRAME_H
+#  include "cpython/pyframe.h"
+#  undef Py_CPYTHON_PYFRAME_H
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1576,6 +1576,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/cpython/pydebug.h \
 		$(srcdir)/Include/cpython/pyerrors.h \
 		$(srcdir)/Include/cpython/pyfpe.h \
+		$(srcdir)/Include/cpython/pyframe.h \
 		$(srcdir)/Include/cpython/pylifecycle.h \
 		$(srcdir)/Include/cpython/pymem.h \
 		$(srcdir)/Include/cpython/pystate.h \

--- a/Misc/NEWS.d/next/C API/2022-06-17-13-41-38.gh-issue-93937.uKVTEh.rst
+++ b/Misc/NEWS.d/next/C API/2022-06-17-13-41-38.gh-issue-93937.uKVTEh.rst
@@ -1,0 +1,14 @@
+The following frame functions and type are now directly available with
+``#include <Python.h>``, it's no longer needed to add ``#include
+<frameobject.h>``:
+
+* :c:func:`PyFrame_Check`
+* :c:func:`PyFrame_GetBack`
+* :c:func:`PyFrame_GetBuiltins`
+* :c:func:`PyFrame_GetGenerator`
+* :c:func:`PyFrame_GetGlobals`
+* :c:func:`PyFrame_GetLasti`
+* :c:func:`PyFrame_GetLocals`
+* :c:type:`PyFrame_Type`
+
+Patch by Victor Stinner.

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -10,7 +10,6 @@
 #endif
 
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
-#include "frameobject.h"
 
 #include <stdbool.h>
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -21,7 +21,6 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "frameobject.h"          // PyFrame_Check()
 #include "datetime.h"             // PyDateTimeAPI
 #include "marshal.h"              // PyMarshal_WriteLongToFile
 #include "structmember.h"         // PyMemberDef

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -6,7 +6,6 @@
 #endif
 
 #include "Python.h"
-#include "frameobject.h"
 #include "pycore_frame.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_interpreteridobject.h"

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -5,8 +5,6 @@
 #include "pycore_signal.h"        // Py_NSIG
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads
 
-#include "frameobject.h"
-
 #include <object.h>
 #include <signal.h>
 #include <signal.h>

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -2,7 +2,6 @@
 #include <ctype.h>
 
 #include "structmember.h"         // PyMemberDef
-#include "frameobject.h"
 #include "expat.h"
 
 #include "pyexpat.h"

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -16,7 +16,6 @@
 #include "pycore_symtable.h"      // PySTEntry_Type
 #include "pycore_typeobject.h"    // _PyTypes_InitSlotDefs()
 #include "pycore_unionobject.h"   // _PyUnion_Type
-#include "frameobject.h"          // PyFrame_Type
 #include "pycore_interpreteridobject.h"  // _PyInterpreterID_Type
 
 #ifdef Py_LIMITED_API

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -11,7 +11,6 @@
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_typeobject.h"    // struct type_cache
 #include "pycore_unionobject.h"   // _Py_union_type_or
-#include "frameobject.h"          // PyFrameObject
 #include "pycore_frame.h"         // _PyInterpreterFrame
 #include "opcode.h"               // MAKE_CELL
 #include "structmember.h"         // PyMemberDef

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -167,6 +167,7 @@
     <ClInclude Include="..\Include\cpython\pydebug.h" />
     <ClInclude Include="..\Include\cpython\pyerrors.h" />
     <ClInclude Include="..\Include\cpython\pyfpe.h" />
+    <ClInclude Include="..\Include\cpython\pyframe.h" />
     <ClInclude Include="..\Include\cpython\pylifecycle.h" />
     <ClInclude Include="..\Include\cpython\pymem.h" />
     <ClInclude Include="..\Include\cpython\pystate.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -435,6 +435,9 @@
     <ClInclude Include="..\Include\cpython\pymem.h">
       <Filter>Include\cpython</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\cpython\pyframe.h">
+      <Filter>Include\cpython</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\cpython\pylifecycle.h">
       <Filter>Include\cpython</Filter>
     </ClInclude>

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -4,7 +4,6 @@
 #include "pycore_long.h"          // _PyLong_GetZero()
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "frameobject.h"          // PyFrame_GetBack()
 #include "pycore_frame.h"
 #include "clinic/_warnings.c.h"
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -26,7 +26,6 @@
 
 #include "pycore_dict.h"
 #include "dictobject.h"
-#include "frameobject.h"
 #include "pycore_frame.h"
 #include "opcode.h"
 #include "pydtrace.h"

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -1,7 +1,7 @@
 
 #include "Python.h"
 #include "frameobject.h"
-#include "pycore_code.h"           // stats
+#include "pycore_code.h"          // stats
 #include "pycore_frame.h"
 #include "pycore_object.h"        // _PyObject_GC_UNTRACK()
 #include "opcode.h"

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -1,5 +1,4 @@
 #include "Python.h"
-#include "frameobject.h"
 #include "pycore_frame.h"
 
 #include "pycore_pyerrors.h"

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -31,7 +31,7 @@ Data members:
 #include "pycore_structseq.h"     // _PyStructSequence_InitType()
 #include "pycore_tuple.h"         // _PyTuple_FromArray()
 
-#include "frameobject.h"          // PyFrame_GetBack()
+#include "frameobject.h"          // PyFrame_FastToLocalsWithError()
 #include "pydtrace.h"
 #include "osdefs.h"               // DELIM
 #include "stdlib_module_names.h"  // _Py_stdlib_module_names

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -3,7 +3,6 @@
 
 #include "Python.h"
 
-#include "frameobject.h"          // PyFrame_GetBack()
 #include "pycore_ast.h"           // asdl_seq_*
 #include "pycore_call.h"          // _PyObject_CallMethodFormat()
 #include "pycore_compile.h"       // _PyAST_Optimize
@@ -15,7 +14,9 @@
 #include "pycore_pyerrors.h"      // _PyErr_Fetch()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_traceback.h"     // EXCEPTION_TB_HEADER
+
 #include "../Parser/pegen.h"      // _PyPegen_byte_offset_to_character_offset()
+#include "frameobject.h"          // PyFrame_New()
 #include "structmember.h"         // PyMemberDef
 #include "osdefs.h"               // SEP
 #ifdef HAVE_FCNTL_H


### PR DESCRIPTION
Move the follow functions and type from frameobject.h to pyframe.h,
so the standard <Python.h> provide frame getter functions:

* PyFrame_Check()
* PyFrame_GetBack()
* PyFrame_GetBuiltins()
* PyFrame_GetGenerator()
* PyFrame_GetGlobals()
* PyFrame_GetLasti()
* PyFrame_GetLocals()
* PyFrame_Type

Remove #include "frameobject.h" from many C files. It's no longer
needed.

(cherry picked from commit 27b989403356ccdd47545a93aeab8434e9c69f21)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
