### PR TITLE
Add ABI dump to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ Python/frozen_modules/MANIFEST
 # Ignore ./python binary on Unix but still look into ./Python/ directory.
 /python
 !/Python/
+
+# main branch only: ABI files are not checked/maintained
+Doc/data/python*.abi

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1204,7 +1204,7 @@ regen-global-objects: $(srcdir)/Tools/scripts/generate_global_objects.py
 regen-abidump: all
 	@$(MKDIR_P) $(srcdir)/Doc/data/
 	abidw "libpython$(LDVERSION).so" --no-architecture --out-file $(srcdir)/Doc/data/python$(LDVERSION).abi.new
-	@$(UPDATE_FILE) $(srcdir)/Doc/data/python$(LDVERSION).abi $(srcdir)/Doc/data/python$(LDVERSION).abi.new
+	@$(UPDATE_FILE) --create $(srcdir)/Doc/data/python$(LDVERSION).abi $(srcdir)/Doc/data/python$(LDVERSION).abi.new
 
 check-abidump: all
 	abidiff $(srcdir)/Doc/data/python$(LDVERSION).abi "libpython$(LDVERSION).so" --drop-private-types --no-architecture --no-added-syms


### PR DESCRIPTION
The ABI is only checked in maintenance branches, but it is sometimes useful to generate it for main.

- The resulting file should be ignored in main.
- The file should be created if it doesn't exist.

If this goes in, some “make maintenance branch” RM checklist/script will need a “remove `Doc/data/python*.abi` from `.gitignore`” entry.

@pablogsal, this could be combined with #94135

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
