### PR TITLE
[3.11] GH-95736: fix IsolatedAsyncioTestCase to initialize Runner bef…

### DIFF
--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -79,6 +79,10 @@ class IsolatedAsyncioTestCase(TestCase):
         return result
 
     def _callSetUp(self):
+        # Force loop to be initialized and set as the current loop
+        # so that setUp functions can use get_event_loop() and get the
+        # correct loop instance.
+        self._asyncioRunner.get_loop()
         self._asyncioTestContext.run(self.setUp)
         self._callAsync(self.asyncSetUp)
 

--- a/Lib/unittest/test/test_async_case.py
+++ b/Lib/unittest/test/test_async_case.py
@@ -434,6 +434,21 @@ class TestAsyncCase(unittest.TestCase):
         test.doCleanups()
         self.assertEqual(events, ['asyncSetUp', 'test', 'cleanup'])
 
+    def test_setup_get_event_loop(self):
+        # See https://github.com/python/cpython/issues/95736
+        # Make sure the default event loop is not used
+        asyncio.set_event_loop(None)
+
+        class TestCase1(unittest.IsolatedAsyncioTestCase):
+            def setUp(self):
+                asyncio.get_event_loop_policy().get_event_loop()
+
+            async def test_demo1(self):
+                pass
+
+        test = TestCase1('test_demo1')
+        result = test.run()
+        self.assertTrue(result.wasSuccessful())
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2022-08-11-18-22-29.gh-issue-95736.LzRZXe.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-11-18-22-29.gh-issue-95736.LzRZXe.rst
@@ -1,0 +1,1 @@
+Fix :class:`unittest.IsolatedAsyncioTestCase` to set event loop before calling setup functions. Patch by Kumar Aditya.


### PR DESCRIPTION
…ore calling setup functions  (GH-95898)

(cherry picked from commit 9d515997f943b7b510268448f372dabcbf957858)

Co-authored-by: Kumar Aditya <59607654+kumaraditya303@users.noreply.github.com>
Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95736 -->
* Issue: gh-95736
<!-- /gh-issue-number -->
