### PR TITLE
gh-94052: Don't re-run failed tests with --python option

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import shlex
 import sys
 from test.support import os_helper
 
@@ -372,8 +373,11 @@ def _parse_args(args, **kwargs):
         parser.error("-s and -f don't go together!")
     if ns.use_mp is not None and ns.trace:
         parser.error("-T and -j don't go together!")
-    if ns.python is not None and ns.use_mp is None:
-        parser.error("-p requires -j!")
+    if ns.python is not None:
+        if ns.use_mp is None:
+            parser.error("-p requires -j!")
+        # The "executable" may be two or more parts, e.g. "node python.js"
+        ns.python = shlex.split(ns.python)
     if ns.failfast and not (ns.verbose or ns.verbose3):
         parser.error("-G/--failfast needs either -v or -W")
     if ns.pgo and (ns.verbose or ns.verbose2 or ns.verbose3):

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -306,13 +306,22 @@ class Regrtest:
             printlist(self.skipped, file=sys.stderr)
 
     def rerun_failed_tests(self):
+        self.log()
+
+        if self.ns.python:
+            # Temp patch for https://github.com/python/cpython/issues/94052
+            self.log(
+                "Re-running failed tests is not supported with --python "
+                "host runner option."
+            )
+            return
+
         self.ns.verbose = True
         self.ns.failfast = False
         self.ns.verbose3 = False
 
         self.first_result = self.get_tests_result()
 
-        self.log()
         self.log("Re-running failed tests in verbose mode")
         rerun_list = list(self.need_rerun)
         self.need_rerun.clear()

--- a/Lib/test/libregrtest/runtest_mp.py
+++ b/Lib/test/libregrtest/runtest_mp.py
@@ -2,7 +2,6 @@ import faulthandler
 import json
 import os.path
 import queue
-import shlex
 import signal
 import subprocess
 import sys
@@ -59,8 +58,7 @@ def run_test_in_subprocess(testname: str, ns: Namespace, tmp_dir: str) -> subpro
     worker_args = (ns_dict, testname)
     worker_args = json.dumps(worker_args)
     if ns.python is not None:
-        # The "executable" may be two or more parts, e.g. "node python.js"
-        executable = shlex.split(ns.python)
+        executable = ns.python
     else:
         executable = [sys.executable]
     cmd = [*executable, *support.args_from_interpreter_flags(),


### PR DESCRIPTION
Disable re-run when tests are using a `--python`` host runner process.
It's a temporary patch until we have refactored the code support
subprocesses in the re-run function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
