### PR TITLE
GH-81620: Add random.binomialvariate()

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -263,12 +263,14 @@ Discrete distributions
 
 The following function generates a discrete distribution.
 
-.. function:: binomial(n=1, p=0.5)
+.. function:: binomialvariate(n=1, p=0.5)
 
+   `Binomial distribution
+   <http://mathworld.wolfram.com/BinomialDistribution.html>`_.
    Return the number of successes for *n* independent trials with the
    probability of success in each trial being *p*:
 
-   Roughly equivalent to::
+   Mathematically equivalent to::
 
        sum(random() < p for i in range(n))
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -474,16 +474,13 @@ Simulations::
    >>> # Deal 20 cards without replacement from a deck
    >>> # of 52 playing cards, and determine the proportion of cards
    >>> # with a ten-value:  ten, jack, queen, or king.
-   >>> dealt = sample(['tens', 'low cards'], counts=[16, 36], k=20)
-   >>> dealt.count('tens') / 20
+   >>> deal = sample(['tens', 'low cards'], counts=[16, 36], k=20)
+   >>> deal.count('tens') / 20
    0.15
 
    >>> # Estimate the probability of getting 5 or more heads from 7 spins
    >>> # of a biased coin that settles on heads 60% of the time.
-   >>> def trial():
-   ...     return choices('HT', cum_weights=(0.60, 1.00), k=7).count('H') >= 5
-   ...
-   >>> sum(trial() for i in range(10_000)) / 10_000
+   >>> sum(binomialvariate(n=7, p=0.6) >= 5 for i in range(10_000)) / 10_000
    0.4169
 
    >>> # Probability of the median of 5 samples being in middle two quartiles

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -258,6 +258,26 @@ Functions for sequences
       The *population* must be a sequence.  Automatic conversion of sets
       to lists is no longer supported.
 
+Discrete distributions
+----------------------
+
+The following function generates a discrete distribution.
+
+.. function:: binomial(n=1, p=0.5)
+
+   Return the number of successes for *n* independent trials with the
+   probability of success in each trial being *p*:
+
+   Roughly equivalent to::
+
+       sum(random() < p for i in range(n))
+
+   The number of trials *n* should be a non-negative integer.
+   The probability of success *p* should be between ``0.0 <= p <= 1.0``.
+   The result is an integer in the range ``0 <= X <= n``.
+
+   .. versionadded:: 3.12
+
 
 .. _real-valued-distributions:
 

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -781,6 +781,7 @@ class Random(_random.Random):
         # See "The Generation of Binomial Random Variates" by Wolfgang Hörmann
         # https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.47.8407&rep=rep1&type=pdf
         assert n*p >= 10.0 and p <= 0.5
+        step_three_setup = False
 
         # Step 0: Setup for step 1
         spq = _sqrt(n * p * (1.0 - p))  # Standard deviation of the distribution
@@ -788,12 +789,6 @@ class Random(_random.Random):
         a = -0.0873 + 0.0248 * b + 0.01 * p
         c = n * p + 0.5
         vr = 0.92 - 4.2 / b
-
-        # Step 3.0: Setup for step 3.1
-        alpha = (2.83 + 5.1 / b) * spq
-        lpq = _log(p / (1.0 - p))       # Log of p / q ratio
-        m = _floor((n + 1) * p)         # Mode of the distribution
-        h = _logfact(m) + _logfact(n - m)
 
         while True:
 
@@ -814,6 +809,14 @@ class Random(_random.Random):
             # the u-axis and the curve.
             if us >= 0.07 and v <= vr:
                 return k
+
+            if not step_three_setup:
+                # Step 3.0: Compute constants for step 3.1
+                alpha = (2.83 + 5.1 / b) * spq
+                lpq = _log(p / (1.0 - p))       # Log of p / q ratio
+                m = _floor((n + 1) * p)         # Mode of the distribution
+                h = _logfact(m) + _logfact(n - m)
+                step_three_setup = True         # Only needs to be done once
 
             # Step 3.1: Acceptance-rejection test.
             # N.B. The original paper errorneously omits the call to

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -780,11 +780,14 @@ class Random(_random.Random):
         # https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.47.8407&rep=rep1&type=pdf
         assert n*p >= 10.0 and p <= 0.5
 
