### PR TITLE
gh-95413: Remove references to deprecated CGI library

### DIFF
--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -113,8 +113,8 @@ to many different classes of problems.
 
 The language comes with a large standard library that covers areas such as
 string processing (regular expressions, Unicode, calculating differences between
-files), internet protocols (HTTP, FTP, SMTP, XML-RPC, POP, IMAP), software
-engineering (unit testing, logging, profiling, parsing
+files), internet protocols (HTTP, FTP, SMTP, XML-RPC, POP, IMAP),
+software engineering (unit testing, logging, profiling, parsing
 Python code), and operating system interfaces (system calls, filesystems, TCP/IP
 sockets).  Look at the table of contents for :ref:`library-index` to get an idea
 of what's available.  A wide variety of third-party extensions are also

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -113,8 +113,8 @@ to many different classes of problems.
 
 The language comes with a large standard library that covers areas such as
 string processing (regular expressions, Unicode, calculating differences between
-files), internet protocols (HTTP, FTP, SMTP, XML-RPC, POP, IMAP, CGI
-programming), software engineering (unit testing, logging, profiling, parsing
+files), internet protocols (HTTP, FTP, SMTP, XML-RPC, POP, IMAP), software
+engineering (unit testing, logging, profiling, parsing
 Python code), and operating system interfaces (system calls, filesystems, TCP/IP
 sockets).  Look at the table of contents for :ref:`library-index` to get an idea
 of what's available.  A wide variety of third-party extensions are also

--- a/Doc/tutorial/whatnow.rst
+++ b/Doc/tutorial/whatnow.rst
@@ -17,7 +17,7 @@ the set are:
   reference material about types, functions, and the modules in the standard
   library.  The standard Python distribution includes a *lot* of additional code.
   There are modules to read Unix mailboxes, retrieve documents via HTTP, generate
-  random numbers, parse command-line options, write CGI programs, compress data,
+  random numbers, parse command-line options, compress data,
   and many other tasks. Skimming through the Library Reference will give you an
   idea of what's available.
 


### PR DESCRIPTION
Remove references to CGI library because it has deprecated since version 3.11 and will be removed in version 3.13

https://docs.python.org/3.12/library/cgi.html

<!-- gh-issue-number: gh-95413 -->
* Issue: gh-95413
<!-- /gh-issue-number -->
