### PR TITLE
gh-96021: Explicitly close the IsolatedAsyncioTestCase runner in tests

### DIFF
--- a/Lib/test/test_unittest/test_async_case.py
+++ b/Lib/test/test_unittest/test_async_case.py
@@ -43,10 +43,10 @@ VAR = contextvars.ContextVar('VAR', default=())
 class TestAsyncCase(unittest.TestCase):
     maxDiff = None
 
-    def tearDown(self):
+    def setUp(self):
         # Ensure that IsolatedAsyncioTestCase instances are destroyed before
         # starting a new event loop
-        support.gc_collect()
+        self.addCleanup(support.gc_collect)
 
     def test_full_cycle(self):
         class Test(unittest.IsolatedAsyncioTestCase):

--- a/Lib/test/test_unittest/test_async_case.py
+++ b/Lib/test/test_unittest/test_async_case.py
@@ -151,6 +151,7 @@ class TestAsyncCase(unittest.TestCase):
 
         events = []
         test = Test("test_func")
+        self.addCleanup(test._tearDownAsyncioRunner)
         try:
             test.debug()
         except MyException:
@@ -186,6 +187,7 @@ class TestAsyncCase(unittest.TestCase):
 
         events = []
         test = Test("test_func")
+        self.addCleanup(test._tearDownAsyncioRunner)
         try:
             test.debug()
         except MyException:
@@ -221,6 +223,7 @@ class TestAsyncCase(unittest.TestCase):
 
         events = []
         test = Test("test_func")
+        self.addCleanup(test._tearDownAsyncioRunner)
         try:
             test.debug()
         except MyException:
@@ -262,6 +265,7 @@ class TestAsyncCase(unittest.TestCase):
 
         events = []
         test = Test("test_func")
+        self.addCleanup(test._tearDownAsyncioRunner)
         try:
             test.debug()
         except MyException:
@@ -424,6 +428,7 @@ class TestAsyncCase(unittest.TestCase):
 
         events = []
         test = Test("test_func")
+        self.addCleanup(test._tearDownAsyncioRunner)
         try:
             test.debug()
         except MyException:


### PR DESCRIPTION
Tests for IsolatedAsyncioTestCase.debug() rely on the runner be closed
in `__del__`. It makes tests depending on the GC an unreliable on other
implementations. It is better to close the runner explicitly even if
currently there is no a public API for this.

It does not fix gh-96021, it only uses a workaround until we find better solution (which perhaps could not be backported).