### PR TITLE
Convert references to links in documentation of async compound statements

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1495,7 +1495,7 @@ Is semantically equivalent to::
     else:
         SUITE2
 
-See also :meth:`__aiter__` and :meth:`__anext__` for details.
+See also :meth:`~object.__aiter__` and :meth:`~object.__anext__` for details.
 
 It is a :exc:`SyntaxError` to use an ``async for`` statement outside the
 body of a coroutine function.
@@ -1537,7 +1537,7 @@ is semantically equivalent to::
         if not hit_except:
             await aexit(manager, None, None, None)
 
-See also :meth:`__aenter__` and :meth:`__aexit__` for details.
+See also :meth:`~object.__aenter__` and :meth:`~object.__aexit__` for details.
 
 It is a :exc:`SyntaxError` to use an ``async with`` statement outside the
 body of a coroutine function.


### PR DESCRIPTION
This is a trivial change in documentation. Just references that clearly were intended to be links to the descriptions of the special method names; but the documentation generator fails to recognize them unless they are prefixed with `~object.`.