### PR TITLE
gh-90005: Rename MODULE_EGG variable to MODULE_EGG_STATE

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -222,7 +222,7 @@ OPENSSL_RPATH=@OPENSSL_RPATH@
 #   * missing: build dependency is missing
 #   * disabled: module is disabled
 #   * n/a: module is not available on the current platform
-# MODULE_EGG=yes  # yes, missing, disabled, n/a
+# MODULE_EGG_STATE=yes  # yes, missing, disabled, n/a
 # MODULE_EGG_CFLAGS=
 # MODULE_EGG_LDFLAGS=
 @MODULE_BLOCK@

--- a/configure
+++ b/configure
@@ -23124,7 +23124,7 @@ else
   MODULE__IO_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__IO=$py_cv_module__io$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__IO_STATE=$py_cv_module__io$as_nl"
   if test "x$py_cv_module__io" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__IO_CFLAGS=-I\$(srcdir)/Modules/_io$as_nl"
@@ -23144,7 +23144,7 @@ else
   MODULE_TIME_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE_TIME=$py_cv_module_time$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_TIME_STATE=$py_cv_module_time$as_nl"
   if test "x$py_cv_module_time" = xyes; then :
 
 
@@ -23165,7 +23165,7 @@ else
   MODULE_ARRAY_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE_ARRAY=$py_cv_module_array$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_ARRAY_STATE=$py_cv_module_array$as_nl"
   if test "x$py_cv_module_array" = xyes; then :
 
 
@@ -23185,7 +23185,7 @@ else
   MODULE__ASYNCIO_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__ASYNCIO=$py_cv_module__asyncio$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__ASYNCIO_STATE=$py_cv_module__asyncio$as_nl"
   if test "x$py_cv_module__asyncio" = xyes; then :
 
 
@@ -23205,7 +23205,7 @@ else
   MODULE__BISECT_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__BISECT=$py_cv_module__bisect$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__BISECT_STATE=$py_cv_module__bisect$as_nl"
   if test "x$py_cv_module__bisect" = xyes; then :
 
 
@@ -23225,7 +23225,7 @@ else
   MODULE__CONTEXTVARS_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__CONTEXTVARS=$py_cv_module__contextvars$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__CONTEXTVARS_STATE=$py_cv_module__contextvars$as_nl"
   if test "x$py_cv_module__contextvars" = xyes; then :
 
 
@@ -23245,7 +23245,7 @@ else
   MODULE__CSV_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__CSV=$py_cv_module__csv$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__CSV_STATE=$py_cv_module__csv$as_nl"
   if test "x$py_cv_module__csv" = xyes; then :
 
 
@@ -23265,7 +23265,7 @@ else
   MODULE__HEAPQ_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__HEAPQ=$py_cv_module__heapq$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__HEAPQ_STATE=$py_cv_module__heapq$as_nl"
   if test "x$py_cv_module__heapq" = xyes; then :
 
 
@@ -23285,7 +23285,7 @@ else
   MODULE__JSON_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__JSON=$py_cv_module__json$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__JSON_STATE=$py_cv_module__json$as_nl"
   if test "x$py_cv_module__json" = xyes; then :
 
 
@@ -23305,7 +23305,7 @@ else
   MODULE__LSPROF_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__LSPROF=$py_cv_module__lsprof$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__LSPROF_STATE=$py_cv_module__lsprof$as_nl"
   if test "x$py_cv_module__lsprof" = xyes; then :
 
 
@@ -23325,7 +23325,7 @@ else
   MODULE__OPCODE_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__OPCODE=$py_cv_module__opcode$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__OPCODE_STATE=$py_cv_module__opcode$as_nl"
   if test "x$py_cv_module__opcode" = xyes; then :
 
 
@@ -23345,7 +23345,7 @@ else
   MODULE__PICKLE_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__PICKLE=$py_cv_module__pickle$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__PICKLE_STATE=$py_cv_module__pickle$as_nl"
   if test "x$py_cv_module__pickle" = xyes; then :
 
 
@@ -23365,7 +23365,7 @@ else
   MODULE__POSIXSUBPROCESS_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__POSIXSUBPROCESS=$py_cv_module__posixsubprocess$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__POSIXSUBPROCESS_STATE=$py_cv_module__posixsubprocess$as_nl"
   if test "x$py_cv_module__posixsubprocess" = xyes; then :
 
 
