### PR TITLE
gh-94404: makesetup: use correct CFLAGS and macOS workaround

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-06-29-08-58-31.gh-issue-94404.3MadM6.rst
+++ b/Misc/NEWS.d/next/Build/2022-06-29-08-58-31.gh-issue-94404.3MadM6.rst
@@ -1,0 +1,2 @@
+``makesetup`` now works around an issue with sed on macOS and uses correct
+CFLAGS for object files that end up in a shared extension.

--- a/Modules/makesetup
+++ b/Modules/makesetup
@@ -1,4 +1,5 @@
 #! /bin/sh
+set -e
 
 # Convert templates into Makefile and config.c, based on the module
 # definitions found in the file Setup.
@@ -260,7 +261,7 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 			*) src='$(srcdir)/'"$srcdir/$src";;
 			esac
 			case $doconfig in
-			no)	cc="$cc \$(CCSHARED) \$(PY_CFLAGS_NODIST) \$(PY_CPPFLAGS)";;
+			no)	cc="$cc \$(PY_STDMODULE_CFLAGS) \$(CCSHARED)";;
 			*)
 				cc="$cc \$(PY_BUILTIN_MODULE_CFLAGS)";;
 			esac
@@ -322,8 +323,13 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 
 	case $makepre in
 	-)	;;
-	*)	sedf="@sed.in.$$"
-		trap 'rm -f $sedf' 0 1 2 3
+	*)
+		# macOS' sed has issues with 'a' command. Use 'r' command with an
+		# external replacement file instead.
+		sedf="@sed.in.$$"
+		sedr="@sed.replace.$$"
+		trap 'rm -f $sedf $sedr' 0 1 2 3
+		echo "$NL$NL$DEFS" | sed 's/\\$//' > $sedr
 		echo "1i\\" >$sedf
 		str="# Generated automatically from $makepre by makesetup."
 		echo "$str" >>$sedf
@@ -332,10 +338,10 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 		echo "s%_MODDISABLED_NAMES_%$DISABLED%" >>$sedf
 		echo "s%_MODOBJS_%$OBJS%" >>$sedf
 		echo "s%_MODLIBS_%$LIBS%" >>$sedf
-		echo "/Definitions added by makesetup/a$NL$NL$DEFS" >>$sedf
+		echo "/Definitions added by makesetup/r $sedr" >>$sedf
 		sed -f $sedf $makepre >Makefile
 		cat $rulesf >>Makefile
-		rm -f $sedf
+		rm -f $sedf $sedr
 	    ;;
 	esac
 


### PR DESCRIPTION
``makesetup`` now works around an issue with sed on macOS and uses correct
CFLAGS for object files that end up in a shared extension.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94404 -->
* Issue: gh-94404
<!-- /gh-issue-number -->
