### PR TITLE
gh-88116: Avoid undefined behavior when decoding varints in code objects

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-28-12-41-17.gh-issue-88116.A7fEl_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-28-12-41-17.gh-issue-88116.A7fEl_.rst
@@ -1,0 +1,2 @@
+Fix an issue when reading line numbers from code objects if the encoded line
+numbers are close to ``INT_MIN``. Patch by Pablo Galindo

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -354,9 +354,9 @@ init_code(PyCodeObject *co, struct _PyCodeConstructor *con)
 static int
 scan_varint(const uint8_t *ptr)
 {
-    int read = *ptr++;
-    int val = read & 63;
-    int shift = 0;
+    unsigned int read = *ptr++;
+    unsigned int val = read & 63;
+    unsigned int shift = 0;
     while (read & 64) {
         read = *ptr++;
         shift += 6;
@@ -368,7 +368,7 @@ scan_varint(const uint8_t *ptr)
 static int
 scan_signed_varint(const uint8_t *ptr)
 {
-    int uval = scan_varint(ptr);
+    unsigned int uval = scan_varint(ptr);
     if (uval & 1) {
         return -(int)(uval >> 1);
     }
@@ -847,9 +847,9 @@ read_byte(PyCodeAddressRange *bounds)
 static int
 read_varint(PyCodeAddressRange *bounds)
 {
-    int read = read_byte(bounds);
-    int val = read & 63;
-    int shift = 0;
+    unsigned int read = read_byte(bounds);
+    unsigned int val = read & 63;
+    unsigned int shift = 0;
     while (read & 64) {
         read = read_byte(bounds);
         shift += 6;
@@ -861,7 +861,7 @@ read_varint(PyCodeAddressRange *bounds)
 static int
 read_signed_varint(PyCodeAddressRange *bounds)
 {
-    int uval = read_varint(bounds);
+    unsigned int uval = read_varint(bounds);
     if (uval & 1) {
         return -(int)(uval >> 1);
     }


### PR DESCRIPTION
 It seems like we'll fail to correctly decode a varint between INT_MAX
 and UINT_MAX or if a signed varint is > INT_MAX / 2 or < INT_MIN / 2 as
 this is written today. In fact, it might left shift a 1 into the sign
 bit, which would be UB.

 Indeed, this test program shows the issue:

```

int main()
{
    int val = 2147483647;
    unsigned int shift = 1;
    std::cout << (val << shift) << std::endl;
}
```

As this prints -2.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-88116 -->
* Issue: gh-88116
<!-- /gh-issue-number -->
