### PR TITLE
gh-95991: Add some infrastructure for testing Limited API in _testcapi

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -794,6 +794,12 @@ The :mod:`test.support` module defines the following functions:
    Decorator for only running the test if :data:`HAVE_DOCSTRINGS`.
 
 
+.. decorator:: requires_limited_api
+
+   Decorator for only running the test if :ref:`Limited C API <stable>`
+   is available.
+
+
 .. decorator:: cpython_only
 
    Decorator for tests only applicable to CPython.

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -46,6 +46,7 @@ __all__ = [
     "anticipate_failure", "load_package_tests", "detect_api_mismatch",
     "check__all__", "skip_if_buggy_ucrt_strfptime",
     "check_disallow_instantiation", "check_sanitizer", "skip_if_sanitizer",
+    "requires_limited_api",
     # sys
     "is_jython", "is_android", "is_emscripten", "is_wasi",
     "check_impl_detail", "unix_shell", "setswitchinterval",
@@ -1067,6 +1068,15 @@ def refcount_test(test):
 
     """
     return no_tracing(cpython_only(test))
+
+
+def requires_limited_api(test):
+    try:
+        import _testcapi
+    except ImportError:
+        return unittest.skipIf(True, 'needs _testcapi module')(test)
+    return unittest.skipIf(
+        not _testcapi.LIMITED_API_AVAILABLE, 'needs Limited API support')(test)
 
 
 def _filter_suite(suite, pred):

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1074,9 +1074,9 @@ def requires_limited_api(test):
     try:
         import _testcapi
     except ImportError:
-        return unittest.skipIf(True, 'needs _testcapi module')(test)
-    return unittest.skipIf(
-        not _testcapi.LIMITED_API_AVAILABLE, 'needs Limited API support')(test)
+        return unittest.skip('needs _testcapi module')(test)
+    return unittest.skipUnless(
+        _testcapi.LIMITED_API_AVAILABLE, 'needs Limited API support')(test)
 
 
 def _filter_suite(suite, pred):

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -1,5 +1,5 @@
 import unittest
-from test.support import cpython_only
+from test.support import cpython_only, requires_limited_api
 try:
     import _testcapi
 except ImportError:
@@ -760,9 +760,7 @@ class TestPEP590(unittest.TestCase):
                 self.assertEqual(expected, meth(*args1, **kwargs))
                 self.assertEqual(expected, wrapped(*args, **kwargs))
 
-    @unittest.skipIf(
-        hasattr(sys, 'getobjects'),
-        "Limited API is not compatible with Py_TRACE_REFS")
+    @requires_limited_api
     def test_vectorcall_limited(self):
         from _testcapi import pyobject_vectorcall
         obj = _testcapi.LimitedVectorCallClass()

--- a/Modules/_testcapi/parts.h
+++ b/Modules/_testcapi/parts.h
@@ -24,9 +24,6 @@
 
 #include "Python.h"
 
-/* Always enable assertions */
-#undef NDEBUG
-
 int _PyTestCapi_Init_Vectorcall(PyObject *module);
 int _PyTestCapi_Init_Heaptype(PyObject *module);
 int _PyTestCapi_Init_Unicode(PyObject *module);

--- a/Modules/_testcapi/parts.h
+++ b/Modules/_testcapi/parts.h
@@ -1,9 +1,39 @@
+#ifndef Py_TESTCAPI_PARTS_H
+#define Py_TESTCAPI_PARTS_H
+
+#include "pyconfig.h"  // for Py_TRACE_REFS
+
+// Figure out if Limited API is available for this build. If it isn't we won't
+// build tests for it.
+// Currently, only Py_TRACE_REFS disables Limited API.
+#ifdef Py_TRACE_REFS
+#undef LIMITED_API_AVAILABLE
+#else
+#define LIMITED_API_AVAILABLE 1
+#endif
+
+// Always enable assertions
+#undef NDEBUG
+
+#if !defined(LIMITED_API_AVAILABLE) && defined(Py_LIMITED_API)
+// Limited API being unavailable means that with Py_LIMITED_API defined
+// we can't even include Python.h.
+// Do nothing; the .c file that defined Py_LIMITED_API should also do nothing.
+
+#else
+
 #include "Python.h"
 
 /* Always enable assertions */
 #undef NDEBUG
 
 int _PyTestCapi_Init_Vectorcall(PyObject *module);
-int _PyTestCapi_Init_VectorcallLimited(PyObject *module);
 int _PyTestCapi_Init_Heaptype(PyObject *module);
 int _PyTestCapi_Init_Unicode(PyObject *module);
+
+#ifdef LIMITED_API_AVAILABLE
+int _PyTestCapi_Init_VectorcallLimited(PyObject *module);
+#endif // LIMITED_API_AVAILABLE
+
+#endif
+#endif // Py_TESTCAPI_PARTS_H

--- a/Modules/_testcapi/vectorcall_limited.c
+++ b/Modules/_testcapi/vectorcall_limited.c
@@ -1,18 +1,8 @@
-#include "pyconfig.h"  // Py_TRACE_REFS
-
-#ifdef Py_TRACE_REFS
-
-// Py_TRACE_REFS is incompatible with Limited API
-#include "parts.h"
-int
-_PyTestCapi_Init_VectorcallLimited(PyObject *m) {
-    return 0;
-}
-
-#else
-
 #define Py_LIMITED_API 0x030c0000 // 3.12
 #include "parts.h"
+
+#ifdef LIMITED_API_AVAILABLE
+
 #include "structmember.h"         // PyMemberDef
 
 /* Test Vectorcall in the limited API */
@@ -89,4 +79,4 @@ _PyTestCapi_Init_VectorcallLimited(PyObject *m) {
     return 0;
 }
 
-#endif // Py_TRACE_REFS
+#endif // LIMITED_API_AVAILABLE

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -6544,15 +6544,21 @@ PyInit__testcapi(void)
     if (_PyTestCapi_Init_Vectorcall(m) < 0) {
         return NULL;
     }
-    if (_PyTestCapi_Init_VectorcallLimited(m) < 0) {
-        return NULL;
-    }
     if (_PyTestCapi_Init_Heaptype(m) < 0) {
         return NULL;
     }
     if (_PyTestCapi_Init_Unicode(m) < 0) {
         return NULL;
     }
+
+#ifndef LIMITED_API_AVAILABLE
+    PyModule_AddObjectRef(m, "LIMITED_API_AVAILABLE", Py_False);
+#else
+    PyModule_AddObjectRef(m, "LIMITED_API_AVAILABLE", Py_True);
+    if (_PyTestCapi_Init_VectorcallLimited(m) < 0) {
+        return NULL;
+    }
+#endif
 
     PyState_AddModule(m, &_testcapimodule);
     return m;

--- a/PCbuild/_testcapi.vcxproj
+++ b/PCbuild/_testcapi.vcxproj
@@ -107,6 +107,10 @@
       <Project>{cf7ac3d1-e2df-41d2-bea6-1e2556cdea26}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="python3dll.vcxproj">
+      <Project>{885d4898-d08d-4091-9c40-c700cfe3fc5a}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
- Limited API needs to be enabled per source file
- Some builds don't support Limited API, so Limited API tests must be skipped on those builds
  (currently this is `Py_TRACE_REFS`, but that may change.)
- `Py_LIMITED_API` must be defined before `<Python.h>` is included.

This puts the hoop-jumping in `testcapi/parts.h`, so individual
test files can be relatively simple. (Currently that's only
`vectorcall_limited.c`, imagine more.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95991 -->
* Issue: gh-95991
<!-- /gh-issue-number -->
