### PR TITLE
GH-83901: Improve Signature.bind error message for missing keyword-only params

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -3114,8 +3114,12 @@ class Signature:
                             parameters_ex = (param,)
                             break
                         else:
-                            msg = 'missing a required argument: {arg!r}'
-                            msg = msg.format(arg=param.name)
+                            if param.kind == _KEYWORD_ONLY:
+                                argtype = ' keyword-only'
+                            else:
+                                argtype = ''
+                            msg = 'missing a required{argtype} argument: {arg!r}'
+                            msg = msg.format(arg=param.name, argtype=argtype)
                             raise TypeError(msg) from None
             else:
                 # We have a positional argument to process

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -3891,7 +3891,8 @@ class TestSignatureBind(unittest.TestCase):
             self.call(test, 1, bar=2, spam='ham')
 
         with self.assertRaisesRegex(TypeError,
-                                     "missing a required argument: 'bar'"):
+                                     "missing a required keyword-only "
+                                     "argument: 'bar'"):
             self.call(test, 1)
 
         def test(foo, *, bar, **bin):

--- a/Misc/NEWS.d/next/Library/2022-07-27-19-47-51.gh-issue-83901.OSw06c.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-27-19-47-51.gh-issue-83901.OSw06c.rst
@@ -1,0 +1,1 @@
+Improve :meth:`Signature.bind <inspect.Signature.bind>` error message for missing keyword-only arguments.


### PR DESCRIPTION
Changes Signature.bind errors to more closely match those of Python itself when a keyword-only argument is missing.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-83901 -->
* Issue: gh-83901
<!-- /gh-issue-number -->
