### PR TITLE
GH-95899: fix asyncio.Runner to call set_event_loop once

### DIFF
--- a/Lib/asyncio/runners.py
+++ b/Lib/asyncio/runners.py
@@ -114,8 +114,6 @@ class Runner:
 
         self._interrupt_count = 0
         try:
-            if self._set_event_loop:
-                events.set_event_loop(self._loop)
             return self._loop.run_until_complete(task)
         except exceptions.CancelledError:
             if self._interrupt_count > 0:
@@ -136,7 +134,11 @@ class Runner:
             return
         if self._loop_factory is None:
             self._loop = events.new_event_loop()
-            self._set_event_loop = True
+            if not self._set_event_loop:
+                # Call set_event_loop only once to avoid calling
+                # attach_loop multiple times on child watchers
+                events.set_event_loop(self._loop)
+                self._set_event_loop = True
         else:
             self._loop = self._loop_factory()
         if self._debug is not None:

--- a/Lib/test/test_asyncio/test_runners.py
+++ b/Lib/test/test_asyncio/test_runners.py
@@ -455,6 +455,20 @@ class RunnerTests(BaseTest):
             ):
                 runner.run(coro())
 
+    def test_set_event_loop_called_once(self):
+        # See https://github.com/python/cpython/issues/95736
+        async def coro():
+            pass
+
+        policy = asyncio.get_event_loop_policy()
+        policy.set_event_loop = mock.Mock()
+        runner = asyncio.Runner()
+        runner.run(coro())
+        runner.run(coro())
+
+        self.assertEqual(1, policy.set_event_loop.call_count)
+        runner.close()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2022-08-11-18-52-17.gh-issue-95899._Bi4uG.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-11-18-52-17.gh-issue-95899._Bi4uG.rst
@@ -1,0 +1,1 @@
+Fix :class:`asyncio.Runner` to call :func:`asyncio.set_event_loop` only once to avoid calling :meth:`~asyncio.AbstractChildWatcher.attach_loop` multiple times on child watchers. Patch by Kumar Aditya.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95899 -->
* Issue: gh-95899
<!-- /gh-issue-number -->
