### PR TITLE
gh-95174: WASI: skip missing sockets functions (GH-95179)

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -965,6 +965,19 @@ class GeneralModuleTests(unittest.TestCase):
         socket.IPPROTO_L2TP
         socket.IPPROTO_SCTP
 
+    @unittest.skipIf(support.is_wasi, "WASI is missing these methods")
+    def test_socket_methods(self):
+        # socket methods that depend on a configure HAVE_ check. They should
+        # be present on all platforms except WASI.
+        names = [
+            "bind", "connect", "connect_ex", "getpeername", "getsockname",
+            "listen", "recvfrom", "recvfrom_into", "sendto", "setsockopt",
+            "shutdown"
+        ]
+        for name in names:
+            if not hasattr(socket.socket, name):
+                self.fail(f"socket method {name} is missing")
+
     @unittest.skipUnless(sys.platform == 'darwin', 'macOS specific test')
     @unittest.skipUnless(socket_helper.IPV6_ENABLED, 'IPv6 required for this test')
     def test3542SocketOptions(self):

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -970,9 +970,9 @@ class GeneralModuleTests(unittest.TestCase):
         # socket methods that depend on a configure HAVE_ check. They should
         # be present on all platforms except WASI.
         names = [
-            "bind", "connect", "connect_ex", "getpeername", "getsockname",
-            "listen", "recvfrom", "recvfrom_into", "sendto", "setsockopt",
-            "shutdown"
+            "_accept", "bind", "connect", "connect_ex", "getpeername",
+            "getsockname", "listen", "recvfrom", "recvfrom_into", "sendto",
+            "setsockopt", "shutdown"
         ]
         for name in names:
             if not hasattr(socket.socket, name):

--- a/Misc/NEWS.d/next/Build/2022-07-23-21-39-09.gh-issue-95174.7cYMZR.rst
+++ b/Misc/NEWS.d/next/Build/2022-07-23-21-39-09.gh-issue-95174.7cYMZR.rst
@@ -1,0 +1,1 @@
+Python now skips missing :mod:`socket` functions and methods on WASI. WASI can only create sockets from existing fd / accept and has no netdb.

--- a/Modules/addrinfo.h
+++ b/Modules/addrinfo.h
@@ -162,7 +162,9 @@ struct sockaddr_storage {
 #ifdef __cplusplus
 extern "C" {
 #endif
+#ifdef ENABLE_IPV6
 extern void freehostent(struct hostent *);
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/Modules/getaddrinfo.c
+++ b/Modules/getaddrinfo.c
@@ -61,6 +61,9 @@
 # define FAITH
 #endif
 
+#ifdef HAVE_NETDB_H
+#define HAVE_GETADDRINFO 1
+
 #define SUCCESS 0
 #define GAI_ANY 0
 #define YES 1
@@ -636,3 +639,5 @@ get_addr(hostname, af, res, pai, port0)
     *res = NULL;
     return error;
 }
+
+#endif // HAVE_NETDB_H

--- a/Modules/getnameinfo.c
+++ b/Modules/getnameinfo.c
@@ -48,6 +48,9 @@
 #include "addrinfo.h"
 #endif
 
+#ifdef HAVE_NETDB_H
+#define HAVE_GETNAMEINFO 1
+
 #define SUCCESS 0
 #define YES 1
 #define NO  0
@@ -211,3 +214,4 @@ getnameinfo(sa, salen, host, hostlen, serv, servlen, flags)
     }
     return SUCCESS;
 }
+#endif // HAVE_NETDB_H

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -227,7 +227,7 @@ shutdown(how) -- shut down traffic in one or both directions\n\
 
 #define HAVE_INET_PTON
 #include <netdb.h>
-#endif
+#endif // __sgi
 
 /* Solaris fails to define this variable at all. */
 #if (defined(__sun) && defined(__SVR4)) && !defined(INET_ADDRSTRLEN)
@@ -256,7 +256,9 @@ shutdown(how) -- shut down traffic in one or both directions\n\
 #ifndef MS_WINDOWS
 
 /* Non-MS WINDOWS includes */
-# include <netdb.h>
+#ifdef HAVE_NETDB_H
+#  include <netdb.h>
+#endif
 # include <unistd.h>
 
 /* Headers needed for inet_ntoa() and inet_addr() */
@@ -439,10 +441,11 @@ remove_unusable_flags(PyObject *m)
 #define freeaddrinfo fake_freeaddrinfo
 #include "getaddrinfo.c"
 #endif
+
 #if !defined(HAVE_GETNAMEINFO)
 #define getnameinfo fake_getnameinfo
 #include "getnameinfo.c"
-#endif
+#endif // HAVE_GETNAMEINFO
 
 #ifdef MS_WINDOWS
 #define SOCKETCLOSE closesocket
@@ -623,6 +626,7 @@ set_error(void)
 }
 
 
+#if defined(HAVE_GETHOSTBYNAME_R) || defined (HAVE_GETHOSTBYNAME) || defined (HAVE_GETHOSTBYADDR)
 static PyObject *
 set_herror(int h_error)
 {
@@ -640,8 +644,10 @@ set_herror(int h_error)
 
     return NULL;
 }
+#endif
 
 
+#ifdef HAVE_GETADDRINFO
 static PyObject *
 set_gaierror(int error)
 {
@@ -665,6 +671,7 @@ set_gaierror(int error)
 
     return NULL;
 }
+#endif
 
 /* Function to perform the setting of socket blocking mode
    internally. block = (1 | 0). */
@@ -1046,6 +1053,7 @@ static PyThread_type_lock netdb_lock;
 #endif
 
 
+#ifdef HAVE_GETADDRINFO
 /* Convert a string specifying a host name or one of a few symbolic
    names to a numeric IP address.  This usually calls gethostbyname()
    to do the work; the names "" and "<broadcast>" are special.
@@ -1202,7 +1210,7 @@ setipaddr(const char *name, struct sockaddr *addr_ret, size_t addr_ret_size, int
         return -1;
     }
 }
-
+#endif // HAVE_GETADDRINFO
 
 /* Convert IPv4 sockaddr to a Python str. */
 
@@ -1626,6 +1634,7 @@ makesockaddr(SOCKET_T sockfd, struct sockaddr *addr, size_t addrlen, int proto)
     }
 }
 
+#if defined(HAVE_BIND) || defined(HAVE_CONNECTTO) || defined(CMSG_LEN)
 /* Helper for getsockaddrarg: bypass IDNA for ASCII-only host names
    (in particular, numeric IP addresses). */
 struct maybe_idna {
@@ -2490,6 +2499,7 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
 
     }
 }
