### PR TITLE
gh-94596: Clarify raising exception instance docs in errors tutorial 

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -263,6 +263,20 @@ instantiated by calling its constructor with no arguments::
 
    raise ValueError  # shorthand for 'raise ValueError()'
 
+If you want to use an exception instance as the argument of :keyword:`raise`,
+you need to construct the exception instance in the :keyword:`raise` statement.
+Otherwise, unexpected stack trace entries may be obtained::
+
+  >>> try:
+  ...     raise NameError('HiThere')  # Good: call exception constructor
+  ... except NameError as e:
+  ...     traceback.print_exception(e)
+  ...
+  Traceback (most recent call last):
+    File "<stdin>", line 2, in <module>
+      raise NameError('HiThere')  # Good: call exception constructor
+  NameError: HiThere
+
 If you need to determine whether an exception was raised but don't intend to
 handle it, a simpler form of the :keyword:`raise` statement allows you to
 re-raise the exception::


### PR DESCRIPTION
#94596 
Provide best practices for raising exception instance.
When using the `raise` keyword, it is recommended that users call exception constructor in place. 
```python
raise Exception
raise Exception()  # call exception constructor
raise
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
