### PR TITLE
gh-85454: Remove links from historical mentions of distutils (GH-95192)

### DIFF
--- a/Doc/distributing/index.rst
+++ b/Doc/distributing/index.rst
@@ -41,21 +41,21 @@ Key terms
   file format standards. They maintain a variety of tools, documentation
   and issue trackers on both `GitHub <https://github.com/pypa>`__ and
   `Bitbucket <https://bitbucket.org/pypa/>`__.
-* :mod:`distutils` is the original build and distribution system first added
-  to the Python standard library in 1998. While direct use of :mod:`distutils`
+* ``distutils`` is the original build and distribution system first added
+  to the Python standard library in 1998. While direct use of ``distutils``
   is being phased out, it still laid the foundation for the current packaging
   and distribution infrastructure, and it not only remains part of the
   standard library, but its name lives on in other ways (such as the name
   of the mailing list used to coordinate Python packaging standards
   development).
-* `setuptools`_ is a (largely) drop-in replacement for :mod:`distutils` first
+* `setuptools`_ is a (largely) drop-in replacement for ``distutils`` first
   published in 2004. Its most notable addition over the unmodified
-  :mod:`distutils` tools was the ability to declare dependencies on other
+  ``distutils`` tools was the ability to declare dependencies on other
   packages. It is currently recommended as a more regularly updated
-  alternative to :mod:`distutils` that offers consistent support for more
+  alternative to ``distutils`` that offers consistent support for more
   recent packaging standards across a wide range of Python versions.
 * `wheel`_ (in this context) is a project that adds the ``bdist_wheel``
-  command to :mod:`distutils`/`setuptools`_. This produces a cross platform
+  command to ``distutils``/`setuptools`_. This produces a cross platform
   binary packaging format (called "wheels" or "wheel files" and defined in
   :pep:`427`) that allows Python libraries, even those including binary
   extensions, to be installed on a system without needing to be built

--- a/Doc/whatsnew/2.0.rst
+++ b/Doc/whatsnew/2.0.rst
@@ -820,7 +820,7 @@ packages, which made administering a Python installation something of  a chore.
 
 The SIG for distribution utilities, shepherded by Greg Ward, has created the
 Distutils, a system to make package installation much easier.  They form the
-:mod:`distutils` package, a new part of Python's standard library. In the best
+``distutils`` package, a new part of Python's standard library. In the best
 case, installing a Python module from source will require the same steps: first
 you simply mean unpack the tarball or zip archive, and the run "``python
 setup.py install``".  The platform will be automatically detected, the compiler

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -2056,7 +2056,7 @@ information:
   such as "3.2".
 
 It also provides access to the paths and variables corresponding to one of
-seven named schemes used by :mod:`distutils`.  Those include *posix_prefix*,
+seven named schemes used by ``distutils``.  Those include *posix_prefix*,
 *posix_home*, *posix_user*, *nt*, *nt_user*, *os2*, *os2_home*:
 
 * :func:`~sysconfig.get_paths` makes a dictionary containing installation paths

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -1079,7 +1079,7 @@ Both the ``build`` and ``build_ext`` commands now accept a ``-j`` option to
 enable parallel building of extension modules.
 (Contributed by Antoine Pitrou in :issue:`5309`.)
 
-The :mod:`distutils` module now supports ``xz`` compression, and can be
+The ``distutils`` module now supports ``xz`` compression, and can be
 enabled by passing ``xztar`` as an argument to ``bdist --format``.
 (Contributed by Serhiy Storchaka in :issue:`16314`.)
 

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -1012,7 +1012,7 @@ distutils
 ---------
 
 The ``default_format`` attribute has been removed from
-:class:`distutils.command.sdist.sdist` and the ``formats``
+``distutils.command.sdist.sdist`` and the ``formats``
 attribute defaults to ``['gztar']``. Although not anticipated,
 any code relying on the presence of ``default_format`` may
 need to be adapted. See :issue:`27819` for more details.
@@ -1986,7 +1986,7 @@ distutils
 ~~~~~~~~~
 
 The undocumented ``extra_path`` argument to the
-:class:`~distutils.Distribution` constructor is now considered deprecated
+``distutils.Distribution`` constructor is now considered deprecated
 and will raise a warning if set.   Support for this parameter will be
 removed in a future Python release.  See :issue:`27919` for details.
 
