### PR TITLE
gh-95348: Split clear_weakref into two functions

### DIFF
--- a/Misc/NEWS.d/next/C API/2022-07-29-19-35-30.gh-issue-95348.p5CDaH.rst
+++ b/Misc/NEWS.d/next/C API/2022-07-29-19-35-30.gh-issue-95348.p5CDaH.rst
@@ -1,3 +1,4 @@
-Split `clear_weakref` into two functions: `clear_weakref`
-and `remove_weakref`. Abstracts `remove_weakref` with
-`remove_weakref_from_referent`. Patch by Robert O'Shea.
+Split ``clear_weakref`` into two functions: ``clear_weakref``
+and ``remove_weakref``. Abstracts ``remove_weakref`` with
+``remove_weakref_from_referent`` in weakrefobject.c.
+Patch by Robert O'Shea.

--- a/Misc/NEWS.d/next/C API/2022-07-29-19-35-30.gh-issue-95348.p5CDaH.rst
+++ b/Misc/NEWS.d/next/C API/2022-07-29-19-35-30.gh-issue-95348.p5CDaH.rst
@@ -1,4 +1,0 @@
-Split ``clear_weakref`` into two functions: ``clear_weakref``
-and ``remove_weakref``. Abstracts ``remove_weakref`` with
-``remove_weakref_from_referent`` in weakrefobject.c.
-Patch by Robert O'Shea.

--- a/Misc/NEWS.d/next/C API/2022-07-29-19-35-30.gh-issue-95348.p5CDaH.rst
+++ b/Misc/NEWS.d/next/C API/2022-07-29-19-35-30.gh-issue-95348.p5CDaH.rst
@@ -1,0 +1,3 @@
+Split `clear_weakref` into two functions: `clear_weakref`
+and `remove_weakref`. Abstracts `remove_weakref` with
+`remove_weakref_from_referent`. Patch by Robert O'Shea.

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -47,36 +47,41 @@ new_weakref(PyObject *ob, PyObject *callback)
 
 
 /* This function is responsible for clearing the callback slot. When using this
- * It must be called before calling remove_weakref, otherwise a segmentation fault will 
- * occur at build time.
+ * function it must be called before calling remove_weakref_from_referent,
+ * otherwise a segmentation fault will occur at build time.
  */
 static void
 clear_weakref(PyWeakReference *self)
 {
     PyObject *callback = self->wr_callback;
+
     if (callback != NULL) {
         Py_DECREF(callback);
         self->wr_callback = NULL;
     }
 }
 
-/* This function removes the pass in reference from the list of weak references 
- * for the referent. This should be called from remove_weakref_fromt_referent
- * as it will pass the required list argument.
+/* This function removes the pass in reference from the list of weak
+ * references for the referent. This should be called from 
+ * remove_weakref_fromt_referent as it will pass the required list
+ * argument.
  */
 static void
 remove_weakref(PyWeakReference *self, PyWeakReference **list)
 {
-    if (*list == self)
+    if (*list == self) {
         /* If 'self' is the end of the list (and thus self->wr_next == NULL)
             then the weakref list itself (and thus the value of *list) will
             end up being set to NULL. */
         *list = self->wr_next;
+    }
     self->wr_object = Py_None;
-    if (self->wr_prev != NULL)
+    if (self->wr_prev != NULL) {
         self->wr_prev->wr_next = self->wr_next;
-    if (self->wr_next != NULL)
+    }
+    if (self->wr_next != NULL) {
         self->wr_next->wr_prev = self->wr_prev;
+    }
     self->wr_prev = NULL;
     self->wr_next = NULL;
 }


### PR DESCRIPTION
Fixes #95348 

Moves the removal of the passed in reference from a list to a function called `remove_weakref` adding a parameter called `list` that is a list of weak references. Then to abstract the need to get this list a function `remove_weakref_from_referent` has been added to automatically pass the list to the `remove_weakref`.

This is added to make the process more transparent as to what it is doing because as the issue mentions that where `clear_weakref` is used it isn't clear what it is doing.

Functions added:
* `remove_weakref`
* `remove_weakref_from_referent`

`remove_weakref` shouldn't be called by itself as `remove_weakref_from_referent` will call it and pass the list of references.

Also `remove_weakref_from_referent` should always be called after `clear_weakref, otherwise a segmentation fault will occur.

3 tests were found to have failed but seem to occur even without changes to code:
* test_strftime
* test_strptime
* test_time

<!-- gh-issue-number: gh-95348 -->
* Issue: gh-95348
<!-- /gh-issue-number -->
