### PR TITLE
gh-95511: IDLE - fix Shell context menu copy-with-prompts bug

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -4,6 +4,9 @@ Released on 2022-10-03
 =========================
 
 
+gh-95511: Fix the Shell context menu copy-with-prompts bug of copying
+an extra line when one selects whole lines.
+
 gh-95471: Tweak Edit menu. Move 'Select All' above 'Cut' as it is used
 with 'Cut' and 'Copy' but not 'Paste'.  Add a separator between 'Replace'
 and 'Go to Line' to help IDLE issue triagers.

--- a/Lib/idlelib/idle_test/test_sidebar.py
+++ b/Lib/idlelib/idle_test/test_sidebar.py
@@ -733,7 +733,7 @@ class ShellSidebarTest(unittest.TestCase):
         first_line = get_end_linenumber(text)
         self.do_input(dedent('''\
             if True:
-            print(1)
+                print(1)
 
             '''))
         yield
@@ -744,9 +744,10 @@ class ShellSidebarTest(unittest.TestCase):
 
         selected_lines_text = text.get('sel.first linestart', 'sel.last')
         selected_lines = selected_lines_text.split('\n')
-        # Expect a block of input, a single output line, and a new prompt
+        selected_lines.pop()  # Final '' is a split artifact, not a line.
+        # Expect a block of input and a single output line.
         expected_prompts = \
-            ['>>>'] + ['...'] * (len(selected_lines) - 3) + [None, '>>>']
+            ['>>>'] + ['...'] * (len(selected_lines) - 2) + [None]
         selected_text_with_prompts = '\n'.join(
             line if prompt is None else prompt + ' ' + line
             for prompt, line in zip(expected_prompts,

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -996,19 +996,17 @@ class PyShell(OutputWindow):
         and/or last lines is selected.
         """
         text = self.text
+        selfirst = text.index('sel.first linestart')
+        if selfirst is None:  # Should not be possible.
+            return  # No selection, do nothing.
+        sellast = text.index('sel.last')
+        if sellast[-1] != '0':
+            sellast = text.index("sel.last+1line linestart")
 
-        selection_indexes = (
-            self.text.index("sel.first linestart"),
-            self.text.index("sel.last +1line linestart"),
-        )
-        if selection_indexes[0] is None:
-            # There is no selection, so do nothing.
-            return
-
-        selected_text = self.text.get(*selection_indexes)
+        selected_text = self.text.get(selfirst, sellast)
         selection_lineno_range = range(
-            int(float(selection_indexes[0])),
-            int(float(selection_indexes[1]))
+            int(float(selfirst)),
+            int(float(sellast))
         )
         prompts = [
             self.shell_sidebar.line_prompts.get(lineno)

--- a/Misc/NEWS.d/next/IDLE/2022-07-31-22-15-14.gh-issue-95511.WX6PmB.rst
+++ b/Misc/NEWS.d/next/IDLE/2022-07-31-22-15-14.gh-issue-95511.WX6PmB.rst
@@ -1,0 +1,2 @@
+Fix the Shell context menu copy-with-prompts bug of copying an extra line
+when one selects whole lines.


### PR DESCRIPTION
If one selects whole lines, as the sidebar makes easy, do not
add an extra line.  Only move the end of a selection to the
beginning of the next line when not already at the beginning
of a line.  (Also improve the surrounding code.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95511 -->
* Issue: gh-#95511
<!-- /gh-issue-number -->
