### PR TITLE
gh-95087: make email date parsing more robust

### DIFF
--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -110,7 +110,7 @@ def _parsedate_tz(data):
         yy, tm = tm, yy
     if yy[-1] == ',':
         yy = yy[:-1]
-    if not yy[0].isdigit():
+    if yy and not yy[0].isdigit():
         yy, tz = tz, yy
     if tm[-1] == ',':
         tm = tm[:-1]

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3053,6 +3053,7 @@ class TestMiscellaneous(TestEmailBase):
         self.assertIsNone(utils.parsedate_tz(' '))
         self.assertIsNone(utils.parsedate('0'))
         self.assertIsNone(utils.parsedate_tz('0'))
+        self.assertIsNone(utils.parsedate_tz('17 June , 2022'))
         self.assertIsNone(utils.parsedate('A Complete Waste of Time'))
         self.assertIsNone(utils.parsedate_tz('A Complete Waste of Time'))
         self.assertIsNone(utils.parsedate_tz('Wed, 3 Apr 2002 12.34.56.78+0800'))


### PR DESCRIPTION
Similar to bpo-45001 (GH-89164), this makes email date parsing more
robust against malformed input. parsedate_tz() is supposed to return
None for malformed input, but could crash on certain inputs, e.g.

    >>> email.utils.parsedate_tz('17 June , 2022')
    IndexError: string index out of range

Fixes gh-95087.

