### PR TITLE
gh-94814: Improve coverage of _PyCode_CreateLineArray

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -1577,9 +1577,7 @@ class TraceTestCase(unittest.TestCase):
         exec("""def f():              # line 0
             x = 0                     # line 1
             y = 1                     # line 2
-            '''                       # line 3
-            %s                        # lines 4 through (1 << 16)
-            '''                       #
+            %s                        # lines 3 through (1 << 16)
             x += 1                    #
             return""" % ('\n' * (1 << 16),), d)
         f = d['f']
@@ -1588,10 +1586,9 @@ class TraceTestCase(unittest.TestCase):
             (0, 'call'),
             (1, 'line'),
             (2, 'line'),
-            (3, 'line'),
-            (65542, 'line'),
-            (65543, 'line'),
-            (65543, 'return'),
+            (65540, 'line'),
+            (65541, 'line'),
+            (65541, 'return'),
         ]
 
         self.run_and_compare(f, EXPECTED_EVENTS)

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -1571,6 +1571,31 @@ class TraceTestCase(unittest.TestCase):
 
         self.run_and_compare(func, EXPECTED_EVENTS)
 
+    def test_very_large_function(self):
+        # There is a separate code path when the number of lines > (1 << 15).
+        d = {}
+        exec("""def f():              # line 0
+            x = 0                     # line 1
+            y = 1                     # line 2
+            '''                       # line 3
+            %s                        # lines 4 through (1 << 16)
+            '''                       #
+            x += 1                    #
+            return""" % ('\n' * (1 << 16),), d)
+        f = d['f']
+
+        EXPECTED_EVENTS = [
+            (0, 'call'),
+            (1, 'line'),
+            (2, 'line'),
+            (3, 'line'),
+            (65542, 'line'),
+            (65543, 'line'),
+            (65543, 'return'),
+        ]
+
+        self.run_and_compare(f, EXPECTED_EVENTS)
+
 
 EVENT_NAMES = [
     'call',


### PR DESCRIPTION
The case where there are more than (1 << 15) lines was not covered.

I don't know if increasing test coverage requires a blurb -- let me know if it does.

<!-- gh-issue-number: gh-94814 -->
* Issue: gh-94814
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:brandtbucher