### PR TITLE
gh-94673: Add Per-Interpreter Storage for Static Builtin Types

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -227,7 +227,7 @@ struct _typeobject {
 
     destructor tp_finalize;
     vectorcallfunc tp_vectorcall;
-    ssize_t tp_static_builtin_index;  /* 0 means "not initialized" */
+    size_t tp_static_builtin_index;  /* 0 means "not initialized" */
 };
 
 /* This struct is used by the specializer

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -227,6 +227,7 @@ struct _typeobject {
 
     destructor tp_finalize;
     vectorcallfunc tp_vectorcall;
+    ssize_t tp_static_builtin_index;  /* 0 means "not initialized" */
 };
 
 /* This struct is used by the specializer

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -173,7 +173,7 @@ struct _is {
     struct _Py_exc_state exc_state;
 
     struct ast_state ast;
-    struct type_cache type_cache;
+    struct types_state types;
     struct callable_cache callable_cache;
 
     /* The following fields are here to avoid allocation during init.

--- a/Include/internal/pycore_structseq.h
+++ b/Include/internal/pycore_structseq.h
@@ -15,10 +15,17 @@ PyAPI_FUNC(PyTypeObject *) _PyStructSequence_NewType(
     PyStructSequence_Desc *desc,
     unsigned long tp_flags);
 
-PyAPI_FUNC(int) _PyStructSequence_InitType(
+PyAPI_FUNC(int) _PyStructSequence_InitBuiltinWithFlags(
     PyTypeObject *type,
     PyStructSequence_Desc *desc,
     unsigned long tp_flags);
+
+static inline int
+_PyStructSequence_InitBuiltin(PyTypeObject *type,
+                              PyStructSequence_Desc *desc)
+{
+    return _PyStructSequence_InitBuiltinWithFlags(type, desc, 0);
+}
 
 extern void _PyStructSequence_FiniType(PyTypeObject *type);
 

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -39,6 +39,11 @@ struct type_cache {
 #endif
 };
 
+struct types_state {
+    struct type_cache type_cache;
+};
+
+
 extern PyStatus _PyTypes_InitSlotDefs(void);
 
 extern void _PyStaticType_Dealloc(PyTypeObject *type);

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -39,13 +39,17 @@ struct type_cache {
 #endif
 };
 
+#define _Py_MAX_STATIC_BUILTIN_TYPES 1000
+
 struct types_state {
     struct type_cache type_cache;
+    ssize_t num_builtins_initialized;
 };
 
 
 extern PyStatus _PyTypes_InitSlotDefs(void);
 
+extern int _PyStaticType_InitBuiltin(PyTypeObject *type);
 extern void _PyStaticType_Dealloc(PyTypeObject *type);
 
 

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -43,9 +43,14 @@ struct type_cache {
    all the static builtin types will fit (for all builds). */
 #define _Py_MAX_STATIC_BUILTIN_TYPES 200
 
+struct builtin_static_type_state {
+    PyTypeObject *type;
+};
+
 struct types_state {
     struct type_cache type_cache;
     ssize_t num_builtins_initialized;
+    struct builtin_static_type_state builtins[_Py_MAX_STATIC_BUILTIN_TYPES];
 };
 
 

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -39,7 +39,9 @@ struct type_cache {
 #endif
 };
 
