### PR TITLE
[3.11] gh-94430: Allow params named `module` or `self` with custom C names in AC (GH-94431)

### DIFF
--- a/Lib/test/clinic.test
+++ b/Lib/test/clinic.test
@@ -3524,3 +3524,44 @@ static PyObject *
 test_vararg_with_only_defaults_impl(PyObject *module, PyObject *args, int b,
                                     PyObject *c)
 /*[clinic end generated code: output=7e393689e6ce61a3 input=fa56a709a035666e]*/
+
+/*[clinic input]
+test_paramname_module
+
+    module as mod: object
+[clinic start generated code]*/
+
+PyDoc_STRVAR(test_paramname_module__doc__,
+"test_paramname_module($module, /, module)\n"
+"--\n"
+"\n");
+
+#define TEST_PARAMNAME_MODULE_METHODDEF    \
+    {"test_paramname_module", _PyCFunction_CAST(test_paramname_module), METH_FASTCALL|METH_KEYWORDS, test_paramname_module__doc__},
+
+static PyObject *
+test_paramname_module_impl(PyObject *module, PyObject *mod);
+
+static PyObject *
+test_paramname_module(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"module", NULL};
+    static _PyArg_Parser _parser = {NULL, _keywords, "test_paramname_module", 0};
+    PyObject *argsbuf[1];
+    PyObject *mod;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    mod = args[0];
+    return_value = test_paramname_module_impl(module, mod);
+
+exit:
+    return return_value;
+}
+
+static PyObject *
+test_paramname_module_impl(PyObject *module, PyObject *mod)
+/*[clinic end generated code: output=23379a7ffa65c514 input=afefe259667f13ba]*/

--- a/Misc/NEWS.d/next/Tools-Demos/2022-06-29-22-47-11.gh-issue-94430.hdov8L.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2022-06-29-22-47-11.gh-issue-94430.hdov8L.rst
@@ -1,0 +1,2 @@
+Allow parameters named ``module`` and ``self`` with custom C names in Argument
+Clinic. Patch by Erlend E. Aasland

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4721,9 +4721,14 @@ class DSLParser:
 
         p = Parameter(parameter_name, kind, function=self.function, converter=converter, default=value, group=self.group)
 
-        if parameter_name in self.function.parameters:
+        names = [k.name for k in self.function.parameters.values()]
+        if parameter_name in names[1:]:
             fail("You can't have two parameters named " + repr(parameter_name) + "!")
-        self.function.parameters[parameter_name] = p
+        elif names and parameter_name == names[0] and c_name is None:
+            fail(f"Parameter '{parameter_name}' requires a custom C name")
+
+        key = f"{parameter_name}_as_{c_name}" if c_name else parameter_name
+        self.function.parameters[key] = p
 
     def parse_converter(self, annotation):
         if (hasattr(ast, 'Constant') and


### PR DESCRIPTION
(cherry picked from commit 8bbd70b4d130f060f87e3f53810dc747a49fa369)

Co-authored-by: Erlend Egeberg Aasland <erlend.aasland@protonmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94430 -->
* Issue: gh-94430
<!-- /gh-issue-number -->
