### PR TITLE
gh-95463: Remove backwards incompatible change regarding the _MASK_UTF_FILENAME flags in bpo-28080

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -480,7 +480,7 @@ class ZipInfo (object):
 
     def _encodeFilenameFlags(self):
         try:
-            return self.filename.encode('ascii'), self.flag_bits & ~_MASK_UTF_FILENAME
+            return self.filename.encode('ascii'), self.flag_bits
         except UnicodeEncodeError:
             return self.filename.encode('utf-8'), self.flag_bits | _MASK_UTF_FILENAME
 

--- a/Misc/NEWS.d/next/Library/2022-08-18-14-53-53.gh-issue-95463.GpP05c.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-18-14-53-53.gh-issue-95463.GpP05c.rst
@@ -1,0 +1,2 @@
+Remove an incompatible change from :issue:`28080` that caused a regression
+that ignored the utf8 in ``ZipInfo.flag_bits``. Patch by Pablo Galindo.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:pablogsal

<!-- gh-issue-number: gh-95463 -->
* Issue: gh-95463
<!-- /gh-issue-number -->
