### PR TITLE
gh-99069: Consolidate checks for static_assert

### DIFF
--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -15,7 +15,7 @@
 // MSVC makes static_assert a keyword, contrary to the C standard.
 //
 // In C++ 11 static_assert is a keyword, redefining is undefined behaviour.
-// So only define if building as C, not C++.
+// So only define if building as C (if __STDC_VERSION__ is defined), not C++.
 #if !defined(static_assert) && defined(__GNUC__) \
      && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #  define static_assert _Static_assert

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -15,6 +15,7 @@
 // MSVC makes static_assert a keyword, contrary to the C standard.
 //
 // In C++ 11 static_assert is a keyword, redefining is undefined behaviour.
+// So only define if building as C, not C++.
 #if !defined(static_assert) && defined(__GNUC__) \
      && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #  define static_assert _Static_assert

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -12,8 +12,10 @@
 // static_assert is defined in glibc from version 2.16. Compiler support for
 // the C11 _Static_assert keyword is in gcc >= 4.6.
 
+// MSVC makes static_assert a keyword, contrary to the C standard.
+
 // In C++ 11 static_assert is a keyword, redefining is undefined behaviour.
-#if !defined(static_assert) \
+#if !defined(static_assert) && !defined(_MSC_VER) \
      && !(defined(__cplusplus) && __cplusplus >= 201103L)
 #  define static_assert _Static_assert
 #endif

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -5,15 +5,15 @@
 // defined, <sys/cdefs.h> disables C11 support and <assert.h> does not define
 // the static_assert() macro.
 // https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255290
-
+//
 // macOS <= 10.10 doesn't define static_assert in assert.h at all despite
 // having C11 compiler support.
-
+//
 // static_assert is defined in glibc from version 2.16. Compiler support for
 // the C11 _Static_assert keyword is in gcc >= 4.6.
-
+//
 // MSVC makes static_assert a keyword, contrary to the C standard.
-
+//
 // In C++ 11 static_assert is a keyword, redefining is undefined behaviour.
 #if !defined(static_assert) && !defined(_MSC_VER) \
      && !(defined(__cplusplus) && __cplusplus >= 201103L)

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -3,20 +3,18 @@
 
 // gh-91782: On FreeBSD 12, if the _POSIX_C_SOURCE and _XOPEN_SOURCE macros are
 // defined, <sys/cdefs.h> disables C11 support and <assert.h> does not define
-// the static_assert() macro. Define the static_assert() macro in Python until
-// <sys/cdefs.h> suports C11:
+// the static_assert() macro.
 // https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255290
-#if defined(__FreeBSD__) && !defined(static_assert)
-#  define static_assert _Static_assert
-#endif
 
-// static_assert is defined in glibc from version 2.16. Before it requires
-// compiler support (gcc >= 4.6) and is called _Static_assert.
+// macOS <= 10.10 doesn't define static_assert in assert.h at all despite
+// having C11 compiler support.
+
+// static_assert is defined in glibc from version 2.16. Compiler support for
+// the C11 _Static_assert keyword is in gcc >= 4.6.
+
 // In C++ 11 static_assert is a keyword, redefining is undefined behaviour.
-#if (defined(__GLIBC__) \
-     && (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ <= 16)) \
-     && !(defined(__cplusplus) && __cplusplus >= 201103L) \
-     && !defined(static_assert))
+#if !defined(static_assert) \
+     && !(defined(__cplusplus) && __cplusplus >= 201103L)
 #  define static_assert _Static_assert
 #endif
 

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -15,8 +15,8 @@
 // MSVC makes static_assert a keyword, contrary to the C standard.
 //
 // In C++ 11 static_assert is a keyword, redefining is undefined behaviour.
-#if !defined(static_assert) && !defined(_MSC_VER) \
-     && !(defined(__cplusplus) && __cplusplus >= 201103L)
+#if !defined(static_assert) && defined(__GNUC__) \
+     && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #  define static_assert _Static_assert
 #endif
 

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -16,7 +16,7 @@
 //
 // In C++ 11 static_assert is a keyword, redefining is undefined behaviour.
 // So only define if building as C (if __STDC_VERSION__ is defined), not C++.
-#if !defined(static_assert) && defined(__GNUC__) \
+#if !defined(static_assert) && (defined(__GNUC__) || defined(__clang__)) \
      && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #  define static_assert _Static_assert
 #endif

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -12,12 +12,14 @@
 // static_assert is defined in glibc from version 2.16. Compiler support for
 // the C11 _Static_assert keyword is in gcc >= 4.6.
 //
-// MSVC makes static_assert a keyword, contrary to the C standard.
+// MSVC makes static_assert a keyword in C11-17, contrary to the standards.
 //
-// In C++ 11 static_assert is a keyword, redefining is undefined behaviour.
-// So only define if building as C (if __STDC_VERSION__ is defined), not C++.
+// In C++11 and C2x, static_assert is a keyword, redefining is undefined
+// behaviour. So only define if building as C (if __STDC_VERSION__ is defined),
+// not C++, and only for C11-17.
 #if !defined(static_assert) && (defined(__GNUC__) || defined(__clang__)) \
-     && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+     && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
+     && __STDC_VERSION__ <= 201710L
 #  define static_assert _Static_assert
 #endif
 

--- a/Misc/NEWS.d/next/Build/2023-02-11-05-31-05.gh-issue-99069.X4LDvY.rst
+++ b/Misc/NEWS.d/next/Build/2023-02-11-05-31-05.gh-issue-99069.X4LDvY.rst
@@ -1,0 +1,1 @@
+Extended workaround defining ``static_assert`` when missing from the libc headers to all clang and gcc builds. In particular, this fixes building on macOS <= 10.10.


### PR DESCRIPTION
Several platforms don't define the static_assert macro despite having
compiler support for the _Static_assert keyword. The macro needs to be
defined since it is used unconditionally in the Python code. So it
should always be safe to define it if undefined and not in C++11 (or
later) mode.

Hence, remove the checks for particular platforms or libc versions,
and just define static_assert anytime it needs to be defined but isn't.
That way, all platforms that need the fix will get it, regardless of
whether someone specifically thought of them.

Also document that certain macOS versions are among the platforms that
need this.


<!-- gh-issue-number: gh-91731 -->
* Issue: gh-91731
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-99069 -->
* Issue: gh-99069
<!-- /gh-issue-number -->
