### PR TITLE
gh-84753: Clarify change made to `inspect` functions

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-06-21-11-40-31.gh-issue-84753.FW1pxO.rst
+++ b/Misc/NEWS.d/next/Library/2022-06-21-11-40-31.gh-issue-84753.FW1pxO.rst
@@ -1,3 +1,7 @@
-:func:`inspect.iscoroutinefunction` now properly returns ``True`` when an instance
-of :class:`unittest.mock.AsyncMock` is passed to it.  This makes it consistent with
+:func:`inspect.iscoroutinefunction`, :func:`inspect.isgeneratorfunction`,
+and :func:`inspect.isasyncgenfunction` now properly return ``True`` for
+duck-typed function-like objects like instances of
+:class:`unittest.mock.AsyncMock`.
+
+This makes :func:`inspect.iscoroutinefunction` consistent with the
 behavior of :func:`asyncio.iscoroutinefunction`.  Patch by Mehdi ABAAKOUK.


### PR DESCRIPTION
The wording used in GH-94050 suggests narrower scope than what was actually implemented. This commit clarifies the full impact of GH-94050 in the change log.

New wording:
<img width="819" alt="Screen Shot 2022-07-05 at 11 03 02" src="https://user-images.githubusercontent.com/55281/177291962-49fb80d1-08eb-437d-bef1-89913c638c56.png">



<!-- gh-issue-number: gh-84753 -->
* Issue: gh-84753
<!-- /gh-issue-number -->
