### PR TITLE
gh-95573: Fix a mistake in asyncio ssl test suppressing all logs

### DIFF
--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -58,6 +58,16 @@ class MyBaseProto(asyncio.Protocol):
             self.done.set_result(None)
 
 
+class MessageOutFilter(logging.Filter):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def filter(self, record):
+        if self.msg in record.msg:
+            return False
+        return True
+
+
 @unittest.skipIf(ssl is None, 'No ssl module')
 class TestSSL(test_utils.TestCase):
 
@@ -149,7 +159,7 @@ class TestSSL(test_utils.TestCase):
     def _silence_eof_received_warning(self):
         # TODO This warning has to be fixed in asyncio.
         logger = logging.getLogger('asyncio')
-        filter = logging.Filter('has no effect when using ssl')
+        filter = MessageOutFilter('has no effect when using ssl')
         logger.addFilter(filter)
         try:
             yield


### PR DESCRIPTION
This was originally introduced [here](https://github.com/MagicStack/uvloop/commit/494894701e9b3d140a875d46325bb680f07b8ad5#diff-23442418a7f45a49ff1d261f37aadda00d56fa0fba5117ab2e022102b9306a09R88-R97) and inherited in the cpython test suite, preventing the root reason of issues like #95573 from being easily seen.

Basically the idea of this filter is to prevent a warning saying `returning true from eof_received() has no effect when using ssl`, so we need to check the message instead of the logger name (like `logging.Filter` does).

<!-- gh-issue-number: gh-95573 -->
* Issue: gh-95573
<!-- /gh-issue-number -->
