### PR TITLE
gh-93678: Address stack exhaustion on WASI (GH-95296)

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -108,6 +108,7 @@ class TestSpecifics(unittest.TestCase):
         exec('z = a', g, d)
         self.assertEqual(d['z'], 12)
 
+    @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_extended_arg(self):
         # default: 1000 * 2.5 = 2500 repetitions
         repeat = int(sys.getrecursionlimit() * 2.5)
@@ -542,6 +543,7 @@ if 1:
         self.assertIn(b"Non-UTF-8", res.err)
 
     @support.cpython_only
+    @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_compiler_recursion_limit(self):
         # Expected limit is sys.getrecursionlimit() * the scaling factor
         # in symtable.c (currently 3)

--- a/Lib/test/test_dynamic.py
+++ b/Lib/test/test_dynamic.py
@@ -1,6 +1,7 @@
 # Test the most dynamic corner cases of Python's runtime semantics.
 
 import builtins
+import sys
 import unittest
 
 from test.support import swap_item, swap_attr
@@ -139,12 +140,14 @@ class RebindBuiltinsTests(unittest.TestCase):
             def __missing__(self, key):
                 return int(key.removeprefix("_number_"))
 
-        code = "lambda: " + "+".join(f"_number_{i}" for i in range(1000))
-        sum_1000 = eval(code, MyGlobals())
-        expected = sum(range(1000))
+        # 1,000 on most systems
+        limit = sys.getrecursionlimit()
+        code = "lambda: " + "+".join(f"_number_{i}" for i in range(limit))
+        sum_func = eval(code, MyGlobals())
+        expected = sum(range(limit))
         # Warm up the the function for quickening (PEP 659)
         for _ in range(30):
-            self.assertEqual(sum_1000(), expected)
+            self.assertEqual(sum_func(), expected)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Commit 75c0c1b9 added function calls that increase stack consumption
slightly. This pushed recursion tests over the call stack limit of
wasmtime and broke three tests on wasm32-wasi.

Skip two tests and lower recursion limit of the third test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-93678 -->
* Issue: gh-93678
<!-- /gh-issue-number -->
