### PR TITLE
gh-91838: Resolve HTTP links which redirect to HTTPS

### DIFF
--- a/Doc/about.rst
+++ b/Doc/about.rst
@@ -6,7 +6,7 @@ About these documents
 These documents are generated from `reStructuredText`_ sources by `Sphinx`_, a
 document processor specifically written for the Python documentation.
 
-.. _reStructuredText: http://docutils.sourceforge.net/rst.html
+.. _reStructuredText: https://docutils.sourceforge.io/rst.html
 .. _Sphinx: http://sphinx-doc.org/
 
 .. In the online version of these documents, you can submit comments and suggest
@@ -21,7 +21,7 @@ Many thanks go to:
 
 * Fred L. Drake, Jr., the creator of the original Python documentation toolset
   and writer of much of the content;
-* the `Docutils <http://docutils.sourceforge.net/>`_ project for creating
+* the `Docutils <https://docutils.sourceforge.io/>`_ project for creating
   reStructuredText and the Docutils suite;
 * Fredrik Lundh for his Alternative Python Reference project from which Sphinx
   got many good ideas.

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -330,7 +330,7 @@ different companies and organizations.
 
 High-profile Python projects include `the Mailman mailing list manager
 <http://www.list.org>`_ and `the Zope application server
-<http://www.zope.org>`_.  Several Linux distributions, most notably `Red Hat
+<https://www.zope.dev>`_.  Several Linux distributions, most notably `Red Hat
 <https://www.redhat.com>`_, have written part or all of their installer and
 system administration software in Python.  Companies that use Python internally
 include Google, Yahoo, and Lucasfilm Ltd.

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -95,7 +95,7 @@ The following packages can help with the creation of console and GUI
 executables:
 
 * `Nuitka <https://nuitka.net/>`_ (Cross-platform)
-* `PyInstaller <http://www.pyinstaller.org/>`_ (Cross-platform)
+* `PyInstaller <https://pyinstaller.org/>`_ (Cross-platform)
 * `PyOxidizer <https://pyoxidizer.readthedocs.io/en/stable/>`_ (Cross-platform)
 * `cx_Freeze <https://marcelotduarte.github.io/cx_Freeze/>`_ (Cross-platform)
 * `py2app <https://github.com/ronaldoussoren/py2app>`_ (macOS only)

--- a/Doc/howto/curses.rst
+++ b/Doc/howto/curses.rst
@@ -542,6 +542,6 @@ learn more about submitting patches to Python.
 * `The ncurses FAQ <https://invisible-island.net/ncurses/ncurses.faq.html>`_
 * `"Use curses... don't swear" <https://www.youtube.com/watch?v=eN1eZtjLEnU>`_:
   video of a PyCon 2013 talk on controlling terminals using curses or Urwid.
-* `"Console Applications with Urwid" <http://www.pyvideo.org/video/1568/console-applications-with-urwid>`_:
+* `"Console Applications with Urwid" <https://pyvideo.org/video/1568/console-applications-with-urwid>`_:
   video of a PyCon CA 2012 talk demonstrating some applications written using
   Urwid.

--- a/Doc/install/index.rst
+++ b/Doc/install/index.rst
@@ -1066,7 +1066,7 @@ normal libraries do.
 
 .. seealso::
 
-   `Building Python modules on MS Windows platform with MinGW <http://old.zope.org/Members/als/tips/win32_mingw_modules>`_
+   `Building Python modules on MS Windows platform with MinGW <https://old.zope.dev/Members/als/tips/win32_mingw_modules>`_
       Information about building the required libraries for the MinGW environment.
 
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -494,7 +494,7 @@ Example of `statistical bootstrapping
 <https://en.wikipedia.org/wiki/Bootstrapping_(statistics)>`_ using resampling
 with replacement to estimate a confidence interval for the mean of a sample::
 
-   # http://statistics.about.com/od/Applications/a/Example-Of-Bootstrapping.htm
+   # https://www.thoughtco.com/example-of-bootstrapping-3126155
    from statistics import fmean as mean
    from random import choices
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1453,7 +1453,7 @@ objects that compare equal might have different :attr:`~range.start`,
 
 .. seealso::
 
-   * The `linspace recipe <http://code.activestate.com/recipes/579000/>`_
+   * The `linspace recipe <https://code.activestate.com/recipes/579000/>`_
      shows how to implement a lazy version of range suitable for floating
      point applications.
 

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -90,7 +90,7 @@ Tcl
    (see `Threading model`_ for details).
 
 Tk
