### PR TITLE
gh-91146: More reduce allocation size of list from str.split/rsplit

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-31-03-22-58.gh-issue-91146.Y2Hziy.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-31-03-22-58.gh-issue-91146.Y2Hziy.rst
@@ -1,2 +1,2 @@
 Reduce allocation size of :class:`list` from :meth:`str.split`
-and :meth:`str.rsplit`. Patch by Dong-hee Na.
+and :meth:`str.rsplit`. Patch by Dong-hee Na and Inada Naoki.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9701,7 +9701,7 @@ split(PyObject *self,
 
     if (substring == NULL) {
         if (maxcount < 0) {
-            maxcount = (len1 + 1) / 2;
+            maxcount = (len1 - 1) / 2 + 1;
         }
         switch (kind1) {
         case PyUnicode_1BYTE_KIND:
@@ -9733,7 +9733,7 @@ split(PyObject *self,
     kind2 = PyUnicode_KIND(substring);
     len2 = PyUnicode_GET_LENGTH(substring);
     if (maxcount < 0) {
-        // if len2 == 0, it will raise TypeError.
+        // if len2 == 0, it will raise ValueError.
         maxcount = len2 == 0 ? 0 : (len1 / len2) + 1;
     }
     if (kind1 < kind2 || len1 < len2) {
@@ -9793,7 +9793,7 @@ rsplit(PyObject *self,
 
     if (substring == NULL) {
         if (maxcount < 0) {
-            maxcount = (len1 + 1) / 2;
+            maxcount = (len1 - 1) / 2 + 1;
         }
         switch (kind1) {
         case PyUnicode_1BYTE_KIND:
@@ -9824,7 +9824,7 @@ rsplit(PyObject *self,
     kind2 = PyUnicode_KIND(substring);
     len2 = PyUnicode_GET_LENGTH(substring);
     if (maxcount < 0) {
-        // if len2 == 0, it will raise TypeError.
+        // if len2 == 0, it will raise ValueError.
         maxcount = len2 == 0 ? 0 : (len1 / len2) + 1;
     }
     if (kind1 < kind2 || len1 < len2) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9698,11 +9698,11 @@ split(PyObject *self,
     PyObject* out;
     len1 = PyUnicode_GET_LENGTH(self);
     kind1 = PyUnicode_KIND(self);
-    if (maxcount < 0) {
-        maxcount = len1;
-    }
 
-    if (substring == NULL)
+    if (substring == NULL) {
+        if (maxcount < 0) {
+            maxcount = (len1 + 1) / 2;
+        }
         switch (kind1) {
         case PyUnicode_1BYTE_KIND:
             if (PyUnicode_IS_ASCII(self))
@@ -9728,9 +9728,13 @@ split(PyObject *self,
         default:
             Py_UNREACHABLE();
         }
+    }
 
     kind2 = PyUnicode_KIND(substring);
     len2 = PyUnicode_GET_LENGTH(substring);
+    if (maxcount < 0) {
+        maxcount = len1 / len2 + 1;
+    }
     if (kind1 < kind2 || len1 < len2) {
         out = PyList_New(1);
         if (out == NULL)
@@ -9785,11 +9789,11 @@ rsplit(PyObject *self,
 
     len1 = PyUnicode_GET_LENGTH(self);
     kind1 = PyUnicode_KIND(self);
-    if (maxcount < 0) {
-        maxcount = len1;
-    }
 
-    if (substring == NULL)
+    if (substring == NULL) {
+        if (maxcount < 0) {
+            maxcount = (len1 + 1) / 2;
+        }
         switch (kind1) {
         case PyUnicode_1BYTE_KIND:
             if (PyUnicode_IS_ASCII(self))
@@ -9815,9 +9819,12 @@ rsplit(PyObject *self,
         default:
             Py_UNREACHABLE();
         }
-
+    }
     kind2 = PyUnicode_KIND(substring);
     len2 = PyUnicode_GET_LENGTH(substring);
+    if (maxcount < 0) {
+        maxcount = len1 / len2 + 1;
+    }
     if (kind1 < kind2 || len1 < len2) {
         out = PyList_New(1);
         if (out == NULL)

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9735,6 +9735,8 @@ split(PyObject *self,
     if (maxcount < 0) {
         // if len2 == 0, it will raise ValueError.
         maxcount = len2 == 0 ? 0 : (len1 / len2) + 1;
+        // handle expected overflow case: (Py_SSIZE_T_MAX / 1) + 1
+        maxcount = maxcount < 0 ? len1 : maxcount;
     }
     if (kind1 < kind2 || len1 < len2) {
         out = PyList_New(1);
@@ -9826,6 +9828,8 @@ rsplit(PyObject *self,
     if (maxcount < 0) {
         // if len2 == 0, it will raise ValueError.
         maxcount = len2 == 0 ? 0 : (len1 / len2) + 1;
+        // handle expected overflow case: (Py_SSIZE_T_MAX / 1) + 1
+        maxcount = maxcount < 0 ? len1 : maxcount;
     }
     if (kind1 < kind2 || len1 < len2) {
         out = PyList_New(1);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9733,7 +9733,7 @@ split(PyObject *self,
     kind2 = PyUnicode_KIND(substring);
     len2 = PyUnicode_GET_LENGTH(substring);
     if (maxcount < 0) {
-        maxcount = len1 / len2 + 1;
+        maxcount = len2 == 0 ? (len1 + 1) / 2 : (len1 / len2) + 1;
     }
     if (kind1 < kind2 || len1 < len2) {
         out = PyList_New(1);
@@ -9823,7 +9823,7 @@ rsplit(PyObject *self,
     kind2 = PyUnicode_KIND(substring);
     len2 = PyUnicode_GET_LENGTH(substring);
     if (maxcount < 0) {
-        maxcount = len1 / len2 + 1;
+        maxcount = len2 == 0 ? (len1 + 1) / 2 : (len1 / len2) + 1;
     }
     if (kind1 < kind2 || len1 < len2) {
         out = PyList_New(1);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9733,7 +9733,8 @@ split(PyObject *self,
     kind2 = PyUnicode_KIND(substring);
     len2 = PyUnicode_GET_LENGTH(substring);
     if (maxcount < 0) {
-        maxcount = len2 == 0 ? (len1 + 1) / 2 : (len1 / len2) + 1;
+        // if len2 == 0, it will raise TypeError.
+        maxcount = len2 == 0 ? 0 : (len1 / len2) + 1;
     }
     if (kind1 < kind2 || len1 < len2) {
         out = PyList_New(1);
@@ -9823,7 +9824,8 @@ rsplit(PyObject *self,
     kind2 = PyUnicode_KIND(substring);
     len2 = PyUnicode_GET_LENGTH(substring);
     if (maxcount < 0) {
-        maxcount = len2 == 0 ? (len1 + 1) / 2 : (len1 / len2) + 1;
+        // if len2 == 0, it will raise TypeError.
+        maxcount = len2 == 0 ? 0 : (len1 / len2) + 1;
     }
     if (kind1 < kind2 || len1 < len2) {
         out = PyList_New(1);


### PR DESCRIPTION
## Memory size
### AS-IS 50b2261bdac98303087287b24eef96abd45a82f9
```

>>> import sys
>>> s = "1 2".split()
>>> sys.getsizeof(s)
88
>>> s = "12345".split()
>>> sys.getsizeof(s)
104
>>> s = "1 2 3 4 5".split()
>>> sys.getsizeof(s)
136
>>> s = "1 2 3 4 5 1 2 3 4 5 1 2 3 4 5 1 2 3 4 5 1 2 3 4 5".split()
>>> sys.getsizeof(s)
280
```

### TO-BE (Allocation is reduced & No regression)
```
>>> import sys
>>> s = "1 2".split()
>>> sys.getsizeof(s)
80
>>> s = "12345".split()
>>> sys.getsizeof(s)
88
>>> s = "1 2 3 4 5".split()
>>> sys.getsizeof(s)
104
>>> s = "1 2 3 4 5 1 2 3 4 5 1 2 3 4 5 1 2 3 4 5 1 2 3 4 5".split()
>>> sys.getsizeof(s)
280
```

## Performance: No regression
### Script
````python

import pyperf

def bench_split_tiny():
    s = "1 2".split()

def bench_split_small():
    s = "1 2 3 4 5".split()

def bench_split_larger():
    s = "1 2 3 4 5 1 2 3 4 5 1 2 3 4 5 1 2 3 4 5 1 2 3 4 5".split()

def bench_split_tiny_append():
    s = "1 2".split()
    for e in range(100):
        s.append("9")

def bench_split_small_append():
    s = "1 2 3 4 5".split()
    for e in range(100):
        s.append("9")

def bench_split_larger_append():
    s = "1 2 3 4 5 1 2 3 4 5 1 2 3 4 5 1 2 3 4 5 1 2 3 4 5".split()
    for e in range(100):
        s.append("9")

runner = pyperf.Runner()
runner.bench_func('bench_split_tiny', bench_split_tiny)
runner.bench_func('bench_split_small', bench_split_small)
runner.bench_func('bench_split_larger', bench_split_larger)
runner.bench_func('bench_split_tiny_append', bench_split_tiny_append)
runner.bench_func('bench_split_small_append', bench_split_small_append)
runner.bench_func('bench_split_larger_append', bench_split_larger_append)

````

### Result
| Benchmark                | origin (before https://github.com/python/cpython/commit/50b2261bdac98303087287b24eef96abd45a82f9)  | 50b2261bdac98303087287b24eef96abd45a82f9                  | PR                   |
|--------------------------|:-------:|:---------------------:|:---------------------:|
| bench_split_small        | 63.3 ns | 62.5 ns: 1.01x faster | 62.5 ns: 1.01x faster |
| bench_split_larger       | 164 ns  | 166 ns: 1.01x slower  | not significant       |
| bench_split_small_append | 1.61 us | 1.56 us: 1.03x faster | not significant       |
| Geometric mean           | (ref)   | 1.00x faster          | 1.00x faster          |

Benchmark hidden because not significant (3): bench_split_tiny, bench_split_tiny_append, bench_split_larger_append

<!-- gh-issue-number: gh-91146 -->
* Issue: gh-91146
<!-- /gh-issue-number -->
