### PR TITLE
Add a warning message about PyOS_snprintf

### DIFF
--- a/Doc/c-api/conversion.rst
+++ b/Doc/c-api/conversion.rst
@@ -28,7 +28,8 @@ not.
 The wrappers ensure that ``str[size-1]`` is always ``'\0'`` upon return. They
 never write more than *size* bytes (including the trailing ``'\0'``) into str.
 Both functions require that ``str != NULL``, ``size > 0``, ``format != NULL``
-and ``size < INT_MAX``.
+and ``size < INT_MAX``. Note that this means there is no equivalent to the C99
+``n = snprintf(NULL, 0, ...)`` which would determine the necessary buffer size.
 
 The return value (*rv*) for these functions should be interpreted as follows:
 

--- a/Python/mysnprintf.c
+++ b/Python/mysnprintf.c
@@ -9,6 +9,7 @@
    would have been written had the buffer not been too small, and to set
    the last byte of the buffer to \0.  At least MS _vsnprintf returns a
    negative value instead, and fills the entire buffer with non-\0 data.
+   Unlike C99, our wrappers do not support passing a null buffer.
 
    The wrappers ensure that str[size-1] is always \0 upon return.
 


### PR DESCRIPTION
The top google result for "determine sprintf buffer size" is https://stackoverflow.com/a/3923207/102441, which advocates code along the lines of
```C
int size = snprintf(NULL, 0, "%d", 132);
char * a = malloc(size + 1);
sprintf(a, "%d", 132);
```
Unfortunately, this does not work for `PyOS_snprintf`, as it includes an `assert` to ensure the arguments are not `NULL` and `0`.

This PR simply documents this limitation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
