### PR TITLE
gh-91256: Ensure help text has the program name even before getpath is called

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-17-15-54-29.gh-issue-91256.z7i7Q5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-17-15-54-29.gh-issue-91256.z7i7Q5.rst
@@ -1,0 +1,1 @@
+Ensures the program name is known for help text during interpreter startup.

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2310,6 +2310,9 @@ config_parse_cmdline(PyConfig *config, PyWideStringList *warnoptions,
     const PyWideStringList *argv = &config->argv;
     int print_version = 0;
     const wchar_t* program = config->program_name;
+    if (!program && argv->length >= 1) {
+        program = argv->items[0];
+    }
 
     _PyOS_ResetGetOpt();
     do {


### PR DESCRIPTION


<!-- gh-issue-number: gh-91256 -->
* Issue: gh-91256
<!-- /gh-issue-number -->
