### PR TITLE
Replace BG with faster BINV that uses only one call to random()

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -763,13 +763,22 @@ class Random(_random.Random):
         if n * p < 10.0:
             # BINV: Inverse transform method with running time of O(np).
             # https://dl.acm.org/doi/pdf/10.1145/42372.42381
+
+            # This algorithm is susceptible to round-off errors in the
+            # calculation of q**n, in the incremental calculation of r,
+            # and the deaccumulation of u.  Accordingly, we add a guard
+            # to prevent returning k > n and another guard to exit when
+            # u stops decreasing.
+
             q = 1.0 - p
             s = p / q
             a = (n + 1) * s
+            last_u = 1.0
             u = random()
             k = 0
             r = q ** n
-            while r < u:
+            while r < u and k < n and u != last_u:
+                last_u = u
                 u -= r
                 k += 1
                 r *= (a / k) - s  # r ← comb(n, k) * p**k * q**(n-k)

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -761,17 +761,19 @@ class Random(_random.Random):
             return n - self.binomialvariate(n, 1.0 - p)
 
         if n * p < 10.0:
-            # BG: Geometric method by Devroye with running time of O(np).
+            # BINV: Inverse transform method with running time of O(np).
             # https://dl.acm.org/doi/pdf/10.1145/42372.42381
-            x = y = 0
-            c = _log(1.0 - p)
-            if not c:
-                return x
-            while True:
-                y += _floor(_log(random()) / c) + 1
-                if y > n:
-                    return x
-                x += 1
+            q = 1.0 - p
+            s = p / q
+            a = (n + 1) * s
+            u = random()
+            k = 0
+            sum_r = r = q ** n
+            while u >= sum_r and k < n:
+                k += 1
+                r *= (a / k) - s  # r ← comb(n, k) * p**k * q**(n-k)
+                sum_r += r
+            return k
 
         # BTRS: Transformed rejection with squeeze method by Wolfgang Hörmann
         # https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.47.8407&rep=rep1&type=pdf

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -768,11 +768,11 @@ class Random(_random.Random):
             a = (n + 1) * s
             u = random()
             k = 0
-            sum_r = r = q ** n
-            while u >= sum_r and k < n:
+            r = q ** n
+            while r < u:
+                u -= r
                 k += 1
                 r *= (a / k) - s  # r ← comb(n, k) * p**k * q**(n-k)
-                sum_r += r
             return k
 
         # BTRS: Transformed rejection with squeeze method by Wolfgang Hörmann


### PR DESCRIPTION
The BINV algorithm is faster and uses only one call to random(), but I am concerned about numerical issues with the initial ``q**n`` calculation, round-off errors in ``r *= (a / k) - s`` and the accumulation of errors in ``sum_r += r``.

For example, with n=322580 and p=0.000031, the cumulative sum hits a maximum of 0.9999999999989545 at k=46. The random value *u* can be larger than that, leaving BINV trapped in the loop until k=322580.

Using only one call to random() is nice but is that enough information to be able to subdivide the inverse distribution with a small *p* and large *n*?

The version in the paper (with ``u -= r`` instead of ``sum_r`` and without the bounds test) gets stuck in an infinite loop with ``Binv(n=100, p=0.01)`` and u >= 0.9999999999999993 (0x1.ffffffffffffap-1) the sixth largest possible value of ``random()``.  