### PR TITLE
Fix typo in ceval.c

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -630,8 +630,8 @@ _PyEval_AddPendingCall(PyInterpreterState *interp,
 {
     struct _pending_calls *pending = &interp->ceval.pending;
 
-    /* Ensure that _PyEval_InitPendingCalls() was called
-       and that _PyEval_FiniPendingCalls() is not called yet. */
+    /* Ensure that _PyEval_InitState() was called
+       and that _PyEval_FiniState() is not called yet. */
     assert(pending->lock != NULL);
 
     PyThread_acquire_lock(pending->lock, WAIT_LOCK);


### PR DESCRIPTION
There are no functions named `_PyEval_InitPendingCalls()` nor `_PyEval_FiniPendingCalls()`:

```
$ git rev-parse HEAD
78a85a34ea2583b8489eeafba5b2018fa2048a4d

$ git grep _PyEval_InitPendingCalls
Python/ceval.c:    /* Ensure that _PyEval_InitPendingCalls() was called

$ git grep _PyEval_FiniPendingCalls
Python/ceval.c:       and that _PyEval_FiniPendingCalls() is not called yet. */
```

I suppose the intended functions are `_PyEval_InitState()` and `_PyEval_FiniState()`. FYI, the original comment is introduced in dda5d6e071c6a9d65993d45b90232565cfad2cde of #19436.

(I belive this PR doesn't require an issue)