@@ -23385,7 +23385,7 @@ else
   MODULE__QUEUE_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__QUEUE=$py_cv_module__queue$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__QUEUE_STATE=$py_cv_module__queue$as_nl"
   if test "x$py_cv_module__queue" = xyes; then :
 
 
@@ -23405,7 +23405,7 @@ else
   MODULE__RANDOM_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__RANDOM=$py_cv_module__random$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__RANDOM_STATE=$py_cv_module__random$as_nl"
   if test "x$py_cv_module__random" = xyes; then :
 
 
@@ -23425,7 +23425,7 @@ else
   MODULE_SELECT_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE_SELECT=$py_cv_module_select$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_SELECT_STATE=$py_cv_module_select$as_nl"
   if test "x$py_cv_module_select" = xyes; then :
 
 
@@ -23445,7 +23445,7 @@ else
   MODULE__STRUCT_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__STRUCT=$py_cv_module__struct$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__STRUCT_STATE=$py_cv_module__struct$as_nl"
   if test "x$py_cv_module__struct" = xyes; then :
 
 
@@ -23465,7 +23465,7 @@ else
   MODULE__TYPING_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__TYPING=$py_cv_module__typing$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__TYPING_STATE=$py_cv_module__typing$as_nl"
   if test "x$py_cv_module__typing" = xyes; then :
 
 
@@ -23485,7 +23485,7 @@ else
   MODULE__XXSUBINTERPRETERS_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__XXSUBINTERPRETERS=$py_cv_module__xxsubinterpreters$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__XXSUBINTERPRETERS_STATE=$py_cv_module__xxsubinterpreters$as_nl"
   if test "x$py_cv_module__xxsubinterpreters" = xyes; then :
 
 
@@ -23505,7 +23505,7 @@ else
   MODULE__ZONEINFO_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__ZONEINFO=$py_cv_module__zoneinfo$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__ZONEINFO_STATE=$py_cv_module__zoneinfo$as_nl"
   if test "x$py_cv_module__zoneinfo" = xyes; then :
 
 
@@ -23530,7 +23530,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__MULTIPROCESSING=$py_cv_module__multiprocessing$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__MULTIPROCESSING_STATE=$py_cv_module__multiprocessing$as_nl"
   if test "x$py_cv_module__multiprocessing" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__MULTIPROCESSING_CFLAGS=-I\$(srcdir)/Modules/_multiprocessing$as_nl"
@@ -23564,7 +23564,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__POSIXSHMEM=$py_cv_module__posixshmem$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__POSIXSHMEM_STATE=$py_cv_module__posixshmem$as_nl"
   if test "x$py_cv_module__posixshmem" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__POSIXSHMEM_CFLAGS=$POSIXSHMEM_CFLAGS$as_nl"
@@ -23595,7 +23595,7 @@ else
   MODULE_AUDIOOP_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE_AUDIOOP=$py_cv_module_audioop$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_AUDIOOP_STATE=$py_cv_module_audioop$as_nl"
   if test "x$py_cv_module_audioop" = xyes; then :
 
 
@@ -23615,7 +23615,7 @@ else
   MODULE__STATISTICS_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__STATISTICS=$py_cv_module__statistics$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__STATISTICS_STATE=$py_cv_module__statistics$as_nl"
   if test "x$py_cv_module__statistics" = xyes; then :
 
 
@@ -23635,7 +23635,7 @@ else
   MODULE_CMATH_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE_CMATH=$py_cv_module_cmath$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_CMATH_STATE=$py_cv_module_cmath$as_nl"
   if test "x$py_cv_module_cmath" = xyes; then :
 
 
@@ -23655,7 +23655,7 @@ else
   MODULE_MATH_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE_MATH=$py_cv_module_math$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_MATH_STATE=$py_cv_module_math$as_nl"
   if test "x$py_cv_module_math" = xyes; then :
 
 
@@ -23676,7 +23676,7 @@ else
   MODULE__DATETIME_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__DATETIME=$py_cv_module__datetime$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__DATETIME_STATE=$py_cv_module__datetime$as_nl"
   if test "x$py_cv_module__datetime" = xyes; then :
 
 
@@ -23701,7 +23701,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_FCNTL=$py_cv_module_fcntl$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_FCNTL_STATE=$py_cv_module_fcntl$as_nl"
   if test "x$py_cv_module_fcntl" = xyes; then :
 
 
