### PR TITLE
docs: use 'recursively' in the description of rglob, and mention globs in the os equivalences

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1122,8 +1122,8 @@ call fails (for example because the path doesn't exist).
 
 .. method:: Path.rglob(pattern)
 
-   This is like calling :func:`Path.glob` with "``**/``" added in front of the
-   given relative *pattern*::
+   Glob the given relative *pattern* recursively.  This is like calling
+   :func:`Path.glob` with "``**/``" added in front of the *pattern*::
 
       >>> sorted(Path().rglob("*.py"))
       [PosixPath('build/lib/pathlib.py'),
@@ -1302,6 +1302,7 @@ Below is a table mapping various :mod:`os` functions to their corresponding
 :func:`os.path.samefile`               :meth:`Path.samefile`
 :func:`os.path.splitext`               :data:`PurePath.stem` and
                                        :data:`PurePath.suffix`
+:func:`os.walk`                        :meth:`Path.glob` and :meth:`Path.rglob`
 ====================================   ==============================
 
 .. rubric:: Footnotes

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1302,7 +1302,6 @@ Below is a table mapping various :mod:`os` functions to their corresponding
 :func:`os.path.samefile`               :meth:`Path.samefile`
 :func:`os.path.splitext`               :data:`PurePath.stem` and
                                        :data:`PurePath.suffix`
-:func:`os.walk`                        :meth:`Path.glob` and :meth:`Path.rglob`
 ====================================   ==============================
 
 .. rubric:: Footnotes


### PR DESCRIPTION
The r in `rglob` stands for "recursively", so use the word in the description. Also, glob and rglob can usefully be mentioned as the pathlib equivalent of os.walk.

Automerge-Triggered-By: GH:brettcannon