### PR TITLE
gh-95922: compiler's eliminate_empty_basic_blocks ignores the last block of the compilation unit

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-12-13-04-25.gh-issue-95922.YNCtyX.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-12-13-04-25.gh-issue-95922.YNCtyX.rst
@@ -1,0 +1,2 @@
+Fixed bug where the compiler's ``eliminate_empty_basic_blocks`` function
+ignores the last block of the code unit.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -9355,9 +9355,7 @@ eliminate_empty_basic_blocks(basicblock *entryblock) {
         b->b_next = next;
     }
     for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
-        if (b->b_iused == 0) {
-            continue;
-        }
+        assert(b->b_iused > 0);
         for (int i = 0; i < b->b_iused; i++) {
             struct instr *instr = &b->b_instr[i];
             if (HAS_TARGET(instr->i_opcode)) {
@@ -9366,11 +9364,9 @@ eliminate_empty_basic_blocks(basicblock *entryblock) {
                     target = target->b_next;
                 }
                 instr->i_target = target;
+                assert(instr->i_target && instr->i_target->b_iused > 0);
             }
         }
-    }
-    for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
-        assert(b->b_iused > 0);
     }
 }
 

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -9349,12 +9349,10 @@ eliminate_empty_basic_blocks(basicblock *entryblock) {
     /* Eliminate empty blocks */
     for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
         basicblock *next = b->b_next;
-        if (next) {
-            while (next->b_iused == 0 && next->b_next) {
-                next = next->b_next;
-            }
-            b->b_next = next;
+        while (next && next->b_iused == 0) {
+            next = next->b_next;
         }
+        b->b_next = next;
     }
     for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
         if (b->b_iused == 0) {
@@ -9370,6 +9368,9 @@ eliminate_empty_basic_blocks(basicblock *entryblock) {
                 instr->i_target = target;
             }
         }
+    }
+    for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
+        assert(b->b_iused > 0);
     }
 }
 


### PR DESCRIPTION
Fixes #95922.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95922 -->
* Issue: gh-95922
<!-- /gh-issue-number -->