+        # Step 0: Setup for step 1
         spq = _sqrt(n * p * (1.0 - p))
         b = 1.15 + 2.53 * spq
         a = -0.0873 + 0.0248 * b + 0.01 * p
         c = n * p + 0.5
         vr = 0.92 - 4.2 / b
+
+        # Step 3.0: Setup for 3.1
         alpha = (2.83 + 5.1 / b) * spq
         lpq = _log(p / (1.0 - p))
         m = _floor((n + 1) * p)
@@ -792,17 +795,20 @@ class Random(_random.Random):
 
         while True:
 
+            # Step 1: Generate two uniform random numbers
             u = random()
             v = random()
             u -= 0.5
             us = 0.5 - _fabs(u)
             k = _floor((2.0 * a / us + b) * u + c)
 
+            # Step 2: Skip invalid k and test bounding box
             if k < 0 or k > n:
                 continue
             if us >= 0.07 and v <= vr:
                 return k
 
+            # Step 3.1: Acceptance-rejection test
             # Original paper errorneously omits the call to log()
             v = _log(v * alpha / (a / (us * us) + b))
             if v <= h - _logfact(k) - _logfact(n - k) + (k - m) * lpq:

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -785,7 +785,7 @@ class Random(_random.Random):
 
         # Step 0: Setup for step 1
         spq = _sqrt(n * p * (1.0 - p))  # Standard deviation of the distribution
-        b = 1.15 + 2.53 * spq           # Dominating density function parameters
+        b = 1.15 + 2.53 * spq
         a = -0.0873 + 0.0248 * b + 0.01 * p
         c = n * p + 0.5
         vr = 0.92 - 4.2 / b
@@ -798,30 +798,27 @@ class Random(_random.Random):
             u -= 0.5
             us = 0.5 - _fabs(u)
             k = _floor((2.0 * a / us + b) * u + c)
-
-            # Step 2: Skip over invalid k arising due to numeric issues.
             if k < 0 or k > n:
                 continue
 
-            # This early-out "squeeze" test substantially reduces the
-            # number of acceptance condition evaluations.  Checks to see
-            # whether *us* and *vr* lie in the large rectangle between
+            # Step 2: This early-out "squeeze" test substantially reduces
+            # the number of acceptance condition evaluations.  Checks to
+            # see whether *us* and *vr* lie in the large rectangle between
             # the u-axis and the curve.
             if us >= 0.07 and v <= vr:
                 return k
 
             if not step_three_setup:
-                # Step 3.0: Compute constants for step 3.1
+                # Step 3.0: Set up constants for step 3.1
                 alpha = (2.83 + 5.1 / b) * spq
-                lpq = _log(p / (1.0 - p))       # Log of p / q ratio
+                lpq = _log(p / (1.0 - p))
                 m = _floor((n + 1) * p)         # Mode of the distribution
                 h = _logfact(m) + _logfact(n - m)
                 step_three_setup = True         # Only needs to be done once
 
             # Step 3.1: Acceptance-rejection test.
-            # N.B. The original paper errorneously omits the call to
-            # log(v) which is needed because we're comparing to the log
-            # of the rescaled binomial distribution.
+            # N.B. The original paper errorneously omits the call to log(v)
+            # when comparing to the log of the rescaled binomial distribution.
             v *= alpha / (a / (us * us) + b)
             if _log(v) <= h - _logfact(k) - _logfact(n - k) + (k - m) * lpq:
                 return k

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -771,7 +771,7 @@ class Random(_random.Random):
                 return x
             while True:
                 y += _floor(_log(random()) / c) + 1
-                if y >= n:
+                if y > n:
                     return x
                 x += 1
 

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -785,6 +785,10 @@ class Random(_random.Random):
         a = -0.0873 + 0.0248 * b + 0.01 * p
         c = n * p + 0.5
         vr = 0.92 - 4.2 / b
