### PR TITLE
bpo-37000: Remove obsolete comment in _randbelow_with_getrandbits

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -239,12 +239,6 @@ class Random(_random.Random):
         "Return a random int in the range [0,n).  Defined for n > 0."
 
         getrandbits = self.getrandbits
-        # For efficiency, we'd like to use k = (n-1).bit_length() here, but
-        # before Python 3.9, `getrandbits()` did not accept 0 as an argument.
-        # That's why using `n-1` was a problem when `n` was 1.
-        #
-        # Now we are stuck with this version, because we want to reproduce
-        # results after explicitly setting a seed even between releases.
         k = n.bit_length()
         r = getrandbits(k)  # 0 <= r < 2**k
         while r >= n:

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -239,7 +239,13 @@ class Random(_random.Random):
         "Return a random int in the range [0,n).  Defined for n > 0."
 
         getrandbits = self.getrandbits
-        k = n.bit_length()  # don't use (n-1) here because n can be 1
+        # For efficiency, we'd like to use k = (n-1).bit_length() here, but
+        # before Python 3.9, `getrandbits()` did not accept 0 as an argument.
+        # That's why using `n-1` was a problem when `n` was 1.
+        #
+        # Now we are stuck with this version, because we want to reproduce
+        # results after explicitly setting a seed even between releases.
+        k = n.bit_length()
         r = getrandbits(k)  # 0 <= r < 2**k
         while r >= n:
             r = getrandbits(k)

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -239,7 +239,7 @@ class Random(_random.Random):
         "Return a random int in the range [0,n).  Defined for n > 0."
 
         getrandbits = self.getrandbits
-        k = (n-1).bit_length()
+        k = n.bit_length()  # don't use (n-1) here because n can be 1
         r = getrandbits(k)  # 0 <= r < 2**k
         while r >= n:
             r = getrandbits(k)

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -239,7 +239,7 @@ class Random(_random.Random):
         "Return a random int in the range [0,n).  Defined for n > 0."
 
         getrandbits = self.getrandbits
-        k = n.bit_length()  # don't use (n-1) here because n can be 1
+        k = (n-1).bit_length()
         r = getrandbits(k)  # 0 <= r < 2**k
         while r >= n:
             r = getrandbits(k)

--- a/Misc/NEWS.d/next/Documentation/2022-08-08-10-57-32.gh-issue-13485.xtWoE8.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-08-08-10-57-32.gh-issue-13485.xtWoE8.rst
@@ -1,0 +1,1 @@
+Remove obsolete comment in _randbelow_with_getrandbits

--- a/Misc/NEWS.d/next/Documentation/2022-08-08-10-57-32.gh-issue-13485.xtWoE8.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-08-08-10-57-32.gh-issue-13485.xtWoE8.rst
@@ -1,1 +1,0 @@
-Remove obsolete comment in _randbelow_with_getrandbits


### PR DESCRIPTION
In `random._randbelow_with_getrandbits` we are generating a random integer
in [0,n).  We do that by repeatedly drawing a random number, r, in [0,2**k)
until we hit an r < n.

That's a great strategy.  It's not only very simple, but even with worst
case input, we only need to draw 2 random numbers on average, before we
hit the jackpot.

However, the code is a bit overly cautious.  When n is a power of 2, we
ask `getrandbits` to sample from [0,2*n].  The code justifies that
strange behaviour with a comment expressing fear of the special case n==1.

That fear is unfounded: the obvious code works just fine for n==1.

Fixing this not only makes the code simpler to understand, it also
guarantees that the important special case of n being a power of two now
has a guaranteed worst case runtime of only a single call to
getrandbits; instead of an expected runtime of two calls with no worst
case bound.

Existing tests already cover this code and the special cases of
interest.  So we don't need any new tests.

This minor performance bug was introduced in
0515661314c4e5b9235e07b2c46b8f456c7fadc3 as far as I can tell.  But I
can't really tell what the original author was thinking.

Since this is a fairly trivial change, I did not create an issue.  (But I am happy to create one, if you think it's better this way.)

I discovered this problem while working on https://discuss.python.org/t/random-choice-from-a-dict/17834

Automerge-Triggered-By: GH:rhettinger