### PR TITLE
gh-94588: Remove misleading future version for postponed evaluation (fixes #94588)

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -171,7 +171,9 @@ on a per-module basis in Python 3.7 using a :mod:`__future__` import::
 
     from __future__ import annotations
 
-It will become the default in Python 3.10.
+Postponed evaluation will become the default `in a future version of Python`_.
+
+.. _in a future version of Python: https://mail.python.org/archives/list/python-dev@python.org/message/VIZEBX5EYMSYIJNDBF6DMUMZOCWHARSO/
 
 .. seealso::
 


### PR DESCRIPTION
This PR changes the language of the 3.7 change notes to drop the now-incorrect reference to 3.10 as when postponed evaluation of annotations becomes default (see #94588 for details)

<!-- gh-issue-number: gh-94588 -->
* Issue: gh-94588
<!-- /gh-issue-number -->