@@ -23735,7 +23735,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_MMAP=$py_cv_module_mmap$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_MMAP_STATE=$py_cv_module_mmap$as_nl"
   if test "x$py_cv_module_mmap" = xyes; then :
 
 
@@ -23769,7 +23769,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__SOCKET=$py_cv_module__socket$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__SOCKET_STATE=$py_cv_module__socket$as_nl"
   if test "x$py_cv_module__socket" = xyes; then :
 
 
@@ -23804,7 +23804,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_GRP=$py_cv_module_grp$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_GRP_STATE=$py_cv_module_grp$as_nl"
   if test "x$py_cv_module_grp" = xyes; then :
 
 
@@ -23838,7 +23838,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_OSSAUDIODEV=$py_cv_module_ossaudiodev$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_OSSAUDIODEV_STATE=$py_cv_module_ossaudiodev$as_nl"
   if test "x$py_cv_module_ossaudiodev" = xyes; then :
 
 
@@ -23872,7 +23872,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_PWD=$py_cv_module_pwd$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_PWD_STATE=$py_cv_module_pwd$as_nl"
   if test "x$py_cv_module_pwd" = xyes; then :
 
 
@@ -23906,7 +23906,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_RESOURCE=$py_cv_module_resource$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_RESOURCE_STATE=$py_cv_module_resource$as_nl"
   if test "x$py_cv_module_resource" = xyes; then :
 
 
@@ -23940,7 +23940,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__SCPROXY=$py_cv_module__scproxy$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__SCPROXY_STATE=$py_cv_module__scproxy$as_nl"
   if test "x$py_cv_module__scproxy" = xyes; then :
 
 
@@ -23974,7 +23974,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_SPWD=$py_cv_module_spwd$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_SPWD_STATE=$py_cv_module_spwd$as_nl"
   if test "x$py_cv_module_spwd" = xyes; then :
 
 
@@ -24008,7 +24008,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_SYSLOG=$py_cv_module_syslog$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_SYSLOG_STATE=$py_cv_module_syslog$as_nl"
   if test "x$py_cv_module_syslog" = xyes; then :
 
 
@@ -24042,7 +24042,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_TERMIOS=$py_cv_module_termios$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_TERMIOS_STATE=$py_cv_module_termios$as_nl"
   if test "x$py_cv_module_termios" = xyes; then :
 
 
@@ -24077,7 +24077,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_PYEXPAT=$py_cv_module_pyexpat$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_PYEXPAT_STATE=$py_cv_module_pyexpat$as_nl"
   if test "x$py_cv_module_pyexpat" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE_PYEXPAT_CFLAGS=$LIBEXPAT_CFLAGS$as_nl"
@@ -24111,7 +24111,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__ELEMENTTREE=$py_cv_module__elementtree$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__ELEMENTTREE_STATE=$py_cv_module__elementtree$as_nl"
   if test "x$py_cv_module__elementtree" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__ELEMENTTREE_CFLAGS=$LIBEXPAT_CFLAGS$as_nl"
@@ -24141,7 +24141,7 @@ else
   MODULE__CODECS_CN_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__CODECS_CN=$py_cv_module__codecs_cn$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__CODECS_CN_STATE=$py_cv_module__codecs_cn$as_nl"
   if test "x$py_cv_module__codecs_cn" = xyes; then :
 
 
@@ -24161,7 +24161,7 @@ else
   MODULE__CODECS_HK_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__CODECS_HK=$py_cv_module__codecs_hk$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__CODECS_HK_STATE=$py_cv_module__codecs_hk$as_nl"
   if test "x$py_cv_module__codecs_hk" = xyes; then :
 
 
@@ -24181,7 +24181,7 @@ else
   MODULE__CODECS_ISO2022_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__CODECS_ISO2022=$py_cv_module__codecs_iso2022$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__CODECS_ISO2022_STATE=$py_cv_module__codecs_iso2022$as_nl"
   if test "x$py_cv_module__codecs_iso2022" = xyes; then :
 
 
@@ -24201,7 +24201,7 @@ else
   MODULE__CODECS_JP_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__CODECS_JP=$py_cv_module__codecs_jp$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__CODECS_JP_STATE=$py_cv_module__codecs_jp$as_nl"
   if test "x$py_cv_module__codecs_jp" = xyes; then :
 
 
