### PR TITLE
Add `PyDict_ContainsString`

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3706,6 +3706,23 @@ PyDict_Contains(PyObject *op, PyObject *key)
     return (ix != DKIX_EMPTY && value != NULL);
 }
 
+int
+PyDict_ContainsString(PyObject *op, const char *key)
+{
+    PyObject *unicode, *rv;
+
+    unicode = PyUnicode_FromString(key);
+    if (unicode == NULL) {
+        PyErr_Clear();
+        return NULL;
+    }
+
+    rv = PyDict_Contains(op, unicode);
+    Py_DECREF(unicode);
+
+    return rv;
+}
+
 /* Internal version of PyDict_Contains used when the hash value is already known */
 int
 _PyDict_Contains_KnownHash(PyObject *op, PyObject *key, Py_hash_t hash)

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3706,6 +3706,7 @@ PyDict_Contains(PyObject *op, PyObject *key)
     return (ix != DKIX_EMPTY && value != NULL);
 }
 
+/* Return 1 if `key` is in the dict `op`, 0 if not, and -1 on error. */
 int
 PyDict_ContainsString(PyObject *op, const char *key)
 {


### PR DESCRIPTION
I noticed that some functions like `PyDict_GetItem()`, `PyDict_SetItem()`, `PyDict_DelItem()`, etc has their variants that takes in a character array instead, but `PyDict_ContainsString()` does not.