### PR TITLE
gh-94215: Fix error handling for line-tracing events

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2085,7 +2085,6 @@ def bœr():
             expected = '(Pdb) The correct file was executed'
             self.assertEqual(stdout.split('\n')[6].rstrip('\r'), expected)
 
-    @unittest.skip("test crashes, see gh-94215")
     def test_gh_94215_crash(self):
         script = """\
             def func():

--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-07-21-13-25.gh-issue-94215._Sv9Ms.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-07-21-13-25.gh-issue-94215._Sv9Ms.rst
@@ -1,0 +1,3 @@
+Fix an issue where exceptions raised by line-tracing events would cause
+frames to be left in an invalid state, possibly resulting in a hard crash of
+the interpreter.


### PR DESCRIPTION
Supersedes #94659. This properly restores frame state following an exception raised by a line-tracing event. It also adds some comments to clarify the (somewhat subtle) nearby code.


<!-- gh-issue-number: gh-94215 -->
* Issue: gh-94215
<!-- /gh-issue-number -->
