### PR TITLE
Improve dataclass docstring

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1193,8 +1193,7 @@ def _add_slots(cls, is_frozen, weakref_slot):
 def dataclass(cls=None, /, *, init=True, repr=True, eq=True, order=False,
               unsafe_hash=False, frozen=False, match_args=True,
               kw_only=False, slots=False, weakref_slot=False):
-    """Return the same class as was passed in, with dunder methods added
-    based on the fields defined in the class.
+    """Add dunder methods based on the fields defined in the class.
 
     Examines PEP 526 __annotations__ to determine fields.
 
@@ -1204,8 +1203,8 @@ def dataclass(cls=None, /, *, init=True, repr=True, eq=True, order=False,
     __hash__() method is added. If frozen is true, fields may not be
     assigned to after instance creation. If match_args is true, the
     __match_args__ tuple is added. If kw_only is true, then by default
-    all fields are keyword-only. If slots is true, a __slots__ attribute
-    is added.
+    all fields are keyword-only. If slots is true, a new class with a
+    __slots__ attribute is returned.
     """
 
     def wrap(cls):

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1193,19 +1193,19 @@ def _add_slots(cls, is_frozen, weakref_slot):
 def dataclass(cls=None, /, *, init=True, repr=True, eq=True, order=False,
               unsafe_hash=False, frozen=False, match_args=True,
               kw_only=False, slots=False, weakref_slot=False):
-    """Returns the same class as was passed in, with dunder methods
-    added based on the fields defined in the class.
+    """Return the same class as was passed in, with dunder methods added
+    based on the fields defined in the class.
 
     Examines PEP 526 __annotations__ to determine fields.
 
-    If init is true, an __init__() method is added to the class. If
-    repr is true, a __repr__() method is added. If order is true, rich
+    If init is true, an __init__() method is added to the class. If repr
+    is true, a __repr__() method is added. If order is true, rich
     comparison dunder methods are added. If unsafe_hash is true, a
-    __hash__() method function is added. If frozen is true, fields may
-    not be assigned to after instance creation. If match_args is true,
-    the __match_args__ tuple is added. If kw_only is true, then by
-    default all fields are keyword-only. If slots is true, an
-    __slots__ attribute is added.
+    __hash__() method is added. If frozen is true, fields may not be
+    assigned to after instance creation. If match_args is true, the
+    __match_args__ tuple is added. If kw_only is true, then by default
+    all fields are keyword-only. If slots is true, a __slots__ attribute
+    is added.
     """
 
     def wrap(cls):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This fixes three trivial issues:
* The summary line was in the wrong tense.
* Assuming the underscores are not pronounced, 'an \_\_slots\_\_' should be 'a'. If they should be, then the earlier 'a \_\_hash\_\_' would be wrong.
* 'method function' is a bit of an odd phrase that seems unnecessary.