### PR TITLE
Fix test_get_ciphers to work also in environments with FIPS

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -938,8 +938,10 @@ class ContextTests(unittest.TestCase):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.set_ciphers('AESGCM')
         names = set(d['name'] for d in ctx.get_ciphers())
-        self.assertIn('AES256-GCM-SHA384', names)
-        self.assertIn('AES128-GCM-SHA256', names)
+        aes128 = any('AES128-GCM-SHA256' in name for name in names)
+        aes256 = any('AES256-GCM-SHA384' in name for name in names)
+        self.assertTrue(aes128)
+        self.assertTrue(aes256)
 
     def test_options(self):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)


### PR DESCRIPTION
If FIPS is enabled, cipher "AES256-GCM-SHA384" is not available
but a variant of it is, like "ECDHE-ECDSA-AES256-GCM-SHA384".

We have briefly discussed this with @tiran. He said that we can also remove the test but because the `get_ciphers` method is used only in two tests in this file and `test_python_ciphers` is skipped unless `PY_SSL_DEFAULT_CIPHERS == 1`, I believe it's still useful.

Cc @stratakis 