### PR TITLE
Removed an old comment asking if the ismount() function works on all UNIXes

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -181,7 +181,6 @@ def lexists(path):
 
 
 # Is a path a mount point?
-# (Does this work for all UNIXes?  Is it even guaranteed to work by Posix?)
 
 def ismount(path):
     """Test whether a path is a mount point"""


### PR DESCRIPTION
To celebrate the [26th birthday of this comment](https://github.com/python/cpython/blame/main/Lib/posixpath.py#L184), I feel confident that after this length of time that it does work across all UNIXes and its time to remove the comment.

I felt this was a trivial issue so I haven't created an issue number or an entry in `Misc/NEWS.d` 