+#endif // defined(HAVE_BIND) || defined(HAVE_CONNECTTO) || defined(CMSG_LEN)
 
 
 /* Get the address length according to the socket object's address family.
@@ -3064,6 +3074,7 @@ Returns the timeout in seconds (float) associated with socket\n\
 operations. A timeout of None indicates that timeouts on socket\n\
 operations are disabled.");
 
+#ifdef HAVE_SETSOCKOPT
 /* s.setsockopt() method.
    With an integer third argument, sets an integer optval with optlen=4.
    With None as third argument and an integer fourth argument, set
@@ -3153,7 +3164,7 @@ setsockopt(level, option, None, optlen: int)\n\
 Set a socket option.  See the Unix manual for level and option.\n\
 The value argument can either be an integer, a string buffer, or\n\
 None, optlen.");
-
+#endif
 
 /* s.getsockopt() method.
    With two arguments, retrieves an integer option.
@@ -3227,6 +3238,7 @@ If a nonzero buffersize argument is given, the return value is a\n\
 string of that length; otherwise it is an integer.");
 
 
+#ifdef HAVE_BIND
 /* s.bind(sockaddr) method */
 
 static PyObject *
@@ -3258,6 +3270,7 @@ PyDoc_STRVAR(bind_doc,
 Bind the socket to a local address.  For IP sockets, the address is a\n\
 pair (host, port); the host must refer to the local host. For raw packet\n\
 sockets the address is a tuple (ifname, proto [,pkttype [,hatype [,addr]]])");
+#endif
 
 
 /* s.close() method.
@@ -3310,6 +3323,7 @@ Close the socket object without closing the underlying file descriptor.\n\
 The object cannot be used after this call, but the file descriptor\n\
 can be reused for other purposes.  The file descriptor is returned.");
 
+#ifdef HAVE_CONNECT
 static int
 sock_connect_impl(PySocketSockObject *s, void* Py_UNUSED(data))
 {
@@ -3457,6 +3471,7 @@ PyDoc_STRVAR(connect_ex_doc,
 \n\
 This is like connect(address), but returns an error code (the errno value)\n\
 instead of raising an exception when an error occurs.");
+#endif // HAVE_CONNECT
 
 
 /* s.fileno() method */
@@ -3473,6 +3488,7 @@ PyDoc_STRVAR(fileno_doc,
 Return the integer file descriptor of the socket.");
 
 
+#ifdef HAVE_GETSOCKNAME
 /* s.getsockname() method */
 
 static PyObject *
@@ -3500,6 +3516,7 @@ PyDoc_STRVAR(getsockname_doc,
 Return the address of the local endpoint. The format depends on the\n\
 address family. For IPv4 sockets, the address info is a pair\n\
 (hostaddr, port).");
+#endif
 
 
 #ifdef HAVE_GETPEERNAME         /* Cray APP doesn't have this :-( */
@@ -3533,6 +3550,7 @@ info is a pair (hostaddr, port).");
 #endif /* HAVE_GETPEERNAME */
 
 
+#ifdef HAVE_LISTEN
 /* s.listen(n) method */
 
 static PyObject *
@@ -3565,6 +3583,7 @@ Enable a server to accept connections.  If backlog is specified, it must be\n\
 at least 0 (if it is lower, it is set to 0); it specifies the number of\n\
 unaccepted connections that the system will allow before refusing new\n\
 connections. If not specified, a default reasonable value is chosen.");
+#endif
 
 struct sock_recv {
     char *cbuf;
@@ -3741,6 +3760,7 @@ struct sock_recvfrom {
     Py_ssize_t result;
 };
 
+#ifdef HAVE_RECVFROM
 static int
 sock_recvfrom_impl(PySocketSockObject *s, void *data)
 {
@@ -3913,6 +3933,7 @@ PyDoc_STRVAR(recvfrom_into_doc,
 "recvfrom_into(buffer[, nbytes[, flags]]) -> (nbytes, address info)\n\
 \n\
 Like recv_into(buffer[, nbytes[, flags]]) but also return the sender's address info.");
+#endif
 
 /* The sendmsg() and recvmsg[_into]() methods require a working
    CMSG_LEN().  See the comment near get_CMSG_LEN(). */
@@ -4379,6 +4400,7 @@ until all data is sent.  If an error occurs, it's impossible\n\
 to tell how much data has been sent.");
 
 
+#ifdef HAVE_SENDTO
 struct sock_sendto {
     char *buf;
     Py_ssize_t len;
@@ -4471,6 +4493,7 @@ PyDoc_STRVAR(sendto_doc,
 \n\
 Like send(data, flags) but allows specifying the destination address.\n\
 For IP sockets, the address is a pair (hostaddr, port).");
+#endif
 
 
 /* The sendmsg() and recvmsg[_into]() methods require a working
@@ -5036,14 +5059,18 @@ socket.fromshare().");
 static PyMethodDef sock_methods[] = {
     {"_accept",           (PyCFunction)sock_accept, METH_NOARGS,
                       accept_doc},
+#ifdef HAVE_BIND
     {"bind",              (PyCFunction)sock_bind, METH_O,
                       bind_doc},
+#endif
     {"close",             (PyCFunction)sock_close, METH_NOARGS,
                       sock_close_doc},
+#ifdef HAVE_CONNECT
     {"connect",           (PyCFunction)sock_connect, METH_O,
                       connect_doc},
     {"connect_ex",        (PyCFunction)sock_connect_ex, METH_O,
                       connect_ex_doc},
+#endif
     {"detach",            (PyCFunction)sock_detach, METH_NOARGS,
                       detach_doc},
     {"fileno",            (PyCFunction)sock_fileno, METH_NOARGS,
@@ -5052,8 +5079,10 @@ static PyMethodDef sock_methods[] = {
     {"getpeername",       (PyCFunction)sock_getpeername,
                       METH_NOARGS, getpeername_doc},
 #endif
+#ifdef HAVE_GETSOCKNAME
     {"getsockname",       (PyCFunction)sock_getsockname,
                       METH_NOARGS, getsockname_doc},
+#endif
     {"getsockopt",        (PyCFunction)sock_getsockopt, METH_VARARGS,
                       getsockopt_doc},
 #if defined(MS_WINDOWS) && defined(SIO_RCVALL)
@@ -5064,22 +5093,28 @@ static PyMethodDef sock_methods[] = {
     {"share",         (PyCFunction)sock_share, METH_VARARGS,
                       sock_share_doc},
 #endif
+#ifdef HAVE_LISTEN
     {"listen",            (PyCFunction)sock_listen, METH_VARARGS,
                       listen_doc},
+#endif
     {"recv",              (PyCFunction)sock_recv, METH_VARARGS,
                       recv_doc},
     {"recv_into",         _PyCFunction_CAST(sock_recv_into), METH_VARARGS | METH_KEYWORDS,
                       recv_into_doc},
+#ifdef HAVE_RECVFROM
     {"recvfrom",          (PyCFunction)sock_recvfrom, METH_VARARGS,
                       recvfrom_doc},
     {"recvfrom_into",  _PyCFunction_CAST(sock_recvfrom_into), METH_VARARGS | METH_KEYWORDS,
                       recvfrom_into_doc},
+#endif
     {"send",              (PyCFunction)sock_send, METH_VARARGS,
                       send_doc},
     {"sendall",           (PyCFunction)sock_sendall, METH_VARARGS,
                       sendall_doc},
+#ifdef HAVE_SENDTO
     {"sendto",            (PyCFunction)sock_sendto, METH_VARARGS,
                       sendto_doc},
+#endif
     {"setblocking",       (PyCFunction)sock_setblocking, METH_O,
                       setblocking_doc},
     {"getblocking",   (PyCFunction)sock_getblocking, METH_NOARGS,
@@ -5088,8 +5123,10 @@ static PyMethodDef sock_methods[] = {
                       settimeout_doc},
     {"gettimeout",    (PyCFunction)sock_gettimeout, METH_NOARGS,
                       gettimeout_doc},
+#ifdef HAVE_SETSOCKOPT
     {"setsockopt",        (PyCFunction)sock_setsockopt, METH_VARARGS,
                       setsockopt_doc},
+#endif
 #ifdef HAVE_SHUTDOWN
     {"shutdown",          (PyCFunction)sock_shutdown, METH_O,
                       shutdown_doc},
@@ -5225,6 +5262,16 @@ static int sock_cloexec_works = -1;
 
 /*ARGSUSED*/
 
+#ifndef HAVE_SOCKET
+#define socket stub_socket
+static int
+socket(int domain, int type, int protocol)
+{
+    errno = ENOTSUP;
+    return INVALID_SOCKET;
+}
+#endif
+
 /*[clinic input]
 _socket.socket.__init__ as sock_initobj
     family: int = -1
@@ -5311,6 +5358,7 @@ sock_initobj_impl(PySocketSockObject *self, int family, int type, int proto,
             socklen_t addrlen = sizeof(sock_addr_t);
 
             memset(&addrbuf, 0, addrlen);
+#ifdef HAVE_GETSOCKNAME
             if (getsockname(fd, SAS2SA(&addrbuf), &addrlen) == 0) {
                 if (family == -1) {
                     family = SAS2SA(&addrbuf)->sa_family;
@@ -5329,6 +5377,7 @@ sock_initobj_impl(PySocketSockObject *self, int family, int type, int proto,
                     return -1;
                 }
             }
+#endif // HAVE_GETSOCKNAME
 #ifdef SO_TYPE
             if (type == -1) {
                 int tmp;
@@ -5507,6 +5556,7 @@ static PyTypeObject sock_type = {
 };
 
 
+#ifdef HAVE_GETHOSTNAME
 /* Python interface to gethostname(). */
 
 /*ARGSUSED*/
@@ -5570,6 +5620,7 @@ PyDoc_STRVAR(gethostname_doc,
 "gethostname() -> string\n\
 \n\
 Return the current host name.");
+#endif
 
 #ifdef HAVE_SETHOSTNAME
 PyDoc_STRVAR(sethostname_doc,
@@ -5613,6 +5664,7 @@ extern int sethostname(const char *, size_t);
 }
 #endif
 
+#ifdef HAVE_GETADDRINFO
 /* Python interface to gethostbyname(name). */
 
 /*ARGSUSED*/
@@ -5640,8 +5692,10 @@ PyDoc_STRVAR(gethostbyname_doc,
 "gethostbyname(host) -> address\n\
 \n\
 Return the IP address (a string of the form '255.255.255.255') for a host.");
+#endif
 
 
+#if defined(HAVE_GETHOSTBYNAME_R) || defined (HAVE_GETHOSTBYNAME) || defined (HAVE_GETHOSTBYADDR)
 static PyObject*
 sock_decode_hostname(const char *name)
 {
@@ -5783,8 +5837,9 @@ gethost_common(struct hostent *h, struct sockaddr *addr, size_t alen, int af)
     Py_XDECREF(addr_list);
     return rtn_tuple;
 }
+#endif
 
-
+#if defined(HAVE_GETHOSTBYNAME_R) || defined (HAVE_GETHOSTBYNAME)
 /* Python interface to gethostbyname_ex(name). */
 
 /*ARGSUSED*/
@@ -5857,8 +5912,9 @@ PyDoc_STRVAR(ghbn_ex_doc,
 \n\
 Return the true host name, a list of aliases, and a list of IP addresses,\n\
 for a host.  The host argument is a string giving a host name or IP number.");
+#endif
 
-
+#if defined(HAVE_GETHOSTBYNAME_R) || defined (HAVE_GETHOSTBYADDR)
 /* Python interface to gethostbyaddr(IP). */
 
 /*ARGSUSED*/
@@ -5953,8 +6009,9 @@ PyDoc_STRVAR(gethostbyaddr_doc,
 \n\
 Return the true host name, a list of aliases, and a list of IP addresses,\n\
 for a host.  The host argument is a string giving a host name or IP number.");
+#endif
 
-
+#ifdef HAVE_GETSERVBYNAME
 /* Python interface to getservbyname(name).
    This only returns the port number, since the other info is already
    known or not useful (like the list of aliases). */
@@ -5988,8 +6045,9 @@ PyDoc_STRVAR(getservbyname_doc,
 Return a port number from a service name and protocol name.\n\
 The optional protocol name, if given, should be 'tcp' or 'udp',\n\
 otherwise any protocol will match.");
+#endif
 
-
+#ifdef HAVE_GETSERVBYPORT
 /* Python interface to getservbyport(port).
    This only returns the service name, since the other info is already
    known or not useful (like the list of aliases). */
@@ -6030,7 +6088,9 @@ PyDoc_STRVAR(getservbyport_doc,
 Return the service name from a port number and protocol name.\n\
 The optional protocol name, if given, should be 'tcp' or 'udp',\n\
 otherwise any protocol will match.");
+#endif
 
+#ifdef HAVE_GETPROTOBYNAME
 /* Python interface to getprotobyname(name).
    This only returns the protocol number, since the other info is
    already known or not useful (like the list of aliases). */
@@ -6057,6 +6117,7 @@ PyDoc_STRVAR(getprotobyname_doc,
 "getprotobyname(name) -> integer\n\
 \n\
 Return the protocol number for the named protocol.  (Rarely used.)");
+#endif
 
 static PyObject *
 socket_close(PyObject *self, PyObject *fdobj)
@@ -6426,6 +6487,7 @@ socket_inet_aton(PyObject *self, PyObject *args)
 #endif
 }
 
+#ifdef HAVE_INET_NTOA
 PyDoc_STRVAR(inet_ntoa_doc,
 "inet_ntoa(packed_ip) -> ip_address_string\n\
 \n\
@@ -6454,6 +6516,7 @@ socket_inet_ntoa(PyObject *self, PyObject *args)
     SUPPRESS_DEPRECATED_CALL
     return PyUnicode_FromString(inet_ntoa(packed_addr));
 }
+#endif // HAVE_INET_NTOA
 
 #ifdef HAVE_INET_PTON
 
@@ -6565,6 +6628,7 @@ socket_inet_ntop(PyObject *self, PyObject *args)
 
 #endif /* HAVE_INET_PTON */
 
+#ifdef HAVE_GETADDRINFO
 /* Python interface to getaddrinfo(host, port). */
 
 /*ARGSUSED*/
@@ -6692,7 +6756,9 @@ PyDoc_STRVAR(getaddrinfo_doc,
     -> list of (family, type, proto, canonname, sockaddr)\n\
 \n\
 Resolve host and port into addrinfo struct.");
+#endif // HAVE_GETADDRINFO
 
+#ifdef HAVE_GETNAMEINFO
 /* Python interface to getnameinfo(sa, flags). */
 
 /*ARGSUSED*/
@@ -6793,7 +6859,7 @@ PyDoc_STRVAR(getnameinfo_doc,
 "getnameinfo(sockaddr, flags) --> (host, port)\n\
 \n\
 Get host and port for a sockaddr.");
-
+#endif // HAVE_GETNAMEINFO
 
 /* Python API to getting and setting the default timeout value. */
 
@@ -7049,24 +7115,38 @@ range of values.");
 /* List of functions exported by this module. */
 
 static PyMethodDef socket_methods[] = {
+#ifdef HAVE_GETADDRINFO
     {"gethostbyname",           socket_gethostbyname,
      METH_VARARGS, gethostbyname_doc},
+#endif
+#if defined(HAVE_GETHOSTBYNAME_R) || defined (HAVE_GETHOSTBYNAME)
     {"gethostbyname_ex",        socket_gethostbyname_ex,
      METH_VARARGS, ghbn_ex_doc},
+#endif
+#if defined(HAVE_GETHOSTBYNAME_R) || defined (HAVE_GETHOSTBYADDR)
     {"gethostbyaddr",           socket_gethostbyaddr,
      METH_VARARGS, gethostbyaddr_doc},
+#endif
+#ifdef HAVE_GETHOSTNAME
     {"gethostname",             socket_gethostname,
      METH_NOARGS,  gethostname_doc},
+#endif
 #ifdef HAVE_SETHOSTNAME
     {"sethostname",             socket_sethostname,
      METH_VARARGS,  sethostname_doc},
 #endif
+#ifdef HAVE_GETSERVBYNAME
     {"getservbyname",           socket_getservbyname,
      METH_VARARGS, getservbyname_doc},
+#endif
+#ifdef HAVE_GETSERVBYPORT
     {"getservbyport",           socket_getservbyport,
      METH_VARARGS, getservbyport_doc},
+#endif
+#ifdef HAVE_GETPROTOBYNAME
     {"getprotobyname",          socket_getprotobyname,
      METH_VARARGS, getprotobyname_doc},
+#endif
     {"close",                   socket_close,
      METH_O, close_doc},
 #ifndef NO_DUP
@@ -7087,18 +7167,24 @@ static PyMethodDef socket_methods[] = {
      METH_O, htonl_doc},
     {"inet_aton",               socket_inet_aton,
      METH_VARARGS, inet_aton_doc},
+#ifdef HAVE_INET_NTOA
     {"inet_ntoa",               socket_inet_ntoa,
      METH_VARARGS, inet_ntoa_doc},
+#endif
 #ifdef HAVE_INET_PTON
     {"inet_pton",               socket_inet_pton,
      METH_VARARGS, inet_pton_doc},
     {"inet_ntop",               socket_inet_ntop,
      METH_VARARGS, inet_ntop_doc},
 #endif
+#ifdef HAVE_GETADDRINFO
     {"getaddrinfo",             _PyCFunction_CAST(socket_getaddrinfo),
      METH_VARARGS | METH_KEYWORDS, getaddrinfo_doc},
+#endif
+#ifdef HAVE_GETNAMEINFO
     {"getnameinfo",             socket_getnameinfo,
      METH_VARARGS, getnameinfo_doc},
+#endif
     {"getdefaulttimeout",       socket_getdefaulttimeout,
      METH_NOARGS, getdefaulttimeout_doc},
     {"setdefaulttimeout",       socket_setdefaulttimeout,
@@ -7628,7 +7714,9 @@ PyInit__socket(void)
     /* SOCK_RAW is marked as optional in the POSIX specification */
     PyModule_AddIntMacro(m, SOCK_RAW);
 #endif
+#ifdef SOCK_SEQPACKET
     PyModule_AddIntMacro(m, SOCK_SEQPACKET);
+#endif
 #if defined(SOCK_RDM)
     PyModule_AddIntMacro(m, SOCK_RDM);
 #endif
@@ -7786,6 +7874,10 @@ PyInit__socket(void)
     PyModule_AddIntMacro(m, MSG_EOR);
 #endif
 #ifdef  MSG_TRUNC
+    // workaround for https://github.com/WebAssembly/wasi-libc/issues/305
+    #if defined(__wasi__) && !defined(__WASI_RIFLAGS_RECV_DATA_TRUNCATED)
+    #  define __WASI_RIFLAGS_RECV_DATA_TRUNCATED 2
+    #endif
     PyModule_AddIntMacro(m, MSG_TRUNC);
 #endif
 #ifdef  MSG_CTRUNC

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2797,6 +2797,7 @@ struct sock_accept {
     SOCKET_T result;
 };
 
+#if defined(HAVE_ACCEPT) || defined(HAVE_ACCEPT4)
 #if defined(HAVE_ACCEPT4) && defined(SOCK_CLOEXEC)
 /* accept4() is available on Linux 2.6.28+ and glibc 2.10 */
 static int accept4_works = -1;
@@ -2910,6 +2911,8 @@ PyDoc_STRVAR(accept_doc,
 Wait for an incoming connection.  Return a new socket file descriptor\n\
 representing the connection, and the address of the client.\n\
 For IP sockets, the address info is a pair (hostaddr, port).");
+#endif // defined(HAVE_ACCEPT) || defined(HAVE_ACCEPT4)
+
 
 /* s.setblocking(flag) method.  Argument:
    False -- non-blocking mode; same as settimeout(0)
@@ -5057,8 +5060,10 @@ socket.fromshare().");
 /* List of methods for socket objects */
 
 static PyMethodDef sock_methods[] = {
+#if defined(HAVE_ACCEPT) || defined(HAVE_ACCEPT4)
     {"_accept",           (PyCFunction)sock_accept, METH_NOARGS,
                       accept_doc},
+#endif
 #ifdef HAVE_BIND
     {"bind",              (PyCFunction)sock_bind, METH_O,
                       bind_doc},

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -675,8 +675,24 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 /* Define to 1 if you have the `erfc' function. */
 #define HAVE_ERFC 1
 
-/* Define if you have the 'inet_pton' function. */
+// netdb.h functions (provided by winsock.h)
+#define HAVE_GETHOSTNAME 1
+#define HAVE_GETHOSTBYADDR 1
+#define HAVE_GETHOSTBYNAME 1
+#define HAVE_GETPROTOBYNAME 1
+#define HAVE_GETSERVBYNAME 1
+#define HAVE_GETSERVBYPORT 1
+// sys/socket.h functions (provided by winsock.h)
 #define HAVE_INET_PTON 1
+#define HAVE_INET_NTOA 1
+#define HAVE_BIND 1
+#define HAVE_CONNECT 1
+#define HAVE_GETSOCKNAME 1
+#define HAVE_LISTEN 1
+#define HAVE_RECVFROM 1
+#define HAVE_SENDTO 1
+#define HAVE_SETSOCKOPT 1
+#define HAVE_SOCKET 1
 
 /* framework name */
 #define _PYTHONFRAMEWORK ""

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -685,6 +685,7 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 // sys/socket.h functions (provided by winsock.h)
 #define HAVE_INET_PTON 1
 #define HAVE_INET_NTOA 1
+#define HAVE_ACCEPT 1
 #define HAVE_BIND 1
 #define HAVE_CONNECT 1
 #define HAVE_GETSOCKNAME 1

--- a/Tools/wasm/config.site-wasm32-wasi
+++ b/Tools/wasm/config.site-wasm32-wasi
@@ -44,3 +44,7 @@ ac_cv_func_fchmod=no
 # Disable AF_UNIX and AF_PACKET support, see socketmodule.h.
 ac_cv_header_sys_un_h=no
 ac_cv_header_netpacket_packet_h=no
+
+# disable accept for WASM runtimes without sock_accept
+#ac_cv_func_accept=no
+#ac_cv_func_accept4=no

--- a/configure
+++ b/configure
@@ -9054,7 +9054,7 @@ for ac_header in  \
   alloca.h asm/types.h bluetooth.h conio.h crypt.h direct.h dlfcn.h endian.h errno.h fcntl.h grp.h \
   ieeefp.h io.h langinfo.h libintl.h libutil.h linux/auxvec.h sys/auxv.h linux/fs.h linux/memfd.h \
   linux/random.h linux/soundcard.h \
-  linux/tipc.h linux/wait.h netinet/in.h netpacket/packet.h poll.h process.h pthread.h pty.h \
+  linux/tipc.h linux/wait.h netdb.h netinet/in.h netpacket/packet.h poll.h process.h pthread.h pty.h \
   sched.h setjmp.h shadow.h signal.h spawn.h stropts.h sys/audioio.h sys/bsdtty.h sys/devpoll.h \
   sys/endian.h sys/epoll.h sys/event.h sys/eventfd.h sys/file.h sys/ioctl.h sys/kern_control.h \
   sys/loadavg.h sys/lock.h sys/memfd.h sys/mkdev.h sys/mman.h sys/modem.h sys/param.h sys/poll.h \
@@ -14906,7 +14906,6 @@ done
 
 fi
 
-
 # Check for enable-ipv6
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if --enable-ipv6 is specified" >&5
@@ -15545,11 +15544,11 @@ fi
 # checks for library functions
 for ac_func in  \
   accept4 alarm bind_textdomain_codeset chmod chown clock close_range confstr \
-  copy_file_range ctermid dup3 execv explicit_bzero explicit_memset \
+  copy_file_range ctermid dup dup3 execv explicit_bzero explicit_memset \
   faccessat fchmod fchmodat fchown fchownat fdopendir fdwalk fexecve \
   fork fork1 fpathconf fstatat ftime ftruncate futimens futimes futimesat \
   gai_strerror getegid getentropy geteuid getgid getgrgid getgrgid_r \
-  getgrnam_r getgrouplist getgroups getitimer getloadavg getlogin \
+  getgrnam_r getgrouplist getgroups gethostname getitimer getloadavg getlogin \
   getpeername getpgid getpid getppid getpriority _getpty \
   getpwent getpwnam_r getpwuid getpwuid_r getresgid getresuid getrusage getsid getspent \
   getspnam getuid getwd if_nameindex initgroups kill killpg lchown linkat \
@@ -17354,6 +17353,8 @@ fi
 
 
 
+
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for hstrerror" >&5
 $as_echo_n "checking for hstrerror... " >&6; }
 if ${ac_cv_func_hstrerror+:} false; then :
@@ -17385,6 +17386,188 @@ $as_echo "$ac_cv_func_hstrerror" >&6; }
 $as_echo "#define HAVE_HSTRERROR 1" >>confdefs.h
 
 fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getservbyname" >&5
+$as_echo_n "checking for getservbyname... " >&6; }
+if ${ac_cv_func_getservbyname+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <netdb.h>
+int
+main ()
+{
+void *x=getservbyname
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_getservbyname=yes
+else
+  ac_cv_func_getservbyname=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getservbyname" >&5
+$as_echo "$ac_cv_func_getservbyname" >&6; }
+  if test "x$ac_cv_func_getservbyname" = xyes; then :
+
+$as_echo "#define HAVE_GETSERVBYNAME 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getservbyport" >&5
+$as_echo_n "checking for getservbyport... " >&6; }
+if ${ac_cv_func_getservbyport+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <netdb.h>
+int
+main ()
+{
+void *x=getservbyport
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_getservbyport=yes
+else
+  ac_cv_func_getservbyport=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getservbyport" >&5
+$as_echo "$ac_cv_func_getservbyport" >&6; }
+  if test "x$ac_cv_func_getservbyport" = xyes; then :
+
+$as_echo "#define HAVE_GETSERVBYPORT 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname" >&5
+$as_echo_n "checking for gethostbyname... " >&6; }
+if ${ac_cv_func_gethostbyname+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <netdb.h>
+int
+main ()
+{
+void *x=gethostbyname
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_gethostbyname=yes
+else
+  ac_cv_func_gethostbyname=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_gethostbyname" >&5
+$as_echo "$ac_cv_func_gethostbyname" >&6; }
+  if test "x$ac_cv_func_gethostbyname" = xyes; then :
+
+$as_echo "#define HAVE_GETHOSTBYNAME 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyaddr" >&5
+$as_echo_n "checking for gethostbyaddr... " >&6; }
+if ${ac_cv_func_gethostbyaddr+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <netdb.h>
+int
+main ()
+{
+void *x=gethostbyaddr
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_gethostbyaddr=yes
+else
+  ac_cv_func_gethostbyaddr=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_gethostbyaddr" >&5
+$as_echo "$ac_cv_func_gethostbyaddr" >&6; }
+  if test "x$ac_cv_func_gethostbyaddr" = xyes; then :
+
+$as_echo "#define HAVE_GETHOSTBYADDR 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getprotobyname" >&5
+$as_echo_n "checking for getprotobyname... " >&6; }
+if ${ac_cv_func_getprotobyname+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <netdb.h>
+int
+main ()
+{
+void *x=getprotobyname
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_getprotobyname=yes
+else
+  ac_cv_func_getprotobyname=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getprotobyname" >&5
+$as_echo "$ac_cv_func_getprotobyname" >&6; }
+  if test "x$ac_cv_func_getprotobyname" = xyes; then :
+
+$as_echo "#define HAVE_GETPROTOBYNAME 1" >>confdefs.h
+
+fi
+
+
 
 
 
@@ -17432,6 +17615,46 @@ fi
 
 
 
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for inet_ntoa" >&5
+$as_echo_n "checking for inet_ntoa... " >&6; }
+if ${ac_cv_func_inet_ntoa+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=inet_ntoa
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_inet_ntoa=yes
+else
+  ac_cv_func_inet_ntoa=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_inet_ntoa" >&5
+$as_echo "$ac_cv_func_inet_ntoa" >&6; }
+  if test "x$ac_cv_func_inet_ntoa" = xyes; then :
+
+$as_echo "#define HAVE_INET_NTOA 1" >>confdefs.h
+
+fi
+
+
+
+
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for inet_pton" >&5
 $as_echo_n "checking for inet_pton... " >&6; }
@@ -17467,6 +17690,375 @@ $as_echo "$ac_cv_func_inet_pton" >&6; }
   if test "x$ac_cv_func_inet_pton" = xyes; then :
 
 $as_echo "#define HAVE_INET_PTON 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getpeername" >&5
+$as_echo_n "checking for getpeername... " >&6; }
+if ${ac_cv_func_getpeername+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=getpeername
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_getpeername=yes
+else
+  ac_cv_func_getpeername=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getpeername" >&5
+$as_echo "$ac_cv_func_getpeername" >&6; }
+  if test "x$ac_cv_func_getpeername" = xyes; then :
+
+$as_echo "#define HAVE_GETPEERNAME 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getsockname" >&5
+$as_echo_n "checking for getsockname... " >&6; }
+if ${ac_cv_func_getsockname+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=getsockname
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_getsockname=yes
+else
+  ac_cv_func_getsockname=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getsockname" >&5
+$as_echo "$ac_cv_func_getsockname" >&6; }
+  if test "x$ac_cv_func_getsockname" = xyes; then :
+
+$as_echo "#define HAVE_GETSOCKNAME 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for bind" >&5
+$as_echo_n "checking for bind... " >&6; }
+if ${ac_cv_func_bind+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=bind
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_bind=yes
+else
+  ac_cv_func_bind=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_bind" >&5
+$as_echo "$ac_cv_func_bind" >&6; }
+  if test "x$ac_cv_func_bind" = xyes; then :
+
+$as_echo "#define HAVE_BIND 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for connect" >&5
+$as_echo_n "checking for connect... " >&6; }
+if ${ac_cv_func_connect+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=connect
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_connect=yes
+else
+  ac_cv_func_connect=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_connect" >&5
+$as_echo "$ac_cv_func_connect" >&6; }
+  if test "x$ac_cv_func_connect" = xyes; then :
+
+$as_echo "#define HAVE_CONNECT 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for listen" >&5
+$as_echo_n "checking for listen... " >&6; }
+if ${ac_cv_func_listen+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=listen
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_listen=yes
+else
+  ac_cv_func_listen=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_listen" >&5
+$as_echo "$ac_cv_func_listen" >&6; }
+  if test "x$ac_cv_func_listen" = xyes; then :
+
+$as_echo "#define HAVE_LISTEN 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for recvfrom" >&5
+$as_echo_n "checking for recvfrom... " >&6; }
+if ${ac_cv_func_recvfrom+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=recvfrom
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_recvfrom=yes
+else
+  ac_cv_func_recvfrom=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_recvfrom" >&5
+$as_echo "$ac_cv_func_recvfrom" >&6; }
+  if test "x$ac_cv_func_recvfrom" = xyes; then :
+
+$as_echo "#define HAVE_RECVFROM 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sendto" >&5
+$as_echo_n "checking for sendto... " >&6; }
+if ${ac_cv_func_sendto+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=sendto
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_sendto=yes
+else
+  ac_cv_func_sendto=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_sendto" >&5
+$as_echo "$ac_cv_func_sendto" >&6; }
+  if test "x$ac_cv_func_sendto" = xyes; then :
+
+$as_echo "#define HAVE_SENDTO 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for setsockopt" >&5
+$as_echo_n "checking for setsockopt... " >&6; }
+if ${ac_cv_func_setsockopt+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=setsockopt
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_setsockopt=yes
+else
+  ac_cv_func_setsockopt=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_setsockopt" >&5
+$as_echo "$ac_cv_func_setsockopt" >&6; }
+  if test "x$ac_cv_func_setsockopt" = xyes; then :
+
+$as_echo "#define HAVE_SETSOCKOPT 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for socket" >&5
+$as_echo_n "checking for socket... " >&6; }
+if ${ac_cv_func_socket+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=socket
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_socket=yes
+else
+  ac_cv_func_socket=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_socket" >&5
+$as_echo "$ac_cv_func_socket" >&6; }
+  if test "x$ac_cv_func_socket" = xyes; then :
+
+$as_echo "#define HAVE_SOCKET 1" >>confdefs.h
 
 fi
 

--- a/configure
+++ b/configure
@@ -17779,6 +17779,47 @@ fi
 
 
 
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for accept" >&5
+$as_echo_n "checking for accept... " >&6; }
+if ${ac_cv_func_accept+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+main ()
+{
+void *x=accept
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_func_accept=yes
+else
+  ac_cv_func_accept=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_accept" >&5
+$as_echo "$ac_cv_func_accept" >&6; }
+  if test "x$ac_cv_func_accept" = xyes; then :
+
+$as_echo "#define HAVE_ACCEPT 1" >>confdefs.h
+
+fi
+
+
+
+
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for bind" >&5
 $as_echo_n "checking for bind... " >&6; }
 if ${ac_cv_func_bind+:} false; then :

