### PR TITLE
[3.11] gh-93675: Fix typos in `Doc/` (GH-93676)

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -257,7 +257,7 @@ to a :class:`ProcessPoolExecutor` will result in deadlock.
    replaced with a fresh worker process. By default *max_tasks_per_child* is
    ``None`` which means worker processes will live as long as the pool. When
    a max is specified, the "spawn" multiprocessing start method will be used by
-   default in absense of a *mp_context* parameter. This feature is incompatible
+   default in absence of a *mp_context* parameter. This feature is incompatible
    with the "fork" start method.
 
    .. versionchanged:: 3.3

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -361,7 +361,7 @@ Functions and classes provided:
    As this changes a global state, the working directory, it is not suitable
    for use in most threaded or async contexts. It is also not suitable for most
    non-linear code execution, like generators, where the program execution is
-   temporarily relinquished -- unless explicitely desired, you should not yield
+   temporarily relinquished -- unless explicitly desired, you should not yield
    when this context manager is active.
 
    This is a simple wrapper around :func:`~os.chdir`, it changes the current

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -739,7 +739,7 @@ To illustrate this issue, consider the following code::
         def __enter__(self):
             # If KeyboardInterrupt occurs here, everything is fine
             self.lock.acquire()
-            # If KeyboardInterrupt occcurs here, __exit__ will not be called
+            # If KeyboardInterrupt occurs here, __exit__ will not be called
             ...
             # KeyboardInterrupt could occur just before the function returns
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -573,7 +573,7 @@ is already executing raises a :exc:`ValueError` exception.
    In typical use, this is called with a single exception instance similar to the
    way the :keyword:`raise` keyword is used.
 
-   For backwards compatability, however, the second signature is
+   For backwards compatibility, however, the second signature is
    supported, following a convention from older versions of Python.
    The *type* argument should be an exception class, and *value*
    should be an exception instance. If the *value* is not provided, the

--- a/Doc/tools/rstlint.py
+++ b/Doc/tools/rstlint.py
@@ -130,7 +130,7 @@ role_with_no_backticks = re.compile(r"%s[^` ]" % all_roles)
 
 # Find role glued with another word like:
 # the:c:func:`PyThreadState_LeaveTracing` function.
-# instad of:
+# instead of:
 # the :c:func:`PyThreadState_LeaveTracing` function.
 role_glued_with_word = re.compile(r"[a-zA-Z]%s" % all_roles)
 


### PR DESCRIPTION
Closes GH-93675
(cherry picked from commit 830513754d081619b2d72db17770627312072fa5)

Co-authored-by: luzpaz <luzpaz@users.noreply.github.com>
