### PR TITLE
gh-95376: Add test for names containing null

### DIFF
--- a/Lib/test/test_pwd.py
+++ b/Lib/test/test_pwd.py
@@ -60,7 +60,7 @@ class PwdTest(unittest.TestCase):
         self.assertRaises(TypeError, pwd.getpwnam, 42)
         self.assertRaises(TypeError, pwd.getpwall, 42)
         # embedded null character
-        self.assertRaises(ValueError, pwd.getpwnam, 'a\x00b')
+        self.assertRaisesRegex(ValueError, 'null', pwd.getpwnam, 'a\x00b')
 
         # try to get some errors
         bynames = {}

--- a/Lib/test/test_pwd.py
+++ b/Lib/test/test_pwd.py
@@ -59,6 +59,8 @@ class PwdTest(unittest.TestCase):
         self.assertRaises(TypeError, pwd.getpwnam)
         self.assertRaises(TypeError, pwd.getpwnam, 42)
         self.assertRaises(TypeError, pwd.getpwall, 42)
+        # embedded null character
+        self.assertRaises(ValueError, pwd.getpwnam, 'a\x00b')
 
         # try to get some errors
         bynames = {}


### PR DESCRIPTION
In grp, a module similar to pwd, it tests the case that the name value contains null, but pwd does not test it, so it was added.

<!-- gh-issue-number: gh-95376 -->
* Issue: gh-95376
<!-- /gh-issue-number -->
