### PR TITLE
gh-95007: Remove the NoneType return converter

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -3826,17 +3826,6 @@ class CReturnConverter(metaclass=CReturnConverterAutoRegister):
 
 add_c_return_converter(CReturnConverter, 'object')
 
-class NoneType_return_converter(CReturnConverter):
-    def render(self, function, data):
-        self.declare(data)
-        data.return_conversion.append('''
-if (_return_value != Py_None) {
-    goto exit;
-}
-return_value = Py_None;
-Py_INCREF(Py_None);
-'''.strip())
-
 class bool_return_converter(CReturnConverter):
     type = 'int'
 


### PR DESCRIPTION
It has confusing semantic which does not provide any benefit (the
only difference is that you should write "return Py_None" instead
of "Py_RETURN_NONE"), it is not currently used, and it is broken.


<!-- gh-issue-number: gh-95007 -->
* Issue: gh-95007
<!-- /gh-issue-number -->
