### PR TITLE
GH-91409: Don't overwrite valid locations with `NOP` locations

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-20-13-46-01.gh-issue-91409.dhL8Zo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-20-13-46-01.gh-issue-91409.dhL8Zo.rst
@@ -1,0 +1,2 @@
+Fix incorrect source location info caused by certain optimizations in the
+bytecode compiler.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -9278,7 +9278,10 @@ clean_basic_block(basicblock *bb) {
             /* or, if the next instruction has same line number or no line number */
             if (src < bb->b_iused - 1) {
                 int next_lineno = bb->b_instr[src+1].i_loc.lineno;
-                if (next_lineno < 0 || next_lineno == lineno) {
+                if (next_lineno == lineno) {
+                    continue;
+                }
+                if (next_lineno < 0) {
                     bb->b_instr[src+1].i_loc = bb->b_instr[src].i_loc;
                     continue;
                 }


### PR DESCRIPTION
If a `NOP` is followed by a "real" instruction with the same line number, don't overwrite the instruction's location with the `NOP`'s location. That only makes sense if the instruction has no location at all.

<!-- gh-issue-number: gh-91409 -->
* Issue: gh-91409
<!-- /gh-issue-number -->
