### PR TITLE
gh-94991 Make `wave._wave_params` public -> `wave.wave_params`

### DIFF
--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -88,6 +88,7 @@ _array_fmts = None, 'b', 'h', None, 'i'
 
 wave_params = namedtuple('wave_params',
                     'nchannels sampwidth framerate nframes comptype compname')
+_wave_params = wave_params  # alias to keep compatibility
 
 def _byteswap(data, width):
     swapped_data = bytearray(len(data))

--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -86,8 +86,8 @@ WAVE_FORMAT_PCM = 0x0001
 
 _array_fmts = None, 'b', 'h', None, 'i'
 
-_wave_params = namedtuple('_wave_params',
-                     'nchannels sampwidth framerate nframes comptype compname')
+wave_params = namedtuple('wave_params',
+                    'nchannels sampwidth framerate nframes comptype compname')
 
 def _byteswap(data, width):
     swapped_data = bytearray(len(data))
@@ -335,9 +335,9 @@ class Wave_read:
         return self._compname
 
     def getparams(self):
-        return _wave_params(self.getnchannels(), self.getsampwidth(),
-                       self.getframerate(), self.getnframes(),
-                       self.getcomptype(), self.getcompname())
+        return wave_params(self.getnchannels(), self.getsampwidth(),
+                      self.getframerate(), self.getnframes(),
+                      self.getcomptype(), self.getcompname())
 
     def getmarkers(self):
         return None
@@ -526,7 +526,7 @@ class Wave_write:
     def getparams(self):
         if not self._nchannels or not self._sampwidth or not self._framerate:
             raise Error('not all parameters set')
-        return _wave_params(self._nchannels, self._sampwidth, self._framerate,
+        return wave_params(self._nchannels, self._sampwidth, self._framerate,
               self._nframes, self._comptype, self._compname)
 
     def setmark(self, id, pos, name):

--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -77,7 +77,7 @@ import struct
 import sys
 
 
-__all__ = ["open", "Error", "Wave_read", "Wave_write"]
+__all__ = ["open", "Error", "Wave_read", "Wave_write", "wave_params"]
 
 class Error(Exception):
     pass

--- a/Misc/NEWS.d/next/Library/2022-07-19-02-20-29.gh-issue-94991.kRGnFh.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-19-02-20-29.gh-issue-94991.kRGnFh.rst
@@ -1,0 +1,1 @@
+Make wave._wave_params public


### PR DESCRIPTION
This namedtuple is the public interface for Wave_write.setparams, making this private does not allow users to create an input that is typechecked to Wave_write.setparams.

If this were public users could call with more readable code such as:

```python
import wave
with wave.open("test.wav", "wb") as wav_file:
    params = wave.wave_params(
        nchannels=1, sampwidth=2, framerate=16_000, nframes=0, comptype="NONE", compname="NONE",
    )
    wav_file.setparams(params)
```
rather than the less readable
```python
import wave
with wave.open("test.wav", "wb") as wav_file:
    params = (1, 2, 16_000, 0, "NONE", "NONE")
    wav_file.setparams(params)
```
This is even worse in a typed environment where the private type of `wave._wave_params` is the only way to call `setparams` which use of private values from the stdlib should be avoided.

<!-- gh-issue-number: gh-94991 -->
* Issue: gh-94991
<!-- /gh-issue-number -->
