### PR TITLE
gh-94590: add signatures to operator itemgetter, attrgetter, methodcaller

### DIFF
--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -1162,8 +1162,7 @@ static PyMemberDef itemgetter_members[] = {
 };
 
 PyDoc_STRVAR(itemgetter_doc,
-"itemgetter(item, ...) --> itemgetter object\n\
-\n\
+"itemgetter(item, /, *items)\n--\n\n\
 Return a callable object that fetches the given item(s) from its operand.\n\
 After f = itemgetter(2), the call f(r) returns r[2].\n\
 After g = itemgetter(2, 5, 3), the call g(r) returns (r[2], r[5], r[3])");
@@ -1523,8 +1522,7 @@ static PyMemberDef attrgetter_members[] = {
 };
 
 PyDoc_STRVAR(attrgetter_doc,
-"attrgetter(attr, ...) --> attrgetter object\n\
-\n\
+"attrgetter(attr, /, *attrs)\n--\n\n\
 Return a callable object that fetches the given attribute(s) from its operand.\n\
 After f = attrgetter('name'), the call f(r) returns r.name.\n\
 After g = attrgetter('name', 'date'), the call g(r) returns (r.name, r.date).\n\
@@ -1775,8 +1773,7 @@ static PyMethodDef methodcaller_methods[] = {
     {NULL}
 };
 PyDoc_STRVAR(methodcaller_doc,
-"methodcaller(name, ...) --> methodcaller object\n\
-\n\
+"methodcaller(name, /, *args, **kwargs)\n--\n\n\
 Return a callable object that calls the given method on its operand.\n\
 After f = methodcaller('name'), the call f(r) returns r.name().\n\
 After g = methodcaller('name', 'date', foo=1), the call g(r) returns\n\


### PR DESCRIPTION
Closes #94590

These functions were intentionally skipped when operator was updated to use the argument clinic:
https://github.com/python/cpython/issues/64385#issuecomment-1093641466

However, by not using the argument clinic, they missed out on getting signatures.  This is a narrow PR to update the docstrings so that `__text_signature__` can be extracted from them.  Updating to use the argument clinic is beyond scope.

`methodcaller` uses `*args, **kwargs` to match variadic names used elsewhere (e.g., `operator.call` uses `*args, **kwargs`).

These changes are pretty minimal.  Should I add tests (if so, where?) or a blurb?

<!-- gh-issue-number: gh-94590 -->
* Issue: gh-94590
<!-- /gh-issue-number -->
