### PR TITLE
gh-95865: Speed up urllib.parse.quote_from_bytes()

### DIFF
--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -906,7 +906,7 @@ def quote_from_bytes(bs, safe='/'):
     if not bs.rstrip(_ALWAYS_SAFE_BYTES + safe):
         return bs.decode()
     quoter = _byte_quoter_factory(safe)
-    return ''.join([quoter(char) for char in bs])
+    return ''.join(map(quoter, bs))
 
 def urlencode(query, doseq=False, safe='', encoding=None, errors=None,
               quote_via=quote_plus):

--- a/Misc/NEWS.d/next/Library/2022-08-11-03-16-48.gh-issue-95865.0IOkFP.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-11-03-16-48.gh-issue-95865.0IOkFP.rst
@@ -1,0 +1,1 @@
+Speed up :func:`urllib.parse.quote_from_bytes` by replacing a list comprehension with ``map()``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Roughly 1.8x faster:
```
.\python.bat -m pyperf timeit -s "from urllib.parse import quote_from_bytes as f; b = b'A'*10_000 + b'='" "f(b)"

Before: Mean +- std dev: 570 us +- 6 us
After:  Mean +- std dev: 309 us +- 3 us
```



<!-- gh-issue-number: gh-95865 -->
* Issue: gh-95865
<!-- /gh-issue-number -->
