### PR TITLE
gh-95041: Fail syslog.syslog in case inner call to syslog.openlog fails

### DIFF
--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -196,7 +196,8 @@ syslog_syslog(PyObject * self, PyObject * args)
                 return NULL;
             }
             Py_DECREF(openlog_ret);
-        } else {
+        }
+        else {
             return NULL;
         }
     }

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -196,6 +196,8 @@ syslog_syslog(PyObject * self, PyObject * args)
             if (openlog_ret == NULL) {
                 return NULL;
             }
+        } else {
+            return NULL;
         }
     }
 

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -192,8 +192,9 @@ syslog_syslog(PyObject * self, PyObject * args)
         if ((openargs = PyTuple_New(0))) {
             PyObject *openlog_ret = syslog_openlog(self, openargs, NULL);
             Py_DECREF(openargs);
-            Py_XDECREF(openlog_ret);
-            if (openlog_ret == NULL) {
+            if (openlog_ret != NULL) {
+                Py_DECREF(openlog_ret);
+            } else {
                 return NULL;
             }
         } else {

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -191,8 +191,11 @@ syslog_syslog(PyObject * self, PyObject * args)
          */
         if ((openargs = PyTuple_New(0))) {
             PyObject *openlog_ret = syslog_openlog(self, openargs, NULL);
-            Py_XDECREF(openlog_ret);
             Py_DECREF(openargs);
+            Py_XDECREF(openlog_ret);
+            if (openlog_ret == NULL) {
+                return NULL;
+            }
         }
     }
 

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -192,11 +192,10 @@ syslog_syslog(PyObject * self, PyObject * args)
         if ((openargs = PyTuple_New(0))) {
             PyObject *openlog_ret = syslog_openlog(self, openargs, NULL);
             Py_DECREF(openargs);
-            if (openlog_ret != NULL) {
-                Py_DECREF(openlog_ret);
-            } else {
+            if (openlog_ret == NULL) {
                 return NULL;
             }
+            Py_DECREF(openlog_ret);
         } else {
             return NULL;
         }


### PR DESCRIPTION


<!-- gh-issue-number: gh-95041 -->
* Issue: gh-95041
<!-- /gh-issue-number -->
