### PR TITLE
gh-51511: Note that codecs.open()'s encoding parameter affects automatic conversion to binary mode

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -189,7 +189,8 @@ wider range of codecs when working with binary files:
 
    .. note::
 
-      Underlying encoded files are always opened in binary mode.
+      If ``encoding`` is not None, then the
+      underlying encoded files are always opened in binary mode.
       No automatic conversion of ``'\n'`` is done on reading and writing.
       The *mode* argument may be any binary mode acceptable to the built-in
       :func:`open` function; the ``'b'`` is automatically added.

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -189,7 +189,7 @@ wider range of codecs when working with binary files:
 
    .. note::
 
-      If ``encoding`` is not None, then the
+      If *encoding* is not ``None``, then the
       underlying encoded files are always opened in binary mode.
       No automatic conversion of ``'\n'`` is done on reading and writing.
       The *mode* argument may be any binary mode acceptable to the built-in

--- a/Lib/codecs.py
+++ b/Lib/codecs.py
@@ -878,7 +878,8 @@ def open(filename, mode='r', encoding=None, errors='strict', buffering=-1):
         codecs. Output is also codec dependent and will usually be
         Unicode as well.
 
-        Underlying encoded files are always opened in binary mode.
+        If encoding is not None, then the
+        underlying encoded files are always opened in binary mode.
         The default file mode is 'r', meaning to open the file in read mode.
 
         encoding specifies the encoding which is to be used for the

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -708,7 +708,8 @@ class UTF16Test(ReadTest, unittest.TestCase):
                                          "spamspam", self.spambe)
 
     def test_bug691291(self):
-        # Files are always opened in binary mode, even if no binary mode was
+        # If encoding is not None, then
+        # files are always opened in binary mode, even if no binary mode was
         # specified.  This means that no automatic conversion of '\n' is done
         # on reading and writing.
         s1 = 'Hello\r\nworld\r\n'


### PR DESCRIPTION
#51511

Partially related: #54553

[codecs.open docs](https://docs.python.org/3/library/codecs.html#codecs.open)

See https://github.com/python/cpython/blob/bc7f6fcdf14da32a8f7816ace800a6a91dc1554f/Lib/codecs.py#L901-L904

Affected lines found by `grep 'always opened in binary' -r`