### PR TITLE
ast.parse: check `feature_version` common case first

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -40,12 +40,12 @@ def parse(source, filename='<unknown>', mode='exec', *,
     flags = PyCF_ONLY_AST
     if type_comments:
         flags |= PyCF_TYPE_COMMENTS
-    if isinstance(feature_version, tuple):
+    if feature_version is None:
+        feature_version = -1
+    elif isinstance(feature_version, tuple):
         major, minor = feature_version  # Should be a 2-tuple.
         assert major == 3
         feature_version = minor
-    elif feature_version is None:
-        feature_version = -1
     # Else it should be an int giving the minor version for 3.x.
     return compile(source, filename, mode, flags,
                    _feature_version=feature_version)


### PR DESCRIPTION
this doesn't really improve much -- in a macro benchmark for reorder-python-imports the `isinstance` call here takes about .1% of the total time

totally understand if this is too minor to be considered, feel free to close