### PR TITLE
gh-94787: Add tip to put mutually-exclusive group into help group

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1930,7 +1930,26 @@ Mutual exclusion
 
    Note that currently mutually exclusive argument groups do not support the
    *title* and *description* arguments of
-   :meth:`~ArgumentParser.add_argument_group`.
+   :meth:`~ArgumentParser.add_argument_group`. However, you can still add a
+   mutually exclusive group to another group so they are organized within
+   the help messages as follows:
+
+     >>> parser = argparse.ArgumentParser(prog='PROG')
+     >>> group = parser.add_argument_group('Group title', 'Group desciption')
+     >>> exclusive_group = group.add_mutually_exclusive_group(required=True)
+     >>> exclusive_group.add_argument('--foo', help='foo help')
+     >>> exclusive_group.add_argument('--bar', help='bar help')
+     >>> parser.print_help()
+     usage: PROG [-h] (--foo | --bar)
+
+     optional arguments:
+       -h, --help  show this help message and exit
+
+     Group title:
+       Group desciption
+
+       --foo FOO   foo help
+       --bar BAR   bar help
 
 
 Parser defaults


### PR DESCRIPTION
It's not obvious that a group can be added to a group, and this is important when trying to organize your help output. 



<!-- gh-issue-number: gh-94787 -->
* Issue: gh-94787
<!-- /gh-issue-number -->