+        alpha = (2.83 + 5.1 / b) * spq
+        lpq = _log(p / (1.0 - p))
+        m = _floor((n + 1) * p)
+        h = _logfact(m) + _logfact(n - m)
 
         while True:
 
@@ -798,11 +802,6 @@ class Random(_random.Random):
                 continue
             if us >= 0.07 and v <= vr:
                 return k
-
-            alpha = (2.83 + 5.1 / b) * spq
-            lpq = _log(p / (1.0 - p))
-            m = _floor((n + 1) * p)
-            h = _logfact(m) + _logfact(n - m)
 
             # Original paper errorneously omits the call to log()
             v = _log(v * alpha / (a / (us * us) + b))

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -937,15 +937,17 @@ def _test_generator(n, func, args):
     low = min(data)
     high = max(data)
 
-    print(f'{t1 - t0:.3f} sec, {n} times {func.__name__}')
+    print(f'{t1 - t0:.3f} sec, {n} times {func.__name__}{args!r}')
     print('avg %g, stddev %g, min %g, max %g\n' % (xbar, sigma, low, high))
 
 
-def _test(N=2000):
+def _test(N=10_000):
     _test_generator(N, random, ())
     _test_generator(N, normalvariate, (0.0, 1.0))
     _test_generator(N, lognormvariate, (0.0, 1.0))
     _test_generator(N, vonmisesvariate, (0.0, 1.0))
+    _test_generator(N, binomialvariate, (15, 0.60))
+    _test_generator(N, binomialvariate, (100, 0.75))
     _test_generator(N, gammavariate, (0.01, 1.0))
     _test_generator(N, gammavariate, (0.1, 1.0))
     _test_generator(N, gammavariate, (0.1, 2.0))

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -778,7 +778,7 @@ class Random(_random.Random):
         # BTRS: Transformed rejection with squeeze method
         # See "The Generation of Binomial Random Variates" by Wolfgang Hörmann
         # https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.47.8407&rep=rep1&type=pdf
-        # Assumes n*p >= 10 and p <= 0.5
+        assert n*p >= 10.0 and p <= 0.5
 
         spq = _sqrt(n * p * (1.0 - p))
         b = 1.15 + 2.53 * spq
@@ -794,17 +794,18 @@ class Random(_random.Random):
             us = 0.5 - _fabs(u)
             k = _floor((2.0 * a / us + b) * u + c)
 
-            if us >= 0.07 and v <= vr:
-                return k
             if k < 0 or k > n:
                 continue
+            if us >= 0.07 and v <= vr:
+                return k
 
             alpha = (2.83 + 5.1 / b) * spq
             lpq = _log(p / (1.0 - p))
             m = _floor((n + 1) * p)
             h = _logfact(m) + _logfact(n - m)
 
-            v *= alpha / (a / (us * us) + b)
+            # Original paper errorneously omits the call to log()
+            v = _log(v * alpha / (a / (us * us) + b))
             if v <= h - _logfact(k) - _logfact(n - k) + (k - m) * lpq:
                 return k
 

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -102,10 +102,6 @@ BPF = 53        # Number of bits in a float
 RECIP_BPF = 2 ** -BPF
 _ONE = 1
 
