### PR TITLE
gh-94194: gettext plural values must now be integers

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -245,6 +245,11 @@ Changes in the Python API
   to :term:`filesystem encoding and error handler`.
   Argument files should be encoded in UTF-8 instead of ANSI Codepage on Windows.
 
+* :mod:`gettext`: Using non-integer value for selecting a plural form is no
+  longer supported.  It never correctly worked and was deprecated since Python
+  3.7.
+  (Contributed by Victor Stinner in :gh:`94194`.)
+
 
 Build Changes
 =============

--- a/Lib/gettext.py
+++ b/Lib/gettext.py
@@ -168,8 +168,6 @@ def c2py(plural):
     """Gets a C expression as used in PO files for plural forms and returns a
     Python function that implements an equivalent expression.
     """
-    import textwrap
-
     if len(plural) > 1000:
         raise ValueError('plural form expression is too long')
 
@@ -190,13 +188,13 @@ def c2py(plural):
                 depth -= 1
 
         ns = {}
-        code = textwrap.dedent('''
+        code = '''if True:
             def func(n):
                 if not isinstance(n, int):
                     raise TypeError(f'Plural value must be an integer, '
                                     f'got {n.__class__.__name__}')
                 return int(%s)
-            ''')
+        '''
         code = code % result
         exec(code, ns)
         return ns['func']

--- a/Lib/test/test_gettext.py
+++ b/Lib/test/test_gettext.py
@@ -488,12 +488,8 @@ class PluralFormsTestCase(GettextBaseTest):
         f = gettext.c2py('n != 1')
         self.assertEqual(f(1), 0)
         self.assertEqual(f(2), 1)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(f(1.0), 0)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(f(2.0), 1)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(f(1.1), 1)
+
+        self.assertRaises(TypeError, f, 1.0)
         self.assertRaises(TypeError, f, '2')
         self.assertRaises(TypeError, f, b'2')
         self.assertRaises(TypeError, f, [])

--- a/Misc/NEWS.d/next/Library/2022-06-24-09-21-09.gh-issue-94194.GPDO6N.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-24-09-21-09.gh-issue-94194.GPDO6N.rst
@@ -1,0 +1,3 @@
+:mod:`gettext`: Using non-integer value for selecting a plural form is no
+longer supported.  It never correctly worked and was deprecated since Python
+3.7. Patch by Victor Stinner.


### PR DESCRIPTION
Using non-integer value for selecting a plural form in gettext is
no longer supported.  It never correctly worked and was deprecated
since Python 3.7.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94194 -->
* Issue: gh-94194
<!-- /gh-issue-number -->
