### PR TITLE
gh-91838: Use HTTPS links in docs for resources which redirect to HTTPS

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -6,19 +6,19 @@ Build Status
 
 - main
 
-  + `Stable buildbots <http://buildbot.python.org/3.x.stable/>`_
+  + `Stable buildbots <https://buildbot.python.org/3.x.stable/>`_
 
 - 3.9
 
-  + `Stable buildbots <http://buildbot.python.org/3.9.stable/>`_
+  + `Stable buildbots <https://buildbot.python.org/3.9.stable/>`_
 
 - 3.8
 
-  + `Stable buildbots <http://buildbot.python.org/3.8.stable/>`_
+  + `Stable buildbots <https://buildbot.python.org/3.8.stable/>`_
 
 - 3.7
 
-  + `Stable buildbots <http://buildbot.python.org/3.7.stable/>`_
+  + `Stable buildbots <https://buildbot.python.org/3.7.stable/>`_
 
 
 Thank You

--- a/Doc/extending/index.rst
+++ b/Doc/extending/index.rst
@@ -27,8 +27,8 @@ Recommended third party tools
 
 This guide only covers the basic tools for creating extensions provided
 as part of this version of CPython. Third party tools like
-`Cython <http://cython.org/>`_, `cffi <https://cffi.readthedocs.io>`_,
-`SWIG <http://www.swig.org>`_ and `Numba <https://numba.pydata.org/>`_
+`Cython <https://cython.org/>`_, `cffi <https://cffi.readthedocs.io>`_,
+`SWIG <https://www.swig.org>`_ and `Numba <https://numba.pydata.org/>`_
 offer both simpler and more sophisticated approaches to creating C and C++
 extensions for Python.
 

--- a/Doc/faq/design.rst
+++ b/Doc/faq/design.rst
@@ -321,8 +321,8 @@ is exactly the same type of object that a lambda expression yields) is assigned!
 Can Python be compiled to machine code, C or some other language?
 -----------------------------------------------------------------
 
-`Cython <http://cython.org/>`_ compiles a modified version of Python with
-optional annotations into C extensions.  `Nuitka <http://www.nuitka.net/>`_ is
+`Cython <https://cython.org/>`_ compiles a modified version of Python with
+optional annotations into C extensions.  `Nuitka <https://www.nuitka.net/>`_ is
 an up-and-coming compiler of Python into C++ code, aiming to support the full
 Python language.
 
@@ -338,8 +338,8 @@ cycles and deletes the objects involved. The :mod:`gc` module provides functions
 to perform a garbage collection, obtain debugging statistics, and tune the
 collector's parameters.
 
-Other implementations (such as `Jython <http://www.jython.org>`_ or
-`PyPy <http://www.pypy.org>`_), however, can rely on a different mechanism
+Other implementations (such as `Jython <https://www.jython.org>`_ or
+`PyPy <https://www.pypy.org>`_), however, can rely on a different mechanism
 such as a full-blown garbage collector.  This difference can cause some
 subtle porting problems if your Python code depends on the behavior of the
 reference counting implementation.

--- a/Doc/faq/extending.rst
+++ b/Doc/faq/extending.rst
@@ -41,7 +41,7 @@ on what you're trying to do.
 
 .. XXX make sure these all work
 
-`Cython <http://cython.org>`_ and its relative `Pyrex
+`Cython <https://cython.org>`_ and its relative `Pyrex
 <https://www.cosc.canterbury.ac.nz/greg.ewing/python/Pyrex/>`_ are compilers
 that accept a slightly modified form of Python and generate the corresponding
 C code.  Cython and Pyrex make it possible to write an extension without having
@@ -49,10 +49,10 @@ to learn Python's C API.
 
 If you need to interface to some C or C++ library for which no Python extension
 currently exists, you can try wrapping the library's data types and functions
-with a tool such as `SWIG <http://www.swig.org>`_.  `SIP
+with a tool such as `SWIG <https://www.swig.org>`_.  `SIP
 <https://riverbankcomputing.com/software/sip/intro>`__, `CXX
 <http://cxx.sourceforge.net/>`_ `Boost
-<http://www.boost.org/libs/python/doc/index.html>`_, or `Weave
+<https://www.boost.org/libs/python/doc/index.html>`_, or `Weave
 <https://github.com/scipy/weave>`_ are also
 alternatives for wrapping C++ libraries.
 
@@ -286,6 +286,6 @@ Can I create an object class with some methods implemented in C and others in Py
 Yes, you can inherit from built-in classes such as :class:`int`, :class:`list`,
 :class:`dict`, etc.
 
