### PR TITLE
Generalize `build_msi` GitHub action

### DIFF
--- a/.github/workflows/build_msi.yml
+++ b/.github/workflows/build_msi.yml
@@ -5,21 +5,13 @@ on:
   push:
     branches:
     - 'main'
-    - '3.11'
-    - '3.10'
-    - '3.9'
-    - '3.8'
-    - '3.7'
+    - '3.*'
     paths:
     - 'Tools/msi/**'
   pull_request:
     branches:
     - 'main'
-    - '3.11'
-    - '3.10'
-    - '3.9'
-    - '3.8'
-    - '3.7'
+    - '3.*'
     paths:
     - 'Tools/msi/**'
 
@@ -27,26 +19,13 @@ permissions:
   contents: read
 
 jobs:
-  build_win32:
-    name: 'Windows (x86) Installer'
+  build:
+    name: Windows Installer
     runs-on: windows-latest
+    strategy:
+      matrix:
+        type: [x86, x64, arm64]
     steps:
     - uses: actions/checkout@v3
     - name: Build CPython installer
-      run: .\Tools\msi\build.bat -x86
-
-  build_win_amd64:
-    name: 'Windows (x64) Installer'
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build CPython installer
-      run: .\Tools\msi\build.bat -x64
-
-  build_win_arm64:
-    name: 'Windows (ARM64) Installer'
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build CPython installer
-      run: .\Tools\msi\build.bat -arm64
+      run: .\Tools\msi\build.bat -${{ matrix.type }}


### PR DESCRIPTION
Currently, `.github/workflows/build_msi.yml` has two places of duplication:

- enumeration of trigger branches manually updated each minor release (`['main', '3.11', '3.10', '3.9', '3.8', '3.7']`) instead of permavalid [wildcards](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore) (`['main', '3.*']`):

   > The `branches`, `branches-ignore`, `tags`, and `tags-ignore` keywords accept glob patterns that use characters like `*`, `**`, `+`, `?`, `!` and others to match more than one branch or tag name.

- enumeration of three build configurations (x86, x64, arm64) that are carbon copies of each other except a title and a single command line parameter.

This PR generalizes them into a wildcard and a matrix respectively.

*It also modifies the GitHub run report. Before:*

![image](https://user-images.githubusercontent.com/4881073/175494029-3d46ffc5-5e7b-4eb0-850a-f284b00c3498.png)

*After:*

![image](https://user-images.githubusercontent.com/4881073/175493913-064e7511-5217-4339-9087-5d76713e8fad.png)
