### PR TITLE
gh-95733: Allow installing Store package on older Windows versions

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-08-10-22-46-48.gh-issue-95733.2_urOp.rst
+++ b/Misc/NEWS.d/next/Windows/2022-08-10-22-46-48.gh-issue-95733.2_urOp.rst
@@ -1,0 +1,2 @@
+Make certain requirements of the Windows Store package optional to allow
+installing on earlier updates of Windows.

--- a/PC/layout/support/appxmanifest.py
+++ b/PC/layout/support/appxmanifest.py
@@ -86,7 +86,8 @@ APPXMANIFEST_NS = {
 }
 
 APPXMANIFEST_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+<Package IgnorableNamespaces="desktop4 desktop6"
+    xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
     xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
     xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
     xmlns:rescap4="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/4"


### PR DESCRIPTION
IgnorableNamespaces instructs the installer to allow the package to be installed even if certain features are missing.

<!-- gh-issue-number: gh-95733 -->
* Issue: gh-95733
<!-- /gh-issue-number -->
