### PR TITLE
gh-90815: Fix test_embed for Windows PGO build with mimalloc

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-07-13-14-02-01.gh-issue-90815.TGQx-y.rst
+++ b/Misc/NEWS.d/next/Build/2022-07-13-14-02-01.gh-issue-90815.TGQx-y.rst
@@ -1,2 +1,0 @@
-Add :c:func:`Py_Finalize` to an embedded interpreter test case,
-so that the PGO profiler on Windows can avoid generating broken data.

--- a/Misc/NEWS.d/next/Build/2022-07-13-14-02-01.gh-issue-90815.TGQx-y.rst
+++ b/Misc/NEWS.d/next/Build/2022-07-13-14-02-01.gh-issue-90815.TGQx-y.rst
@@ -1,0 +1,2 @@
+Add :c:func:`Py_Finalize` to an embedded interpreter test case,
+so that the PGO profiler on Windows can avoid generating broken data.

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -368,6 +368,8 @@ static int test_bpo20891(void)
 
     PyThread_free_lock(lock);
 
+    Py_Finalize();
+
     return 0;
 }
 


### PR DESCRIPTION
Fixes the failure of PGO building with `mimalloc` on Windows, ensuring that `test_bpo20891` does not break profiling data (`python31*.pgc`).

<!-- gh-issue-number: gh-90815 -->
* Issue: gh-90815
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:tiran