### PR TITLE
gh-94642: Remove -D_XOPEN_SOURCE from more pkg-config CFLAGS

### DIFF
--- a/configure
+++ b/configure
@@ -21031,6 +21031,7 @@ fi
 
 fi
 
+READLINE_CFLAGS=$(echo $READLINE_CFLAGS | sed 's/-D_XOPEN_SOURCE=600//g')
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking how to link readline" >&5
 $as_echo_n "checking how to link readline... " >&6; }
@@ -22028,7 +22029,7 @@ fi
 
 
 fi
-CURSES_CFLAGS=$(echo $CURSES_CFLAGS | sed 's/-D_XOPEN_SOURCE=600//')
+CURSES_CFLAGS=$(echo $CURSES_CFLAGS | sed 's/-D_XOPEN_SOURCE=600//g')
 
 if test "$have_curses" = no -a "$ac_sys_system" = "Darwin"; then
 
@@ -22460,6 +22461,8 @@ fi
 
 
 fi
+PANEL_CFLAGS=$(echo $PANEL_CFLAGS | sed 's/-D_XOPEN_SOURCE=600//g')
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking panel flags" >&5
 $as_echo_n "checking panel flags... " >&6; }
 if test "x$have_panel" = xno; then :

--- a/configure.ac
+++ b/configure.ac
@@ -5850,6 +5850,8 @@ AS_VAR_IF([with_readline], [edit], [
   ])
 ])
 
+dnl pyconfig.h defines _XOPEN_SOURCE=700
+READLINE_CFLAGS=$(echo $READLINE_CFLAGS | sed 's/-D_XOPEN_SOURCE=600//g')
 
 AC_MSG_CHECKING([how to link readline])
 AS_VAR_IF([with_readline], [no], [
@@ -6144,7 +6146,7 @@ AS_VAR_IF([ac_cv_header_ncurses_h], [yes], [
 
 dnl remove _XOPEN_SOURCE macro from curses cflags. pyconfig.h sets
 dnl the macro to 700.
-CURSES_CFLAGS=$(echo $CURSES_CFLAGS | sed 's/-D_XOPEN_SOURCE=600//')
+CURSES_CFLAGS=$(echo $CURSES_CFLAGS | sed 's/-D_XOPEN_SOURCE=600//g')
 
 if test "$have_curses" = no -a "$ac_sys_system" = "Darwin"; then
   dnl On macOS, there is no separate /usr/lib/libncursesw nor libpanelw.
@@ -6203,6 +6205,9 @@ AS_VAR_IF([ac_cv_header_panel_h], [yes], [
   ])
 
 ])dnl ac_cv_header_panel_h = yes
+
+dnl pyconfig.h defines _XOPEN_SOURCE=700
+PANEL_CFLAGS=$(echo $PANEL_CFLAGS | sed 's/-D_XOPEN_SOURCE=600//g')
 
 AC_MSG_CHECKING([panel flags])
 AS_VAR_IF([have_panel], [no], [


### PR DESCRIPTION
Some pkg-config pc files define CFLAGS with -D_XOPEN_SOURCE=600. We
always want _XOPEN_SOURCE=700.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94642 -->
* Issue: gh-94642
<!-- /gh-issue-number -->
