### PR TITLE
[3.10] gh-94998: Make 3.10 sqlite3 tests run

### DIFF
--- a/Lib/test/test_sqlite3/__init__.py
+++ b/Lib/test/test_sqlite3/__init__.py
@@ -1,0 +1,18 @@
+from test.support import import_helper, load_package_tests, verbose
+
+# Skip test if _sqlite3 module not installed.
+import_helper.import_module('_sqlite3')
+
+import unittest
+import os
+import sqlite3
+
+# Implement the unittest "load tests" protocol.
+def load_tests(*args):
+    pkg_dir = os.path.dirname(__file__)
+    return load_package_tests(pkg_dir, *args)
+
+if verbose:
+    print("test_sqlite3: testing with version",
+          "{!r}, sqlite_version {!r}".format(sqlite3.version,
+                                             sqlite3.sqlite_version))

--- a/Lib/test/test_sqlite3/__main__.py
+++ b/Lib/test/test_sqlite3/__main__.py
@@ -1,0 +1,4 @@
+#from test.test_sqlite3 import load_tests
+import unittest
+
+unittest.main('test.test_sqlite3')

--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -42,14 +42,14 @@ def memory_database(*args, **kwargs):
     return contextlib.closing(cx)
 
 
-# Temporarily limit a database connection parameter
-@contextlib.contextmanager
-def cx_limit(cx, category=sqlite.SQLITE_LIMIT_SQL_LENGTH, limit=128):
-    try:
-        _prev = cx.setlimit(category, limit)
-        yield limit
-    finally:
-        cx.setlimit(category, _prev)
+### Temporarily limit a database connection parameter
+##@contextlib.contextmanager
+##def cx_limit(cx, category=sqlite.SQLITE_LIMIT_SQL_LENGTH, limit=128):
+##    try:
+##        _prev = cx.setlimit(category, limit)
+##        yield limit
+##    finally:
+##        cx.setlimit(category, _prev)
 
 
 class ModuleTests(unittest.TestCase):
@@ -1889,4 +1889,4 @@ class MultiprocessTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Add __init__ and __main__ to 3.10 test_sqlite3 directory.
In test_dbapi, comment out def cx_limit, line 42.
Add 'verbosity=2' to unittest.main().

**Multiple tests in test_dbapi fail before crashing on Windows.**


<!-- gh-issue-number: gh-94998 -->
* Issue: gh-94998
<!-- /gh-issue-number -->
