### PR TITLE
gh-94439: Update typing library documentation

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1827,6 +1827,7 @@ These are not used in annotations. They are building blocks for declaring types.
    .. attribute:: __required_keys__
 
       .. versionadded:: 3.9
+
    .. attribute:: __optional_keys__
 
       ``Point2D.__required_keys__`` and ``Point2D.__optional_keys__`` return

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1825,6 +1825,8 @@ These are not used in annotations. They are building blocks for declaring types.
          True
 
    .. attribute:: __required_keys__
+
+      .. versionadded:: 3.9
    .. attribute:: __optional_keys__
 
       ``Point2D.__required_keys__`` and ``Point2D.__optional_keys__`` return
@@ -1851,6 +1853,8 @@ These are not used in annotations. They are building blocks for declaring types.
          True
          >>> Point3D.__optional_keys__ == frozenset({'x', 'y'})
          True
+
+      .. versionadded:: 3.9
 
    See :pep:`589` for more examples and detailed rules of using ``TypedDict``.
 


### PR DESCRIPTION
Add a minimum version reminder to the `__required_keys__` and `__optional_keys__` attributes.

<!-- gh-issue-number: gh-94439 -->
* Issue: gh-94439
<!-- /gh-issue-number -->
