### PR TITLE
gh-94808: Add coverage for boolobject.c:bool_new

### DIFF
--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -369,6 +369,13 @@ class BoolTest(unittest.TestCase):
         f(x)
         self.assertGreaterEqual(x.count, 1)
 
+    def test_bool_new(self):
+        assert bool.__new__(bool) is False
+        assert bool.__new__(bool, 1) is True
+        assert bool.__new__(bool, 0) is False
+        assert bool.__new__(bool, False) is False
+        assert bool.__new__(bool, True) is True
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -370,11 +370,11 @@ class BoolTest(unittest.TestCase):
         self.assertGreaterEqual(x.count, 1)
 
     def test_bool_new(self):
-        assert bool.__new__(bool) is False
-        assert bool.__new__(bool, 1) is True
-        assert bool.__new__(bool, 0) is False
-        assert bool.__new__(bool, False) is False
-        assert bool.__new__(bool, True) is True
+        self.assertIs(bool.__new__(bool), False)
+        self.assertIs(bool.__new__(bool, 1), True)
+        self.assertIs(bool.__new__(bool, 0), False)
+        self.assertIs(bool.__new__(bool, False), False)
+        self.assertIs(bool.__new__(bool, True), True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`bool_new` had no coverage.

<!-- gh-issue-number: gh-94808 -->
* Issue: gh-94808
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:brandtbucher