### PR TITLE
Automatically update more GitHub projects.

### DIFF
--- a/.github/workflows/project-updater.yml
+++ b/.github/workflows/project-updater.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   add-to-project:
     name: Add issues to projects
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:

--- a/.github/workflows/project-updater.yml
+++ b/.github/workflows/project-updater.yml
@@ -7,7 +7,7 @@ on:
       - labeled
 
 jobs:
-  add-to-project:
+  add-to-blockers:
     name: Add to the Release and Deferred Blocker project
     runs-on: ubuntu-latest
     steps:
@@ -17,3 +17,13 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: release-blocker, deferred-blocker
           label-operator: OR
+
+  add-to-asyncio:
+    name: Add to the asyncio project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.1.0
+        with:
+          project-url: https://github.com/orgs/python/projects/29
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: expert-asyncio

--- a/.github/workflows/project-updater.yml
+++ b/.github/workflows/project-updater.yml
@@ -7,23 +7,21 @@ on:
       - labeled
 
 jobs:
-  add-to-blockers:
-    name: Add to the Release and Deferred Blocker project
-    runs-on: ubuntu-latest
+  add-to-project:
+    name: Add issues to projects
+    runs-on: ubuntu-latest    
+    strategy:
+      matrix:
+        include:
+          # if an issue has any of these labels, it will be added
+          # to the corresponding project
+          - { project:  2, label: "release-blocker, deferred-blocker" }
+          - { project:  3, label: expert-subinterpreters }
+          - { project: 29, label: expert-asyncio }
+    
     steps:
       - uses: actions/add-to-project@v0.1.0
         with:
-          project-url: https://github.com/orgs/python/projects/2
+          project-url: https://github.com/orgs/python/projects/${{ matrix.project }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          labeled: release-blocker, deferred-blocker
-          label-operator: OR
-
-  add-to-asyncio:
-    name: Add to the asyncio project
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/add-to-project@v0.1.0
-        with:
-          project-url: https://github.com/orgs/python/projects/29
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          labeled: expert-asyncio
+          labeled: ${{ matrix.label }}


### PR DESCRIPTION
This PR updates the workflows so that issues labeled `expert-asyncio` are automatically added to the corresponding project.
* Meta issue: https://github.com/python/core-workflow/issues/467
* `asyncio` project: https://github.com/orgs/python/projects/29

I also updated the project itself:
* add views for bugs, features, docs
* reorganized/added a few columns
* set the status to `Todo` on all the issues with `No status`
* enabled a few project workflows to automatically updated the status
* added all the remaining open issues with the `expert-asyncio` label

Edit: the workflow was updated to use a matrix to update more projects.