### PR TITLE
gh-93096: Remove `python -m codecs`

### DIFF
--- a/Lib/codecs.py
+++ b/Lib/codecs.py
@@ -1114,13 +1114,3 @@ except LookupError:
 _false = 0
 if _false:
     import encodings
-
-### Tests
-
-if __name__ == '__main__':
-
-    # Make stdout translate Latin-1 output into UTF-8 output
-    sys.stdout = EncodedFile(sys.stdout, 'latin-1', 'utf-8')
-
-    # Have stdin translate Latin-1 input into UTF-8 input
-    sys.stdin = EncodedFile(sys.stdin, 'utf-8', 'latin-1')

--- a/Misc/NEWS.d/next/Library/2022-06-24-19-40-40.gh-issue-93096.3RlK2d.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-24-19-40-40.gh-issue-93096.3RlK2d.rst
@@ -1,0 +1,2 @@
+Removed the undocumented ``python -m codecs``. Use ``python -m unittest
+test.test_codecs.EncodedFileTest`` instead.

--- a/Misc/NEWS.d/next/Library/2022-06-24-19-40-40.gh-issue-93096.3RlK2d.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-24-19-40-40.gh-issue-93096.3RlK2d.rst
@@ -1,2 +1,2 @@
-Removed the undocumented ``python -m codecs``. Use ``python -m unittest
+Removed undocumented ``python -m codecs``. Use ``python -m unittest
 test.test_codecs.EncodedFileTest`` instead.


### PR DESCRIPTION
`test_codecs.EncodedFileTest` is a more advanced variant of the removed CLI.

<!-- gh-issue-number: gh-93096 -->
* Issue: gh-93096
<!-- /gh-issue-number -->
