### PR TITLE
gh-96125: Fix sys.thread_info.name on pthread platforms

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -628,6 +628,14 @@ class SysModuleTest(unittest.TestCase):
         self.assertEqual(len(info), 3)
         self.assertIn(info.name, ('nt', 'pthread', 'pthread-stubs', 'solaris', None))
         self.assertIn(info.lock, ('semaphore', 'mutex+cond', None))
+        if sys.platform.startswith(("linux", "freebsd")):
+            self.assertEqual(info.name, "pthread")
+        elif sys.platform == "win32":
+            self.assertEqual(info.name, "nt")
+        elif sys.platform == "emscripten":
+            self.assertIn(info.name, {"pthread", "pthread-stubs"})
+        elif sys.platform == "wasi":
+            self.assertEqual(info.name, "pthread-stubs")
 
     @unittest.skipUnless(support.is_emscripten, "only available on Emscripten")
     def test_emscripten_info(self):

--- a/Misc/NEWS.d/next/Library/2022-08-19-18-21-01.gh-issue-96125.ODcF1Y.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-19-18-21-01.gh-issue-96125.ODcF1Y.rst
@@ -1,0 +1,2 @@
+Fix incorrect condition that cause ``sys.thread_info.name`` to be wrong on
+pthread platforms.

--- a/Misc/NEWS.d/next/Library/2022-08-19-18-21-01.gh-issue-96125.ODcF1Y.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-19-18-21-01.gh-issue-96125.ODcF1Y.rst
@@ -1,2 +1,2 @@
-Fix incorrect condition that cause ``sys.thread_info.name`` to be wrong on
+Fix incorrect condition that causes ``sys.thread_info.name`` to be wrong on
 pthread platforms.

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -59,7 +59,7 @@ PyThread_init_thread(void)
 #   define PYTHREAD_NAME "pthread-stubs"
 #   include "thread_pthread_stubs.h"
 #elif defined(_POSIX_THREADS)
-#   if defined(__EMSCRIPTEN__) || !defined(__EMSCRIPTEN_PTHREADS__)
+#   if defined(__EMSCRIPTEN__) && !defined(__EMSCRIPTEN_PTHREADS__)
 #     define PYTHREAD_NAME "pthread-stubs"
 #   else
 #     define PYTHREAD_NAME "pthread"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96125 -->
* Issue: gh-96125
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:tiran