### PR TITLE
[3.10] Docs: sqlite3 docs fixup (GH-95681)

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -146,12 +146,12 @@ Module functions and constants
 .. data:: paramstyle
 
    String constant stating the type of parameter marker formatting expected by
-   the :mod:`sqlite3` module. Required by the DB-API. Hard-coded to
+   the :mod:`!sqlite3` module. Required by the DB-API. Hard-coded to
    ``"qmark"``.
 
    .. note::
 
-      The :mod:`sqlite3` module supports both ``qmark`` and ``numeric`` DB-API
+      The :mod:`!sqlite3` module supports both ``qmark`` and ``numeric`` DB-API
       parameter styles, because that is what the underlying SQLite library
       supports. However, the DB-API does not allow multiple values for
       the ``paramstyle`` attribute.
@@ -182,7 +182,7 @@ Module functions and constants
 .. data:: threadsafety
 
    Integer constant required by the DB-API, stating the level of thread safety
-   the :mod:`sqlite3` module supports. Currently hard-coded to ``1``, meaning
+   the :mod:`!sqlite3` module supports. Currently hard-coded to ``1``, meaning
    *"Threads may share the module, but not connections."* However, this may not
    always be true. You can check the underlying SQLite library's compile-time
    threaded mode using the following query::
@@ -205,7 +205,7 @@ Module functions and constants
    :func:`connect` to look up a converter function using
    the declared types for each column.
    The types are declared when the database table is created.
-   ``sqlite3`` will look up a converter function using the first word of the
+   :mod:`!sqlite3` will look up a converter function using the first word of the
    declared type as the converter dictionary key.
    For example:
 
@@ -289,7 +289,7 @@ Module functions and constants
        if not the default :class:`Connection` class.
 
    :param int cached_statements:
-       The number of statements that ``sqlite3``
+       The number of statements that :mod:`!sqlite3`
        should internally cache for this connection, to avoid parsing overhead.
        By default, 100 statements.
 
@@ -337,7 +337,7 @@ Module functions and constants
    SQLite type.
    The adapter is called with a Python object of type *type* as its sole
    argument, and must return a value of a
-   :ref:`type that SQLite natively understands<sqlite3-types>`.
+   :ref:`type that SQLite natively understands <sqlite3-types>`.
 
 
 .. function:: complete_statement(statement)
