### PR TITLE
docs: Fix a few typos

### DIFF
--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -5769,4 +5769,4 @@ Convert posixmodule.c statically allocated types ``DirEntryType`` and
 .. section: C API
 
 Use singular/plural noun in error message when instantiating an abstract
-class with non-overriden abstract method(s).
+class with non-overridden abstract method(s).

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -422,7 +422,7 @@ if not real_executable_dir:
 # ******************************************************************************
 
 # The contents of an optional ._pth file are used to totally override
-# sys.path calcualation. Its presence also implies isolated mode and
+# sys.path calculation. Its presence also implies isolated mode and
 # no-site (unless explicitly requested)
 pth = None
 pth_dir = None

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5253,7 +5253,7 @@ object_getstate(PyObject *obj, int required)
         PyCFunction_GET_SELF(getstate) == obj &&
         PyCFunction_GET_FUNCTION(getstate) == object___getstate__)
     {
-        /* If __getstate__ is not overriden pass the required argument. */
+        /* If __getstate__ is not overridden pass the required argument. */
         state = object_getstate_default(obj, required);
     }
     else {


### PR DESCRIPTION
There are small typos in:
- Misc/NEWS.d/3.9.0a1.rst
- Modules/getpath.py
- Objects/typeobject.c

Fixes:
- Should read `overridden` rather than `overriden`.
- Should read `calculation` rather than `calcualation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md