### PR TITLE
gh-95359: Fix py.exe launcher handling of per-user py.ini and command names

### DIFF
--- a/Lib/test/test_launcher.py
+++ b/Lib/test/test_launcher.py
@@ -69,7 +69,7 @@ TEST_PY_ENV = dict(
 
 TEST_PY_COMMANDS = "\n".join([
     "[defaults]",
-    *[f"{k.lower()}={v}" for k, v in TEST_PY_ENV.items()]
+    *[f"{k[3:].lower()}={v}" for k, v in TEST_PY_ENV.items()]
 ])
 
 

--- a/Misc/NEWS.d/next/Windows/2022-07-28-20-21-38.gh-issue-95359.ywMrgu.rst
+++ b/Misc/NEWS.d/next/Windows/2022-07-28-20-21-38.gh-issue-95359.ywMrgu.rst
@@ -1,0 +1,3 @@
+Fix :ref:`launcher` handling of :file:`py.ini` commands (it was incorrectly
+expecting a ``py_`` prefix on keys) and crashes when reading per-user
+configuration file.

--- a/PC/launcher2.c
+++ b/PC/launcher2.c
@@ -761,7 +761,7 @@ _readIni(const wchar_t *section, const wchar_t *settingName, wchar_t *buffer, in
         n = GetPrivateProfileStringW(section, settingName, NULL, buffer, bufferLength, iniPath);
         if (n) {
             debug(L"# Found %s in %s\n", settingName, iniPath);
-            return true;
+            return n;
         } else if (GetLastError() == ERROR_FILE_NOT_FOUND) {
             debug(L"# Did not find file %s\n", iniPath);
         } else {
@@ -946,13 +946,17 @@ checkDefaults(SearchInfo *search)
 
     // If tag is only a major version number, expand it from the environment
     // or an ini file
-    const wchar_t *settingName = NULL;
+    const wchar_t *iniSettingName = NULL;
+    const wchar_t *envSettingName = NULL;
     if (!search->tag || !search->tagLength) {
-        settingName = L"py_python";
+        iniSettingName = L"python";
+        envSettingName = L"py_python";
     } else if (0 == wcsncmp(search->tag, L"3", search->tagLength)) {
-        settingName = L"py_python3";
+        iniSettingName = L"python3";
+        envSettingName = L"py_python3";
     } else if (0 == wcsncmp(search->tag, L"2", search->tagLength)) {
-        settingName = L"py_python2";
+        iniSettingName = L"python2";
+        envSettingName = L"py_python2";
     } else {
         debug(L"# Cannot select defaults for tag '%.*s'\n", search->tagLength, search->tag);
         return 0;
@@ -960,11 +964,11 @@ checkDefaults(SearchInfo *search)
 
     // First, try to read an environment variable
     wchar_t buffer[MAXLEN];
-    int n = GetEnvironmentVariableW(settingName, buffer, MAXLEN);
+    int n = GetEnvironmentVariableW(envSettingName, buffer, MAXLEN);
 
     // If none found, check in our two .ini files instead
     if (!n) {
-        n = _readIni(L"defaults", settingName, buffer, MAXLEN);
+        n = _readIni(L"defaults", iniSettingName, buffer, MAXLEN);
     }
 
     if (n) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-95359 -->
* Issue: gh-95359
<!-- /gh-issue-number -->