@@ -385,7 +385,7 @@ Connection objects
    .. attribute:: isolation_level
 
       This attribute controls the :ref:`transaction handling
-      <sqlite3-controlling-transactions>` performed by ``sqlite3``.
+      <sqlite3-controlling-transactions>` performed by :mod:`!sqlite3`.
       If set to ``None``, transactions are never implicitly opened.
       If set to one of ``"DEFERRED"``, ``"IMMEDIATE"``, or ``"EXCLUSIVE"``,
       corresponding to the underlying `SQLite transaction behaviour`_,
@@ -541,7 +541,7 @@ Connection objects
       :const:`SQLITE_OK` if access is allowed, :const:`SQLITE_DENY` if the entire SQL
       statement should be aborted with an error and :const:`SQLITE_IGNORE` if the
       column should be treated as a NULL value. These constants are available in the
-      :mod:`sqlite3` module.
+      :mod:`!sqlite3` module.
 
       The first argument to the callback signifies what kind of operation is to be
       authorized. The second and third argument will be arguments or ``None``
@@ -552,7 +552,7 @@ Connection objects
 
       Please consult the SQLite documentation about the possible values for the first
       argument and the meaning of the second and third argument depending on the first
-      one. All necessary constants are available in the :mod:`sqlite3` module.
+      one. All necessary constants are available in the :mod:`!sqlite3` module.
 
 
    .. method:: set_progress_handler(progress_handler, n)
@@ -605,7 +605,7 @@ Connection objects
 
       .. note::
 
-         The ``sqlite3`` module is not built with loadable extension support by
+         The :mod:`!sqlite3` module is not built with loadable extension support by
          default, because some platforms (notably macOS) have SQLite
          libraries which are compiled without this feature.
          To get loadable extension support,
@@ -875,11 +875,11 @@ Cursor objects
 
    .. method:: setinputsizes(sizes, /)
 
-      Required by the DB-API. Does nothing in :mod:`sqlite3`.
+      Required by the DB-API. Does nothing in :mod:`!sqlite3`.
 
    .. method:: setoutputsize(size, column=None, /)
 
-      Required by the DB-API. Does nothing in :mod:`sqlite3`.
+      Required by the DB-API. Does nothing in :mod:`!sqlite3`.
 
    .. attribute:: rowcount
 
@@ -1013,7 +1013,7 @@ The exception hierarchy is defined by the DB-API 2.0 (:pep:`249`).
 
 .. exception:: Warning
 
-   This exception is raised by ``sqlite3`` if an SQL query is not a
+   This exception is raised by :mod:`!sqlite3` if an SQL query is not a
    :class:`string <str>`, or if multiple statements are passed to
    :meth:`~Cursor.execute` or :meth:`~Cursor.executemany`.
    ``Warning`` is a subclass of :exc:`Exception`.
@@ -1026,8 +1026,8 @@ The exception hierarchy is defined by the DB-API 2.0 (:pep:`249`).
 
 .. exception:: InterfaceError
 
-   This exception is raised by ``sqlite3`` for fetch across rollback,
-   or if ``sqlite3`` is unable to bind parameters.
+   This exception is raised by :mod:`!sqlite3` for fetch across rollback,
+   or if :mod:`!sqlite3` is unable to bind parameters.
    ``InterfaceError`` is a subclass of :exc:`Error`.
 
 .. exception:: DatabaseError
@@ -1065,7 +1065,7 @@ The exception hierarchy is defined by the DB-API 2.0 (:pep:`249`).
 
 .. exception:: ProgrammingError
 
-   Exception raised for ``sqlite3`` API programming errors,
+   Exception raised for :mod:`!sqlite3` API programming errors,
    for example trying to operate on a closed :class:`Connection`,
    or trying to execute non-DML statements with :meth:`~Cursor.executemany`.
    ``ProgrammingError`` is a subclass of :exc:`DatabaseError`.
@@ -1121,10 +1121,10 @@ This is how SQLite types are converted to Python types by default:
 | ``BLOB``    | :class:`bytes`                               |
 +-------------+----------------------------------------------+
 
-The type system of the :mod:`sqlite3` module is extensible in two ways: you can
+The type system of the :mod:`!sqlite3` module is extensible in two ways: you can
 store additional Python types in an SQLite database via
 :ref:`object adapters <sqlite3-adapters>`,
-and you can let the ``sqlite3`` module convert SQLite types to
+and you can let the :mod:`!sqlite3` module convert SQLite types to
 Python types via :ref:`converters <sqlite3-converters>`.
 
 
@@ -1170,7 +1170,7 @@ Using adapters to store custom Python types in SQLite databases
 
 SQLite supports only a limited set of data types natively.
 To store custom Python types in SQLite databases, *adapt* them to one of the
-:ref:`Python types SQLite natively understands<sqlite3-types>`.
+:ref:`Python types SQLite natively understands <sqlite3-types>`.
 
 There are two ways to adapt Python objects to SQLite types:
 letting your object adapt itself, or using an *adapter callable*.
@@ -1234,7 +1234,7 @@ and constructs a :class:`Point` object from it.
        x, y = map(float, s.split(b";"))
        return Point(x, y)
 
-We now need to tell ``sqlite3`` when it should convert a given SQLite value.
+We now need to tell :mod:`!sqlite3` when it should convert a given SQLite value.
 This is done when connecting to a database, using the *detect_types* parameter
 of :func:`connect`. There are three options:
 
@@ -1346,7 +1346,7 @@ directly using only a single call on the :class:`Connection` object.
 Accessing columns by name instead of by index
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-One useful feature of the :mod:`sqlite3` module is the built-in
+One useful feature of the :mod:`!sqlite3` module is the built-in
 :class:`sqlite3.Row` class designed to be used as a row factory.
 
 Rows wrapped with this class can be accessed both by index (like tuples) and
@@ -1421,7 +1421,7 @@ Explanation
 Transaction control
 ^^^^^^^^^^^^^^^^^^^
 
-The ``sqlite3`` module does not adhere to the transaction handling recommended
+The :mod:`!sqlite3` module does not adhere to the transaction handling recommended
 by :pep:`249`.
 
 If the connection attribute :attr:`~Connection.isolation_level`
@@ -1432,7 +1432,7 @@ new transactions are implicitly opened before
 Use the :meth:`~Connection.commit` and :meth:`~Connection.rollback` methods
 to respectively commit and roll back pending transactions.
 You can choose the underlying `SQLite transaction behaviour`_ —
-that is, whether and what type of ``BEGIN`` statements ``sqlite3``
+that is, whether and what type of ``BEGIN`` statements :mod:`!sqlite3`
 implicitly executes –
 via the :attr:`~Connection.isolation_level` attribute.
 
@@ -1449,7 +1449,7 @@ any pending transaction before execution of the given SQL script,
 regardless of the value of :attr:`~Connection.isolation_level`.
 
 .. versionchanged:: 3.6
-   :mod:`sqlite3` used to implicitly commit an open transaction before DDL
+   :mod:`!sqlite3` used to implicitly commit an open transaction before DDL
    statements.  This is no longer the case.
 
 .. _autocommit mode:


### PR DESCRIPTION
- Consistent ref markup
- Disable links to the module itself

(cherry picked from commit 44f1f63ad5cf00b6f50cef0cc1a62c42632138be)

Co-authored-by: Erlend Egeberg Aasland <erlend.aasland@protonmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
