### PR TITLE
gh-95285: py.exe launcher fails with short argv0

### DIFF
--- a/Lib/test/test_launcher.py
+++ b/Lib/test/test_launcher.py
@@ -149,7 +149,7 @@ class RunPyMixin:
     @classmethod
     def find_py(cls):
         py_exe = None
-        if sysconfig.is_python_build(True):
+        if sysconfig.is_python_build():
             py_exe = Path(sys.executable).parent / PY_EXE
         else:
             for p in os.getenv("PATH").split(";"):
@@ -187,7 +187,7 @@ class RunPyMixin:
             )
         return py_exe
 
-    def run_py(self, args, env=None, allow_fail=False, expect_returncode=0, short_argv0=False):
+    def run_py(self, args, env=None, allow_fail=False, expect_returncode=0, argv=None):
         if not self.py_exe:
             self.py_exe = self.find_py()
 
@@ -198,13 +198,11 @@ class RunPyMixin:
             "PYLAUNCHER_DEBUG": "1",
             "PYLAUNCHER_DRYRUN": "1",
         }
-        cwd, py_exe = None, self.py_exe
-        if short_argv0:
-            cwd, py_exe = str(py_exe.parent), f'"{py_exe.name}"'
+        if not argv:
+            argv = [self.py_exe, *args]
         with subprocess.Popen(
-            [py_exe, *args],
+            argv,
             env=env,
-            cwd=cwd,
             executable=self.py_exe,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -547,10 +545,11 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
     def test_py_shebang_short_argv0(self):
         with self.py_ini(TEST_PY_COMMANDS):
             with self.script("#! /usr/bin/env python -prearg") as script:
-                data = self.run_py([script, "-postarg"], short_argv0=True)
+                # Override argv to only pass "py.exe" as the command
+                data = self.run_py([script, "-postarg"], argv=f'"py.exe" "{script}" -postarg')
         self.assertEqual("PythonTestSuite", data["SearchInfo.company"])
         self.assertEqual("3.100", data["SearchInfo.tag"])
-        self.assertEqual(f"X.Y.exe -prearg {script} -postarg", data["stdout"].strip())
+        self.assertEqual(f'X.Y.exe -prearg "{script}" -postarg', data["stdout"].strip())
 
     def test_install(self):
         data = self.run_py(["-V:3.10"], env={"PYLAUNCHER_ALWAYS_INSTALL": "1"}, expect_returncode=111)

--- a/Misc/NEWS.d/next/Windows/2022-07-26-20-33-12.gh-issue-95285.w6fa22.rst
+++ b/Misc/NEWS.d/next/Windows/2022-07-26-20-33-12.gh-issue-95285.w6fa22.rst
@@ -1,0 +1,2 @@
+Fix :ref:`launcher` handling of command lines where it is only passed a
+short executable name.

--- a/PC/launcher2.c
+++ b/PC/launcher2.c
@@ -580,6 +580,9 @@ parseCommandLine(SearchInfo *search)
             break;
         }
     }
+    if (tail == search->originalCmdLine && tail[0] == L'"') {
+        ++tail;
+    }
     // Without special cases, we can now fill in the search struct
     int tailLen = (int)(end ? (end - tail) : wcsnlen_s(tail, MAXLEN));
     search->executableLength = -1;


### PR DESCRIPTION


<!-- gh-issue-number: gh-95285 -->
* Issue: gh-95285
<!-- /gh-issue-number -->
