### PR TITLE
gh-93274: Disable Limited API tests with Py_TRACE_REFS

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -9,6 +9,7 @@ import collections
 import itertools
 import gc
 import contextlib
+import sys
 
 
 class BadStr(str):
@@ -759,6 +760,9 @@ class TestPEP590(unittest.TestCase):
                 self.assertEqual(expected, meth(*args1, **kwargs))
                 self.assertEqual(expected, wrapped(*args, **kwargs))
 
+    @unittest.skipIf(
+        hasattr(sys, 'getobjects'),
+        "Limited API is not compatible with Py_TRACE_REFS")
     def test_vectorcall_limited(self):
         from _testcapi import pyobject_vectorcall
         obj = _testcapi.LimitedVectorCallClass()

--- a/Modules/_testcapi/vectorcall_limited.c
+++ b/Modules/_testcapi/vectorcall_limited.c
@@ -1,3 +1,16 @@
+#include "pyconfig.h"  // Py_TRACE_REFS
+
+#ifdef Py_TRACE_REFS
+
+// Py_TRACE_REFS is incompatible with Limited API
+#include "parts.h"
+int
+_PyTestCapi_Init_VectorcallLimited(PyObject *m) {
+    return 0;
+}
+
+#else
+
 #define Py_LIMITED_API 0x030c0000 // 3.12
 #include "parts.h"
 #include "structmember.h"         // PyMemberDef
@@ -75,3 +88,5 @@ _PyTestCapi_Init_VectorcallLimited(PyObject *m) {
 
     return 0;
 }
+
+#endif // Py_TRACE_REFS


### PR DESCRIPTION
This should fix the Py_TRACE_REFS buildbot.

(In the future we'll need a better way to write limited API tests.)

<!-- gh-issue-number: gh-93274 -->
* Issue: gh-93274
<!-- /gh-issue-number -->
