### PR TITLE
gh-95914: Add missing PEPs to the Summary section of 3.11 What's New

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -66,19 +66,35 @@ New syntax features:
 * :pep:`654`: Exception Groups and ``except*``.
   (Contributed by Irit Katriel in :issue:`45292`.)
 
+New built-in features:
+
+* :pep:`678`: Enriching Exceptions with Notes.
+
+New standard library modules:
+
+* :pep:`680`: ``tomllib`` — Support for Parsing TOML in the Standard Library.
+
+Interpreter improvements:
+
+* :pep:`657`: Include Fine Grained Error Locations in Tracebacks.
+* New :option:`-P` command line option and :envvar:`PYTHONSAFEPATH` environment
+  variable to disable automatically prepending a potentially unsafe path
+  (the working dir or script directory, depending on invocation)
+  to :data:`sys.path`.
+
 New typing features:
 
 * :pep:`646`: Variadic generics.
 * :pep:`655`: Marking individual TypedDict items as required or potentially missing.
 * :pep:`673`: ``Self`` type.
 * :pep:`675`: Arbitrary literal string type.
+* :pep:`681`: Data Class Transforms.
 
-Security improvements:
+Important deprecations, removals or restrictions:
 
-* New :option:`-P` command line option and :envvar:`PYTHONSAFEPATH` environment
-  variable to disable automatically prepending a potentially unsafe path
-  (the working dir or script directory, depending on invocation)
-  to :data:`sys.path`.
+* :pep:`594`: Removing dead batteries from the standard library.
+* :pep:`624`: Remove ``Py_UNICODE`` encoder APIs.
+* :pep:`670`: Convert macros to functions in the Python C API.
 
 
 New Features

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -49,13 +49,14 @@ This article explains the new features in Python 3.11, compared to 3.10.
 
 For full details, see the :ref:`changelog <changelog>`.
 
+
 Summary -- Release highlights
 =============================
 
 .. This section singles out the most important changes in Python 3.11.
    Brevity is key.
 
-- Python 3.11 is up to 10-60% faster than Python 3.10. On average, we measured a
+- Python 3.11 is between 10-60% faster than Python 3.10. On average, we measured a
   1.25x speedup on the standard benchmark suite. See `Faster CPython`_ for details.
 
 .. PEP-sized items next.
@@ -75,8 +76,9 @@ New typing features:
 Security improvements:
 
 * New :option:`-P` command line option and :envvar:`PYTHONSAFEPATH` environment
-  variable to not prepend a potentially unsafe path to :data:`sys.path` such as
-  the current directory, the script's directory or an empty string.
+  variable to disable automatically prepending a potentially unsafe path
+  (the working dir or script directory, depending on invocation)
+  to :data:`sys.path`.
 
 
 New Features


### PR DESCRIPTION
As described in #95914, the Summary section of the [What's New in Python 3.11](https://docs.python.org/3.12/whatsnew/3.11.html) document is missing most of the PEPs implemented in that release, unlike e.g. [the 3.10 What's New](https://docs.python.org/3.12/whatsnew/3.10.html). Therefore, this PR adds the missing PEPs, following the categories from previous What's New documents.

Also, to clean things up a bit and avoid too many categories with only a single item, it moves the `-P` item to the added `Interpreter Changes` category.

<!-- gh-issue-number: gh-95914 -->
* Issue: gh-95914
<!-- /gh-issue-number -->
