### PR TITLE
gh-94983: include the full path in find_library on BSDs

### DIFF
--- a/Lib/ctypes/util.py
+++ b/Lib/ctypes/util.py
@@ -205,7 +205,7 @@ elif os.name == "posix":
 
         def find_library(name):
             ename = re.escape(name)
-            expr = r':-l%s\.\S+ => \S*/(lib%s\.\S+)' % (ename, ename)
+            expr = r':-l%s\.\S+ => (\S*/lib%s\.\S+)' % (ename, ename)
             expr = os.fsencode(expr)
 
             try:

--- a/Misc/NEWS.d/next/Library/2022-07-18-22-22-14.gh-issue-94983.1ruuXL.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-18-22-22-14.gh-issue-94983.1ruuXL.rst
@@ -1,0 +1,1 @@
+Fix partial path being returned from find_library(name).


### PR DESCRIPTION
While able to find the full library, the regular expression included
only the basename of the library, without the full path.

This lead to a different behavior across operating systems.

fixes #94983

<!-- gh-issue-number: gh-94983 -->
* Issue: gh-94983
<!-- /gh-issue-number -->
