### PR TITLE
gh-94174: asyncio.get_event_loop() fails if no current event loop

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -239,6 +239,10 @@ Changes in the Python API
   to :term:`filesystem encoding and error handler`.
   Argument files should be encoded in UTF-8 instead of ANSI Codepage on Windows.
 
+* :func:`asyncio.get_event_loop` now fails if there is no current event loop.
+  In Python 3.10, it emits a :exc:`DeprecationWarning` in this case.
+  (Contributed by Victor Stinner in :gh:`94174`.)
+
 
 Build Changes
 =============

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -789,10 +789,8 @@ def _get_event_loop(stacklevel=3):
     current_loop = _get_running_loop()
     if current_loop is not None:
         return current_loop
-    import warnings
-    warnings.warn('There is no current event loop',
-                  DeprecationWarning, stacklevel=stacklevel)
-    return get_event_loop_policy().get_event_loop()
+    raise RuntimeError('There is no current event loop in thread %r.'
+                       % threading.current_thread().name)
 
 
 def set_event_loop(loop):

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2708,15 +2708,11 @@ class GetEventLoopTestsMixin:
             asyncio.set_event_loop_policy(Policy())
             loop = asyncio.new_event_loop()
 
-            with self.assertWarns(DeprecationWarning) as cm:
-                with self.assertRaises(TestError):
-                    asyncio.get_event_loop()
-            self.assertEqual(cm.filename, __file__)
+            with self.assertRaisesRegex(RuntimeError, 'no current event loop'):
+                asyncio.get_event_loop()
             asyncio.set_event_loop(None)
-            with self.assertWarns(DeprecationWarning) as cm:
-                with self.assertRaises(TestError):
-                    asyncio.get_event_loop()
-            self.assertEqual(cm.filename, __file__)
+            with self.assertRaisesRegex(RuntimeError, 'no current event loop'):
+                asyncio.get_event_loop()
 
             with self.assertRaisesRegex(RuntimeError, 'no running'):
                 asyncio.get_running_loop()
@@ -2730,16 +2726,12 @@ class GetEventLoopTestsMixin:
             loop.run_until_complete(func())
 
             asyncio.set_event_loop(loop)
-            with self.assertWarns(DeprecationWarning) as cm:
-                with self.assertRaises(TestError):
-                    asyncio.get_event_loop()
-            self.assertEqual(cm.filename, __file__)
+            with self.assertRaisesRegex(RuntimeError, 'no current event loop'):
+                asyncio.get_event_loop()
 
             asyncio.set_event_loop(None)
-            with self.assertWarns(DeprecationWarning) as cm:
-                with self.assertRaises(TestError):
-                    asyncio.get_event_loop()
-            self.assertEqual(cm.filename, __file__)
+            with self.assertRaisesRegex(RuntimeError, 'no current event loop'):
+                asyncio.get_event_loop()
 
         finally:
             asyncio.set_event_loop_policy(old_policy)
@@ -2758,15 +2750,11 @@ class GetEventLoopTestsMixin:
             loop = asyncio.new_event_loop()
             self.addCleanup(loop.close)
 
-            with self.assertWarns(DeprecationWarning) as cm:
-                loop2 = asyncio.get_event_loop()
-            self.addCleanup(loop2.close)
-            self.assertEqual(cm.filename, __file__)
+            with self.assertRaisesRegex(RuntimeError, 'no current event loop'):
+                asyncio.get_event_loop()
             asyncio.set_event_loop(None)
-            with self.assertWarns(DeprecationWarning) as cm:
-                with self.assertRaisesRegex(RuntimeError, 'no current'):
-                    asyncio.get_event_loop()
-            self.assertEqual(cm.filename, __file__)
+            with self.assertRaisesRegex(RuntimeError, 'no current event loop'):
+                asyncio.get_event_loop()
 
             with self.assertRaisesRegex(RuntimeError, 'no running'):
                 asyncio.get_running_loop()
@@ -2780,15 +2768,12 @@ class GetEventLoopTestsMixin:
             loop.run_until_complete(func())
 
             asyncio.set_event_loop(loop)
-            with self.assertWarns(DeprecationWarning) as cm:
-                self.assertIs(asyncio.get_event_loop(), loop)
-            self.assertEqual(cm.filename, __file__)
+            with self.assertRaisesRegex(RuntimeError, 'no current event loop'):
+                asyncio.get_event_loop()
 
             asyncio.set_event_loop(None)
-            with self.assertWarns(DeprecationWarning) as cm:
-                with self.assertRaisesRegex(RuntimeError, 'no current'):
-                    asyncio.get_event_loop()
-            self.assertEqual(cm.filename, __file__)
+            with self.assertRaisesRegex(RuntimeError, 'no current event loop'):
+                asyncio.get_event_loop()
 
         finally:
             asyncio.set_event_loop_policy(old_policy)

--- a/Misc/NEWS.d/next/Library/2022-06-23-16-11-20.gh-issue-94174.RwQhUA.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-23-16-11-20.gh-issue-94174.RwQhUA.rst
@@ -1,0 +1,3 @@
+:func:`asyncio.get_event_loop` now fails if there is no current event loop.
+In Python 3.10, it emits a :exc:`DeprecationWarning` in this case.
+Patch by Victor Stinner

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -21,7 +21,6 @@ _Py_IDENTIFIER(_asyncio_future_blocking);
 _Py_IDENTIFIER(add_done_callback);
 _Py_IDENTIFIER(call_soon);
 _Py_IDENTIFIER(cancel);
-_Py_IDENTIFIER(get_event_loop);
 _Py_IDENTIFIER(throw);
 _Py_IDENTIFIER(_check_future);
 
@@ -330,8 +329,6 @@ static PyObject *
 get_event_loop(int stacklevel)
 {
     PyObject *loop;
-    PyObject *policy;
-
     if (get_running_loop(&loop)) {
         return NULL;
     }
@@ -339,21 +336,8 @@ get_event_loop(int stacklevel)
         return loop;
     }
 
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                     "There is no current event loop",
-                     stacklevel))
-    {
-        return NULL;
-    }
-
-    policy = PyObject_CallNoArgs(asyncio_get_event_loop_policy);
-    if (policy == NULL) {
-        return NULL;
-    }
-
-    loop = _PyObject_CallMethodIdNoArgs(policy, &PyId_get_event_loop);
-    Py_DECREF(policy);
-    return loop;
+    PyErr_SetString(PyExc_RuntimeError, "There is no current event loop");
+    return NULL;
 }
 
 


### PR DESCRIPTION
asyncio.get_event_loop() now fails if there is no current event loop.
In Python 3.10, it emits a DeprecationWarning in this case.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94174 -->
* Issue: gh-94174
<!-- /gh-issue-number -->
