### PR TITLE
gh-90817: Fix docs: use 'deprecated-removed' when removal version known

### DIFF
--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -301,7 +301,7 @@ The :mod:`locale` module defines the following exception and functions:
    *language code* and *encoding* may be ``None`` if their values cannot be
    determined.
 
-   .. deprecated:: 3.11 3.13
+   .. deprecated-removed:: 3.11 3.13
 
 
 .. function:: getlocale(category=LC_CTYPE)
@@ -375,7 +375,7 @@ The :mod:`locale` module defines the following exception and functions:
    The default setting is determined by calling :func:`getdefaultlocale`.
    *category* defaults to :const:`LC_ALL`.
 
-   .. deprecated:: 3.11 3.13
+   .. deprecated-removed:: 3.11 3.13
 
 
 .. function:: strcoll(string1, string2)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

`.. deprecated:: 3.11 3.13` should be `.. deprecated-removed:: 3.11 3.13`

So instead of:

> _Deprecated since version 3.11:_ 3.13

We get:

> _Deprecated since version 3.11, will be removed in version 3.13._

https://docs.python.org/3.12/library/locale.html#locale.getdefaultlocale


<!-- gh-issue-number: gh-90817 -->
* Issue: gh-90817
<!-- /gh-issue-number -->
