### PR TITLE
[3.10] gh-94947: Disallow parsing walrus with feature_version < (3, 8) (GH-94948)

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -515,7 +515,9 @@ star_named_expression[expr_ty]:
 
 
 assignment_expression[expr_ty]:
-    | a=NAME ':=' ~ b=expression { _PyAST_NamedExpr(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), b, EXTRA) }
+    | a=NAME ':=' ~ b=expression {
+        CHECK_VERSION(expr_ty, 8, "Assignment expressions are",
+        _PyAST_NamedExpr(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), b, EXTRA)) }
 
 named_expression[expr_ty]:
     | assignment_expression

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -691,6 +691,11 @@ class AST_Tests(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             ast.parse('f"{x=}"', feature_version=(3, 7))
 
+    def test_assignment_expression_feature_version(self):
+        ast.parse('(x := 0)', feature_version=(3, 8))
+        with self.assertRaises(SyntaxError):
+            ast.parse('(x := 0)', feature_version=(3, 7))
+
     def test_constant_as_name(self):
         for constant in "True", "False", "None":
             expr = ast.Expression(ast.Name(constant, ast.Load()))

--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-18-04-48-34.gh-issue-94947.df9gUw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-18-04-48-34.gh-issue-94947.df9gUw.rst
@@ -1,0 +1,1 @@
+:func:`ast.parse` will no longer parse assignment expressions when passed ``feature_version`` less than ``(3, 8)``. Patch by Shantanu Jain.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -10582,7 +10582,7 @@ assignment_expression_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_NamedExpr ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , b , EXTRA );
+            _res = CHECK_VERSION ( expr_ty , 8 , "Assignment expressions are" , _PyAST_NamedExpr ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , b , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;


### PR DESCRIPTION
Co-authored-by: blurb-it[bot] <43283697+blurb-it[bot]@users.noreply.github.com>.
(cherry picked from commit ae0be5a53bb4caee3de4888341addd9c94133f2d)

Co-authored-by: Shantanu <12621235+hauntsaninja@users.noreply.github.com>

<!-- gh-issue-number: gh-94947 -->
* Issue: gh-94947
<!-- /gh-issue-number -->
