### PR TITLE
Fix a mistake in isSet() deprecated message doc

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -570,7 +570,7 @@ class Event:
     def isSet(self):
         """Return true if and only if the internal flag is true.
 
-        This method is deprecated, use notify_all() instead.
+        This method is deprecated, use is_set() instead.
 
         """
         import warnings


### PR DESCRIPTION
Fix a mistake in isSet() deprecated message where it recommends to use notify_all() instead of is_set().