### PR TITLE
gh-94205: Ensures all required DLLs are copied on Windows for underpth tests

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -570,6 +570,8 @@ class _pthFileTests(unittest.TestCase):
             dll_file = os.path.join(temp_dir, os.path.split(dll_src_file)[1])
             shutil.copy(sys.executable, exe_file)
             shutil.copy(dll_src_file, dll_file)
+            for fn in glob.glob(os.path.join(os.path.split(dll_src_file)[0], "vcruntime*.dll")):
+                shutil.copy(fn, os.path.join(temp_dir, os.path.split(fn)[1]))
             if exe_pth:
                 _pth_file = os.path.splitext(exe_file)[0] + '._pth'
             else:


### PR DESCRIPTION


<!-- gh-issue-number: gh-94205 -->
* Issue: gh-94205
<!-- /gh-issue-number -->
