### PR TITLE
gh-91212: Fixed flickering when the tracer is turned off

### DIFF
--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -596,7 +596,6 @@ class TurtleScreenBase(object):
         item = self.cv.create_text(x-1, -y, text = txt, anchor = anchor[align],
                                         fill = pencolor, font = font)
         x0, y0, x1, y1 = self.cv.bbox(item)
-        self.cv.update()
         return item, x1-1
 
 ##    def _dot(self, pos, size, color):
@@ -3419,6 +3418,7 @@ class RawTurtle(TPen, TNavigator):
         """
         item, end = self.screen._write(self._position, txt, align, font,
                                                           self._pencolor)
+        self._update()
         self.items.append(item)
         if self.undobuffer:
             self.undobuffer.push(("wri", item))

--- a/Lib/turtledemo/clock.py
+++ b/Lib/turtledemo/clock.py
@@ -109,7 +109,6 @@ def tick():
         writer.write(datum(t),
                      align="center", font=("Courier", 14, "bold"))
         writer.forward(85)
-        tracer(True)
         second_hand.setheading(6*sekunde)  # or here
         minute_hand.setheading(6*minute)
         hour_hand.setheading(30*stunde)

--- a/Misc/NEWS.d/next/Library/2022-07-22-09-09-08.gh-issue-91212.53O8Ab.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-22-09-09-08.gh-issue-91212.53O8Ab.rst
@@ -1,0 +1,1 @@
+Fixed flickering of the turtle window when the tracer is turned off. Patch by Shin-myoung-serp.


### PR DESCRIPTION
*RawTurtle.write()* calls *RawTurtle._write()*, that calls *TurtleScreenBase._write()*, and finally that calls *update()* of the underlying canvas.

When the tracer is turned off, the *update()* of the underlying canvas should not be called.
That is done by removing *self.cv.update()* inside *TurtleScreenBase._write()*.
But *update()* of the underlying canvas should be called if the tracer is turned on.
That is done by the added *self._update()* after *self.screen._write()* inside *RawTurtle._write()*.


<!-- gh-issue-number: gh-91212 -->
* Issue: gh-91212
<!-- /gh-issue-number -->
