### PR TITLE
gh-94808: Add coverage for bytesarray_setitem

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4847,6 +4847,20 @@ sequence_setitem(PyObject *self, PyObject *args)
 
 
 static PyObject *
+sequence_delitem(PyObject *self, PyObject *args)
+{
+    Py_ssize_t i;
+    PyObject *seq;
+    if (!PyArg_ParseTuple(args, "On", &seq, &i)) {
+        return NULL;
+    }
+    if (PySequence_DelItem(seq, i)) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *
 hasattr_string(PyObject *self, PyObject* args)
 {
     PyObject* obj;
@@ -5732,6 +5746,7 @@ static PyMethodDef TestMethods[] = {
     {"write_unraisable_exc", test_write_unraisable_exc, METH_VARARGS},
     {"sequence_getitem", sequence_getitem, METH_VARARGS},
     {"sequence_setitem", sequence_setitem, METH_VARARGS},
+    {"sequence_delitem", sequence_delitem, METH_VARARGS},
     {"hasattr_string", hasattr_string, METH_VARARGS},
     {"meth_varargs", meth_varargs, METH_VARARGS},
     {"meth_varargs_keywords", _PyCFunction_CAST(meth_varargs_keywords), METH_VARARGS|METH_KEYWORDS},


### PR DESCRIPTION
When both are provided, `tp_ass_subscript` takes precedence over `tp_ass_item`.  Since `bytesarray` provides both, the existing `test_setitem` tests for `bytesarray` were not testing `bytesarray_setitem`, but `bytesarray_ass_subscript`.  This is mostly fine, since Python code has to jump through some hoops to even call it, but a third-party library using `PySequence_SetItem` could potentially run into this uncovered case.

<!-- gh-issue-number: gh-94808 -->
* Issue: gh-94808
<!-- /gh-issue-number -->
