### PR TITLE
Statistics inv_cdf sync with corresponding random module normal distributions

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1221,8 +1221,6 @@ class NormalDist:
         """
         if p <= 0.0 or p >= 1.0:
             raise StatisticsError('p must be in the range 0.0 < p < 1.0')
-        if self._sigma <= 0.0:
-            raise StatisticsError('cdf() not defined when sigma at or below zero')
         return _normal_dist_inv_cdf(p, self._mu, self._sigma)
 
     def quantiles(self, n=4):

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -2801,9 +2801,10 @@ class TestNormalDist:
             iq.inv_cdf(1.0)                         # p is one
         with self.assertRaises(self.module.StatisticsError):
             iq.inv_cdf(1.1)                         # p over one
-        with self.assertRaises(self.module.StatisticsError):
-            iq = NormalDist(100, 0)                 # sigma is zero
-            iq.inv_cdf(0.5)
+
+        # Supported case:
+        iq = NormalDist(100, 0)                     # sigma is zero
+        self.assertEqual(iq.inv_cdf(0.5), 100)
 
         # Special values
         self.assertTrue(math.isnan(Z.inv_cdf(float('NaN'))))

--- a/Modules/_statisticsmodule.c
+++ b/Modules/_statisticsmodule.c
@@ -31,7 +31,7 @@ _statistics__normal_dist_inv_cdf_impl(PyObject *module, double p, double mu,
 /*[clinic end generated code: output=02fd19ddaab36602 input=24715a74be15296a]*/
 {
     double q, num, den, r, x;
-    if (p <= 0.0 || p >= 1.0 || sigma <= 0.0) {
+    if (p <= 0.0 || p >= 1.0) {
         goto error;
     }
 


### PR DESCRIPTION
Remove the inconsistent restriction that inv_cdf() is undefined when sigma is zero.

* Aligns the C `_normal_dist_inv_cdf()` function with its pure python equivalent.
* Restores the invariant that ``NormalDist(mu, sigma).inv_cdf(p)`` is equivalent to `NormalDist(0.0, 1.0)inv_cdf(p) * sigma + mi``.   In general, operations on *NormalDist* should always match the rescaled and reentered results for the same operation on the standard normal distribution.
* Restores alignment with ``random.gauss(mu, sigma)`` and ``random.normalvariate(mu, sigma)`` both. of which are equivalent to sampling from ``NormalDist(mu, sigma).inv_cdf(random())``.  The two functions in the random module happy accept sigma=0 and give a well-defined result.
* This also lets the function gently handle a sigma getting smaller, eventually becoming zero.  As *sigma* decrease, `NormalDist(mu, sigma).inv_cdf(p)` forms a tighter and tighter internal around *mu* and becoming exactly *mu* in the limit. For example, ``NormalDist(100, 1E-300).inv_cdf(0.3)`` cleanly evaluates to 100.0`` but with ``sigma=1e-500`` the function previously would raised an unexpected error.

* The only opposing idea is that ``inv_cdf()`` means to give the inverse of ``cdf()``, but the cdf isn't defined with sigma=0.   This is fine though. all supported inputs to ``cdf()`` are still invertible. There is just a relaxation of a restriction beyond the supported range which makes ``inv_cdf()`` obey other invariants and handle edge cases cleanly.

* The edit also gives a very small performance improvement.