### PR TITLE
[3.9] gh-92743 - Fix #92743 for python 3.9 - Remove copyright sign next to "Raymond Hettinger"

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -915,7 +915,7 @@ These are not used in annotations. They are building blocks for creating generic
 
     Bound type variables are particularly useful for annotating
     :func:`classmethods <classmethod>` that serve as alternative constructors.
-    In the following example (©
+    In the following example (by
     `Raymond Hettinger <https://www.youtube.com/watch?v=HTLu2DFOdTg>`_), the
     type variable ``C`` is bound to the ``Circle`` class through the use of a
     forward reference. Using this type variable to annotate the


### PR DESCRIPTION
[#92743](https://github.com/python/cpython/issues/92743)
Remove copyright sign next to "Raymond Hettinger"

<!-- gh-issue-number: gh-92743 -->
* Issue: gh-92743
<!-- /gh-issue-number -->
