### PR TITLE
gh-92678: Fix MRO calculation for C extension types with manual __dict__

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-25-20-09-21.gh-issue-92678.8IfNdU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-25-20-09-21.gh-issue-92678.8IfNdU.rst
@@ -1,0 +1,2 @@
+Fix MRO calculation issue which caused C extension types manually managing
+their own ``__dict__`` to fail in Python 3.11.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2241,6 +2241,12 @@ extra_ivars(PyTypeObject *type, PyTypeObject *base)
         type->tp_weaklistoffset + sizeof(PyObject *) == t_size &&
         type->tp_flags & Py_TPFLAGS_HEAPTYPE)
         t_size -= sizeof(PyObject *);
+    if (!(type->tp_flags & Py_TPFLAGS_MANAGED_DICT) &&
+        type->tp_dictoffset && base->tp_dictoffset == 0 &&
+        type->tp_dictoffset + sizeof(PyObject *) == t_size &&
+        type->tp_flags & Py_TPFLAGS_HEAPTYPE) {
+        t_size -= sizeof(PyObject *);
+    }
     return t_size != b_size;
 }
 


### PR DESCRIPTION
We need to account for C extension types with don't set `Py_TPFLAGS_MANAGED_DICT` and manually manage their own dict instead.

This may be unsightly, but this special case is special enough to break the rules. Unless we get a proper class creation and dict management API in 3.12, we will break a lot of code.

<!-- gh-issue-number: gh-92678 -->
* Issue: gh-92678
<!-- /gh-issue-number -->
