### PR TITLE
GH-94262: Don't create frame objects for frames that aren't complete.

### DIFF
--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -210,6 +210,13 @@ PyGenObject *_PyFrame_GetGenerator(_PyInterpreterFrame *frame)
     return (PyGenObject *)(((char *)frame) - offset_in_gen);
 }
 
+
+static inline bool
+_PyFrame_IsIncomplete(_PyInterpreterFrame *frame)
+{
+    return frame->prev_instr < _PyCode_CODE(frame->f_code) + frame->f_code->_co_firsttraceable;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -210,7 +210,10 @@ PyGenObject *_PyFrame_GetGenerator(_PyInterpreterFrame *frame)
     return (PyGenObject *)(((char *)frame) - offset_in_gen);
 }
 
-
+/* Determine whether a frame is incomplete.
+ * A frame is incomplete until the first RESUME instruction
+ * as it may be part way through creating cell objects or a
+ * generator or coroutine. */
 static inline bool
 _PyFrame_IsIncomplete(_PyInterpreterFrame *frame)
 {

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -134,6 +134,21 @@ _PyFrame_SetStackPointer(_PyInterpreterFrame *frame, PyObject **stack_pointer)
     frame->stacktop = (int)(stack_pointer - frame->localsplus);
 }
 
+/* Determine whether a frame is incomplete.
+ * A frame is incomplete if it is part way through
+ * creating cell objects or a generator or coroutine.
+ *
+ * Frames on the frame stack are incomplete until the
+ * first RESUME instruction.
+ * Frames owned by a generator are always complete.
+ */
+static inline bool
+_PyFrame_IsIncomplete(_PyInterpreterFrame *frame)
+{
+    return frame->owner != FRAME_OWNED_BY_GENERATOR &&
+    frame->prev_instr < _PyCode_CODE(frame->f_code) + frame->f_code->_co_firsttraceable;
+}
+
 /* For use by _PyFrame_GetFrameObject
   Do not call directly. */
 PyFrameObject *
@@ -145,6 +160,8 @@ _PyFrame_MakeAndSetFrameObject(_PyInterpreterFrame *frame);
 static inline PyFrameObject *
 _PyFrame_GetFrameObject(_PyInterpreterFrame *frame)
 {
+
+    assert(!_PyFrame_IsIncomplete(frame));
     PyFrameObject *res =  frame->frame_obj;
     if (res != NULL) {
         return res;
@@ -208,16 +225,6 @@ PyGenObject *_PyFrame_GetGenerator(_PyInterpreterFrame *frame)
     assert(frame->owner == FRAME_OWNED_BY_GENERATOR);
     size_t offset_in_gen = offsetof(PyGenObject, gi_iframe);
     return (PyGenObject *)(((char *)frame) - offset_in_gen);
-}
-
-/* Determine whether a frame is incomplete.
- * A frame is incomplete until the first RESUME instruction
- * as it may be part way through creating cell objects or a
- * generator or coroutine. */
-static inline bool
-_PyFrame_IsIncomplete(_PyInterpreterFrame *frame)
-{
-    return frame->prev_instr < _PyCode_CODE(frame->f_code) + frame->f_code->_co_firsttraceable;
 }
 
 #ifdef __cplusplus

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -170,6 +170,21 @@ class GeneratorTest(unittest.TestCase):
             g.send(0)
         self.assertEqual(next(g), 1)
 
+    def test_handle_frame_object_in_creation(self):
+
+        def cb(*args):
+            try:
+                sys._getframe(1)
+            except ValueError:
+                pass
+
+        gc.set_threshold(1, 0, 0)
+        gc.callbacks.append(cb)
+
+        def gen():
+            yield 1
+
+        gen()
 
 class ExceptionTest(unittest.TestCase):
     # Tests for the issue #23353: check that the currently handled exception

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -193,10 +193,7 @@ class GeneratorTest(unittest.TestCase):
 
         class Sneaky:
             def __del__(self):
-                try:
-                    raise KeyboardInterrupt
-                except:
-                    pass
+                inspect.stack()
 
         sneaky = Sneaky()
         sneaky._s = Sneaky()

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -182,6 +182,7 @@ class GeneratorTest(unittest.TestCase):
             yield 1
 
         thresholds = gc.get_threshold()
+
         gc.callbacks.append(cb)
         gc.set_threshold(1, 0, 0)
         try:
@@ -197,11 +198,14 @@ class GeneratorTest(unittest.TestCase):
         sneaky = Sneaky()
         sneaky._s = Sneaky()
         sneaky._s._s = sneaky
-        del sneaky
 
         gc.set_threshold(1, 0, 0)
         try:
-            gen()
+            del sneaky
+            try:
+                gen()
+            except KeyboardInterrupt:
+                pass
         finally:
             gc.set_threshold(*thresholds)
 

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -178,13 +178,18 @@ class GeneratorTest(unittest.TestCase):
             except ValueError:
                 pass
 
-        gc.set_threshold(1, 0, 0)
-        gc.callbacks.append(cb)
-
         def gen():
             yield 1
 
-        gen()
+        thresholds = gc.get_threshold()
+        gc.callbacks.append(cb)
+        gc.set_threshold(1, 0, 0)
+
+        try:
+            gen()
+        finally:
+            gc.set_threshold(*thresholds)
+            gc.callbacks.pop()
 
 class ExceptionTest(unittest.TestCase):
     # Tests for the issue #23353: check that the currently handled exception

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -193,7 +193,10 @@ class GeneratorTest(unittest.TestCase):
 
         class Sneaky:
             def __del__(self):
-                raise KeyboardInterrupt
+                try:
+                    raise KeyboardInterrupt
+                except:
+                    pass
 
         sneaky = Sneaky()
         sneaky._s = Sneaky()
@@ -202,10 +205,7 @@ class GeneratorTest(unittest.TestCase):
         gc.set_threshold(1, 0, 0)
         try:
             del sneaky
-            try:
-                gen()
-            except KeyboardInterrupt:
-                pass
+            gen()
         finally:
             gc.set_threshold(*thresholds)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-28-10-08-06.gh-issue-94262.m-HWUZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-28-10-08-06.gh-issue-94262.m-HWUZ.rst
@@ -1,0 +1,3 @@
+Don't create frame objects for incomplete frames. Prevents the creation of
+generators and closures from being observable to Python and C extensions,
+restoring the behavior of 3.10 and earlier.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -638,11 +638,10 @@ PyCode_New(int argcount, int kwonlyargcount,
                                      exceptiontable);
 }
 
