### PR TITLE
gh-71316: Update dis documentation to include changes to jump arguments

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -31,9 +31,8 @@ interpreter.
       by instruction.
 
    .. versionchanged:: 3.10
-      The argument for instructions that have a jump now use the instruction
-      offset instead of the byte offset. Because each instruction take two
-      bytes, the instruction offset is exactly half of the byte offset.
+      The argument of jump, exception handling and loop instructions is now
+      the instruction offset rather than the byte offset.
 
    .. versionchanged:: 3.11
       Some instructions are accompanied by one or more inline cache entries,

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -30,6 +30,11 @@ interpreter.
       Use 2 bytes for each instruction. Previously the number of bytes varied
       by instruction.
 
+   .. versionchanged:: 3.10
+      The argument for instructions that have a jump now use the instruction
+      offset instead of the byte offset. Because each instruction take two
+      bytes, the instruction offset is exactly half of the byte offset.
+
    .. versionchanged:: 3.11
       Some instructions are accompanied by one or more inline cache entries,
       which take the form of :opcode:`CACHE` instructions. These instructions


### PR DESCRIPTION
Since 3.10, the instruction offset is used instead of the byte
offset. Thus, for jump instructions, the argument is half
of what it would of been in 3.9. For instance, this code:

def test(x):
    return 1 if x else 0

in 3.9 disassembles into

  4           0 LOAD_FAST                0 (x)
              2 POP_JUMP_IF_FALSE        8
              4 LOAD_CONST               1 (1)
              6 RETURN_VALUE
        >>    8 LOAD_CONST               2 (0)
             10 RETURN_VALUE

but in 3.10 disassembles into

  4           0 LOAD_FAST                0 (x)
              2 POP_JUMP_IF_FALSE        4 (to 8)
              4 LOAD_CONST               1 (1)
              6 RETURN_VALUE
        >>    8 LOAD_CONST               2 (0)
             10 RETURN_VALUE

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-71316 -->
* Issue: gh-71316
<!-- /gh-issue-number -->
