### PR TITLE
gh-91719: Reload opcode on unknown error so that C can optimize the dispatching in ceval.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-29-22-18-36.gh-issue-91719.3APYYI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-29-22-18-36.gh-issue-91719.3APYYI.rst
@@ -1,2 +1,2 @@
-The MSVC compiler is now expected to generate faster switch code to dispatch
-an opcode in the interpreter main loop, reducing memory access instructions.
+Reload ``opcode`` when raising ``unknown opcode error`` in the interpreter main loop,
+for C compilers to generate dispatching code independently.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-29-22-18-36.gh-issue-91719.3APYYI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-29-22-18-36.gh-issue-91719.3APYYI.rst
@@ -1,0 +1,2 @@
+The MSVC compiler is now expected to generate faster switch code in the 
+interpreter main loop, which reduces memory access in dispatching opcode.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-29-22-18-36.gh-issue-91719.3APYYI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-29-22-18-36.gh-issue-91719.3APYYI.rst
@@ -1,1 +1,2 @@
-The MSVC compiler is now expected to generate faster switch code in the interpreter main loop, which reduces memory access in dispatching an opcode.
+The MSVC compiler is now expected to generate faster switch code to dispatch
+an opcode in the interpreter main loop, reducing memory access instructions.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-29-22-18-36.gh-issue-91719.3APYYI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-29-22-18-36.gh-issue-91719.3APYYI.rst
@@ -1,2 +1,1 @@
-The MSVC compiler is now expected to generate faster switch code in the 
-interpreter main loop, which reduces memory access in dispatching opcode.
+The MSVC compiler is now expected to generate faster switch code in the interpreter main loop, which reduces memory access in dispatching an opcode.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5705,7 +5705,9 @@ handle_eval_breaker:
         _unknown_opcode:
 #else
         EXTRA_CASES  // From opcode.h, a 'case' for each unused opcode
-            /* Load opcode for MSVC to optimize switch(opcode) separately */
+            /* Load opcode for MSVC to optimize switch(opcode) separately.
+               next_instr, which EXTRA_CASES do not increment, points
+               the current instruction here. */
             opcode = _Py_OPCODE(*next_instr);
 #endif
             fprintf(stderr, "XXX lineno: %d, opcode: %d\n",

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5706,7 +5706,7 @@ handle_eval_breaker:
 #else
         EXTRA_CASES  // From opcode.h, a 'case' for each unused opcode
 #endif
-            /* Load opcode for MSVC to optimize switch(opcode) separately.
+            /* Reload opcode for MSVC to optimize switch(opcode) separately.
                next_instr, which EXTRA_CASES do not increment, points
                the current instruction here. */
             opcode = _Py_OPCODE(*next_instr);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5705,6 +5705,8 @@ handle_eval_breaker:
         _unknown_opcode:
 #else
         EXTRA_CASES  // From opcode.h, a 'case' for each unused opcode
+            /* Load opcode for MSVC to optimize switch(opcode) separately */
+            opcode = _Py_OPCODE(*next_instr);
 #endif
             fprintf(stderr, "XXX lineno: %d, opcode: %d\n",
                     _PyInterpreterFrame_GetLine(frame),  opcode);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5706,9 +5706,8 @@ handle_eval_breaker:
 #else
         EXTRA_CASES  // From opcode.h, a 'case' for each unused opcode
 #endif
-            /* Reload opcode for MSVC to optimize switch(opcode) separately.
-               next_instr, which EXTRA_CASES do not increment, points
-               the current instruction here. */
+            /* Tell C compilers not to hold the opcode variable in the loop.
+               next_instr points the current instruction without TARGET(). */
             opcode = _Py_OPCODE(*next_instr);
             fprintf(stderr, "XXX lineno: %d, opcode: %d\n",
                     _PyInterpreterFrame_GetLine(frame),  opcode);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5705,11 +5705,11 @@ handle_eval_breaker:
         _unknown_opcode:
 #else
         EXTRA_CASES  // From opcode.h, a 'case' for each unused opcode
+#endif
             /* Load opcode for MSVC to optimize switch(opcode) separately.
                next_instr, which EXTRA_CASES do not increment, points
                the current instruction here. */
             opcode = _Py_OPCODE(*next_instr);
-#endif
             fprintf(stderr, "XXX lineno: %d, opcode: %d\n",
                     _PyInterpreterFrame_GetLine(frame),  opcode);
             _PyErr_SetString(tstate, PyExc_SystemError, "unknown opcode");


### PR DESCRIPTION
This patch helps MSVC to optimize the switch code in `_PyEval_EvalFrameDefault()`, making the situation in which only the dispatcher reads the given `opcode` variable on non-debug builds.

Currently, each case loads an opcode from other places when needed, except `unknown opcode` case.

https://github.com/faster-cpython/ideas/issues/422

<!-- gh-issue-number: gh-91719 -->
* Issue: gh-91719
<!-- /gh-issue-number -->
