### PR TITLE
GH-94736: mark SemLock test as linux only

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6023,6 +6023,7 @@ def install_tests_in_module_dict(remote_globs, start_method):
 
 
 @unittest.skipIf(not hasattr(_multiprocessing, 'SemLock'), 'SemLock not available')
+@unittest.skipIf(sys.platform != "linux", "Linux only")
 class SemLockTests(unittest.TestCase):
 
     def test_semlock_subclass(self):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94736 -->
* Issue: gh-94736
<!-- /gh-issue-number -->

See https://buildbot.python.org/all/#/builders/172/builds/2522
The PR skips the test on non-linux platforms.

Automerge-Triggered-By: GH:pablogsal