### PR TITLE
gh-56133: Clarify function/constructor parameter for pickle module

### DIFF
--- a/Doc/library/copyreg.rst
+++ b/Doc/library/copyreg.rst
@@ -25,14 +25,14 @@ Such constructors may be factory functions or class instances.
    hence not valid as a constructor), raises :exc:`TypeError`.
 
 
-.. function:: pickle(type, function, constructor=None)
+.. function:: pickle(type, function, constructor_ob=None)
 
    Declares that *function* should be used as a "reduction" function for objects
    of type *type*.  *function* should return either a string or a tuple
    containing two or three elements. See the :attr:`~pickle.Pickler.dispatch_table`
    for more details on the interface of *function*.
 
-   The *constructor* parameter is a legacy feature and is now ignored, but if
+   The *constructor_ob* parameter is a legacy feature and is now ignored, but if
    passed it must be a callable.
 
    Note that the :attr:`~pickle.Pickler.dispatch_table` attribute of a pickler

--- a/Doc/library/copyreg.rst
+++ b/Doc/library/copyreg.rst
@@ -32,8 +32,8 @@ Such constructors may be factory functions or class instances.
    containing two or three elements. See the :attr:`~pickle.Pickler.dispatch_table`
    for more details on the interface of *function*.
 
-   The optional *constructor* parameter, if provided, validates that
-   *constructor* is callable, and if uncallable then :exc:`TypeError` is raised.
+   The *constructor* parameter is a legacy feature and is now ignored, but if
+   passed it must be a callable.
 
    Note that the :attr:`~pickle.Pickler.dispatch_table` attribute of a pickler
    object or subclass of :class:`pickle.Pickler` can also be used for

--- a/Doc/library/copyreg.rst
+++ b/Doc/library/copyreg.rst
@@ -29,16 +29,13 @@ Such constructors may be factory functions or class instances.
 
    Declares that *function* should be used as a "reduction" function for objects
    of type *type*.  *function* should return either a string or a tuple
-   containing two or three elements.
+   containing two or three elements. See the :attr:`~pickle.Pickler.dispatch_table`
+   for more details on the interface of *function*.
 
-   The optional *constructor* parameter, if provided, is a callable object which
-   can be used to reconstruct the object when called with the tuple of arguments
-   returned by *function* at pickling time.  A :exc:`TypeError` is raised if the
-   *constructor* is not callable.
+   The optional *constructor* parameter, if provided, validates that
+   *constructor* is callable, and if uncallable then :exc:`TypeError` is raised.
 
-   See the :mod:`pickle` module for more details on the interface
-   expected of *function* and *constructor*.  Note that the
-   :attr:`~pickle.Pickler.dispatch_table` attribute of a pickler
+   Note that the :attr:`~pickle.Pickler.dispatch_table` attribute of a pickler
    object or subclass of :class:`pickle.Pickler` can also be used for
    declaring reduction functions.
 


### PR DESCRIPTION
The `dispatch_table` doc was added in [this commit](https://github.com/python/cpython/commit/8d3c290de4de275fc725b116050ea9d109af1ba8#diff-f288883aeb98d2d81a4f44ab1ce1f644a62180b2584f0c226e0b3b7a105d1a2b), which adds many more 'copyreg' references to the `pickle` doc, but finding info on the function/constructor parameter isn't too clear.

Constructor argument doesn't seem to do anything:
https://github.com/python/cpython/blob/50b2261bdac98303087287b24eef96abd45a82f9/Lib/copyreg.py#L17-L24

<!-- gh-issue-number: gh-56133 -->
* Issue: gh-56133
<!-- /gh-issue-number -->