@@ -24221,7 +24221,7 @@ else
   MODULE__CODECS_KR_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__CODECS_KR=$py_cv_module__codecs_kr$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__CODECS_KR_STATE=$py_cv_module__codecs_kr$as_nl"
   if test "x$py_cv_module__codecs_kr" = xyes; then :
 
 
@@ -24241,7 +24241,7 @@ else
   MODULE__CODECS_TW_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__CODECS_TW=$py_cv_module__codecs_tw$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__CODECS_TW_STATE=$py_cv_module__codecs_tw$as_nl"
   if test "x$py_cv_module__codecs_tw" = xyes; then :
 
 
@@ -24261,7 +24261,7 @@ else
   MODULE__MULTIBYTECODEC_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE__MULTIBYTECODEC=$py_cv_module__multibytecodec$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__MULTIBYTECODEC_STATE=$py_cv_module__multibytecodec$as_nl"
   if test "x$py_cv_module__multibytecodec" = xyes; then :
 
 
@@ -24281,7 +24281,7 @@ else
   MODULE_UNICODEDATA_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE_UNICODEDATA=$py_cv_module_unicodedata$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_UNICODEDATA_STATE=$py_cv_module_unicodedata$as_nl"
   if test "x$py_cv_module_unicodedata" = xyes; then :
 
 
@@ -24306,7 +24306,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__MD5=$py_cv_module__md5$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__MD5_STATE=$py_cv_module__md5$as_nl"
   if test "x$py_cv_module__md5" = xyes; then :
 
 
@@ -24340,7 +24340,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__SHA1=$py_cv_module__sha1$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__SHA1_STATE=$py_cv_module__sha1$as_nl"
   if test "x$py_cv_module__sha1" = xyes; then :
 
 
@@ -24374,7 +24374,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__SHA256=$py_cv_module__sha256$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__SHA256_STATE=$py_cv_module__sha256$as_nl"
   if test "x$py_cv_module__sha256" = xyes; then :
 
 
@@ -24408,7 +24408,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__SHA512=$py_cv_module__sha512$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__SHA512_STATE=$py_cv_module__sha512$as_nl"
   if test "x$py_cv_module__sha512" = xyes; then :
 
 
@@ -24442,7 +24442,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__SHA3=$py_cv_module__sha3$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__SHA3_STATE=$py_cv_module__sha3$as_nl"
   if test "x$py_cv_module__sha3" = xyes; then :
 
 
@@ -24476,7 +24476,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__BLAKE2=$py_cv_module__blake2$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__BLAKE2_STATE=$py_cv_module__blake2$as_nl"
   if test "x$py_cv_module__blake2" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__BLAKE2_CFLAGS=$LIBB2_CFLAGS$as_nl"
@@ -24511,7 +24511,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__CRYPT=$py_cv_module__crypt$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__CRYPT_STATE=$py_cv_module__crypt$as_nl"
   if test "x$py_cv_module__crypt" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__CRYPT_CFLAGS=$LIBCRYPT_CFLAGS$as_nl"
@@ -24545,7 +24545,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__CTYPES=$py_cv_module__ctypes$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__CTYPES_STATE=$py_cv_module__ctypes$as_nl"
   if test "x$py_cv_module__ctypes" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__CTYPES_CFLAGS=$LIBFFI_CFLAGS$as_nl"
@@ -24579,7 +24579,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__DECIMAL=$py_cv_module__decimal$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__DECIMAL_STATE=$py_cv_module__decimal$as_nl"
   if test "x$py_cv_module__decimal" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__DECIMAL_CFLAGS=$LIBMPDEC_CFLAGS$as_nl"
@@ -24613,7 +24613,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__GDBM=$py_cv_module__gdbm$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__GDBM_STATE=$py_cv_module__gdbm$as_nl"
   if test "x$py_cv_module__gdbm" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__GDBM_CFLAGS=$GDBM_CFLAGS$as_nl"
@@ -24647,7 +24647,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_NIS=$py_cv_module_nis$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_NIS_STATE=$py_cv_module_nis$as_nl"
   if test "x$py_cv_module_nis" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE_NIS_CFLAGS=$LIBNSL_CFLAGS$as_nl"
@@ -24681,7 +24681,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__SQLITE3=$py_cv_module__sqlite3$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__SQLITE3_STATE=$py_cv_module__sqlite3$as_nl"
   if test "x$py_cv_module__sqlite3" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__SQLITE3_CFLAGS=$LIBSQLITE3_CFLAGS$as_nl"
