### PR TITLE
gh-93096: Remove `python -m base64 -t`

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -570,8 +570,7 @@ def main():
     usage = """usage: %s [-h|-d|-e|-u|-t] [file|-]
         -h: print this help message and exit
         -d, -u: decode
-        -e: encode (default)
-        -t: encode and decode string 'Aladdin:open sesame'"""%sys.argv[0]
+        -e: encode (default)"""%sys.argv[0]
     try:
         opts, args = getopt.getopt(sys.argv[1:], 'hdeut')
     except getopt.error as msg:
@@ -584,23 +583,12 @@ def main():
         if o == '-e': func = encode
         if o == '-d': func = decode
         if o == '-u': func = decode
-        if o == '-t': test(); return
         if o == '-h': print(usage); return
     if args and args[0] != '-':
         with open(args[0], 'rb') as f:
             func(f, sys.stdout.buffer)
     else:
         func(sys.stdin.buffer, sys.stdout.buffer)
-
-
-def test():
-    s0 = b"Aladdin:open sesame"
-    print(repr(s0))
-    s1 = encodebytes(s0)
-    print(repr(s1))
-    s2 = decodebytes(s1)
-    print(repr(s2))
-    assert s0 == s2
 
 
 if __name__ == '__main__':

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -567,10 +567,10 @@ def decodebytes(s):
 def main():
     """Small main program"""
     import sys, getopt
-    usage = """usage: %s [-h|-d|-e|-u|-t] [file|-]
+    usage = f"""usage: {sys.argv[0]} [-h|-d|-e|-u|-t] [file|-]
         -h: print this help message and exit
         -d, -u: decode
-        -e: encode (default)"""%sys.argv[0]
+        -e: encode (default)"""
     try:
         opts, args = getopt.getopt(sys.argv[1:], 'hdeut')
     except getopt.error as msg:

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -31,6 +31,8 @@ class LegacyBase64TestCase(unittest.TestCase):
            b"YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNE"
            b"RUZHSElKS0xNTk9QUVJTVFVWV1hZWjAxMjM0\nNT"
            b"Y3ODkhQCMwXiYqKCk7Ojw+LC4gW117fQ==\n")
+        eq(base64.encodebytes(b"Aladdin:open sesame",
+                              b"QWxhZGRpbjpvcGVuIHNlc2FtZQ==\n"))
         # Non-bytes
         eq(base64.encodebytes(bytearray(b'abc')), b'YWJj\n')
         eq(base64.encodebytes(memoryview(b'abc')), b'YWJj\n')
@@ -50,6 +52,8 @@ class LegacyBase64TestCase(unittest.TestCase):
            b"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
            b"0123456789!@#0^&*();:<>,. []{}")
         eq(base64.decodebytes(b''), b'')
+        eq(base64.encodebytes(b"QWxhZGRpbjpvcGVuIHNlc2FtZQ==\n",
+                              b"Aladdin:open sesame"))
         # Non-bytes
         eq(base64.decodebytes(bytearray(b'YWJj\n')), b'abc')
         eq(base64.decodebytes(memoryview(b'YWJj\n')), b'abc')

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -31,8 +31,8 @@ class LegacyBase64TestCase(unittest.TestCase):
            b"YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNE"
            b"RUZHSElKS0xNTk9QUVJTVFVWV1hZWjAxMjM0\nNT"
            b"Y3ODkhQCMwXiYqKCk7Ojw+LC4gW117fQ==\n")
-        eq(base64.encodebytes(b"Aladdin:open sesame",
-                              b"QWxhZGRpbjpvcGVuIHNlc2FtZQ==\n"))
+        eq(base64.encodebytes(b"Aladdin:open sesame"),
+                              b"QWxhZGRpbjpvcGVuIHNlc2FtZQ==\n")
         # Non-bytes
         eq(base64.encodebytes(bytearray(b'abc')), b'YWJj\n')
         eq(base64.encodebytes(memoryview(b'abc')), b'YWJj\n')
@@ -52,8 +52,8 @@ class LegacyBase64TestCase(unittest.TestCase):
            b"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
            b"0123456789!@#0^&*();:<>,. []{}")
         eq(base64.decodebytes(b''), b'')
-        eq(base64.encodebytes(b"QWxhZGRpbjpvcGVuIHNlc2FtZQ==\n",
-                              b"Aladdin:open sesame"))
+        eq(base64.decodebytes(b"QWxhZGRpbjpvcGVuIHNlc2FtZQ==\n"),
+                              b"Aladdin:open sesame")
         # Non-bytes
         eq(base64.decodebytes(bytearray(b'YWJj\n')), b'abc')
         eq(base64.decodebytes(memoryview(b'YWJj\n')), b'abc')

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -759,17 +759,6 @@ class TestMain(unittest.TestCase):
         if os.path.exists(os_helper.TESTFN):
             os.unlink(os_helper.TESTFN)
 
-    def get_output(self, *args):
-        return script_helper.assert_python_ok('-m', 'base64', *args).out
-
-    def test_encode_decode(self):
-        output = self.get_output('-t')
-        self.assertSequenceEqual(output.splitlines(), (
-            b"b'Aladdin:open sesame'",
-            br"b'QWxhZGRpbjpvcGVuIHNlc2FtZQ==\n'",
-            b"b'Aladdin:open sesame'",
-        ))
-
     def test_encode_file(self):
         with open(os_helper.TESTFN, 'wb') as fp:
             fp.write(b'a\xffb\n')

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -759,6 +759,9 @@ class TestMain(unittest.TestCase):
         if os.path.exists(os_helper.TESTFN):
             os.unlink(os_helper.TESTFN)
 
+    def get_output(self, *args):
+        return script_helper.assert_python_ok('-m', 'base64', *args).out
+
     def test_encode_file(self):
         with open(os_helper.TESTFN, 'wb') as fp:
             fp.write(b'a\xffb\n')

--- a/Misc/NEWS.d/next/Library/2022-06-24-19-16-09.gh-issue-93096.r1_oIc.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-24-19-16-09.gh-issue-93096.r1_oIc.rst
@@ -1,3 +1,3 @@
-Removed the ``-t`` argument from undocumented ``python -m base64``. This
-argument performed an encode/decode test that lost any value after
-``test.test_base64.LegacyBase64TestCase.test_encodebytes`` was introduced.
+Removed undocumented ``-t`` argument of ``python -m base64``. Use
+``python -m unittest test.test_base64.LegacyBase64TestCase.test_encodebytes``
+instead.

--- a/Misc/NEWS.d/next/Library/2022-06-24-19-16-09.gh-issue-93096.r1_oIc.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-24-19-16-09.gh-issue-93096.r1_oIc.rst
@@ -1,0 +1,3 @@
+Removed the ``-t`` argument from undocumented ``python -m base64``. This
+argument performed an encode/decode test that lost any value after
+``test.test_base64.LegacyBase64TestCase.test_encodebytes`` was introduced.


### PR DESCRIPTION
`test_base64.LegacyBase64TestCase.test_encodebytes`/`test_decodebytes` is a more advanced version of the removed CLI argument.

The removed feature brings no benefit to an end user (unlike the rest of `python -m base64`).

<!-- gh-issue-number: gh-93096 -->
* Issue: gh-93096
<!-- /gh-issue-number -->
