### PR TITLE
gh-94087: Update function used to construct Unicode string (in doc and code)

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -819,7 +819,7 @@ wchar_t Support
    most C functions. If *size* is ``NULL`` and the :c:type:`wchar_t*` string
    contains null characters a :exc:`ValueError` is raised.
 
-   Returns a buffer allocated by :c:func:`PyMem_Alloc` (use
+   Returns a buffer allocated by :c:func:`PyMem_New` (use
    :c:func:`PyMem_Free` to free it) on success. On error, returns ``NULL``
    and *\*size* is undefined. Raises a :exc:`MemoryError` if memory allocation
    is failed.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -2842,7 +2842,7 @@ PyUnicode_AsWideCharString(PyObject *unicode,
     }
 
     buflen = unicode_get_widechar_size(unicode);
-    buffer = (wchar_t *) PyMem_NEW(wchar_t, (buflen + 1));
+    buffer = (wchar_t *) PyMem_New(wchar_t, (buflen + 1));
     if (buffer == NULL) {
         PyErr_NoMemory();
         return NULL;


### PR DESCRIPTION
This PR updates unicode.rst so that it refers to PyMem_New instead of PyMem_Alloc, a seemingly non-existent function.

This PR also replaces the PyMem_NEW macro with a direct call to PyMem_New, since pymem.h claims PyMEM_NEW is a deprecated alias, and as far as I can tell, there is no reason not to use PyMem_New instead. The other parts of unicode.c use PyMem_New, not PyMem_NEW. 

Here's the PyMem_NEW macro, for reference:
#define PyMem_NEW(type, n)        PyMem_New(type, n)

I'm not an expert C programmer however so perhaps I'm missing something.