### PR TITLE
[3.10] gh-93592: Fix frame chain when throwing exceptions into coroutines

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-24-19-23-23.gh-issue-93592.zdgp6o.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-24-19-23-23.gh-issue-93592.zdgp6o.rst
@@ -1,0 +1,2 @@
+``coroutine.throw()`` now properly initializes the ``frame.f_back`` when resuming a stack of coroutines.
+This allows e.g. ``traceback.print_stack()`` to work correctly when an exception (such as ``CancelledError``) is thrown into a coroutine.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Issue #93592 describes how a `coro.throw()` will wake up the coroutine, but the frame chain is broken, making it
impossible to get a proper traceback.  This impedes debuggers when they break on thrown exceptions, among other things.

The problem is observed in versions `3.7`-`3.10` but is fixed in `3.11`, since there appears to have been structural changes made in frame objects in that version, and the necessary re-write of the generator code seems to have (accidentally?) fixed the issue.

A regression tests is provided, which could also be applied to the `3.11` and `main` branches.


<!-- gh-issue-number: gh-93592 -->
* Issue: gh-93592
<!-- /gh-issue-number -->
