### PR TITLE
gh-95472: [xml.etree.ElementTree] Add fine-grained formatting classes

### DIFF
--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -511,6 +511,7 @@ class QName:
 
 # --------------------------------------------------------------------
 
+
 class XMLDeclarationQuotes(enum.Enum):
     """
     Whether or not single quotes or double quotes ought to be used in the XML

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -72,24 +72,12 @@
 
 __all__ = [
     # public symbols
-    "Comment",
-    "dump",
-    "Element", "ElementTree",
-    "fromstring", "fromstringlist",
-    "indent", "iselement", "iterparse",
-    "parse", "ParseError",
-    "PI", "ProcessingInstruction",
-    "QName",
-    "SubElement",
-    "tostring", "tostringlist",
-    "TreeBuilder",
-    "VERSION",
-    "XML", "XMLID",
-    "XMLParser", "XMLPullParser",
-    "register_namespace",
-    "canonicalize", "C14NWriterTarget",
-    "XMLDeclarationQuotes",
-    "ShortEmptyElements"
+    "Comment", "dump", "Element", "ElementTree", "fromstring",
+    "fromstringlist", "indent", "iselement", "iterparse", "parse",
+    "ParseError", "PI", "ProcessingInstruction", "QName", "SubElement",
+    "tostring", "tostringlist", "TreeBuilder", "VERSION", "XML", "XMLID",
+    "XMLParser", "XMLPullParser", "register_namespace", "canonicalize",
+    "C14NWriterTarget", "ShortEmptyElements"
 ]
 
 VERSION = "1.3.0"
@@ -512,21 +500,6 @@ class QName:
 # --------------------------------------------------------------------
 
 
-class XMLDeclarationQuotes(enum.Enum):
-    """
-    Whether or not single quotes or double quotes ought to be used in the XML
-    declaration.
-
-    *SINGLE* (default): <?xml version='1.0' encoding='UTF-8'?>
-    *DOUBLE*: <?xml version="1.0" encoding="UTF-8"?>
-    """
-    SINGLE = "'"
-    DOUBLE = '"'
-
-    def __str__(self):
-        return self.value
-
-
 class ShortEmptyElements(enum.Enum):
     """
     This class creates backwards compatibility with the boolean value of
@@ -738,7 +711,7 @@ class ElementTree:
     def write(self, file_or_filename,
               encoding=None,
               xml_declaration=None,
-              xml_declaration_quotes=XMLDeclarationQuotes.SINGLE,
+              xml_declaration_quotes="'",
               default_namespace=None,
               method=None, *,
               short_empty_elements=True):
@@ -755,7 +728,7 @@ class ElementTree:
                                US-ASCII, UTF-8, or Unicode
 
           *xml_declaration_quotes* -- Changes character used in XML declaration,
-                                      see *XMLDeclarationQuotes*.
+                                      should be a *str*.
 
           *default_namespace* -- sets the default XML namespace (for "xmlns")
 
@@ -781,6 +754,8 @@ class ElementTree:
                 encoding = "utf-8"
             else:
                 encoding = "us-ascii"
+        if not xml_declaration_quotes in ['"', "'"]:
+            raise ValueError("xml_declaration_quotes must be either ' or \"")
         with _get_writer(file_or_filename, encoding) as (write, declared_encoding):
             if method == "xml" and (xml_declaration or
                     (xml_declaration is None and
@@ -788,8 +763,6 @@ class ElementTree:
                      declared_encoding.lower() not in ("utf-8", "us-ascii"))):
                 write("<?xml version={0}1.0{0} encoding={0}{1}{0}?>\n"
                       .format(xml_declaration_quotes, declared_encoding))
-                if not isinstance(xml_declaration_quotes, XMLDeclarationQuotes):
-                    raise ValueError("Unknown type for `xml_declaration_quotes`")
             if method == "text":
                 _serialize_text(write, self._root)
             else:

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -88,7 +88,9 @@ __all__ = [
     "XMLParser", "XMLPullParser",
     "register_namespace",
     "canonicalize", "C14NWriterTarget",
-    ]
+    "XMLDeclarationQuotes",
+    "ShortEmptyElements"
+]
 
 VERSION = "1.3.0"
 
@@ -99,6 +101,7 @@ import io
 import collections
 import collections.abc
 import contextlib
+import enum
 
 from . import ElementPath
 
@@ -508,6 +511,58 @@ class QName:
 
 # --------------------------------------------------------------------
 
