### PR TITLE
gh-84623: Move imports in doctests

### DIFF
--- a/Lib/test/test_descrtut.py
+++ b/Lib/test/test_descrtut.py
@@ -9,7 +9,6 @@
 # deterministic.
 
 from test.support import sortdict
-import pprint
 import doctest
 import unittest
 
@@ -167,6 +166,7 @@ For instance of built-in types, x.__class__ is now the same as type(x):
 
 You can get the information from the list type:
 
+    >>> import pprint
     >>> pprint.pprint(dir(list))    # like list.__dict__.keys(), but sorted
     ['__add__',
      '__class__',

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -4,7 +4,6 @@ Test script for doctest.
 
 from test import support
 from test.support import import_helper
-from test.support import os_helper
 import doctest
 import functools
 import os
@@ -14,7 +13,6 @@ import importlib.abc
 import importlib.util
 import unittest
 import tempfile
-import shutil
 import types
 import contextlib
 
@@ -461,7 +459,7 @@ We'll simulate a __file__ attr that ends in pyc:
     >>> tests = finder.find(sample_func)
 
     >>> print(tests)  # doctest: +ELLIPSIS
-    [<DocTest sample_func from test_doctest.py:34 (1 example)>]
+    [<DocTest sample_func from test_doctest.py:32 (1 example)>]
 
 The exact name depends on how test_doctest was invoked, so allow for
 leading path components.
@@ -2811,6 +2809,8 @@ in it, and use a package hook to install a custom loader; on any platform,
 at least one of the line endings will raise a ValueError for inconsistent
 whitespace if doctest does not correctly do the newline conversion.
 
+    >>> from test.support import os_helper
+    >>> import shutil
     >>> dn = tempfile.mkdtemp()
     >>> pkg = os.path.join(dn, "doctest_testpkg")
     >>> os.mkdir(pkg)

--- a/Lib/test/test_extcall.py
+++ b/Lib/test/test_extcall.py
@@ -8,6 +8,7 @@ We're going the use these types for extra testing
 
 We're defining four helper functions
 
+    >>> from test import support
     >>> def e(a,b):
     ...     print(a, b)
 
@@ -522,7 +523,6 @@ Same with keyword only args:
 
 import doctest
 import unittest
-from test import support
 
 def load_tests(loader, tests, pattern):
     tests.addTest(doctest.DocTestSuite())


### PR DESCRIPTION
Move imports in doctests to prevent false alarms in pyflakes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-84623 -->
* gh-84623
<!-- /gh-issue-number -->
