### PR TITLE
gh-95051: ensure that timeouts scheduled with `asyncio.Timeout` that have already expired are deliverered promptly

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -625,6 +625,9 @@ Timeouts
 
             If *when* is a float, it is set as the new deadline.
 
+            if *when* is in the past, the timeout will trigger on the next
+            iteration of the event loop.
+
         .. method:: expired() -> bool
 
            Return whether the context manager has exceeded its deadline

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -52,7 +52,7 @@ class Timeout:
             self._timeout_handler = None
         else:
             loop = events.get_running_loop()
-            if loop.time() >= when:
+            if when <= loop.time():
                 self._timeout_handler = loop.call_soon(self._on_timeout)
             else:
                 self._timeout_handler = loop.call_at(when, self._on_timeout)

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -126,13 +126,7 @@ def timeout(delay: Optional[float]) -> Timeout:
     into TimeoutError.
     """
     loop = events.get_running_loop()
-    if delay is None:
-        return Timeout(None)
-
-    if delay <= 0:
-        return Timeout(0)
-
-    return Timeout(loop.time() + delay)
+    return Timeout(loop.time() + delay if delay is not None else None)
 
 
 def timeout_at(when: Optional[float]) -> Timeout:

--- a/Lib/test/test_asyncio/test_timeouts.py
+++ b/Lib/test/test_asyncio/test_timeouts.py
@@ -127,7 +127,7 @@ class TimeoutTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(cm.expired())
         # 2 sec for slow CI boxes
         self.assertLess(t1-t0, 2)
-        self.assertTrue(t0 <= cm.when() <= t1)
+        self.assertTrue(t0 >= cm.when() <= t1)
 
     async def test_foreign_exception_passed(self):
         with self.assertRaises(KeyError):

--- a/Lib/test/test_asyncio/test_timeouts.py
+++ b/Lib/test/test_asyncio/test_timeouts.py
@@ -105,6 +105,30 @@ class TimeoutTests(unittest.IsolatedAsyncioTestCase):
         self.assertLess(t1-t0, 2)
         self.assertTrue(t0 <= cm.when() <= t1)
 
+    async def test_timeout_zero_sleep_zero(self):
+        loop = asyncio.get_running_loop()
+        t0 = loop.time()
+        with self.assertRaises(TimeoutError):
+            async with asyncio.timeout(0) as cm:
+                await asyncio.sleep(0)
+        t1 = loop.time()
+        self.assertTrue(cm.expired())
+        # 2 sec for slow CI boxes
+        self.assertLess(t1-t0, 2)
+        self.assertTrue(t0 <= cm.when() <= t1)
+
+    async def test_timeout_in_the_past_sleep_zero(self):
+        loop = asyncio.get_running_loop()
+        t0 = loop.time()
+        with self.assertRaises(TimeoutError):
+            async with asyncio.timeout(-11) as cm:
+                await asyncio.sleep(0)
+        t1 = loop.time()
+        self.assertTrue(cm.expired())
+        # 2 sec for slow CI boxes
+        self.assertLess(t1-t0, 2)
+        self.assertTrue(t0 <= cm.when() <= t1)
+
     async def test_foreign_exception_passed(self):
         with self.assertRaises(KeyError):
             async with asyncio.timeout(0.01) as cm:

--- a/Misc/NEWS.d/next/Library/2022-07-21-22-59-22.gh-issue-95109.usxA9r.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-21-22-59-22.gh-issue-95109.usxA9r.rst
@@ -1,0 +1,1 @@
+special case asyncio.timeout(0) and timeouts in the past

--- a/Misc/NEWS.d/next/Library/2022-07-21-22-59-22.gh-issue-95109.usxA9r.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-21-22-59-22.gh-issue-95109.usxA9r.rst
@@ -1,1 +1,1 @@
-ensure that timeouts scheduled with :class:`asyncio.Timeout` that have already expired are delivered promptly
+Ensure that timeouts scheduled with :class:`asyncio.Timeout` that have already expired are delivered promptly.

--- a/Misc/NEWS.d/next/Library/2022-07-21-22-59-22.gh-issue-95109.usxA9r.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-21-22-59-22.gh-issue-95109.usxA9r.rst
@@ -1,1 +1,1 @@
-special case asyncio.timeout(0) and timeouts in the past
+ensure that timeouts scheduled with :class:`asyncio.Timeout` that have already expired are delivered promptly


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95051 -->
* Issue: gh-95051
<!-- /gh-issue-number -->
