### PR TITLE
docs: typing.Self, fix typo

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -683,7 +683,7 @@ These can be used as types in annotations and do not support ``[]``.
       from typing import Self
 
       class Foo:
-         def returns_self(self) -> Self:
+         def return_self(self) -> Self:
             ...
             return self
 
@@ -696,7 +696,7 @@ These can be used as types in annotations and do not support ``[]``.
       Self = TypeVar("Self", bound="Foo")
 
       class Foo:
-         def returns_self(self: Self) -> Self:
+         def return_self(self: Self) -> Self:
             ...
             return self
 
@@ -707,7 +707,7 @@ These can be used as types in annotations and do not support ``[]``.
             ...
             return self
 
-   You should use :data:`Self` as calls to ``SubclassOfFoo.returns_self`` would have
+   You should use :data:`Self` as calls to ``SubclassOfFoo.return_self`` would have
    ``Foo`` as the return type and not ``SubclassOfFoo``.
 
    Other common use cases include:

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -707,7 +707,7 @@ These can be used as types in annotations and do not support ``[]``.
             ...
             return self
 
-   You should use use :data:`Self` as calls to ``SubclassOfFoo.returns_self`` would have
+   You should use :data:`Self` as calls to ``SubclassOfFoo.returns_self`` would have
    ``Foo`` as the return type and not ``SubclassOfFoo``.
 
    Other common use cases include:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -569,7 +569,7 @@ def Self(self, parameters):
       from typing import Self
 
       class Foo:
-          def returns_self(self) -> Self:
+          def return_self(self) -> Self:
               ...
               return self
 


### PR DESCRIPTION
- fix double spelled word 'use'

> You should **use use** [Self](https://docs.python.org/3.11/library/typing.html?highlight=typing#typing.Self) as calls to ...

- change methods names in the code blocks to the infinitive form

> return**s**_self > return_self

Simple typo fixes, no issue was created.