### PR TITLE
Doc: Fix ref warnings for Point class in sqlite3 & make consistant

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1611,7 +1611,7 @@ registering custom adapter functions.
 Letting your object adapt itself
 """"""""""""""""""""""""""""""""
 
-Suppose we have a ``Point`` class that represents a pair of coordinates,
+Suppose we have a :class:`!Point` class that represents a pair of coordinates,
 ``x`` and ``y``, in a Cartesian coordinate system.
 The coordinate pair will be stored as a text string in the database,
 using a semicolon to separate the coordinates.
@@ -1642,11 +1642,11 @@ values.
 To be able to convert *from* SQLite values *to* custom Python types,
 we use *converters*.
 
-Let's go back to the :class:`Point` class. We stored the x and y coordinates
+Let's go back to the :class:`!Point` class. We stored the x and y coordinates
 separated via semicolons as strings in SQLite.
 
 First, we'll define a converter function that accepts the string as a parameter
-and constructs a :class:`Point` object from it.
+and constructs a :class:`!Point` object from it.
 
 .. note::
 


### PR DESCRIPTION
After all of @erlend-aasland 's work in the `sqlite3` module docs, there are only a few broken references (causing warnings) left. Following our guidance established earlier, this fixes `:class:` references to the example `Point` class to be non-resolved (`!`), and also converts a ``literal`` reference to a non-resolved `:class:` for syntactic, semantic and formatting consistency.

This leaves only warnings about the missing `SQLITE_*` module-level constants that are currently not explicitly documented (like `sqlite.PrepareProtocol`), but I'll open a separate issue for that, since the fix is somewhat less trivial.