### PR TITLE
gh-94215: Fix reference count issue in exception_unwind

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2085,7 +2085,7 @@ def bœr():
             expected = '(Pdb) The correct file was executed'
             self.assertEqual(stdout.split('\n')[6].rstrip('\r'), expected)
 
-    @unittest.skip("test crashes, see gh-94215")
+    # @unittest.skip("test crashes, see gh-94215")
     def test_gh_94215_crash(self):
         script = """\
             def func():

--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-07-17-07-00.gh-issue-94215.cXltGH.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-07-17-07-00.gh-issue-94215.cXltGH.rst
@@ -1,0 +1,4 @@
+Fix a reference counting bug in exception unwinding code for zero-cost
+exception handling. The code did not take into account that
+``frame_setlineno()`` can pop off stacks, too.
+Patch by Irit Katriel and Christian Heimes.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5683,6 +5683,8 @@ handle_eval_breaker:
                     err = maybe_call_line_trace(tstate->c_tracefunc,
                                                 tstate->c_traceobj,
                                                 tstate, frame, instr_prev);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    frame->stacktop = -1;
                     if (err) {
                         /* trace function raised an exception */
                         next_instr++;
@@ -5690,9 +5692,6 @@ handle_eval_breaker:
                     }
                     /* Reload possibly changed frame fields */
                     next_instr = frame->prev_instr;
-
-                    stack_pointer = _PyFrame_GetStackPointer(frame);
-                    frame->stacktop = -1;
                 }
             }
         }
@@ -5795,11 +5794,6 @@ exception_unwind:
 
                 /* Pop remaining stack entries. */
                 PyObject **stackbase = _PyFrame_Stackbase(frame);
-                if (frame->stacktop != -1) {
-                    // frame_setlineno() may have popped off additional stacks in
-                    // frame_stack_pop(). Re-calculate stack pointer.
-                    stack_pointer = _PyFrame_GetStackPointer(frame);
-                }
                 while (stack_pointer > stackbase) {
                     PyObject *o = POP();
                     Py_XDECREF(o);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5795,6 +5795,11 @@ exception_unwind:
 
                 /* Pop remaining stack entries. */
                 PyObject **stackbase = _PyFrame_Stackbase(frame);
+                if (frame->stacktop != -1) {
+                    // frame_setlineno() may have popped off additional stacks in
+                    // frame_stack_pop(). Re-calculate stack pointer.
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                }
                 while (stack_pointer > stackbase) {
                     PyObject *o = POP();
                     Py_XDECREF(o);


### PR DESCRIPTION
Zero-cost exception handling did not take ``frame_setlineno()`` into
account. It can pop off stacks. This can lead to a crash.

Exception unwinding now re-calculates the stack pointer.

Co-authored-by: Irit Katriel <1055913+iritkatriel@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94215 -->
* Issue: gh-94215
<!-- /gh-issue-number -->
