### PR TITLE
GH-90927: docs for asyncio.timeout and task cancellation

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -567,7 +567,7 @@ Timeouts
     the context manager is created.
 
     In either case, the context manager can be rescheduled after
-    creation using :meth:`asyncio.Timeout.reschedule`.
+    creation using :meth:`Timeout.reschedule`.
 
     Example::
 
@@ -600,6 +600,35 @@ Timeouts
 
     The context manager produced by :func:`asyncio.timeout` can be
     rescheduled to a different deadline and inspected.
+
+    .. class:: Timeout()
+
+       An :ref:`asynchronous context manager <async-context-managers>`
+       that limits time spent inside of it.
+
+        .. versionadded:: 3.11
+
+        .. method:: when() -> float | None
+
+           Return the current deadline, or `None` if the current
+           deadline is not set.
+
+           The deadline is a float, consistent with the time returned by
+           :meth:`loop.time`.
+
+        .. method:: reschedule(when: float | None)
+
+            Change the time the timeout will trigger.
+
+            If *when* is `None`, any current deadline will be removed, and the
+            context manager will wait indefinitely.
+
+            If *when* is a float, it is set as the new deadline.
+
+        .. method:: expired() -> bool
+
+           Return whether the context manager has exceeded its deadline
+           (expired).
 
     Example::
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -286,7 +286,7 @@ Task Cancellation
 =================
 
 Tasks can easily and safely be cancelled.
-When a task is cancelled, asyncio will raise :exc:`asyncio.CancelledError`
+When a task is cancelled, :exc:`asyncio.CancelledError` will be raised
 in the task at the next opportunity.
 
 It is recommended that coroutines use ``try/finally`` blocks to robustly

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -289,10 +289,10 @@ Tasks can easily and safely be cancelled.
 When a task is cancelled, asyncio will raise a :exc:`asyncio.CancelledError`
 into the task at the next opportunity.
 
-Coroutines should only catch :exc:`asyncio.CancelledError` if they
-need to perform clean-up logic when they are cancelled, and even in
-that case the :exc:`asyncio.CancelledError` should be propagated when
-clean-up is complete. Most code can safely ignore `CancelledError`.
+Coroutines are recommended to use ``try/finally`` blocks to robustly
+perform clean-up logic. In the case the :exc:`asyncio.CancelledError`
+is explicitly caught, it should generally be propagated when
+clean-up is complete. Most code can safely ignore :exc:`asyncio.CancelledError`.
 
 Important asyncio components, like :class:`asyncio.TaskGroup` and the
 :func:`asyncio.timeout` context manager, are implemented using cancellation
@@ -557,8 +557,7 @@ Timeouts
 .. coroutinefunction:: timeout(delay)
 
     A convenient way to limit the amount of time spent waiting on
-    something is to use the :func:`asyncio.timeout` and
-    :func:`asyncio.timeout_at`
+    something is to use the :func:`asyncio.timeout`
     :ref:`asynchronous context manager <async-context-managers>`.
 
     *delay* can either be ``None`` or a float or int number of
@@ -577,7 +576,14 @@ Timeouts
     the resulting :exc:`asyncio.CancelledError` internally, transforming it
     into a :exc:`asyncio.TimeoutError` which can be caught and handled.
 
-    Example::
+    .. note::
+
+      The :func:`asyncio.timeout` context manager is what transforms
+      the :exc:`asyncio.CancelledError` into an :exc:`asyncio.TimeoutError`,
+      which means the :exc:`asyncio.TimeoutError` can only be caught
+      *outside* of the context manager.
+
+    Example of catching :exc:`asyncio.TimeoutError`::
 
         async def main():
             try:
@@ -608,7 +614,7 @@ Timeouts
             if cm.expired:
                 print("Looks like we haven't finished on time.")
 
-    The timeout context managers can be safely nested.
+    Timeout context managers can be safely nested.
 
     .. versionadded:: 3.11
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -290,7 +290,7 @@ When a task is cancelled, asyncio will raise a :exc:`asyncio.CancelledError`
 into the task at the next opportunity.
 
 It is recommended that coroutines use ``try/finally`` blocks to robustly
