### PR TITLE
[3.10] Clean up junk and fix typo in 3.10.6 release notes

### DIFF
--- a/Misc/NEWS.d/3.10.6.rst
+++ b/Misc/NEWS.d/3.10.6.rst
@@ -587,7 +587,7 @@ The minimum Sphinx version required to build the documentation is now 3.2.
 .. section: Documentation
 
 Augmented documentation of asyncio.create_task(). Clarified the need to keep
-strong references to tasks and added a code snippet detailing how to to
+strong references to tasks and added a code snippet detailing how to do
 this.
 
 ..
@@ -629,11 +629,6 @@ parallel-safe.
 
 Added more tests for :mod:`dataclasses` to cover behavior with data
 descriptor-based fields.
-
-# Write your Misc/NEWS entry below.  It should be a simple ReST paragraph. #
-Don't start with "- Issue #<n>: " or "- gh-issue-<n>: " or that sort of
-stuff.
-###########################################################################
 
 ..
 


### PR DESCRIPTION
There was some awkward junk left around between release notes, and I also noticed and fixed a typo.

I think this PR warrants a "skip issue" label.

![image](https://user-images.githubusercontent.com/137616/184648677-cb1b9126-f44b-478e-8c2f-de5b65191970.png)