@@ -2243,7 +2243,7 @@ Changes in the Python API
   accepting additional keyword arguments will need to adjust their calls to
   :meth:`type.__new__` (whether direct or via :class:`super`) accordingly.
 
-* In :class:`distutils.command.sdist.sdist`, the ``default_format``
+* In ``distutils.command.sdist.sdist``, the ``default_format``
   attribute has been removed and is no longer honored. Instead, the
   gzipped tarfile format is the default on all platforms and no
   platform-specific selection is made.

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1906,7 +1906,7 @@ Other CPython Implementation Changes
   variables were defined.  Previously, the order was undefined.
   (Contributed by Raymond Hettinger in :issue:`32690`.)
 
-* The :mod:`distutils` ``upload`` command no longer tries to change CR
+* The ``distutils`` ``upload`` command no longer tries to change CR
   end-of-line characters to CRLF.  This fixes a corruption issue with sdists
   that ended with a byte equivalent to CR.
   (Contributed by Bo Bayles in :issue:`32304`.)
@@ -2181,7 +2181,7 @@ The following features and APIs have been removed from Python 3.7:
   :func:`ssl.wrap_socket` or :class:`ssl.SSLContext`.
   (Contributed by Christian Heimes in :issue:`32951`.)
 
-* The unused :mod:`distutils` ``install_misc`` command has been removed.
+* The unused ``distutils`` ``install_misc`` command has been removed.
   (Contributed by Eric N. Vander Weele in :issue:`29218`.)
 
 

--- a/Misc/NEWS.d/3.10.0a1.rst
+++ b/Misc/NEWS.d/3.10.0a1.rst
@@ -2204,7 +2204,7 @@ Handle cases where the ``end_lineno`` is ``None`` on
 .. nonce: zwl5Hc
 .. section: Library
 
-:mod:`distutils` upload creates SHA2-256 and Blake2b-256 digests. MD5
+``distutils`` upload creates SHA2-256 and Blake2b-256 digests. MD5
 digests is skipped if platform blocks MD5.
 
 ..

--- a/Misc/NEWS.d/3.10.0b1.rst
+++ b/Misc/NEWS.d/3.10.0b1.rst
@@ -1142,7 +1142,7 @@ name>`` instead of ``SQL logic error``. Patch by Erlend E. Aasland.
 .. nonce: GK9a0l
 .. section: Library
 
-Install schemes in :mod:`distutils.command.install` are now loaded from
+Install schemes in ``distutils.command.install`` are now loaded from
 :mod:`sysconfig`.
 
 ..
@@ -1152,7 +1152,7 @@ Install schemes in :mod:`distutils.command.install` are now loaded from
 .. nonce: SenEje
 .. section: Library
 
-:mod:`distutils.sysconfig` has been merged to :mod:`sysconfig`.
+``distutils.sysconfig`` has been merged to :mod:`sysconfig`.
 
 ..
 

--- a/Misc/NEWS.d/3.11.0a1.rst
+++ b/Misc/NEWS.d/3.11.0a1.rst
@@ -1445,7 +1445,7 @@ asynchronous.
 .. nonce: NOwcDJ
 .. section: Library
 
-Fix clang rpath issue in :mod:`distutils`. The UnixCCompiler now uses
+Fix clang rpath issue in ``distutils``. The UnixCCompiler now uses
 correct clang option to add a runtime library directory (rpath) to a shared
 library.
 
@@ -2798,7 +2798,7 @@ documentation for deprecations.
 .. nonce: rvyf2v
 .. section: Library
 
-Restore back :func:`parse_makefile` in :mod:`distutils.sysconfig` because it
+Restore back :func:`parse_makefile` in ``distutils.sysconfig`` because it
 behaves differently than the similar implementation in :mod:`sysconfig`.
 
 ..

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -17,7 +17,7 @@ malicious or buggy certificate can result into segfault. Vulnerability
 .. section: Security
 
 The :option:`-I` command line option (run Python in isolated mode) is now
-also copied by the :mod:`multiprocessing` and :mod:`distutils` modules when
+also copied by the :mod:`multiprocessing` and ``distutils`` modules when
 spawning child processes. Previously, only :option:`-E` and :option:`-s`
 options (enabled by :option:`-I`) were copied.
 
@@ -2270,7 +2270,7 @@ last release was in 2000. Mac OS 9 last release was in 2001.
 .. nonce: laV_IE
 .. section: Library
 
