### PR TITLE
[3.10] gh-93675: Fix typos in `Doc/` (GH-93676)

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -703,7 +703,7 @@ To illustrate this issue, consider the following code::
         def __enter__(self):
             # If KeyboardInterrupt occurs here, everything is fine
             self.lock.acquire()
-            # If KeyboardInterrupt occcurs here, __exit__ will not be called
+            # If KeyboardInterrupt occurs here, __exit__ will not be called
             ...
             # KeyboardInterrupt could occur just before the function returns
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -568,7 +568,7 @@ is already executing raises a :exc:`ValueError` exception.
    In typical use, this is called with a single exception instance similar to the
    way the :keyword:`raise` keyword is used.
 
-   For backwards compatability, however, the second signature is
+   For backwards compatibility, however, the second signature is
    supported, following a convention from older versions of Python.
    The *type* argument should be an exception class, and *value*
    should be an exception instance. If the *value* is not provided, the


### PR DESCRIPTION
Closes GH-93675
(cherry picked from commit 830513754d081619b2d72db17770627312072fa5)

Co-authored-by: luzpaz <luzpaz@users.noreply.github.com>
