### PR TITLE
GH-95977: Speed up calling pure python descriptor __get__ with vectorcall

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-14-10-04-44.gh-issue-95977.gCTZb9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-14-10-04-44.gh-issue-95977.gCTZb9.rst
@@ -1,0 +1,1 @@
+Optimized calling :meth:`~object.__get__` with vectorcall. Patch by Kumar Aditya.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8242,7 +8242,8 @@ slot_tp_descr_get(PyObject *self, PyObject *obj, PyObject *type)
         obj = Py_None;
     if (type == NULL)
         type = Py_None;
-    return PyObject_CallFunctionObjArgs(get, self, obj, type, NULL);
+    PyObject *stack[3] = {self, obj, type};
+    return PyObject_Vectorcall(get, stack, 3, NULL);
 }
 
 static int


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95977 -->
* Issue: gh-95977
<!-- /gh-issue-number -->
Closes https://github.com/python/cpython/issues/95977