### PR TITLE
gh-92546: Move pprint benchmark into pyperformance

### DIFF
--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -637,19 +637,6 @@ def _recursion(object):
             % (type(object).__name__, id(object)))
 
 
-def _perfcheck(object=None):
-    import time
-    if object is None:
-        object = [("string", (1, 2), [3, 4], {5: 6, 7: 8})] * 100000
-    p = PrettyPrinter()
-    t1 = time.perf_counter()
-    p._safe_repr(object, {}, None, 0, True)
-    t2 = time.perf_counter()
-    p.pformat(object)
-    t3 = time.perf_counter()
-    print("_safe_repr:", t2 - t1)
-    print("pformat:", t3 - t2)
-
 def _wrap_bytes_repr(object, width, allowance):
     current = b''
     last = len(object) // 4 * 4
@@ -666,6 +653,3 @@ def _wrap_bytes_repr(object, width, allowance):
             current = candidate
     if current:
         yield repr(current)
-
-if __name__ == "__main__":
-    _perfcheck()

--- a/Misc/NEWS.d/next/Library/2022-07-06-21-24-03.gh-issue-92546.s5Upkh.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-06-21-24-03.gh-issue-92546.s5Upkh.rst
@@ -1,2 +1,2 @@
 An undocumented ``python -m pprint`` benchmark is moved into ``from_stdlib``
-suit of pyperformance. Patch by Oleg Iarygin.
+suite of pyperformance. Patch by Oleg Iarygin.

--- a/Misc/NEWS.d/next/Library/2022-07-06-21-24-03.gh-issue-92546.s5Upkh.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-06-21-24-03.gh-issue-92546.s5Upkh.rst
@@ -1,0 +1,2 @@
+An undocumented ``python -m pprint`` benchmark is moved into ``from_stdlib``
+suit of pyperformance. Patch by Oleg Iarygin.

--- a/Misc/NEWS.d/next/Library/2022-07-06-21-24-03.gh-issue-92546.s5Upkh.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-06-21-24-03.gh-issue-92546.s5Upkh.rst
@@ -1,2 +1,2 @@
-An undocumented ``python -m pprint`` benchmark is moved into ``from_stdlib``
+An undocumented ``python -m pprint`` benchmark is moved into ``pprint``
 suite of pyperformance. Patch by Oleg Iarygin.


### PR DESCRIPTION
This PR couples with https://github.com/python/pyperformance/pull/222 and supersedes https://github.com/python/cpython/pull/92560. Inspired by https://github.com/python/cpython/issues/93096#issuecomment-1134576471.

<!-- gh-issue-number: gh-92546 -->
* Issue: gh-92546
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:ericsnowcurrently