### PR TITLE
GH-95245: Move weakreflist into the pre-header.

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -263,7 +263,7 @@ extern int _Py_CheckSlotResult(
 
 // Test if a type supports weak references
 static inline int _PyType_SUPPORTS_WEAKREFS(PyTypeObject *type) {
-    return (type->tp_weaklistoffset > 0);
+    return (type->tp_weaklistoffset != 0);
 }
 
 extern PyObject* _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems);

--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-04-16-04-18.gh-issue-95245.N4gOUV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-04-16-04-18.gh-issue-95245.N4gOUV.rst
@@ -1,0 +1,3 @@
+Reduces the size of a "simple" Python object from 8 to 6 words by moving the
+weakreflist pointer into the pre-header directly before the object's
+dict/values pointer.


### PR DESCRIPTION
Part 2 of #95245

Stores the weakreflist pointer in the now vacant space before the dict/values pointer.

<!-- gh-issue-number: gh-95245 -->
* Issue: gh-95245
<!-- /gh-issue-number -->
