### PR TITLE
gh-90085: Remove vestigial -t and -c timeit options

### DIFF
--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -259,10 +259,9 @@ def main(args=None, *, _wrap_timer=None):
         args = sys.argv[1:]
     import getopt
     try:
-        opts, args = getopt.getopt(args, "n:u:s:r:tcpvh",
+        opts, args = getopt.getopt(args, "n:u:s:r:pvh",
                                    ["number=", "setup=", "repeat=",
-                                    "time", "clock", "process",
-                                    "verbose", "unit=", "help"])
+                                    "process", "verbose", "unit=", "help"])
     except getopt.error as err:
         print(err)
         print("use -h/--help for command line help")

--- a/Misc/NEWS.d/next/Library/2022-07-17-22-31-32.gh-issue-90085.c4FWcS.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-17-22-31-32.gh-issue-90085.c4FWcS.rst
@@ -1,0 +1,3 @@
+Remove ``-c/--clock`` and ``-t/--time`` CLI options of :mod:`timeit`.
+The options had been deprecated since Python 3.3 and the functionality
+was removed in Python 3.7. Patch by Shantanu Jain.


### PR DESCRIPTION
The functionality was removed in 3d7feb9ac2 / bpo-28240.
The options had been deprecated since Python 3.3

<!-- gh-issue-number: gh-90085 -->
* Issue: gh-90085
<!-- /gh-issue-number -->
