### PR TITLE
[3.11] GH-93516: Drop broken assert, fixes GH-93769

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5611,10 +5611,6 @@ handle_eval_breaker:
         if (tstate->tracing == 0 &&
             INSTR_OFFSET() >= frame->f_code->_co_firsttraceable
         ) {
-            assert(
-                _PyOpcode_Deopt[first_instr[frame->f_code->_co_firsttraceable]]
-                == RESUME
-            );
             int instr_prev = _PyInterpreterFrame_LASTI(frame);
             frame->prev_instr = next_instr;
             TRACING_NEXTOPARG();


### PR DESCRIPTION
The ``assert`` is broken on big endian platforms and not present in the
main branch. Drop it.

Correct version would be ``_PyOpcode_Deopt[_Py_OPCODE(...)]`` instead of
``_PyOpcode_Deopt[...]``.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-93516 -->
* Issue: gh-93516
<!-- /gh-issue-number -->
