### PR TITLE
gh-94684 uuid3/5 support name argument as bytes

### DIFF
--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -186,7 +186,7 @@ The :mod:`uuid` module defines the following functions:
 .. function:: uuid3(namespace, name)
 
    Generate a UUID based on the MD5 hash of a namespace identifier (which is a
-   UUID) and a name (which is a string).
+   UUID) and a name (which is a byte sequence or a UTF-8-encoded string).
 
 .. index:: single: uuid3
 
@@ -201,7 +201,7 @@ The :mod:`uuid` module defines the following functions:
 .. function:: uuid5(namespace, name)
 
    Generate a UUID based on the SHA-1 hash of a namespace identifier (which is a
-   UUID) and a name (which is a string).
+   UUID) and a name (which is a byte sequence or a UTF-8-encoded string).
 
 .. index:: single: uuid5
 

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -186,7 +186,8 @@ The :mod:`uuid` module defines the following functions:
 .. function:: uuid3(namespace, name)
 
    Generate a UUID based on the MD5 hash of a namespace identifier (which is a
-   UUID) and a name (which is a :class:`bytes` object or a UTF-8 string).
+   UUID) and a name (which is a :class:`bytes` object or a string
+   that will be encoded using UTF-8).
 
 .. index:: single: uuid3
 
@@ -201,7 +202,8 @@ The :mod:`uuid` module defines the following functions:
 .. function:: uuid5(namespace, name)
 
    Generate a UUID based on the SHA-1 hash of a namespace identifier (which is a
-   UUID) and a name (which is a :class:`bytes` object or a UTF-8 string).
+   UUID) and a name (which is a :class:`bytes` object or a string
+   that will be encoded using UTF-8).
 
 .. index:: single: uuid5
 

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -186,7 +186,7 @@ The :mod:`uuid` module defines the following functions:
 .. function:: uuid3(namespace, name)
 
    Generate a UUID based on the MD5 hash of a namespace identifier (which is a
-   UUID) and a name (which is a byte sequence or a UTF-8-encoded string).
+   UUID) and a name (which is a :class:`bytes` object or a UTF-8 string).
 
 .. index:: single: uuid3
 
@@ -201,7 +201,7 @@ The :mod:`uuid` module defines the following functions:
 .. function:: uuid5(namespace, name)
 
    Generate a UUID based on the SHA-1 hash of a namespace identifier (which is a
-   UUID) and a name (which is a byte sequence or a UTF-8-encoded string).
+   UUID) and a name (which is a :class:`bytes` object or a UTF-8 string).
 
 .. index:: single: uuid5
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -600,7 +600,26 @@ class BaseTestUUID:
     def test_uuid3(self):
         equal = self.assertEqual
 