-   Tk is a `Tcl package <http://wiki.tcl.tk/37432>`_ implemented in C
+   Tk is a `Tcl package <https://wiki.tcl-lang.org/37432>`_ implemented in C
    that adds custom commands to create and manipulate GUI widgets. Each
    :class:`Tk` object embeds its own Tcl interpreter instance with Tk loaded into
    it. Tk's widgets are very customizable, though at the cost of a dated appearance.

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -1082,7 +1082,7 @@ Here are all of the changes that Python 2.3 makes to the core Python language.
   hierarchy.  Classic classes are unaffected by this change.  Python 2.2
   originally used a topological sort of a class's ancestors, but 2.3 now uses the
   C3 algorithm as described in the paper `"A Monotonic Superclass Linearization
-  for Dylan" <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.19.3910>`_. To
+  for Dylan" <https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.19.3910>`_. To
   understand the motivation for this change,  read Michele Simionato's article
   `"Python 2.3 Method Resolution Order" <http://www.phyast.pitt.edu/~micheles/mro.html>`_, or
   read the thread on python-dev starting with the message at

--- a/Doc/whatsnew/2.5.rst
+++ b/Doc/whatsnew/2.5.rst
@@ -882,7 +882,7 @@ in an :c:type:`int`.  The C compilers for most 64-bit platforms still define
 :c:type:`int` as a 32-bit type, so that meant that lists could only hold up to
 ``2**31 - 1`` = 2147483647 items. (There are actually a few different
 programming models that 64-bit C compilers can use -- see
-http://www.unix.org/version2/whatsnew/lp64_wp.html for a discussion -- but the
+https://unix.org/version2/whatsnew/lp64_wp.html for a discussion -- but the
 most commonly available model leaves :c:type:`int` as 32 bits.)
 
 A limit of 2147483647 items doesn't really matter on a 32-bit platform because

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -155,7 +155,7 @@ up different products and import some of the bugs and patches from
 SourceForge.  Four different trackers were examined: `Jira
 <https://www.atlassian.com/software/jira/>`__,
 `Launchpad <https://launchpad.net/>`__,
-`Roundup <http://roundup.sourceforge.net/>`__, and
+`Roundup <https://roundup.sourceforge.io/>`__, and
 `Trac <https://trac.edgewall.org/>`__.
 The committee eventually settled on Jira
 and Roundup as the two candidates.  Jira is a commercial product that
@@ -187,7 +187,7 @@ other projects wishing to move from SourceForge to Roundup.
   https://bugs.jython.org:
     The Jython bug tracker.
 
-  http://roundup.sourceforge.net/
+  https://roundup.sourceforge.io/
     Roundup downloads and documentation.
 
   https://svn.python.org/view/tracker/importer/
@@ -238,7 +238,7 @@ have adopted Sphinx as their documentation tool.
    `Sphinx <http://sphinx-doc.org/>`__
      Documentation and code for the Sphinx toolchain.
 
-   `Docutils <http://docutils.sourceforge.net>`__
+   `Docutils <https://docutils.sourceforge.io>`__
      The underlying reStructuredText parser and toolset.
 
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1,6 +1,6 @@
 """Test date/time type.
 
-See http://www.zope.org/Members/fdrake/DateTimeWiki/TestCases
+See https://www.zope.dev/Members/fdrake/DateTimeWiki/TestCases
 """
 import io
 import itertools

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1,5 +1,5 @@
 /*  C implementation for the date/time type documented at
- *  http://www.zope.org/Members/fdrake/DateTimeWiki/FrontPage
+ *  https://www.zope.dev/Members/fdrake/DateTimeWiki/FrontPage
  */
 
 /* bpo-35081: Defining this prevents including the C API capsule;


### PR DESCRIPTION
It updates links which redirect to HTTPS with different authority or path.

> http://citeseerx.ist.psu.edu/viewdoc/summary -> https://citeseerx.ist.psu.edu/viewdoc/summary [^1]
> http://code.activestate.com/recipes/579000 -> https://code.activestate.com/recipes/579000 [^1]
> http://docutils.sourceforge.net -> https://docutils.sourceforge.io
> http://old.zope.org/Members/als/tips/win32_mingw_modules -> https://old.zope.dev/Members/als/tips/win32_mingw_modules
> http://roundup.sourceforge.net -> https://roundup.sourceforge.io
> http://statistics.about.com/od/Applications/a/Example-Of-Bootstrapping.htm -> https://www.thoughtco.com/example-of-bootstrapping-3126155
> http://wiki.tcl.tk/37432 -> https://wiki.tcl-lang.org/37432
> ~http://www.netlib.org/fp/dtoa.c -> https://netlib.org/fp/dtoa.c~
> http://www.pyinstaller.org -> https://pyinstaller.org [^2]
> http://www.pyvideo.org/video/1568/console-applications-with-urwid -> https://pyvideo.org/video/1568/console-applications-with-urwid
> http://www.unix.org/version2/whatsnew/lp64_wp.html -> https://unix.org/version2/whatsnew/lp64_wp.html
> http://www.zope.org -> https://www.zope.dev

[^1]: Redirection also adds explicit port `:443`.
[^2]: Redirection also adds path`/en/stable/`.

<!-- gh-issue-number: gh-91838 -->
* Issue: gh-91838
<!-- /gh-issue-number -->
