### PR TITLE
Revert "gh-93910: [Enum] restore member.member restriction while keeping performance boost"

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1112,14 +1112,6 @@ class Enum(metaclass=EnumType):
     def __init__(self, *args, **kwds):
         pass
 
-    def __getattribute__(self, name):
-        self_dict = super().__getattribute__('__dict__')
-        cls = super().__getattribute__('__class__')
-        value = super().__getattribute__(name)
-        if isinstance(value, cls) and name not in self_dict and name in self._member_names_:
-            raise AttributeError("<enum '%s'> member has no attribute %r" % (cls.__name__, name))
-        return super().__getattribute__(name)
-
     def _generate_next_value_(name, start, count, last_values):
         """
         Generate the next value when not given.

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2646,6 +2646,7 @@ class TestSpecial(unittest.TestCase):
         self.assertEqual(Private._Private__corporal, 'Radar')
         self.assertEqual(Private._Private__major_, 'Hoolihan')
 
+    @unittest.skip("Accessing all values retained for performance reasons, see GH-93910")
     def test_exception_for_member_from_member_access(self):
         with self.assertRaisesRegex(AttributeError, "<enum .Di.> member has no attribute .NO."):
             class Di(Enum):
@@ -2653,12 +2654,6 @@ class TestSpecial(unittest.TestCase):
                 NO = 0
             nope = Di.YES.NO
 
-    def test_no_exception_for_overridden_member_from_member_access(self):
-        class Di(Enum):
-            YES = 1
-            NO = 0
-        Di.YES.NO = Di.NO
-        nope = Di.YES.NO
 
     def test_dynamic_members_with_static_methods(self):
         #


### PR DESCRIPTION
Reverts python/cpython#94913

<!-- gh-issue-number: gh-93910 -->
* Issue: gh-93910
<!-- /gh-issue-number -->
