### PR TITLE
gh-82786: Set the release for `__future__.annotations` to 3.12

### DIFF
--- a/Lib/__future__.py
+++ b/Lib/__future__.py
@@ -143,5 +143,5 @@ generator_stop = _Feature((3, 5, 0, "beta", 1),
                           CO_FUTURE_GENERATOR_STOP)
 
 annotations = _Feature((3, 7, 0, "beta", 1),
-                       (3, 11, 0, "alpha", 0),
+                       (3, 12, 0, "alpha", 0),
                        CO_FUTURE_ANNOTATIONS)


### PR DESCRIPTION
same as #25596

just kicking the can down the road once again -- this should also land in 3.11 before that releases CC @pablogsal 

<!-- gh-issue-number: gh-82786 -->
* Issue: gh-82786
<!-- /gh-issue-number -->
