### PR TITLE
gh-94961: remove YIELD_FROM from dis documentation

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -604,12 +604,6 @@ iterations of the loop.
     .. versionchanged:: 3.11
        oparg set to be the stack depth, for efficient handling on frames.
 
-.. opcode:: YIELD_FROM
-
-   Pops TOS and delegates to it as a subiterator from a :term:`generator`.
-
-   .. versionadded:: 3.3
-
 
 .. opcode:: SETUP_ANNOTATIONS
 


### PR DESCRIPTION
Should be backported to 3.11 I believe


<!-- gh-issue-number: gh-94961 -->
* Issue: gh-94961
<!-- /gh-issue-number -->
