### PR TITLE
gh-90300: [docs] Add whatsnew entry for new --help output (GH-95856)

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -435,6 +435,12 @@ Other CPython Implementation Changes
   :data:`sys.path`. Otherwise, initialization will recalculate the path and replace
   any values added to ``module_search_paths``.
 
+* The output of the :option:`--help` option is changed to fit inside 50 lines and 80
+  columns.  Information about :ref:`Python environment variables <using-on-envvars>`
+  and :option:`-X options <-X>` is available with the new :option:`--help-env` or
+  :option:`--help-xoptions` flags, and with :option:`--help-all`.
+  (Contributed by Éric Araujo in :issue:`46142`.)
+
 
 New Modules
 ===========


### PR DESCRIPTION
This is a forward port of https://github.com/python/cpython/pull/95856 from 3.11 to main.

<!-- gh-issue-number: gh-90300 -->
* Issue: gh-90300
<!-- /gh-issue-number -->
