### PR TITLE
gh-94199: Remove the ssl.wrap_socket() function

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -304,6 +304,15 @@ Removed
   :pep:`451` for the rationale.
   (Contributed by Victor Stinner in :gh:`94379`.)
 
+* Remove the :func:`ssl.wrap_socket` function, deprecated in Python 3.7:
+  instead, create a :class:`ssl.SSLContext` object and call its
+  :class:`ssl.SSLContext.wrap_socket` method. Any package that still uses
+  :func:`ssl.wrap_socket` is broken and insecure. The function neither sends a
+  SNI TLS extension nor validates server hostname. Code is subject to `CWE-295
+  <https://cwe.mitre.org/data/definitions/295.html>`_: Improper Certificate
+  Validation.
+  (Contributed by Victor Stinner in :gh:`94199`.)
+
 
 Porting to Python 3.12
 ======================

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -1357,36 +1357,6 @@ SSLContext.sslsocket_class = SSLSocket
 SSLContext.sslobject_class = SSLObject
 
 
-def wrap_socket(sock, keyfile=None, certfile=None,
-                server_side=False, cert_reqs=CERT_NONE,
-                ssl_version=PROTOCOL_TLS, ca_certs=None,
-                do_handshake_on_connect=True,
-                suppress_ragged_eofs=True,
-                ciphers=None):
-    warnings.warn(
-        "ssl.wrap_socket() is deprecated, use SSLContext.wrap_socket()",
-        category=DeprecationWarning,
-        stacklevel=2
-    )
-    if server_side and not certfile:
-        raise ValueError("certfile must be specified for server-side "
-                         "operations")
-    if keyfile and not certfile:
-        raise ValueError("certfile must be specified")
-    context = SSLContext(ssl_version)
-    context.verify_mode = cert_reqs
-    if ca_certs:
-        context.load_verify_locations(ca_certs)
-    if certfile:
-        context.load_cert_chain(certfile, keyfile)
-    if ciphers:
-        context.set_ciphers(ciphers)
-    return context.wrap_socket(
-        sock=sock, server_side=server_side,
-        do_handshake_on_connect=do_handshake_on_connect,
-        suppress_ragged_eofs=suppress_ragged_eofs
-    )
-
 # some utility functions
 
 def cert_time_to_seconds(cert_time):

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -629,36 +629,6 @@ class BasicSocketTests(unittest.TestCase):
                     str(cm.warning)
                 )
 
-    @ignore_deprecation
-    def test_errors_sslwrap(self):
-        sock = socket.socket()
-        self.assertRaisesRegex(ValueError,
-                        "certfile must be specified",
-                        ssl.wrap_socket, sock, keyfile=CERTFILE)
-        self.assertRaisesRegex(ValueError,
-                        "certfile must be specified for server-side operations",
-                        ssl.wrap_socket, sock, server_side=True)
-        self.assertRaisesRegex(ValueError,
-                        "certfile must be specified for server-side operations",
-                         ssl.wrap_socket, sock, server_side=True, certfile="")
-        with ssl.wrap_socket(sock, server_side=True, certfile=CERTFILE) as s:
-            self.assertRaisesRegex(ValueError, "can't connect in server-side mode",
-                                     s.connect, (HOST, 8080))
-        with self.assertRaises(OSError) as cm:
-            with socket.socket() as sock:
-                ssl.wrap_socket(sock, certfile=NONEXISTINGCERT)
-        self.assertEqual(cm.exception.errno, errno.ENOENT)
-        with self.assertRaises(OSError) as cm:
-            with socket.socket() as sock:
-                ssl.wrap_socket(sock,
-                    certfile=CERTFILE, keyfile=NONEXISTINGCERT)
-        self.assertEqual(cm.exception.errno, errno.ENOENT)
-        with self.assertRaises(OSError) as cm:
-            with socket.socket() as sock:
-                ssl.wrap_socket(sock,
-                    certfile=NONEXISTINGCERT, keyfile=NONEXISTINGCERT)
-        self.assertEqual(cm.exception.errno, errno.ENOENT)
-
     def bad_cert_test(self, certfile):
         """Check that trying to use the given client certificate fails"""
         certfile = os.path.join(os.path.dirname(__file__) or os.curdir,

--- a/Misc/NEWS.d/next/Library/2022-06-24-10-39-56.gh-issue-94199.MIuckY.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-24-10-39-56.gh-issue-94199.MIuckY.rst
@@ -1,0 +1,7 @@
+Remove the :func:`ssl.wrap_socket` function, deprecated in Python 3.7: instead,
+create a :class:`ssl.SSLContext` object and call its
+:class:`ssl.SSLContext.wrap_socket` method. Any package that still uses
+:func:`ssl.wrap_socket` is broken and insecure. The function neither sends a
+SNI TLS extension nor validates server hostname. Code is subject to `CWE-295
+<https://cwe.mitre.org/data/definitions/295.html>`_: Improper Certificate
+Validation. Patch by Victor Stinner.


### PR DESCRIPTION
Remove the ssl.wrap_socket() function, deprecated in Python 3.7:
instead, create a ssl.SSLContext object and call its
SSLContext.wrap_socket() method.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94199 -->
* Issue: gh-94199
<!-- /gh-issue-number -->