-        # Test some known version-3 UUIDs.
+        # Test some known version-3 UUIDs with name passed as a byte object
+        for u, v in [(self.uuid.uuid3(self.uuid.NAMESPACE_DNS,
+                        bytes('python.org', encoding='UTF-8')),
+                      '6fa459ea-ee8a-3ca4-894e-db77e160355e'),
+                     (self.uuid.uuid3(self.uuid.NAMESPACE_URL,
+                        bytes('http://python.org/', encoding='UTF-8')),
+                      '9fe8e8c4-aaa8-32a9-a55c-4535a88b748d'),
+                     (self.uuid.uuid3(self.uuid.NAMESPACE_OID,
+                        bytes('1.3.6.1', encoding='UTF-8')),
+                      'dd1a1cef-13d5-368a-ad82-eca71acd4cd1'),
+                     (self.uuid.uuid3(self.uuid.NAMESPACE_X500,
+                        bytes('c=ca', encoding='UTF-8')),
+                      '658d3002-db6b-3040-a1d1-8ddd7d189a4d'),
+                    ]:
+            equal(u.variant, self.uuid.RFC_4122)
+            equal(u.version, 3)
+            equal(u, self.uuid.UUID(v))
+            equal(str(u), v)
+
+        # Test some known version-3 UUIDs with name passed as a string
         for u, v in [(self.uuid.uuid3(self.uuid.NAMESPACE_DNS, 'python.org'),
                       '6fa459ea-ee8a-3ca4-894e-db77e160355e'),
                      (self.uuid.uuid3(self.uuid.NAMESPACE_URL, 'http://python.org/'),
@@ -632,7 +651,26 @@ class BaseTestUUID:
     def test_uuid5(self):
         equal = self.assertEqual
 
-        # Test some known version-5 UUIDs.
+        # Test some known version-5 UUIDs with names given as byte objects
+        for u, v in [(self.uuid.uuid5(self.uuid.NAMESPACE_DNS,
+                        bytes('python.org', encoding='UTF-8')),
+                      '886313e1-3b8a-5372-9b90-0c9aee199e5d'),
+                     (self.uuid.uuid5(self.uuid.NAMESPACE_URL,
+                        bytes('http://python.org/', encoding='UTF-8')),
+                      '4c565f0d-3f5a-5890-b41b-20cf47701c5e'),
+                     (self.uuid.uuid5(self.uuid.NAMESPACE_OID,
+                        bytes('1.3.6.1', encoding='UTF-8')),
+                      '1447fa61-5277-5fef-a9b3-fbc6e44f4af3'),
+                     (self.uuid.uuid5(self.uuid.NAMESPACE_X500,
+                        bytes('c=ca', encoding='UTF-8')),
+                      'cc957dd1-a972-5349-98cd-874190002798'),
+                    ]:
+            equal(u.variant, self.uuid.RFC_4122)
+            equal(u.version, 5)
+            equal(u, self.uuid.UUID(v))
+            equal(str(u), v)
+
+        # Test some known version-5 UUIDs with names given as strings
         for u, v in [(self.uuid.uuid5(self.uuid.NAMESPACE_DNS, 'python.org'),
                       '886313e1-3b8a-5372-9b90-0c9aee199e5d'),
                      (self.uuid.uuid5(self.uuid.NAMESPACE_URL, 'http://python.org/'),

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -601,17 +601,13 @@ class BaseTestUUID:
         equal = self.assertEqual
 
         # Test some known version-3 UUIDs with name passed as a byte object
-        for u, v in [(self.uuid.uuid3(self.uuid.NAMESPACE_DNS,
-                        bytes('python.org', encoding='UTF-8')),
+        for u, v in [(self.uuid.uuid3(self.uuid.NAMESPACE_DNS, b'python.org'),
                       '6fa459ea-ee8a-3ca4-894e-db77e160355e'),
-                     (self.uuid.uuid3(self.uuid.NAMESPACE_URL,
-                        bytes('http://python.org/', encoding='UTF-8')),
+                     (self.uuid.uuid3(self.uuid.NAMESPACE_URL, b'http://python.org/'),
                       '9fe8e8c4-aaa8-32a9-a55c-4535a88b748d'),
-                     (self.uuid.uuid3(self.uuid.NAMESPACE_OID,
-                        bytes('1.3.6.1', encoding='UTF-8')),
+                     (self.uuid.uuid3(self.uuid.NAMESPACE_OID, b'1.3.6.1'),
                       'dd1a1cef-13d5-368a-ad82-eca71acd4cd1'),
-                     (self.uuid.uuid3(self.uuid.NAMESPACE_X500,
-                        bytes('c=ca', encoding='UTF-8')),
+                     (self.uuid.uuid3(self.uuid.NAMESPACE_X500, b'c=ca'),
                       '658d3002-db6b-3040-a1d1-8ddd7d189a4d'),
                     ]:
             equal(u.variant, self.uuid.RFC_4122)
@@ -652,17 +648,13 @@ class BaseTestUUID:
         equal = self.assertEqual
 
         # Test some known version-5 UUIDs with names given as byte objects
-        for u, v in [(self.uuid.uuid5(self.uuid.NAMESPACE_DNS,
-                        bytes('python.org', encoding='UTF-8')),
+        for u, v in [(self.uuid.uuid5(self.uuid.NAMESPACE_DNS, b'python.org'),
                       '886313e1-3b8a-5372-9b90-0c9aee199e5d'),
-                     (self.uuid.uuid5(self.uuid.NAMESPACE_URL,
-                        bytes('http://python.org/', encoding='UTF-8')),
+                     (self.uuid.uuid5(self.uuid.NAMESPACE_URL, b'http://python.org/'),
                       '4c565f0d-3f5a-5890-b41b-20cf47701c5e'),
-                     (self.uuid.uuid5(self.uuid.NAMESPACE_OID,
-                        bytes('1.3.6.1', encoding='UTF-8')),
+                     (self.uuid.uuid5(self.uuid.NAMESPACE_OID, b'1.3.6.1'),
                       '1447fa61-5277-5fef-a9b3-fbc6e44f4af3'),
-                     (self.uuid.uuid5(self.uuid.NAMESPACE_X500,
-                        bytes('c=ca', encoding='UTF-8')),
+                     (self.uuid.uuid5(self.uuid.NAMESPACE_X500, b'c=ca'),
                       'cc957dd1-a972-5349-98cd-874190002798'),
                     ]:
             equal(u.variant, self.uuid.RFC_4122)

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -704,9 +704,11 @@ def uuid1(node=None, clock_seq=None):
 
 def uuid3(namespace, name):
     """Generate a UUID from the MD5 hash of a namespace UUID and a name."""
+    if isinstance(name, str):
+        name = bytes(name, "utf-8")
     from hashlib import md5
     digest = md5(
-        namespace.bytes + bytes(name, "utf-8"),
+        namespace.bytes + name,
         usedforsecurity=False
     ).digest()
     return UUID(bytes=digest[:16], version=3)
@@ -717,8 +719,10 @@ def uuid4():
 
 def uuid5(namespace, name):
     """Generate a UUID from the SHA-1 hash of a namespace UUID and a name."""
+    if isinstance(name, str):
+        name = bytes(name, "utf-8")
     from hashlib import sha1
-    hash = sha1(namespace.bytes + bytes(name, "utf-8")).digest()
+    hash = sha1(namespace.bytes + name).digest()
     return UUID(bytes=hash[:16], version=5)
 
 # The following standard UUIDs are for use with uuid3() or uuid5().

--- a/Misc/NEWS.d/next/Library/2022-07-09-13-07-30.gh-issue-94684.nV5yno.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-09-13-07-30.gh-issue-94684.nV5yno.rst
@@ -1,0 +1,1 @@
+Now uuid.uuid3 and uuid.uuid5 functions support also the name argument given as a byte sequence (i.e. bytes object)

--- a/Misc/NEWS.d/next/Library/2022-07-09-13-07-30.gh-issue-94684.nV5yno.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-09-13-07-30.gh-issue-94684.nV5yno.rst
@@ -1,1 +1,1 @@
-Now uuid.uuid3 and uuid.uuid5 functions support also the name argument given as a byte sequence (i.e. bytes object)
+Now :func:`uuid.uuid3` and :func:`uuid.uuid5` functions support :class:`bytes` objects as their *name* argument.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
As discussed in #94684, RFC 4122 does not specify that the name argument in uuid3/uui5 functions should be a string, so for completness the functions should also support a name given as a raw byte sequence.

<!-- gh-issue-number: gh-94684 -->
* Issue: gh-94684
<!-- /gh-issue-number -->
