### PR TITLE
GH-94694: Fix column offsets for multi-line method lookups

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1182,7 +1182,8 @@ f(
             line=1, end_line=1, column=0, end_column=27, occurrence=4)
 
     def test_multiline_assert_rewritten_as_method_call(self):
-        # GH-94694
+        # GH-94694: Copying location information from a "real" node to a
+        # handwritten one should always be valid!
         tree = ast.parse("assert (\n42\n)")
         old_node = tree.body[0]
         new_node = ast.Expr(

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1181,6 +1181,26 @@ f(
         self.assertOpcodeSourcePositionIs(compiled_code, 'BINARY_OP',
             line=1, end_line=1, column=0, end_column=27, occurrence=4)
 
+    def test_multiline_assert_rewritten_as_method_call(self):
+        # GH-94694
+        tree = ast.parse("assert (\n42\n)")
+        old_node = tree.body[0]
+        new_node = ast.Expr(
+            ast.Call(
+                ast.Attribute(
+                    ast.Name("spam", ast.Load()),
+                    "eggs",
+                    ast.Load(),
+                ),
+                [],
+                [],
+            )
+        )
+        ast.copy_location(new_node, old_node)
+        ast.fix_missing_locations(new_node)
+        tree.body[0] = new_node
+        compile(tree, "<test>", "exec")
+
 
 class TestExpressionStackSize(unittest.TestCase):
     # These tests check that the computed stack size for a code object

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1182,8 +1182,8 @@ f(
             line=1, end_line=1, column=0, end_column=27, occurrence=4)
 
     def test_multiline_assert_rewritten_as_method_call(self):
-        # GH-94694: Copying location information from a "real" node to a
-        # handwritten one should always be valid!
+        # GH-94694: Don't crash if pytest rewrites a multiline assert as a
+        # method call with the same location information:
         tree = ast.parse("assert (\n42\n)")
         old_node = tree.body[0]
         new_node = ast.Expr(

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -702,6 +702,57 @@ class TracebackErrorLocationCaretTests(unittest.TestCase):
         )
         self.assertEqual(result_lines, expected_error.splitlines())
 
+    def test_multiline_method_call_a(self):
+        def f():
+            (None
+                .method
+            )()
+        actual = self.get_exception(f)
+        expected = [
+            f"Traceback (most recent call last):",
+            f"  File \"{__file__}\", line {self.callable_line}, in get_exception",
+            f"    callable()",
+            f"    ^^^^^^^^^^",
+            f"  File \"{__file__}\", line {f.__code__.co_firstlineno + 2}, in f",
+            f"    .method",
+            f"     ^^^^^^",
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_multiline_method_call_b(self):
+        def f():
+            (None.
+                method
+            )()
+        actual = self.get_exception(f)
+        expected = [
+            f"Traceback (most recent call last):",
+            f"  File \"{__file__}\", line {self.callable_line}, in get_exception",
+            f"    callable()",
+            f"    ^^^^^^^^^^",
+            f"  File \"{__file__}\", line {f.__code__.co_firstlineno + 2}, in f",
+            f"    method",
+            f"    ^^^^^^",
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_multiline_method_call_c(self):
+        def f():
+            (None
+                . method
+            )()
+        actual = self.get_exception(f)
+        expected = [
+            f"Traceback (most recent call last):",
+            f"  File \"{__file__}\", line {self.callable_line}, in get_exception",
+            f"    callable()",
+            f"    ^^^^^^^^^^",
+            f"  File \"{__file__}\", line {f.__code__.co_firstlineno + 2}, in f",
+            f"    . method",
+            f"      ^^^^^^",
+        ]
+        self.assertEqual(actual, expected)
+
 @cpython_only
 @requires_debug_ranges()
 class CPythonTracebackErrorCaretTests(TracebackErrorLocationCaretTests):

--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-08-16-44-11.gh-issue-94694.VkL2CM.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-08-16-44-11.gh-issue-94694.VkL2CM.rst
@@ -1,0 +1,4 @@
+Fix an issue that could cause code with multi-line method lookups to have
+misleading or incorrect column offset information. In some cases (when
+compiling a hand-built AST) this could have resulted in a hard crash of the
+interpreter.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4736,14 +4736,9 @@ update_location_to_match_attr(struct compiler *c, expr_ty meth)
 {
     if (meth->lineno != meth->end_lineno) {
         // Make start location match attribute
-        c->u->u_loc.lineno = meth->end_lineno;
+        c->u->u_loc.lineno = c->u->u_loc.end_lineno = meth->end_lineno;
         int len = (int)PyUnicode_GET_LENGTH(meth->v.Attribute.attr);
-        // We have no idea where the dot is. Don't try to include it in the
-        // column span, it's more trouble than it's worth:
         if (len <= meth->end_col_offset) {
-            //        |---- end_col_offset
-            // .method(...)
-            //  |---------- new col_offset
             c->u->u_loc.col_offset = meth->end_col_offset - len;
         }
         else {

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4738,7 +4738,7 @@ update_location_to_match_attr(struct compiler *c, expr_ty meth)
         // Make start location match attribute
         c->u->u_loc.lineno = meth->end_lineno;
         int len = (int)PyUnicode_GET_LENGTH(meth->v.Attribute.attr);
-        // The dot may or not be on this line. Don't try to include it in the
+        // We have no idea where the dot is. Don't try to include it in the
         // column span, it's more trouble than it's worth:
         if (len <= meth->end_col_offset) {
             //        |---- end_col_offset


### PR DESCRIPTION
If we're given an AST that doesn't make much sense here, just wipe out the column info instead of crashing later.

Also, don't try to include the dot in the column span.

<!-- gh-issue-number: gh-94694 -->
* Issue: gh-94694
<!-- /gh-issue-number -->
