### PR TITLE
gh-93678: move normalize_basic_block and extend_block call into optimize_cfg

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -85,7 +85,8 @@
          (opcode) == SETUP_WITH || \
          (opcode) == SETUP_CLEANUP)
 
-#define IS_END_OF_BASICBLOCK_OPCODE(opcode) \
+/* opcodes that must be last in the basicblock */
+#define IS_TERMINTATOR_OPCODE(opcode) \
         (IS_JUMP_OPCODE(opcode) || IS_SCOPE_EXIT_OPCODE(opcode))
 
 /* opcodes which are not emitted in codegen stage, only by the assembler */
@@ -1251,7 +1252,7 @@ compiler_use_new_implicit_block_if_needed(struct compiler *c)
 {
     basicblock *b = c->u->u_curblock;
     struct instr *last = basicblock_last_instr(b);
-    if (last && IS_END_OF_BASICBLOCK_OPCODE(last->i_opcode)) {
+    if (last && IS_TERMINTATOR_OPCODE(last->i_opcode)) {
         basicblock *b = compiler_new_block(c);
         if (b == NULL) {
             return -1;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -9323,8 +9323,8 @@ clean_basic_block(basicblock *bb) {
 
 static int
 normalize_basic_block(basicblock *bb) {
-    /* Mark blocks as exit and/or nofallthrough.
-     Raise SystemError if CFG is malformed. */
+    /* Skip over empty blocks.
+     * Raise SystemError if jump or exit is not last instruction in the block. */
     for (int i = 0; i < bb->b_iused; i++) {
         int opcode = bb->b_instr[i].i_opcode;
         assert(!IS_ASSEMBLER_OPCODE(opcode));
@@ -9461,8 +9461,7 @@ propagate_line_numbers(basicblock *entryblock) {
    The consts object should still be in list form to allow new constants
    to be appended.
 
-   All transformations keep the code size the same or smaller.
-   For those that reduce size, the gaps are initially filled with
+   Code trasnformations that reduce code size initially fill the gaps with
    NOPs.  Later those NOPs are removed.
 */
 

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -85,6 +85,9 @@
          (opcode) == SETUP_WITH || \
          (opcode) == SETUP_CLEANUP)
 
+#define IS_END_OF_BASICBLOCK_OPCODE(opcode) \
+        (IS_JUMP_OPCODE(opcode) || IS_SCOPE_EXIT_OPCODE(opcode))
+
 /* opcodes which are not emitted in codegen stage, only by the assembler */
 #define IS_ASSEMBLER_OPCODE(opcode) \
         ((opcode) == JUMP_FORWARD || \
@@ -1244,17 +1247,11 @@ PyCompile_OpcodeStackEffect(int opcode, int oparg)
 }
 
 static int
-is_end_of_basic_block(struct instr *instr)
-{
-    int opcode = instr->i_opcode;
-    return IS_JUMP_OPCODE(opcode) || IS_SCOPE_EXIT_OPCODE(opcode);
-}
-
-static int
 compiler_use_new_implicit_block_if_needed(struct compiler *c)
 {
     basicblock *b = c->u->u_curblock;
-    if (b->b_iused && is_end_of_basic_block(basicblock_last_instr(b))) {
+    struct instr *last = basicblock_last_instr(b);
+    if (last && IS_END_OF_BASICBLOCK_OPCODE(last->i_opcode)) {
         basicblock *b = compiler_new_block(c);
         if (b == NULL) {
             return -1;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -266,7 +266,7 @@ typedef struct basicblock_ {
 
 
 static struct instr *
-basicblock_last_instr(basicblock *b) {
+basicblock_last_instr(const basicblock *b) {
     if (b->b_iused) {
         return &b->b_instr[b->b_iused - 1];
     }
@@ -274,19 +274,19 @@ basicblock_last_instr(basicblock *b) {
 }
 
 static inline int
-basicblock_returns(basicblock *b) {
+basicblock_returns(const basicblock *b) {
     struct instr *last = basicblock_last_instr(b);
     return last && last->i_opcode == RETURN_VALUE;
 }
 
 static inline int
-basicblock_exits_scope(basicblock *b) {
+basicblock_exits_scope(const basicblock *b) {
     struct instr *last = basicblock_last_instr(b);
     return last && IS_SCOPE_EXIT_OPCODE(last->i_opcode);
 }
 
 static inline int
-basicblock_nofallthrough(basicblock *b) {
+basicblock_nofallthrough(const basicblock *b) {
     struct instr *last = basicblock_last_instr(b);
     return (last &&
             (IS_SCOPE_EXIT_OPCODE(last->i_opcode) ||

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -86,7 +86,7 @@
          (opcode) == SETUP_CLEANUP)
 
 /* opcodes that must be last in the basicblock */
-#define IS_TERMINTATOR_OPCODE(opcode) \
+#define IS_TERMINATOR_OPCODE(opcode) \
         (IS_JUMP_OPCODE(opcode) || IS_SCOPE_EXIT_OPCODE(opcode))
 
 /* opcodes which are not emitted in codegen stage, only by the assembler */
@@ -1252,7 +1252,7 @@ compiler_use_new_implicit_block_if_needed(struct compiler *c)
 {
     basicblock *b = c->u->u_curblock;
     struct instr *last = basicblock_last_instr(b);
-    if (last && IS_TERMINTATOR_OPCODE(last->i_opcode)) {
+    if (last && IS_TERMINATOR_OPCODE(last->i_opcode)) {
         basicblock *b = compiler_new_block(c);
         if (b == NULL) {
             return -1;


### PR DESCRIPTION
This collects all cfg related code into a single function that can be exposed to python for unit testing.

Also updated a couple of obsolete comments and arranged all line number related calculations together.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-93678 -->
* Issue: gh-93678
<!-- /gh-issue-number -->
