### PR TITLE
GH-94893: Ignore caches when adding `LOAD_FAST_CHECK`s

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-15-22-47-44.gh-issue-94893.YiJYcW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-15-22-47-44.gh-issue-94893.YiJYcW.rst
@@ -1,0 +1,2 @@
+Fix an issue where frame object manipulations could corrupt inline bytecode
+caches.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -493,7 +493,8 @@ add_load_fast_null_checks(PyCodeObject *co)
     int changed = 0;
     _Py_CODEUNIT *instructions = _PyCode_CODE(co);
     for (Py_ssize_t i = 0; i < Py_SIZE(co); i++) {
-        switch (_Py_OPCODE(instructions[i])) {
+        int opcode = _Py_OPCODE(instructions[i]);
+        switch (opcode) {
             case LOAD_FAST:
             case LOAD_FAST__LOAD_FAST:
             case LOAD_FAST__LOAD_CONST:
@@ -509,6 +510,7 @@ add_load_fast_null_checks(PyCodeObject *co)
                 _Py_SET_OPCODE(instructions[i], STORE_FAST);
                 break;
         }
+        i += _PyOpcode_Caches[_PyOpcode_Deopt[opcode]];
     }
     if (changed) {
         // invalidate cached co_code object


### PR DESCRIPTION


<!-- gh-issue-number: gh-94893 -->
* Issue: gh-94893
<!-- /gh-issue-number -->
