### PR TITLE
gh-95841: IDLE - Revise Windows local doc url

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -8,7 +8,6 @@ import sys
 import tokenize
 import traceback
 import webbrowser
-import winreg
 
 from tkinter import *
 from tkinter.font import Font
@@ -87,7 +86,8 @@ class EditorWindow:
                     dochome = os.path.join(basepath, pyver,
                                            'Doc', 'index.html')
             elif sys.platform[:3] == 'win':
-                docfile = "Dummy^file&name*that(should)fail-isfile#check"
+                import winreg  # Windows only, block only executed once.
+                docfile = ''
                 KEY = (rf"Software\Python\PythonCore\{sys.winver}"
                         r"\Help\Main Python Documentation")
                 try:

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -8,6 +8,7 @@ import sys
 import tokenize
 import traceback
 import webbrowser
+import winreg
 
 from tkinter import *
 from tkinter.font import Font
@@ -86,10 +87,19 @@ class EditorWindow:
                     dochome = os.path.join(basepath, pyver,
                                            'Doc', 'index.html')
             elif sys.platform[:3] == 'win':
-                chmfile = os.path.join(sys.base_prefix, 'Doc',
-                                       'Python%s.chm' % _sphinx_version())
-                if os.path.isfile(chmfile):
-                    dochome = chmfile
+                docfile = "Dummy^file&name*that(should)fail-isfile#check"
+                KEY = (rf"Software\Python\PythonCore\{sys.winver}"
+                        r"\Help\Main Python Documentation")
+                try:
+                    docfile = winreg.QueryValue(winreg.HKEY_CURRENT_USER, KEY)
+                except FileNotFoundError:
+                    try:
+                        docfile = winreg.QueryValue(winreg.HKEY_LOCAL_MACHINE,
+                                                    KEY)
+                    except FileNotFoundError:
+                        pass
+                if os.path.isfile(docfile):
+                    dochome = docfile
             elif sys.platform == 'darwin':
                 # documentation may be stored inside a python framework
                 dochome = os.path.join(sys.base_prefix,


### PR DESCRIPTION
#91242 replaced the Windows chm help file with a copy
of the html docs.  This PR replaces the IDLE code that
fetches the Windows local help url passed to os.startfile.
It is based on Steve Dower's https://github.com/python/cpython/issues/91242#issuecomment-1093946988.

Co-authored-by: Steve Dower

<!-- gh-issue-number: gh-95841 -->
* Issue: gh-95841
<!-- /gh-issue-number -->
