### PR TITLE
Update code sample when importing modules in queue doc

### DIFF
--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -190,7 +190,8 @@ fully processed by daemon consumer threads.
 
 Example of how to wait for enqueued tasks to be completed::
 
-    import threading, queue
+    import threading
+    import queue
 
     q = queue.Queue()
 


### PR DESCRIPTION
In the queue documentation, the code snippet shows the import to be not PEP 8 compliant.

https://docs.python.org/3/library/queue.html

Since people typically copy-paste from such code samples, I think it's important to show best-practices here.
