### PR TITLE
gh-95174: Move WASIX logic into wasi-env (GH-95320)

### DIFF
--- a/Tools/wasm/README.md
+++ b/Tools/wasm/README.md
@@ -234,15 +234,14 @@ compatibility stubs.
 
 The script ``wasi-env`` sets necessary compiler and linker flags as well as
 ``pkg-config`` overrides. The script assumes that WASI-SDK is installed in
-``/opt/wasi-sdk`` or ``$WASI_SDK_PATH``.
+``/opt/wasi-sdk`` or ``$WASI_SDK_PATH`` and WASIX is installed in
+``/opt/wasix`` or ``$WASIX_PATH``.
 
 ```shell
 mkdir -p builddir/wasi
 pushd builddir/wasi
 
 CONFIG_SITE=../../Tools/wasm/config.site-wasm32-wasi \
-  CFLAGS="-isystem /opt/wasix/include" \
-  LDFLAGS="-L/opt/wasix/lib -lwasix" \
   ../../Tools/wasm/wasi-env ../../configure -C \
     --host=wasm32-unknown-wasi \
     --build=$(../../config.guess) \

--- a/Tools/wasm/wasi-env
+++ b/Tools/wasm/wasi-env
@@ -30,17 +30,24 @@ if test -z "$1"; then
 fi
 
 WASI_SDK_PATH="${WASI_SDK_PATH:-/opt/wasi-sdk}"
+WASI_SYSROOT="${WASI_SDK_PATH}/share/wasi-sysroot"
+WASIX_PATH="${WASIX_PATH:-/opt/wasix}"
 
 if ! test -x "${WASI_SDK_PATH}/bin/clang"; then
     echo "Error: ${WASI_SDK_PATH}/bin/clang does not exist." >&2
     exit 2
 fi
 
+CC="${WASI_SDK_PATH}/bin/clang"
+CPP="${WASI_SDK_PATH}/bin/clang-cpp"
+CXX="${WASI_SDK_PATH}/bin/clang++"
+
 # --sysroot is required if WASI-SDK is not installed in /opt/wasi-sdk.
-WASI_SYSROOT="${WASI_SDK_PATH}/share/wasi-sysroot"
-CC="${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SYSROOT}"
-CPP="${WASI_SDK_PATH}/bin/clang-cpp --sysroot=${WASI_SYSROOT}"
-CXX="${WASI_SDK_PATH}/bin/clang++ --sysroot=${WASI_SYSROOT}"
+if test "${WASI_SDK_PATH}" != "/opt/wasi-sdk"; then
+    CC="${CC} --sysroot=${WASI_SYSROOT}"
+    CPP="${CPP} --sysroot=${WASI_SYSROOT}"
+    CXX="${CXX} --sysroot=${WASI_SYSROOT}"
+fi
 
 # use ccache if available
 if command -v ccache >/dev/null 2>&1; then
@@ -58,10 +65,17 @@ PKG_CONFIG_PATH=""
 PKG_CONFIG_LIBDIR="${WASI_SYSROOT}/lib/pkgconfig:${WASI_SYSROOT}/share/pkgconfig"
 PKG_CONFIG_SYSROOT_DIR="${WASI_SYSROOT}"
 
-PATH="${WASI_SDK_PATH}/bin:$PATH"
+# add WASIX (POSIX stubs for WASI) if WASIX is installed
+if test -f "${WASIX_PATH}/lib/libwasix.a"; then
+    CFLAGS="${CFLAGS} -isystem ${WASIX_PATH}/include"
+    LDFLAGS="${LDFLAGS} -L${WASIX_PATH}/lib -lwasix"
+fi
 
-export WASI_SDK_PATH
+PATH="${WASI_SDK_PATH}/bin:${PATH}"
+
+export WASI_SDK_PATH WASI_SYSROOT
 export CC CPP CXX LDSHARED AR RANLIB
+export CFLAGS LDFLAGS
 export PKG_CONFIG_PATH PKG_CONFIG_LIBDIR PKG_CONFIG_SYSROOT_DIR
 export PATH
 


### PR DESCRIPTION
wasi-env now sets WASIX flags. This allows us to control all build
parameter for wasm32-wasi buildbot from CPython repository.

Also export and improve SYSROOT parameter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95174 -->
* Issue: gh-95174
<!-- /gh-issue-number -->
