### PR TITLE
gh-94759: Collect C-level coverage using llvm-cov

### DIFF
--- a/.github/workflows/c-coverage.yml
+++ b/.github/workflows/c-coverage.yml
@@ -46,7 +46,7 @@ jobs:
       run: ./configure --with-pydebug --with-openssl=$OPENSSL_DIR
     - name: Generate coverage report
       # Using "-j1" is important, or the Github Action runs out of memory
-      run: EXTRATESTOPTS=-j1 xvfb-run make coverage-report-llvm
+      run: EXTRATESTOPTS=-j1 xvfb-run make coverage-report
     - name: Publish coverage-report
       uses: JamesIves/github-pages-deploy-action@v4
       with:

--- a/.github/workflows/c-coverage.yml
+++ b/.github/workflows/c-coverage.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Publish coverage-report
       uses: JamesIves/github-pages-deploy-action@v4
       with:
-        folder: llvm-cov-report
+        folder: coverage-report
         repository-name: '' # TODO Destination
         token: ${{ secrets.COVERAGE_DEPLOY_TOKEN }} # TODO: Use an organization-level token
         single-commit: true

--- a/.github/workflows/c-coverage.yml
+++ b/.github/workflows/c-coverage.yml
@@ -24,7 +24,7 @@ jobs:
         echo "MULTISSL_DIR=${GITHUB_WORKSPACE}/multissl" >> $GITHUB_ENV
         echo "OPENSSL_DIR=${GITHUB_WORKSPACE}/multissl/openssl/${OPENSSL_VER}" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/multissl/openssl/${OPENSSL_VER}/lib" >> $GITHUB_ENV
-    - name: 'Restore OpenSSL build'
+    - name: Restore OpenSSL build
       id: cache-openssl
       uses: actions/cache@v3
       with:

--- a/.github/workflows/c-coverage.yml
+++ b/.github/workflows/c-coverage.yml
@@ -1,0 +1,65 @@
+name: C coverage
+
+on:
+  schedule:
+    # Run this daily at 2400 UTC
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  c-coverage:
+    name: 'C-level coverage (using llvm-cov)'
+    runs-on: ubuntu-20.04
+    env:
+      OPENSSL_VER: 1.1.1n
+      PYTHONSTRICTEXTENSIONBUILD: 1
+    steps:
+    - name: Install Dependencies
+      run: |
+        sudo ./.github/workflows/posix-deps-apt.sh
+    - name: Configure OpenSSL env vars
+      run: |
+        echo "MULTISSL_DIR=${GITHUB_WORKSPACE}/multissl" >> $GITHUB_ENV
+        echo "OPENSSL_DIR=${GITHUB_WORKSPACE}/multissl/openssl/${OPENSSL_VER}" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/multissl/openssl/${OPENSSL_VER}/lib" >> $GITHUB_ENV
+    - name: 'Restore OpenSSL build'
+      id: cache-openssl
+      uses: actions/cache@v3
+      with:
+        path: ./multissl/openssl/${{ env.OPENSSL_VER }}
+        key: ${{ runner.os }}-multissl-openssl-${{ env.OPENSSL_VER }}
+    - name: Install OpenSSL
+      if: steps.cache-openssl.outputs.cache-hit != 'true'
+      run: python3 Tools/ssl/multissltests.py --steps=library --base-directory $MULTISSL_DIR --openssl $OPENSSL_VER --system Linux
+    - name: Add ccache to PATH
+      run: |
+        echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
+    - name: Configure ccache action
+      uses: hendrikmuhs/ccache-action@v1
+    - name: Configure clang (with coverage)
+      run: |
+        echo "CC=/usr/lib/ccache/clang-12 -fprofile-instr-generate -fcoverage-mapping" >> $GITHUB_ENV
+        echo "CXX=/usr/lib/ccache/clang++-12 -fprofile-instr-generate -fcoverage-mapping" >> $GITHUB_ENV
+    - name: Configure CPython
+      run: ./configure --with-pydebug --with-openssl=$OPENSSL_DIR
+    - name: Build CPython
+      run: make -j4
+    - name: Collect coverage data
+      # Specify the LLVM_PROFILE_FILE using %m so multiple shared objects can write
+      # in parallel. Set the full path to the directory so results aren't written
+      # into temporary directories created by tests.
+      # Using "-j 1" is important, or the Github Action runs out of memory
+      run: LLVM_PROFILE_FILE=${PWD}/python%m.profraw xvfb-run ./python -m test -j 1
+    - name: Generate coverage report
+      run: |
+        llvm-profdata-12 merge -sparse python*.profraw -o python.profdata
+        llvm-cov-12 show -format=html -output-dir=cpython-coverage -instr-profile=python.profdata -show-branches=count -show-regions python .
+    - name: Publish coverage-report
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: cpython-coverage
+        repository-name: '' # TODO Destination
+        token: ${{ secrets.COVERAGE_DEPLOY_TOKEN }} # TODO: Use an organization-level token
+        single-commit: true