-The Boost Python Library (BPL, http://www.boost.org/libs/python/doc/index.html)
+The Boost Python Library (BPL, https://www.boost.org/libs/python/doc/index.html)
 provides a way of doing this from C++ (i.e. you can inherit from an extension
 class written in C++ using the BPL).

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1066,7 +1066,7 @@ performance levels:
   detrimental to readability).
 
 If you have reached the limit of what pure Python can allow, there are tools
-to take you further away.  For example, `Cython <http://cython.org>`_ can
+to take you further away.  For example, `Cython <https://cython.org>`_ can
 compile a slightly modified version of Python code into a C extension, and
 can be used on many different platforms.  Cython can take advantage of
 compilation (and optional type annotations) to make your code significantly

--- a/Doc/howto/cporting.rst
+++ b/Doc/howto/cporting.rst
@@ -22,5 +22,5 @@ We recommend the following resources for porting extension modules to Python 3:
 
 .. _Migrating C extensions: http://python3porting.com/cextensions.html
 .. _Porting guide: https://py3c.readthedocs.io/en/latest/guide.html
-.. _Cython: http://cython.org/
+.. _Cython: https://cython.org/
 .. _CFFI: https://cffi.readthedocs.io/en/latest/

--- a/Doc/howto/curses.rst
+++ b/Doc/howto/curses.rst
@@ -536,10 +536,10 @@ Patches adding support for these would be welcome; see
 `the Python Developer's Guide <https://devguide.python.org/>`_ to
 learn more about submitting patches to Python.
 
-* `Writing Programs with NCURSES <http://invisible-island.net/ncurses/ncurses-intro.html>`_:
+* `Writing Programs with NCURSES <https://invisible-island.net/ncurses/ncurses-intro.html>`_:
   a lengthy tutorial for C programmers.
 * `The ncurses man page <https://linux.die.net/man/3/ncurses>`_
-* `The ncurses FAQ <http://invisible-island.net/ncurses/ncurses.faq.html>`_
+* `The ncurses FAQ <https://invisible-island.net/ncurses/ncurses.faq.html>`_
 * `"Use curses... don't swear" <https://www.youtube.com/watch?v=eN1eZtjLEnU>`_:
   video of a PyCon 2013 talk on controlling terminals using curses or Urwid.
 * `"Console Applications with Urwid" <http://www.pyvideo.org/video/1568/console-applications-with-urwid>`_:

--- a/Doc/howto/functional.rst
+++ b/Doc/howto/functional.rst
@@ -1215,7 +1215,7 @@ flow inside a program.  The book uses Scheme for its examples, but many of the
 design approaches described in these chapters are applicable to functional-style
 Python code.
 
-http://www.defmacro.org/ramblings/fp.html: A general introduction to functional
+https://www.defmacro.org/ramblings/fp.html: A general introduction to functional
 programming that uses Java examples and has a lengthy historical introduction.
 
 https://en.wikipedia.org/wiki/Functional_programming: General Wikipedia entry
@@ -1228,7 +1228,7 @@ https://en.wikipedia.org/wiki/Currying: Entry for the concept of currying.
 Python-specific
 ---------------
 
-http://gnosis.cx/TPiP/: The first chapter of David Mertz's book
+https://gnosis.cx/TPiP/: The first chapter of David Mertz's book
 :title-reference:`Text Processing in Python` discusses functional programming
 for text processing, in the section titled "Utilizing Higher-Order Functions in
 Text Processing".

--- a/Doc/howto/pyporting.rst
+++ b/Doc/howto/pyporting.rst
@@ -433,9 +433,9 @@ to make sure everything functions as expected in both versions of Python.
 
 
 .. _caniusepython3: https://pypi.org/project/caniusepython3
-.. _cheat sheet: http://python-future.org/compatible_idioms.html
+.. _cheat sheet: https://python-future.org/compatible_idioms.html
 .. _coverage.py: https://pypi.org/project/coverage
-.. _Futurize: http://python-future.org/automatic_conversion.html
+.. _Futurize: https://python-future.org/automatic_conversion.html
 .. _importlib2: https://pypi.org/project/importlib2
 .. _Modernize: https://python-modernize.readthedocs.io/
 .. _mypy: http://mypy-lang.org/
@@ -445,7 +445,7 @@ to make sure everything functions as expected in both versions of Python.
 .. _Python 3 Q & A: https://ncoghlan-devs-python-notes.readthedocs.io/en/latest/python3/questions_and_answers.html
 
 .. _pytype: https://github.com/google/pytype
-.. _python-future: http://python-future.org/
+.. _python-future: https://python-future.org/
 .. _python-porting: https://mail.python.org/pipermail/python-porting/
 .. _six: https://pypi.org/project/six
 .. _tox: https://pypi.org/project/tox

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -167,7 +167,7 @@ On the Computerphile Youtube channel, Tom Scott briefly
 (9 minutes 36 seconds).
 
 To help understand the standard, Jukka Korpela has written `an introductory
-guide <http://jkorpela.fi/unicode/guide.html>`_ to reading the
+guide <https://jkorpela.fi/unicode/guide.html>`_ to reading the
 Unicode character tables.
 
 Another `good introductory article <https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/>`_
@@ -735,7 +735,7 @@ References
 ----------
 
 One section of `Mastering Python 3 Input/Output
-<http://pyvideo.org/video/289/pycon-2010--mastering-python-3-i-o>`_,
+<https://pyvideo.org/video/289/pycon-2010--mastering-python-3-i-o>`_,
 a PyCon 2010 talk by David Beazley, discusses text processing and binary data handling.
 
 The `PDF slides for Marc-André Lemburg's presentation "Writing Unicode-aware
@@ -745,7 +745,7 @@ discuss questions of character encodings as well as how to internationalize
 and localize an application.  These slides cover Python 2.x only.
 
 `The Guts of Unicode in Python
-<http://pyvideo.org/video/1768/the-guts-of-unicode-in-python>`_
+<https://pyvideo.org/video/1768/the-guts-of-unicode-in-python>`_
 is a PyCon 2013 talk by Benjamin Peterson that discusses the internal Unicode
 representation in Python 3.3.
 

--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -411,7 +411,7 @@ fetched, particularly the headers sent by the server. It is currently an
 :class:`http.client.HTTPMessage` instance.
 
 Typical headers include 'Content-length', 'Content-type', and so on. See the
-`Quick Reference to HTTP Headers <http://jkorpela.fi/http.html>`_
+`Quick Reference to HTTP Headers <https://jkorpela.fi/http.html>`_
 for a useful listing of HTTP headers with brief explanations of their meaning
 and use.
 

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -664,7 +664,7 @@ added elements by appending to the right and popping to the left::
 
     def moving_average(iterable, n=3):
         # moving_average([40, 30, 50, 46, 39, 44]) --> 40.0 42.0 45.0 43.0
-        # http://en.wikipedia.org/wiki/Moving_average
+        # https://en.wikipedia.org/wiki/Moving_average
         it = iter(iterable)
         d = deque(itertools.islice(it, n-1))
         d.appendleft(0)

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -353,9 +353,9 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
 
 .. seealso::
 
-   `Pattern Matching: The Gestalt Approach <http://www.drdobbs.com/database/pattern-matching-the-gestalt-approach/184407970>`_
+   `Pattern Matching: The Gestalt Approach <https://www.drdobbs.com/database/pattern-matching-the-gestalt-approach/184407970>`_
       Discussion of a similar algorithm by John W. Ratcliff and D. E. Metzener. This
-      was published in `Dr. Dobb's Journal <http://www.drdobbs.com/>`_ in July, 1988.
+      was published in `Dr. Dobb's Journal <https://www.drdobbs.com/>`_ in July, 1988.
 
 
 .. _sequence-matcher:

--- a/Doc/library/gettext.rst
+++ b/Doc/library/gettext.rst
@@ -445,7 +445,7 @@ There are a few tools to extract the strings meant for translation.
 The original GNU :program:`gettext` only supported C or C++ source
 code but its extended version :program:`xgettext` scans code written
 in a number of languages, including Python, to find strings marked as
-translatable.  `Babel <http://babel.pocoo.org/>`__ is a Python
+translatable.  `Babel <https://babel.pocoo.org/>`__ is a Python
 internationalization library that includes a :file:`pybabel` script to
 extract and compile message catalogs.  François Pinard's program
 called :program:`xpot` does a similar job and is available as part of

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -589,7 +589,7 @@ Here is an example session that shows how to ``POST`` requests::
    302 Found
    >>> data = response.read()
    >>> data
-   b'Redirecting to <a href="http://bugs.python.org/issue12524">http://bugs.python.org/issue12524</a>'
+   b'Redirecting to <a href="https://bugs.python.org/issue12524">https://bugs.python.org/issue12524</a>'
    >>> conn.close()
 
 Client side ``HTTP PUT`` requests are very similar to ``POST`` requests. The

--- a/Doc/library/importlib.resources.rst
+++ b/Doc/library/importlib.resources.rst
@@ -26,16 +26,16 @@ for example, a package and its resources can be imported from a zip file using
    This module provides functionality similar to `pkg_resources
    <https://setuptools.readthedocs.io/en/latest/pkg_resources.html>`_ `Basic
    Resource Access
-   <http://setuptools.readthedocs.io/en/latest/pkg_resources.html#basic-resource-access>`_
+   <https://setuptools.readthedocs.io/en/latest/pkg_resources.html#basic-resource-access>`_
    without the performance overhead of that package.  This makes reading
    resources included in packages easier, with more stable and consistent
    semantics.
 
    The standalone backport of this module provides more information
    on `using importlib.resources
-   <http://importlib-resources.readthedocs.io/en/latest/using.html>`_ and
+   <https://importlib-resources.readthedocs.io/en/latest/using.html>`_ and
    `migrating from pkg_resources to importlib.resources
-   <http://importlib-resources.readthedocs.io/en/latest/migration.html>`_.
+   <https://importlib-resources.readthedocs.io/en/latest/migration.html>`_.
 
 :class:`Loaders <importlib.abc.Loader>` that wish to support resource reading should implement a
 ``get_resource_reader(fullname)`` method as specified by

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -226,7 +226,7 @@ Basic Usage
    *object_hook* is an optional function that will be called with the result of
    any object literal decoded (a :class:`dict`).  The return value of
    *object_hook* will be used instead of the :class:`dict`.  This feature can be used
-   to implement custom decoders (e.g. `JSON-RPC <http://www.jsonrpc.org>`_
+   to implement custom decoders (e.g. `JSON-RPC <https://www.jsonrpc.org>`_
    class hinting).
 
    *object_pairs_hook* is an optional function that will be called with the
@@ -326,7 +326,7 @@ Encoders and Decoders
    *object_hook*, if specified, will be called with the result of every JSON
    object decoded and its return value will be used in place of the given
    :class:`dict`.  This can be used to provide custom deserializations (e.g. to
-   support `JSON-RPC <http://www.jsonrpc.org>`_ class hinting).
+   support `JSON-RPC <https://www.jsonrpc.org>`_ class hinting).
 
    *object_pairs_hook*, if specified will be called with the result of every
    JSON object decoded with an ordered list of pairs.  The return value of

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -335,7 +335,7 @@ the :mod:`glob` module.)
 
   .. note::
       On POSIX systems, in accordance with `IEEE Std 1003.1 2013 Edition; 4.13
-      Pathname Resolution <http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13>`_,
+      Pathname Resolution <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13>`_,
       if a pathname begins with exactly two slashes, the first component
       following the leading characters may be interpreted in an implementation-defined
       manner, although more than two leading characters shall be treated as a

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2474,9 +2474,9 @@ features:
    .. note::
 
       On Unix-based systems, :func:`scandir` uses the system's
-      `opendir() <http://pubs.opengroup.org/onlinepubs/009695399/functions/opendir.html>`_
+      `opendir() <https://pubs.opengroup.org/onlinepubs/009695399/functions/opendir.html>`_
       and
