### PR TITLE
GH-94822: Respect metaclasses when caching class attributes

### DIFF
--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -21,3 +21,88 @@ class TestLoadAttrCache(unittest.TestCase):
         Descriptor.__set__ = lambda *args: None
 
         self.assertEqual(f(o), 2)
+
+    def test_metaclass_descriptor_added_after_optimization(self):
+        class Descriptor:
+            pass
+
+        class Metaclass(type):
+            attribute = Descriptor()
+
+        class Class(metaclass=Metaclass):
+            attribute = True
+
+        def f():
+            return Class.attribute
+
+        for _ in range(1025):
+            self.assertTrue(f())
+
+        Descriptor.__get__ = lambda self, instance, value: False
+        Descriptor.__set__ = lambda *args: None
+
+        self.assertFalse(f())
+
+    def test_metaclass_descriptor_shadows_class_attribute(self):
+        class Metaclass(type):
+            @property
+            def attribute(self):
+                return True
+
+        class Class(metaclass=Metaclass):
+            attribute = False
+
+        def f():
+            return Class.attribute
+
+        for _ in range(1025):
+            self.assertTrue(f())
+
+    def test_metaclass_set_descriptor_after_optimization(self):
+        class Metaclass(type):
+            pass
+
+        class Class(metaclass=Metaclass):
+            attribute = True
+
+        @property
+        def attribute(self):
+            return False
+
+        def f():
+            return Class.attribute
+
+        for _ in range(1025):
+            self.assertTrue(f())
+
+        Metaclass.attribute = attribute
+        self.assertFalse(f())
+
+    def test_metaclass_del_descriptor_after_optimization(self):
+        class Metaclass(type):
+            @property
+            def attribute(self):
+                return True
+
+        class Class(metaclass=Metaclass):
+            attribute = False
+
+        def f():
+            return Class.attribute
+
+        for _ in range(1025):
+            self.assertTrue(f())
+        
+        del Metaclass.attribute
+        self.assertFalse(f())
+
+    def test_type_descriptor_shadows_attribute(self):
+        class Class:
+            __name__ = "Spam"
+
+        for _ in range(1025):
+            self.assertEqual(Class.__name__, "Class")
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -100,8 +100,187 @@ class TestLoadAttrCache(unittest.TestCase):
         class Class:
             __name__ = "Spam"
 
+        def f():
+            return Class.__name__
+
         for _ in range(1025):
-            self.assertEqual(Class.__name__, "Class")
+            self.assertEqual(f(), "Class")
+
+    def test_type_descriptor_shadows_attribute_method(self):
+        class Class:
+            mro = None
+
+        def f():
+            return Class.mro
+
+        for _ in range(1025):
+            self.assertIsNone(f())
+
+    def test_type_descriptor_shadows_attribute_member(self):
+        class Class:
+            __base__ = None
+
+        def f():
+            return Class.__base__
+
+        for _ in range(1025):
+            self.assertIs(f(), object)
+
+    def test_type_descriptor_shadows_attribute_getset(self):
+        class Class:
+            __name__ = "Spam"
+
+        def f():
+            return Class.__name__
+
+        for _ in range(1025):
+            self.assertEqual(f(), "Class")
+
+    @unittest.skip("Not fixed yet!")
+    def test_metaclass_getattribute(self):
+        class Metaclass(type):
+            def __getattribute__(self, name):
+                return True
+
+        class Class(metaclass=Metaclass):
+            attribute = False
+
+        def f():
+            return Class.attribute
+
+        for _ in range(1025):
+            self.assertTrue(f())
+
+class TestLoadMethodCache(unittest.TestCase):
+    def test_descriptor_added_after_optimization(self):
+        class Descriptor:
+            pass
+
+        class C:
+            def __init__(self):
+                self.x = lambda: 1
+            x = Descriptor()
+
+        def f(o):
+            return o.x()
+
+        o = C()
+        for i in range(1025):
+            assert f(o) == 1
+
+        Descriptor.__get__ = lambda self, instance, value: lambda: 2
+        Descriptor.__set__ = lambda *args: None
+
+        self.assertEqual(f(o), 2)
+
+    def test_metaclass_descriptor_added_after_optimization(self):
+        class Descriptor:
+            pass
+
+        class Metaclass(type):
+            attribute = Descriptor()
+
+        class Class(metaclass=Metaclass):
+            attribute = lambda: True
+
+        def f():
+            return Class.attribute()
+
+        for _ in range(1025):
+            self.assertTrue(f())
+
+        Descriptor.__get__ = lambda self, instance, value: lambda: False
+        Descriptor.__set__ = lambda *args: None
+
+        self.assertFalse(f())
+
+    def test_metaclass_descriptor_shadows_class_attribute(self):
+        class Metaclass(type):
+            @property
+            def attribute(self):
+                return lambda: True
+
+        class Class(metaclass=Metaclass):
+            attribute = lambda: False
+
+        def f():
+            return Class.attribute()
+
+        for _ in range(1025):
+            self.assertTrue(f())
+
+    def test_metaclass_set_descriptor_after_optimization(self):
+        class Metaclass(type):
+            pass
+
+        class Class(metaclass=Metaclass):
+            attribute = lambda: True
+
+        @property
+        def attribute(self):
+            return lambda: False
+
+        def f():
+            return Class.attribute()
+
+        for _ in range(1025):
+            self.assertTrue(f())
+
+        Metaclass.attribute = attribute
+        self.assertFalse(f())
+
+    def test_metaclass_del_descriptor_after_optimization(self):
+        class Metaclass(type):
+            @property
+            def attribute(self):
+                return lambda: True
+
+        class Class(metaclass=Metaclass):
+            attribute = lambda: False
+
+        def f():
+            return Class.attribute()
+
+        for _ in range(1025):
+            self.assertTrue(f())
+        
+        del Metaclass.attribute
+        self.assertFalse(f())
+
+    def test_type_descriptor_shadows_attribute_method(self):
+        class Class:
+            mro = lambda: ["Spam", "eggs"]
+
+        def f():
+            return Class.mro()
+
+        for _ in range(1025):
+            self.assertEqual(f(), ["Spam", "eggs"])
+
+    def test_type_descriptor_shadows_attribute_member(self):
+        class Class:
+            __base__ = lambda: "Spam"
+
+        def f():
+            return Class.__base__()
+
+        for _ in range(1025):
+            self.assertNotEqual(f(), "Spam")
+
+    @unittest.skip("Not fixed yet!")
+    def test_metaclass_getattribute(self):
+        class Metaclass(type):
+            def __getattribute__(self, name):
+                return lambda: True
+
+        class Class(metaclass=Metaclass):
+            attribute = lambda: False
+
+        def f():
+            return Class.attribute()
+
+        for _ in range(1025):
+            self.assertTrue(f())
 
 if __name__ == "__main__":
     import unittest

