### PR TITLE
Remove `fcntl_fcntl_impl` keeping `fcntl_ioctl_impl`

### DIFF
--- a/Modules/clinic/fcntlmodule.c.h
+++ b/Modules/clinic/fcntlmodule.c.h
@@ -79,8 +79,7 @@ PyDoc_STRVAR(fcntl_ioctl__doc__,
 "If the argument is an immutable buffer (most likely a string) then a copy\n"
 "of the buffer is passed to the operating system and the return value is a\n"
 "string of the same length containing whatever the operating system put in\n"
-"the buffer.  The length of the arg buffer in this case is not allowed to\n"
-"exceed 1024 bytes.\n"
+"the buffer.\n"
 "\n"
 "If the arg given is an integer or if none is specified, the result value is\n"
 "an integer corresponding to the return value of the ioctl call in the C\n"
@@ -243,4 +242,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b8cb14ab35de4c6a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fdcb77f29c5b8df1 input=a9049054013a1b77]*/

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -161,7 +161,7 @@ code.
 static PyObject *
 fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
                  PyObject *ob_arg, int mutate_arg)
-/*[clinic end generated code: output=7f7f5840c65991be input=967b4a4cbeceb0a8]*/
+/*[clinic end generated code: output=7f7f5840c65991be input=6b70e7e5a8df40fa]*/
 {
     /* We use the unsigned non-checked 'I' format for the 'code' parameter
        because the system expects it to be a 32bit bit field value


### PR DESCRIPTION
~~Function `fcntl_fcntl_impl` is already covered by gh-95429 so it's worth to focus on `fcntl_ioctl_impl` instead by removing duplication of gh-95439.~~

~~Also, regenerated code that converts Python calls into C ones with checks and conversion of arguments.~~