### PR TITLE
gh-94220: Replaced name(s) & pat with filename(s) & pattern in fnmatch module as per docs

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2022-06-25-15-19-42.gh-issue-94220.v3dHWp.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-25-15-19-42.gh-issue-94220.v3dHWp.rst
@@ -1,0 +1,1 @@
+Change parameters of functions in fnmatch module in `lib\fnmatch.py` from `name(s)` and `pat` to `filename(s)` and `pattern`. To make it consistent with the documentation which uses `filename(s)` and `pattern`.

--- a/Misc/NEWS.d/next/Documentation/2022-06-25-15-25-04.gh-issue-94220.duEQ-L.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-25-15-25-04.gh-issue-94220.duEQ-L.rst
@@ -1,0 +1,1 @@
+Change parameters of function in ``fnmatch`` module in ``lib/fnmatch.py`` from ``name(s)`` and ``pat`` to ``filename(s)`` and ``patern`` to bring as they are used in docs.

--- a/Misc/NEWS.d/next/Documentation/2022-06-25-15-26-58.gh-issue-94220.fCefn-.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-25-15-26-58.gh-issue-94220.fCefn-.rst
@@ -1,0 +1,1 @@
+Change parameters of function in ``fnmatch`` module in ``lib/fnmatch.py`` from ``name(s)`` and ``pat`` to ``filename(s)`` and ``pattern`` to bring as they are used in docs.

--- a/Misc/NEWS.d/next/Documentation/2022-06-25-15-32-45.gh-issue-94220.FN7Elt.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-25-15-32-45.gh-issue-94220.FN7Elt.rst
@@ -1,0 +1,1 @@
+Change parameters of function in ``fnmatch`` module in ``lib/fnmatch.py`` from ``name(s)`` and ``pat`` to ``filename(s)`` and ``pattern`` as they are used in docs.


### PR DESCRIPTION
The parameters used by fnmatch and its sister functions at fnmatch module are different then the one metion at [docs](https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch). 
 
![image](https://user-images.githubusercontent.com/83943218/175769168-89e05df4-a5c4-458d-9028-f35bfb88769d.png)

[lib/fnmatch.py](https://github.com/python/cpython/blob/3.10/Lib/fnmatch.py)
```python
def fnmatch(name, pat):
    """Test whether FILENAME matches PATTERN.
    .
    .
    .
    """
    name = os.path.normcase(name)
    pat = os.path.normcase(pat)
    return fnmatchcase(name, pat)
```

The doc uses `filename(s)` and `pattern` as parameters while the source code uses `name(s)` and `pat`. Both of them should use the same parameters. I have converted the parameters of all functions in  fnmatch module to `filename(s)` and `pattern`.
source :


<!-- gh-issue-number: gh-94220 -->
* Issue: gh-94220
<!-- /gh-issue-number -->