@@ -24715,7 +24715,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__TKINTER=$py_cv_module__tkinter$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__TKINTER_STATE=$py_cv_module__tkinter$as_nl"
   if test "x$py_cv_module__tkinter" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__TKINTER_CFLAGS=$TCLTK_CFLAGS$as_nl"
@@ -24749,7 +24749,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__UUID=$py_cv_module__uuid$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__UUID_STATE=$py_cv_module__uuid$as_nl"
   if test "x$py_cv_module__uuid" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__UUID_CFLAGS=$LIBUUID_CFLAGS$as_nl"
@@ -24784,7 +24784,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_ZLIB=$py_cv_module_zlib$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_ZLIB_STATE=$py_cv_module_zlib$as_nl"
   if test "x$py_cv_module_zlib" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE_ZLIB_CFLAGS=$ZLIB_CFLAGS$as_nl"
@@ -24814,7 +24814,7 @@ else
   MODULE_BINASCII_FALSE=
 fi
 
-  as_fn_append MODULE_BLOCK "MODULE_BINASCII=$py_cv_module_binascii$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_BINASCII_STATE=$py_cv_module_binascii$as_nl"
   if test "x$py_cv_module_binascii" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE_BINASCII_CFLAGS=$BINASCII_CFLAGS$as_nl"
@@ -24838,7 +24838,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__BZ2=$py_cv_module__bz2$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__BZ2_STATE=$py_cv_module__bz2$as_nl"
   if test "x$py_cv_module__bz2" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__BZ2_CFLAGS=$BZIP2_CFLAGS$as_nl"
@@ -24872,7 +24872,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__LZMA=$py_cv_module__lzma$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__LZMA_STATE=$py_cv_module__lzma$as_nl"
   if test "x$py_cv_module__lzma" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__LZMA_CFLAGS=$LIBLZMA_CFLAGS$as_nl"
@@ -24907,7 +24907,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__SSL=$py_cv_module__ssl$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__SSL_STATE=$py_cv_module__ssl$as_nl"
   if test "x$py_cv_module__ssl" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__SSL_CFLAGS=$OPENSSL_INCLUDES$as_nl"
@@ -24941,7 +24941,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__HASHLIB=$py_cv_module__hashlib$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__HASHLIB_STATE=$py_cv_module__hashlib$as_nl"
   if test "x$py_cv_module__hashlib" = xyes; then :
 
     as_fn_append MODULE_BLOCK "MODULE__HASHLIB_CFLAGS=$OPENSSL_INCLUDES$as_nl"
@@ -24976,7 +24976,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__TESTCAPI=$py_cv_module__testcapi$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__TESTCAPI_STATE=$py_cv_module__testcapi$as_nl"
   if test "x$py_cv_module__testcapi" = xyes; then :
 
 
@@ -25010,7 +25010,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__TESTINTERNALCAPI=$py_cv_module__testinternalcapi$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__TESTINTERNALCAPI_STATE=$py_cv_module__testinternalcapi$as_nl"
   if test "x$py_cv_module__testinternalcapi" = xyes; then :
 
 
@@ -25044,7 +25044,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__TESTBUFFER=$py_cv_module__testbuffer$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__TESTBUFFER_STATE=$py_cv_module__testbuffer$as_nl"
   if test "x$py_cv_module__testbuffer" = xyes; then :
 
 
@@ -25078,7 +25078,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__TESTIMPORTMULTIPLE=$py_cv_module__testimportmultiple$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__TESTIMPORTMULTIPLE_STATE=$py_cv_module__testimportmultiple$as_nl"
   if test "x$py_cv_module__testimportmultiple" = xyes; then :
 
 
@@ -25112,7 +25112,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__TESTMULTIPHASE=$py_cv_module__testmultiphase$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__TESTMULTIPHASE_STATE=$py_cv_module__testmultiphase$as_nl"
   if test "x$py_cv_module__testmultiphase" = xyes; then :
 
 
@@ -25146,7 +25146,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__XXTESTFUZZ=$py_cv_module__xxtestfuzz$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__XXTESTFUZZ_STATE=$py_cv_module__xxtestfuzz$as_nl"
   if test "x$py_cv_module__xxtestfuzz" = xyes; then :
 
 
