### PR TITLE
gh-95605: Fix `float(s)` error message when `s` contains only whitespace

### DIFF
--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -137,6 +137,9 @@ class GeneralFloatCases(unittest.TestCase):
         check('123\xbd')
         check('  123 456  ')
         check(b'  123 456  ')
+        # all whitespace (cf. https://github.com/python/cpython/issues/95605)
+        check(' ')
+        check('\t \n')
 
         # non-ascii digits (error came from non-digit '!')
         check('\u0663\u0661\u0664!')

--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -138,6 +138,7 @@ class GeneralFloatCases(unittest.TestCase):
         check('  123 456  ')
         check(b'  123 456  ')
         # all whitespace (cf. https://github.com/python/cpython/issues/95605)
+        check('')
         check(' ')
         check('\t \n')
 

--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-04-18-46-54.gh-issue-95605.FbpCoG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-04-18-46-54.gh-issue-95605.FbpCoG.rst
@@ -1,0 +1,2 @@
+Fix misleading contents of error message when converting an all-whitespace
+string to :class:`float`.

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -162,11 +162,18 @@ float_from_string_inner(const char *s, Py_ssize_t len, void *obj)
     double x;
     const char *end;
     const char *last = s + len;
-    /* strip space */
+    /* strip leading whitespace */
     while (s < last && Py_ISSPACE(*s)) {
         s++;
     }
+    if (s == last) {
+        PyErr_Format(PyExc_ValueError,
+                     "could not convert string to float: "
+                     "%R", obj);
+        return NULL;
+    }
 
+    /* strip trailing whitespace */
     while (s < last - 1 && Py_ISSPACE(last[-1])) {
         last--;
     }


### PR DESCRIPTION
This PR fixes the error message from `float(s)` in the case where `s` contains only whitespace.

Closes #95605.

<!-- gh-issue-number: gh-95605 -->
* Issue: gh-95605
<!-- /gh-issue-number -->
