### PR TITLE
remove repetitive credit from what's new in 3.11

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -64,7 +64,6 @@ Summary -- Release highlights
 New syntax features:
 
 * :pep:`654`: Exception Groups and ``except*``.
-  (Contributed by Irit Katriel in :issue:`45292`.)
 
 New built-in features:
 


### PR DESCRIPTION
Contribution credits for the other PEPs appear only in the extended description. Do the same for PEP 654. 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
