### PR TITLE
gh-94242: Update calculation of _MAX_WINDOWS_WORKERS

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -108,10 +108,12 @@ EXTRA_QUEUED_CALLS = 1
 
 
 # On Windows, WaitForMultipleObjects is used to wait for processes to finish.
-# It can wait on, at most, 63 objects. There is an overhead of two objects:
+# It can wait on, at most, 64 objects. There is an overhead of two to three
+# objects:
 # - the result queue reader
 # - the thread wakeup reader
-_MAX_WINDOWS_WORKERS = 63 - 2
+# - sometimes _PyOS_SigintEvent
+_MAX_WINDOWS_WORKERS = 64 - 3
 
 # Hack to embed stringification of remote traceback in local traceback
 

--- a/Misc/NEWS.d/next/Documentation/2022-06-26-05-14-43.gh-issue-94242.8iYmFK.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-06-26-05-14-43.gh-issue-94242.8iYmFK.rst
@@ -1,0 +1,1 @@
+This change updates some comments and the calculation of _MAX_WINDOWS_WORKERS but the actual value is unchanged.


### PR DESCRIPTION
The calculation of _MAX_WINDOWS_WORKERS contained two off-by-one errors.
They cancelled each other out so this does not change the value of
_MAX_WINDOWS_WORKERS, just how it is determined. This could avoid future
confusion about where the 61 value comes from.


<!-- gh-issue-number: gh-94242 -->
* Issue: gh-94242
<!-- /gh-issue-number -->
