### PR TITLE
Stats: Add summary of top instructions for misses and deferred specialization.

### DIFF
--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -188,6 +188,12 @@ class Section:
         print("</details>")
         print()
 
+def to_str(x):
+    if isinstance(x, int):
+        return format(x, ",d")
+    else:
+        return str(x)
+
 def emit_table(header, rows):
     width = len(header)
     header_line = "|"
@@ -203,8 +209,8 @@ def emit_table(header, rows):
     print(under_line)
     for row in rows:
         if width is not None and len(row) != width:
-            raise ValueError("Wrong number of elements in row '" + str(rows) + "'")
-        print("|", " | ".join(str(i) for i in row), "|")
+            raise ValueError("Wrong number of elements in row '" + str(row) + "'")
+        print("|", " | ".join(to_str(i) for i in row), "|")
     print()
 
 def emit_execution_counts(opcode_stats, total):
@@ -251,6 +257,18 @@ def emit_specialization_overview(opcode_stats, total):
             ("Not specialized", not_specialized, f"{not_specialized*100/total:0.1f}%"),
             ("Specialized", specialized, f"{specialized*100/total:0.1f}%"),
         ))
+        for title, field in (("Deferred", "specialization.deferred"), ("Misses", "specialization.miss")):
+            total = 0
+            counts = []
+            for i, opcode_stat in enumerate(opcode_stats):
+                value = opcode_stat.get(field, 0)
+                counts.append((value, opname[i]))
+                total += value
+            counts.sort(reverse=True)
+            if total:
+                with Section(f"{title} by instruction", 3):
+                    rows = [ (name, count, f"{100*count/total:0.1f}%") for (count, name) in counts[:10] ]
+                    emit_table(("Name", "Count:", "Ratio:"), rows)
 
 def emit_call_stats(stats):
     stats_path = os.path.join(os.path.dirname(__file__), "../../Include/pystats.h")


### PR DESCRIPTION
Adds a couple of new tables:


### Deferred by instruction

<details>
<summary> deferred by instruction </summary>

|Name | Count | Ratio | 
|---|---:|---:|
| BINARY_SUBSCR | 1,099,812,093 | 24.9% |
| BINARY_OP | 953,851,638 | 21.6% |
| LOAD_ATTR | 610,811,518 | 13.8% |
| STORE_SUBSCR | 526,374,584 | 11.9% |
| FOR_ITER | 511,141,102 | 11.6% |
| CALL | 448,909,163 | 10.2% |
| COMPARE_OP | 241,006,833 | 5.5% |
| STORE_ATTR | 22,562,679 | 0.5% |
| LOAD_GLOBAL | 2,643,410 | 0.1% |
| UNPACK_SEQUENCE | 2,037,563 | 0.0% |


</details>

### Misses by instruction

<details>
<summary> misses by instruction </summary>

|Name | Count | Ratio | 
|---|---:|---:|
| LOAD_ATTR | 140,209,308 | 22.2% |
| CALL | 97,721,200 | 15.5% |
| CALL_PY_EXACT_ARGS | 58,332,324 | 9.2% |
| LOAD_ATTR_INSTANCE_VALUE | 52,605,699 | 8.3% |
| LOAD_ATTR_SLOT | 31,940,136 | 5.1% |
| LOAD_ATTR_METHOD_WITH_VALUES | 31,855,516 | 5.0% |
| BINARY_OP | 29,310,405 | 4.6% |
| CALL_NO_KW_METHOD_DESCRIPTOR_FAST | 24,279,275 | 3.8% |
| BINARY_SUBSCR | 21,378,050 | 3.4% |
| BINARY_SUBSCR_LIST_INT | 18,473,953 | 2.9% |


</details>
