### PR TITLE
gh-95781: More strict format string checking in PyUnicode_FromFormatV()

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -477,9 +477,6 @@ APIs:
    |                   |                     | :c:func:`PyObject_Repr`.         |
    +-------------------+---------------------+----------------------------------+
 
-   An unrecognized format character causes all the rest of the format string to be
-   copied as-is to the result string, and any extra arguments discarded.
-
    .. note::
       The width formatter unit is number of characters rather than bytes.
       The precision formatter unit is number of bytes for ``"%s"`` and
@@ -499,6 +496,11 @@ APIs:
    .. versionchanged:: 3.4
       Support width and precision formatter for ``"%s"``, ``"%A"``, ``"%U"``,
       ``"%V"``, ``"%S"``, ``"%R"`` added.
+
+   .. versionchanged:: 3.12
+      An unrecognized format character now sets a :exc:`SystemError`.
+      In previous versions it caused all the rest of the format string to be
+      copied as-is to the result string, and any extra arguments discarded.
 
 
 .. c:function:: PyObject* PyUnicode_FromFormatV(const char *format, va_list vargs)

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -461,6 +461,11 @@ Porting to Python 3.12
   :py:meth:`~class.__subclasses__` (using :c:func:`PyObject_CallMethod`,
   for example).
 
+* An unrecognized format character in :c:func:`PyUnicode_FromFormat` and
+  :c:func:`PyUnicode_FromFormatV` now sets a :exc:`SystemError`.
+  In previous versions it caused all the rest of the format string to be
+  copied as-is to the result string, and any extra arguments discarded.
+
 
 Deprecated
 ----------

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -465,6 +465,7 @@ Porting to Python 3.12
   :c:func:`PyUnicode_FromFormatV` now sets a :exc:`SystemError`.
   In previous versions it caused all the rest of the format string to be
   copied as-is to the result string, and any extra arguments discarded.
+  (Contributed by Serhiy Storchaka in :gh:`95781`.)
 
 
 Deprecated

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -2642,8 +2642,6 @@ class CAPITest(unittest.TestCase):
 
         # test "%"
         check_format('%',
-                     b'%')
-        check_format('%',
                      b'%%')
         check_format('%s',
                      b'%%s')
@@ -2819,22 +2817,21 @@ class CAPITest(unittest.TestCase):
         check_format('repr=abc\ufffd',
                      b'repr=%V', None, b'abc\xff')
 
-        # not supported: copy the raw format string. these tests are just here
-        # to check for crashes and should not be considered as specifications
-        check_format('%s',
-                     b'%1%s', b'abc')
-        check_format('%1abc',
-                     b'%1abc')
-        check_format('%+i',
-                     b'%+i', c_int(10))
-        check_format('%.%s',
-                     b'%.%s', b'abc')
-
         # Issue #33817: empty strings
         check_format('',
                      b'')
         check_format('',
                      b'%s', b'')
+
+        # check for crashes
+        for fmt in (b'%', b'%0', b'%01', b'%.', b'%.1',
+                    b'%0%s', b'%1%s', b'%.%s', b'%.1%s', b'%1abc',
+                    b'%l', b'%ll', b'%z', b'%ls', b'%lls', b'%zs'):
+            with self.subTest(fmt=fmt):
+                self.assertRaisesRegex(SystemError, 'invalid format string',
+                    PyUnicode_FromFormat, fmt, b'abc')
+        self.assertRaisesRegex(SystemError, 'invalid format string',
+            PyUnicode_FromFormat, b'%+i', c_int(10))
 
     # Test PyUnicode_AsWideChar()
     @support.cpython_only

--- a/Misc/NEWS.d/next/C API/2022-08-08-14-36-31.gh-issue-95781.W_G8YW.rst
+++ b/Misc/NEWS.d/next/C API/2022-08-08-14-36-31.gh-issue-95781.W_G8YW.rst
@@ -1,0 +1,4 @@
+An unrecognized format character in :c:func:`PyUnicode_FromFormat` and
+:c:func:`PyUnicode_FromFormatV` now sets a :exc:`SystemError`.
+In previous versions it caused all the rest of the format string to be
+copied as-is to the result string, and any extra arguments discarded.


### PR DESCRIPTION
An unrecognized format character in PyUnicode_FromFormat() and
PyUnicode_FromFormatV() now sets a SystemError.
In previous versions it caused all the rest of the format string to be
copied as-is to the result string, and any extra arguments discarded.


<!-- gh-issue-number: gh-95781 -->
* Issue: gh-95781
<!-- /gh-issue-number -->
