### PR TITLE
gh-95804: Respect MemoryHandler.flushOnClose in logging shutdown. (GH-95857)

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -2245,7 +2245,11 @@ def shutdown(handlerList=_handlerList):
             if h:
                 try:
                     h.acquire()
-                    h.flush()
+                    # MemoryHandlers might not want to be flushed on close,
+                    # but circular imports prevent us scoping this to just
+                    # those handlers.  hence the default to True.
+                    if getattr(h, 'flushOnClose', True):
+                        h.flush()
                     h.close()
                 except (OSError, ValueError):
                     # Ignore errors which might be caused

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -198,6 +198,7 @@ Gawain Bolton
 Carl Friedrich Bolz-Tereick
 Forest Bond
 Gregory Bond
+David Bonner
 Angelin Booz
 Médéric Boquien
 Matias Bordese

--- a/Misc/NEWS.d/next/Library/2022-08-10-11-54-04.gh-issue-95804.i5FCFK.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-10-11-54-04.gh-issue-95804.i5FCFK.rst
@@ -1,0 +1,2 @@
+Fix ``logging`` shutdown handler so it respects
+``MemoryHandler.flushOnClose``.


### PR DESCRIPTION
logging.shutdown() now checks to see if a handler has set flushOnClose
to False before flushing it.


<!-- gh-issue-number: gh-95804 -->
* Issue: gh-95804
<!-- /gh-issue-number -->
