### PR TITLE
gh-94471: Enable pointer authentication on aarch64 builds

### DIFF
--- a/Misc/NEWS.d/next/Security/2022-07-01-00-46-46.gh-issue-94471.rHC21U.rst
+++ b/Misc/NEWS.d/next/Security/2022-07-01-00-46-46.gh-issue-94471.rHC21U.rst
@@ -1,0 +1,1 @@
+Enable pointer authentication on arm64 builds to mitigate return oriented programming.

--- a/configure
+++ b/configure
@@ -6341,6 +6341,63 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
+case $host in #(
+  aarch64*) :
+
+    for opt in -mbranch-protection=pac-ret -msign-return-address=all
+do :
+
+      as_CACHEVAR=`$as_echo "ax_cv_check_cflags__$opt" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts $opt" >&5
+$as_echo_n "checking whether C compiler accepts $opt... " >&6; }
+if eval \${$as_CACHEVAR+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  $opt"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$as_CACHEVAR=yes"
+else
+  eval "$as_CACHEVAR=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
+  branch_protection=yes
+else
+  branch_protection=no
+fi
+
+      if test "x$branch_protection" = xyes; then :
+
+        BASECFLAGS="${BASECFLAGS} $opt"
+        break
+
+fi
+
+done
+
+ ;; #(
+  *) :
+     ;;
+esac
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for -Wl,--no-as-needed" >&5
 $as_echo_n "checking for -Wl,--no-as-needed... " >&6; }
 if ${ac_cv_wl_no_as_needed+:} false; then :

--- a/configure
+++ b/configure
@@ -6344,18 +6344,14 @@ _ACEOF
 case $host in #(
   aarch64*) :
 
-    for opt in -mbranch-protection=pac-ret -msign-return-address=all
-do :
-
-      as_CACHEVAR=`$as_echo "ax_cv_check_cflags__$opt" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts $opt" >&5
-$as_echo_n "checking whether C compiler accepts $opt... " >&6; }
-if eval \${$as_CACHEVAR+:} false; then :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -mbranch-protection=pac-ret" >&5
+$as_echo_n "checking whether C compiler accepts -mbranch-protection=pac-ret... " >&6; }
+if ${ax_cv_check_cflags___mbranch_protection_pac_ret+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
   ax_check_save_flags=$CFLAGS
-  CFLAGS="$CFLAGS  $opt"
+  CFLAGS="$CFLAGS  -mbranch-protection=pac-ret"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -6368,30 +6364,61 @@ main ()
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  eval "$as_CACHEVAR=yes"
+  ax_cv_check_cflags___mbranch_protection_pac_ret=yes
 else
-  eval "$as_CACHEVAR=no"
+  ax_cv_check_cflags___mbranch_protection_pac_ret=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   CFLAGS=$ax_check_save_flags
 fi
-eval ac_res=\$$as_CACHEVAR
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
-  branch_protection=yes
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___mbranch_protection_pac_ret" >&5
+$as_echo "$ax_cv_check_cflags___mbranch_protection_pac_ret" >&6; }
+if test "x$ax_cv_check_cflags___mbranch_protection_pac_ret" = xyes; then :
+
+      BASECFLAGS="${BASECFLAGS} -mbranch-protection=pac-ret"
 else
-  branch_protection=no
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -msign-return-address=all" >&5
+$as_echo_n "checking whether C compiler accepts -msign-return-address=all... " >&6; }
+if ${ax_cv_check_cflags___msign_return_address_all+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -msign-return-address=all"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ax_cv_check_cflags___msign_return_address_all=yes
+else
+  ax_cv_check_cflags___msign_return_address_all=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___msign_return_address_all" >&5
+$as_echo "$ax_cv_check_cflags___msign_return_address_all" >&6; }
+if test "x$ax_cv_check_cflags___msign_return_address_all" = xyes; then :
+
+          BASECFLAGS="${BASECFLAGS} -msign-return-address=all"
+
+else
+  :
 fi
 
-      if test "x$branch_protection" = xyes; then :
 
-        BASECFLAGS="${BASECFLAGS} $opt"
-        break
 
 fi
 
-done
 
  ;; #(
   *) :

