### PR TITLE
gh-94352: shlex.split() no longer accepts None

### DIFF
--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -36,9 +36,9 @@ The :mod:`shlex` module defines the following functions:
       instance, passing ``None`` for *s* will read the string to split from
       standard input.
 
-   .. deprecated:: 3.9
-      Passing ``None`` for *s* will raise an exception in future Python
-      versions.
+   .. versionchanged:: 3.12
+      Passing ``None`` for *s* argument now raises an exception, rather than
+      reading :data:`sys.stdin`.
 
 .. function:: join(split_command)
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -324,6 +324,11 @@ Changes in the Python API
   to :term:`filesystem encoding and error handler`.
   Argument files should be encoded in UTF-8 instead of ANSI Codepage on Windows.
 
+* :func:`shlex.split`: Passing ``None`` for *s* argument now raises an
+  exception, rather than reading :data:`sys.stdin`. The feature was deprecated
+  in Python 3.9.
+  (Contributed by Victor Stinner in :gh:`94352`.)
+
 
 Build Changes
 =============

--- a/Lib/shlex.py
+++ b/Lib/shlex.py
@@ -305,9 +305,7 @@ class shlex:
 def split(s, comments=False, posix=True):
     """Split the string *s* using shell-like syntax."""
     if s is None:
-        import warnings
-        warnings.warn("Passing None for 's' to shlex.split() is deprecated.",
-                      DeprecationWarning, stacklevel=2)
+        raise ValueError("s argument must not be None")
     lex = shlex(s, posix=posix)
     lex.whitespace_split = True
     if not comments:

--- a/Lib/test/test_shlex.py
+++ b/Lib/test/test_shlex.py
@@ -162,9 +162,8 @@ class ShlexTest(unittest.TestCase):
             tok = lex.get_token()
         return ret
 
-    @mock.patch('sys.stdin', io.StringIO())
-    def testSplitNoneDeprecation(self):
-        with self.assertWarns(DeprecationWarning):
+    def testSplitNone(self):
+        with self.assertRaises(ValueError):
             shlex.split(None)
 
     def testSplitPosix(self):

--- a/Misc/NEWS.d/next/Library/2022-06-28-00-24-48.gh-issue-94352.JY1Ayt.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-28-00-24-48.gh-issue-94352.JY1Ayt.rst
@@ -1,0 +1,3 @@
+:func:`shlex.split`: Passing ``None`` for *s* argument now raises an exception,
+rather than reading :data:`sys.stdin`. The feature was deprecated in Python
+3.9. Patch by Victor Stinner.


### PR DESCRIPTION
shlex.split(): Passing None for s argument now raises an exception.
Read sys.stdin instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94352 -->
* Issue: gh-94352
<!-- /gh-issue-number -->
