### PR TITLE
Add additional pointers to pathlib's mapping to os.path functions

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1300,7 +1300,7 @@ Below is a table mapping various :mod:`os` functions to their corresponding
 :func:`os.path.basename`               :data:`PurePath.name`
 :func:`os.path.dirname`                :data:`PurePath.parent`
 :func:`os.path.samefile`               :meth:`Path.samefile`
-:func:`os.path.splitext`               :data:`PurePath.suffix`
+:func:`os.path.splitext`               :data:`PurePath.stem` and :data:`PurePath.suffix`
 ====================================   ==============================
 
 .. rubric:: Footnotes

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1300,7 +1300,8 @@ Below is a table mapping various :mod:`os` functions to their corresponding
 :func:`os.path.basename`               :data:`PurePath.name`
 :func:`os.path.dirname`                :data:`PurePath.parent`
 :func:`os.path.samefile`               :meth:`Path.samefile`
-:func:`os.path.splitext`               :data:`PurePath.stem` and :data:`PurePath.suffix`
+:func:`os.path.splitext`               :data:`PurePath.stem` and
+                                       :data:`PurePath.suffix`
 ====================================   ==============================
 
 .. rubric:: Footnotes


### PR DESCRIPTION
os.path.splitext has a somewhat quirky signature since it mixes the path and filename components but I wanted the documentation to mention `PurePath.stem` as the natural counterpart to `PurePath.suffix` for the common use of `os.path.splitext` to turn "file.py" into "file" and "py".

Technically this could have some discussion of how to handle the parent directory hierarchy but that seems a bit out of keeping with the spirit of this table so I omitted mentioning `PurePath.parents` here.