### PR TITLE
gh-93157: Fix fileinput didn't support `errors` in `inplace` mode

### DIFF
--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -335,18 +335,21 @@ class FileInput:
                     pass
                 # The next few lines may raise OSError
                 os.rename(self._filename, self._backupfilename)
-                self._file = open(self._backupfilename, self._mode, encoding=encoding)
+                self._file = open(self._backupfilename, self._mode,
+                                  encoding=encoding, errors=self._errors)
                 try:
                     perm = os.fstat(self._file.fileno()).st_mode
                 except OSError:
-                    self._output = open(self._filename, self._write_mode, encoding=encoding)
+                    self._output = open(self._filename, self._write_mode,
+                                        encoding=encoding, errors=self._errors)
                 else:
                     mode = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
                     if hasattr(os, 'O_BINARY'):
                         mode |= os.O_BINARY
 
                     fd = os.open(self._filename, mode, perm)
-                    self._output = os.fdopen(fd, self._write_mode, encoding=encoding)
+                    self._output = os.fdopen(fd, self._write_mode,
+                                             encoding=encoding, errors=self._errors)
                     try:
                         os.chmod(self._filename, perm)
                     except OSError:

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -326,6 +326,17 @@ class FileInputTests(BaseTests, unittest.TestCase):
         with open(temp_file, 'rb') as f:
             self.assertEqual(f.read(), b'New line.')
 
+    def test_inplace_encoding_errors(self):
+        temp_file = self.writeTmp(b'Initial text \x88', mode='wb')
+        with FileInput(temp_file, inplace=True,
+                       encoding="ascii", errors="replace") as fobj:
+            line = fobj.readline()
+            self.assertEqual(line, 'Initial text \ufffd')
+            #print("New line \x88")
+            sys.stdout.write("New line \x88\n")
+        with open(temp_file, 'rb') as f:
+            self.assertEqual(f.read(), b'New line ?\n')
+
     def test_file_hook_backward_compatibility(self):
         def old_hook(filename, mode):
             return io.StringIO("I used to receive only filename and mode")

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -332,10 +332,9 @@ class FileInputTests(BaseTests, unittest.TestCase):
                        encoding="ascii", errors="replace") as fobj:
             line = fobj.readline()
             self.assertEqual(line, 'Initial text \ufffd')
-            #print("New line \x88")
-            sys.stdout.write("New line \x88\n")
+            print("New line \x88")
         with open(temp_file, 'rb') as f:
-            self.assertEqual(f.read(), b'New line ?\n')
+            self.assertEqual(f.read().rstrip(b'\r\n'), b'New line ?')
 
     def test_file_hook_backward_compatibility(self):
         def old_hook(filename, mode):

--- a/Misc/NEWS.d/next/Library/2022-07-22-17-19-57.gh-issue-93157.RXByAk.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-22-17-19-57.gh-issue-93157.RXByAk.rst
@@ -1,0 +1,2 @@
+Fix :mod:`fileinput` module didn't support ``errors`` option when
+``inplace`` is true.


### PR DESCRIPTION


<!-- gh-issue-number: gh-93157 -->
* Issue: gh-93157
<!-- /gh-issue-number -->
