### PR TITLE
GH-94329: Don't raise on excessive stack consumption

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1207,10 +1207,10 @@ class TestExpressionStackSize(unittest.TestCase):
         code += "   x and x\n" * self.N
         self.check_stack_size(code)
 
-    # Test that this compiles
     def test_stack_3050(self):
         M = 3050
         code = "x," * M + "=t"
+        # This raised on 3.10.0 to 3.10.5
         compile(code, "<foo>", "single")
 
 

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1213,6 +1213,7 @@ class TestExpressionStackSize(unittest.TestCase):
         code = "x," * M + "=t"
         compile(code, "<foo>", "single")
 
+
 class TestStackSizeStability(unittest.TestCase):
     # Check that repeating certain snippets doesn't increase the stack size
     # beyond what a single snippet requires.

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1207,6 +1207,11 @@ class TestExpressionStackSize(unittest.TestCase):
         code += "   x and x\n" * self.N
         self.check_stack_size(code)
 
+    # Test that this compiles
+    def test_stack_3050(self):
+        M = 3050
+        code = "x," * M + "=t"
+        compile(code, "<foo>", "single")
 
 class TestStackSizeStability(unittest.TestCase):
     # Check that repeating certain snippets doesn't increase the stack size

--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-29-15-45-04.gh-issue-94329.olUQyk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-29-15-45-04.gh-issue-94329.olUQyk.rst
@@ -1,0 +1,2 @@
+Compile and run code with unpacking of extremely large sequences (1000s of elements).
+Such code failed to compile. It now compiles and runs correctly.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -8598,12 +8598,7 @@ assemble(struct compiler *c, int addNone)
     if (maxdepth < 0) {
         goto error;
     }
-    if (maxdepth > MAX_ALLOWED_STACK_USE) {
-        PyErr_Format(PyExc_SystemError,
-                     "excessive stack use: stack is %d deep",
-                     maxdepth);
-        goto error;
-    }
+    /* TO DO -- For 3.12, make sure that `maxdepth <= MAX_ALLOWED_STACK_USE` */
 
     if (label_exception_targets(entryblock)) {
         goto error;


### PR DESCRIPTION
We want the compiler to produce code that doesn't use excessive amounts of stack, but we shouldn't limit what we can compile.

This PR allows code like `x0, x1, ..., x4000 = t` to compile and run correctly.

For 3.12 we want to compile the above code in a way that doesn't use too much stack, but for now let's just accept that we need a lot of stack.

<!-- gh-issue-number: gh-94329 -->
* Issue: gh-94329
<!-- /gh-issue-number -->