-      `readdir() <http://pubs.opengroup.org/onlinepubs/009695399/functions/readdir_r.html>`_
+      `readdir() <https://pubs.opengroup.org/onlinepubs/009695399/functions/readdir_r.html>`_
       functions. On Windows, it uses the Win32
       `FindFirstFileW <https://msdn.microsoft.com/en-us/library/windows/desktop/aa364418(v=vs.85).aspx>`_
       and
@@ -4934,7 +4934,7 @@ Random numbers
    :py:data:`GRND_NONBLOCK`.
 
    See also the `Linux getrandom() manual page
-   <http://man7.org/linux/man-pages/man2/getrandom.2.html>`_.
+   <https://man7.org/linux/man-pages/man2/getrandom.2.html>`_.
 
    .. availability:: Linux >= 3.17.
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -266,7 +266,7 @@ The following function generates a discrete distribution.
 .. function:: binomialvariate(n=1, p=0.5)
 
    `Binomial distribution
-   <http://mathworld.wolfram.com/BinomialDistribution.html>`_.
+   <https://mathworld.wolfram.com/BinomialDistribution.html>`_.
    Return the number of successes for *n* independent trials with the
    probability of success in each trial being *p*:
 

--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -153,7 +153,7 @@ Generate an eight-character alphanumeric password:
 .. note::
 
    Applications should not
