### PR TITLE
gh-87347: Fix test_pymem_new() reference leak

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4189,39 +4189,39 @@ test_pymem_alloc0(PyObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 static PyObject *
-test_pymem_new(PyObject *self, PyObject *Py_UNUSED(ignored))
+test_pyobject_new(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
-    char *ptr;
+    PyObject *obj;
     PyTypeObject *type = &PyBaseObject_Type;
     PyTypeObject *var_type = &PyLong_Type;
 
     // PyObject_New()
-    ptr = PyObject_New(char, type);
-    if (ptr == NULL) {
+    obj = PyObject_New(PyObject, type);
+    if (obj == NULL) {
         goto alloc_failed;
     }
-    PyObject_Free(ptr);
+    Py_DECREF(obj);
 
     // PyObject_NEW()
-    ptr = PyObject_NEW(char, type);
-    if (ptr == NULL) {
+    obj = PyObject_NEW(PyObject, type);
+    if (obj == NULL) {
         goto alloc_failed;
     }
-    PyObject_Free(ptr);
+    Py_DECREF(obj);
 
     // PyObject_NewVar()
-    ptr = PyObject_NewVar(char, var_type, 3);
-    if (ptr == NULL) {
+    obj = PyObject_NewVar(PyObject, var_type, 3);
+    if (obj == NULL) {
         goto alloc_failed;
     }
-    PyObject_Free(ptr);
+    Py_DECREF(obj);
 
     // PyObject_NEW_VAR()
-    ptr = PyObject_NEW_VAR(char, var_type, 3);
-    if (ptr == NULL) {
+    obj = PyObject_NEW_VAR(PyObject, var_type, 3);
+    if (obj == NULL) {
         goto alloc_failed;
     }
-    PyObject_Free(ptr);
+    Py_DECREF(obj);
 
     Py_RETURN_NONE;
 
@@ -6326,7 +6326,7 @@ static PyMethodDef TestMethods[] = {
     {"with_tp_del",             with_tp_del,                     METH_VARARGS},
     {"create_cfunction",        create_cfunction,                METH_NOARGS},
     {"test_pymem_alloc0",       test_pymem_alloc0,               METH_NOARGS},
-    {"test_pymem_new",          test_pymem_new,                  METH_NOARGS},
+    {"test_pyobject_new",       test_pyobject_new,               METH_NOARGS},
     {"test_pymem_setrawallocators",test_pymem_setrawallocators,  METH_NOARGS},
     {"test_pymem_setallocators",test_pymem_setallocators,        METH_NOARGS},
     {"test_pyobject_setallocators",test_pyobject_setallocators,  METH_NOARGS},


### PR DESCRIPTION
Delete the allocated object with Py_DECREF() rather than
PyObject_Free().

Rename also test_pymem_new() to test_pyobject_new().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-87347 -->
* Issue: gh-87347
<!-- /gh-issue-number -->
