### PR TITLE
gh-94028: Clear and reset sqlite3 statements properly in cursor iternext (GH-94042)

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-06-20-23-14-43.gh-issue-94028.UofEcX.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-20-23-14-43.gh-issue-94028.UofEcX.rst
@@ -1,3 +1,3 @@
 Fix a regression in the :mod:`sqlite3` where statement objects were not
 properly cleared and reset after use in cursor iters. The regression was
-introduced by gh-27884 in Python 3.11a1. Patch by Erlend E. Aasland.
+introduced by :gh:`27884` in Python 3.11a1. Patch by Erlend E. Aasland.

--- a/Misc/NEWS.d/next/Library/2022-06-20-23-14-43.gh-issue-94028.UofEcX.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-20-23-14-43.gh-issue-94028.UofEcX.rst
@@ -1,3 +1,3 @@
 Fix a regression in the :mod:`sqlite3` where statement objects were not
 properly cleared and reset after use in cursor iters. The regression was
-introduced by :gh:`27884` in Python 3.11a1. Patch by Erlend E. Aasland.
+introduced by PR 27884 in Python 3.11a1. Patch by Erlend E. Aasland.

--- a/Misc/NEWS.d/next/Library/2022-06-20-23-14-43.gh-issue-94028.UofEcX.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-20-23-14-43.gh-issue-94028.UofEcX.rst
@@ -1,0 +1,3 @@
+Fix a regression in the :mod:`sqlite3` where statement objects were not
+properly cleared and reset after use in cursor iters. The regression was
+introduced by gh-27884 in Python 3.11a1. Patch by Erlend E. Aasland.

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -1129,10 +1129,13 @@ pysqlite_cursor_iternext(pysqlite_Cursor *self)
             self->rowcount = (long)sqlite3_changes(self->connection->db);
         }
         (void)stmt_reset(self->statement);
+        Py_CLEAR(self->statement);
     }
     else if (rc != SQLITE_ROW) {
         (void)_pysqlite_seterror(self->connection->state,
                                  self->connection->db);
+        (void)stmt_reset(self->statement);
+        Py_CLEAR(self->statement);
         Py_DECREF(row);
         return NULL;
     }


### PR DESCRIPTION
Fixes #94028 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
