### PR TITLE
gh-94438: in frameobject's mark_stacks switch, the PUSH_EXC_INFO and POP_EXCEPT cases are no longer reachable

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -304,8 +304,12 @@ mark_stacks(PyCodeObject *code_obj, int len)
                     /* These instructions only appear in exception handlers, which
                      * skip this switch ever since the move to zero-cost exceptions
                      * (their stack remains UNINITIALIZED because nothing sets it).
+                     *
+                     * Note that explain_incompatible_stack interprets an
+                     * UNINITIALIZED stack as belonging to an exception handler.
                      */
                     Py_UNREACHABLE();
+                    break;
                 case RETURN_VALUE:
                 case RAISE_VARARGS:
                 case RERAISE:

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -256,10 +256,6 @@ mark_stacks(PyCodeObject *code_obj, int len)
                     stacks[i+1] = next_stack;
                     break;
                 }
-                case POP_EXCEPT:
-                    next_stack = pop_value(pop_value(pop_value(next_stack)));
-                    stacks[i+1] = next_stack;
-                    break;
                 case SEND:
                     j = get_arg(code, i) + i + 1;
                     assert(j < len);
@@ -304,10 +300,12 @@ mark_stacks(PyCodeObject *code_obj, int len)
                     stacks[i+1] = next_stack;
                     break;
                 case PUSH_EXC_INFO:
-                    next_stack = push_value(next_stack, Except);
-                    next_stack = push_value(next_stack, Except);
-                    next_stack = push_value(next_stack, Except);
-                    stacks[i+1] = next_stack;
+                case POP_EXCEPT:
+                    /* These instructions only appear in exception handlers, which
+                     * skip this switch ever since the move to zero-cost exceptions
+                     * (their stack remains UNINITIALIZED because nothing sets it).
+                     */
+                    Py_UNREACHABLE();
                 case RETURN_VALUE:
                 case RAISE_VARARGS:
                 case RERAISE:


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94438 -->
* Issue: gh-94438
<!-- /gh-issue-number -->
