### PR TITLE
[3.10] Override stylesheet fingerprinting for Windows CHM HTML help (gh-91207)

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -74,6 +74,11 @@ html_theme_options = {
     'root_include_title': False   # We use the version switcher instead.
 }
 
+# Override stylesheet fingerprinting for Windows CHM htmlhelp to fix GH-91207
+# https://github.com/python/cpython/issues/91207
+if any('htmlhelp' in arg for arg in sys.argv):
+    html_style = 'pydoctheme.css'
+
 # Short title used e.g. for <title> HTML tags.
 html_short_title = '%s Documentation' % release
 

--- a/Misc/NEWS.d/next/Documentation/2022-08-01-23-17-04.gh-issue-91207._P8i0B.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-08-01-23-17-04.gh-issue-91207._P8i0B.rst
@@ -1,0 +1,2 @@
+Fix stylesheet not working in Windows CHM htmlhelp docs.
+Contributed by C.A.M. Gerlach.


### PR DESCRIPTION
As discussed on #91207 , this overrides for the `htmlhelp` builder (legacy Windows CHM files) the stylesheet fingerprinting introduced in https://github.com/python/python-docs-theme/pull/79 to fix the caching issue in https://github.com/python/python-docs-theme/issues/78 , which breaks HTML help rendering. `htmlhelp` support was removed in 3.11, so only targets 3.10.

@zooba I tested this locally and it produced the intended result in the `htmlhelp` source files while not affecting other builds, but I cannot be 100% sure it fixes the actual problem without testing it in a real Windows HTML help viewer. Are you or someone else able to do so? Thanks!

<!-- gh-issue-number: gh-91207 -->
* Issue: gh-91207
<!-- /gh-issue-number -->
