### PR TITLE
gh-89639: Revert Py_SIZE() static inline function

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -99,7 +99,7 @@ the definition of all other Python objects.
 
    Return a :term:`borrowed reference`.
 
-   Use the :c:func:`Py_SET_TYPE` function to set an object type.
+   The :c:func:`Py_SET_TYPE` function must be used to set an object type.
 
    .. versionchanged:: 3.11
       :c:func:`Py_TYPE()` is changed to an inline static function.
@@ -125,7 +125,8 @@ the definition of all other Python objects.
 
    Get the reference count of the Python object *o*.
 
-   Use the :c:func:`Py_SET_REFCNT()` function to set an object reference count.
+   The :c:func:`Py_SET_REFCNT()` function must be used to set an object
+   reference count.
 
    .. versionchanged:: 3.11
       The parameter type is no longer :c:type:`const PyObject*`.
@@ -145,10 +146,9 @@ the definition of all other Python objects.
 
    Get the size of the Python object *o*.
 
-   Use the :c:func:`Py_SET_SIZE` function to set an object size.
+   The :c:func:`Py_SET_SIZE` function must be used to set an object size.
 
    .. versionchanged:: 3.11
-      :c:func:`Py_SIZE()` is changed to an inline static function.
       The parameter type is no longer :c:type:`const PyVarObject*`.
 
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1870,20 +1870,6 @@ Porting to Python 3.11
 
   (Contributed by Victor Stinner in :issue:`39573`.)
 
-* Since :c:func:`Py_SIZE()` is changed to a inline static function,
-  ``Py_SIZE(obj) = new_size`` must be replaced with
-  ``Py_SET_SIZE(obj, new_size)``: see the :c:func:`Py_SET_SIZE()` function
-  (available since Python 3.9). For backward compatibility, this macro can be
-  used::
-
-      #if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_SIZE)
-      static inline void _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
-      { ob->ob_size = size; }
-      #define Py_SET_SIZE(ob, size) _Py_SET_SIZE((PyVarObject*)(ob), size)
-      #endif
-
-  (Contributed by Victor Stinner in :issue:`39573`.)
-
 * ``<Python.h>`` no longer includes the header files ``<stdlib.h>``,
   ``<stdio.h>``, ``<errno.h>`` and ``<string.h>`` when the ``Py_LIMITED_API``
   macro is set to ``0x030b0000`` (Python 3.11) or higher. C extensions should

--- a/Include/object.h
+++ b/Include/object.h
@@ -138,14 +138,9 @@ static inline PyTypeObject* Py_TYPE(PyObject *ob) {
 #  define Py_TYPE(ob) Py_TYPE(_PyObject_CAST(ob))
 #endif
 
+
 // bpo-39573: The Py_SET_SIZE() function must be used to set an object size.
-static inline Py_ssize_t Py_SIZE(PyObject *ob) {
-    PyVarObject *var_ob = _PyVarObject_CAST(ob);
-    return var_ob->ob_size;
-}
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
-#  define Py_SIZE(ob) Py_SIZE(_PyObject_CAST(ob))
-#endif
+#define Py_SIZE(ob)             (_PyVarObject_CAST(ob)->ob_size)
 
 
 static inline int Py_IS_TYPE(PyObject *ob, PyTypeObject *type) {

--- a/Misc/NEWS.d/next/C API/2022-08-19-12-06-57.gh-issue-89639.mKduYZ.rst
+++ b/Misc/NEWS.d/next/C API/2022-08-19-12-06-57.gh-issue-89639.mKduYZ.rst
@@ -1,0 +1,2 @@
+Allow again to use :c:func:`Py_SIZE` to set an object size:
+``Py_SIZE(obj) = size``. Patch by Victor Stinner.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4950,7 +4950,11 @@ test_set_type_size(PyObject *self, PyObject *Py_UNUSED(ignored))
     assert(Py_TYPE(obj) == &PyList_Type);
     assert(Py_SIZE(obj) == 0);
 
-    // bpo-39573: Test Py_SET_TYPE() and Py_SET_SIZE() functions.
+    // gh-89639: Check that Py_SIZE() can be used as l-value
+    // to set an object size.
+    Py_SIZE(obj) = 0;
+
+    // gh-89639: Test Py_SET_TYPE() and Py_SET_SIZE() functions.
     Py_SET_TYPE(obj, &PyList_Type);
     Py_SET_SIZE(obj, 0);
 


### PR DESCRIPTION
Allow again to use Py_SIZE() to set an object size:
"Py_SIZE(obj) = size".

Partially revert commit cb15afcccffc6c42cbfb7456ce8db89cd2f77512.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-89639 -->
* Issue: gh-89639
<!-- /gh-issue-number -->
