### PR TITLE
Use triple double quotes for docstrings in statistics lib

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1168,7 +1168,7 @@ except ImportError:
 
 
 class NormalDist:
-    "Normal distribution of a random variable"
+    """Normal distribution of a random variable"""
     # https://en.wikipedia.org/wiki/Normal_distribution
     # https://en.wikipedia.org/wiki/Variance#Properties
 
@@ -1178,7 +1178,7 @@ class NormalDist:
     }
 
     def __init__(self, mu=0.0, sigma=1.0):
-        "NormalDist where mu is the mean and sigma is the standard deviation."
+        """NormalDist where mu is the mean and sigma is the standard deviation."""
         if sigma < 0.0:
             raise StatisticsError('sigma must be non-negative')
         self._mu = float(mu)
@@ -1186,17 +1186,17 @@ class NormalDist:
 
     @classmethod
     def from_samples(cls, data):
-        "Make a normal distribution instance from sample data."
+        """Make a normal distribution instance from sample data."""
         return cls(*_mean_stdev(data))
 
     def samples(self, n, *, seed=None):
-        "Generate *n* samples for a given mean and standard deviation."
+        """Generate *n* samples for a given mean and standard deviation."""
         gauss = random.gauss if seed is None else random.Random(seed).gauss
         mu, sigma = self._mu, self._sigma
         return [gauss(mu, sigma) for _ in repeat(None, n)]
 
     def pdf(self, x):
-        "Probability density function.  P(x <= X < x+dx) / dx"
+        """Probability density function.  P(x <= X < x+dx) / dx"""
         variance = self._sigma * self._sigma
         if not variance:
             raise StatisticsError('pdf() not defined when sigma is zero')
@@ -1204,7 +1204,7 @@ class NormalDist:
         return exp(diff * diff / (-2.0 * variance)) / sqrt(tau * variance)
 
     def cdf(self, x):
-        "Cumulative distribution function.  P(X <= x)"
+        """Cumulative distribution function.  P(X <= x)"""
         if not self._sigma:
             raise StatisticsError('cdf() not defined when sigma is zero')
         return 0.5 * (1.0 + erf((x - self._mu) / (self._sigma * _SQRT2)))
@@ -1281,12 +1281,12 @@ class NormalDist:
 
     @property
     def mean(self):
-        "Arithmetic mean of the normal distribution."
+        """Arithmetic mean of the normal distribution."""
         return self._mu
 
     @property
     def median(self):
-        "Return the median of the normal distribution"
+        """Return the median of the normal distribution"""
         return self._mu
 
     @property
@@ -1300,12 +1300,12 @@ class NormalDist:
 
     @property
     def stdev(self):
-        "Standard deviation of the normal distribution."
+        """Standard deviation of the normal distribution."""
         return self._sigma
 
     @property
     def variance(self):
-        "Square of the standard deviation."
+        """Square of the standard deviation."""
         return self._sigma * self._sigma
 
     def __add__(x1, x2):
@@ -1353,29 +1353,29 @@ class NormalDist:
         return NormalDist(x1._mu / x2, x1._sigma / fabs(x2))
 
     def __pos__(x1):
-        "Return a copy of the instance."
+        """Return a copy of the instance."""
         return NormalDist(x1._mu, x1._sigma)
 
     def __neg__(x1):
-        "Negates mu while keeping sigma the same."
+        """Negates mu while keeping sigma the same."""
         return NormalDist(-x1._mu, x1._sigma)
 
     __radd__ = __add__
 
     def __rsub__(x1, x2):
-        "Subtract a NormalDist from a constant or another NormalDist."
+        """Subtract a NormalDist from a constant or another NormalDist."""
         return -(x1 - x2)
 
     __rmul__ = __mul__
 
     def __eq__(x1, x2):
-        "Two NormalDist objects are equal if their mu and sigma are both equal."
+        """Two NormalDist objects are equal if their mu and sigma are both equal."""
         if not isinstance(x2, NormalDist):
             return NotImplemented
         return x1._mu == x2._mu and x1._sigma == x2._sigma
 
     def __hash__(self):
-        "NormalDist objects hash equal if their mu and sigma are both equal."
+        """NormalDist objects hash equal if their mu and sigma are both equal."""
         return hash((self._mu, self._sigma))
 
     def __repr__(self):


### PR DESCRIPTION
This PR changes the quotes of some docstrings in `Lib/statistics.py` to triple double quotes, as dictated by [PEP 257](https://peps.python.org/pep-0257/).
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
