### PR TITLE
gh-94246: Prefer user argument names in AC doctrings

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2022-06-25-00-50-14.gh-issue-94246.TBRWQL.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2022-06-25-00-50-14.gh-issue-94246.TBRWQL.rst
@@ -1,0 +1,2 @@
+Argument Clinic started to prefer user supplied names for document string
+rendering of special variables (like ``self`` and ``module``).

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -522,7 +522,7 @@ exit:
 }
 
 PyDoc_STRVAR(builtin_id__doc__,
-"id($module, obj, /)\n"
+"id($self, obj, /)\n"
 "--\n"
 "\n"
 "Return the identity of an object.\n"
@@ -1045,4 +1045,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=a2c5c53e8aead7c3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1c58745b448d11ff input=a9049054013a1b77]*/

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4972,7 +4972,7 @@ class DSLParser:
             if p.is_vararg():
                 p_add("*")
 
-            name = p.converter.signature_name or p.name
+            name = p.name or p.converter.signature_name
             p_add(name)
 
             if not p.is_vararg() and p.converter.is_optional():


### PR DESCRIPTION
The fixed Argument Clinic now converts this:

```c
/*[clinic input]
my_method
    _foo: self(type="PyObject *")
    module: object
[clinic start generated code]*/
```

to this:

```c
/*[clinic input]
preserve
[clinic start generated code]*/

PyDoc_STRVAR(my_method__doc__,
"my_method($_foo, /, module)\n"
"--\n"
"\n");

[snip]
```

instead of previous, incorrect:

```c
/*[clinic input]
preserve
[clinic start generated code]*/

PyDoc_STRVAR(my_method__doc__,
"my_method($module, /, module)\n"
"--\n"
"\n");

[snip]
```

*Note: already existing generated files are updated with `python Tools/clinic/clinic.py --make --srcdir .`*

<!-- gh-issue-number: gh-94246 -->
* Issue: gh-94246
<!-- /gh-issue-number -->
