### PR TITLE
Remove `pull_request` trigger from the project-updater GHA.

### DIFF
--- a/.github/workflows/project-updater.yml
+++ b/.github/workflows/project-updater.yml
@@ -5,10 +5,6 @@ on:
     types:
       - opened
       - labeled
-  pull_request:
-    types:
-      - opened
-      - labeled
 
 jobs:
   add-to-project:


### PR DESCRIPTION
This is a follow-up of #94447 that removes the check for `pull_requests`, for the reasons stated in https://github.com/python/cpython/pull/94447#issuecomment-1172141680.