### PR TITLE
Makefile: have "install" depend on pgo

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1760,7 +1760,7 @@ $(DESTSHARED):
 
 # Install the interpreter with $(VERSION) affixed
 # This goes into $(exec_prefix)
-altbininstall: $(BUILDPYTHON) @FRAMEWORKPYTHONW@
+altbininstall: all @FRAMEWORKPYTHONW@
 	@for i in $(BINDIR) $(LIBDIR); \
 	do \
 		if test ! -d $(DESTDIR)$$i; then \


### PR DESCRIPTION
Previously, `make install` would ignore pgo. This isn't an
issue if one runs `make && make install`, since `make` will
build with pgo (if requested) and then `make install` won't
rebuild anything.

But if one simply does `./configure --enable-optimizations && make install`,
the build system would build a non-pgo build and then install that.

This commit changes the Makefile so that `install` depends on
`all`, which includes pgo when requested.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
