### PR TITLE
gh-92584: Add Makefile rules for test cpp extensions

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1686,6 +1686,31 @@ buildbottest: all
 		fi
 		$(TESTRUNNER) -j 1 -u all -W --slowest --fail-env-changed --timeout=$(TESTTIMEOUT) $(TESTOPTS)
 
+TEST_CPPMODS= \
+	Modules/_testcpp03ext$(EXT_SUFFIX) \
+	Modules/_testcpp11ext$(EXT_SUFFIX)
+
+.PHONY: test_cppmods
+test_cppmods: $(TEST_CPPMODS) pybuilddir.txt
+	@target=`cat pybuilddir.txt`; \
+	$(MKDIR_P) $$target; \
+	for mod in $(TEST_CPPMODS); do \
+		$(LN) -sf ../../$$mod $$target/`basename $$mod`; \
+	done
+
+# gh-91321: Build a basic C++ test extension to check that the Python C API is
+# compatible with C++ and does not emit C++ compiler warnings. The purpose of
+# _testcppext extension is to check that building a C++ extension using the
+# Python C API does not emit C++ compiler warnings
+Modules/_testcpp03ext.o: $(srcdir)/Lib/test/_testcppext.cpp $(PYTHON_HEADERS)
+	$(CXX) -Werror -std=c++03 $(CCSHARED) $(PY_CPPFLAGS) $(PY_CFLAGS) -c $(srcdir)/Lib/test/_testcppext.cpp -o $@
+Modules/_testcpp03ext$(EXT_SUFFIX): Modules/_testcpp03ext.o
+	$(LDCXXSHARED) $< -o $@
+Modules/_testcpp11ext.o: $(srcdir)/Lib/test/_testcppext.cpp $(PYTHON_HEADERS)
+	$(CXX) -Werror -std=c++11 $(CCSHARED) $(PY_CPPFLAGS) $(PY_CFLAGS) -c $(srcdir)/Lib/test/_testcppext.cpp -o $@
+Modules/_testcpp11ext$(EXT_SUFFIX): Modules/_testcpp11ext.o
+	$(LDCXXSHARED) $< -o $@
+
 pythoninfo: all
 		$(RUNSHARED) $(HOSTRUNNER) ./$(BUILDPYTHON) -m test.pythoninfo
 


### PR DESCRIPTION
`make test_cppmods` compiles C++ test extension modules.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-92584 -->
* Issue: gh-92584
<!-- /gh-issue-number -->