--- a/.github/workflows/c-coverage.yml
+++ b/.github/workflows/c-coverage.yml
@@ -40,26 +40,17 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1
     - name: Configure clang (with coverage)
       run: |
-        echo "CC=/usr/lib/ccache/clang-12 -fprofile-instr-generate -fcoverage-mapping" >> $GITHUB_ENV
-        echo "CXX=/usr/lib/ccache/clang++-12 -fprofile-instr-generate -fcoverage-mapping" >> $GITHUB_ENV
+        echo "CC=clang" >> $GITHUB_ENV
+        echo "CXX=clang++" >> $GITHUB_ENV
     - name: Configure CPython
       run: ./configure --with-pydebug --with-openssl=$OPENSSL_DIR
-    - name: Build CPython
-      run: make -j4
-    - name: Collect coverage data
-      # Specify the LLVM_PROFILE_FILE using %m so multiple shared objects can write
-      # in parallel. Set the full path to the directory so results aren't written
-      # into temporary directories created by tests.
-      # Using "-j 1" is important, or the Github Action runs out of memory
-      run: LLVM_PROFILE_FILE=${PWD}/python%m.profraw xvfb-run ./python -m test -j 1
     - name: Generate coverage report
-      run: |
-        llvm-profdata-12 merge -sparse python*.profraw -o python.profdata
-        llvm-cov-12 show -format=html -output-dir=cpython-coverage -instr-profile=python.profdata -show-branches=count -show-regions python .
+      # Using "-j1" is important, or the Github Action runs out of memory
+      run: EXTRATESTOPTS=-j1 xvfb-run make coverage-report-llvm
     - name: Publish coverage-report
       uses: JamesIves/github-pages-deploy-action@v4
       with:
-        folder: cpython-coverage
+        folder: llvm-cov-report
         repository-name: '' # TODO Destination
         token: ${{ secrets.COVERAGE_DEPLOY_TOKEN }} # TODO: Use an organization-level token
         single-commit: true

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 *.gc??
 *.profclang?
 *.profraw
+*.profdata
 *.dyn
 .gdb_history
 .purify

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -797,9 +797,11 @@ class ProcessTestCase(BaseTestCase):
             # This excludes some __CF_* and VERSIONER_* keys MacOS insists
             # on adding even when the environment in exec is empty.
             # Gentoo sandboxes also force LD_PRELOAD and SANDBOX_* to exist.
