### PR TITLE
gh-94350: mailbox: Remove support for text mode files

### DIFF
--- a/Doc/library/mailbox.rst
+++ b/Doc/library/mailbox.rst
@@ -768,8 +768,7 @@ Supported mailbox formats are Maildir, mbox, MH, Babyl, and MMDF.
    possible if *message* is a :class:`Message` instance. If *message* is a string,
    a byte string,
    or a file, it should contain an :rfc:`2822`\ -compliant message, which is read
-   and parsed.  Files should be open in binary mode, but text mode files
-   are accepted for backward compatibility.
+   and parsed.  Files should be open in binary mode.
 
    The format-specific state and behaviors offered by subclasses vary, but in
    general it is only the properties that are not specific to a particular
@@ -786,6 +785,9 @@ Supported mailbox formats are Maildir, mbox, MH, Babyl, and MMDF.
    not be acceptable. For such situations, :class:`Mailbox` instances also
    offer string and file-like representations, and a custom message factory may
    be specified when a :class:`Mailbox` instance is initialized.
+
+   .. versionchanged:: 3.12
+      Text mode files are no longer accepted.
 
 
 .. _mailbox-maildirmessage:

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -273,6 +273,11 @@ Removed
   use :func:`locale.format_string` instead.
   (Contributed by Victor Stinner in :gh:`94226`.)
 
+* The :mod:`mailbox` no longer accepts text mode files and
+  :class:`io.StringIO`. The support for text files was marked as deprecated
+  since Python 3.2. The module now only accepts binary files and
+  :class:`io.BytesIO`.
+  (Contributed by Victor Stinner in :gh:`94350`.)
 
 Porting to Python 3.12
 ======================

--- a/Lib/mailbox.py
+++ b/Lib/mailbox.py
@@ -6,18 +6,17 @@
 # or returning from a flush() method.  See functions _sync_flush() and
 # _sync_close().
 
-import os
-import time
 import calendar
-import socket
-import errno
-import copy
-import warnings
-import email
-import email.message
-import email.generator
-import io
 import contextlib
+import copy
+import email
+import email.generator
+import email.message
+import errno
+import io
+import os
+import socket
+import time
 from types import GenericAlias
 try:
     import fcntl
@@ -222,10 +221,6 @@ class Mailbox:
                 # Make sure the message ends with a newline
                 target.write(linesep)
         elif isinstance(message, (str, bytes, io.StringIO)):
-            if isinstance(message, io.StringIO):
-                warnings.warn("Use of StringIO input is deprecated, "
-                    "use BytesIO instead", DeprecationWarning, 3)
-                message = message.getvalue()
             if isinstance(message, str):
                 message = self._string_to_bytes(message)
             if mangle_from_:
@@ -236,10 +231,6 @@ class Mailbox:
                 # Make sure the message ends with a newline
                 target.write(linesep)
         elif hasattr(message, 'read'):
-            if hasattr(message, 'buffer'):
-                warnings.warn("Use of text mode files is deprecated, "
-                    "use a binary mode file instead", DeprecationWarning, 3)
-                message = message.buffer
             lastline = None
             while True:
                 line = message.readline()
@@ -1431,10 +1422,6 @@ class Babyl(_singlefileMailbox):
                     break
                 self._file.write(buffer.replace(b'\n', linesep))
         elif isinstance(message, (bytes, str, io.StringIO)):
-            if isinstance(message, io.StringIO):
-                warnings.warn("Use of StringIO input is deprecated, "
-                    "use BytesIO instead", DeprecationWarning, 3)
-                message = message.getvalue()
             if isinstance(message, str):
                 message = self._string_to_bytes(message)
             body_start = message.find(b'\n\n') + 2
@@ -1447,10 +1434,6 @@ class Babyl(_singlefileMailbox):
                 self._file.write(b'*** EOOH ***' + linesep + linesep)
                 self._file.write(message.replace(b'\n', linesep))
         elif hasattr(message, 'readline'):
-            if hasattr(message, 'buffer'):
-                warnings.warn("Use of text mode files is deprecated, "
-                    "use a binary mode file instead", DeprecationWarning, 3)
-                message = message.buffer
             original_pos = message.tell()
             first_pass = True
             while True:

--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -80,12 +80,8 @@ class TestMailbox(TestBase):
         self.assertEqual(len(self._box), 5)
         keys.append(self._box.add(_bytes_sample_message))
         self.assertEqual(len(self._box), 6)
-        with self.assertWarns(DeprecationWarning):
-            keys.append(self._box.add(
-                io.TextIOWrapper(io.BytesIO(_bytes_sample_message), encoding="utf-8")))
-        self.assertEqual(len(self._box), 7)
         self.assertEqual(self._box.get_string(keys[0]), self._template % 0)
-        for i in (1, 2, 3, 4, 5, 6):
+        for i in range(1, 6):
             self._check_sample(self._box[keys[i]])
 
     _nonascii_msg = textwrap.dedent("""\
@@ -163,28 +159,6 @@ class TestMailbox(TestBase):
             key = self._box.add(f)
         self.assertEqual(self._box.get_bytes(key).split(b'\n'),
             self._non_latin_bin_msg.split(b'\n'))
-
-    def test_add_text_file_warns(self):
-        with tempfile.TemporaryFile('w+', encoding='utf-8') as f:
-            f.write(_sample_message)
-            f.seek(0)
-            with self.assertWarns(DeprecationWarning):
-                key = self._box.add(f)
-        self.assertEqual(self._box.get_bytes(key).split(b'\n'),
-            _bytes_sample_message.split(b'\n'))
-
-    def test_add_StringIO_warns(self):
-        with self.assertWarns(DeprecationWarning):
-            key = self._box.add(io.StringIO(self._template % "0"))
-        self.assertEqual(self._box.get_string(key), self._template % "0")
-
-    def test_add_nonascii_StringIO_raises(self):
-        with self.assertWarns(DeprecationWarning):
-            with self.assertRaisesRegex(ValueError, "ASCII-only"):
-                self._box.add(io.StringIO(self._nonascii_msg))
-        self.assertEqual(len(self._box), 0)
-        self._box.close()
-        self.assertMailboxEmpty()
 
     def test_remove(self):
         # Remove messages using remove()

--- a/Misc/NEWS.d/next/Library/2022-06-28-00-02-58.gh-issue-94350.1ic4T8.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-28-00-02-58.gh-issue-94350.1ic4T8.rst
@@ -1,0 +1,4 @@
+The :mod:`mailbox` no longer accepts text mode files and
+:class:`io.StringIO`. The support for text files was marked as deprecated
+since Python 3.2. The module now only accepts binary files and
+:class:`io.BytesIO`. Patch by Victor Stinner.


### PR DESCRIPTION
The mailbox module now only accepts binary files and BytesIO: text
mode files and StringIO are no longer accepted. The support fort text
mode files was deprecated since Python 3.2.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94350 -->
* Issue: gh-94350
<!-- /gh-issue-number -->
