### PR TITLE
gh-95597: Fix typo in Lib directory files

### DIFF
--- a/Lib/idlelib/config.py
+++ b/Lib/idlelib/config.py
@@ -578,7 +578,7 @@ class IdleConf:
         """
         return ('<<'+virtualEvent+'>>') in self.GetCoreKeys()
 
-# TODO make keyBindins a file or class attribute used for test above
+# TODO make keyBindings a file or class attribute used for test above
 # and copied in function below.
 
     former_extension_events = {  #  Those with user-configurable keys.

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -1531,7 +1531,7 @@ class ChildWatcherTestsMixin:
             self.watcher._sig_chld()
 
         if isinstance(self.watcher, asyncio.FastChildWatcher):
-            # here the FastChildWatche enters a deadlock
+            # here the FastChildWatcher enters a deadlock
             # (there is no way to prevent it)
             self.assertFalse(callback.called)
         else:

--- a/Misc/NEWS.d/next/Documentation/2022-08-03-14-33-57.gh-issue-95597.joP_1w.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-08-03-14-33-57.gh-issue-95597.joP_1w.rst
@@ -1,0 +1,1 @@
+Fix typo in Lib directory files

--- a/Misc/NEWS.d/next/Documentation/2022-08-03-14-33-57.gh-issue-95597.joP_1w.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-08-03-14-33-57.gh-issue-95597.joP_1w.rst
@@ -1,1 +1,0 @@
-Fix typo in Lib directory files


### PR DESCRIPTION
Minor changes, Fix typo in Lib directory files

<!-- gh-issue-number: gh-95597 -->
* Issue: gh-95597
<!-- /gh-issue-number -->