--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -35,7 +35,7 @@ class TestLoadAttrCache(unittest.TestCase):
 
         def __get__(self, instance, owner):
             return False
-        
+
         def __set__(self, instance, value):
             return None
 
@@ -102,9 +102,9 @@ class TestLoadAttrCache(unittest.TestCase):
 
         for _ in range(1025):
             self.assertTrue(f())
-        
+
         del Metaclass.attribute
-        
+
         for _ in range(1025):
             self.assertFalse(f())
 
@@ -163,7 +163,7 @@ class TestLoadMethodCache(unittest.TestCase):
 
         def __get__(self, instance, owner):
             return lambda: False
-        
+
         def __set__(self, instance, value):
             return None
 
@@ -198,7 +198,7 @@ class TestLoadMethodCache(unittest.TestCase):
 
         def __get__(self, instance, owner):
             return lambda: False
-        
+
         def __set__(self, instance, value):
             return None
 
@@ -249,7 +249,7 @@ class TestLoadMethodCache(unittest.TestCase):
             self.assertTrue(f())
 
         Metaclass.attribute = attribute
-        
+
         for _ in range(1025):
             self.assertFalse(f())
 
@@ -268,9 +268,9 @@ class TestLoadMethodCache(unittest.TestCase):
 
         for _ in range(1025):
             self.assertTrue(f())
-        
+
         del Metaclass.attribute
-        
+
         for _ in range(1025):
             self.assertFalse(f())
 

--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-13-16-42-57.gh-issue-94822.zRRzBN.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-13-16-42-57.gh-issue-94822.zRRzBN.rst
@@ -1,0 +1,2 @@
+Fix an issue where lookups of metaclass descriptors may be ignored when an
+identically-named attribute also exists on the class itself.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3672,7 +3672,9 @@ handle_eval_breaker:
             DEOPT_IF(((PyTypeObject *)cls)->tp_version_tag != type_version,
                 LOAD_ATTR);
             assert(type_version != 0);
-
+            uint32_t meta_version = read_u32(cache->keys_version);
+            DEOPT_IF(Py_TYPE(cls)->tp_version_tag != meta_version, LOAD_ATTR);
+            assert(meta_version != 0);
             STAT_INC(LOAD_ATTR, hit);
             PyObject *res = read_obj(cache->descr);
             assert(res != NULL);

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -947,22 +947,22 @@ specialize_class_load_attr(PyObject *owner, _Py_CODEUNIT *instr,
     _PyLoadMethodCache *cache = (_PyLoadMethodCache *)(instr + 1);
     PyObject *descr = NULL;
     DescriptorClassification kind = 0;
+    if (_PyType_Lookup(Py_TYPE(owner), name)) {
+        SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_METACLASS_ATTRIBUTE);
+        return -1;
+    }
     kind = analyze_descriptor((PyTypeObject *)owner, name, &descr, 0);
     switch (kind) {
         case METHOD:
         case NON_DESCRIPTOR:
             write_u32(cache->type_version, ((PyTypeObject *)owner)->tp_version_tag);
+            write_u32(cache->keys_version, Py_TYPE(owner)->tp_version_tag);
             write_obj(cache->descr, descr);
             _Py_SET_OPCODE(*instr, LOAD_ATTR_CLASS);
             return 0;
 #ifdef Py_STATS
         case ABSENT:
-            if (_PyType_Lookup(Py_TYPE(owner), name) != NULL) {
-                SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_METACLASS_ATTRIBUTE);
-            }
-            else {
-                SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_EXPECTED_ERROR);
-            }
+            SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_EXPECTED_ERROR);
             return -1;
 #endif
         default:


### PR DESCRIPTION
This patch changes `LOAD_ATTR_CLASS` to:
- fail if the named attribute is present on the metaclass
- fail if the metaclass defines `__getattribute__`
- use the metaclass type version for additional cache validation

It also adds a bunch of regression tests for nasty edge-cases when caching class attributes and methods.

<!-- gh-issue-number: gh-94822 -->
* Issue: gh-94822
<!-- /gh-issue-number -->
