### PR TITLE
GH-96079 Fix missing field name for _AnnotatedAlias

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7131,6 +7131,7 @@ class SpecialAttrsTests(BaseTestCase):
             typing.Self: 'Self',
             # Subscribed special forms
             typing.Annotated[Any, "Annotation"]: 'Annotated',
+            typing.Annotated[int, 'Annotation']: 'Annotated',
             typing.ClassVar[Any]: 'ClassVar',
             typing.Concatenate[Any, SpecialAttrsP]: 'Concatenate',
             typing.Final[Any]: 'Final',

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2099,7 +2099,7 @@ class _AnnotatedAlias(_NotIterable, _GenericAlias, _root=True):
         if isinstance(origin, _AnnotatedAlias):
             metadata = origin.__metadata__ + metadata
             origin = origin.__origin__
-        super().__init__(origin, origin)
+        super().__init__(origin, origin, name='Annotated')
         self.__metadata__ = metadata
 
     def copy_with(self, params):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2132,6 +2132,9 @@ class _AnnotatedAlias(_NotIterable, _GenericAlias, _root=True):
             return 'Annotated'
         return super().__getattr__(attr)
 
+    def __mro_entries__(self, bases):
+        return (self.__origin__,)
+
 
 class Annotated:
     """Add context specific metadata to a type.

--- a/Misc/NEWS.d/next/Library/2022-08-31-11-10-21.gh-issue-96079.uqrXdJ.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-31-11-10-21.gh-issue-96079.uqrXdJ.rst
@@ -1,1 +1,1 @@
-In :mod:`typing`, fix missing field `name` and incorrect `__module__` in _AnnotatedAlias.
+In :mod:`typing`, fix missing field ``name`` and incorrect ``__module__`` in _AnnotatedAlias.

--- a/Misc/NEWS.d/next/Library/2022-08-31-11-10-21.gh-issue-96079.uqrXdJ.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-31-11-10-21.gh-issue-96079.uqrXdJ.rst
@@ -1,0 +1,1 @@
+In :mod:`typing`, fix missing field `name` and incorrect `__module__` in _AnnotatedAlias.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96079 -->
* Issue: gh-96079
<!-- /gh-issue-number -->
