### PR TITLE
GH-93179: Document the thread safety of functools.lru_cache

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -49,6 +49,9 @@ The :mod:`functools` module defines the following functions:
         >>> factorial(12)      # makes two new recursive calls, the other 10 are cached
         479001600
 
+   The cache is threadsafe so the wrapped function can be used in multiple
+   threads.
+
    .. versionadded:: 3.9
 
 
@@ -139,6 +142,9 @@ The :mod:`functools` module defines the following functions:
    Decorator to wrap a function with a memoizing callable that saves up to the
    *maxsize* most recent calls.  It can save time when an expensive or I/O bound
    function is periodically called with the same arguments.
+
+   The cache is threadsafe so the wrapped function can be used in multiple
+   threads.
 
    Since a dictionary is used to cache results, the positional and keyword
    arguments to the function must be hashable.


### PR DESCRIPTION


<!-- gh-issue-number: gh-93179 -->
* Issue: gh-93179
<!-- /gh-issue-number -->
