### PR TITLE
gh-94888: use _ (underscore) instead of "i" as iteration variable

### DIFF
--- a/Doc/library/heapq.rst
+++ b/Doc/library/heapq.rst
@@ -143,7 +143,7 @@ time::
    ...     h = []
    ...     for value in iterable:
    ...         heappush(h, value)
-   ...     return [heappop(h) for i in range(len(h))]
+   ...     return [heappop(h) for _ in range(len(h))]
    ...
    >>> heapsort([1, 3, 5, 7, 9, 2, 4, 6, 8, 0])
    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]


### PR DESCRIPTION
The example In the docs of the usage of the `heapq` module, we use an iteration variable `i` which is not used. So this PR will replace it with the `_`

<img width="499" alt="Schermata 2022-07-15 alle 22 30 24" src="https://user-images.githubusercontent.com/19170381/179306563-e62e676a-c30e-4328-95a7-caf63863d126.png">


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94888 -->
* Issue: gh-94888
<!-- /gh-issue-number -->
