### PR TITLE
Delete unused PC/empty.c

### DIFF
--- a/PC/empty.c
+++ b/PC/empty.c
@@ -1,6 +1,0 @@
-#include <windows.h>
-int __stdcall
-WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
-{
-    return 0;
-}


### PR DESCRIPTION
The file contains a `return 0` stub implementation of `WinMain`. It invokes neither CPython nor the mysterious "icon file" mentioned in a commit message. Also, `git grep empty\.c` finds no match.

It was created in ab9351bf369c6dfc4b29eff18236a1fcaefe94b6 18 years ago with no annotation or any other associated file, and was never modified since.