### PR TITLE
gh-86128: Add warning to ThreadPoolExecutor docs

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -149,6 +149,13 @@ And::
    An :class:`Executor` subclass that uses a pool of at most *max_workers*
    threads to execute calls asynchronously.
 
+   All threads enqueued to ``ThreadPoolExecutor`` will be joined before the
+   interpreter can exit. Note that the exit handler which does this is
+   executed *before* any exit handlers added using `atexit`. This means
+   exceptions in the main thread must be caught and handled in order to
+   signal threads to exit gracefully. For this reason, it is recommended
+   that ``ThreadPoolExecutor`` not be used for long-running tasks.
+
    *initializer* is an optional callable that is called at the start of
    each worker thread; *initargs* is a tuple of arguments passed to the
    initializer.  Should *initializer* raise an exception, all currently

--- a/Misc/NEWS.d/next/Documentation/2022-06-19-18-18-22.gh-issue-86128.39DDTD.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-19-18-18-22.gh-issue-86128.39DDTD.rst
@@ -1,0 +1,1 @@
+Document a limitation in ThreadPoolExecutor where its exit handler is executed before any handlers in atexit.


### PR DESCRIPTION
ThreadPoolExecutor has unusual atexit behavior that can cause threads to block indefinitely. This PR documents that limitation, and adds an explicit warning to the documentation for ThreadPoolExecutor.

See https://github.com/python/cpython/issues/86128#issuecomment-1159332994 for an example where this happens. Essentially, even if it looks like you added an `atexit` handler to instruct your thread to exit gracefully, it will only be executed _after_ your thread has finished. For long-running threads (e.g. threads listening to a queue), that may never happen at all.

Elsewhere in #86128, it's recommended that `ThreadPoolExecutor` not be used for long-running tasks, but this was not reflected in the documentation. Based solely on the API, there is no reason to think you shouldn't use it for long-running tasks. The only reason appears to be a limitation in its implementation, so that should be made explicit in the docs.

<hr>

Thanks very much reviewing! 

I'm also open to attempting to fix the underlying odd behavior, though I don't think I have enough context to know what the right fix would be.