### PR TITLE
gh-82180: Document support for non-integer arg removed from grp.getgrgid in 3.10

### DIFF
--- a/Doc/library/grp.rst
+++ b/Doc/library/grp.rst
@@ -43,9 +43,8 @@ It defines the following items:
    Return the group database entry for the given numeric group ID. :exc:`KeyError`
    is raised if the entry asked for cannot be found.
 
-   .. deprecated:: 3.6
-      Since Python 3.6 the support of non-integer arguments like floats or
-      strings in :func:`getgrgid` is deprecated.
+   .. versionchanged:: 3.10
+      :exc:`TypeError` is raised for non-integer arguments like floats or strings.
 
 .. function:: getgrnam(name)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Support for a non-integer argument like floats or strings in `getgrgid` was deprecated in Python 3.6:

* https://github.com/python/cpython/commit/9cc4ed5c7a86b2aa58176222107dbb01d40a3680
* https://github.com/python/cpython/issues/70317

This support was removed in Python 3.10:

* https://github.com/python/cpython/commit/578c3955e0222ec7b3146197467fbb0fcfae12fe#diff-d930482a13f06d943cffe3b4e253cea42d5759209d472603d6cccb28aadbf243
* https://github.com/python/cpython/pull/15636
* https://github.com/python/cpython/issues/82180

But the docs were not updated to remove the deprecation warning:

* https://docs.python.org/3/library/grp.html#grp.getgrgid

Let's update to reflect the behaviour changed in Python 3.10.

---

<!-- gh-issue-number: gh-82180 -->
* Issue: gh-82180
<!-- /gh-issue-number -->
