### PR TITLE
GH-92678: Expose managed dict clear and visit functions

### DIFF
--- a/Include/cpython/dictobject.h
+++ b/Include/cpython/dictobject.h
@@ -83,3 +83,6 @@ typedef struct {
 
 PyAPI_FUNC(PyObject *) _PyDictView_New(PyObject *, PyTypeObject *);
 PyAPI_FUNC(PyObject *) _PyDictView_Intersect(PyObject* self, PyObject *other);
+
+PyAPI_FUNC(int) _PyObject_VisitManagedDict(PyObject *self, visitproc visit, void *arg);
+PyAPI_FUNC(void) _PyObject_ClearManagedDict(PyObject *self);

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -722,6 +722,20 @@ class CAPITest(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertTrue(hasattr(ctypes.pythonapi, name))
 
+    def test_clear_managed_dict(self):
+
+        class C:
+            def __init__(self):
+                self.a = 1
+
+        c = C()
+        _testcapi.clear_managed_dict(c)
+        self.assertEqual(c.__dict__, {})
+        c = C()
+        self.assertEqual(c.__dict__, {'a':1})
+        _testcapi.clear_managed_dict(c)
+        self.assertEqual(c.__dict__, {})
+
 
 class TestPendingCalls(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/C API/2022-07-25-15-54-27.gh-issue-92678.ziZpxz.rst
+++ b/Misc/NEWS.d/next/C API/2022-07-25-15-54-27.gh-issue-92678.ziZpxz.rst
@@ -1,0 +1,3 @@
+Adds unstable C-API functions ``_PyObject_VisitManagedDict`` and
+``_PyObject_ClearManagedDict`` to allow C extensions to allow the VM to
+manage their object's dictionaries.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -6009,6 +6009,13 @@ settrace_to_record(PyObject *self, PyObject *list)
     Py_RETURN_NONE;
 }
 
+static PyObject *
+clear_managed_dict(PyObject *self, PyObject *obj)
+{
+    _PyObject_ClearManagedDict(obj);
+    Py_RETURN_NONE;
+}
+
 
 static PyObject *
 test_macros(PyObject *self, PyObject *Py_UNUSED(args))
@@ -6347,6 +6354,7 @@ static PyMethodDef TestMethods[] = {
     {"test_code_api", test_code_api, METH_NOARGS, NULL},
     {"settrace_to_record", settrace_to_record, METH_O, NULL},
     {"test_macros", test_macros, METH_NOARGS, NULL},
+    {"clear_managed_dict", clear_managed_dict, METH_O, NULL},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5583,6 +5583,35 @@ _PyObject_FreeInstanceAttributes(PyObject *self)
     free_values(*values_ptr);
 }
 
+int
+_PyObject_VisitManagedDict(PyObject *self, visitproc visit, void *arg)
+{
+    PyTypeObject *tp = Py_TYPE(self);
+    if((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0) {
+        return 0;
+    }
+    assert(tp->tp_dictoffset);
+    int err = _PyObject_VisitInstanceAttributes(self, visit, arg);
+    if (err) {
+        return err;
+    }
+    Py_VISIT(*_PyObject_DictPointer(self));
+    return 0;
+}
+
+
+void
+_PyObject_ClearManagedDict(PyObject *self)
+{
+    PyTypeObject *tp = Py_TYPE(self);
+    if((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0) {
+        return;
+    }
+    _PyObject_FreeInstanceAttributes(self);
+    *_PyObject_ValuesPointer(self) = NULL;
+    Py_CLEAR(*_PyObject_DictPointer(self));
+}
+
 PyObject *
 PyObject_GenericGetDict(PyObject *obj, void *context)
 {

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5595,7 +5595,7 @@ _PyObject_VisitManagedDict(PyObject *self, visitproc visit, void *arg)
     if (err) {
         return err;
     }
-    Py_VISIT(*_PyObject_DictPointer(self));
+    Py_VISIT(*_PyObject_ManagedDictPointer(self));
     return 0;
 }
 
@@ -5609,7 +5609,7 @@ _PyObject_ClearManagedDict(PyObject *self)
     }
     _PyObject_FreeInstanceAttributes(self);
     *_PyObject_ValuesPointer(self) = NULL;
-    Py_CLEAR(*_PyObject_DictPointer(self));
+    Py_CLEAR(*_PyObject_ManagedDictPointer(self));
 }
 
 PyObject *


### PR DESCRIPTION
Adds the unstable API functions
```
PyAPI_FUNC(int) _PyObject_VisitManagedDict(PyObject *self, visitproc visit, void *arg);
PyAPI_FUNC(void) _PyObject_ClearManagedDict(PyObject *self);
```

I've only added a test for `_PyObject_ClearManagedDict` as there doesn't seem to be a straightforward way to test the visit function.

<!-- gh-issue-number: gh-92678 -->
* Issue: gh-92678
<!-- /gh-issue-number -->
