### PR TITLE
Alert when using random.choice on sets and dicts

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -336,6 +336,9 @@ class Random(_random.Random):
 
     def choice(self, seq):
         """Choose a random element from a non-empty sequence."""
+        if not isinstance(seq, _Sequence):
+            raise TypeError("Population must be a sequence.  "
+                            "For dicts or sets, use sorted(d).")
         if not seq:
             raise IndexError('Cannot choose from an empty sequence')
         return seq[self._randbelow(len(seq))]


### PR DESCRIPTION
At the moment, `random.sample` from a dict gives a reasonable error message. When running `random.choice` on a dict, at best you get a confusing KeyError, and at worst you get silently wrong results. Examples:

```python
>>> random.choice({0: 'a'})
'a'
>>> random.choice({1: 'a'})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.10/random.py", line 378, in choice
    return seq[self._randbelow(len(seq))]
KeyError: 0
>>> random.choice({'foo': 'bar', **{i: str(10*i) for i in range(10)}})
'90'
>>> random.choice({'foo': 'bar', **{i: str(10*i) for i in range(10)}})
'10'
>>> random.choice({'foo': 'bar', **{i: str(10*i) for i in range(10)}})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.10/random.py", line 378, in choice
    return seq[self._randbelow(len(seq))]
KeyError: 10
>>> random.choice({'foo': 'bar', **{i: str(10*i) for i in range(10)}})
'50'
```

As a first simple suggestion, I propose adding the error handling from `random.sample` to `random.choice`. As a reminder on my system `random.sample`’s error handling looks like this:

```python
>>> random.sample({}, 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/random.py", line 466, in sample
    raise TypeError("Population must be a sequence.  For dicts or sets, use sorted(d).")
TypeError: Population must be a sequence.  For dicts or sets, use sorted(d)
```

See [this discussion](https://discuss.python.org/t/random-choice-from-a-dict/17834).

The problem this PR fixes is fairly straightforward, so I don't think it needs an issue or a NEWS items?  If you disagree, please let me know, and I create one.