### PR TITLE
gh-94169: Remove deprecated io.OpenWrapper

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -208,6 +208,12 @@ Removed
   (and corresponding ``EXPERIMENTAL_ISOLATED_SUBINTERPRETERS``)
   have been removed.
 
+* Remove ``io.OpenWrapper`` and ``_pyio.OpenWrapper``, deprecated in Python
+  3.10: just use :func:`open` instead. The :func:`open` (:func:`io.open`)
+  function is a built-in function. Since Python 3.10, :func:`_pyio.open` is
+  also a static method.
+  (Contributed by Victor Stinner in :gh:`94169`.)
+
 
 Porting to Python 3.12
 ======================

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -303,22 +303,6 @@ except AttributeError:
     open_code = _open_code_with_warning
 
 
-def __getattr__(name):
-    if name == "OpenWrapper":
-        # bpo-43680: Until Python 3.9, _pyio.open was not a static method and
-        # builtins.open was set to OpenWrapper to not become a bound method
-        # when set to a class variable. _io.open is a built-in function whereas
-        # _pyio.open is a Python function. In Python 3.10, _pyio.open() is now
-        # a static method, and builtins.open() is now io.open().
-        import warnings
-        warnings.warn('OpenWrapper is deprecated, use open instead',
-                      DeprecationWarning, stacklevel=2)
-        global OpenWrapper
-        OpenWrapper = open
-        return OpenWrapper
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
 # In normal operation, both `UnsupportedOperation`s should be bound to the
 # same object.
 try:

--- a/Lib/io.py
+++ b/Lib/io.py
@@ -57,22 +57,6 @@ from _io import (DEFAULT_BUFFER_SIZE, BlockingIOError, UnsupportedOperation,
                  IncrementalNewlineDecoder, text_encoding, TextIOWrapper)
 
 
-def __getattr__(name):
-    if name == "OpenWrapper":
-        # bpo-43680: Until Python 3.9, _pyio.open was not a static method and
-        # builtins.open was set to OpenWrapper to not become a bound method
-        # when set to a class variable. _io.open is a built-in function whereas
-        # _pyio.open is a Python function. In Python 3.10, _pyio.open() is now
-        # a static method, and builtins.open() is now io.open().
-        import warnings
-        warnings.warn('OpenWrapper is deprecated, use open instead',
-                      DeprecationWarning, stacklevel=2)
-        global OpenWrapper
-        OpenWrapper = open
-        return OpenWrapper
-    raise AttributeError("module {__name__!r} has no attribute {name!r}")
-
-
 # Pretend this exception was created here.
 UnsupportedOperation.__module__ = "io"
 

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4301,14 +4301,6 @@ class MiscIOTest(unittest.TestCase):
         proc = assert_python_ok('-X', 'utf8=1', '-c', code)
         self.assertEqual(b"utf-8", proc.out.strip())
 
-    @support.cpython_only
-    # Depending if OpenWrapper was already created or not, the warning is
-    # emitted or not. For example, the attribute is already created when this
-    # test is run multiple times.
-    @warnings_helper.ignore_warnings(category=DeprecationWarning)
-    def test_openwrapper(self):
-        self.assertIs(self.io.OpenWrapper, self.io.open)
-
 
 class CMiscIOTest(MiscIOTest):
     io = io

--- a/Misc/NEWS.d/next/Library/2022-06-23-14-35-10.gh-issue-94169.jeba90.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-23-14-35-10.gh-issue-94169.jeba90.rst
@@ -1,0 +1,4 @@
+Remove ``io.OpenWrapper`` and ``_pyio.OpenWrapper``, deprecated in Python
+3.10: just use :func:`open` instead. The :func:`open` (:func:`io.open`)
+function is a built-in function. Since Python 3.10, :func:`_pyio.open` is
+also a static method. Patch by Victor Stinner.


### PR DESCRIPTION
Remove io.OpenWrapper and _pyio.OpenWrapper, deprecated in Python
3.10: just use :func:`open` instead. The open() (io.open()) function
is a built-in function. Since Python 3.10, _pyio.open() is also a
static method.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94169 -->
* Issue: gh-94169
<!-- /gh-issue-number -->
