### PR TITLE
gh-94757: Fix documentation to include possible Exception for datetime.timestamp()

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1370,8 +1370,8 @@ Instance methods:
    time and this method relies on the platform C :c:func:`mktime`
    function to perform the conversion. Since :class:`.datetime`
    supports wider range of values than :c:func:`mktime` on many
-   platforms, this method may raise :exc:`OverflowError` for times far
-   in the past or far in the future.
+   platforms, this method may raise :exc:`OverflowError` or :exc:`OSError`
+   for times far in the past or far in the future.
 
    For aware :class:`.datetime` instances, the return value is computed
    as::


### PR DESCRIPTION
The function `_PyTime_localtime` may raise the `OSError` exception for windows when the datetime overflows


<!-- gh-issue-number: gh-94757 -->
* Issue: gh-94757
<!-- /gh-issue-number -->
