### PR TITLE
gh-95914: Add Py_UNICODE encode APIs removed in PEP 624 to 3.11 What's New

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -2116,5 +2116,30 @@ Removed
   API).
   (Contributed by Victor Stinner in :issue:`45412`.)
 
+* Remove the :c:type:`Py_UNICODE` encoder APIs,
+  as they have been deprecated since Python 3.3,
+  are little used
+  and are inefficient relative to the recommended alternatives.
+
+  The removed functions are:
+
+  * :c:func:`!PyUnicode_Encode`
+  * :c:func:`!PyUnicode_EncodeASCII`
+  * :c:func:`!PyUnicode_EncodeLatin1`
+  * :c:func:`!PyUnicode_EncodeUTF7`
+  * :c:func:`!PyUnicode_EncodeUTF8`
+  * :c:func:`!PyUnicode_EncodeUTF16`
+  * :c:func:`!PyUnicode_EncodeUTF32`
+  * :c:func:`!PyUnicode_EncodeUnicodeEscape`
+  * :c:func:`!PyUnicode_EncodeRawUnicodeEscape`
+  * :c:func:`!PyUnicode_EncodeCharmap`
+  * :c:func:`!PyUnicode_TranslateCharmap`
+  * :c:func:`!PyUnicode_EncodeDecimal`
+  * :c:func:`!PyUnicode_TransformDecimalToASCII`
+
+  See :pep:`624` for details and
+  :pep:`migration guidance <624#alternative-apis>`.
+  (Contributed by Inada Naoki in :issue:`44029`.)
+
 
 .. _libb2: https://www.blake2.net/

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -2123,19 +2123,19 @@ Removed
 
   The removed functions are:
 
-  * :c:func:`!PyUnicode_Encode`
-  * :c:func:`!PyUnicode_EncodeASCII`
-  * :c:func:`!PyUnicode_EncodeLatin1`
-  * :c:func:`!PyUnicode_EncodeUTF7`
-  * :c:func:`!PyUnicode_EncodeUTF8`
-  * :c:func:`!PyUnicode_EncodeUTF16`
-  * :c:func:`!PyUnicode_EncodeUTF32`
-  * :c:func:`!PyUnicode_EncodeUnicodeEscape`
-  * :c:func:`!PyUnicode_EncodeRawUnicodeEscape`
-  * :c:func:`!PyUnicode_EncodeCharmap`
-  * :c:func:`!PyUnicode_TranslateCharmap`
-  * :c:func:`!PyUnicode_EncodeDecimal`
-  * :c:func:`!PyUnicode_TransformDecimalToASCII`
+  * :func:`!PyUnicode_Encode`
+  * :func:`!PyUnicode_EncodeASCII`
+  * :func:`!PyUnicode_EncodeLatin1`
+  * :func:`!PyUnicode_EncodeUTF7`
+  * :func:`!PyUnicode_EncodeUTF8`
+  * :func:`!PyUnicode_EncodeUTF16`
+  * :func:`!PyUnicode_EncodeUTF32`
+  * :func:`!PyUnicode_EncodeUnicodeEscape`
+  * :func:`!PyUnicode_EncodeRawUnicodeEscape`
+  * :func:`!PyUnicode_EncodeCharmap`
+  * :func:`!PyUnicode_TranslateCharmap`
+  * :func:`!PyUnicode_EncodeDecimal`
+  * :func:`!PyUnicode_TransformDecimalToASCII`
 
   See :pep:`624` for details and
   :pep:`migration guidance <624#alternative-apis>`.


### PR DESCRIPTION
Add a mention of the deprecated ``Py_UNICODE`` encode functions removed in Python 3.11 per PEP-624 by @methane in issue #88195 / PR #25881 to 3.11 What's New, as discussed in #95914 .

Inada-san, could you take a look at this?

Also, @AA-Turner @ezio-melotti @hugovk , any idea why `!` appears to not be working as documented in `:c:func:` here, resulting in `-n` warnings and incorrect rendering? Does it have something to do with the legacy C role support still used by the CPython docs?

<!-- gh-issue-number: gh-95914 -->
* Issue: gh-95914
<!-- /gh-issue-number -->
