### PR TITLE
gh-91207: Fix CSS bug with docs for Windows CHM help & add depr msg

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -83,6 +83,8 @@ html_theme_options = {
 # https://github.com/python/cpython/issues/91207
 if any('htmlhelp' in arg for arg in sys.argv):
     html_style = 'pydoctheme.css'
+    print("\nWARNING: Windows CHM Help is no longer supported.")
+    print("It may be removed in the future\n")
 
 # Short title used e.g. for <title> HTML tags.
 html_short_title = '%s Documentation' % release

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -79,6 +79,11 @@ html_theme_options = {
     'root_include_title': False   # We use the version switcher instead.
 }
 
+# Override stylesheet fingerprinting for Windows CHM htmlhelp to fix GH-91207
+# https://github.com/python/cpython/issues/91207
+if any('htmlhelp' in arg for arg in sys.argv):
+    html_style = 'pydoctheme.css'
+
 # Short title used e.g. for <title> HTML tags.
 html_short_title = '%s Documentation' % release
 

--- a/Misc/NEWS.d/next/Documentation/2022-08-03-13-35-08.gh-issue-91207.eJ4pPf.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-08-03-13-35-08.gh-issue-91207.eJ4pPf.rst
@@ -1,0 +1,3 @@
+Fix stylesheet not working in Windows CHM htmlhelp docs
+and add warning that they are deprecated.
+Contributed by C.A.M. Gerlach.


### PR DESCRIPTION
Reported as #91207 and originally fixed just on 3.10 as #95556 ; forward-ported to 3.12 and 3.11 here, along with a deprecation message for the discontinued legacy CHM builds.

<!-- gh-issue-number: gh-91207 -->
* Issue: gh-91207
<!-- /gh-issue-number -->
