### PR TITLE
[3.10] gh-94332: make it safe to call assemble_free when assemble_init has not been called (GH-94389)

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7116,6 +7116,7 @@ assemble(struct compiler *c, int addNone)
     int j, nblocks;
     PyCodeObject *co = NULL;
     PyObject *consts = NULL;
+    memset(&a, 0, sizeof(struct assembler));
 
     /* Make sure every block that falls off the end returns None.
        XXX NEXT_BLOCK() isn't quite right, because if the last


### PR DESCRIPTION

(cherry picked from commit be82d26570343dafc8a89be5a1a0e2f58d51a904)

Co-authored-by: Irit Katriel <1055913+iritkatriel@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94332 -->
* Issue: gh-94332
<!-- /gh-issue-number -->
