### PR TITLE
gh-94607: Fix subclassing generics

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3650,6 +3650,19 @@ class GenericTests(BaseTestCase):
                     class Foo(obj):
                         pass
 
+    def test_complex_subclasses(self):
+        T_co = TypeVar("T_co", covariant=True)
+
+        class Base(Generic[T_co]):
+            ...
+
+        T = TypeVar("T")
+
+        # see gh-94607: this fails in that bug
+        class Sub(Base, Generic[T]):
+            ...
+
+
 class ClassVarTests(BaseTestCase):
 
     def test_basics(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3662,6 +3662,17 @@ class GenericTests(BaseTestCase):
         class Sub(Base, Generic[T]):
             ...
 
+    def test_parameter_detection(self):
+        self.assertEqual(List[T].__parameters__, (T,))
+        self.assertEqual(List[List[T]].__parameters__, (T,))
+        class A:
+            __parameters__ = (T,)
+        # Bare classes should be skipped
+        self.assertEqual(List[A].__parameters__, ())
+        # Duck-typing anything that looks like it has __parameters__.
+        # This test is optional and failure is okay.
+        self.assertEqual(List[A()].__parameters__, (T,))
+
 
 class ClassVarTests(BaseTestCase):
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3668,15 +3668,16 @@ class GenericTests(BaseTestCase):
         class A:
             __parameters__ = (T,)
         # Bare classes should be skipped
-        for a in List, list:
+        for a in (List, list):
             for b in (A, int, TypeVar, TypeVarTuple, ParamSpec, types.GenericAlias, types.UnionType):
                 with self.subTest(generic=a, sub=b):
                     with self.assertRaisesRegex(TypeError, '.* is not a generic class'):
                         a[b][str]
         # Duck-typing anything that looks like it has __parameters__.
-        # This test is optional and failure is okay.
+        # These tests are optional and failure is okay.
         self.assertEqual(List[A()].__parameters__, (T,))
-
+        # C version of GenericAlias
+        self.assertEqual(list[A()].__parameters__, (T,))
 
 class ClassVarTests(BaseTestCase):
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3668,7 +3668,11 @@ class GenericTests(BaseTestCase):
         class A:
             __parameters__ = (T,)
         # Bare classes should be skipped
-        self.assertEqual(List[A].__parameters__, ())
+        for a in List, list:
+            for b in (A, int, TypeVar, TypeVarTuple, ParamSpec, types.GenericAlias, types.UnionType):
+                with self.subTest(generic=a, sub=b):
+                    with self.assertRaisesRegex(TypeError, '.* is not a generic class'):
+                        a[b][str]
         # Duck-typing anything that looks like it has __parameters__.
         # This test is optional and failure is okay.
         self.assertEqual(List[A()].__parameters__, (T,))

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -250,7 +250,7 @@ def _collect_parameters(args):
     """
     parameters = []
     for t in args:
-        # A bare Python class isn't generic.
+        # We don't want __parameters__ descriptor of a bare Python class.
         if isinstance(t, type):
             continue
         if hasattr(t, '__typing_subst__'):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -254,7 +254,7 @@ def _collect_parameters(args):
             if t not in parameters:
                 parameters.append(t)
         # We need to avoid bare Python types as those aren't really objects.
-        elif not type(t) is type:
+        elif type(t) is not type:
             for x in getattr(t, '__parameters__', ()):
                 if x not in parameters:
                     parameters.append(x)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -253,8 +253,8 @@ def _collect_parameters(args):
         if hasattr(t, '__typing_subst__'):
             if t not in parameters:
                 parameters.append(t)
-        # We need to avoid bare Python types as those aren't really objects.
-        elif type(t) is not type:
+        # Ensures we aren't grabbing from something non-generic. E.g. a bare Python class isn't generic.
+        elif isinstance(t, (_GenericAlias, GenericAlias, types.UnionType)):
             for x in getattr(t, '__parameters__', ()):
                 if x not in parameters:
                     parameters.append(x)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -253,7 +253,7 @@ def _collect_parameters(args):
         if hasattr(t, '__typing_subst__'):
             if t not in parameters:
                 parameters.append(t)
-        # We need to avoid bare Python types as those aren't really generic.
+        # We need to avoid bare Python types as those aren't really objects.
         elif not type(t) is type:
             for x in getattr(t, '__parameters__', ()):
                 if x not in parameters:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -253,7 +253,8 @@ def _collect_parameters(args):
         if hasattr(t, '__typing_subst__'):
             if t not in parameters:
                 parameters.append(t)
-        else:
+        # We need to avoid bare Python types as those aren't really generic.
+        elif not type(t) is type:
             for x in getattr(t, '__parameters__', ()):
                 if x not in parameters:
                     parameters.append(x)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -253,7 +253,8 @@ def _collect_parameters(args):
         if hasattr(t, '__typing_subst__'):
             if t not in parameters:
                 parameters.append(t)
-        # Ensures we aren't grabbing from something non-generic. E.g. a bare Python class isn't generic.
+        # Ensures we aren't grabbing from something non-generic.
+        # E.g. a bare Python class isn't generic.
         elif isinstance(t, (_GenericAlias, GenericAlias, types.UnionType)):
             for x in getattr(t, '__parameters__', ()):
                 if x not in parameters:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -250,12 +250,13 @@ def _collect_parameters(args):
     """
     parameters = []
     for t in args:
+        # A bare Python class isn't generic.
+        if isinstance(t, type):
+            continue
         if hasattr(t, '__typing_subst__'):
             if t not in parameters:
                 parameters.append(t)
-        # Ensures we aren't grabbing from something non-generic.
-        # E.g. a bare Python class isn't generic.
-        elif isinstance(t, (_GenericAlias, GenericAlias, types.UnionType)):
+        else:
             for x in getattr(t, '__parameters__', ()):
                 if x not in parameters:
                     parameters.append(x)

--- a/Misc/NEWS.d/next/Library/2022-07-06-16-01-08.gh-issue-94607.Q6RYfz.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-06-16-01-08.gh-issue-94607.Q6RYfz.rst
@@ -1,1 +1,2 @@
 Fix subclassing complex generics with type variables in :mod:`typing`. Previously an error message saying ``Some type variables ... are not listed in Generic[...]`` was shown.
+:mod:`typing` no longer populates ``__parameters__`` with the ``__parameters__`` of a Python class.

--- a/Misc/NEWS.d/next/Library/2022-07-06-16-01-08.gh-issue-94607.Q6RYfz.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-06-16-01-08.gh-issue-94607.Q6RYfz.rst
@@ -1,0 +1,1 @@
+Fix subclassing complex generics with type variables in :mod:`typing`. Previously an error message saying ``Some type variables ... are not listed in Generic[...]`` was shown.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -219,7 +219,7 @@ _Py_make_parameters(PyObject *args)
     for (Py_ssize_t iarg = 0; iarg < nargs; iarg++) {
         PyObject *t = PyTuple_GET_ITEM(args, iarg);
         PyObject *subst;
-        // A bare Python class isn't generic.
+        // We don't want __parameters__ descriptor of a bare Python class.
         if (PyType_Check(t)) {
             continue;
         }

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -219,6 +219,10 @@ _Py_make_parameters(PyObject *args)
     for (Py_ssize_t iarg = 0; iarg < nargs; iarg++) {
         PyObject *t = PyTuple_GET_ITEM(args, iarg);
         PyObject *subst;
+        // A bare Python class isn't generic.
+        if (PyType_Check(t)) {
+            continue;
+        }
         if (_PyObject_LookupAttr(t, &_Py_ID(__typing_subst__), &subst) < 0) {
             Py_DECREF(parameters);
             return NULL;


### PR DESCRIPTION
The breakage is caused by a discrepancy between the old and new behavior of grabbing type parameters. Previously we only allowed `(_GenericAlias, GenericAlias, types.UnionType)` and would extend with the `__parameters__` of these three.

After commit b6a5d8590c4bfe4553d796b36af03bda8c0d5af5, our code grabs anything that has `__parameters__`. The problem is that we shouldn't be extracting `__parameters__` from bare Python types which subclass a Generic.

There are two possible fixes, either restore the restrictive checks or block bare Python types. ~I chose the latter because it allows our code to be more flexible.~

<!-- gh-issue-number: gh-94607 -->
* Issue: gh-94607
<!-- /gh-issue-number -->
