### PR TITLE
gh-93939: Use new MODULE_name_STATE in wasm_assets script (GH-95035)

### DIFF
--- a/Tools/wasm/wasm_assets.py
+++ b/Tools/wasm/wasm_assets.py
@@ -165,14 +165,13 @@ def detect_extension_modules(args: argparse.Namespace):
     loc = {}
     exec(data, globals(), loc)
 
-    for name, value in loc["build_time_vars"].items():
-        if value not in {"yes", "missing", "disabled", "n/a"}:
+    for key, value in loc["build_time_vars"].items():
+        if not key.startswith("MODULE_") or not key.endswith("_STATE"):
             continue
-        if not name.startswith("MODULE_"):
-            continue
-        if name.endswith(("_CFLAGS", "_DEPS", "_LDFLAGS")):
-            continue
-        modname = name.removeprefix("MODULE_").lower()
+        if value not in {"yes", "disabled", "missing", "n/a"}:
+            raise ValueError(f"Unsupported value '{value}' for {key}")
+
+        modname = key[7:-6].lower()
         if modname not in modules:
             modules[modname] = value == "yes"
     return modules


### PR DESCRIPTION
``wasm_assets.py`` was using the old ``MODULE_name`` variable to detect
if a shared extension is available. Emscripten browser builds now
correctly detect that e.g. ``json`` module is available.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-93939 -->
* Issue: gh-93939
<!-- /gh-issue-number -->
