### PR TITLE
[3.11] gh-93240: clarify wording in IO tutorial (GH-93276)

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -179,7 +179,7 @@ square brackets ``'[]'`` to access the keys. ::
    ...       'Dcab: {0[Dcab]:d}'.format(table))
    Jack: 4098; Sjoerd: 4127; Dcab: 8637678
 
-This could also be done by passing the table as keyword arguments with the '**'
+This could also be done by passing the ``table`` dictionary as keyword arguments with the ``**``
 notation. ::
 
    >>> table = {'Sjoerd': 4127, 'Jack': 4098, 'Dcab': 8637678}


### PR DESCRIPTION
Co-authored-by: Adam Turner <9087854+AA-Turner@users.noreply.github.com>
(cherry picked from commit 51d673176ac90f2144e3e7a492e5b3ea53bdba2e)

Co-authored-by: paulreece <96156234+paulreece@users.noreply.github.com>
