### PR TITLE
[3.11] gh-94404: Use module CFLAGS before PY_STDMODULE_CFLAGS (GH-94413) (GH-94415)

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -831,7 +831,7 @@ python.worker.js: $(srcdir)/Tools/wasm/python.worker.js
 
 ##########################################################################
 # Build static libmpdec.a
-LIBMPDEC_CFLAGS=$(PY_STDMODULE_CFLAGS) $(CCSHARED) @LIBMPDEC_CFLAGS@
+LIBMPDEC_CFLAGS=@LIBMPDEC_CFLAGS@ $(PY_STDMODULE_CFLAGS) $(CCSHARED)
 
 # for setup.py
 DECIMAL_CFLAGS=@LIBMPDEC_CFLAGS@
@@ -889,7 +889,7 @@ $(LIBMPDEC_A): $(LIBMPDEC_OBJS)
 
 ##########################################################################
 # Build static libexpat.a
-LIBEXPAT_CFLAGS=$(PY_STDMODULE_CFLAGS) $(CCSHARED) @LIBEXPAT_CFLAGS@
+LIBEXPAT_CFLAGS=@LIBEXPAT_CFLAGS@ $(PY_STDMODULE_CFLAGS) $(CCSHARED)
 
 # for setup.py
 EXPAT_CFLAGS=@LIBEXPAT_CFLAGS@

--- a/Misc/NEWS.d/next/Build/2022-06-29-08-58-31.gh-issue-94404.3MadM6.rst
+++ b/Misc/NEWS.d/next/Build/2022-06-29-08-58-31.gh-issue-94404.3MadM6.rst
@@ -1,2 +1,3 @@
 ``makesetup`` now works around an issue with sed on macOS and uses correct
-CFLAGS for object files that end up in a shared extension.
+CFLAGS for object files that end up in a shared extension. Module CFLAGS
+are used before PY_STDMODULE_CFLAGS to avoid clashes with system headers.

--- a/Modules/makesetup
+++ b/Modules/makesetup
@@ -260,13 +260,14 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 			\$*) ;;
 			*) src='$(srcdir)/'"$srcdir/$src";;
 			esac
+			# custom flags first, PY_STDMODULE_CFLAGS may contain -I with system libmpdec
 			case $doconfig in
-			no)	cc="$cc \$(PY_STDMODULE_CFLAGS) \$(CCSHARED)";;
+			no)	cc="$cc $cpps \$(PY_STDMODULE_CFLAGS) \$(CCSHARED)";;
 			*)
-				cc="$cc \$(PY_BUILTIN_MODULE_CFLAGS)";;
+				cc="$cc $cpps \$(PY_BUILTIN_MODULE_CFLAGS)";;
 			esac
 			# force rebuild when header file or module build flavor (static/shared) is changed
-			rule="$obj: $src \$(MODULE_${mods_upper}_DEPS) \$(PYTHON_HEADERS) Modules/config.c; $cc $cpps -c $src -o $obj"
+			rule="$obj: $src \$(MODULE_${mods_upper}_DEPS) \$(PYTHON_HEADERS) Modules/config.c; $cc -c $src -o $obj"
 			echo "$rule" >>$rulesf
 		done
 		case $doconfig in


### PR DESCRIPTION
``PY_STDMODULE_CFLAGS`` may contain include directories with system
headers. This can break compiling with built-in libmpdec.
(cherry picked from commit 6485c3c7267eeb4095530af474c43f1244cb492b)

Co-authored-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94404 -->
* Issue: gh-94404
<!-- /gh-issue-number -->
