### PR TITLE
gh-92348: Add quotes to support building on Windows with spaces in directory name

### DIFF
--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -229,7 +229,7 @@ public override bool Execute() {
   </Target>
 
   <Target Name="FindPythonForBuild" Condition="$(PythonForBuild) == ''">
-    <Exec Command="$(MSBuildThisFileDirectory)\find_python.bat -q"
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)\find_python.bat&quot; -q"
           EchoOff="true"
           ConsoleToMsBuild="true">
         <Output TaskParameter="ConsoleOutput" ItemName="_CmdExeLines" />


### PR DESCRIPTION


<!-- gh-issue-number: gh-92348 -->
* Issue: gh-92348
<!-- /gh-issue-number -->
