### PR TITLE
gh-95173: Add a regression test for sorting tuples containing None

### DIFF
--- a/Lib/test/test_sort.py
+++ b/Lib/test/test_sort.py
@@ -380,7 +380,9 @@ class TestOptimizedCompares(unittest.TestCase):
         self.assertRaises(TypeError, [(1, 'a'), ('a', 1)].sort)
 
     def test_none_in_tuples(self):
-        self.assertEqual(sorted([(None, 2), (None, 1)]), [(None, 1), (None, 2)])
+        expected = [(None, 1), (None, 2)]
+        actual = sorted([(None, 2), (None, 1)])
+        self.assertEqual(actual, expected)
 
 #==============================================================================
 

--- a/Lib/test/test_sort.py
+++ b/Lib/test/test_sort.py
@@ -378,6 +378,10 @@ class TestOptimizedCompares(unittest.TestCase):
         self.assertRaises(TypeError, [(1.0, 1.0), (False, "A"), 6].sort)
         self.assertRaises(TypeError, [('a', 1), (1, 'a')].sort)
         self.assertRaises(TypeError, [(1, 'a'), ('a', 1)].sort)
+
+    def test_none_in_tuples(self):
+        self.assertEqual(sorted([(None, 2), (None, 1)]), [(None, 1), (None, 2)])
+
 #==============================================================================
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the test case from #95173 to `test_sort.py`.

<!-- gh-issue-number: gh-95173 -->
* Issue: gh-95173
<!-- /gh-issue-number -->
