### PR TITLE
gh-93649: Fix linkage of _PyTestCapi_Init_Vectorcall

### DIFF
--- a/Modules/_testcapi/parts.h
+++ b/Modules/_testcapi/parts.h
@@ -1,3 +1,3 @@
 #include "Python.h"
 
-PyAPI_FUNC(int) _PyTestCapi_Init_Vectorcall(PyObject *module);
+int _PyTestCapi_Init_Vectorcall(PyObject *module);

--- a/Modules/_testcapi/vectorcall.c
+++ b/Modules/_testcapi/vectorcall.c
@@ -229,7 +229,7 @@ static PyTypeObject MethodDescriptor2_Type = {
 };
 
 
-PyAPI_FUNC(int) 
+int
 _PyTestCapi_Init_Vectorcall(PyObject *m) {
     if (PyModule_AddFunctions(m, TestMethods) < 0) {
         return -1;

--- a/Modules/_testcapi/vectorcall.c
+++ b/Modules/_testcapi/vectorcall.c
@@ -229,7 +229,7 @@ static PyTypeObject MethodDescriptor2_Type = {
 };
 
 
-int
+PyAPI_FUNC(int) 
 _PyTestCapi_Init_Vectorcall(PyObject *m) {
     if (PyModule_AddFunctions(m, TestMethods) < 0) {
         return -1;


### PR DESCRIPTION
Addresses this:

> ##[warning]D:\a\cpython\cpython\Modules\_testcapi\vectorcall.c(233,42): warning C4273: '_PyTestCapi_Init_Vectorcall': inconsistent dll linkage [D:\a\cpython\cpython\PCbuild\_testcapi.vcxproj]
> D:\a\cpython\cpython\Modules\_testcapi\parts.h(3,17): message : see previous definition of '_PyTestCapi_Init_Vectorcall' (compiling source file ..\Modules\_testcapi\vectorcall.c) [D:\a\cpython\cpython\PCbuild\_testcapi.vcxproj]

A follow-up to gh-94549 so cc @encukou.

<!-- gh-issue-number: gh-93649 -->
* Issue: gh-93649
<!-- /gh-issue-number -->
