### PR TITLE
gh-94379: Remove zipimport find_loader() and find_module() methods

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -299,6 +299,11 @@ Removed
   has no ``copy()`` method, only a ``__copy__()`` method.
   (Contributed by Victor Stinner in :gh:`94383`.)
 
+* :mod:`zipimport`: Remove ``find_loader()`` and ``find_module()`` methods,
+  deprecated in Python 3.10: use the ``find_spec()`` method instead.  See
+  :pep:`451` for the rationale.
+  (Contributed by Victor Stinner in :gh:`94379`.)
+
 
 Porting to Python 3.12
 ======================

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -460,12 +460,6 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         # PEP 302
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            find_mod = zi.find_module('spam')
-            self.assertIsNotNone(find_mod)
-            self.assertIsInstance(find_mod, zipimport.zipimporter)
-            self.assertFalse(find_mod.is_package('spam'))
-            load_mod = find_mod.load_module('spam')
-            self.assertEqual(find_mod.get_filename('spam'), load_mod.__file__)
 
             mod = zi.load_module(TESTPACK)
             self.assertEqual(zi.get_filename(TESTPACK), mod.__file__)
@@ -586,16 +580,6 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
 
         pkg_path = TEMP_ZIP + os.sep + packdir + TESTPACK2
         zi2 = zipimport.zipimporter(pkg_path)
-        # PEP 302
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            find_mod_dotted = zi2.find_module(TESTMOD)
-            self.assertIsNotNone(find_mod_dotted)
-            self.assertIsInstance(find_mod_dotted, zipimport.zipimporter)
-            self.assertFalse(zi2.is_package(TESTMOD))
-            load_mod = find_mod_dotted.load_module(TESTMOD)
-            self.assertEqual(
-                find_mod_dotted.get_filename(TESTMOD), load_mod.__file__)
 
         # PEP 451
         spec = zi2.find_spec(TESTMOD)

--- a/Lib/zipimport.py
+++ b/Lib/zipimport.py
@@ -102,64 +102,6 @@ class zipimporter(_bootstrap_external._LoaderBasics):
             self.prefix += path_sep
 
 
-    # Check whether we can satisfy the import of the module named by
-    # 'fullname', or whether it could be a portion of a namespace
-    # package. Return self if we can load it, a string containing the
-    # full path if it's a possible namespace portion, None if we
-    # can't load it.
-    def find_loader(self, fullname, path=None):
-        """find_loader(fullname, path=None) -> self, str or None.
-
-        Search for a module specified by 'fullname'. 'fullname' must be the
-        fully qualified (dotted) module name. It returns the zipimporter
-        instance itself if the module was found, a string containing the
-        full path name if it's possibly a portion of a namespace package,
-        or None otherwise. The optional 'path' argument is ignored -- it's
-        there for compatibility with the importer protocol.
-
-        Deprecated since Python 3.10. Use find_spec() instead.
-        """
-        _warnings.warn("zipimporter.find_loader() is deprecated and slated for "
-                       "removal in Python 3.12; use find_spec() instead",
-                       DeprecationWarning)
-        mi = _get_module_info(self, fullname)
-        if mi is not None:
-            # This is a module or package.
-            return self, []
-
-        # Not a module or regular package. See if this is a directory, and
-        # therefore possibly a portion of a namespace package.
-
-        # We're only interested in the last path component of fullname
-        # earlier components are recorded in self.prefix.
-        modpath = _get_module_path(self, fullname)
-        if _is_dir(self, modpath):
-            # This is possibly a portion of a namespace
-            # package. Return the string representing its path,
-            # without a trailing separator.
-            return None, [f'{self.archive}{path_sep}{modpath}']
-
-        return None, []
-
-
-    # Check whether we can satisfy the import of the module named by
-    # 'fullname'. Return self if we can, None if we can't.
-    def find_module(self, fullname, path=None):
-        """find_module(fullname, path=None) -> self or None.
-
-        Search for a module specified by 'fullname'. 'fullname' must be the
-        fully qualified (dotted) module name. It returns the zipimporter
-        instance itself if the module was found, or None if it wasn't.
-        The optional 'path' argument is ignored -- it's there for compatibility
-        with the importer protocol.
-
-        Deprecated since Python 3.10. Use find_spec() instead.
-        """
-        _warnings.warn("zipimporter.find_module() is deprecated and slated for "
-                       "removal in Python 3.12; use find_spec() instead",
-                       DeprecationWarning)
-        return self.find_loader(fullname, path)[0]
-
     def find_spec(self, fullname, target=None):
         """Create a ModuleSpec for the specified module.
 

--- a/Misc/NEWS.d/next/Library/2022-06-28-14-29-21.gh-issue-94379.RrgKfh.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-28-14-29-21.gh-issue-94379.RrgKfh.rst
@@ -1,0 +1,3 @@
+:mod:`zipimport`: Remove ``find_loader()`` and ``find_module()`` methods,
+deprecated in Python 3.10: use the ``find_spec()`` method instead. See
+:pep:`451` for the rationale. Patch by Victor Stinner.


### PR DESCRIPTION
zipimport: Remove find_loader() and find_module() methods, deprecated
in Python 3.10. Use the find_spec()` method instead. See PEP 451 for
the rationale.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94379 -->
* Issue: gh-94379
<!-- /gh-issue-number -->