-   `store passwords in a recoverable format <http://cwe.mitre.org/data/definitions/257.html>`_,
+   `store passwords in a recoverable format <https://cwe.mitre.org/data/definitions/257.html>`_,
    whether plain text or encrypted.  They should be salted and hashed
    using a cryptographically strong one-way (irreversible) hash function.
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -801,4 +801,4 @@ Querying the size of the output terminal
    http://www.manpagez.com/man/3/copyfile/
 
 .. _`Other Environment Variables`:
-   http://pubs.opengroup.org/onlinepubs/7908799/xbd/envvar.html#tag_002_003
+   https://pubs.opengroup.org/onlinepubs/7908799/xbd/envvar.html#tag_002_003

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -367,7 +367,7 @@ Constants
 
    .. seealso::
 
-      `Secure File Descriptor Handling <http://udrepper.livejournal.com/20407.html>`_
+      `Secure File Descriptor Handling <https://udrepper.livejournal.com/20407.html>`_
       for a more thorough explanation.
 
    .. availability:: Linux >= 2.6.27.

--- a/Doc/library/statistics.rst
+++ b/Doc/library/statistics.rst
@@ -938,7 +938,7 @@ Carlo simulation <https://en.wikipedia.org/wiki/Monte_Carlo_method>`_:
     [1.4591308524824727, 1.8035946855390597, 2.175091447274739]
 
 Normal distributions can be used to approximate `Binomial
-distributions <http://mathworld.wolfram.com/BinomialDistribution.html>`_
+distributions <https://mathworld.wolfram.com/BinomialDistribution.html>`_
 when the sample size is large and when the probability of a successful
 trial is near 50%.
 

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -738,7 +738,7 @@ internationalization (i18n) since in that context, the simpler syntax and
 functionality makes it easier to translate than other built-in string
 formatting facilities in Python.  As an example of a library built on template
 strings for i18n, see the
