### PR TITLE
GH-94149: Fix unaligned access in convertsimple().

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-23-00-25-53.gh-issue-94149.e0Q1dg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-23-00-25-53.gh-issue-94149.e0Q1dg.rst
@@ -1,0 +1,1 @@
+Fixed an unaligned write in convertsimple() which could crash on architectures requiring strict alignment, e.g. sparc.

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -919,7 +919,7 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
         if (*format == '#') {
             REQUIRE_PY_SSIZE_T_CLEAN;
             Py_ssize_t *psize = va_arg(*p_va, Py_ssize_t*);
-            *psize = count;
+            memcpy(psize, &count, sizeof(Py_ssize_t));
             format++;
         } else {
             if (strlen(*p) != (size_t)count) {


### PR DESCRIPTION
Like https://github.com/python/cpython/pull/6123 this pointer may be unaligned, so a memcpy() instead of simple assignment is required for strict architectures e.g. sparc.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94149 -->
* Issue: gh-94149
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-94149 -->
* Issue: gh-94149
<!-- /gh-issue-number -->