+            # LLVM coverage adds __LLVM_PROFILE_RT_INIT_ONCE variable.
             return ('VERSIONER' in n or '__CF' in n or  # MacOS
                     n == 'LD_PRELOAD' or n.startswith('SANDBOX') or # Gentoo
-                    n == 'LC_CTYPE') # Locale coercion triggered
+                    n == 'LC_CTYPE' or # Locale coercion triggered
+                    n == '__LLVM_PROFILE_RT_INIT_ONCE')
 
         with subprocess.Popen([sys.executable, "-c",
                                'import os; print(list(os.environ.keys()))'],

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -313,16 +313,15 @@ HOST_GNU_TYPE=	@host@
 # PROFILE_TASK="-m test --pgo-extended"
 PROFILE_TASK=	@PROFILE_TASK@
 
-# report files for gcov / lcov coverage report
-COVERAGE_INFO=	$(abs_builddir)/coverage.info
-COVERAGE_REPORT=$(abs_builddir)/lcov-report
-COVERAGE_LCOV_OPTIONS=--rc lcov_branch_coverage=1
-COVERAGE_REPORT_OPTIONS=--rc lcov_branch_coverage=1 --branch-coverage --title "CPython $(VERSION) LCOV report [commit $(shell $(GITVERSION))]"
-
-# report files for llvm-cov coverage report
-COVERAGE_INFO_LLVM=	$(abs_builddir)/coverage.profdata
-COVERAGE_REPORT_LLVM=$(abs_builddir)/llvm-cov-report
-COVERAGE_REPORT_OPTIONS_LLVM=-show-branches=count -show-regions
+# parameters for coverage
+COVERAGE_CC=@COVERAGE_CC@
+COVERAGE_CFLAGS=@COVERAGE_CFLAGS@
+COVERAGE_LDFLAGS=@COVERAGE_LDFLAGS@
+COVERAGE_GEN_TARGET=@COVERAGE_GEN_TARGET@
+COVERAGE_INFO=$(abs_builddir)/@COVERAGE_INFO@
+COVERAGE_REPORT=$(abs_builddir)/coverage-report
+COVERAGE_OPTIONS=@COVERAGE_OPTIONS@
+COVERAGE_REPORT_OPTIONS=@COVERAGE_REPORT_OPTIONS@
 
 # === Definitions added by makesetup ===
 
@@ -662,36 +661,38 @@ bolt-opt: @PREBOLT_RULE@
 	rm -f $(BUILDPYTHON).bolt_inst
 	mv $(BUILDPYTHON).bolt $(BUILDPYTHON)
 
-.PHONY=coverage-report
+.PHONY=coverage-report coverage coverage-generate-lcov coverage-generate-profdata
 coverage-report:
-	@if [ $(CC_NAME) = "gcc" ]; then \
-		$(MAKE) coverage-report-lcov; \
-	elif [ $(CC_NAME) = "clang" ]; then \
-		$(MAKE) coverage-report-llvm; \
-	else \
-		echo "Coverage is not supported with the $(CC_NAME) compiler"; \
-		exit 1; \
-	fi
+	@ # build with coverage info
+	$(MAKE) coverage
+	@ # run tests, ignore failures
+	@ # The LLVM_PROFILE_FILE must specify %m so results can be collected in parallel.
+	@ # Also, must be an absolute path since test suite changes working directory.
+	LLVM_PROFILE_FILE=${abs_builddir}/python%m.profraw $(TESTRUNNER) $(TESTOPTS) || true
+	@ # build lcov report
+	$(MAKE) $(COVERAGE_GEN_TARGET)
+	@echo
+	@echo "coverage report at $(COVERAGE_REPORT)/index.html"
+	@echo
 
-# Compile and run with gcov
-.PHONY=coverage-gcc coverage-lcov coverage-report-lcov
-coverage-gcc:
+# Compile and run generating coverage
+coverage:
 	@echo "Building with support for coverage checking:"
 	$(MAKE) clean
-	$(MAKE) @DEF_MAKE_RULE@ CFLAGS="$(CFLAGS) -O0 -pg --coverage" LDFLAGS="$(LDFLAGS) --coverage"
+	$(MAKE) @DEF_MAKE_RULE@ CC="$(COVERAGE_CC)" CFLAGS="$(CFLAGS) $(COVERAGE_CFLAGS)" LDFLAGS="$(LDFLAGS) $(COVERAGE_LDFLAGS)"
 
-coverage-lcov:
+coverage-generate-lcov:
 	@echo "Creating Coverage HTML report with LCOV:"
 	@rm -f $(COVERAGE_INFO)
 	@rm -rf $(COVERAGE_REPORT)
-	@lcov $(COVERAGE_LCOV_OPTIONS) --capture \
+	@lcov $(COVERAGE_OPTIONS) --capture \
 	    --directory $(abs_builddir) \
 	    --base-directory $(realpath $(abs_builddir)) \
 	    --path $(realpath $(abs_srcdir)) \
 	    --output-file $(COVERAGE_INFO)
 	@ # remove 3rd party modules, system headers and internal files with
 	@ # debug, test or dummy functions.
-	@lcov $(COVERAGE_LCOV_OPTIONS) --remove $(COVERAGE_INFO) \
+	@lcov $(COVERAGE_OPTIONS) --remove $(COVERAGE_INFO) \
 	    '*/Modules/_blake2/impl/*' \
 	    '*/Modules/_ctypes/libffi*/*' \
 	    '*/Modules/_decimal/libmpdec/*' \
@@ -706,51 +707,15 @@ coverage-lcov:
 	@genhtml $(COVERAGE_INFO) \
 	    --output-directory $(COVERAGE_REPORT) \
 	    $(COVERAGE_REPORT_OPTIONS)
-	@echo
-	@echo "lcov report at $(COVERAGE_REPORT)/index.html"
-	@echo
 
-# Force regeneration of parser and frozen modules
-coverage-report-lcov: regen-token regen-frozen
-	@ # build with coverage info
-	$(MAKE) coverage-gcc
-	@ # run tests, ignore failures
-	$(TESTRUNNER) $(TESTOPTS) || true
-	@ # build lcov report
-	$(MAKE) coverage-lcov
-
-# Compile and calculate coverage with llvm-cov
-.PHONY=coverage-clang coverage-profdata coverage-report-llvm
-
-coverage-clang: 
-	@echo "Building with support for coverage checking:"
-	$(MAKE) clean
-	@ # Override CC rather than CFLAGS since these flags must come first
-	$(MAKE) @DEF_MAKE_RULE@ CC="$(CC) -fprofile-instr-generate -fcoverage-mapping"
-
-coverage-profdata:
+coverage-generate-profdata:
 	@echo "Creating Coverage HTML report with llvm-profdata/llvm-cov:"
-	@rm -f $(COVERAGE_INFO_LLVM)
-	@rm -rf $(COVERAGE_REPORT_LLVM)
+	@rm -f $(COVERAGE_INFO)
+	@rm -rf $(COVERAGE_REPORT)
 	@ # Merge coverage results
-	$(LLVM_PROFDATA) merge -sparse python*.profraw -o $(COVERAGE_INFO_LLVM)
+	$(LLVM_PROFDATA) merge -sparse python*.profraw -o $(COVERAGE_INFO)
 	@ # Generate HTML
-	$(LLVM_COV) show -format=html -output-dir=$(COVERAGE_REPORT_LLVM) -instr-profile=$(COVERAGE_INFO_LLVM) $(COVERAGE_REPORT_OPTIONS_LLVM) python .
-	@echo
-	@echo "llvm-cov report at $(COVERAGE_REPORT_LLVM)/index.html"
-	@echo
-
-# Force regeneration of parser and importlib
-# Specify the LLVM_PROFILE_FILE using %m so multiple shared objects can write
-# in parallel. Set the full path to the directory so results aren't written
-# into temporary directories created by tests.
-coverage-report-llvm: regen-token regen-importlib
-	@ # build with coverage info
-	$(MAKE) coverage-clang
-	@ # run tests, ignore failures
-	LLVM_PROFILE_FILE=${PWD}/python%m.profraw $(TESTRUNNER) $(TESTOPTS) || true
-	@ # build llvm-cov report
-	$(MAKE) coverage-profdata
+	$(LLVM_COV) show -format=html -output-dir=$(COVERAGE_REPORT) -instr-profile=$(COVERAGE_INFO) $(COVERAGE_REPORT_OPTIONS) python .
 
 # Run "Argument Clinic" over all source files
 .PHONY=clinic

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -50,6 +50,8 @@ PGO_PROF_USE_FLAG=@PGO_PROF_USE_FLAG@
 LLVM_PROF_MERGER=@LLVM_PROF_MERGER@
 LLVM_PROF_FILE=@LLVM_PROF_FILE@
 LLVM_PROF_ERR=@LLVM_PROF_ERR@
+LLVM_PROFDATA=@LLVM_PROFDATA@
+LLVM_COV=@LLVM_COV@
 DTRACE=         @DTRACE@
 DFLAGS=         @DFLAGS@
 DTRACE_HEADERS= @DTRACE_HEADERS@
@@ -316,6 +318,10 @@ COVERAGE_REPORT=$(abs_builddir)/lcov-report
 COVERAGE_LCOV_OPTIONS=--rc lcov_branch_coverage=1
 COVERAGE_REPORT_OPTIONS=--rc lcov_branch_coverage=1 --branch-coverage --title "CPython $(VERSION) LCOV report [commit $(shell $(GITVERSION))]"
 
+# report files for llvm-cov coverage report
+COVERAGE_INFO_LLVM=	$(abs_builddir)/coverage.profdata
+COVERAGE_REPORT_LLVM=$(abs_builddir)/llvm-cov-report
+COVERAGE_REPORT_OPTIONS_LLVM=-show-branches=count -show-regions
 
 # === Definitions added by makesetup ===
 
@@ -700,6 +706,44 @@ coverage-report: regen-token regen-frozen
 	$(TESTRUNNER) $(TESTOPTS) || true
 	@ # build lcov report
 	$(MAKE) coverage-lcov
+
+# Compile and calculate coverage with llvm-cov
+.PHONY=check-clang coverage-llvm coverage-profdata coverage-report-llvm
+
+# Check whether the compiler is clang, and if not, error out.
+check-clang:
+	($(CC) --version | grep clang) || \
+	(echo "LLVM coverage only works with clang. Set CC=clang and CXX=clang++ and re-run ./configure"; exit 1)
+
+coverage-llvm: check-clang
+	@echo "Building with support for coverage checking:"
+	$(MAKE) clean
+	@ # Override CC rather than CFLAGS since these flags must come first
+	$(MAKE) @DEF_MAKE_RULE@ CC="$(CC) -fprofile-instr-generate -fcoverage-mapping"
+
+coverage-profdata:
+	@echo "Creating Coverage HTML report with llvm-profdata/llvm-cov:"
+	@rm -f $(COVERAGE_INFO_LLVM)
+	@rm -rf $(COVERAGE_REPORT_LLVM)
+	@ # Merge coverage results
+	$(LLVM_PROFDATA) merge -sparse python*.profraw -o $(COVERAGE_INFO_LLVM)
+	@ # Generate HTML
+	$(LLVM_COV) show -format=html -output-dir=$(COVERAGE_REPORT_LLVM) -instr-profile=$(COVERAGE_INFO_LLVM) $(COVERAGE_REPORT_OPTIONS_LLVM) python .
+	@echo
+	@echo "llvm-cov report at $(COVERAGE_REPORT_LLVM)/index.html"
+	@echo
+
+# Force regeneration of parser and importlib
+# Specify the LLVM_PROFILE_FILE using %m so multiple shared objects can write
+# in parallel. Set the full path to the directory so results aren't written
+# into temporary directories created by tests.
+coverage-report-llvm: regen-token regen-importlib
+	@ # build with coverage info
+	$(MAKE) coverage-llvm
+	@ # run tests, ignore failures
+	LLVM_PROFILE_FILE=${PWD}/python%m.profraw $(TESTRUNNER) $(TESTOPTS) || true
+	@ # build llvm-cov report
+	$(MAKE) coverage-profdata
 
 # Run "Argument Clinic" over all source files
 .PHONY=clinic

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -37,7 +37,6 @@ abs_builddir=	@abs_builddir@
 CC=		@CC@
 CXX=		@CXX@
 LINKCC=		@LINKCC@
-CC_NAME=@CC_NAME@
 AR=		@AR@
 READELF=	@READELF@
 SOABI=		@SOABI@
@@ -661,8 +660,9 @@ bolt-opt: @PREBOLT_RULE@
 	rm -f $(BUILDPYTHON).bolt_inst
 	mv $(BUILDPYTHON).bolt $(BUILDPYTHON)
 
+# Support generating coverage reports
 .PHONY=coverage-report coverage coverage-generate-lcov coverage-generate-profdata
-coverage-report:
+coverage-report: regen-token regen-frozen
 	@ # build with coverage info
 	$(MAKE) coverage
 	@ # run tests, ignore failures
@@ -679,7 +679,9 @@ coverage-report:
 coverage:
 	@echo "Building with support for coverage checking:"
 	$(MAKE) clean
-	$(MAKE) @DEF_MAKE_RULE@ CC="$(COVERAGE_CC)" CFLAGS="$(CFLAGS) $(COVERAGE_CFLAGS)" LDFLAGS="$(LDFLAGS) $(COVERAGE_LDFLAGS)"
+	$(MAKE) @DEF_MAKE_RULE@ CC="$(COVERAGE_CC)" \
+		CFLAGS="$(CFLAGS) $(COVERAGE_CFLAGS)" \
+		LDFLAGS="$(LDFLAGS) $(COVERAGE_LDFLAGS)"
 
 coverage-generate-lcov:
 	@echo "Creating Coverage HTML report with LCOV:"

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -713,7 +713,7 @@ coverage-lcov:
 # Force regeneration of parser and frozen modules
 coverage-report-lcov: regen-token regen-frozen
 	@ # build with coverage info
-	$(MAKE) coverage
+	$(MAKE) coverage-gcc
 	@ # run tests, ignore failures
 	$(TESTRUNNER) $(TESTOPTS) || true
 	@ # build lcov report

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -37,6 +37,7 @@ abs_builddir=	@abs_builddir@
 CC=		@CC@
 CXX=		@CXX@
 LINKCC=		@LINKCC@
+CC_NAME=@CC_NAME@
 AR=		@AR@
 READELF=	@READELF@
 SOABI=		@SOABI@
@@ -661,9 +662,20 @@ bolt-opt: @PREBOLT_RULE@
 	rm -f $(BUILDPYTHON).bolt_inst
 	mv $(BUILDPYTHON).bolt $(BUILDPYTHON)
 
+.PHONY=coverage-report
+coverage-report:
+	@if [ $(CC_NAME) = "gcc" ]; then \
+		$(MAKE) coverage-report-lcov; \
+	elif [ $(CC_NAME) = "clang" ]; then \
+		$(MAKE) coverage-report-llvm; \
+	else \
+		echo "Coverage is not supported with the $(CC_NAME) compiler"; \
+		exit 1; \
+	fi
+
 # Compile and run with gcov
-.PHONY=coverage coverage-lcov coverage-report
-coverage:
+.PHONY=coverage-gcc coverage-lcov coverage-report-lcov
+coverage-gcc:
 	@echo "Building with support for coverage checking:"
 	$(MAKE) clean
 	$(MAKE) @DEF_MAKE_RULE@ CFLAGS="$(CFLAGS) -O0 -pg --coverage" LDFLAGS="$(LDFLAGS) --coverage"
@@ -699,7 +711,7 @@ coverage-lcov:
 	@echo
 
 # Force regeneration of parser and frozen modules
-coverage-report: regen-token regen-frozen
+coverage-report-lcov: regen-token regen-frozen
 	@ # build with coverage info
 	$(MAKE) coverage
 	@ # run tests, ignore failures
@@ -708,14 +720,9 @@ coverage-report: regen-token regen-frozen
 	$(MAKE) coverage-lcov
 
 # Compile and calculate coverage with llvm-cov
-.PHONY=check-clang coverage-llvm coverage-profdata coverage-report-llvm
+.PHONY=coverage-clang coverage-profdata coverage-report-llvm
 
-# Check whether the compiler is clang, and if not, error out.
-check-clang:
-	($(CC) --version | grep clang) || \
-	(echo "LLVM coverage only works with clang. Set CC=clang and CXX=clang++ and re-run ./configure"; exit 1)
-
-coverage-llvm: check-clang
+coverage-clang: 
 	@echo "Building with support for coverage checking:"
 	$(MAKE) clean
 	@ # Override CC rather than CFLAGS since these flags must come first
@@ -739,7 +746,7 @@ coverage-profdata:
 # into temporary directories created by tests.
 coverage-report-llvm: regen-token regen-importlib
 	@ # build with coverage info
-	$(MAKE) coverage-llvm
+	$(MAKE) coverage-clang
 	@ # run tests, ignore failures
 	LLVM_PROFILE_FILE=${PWD}/python%m.profraw $(TESTRUNNER) $(TESTOPTS) || true
 	@ # build llvm-cov report

--- a/Misc/NEWS.d/next/Build/2022-07-13-13-24-01.gh-issue-94759.dTLMod.rst
+++ b/Misc/NEWS.d/next/Build/2022-07-13-13-24-01.gh-issue-94759.dTLMod.rst
@@ -1,2 +1,1 @@
-The ``coverage-report`` Makefile target will now automatically use ``llvm-cov`` to generate a coverage report when using ``clang``.
-This provides more details about branch coverage and subexpressions than the existing ``gcc`` and ``lcov`` based ``coverage-report``.
+The ``coverage-report`` Makefile now supports both the ``gcc/lcov`` and ``clang/llvm-profdata`` stacks to generate coverage reports, and will select the correct one based on the compiler in use.

--- a/Misc/NEWS.d/next/Build/2022-07-13-13-24-01.gh-issue-94759.dTLMod.rst
+++ b/Misc/NEWS.d/next/Build/2022-07-13-13-24-01.gh-issue-94759.dTLMod.rst
@@ -1,4 +1,2 @@
-A new Makefile target ``coverage-report-llvm`` will use ``clang`` and
-``llvm-cov`` to generate a coverage report. This provides more details about
-branch coverage and subexpressions than the existing ``gcc`` and ``lcov``
-based ``coverage-report``.
+The ``coverage-report`` Makefile target will now automatically use ``llvm-cov`` to generate a coverage report when using ``clang``.
+This provides more details about branch coverage and subexpressions than the existing ``gcc`` and ``lcov`` based ``coverage-report``.

--- a/Misc/NEWS.d/next/Build/2022-07-13-13-24-01.gh-issue-94759.dTLMod.rst
+++ b/Misc/NEWS.d/next/Build/2022-07-13-13-24-01.gh-issue-94759.dTLMod.rst
@@ -1,0 +1,4 @@
+A new Makefile target ``coverage-report-llvm`` will use ``clang`` and
+``llvm-cov`` to generate a coverage report. This provides more details about
+branch coverage and subexpressions than the existing ``gcc`` and ``lcov``
+based ``coverage-report``.

--- a/configure
+++ b/configure
@@ -936,6 +936,7 @@ PLATFORM_TRIPLET
 MULTIARCH
 ac_ct_CXX
 CXX
+CC_NAME
 EGREP
 SED
 GREP
@@ -5370,6 +5371,9 @@ rm -f conftest.c conftest.out
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cc_name" >&5
 $as_echo "$ac_cv_cc_name" >&6; }
