### PR TITLE
gh-95233: Correct grp.getgrgid parameter name in documentation (gid -> id)

### DIFF
--- a/Doc/library/grp.rst
+++ b/Doc/library/grp.rst
@@ -38,7 +38,7 @@ accessible via :func:`getgrnam` or :func:`getgrgid`.)
 It defines the following items:
 
 
-.. function:: getgrgid(gid)
+.. function:: getgrgid(id)
 
    Return the group database entry for the given numeric group ID. :exc:`KeyError`
    is raised if the entry asked for cannot be found.


### PR DESCRIPTION
As demonstrated below, this parameter name was incorrect.
The correct version is in typeshed already.

```
>>> import sys
>>> sys.version
'3.9.13 (main, May 24 2022, 21:13:51) \n[Clang 13.1.6 (clang-1316.0.21.2)]'
>>> import grp
>>> grp.getgrgid(id=1)
grp.struct_group(gr_name='daemon', gr_passwd='*', gr_gid=1, gr_mem=['root'])
>>> grp.getgrgid(gid=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: getgrgid() missing required argument 'id' (pos 1)
>>>
```

<!-- gh-issue-number: gh-95233 -->
* Issue: gh-95233
<!-- /gh-issue-number -->
