### PR TITLE
[3.10] gh-95876: Fix format string in pegen error location code (GH-95877

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-11-09-19-55.gh-issue-95876.YpQfoV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-11-09-19-55.gh-issue-95876.YpQfoV.rst
@@ -1,0 +1,4 @@
+Fix format string in ``_PyPegen_raise_error_known_location`` that can lead
+to memory corruption on some 64bit systems. The function was building a
+tuple with ``i`` (int) instead of ``n`` (Py_ssize_t) for Py_ssize_t
+arguments.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -547,7 +547,7 @@ _PyPegen_raise_error_known_location(Parser *p, PyObject *errtype,
                          byte_offset_to_character_offset(error_line, end_col_offset) :
                          end_col_number;
     }
-    tmp = Py_BuildValue("(OiiNii)", p->tok->filename, lineno, col_number, error_line, end_lineno, end_col_number);
+    tmp = Py_BuildValue("(OnnNnn)", p->tok->filename, lineno, col_number, error_line, end_lineno, end_col_number);
     if (!tmp) {
         goto error;
     }


### PR DESCRIPTION
(cherry picked from commit b4c857d0fd74abb1ede6fe083c4fa3ca728b2b83)

Co-authored-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95876 -->
* Issue: gh-95876
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:lysnikolaou