-`flufl.i18n <http://flufli18n.readthedocs.io/en/latest/>`_ package.
+`flufl.i18n <https://flufli18n.readthedocs.io/en/latest/>`_ package.
 
 .. index:: single: $ (dollar); in template strings
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1799,4 +1799,4 @@ always available.
 
 .. rubric:: Citations
 
-.. [C99] ISO/IEC 9899:1999.  "Programming languages -- C."  A public draft of this standard is available at http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf\ .
+.. [C99] ISO/IEC 9899:1999.  "Programming languages -- C."  A public draft of this standard is available at https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf\ .

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -61,7 +61,7 @@ details that are unchanged.
    * `Python and Tkinter Programming <https://www.packtpub.com/product/python-gui-programming-with-tkinter/9781788835886>`_
       By Alan Moore. (ISBN 978-1788835886)
 
-   * `Programming Python <http://learning-python.com/about-pp4e.html>`_
+   * `Programming Python <https://learning-python.com/about-pp4e.html>`_
       By Mark Lutz; has excellent coverage of Tkinter. (ISBN 978-0596158101)
 
    * `Tcl and the Tk Toolkit (2nd edition)  <https://www.amazon.com/exec/obidos/ASIN/032133633X>`_
@@ -988,7 +988,7 @@ wherever the image was used.
 
 .. seealso::
 
-    The `Pillow <http://python-pillow.org/>`_ package adds support for
+    The `Pillow <https://python-pillow.org/>`_ package adds support for
     formats such as BMP, JPEG, TIFF, and WebP, among others.
 
 .. _tkinter-file-handlers:

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -154,12 +154,12 @@ between conformable Python objects and XML on the wire.
       Added support of unmarshalling additional types used by Apache XML-RPC
       implementation for numerics: ``i1``, ``i2``, ``i8``, ``biginteger``,
       ``float`` and ``bigdecimal``.
-      See http://ws.apache.org/xmlrpc/types.html for a description.
+      See https://ws.apache.org/xmlrpc/types.html for a description.
 
 
 .. seealso::
 
-   `XML-RPC HOWTO <http://www.tldp.org/HOWTO/XML-RPC-HOWTO/index.html>`_
+   `XML-RPC HOWTO <https://www.tldp.org/HOWTO/XML-RPC-HOWTO/index.html>`_
       A good description of XML-RPC operation and client software in several languages.
       Contains pretty much everything an XML-RPC client developer needs to know.
 

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -690,7 +690,7 @@ of the OpenSSL license here::
      * 3. All advertising materials mentioning features or use of this
      *    software must display the following acknowledgment:
      *    "This product includes software developed by the OpenSSL Project
