### PR TITLE
gh-96052: codeop: fix handling compiler warnings in incomplete input

### DIFF
--- a/Lib/test/test_codeop.py
+++ b/Lib/test/test_codeop.py
@@ -321,6 +321,26 @@ class CodeopTests(unittest.TestCase):
             warnings.simplefilter('error', SyntaxWarning)
             compile_command('1 is 1', symbol='exec')
 
+        # Check DeprecationWarning treated as an SyntaxError
+        with warnings.catch_warnings(), self.assertRaises(SyntaxError):
+            warnings.simplefilter('error', DeprecationWarning)
+            compile_command(r"'\e'", symbol='exec')
+
+    def test_incomplete_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self.assertIncomplete("'\\e' + (")
+        self.assertEqual(w, [])
+
+    def test_invalid_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self.assertInvalid("'\\e' 1")
+        self.assertEqual(len(w), 1)
+        self.assertEqual(w[0].category, DeprecationWarning)
+        self.assertRegex(str(w[0].message), 'invalid escape sequence')
+        self.assertEqual(w[0].filename, '<input>')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2022-08-20-10-31-01.gh-issue-96052.a6FhaD.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-20-10-31-01.gh-issue-96052.a6FhaD.rst
@@ -1,0 +1,4 @@
+Fix handling compiler warnings (SyntaxWarning and DeprecationWarning) in
+:func:`codeop.compile_command` when checking for incomplete input.
+Previously it emitted warnings and raised a SyntaxError. Now it always
+returns ``None`` for incomplete input without emitting any warnings.


### PR DESCRIPTION
Previously codeop.compile_command() emitted compiler warnings (SyntaxWarning or
DeprecationWarning) and raised a SyntaxError for incomplete input containing
a potentially incorrect code. Now it always returns None for incomplete input
without emitting any warnings.


<!-- gh-issue-number: gh-96052 -->
* Issue: gh-96052
<!-- /gh-issue-number -->