-:func:`~distutils.utils.check_environ` of :mod:`distutils.utils` now catches
+:func:`~distutils.utils.check_environ` of ``distutils.utils`` now catches
 :exc:`KeyError` on calling :func:`pwd.getpwuid`: don't create the ``HOME``
 environment variable in this case.
 
@@ -3070,7 +3070,7 @@ Add deprecation warning when `loop` is used in methods: `asyncio.sleep`,
 .. nonce: Pr3-iG
 .. section: Library
 
-ZIP files created by :mod:`distutils` will now include entries for
+ZIP files created by ``distutils`` will now include entries for
 directories.
 
 ..
@@ -3720,7 +3720,7 @@ Deprecate passing non-ThreadPoolExecutor instances to
 .. section: Library
 
 Restore ``msilib.Win64`` to preserve backwards compatibility since it's
-already used by :mod:`distutils`' ``bdist_msi`` command.
+already used by ``distutils``' ``bdist_msi`` command.
 
 ..
 

--- a/Misc/NEWS.d/3.8.0a4.rst
+++ b/Misc/NEWS.d/3.8.0a4.rst
@@ -338,7 +338,7 @@ unexpected cache miss.
 .. nonce: MW1TLt
 .. section: Library
 
-Fix :mod:`distutils.sysconfig` if :data:`sys.executable` is ``None`` or an
+Fix ``distutils.sysconfig`` if :data:`sys.executable` is ``None`` or an
 empty string: use :func:`os.getcwd` to initialize ``project_base``.  Fix
 also the distutils build command: don't use :data:`sys.executable` if it is
 ``None`` or an empty string.
@@ -350,7 +350,7 @@ also the distutils build command: don't use :data:`sys.executable` if it is
 .. nonce: Fg4EXb
 .. section: Library
 
-:func:`shutil.which` and :func:`distutils.spawn.find_executable` now use
+:func:`shutil.which` and ``distutils.spawn.find_executable`` now use
 ``os.confstr("CS_PATH")`` if available instead of :data:`os.defpath`, if the
 ``PATH`` environment variable is not set. Moreover, don't use
 ``os.confstr("CS_PATH")`` nor :data:`os.defpath` if the ``PATH`` environment

--- a/Misc/NEWS.d/3.9.0a5.rst
+++ b/Misc/NEWS.d/3.9.0a5.rst
@@ -623,7 +623,7 @@ connections.
 .. nonce: 5a822c
 .. section: Library
 
-Reimplement :func:`distutils.spawn.spawn` function with the
+Reimplement ``distutils.spawn.spawn`` function with the
 :mod:`subprocess` module.
 
 ..
@@ -1022,7 +1022,7 @@ lock-related objects from :mod:`threading`) around 49-day uptime.
 .. nonce: MnHdYl
 .. section: Windows
 
-:mod:`distutils` will no longer statically link :file:`vcruntime140.dll`
+``distutils`` will no longer statically link :file:`vcruntime140.dll`
 when a redistributable version is unavailable. All future releases of
 CPython will include a copy of this DLL to ensure distributed extensions can
 continue to load.

--- a/Misc/NEWS.d/next/Build/2022-06-28-09-42-10.gh-issue-93939._VWxKW.rst
+++ b/Misc/NEWS.d/next/Build/2022-06-28-09-42-10.gh-issue-93939._VWxKW.rst
@@ -1,2 +1,2 @@
 C extension modules are now built by ``configure`` and ``make``
-instead of :mod:`distutils` and ``setup.py``.
+instead of ``distutils`` and ``setup.py``.


### PR DESCRIPTION
Addresses the second half of https://github.com/python/cpython/issues/85454#issuecomment-1184766249.

*Note: In `whatsnew/3.6.rst`, I've replaced <code>:class:\`~distutils.Distribution\`</code> with <code>\`\`distutils.Distribution\`\`</code> to match `Improved Modules` of the same file. Compare original `Deprecated [...] → distutils` section (`distutils` namespace is hidden by `~`):*

https://github.com/python/cpython/blob/8184f0fce3b734413e3d3a282f1425d3cb8507fd/Doc/whatsnew/3.6.rst#L1989

*with `Improved Modules → distutils`:*

https://github.com/python/cpython/blob/c1e929858ad96fc6e41bc637e5ec9343b4f7e3c7/Doc/whatsnew/3.6.rst#L1015

<!-- gh-issue-number: gh-85454 -->
* Issue: gh-85454
<!-- /gh-issue-number -->