-#define _Py_MAX_STATIC_BUILTIN_TYPES 1000
+/* For now we hard-code this to a value for which we are confident
+   all the static builtin types will fit (for all builds). */
+#define _Py_MAX_STATIC_BUILTIN_TYPES 200
 
 struct types_state {
     struct type_cache type_cache;

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -43,20 +43,21 @@ struct type_cache {
    all the static builtin types will fit (for all builds). */
 #define _Py_MAX_STATIC_BUILTIN_TYPES 200
 
-struct builtin_static_type_state {
+typedef struct {
     PyTypeObject *type;
-};
+} static_builtin_type_state;
 
 struct types_state {
     struct type_cache type_cache;
     ssize_t num_builtins_initialized;
-    struct builtin_static_type_state builtins[_Py_MAX_STATIC_BUILTIN_TYPES];
+    static_builtin_type_state builtins[_Py_MAX_STATIC_BUILTIN_TYPES];
 };
 
 
 extern PyStatus _PyTypes_InitSlotDefs(void);
 
 extern int _PyStaticType_InitBuiltin(PyTypeObject *type);
+extern static_builtin_type_state * _PyStaticType_GetState(PyTypeObject *);
 extern void _PyStaticType_Dealloc(PyTypeObject *type);
 
 

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -49,7 +49,7 @@ typedef struct {
 
 struct types_state {
     struct type_cache type_cache;
-    ssize_t num_builtins_initialized;
+    size_t num_builtins_initialized;
     static_builtin_type_state builtins[_Py_MAX_STATIC_BUILTIN_TYPES];
 };
 

--- a/Include/object.h
+++ b/Include/object.h
@@ -352,6 +352,9 @@ given type object has a specified feature.
 
 #ifndef Py_LIMITED_API
 
+/* Track types initialized using _PyStaticType_InitBuiltin(). */
+#define _Py_TPFLAGS_STATIC_BUILTIN (1 << 1)
+
 /* Placement of dict (and values) pointers are managed by the VM, not by the type.
  * The VM will automatically set tp_dictoffset. Should not be used for variable sized
  * classes, such as classes that extend tuple.

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1507,7 +1507,7 @@ class SizeofTest(unittest.TestCase):
         check((1,2,3), vsize('') + 3*self.P)
         # type
         # static type: PyTypeObject
-        fmt = 'P2nPI13Pl4Pn9Pn12PIP'
+        fmt = 'P2nPI13Pl4Pn9Pn12PIPI'
         s = vsize('2P' + fmt)
         check(int, s)
         # class

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3556,8 +3556,7 @@ _PyExc_InitTypes(PyInterpreterState *interp)
 
     for (size_t i=0; i < Py_ARRAY_LENGTH(static_exceptions); i++) {
         PyTypeObject *exc = static_exceptions[i].exc;
-
-        if (PyType_Ready(exc) < 0) {
+        if (_PyStaticType_InitBuiltin(exc) < 0) {
             return -1;
         }
     }

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1992,7 +1992,8 @@ _PyFloat_InitTypes(PyInterpreterState *interp)
 
     /* Init float info */
     if (FloatInfoType.tp_name == NULL) {
-        if (PyStructSequence_InitType2(&FloatInfoType, &floatinfo_desc) < 0) {
+        if (_PyStructSequence_InitBuiltin(&FloatInfoType,
+                                          &floatinfo_desc) < 0) {
             return _PyStatus_ERR("can't init float info type");
         }
     }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6135,7 +6135,7 @@ _PyLong_InitTypes(PyInterpreterState *interp)
 
     /* initialize int_info */
     if (Int_InfoType.tp_name == NULL) {
-        if (PyStructSequence_InitType2(&Int_InfoType, &int_info_desc) < 0) {
+        if (_PyStructSequence_InitBuiltin(&Int_InfoType, &int_info_desc) < 0) {
             return _PyStatus_ERR("can't init int info type");
         }
     }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1978,9 +1978,6 @@ _PyTypes_InitTypes(PyInterpreterState *interp)
         if (_PyStaticType_InitBuiltin(type) < 0) {
             return _PyStatus_ERR("Can't initialize builtin type");
         }
-        if (PyType_Ready(type) < 0) {
-            return _PyStatus_ERR("Can't initialize types");
-        }
         if (type == &PyType_Type) {
             // Sanitify checks of the two most important types
             assert(PyBaseObject_Type.tp_base == NULL);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1975,6 +1975,9 @@ _PyTypes_InitTypes(PyInterpreterState *interp)
     // All other static types (unless initialized elsewhere)
     for (size_t i=0; i < Py_ARRAY_LENGTH(static_types); i++) {
         PyTypeObject *type = static_types[i];
+        if (_PyStaticType_InitBuiltin(type) < 0) {
+            return _PyStatus_ERR("Can't initialize builtin type");
+        }
         if (PyType_Ready(type) < 0) {
             return _PyStatus_ERR("Can't initialize types");
         }

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -465,7 +465,7 @@ initialize_members(PyStructSequence_Desc *desc,
     members[k].name = NULL;
 
     *pn_members = n_members;
-    *pn_unnamed_members = n_members;
+    *pn_unnamed_members = n_unnamed_members;
     return members;
 }
 

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -432,11 +432,21 @@ error:
     return -1;
 }
 
-static void
-initialize_members(PyStructSequence_Desc *desc, PyMemberDef* members,
-                   Py_ssize_t n_members) {
-    Py_ssize_t i, k;
+static PyMemberDef *
+initialize_members(PyStructSequence_Desc *desc,
+                   Py_ssize_t *pn_members, Py_ssize_t *pn_unnamed_members)
+{
+    PyMemberDef *members;
+    Py_ssize_t n_members, n_unnamed_members;
 
+    n_members = count_members(desc, &n_unnamed_members);
+    members = PyMem_NEW(PyMemberDef, n_members - n_unnamed_members + 1);
+    if (members == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    Py_ssize_t i, k;
     for (i = k = 0; i < n_members; ++i) {
         if (desc->fields[i].name == PyStructSequence_UnnamedField) {
             continue;
@@ -453,12 +463,77 @@ initialize_members(PyStructSequence_Desc *desc, PyMemberDef* members,
         k++;
     }
     members[k].name = NULL;
+
+    *pn_members = n_members;
+    *pn_unnamed_members = n_members;
+    return members;
 }
 
 
+static void
+initialize_static_fields(PyTypeObject *type, PyStructSequence_Desc *desc,
+                         PyMemberDef *tp_members, unsigned long tp_flags)
+{
+    type->tp_name = desc->name;
+    type->tp_basicsize = sizeof(PyStructSequence) - sizeof(PyObject *);
+    type->tp_itemsize = sizeof(PyObject *);
+    type->tp_dealloc = (destructor)structseq_dealloc;
+    type->tp_repr = (reprfunc)structseq_repr;
+    type->tp_doc = desc->doc;
+    type->tp_base = &PyTuple_Type;
+    type->tp_methods = structseq_methods;
+    type->tp_new = structseq_new;
+    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | tp_flags;
+    type->tp_traverse = (traverseproc) structseq_traverse;
+    type->tp_members = tp_members;
+}
+
+static int
+initialize_static_type(PyTypeObject *type, PyStructSequence_Desc *desc,
+                       Py_ssize_t n_members, Py_ssize_t n_unnamed_members) {
+    /* initialize_static_fields() should have been called already. */
+    if (PyType_Ready(type) < 0) {
+        return -1;
+    }
+    Py_INCREF(type);
+
+    if (initialize_structseq_dict(
+            desc, type->tp_dict, n_members, n_unnamed_members) < 0) {
+        Py_DECREF(type);
+        return -1;
+    }
+
+    return 0;
+}
+
 int
-_PyStructSequence_InitType(PyTypeObject *type, PyStructSequence_Desc *desc,
-                           unsigned long tp_flags)
+_PyStructSequence_InitBuiltinWithFlags(PyTypeObject *type,
+                                       PyStructSequence_Desc *desc,
+                                       unsigned long tp_flags)
+{
+    PyMemberDef *members;
+    Py_ssize_t n_members, n_unnamed_members;
+
+    members = initialize_members(desc, &n_members, &n_unnamed_members);
+    if (members == NULL) {
+        return -1;
+    }
+    initialize_static_fields(type, desc, members, tp_flags);
+    if (_PyStaticType_InitBuiltin(type) < 0) {
+        PyErr_Format(PyExc_RuntimeError,
+                     "Can't initialize builtin type %s",
+                     desc->name);
+        return -1;
+    }
+    if (initialize_static_type(type, desc, n_members, n_unnamed_members) < 0) {
+        PyMem_Free(members);
+        return -1;
+    }
+    return 0;
+}
+
+int
+PyStructSequence_InitType2(PyTypeObject *type, PyStructSequence_Desc *desc)
 {
     PyMemberDef *members;
     Py_ssize_t n_members, n_unnamed_members;
@@ -477,47 +552,16 @@ _PyStructSequence_InitType(PyTypeObject *type, PyStructSequence_Desc *desc,
         return -1;
     }
 
-    type->tp_name = desc->name;
-    type->tp_basicsize = sizeof(PyStructSequence) - sizeof(PyObject *);
-    type->tp_itemsize = sizeof(PyObject *);
-    type->tp_dealloc = (destructor)structseq_dealloc;
-    type->tp_repr = (reprfunc)structseq_repr;
-    type->tp_doc = desc->doc;
-    type->tp_base = &PyTuple_Type;
-    type->tp_methods = structseq_methods;
-    type->tp_new = structseq_new;
-    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | tp_flags;
-    type->tp_traverse = (traverseproc) structseq_traverse;
-
-    n_members = count_members(desc, &n_unnamed_members);
-    members = PyMem_NEW(PyMemberDef, n_members - n_unnamed_members + 1);
+    members = initialize_members(desc, &n_members, &n_unnamed_members);
     if (members == NULL) {
-        PyErr_NoMemory();
         return -1;
     }
-    initialize_members(desc, members, n_members);
-    type->tp_members = members;
-
-    if (PyType_Ready(type) < 0) {
+    initialize_static_fields(type, desc, members, 0);
+    if (initialize_static_type(type, desc, n_members, n_unnamed_members) < 0) {
         PyMem_Free(members);
         return -1;
     }
-    Py_INCREF(type);
-
-    if (initialize_structseq_dict(
-            desc, type->tp_dict, n_members, n_unnamed_members) < 0) {
-        PyMem_Free(members);
-        Py_DECREF(type);
-        return -1;
-    }
-
     return 0;
-}
-
-int
-PyStructSequence_InitType2(PyTypeObject *type, PyStructSequence_Desc *desc)
-{
-    return _PyStructSequence_InitType(type, desc, 0);
 }
 
 void
@@ -569,13 +613,10 @@ _PyStructSequence_NewType(PyStructSequence_Desc *desc, unsigned long tp_flags)
     Py_ssize_t n_members, n_unnamed_members;
 
     /* Initialize MemberDefs */
-    n_members = count_members(desc, &n_unnamed_members);
-    members = PyMem_NEW(PyMemberDef, n_members - n_unnamed_members + 1);
+    members = initialize_members(desc, &n_members, &n_unnamed_members);
     if (members == NULL) {
-        PyErr_NoMemory();
         return NULL;
     }
-    initialize_members(desc, members, n_members);
 
     /* Initialize Slots */
     slots[0] = (PyType_Slot){Py_tp_dealloc, (destructor)structseq_dealloc};

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -66,17 +66,6 @@ static int
 slot_tp_setattro(PyObject *self, PyObject *name, PyObject *value);
 
 
-static_builtin_type_state *
-_PyStaticType_GetState(PyTypeObject *self)
-{
-    if (self->tp_static_builtin_index == 0) {
-        return NULL;
-    }
-    PyInterpreterState *interp = _PyInterpreterState_GET();
-    return &(interp->types.builtins[self->tp_static_builtin_index - 1]);
-}
-
-
 /*
  * finds the beginning of the docstring's introspection signature.
  * if present, returns a pointer pointing to the first '('.
@@ -6687,6 +6676,16 @@ _PyStaticType_InitBuiltin(PyTypeObject *self)
     state->type = self;
 
     return PyType_Ready(self);
+}
+
+static_builtin_type_state *
+_PyStaticType_GetState(PyTypeObject *self)
+{
+    if (self->tp_static_builtin_index == 0) {
+        return NULL;
+    }
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    return &(interp->types.builtins[self->tp_static_builtin_index - 1]);
 }
 
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -204,7 +204,7 @@ static struct type_cache*
 get_type_cache(void)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    return &interp->type_cache;
+    return &interp->types.type_cache;
 }
 
 
@@ -223,7 +223,7 @@ type_cache_clear(struct type_cache *cache, PyObject *value)
 void
 _PyType_InitCache(PyInterpreterState *interp)
 {
-    struct type_cache *cache = &interp->type_cache;
+    struct type_cache *cache = &interp->types.type_cache;
     for (Py_ssize_t i = 0; i < (1 << MCACHE_SIZE_EXP); i++) {
         struct type_cache_entry *entry = &cache->hashtable[i];
         assert(entry->name == NULL);
@@ -240,7 +240,7 @@ _PyType_InitCache(PyInterpreterState *interp)
 static unsigned int
 _PyType_ClearCache(PyInterpreterState *interp)
 {
-    struct type_cache *cache = &interp->type_cache;
+    struct type_cache *cache = &interp->types.type_cache;
 #if MCACHE_STATS
     size_t total = cache->hits + cache->collisions + cache->misses;
     fprintf(stderr, "-- Method cache hits        = %zd (%d%%)\n",
@@ -272,7 +272,7 @@ PyType_ClearCache(void)
 void
 _PyTypes_Fini(PyInterpreterState *interp)
 {
-    struct type_cache *cache = &interp->type_cache;
+    struct type_cache *cache = &interp->types.type_cache;
     type_cache_clear(cache, NULL);
     if (_Py_IsMainInterpreter(interp)) {
         clear_slotdefs();

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6650,6 +6650,16 @@ PyType_Ready(PyTypeObject *type)
     return 0;
 }
 
+int
+_PyStaticType_InitBuiltin(PyTypeObject *self)
+{
+    /* For static types we store them in an array on each interpreter. */
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    interp->types.num_builtins_initialized++;
+    assert(interp->types.num_builtins_initialized < _Py_MAX_STATIC_BUILTIN_TYPES);
+    return 0;
+}
+
 
 static int
 add_subclass(PyTypeObject *base, PyTypeObject *type)

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4241,6 +4241,8 @@ _PyStaticType_Dealloc(PyTypeObject *type)
     }
 
     type->tp_flags &= ~Py_TPFLAGS_READY;
+    // Reset tp_static_builtin_index after each finalization.
+    type->tp_static_builtin_index = 0;
 }
 
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6657,7 +6657,8 @@ _PyStaticType_InitBuiltin(PyTypeObject *self)
     PyInterpreterState *interp = _PyInterpreterState_GET();
     interp->types.num_builtins_initialized++;
     assert(interp->types.num_builtins_initialized < _Py_MAX_STATIC_BUILTIN_TYPES);
-    return 0;
+
+    return PyType_Ready(self);
 }
 
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -66,8 +66,8 @@ static int
 slot_tp_setattro(PyObject *self, PyObject *name, PyObject *value);
 
 
-static inline struct builtin_static_type_state *
-lookup_static_builtin_type(PyTypeObject *self)
+static_builtin_type_state *
+_PyStaticType_GetState(PyTypeObject *self)
 {
     if (self->tp_static_builtin_index == 0) {
         return NULL;
@@ -4233,7 +4233,7 @@ _PyStaticType_Dealloc(PyTypeObject *type)
         return;
     }
 
-    struct builtin_static_type_state *state = lookup_static_builtin_type(type);
+    static_builtin_type_state *state = _PyStaticType_GetState(type);
     if (state != NULL) {
         state->type = NULL;
     }
@@ -6682,7 +6682,7 @@ _PyStaticType_InitBuiltin(PyTypeObject *self)
     self->tp_static_builtin_index = interp->types.num_builtins_initialized;
 
     /* Now we initialize the type's per-interpreter state. */
-    struct builtin_static_type_state *state = lookup_static_builtin_type(self);
+    static_builtin_type_state *state = _PyStaticType_GetState(self);
     assert(state != NULL);
     state->type = self;
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4282,6 +4282,10 @@ _PyStaticType_Dealloc(PyTypeObject *type)
         assert(state != NULL);
         state->type = NULL;
         set_static_builtin_index(type, 0);
+
+        PyInterpreterState *interp = _PyInterpreterState_GET();
+        assert(interp->types.num_builtins_initialized > 0);
+        interp->types.num_builtins_initialized--;
     }
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4257,6 +4257,8 @@ static inline void set_static_builtin_index(PyTypeObject *, size_t);
 void
 _PyStaticType_Dealloc(PyTypeObject *type)
 {
+    assert(!(type->tp_flags & Py_TPFLAGS_HEAPTYPE));
+
     type_dealloc_common(type);
 
     Py_CLEAR(type->tp_dict);
@@ -4275,6 +4277,7 @@ _PyStaticType_Dealloc(PyTypeObject *type)
     if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
         /* Reset the type's per-interpreter state.
            This basically undoes what _PyStaticType_InitBuiltin() did. */
+        assert(get_static_builtin_index(type) > 0);
         static_builtin_type_state *state = _PyStaticType_GetState(type);
         assert(state != NULL);
         state->type = NULL;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -279,6 +279,12 @@ _PyTypes_Fini(PyInterpreterState *interp)
     if (_Py_IsMainInterpreter(interp)) {
         clear_slotdefs();
     }
+
+    assert(interp->types.num_builtins_initialized == 0);
+    // All the static builtin types should have been finalized already.
+    for (size_t i = 0; i < _Py_MAX_STATIC_BUILTIN_TYPES; i++) {
+        assert(interp->types.builtins[i].type == NULL);
+    }
 }
 
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4257,11 +4257,6 @@ static inline void set_static_builtin_index(PyTypeObject *, size_t);
 void
 _PyStaticType_Dealloc(PyTypeObject *type)
 {
-    static_builtin_type_state *state = _PyStaticType_GetState(type);
-    if (state != NULL) {
-        state->type = NULL;
-    }
-
     type_dealloc_common(type);
 
     Py_CLEAR(type->tp_dict);
@@ -4280,6 +4275,9 @@ _PyStaticType_Dealloc(PyTypeObject *type)
     if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
         /* Reset the type's per-interpreter state.
            This basically undoes what _PyStaticType_InitBuiltin() did. */
+        static_builtin_type_state *state = _PyStaticType_GetState(type);
+        assert(state != NULL);
+        state->type = NULL;
         set_static_builtin_index(type, 0);
     }
 }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4241,6 +4241,9 @@ has_lingering_subclasses(PyTypeObject *type)
     return 0;
 }
 
+static inline size_t get_static_builtin_index(PyTypeObject *);
+static inline void set_static_builtin_index(PyTypeObject *, size_t);
+
 void
 _PyStaticType_Dealloc(PyTypeObject *type)
 {
@@ -4274,7 +4277,7 @@ _PyStaticType_Dealloc(PyTypeObject *type)
     if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
         /* Reset the type's per-interpreter state.
            This basically undoes what _PyStaticType_InitBuiltin() did. */
-        type->tp_static_builtin_index = 0;
+        set_static_builtin_index(type, 0);
     }
 }
 
@@ -6691,11 +6694,24 @@ PyType_Ready(PyTypeObject *type)
     return 0;
 }
 
+
+static inline size_t
+get_static_builtin_index(PyTypeObject *self)
+{
+    return self->tp_static_builtin_index;
+}
+
+static inline void
+set_static_builtin_index(PyTypeObject *self, size_t index)
+{
+    self->tp_static_builtin_index = index;
+}
+
 int
 _PyStaticType_InitBuiltin(PyTypeObject *self)
 {
     /* It should only be called once for each builtin type. */
-    assert(self->tp_static_builtin_index == 0);
+    assert(get_static_builtin_index(self) == 0);
 
     /* For static types we store some state in an array on each interpreter. */
     PyInterpreterState *interp = _PyInterpreterState_GET();
@@ -6703,7 +6719,7 @@ _PyStaticType_InitBuiltin(PyTypeObject *self)
     assert(interp->types.num_builtins_initialized < _Py_MAX_STATIC_BUILTIN_TYPES);
 
     /* We use 1-based indexing so 0 can mean "not initialized". */
-    self->tp_static_builtin_index = interp->types.num_builtins_initialized;
+    set_static_builtin_index(self, interp->types.num_builtins_initialized);
 
     /* Now we initialize the type's per-interpreter state. */
     static_builtin_type_state *state = _PyStaticType_GetState(self);
@@ -6718,11 +6734,11 @@ _PyStaticType_InitBuiltin(PyTypeObject *self)
 static_builtin_type_state *
 _PyStaticType_GetState(PyTypeObject *self)
 {
-    if (self->tp_static_builtin_index == 0) {
+    if (get_static_builtin_index(self) == 0) {
         return NULL;
     }
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    return &(interp->types.builtins[self->tp_static_builtin_index - 1]);
+    return &(interp->types.builtins[get_static_builtin_index(self) - 1]);
 }
 
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14604,13 +14604,13 @@ _PyUnicode_InitTypes(PyInterpreterState *interp)
         return _PyStatus_OK();
     }
 
-    if (PyType_Ready(&EncodingMapType) < 0) {
+    if (_PyStaticType_InitBuiltin(&EncodingMapType) < 0) {
         goto error;
     }
-    if (PyType_Ready(&PyFieldNameIter_Type) < 0) {
+    if (_PyStaticType_InitBuiltin(&PyFieldNameIter_Type) < 0) {
         goto error;
     }
-    if (PyType_Ready(&PyFormatterIter_Type) < 0) {
+    if (_PyStaticType_InitBuiltin(&PyFormatterIter_Type) < 0) {
         goto error;
     }
     return _PyStatus_OK();

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -1229,8 +1229,8 @@ _PyErr_InitTypes(PyInterpreterState *interp)
     }
 
     if (UnraisableHookArgsType.tp_name == NULL) {
-        if (PyStructSequence_InitType2(&UnraisableHookArgsType,
-                                       &UnraisableHookArgs_desc) < 0) {
+        if (_PyStructSequence_InitBuiltin(&UnraisableHookArgsType,
+                                          &UnraisableHookArgs_desc) < 0) {
             return _PyStatus_ERR("failed to initialize UnraisableHookArgs type");
         }
     }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1672,8 +1672,9 @@ finalize_interp_types(PyInterpreterState *interp)
     _PyLong_FiniTypes(interp);
     _PyThread_FiniType(interp);
     _PyErr_FiniTypes(interp);
-    _PyTypes_Fini(interp);
     _PyTypes_FiniTypes(interp);
+
+    _PyTypes_Fini(interp);
 
     // Call _PyUnicode_ClearInterned() before _PyDict_Fini() since it uses
     // a dict internally.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -28,7 +28,7 @@ Data members:
 #include "pycore_pymath.h"        // _PY_SHORT_FLOAT_REPR
 #include "pycore_pymem.h"         // _PyMem_SetDefaultAllocator()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "pycore_structseq.h"     // _PyStructSequence_InitType()
+#include "pycore_structseq.h"     // _PyStructSequence_InitBuiltinWithFlags()
 #include "pycore_tuple.h"         // _PyTuple_FromArray()
 
 #include "frameobject.h"          // PyFrame_FastToLocalsWithError()
@@ -2921,7 +2921,7 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
     SET_SYS("int_info", PyLong_GetInfo());
     /* initialize hash_info */
     if (Hash_InfoType.tp_name == NULL) {
-        if (PyStructSequence_InitType2(&Hash_InfoType, &hash_info_desc) < 0) {
+        if (_PyStructSequence_InitBuiltin(&Hash_InfoType, &hash_info_desc) < 0) {
             goto type_init_failed;
         }
     }
@@ -2943,14 +2943,18 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
     SET_SYS_FROM_STRING("abiflags", ABIFLAGS);
 #endif
 
+#define ENSURE_INFO_TYPE(TYPE, DESC) \
+    do { \
+        if (TYPE.tp_name == NULL) { \
+            if (_PyStructSequence_InitBuiltinWithFlags( \
+                    &TYPE, &DESC, Py_TPFLAGS_DISALLOW_INSTANTIATION) < 0) { \
+                goto type_init_failed; \
+            } \
+        } \
+    } while (0)
+
     /* version_info */
-    if (VersionInfoType.tp_name == NULL) {
-        if (_PyStructSequence_InitType(&VersionInfoType,
-                                       &version_info_desc,
-                                       Py_TPFLAGS_DISALLOW_INSTANTIATION) < 0) {
-            goto type_init_failed;
-        }
-    }
+    ENSURE_INFO_TYPE(VersionInfoType, version_info_desc);
     version_info = make_version_info(tstate);
     SET_SYS("version_info", version_info);
 
@@ -2958,26 +2962,17 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
     SET_SYS("implementation", make_impl_info(version_info));
 
     // sys.flags: updated in-place later by _PySys_UpdateConfig()
-    if (FlagsType.tp_name == 0) {
-        if (_PyStructSequence_InitType(&FlagsType, &flags_desc,
-                                       Py_TPFLAGS_DISALLOW_INSTANTIATION) < 0) {
-            goto type_init_failed;
-        }
-    }
+    ENSURE_INFO_TYPE(FlagsType, flags_desc);
     SET_SYS("flags", make_flags(tstate->interp));
 
 #if defined(MS_WINDOWS)
     /* getwindowsversion */
-    if (WindowsVersionType.tp_name == 0) {
-        if (_PyStructSequence_InitType(&WindowsVersionType,
-                                       &windows_version_desc,
-                                       Py_TPFLAGS_DISALLOW_INSTANTIATION) < 0) {
-            goto type_init_failed;
-        }
-    }
+    ENSURE_INFO_TYPE(WindowsVersionType, windows_version_desc);
 
     SET_SYS_FROM_STRING("_vpath", VPATH);
 #endif
+
+#undef ENSURE_INFO_TYPE
 
     /* float repr style: 0.03 (short) vs 0.029999999999999999 (legacy) */
 #if _PY_SHORT_FLOAT_REPR == 1
@@ -2990,7 +2985,7 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
 
     /* initialize asyncgen_hooks */
     if (AsyncGenHooksType.tp_name == NULL) {
-        if (PyStructSequence_InitType2(
+        if (_PyStructSequence_InitBuiltin(
                 &AsyncGenHooksType, &asyncgen_hooks_desc) < 0) {
             goto type_init_failed;
         }

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -155,7 +155,8 @@ PyThread_GetInfo(void)
 #endif
 
     if (ThreadInfoType.tp_name == 0) {
-        if (PyStructSequence_InitType2(&ThreadInfoType, &threadinfo_desc) < 0)
+        if (_PyStructSequence_InitBuiltin(&ThreadInfoType,
+                                          &threadinfo_desc) < 0)
             return NULL;
     }
 


### PR DESCRIPTION
This is a precursor to storing tp_subclasses (and tp_weaklist) on the interpreter state for static builtin types.  At a high level, we add the following:

* `_PyStaticType_InitBuiltin()`
* `PyInterpreterState.types.builtins`

We also shuffle some code around to be able to use `_PyStaticType_InitBuiltin()`, especially in Objects/structseq.c.

One thing to note is that we add a new "tp_" field: `PyTypeObject.tp_static_builtin_index`.  If adding another field to PyTypeObject is too costly then we could conditionally re-purpose some other field (e.g. `tp_subclasses` once we don't use it for static types).

<!-- gh-issue-number: gh-94673 -->
* Issue: gh-94673
<!-- /gh-issue-number -->
