### PR TITLE
GH-95029: Describe MSIX isolation and redirection in more detail

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -355,7 +355,7 @@ Redirection of local data, registry, and temporary paths
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Because of restrictions on Microsoft Store apps, Python scripts may not have
-full write access to shared locations such as ``TEMP`` and the registry.
+full write access to shared locations such as :envvar:`TEMP` and the registry.
 Instead, it will write to a private copy. If your scripts must modify the
 shared locations, you will need to install the full installer.
 
@@ -382,7 +382,7 @@ You can find the real path of any existing file using :func:`os.path.realpath`:
 
 When writing to the Windows Registry, the following behaviors exist:
 
-* Reading from ``HKLM\\Software`` is allowed and results are merged with the `registry.dat` file in the package.
+* Reading from ``HKLM\\Software`` is allowed and results are merged with the :file:`registry.dat` file in the package.
 * Writing to ``HKLM\\Software`` is not allowed if the corresponding key/value exists, i.e. modifying existing keys.
 * Writing to ``HKLM\\Software`` is allowed as long as a corresponding key/value does not exist in the package
   and the user has the correct access permissions.

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -34,7 +34,7 @@ developers using Python for any kind of project.
 
 :ref:`windows-store` is a simple installation of Python that is suitable for
 running scripts and packages, and using IDLE or other development environments.
-It requires Windows 10, but can be safely installed without corrupting other
+It requires Windows 10 and above, but can be safely installed without corrupting other
 programs. It also provides many convenient commands for launching Python and
 its tools.
 
@@ -348,13 +348,44 @@ Python in Start and right-click to select Uninstall. Uninstalling will
 remove all packages you installed directly into this Python installation, but
 will not remove any virtual environments
 
-Known Issues
+Known issues
 ------------
+
+Redirection of local data, registry, and temporary paths
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Because of restrictions on Microsoft Store apps, Python scripts may not have
 full write access to shared locations such as ``TEMP`` and the registry.
 Instead, it will write to a private copy. If your scripts must modify the
 shared locations, you will need to install the full installer.
+
+This behavior, called "Application Execution Aliases" is enabled by default in all Microsoft Store apps.
+It can be disabled for ``python.exe`` in Windows Settings under the ``Manage App Execution Aliases`` screen.
+
+At runtime, Python will use a private copy of well-known Windows folders and the registry.
+For example, if the environment variable :envvar:`%APPDATA%` is :file:`c:\\Users\\<user>\\AppData\\`,
+then when writing to :file:`C:\\Users\\<user>\\AppData\\Local` will write to
+:file:`C:\\Users\\<user>\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\\LocalCache\\Local\\`.
+
+When reading files, Windows will return the file from the private folder, or if that does not exist, the
+real Windows directory. For example reading :file:`C:\\Windows\\System32` returns the contents of :file:`C:\\Windows\\System32`
+plus the contents of :file:`C:\\Program Files\\WindowsApps\\package_name\\VFS\\SystemX86`.
+
+You can find the real path of any existing file using :func:`os.path.realpath`:
+
+.. code-block:: python
+
+  >>> import os
+  >>> test_file = 'C:\\Users\\example\\AppData\\Local\\test.txt'
+  >>> os.path.realpath(test_file)
+  'C:\\Users\\example\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\\LocalCache\\Local\\test.txt'
+
+When writing to the Windows Registry, the following behaviors exist:
+
+* Reading from ``HKLM\\Software`` is allowed and results are merged with the `registry.dat` file in the package.
+* Writing to ``HKLM\\Software`` is not allowed if the corresponding key/value exists, i.e. modifying existing keys.
+* Writing to ``HKLM\\Software`` is allowed as long as a corresponding key/value does not exist in the package
+  and the user has the correct access permissions.
 
 For more detail on the technical basis for these limitations, please consult
 Microsoft's documentation on packaged full-trust apps, currently available at

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -359,9 +359,6 @@ full write access to shared locations such as :envvar:`TEMP` and the registry.
 Instead, it will write to a private copy. If your scripts must modify the
 shared locations, you will need to install the full installer.
 
-This behavior, called "Application Execution Aliases" is enabled by default in all Microsoft Store apps.
-It can be disabled for ``python.exe`` in Windows Settings under the ``Manage App Execution Aliases`` screen.
-
 At runtime, Python will use a private copy of well-known Windows folders and the registry.
 For example, if the environment variable :envvar:`%APPDATA%` is :file:`c:\\Users\\<user>\\AppData\\`,
 then when writing to :file:`C:\\Users\\<user>\\AppData\\Local` will write to


### PR DESCRIPTION
# Expand the documentation on Windows Store Python to explain folder redirects and registry security

This PR documents the following:

- What folder redirection exists
- What registry behaviors exist
- What workarounds there are

The existing docs suggest installing the "full-package" from python.org as a workaround, which is fine for end-users but package maintainers are trying to diagnose bug reports caused by the Windows Store package and there isn't a resource documenting what these are.

Please backport to 3.7-3.11

<!-- gh-issue-number: gh-95029 -->
* Issue: gh-95029
<!-- /gh-issue-number -->
