### PR TITLE
gh-95174: Handle missing waitpid and gethostbyname in WASI (GH-95181)

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -524,6 +524,8 @@ def _ip_getnode():
 def _arp_getnode():
     """Get the hardware address on Unix by running arp."""
     import os, socket
+    if not hasattr(socket, "gethostbyname"):
+        return None
     try:
         ip_addr = socket.gethostbyname(socket.gethostname())
     except OSError:


### PR DESCRIPTION
WASI has no process or netdb API. The code will fail with AttributeError
when we remove the stubs from WASIX.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95174 -->
* Issue: gh-95174
<!-- /gh-issue-number -->
