### PR TITLE
GH-95685: Fix rendering of the string documentation

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -6,6 +6,9 @@
 
 **Source code:** :source:`Lib/string.py`
 
+--------------
+
+
 .. seealso::
 
    :ref:`textseq`

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -6,8 +6,6 @@
 
 **Source code:** :source:`Lib/string.py`
 
---------------
-
 .. seealso::
 
    :ref:`textseq`


### PR DESCRIPTION
There's an extra underlines that messed the rest of the documentation rendering.

Closes GH-95685
