### PR TITLE
gh-95095: Use SSL_CTX_get_max_proto_version instead of SSL_CTX_ctrl

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3515,7 +3515,7 @@ set_min_max_proto_version(PySSLContext *self, PyObject *arg, int what)
 static PyObject *
 get_minimum_version(PySSLContext *self, void *c)
 {
-    int v = SSL_CTX_ctrl(self->ctx, SSL_CTRL_GET_MIN_PROTO_VERSION, 0, NULL);
+    int v = SSL_CTX_get_min_proto_version(self->ctx);
     if (v == 0) {
         v = PY_PROTO_MINIMUM_SUPPORTED;
     }
@@ -3531,7 +3531,7 @@ set_minimum_version(PySSLContext *self, PyObject *arg, void *c)
 static PyObject *
 get_maximum_version(PySSLContext *self, void *c)
 {
-    int v = SSL_CTX_ctrl(self->ctx, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, NULL);
+    int v = SSL_CTX_get_max_proto_version(self->ctx);
     if (v == 0) {
         v = PY_PROTO_MAXIMUM_SUPPORTED;
     }


### PR DESCRIPTION
The wrapper macros are more readable and match the form recommended in
the OpenSSL documentation. They also slightly less error-prone, as the
mapping of arguments to SSL_CTX_ctrl is not always clear. (Though in
this case it's straightforward.)
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_get_max_proto_version.html

<!-- gh-issue-number: gh-95095 -->
* Issue: gh-95095
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:tiran