### PR TITLE
gh-94309: Deprecate typing.Hashable/Sized

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2216,7 +2216,7 @@ Corresponding to other types in :mod:`collections.abc`
    An alias to :class:`collections.abc.Hashable`.
 
    .. deprecated:: 3.12
-      :class:`collections.abc.Hashable` should be directly imported from the original module.
+      :class:`collections.abc.Hashable` should be directly imported from the :class:`collections.abc`.
 
 .. class:: Reversible(Iterable[T_co])
 
@@ -2231,7 +2231,7 @@ Corresponding to other types in :mod:`collections.abc`
    An alias to :class:`collections.abc.Sized`.
 
    .. deprecated:: 3.12
-      :class:`collections.abc.Sized` should be directly imported from the original module.
+      :class:`collections.abc.Sized` should be directly imported from the :class:`collections.abc`.
 
 Asynchronous programming
 """"""""""""""""""""""""

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2216,7 +2216,7 @@ Corresponding to other types in :mod:`collections.abc`
    An alias to :class:`collections.abc.Hashable`.
 
    .. deprecated:: 3.12
-      :class:`collections.abc.Hashable` should be directly imported from the :class:`collections.abc`.
+      Use :class:`collections.abc.Hashable` directly instead.
 
 .. class:: Reversible(Iterable[T_co])
 
@@ -2231,7 +2231,7 @@ Corresponding to other types in :mod:`collections.abc`
    An alias to :class:`collections.abc.Sized`.
 
    .. deprecated:: 3.12
-      :class:`collections.abc.Sized` should be directly imported from the :class:`collections.abc`.
+      Use :class:`collections.abc.Sized` directly instead.
 
 Asynchronous programming
 """"""""""""""""""""""""
@@ -2854,4 +2854,7 @@ convenience. This is subject to change, and not all deprecations are listed.
 |  collections                     |               |                   |                |
 +----------------------------------+---------------+-------------------+----------------+
 |  ``typing.Text``                 | 3.11          | Undecided         | :gh:`92332`    |
++----------------------------------+---------------+-------------------+----------------+
+|  ``typing.Hashable`` and         | 3.12          | Undecided         | :gh:`94309`    |
+|  ``typing.Sized``                |               |                   |                |
 +----------------------------------+---------------+-------------------+----------------+

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2215,6 +2215,9 @@ Corresponding to other types in :mod:`collections.abc`
 
    An alias to :class:`collections.abc.Hashable`.
 
+   .. deprecated:: 3.12
+      :class:`collections.abc.Hashable` should be directly imported from the original module.
+
 .. class:: Reversible(Iterable[T_co])
 
    A generic version of :class:`collections.abc.Reversible`.
@@ -2226,6 +2229,9 @@ Corresponding to other types in :mod:`collections.abc`
 .. class:: Sized
 
    An alias to :class:`collections.abc.Sized`.
+
+   .. deprecated:: 3.12
+      :class:`collections.abc.Sized` should be directly imported from the original module.
 
 Asynchronous programming
 """"""""""""""""""""""""

--- a/Misc/NEWS.d/next/Library/2022-07-06-22-41-51.gh-issue-94309._XswsX.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-06-22-41-51.gh-issue-94309._XswsX.rst
@@ -1,0 +1,1 @@
+Deprecate aliases :class:`typing.Hashable` and :class:`typing.Sized`


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
#94309 
To be consistent with PEP 585, deprecated aliases should not raise any DeprecationWarning.

I put as first version of deprecation the upcoming Python 3.12 (I am not fully sure about this though).


<!-- gh-issue-number: gh-94309 -->
* Issue: gh-94309
<!-- /gh-issue-number -->
