### PR TITLE
gh-94949: Disallow parsing parenthesised ctx mgr with old feature_version

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -391,7 +391,7 @@ for_stmt[stmt_ty]:
 with_stmt[stmt_ty]:
     | invalid_with_stmt_indent
     | 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' b=block {
-        _PyAST_With(a, b, NULL, EXTRA) }
+        CHECK_VERSION(stmt_ty, 10, "Parenthesized context managers are", _PyAST_With(a, b, NULL, EXTRA)) }
     | 'with' a[asdl_withitem_seq*]=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
         _PyAST_With(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
     | ASYNC 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' b=block {

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -391,7 +391,7 @@ for_stmt[stmt_ty]:
 with_stmt[stmt_ty]:
     | invalid_with_stmt_indent
     | 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' b=block {
-        CHECK_VERSION(stmt_ty, 10, "Parenthesized context managers are", _PyAST_With(a, b, NULL, EXTRA)) }
+        CHECK_VERSION(stmt_ty, 9, "Parenthesized context managers are", _PyAST_With(a, b, NULL, EXTRA)) }
     | 'with' a[asdl_withitem_seq*]=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
         _PyAST_With(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
     | ASYNC 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' b=block {

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -738,6 +738,12 @@ class AST_Tests(unittest.TestCase):
         expressions[0] = f"expr = {ast.expr.__subclasses__()[0].__doc__}"
         self.assertCountEqual(ast.expr.__doc__.split("\n"), expressions)
 
+    def test_parenthesized_with_feature_version(self):
+        ast.parse('with (CtxManager() as example): ...', feature_version=(3, 10))
+        with self.assertRaises(SyntaxError):
+            ast.parse('with (CtxManager() as example): ...', feature_version=(3, 9))
+        ast.parse('with CtxManager() as example: ...', feature_version=(3, 9))
+
     def test_issue40614_feature_version(self):
         ast.parse('f"{x=}"', feature_version=(3, 8))
         with self.assertRaises(SyntaxError):

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -740,9 +740,11 @@ class AST_Tests(unittest.TestCase):
 
     def test_parenthesized_with_feature_version(self):
         ast.parse('with (CtxManager() as example): ...', feature_version=(3, 10))
+        # While advertised as a feature in Python 3.10, this was allowed starting 3.9
+        ast.parse('with (CtxManager() as example): ...', feature_version=(3, 9))
         with self.assertRaises(SyntaxError):
-            ast.parse('with (CtxManager() as example): ...', feature_version=(3, 9))
-        ast.parse('with CtxManager() as example: ...', feature_version=(3, 9))
+            ast.parse('with (CtxManager() as example): ...', feature_version=(3, 8))
+        ast.parse('with CtxManager() as example: ...', feature_version=(3, 8))
 
     def test_issue40614_feature_version(self):
         ast.parse('f"{x=}"', feature_version=(3, 8))

--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-18-05-10-29.gh-issue-94949.OsZ7_s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-18-05-10-29.gh-issue-94949.OsZ7_s.rst
@@ -1,0 +1,1 @@
+:func:`ast.parse` will no longer parse parenthesized context managers when passed ``feature_version`` less than ``(3, 10)``. Patch by Shantanu Jain.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-18-05-10-29.gh-issue-94949.OsZ7_s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-18-05-10-29.gh-issue-94949.OsZ7_s.rst
@@ -1,1 +1,1 @@
-:func:`ast.parse` will no longer parse parenthesized context managers when passed ``feature_version`` less than ``(3, 10)``. Patch by Shantanu Jain.
+:func:`ast.parse` will no longer parse parenthesized context managers when passed ``feature_version`` less than ``(3, 9)``. Patch by Shantanu Jain.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -6515,7 +6515,7 @@ with_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( stmt_ty , 10 , "Parenthesized context managers are" , _PyAST_With ( a , b , NULL , EXTRA ) );
+            _res = CHECK_VERSION ( stmt_ty , 9 , "Parenthesized context managers are" , _PyAST_With ( a , b , NULL , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -6515,7 +6515,7 @@ with_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_With ( a , b , NULL , EXTRA );
+            _res = CHECK_VERSION ( stmt_ty , 10 , "Parenthesized context managers are" , _PyAST_With ( a , b , NULL , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;


### PR DESCRIPTION


<!-- gh-issue-number: gh-94949 -->
* Issue: gh-94949
<!-- /gh-issue-number -->
