### PR TITLE
[3.11] gh-91387: Fix tarfile test on WASI (GH-93984)

### DIFF
--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1031,7 +1031,7 @@ class LongnameTest:
                     os.mkdir(longdir)
                     tar.add(longdir)
                 finally:
-                    os.rmdir(longdir)
+                    os.rmdir(longdir.rstrip("/"))
             with tarfile.open(tmpname) as tar:
                 self.assertIsNotNone(tar.getmember(longdir))
                 self.assertIsNotNone(tar.getmember(longdir.removesuffix('/')))


### PR DESCRIPTION
WASI's rmdir() syscall does not like the trailing slash.
(cherry picked from commit dd78aae34bc3c0fcf14b2e7be64e08246ee277cc)

Co-authored-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