+
+
+CC_NAME=$ac_cv_cc_name
 
 # checks for UNIX variants that set C preprocessor variables
 # may set _GNU_SOURCE, __EXTENSIONS__, _POSIX_PTHREAD_SEMANTICS,

--- a/configure
+++ b/configure
@@ -884,6 +884,13 @@ BASECFLAGS
 CFLAGS_ALIASING
 OPT
 LLVM_COV
+COVERAGE_REPORT_OPTIONS
+COVERAGE_OPTIONS
+COVERAGE_INFO
+COVERAGE_GEN_TARGET
+COVERAGE_LDFLAGS
+COVERAGE_CFLAGS
+COVERAGE_CC
 LLVM_PROF_FOUND
 LLVM_PROFDATA
 LLVM_PROF_ERR
@@ -936,7 +943,6 @@ PLATFORM_TRIPLET
 MULTIARCH
 ac_ct_CXX
 CXX
-CC_NAME
 EGREP
 SED
 GREP
@@ -5372,9 +5378,6 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cc_name" >&5
 $as_echo "$ac_cv_cc_name" >&6; }
 
-CC_NAME=$ac_cv_cc_name
-
-
 # checks for UNIX variants that set C preprocessor variables
 # may set _GNU_SOURCE, __EXTENSIONS__, _POSIX_PTHREAD_SEMANTICS,
 # _POSIX_SOURCE, _POSIX_1_SOURCE, and more
