### PR TITLE
Add a workflow to add issues/PRs to projects.

### DIFF
--- a/.github/workflows/project-updater.yml
+++ b/.github/workflows/project-updater.yml
@@ -1,0 +1,23 @@
+name: Update projects when an issue/PR is created/labeled
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add to the Release and Deferred blocker project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.1.0
+        with:
+          project-url: https://github.com/orgs/python/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: release-blocker, deferred-blocker
+          label-operator: OR

--- a/.github/workflows/project-updater.yml
+++ b/.github/workflows/project-updater.yml
@@ -1,4 +1,4 @@
-name: Update projects when an issue/PR is created/labeled
+name: Update GH projects
 
 on:
   issues:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   add-to-project:
-    name: Add to the Release and Deferred blocker project
+    name: Add to the Release and Deferred Blocker project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.1.0


### PR DESCRIPTION
This PR adds a workflow that uses the ["Add to GitHub Projects Beta" action](https://github.com/marketplace/actions/add-to-github-projects-beta) to automatically add issues and PRs that have been created or labeled to the corresponding project.

So far it only updates the [Release and Deferred blocker project](https://github.com/orgs/python/projects/2), but if that works well we can update the workflow to include other projects that have corresponding labels.  This will also solves in the short term the issue of triagers not being able to update projects from an issue/PR.

cc @encukou, @hugovk, @CAM-Gerlach