### PR TITLE
gh-94841: Ensure arena_map_get() is inlined in PyObject_Free()

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-07-14-02-45-44.gh-issue-94841.lLRTdf.rst
+++ b/Misc/NEWS.d/next/Build/2022-07-14-02-45-44.gh-issue-94841.lLRTdf.rst
@@ -1,0 +1,1 @@
+Fix the possible performance regression of :c:func:`PyObject_Free` compiled with MSVC version 1932.

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1446,7 +1446,7 @@ static arena_map_bot_t arena_map_root;
 
 /* Return a pointer to a bottom tree node, return NULL if it doesn't exist or
  * it cannot be created */
-static arena_map_bot_t *
+static Py_ALWAYS_INLINE arena_map_bot_t *
 arena_map_get(block *p, int create)
 {
 #ifdef USE_INTERIOR_NODES


### PR DESCRIPTION
**NOTE:** This patch cannot be beckported to **3.10**, in which `Py_ALWAYS_INLINE` macro is not introduced.

<!-- gh-issue-number: gh-94841 -->
* Issue: gh-94841
<!-- /gh-issue-number -->