@@ -8434,6 +8437,38 @@ case $CC in
     LLVM_PROF_FILE=""
     ;;
 esac
+
+# Coverage flags
+
+case $CC in
+     *clang*)
+         COVERAGE_CC="\$(CC) -fprofile-instr-generate -fcoverage-mapping"
+         COVERAGE_CFLAGS=""
+         COVERAGE_LDFLAGS=""
+         COVERAGE_GEN_TARGET="coverage-generate-profdata"
+         COVERAGE_INFO="coverage.profdata"
+         COVERAGE_OPTIONS=""
+         COVERAGE_REPORT_OPTIONS="-show-branches=count -show-regions"
+         ;;
+     *gcc*)
+         COVERAGE_CC="\$(CC)"
+         COVERAGE_CFLAGS="-O0 -pg --coverage"
+         COVERAGE_LDFLAGS="--coverage"
+         COVERAGE_GEN_TARGET="coverage-generate-lcov"
+         COVERAGE_INFO="coverage.info"
+         COVERAGE_OPTIONS="--rc lcov_brange_coverage=1"
+         COVERAGE_REPORT_OPTIONS="\$(COVERAGE_OPTIONS) --branch-coverage --title \"CPython \$(VERSION) LCOV report commit \$(shell \$(GITVERSION))\""
+         ;;
+     *)
+esac
+
+
+
+
+
+
+
+
 
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}llvm-cov", so it can be a program name with args.