@@ -25180,7 +25180,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE__CTYPES_TEST=$py_cv_module__ctypes_test$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE__CTYPES_TEST_STATE=$py_cv_module__ctypes_test$as_nl"
   if test "x$py_cv_module__ctypes_test" = xyes; then :
 
 
@@ -25215,7 +25215,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_XXLIMITED=$py_cv_module_xxlimited$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_XXLIMITED_STATE=$py_cv_module_xxlimited$as_nl"
   if test "x$py_cv_module_xxlimited" = xyes; then :
 
 
@@ -25249,7 +25249,7 @@ else
 fi
 
 fi
-  as_fn_append MODULE_BLOCK "MODULE_XXLIMITED_35=$py_cv_module_xxlimited_35$as_nl"
+  as_fn_append MODULE_BLOCK "MODULE_XXLIMITED_35_STATE=$py_cv_module_xxlimited_35$as_nl"
   if test "x$py_cv_module_xxlimited_35" = xyes; then :
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -6791,7 +6791,7 @@ MODULE_BLOCK=
 
 dnl Check for stdlib extension modules
 dnl PY_STDLIB_MOD([NAME], [ENABLED-TEST], [SUPPORTED-TEST], [CFLAGS], [LDFLAGS])
-dnl sets MODULE_$NAME based on PY_STDLIB_MOD_SET_NA(), ENABLED-TEST,
+dnl sets MODULE_$NAME_STATE based on PY_STDLIB_MOD_SET_NA(), ENABLED-TEST,
 dnl and SUPPORTED_TEST. ENABLED-TEST and SUPPORTED-TEST default to true if
 dnl empty.
 dnl    n/a: marked unavailable on platform by PY_STDLIB_MOD_SET_NA()
@@ -6809,7 +6809,7 @@ AC_DEFUN([PY_STDLIB_MOD], [
        [AS_IF([m4_ifblank([$3], [true], [$3])], [modstate=yes], [modstate=missing])],
        [modstate=disabled])
   ])
-  _MODULE_BLOCK_ADD(modcond, [$modstate])
+  _MODULE_BLOCK_ADD(modcond[_STATE], [$modstate])
   AS_VAR_IF([modstate], [yes], [
     m4_ifblank([$4], [], [_MODULE_BLOCK_ADD([MODULE_]m4_toupper([$1])[_CFLAGS], [$4])])
     m4_ifblank([$5], [], [_MODULE_BLOCK_ADD([MODULE_]m4_toupper([$1])[_LDFLAGS], [$5])])
@@ -6830,7 +6830,7 @@ AC_DEFUN([PY_STDLIB_MOD_SIMPLE], [
   dnl Check if module has been disabled by PY_STDLIB_MOD_SET_NA()
   AS_IF([test "$modstate" != "n/a"], [modstate=yes])
   AM_CONDITIONAL(modcond, [test "$modstate" = yes])
-  _MODULE_BLOCK_ADD(modcond, [$modstate])
+  _MODULE_BLOCK_ADD(modcond[_STATE], [$modstate])
   AS_VAR_IF([modstate], [yes], [
     m4_ifblank([$2], [], [_MODULE_BLOCK_ADD([MODULE_]m4_toupper([$1])[_CFLAGS], [$2])])
     m4_ifblank([$3], [], [_MODULE_BLOCK_ADD([MODULE_]m4_toupper([$1])[_LDFLAGS], [$3])])

--- a/setup.py
+++ b/setup.py
@@ -318,7 +318,7 @@ class PyBuildExt(build_ext):
         if update_flags:
             self.update_extension_flags(ext)
 
-        state = sysconfig.get_config_var(f"MODULE_{ext.name.upper()}")
+        state = sysconfig.get_config_var(f"MODULE_{ext.name.upper()}_STATE")
         if state == "yes":
             self.extensions.append(ext)
         elif state == "disabled":
@@ -329,7 +329,7 @@ class PyBuildExt(build_ext):
             # not available on current platform
             pass
         else:
-            # not migrated to MODULE_{name} yet.
+            # not migrated to MODULE_{name}_STATE yet.
             self.announce(
                 f'WARNING: Makefile is missing module variable for "{ext.name}"',
                 level=2


### PR DESCRIPTION
It makes it easier to look for module states in sysconfig without
special casing suffixes "_CFLAGS", "_DEPS", "_LDFLAGS", "_OBJS",
and "CTYPES_MALLOC_CLOSURE".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-90005 -->
* Issue: gh-90005
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:tiran