--- a/configure.ac
+++ b/configure.ac
@@ -1135,13 +1135,13 @@ AC_DEFINE_UNQUOTED([PY_SUPPORT_TIER], [$PY_SUPPORT_TIER], [PEP 11 Support tier (
 
 AS_CASE([$host],
   [aarch64*], [
-    AS_FOR(option, opt, [-mbranch-protection=pac-ret -msign-return-address=all], [
-      AX_CHECK_COMPILE_FLAG(option, [branch_protection=yes], [branch_protection=no])
-      AS_IF([test "x$branch_protection" = xyes], [
-        BASECFLAGS="${BASECFLAGS} $opt"
-        break
-      ])
-    ])
+    AX_CHECK_COMPILE_FLAG([-mbranch-protection=pac-ret], [
+      BASECFLAGS="${BASECFLAGS} -mbranch-protection=pac-ret"],[
+        AX_CHECK_COMPILE_FLAG([-msign-return-address=all], [
+          BASECFLAGS="${BASECFLAGS} -msign-return-address=all"
+          ],[])
+      ]
+    )
   ]
 )
 

--- a/configure.ac
+++ b/configure.ac
@@ -1133,6 +1133,18 @@ AS_CASE([$PY_SUPPORT_TIER],
 
 AC_DEFINE_UNQUOTED([PY_SUPPORT_TIER], [$PY_SUPPORT_TIER], [PEP 11 Support tier (1, 2, 3 or 0 for unsupported)])
 
+AS_CASE([$host],
+  [aarch64*], [
+    AS_FOR(option, opt, [-mbranch-protection=pac-ret -msign-return-address=all], [
+      AX_CHECK_COMPILE_FLAG(option, [branch_protection=yes], [branch_protection=no])
+      AS_IF([test "x$branch_protection" = xyes], [
+        BASECFLAGS="${BASECFLAGS} $opt"
+        break
+      ])
+    ])
+  ]
+)
+
 AC_CACHE_CHECK([for -Wl,--no-as-needed], [ac_cv_wl_no_as_needed], [
   save_LDFLAGS="$LDFLAGS"
   AS_VAR_APPEND([LDFLAGS], [" -Wl,--no-as-needed"])


### PR DESCRIPTION
ARM64v8.3 supports [Pointer Authentication](https://www.qualcomm.com/media/documents/files/whitepaper-pointer-authentication-on-armv8-3.pdf) with the PACIASP and AUTIASP instructions which are interpreted as NOP instructions on pre-8.3 architectures.  These instructions sign the stack pointer and validate the stack pointer prior to return to mitigate [return oriented programming](https://en.wikipedia.org/wiki/Return-oriented_programming).

GCC supports these [options](https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html) on arm64 / aarch64.  The legacy option was `-msign-return-address=[all | non-leaf | none]` and the modern option is `-mbranch-protection=none|standard|pac-ret[+leaf+b-key]|bti`

I would like to suggest that the arm64 build be modified to include `-mbranch-protection=pac-ret` with the `-march` being set to ARMv8.2 or earlier or not configured, so that GCC will generate [PACIASP](https://developer.arm.com/documentation/100076/0100/A64-Instruction-Set-Reference/A64-General-Instructions/PACIA--PACIZA--PACIA1716--PACIASP--PACIAZ?lang=en) and [AUTIASP](https://developer.arm.com/documentation/100076/0100/A64-Instruction-Set-Reference/A64-General-Instructions/AUTIA--AUTIZA--AUTIA1716--AUTIASP--AUTIAZ?lang=en) instructions.  It is critical that `-march=armv8.3` or higher not be passed or the non-backwards compatible RETAA instruction will be generated.

The benefit of enabling pointer authentication for the stack pointer on ARM64 would be to mitigate [return oriented programming](https://en.wikipedia.org/wiki/Return-oriented_programming) attacks against the CPython runtime.

Presently we (GoDaddy) are pursuing custom compiles of the CPython runtime for the new Graviton3 CPUs that support pointer authentication in AWS.

<!-- gh-issue-number: gh-94471 -->
* Issue: gh-94471
<!-- /gh-issue-number -->
