### PR TITLE
GH-94961: Remove out of date reference to YIELD_FROM from docs.

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -604,12 +604,6 @@ iterations of the loop.
     .. versionchanged:: 3.11
        oparg set to be the stack depth, for efficient handling on frames.
 
-.. opcode:: YIELD_FROM
-
-   Pops TOS and delegates to it as a subiterator from a :term:`generator`.
-
-   .. versionadded:: 3.3
-
 
 .. opcode:: SETUP_ANNOTATIONS
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94961 -->
* Issue: gh-94961
<!-- /gh-issue-number -->
