### PR TITLE
gh-87822: Make traceback module robust to exceptions from repr() of local values

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -342,8 +342,8 @@ capture data for later printing in a lightweight fashion.
       representations.
 
       .. versionchanged:: 3.12
-         Exceptions raised from :func:`repr` on a local variable are no longer
-         propagated to the caller.
+         Exceptions raised from :func:`repr` on a local variable (when
+         *capture_locals* is ``True``) are no longer propagated to the caller.
 
    .. classmethod:: from_list(a_list)
 

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -339,7 +339,9 @@ capture data for later printing in a lightweight fashion.
       creating the :class:`StackSummary` cheaper (which may be valuable if it
       may not actually get formatted). If *capture_locals* is ``True`` the
       local variables in each :class:`FrameSummary` are captured as object
-      representations.
+      representations. If, for some reason, a representation can not be
+      created (i.e. :func:`repr` fails), it is replaced with a placeholder
+      (``'<local repr() failed>'``).
 
    .. classmethod:: from_list(a_list)
 

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -343,7 +343,7 @@ capture data for later printing in a lightweight fashion.
 
       .. versionchanged:: 3.12
          Exceptions raised from :func:`repr` on a local variable are no longer
-         propagated to the caller and a placeholder is stored instead.
+         propagated to the caller.
 
    .. classmethod:: from_list(a_list)
 

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -340,7 +340,7 @@ capture data for later printing in a lightweight fashion.
       may not actually get formatted). If *capture_locals* is ``True`` the
       local variables in each :class:`FrameSummary` are captured as object
       representations.
-      
+
       .. versionchanged:: 3.12
          Exceptions raised from :func:`repr` on a local variable are no longer
          propagated to the caller and a placeholder is stored instead.

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -339,9 +339,11 @@ capture data for later printing in a lightweight fashion.
       creating the :class:`StackSummary` cheaper (which may be valuable if it
       may not actually get formatted). If *capture_locals* is ``True`` the
       local variables in each :class:`FrameSummary` are captured as object
-      representations. If, for some reason, a representation can not be
-      created (i.e. :func:`repr` fails), it is replaced with a placeholder
-      (``'<local repr() failed>'``).
+      representations.
+      
+      .. versionchanged:: 3.12
+         Exceptions raised from :func:`repr` on a local variable are no longer
+         propagated to the caller and a placeholder is stored instead.
 
    .. classmethod:: from_list(a_list)
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -2247,6 +2247,9 @@ class TestStack(unittest.TestCase):
             f'  File "{__file__}", line {lno}, in f\n    1/0\n'
         )
 
+class Unrepresentable:
+    def __repr__(self) -> str:
+        raise Exception("Unrepresentable")
 
 class TestTracebackException(unittest.TestCase):
 
@@ -2514,12 +2517,12 @@ class TestTracebackException(unittest.TestCase):
         linecache.updatecache('/foo.py', globals())
         e = Exception("uh oh")
         c = test_code('/foo.py', 'method')
-        f = test_frame(c, globals(), {'something': 1, 'other': 'string'})
+        f = test_frame(c, globals(), {'something': 1, 'other': 'string', 'unrepresentable': Unrepresentable()})
         tb = test_tb(f, 6, None, 0)
         exc = traceback.TracebackException(
             Exception, e, tb, capture_locals=True)
         self.assertEqual(
-            exc.stack[0].locals, {'something': '1', 'other': "'string'"})
+            exc.stack[0].locals, {'something': '1', 'other': "'string'", 'unrepresentable': '<local repr() failed>'})
 
     def test_no_locals(self):
         linecache.updatecache('/foo.py', globals())

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -2522,7 +2522,8 @@ class TestTracebackException(unittest.TestCase):
         exc = traceback.TracebackException(
             Exception, e, tb, capture_locals=True)
         self.assertEqual(
-            exc.stack[0].locals, {'something': '1', 'other': "'string'", 'unrepresentable': '<local repr() failed>'})
+            exc.stack[0].locals,
+            {'something': '1', 'other': "'string'", 'unrepresentable': '<local repr() failed>'})
 
     def test_no_locals(self):
         linecache.updatecache('/foo.py', globals())

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -279,7 +279,8 @@ class FrameSummary:
         self._line = line
         if lookup_line:
             self.line
-        self.locals = {k: repr(v) for k, v in locals.items()} if locals else None
+        self.locals = {k: _safe_string(v, 'local', func=repr)
+            for k, v in locals.items()} if locals else None
         self.end_lineno = end_lineno
         self.colno = colno
         self.end_colno = end_colno

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1590,6 +1590,7 @@ Ed Schouten
 Scott Schram
 Robin Schreiber
 Chad J. Schroeder
+Simon-Martin Schroeder
 Christian Schubert
 Sam Schulenburg
 Andreas Schwab

--- a/Misc/NEWS.d/next/Library/2022-07-08-17-49-12.gh-issue-87822.F9dzkf.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-08-17-49-12.gh-issue-87822.F9dzkf.rst
@@ -1,0 +1,1 @@
+Make FrameSummary robust to unrepresentable values.

--- a/Misc/NEWS.d/next/Library/2022-07-08-17-49-12.gh-issue-87822.F9dzkf.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-08-17-49-12.gh-issue-87822.F9dzkf.rst
@@ -1,1 +1,1 @@
-Make FrameSummary robust to unrepresentable values.
+When called with ``capture_locals=True``, the :mod:`traceback` module functions swallow exceptions raised from calls to ``repr()`` on local variables of frames. This is in order to prioritize the original exception over rendering errors.  An indication of the failure is printed in place of the missing value.  (Patch by Simon-Martin Schroeder).


### PR DESCRIPTION
Fixes #87822.

<!-- gh-issue-number: gh-87822 -->
* Issue: gh-87822
<!-- /gh-issue-number -->