--- a/configure.ac
+++ b/configure.ac
@@ -4904,6 +4904,7 @@ PY_CHECK_SOCKET_FUNC([inet_pton])
 dnl not available in WASI yet
 PY_CHECK_SOCKET_FUNC([getpeername])
 PY_CHECK_SOCKET_FUNC([getsockname])
+PY_CHECK_SOCKET_FUNC([accept])
 PY_CHECK_SOCKET_FUNC([bind])
 PY_CHECK_SOCKET_FUNC([connect])
 PY_CHECK_SOCKET_FUNC([listen])

--- a/configure.ac
+++ b/configure.ac
@@ -2643,7 +2643,7 @@ AC_CHECK_HEADERS([ \
   alloca.h asm/types.h bluetooth.h conio.h crypt.h direct.h dlfcn.h endian.h errno.h fcntl.h grp.h \
   ieeefp.h io.h langinfo.h libintl.h libutil.h linux/auxvec.h sys/auxv.h linux/fs.h linux/memfd.h \
   linux/random.h linux/soundcard.h \
-  linux/tipc.h linux/wait.h netinet/in.h netpacket/packet.h poll.h process.h pthread.h pty.h \
+  linux/tipc.h linux/wait.h netdb.h netinet/in.h netpacket/packet.h poll.h process.h pthread.h pty.h \
   sched.h setjmp.h shadow.h signal.h spawn.h stropts.h sys/audioio.h sys/bsdtty.h sys/devpoll.h \
   sys/endian.h sys/epoll.h sys/event.h sys/eventfd.h sys/file.h sys/ioctl.h sys/kern_control.h \
   sys/loadavg.h sys/lock.h sys/memfd.h sys/mkdev.h sys/mman.h sys/modem.h sys/param.h sys/poll.h \
@@ -4272,7 +4272,6 @@ if test "$posix_threads" = "yes"; then
       AC_CHECK_FUNCS(pthread_getcpuclockid)
 fi
 
-
 # Check for enable-ipv6
 AH_TEMPLATE(ENABLE_IPV6, [Define if --enable-ipv6 is specified])
 AC_MSG_CHECKING([if --enable-ipv6 is specified])
@@ -4653,11 +4652,11 @@ fi
 # checks for library functions
 AC_CHECK_FUNCS([ \
   accept4 alarm bind_textdomain_codeset chmod chown clock close_range confstr \
-  copy_file_range ctermid dup3 execv explicit_bzero explicit_memset \
+  copy_file_range ctermid dup dup3 execv explicit_bzero explicit_memset \
   faccessat fchmod fchmodat fchown fchownat fdopendir fdwalk fexecve \
   fork fork1 fpathconf fstatat ftime ftruncate futimens futimes futimesat \
   gai_strerror getegid getentropy geteuid getgid getgrgid getgrgid_r \
-  getgrnam_r getgrouplist getgroups getitimer getloadavg getlogin \
+  getgrnam_r getgrouplist getgroups gethostname getitimer getloadavg getlogin \
   getpeername getpgid getpid getppid getpriority _getpty \
   getpwent getpwnam_r getpwuid getpwuid_r getresgid getresuid getrusage getsid getspent \
   getspnam getuid getwd if_nameindex initgroups kill killpg lchown linkat \
@@ -4880,21 +4879,38 @@ PKG_CHECK_MODULES([LIBLZMA], [liblzma], [have_liblzma=yes], [
   ])
 ])
 
-PY_CHECK_FUNC([hstrerror], [#include <netdb.h>])
+dnl PY_CHECK_NETDB_FUNC(FUNCTION)
+AC_DEFUN([PY_CHECK_NETDB_FUNC], [PY_CHECK_FUNC([$1], [#include <netdb.h>])])
 
-PY_CHECK_FUNC([inet_aton], [
+PY_CHECK_NETDB_FUNC([hstrerror])
+dnl not available in WASI yet
+PY_CHECK_NETDB_FUNC([getservbyname])
+PY_CHECK_NETDB_FUNC([getservbyport])
+PY_CHECK_NETDB_FUNC([gethostbyname])
+PY_CHECK_NETDB_FUNC([gethostbyaddr])
+PY_CHECK_NETDB_FUNC([getprotobyname])
+
+dnl PY_CHECK_SOCKET_FUNC(FUNCTION)
+AC_DEFUN([PY_CHECK_SOCKET_FUNC], [PY_CHECK_FUNC([$1], [
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-])
+])])
 
-PY_CHECK_FUNC([inet_pton], [
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-])
+PY_CHECK_SOCKET_FUNC([inet_aton])
+PY_CHECK_SOCKET_FUNC([inet_ntoa])
+PY_CHECK_SOCKET_FUNC([inet_pton])
+dnl not available in WASI yet
+PY_CHECK_SOCKET_FUNC([getpeername])
+PY_CHECK_SOCKET_FUNC([getsockname])
+PY_CHECK_SOCKET_FUNC([bind])
+PY_CHECK_SOCKET_FUNC([connect])
+PY_CHECK_SOCKET_FUNC([listen])
+PY_CHECK_SOCKET_FUNC([recvfrom])
+PY_CHECK_SOCKET_FUNC([sendto])
+PY_CHECK_SOCKET_FUNC([setsockopt])
+PY_CHECK_SOCKET_FUNC([socket])
 
 # On some systems, setgroups is in unistd.h, on others, in grp.h
 PY_CHECK_FUNC([setgroups], [

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -51,6 +51,9 @@
 /* Define if getpgrp() must be called as getpgrp(0). */
 #undef GETPGRP_HAVE_ARG
 
+/* Define if you have the 'accept' function. */
+#undef HAVE_ACCEPT
+
 /* Define to 1 if you have the `accept4' function. */
 #undef HAVE_ACCEPT4
 

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -81,6 +81,9 @@
 /* Define to 1 if you have the `atanh' function. */
 #undef HAVE_ATANH
 
+/* Define if you have the 'bind' function. */
+#undef HAVE_BIND
+
 /* Define to 1 if you have the `bind_textdomain_codeset' function. */
 #undef HAVE_BIND_TEXTDOMAIN_CODESET
 
@@ -159,6 +162,9 @@
 
 /* Define to 1 if you have the <conio.h> header file. */
 #undef HAVE_CONIO_H
+
+/* Define if you have the 'connect' function. */
+#undef HAVE_CONNECT
 
 /* Define to 1 if you have the `copy_file_range' function. */
 #undef HAVE_COPY_FILE_RANGE
@@ -277,6 +283,9 @@
 
 /* Define to 1 if you have the `dlopen' function. */
 #undef HAVE_DLOPEN
+
+/* Define to 1 if you have the `dup' function. */
+#undef HAVE_DUP
 
 /* Define to 1 if you have the `dup2' function. */
 #undef HAVE_DUP2
@@ -477,6 +486,9 @@
 /* Define to 1 if you have the `getgroups' function. */
 #undef HAVE_GETGROUPS
 
+/* Define if you have the 'gethostbyaddr' function. */
+#undef HAVE_GETHOSTBYADDR
+
 /* Define to 1 if you have the `gethostbyname' function. */
 #undef HAVE_GETHOSTBYNAME
 
@@ -491,6 +503,9 @@
 
 /* Define this if you have the 6-arg version of gethostbyname_r(). */
 #undef HAVE_GETHOSTBYNAME_R_6_ARG
+
+/* Define to 1 if you have the `gethostname' function. */
+#undef HAVE_GETHOSTNAME
 
 /* Define to 1 if you have the `getitimer' function. */
 #undef HAVE_GETITIMER
@@ -507,7 +522,7 @@
 /* Define if you have the 'getpagesize' function. */
 #undef HAVE_GETPAGESIZE
 
-/* Define to 1 if you have the `getpeername' function. */
+/* Define if you have the 'getpeername' function. */
 #undef HAVE_GETPEERNAME
 
 /* Define to 1 if you have the `getpgid' function. */
@@ -524,6 +539,9 @@
 
 /* Define to 1 if you have the `getpriority' function. */
 #undef HAVE_GETPRIORITY
+
+/* Define if you have the 'getprotobyname' function. */
+#undef HAVE_GETPROTOBYNAME
 
 /* Define to 1 if you have the `getpwent' function. */
 #undef HAVE_GETPWENT
@@ -552,8 +570,17 @@
 /* Define to 1 if you have the `getrusage' function. */
 #undef HAVE_GETRUSAGE
 
+/* Define if you have the 'getservbyname' function. */
+#undef HAVE_GETSERVBYNAME
+
+/* Define if you have the 'getservbyport' function. */
+#undef HAVE_GETSERVBYPORT
+
 /* Define to 1 if you have the `getsid' function. */
 #undef HAVE_GETSID
+
+/* Define if you have the 'getsockname' function. */
+#undef HAVE_GETSOCKNAME
 
 /* Define to 1 if you have the `getspent' function. */
 #undef HAVE_GETSPENT
@@ -588,6 +615,9 @@
 
 /* Define if you have the 'inet_aton' function. */
 #undef HAVE_INET_ATON
+
+/* Define if you have the 'inet_ntoa' function. */
+#undef HAVE_INET_NTOA
 
 /* Define if you have the 'inet_pton' function. */
 #undef HAVE_INET_PTON
@@ -715,6 +745,9 @@
 /* Define to 1 if you have the <linux/wait.h> header file. */
 #undef HAVE_LINUX_WAIT_H
 
+/* Define if you have the 'listen' function. */
+#undef HAVE_LISTEN
+
 /* Define to 1 if you have the `lockf' function. */
 #undef HAVE_LOCKF
 
@@ -798,6 +831,9 @@
 
 /* Define to 1 if you have the <netcan/can.h> header file. */
 #undef HAVE_NETCAN_CAN_H
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#undef HAVE_NETDB_H
 
 /* Define to 1 if you have the <netinet/in.h> header file. */
 #undef HAVE_NETINET_IN_H
@@ -926,6 +962,9 @@
 /* Define to 1 if you have the `realpath' function. */
 #undef HAVE_REALPATH
 
+/* Define if you have the 'recvfrom' function. */
+#undef HAVE_RECVFROM
+
 /* Define to 1 if you have the `renameat' function. */
 #undef HAVE_RENAMEAT
 
@@ -995,6 +1034,9 @@
 /* Define to 1 if you have the `sendfile' function. */
 #undef HAVE_SENDFILE
 
+/* Define if you have the 'sendto' function. */
+#undef HAVE_SENDTO
+
 /* Define to 1 if you have the `setegid' function. */
 #undef HAVE_SETEGID
 
@@ -1042,6 +1084,9 @@
 
 /* Define to 1 if you have the `setsid' function. */
 #undef HAVE_SETSID
+
+/* Define if you have the 'setsockopt' function. */
+#undef HAVE_SETSOCKOPT
 
 /* Define to 1 if you have the `setuid' function. */
 #undef HAVE_SETUID
@@ -1105,6 +1150,9 @@
 
 /* struct sockaddr_storage (sys/socket.h) */
 #undef HAVE_SOCKADDR_STORAGE
+
+/* Define if you have the 'socket' function. */
+#undef HAVE_SOCKET
 
 /* Define if you have the 'socketpair' function. */
 #undef HAVE_SOCKETPAIR


### PR DESCRIPTION
WASI can only create sockets from an existing file descriptor. Hostname
lookups are not available.

- check for missing ``sys/socket.h`` functions
- handle missing ``netdb.h`` functions

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95174 -->
* Issue: gh-95174
<!-- /gh-issue-number -->