-def _logfact(n):
-    "Return log(n!)"
-    return _lgamma(n + 1)
-
 
 class Random(_random.Random):
     """Random number generator base class used by bound module functions.
@@ -810,10 +806,10 @@ class Random(_random.Random):
                 alpha = (2.83 + 5.1 / b) * spq
                 lpq = _log(p / (1.0 - p))
                 m = _floor((n + 1) * p)         # Mode of the distribution
-                h = _logfact(m) + _logfact(n - m)
+                h = _lgamma(m + 1) + _lgamma(n - m + 1)
                 setup_complete = True           # Only needs to be done once
             v *= alpha / (a / (us * us) + b)
-            if _log(v) <= h - _logfact(k) - _logfact(n - k) + (k - m) * lpq:
+            if _log(v) <= h - _lgamma(k + 1) - _lgamma(n - k + 1) + (k - m) * lpq:
                 return k
 
 

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -781,16 +781,16 @@ class Random(_random.Random):
         assert n*p >= 10.0 and p <= 0.5
 
         # Step 0: Setup for step 1
-        spq = _sqrt(n * p * (1.0 - p))
-        b = 1.15 + 2.53 * spq
+        spq = _sqrt(n * p * (1.0 - p))  # Standard deviation of the distribution
+        b = 1.15 + 2.53 * spq           # Dominating density function parameters
         a = -0.0873 + 0.0248 * b + 0.01 * p
         c = n * p + 0.5
         vr = 0.92 - 4.2 / b
 
-        # Step 3.0: Setup for 3.1
+        # Step 3.0: Setup for step 3.1
         alpha = (2.83 + 5.1 / b) * spq
-        lpq = _log(p / (1.0 - p))
-        m = _floor((n + 1) * p)
+        lpq = _log(p / (1.0 - p))       # Log of p / q ratio
+        m = _floor((n + 1) * p)         # Mode of the distribution
         h = _logfact(m) + _logfact(n - m)
 
         while True:
@@ -802,16 +802,18 @@ class Random(_random.Random):
             us = 0.5 - _fabs(u)
             k = _floor((2.0 * a / us + b) * u + c)
 
-            # Step 2: Skip invalid k and test bounding box
+            # Step 2: Skip over invalid k due to numeric issues.
+            # Then make the bounding box test.
             if k < 0 or k > n:
                 continue
             if us >= 0.07 and v <= vr:
                 return k
 
             # Step 3.1: Acceptance-rejection test
-            # Original paper errorneously omits the call to log()
-            v = _log(v * alpha / (a / (us * us) + b))
-            if v <= h - _logfact(k) - _logfact(n - k) + (k - m) * lpq:
+            # Original paper errorneously omits the call to log(v) which
+            # is needed because we're comparing to the log factorials.
+            v *= alpha / (a / (us * us) + b)
+            if _log(v) <= h - _logfact(k) - _logfact(n - k) + (k - m) * lpq:
                 return k
 
 

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -1103,6 +1103,12 @@ class TestDistributions(unittest.TestCase):
         self.assertTrue(set(c) <= set(range(101)))
         self.assertEqual(c.total(), 100_000)
 
+        # Demonstrate the BTRS works for huge values of n
+        X = bv(100_000_000, 0.2)
+        self.assertTrue(19_000_000 <= X <= 21_000_000)
+        X = bv(100_000_000, 0.9)
+        self.assertTrue(89_000_000 <= X <= 91_000_000)
+
 
     def test_von_mises_range(self):
         # Issue 17149: von mises variates were not consistently in the

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -1045,12 +1045,64 @@ class TestDistributions(unittest.TestCase):
                 (g.lognormvariate, (0.0, 0.0), 1.0),
                 (g.lognormvariate, (-float('inf'), 0.0), 0.0),
                 (g.normalvariate, (10.0, 0.0), 10.0),
+                (g.binomialvariate, (0, 0.5), 0),
+                (g.binomialvariate, (10, 0.0), 0),
+                (g.binomialvariate, (10, 1.0), 10),
                 (g.paretovariate, (float('inf'),), 1.0),
                 (g.weibullvariate, (10.0, float('inf')), 10.0),
                 (g.weibullvariate, (0.0, 10.0), 0.0),
             ]:
             for i in range(N):
                 self.assertEqual(variate(*args), expected)
+
+    def test_binomialvariate(self):
+        bv = random.binomialvariate
+
+        # Cover all the code paths
+        with self.assertRaises(ValueError):
+            bv(n=-1)                            # Negative n
+        with self.assertRaises(ValueError):
+            bv(n=1, p=-0.5)                     # Negative p
+        with self.assertRaises(ValueError):
+            bv(n=1, p=1.5)                      # p > 1.0
+        self.assertEqual(bv(10, 0.0), 0)        # p == 0.0
+        self.assertEqual(bv(10, 1.0), 10)       # p == 1.0
+        self.assertTrue(bv(1, 0.3) in {0, 1})   # n == 1 fast path
+        self.assertTrue(bv(1, 0.9) in {0, 1})   # n == 1 fast path
+        self.assertTrue(bv(1, 0.0) in {0})      # n == 1 fast path
+        self.assertTrue(bv(1, 1.0) in {1})      # n == 1 fast path
+
+        # BG method p <= 0.5 and n*p=1.25
+        self.assertTrue(bv(5, 0.25) in set(range(6)))
+
+        # BG method p >= 0.5 and n*(1-p)=1.25
+        self.assertTrue(bv(5, 0.75) in set(range(6)))
+
+        # BTRS method p <= 0.5 and n*p=25
+        self.assertTrue(bv(100, 0.25) in set(range(101)))
+
+        # BTRS method p > 0.5 and n*(1-p)=25
+        self.assertTrue(bv(100, 0.75) in set(range(101)))
+
+        # Statistical tests chosen such that they are
+        # exceedingly unlikely to ever fail for correct code.
+
+        # BG code path
+        # Expected dist: [31641, 42188, 21094, 4688, 391]
+        c = Counter(bv(4, 0.25) for i in range(100_000))
+        self.assertTrue(29_641 <= c[0] <= 33_641, c)
+        self.assertTrue(40_188 <= c[1] <= 44_188)
+        self.assertTrue(19_094 <= c[2] <= 23_094)
+        self.assertTrue(2_688  <= c[3] <= 6_688)
+        self.assertEqual(set(c), {0, 1, 2, 3, 4})
+
+        # BTRS code path
+        # Sum of c[20], c[21], c[22], c[23], c[24] expected to be 36,214
+        c = Counter(bv(100, 0.25) for i in range(100_000))
+        self.assertTrue(34_214 <= c[20]+c[21]+c[22]+c[23]+c[24] <= 38_214)
+        self.assertTrue(set(c) <= set(range(101)))
+        self.assertEqual(c.total(), 100_000)
+
 
     def test_von_mises_range(self):
         # Issue 17149: von mises variates were not consistently in the

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -1056,40 +1056,40 @@ class TestDistributions(unittest.TestCase):
                 self.assertEqual(variate(*args), expected)
 
     def test_binomialvariate(self):
-        bv = random.binomialvariate
+        B = random.binomialvariate
 
         # Cover all the code paths
         with self.assertRaises(ValueError):
-            bv(n=-1)                            # Negative n
+            B(n=-1)                            # Negative n
         with self.assertRaises(ValueError):
-            bv(n=1, p=-0.5)                     # Negative p
+            B(n=1, p=-0.5)                     # Negative p
         with self.assertRaises(ValueError):
-            bv(n=1, p=1.5)                      # p > 1.0
-        self.assertEqual(bv(10, 0.0), 0)        # p == 0.0
-        self.assertEqual(bv(10, 1.0), 10)       # p == 1.0
-        self.assertTrue(bv(1, 0.3) in {0, 1})   # n == 1 fast path
-        self.assertTrue(bv(1, 0.9) in {0, 1})   # n == 1 fast path
-        self.assertTrue(bv(1, 0.0) in {0})      # n == 1 fast path
-        self.assertTrue(bv(1, 1.0) in {1})      # n == 1 fast path
+            B(n=1, p=1.5)                      # p > 1.0
+        self.assertEqual(B(10, 0.0), 0)        # p == 0.0
+        self.assertEqual(B(10, 1.0), 10)       # p == 1.0
+        self.assertTrue(B(1, 0.3) in {0, 1})   # n == 1 fast path
+        self.assertTrue(B(1, 0.9) in {0, 1})   # n == 1 fast path
+        self.assertTrue(B(1, 0.0) in {0})      # n == 1 fast path
+        self.assertTrue(B(1, 1.0) in {1})      # n == 1 fast path
 
         # BG method p <= 0.5 and n*p=1.25
-        self.assertTrue(bv(5, 0.25) in set(range(6)))
+        self.assertTrue(B(5, 0.25) in set(range(6)))
 
         # BG method p >= 0.5 and n*(1-p)=1.25
-        self.assertTrue(bv(5, 0.75) in set(range(6)))
+        self.assertTrue(B(5, 0.75) in set(range(6)))
 
         # BTRS method p <= 0.5 and n*p=25
-        self.assertTrue(bv(100, 0.25) in set(range(101)))
+        self.assertTrue(B(100, 0.25) in set(range(101)))
 
         # BTRS method p > 0.5 and n*(1-p)=25
-        self.assertTrue(bv(100, 0.75) in set(range(101)))
+        self.assertTrue(B(100, 0.75) in set(range(101)))
 
         # Statistical tests chosen such that they are
         # exceedingly unlikely to ever fail for correct code.
 
         # BG code path
         # Expected dist: [31641, 42188, 21094, 4688, 391]
-        c = Counter(bv(4, 0.25) for i in range(100_000))
+        c = Counter(B(4, 0.25) for i in range(100_000))
         self.assertTrue(29_641 <= c[0] <= 33_641, c)
         self.assertTrue(40_188 <= c[1] <= 44_188)
         self.assertTrue(19_094 <= c[2] <= 23_094)
@@ -1098,16 +1098,14 @@ class TestDistributions(unittest.TestCase):
 
         # BTRS code path
         # Sum of c[20], c[21], c[22], c[23], c[24] expected to be 36,214
-        c = Counter(bv(100, 0.25) for i in range(100_000))
+        c = Counter(B(100, 0.25) for i in range(100_000))
         self.assertTrue(34_214 <= c[20]+c[21]+c[22]+c[23]+c[24] <= 38_214)
         self.assertTrue(set(c) <= set(range(101)))
         self.assertEqual(c.total(), 100_000)
 
         # Demonstrate the BTRS works for huge values of n
-        X = bv(100_000_000, 0.2)
-        self.assertTrue(19_000_000 <= X <= 21_000_000)
-        X = bv(100_000_000, 0.9)
-        self.assertTrue(89_000_000 <= X <= 91_000_000)
+        self.assertTrue(19_000_000 <= B(100_000_000, 0.2) <= 21_000_000)
+        self.assertTrue(89_000_000 <= B(100_000_000, 0.9) <= 91_000_000)
 
 
     def test_von_mises_range(self):

--- a/Misc/NEWS.d/next/Library/2022-07-09-15-17-02.gh-issue-81620.L0O_bV.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-09-15-17-02.gh-issue-81620.L0O_bV.rst
@@ -1,0 +1,1 @@
+Add random.binomialvariate().


### PR DESCRIPTION
<!-- gh-issue-number: gh-81620 -->
* Issue: gh-81620
<!-- /gh-issue-number -->

Here are some comparisons between actual and expected histograms of the random variable across various input parameters chosen to cover all the code paths:

```
raymond@raymonds-mbp cpython % ./python.exe show_dist2.py
n=0	p=0.5	times=131072
[131072] actual
[131072] expected

n=1	p=0.5	times=131072
[65449, 65623] actual
[65536, 65536] expected

n=1	p=0.1	times=131072
[118042, 13030] actual
[117965, 13107] expected

n=1	p=0.9	times=131072
[13093, 117979] actual
[13107, 117965] expected

n=1	p=0.0	times=131072
[131072, 0] actual
[131072, 0] expected

n=1	p=1.0	times=131072
[0, 131072] actual
[0, 131072] expected

n=2	p=0.5	times=131072
[32623, 65655, 32794] actual
[32768, 65536, 32768] expected

n=3	p=0.5	times=131072
[16265, 49238, 49219, 16350] actual
[16384, 49152, 49152, 16384] expected

n=3	p=0.5	times=131072
[16401, 49226, 48791, 16654] actual
[16384, 49152, 49152, 16384] expected

n=4	p=0.5	times=131072
[8182, 32534, 49367, 32803, 8186] actual
[8192, 32768, 49152, 32768, 8192] expected

n=2	p=0.25	times=131072
[73709, 49328, 8035] actual
[73728, 49152, 8192] expected

n=3	p=0.25	times=131072
[55206, 55418, 18407, 2041] actual
[55296, 55296, 18432, 2048] expected

n=3	p=0.25	times=131072
[55739, 54719, 18568, 2046] actual
[55296, 55296, 18432, 2048] expected

n=4	p=0.25	times=131072
[41531, 55530, 27212, 6296, 503] actual
[41472, 55296, 27648, 6144, 512] expected

n=2	p=0.75	times=131072
[8104, 49441, 73527] actual
[8192, 49152, 73728] expected

n=3	p=0.75	times=131072
[2137, 18494, 55245, 55196] actual
[2048, 18432, 55296, 55296] expected

n=3	p=0.75	times=131072
[2125, 18426, 55237, 55284] actual
[2048, 18432, 55296, 55296] expected

n=4	p=0.75	times=131072
[501, 6189, 27652, 55351, 41379] actual
[512, 6144, 27648, 55296, 41472] expected

n=21	p=0.5	times=8388608
[3, 83, 861, 5459, 23954, 81369, 216626, 464857, 814107, 1175105, 1410003, 1412399, 1175408, 813977, 465240, 217611, 81517, 23835, 5267, 849, 75, 3] actual
[4, 84, 840, 5320, 23940, 81396, 217056, 465120, 813960, 1175720, 1410864, 1410864, 1175720, 813960, 465120, 217056, 81396, 23940, 5320, 840, 84, 4] expected

n=23	p=0.44	times=33554432
[50, 996, 8357, 46376, 182566, 546412, 1288350, 2457192, 3860402, 5054928, 5561908, 5163281, 4055424, 2698094, 1514653, 714189, 280545, 91110, 23760, 4920, 827, 85, 7, 0] actual
[54, 980, 8467, 46568, 182945, 546223, 1287525, 2456809, 3860700, 5055678, 5561246, 5164014, 4057440, 2697528, 1513919, 713705, 280384, 90712, 23758, 4912, 772, 87, 6, 0] expected

n=23	p=0.56	times=33554432
[1, 12, 81, 804, 4820, 23672, 90753, 279718, 713524, 1514626, 2698389, 4061304, 5162182, 5560620, 5056002, 3861575, 2455442, 1287630, 544792, 182352, 46622, 8448, 1002, 61] actual
[0, 6, 87, 772, 4912, 23758, 90712, 280384, 713705, 1513919, 2697528, 4057440, 5164014, 5561246, 5055678, 3860700, 2456809, 1287525, 546223, 182945, 46568, 8467, 980, 54] expected

```

The above output was created using this test function:

```
from random import binomialvariate
from collections import Counter
from math import comb

def compare(n=1, p=0.5, times=2**17):
    c = Counter(binomialvariate(n, p) for i in range(times))
    assert c.total() == times
    expected = []
    actual = []
    for r in range(n + 1):
        exp = round(times * comb(n, r) * p ** r * (1 - p) ** (n - r))
        act = c.pop(r, 0)
        expected.append(exp)
        actual.append(act)
    assert not c
    print(f'{n=}\t{p=}\t{times=}')
    print(actual, 'actual')
    print(expected, 'expected')
    print()
```

This code is useful for instrumenting how many calls to *random()* are made:

```
from random import _inst, binomialvariate as B
from unittest.mock import patch

def run(n=1, p=0.5):
    with patch.object(_inst, 'random', side_effect=_inst.random) as mo:
        b = B(n, p)
        print(f"B({n}, {p})={b}   {mo.call_count=}")
```

This demonstrates that how few loops are needed:

```
# Fast path
B(1, 0.5)=1   mo.call_count=1

# BG for n*p < 10
B(10, 0.5)=6   mo.call_count=6
B(10, 0.25)=2   mo.call_count=3
B(10, 0.01)=0   mo.call_count=1
B(10, 0.75)=8   mo.call_count=3
B(10, 0.99)=10   mo.call_count=1

# BTRS for n*p >= 10
B(100000, 0.5)=49853   mo.call_count=4
B(100000, 0.001)=102   mo.call_count=2
B(100000, 0.999)=99909   mo.call_count=2
```

