### PR TITLE
gh-95087: Fix IndexError in parsing invalid date in the email module

### DIFF
--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -95,6 +95,8 @@ def _parsedate_tz(data):
         return None
     data = data[:5]
     [dd, mm, yy, tm, tz] = data
+    if not (dd and mm and yy):
+        return None
     mm = mm.lower()
     if mm not in _monthnames:
         dd, mm = mm, dd.lower()
@@ -110,6 +112,8 @@ def _parsedate_tz(data):
         yy, tm = tm, yy
     if yy[-1] == ',':
         yy = yy[:-1]
+        if not yy:
+            return None
     if not yy[0].isdigit():
         yy, tz = tz, yy
     if tm[-1] == ',':

--- a/Lib/test/test_email/test_utils.py
+++ b/Lib/test/test_email/test_utils.py
@@ -49,12 +49,21 @@ class DateTimeTests(unittest.TestCase):
             self.naive_dt)
 
     def test_parsedate_to_datetime_with_invalid_raises_valueerror(self):
-        invalid_dates = ['',
-                         '0',
-                         'A Complete Waste of Time'
-                         'Tue, 06 Jun 2017 27:39:33 +0600',
-                         'Tue, 06 Jun 2017 07:39:33 +2600',
-                         'Tue, 06 Jun 2017 27:39:33']
+        # See also test_parsedate_returns_None_for_invalid_strings in test_email.
+        invalid_dates = [
+            '',
+            ' ',
+            '0',
+            'A Complete Waste of Time',
+            'Wed, 3 Apr 2002 12.34.56.78+0800'
+            'Tue, 06 Jun 2017 27:39:33 +0600',
+            'Tue, 06 Jun 2017 07:39:33 +2600',
+            'Tue, 06 Jun 2017 27:39:33',
+            '17 June , 2022',
+            'Friday, -Nov-82 16:14:55 EST',
+            'Friday, Nov--82 16:14:55 EST',
+            'Friday, 19-Nov- 16:14:55 EST',
+        ]
         for dtstr in invalid_dates:
             with self.subTest(dtstr=dtstr):
                 self.assertRaises(ValueError, utils.parsedate_to_datetime, dtstr)

--- a/Misc/NEWS.d/next/Library/2022-07-24-12-59-02.gh-issue-95087.VvqXkN.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-24-12-59-02.gh-issue-95087.VvqXkN.rst
@@ -1,0 +1,1 @@
+Fix IndexError in parsing invalid date in the :mod:`email` module.


### PR DESCRIPTION
Co-authored-by: wouter bolsterlee <wouter@bolsterl.ee>


<!-- gh-issue-number: gh-95087 -->
* Issue: gh-95087
<!-- /gh-issue-number -->
