### PR TITLE
gh-95349: Hide a Distutils Warning Filter for test_check_c_globals

### DIFF
--- a/Lib/test/test_check_c_globals.py
+++ b/Lib/test/test_check_c_globals.py
@@ -1,9 +1,14 @@
 import unittest
 import test.test_tools
+from test.support.warnings_helper import save_restore_warnings_filters
 
 test.test_tools.skip_if_missing('c-analyzer')
 with test.test_tools.imports_under_tool('c-analyzer'):
-    from cpython.__main__ import main
+    # gh-95349: Save/restore warnings filters to leave them unchanged.
+    # Importing the c-analyzer imports docutils which imports pkg_resources
+    # which adds a warnings filter.
+    with save_restore_warnings_filters():
+        from cpython.__main__ import main
 
 
 class ActualChecks(unittest.TestCase):


### PR DESCRIPTION
Under certain build conditions, test_check_c_globals fails.  This fix takes the same approach as we took for gh-84236 (via gh-20095).  We'll be removing use of distutils in the c-analyzer at some point.  Until then we'll hide the warning filter.

<!-- gh-issue-number: gh-95349 -->
* Issue: gh-95349
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:ericsnowcurrently