### PR TITLE
gh-95133: docs, fix indentation level in TestCase.assertLogs example

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1150,8 +1150,8 @@ Test cases
       Example::
 
          with self.assertLogs('foo', level='INFO') as cm:
-            logging.getLogger('foo').info('first message')
-            logging.getLogger('foo.bar').error('second message')
+             logging.getLogger('foo').info('first message')
+             logging.getLogger('foo.bar').error('second message')
          self.assertEqual(cm.output, ['INFO:foo:first message',
                                       'ERROR:foo.bar:second message'])
 


### PR DESCRIPTION
Fixes typo indicated in https://github.com/python/cpython/issues/95133

<!-- gh-issue-number: gh-95133 -->
* Issue: gh-95133
<!-- /gh-issue-number -->