--- a/configure
+++ b/configure
@@ -883,6 +883,7 @@ CFLAGS_NODIST
 BASECFLAGS
 CFLAGS_ALIASING
 OPT
+LLVM_COV
 LLVM_PROF_FOUND
 LLVM_PROFDATA
 LLVM_PROF_ERR
@@ -8429,6 +8430,105 @@ case $CC in
     LLVM_PROF_FILE=""
     ;;
 esac
+
+if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}llvm-cov", so it can be a program name with args.
+set dummy ${ac_tool_prefix}llvm-cov; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_LLVM_COV+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $LLVM_COV in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_LLVM_COV="$LLVM_COV" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in ${llvm_path}
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_LLVM_COV="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+LLVM_COV=$ac_cv_path_LLVM_COV
+if test -n "$LLVM_COV"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LLVM_COV" >&5
+$as_echo "$LLVM_COV" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+fi
+if test -z "$ac_cv_path_LLVM_COV"; then
+  ac_pt_LLVM_COV=$LLVM_COV
+  # Extract the first word of "llvm-cov", so it can be a program name with args.
+set dummy llvm-cov; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_ac_pt_LLVM_COV+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $ac_pt_LLVM_COV in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_ac_pt_LLVM_COV="$ac_pt_LLVM_COV" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in ${llvm_path}
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_ac_pt_LLVM_COV="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+ac_pt_LLVM_COV=$ac_cv_path_ac_pt_LLVM_COV
+if test -n "$ac_pt_LLVM_COV"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_pt_LLVM_COV" >&5
+$as_echo "$ac_pt_LLVM_COV" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+  if test "x$ac_pt_LLVM_COV" = x; then
+    LLVM_COV="''"
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    LLVM_COV=$ac_pt_LLVM_COV
+  fi
+else
+  LLVM_COV="$ac_cv_path_LLVM_COV"
+fi
+
 
 # XXX Shouldn't the code above that fiddles with BASECFLAGS and OPT be
 # merged with this chunk of code?

