### PR TITLE
gh-74953: _PyThread_cond_after() uses _PyTime_t

### DIFF
--- a/Python/condvar.h
+++ b/Python/condvar.h
@@ -68,9 +68,9 @@ void _PyThread_cond_after(long long us, struct timespec *abs);
 Py_LOCAL_INLINE(int)
 PyCOND_TIMEDWAIT(PyCOND_T *cond, PyMUTEX_T *mut, long long us)
 {
-    struct timespec abs;
-    _PyThread_cond_after(us, &abs);
-    int ret = pthread_cond_timedwait(cond, mut, &abs);
+    struct timespec abs_timeout;
+    _PyThread_cond_after(us, &abs_timeout);
+    int ret = pthread_cond_timedwait(cond, mut, &abs_timeout);
     if (ret == ETIMEDOUT) {
         return 1;
     }

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -113,19 +113,6 @@
 #endif
 
 
-#define MICROSECONDS_TO_TIMESPEC(microseconds, ts) \
-do { \
-    struct timeval tv; \
-    gettimeofday(&tv, NULL); \
-    tv.tv_usec += microseconds % 1000000; \
-    tv.tv_sec += microseconds / 1000000; \
-    tv.tv_sec += tv.tv_usec / 1000000; \
-    tv.tv_usec %= 1000000; \
-    ts.tv_sec = tv.tv_sec; \
-    ts.tv_nsec = tv.tv_usec * 1000; \
-} while(0)
-
-
 /*
  * pthread_cond support
  */


### PR DESCRIPTION
pthread _PyThread_cond_after() implementation now uses the _PyTime_t
type to handle properly overflow: clamp to the maximum value.