### PR TITLE
gh-81054: Document that SimpleHTTPRequestHandler follows symbolic links

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -20,7 +20,9 @@ This module defines classes for implementing HTTP servers.
 .. warning::
 
     :mod:`http.server` is not recommended for production. It only implements
-    basic security checks.
+    basic security checks. :class:`SimpleHTTPRequestHandler` will follow
+    symbolic links when handling requests, this makes it possible for files
+    outside of the specified directory to be served.
 
 One class, :class:`HTTPServer`, is a :class:`socketserver.TCPServer` subclass.
 It creates and listens at the HTTP socket, dispatching the requests to a

--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -20,9 +20,7 @@ This module defines classes for implementing HTTP servers.
 .. warning::
 
     :mod:`http.server` is not recommended for production. It only implements
-    basic security checks. :class:`SimpleHTTPRequestHandler` will follow
-    symbolic links when handling requests, this makes it possible for files
-    outside of the specified directory to be served.
+    :ref:`basic security checks <http.server-security>`.
 
 One class, :class:`HTTPServer`, is a :class:`socketserver.TCPServer` subclass.
 It creates and listens at the HTTP socket, dispatching the requests to a
@@ -501,3 +499,14 @@ following command runs an HTTP/1.1 conformant server::
 the ``--cgi`` option::
 
         python -m http.server --cgi
+
+.. _http.server-security:
+
+Security Considerations
+-----------------------
+
+.. index:: pair: http.server; security
+
+:class:`SimpleHTTPRequestHandler` will follow symbolic links when handling
+requests, this makes it possible for files outside of the specified directory
+to be served.

--- a/Doc/library/security_warnings.rst
+++ b/Doc/library/security_warnings.rst
@@ -14,7 +14,7 @@ The following modules have specific security considerations:
   argument disabling known insecure and blocked algorithms
   <hashlib-usedforsecurity>`
 * :mod:`http.server` is not suitable for production use, only implementing
-  basic security checks
+  basic security checks. See the :ref:`security considerations <http.server-security>`.
 * :mod:`logging`: :ref:`Logging configuration uses eval()
   <logging-eval-security>`
 * :mod:`multiprocessing`: :ref:`Connection.recv() uses pickle


### PR DESCRIPTION
Documents that [`SimpleHTTPRequestHandler`](https://docs.python.org/3/library/http.server.html#http.server.SimpleHTTPRequestHandler) follows symbolic links when handling requests and explains the security implications.

Resolves #81054

<!-- gh-issue-number: gh-81054 -->
* Issue: gh-81054
<!-- /gh-issue-number -->
