### PR TITLE
gh-95222: Disallow out-of-bounds `co_consts`/`co_names` access

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -266,8 +266,8 @@ class CodeTest(unittest.TestCase):
             ("co_stacksize", 0),
             ("co_flags", code.co_flags | inspect.CO_COROUTINE),
             ("co_firstlineno", 100),
-            ("co_consts", code2.co_consts),
             ("co_code", code2.co_code),
+            ("co_consts", code2.co_consts),
             ("co_names", ("myname",)),
             ("co_varnames", ('spam',)),
             ("co_freevars", ("freevar",)),
@@ -277,7 +277,13 @@ class CodeTest(unittest.TestCase):
             ("co_linetable", code2.co_linetable),
         ):
             with self.subTest(attr=attr, value=value):
-                new_code = code.replace(**{attr: value})
+                if attr == "co_code":
+                    # gh-95222 doesn't allow having a LOAD_CONST index
+                    # greater than len(code.co_consts), so we'll
+                    # temporary replace co_consts
+                    new_code = code.replace(co_consts=code2.co_consts, co_code=value)
+                else:
+                    new_code = code.replace(**{attr: value})
                 self.assertEqual(getattr(new_code, attr), value)
 
         new_code = code.replace(co_varnames=code2.co_varnames,

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -266,8 +266,8 @@ class CodeTest(unittest.TestCase):
             ("co_stacksize", 0),
             ("co_flags", code.co_flags | inspect.CO_COROUTINE),
             ("co_firstlineno", 100),
-            ("co_code", code2.co_code),
             ("co_consts", code2.co_consts),
+            ("co_code", code2.co_code),
             ("co_names", ("myname",)),
             ("co_varnames", ('spam',)),
             ("co_freevars", ("freevar",)),
@@ -330,6 +330,26 @@ class CodeTest(unittest.TestCase):
         code = func.__code__
         newcode = code.replace(co_name="func")  # Should not raise SystemError
         self.assertEqual(code, newcode)
+
+    def test_out_of_bounds_consts_names(self):
+        code = compile("0, a", "<string>", "eval")
+        # Test co_consts
+        with self.assertRaises(ValueError):
+            code.replace(co_consts=())
+        # Test co_names
+        with self.assertRaises(ValueError):
+            code.replace(co_names=())
+        # Test things that shouldn't raise ValueError
+        try:
+            code.replace(co_consts=(7,))
+            code.replace(co_consts=(0, 1))
+        except ValueError:
+            self.fail("co_consts index in-bounds but failed")
+        try:
+            code.replace(co_names=("A",))
+            code.replace(co_names=("a", "b"))
+        except ValueError:
+            self.fail("co_names index in-bounds but failed")
 
     def test_empty_linetable(self):
         def func():

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -279,8 +279,8 @@ class CodeTest(unittest.TestCase):
             with self.subTest(attr=attr, value=value):
                 if attr == "co_code":
                     # gh-95222 doesn't allow having a LOAD_CONST index
-                    # greater than len(code.co_consts), so we'll
-                    # temporary replace co_consts
+                    # greater than len(code.co_consts), so also replace
+                    # co_consts with code2.co_consts
                     new_code = code.replace(co_consts=code2.co_consts, co_code=value)
                 else:
                     new_code = code.replace(**{attr: value})

--- a/Misc/NEWS.d/next/Security/2022-07-25-02-03-29.gh-issue-95222.Skg0bc.rst
+++ b/Misc/NEWS.d/next/Security/2022-07-25-02-03-29.gh-issue-95222.Skg0bc.rst
@@ -1,0 +1,1 @@
+Disallow out-of-bounds indexes of :opcode:`LOAD_CONST`, :opcode:`LOAD_NAME`, and :opcode:`LOAD_GLOBAL`. Patch by Jeremiah Gabriel Pascual.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -228,11 +228,11 @@ get_localsplus_names(PyCodeObject *co, _PyLocals_Kind kind, int num)
     return names;
 }
 
-static unsigned int
+static int
 get_arg(const _Py_CODEUNIT *codestr, int i)
 {
     _Py_CODEUNIT word;
-    unsigned int oparg = _Py_OPARG(codestr[i]);
+    int oparg = _Py_OPARG(codestr[i]);
     if (i >= 1 && _Py_OPCODE(word = codestr[i-1]) == EXTENDED_ARG) {
         oparg |= _Py_OPARG(word) << 8;
         if (i >= 2 && _Py_OPCODE(word = codestr[i-2]) == EXTENDED_ARG) {
@@ -308,14 +308,14 @@ _PyCode_Validate(struct _PyCodeConstructor *con)
     const int ninstr = (int)PyBytes_GET_SIZE(con->code) / sizeof(_Py_CODEUNIT);
     for (int i = 0; i < ninstr; i++) {
         _Py_CODEUNIT instr = codestr[i];
-        unsigned int opcode = _Py_OPCODE(instr);
-        unsigned int oparg = get_arg(codestr, i);
+        int opcode = _Py_OPCODE(instr);
+        int oparg = get_arg(codestr, i);
         if (opcode == LOAD_CONST && oparg >= nconsts) {
             PyErr_SetString(PyExc_ValueError, "code: co_consts is too small");
             return -1;
         }
-        else if (opcode == LOAD_NAME && oparg >= nnames ||
-                 opcode == LOAD_GLOBAL && (oparg >> 1) >= nnames)
+        else if ((opcode == LOAD_NAME && oparg >= nnames) ||
+                 (opcode == LOAD_GLOBAL && (oparg >> 1) >= nnames))
         {
             PyErr_SetString(PyExc_ValueError, "code: co_names is too small");
             return -1;


### PR DESCRIPTION
Disallow out-of-bounds `co_consts`/`co_names` access by adding a check in `_PyCode_Validate` to prevent access violations in `LOAD_CONST`/`LOAD_NAME`/`LOAD_GLOBAL` when executing code.

<!-- gh-issue-number: gh-95222 -->
* Issue: gh-95222
<!-- /gh-issue-number -->
