### PR TITLE
Fix typo in _io.TextIOWrapper Clinic input

### DIFF
--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -21,7 +21,7 @@ module _io
 class _io.IncrementalNewlineDecoder "nldecoder_object *" "&PyIncrementalNewlineDecoder_Type"
 class _io.TextIOWrapper "textio *" "&TextIOWrapper_Type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=2097a4fc85670c26]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=ed072384f8aada2c]*/
 
 /* TextIOBase */
 

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -19,7 +19,7 @@
 /*[clinic input]
 module _io
 class _io.IncrementalNewlineDecoder "nldecoder_object *" "&PyIncrementalNewlineDecoder_Type"
-class _io.TextIOWrapper "textio *" "&TextIOWrapper_TYpe"
+class _io.TextIOWrapper "textio *" "&TextIOWrapper_Type"
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=2097a4fc85670c26]*/
 


### PR DESCRIPTION
line 22 (class _io.TextIOWrapper "textio *" "&TextIOWrapper_TYpe")
possible mistype on TextIOWrapper_Type
proposed change (class _io.TextIOWrapper "textio *" "&TextIOWrapper_Type")

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
