### PR TITLE
gh-84910: Change 'IDLE Help' to 'IDLE Doc'

### DIFF
--- a/Lib/idlelib/mainmenu.py
+++ b/Lib/idlelib/mainmenu.py
@@ -111,7 +111,7 @@ menudefs = [
  ('help', [
    ('_About IDLE', '<<about-idle>>'),
    None,
-   ('_IDLE Help', '<<help>>'),
+   ('_IDLE Doc', '<<help>>'),
    ('Python _Docs', '<<python-docs>>'),
    ]),
 ]


### PR DESCRIPTION
'IDLE Help' was a plain text file.  It was superceded years ago
by a copy of the much more complete html doc.  .

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-84910 -->
* Issue: gh-84910
<!-- /gh-issue-number -->
