### PR TITLE
[3.11] gh-94864: Fix PyArg_Parse* with deprecated format units "u" and "Z"

### DIFF
--- a/Lib/test/test_getargs2.py
+++ b/Lib/test/test_getargs2.py
@@ -2,6 +2,7 @@ import unittest
 import math
 import string
 import sys
+import warnings
 from test import support
 from test.support import import_helper
 from test.support import warnings_helper
@@ -999,6 +1000,9 @@ class String_TestCase(unittest.TestCase):
             self.assertRaises(TypeError, getargs_u, memoryview(b'memoryview'))
         with self.assertWarns(DeprecationWarning):
             self.assertRaises(TypeError, getargs_u, None)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DeprecationWarning)
+            self.assertRaises(DeprecationWarning, getargs_u, 'abc\xe9')
 
     @support.requires_legacy_unicode_capi
     def test_u_hash(self):
@@ -1015,6 +1019,9 @@ class String_TestCase(unittest.TestCase):
             self.assertRaises(TypeError, getargs_u_hash, memoryview(b'memoryview'))
         with self.assertWarns(DeprecationWarning):
             self.assertRaises(TypeError, getargs_u_hash, None)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DeprecationWarning)
+            self.assertRaises(DeprecationWarning, getargs_u_hash, 'abc\xe9')
 
     @support.requires_legacy_unicode_capi
     def test_Z(self):
@@ -1031,6 +1038,9 @@ class String_TestCase(unittest.TestCase):
             self.assertRaises(TypeError, getargs_Z, memoryview(b'memoryview'))
         with self.assertWarns(DeprecationWarning):
             self.assertIsNone(getargs_Z(None))
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DeprecationWarning)
+            self.assertRaises(DeprecationWarning, getargs_Z, 'abc\xe9')
 
     @support.requires_legacy_unicode_capi
     def test_Z_hash(self):
@@ -1047,6 +1057,9 @@ class String_TestCase(unittest.TestCase):
             self.assertRaises(TypeError, getargs_Z_hash, memoryview(b'memoryview'))
         with self.assertWarns(DeprecationWarning):
             self.assertIsNone(getargs_Z_hash(None))
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DeprecationWarning)
+            self.assertRaises(DeprecationWarning, getargs_Z_hash, 'abc\xe9')
 
 
 class Object_TestCase(unittest.TestCase):

--- a/Misc/NEWS.d/next/C API/2022-07-16-14-57-23.gh-issue-94864.Pb41ab.rst
+++ b/Misc/NEWS.d/next/C API/2022-07-16-14-57-23.gh-issue-94864.Pb41ab.rst
@@ -1,0 +1,2 @@
+Fix ``PyArg_Parse*`` with deprecated format units "u" and "Z". It returned 1
+(success) when warnings are turned into exceptions.

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -1017,7 +1017,7 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
     {
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
                 "getargs: The '%c' format is deprecated. Use 'U' instead.", c)) {
-            return NULL;
+            RETURN_ERR_OCCURRED;
         }
 _Py_COMP_DIAG_PUSH
 _Py_COMP_DIAG_IGNORE_DEPR_DECLS


### PR DESCRIPTION
It returned 1 (success) when warnings are turned into exceptions.


<!-- gh-issue-number: gh-94864 -->
* Issue: gh-94864
<!-- /gh-issue-number -->
