### PR TITLE
gh-94847: Don't force inlining in debug builds of libmpdec (GH-94848)

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-07-14-11-13-26.gh-issue-94847.s3Kr5p.rst
+++ b/Misc/NEWS.d/next/Build/2022-07-14-11-13-26.gh-issue-94847.s3Kr5p.rst
@@ -1,0 +1,2 @@
+Fixed ``_decimal`` module build issue on GCC when compiling with LTO and
+pydebug. Debug builds no longer force inlining of functions.

--- a/configure
+++ b/configure
@@ -12522,6 +12522,12 @@ else
   LIBMPDEC_LDFLAGS="-lm \$(LIBMPDEC_A)"
   LIBMPDEC_INTERNAL="\$(LIBMPDEC_A)"
 
+    if test "x$with_pydebug" = xyes; then :
+
+    as_fn_append LIBMPDEC_CFLAGS " -DTEST_COVERAGE"
+
+fi
+
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -3672,6 +3672,11 @@ AS_VAR_IF([with_system_libmpdec], [yes], [
   LIBMPDEC_CFLAGS="-I\$(srcdir)/Modules/_decimal/libmpdec"
   LIBMPDEC_LDFLAGS="-lm \$(LIBMPDEC_A)"
   LIBMPDEC_INTERNAL="\$(LIBMPDEC_A)"
+
+  dnl Disable forced inlining in debug builds, see GH-94847
+  AS_VAR_IF([with_pydebug], [yes], [
+    AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -DTEST_COVERAGE"])
+  ])
 ])
 
 AC_SUBST([LIBMPDEC_CFLAGS])


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94847 -->
* Issue: gh-94847
<!-- /gh-issue-number -->
