### PR TITLE
gh-95007: Remove the NoneType return converter from Argument Clinic Doc

### DIFF
--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1070,11 +1070,6 @@ None of these take parameters.  For the first three, return -1 to indicate
 error.  For ``DecodeFSDefault``, the return type is ``const char *``; return a ``NULL``
 pointer to indicate an error.
 
-(There's also an experimental ``NoneType`` converter, which lets you
-return ``Py_None`` on success or ``NULL`` on failure, without having
-to increment the reference count on ``Py_None``.  I'm not sure it adds
-enough clarity to be worth using.)
-
 To see all the return converters Argument Clinic supports, along with
 their parameters (if any),
 just run ``Tools/clinic/clinic.py --converters`` for the full list.


### PR DESCRIPTION
NoneType return converter was removed in 74b5e4ce80858ac5c7d03411cb8cce7e6865f181 while documentation did not change


<!-- gh-issue-number: gh-95007 -->
* Issue: gh-95007
<!-- /gh-issue-number -->
