### PR TITLE
gh-94026: Workaround for BlockingIOError in runtest_mp on Emscripten

### DIFF
--- a/Misc/NEWS.d/next/Tests/2022-06-23-10-57-37.gh-issue-94026.d3ieKA.rst
+++ b/Misc/NEWS.d/next/Tests/2022-06-23-10-57-37.gh-issue-94026.d3ieKA.rst
@@ -1,0 +1,2 @@
+``runtest_mp`` test worker now handles :exc:`BlockingIOError` to work around
+non-blocking pipes on Emscripten.


### PR DESCRIPTION
`runtest_mp` test worker now handles :exc:`BlockingIOError` to work around
non-blocking pipes on Emscripten.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94026 -->
* Issue: gh-94026
<!-- /gh-issue-number -->
