### PR TITLE
gh-86404: [doc] Fix missing space in idle documentation.

### DIFF
--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -594,7 +594,7 @@ One may edit pasted code first.
 If one pastes more than one statement into Shell, the result will be a
 :exc:`SyntaxError` when multiple statements are compiled as if they were one.
 
-Lines containing`'RESTART'` mean that the user execution process has been
+Lines containing ``'RESTART'`` mean that the user execution process has been
 re-started.  This occurs when the user execution process has crashed,
 when one requests a restart on the Shell menu, or when one runs code
 in an editor window.


### PR DESCRIPTION
This should have been spotted by sphinx-lint, tracked here:

https://github.com/sphinx-contrib/sphinx-lint/issues/39

Introduced in https://github.com/python/cpython/pull/94349 so it needs a backport to 3.11 and 3.10.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-86404 -->
* Issue: gh-86404
<!-- /gh-issue-number -->
