### PR TITLE
gh-95736: Fix event loop creation in IsolatedAsyncioTestCase

### DIFF
--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -79,6 +79,10 @@ class IsolatedAsyncioTestCase(TestCase):
         return result
 
     def _callSetUp(self):
+        # Force loop to be initialized and set as the current loop
+        # so that setUp functions can use get_event_loop() and get the
+        # correct loop instance.
+        self._asyncioRunner.get_loop()
         self._asyncioTestContext.run(self.setUp)
         self._callAsync(self.asyncSetUp)
 
@@ -116,10 +120,6 @@ class IsolatedAsyncioTestCase(TestCase):
         assert self._asyncioRunner is None, 'asyncio runner is already initialized'
         runner = asyncio.Runner(debug=True)
         self._asyncioRunner = runner
-        # Force loop to be initialized and set as the current loop
-        # so that setUp functions can use get_event_loop() and get the
-        # correct loop instance.
-        runner.get_loop()
 
     def _tearDownAsyncioRunner(self):
         runner = self._asyncioRunner


### PR DESCRIPTION
It should be created before calling the setUp() method, but after
checking for skipping a test.


<!-- gh-issue-number: gh-95736 -->
* Issue: gh-95736
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:tiran