### PR TITLE
[3.11] gh-90473: Reduce recursion limit on WASI even further (GH-94333) (GH-94334)

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -12,11 +12,12 @@ extern "C" {
 struct pyruntimestate;
 struct _ceval_runtime_state;
 
-/* WASI has limited call stack. wasmtime 0.36 can handle sufficient amount of
-   C stack frames for little more than 750 recursions. */
+/* WASI has limited call stack. Python's recursion limit depends on code
+   layout, optimization, and WASI runtime. Wasmtime can handle about 700-750
+   recursions, sometimes less. 600 is a more conservative limit. */
 #ifndef Py_DEFAULT_RECURSION_LIMIT
 #  ifdef __wasi__
-#    define Py_DEFAULT_RECURSION_LIMIT 750
+#    define Py_DEFAULT_RECURSION_LIMIT 600
 #  else
 #    define Py_DEFAULT_RECURSION_LIMIT 1000
 #  endif

--- a/Lib/test/test_tomllib/test_misc.py
+++ b/Lib/test/test_tomllib/test_misc.py
@@ -92,8 +92,8 @@ class TestMiscellaneous(unittest.TestCase):
         self.assertEqual(obj_copy, expected_obj)
 
     def test_inline_array_recursion_limit(self):
-        # 470 with default recursion limit
-        nest_count = int(sys.getrecursionlimit() * 0.47)
+        # 465 with default recursion limit
+        nest_count = int(sys.getrecursionlimit() * 0.465)
         recursive_array_toml = "arr = " + nest_count * "[" + nest_count * "]"
         tomllib.loads(recursive_array_toml)
 


### PR DESCRIPTION
750 fails sometimes with newer wasmtime versions. 600 is a more
conservative value.
(cherry picked from commit e5e51556e45ff70053b8a7f90a07ded966401911)

Co-authored-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-90473 -->
* Issue: gh-90473
<!-- /gh-issue-number -->
