### PR TITLE
Optimize away many indirect function calls in the gc

### DIFF
--- a/Objects/cellobject.c
+++ b/Objects/cellobject.c
@@ -113,7 +113,7 @@ cell_repr(PyCellObject *op)
                                op->ob_ref);
 }
 
-static int
+int
 cell_traverse(PyCellObject *op, visitproc visit, void *arg)
 {
     Py_VISIT(op->ob_ref);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3490,7 +3490,7 @@ dict_popitem_impl(PyDictObject *self)
     return res;
 }
 
-static int
+int
 dict_traverse(PyObject *op, visitproc visit, void *arg)
 {
     PyDictObject *mp = (PyDictObject *)op;

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -720,7 +720,7 @@ func_repr(PyFunctionObject *op)
                                 op->func_qualname, op);
 }
 
-static int
+int
 func_traverse(PyFunctionObject *f, visitproc visit, void *arg)
 {
     Py_VISIT(f->func_code);

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2677,7 +2677,7 @@ list_remove(PyListObject *self, PyObject *value)
     return NULL;
 }
 
-static int
+int
 list_traverse(PyListObject *o, visitproc visit, void *arg)
 {
     Py_ssize_t i;

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -609,7 +609,7 @@ tuple_count(PyTupleObject *self, PyObject *value)
     return PyLong_FromSsize_t(count);
 }
 
-static int
+int
 tupletraverse(PyTupleObject *o, visitproc visit, void *arg)
 {
     Py_ssize_t i;


### PR DESCRIPTION
Hi from the Pyston team! We're starting the process of rebasing some of our changes and submitting them upstream, which we'll talk about more soon. The first was #95908, which was not a code change, and this is the first code change.

Our current idea is to propose the changes individually, but this means that the individual effects of each PR will be small, though we have a number of them in the queue. Benchmarking at the sub-1% precision level is difficult but [pyperformance has good tips](https://pyperformance.readthedocs.io/usage.html#how-to-get-stable-benchmarks). Beyond those tips, though, we've found that it's also important to use BOLT (which I did here by cherry-picking the currently-unmerged #95908), since BOLT greatly reduces build-to-build variance by normalizing the layout, which otherwise adds >1% of build-to-build variation. I don't have hard numbers but I personally trust our benchmarking numbers to around +-0.2%, so I believe the numbers in this PR (0.5% / 0.8% speedup) are significant even though they might typically be regarded as noise.

---

The garbage collector is quite hard on the CPU since it involves multiple
indirect function calls during the heap scans: the first is
`PyType(op)->tp_traverse()`, and the second is from the `Py_VISIT` calls inside
the tp_traverse methods. This commit converts both of these cases into static
calls for the most common types.

We get rid of the indirect call to tp_traverse by first checking if the object
is one of a number of common types, and statically calling their traverse
methods. The theory is that direct branches are cheaper than indirect function
calls since the target is known, and inlining is supported.

We get rid of the indirect calls inside of the tp_traverse using some compiler
attributes.  We create a new function `inlined_tp_traverse()` which does this
checking, and this function is annotated with the attributes `always_inline`
and `flatten`.  `always_inline` means that the individual traverse methods
should get inlined into inlined_tp_traverse, and `flatten` means that
`inlined_tp_traverse` will get inlined into the calling function. This means
that in, for example, `move_unreachable`, there is now a complete copy of all
of the individual type-traverse methods such as `tupletraverse`, with a
hardcoded visitproc argument. This means that we end up essentially generating
specializations of the common traverse methods that directly call the various
visitproc functions, instead of having indirect calls.

The set of types to optimize was influenced by looking at stats from a small
flask webserver; when it was up and running, the object counts by type were:

function: 12677
dict: 5851
tuple: 5384
weakref: 2844
list: 1881
type: 1513
getset_descriptor: 1488
cell: 1402
wrapper_descriptor: 1258
method_descriptor: 1114
builtin_function_or_method: 1066
member_descriptor: 810
property: 647
set: 572
module: 462

We picked tuple, function, cell, dict, and list, skipping some of the other
types (such as getset_descriptor) that we guessed would not scale with overall
object count. That said, there could still be a more robust analysis done here
on a larger set of larger benchmarks.

This commit improves the performance of the following gc microbenchmark by
about 9%:

```
l = [C(({1: [2]},)) for i in range(1000000)]
print(timeit.timeit("gc.collect()", number=20))
```

It improves performance on the Pyston webserving macrobenchmarks by about 0.8%,
and on pyperformance by about 0.5% (measured on an Intel i7-6700).

Change originally by @undingen

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
