### PR TITLE
gh-95388: Suppress deprecation warning in test_immutable_type_with_mutable_base

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -645,6 +645,7 @@ class CAPITest(unittest.TestCase):
                 with self.assertRaises(SystemError):
                     _testcapi.create_type_from_repeated_slots(variant)
 
+    @warnings_helper.ignore_warnings(category=DeprecationWarning)
     def test_immutable_type_with_mutable_base(self):
         # Add deprecation warning here so it's removed in 3.14
         warnings._deprecated(


### PR DESCRIPTION
When 3.14 kicks in, it'll be a RuntimeError;
the test will correctly fail then.


<!-- gh-issue-number: gh-95388 -->
* Issue: gh-95388
<!-- /gh-issue-number -->
