### PR TITLE
GH-95704: Don't suppress errors from tasks when TG is cancelled

### DIFF
--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -115,7 +115,8 @@ class TaskGroup:
         if self._base_error is not None:
             raise self._base_error
 
-        if propagate_cancellation_error is not None:
+        if (propagate_cancellation_error is not None and
+                (self._parent_cancel_requested or not self._errors)):
             # The wrapping task was cancelled; since we're done with
             # closing all child tasks, just propagate the cancellation
             # request now.

--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -116,10 +116,8 @@ class TaskGroup:
             raise self._base_error
 
         # Propagate CancelledError if there is one, except if there
-        # are other errors and we're not required by uncancel() != 0.
-        # (The latter means we *must* propagate the cancellation.)
-        if (propagate_cancellation_error is not None and
-                (self._parent_cancel_requested or not self._errors)):
+        # are other errors -- those have priority.
+        if propagate_cancellation_error and not self._errors:
             raise propagate_cancellation_error
 
         if et is not None and et is not exceptions.CancelledError:

--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -115,11 +115,11 @@ class TaskGroup:
         if self._base_error is not None:
             raise self._base_error
 
+        # Propagate CancelledError if there is one, except if there
+        # are other errors and we're not required by uncancel() != 0.
+        # (The latter means we *must* propagate the cancellation.)
         if (propagate_cancellation_error is not None and
                 (self._parent_cancel_requested or not self._errors)):
-            # The wrapping task was cancelled; since we're done with
-            # closing all child tasks, just propagate the cancellation
-            # request now.
             raise propagate_cancellation_error
 
         if et is not None and et is not exceptions.CancelledError:

--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -427,8 +427,9 @@ class TestTaskGroup(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(r.done())
         r.cancel()
-        with self.assertRaises(asyncio.CancelledError):
+        with self.assertRaises(ExceptionGroup) as cm:
             await r
+        self.assertEqual(get_error_types(cm.exception), {ZeroDivisionError})
 
     async def test_taskgroup_16(self):
 
@@ -454,8 +455,9 @@ class TestTaskGroup(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(r.done())
         r.cancel()
-        with self.assertRaises(asyncio.CancelledError):
+        with self.assertRaises(ExceptionGroup) as cm:
             await r
+        self.assertEqual(get_error_types(cm.exception), {ZeroDivisionError})
 
     async def test_taskgroup_17(self):
         NUM = 0

--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -229,29 +229,29 @@ class TestTaskGroup(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(NUM, 15)
 
-    async def test_cancellation_in_body(self):
+    async def test_taskgroup_08(self):
 
         async def foo():
-            await asyncio.sleep(0.1)
-            1 / 0
+            try:
+                await asyncio.sleep(10)
+            finally:
+                1 / 0
 
         async def runner():
             async with taskgroups.TaskGroup() as g:
                 for _ in range(5):
                     g.create_task(foo())
 
-                try:
-                    await asyncio.sleep(10)
-                except asyncio.CancelledError:
-                    raise
+                await asyncio.sleep(10)
 
         r = asyncio.create_task(runner())
         await asyncio.sleep(0.1)
 
         self.assertFalse(r.done())
         r.cancel()
-        with self.assertRaises(asyncio.CancelledError) as cm:
+        with self.assertRaises(ExceptionGroup) as cm:
             await r
+        self.assertEqual(get_error_types(cm.exception), {ZeroDivisionError})
 
     async def test_taskgroup_09(self):
 
@@ -315,8 +315,10 @@ class TestTaskGroup(unittest.IsolatedAsyncioTestCase):
     async def test_taskgroup_11(self):
 
         async def foo():
-            await asyncio.sleep(0.1)
-            1 / 0
+            try:
+                await asyncio.sleep(10)
+            finally:
+                1 / 0
 
         async def runner():
             async with taskgroups.TaskGroup():
@@ -324,24 +326,26 @@ class TestTaskGroup(unittest.IsolatedAsyncioTestCase):
                     for _ in range(5):
                         g2.create_task(foo())
 
-                    try:
-                        await asyncio.sleep(10)
-                    except asyncio.CancelledError:
-                        raise
+                    await asyncio.sleep(10)
 
         r = asyncio.create_task(runner())
         await asyncio.sleep(0.1)
 
         self.assertFalse(r.done())
         r.cancel()
-        with self.assertRaises(asyncio.CancelledError):
+        with self.assertRaises(ExceptionGroup) as cm:
             await r
+
+        self.assertEqual(get_error_types(cm.exception), {ExceptionGroup})
+        self.assertEqual(get_error_types(cm.exception.exceptions[0]), {ZeroDivisionError})
 
     async def test_taskgroup_12(self):
 
         async def foo():
-            await asyncio.sleep(0.1)
-            1 / 0
+            try:
+                await asyncio.sleep(10)
+            finally:
+                1 / 0
 
         async def runner():
             async with taskgroups.TaskGroup() as g1:
@@ -351,18 +355,18 @@ class TestTaskGroup(unittest.IsolatedAsyncioTestCase):
                     for _ in range(5):
                         g2.create_task(foo())
 
-                    try:
-                        await asyncio.sleep(10)
-                    except asyncio.CancelledError:
-                        raise
+                    await asyncio.sleep(10)
 
         r = asyncio.create_task(runner())
         await asyncio.sleep(0.1)
 
         self.assertFalse(r.done())
         r.cancel()
-        with self.assertRaises(asyncio.CancelledError):
+        with self.assertRaises(ExceptionGroup) as cm:
             await r
+
+        self.assertEqual(get_error_types(cm.exception), {ExceptionGroup})
+        self.assertEqual(get_error_types(cm.exception.exceptions[0]), {ZeroDivisionError})
 
     async def test_taskgroup_13(self):
 

--- a/Misc/NEWS.d/next/Library/2022-08-08-01-42-11.gh-issue-95704.MOPFfX.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-08-01-42-11.gh-issue-95704.MOPFfX.rst
@@ -1,0 +1,2 @@
+When a task catches CancelledError and raises some other error,
+the other error should generally not silently be suppressed.

--- a/Misc/NEWS.d/next/Library/2022-08-08-01-42-11.gh-issue-95704.MOPFfX.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-08-01-42-11.gh-issue-95704.MOPFfX.rst
@@ -1,3 +1,2 @@
 When a task catches :exc:`asyncio.CancelledError` and raises some other error,
-
 the other error should generally not silently be suppressed.

--- a/Misc/NEWS.d/next/Library/2022-08-08-01-42-11.gh-issue-95704.MOPFfX.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-08-01-42-11.gh-issue-95704.MOPFfX.rst
@@ -1,2 +1,3 @@
-When a task catches CancelledError and raises some other error,
+When a task catches :exc:`asyncio.CancelledError` and raises some other error,
+
 the other error should generally not silently be suppressed.


### PR DESCRIPTION
When a task catches CancelledError and raises some other error,
the other error should not silently be suppressed.

Exception: when uncancel() != 0, always propagate CancelledError.

NOTE: This represents a change in behavior (hence the need to
change three tests).  But it is only an edge case.

We need to discuss with the RM whether to backport to 3.11RC2,
or 3.11.1, or not at all.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95704 -->
* Issue: gh-95704
<!-- /gh-issue-number -->
