### PR TITLE
gh-94338: fix(distutils): ignore case when checking .exe suffix in find_executable

### DIFF
--- a/Lib/distutils/spawn.py
+++ b/Lib/distutils/spawn.py
@@ -99,7 +99,7 @@ def find_executable(executable, path=None):
     os.environ['PATH'].  Returns the complete filename or None if not found.
     """
     _, ext = os.path.splitext(executable)
-    if (sys.platform == 'win32') and (ext != '.exe'):
+    if (sys.platform == 'win32') and (ext.lower() != '.exe'):
         executable = executable + '.exe'
 
     if os.path.isfile(executable):

--- a/Lib/distutils/tests/test_spawn.py
+++ b/Lib/distutils/tests/test_spawn.py
@@ -67,6 +67,11 @@ class SpawnTestCase(support.TempdirManager,
                 rv = find_executable(program_noeext, path=tmp_dir)
                 self.assertEqual(rv, filename)
 
+            if sys.platform == 'win32':
+                # test with uppercase ".EXE" extension
+                rv = find_executable(program_noeext + ".EXE", path=tmp_dir)
+                self.assertEqual(rv, filename)
+
             # test find in the current directory
             with os_helper.change_cwd(tmp_dir):
                 rv = find_executable(program)

--- a/Misc/NEWS.d/next/Library/2022-06-27-16-19-53.gh-issue-94338.zvqbg0.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-27-16-19-53.gh-issue-94338.zvqbg0.rst
@@ -1,0 +1,1 @@
+Ignore suffix case on Windows in `find_executable`.


### PR DESCRIPTION
Fixes #94338

<!-- gh-issue-number: gh-94338 -->
* Issue: gh-94338
<!-- /gh-issue-number -->
