### PR TITLE
Use Markdown Headers in GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -15,12 +15,12 @@ labels: "type-bug"
     your problem has already been reported
 -->
 
-**Bug report**
+# Bug report
 
 A clear and concise description of what the bug is.
 Include a minimal, reproducible example (https://stackoverflow.com/help/minimal-reproducible-example), if possible.
 
-**Your environment**
+# Your environment
 
 <!-- Include as many relevant details as possible about the environment you experienced the bug in -->
 

--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -13,15 +13,15 @@ labels: "type-crash"
   For CPython, a "crash" is when Python itself fails, leading to a traceback in the C stack.
 -->
 
-**Crash report**
+# Crash report
 
 Tell us what happened, ideally including a minimal, reproducible example (https://stackoverflow.com/help/minimal-reproducible-example).
 
-**Error messages**
+# Error messages
 
 Enter any relevant error message caused by the crash, including a core dump if there is one.
 
-**Your environment**
+# Your environment
 
 <!-- Include as many relevant details as possible about the environment you experienced the bug in -->
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -4,6 +4,6 @@ about: Report a problem with the documentation
 labels: "docs"
 ---
 
-**Documentation**
+# Documentation
 
 (A clear and concise description of the issue.)

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -4,16 +4,16 @@ about: Submit a proposal for a new CPython feature or enhancement
 labels: "type-feature"
 ---
 
-**Feature or enhancement**
+# Feature or enhancement
 
 (A clear and concise description of your proposal.)
 
-**Pitch**
+# Pitch
 
 (Explain why this feature or enhancement should be implemented and how it would be used.
  Add examples, if applicable.)
 
-**Previous discussion**
+# Previous discussion
 
 <!--
   New features to Python should first be discussed elsewhere before creating issues on GitHub,


### PR DESCRIPTION
The Issue templates are using the markup to make text bold.
We should be using proper text headers instead.

I replaced the **bold** text markup with L1 headers.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