-perform clean-up logic. In the case the :exc:`asyncio.CancelledError`
+perform clean-up logic. In case :exc:`asyncio.CancelledError`
 is explicitly caught, it should generally be propagated when
 clean-up is complete. Most code can safely ignore :exc:`asyncio.CancelledError`.
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -610,7 +610,7 @@ Timeouts
 
         .. method:: when() -> float | None
 
-           Return the current deadline, or `None` if the current
+           Return the current deadline, or ``None`` if the current
            deadline is not set.
 
            The deadline is a float, consistent with the time returned by

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -614,7 +614,7 @@ Timeouts
 
 .. coroutinefunction:: timeout_at(when)
 
-   Similar to :ref:`asyncio.timeout`, except *when* is the absolute time
+   Similar to :func:`asyncio.timeout`, except *when* is the absolute time
    to stop waiting, or ``None``.
 
    Example::

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -289,14 +289,15 @@ Tasks can easily and safely be cancelled.
 When a task is cancelled, asyncio will raise a :exc:`asyncio.CancelledError`
 into the task at the next opportunity.
 
-Coroutines are recommended to use ``try/finally`` blocks to robustly
+It is recommended that coroutines use ``try/finally`` blocks to robustly
 perform clean-up logic. In the case the :exc:`asyncio.CancelledError`
 is explicitly caught, it should generally be propagated when
 clean-up is complete. Most code can safely ignore :exc:`asyncio.CancelledError`.
 
 Important asyncio components, like :class:`asyncio.TaskGroup` and the
 :func:`asyncio.timeout` context manager, are implemented using cancellation
-internally.
+internally and might misbehave if a coroutine swallows
+:exc:`asyncio.CancelledError`.
 
 
 Task Groups
@@ -560,10 +561,13 @@ Timeouts
     something is to use the :func:`asyncio.timeout`
     :ref:`asynchronous context manager <async-context-managers>`.
 
-    *delay* can either be ``None`` or a float or int number of
+    *delay* can either be ``None``, or a float/int number of
     seconds to wait. If *delay* is ``None``, no time limit will
-    be applied. In either case, the context manager can be
-    rescheduled after creation.
+    be applied; this can be useful if the delay is unknown when
+    the context manager is created.
+
+    In either case, the context manager can be rescheduled after
+    creation using :meth:`asyncio.Timeout.reschedule`.
 
     Example::
 
@@ -574,7 +578,7 @@ Timeouts
     If ``long_running_task`` takes more than 10 seconds to complete,
     the context manager will cancel the current task and handle
     the resulting :exc:`asyncio.CancelledError` internally, transforming it
-    into a :exc:`asyncio.TimeoutError` which can be caught and handled.
+    into an :exc:`asyncio.TimeoutError` which can be caught and handled.
 
     .. note::
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -286,8 +286,8 @@ Task Cancellation
 =================
 
 Tasks can easily and safely be cancelled.
-When a task is cancelled, asyncio will raise a :exc:`asyncio.CancelledError`
-into the task at the next opportunity.
+When a task is cancelled, asyncio will raise :exc:`asyncio.CancelledError`
+in the task at the next opportunity.
 
 It is recommended that coroutines use ``try/finally`` blocks to robustly
 perform clean-up logic. In case :exc:`asyncio.CancelledError`
@@ -557,9 +557,9 @@ Timeouts
 
 .. coroutinefunction:: timeout(delay)
 
-    A convenient way to limit the amount of time spent waiting on
-    something is to use the :func:`asyncio.timeout`
-    :ref:`asynchronous context manager <async-context-managers>`.
+    An :ref:`asynchronous context manager <async-context-managers>`
+    that can be used to limit the amount of time spent waiting on
+    something.
 
     *delay* can either be ``None``, or a float/int number of
     seconds to wait. If *delay* is ``None``, no time limit will


### PR DESCRIPTION
Add docs for `asyncio.timeout`, `asyncio.timeout_at` and a short section on asyncio cancellation.

Automerge-Triggered-By: GH:gvanrossum

<!-- gh-issue-number: gh-90927 -->
* Issue: gh-90927
<!-- /gh-issue-number -->
