### PR TITLE
gh-95484: Improve `tempfile` docs for conditions when files are removed

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -32,17 +32,18 @@ The module defines the following user-callable items:
 .. function:: TemporaryFile(mode='w+b', buffering=-1, encoding=None, newline=None, suffix=None, prefix=None, dir=None, *, errors=None)
 
    Return a :term:`file-like object` that can be used as a temporary storage area.
-   The file is created securely, using the same rules as :func:`mkstemp`. It will be destroyed as soon
-   as it is closed (including an implicit close when the object is garbage
-   collected).  Under Unix, the directory entry for the file is either not created at all or is removed
-   immediately after the file is created.  Other platforms do not support
+   The file is created securely, using the same rules as :func:`mkstemp`.
+   Under Unix, the directory entry for the file is either not created at all or is
+   removed immediately after the file is created.  Other platforms do not support
    this; your code should not rely on a temporary file created using this
    function having or not having a visible name in the file system.
 
-   The resulting object can be used as a :term:`context manager` (see
-   :ref:`tempfile-examples`).  On completion of the context or
-   destruction of the file object the temporary file will be removed
-   from the filesystem.
+   The temporary file will be removed from the file system under the following conditions:
+
+   - It is closed.
+   - or, it is garbage collected (and is implicitly closed)
+   - or, at the completion of the context if used as a context manager (see
+     :ref:`tempfile-examples`)
 
    The *mode* parameter defaults to ``'w+b'`` so that the file created can
    be read and written without being closed.  Binary mode is used so that it


### PR DESCRIPTION
Lightly edit some prose. On my initial read of the docs, I was confused about when tempfiles are deleted. I think this PR would have helped me.

Now there are two paragraphs, the first one has to do with "creating a tempfile" and the second is "deleting a tempfile". I think this is a better way of organizing things than what it used to be.

Before, an entire paragraph was about "using as a context manager", which I think is less important than "when is a tempfile deleted". The first paragraph was "what happens when you make a tempfile and also here is one way of when it is closed"

<!-- gh-issue-number: gh-95484 -->
* Issue: gh-95484
<!-- /gh-issue-number -->
