### PR TITLE
[3.10] gh-94245: Fix pickling and copying of typing.Tuple[()]

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1099,7 +1099,8 @@ class _GenericAlias(_BaseGenericAlias, _root=True):
         else:
             origin = self.__origin__
         args = tuple(self.__args__)
-        if len(args) == 1 and not isinstance(args[0], tuple):
+        if len(args) == 1 and (not isinstance(args[0], tuple) or
+                               origin is Tuple and not args[0]):
             args, = args
         return operator.getitem, (origin, args)
 

--- a/Misc/NEWS.d/next/Library/2022-06-25-13-33-18.gh-issue-94245.-zQY1a.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-25-13-33-18.gh-issue-94245.-zQY1a.rst
@@ -1,0 +1,1 @@
+Fix pickling and copying of ``typing.Tuple[()]``.


### PR DESCRIPTION
It is an alternate PR, which only fixes pickling and copying `typing.Tuple[()]`, without affecting its `__args__`.

<!-- gh-issue-number: gh-94245 -->
* Issue: gh-94245
<!-- /gh-issue-number -->