-static const char assert0[4] = {
-    LOAD_ASSERTION_ERROR,
-    0,
-    RAISE_VARARGS,
-    1
+static const char assert0[6] = {
+    RESUME, 0,
+    LOAD_ASSERTION_ERROR, 0,
+    RAISE_VARARGS, 1
 };
 
 PyCodeObject *
@@ -666,7 +665,7 @@ PyCode_NewEmpty(const char *filename, const char *funcname, int firstlineno)
     if (filename_ob == NULL) {
         goto failed;
     }
-    code_ob = PyBytes_FromStringAndSize(assert0, 4);
+    code_ob = PyBytes_FromStringAndSize(assert0, 6);
     if (code_ob == NULL) {
         goto failed;
     }

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1169,8 +1169,14 @@ PyFrame_GetBack(PyFrameObject *frame)
 {
     assert(frame != NULL);
     PyFrameObject *back = frame->f_back;
-    if (back == NULL && frame->f_frame->previous != NULL) {
-        back = _PyFrame_GetFrameObject(frame->f_frame->previous);
+    if (back == NULL) {
+        _PyInterpreterFrame *prev = frame->f_frame->previous;
+        while (prev && _PyFrame_IsIncomplete(prev)) {
+            prev = prev->previous;
+        }
+        if (prev) {
+            back = _PyFrame_GetFrameObject(prev);
+        }
     }
     Py_XINCREF(back);
     return back;

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -68,9 +68,13 @@ take_ownership(PyFrameObject *f, _PyInterpreterFrame *frame)
     f->f_frame = frame;
     frame->owner = FRAME_OWNED_BY_FRAME_OBJECT;
     assert(f->f_back == NULL);
-    if (frame->previous != NULL) {
+    _PyInterpreterFrame *prev = frame->previous;
+    while (prev && _PyFrame_IsIncomplete(prev)) {
+        prev = prev->previous;
+    }
+    if (prev) {
         /* Link PyFrameObjects.f_back and remove link through _PyInterpreterFrame.previous */
-        PyFrameObject *back = _PyFrame_GetFrameObject(frame->previous);
+        PyFrameObject *back = _PyFrame_GetFrameObject(prev);
         if (back == NULL) {
             /* Memory error here. */
             assert(PyErr_ExceptionMatches(PyExc_MemoryError));

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1776,9 +1776,17 @@ sys__getframe_impl(PyObject *module, int depth)
         return NULL;
     }
 
-    while (depth > 0 && frame != NULL) {
-        frame = frame->previous;
-        --depth;
+    if (frame != NULL) {
+        while (depth > 0) {
+            frame = frame->previous;
+            if (frame == NULL) {
+                break;
+            }
+            if (_PyFrame_IsIncomplete(frame)) {
+                continue;
+            }
+            --depth;
+        }
     }
     if (frame == NULL) {
         _PyErr_SetString(tstate, PyExc_ValueError,


### PR DESCRIPTION
Since 3.11 we have moved some low level operations to the bytecode which mean that frames can be in a partially constructed state during GC, or other operations that could expose them to Python code (or third party C code).

We already avoid tracing any instructions before the first `RESUME` when executing a frame.
This PR prevents creating a frame object before the first `RESUME` has been reached.



<!-- gh-issue-number: gh-94262 -->
* Issue: gh-94262
<!-- /gh-issue-number -->
