### PR TITLE
gh-94787: [doc] Add to argparse doc an example of a mutually-exclusive group nested in an argument group

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2031,7 +2031,25 @@ Mutual exclusion
 
    Note that currently mutually exclusive argument groups do not support the
    *title* and *description* arguments of
-   :meth:`~ArgumentParser.add_argument_group`.
+   :meth:`~ArgumentParser.add_argument_group`. However, you can still add a
+   mutually exclusive group to another group so they are organized within
+   the help messages as follows::
+
+     >>> parser = argparse.ArgumentParser(prog='PROG')
+     >>> group = parser.add_argument_group('Group title', 'Group desciption')
+     >>> exclusive_group = group.add_mutually_exclusive_group(required=True)
+     >>> exclusive_group.add_argument('--foo', help='foo help')
+     >>> exclusive_group.add_argument('--bar', help='bar help')
+     >>> parser.print_help()
+     usage: PROG [-h] (--foo | --bar)
+     optional arguments:
+       -h, --help  show this help message and exit
+
+     Group title:
+       Group desciption
+
+       --foo FOO   foo help
+       --bar BAR   bar help
 
    .. versionchanged:: 3.11
     Calling :meth:`add_argument_group` or :meth:`add_mutually_exclusive_group`

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2031,9 +2031,8 @@ Mutual exclusion
 
    Note that currently mutually exclusive argument groups do not support the
    *title* and *description* arguments of
-   :meth:`~ArgumentParser.add_argument_group`. However, you can add a
-   mutually exclusive group to an argument group so it appears in the help
-   message with a title and description. For example::
+   :meth:`~ArgumentParser.add_argument_group`. However, a mutually exclusive
+   group can be added to an argument group that has a title and description. For example::
 
      >>> parser = argparse.ArgumentParser(prog='PROG')
      >>> group = parser.add_argument_group('Group title', 'Group description')

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2041,7 +2041,8 @@ Mutual exclusion
      >>> exclusive_group.add_argument('--foo', help='foo help')
      >>> exclusive_group.add_argument('--bar', help='bar help')
      >>> parser.print_help()
-     usage: PROG [-h] (--foo | --bar)
+     usage: PROG [-h] (--foo FOO | --bar BAR)
+
      optional arguments:
        -h, --help  show this help message and exit
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2046,7 +2046,7 @@ Mutual exclusion
        -h, --help  show this help message and exit
 
      Group title:
-       Group desciption
+       Group description
 
        --foo FOO   foo help
        --bar BAR   bar help

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2032,7 +2032,8 @@ Mutual exclusion
    Note that currently mutually exclusive argument groups do not support the
    *title* and *description* arguments of
    :meth:`~ArgumentParser.add_argument_group`. However, a mutually exclusive
-   group can be added to an argument group that has a title and description. For example::
+   group can be added to an argument group that has a title and description.
+   For example::
 
      >>> parser = argparse.ArgumentParser(prog='PROG')
      >>> group = parser.add_argument_group('Group title', 'Group description')

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2031,9 +2031,9 @@ Mutual exclusion
 
    Note that currently mutually exclusive argument groups do not support the
    *title* and *description* arguments of
-   :meth:`~ArgumentParser.add_argument_group`. However, you can still add a
-   mutually exclusive group to another group so they are organized within
-   the help messages as follows::
+   :meth:`~ArgumentParser.add_argument_group`. However, you can add a
+   mutually exclusive group to an argument group so it appears in the help
+   message with a title and description. For example::
 
      >>> parser = argparse.ArgumentParser(prog='PROG')
      >>> group = parser.add_argument_group('Group title', 'Group desciption')

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2043,7 +2043,7 @@ Mutual exclusion
      >>> parser.print_help()
      usage: PROG [-h] (--foo FOO | --bar BAR)
 
-     optional arguments:
+     options:
        -h, --help  show this help message and exit
 
      Group title:

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2036,7 +2036,7 @@ Mutual exclusion
    message with a title and description. For example::
 
      >>> parser = argparse.ArgumentParser(prog='PROG')
-     >>> group = parser.add_argument_group('Group title', 'Group desciption')
+     >>> group = parser.add_argument_group('Group title', 'Group description')
      >>> exclusive_group = group.add_mutually_exclusive_group(required=True)
      >>> exclusive_group.add_argument('--foo', help='foo help')
      >>> exclusive_group.add_argument('--bar', help='bar help')


### PR DESCRIPTION
It's not obvious that a group can be added to a group, and this is important when trying to organize your help output.

(New main branch PR originally from PR #94788)

<!-- gh-issue-number: gh-94787 -->
* Issue: gh-94787
<!-- /gh-issue-number -->
