### PR TITLE
[3.11] gh-95423: Update winreg.DeleteKeyEx documentation and remove dynamic function load (GH-95521)

### DIFF
--- a/Doc/library/winreg.rst
+++ b/Doc/library/winreg.rst
@@ -144,12 +144,6 @@ This module offers the following functions:
 
    Deletes the specified key.
 
-   .. note::
-      The :func:`DeleteKeyEx` function is implemented with the RegDeleteKeyEx
-      Windows API function, which is specific to 64-bit versions of Windows.
-      See the `RegDeleteKeyEx documentation
-      <https://msdn.microsoft.com/en-us/library/ms724847%28VS.85%29.aspx>`__.
-
    *key* is an already open key, or one of the predefined
    :ref:`HKEY_* constants <hkey-constants>`.
 
@@ -159,9 +153,10 @@ This module offers the following functions:
 
    *reserved* is a reserved integer, and must be zero. The default is zero.
 
-   *access* is an integer that specifies an access mask that describes the desired
-   security access for the key.  Default is :const:`KEY_WOW64_64KEY`.  See
-   :ref:`Access Rights <access-rights>` for other allowed values.
+   *access* is an integer that specifies an access mask that describes the
+   desired security access for the key.  Default is :const:`KEY_WOW64_64KEY`.
+   On 32-bit Windows, the WOW64 constants are ignored.
+   See :ref:`Access Rights <access-rights>` for other allowed values.
 
    *This method can not delete keys with subkeys.*
 
@@ -658,13 +653,12 @@ For more information, see `Accessing an Alternate Registry View
 .. data:: KEY_WOW64_64KEY
 
    Indicates that an application on 64-bit Windows should operate on
-   the 64-bit registry view.
+   the 64-bit registry view. On 32-bit Windows, this constant is ignored.
 
 .. data:: KEY_WOW64_32KEY
 
    Indicates that an application on 64-bit Windows should operate on
-   the 32-bit registry view.
-
+   the 32-bit registry view. On 32-bit Windows, this constant is ignored.
 
 .. _value-types:
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -917,6 +917,7 @@ Sanyam Khurana
 Tyler Kieft
 Mads Kiilerich
 Jason Killen
+Derek D. Kim
 Jan Kim
 Taek Joo Kim
 Sam Kimbrel

--- a/PC/clinic/winreg.c.h
+++ b/PC/clinic/winreg.c.h
@@ -390,7 +390,7 @@ PyDoc_STRVAR(winreg_DeleteKeyEx__doc__,
 "            reserved=0)\n"
 "--\n"
 "\n"
-"Deletes the specified key (64-bit OS only).\n"
+"Deletes the specified key (intended for 64-bit OS).\n"
 "\n"
 "  key\n"
 "    An already open key, or any one of the predefined HKEY_* constants.\n"
@@ -403,6 +403,9 @@ PyDoc_STRVAR(winreg_DeleteKeyEx__doc__,
 "    desired security access for the key. Default is KEY_WOW64_64KEY.\n"
 "  reserved\n"
 "    A reserved integer, and must be zero.  Default is zero.\n"
+"\n"
+"While this function is intended to be used for 64-bit OS, it is also\n"
+" available on 32-bit systems.\n"
 "\n"
 "This method can not delete keys with subkeys.\n"
 "\n"
@@ -1346,4 +1349,4 @@ winreg_QueryReflectionKey(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c3454803528f6e97 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7ad1db69bc42cab4 input=a9049054013a1b77]*/

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -991,7 +991,9 @@ winreg_DeleteKey_impl(PyObject *module, HKEY key, const Py_UNICODE *sub_key)
                     (Py_ssize_t)0) < 0) {
         return NULL;
     }
-    rc = RegDeleteKeyW(key, sub_key );
+    Py_BEGIN_ALLOW_THREADS
+    rc = RegDeleteKeyW(key, sub_key);
+    Py_END_ALLOW_THREADS
     if (rc != ERROR_SUCCESS)
         return PyErr_SetFromWindowsErrWithFunction(rc, "RegDeleteKey");
     Py_RETURN_NONE;
@@ -1012,7 +1014,10 @@ winreg.DeleteKeyEx
     reserved: int = 0
         A reserved integer, and must be zero.  Default is zero.
 
-Deletes the specified key (64-bit OS only).
+Deletes the specified key (intended for 64-bit OS).
+
+While this function is intended to be used for 64-bit OS, it is also
+ available on 32-bit systems.
 
 This method can not delete keys with subkeys.
 
@@ -1025,34 +1030,17 @@ static PyObject *
 winreg_DeleteKeyEx_impl(PyObject *module, HKEY key,
                         const Py_UNICODE *sub_key, REGSAM access,
                         int reserved)
-/*[clinic end generated code: output=52a1c8b374ebc003 input=711d9d89e7ecbed7]*/
+/*[clinic end generated code: output=52a1c8b374ebc003 input=a3186db079b3bf85]*/
 {
-    HMODULE hMod;
-    typedef LONG (WINAPI *RDKEFunc)(HKEY, const wchar_t*, REGSAM, int);
-    RDKEFunc pfn = NULL;
     long rc;
-
     if (PySys_Audit("winreg.DeleteKey", "nun",
                     (Py_ssize_t)key, sub_key,
                     (Py_ssize_t)access) < 0) {
         return NULL;
     }
-    /* Only available on 64bit platforms, so we must load it
-       dynamically. */
     Py_BEGIN_ALLOW_THREADS
-    hMod = GetModuleHandleW(L"advapi32.dll");
-    if (hMod)
-        pfn = (RDKEFunc)GetProcAddress(hMod, "RegDeleteKeyExW");
+    rc = RegDeleteKeyExW(key, sub_key, access, reserved);
     Py_END_ALLOW_THREADS
-    if (!pfn) {
-        PyErr_SetString(PyExc_NotImplementedError,
-                                        "not implemented on this platform");
-        return NULL;
-    }
-    Py_BEGIN_ALLOW_THREADS
-    rc = (*pfn)(key, sub_key, access, reserved);
-    Py_END_ALLOW_THREADS
-
     if (rc != ERROR_SUCCESS)
         return PyErr_SetFromWindowsErrWithFunction(rc, "RegDeleteKeyEx");
     Py_RETURN_NONE;


### PR DESCRIPTION


<!-- gh-issue-number: gh-95423 -->
* Issue: gh-95423
<!-- /gh-issue-number -->