-     *    for use in the OpenSSL Toolkit. (https://www.openssl.org/)"
+     *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
      *
      * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
      *    endorse or promote products derived from this software without
@@ -704,7 +704,7 @@ of the OpenSSL license here::
      * 6. Redistributions of any form whatsoever must retain the following
      *    acknowledgment:
      *    "This product includes software developed by the OpenSSL Project
-     *    for use in the OpenSSL Toolkit (https://www.openssl.org/)"
+     *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
      *
      * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
      * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -353,7 +353,7 @@ Sockets
 
 The :mod:`socket` module uses the functions, :func:`getaddrinfo`, and
 :func:`getnameinfo`, which are coded in separate source files from the WIDE
-Project, http://www.wide.ad.jp/. ::
+Project, https://www.wide.ad.jp/. ::
 
    Copyright (C) 1995, 1996, 1997, and 1998 WIDE Project.
    All rights reserved.
@@ -690,7 +690,7 @@ of the OpenSSL license here::
      * 3. All advertising materials mentioning features or use of this
      *    software must display the following acknowledgment:
      *    "This product includes software developed by the OpenSSL Project
-     *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+     *    for use in the OpenSSL Toolkit. (https://www.openssl.org/)"
      *
      * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
      *    endorse or promote products derived from this software without
@@ -704,7 +704,7 @@ of the OpenSSL license here::
      * 6. Redistributions of any form whatsoever must retain the following
      *    acknowledgment:
      *    "This product includes software developed by the OpenSSL Project
-     *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+     *    for use in the OpenSSL Toolkit (https://www.openssl.org/)"
      *
      * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
      * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/Doc/reference/introduction.rst
+++ b/Doc/reference/introduction.rst
@@ -54,7 +54,7 @@ Jython
    Python implemented in Java.  This implementation can be used as a scripting
    language for Java applications, or can be used to create applications using the
    Java class libraries.  It is also often used to create tests for Java libraries.
-   More information can be found at `the Jython website <http://www.jython.org/>`_.
+   More information can be found at `the Jython website <https://www.jython.org/>`_.
 
 Python for .NET
    This implementation actually uses the CPython implementation, but is a managed
@@ -66,7 +66,7 @@ IronPython
    An alternate Python for .NET.  Unlike Python.NET, this is a complete Python
    implementation that generates IL, and compiles Python code directly to .NET
    assemblies.  It was created by Jim Hugunin, the original creator of Jython.  For
-   more information, see `the IronPython website <http://ironpython.net/>`_.
+   more information, see `the IronPython website <https://ironpython.net/>`_.
 
 PyPy
    An implementation of Python written completely in Python. It supports several
@@ -74,7 +74,7 @@ PyPy
    and a Just in Time compiler. One of the goals of the project is to encourage
    experimentation with the language itself by making it easier to modify the
    interpreter (since it is written in Python).  Additional information is
-   available on `the PyPy project's home page <http://pypy.org/>`_.
+   available on `the PyPy project's home page <https://pypy.org/>`_.
 
 Each of these implementations varies in some way from the language as documented
 in this manual, or introduces specific information beyond what's covered in the

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -585,7 +585,7 @@ Options you shouldn't use
 
    Reserved for use by Jython_.
 
-.. _Jython: http://www.jython.org/
+.. _Jython: https://www.jython.org/
 
 
 .. _using-on-envvars:

--- a/Doc/using/mac.rst
+++ b/Doc/using/mac.rst
@@ -65,7 +65,7 @@ number of standard Unix command line editors, :program:`vim` and
 :program:`BBEdit` or :program:`TextWrangler` from Bare Bones Software (see
 http://www.barebones.com/products/bbedit/index.html) are good choices, as is
 :program:`TextMate` (see https://macromates.com/). Other editors include
-:program:`Gvim` (http://macvim-dev.github.io/macvim/) and :program:`Aquamacs`
+:program:`Gvim` (https://macvim-dev.github.io/macvim/) and :program:`Aquamacs`
 (http://aquamacs.org/).
 
 To run your script from the Terminal window you must make sure that

--- a/Doc/whatsnew/2.5.rst
+++ b/Doc/whatsnew/2.5.rst
@@ -1930,7 +1930,7 @@ with the same digest state.
 The sqlite3 package
 -------------------
 
-The pysqlite module (http://www.pysqlite.org), a wrapper for the SQLite embedded
+The pysqlite module (https://www.pysqlite.org), a wrapper for the SQLite embedded
 database, has been added to the standard library under the package name
 :mod:`sqlite3`.
 

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -176,7 +176,7 @@ Hosting of the Python bug tracker is kindly provided by
 of Stellenbosch, South Africa.  Martin von Löwis put a
 lot of effort into importing existing bugs and patches from
 SourceForge; his scripts for this import operation are at
-``http://svn.python.org/view/tracker/importer/`` and may be useful to
+``https://svn.python.org/view/tracker/importer/`` and may be useful to
 other projects wishing to move from SourceForge to Roundup.
 
 .. seealso::
@@ -184,13 +184,13 @@ other projects wishing to move from SourceForge to Roundup.
   https://bugs.python.org
     The Python bug tracker.
 
-  http://bugs.jython.org:
+  https://bugs.jython.org:
     The Jython bug tracker.
 
   http://roundup.sourceforge.net/
     Roundup downloads and documentation.
 
-  http://svn.python.org/view/tracker/importer/
+  https://svn.python.org/view/tracker/importer/
     Martin von Löwis's conversion scripts.
 
 New Documentation Format: reStructuredText Using Sphinx
@@ -1433,7 +1433,7 @@ one, :func:`math.trunc`, that's been backported to Python 2.6.
 
    `Scheme's numerical tower <https://www.gnu.org/software/guile/manual/html_node/Numerical-Tower.html#Numerical-Tower>`__, from the Guile manual.
 
-   `Scheme's number datatypes <http://schemers.org/Documents/Standards/R5RS/HTML/r5rs-Z-H-9.html#%_sec_6.2>`__ from the R5RS Scheme specification.
+   `Scheme's number datatypes <https://schemers.org/Documents/Standards/R5RS/HTML/r5rs-Z-H-9.html#%_sec_6.2>`__ from the R5RS Scheme specification.
 
 
 The :mod:`fractions` Module

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -299,7 +299,7 @@ modules.
   constructor was extended with an *object_pairs_hook* parameter to
   allow :class:`OrderedDict` instances to be built by the decoder.
   Support was also added for third-party tools like
-  `PyYAML <http://pyyaml.org/>`_.
+  `PyYAML <https://pyyaml.org/>`_.
 
 .. seealso::
 
@@ -1048,7 +1048,7 @@ changes, or look through the Subversion logs for all the details.
   The new version features better Python 3.x compatibility, various bug fixes,
   and adds several new BerkeleyDB flags and methods.
   (Updated by Jesús Cea Avión; :issue:`8156`.  The pybsddb
-  changelog can be read at http://hg.jcea.es/pybsddb/file/tip/ChangeLog.)
+  changelog can be read at https://hg.jcea.es/pybsddb/file/tip/ChangeLog.)
 
 * The :mod:`bz2` module's :class:`~bz2.BZ2File` now supports the context
   management protocol, so you can write ``with bz2.BZ2File(...) as f:``.
@@ -1831,7 +1831,7 @@ packaged as the :mod:`unittest2` package, from
 https://pypi.org/project/unittest2.
 
 When used from the command line, the module can automatically discover
-tests.  It's not as fancy as `py.test <http://pytest.org>`__ or
+tests.  It's not as fancy as `py.test <https://pytest.org>`__ or
 `nose <https://nose.readthedocs.io/>`__, but provides a
 simple way to run tests kept within a set of package directories.  For example,
 the following command will search the :file:`test/` subdirectory for
@@ -2692,7 +2692,7 @@ As part of this change, the :ref:`installing-index` and
 completely redesigned as short getting started and FAQ documents. Most
 packaging documentation has now been moved out to the Python Packaging
 Authority maintained `Python Packaging User Guide
-<http://packaging.python.org>`__ and the documentation of the individual
+<https://packaging.python.org>`__ and the documentation of the individual
 projects.
 
 However, as this migration is currently still incomplete, the legacy

--- a/Doc/whatsnew/3.1.rst
+++ b/Doc/whatsnew/3.1.rst
@@ -72,7 +72,7 @@ order.  The *_asdict()* method for :func:`collections.namedtuple` now
 returns an ordered dictionary with the values appearing in the same order as
 the underlying tuple indices.  The :mod:`json` module is being built-out with
 an *object_pairs_hook* to allow OrderedDicts to be built by the decoder.
-Support was also added for third-party tools like `PyYAML <http://pyyaml.org/>`_.
+Support was also added for third-party tools like `PyYAML <https://pyyaml.org/>`_.
 
 .. seealso::
 

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -2506,7 +2506,7 @@ IDLE
 Code Repository
 ===============
 
-In addition to the existing Subversion code repository at http://svn.python.org
+In addition to the existing Subversion code repository at https://svn.python.org
 there is now a `Mercurial <https://www.mercurial-scm.org/>`_ repository at
 https://hg.python.org/\ .
 

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -1106,7 +1106,7 @@ the precision is user configurable, the exact figures may vary. For example,
 in integer bignum arithmetic the differences can be significantly higher.
 
 The following table is meant as an illustration. Benchmarks are available
-at http://www.bytereef.org/mpdecimal/quickstart.html.
+at https://www.bytereef.org/mpdecimal/quickstart.html.
 
    +---------+-------------+--------------+-------------+
    |         |  decimal.py |   _decimal   |   speedup   |

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -1253,7 +1253,7 @@ imghdr
 ------
 
 The :func:`~imghdr.what` function now recognizes the
-`OpenEXR <http://www.openexr.com>`_ format
+`OpenEXR <https://www.openexr.com>`_ format
 (contributed by Martin Vignali and Claudiu Popa in :issue:`20295`),
 and the `WebP <https://en.wikipedia.org/wiki/WebP>`_ format
 (contributed by Fabrice Aneche and Claudiu Popa in :issue:`20197`.)

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -611,7 +611,7 @@ Contributed by Barry Warsaw and Brett Cannon in :issue:`32248`.
 
 .. seealso::
 
-    `importlib_resources <http://importlib-resources.readthedocs.io/en/latest/>`_
+    `importlib_resources <https://importlib-resources.readthedocs.io/en/latest/>`_
     -- a PyPI backport for earlier Python versions.
 
 


### PR DESCRIPTION
If an HTTP link is redirected to a same looking HTTPS link, the latter can
be used directly without changes in readability and behavior.
It protects from a men-in-the-middle attack.

This change does not affect Python examples. It is a different issue.

Changed the following URLs and their sub-URLs:

>http://babel.pocoo.org
>http://bugs.jython.org
>http://bugs.python.org/issue12524
>http://buildbot.python.org/3.7.stable
>http://buildbot.python.org/3.8.stable
>http://buildbot.python.org/3.9.stable
>http://buildbot.python.org/3.x.stable
>http://cwe.mitre.org/data/definitions/257.html
>http://cython.org
>http://en.wikipedia.org/wiki/Moving_average
>http://flufli18n.readthedocs.io/en/latest
>http://gnosis.cx/TPiP
>http://hg.jcea.es/pybsddb/file/tip/ChangeLog
>http://importlib-resources.readthedocs.io/en/latest
>http://invisible-island.net/ncurses/ncurses.faq.html
>http://invisible-island.net/ncurses/ncurses-intro.html
>http://ironpython.net
>http://jkorpela.fi/http.html
>http://jkorpela.fi/unicode/guide.html
>http://learning-python.com/about-pp4e.html
>http://macvim-dev.github.io/macvim
>http://man7.org/linux/man-pages/man2/getrandom.2.html
>http://mathworld.wolfram.com/BinomialDistribution.html
>http://packaging.python.org
>http://pubs.opengroup.org/onlinepubs/009695399/functions/opendir.html
>http://pubs.opengroup.org/onlinepubs/009695399/functions/readdir_r.html
>http://pubs.opengroup.org/onlinepubs/7908799/xbd/envvar.html
>http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html
>http://pypy.org
>http://pytest.org
>http://python-future.org
>http://python.org
>http://python-pillow.org
>http://pyvideo.org/video/1768/the-guts-of-unicode-in-python
>http://pyvideo.org/video/289/pycon-2010--mastering-python-3-i-o
>http://pyyaml.org
>http://schemers.org/Documents/Standards/R5RS/HTML/r5rs-Z-H-9.html
>http://setuptools.readthedocs.io/en/latest/pkg_resources.html
>http://svn.python.org
>http://udrepper.livejournal.com/20407.html
>http://ws.apache.org/xmlrpc/types.html
>http://www.boost.org/libs/python/doc/index.html
>http://www.bytereef.org/mpdecimal/quickstart.html
>http://www.cwi.nl
>http://www.defmacro.org/ramblings/fp.html
>http://www.drdobbs.com
>http://www.jsonrpc.org
>http://www.jython.org
>http://www.nuitka.net
>http://www.openexr.com
>http://www.openssl.org
>http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf
>http://www.pypy.org
>http://www.pysqlite.org
>http://www.python.org
>http://www.swig.org
>http://www.tldp.org/HOWTO/XML-RPC-HOWTO/index.html
>http://www.wide.ad.jp


<!-- gh-issue-number: gh-91838 -->
* Issue: gh-91838
<!-- /gh-issue-number -->
