### PR TITLE
[3.10] gh-95789: update documentation RFC base URL

### DIFF
--- a/Doc/docutils.conf
+++ b/Doc/docutils.conf
@@ -1,0 +1,8 @@
+#
+# Python documentation docutils configuration file
+#
+# https://docutils.sourceforge.io/docs/user/config.html
+
+[parsers]
+# Override the default RFC base URL from sphinx
+rfc_base_url=https://datatracker.ietf.org/doc/html/

--- a/Misc/NEWS.d/next/Documentation/2022-08-09-16-11-36.gh-issue-95789.UO7fJL.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-08-09-16-11-36.gh-issue-95789.UO7fJL.rst
@@ -1,0 +1,1 @@
+Update the default RFC base URL from deprecated tools.ietf.org to datatracker.ietf.org


### PR DESCRIPTION
I did not find any way to override `docutils` default settings through `sphinx` so I had to create this configuration file.

Tested locally :heavy_check_mark: 

The issue is also impacting python `3.7`, `3.8` and `3.9`. So I guess I've to create the exact same PR targeting another branch, may you confirm, please?


<!-- gh-issue-number: gh-95789 -->
* Issue: gh-95789
<!-- /gh-issue-number -->
