### PR TITLE
Remove dead code in _PyDict_GetItemHint

### DIFF
--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -62,7 +62,7 @@ extern Py_ssize_t _PyDict_KeysSize(PyDictKeysObject *keys);
  */
 extern Py_ssize_t _Py_dict_lookup(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
 
-extern Py_ssize_t _PyDict_GetItemSpecialize(PyDictObject *, PyObject *, PyObject **);
+extern Py_ssize_t _PyDict_LookupIndex(PyDictObject *, PyObject *);
 extern Py_ssize_t _PyDictKeys_StringLookup(PyDictKeysObject* dictkeys, PyObject *key);
 extern PyObject *_PyDict_LoadGlobal(PyDictObject *, PyDictObject *, PyObject *);
 

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -62,7 +62,7 @@ extern Py_ssize_t _PyDict_KeysSize(PyDictKeysObject *keys);
  */
 extern Py_ssize_t _Py_dict_lookup(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
 
-extern Py_ssize_t _PyDict_GetItemHint(PyDictObject *, PyObject *, Py_ssize_t, PyObject **);
+extern Py_ssize_t _PyDict_GetItemSpecialize(PyDictObject *, PyObject *, PyObject **);
 extern Py_ssize_t _PyDictKeys_StringLookup(PyDictKeysObject* dictkeys, PyObject *key);
 extern PyObject *_PyDict_LoadGlobal(PyDictObject *, PyDictObject *, PyObject *);
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1686,49 +1686,11 @@ PyDict_GetItem(PyObject *op, PyObject *key)
 }
 
 Py_ssize_t
-_PyDict_GetItemHint(PyDictObject *mp, PyObject *key,
-                    Py_ssize_t hint, PyObject **value)
+_PyDict_GetItemSpecialize(PyDictObject *mp, PyObject *key, PyObject **value)
 {
     assert(*value == NULL);
     assert(PyDict_CheckExact((PyObject*)mp));
     assert(PyUnicode_CheckExact(key));
-
-    if (hint >= 0 && hint < mp->ma_keys->dk_nentries) {
-        PyObject *res = NULL;
-
-        if (DK_IS_UNICODE(mp->ma_keys)) {
-            PyDictUnicodeEntry *ep = DK_UNICODE_ENTRIES(mp->ma_keys) + (size_t)hint;
-            if (ep->me_key == key) {
-                if (mp->ma_keys->dk_kind == DICT_KEYS_SPLIT) {
-                    assert(mp->ma_values != NULL);
-                    res = mp->ma_values->values[(size_t)hint];
-                }
-                else {
-                    res = ep->me_value;
-                }
-                if (res != NULL) {
-                    *value = res;
-                    return hint;
-                }
-            }
-        }
-        else {
-            PyDictKeyEntry *ep = DK_ENTRIES(mp->ma_keys) + (size_t)hint;
-            if (ep->me_key == key) {
-                if (mp->ma_keys->dk_kind == DICT_KEYS_SPLIT) {
-                    assert(mp->ma_values != NULL);
-                    res = mp->ma_values->values[(size_t)hint];
-                }
-                else {
-                    res = ep->me_value;
-                }
-                if (res != NULL) {
-                    *value = res;
-                    return hint;
-                }
-            }
-        }
-    }
 
     Py_hash_t hash = unicode_get_hash(key);
     if (hash == -1) {

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1686,9 +1686,9 @@ PyDict_GetItem(PyObject *op, PyObject *key)
 }
 
 Py_ssize_t
-_PyDict_GetItemSpecialize(PyDictObject *mp, PyObject *key, PyObject **value)
+_PyDict_LookupIndex(PyDictObject *mp, PyObject *key)
 {
-    assert(*value == NULL);
+    PyObject *value;
     assert(PyDict_CheckExact((PyObject*)mp));
     assert(PyUnicode_CheckExact(key));
 
@@ -1700,7 +1700,7 @@ _PyDict_GetItemSpecialize(PyDictObject *mp, PyObject *key, PyObject **value)
         }
     }
 
-    return _Py_dict_lookup(mp, key, hash, value);
+    return _Py_dict_lookup(mp, key, hash, &value);
 }
 
 /* Same as PyDict_GetItemWithError() but with hash supplied by caller.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -655,9 +655,8 @@ specialize_dict_access(
             return 0;
         }
         // We found an instance with a __dict__.
-        PyObject *value = NULL;
         Py_ssize_t index =
-            _PyDict_GetItemSpecialize(dict, name, &value);
+            _PyDict_LookupIndex(dict, name);
         if (index != (uint16_t)index) {
             SPECIALIZATION_FAIL(base_op, SPEC_FAIL_OUT_OF_RANGE);
             return 0;

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -505,7 +505,6 @@ specialize_module_load_attr(PyObject *owner, _Py_CODEUNIT *instr,
 {
     _PyAttrCache *cache = (_PyAttrCache *)(instr + 1);
     PyModuleObject *m = (PyModuleObject *)owner;
-    PyObject *value = NULL;
     assert((owner->ob_type->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0);
     PyDictObject *dict = (PyDictObject *)m->md_dict;
     if (dict == NULL) {
@@ -516,13 +515,13 @@ specialize_module_load_attr(PyObject *owner, _Py_CODEUNIT *instr,
         SPECIALIZATION_FAIL(opcode, SPEC_FAIL_ATTR_NON_STRING_OR_SPLIT);
         return -1;
     }
-    Py_ssize_t index = _PyDict_GetItemSpecialize(dict, &_Py_ID(__getattr__), &value);
+    Py_ssize_t index = _PyDict_LookupIndex(dict, &_Py_ID(__getattr__));
     assert(index != DKIX_ERROR);
     if (index != DKIX_EMPTY) {
         SPECIALIZATION_FAIL(opcode, SPEC_FAIL_ATTR_MODULE_ATTR_NOT_FOUND);
         return -1;
     }
-    index = _PyDict_GetItemSpecialize(dict, name, &value);
+    index = _PyDict_LookupIndex(dict, name);
     assert (index != DKIX_ERROR);
     if (index != (uint16_t)index) {
         SPECIALIZATION_FAIL(opcode, SPEC_FAIL_OUT_OF_RANGE);

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -516,14 +516,13 @@ specialize_module_load_attr(PyObject *owner, _Py_CODEUNIT *instr,
         SPECIALIZATION_FAIL(opcode, SPEC_FAIL_ATTR_NON_STRING_OR_SPLIT);
         return -1;
     }
-    Py_ssize_t index = _PyDict_GetItemHint(dict, &_Py_ID(__getattr__), -1,
-                                           &value);
+    Py_ssize_t index = _PyDict_GetItemSpecialize(dict, &_Py_ID(__getattr__), &value);
     assert(index != DKIX_ERROR);
     if (index != DKIX_EMPTY) {
         SPECIALIZATION_FAIL(opcode, SPEC_FAIL_ATTR_MODULE_ATTR_NOT_FOUND);
         return -1;
     }
-    index = _PyDict_GetItemHint(dict, name, -1, &value);
+    index = _PyDict_GetItemSpecialize(dict, name, &value);
     assert (index != DKIX_ERROR);
     if (index != (uint16_t)index) {
         SPECIALIZATION_FAIL(opcode, SPEC_FAIL_OUT_OF_RANGE);
@@ -658,13 +657,13 @@ specialize_dict_access(
         }
         // We found an instance with a __dict__.
         PyObject *value = NULL;
-        Py_ssize_t hint =
-            _PyDict_GetItemHint(dict, name, -1, &value);
-        if (hint != (uint16_t)hint) {
+        Py_ssize_t index =
+            _PyDict_GetItemSpecialize(dict, name, &value);
+        if (index != (uint16_t)index) {
             SPECIALIZATION_FAIL(base_op, SPEC_FAIL_OUT_OF_RANGE);
             return 0;
         }
-        cache->index = (uint16_t)hint;
+        cache->index = (uint16_t)index;
         write_u32(cache->version, type->tp_version_tag);
         _Py_SET_OPCODE(*instr, hint_op);
     }


### PR DESCRIPTION
`_PyDict_GetItemHint` was an optimization that was subsequently made redundant.
    
So let's remove the dead code.
    
I am not removing` _PyDict_GetItemHint` completely here, because as far as I can tell it performs a different combination of error handling steps than the other ways to get items from a dict, and I don't feel confident rewriting the code in `Python/specialize.c` to work with the different assumptions around error handling.

So I am sticking with removing just the dead code, and a rename of the function (so that people get a proper error message when they are trying to still use the old version of `_PyDict_GetItemHint`).

If a reviewer has a hint for how to rewrite `Python/specialize.c` to use eg `PyDict_GetItemWithError` or `PyDict_GetItem`, I'd be more than happy to rewrite the PR.  Thanks!