### PR TITLE
gh-94478: Fix bug unsafe not set when patching

### DIFF
--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -2215,7 +2215,7 @@ class MockTest(unittest.TestCase):
         class Foo():
             one = 'one'
         # patch, patch.object and create_autospec need to check for misspelled
-        # arguments explicitly and throw a RuntimError if found.
+        # arguments explicitly and throw a RuntimeError if found.
         with self.assertRaises(RuntimeError):
             with patch(f'{__name__}.Something.meth', autospect=True): pass
         with self.assertRaises(RuntimeError):
@@ -2243,16 +2243,39 @@ class MockTest(unittest.TestCase):
             with patch.multiple(
                 f'{__name__}.Something', meth=DEFAULT, set_spec=True): pass
 
-        with patch(f'{__name__}.Something.meth', unsafe=True, autospect=True):
-            pass
-        with patch.object(Foo, 'one', unsafe=True, autospect=True): pass
-        with patch(f'{__name__}.Something.meth', unsafe=True, auto_spec=True):
-            pass
-        with patch.object(Foo, 'one', unsafe=True, auto_spec=True): pass
-        with patch(f'{__name__}.Something.meth', unsafe=True, set_spec=True):
-            pass
-        with patch.object(Foo, 'one', unsafe=True, set_spec=True): pass
+        with patch(
+            f'{__name__}.Something.meth', unsafe=True, autospect=True
+        ) as patched_object:
+            self.assertEqual(patched_object._mock_unsafe, True)
+
+        with patch.object(
+            Foo, 'one', unsafe=True, autospect=True
+        ) as patched_object:
+            self.assertEqual(patched_object._mock_unsafe, True)
+
+        with patch(
+            f'{__name__}.Something.meth', unsafe=True, auto_spec=True
+        ) as patched_object:
+            self.assertEqual(patched_object._mock_unsafe, True)
+
+        with patch.object(
+            Foo, 'one', unsafe=True, auto_spec=True
+        ) as patched_object:
+            self.assertEqual(patched_object._mock_unsafe, True)
+
+        with patch(
+            f'{__name__}.Something.meth', unsafe=True, set_spec=True
+        ) as patched_object:
+            self.assertEqual(patched_object._mock_unsafe, True)
+
+        with patch.object(
+            Foo, 'one', unsafe=True, set_spec=True
+        ) as patched_object:
+            self.assertEqual(patched_object._mock_unsafe, True)
+
         m = create_autospec(Foo, set_spec=True, unsafe=True)
+        self.assertEqual(m._mock_unsafe, True)
+
         with patch.multiple(
             f'{__name__}.Typos', autospect=True, set_spec=True, auto_spec=True):
             pass

--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -2214,6 +2214,7 @@ class MockTest(unittest.TestCase):
     def test_misspelled_arguments(self):
         class Foo():
             one = 'one'
+            assret_testing = False
         # patch, patch.object and create_autospec need to check for misspelled
         # arguments explicitly and throw a RuntimeError if found.
         with self.assertRaises(RuntimeError):
@@ -2246,35 +2247,35 @@ class MockTest(unittest.TestCase):
         with patch(
             f'{__name__}.Something.meth', unsafe=True, autospect=True
         ) as patched_object:
-            self.assertEqual(patched_object._mock_unsafe, True)
+            patched_object.assret_called_once()
 
         with patch.object(
             Foo, 'one', unsafe=True, autospect=True
         ) as patched_object:
-            self.assertEqual(patched_object._mock_unsafe, True)
+            patched_object.assret_called_once()
 
         with patch(
             f'{__name__}.Something.meth', unsafe=True, auto_spec=True
         ) as patched_object:
-            self.assertEqual(patched_object._mock_unsafe, True)
+            patched_object.assret_called_once()
 
         with patch.object(
             Foo, 'one', unsafe=True, auto_spec=True
         ) as patched_object:
-            self.assertEqual(patched_object._mock_unsafe, True)
+            patched_object.assret_called_once()
 
         with patch(
             f'{__name__}.Something.meth', unsafe=True, set_spec=True
         ) as patched_object:
-            self.assertEqual(patched_object._mock_unsafe, True)
+            patched_object.assret_called_once()
 
         with patch.object(
             Foo, 'one', unsafe=True, set_spec=True
         ) as patched_object:
-            self.assertEqual(patched_object._mock_unsafe, True)
+            patched_object.assret_called_once()
 
         m = create_autospec(Foo, set_spec=True, unsafe=True)
-        self.assertEqual(m._mock_unsafe, True)
+        m.assret_testing = True
 
         with patch.multiple(
             f'{__name__}.Typos', autospect=True, set_spec=True, auto_spec=True):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1282,6 +1282,8 @@ class _patch(object):
                 f'Cannot spec attr {attribute!r} as the spec_set '
                 f'target has already been mocked out. [spec_set={spec_set!r}]')
 
+        if unsafe:
+            kwargs.update({'unsafe': unsafe})
         self.getter = getter
         self.attribute = attribute
         self.new = new
@@ -2652,6 +2654,8 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
         _check_spec_arg_typos(kwargs)
 
     _kwargs.update(kwargs)
+    if unsafe:
+        _kwargs.update({'unsafe': unsafe})
 
     Klass = MagicMock
     if inspect.isdatadescriptor(spec):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1283,7 +1283,7 @@ class _patch(object):
                 f'target has already been mocked out. [spec_set={spec_set!r}]')
 
         if unsafe:
-            kwargs.update({'unsafe': unsafe})
+            kwargs['unsafe'] = unsafe
         self.getter = getter
         self.attribute = attribute
         self.new = new
@@ -2655,7 +2655,7 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
 
     _kwargs.update(kwargs)
     if unsafe:
-        _kwargs.update({'unsafe': unsafe})
+        _kwargs['unsafe'] = unsafe
 
     Klass = MagicMock
     if inspect.isdatadescriptor(spec):


### PR DESCRIPTION
Even though mocked objects are created by setting `unsafe=True` the
internal attribute `_mock_unsafe` on the actual mocked instances were
not properly set. 
The test case has been updated to capture this logic.

<!-- gh-issue-number: gh-94478 -->
* Issue: gh-94478
<!-- /gh-issue-number -->
