### PR TITLE
gh-90536: Fix link syntax to LLVM-BOLT repository

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -235,7 +235,7 @@ also be used to improve performance.
 .. cmdoption:: --enable-bolt
 
    Enable usage of the `BOLT post-link binary optimizer
-   <https://github.com/llvm/llvm-project/tree/main/bolt>` (disabled by
+   <https://github.com/llvm/llvm-project/tree/main/bolt>`_ (disabled by
    default).
 
    BOLT is part of the LLVM project but is not always included in their binary


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-90536 -->
* Issue: gh-90536
<!-- /gh-issue-number -->
