### PR TITLE
gh-96005: Handle WASI ENOTCAPABLE in getpath (GH-96006)

### DIFF
--- a/Doc/library/errno.rst
+++ b/Doc/library/errno.rst
@@ -657,3 +657,12 @@ defined by the module.  The specific list of defined symbols is available as
    Interface output queue is full
 
    .. versionadded:: 3.11
+
+.. data:: ENOTCAPABLE
+
+   Capabilities insufficient. This error is mapped to the exception
+   :exc:`PermissionError`.
+
+   .. availability:: WASI
+
+   .. versionadded:: 3.11

--- a/Doc/library/errno.rst
+++ b/Doc/library/errno.rst
@@ -665,4 +665,4 @@ defined by the module.  The specific list of defined symbols is available as
 
    .. availability:: WASI
 
-   .. versionadded:: 3.11
+   .. versionadded:: 3.11.1

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -749,7 +749,7 @@ depending on the system error code.
    Corresponds to :c:data:`errno` :py:data:`~errno.EACCES`,
    :py:data:`~errno.EPERM`, and :py:data:`~errno.ENOTCAPABLE`.
 
-   .. versionchanged:: 3.11
+   .. versionchanged:: 3.11.1
       WASI's :py:data:`~errno.ENOTCAPABLE` is now mapped to
       :exc:`PermissionError`.
 

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -746,7 +746,12 @@ depending on the system error code.
 
    Raised when trying to run an operation without the adequate access
    rights - for example filesystem permissions.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EACCES` and :py:data:`~errno.EPERM`.
+   Corresponds to :c:data:`errno` :py:data:`~errno.EACCES`,
+   :py:data:`~errno.EPERM`, and :py:data:`~errno.ENOTCAPABLE`.
+
+   .. versionchanged:: 3.11
+      WASI's :py:data:`~errno.ENOTCAPABLE` is now mapped to
+      :exc:`PermissionError`.
 
 .. exception:: ProcessLookupError
 

--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-15-21-08-11.gh-issue-96005.6eoc8k.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-15-21-08-11.gh-issue-96005.6eoc8k.rst
@@ -1,0 +1,4 @@
+On WASI :data:`~errno.ENOTCAPABLE` is now mapped to :exc:`PermissionError`.
+The :mod:`errno` modules exposes the new error number. ``getpath.py`` now
+ignores :exc:`PermissionError` when it cannot open landmark files
+``pybuilddir.txt`` and ``pyenv.cfg``.

--- a/Modules/errnomodule.c
+++ b/Modules/errnomodule.c
@@ -927,6 +927,10 @@ errno_exec(PyObject *module)
 #ifdef EQFULL
     add_errcode("EQFULL", EQFULL, "Interface output queue is full");
 #endif
+#ifdef ENOTCAPABLE
+    // WASI extension
+    add_errcode("ENOTCAPABLE", ENOTCAPABLE, "Capabilities insufficient");
+#endif
 
     Py_DECREF(error_dict);
     return 0;

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -351,11 +351,11 @@ if not home and not py_setpath:
         try:
             # Read pyvenv.cfg from one level above executable
             pyvenvcfg = readlines(joinpath(venv_prefix, VENV_LANDMARK))
-        except FileNotFoundError:
+        except (FileNotFoundError, PermissionError):
             # Try the same directory as executable
             pyvenvcfg = readlines(joinpath(venv_prefix2, VENV_LANDMARK))
             venv_prefix = venv_prefix2
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         venv_prefix = None
         pyvenvcfg = []
 
@@ -475,7 +475,7 @@ if ((not home_was_set and real_executable_dir and not py_setpath)
         # File exists but is empty
         platstdlib_dir = real_executable_dir
         build_prefix = joinpath(real_executable_dir, VPATH)
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         if isfile(joinpath(real_executable_dir, BUILD_LANDMARK)):
             build_prefix = joinpath(real_executable_dir, VPATH)
             if os_name == 'nt':

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3635,6 +3635,11 @@ _PyExc_InitState(PyInterpreterState *interp)
     ADD_ERRNO(InterruptedError, EINTR);
     ADD_ERRNO(PermissionError, EACCES);
     ADD_ERRNO(PermissionError, EPERM);
+#ifdef ENOTCAPABLE
+    // Extension for WASI capability-based security. Process lacks
+    // capability to access a resource.
+    ADD_ERRNO(PermissionError, ENOTCAPABLE);
+#endif
     ADD_ERRNO(ProcessLookupError, ESRCH);
     ADD_ERRNO(TimeoutError, ETIMEDOUT);
 


### PR DESCRIPTION
- On WASI `ENOTCAPABLE` is now mapped to `PermissionError`.
- The `errno` modules exposes the new error number.
- `getpath.py` now ignores `PermissionError` when it cannot open landmark
  files `pybuilddir.txt` and `pyenv.cfg`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96005 -->
* Issue: gh-96005
<!-- /gh-issue-number -->
