### PR TITLE
gh-93382: Sync up co_code changes with 3.11

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -90,7 +90,7 @@ typedef uint16_t _Py_CODEUNIT;
     PyObject *co_qualname;        /* unicode (qualname, for reference) */      \
     PyObject *co_linetable;       /* bytes object that holds location info */  \
     PyObject *co_weakreflist;     /* to support weakrefs to code objects */    \
-    PyObject *_co_code;               /* cached co_code object/attribute */    \
+    PyObject *_co_code;           /* cached co_code object/attribute */        \
     int _co_firsttraceable;       /* index of first traceable instruction */   \
     char *_co_linearray;          /* array of line offsets */                  \
     /* Scratch space for extra data relating to the code object.               \

--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -90,7 +90,7 @@ typedef uint16_t _Py_CODEUNIT;
     PyObject *co_qualname;        /* unicode (qualname, for reference) */      \
     PyObject *co_linetable;       /* bytes object that holds location info */  \
     PyObject *co_weakreflist;     /* to support weakrefs to code objects */    \
-    void *_co_code;               /* cached co_code object/attribute */        \
+    PyObject *_co_code;               /* cached co_code object/attribute */    \
     int _co_firsttraceable;       /* index of first traceable instruction */   \
     char *_co_linearray;          /* array of line offsets */                  \
     /* Scratch space for extra data relating to the code object.               \

--- a/Misc/NEWS.d/next/Core and Builtins/2022-05-31-16-36-30.gh-issue-93382.Jf6gAj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-05-31-16-36-30.gh-issue-93382.Jf6gAj.rst
@@ -1,1 +1,2 @@
-Speed up the :c:func:`PyCode_GetCode` function which also improves accessing the :attr:`~types.CodeType.co_code` attribute in Python.
+Cache the result of :c:func:`PyCode_GetCode` function to restore the O(1)
+lookup of the :attr:`~types.CodeType.co_code` attribute.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1440,7 +1440,7 @@ _PyCode_GetCode(PyCodeObject *co)
     }
     deopt_code((_Py_CODEUNIT *)PyBytes_AS_STRING(code), Py_SIZE(co));
     assert(co->_co_code == NULL);
-    co->_co_code = (void *)Py_NewRef(code);
+    co->_co_code = Py_NewRef(code);
     return code;
 }
 

--- a/Tools/scripts/deepfreeze.py
+++ b/Tools/scripts/deepfreeze.py
@@ -274,6 +274,7 @@ class Printer:
             self.write(f".co_name = {co_name},")
             self.write(f".co_qualname = {co_qualname},")
             self.write(f".co_linetable = {co_linetable},")
+            self.write(f"._co_code = NULL,")
             self.write("._co_linearray = NULL,")
             self.write(f".co_code_adaptive = {co_code_adaptive},")
             for i, op in enumerate(code.co_code[::2]):


### PR DESCRIPTION
This syncs up 3.12 branch with 3.11 branch. due to changes in https://github.com/python/cpython/pull/93493.

<!-- gh-issue-number: gh-93382 -->
* Issue: gh-93382
<!-- /gh-issue-number -->
