### PR TITLE
gh-94438: in frameobject's mark_stacks, add explicit case for CACHE opcodes which leaves the stack unchanged

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -220,6 +220,11 @@ mark_stacks(PyCodeObject *code_obj, int len)
             }
             opcode = _Py_OPCODE(code[i]);
             switch (opcode) {
+                case CACHE:
+                {
+                    stacks[i+1] = stacks[i];
+                    break;
+                }
                 case JUMP_IF_FALSE_OR_POP:
                 case JUMP_IF_TRUE_OR_POP:
                 case POP_JUMP_FORWARD_IF_FALSE:


### PR DESCRIPTION

This doesn't change behaviour, but it makes the code more explicit so it doesn't look like we forgot about CACHE opcodes. 

The previous behaviour relied on stack_effect returning 0 for CACHE in the default case of the switch.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94438 -->
* Issue: gh-94438
<!-- /gh-issue-number -->
