### PR TITLE
[3.11] gh-93351: Add news entry and what's new entry for changes in gh-93351 (GH-95175)

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1506,6 +1506,10 @@ Changes in the Python API
   is larger than the population size, a :exc:`ValueError` is raised.
   (Contributed by Raymond Hettinger in :issue:`40465`.)
 
+* :class:`ast.AST` node positions are now validated when provided to
+  :func:`compile` and other related functions. If invalid positions are detected,
+  a :exc:`ValueError` will be raised. (Contributed by Pablo Galindo in :gh:`93351`)
+
 
 Build Changes
 =============

--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-23-19-16-25.gh-issue-93351.0Jyvu-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-23-19-16-25.gh-issue-93351.0Jyvu-.rst
@@ -1,0 +1,3 @@
+:class:`ast.AST` node positions are now validated when provided to
+:func:`compile` and other related functions. If invalid positions are
+detected, a :exc:`ValueError` will be raised.


### PR DESCRIPTION

(cherry picked from commit 9762572d0aa3569ba82eeceb708ddea9f12918fd)

Co-authored-by: Pablo Galindo Salgado <Pablogsal@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-93351 -->
* Issue: gh-93351
<!-- /gh-issue-number -->
