### PR TITLE
[3.11] GH-92678: Revert " Expose managed dict clear and visit functions (GH-95246)."

### DIFF
--- a/Include/cpython/dictobject.h
+++ b/Include/cpython/dictobject.h
@@ -76,6 +76,3 @@ typedef struct {
 
 PyAPI_FUNC(PyObject *) _PyDictView_New(PyObject *, PyTypeObject *);
 PyAPI_FUNC(PyObject *) _PyDictView_Intersect(PyObject* self, PyObject *other);
-
-PyAPI_FUNC(int) _PyObject_VisitManagedDict(PyObject *self, visitproc visit, void *arg);
-PyAPI_FUNC(void) _PyObject_ClearManagedDict(PyObject *self);

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -724,20 +724,6 @@ class CAPITest(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertTrue(hasattr(ctypes.pythonapi, name))
 
-    def test_clear_managed_dict(self):
-
-        class C:
-            def __init__(self):
-                self.a = 1
-
-        c = C()
-        _testcapi.clear_managed_dict(c)
-        self.assertEqual(c.__dict__, {})
-        c = C()
-        self.assertEqual(c.__dict__, {'a':1})
-        _testcapi.clear_managed_dict(c)
-        self.assertEqual(c.__dict__, {})
-
 
 class TestPendingCalls(unittest.TestCase):
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -6014,14 +6014,6 @@ settrace_to_record(PyObject *self, PyObject *list)
     Py_RETURN_NONE;
 }
 
-static PyObject *
-clear_managed_dict(PyObject *self, PyObject *obj)
-{
-    _PyObject_ClearManagedDict(obj);
-    Py_RETURN_NONE;
-}
-
-
 static PyObject *negative_dictoffset(PyObject *, PyObject *);
 static PyObject *test_buildvalue_issue38913(PyObject *, PyObject *);
 static PyObject *getargs_s_hash_int(PyObject *, PyObject *, PyObject*);
@@ -6323,7 +6315,6 @@ static PyMethodDef TestMethods[] = {
     {"get_feature_macros", get_feature_macros, METH_NOARGS, NULL},
     {"test_code_api", test_code_api, METH_NOARGS, NULL},
     {"settrace_to_record", settrace_to_record, METH_O, NULL},
-    {"clear_managed_dict", clear_managed_dict, METH_O, NULL},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5583,35 +5583,6 @@ _PyObject_FreeInstanceAttributes(PyObject *self)
     free_values(*values_ptr);
 }
 
-int
-_PyObject_VisitManagedDict(PyObject *self, visitproc visit, void *arg)
-{
-    PyTypeObject *tp = Py_TYPE(self);
-    if((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0) {
-        return 0;
-    }
-    assert(tp->tp_dictoffset);
-    int err = _PyObject_VisitInstanceAttributes(self, visit, arg);
-    if (err) {
-        return err;
-    }
-    Py_VISIT(*_PyObject_ManagedDictPointer(self));
-    return 0;
-}
-
-
-void
-_PyObject_ClearManagedDict(PyObject *self)
-{
-    PyTypeObject *tp = Py_TYPE(self);
-    if((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0) {
-        return;
-    }
-    _PyObject_FreeInstanceAttributes(self);
-    *_PyObject_ValuesPointer(self) = NULL;
-    Py_CLEAR(*_PyObject_ManagedDictPointer(self));
-}
-
 PyObject *
 PyObject_GenericGetDict(PyObject *obj, void *context)
 {


### PR DESCRIPTION
Reverts python/cpython#95256

We (@pablogsal and myself) have agreed that restoring the behvior of 3.10 is the best fix for https://github.com/python/cpython/issues/92678 and that this API should not be hurried.
We will add a better designed and tested version in 3.12.



<!-- gh-issue-number: gh-92678 -->
* Issue: gh-92678
<!-- /gh-issue-number -->
