### PR TITLE
[3.10] gh-94841: Ensure arena_map_get() is inlined in PyObject_Free()

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-07-14-02-45-44.gh-issue-94841.lLRTdf.rst
+++ b/Misc/NEWS.d/next/Build/2022-07-14-02-45-44.gh-issue-94841.lLRTdf.rst
@@ -1,0 +1,1 @@
+Fix the possible performance regression of :c:func:`PyObject_Free` compiled with MSVC version 1932.

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1397,9 +1397,19 @@ static int arena_map_bot_count;
 static arena_map_bot_t arena_map_root;
 #endif
 
+#if defined(Py_DEBUG)
+#  define ALWAYS_INLINE
+#elif defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
+#  define ALWAYS_INLINE __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#  define ALWAYS_INLINE __forceinline
+#else
+#  define ALWAYS_INLINE
+#endif
+
 /* Return a pointer to a bottom tree node, return NULL if it doesn't exist or
  * it cannot be created */
-static arena_map_bot_t *
+static ALWAYS_INLINE arena_map_bot_t *
 arena_map_get(block *p, int create)
 {
 #ifdef USE_INTERIOR_NODES


### PR DESCRIPTION
Fixes GH-94842.  Need to define ALWAYS_INLINE macro.

Co-authored-by: neonene <53406459+neonene@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94841 -->
* Issue: gh-94841
<!-- /gh-issue-number -->
