### PR TITLE
gh-94196: Remove gzip.GzipFile.filename attribute

### DIFF
--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -165,6 +165,10 @@ The module defines the following items:
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
 
+   .. versionchanged:: 3.12
+      Remove the ``filename`` attribute, use the :attr:`~GzipFile.name`
+      attribute instead.
+
    .. deprecated:: 3.9
       Opening :class:`GzipFile` for writing without specifying the *mode*
       argument is deprecated.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -218,6 +218,12 @@ Removed
   use :func:`os.urandom` or :func:`ssl.RAND_bytes` instead.
   (Contributed by Victor Stinner in :gh:`94199`.)
 
+* :mod:`gzip`: Remove the ``filename`` attribute of :class:`gzip.GzipFile`,
+  deprecated since Python 2.6, use the :attr:`~gzip.GzipFile.name` attribute
+  instead. In write mode, the ``filename`` attribute added ``'.gz'`` file
+  extension if it was not present.
+  (Contributed by Victor Stinner in :gh:`94196`.)
+
 
 Porting to Python 3.12
 ======================

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -213,14 +213,6 @@ class GzipFile(_compression.BaseStream):
             self._write_gzip_header(compresslevel)
 
     @property
-    def filename(self):
-        import warnings
-        warnings.warn("use the name attribute", DeprecationWarning, 2)
-        if self.mode == WRITE and self.name[-3:] != ".gz":
-            return self.name + ".gz"
-        return self.name
-
-    @property
     def mtime(self):
         """Last modification time read from stream, or None"""
         return self._buffer.raw._last_mtime

--- a/Misc/NEWS.d/next/Library/2022-06-24-09-41-41.gh-issue-94196.r2KyfS.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-24-09-41-41.gh-issue-94196.r2KyfS.rst
@@ -1,0 +1,4 @@
+:mod:`gzip`: Remove the ``filename`` attribute of :class:`gzip.GzipFile`,
+deprecated since Python 2.6, use the :attr:`~gzip.GzipFile.name` attribute
+instead. In write mode, the ``filename`` attribute added ``'.gz'`` file
+extension if it was not present. Patch by Victor Stinner.


### PR DESCRIPTION
gzip: Remove the filename attribute of gzip.GzipFile,
deprecated since Python 2.6, use the name attribute instead. In write
mode, the filename attribute added '.gz' file extension if it was not
present.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94196 -->
* Issue: gh-94196
<!-- /gh-issue-number -->
