### PR TITLE
[3.11] gh-84461: Fix Emscripten umask and permission issues (GH-94002) (GH-94006)

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -600,6 +600,16 @@ class Regrtest:
             for s in ET.tostringlist(root):
                 f.write(s)
 
+    def fix_umask(self):
+        if support.is_emscripten:
+            # Emscripten has default umask 0o777, which breaks some tests.
+            # see https://github.com/emscripten-core/emscripten/issues/17269
+            old_mask = os.umask(0)
+            if old_mask == 0o777:
+                os.umask(0o027)
+            else:
+                os.umask(old_mask)
+
     def set_temp_dir(self):
         if self.ns.tempdir:
             self.tmp_dir = self.ns.tempdir
@@ -659,6 +669,8 @@ class Regrtest:
         self.parse_args(kwargs)
 
         self.set_temp_dir()
+
+        self.fix_umask()
 
         if self.ns.cleanup:
             self.cleanup()

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -787,6 +787,7 @@ class PosixTester(unittest.TestCase):
             check_stat(uid, gid)
 
     @os_helper.skip_unless_working_chmod
+    @unittest.skipIf(support.is_emscripten, "getgid() is a stub")
     def test_chown(self):
         # raise an OSError if the file does not exist
         os.unlink(os_helper.TESTFN)
@@ -798,6 +799,7 @@ class PosixTester(unittest.TestCase):
 
     @os_helper.skip_unless_working_chmod
     @unittest.skipUnless(hasattr(posix, 'fchown'), "test needs os.fchown()")
+    @unittest.skipIf(support.is_emscripten, "getgid() is a stub")
     def test_fchown(self):
         os.unlink(os_helper.TESTFN)
 
@@ -1356,6 +1358,7 @@ class TestPosixDirFd(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(os, 'chown') and (os.chown in os.supports_dir_fd),
                          "test needs dir_fd support in os.chown()")
+    @unittest.skipIf(support.is_emscripten, "getgid() is a stub")
     def test_chown_dir_fd(self):
         with self.prepare_file() as (dir_fd, name, fullname):
             posix.chown(name, os.getuid(), os.getgid(), dir_fd=dir_fd)

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -934,6 +934,7 @@ class PydocImportTest(PydocBaseTest):
         self.assertEqual(err.getvalue(), '')
 
     @os_helper.skip_unless_working_chmod
+    @unittest.skipIf(is_emscripten, "cannot remove x bit")
     def test_apropos_empty_doc(self):
         pkgdir = os.path.join(TESTFN, 'walkpkg')
         os.mkdir(pkgdir)

--- a/Tools/wasm/config.site-wasm32-emscripten
+++ b/Tools/wasm/config.site-wasm32-emscripten
@@ -43,6 +43,13 @@ ac_cv_func_symlinkat=no
 ac_cv_func_lchmod=no
 ac_cv_func_lchown=no
 
+# geteuid / getegid are stubs and always return 0 (root). The stub breaks
+# code that assume effective user root has special permissions.
+ac_cv_func_geteuid=no
+ac_cv_func_getegid=no
+ac_cv_func_seteuid=no
+ac_cv_func_setegid=no
+
 # Syscalls not implemented in emscripten
 # [Errno 52] Function not implemented
 ac_cv_func_preadv2=no


### PR DESCRIPTION
- Emscripten's default umask is too strict, see
  https://github.com/emscripten-core/emscripten/issues/17269
- getuid/getgid and geteuid/getegid are stubs that always return 0
  (root). Disable effective uid/gid syscalls and fix tests that use
  chmod() current user.
- Cannot drop X bit from directory.
(cherry picked from commit 2702e408fd0e0dd7aec396b4cf8c7ce9caae81d8)

Co-authored-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