--- a/configure
+++ b/configure
@@ -5372,8 +5372,8 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cc_name" >&5
 $as_echo "$ac_cv_cc_name" >&6; }
 
-
 CC_NAME=$ac_cv_cc_name
+
 
 # checks for UNIX variants that set C preprocessor variables
 # may set _GNU_SOURCE, __EXTENSIONS__, _POSIX_PTHREAD_SEMANTICS,

--- a/configure.ac
+++ b/configure.ac
@@ -869,8 +869,7 @@ fi
 rm -f conftest.c conftest.out
 ])
 
-AC_SUBST(CC_NAME)
-CC_NAME=$ac_cv_cc_name
+AC_SUBST([CC_NAME], [$ac_cv_cc_name])
 
 # checks for UNIX variants that set C preprocessor variables
 # may set _GNU_SOURCE, __EXTENSIONS__, _POSIX_PTHREAD_SEMANTICS,

--- a/configure.ac
+++ b/configure.ac
@@ -869,8 +869,6 @@ fi
 rm -f conftest.c conftest.out
 ])
 
-AC_SUBST([CC_NAME], [$ac_cv_cc_name])
-
 # checks for UNIX variants that set C preprocessor variables
 # may set _GNU_SOURCE, __EXTENSIONS__, _POSIX_PTHREAD_SEMANTICS,
 # _POSIX_SOURCE, _POSIX_1_SOURCE, and more
