### PR TITLE
gh-95468: Fixes issue with ArgumentParser skipping '--' options

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2455,7 +2455,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     # ========================
     def _get_values(self, action, arg_strings):
         # for everything but PARSER, REMAINDER args, strip out first '--'
-        if action.nargs not in [PARSER, REMAINDER]:
+        if action.nargs not in [PARSER, REMAINDER, ONE_OR_MORE]:
             try:
                 arg_strings.remove('--')
             except ValueError:

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2455,7 +2455,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     # ========================
     def _get_values(self, action, arg_strings):
         # for everything but PARSER, REMAINDER args, strip out first '--'
-        if action.nargs not in [PARSER, REMAINDER, ONE_OR_MORE]:
+        if action.nargs not in [PARSER, REMAINDER, ZERO_OR_MORE, ONE_OR_MORE]:
             try:
                 arg_strings.remove('--')
             except ValueError:

--- a/Misc/NEWS.d/next/Library/2022-07-31-01-44-20.gh-issue-95468._4NAAA.rst
+++ b/Misc/NEWS.d/next/Library/2022-07-31-01-44-20.gh-issue-95468._4NAAA.rst
@@ -1,0 +1,2 @@
+Fixed an issue where multiple "--" arguments were not returned by
+`ArgumentParser`. Pathch by Robert O'Shea


### PR DESCRIPTION
Fixes #95468

ArgumentParser does not pass over '--' characters when nargs is set to `*`, `+` or `...` now.


Example program:

```py
import argparse

for nargs in [ '+', '*', '...' ]:
    p = argparse.ArgumentParser()
    p.add_argument('arg1', type=str)
    p.add_argument('args', nargs=nargs)
    p.add_argument('arg2', type=str)
    print(p.parse_args(['foo', '--', '--bar', '--', 'com', "last"]))
```

<!-- gh-issue-number: gh-95468 -->
* Issue: gh-95468
<!-- /gh-issue-number -->
