### PR TITLE
Raise TypeError in genrandbits method

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -851,6 +851,8 @@ class SystemRandom(Random):
 
     def getrandbits(self, k):
         """getrandbits(k) -> x.  Generates an int with k random bits."""
+        if not isinstance(k, int):
+            raise TypeError('number of bits must be integer')
         if k < 0:
             raise ValueError('number of bits must be non-negative')
         numbytes = (k + 7) // 8                       # bits / 8 and rounded up

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -365,6 +365,8 @@ class TestBasicOps:
         self.assertRaises(TypeError, self.gen.getrandbits, 1, 2)
         self.assertRaises(ValueError, self.gen.getrandbits, -1)
         self.assertRaises(TypeError, self.gen.getrandbits, 10.1)
+        self.assertRaises(TypeError, self.gen.getrandbits, 'test')
+        self.assertRaises(TypeError, self.gen.getrandbits, None)
 
     def test_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):


### PR DESCRIPTION
Raise TypeError when values other than integer are
supplied to genrandbits method.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
