### PR TITLE
[3.11] gh-96017: Fix some compiler warnings (GH-96018)

### DIFF
--- a/Python/ceval_gil.h
+++ b/Python/ceval_gil.h
@@ -133,12 +133,14 @@ static void destroy_gil(struct _gil_runtime_state *gil)
     _Py_ANNOTATE_RWLOCK_DESTROY(&gil->locked);
 }
 
+#ifdef HAVE_FORK
 static void recreate_gil(struct _gil_runtime_state *gil)
 {
     _Py_ANNOTATE_RWLOCK_DESTROY(&gil->locked);
     /* XXX should we destroy the old OS resources here? */
     create_gil(gil);
 }
+#endif
 
 static void
 drop_gil(struct _ceval_runtime_state *ceval, struct _ceval_state *ceval2,


### PR DESCRIPTION
- only define recreate_gil with ifdef HAVE_FORK.
(cherry picked from commit d9c1b746b5013f81d1724757bb3c6a1c87c4a8dc)

Co-authored-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96017 -->
* Issue: gh-96017
<!-- /gh-issue-number -->
