### PR TITLE
Fix typo in PROTOCOL_TO_TLS_VERSION in test_ssl

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -47,7 +47,7 @@ PY_SSL_DEFAULT_CIPHERS = sysconfig.get_config_var('PY_SSL_DEFAULT_CIPHERS')
 
 PROTOCOL_TO_TLS_VERSION = {}
 for proto, ver in (
-    ("PROTOCOL_SSLv23", "SSLv3"),
+    ("PROTOCOL_SSLv3", "SSLv3"),
     ("PROTOCOL_TLSv1", "TLSv1"),
     ("PROTOCOL_TLSv1_1", "TLSv1_1"),
 ):


### PR DESCRIPTION
This appears to be a typo. It causes try_protocol_combo to try to turn
on SSL 3.0 when testing PROTOCOL_SSLv23 (aka PROTOCOL_TLS), which
doesn't make any sense. Fix it to be PROTOCOL_SSLv3.

Without this, try_protocol_combo is actually setting
context.minimum_version to SSLv3 when called as
try_protocol_combo(ssl.PROTOCOL_TLS, ssl.PROTOCOL_TLS, True)

One would think this causes a no-ssl3 OpenSSL build to fail, but OpenSSL
forgot to make SSL_CTX_set_min_proto_version(SSL3_VERSION) does not
notice no-ssl3, so this typo has gone undetected. But we should still
fix the typo because, presumably, a future version of OpenSSL will
remove SSL 3.0 and do so more thoroughly, at which point this will
break.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:alex