### PR TITLE
gh-94172: urllib.request avoids deprecated check_hostname

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -786,6 +786,20 @@ class HTTPResponse(io.BufferedIOBase):
         '''
         return self.status
 
+
+def _create_https_context(http_version):
+    # Function also used by urllib.request to be able to set the check_hostname
+    # attribute on a context object.
+    context = ssl._create_default_https_context()
+    # send ALPN extension to indicate HTTP/1.1 protocol
+    if http_version == 11:
+        context.set_alpn_protocols(['http/1.1'])
+    # enable PHA for TLS 1.3 connections if available
+    if context.post_handshake_auth is not None:
+        context.post_handshake_auth = True
+    return context
+
+
 class HTTPConnection:
 
     _http_vsn = 11
@@ -1418,19 +1432,9 @@ else:
             self.key_file = key_file
             self.cert_file = cert_file
             if context is None:
-                context = ssl._create_default_https_context()
-                # send ALPN extension to indicate HTTP/1.1 protocol
-                if self._http_vsn == 11:
-                    context.set_alpn_protocols(['http/1.1'])
-                # enable PHA for TLS 1.3 connections if available
-                if context.post_handshake_auth is not None:
-                    context.post_handshake_auth = True
-            will_verify = context.verify_mode != ssl.CERT_NONE
-            if check_hostname is None:
-                check_hostname = context.check_hostname
-            if check_hostname and not will_verify:
-                raise ValueError("check_hostname needs a SSL context with "
-                                 "either CERT_OPTIONAL or CERT_REQUIRED")
+                context = _create_https_context(self._http_vsn)
+            if check_hostname is not None:
+                context.check_hostname = check_hostname
             if key_file or cert_file:
                 context.load_cert_chain(cert_file, key_file)
                 # cert and key file means the user wants to authenticate.
@@ -1438,8 +1442,6 @@ else:
                 if context.post_handshake_auth is not None:
                     context.post_handshake_auth = True
             self._context = context
-            if check_hostname is not None:
-                self._context.check_hostname = check_hostname
 
         def connect(self):
             "Connect to a host on a given (SSL) port."

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1383,12 +1383,16 @@ if hasattr(http.client, 'HTTPSConnection'):
 
         def __init__(self, debuglevel=0, context=None, check_hostname=None):
             AbstractHTTPHandler.__init__(self, debuglevel)
+            if context is None:
+                http_version = http.client.HTTPSConnection._http_vsn
+                context = http.client._create_https_context(http_version)
+            if check_hostname is not None:
+                context.check_hostname = check_hostname
             self._context = context
-            self._check_hostname = check_hostname
 
         def https_open(self, req):
             return self.do_open(http.client.HTTPSConnection, req,
-                context=self._context, check_hostname=self._check_hostname)
+                                context=self._context)
 
         https_request = AbstractHTTPHandler.do_request_
 


### PR DESCRIPTION
The urllib.request no longer uses the deprecated check_hostname
parameter of the http.client module.

Add http.client._create_https_context() helper to http.client, reused
by urllib.request.

Remove the now redundant check on check_hostname and verify_mode in
http.client: the SSLContext.check_hostname setter already implements
the check.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94172 -->
* Issue: gh-94172
<!-- /gh-issue-number -->
