### PR TITLE
Don't use `assert` as a guard or error handling

### DIFF
--- a/Parser/myreadline.c
+++ b/Parser/myreadline.c
@@ -244,7 +244,10 @@ PyOS_StdioReadline(FILE *sys_stdin, FILE *sys_stdout, const char *prompt)
     size_t n;
     char *p, *pr;
     PyThreadState *tstate = _PyOS_ReadlineTState;
-    assert(tstate != NULL);
+    if (tstate == NULL)
+    {
+        return NULL;
+    }
 
 #ifdef MS_WINDOWS
     const PyConfig *config = _PyInterpreterState_GetConfig(tstate->interp);


### PR DESCRIPTION
There's a potential null pointer deref immediately after this.  You need to be sure the guard still exists when `assert` is optimised away (that function is only to be used as a debugging aid)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
