### PR TITLE
gh-94499 Add test for private name mangling in class pattern matching

### DIFF
--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -2654,6 +2654,21 @@ class TestPatma(unittest.TestCase):
 
         self.assertEqual(y, 'bar')
 
+    def test_patma_249(self):
+        class C:
+            pass
+        class Outer:
+            def f(self, x):
+                match x:
+                    # looks up __attr, not _C__attr or _Outer__attr
+                    case C(__attr=y):
+                        return y
+        c = C()
+        setattr(c, "__attr", 1)
+        setattr(c, "_Outer__attr", 2)
+        setattr(c, "_C__attr", 3)
+        self.assertEqual(Outer().f(c), 1)
+
 
 class TestSyntaxErrors(unittest.TestCase):
 

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -2656,18 +2656,17 @@ class TestPatma(unittest.TestCase):
 
     def test_patma_249(self):
         class C:
-            pass
+            __attr = "_C__attr"
         class Outer:
+            __attr = "_Outer__attr"
             def f(self, x):
                 match x:
                     # looks up __attr, not _C__attr or _Outer__attr
                     case C(__attr=y):
                         return y
         c = C()
-        setattr(c, "__attr", 1)
-        setattr(c, "_Outer__attr", 2)
-        setattr(c, "_C__attr", 3)
-        self.assertEqual(Outer().f(c), 1)
+        c.__attr = "__attr"
+        self.assertEqual(Outer().f(c), "__attr")
 
 
 class TestSyntaxErrors(unittest.TestCase):

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -2665,7 +2665,7 @@ class TestPatma(unittest.TestCase):
                     case C(__attr=y):
                         return y
         c = C()
-        c.__attr = "__attr"
+        setattr(c, "__attr", "__attr")  # setattr is needed because we're in a class scope
         self.assertEqual(Outer().f(c), "__attr")
 
 

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -2656,17 +2656,17 @@ class TestPatma(unittest.TestCase):
 
     def test_patma_249(self):
         class C:
-            __attr = "_C__attr"
+            __attr = "eggs"  # mangled to _C__attr
+            _Outer__attr = "bacon"
         class Outer:
-            __attr = "_Outer__attr"
             def f(self, x):
                 match x:
                     # looks up __attr, not _C__attr or _Outer__attr
                     case C(__attr=y):
                         return y
         c = C()
-        setattr(c, "__attr", "__attr")  # setattr is needed because we're in a class scope
-        self.assertEqual(Outer().f(c), "__attr")
+        setattr(c, "__attr", "spam")  # setattr is needed because we're in a class scope
+        self.assertEqual(Outer().f(c), "spam")
 
 
 class TestSyntaxErrors(unittest.TestCase):


### PR DESCRIPTION
The current status quo is that private attribute names are not
mangled when a class is matched. I've added a test to
document/legitimize this behaviour.

I don't think this needs a news entry (but can create one if required).

I asked about [this in Python-dev](https://mail.python.org/archives/list/python-dev@python.org/thread/LILLO3MBTVY6ZQT3VNUVXATEPS3ASGQF/) and it wasn't clear if the current behaviour was by design or not. My view is that it seems reasonable so the right thing to do is to "lock it in" by testing for it, but I'm also happy for



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94499 -->
* Issue: gh-94499
<!-- /gh-issue-number -->