+class XMLDeclarationQuotes(enum.Enum):
+    """
+    Whether or not single quotes or double quotes ought to be used in the XML
+    declaration.
+
+    *SINGLE* (default): <?xml version='1.0' encoding='UTF-8'?>
+    *DOUBLE*: <?xml version="1.0" encoding="UTF-8"?>
+    """
+    SINGLE = "'"
+    DOUBLE = '"'
+
+    def __str__(self):
+        return self.value
+
+class ShortEmptyElements(enum.Enum):
+    """
+    This class creates backwards compatibility with the boolean value of
+    *short_empty_elements* that existed prior to 3.??.
+
+    Assuming the tag `<q/>`, the results will be:
+
+    *SPACE* (default): `<q />`
+    *NOSPACE*: `<q/>`
+    *NONE*: `<q></q>`
+    """
+    SPACE = " "
+    NOSPACE = ""
+    NONE = False
+
+    def __bool__(self):
+        return self != ShortEmptyElements.NONE
+
+    @classmethod
+    def _missing_(cls, value):
+        if value is enum.no_arg:
+            return cls.SPACE
+        elif isinstance(value, bool):
+            return cls.SPACE if value else cls.NONE
+        else:
+            return super()._missing_(value)
+
+    @classmethod
+    def tag_defaultdict(cls, short_empty_elements):
+        if not isinstance(short_empty_elements, collections.defaultdict):
+            if isinstance(short_empty_elements, ShortEmptyElements):
+                return collections.defaultdict(lambda: short_empty_elements)
+            elif bool(short_empty_elements) is True:
+                return collections.defaultdict(lambda: ShortEmptyElements.SPACE)
+            else:
+                return collections.defaultdict(lambda: ShortEmptyElements.NONE)
+        else:
+            return short_empty_elements
 
 class ElementTree:
     """An XML element hierarchy.
@@ -680,6 +735,7 @@ class ElementTree:
     def write(self, file_or_filename,
               encoding=None,
               xml_declaration=None,
+              xml_declaration_quotes=XMLDeclarationQuotes.SINGLE,
               default_namespace=None,
               method=None, *,
               short_empty_elements=True):
@@ -695,6 +751,9 @@ class ElementTree:
                                is added if encoding IS NOT either of:
                                US-ASCII, UTF-8, or Unicode
 
+          *xml_declaration_quotes* -- Changes character used in XML declaration,
+                                      see *XMLDeclarationQuotes*.
+
           *default_namespace* -- sets the default XML namespace (for "xmlns")
 
           *method* -- either "xml" (default), "html, "text", or "c14n"
@@ -703,8 +762,12 @@ class ElementTree:
                                     that contain no content. If True (default)
                                     they are emitted as a single self-closed
                                     tag, otherwise they are emitted as a pair
-                                    of start/end tags
+                                    of start/end tags.
 
+                                    For more control, can be a
+                                    *ShortEmptyElements* object, or a
+                                    defaultdict keyed by tags as strings and
+                                    valued with such objects.
         """
         if not method:
             method = "xml"
@@ -720,13 +783,16 @@ class ElementTree:
                     (xml_declaration is None and
                      encoding.lower() != "unicode" and
                      declared_encoding.lower() not in ("utf-8", "us-ascii"))):
-                write("<?xml version='1.0' encoding='%s'?>\n" % (
-                    declared_encoding,))
+                write("<?xml version={0}1.0{0} encoding={0}{1}{0}?>\n"
+                      .format(xml_declaration_quotes, declared_encoding))
+                if not isinstance(xml_declaration_quotes, XMLDeclarationQuotes):
+                    raise ValueError("Unknown type for `xml_declaration_quotes`")
             if method == "text":
                 _serialize_text(write, self._root)
             else:
                 qnames, namespaces = _namespaces(self._root, default_namespace)
                 serialize = _serialize[method]
+                short_empty_elements = ShortEmptyElements.tag_defaultdict(short_empty_elements)
                 serialize(write, self._root, qnames, namespaces,
                           short_empty_elements=short_empty_elements)
 
@@ -885,7 +951,7 @@ def _serialize_xml(write, elem, qnames, namespaces,
                     else:
                         v = _escape_attrib(v)
                     write(" %s=\"%s\"" % (qnames[k], v))
-            if text or len(elem) or not short_empty_elements:
+            if text or len(elem) or not bool(short_empty_elements[tag]):
                 write(">")
                 if text:
                     write(_escape_cdata(text))
@@ -894,7 +960,7 @@ def _serialize_xml(write, elem, qnames, namespaces,
                                    short_empty_elements=short_empty_elements)
                 write("</" + tag + ">")
             else:
-                write(" />")
+                write(short_empty_elements[tag].value+"/>")
     if elem.tail:
         write(_escape_cdata(elem.tail))
 

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -525,6 +525,7 @@ class XMLDeclarationQuotes(enum.Enum):
     def __str__(self):
         return self.value
 
+
 class ShortEmptyElements(enum.Enum):
     """
     This class creates backwards compatibility with the boolean value of
@@ -557,12 +558,13 @@ class ShortEmptyElements(enum.Enum):
         if not isinstance(short_empty_elements, collections.defaultdict):
             if isinstance(short_empty_elements, ShortEmptyElements):
                 return collections.defaultdict(lambda: short_empty_elements)
-            elif bool(short_empty_elements) is True:
+            elif short_empty_elements:
                 return collections.defaultdict(lambda: ShortEmptyElements.SPACE)
             else:
                 return collections.defaultdict(lambda: ShortEmptyElements.NONE)
         else:
             return short_empty_elements
+
 
 class ElementTree:
     """An XML element hierarchy.
@@ -951,7 +953,7 @@ def _serialize_xml(write, elem, qnames, namespaces,
                     else:
                         v = _escape_attrib(v)
                     write(" %s=\"%s\"" % (qnames[k], v))
-            if text or len(elem) or not bool(short_empty_elements[tag]):
+            if text or len(elem) or not short_empty_elements[tag]:
                 write(">")
                 if text:
                     write(_escape_cdata(text))

--- a/Misc/NEWS.d/next/Library/2022-07-30-19-41-52.gh-issue-95472.7GOJ4U.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-30-19-41-52.gh-issue-95472.7GOJ4U.rst
@@ -1,0 +1,1 @@
+Added two fine-grained formatting options to ``xml.etree.ElementTree`` so programmers can prevent Git diffs from occurring due to incompatible XML libraries. Spaces can now be eliminated in e.g. ``<q />`` (as ``<q/>``) (``ShortEmptyElements``), and double quotes can be used in the XML declaration (``XMLDeclarationQuotes``).


### PR DESCRIPTION
* ShortEmptyElements — make it possible to remove space between end of
  tag and slash, also make it possible to turn this on and off based on
  tag being processed via `defaultdict`.
* XMLDeclarationQuotes — change quote char used in XML declaration from
  `'` to `"`.

Closes #95472.


<!-- gh-issue-number: gh-95472 -->
* Issue: gh-95472
<!-- /gh-issue-number -->
