### PR TITLE
gh-93771: Clarify how deepfreeze.py is run

### DIFF
--- a/Tools/scripts/deepfreeze.py
+++ b/Tools/scripts/deepfreeze.py
@@ -3,7 +3,7 @@
 The script may be executed by _bootstrap_python interpreter.
 Shared library extension modules are not available in that case.
 On Windows, and in cross-compilation cases, it is executed
-by Python 3.10, and 3.11 features are not avaiable.
+by Python 3.10, and 3.11 features are not available.
 """
 import argparse
 import ast

--- a/Tools/scripts/deepfreeze.py
+++ b/Tools/scripts/deepfreeze.py
@@ -1,7 +1,9 @@
 """Deep freeze
 
-The script is executed by _bootstrap_python interpreter. Shared library
-extension modules are not available.
+The script may be executed by _bootstrap_python interpreter.
+Shared library extension modules are not available in that case.
+On Windows, and in cross-compilation cases, it is executed
+by Python 3.10, and 3.11 features are not avaiable.
 """
 import argparse
 import ast


### PR DESCRIPTION
This is just an update to the docstring in deepfreeze.py, no news.

<!-- gh-issue-number: gh-93771 -->
* Issue: gh-93771
<!-- /gh-issue-number -->
