### PR TITLE
gh-84461: Skip test_unwritable_directory again on Emscripten

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -889,6 +889,7 @@ class PycacheTests(unittest.TestCase):
             "due to varying filesystem permission semantics (issue #11956)")
     @skip_if_dont_write_bytecode
     @os_helper.skip_unless_working_chmod
+    @unittest.skipIf(is_emscripten, "umask is a stub")
     def test_unwritable_directory(self):
         # When the umask causes the new __pycache__ directory to be
         # unwritable, the import still succeeds but no .pyc file is written.


### PR DESCRIPTION
GH-93992 removed geteuid() and enabled the test again on Emscripten.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
