### PR TITLE
gh-91330: Tests and docs for dataclass descriptor-typed fields

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -772,7 +772,7 @@ default value have the following special behaviors:
 
 ::
 
-  class Descriptor:
+  class IntConversionDescriptor:
     def __init__(self, *, default):
       self._default = default
 
@@ -786,14 +786,16 @@ default value have the following special behaviors:
       return getattr(obj, self._name, self._default)
 
     def __set__(self, obj, value):
-      setattr(obj, self._name, value)
+      setattr(obj, self._name, int(value))
 
   @dataclass
   class InventoryItem:
-      quantity_on_hand: Descriptor = Descriptor(default=100)
+    quantity_on_hand: IntConversionDescriptor = IntConversionDescriptor(default=100)
 
   i = InventoryItem()
   print(i.quantity_on_hand)   # 100
+  i.quantity_on_hand = 2.5    # calls __set__ with 2.5
+  print(i.quantity_on_hand)   # 2
 
 Note that if a field is annotated with a descriptor type, but is not assigned
 a descriptor object as its default value, the field will act like a normal

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -776,14 +776,17 @@ default value have the following special behaviors:
     def __init__(self, *, default):
       self._default = default
 
+    def __set_name__(self, owner, name):
+      self._name = "_" + name
+
     def __get__(self, obj, type):
       if obj is None:
         return self._default
 
-      return getattr(obj, "_x", self._default)
+      return getattr(obj, self._name, self._default)
 
     def __set__(self, obj, value):
-      setattr(obj, "_x", value)
+      setattr(obj, self._name, value)
 
   @dataclass
   class InventoryItem:

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -759,25 +759,28 @@ default value have the following special behaviors:
 * The value for the field passed to the dataclass's ``__init__`` method is
   passed to the descriptor's ``__set__`` method rather than overwriting the
   descriptor object.
-* Similiarly, when getting or setting the field, the descriptor's
+* Similarly, when getting or setting the field, the descriptor's
   ``__get__`` or ``__set__`` method is called rather than returning or
   overwriting the descriptor object.
-* The value returned by the descriptor's ``__get__`` method when its
-  ``obj`` parameter is ``None``, will be used as the field's default
-  value. If the descriptor raises an ``AttributeError`` when ``obj``
-  is ``None``, the field will not have a default value.
+* To determine whether a field contains a default value, ``dataclasses``
+  will call the descriptor's ``__get__`` method using its class access
+  form (i.e. ``descriptor.__get__(obj=None, type=cls)``.  If the
+  descriptor returns a value in this case, it will be used as the
+  field's default. On the other hand, if the descriptor raises
+  :exc:`AttributeError` in this situation, no default value will be
+  provided for the field.
 
 ::
 
-  class Descriptor():
+  class Descriptor:
     def __init__(self, *, default):
       self._default = default
 
-    def __get__(self, obj, objtype):
+    def __get__(self, obj, type):
       if obj is None:
         return self._default
 
-      return getattr(obj, "_x")
+      return getattr(obj, "_x", self._default)
 
     def __set__(self, obj, value):
       if obj is not None:
@@ -790,6 +793,6 @@ default value have the following special behaviors:
   i = InventoryItem()
   print(i.quantity_on_hand)   # 100
 
-Note that if a field is annotated with a desriptor type, but is not assigned
+Note that if a field is annotated with a descriptor type, but is not assigned
 a descriptor object as its default value, the field will act like a normal
 field.

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -783,8 +783,7 @@ default value have the following special behaviors:
       return getattr(obj, "_x", self._default)
 
     def __set__(self, obj, value):
-      if obj is not None:
-        setattr(obj, "_x", value)
+      setattr(obj, "_x", value)
 
   @dataclass
   class InventoryItem:

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3257,7 +3257,7 @@ class TestDescriptors(unittest.TestCase):
 
         c = C(5)
 
-        # Make sure D.__set__ is called.
+        # Make sure D.__get__ is called.
         D.__get__.reset_mock()
         value = c.i
         self.assertEqual(D.__get__.call_count, 1)

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3229,6 +3229,55 @@ class TestDescriptors(unittest.TestCase):
 
         self.assertEqual(D.__set_name__.call_count, 1)
 
+    def test_init_calls_set(self):
+        class D:
+            pass
+
+        D.__set__ = Mock()
+
+        @dataclass
+        class C:
+            i: D = D()
+
+        # Make sure D.__set__ is called.
+        D.__set__.reset_mock()
+        c = C(5)
+        self.assertEqual(D.__set__.call_count, 1)
+
+    def test_getting_field_calls_get(self):
+        class D:
+            pass
+
+        D.__set__ = Mock()
+        D.__get__ = Mock()
+
+        @dataclass
+        class C:
+            i: D = D()
+
+        c = C(5)
+
+        # Make sure D.__set__ is called.
+        D.__get__.reset_mock()
+        value = c.i
+        self.assertEqual(D.__get__.call_count, 1)
+
+    def test_setting_field_calls_set(self):
+        class D:
+            pass
+
+        D.__set__ = Mock()
+
+        @dataclass
+        class C:
+            i: D = D()
+
+        c = C(5)
+
+        # Make sure D.__set__ is called.
+        D.__set__.reset_mock()
+        c.i = 10
+        self.assertEqual(D.__set__.call_count, 1)
 
 class TestStringAnnotations(unittest.TestCase):
     def test_classvar(self):

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3305,6 +3305,7 @@ class TestDescriptors(unittest.TestCase):
             def __get__(self, instance: Any, owner: object) -> int:
                 if instance is None:
                     return 100
+
                 return instance._x
 
             def __set__(self, instance: Any, value: int) -> None:
@@ -3319,6 +3320,24 @@ class TestDescriptors(unittest.TestCase):
 
         c = C(5)
         self.assertEqual(c.i, 5)
+
+    def test_no_default_value(self):
+        class D:
+            def __get__(self, instance: Any, owner: object) -> int:
+                if instance is None:
+                    raise AttributeError()
+
+                return instance._x
+
+            def __set__(self, instance: Any, value: int) -> None:
+                instance._x = value
+
+        @dataclass
+        class C:
+            i: D = D()
+
+        with self.assertRaisesRegex(TypeError, 'missing 1 required positional argument'):
+            c = C()
 
 class TestStringAnnotations(unittest.TestCase):
     def test_classvar(self):

--- a/Misc/NEWS.d/next/Tests/2022-07-05-17-53-13.gh-issue-91330.Qys5IL.rst
+++ b/Misc/NEWS.d/next/Tests/2022-07-05-17-53-13.gh-issue-91330.Qys5IL.rst
@@ -1,0 +1,7 @@
+Added more tests for :mod:`dataclasses` to cover behavior with data
+descriptor-based fields.
+
+# Write your Misc/NEWS entry below.  It should be a simple ReST paragraph. #
+Don't start with "- Issue #<n>: " or "- gh-issue-<n>: " or that sort of
+stuff.
+###########################################################################


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Add unit tests and documentation covering the behaviors of descriptor-typed fields on dataclasses.

<!-- gh-issue-number: gh-91330 -->
* Issue: gh-91330
<!-- /gh-issue-number -->
