### PR TITLE
gh-96096: Add undocumented SQLITE_OK/DENY/IGNORE sqlite3 constants

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -417,6 +417,18 @@ Module constants
    This flag may be combined with :const:`PARSE_COLNAMES` using the ``|``
    (bitwise or) operator.
 
+.. data:: SQLITE_OK
+          SQLITE_DENY
+          SQLITE_IGNORE
+
+   Flags used for return values from the callable passed as
+   the *authorizer_callback* argument of :meth:`Connection.set_authorizer`
+   to indicate whether:
+
+   * Access is allowed (:const:`!SQLITE_OK`),
+   * The SQL statement should be aborted with an error (:const:`!SQLITE_DENY`)
+   * The column should be treated as a ``NULL`` value (:const:`!SQLITE_IGNORE`)
+
 .. data:: apilevel
 
    String constant stating the supported DB-API level. Required by the DB-API.

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -804,10 +804,8 @@ Connection objects
 
       Register callable *authorizer_callback* to be invoked for each attempt to
       access a column of a table in the database. The callback should return
-      :const:`SQLITE_OK` if access is allowed, :const:`SQLITE_DENY` if the entire SQL
-      statement should be aborted with an error and :const:`SQLITE_IGNORE` if the
-      column should be treated as a NULL value. These constants are available in the
-      :mod:`!sqlite3` module.
+      one of :const:`SQLITE_OK`, :const:`SQLITE_DENY` or :const:`SQLITE_IGNORE`
+      to signal how the column should be handled.
 
       The first argument to the callback signifies what kind of operation is to be
       authorized. The second and third argument will be arguments or ``None``

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -421,9 +421,8 @@ Module constants
           SQLITE_DENY
           SQLITE_IGNORE
 
-   Flags used for return values from the callable passed as
-   the *authorizer_callback* argument of :meth:`Connection.set_authorizer`
-   to indicate whether:
+   Flags that should be returned by the *authorizer_callback* callable
+   passed to :meth:`Connection.set_authorizer`, to indicate whether:
 
    * Access is allowed (:const:`!SQLITE_OK`),
    * The SQL statement should be aborted with an error (:const:`!SQLITE_DENY`)
@@ -805,7 +804,8 @@ Connection objects
       Register callable *authorizer_callback* to be invoked for each attempt to
       access a column of a table in the database. The callback should return
       one of :const:`SQLITE_OK`, :const:`SQLITE_DENY`, or :const:`SQLITE_IGNORE`
-      to signal how the column should be handled.
+      to signal how access to the column should be handled
+      by the underlying SQLite library.
 
       The first argument to the callback signifies what kind of operation is to be
       authorized. The second and third argument will be arguments or ``None``

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -804,7 +804,7 @@ Connection objects
 
       Register callable *authorizer_callback* to be invoked for each attempt to
       access a column of a table in the database. The callback should return
-      one of :const:`SQLITE_OK`, :const:`SQLITE_DENY` or :const:`SQLITE_IGNORE`
+      one of :const:`SQLITE_OK`, :const:`SQLITE_DENY`, or :const:`SQLITE_IGNORE`
       to signal how the column should be handled.
 
       The first argument to the callback signifies what kind of operation is to be


### PR DESCRIPTION
As discussed in #96096 , add a formal description of the `SQLITE_OK`/`SQLITE_DENY`/`SQLITE_IGNORE` constants referenced in `Connection.set_authorizer()`, and update that method to elide duplicate content.

Maybe some mention should be made of `SQLITE_OK`'s evident broader role? I'm not really well informed about the subject matter on this one to have any opinion on that.

<!-- gh-issue-number: gh-96096 -->
* Issue: gh-96096
<!-- /gh-issue-number -->
