### PR TITLE
[doc] fix: Update default value on Path.mkdir method

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -958,7 +958,7 @@ call fails (for example because the path doesn't exist).
    the symbolic link's information rather than its target's.
 
 
-.. method:: Path.mkdir(mode=0o777, parents=False, exist_ok=False)
+.. method:: Path.mkdir(mode=0o755, parents=False, exist_ok=False)
 
    Create a new directory at this given path.  If *mode* is given, it is
    combined with the process' ``umask`` value to determine the file mode

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -2033,5 +2033,6 @@ Doug Zongker
 Peter Åstrand
 Vlad Emelianov
 Andrey Doroschenko
+Vinicius Gubiani Ferreira
 
 (Entries should be added in rough alphabetical order by last names)


### PR DESCRIPTION
Discovered this when attempting to create a folder with 777 permission.
Docs say 777 is the default, but it seems to be creating with 755 as
the default (for security reasons maybe?).

Tested on Python 3.9 on my MacOS
```
Python 3.9.13 (main, May 24 2022, 21:13:51)
[Clang 13.1.6 (clang-1316.0.21.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pathlib
>>> pathlib.Path("/tmp/something").mkdir()
>>>
(novo_venv) vf@MacBook-Air-de-VF qa-e2e-tests % ls -lah /tmp
lrwxr-xr-x@ 1 root  wheel    11B May  9 18:30 /tmp -> private/tmp
(novo_venv) vf@MacBook-Air-de-VF qa-e2e-tests % ls -lah /private/tmp
total 32
drwxrwxrwt  96 root  wheel   3.0K Jul 22 14:23 .
drwxr-xr-x   6 root  wheel   192B Jun  8 17:06 ..
...
drwxr-xr-x   2 vf    wheel    64B Jul 22 14:23 something
```

and also tested it inside the most recent version of a python docker
container:
```
(novo_venv) vf@MacBook-Air-de-VF qa-e2e-tests % docker run -it python:3.11-rc-bullseye bash
root@6ac8de1e2e1d:/# python
Python 3.11.0b4 (main, Jul 13 2022, 04:45:49) [GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pathlib
>>> pathlib.Path("/tmp/something").mkdir()
>>>
root@6ac8de1e2e1d:/# ls -lah /tmp/
total 12K
drwxrwxrwt 1 root root 4.0K Jul 22 17:27 .
drwxr-xr-x 1 root root 4.0K Jul 22 17:25 ..
drwxr-xr-x 2 root root 4.0K Jul 22 17:27 something
root@6ac8de1e2e1d:/#
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
