### PR TITLE
gh-90005-ffi: Fix building _ctypes without pkg-config (GH-94451)

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-06-30-17-00-54.gh-issue-90005.iiq5qD.rst
+++ b/Misc/NEWS.d/next/Build/2022-06-30-17-00-54.gh-issue-90005.iiq5qD.rst
@@ -1,0 +1,1 @@
+Fix building ``_ctypes`` extension without ``pkg-config``.

--- a/configure
+++ b/configure
@@ -12133,7 +12133,10 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_ffi_ffi_call" >&5
 $as_echo "$ac_cv_lib_ffi_ffi_call" >&6; }
 if test "x$ac_cv_lib_ffi_ffi_call" = xyes; then :
-  have_libffi=yes
+
+          have_libffi=yes
+          LIBFFI_LIBS="-lffi"
+
 else
   have_libffi=no
 fi
@@ -12200,7 +12203,10 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_ffi_ffi_call" >&5
 $as_echo "$ac_cv_lib_ffi_ffi_call" >&6; }
 if test "x$ac_cv_lib_ffi_ffi_call" = xyes; then :
-  have_libffi=yes
+
+          have_libffi=yes
+          LIBFFI_LIBS="-lffi"
+
 else
   have_libffi=no
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -3605,7 +3605,10 @@ AS_VAR_IF([with_system_ffi], [yes], [
   PKG_CHECK_MODULES([LIBFFI], [libffi], [have_libffi=yes], [
     AC_CHECK_HEADER([ffi.h], [
       WITH_SAVE_ENV([
-        AC_CHECK_LIB([ffi], [ffi_call], [have_libffi=yes], [have_libffi=no])
+        AC_CHECK_LIB([ffi], [ffi_call], [
+          have_libffi=yes
+          LIBFFI_LIBS="-lffi"
+        ], [have_libffi=no])
       ])
     ])
   ])


### PR DESCRIPTION
The fallback path did not set ``LIBFFI_LIBS`` variable to link with
``-lffi``.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-90005 -->
* Issue: gh-90005
<!-- /gh-issue-number -->
