### PR TITLE
GH-82874: Use f-strings instead of str.format within importlib.__init__.py

### DIFF
--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -84,13 +84,13 @@ def find_loader(name, path=None):
     try:
         loader = sys.modules[name].__loader__
         if loader is None:
-            raise ValueError('{}.__loader__ is None'.format(name))
+            raise ValueError(f"{name}.__loader__ is None")
         else:
             return loader
     except KeyError:
         pass
     except AttributeError:
-        raise ValueError('{}.__loader__ is not set'.format(name)) from None
+        raise ValueError(f"{name}.__loader__ is not set") from None
 
     spec = _bootstrap._find_spec(name, path)
     # We won't worry about malformed specs (missing attributes).
@@ -98,7 +98,7 @@ def find_loader(name, path=None):
         return None
     if spec.loader is None:
         if spec.submodule_search_locations is None:
-            raise ImportError('spec for {} missing loader'.format(name),
+            raise ImportError(f"spec for {name} missing loader",
                               name=name)
         raise ImportError('namespace packages do not have loaders',
                           name=name)
@@ -117,8 +117,8 @@ def import_module(name, package=None):
     if name.startswith('.'):
         if not package:
             msg = ("the 'package' argument is required to perform a relative "
-                   "import for {!r}")
-            raise TypeError(msg.format(name))
+                   f"import for {name!r}")
+            raise TypeError(msg)
         for character in name:
             if character != '.':
                 break
@@ -144,8 +144,8 @@ def reload(module):
             raise TypeError("reload() argument must be a module")
 
     if sys.modules.get(name) is not module:
-        msg = "module {} not in sys.modules"
-        raise ImportError(msg.format(name), name=name)
+        msg = f"module {name} not in sys.modules"
+        raise ImportError(msg, name=name)
     if name in _RELOADING:
         return _RELOADING[name]
     _RELOADING[name] = module
@@ -155,9 +155,8 @@ def reload(module):
             try:
                 parent = sys.modules[parent_name]
             except KeyError:
-                msg = "parent {!r} not in sys.modules"
-                raise ImportError(msg.format(parent_name),
-                                  name=parent_name) from None
+                msg = f"parent {parent_name!r} not in sys.modules"
+                raise ImportError(msg, name=parent_name) from None
             else:
                 pkgpath = parent.__path__
         else:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -313,6 +313,7 @@ Nicolas Chauvat
 Jerry Chen
 Michael Chermside
 Ingrid Cheung
+Adam Chhina
 Terry Chia
 Albert Chin-A-Young
 Adal Chiriliuc

--- a/Misc/NEWS.d/next/Library/2022-06-19-19-18-13.gh-issue-82874.cdZQw-.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-19-19-18-13.gh-issue-82874.cdZQw-.rst
@@ -1,0 +1,1 @@
+Prefer f-strings to ``.format`` in importlib.__init__.py.


### PR DESCRIPTION
Continuation of [GH-82874](https://github.com/python/cpython/issues/82874) for `importlib.__init__.py`.