@@ -2057,6 +2055,38 @@ case $CC in
     LLVM_PROF_FILE=""
     ;;
 esac
+
+# Coverage flags
+
+case $CC in
+     *clang*)
+         COVERAGE_CC="\$(CC) -fprofile-instr-generate -fcoverage-mapping"
+         COVERAGE_CFLAGS=""
+         COVERAGE_LDFLAGS=""
+         COVERAGE_GEN_TARGET="coverage-generate-profdata"
+         COVERAGE_INFO="coverage.profdata"
+         COVERAGE_OPTIONS=""
+         COVERAGE_REPORT_OPTIONS="-show-branches=count -show-regions"
+         ;;
+     *gcc*)
+         COVERAGE_CC="\$(CC)"
+         COVERAGE_CFLAGS="-O0 -pg --coverage"
+         COVERAGE_LDFLAGS="--coverage"
+         COVERAGE_GEN_TARGET="coverage-generate-lcov"
+         COVERAGE_INFO="coverage.info"
+         COVERAGE_OPTIONS="--rc lcov_brange_coverage=1"
+         COVERAGE_REPORT_OPTIONS="\$(COVERAGE_OPTIONS) --branch-coverage --title \"CPython \$(VERSION) LCOV report [commit \$(shell \$(GITVERSION))]\""
+         ;;
+     *)
+esac
+
+AC_SUBST(COVERAGE_CC)
+AC_SUBST(COVERAGE_CFLAGS)
+AC_SUBST(COVERAGE_LDFLAGS)
+AC_SUBST(COVERAGE_GEN_TARGET)
+AC_SUBST(COVERAGE_INFO)
+AC_SUBST(COVERAGE_OPTIONS)
+AC_SUBST(COVERAGE_REPORT_OPTIONS)
 AC_SUBST(LLVM_COV)
 AC_PATH_TOOL(LLVM_COV, llvm-cov, '', ${llvm_path})
 

--- a/configure.ac
+++ b/configure.ac
@@ -2055,6 +2055,8 @@ case $CC in
     LLVM_PROF_FILE=""
     ;;
 esac
+AC_SUBST(LLVM_COV)
+AC_PATH_TOOL(LLVM_COV, llvm-cov, '', ${llvm_path})
 
 # XXX Shouldn't the code above that fiddles with BASECFLAGS and OPT be
 # merged with this chunk of code?

--- a/configure.ac
+++ b/configure.ac
@@ -869,6 +869,9 @@ fi
 rm -f conftest.c conftest.out
 ])
 
+AC_SUBST(CC_NAME)
+CC_NAME=$ac_cv_cc_name
+
 # checks for UNIX variants that set C preprocessor variables
 # may set _GNU_SOURCE, __EXTENSIONS__, _POSIX_PTHREAD_SEMANTICS,
 # _POSIX_SOURCE, _POSIX_1_SOURCE, and more


### PR DESCRIPTION
This adds a Github Action to collect C-level coverage and publish it to a Github Pages repository.

You can see an example [coverage output](http://droettboom.com/cpython-coverage/llvm-coverage/).

There are two admin things that would need to happen for this to work:

- [ ] Create a new repository in the `python` organization for the results, e.g. `cpython-c-coverage`
- [ ] Create an [organization-scoped token](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-organization) to publish to this repository and use it from this action

<!-- gh-issue-number: gh-94759 -->
* Issue: gh-94759
<!-- /gh-issue-number -->
