### PR TITLE
[3.10] GH-94329: Don't raise on excessive stack consumption (GH-94421)

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1035,6 +1035,12 @@ class TestExpressionStackSize(unittest.TestCase):
         code += "   x and x\n" * self.N
         self.check_stack_size(code)
 
+    def test_stack_3050(self):
+        M = 3050
+        code = "x," * M + "=t"
+        # This raised on 3.10.0 to 3.10.5
+        compile(code, "<foo>", "single")
+
 
 class TestStackSizeStability(unittest.TestCase):
     # Check that repeating certain snippets doesn't increase the stack size

--- a/Misc/NEWS.d/next/Core and Builtins/2022-06-29-15-45-04.gh-issue-94329.olUQyk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-06-29-15-45-04.gh-issue-94329.olUQyk.rst
@@ -1,0 +1,2 @@
+Compile and run code with unpacking of extremely large sequences (1000s of elements).
+Such code failed to compile. It now compiles and runs correctly.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6968,13 +6968,6 @@ makecode(struct compiler *c, struct assembler *a, PyObject *consts)
         Py_DECREF(consts);
         goto error;
     }
-    if (maxdepth > MAX_ALLOWED_STACK_USE) {
-        PyErr_Format(PyExc_SystemError,
-                     "excessive stack use: stack is %d deep",
-                     maxdepth);
-        Py_DECREF(consts);
-        goto error;
-    }
     co = PyCode_NewWithPosOnlyArgs(posonlyargcount+posorkeywordargcount,
                                    posonlyargcount, kwonlyargcount, nlocals_int,
                                    maxdepth, flags, a->a_bytecode, consts, names,


### PR DESCRIPTION
(cherry picked from commit b152bf448b321e3a4c0a7280e0b608840f5ac661)


<!-- gh-issue-number: gh-94329 -->
* Issue: gh-94329
<!-- /gh-issue-number -->
