### PR TITLE
gh-95196: Fixed instances of types.ClassMethodDescriptorType not being pickled correctly

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -83,6 +83,9 @@ Other Language Changes
   mapping is hashable.
   (Contributed by Serhiy Storchaka in :gh:`87995`.)
 
+* :class:`types.ClassMethodDescriptorType` instances are now pickled correctly.
+  (Contributed by Nir Schulman in :gh:`95196`.)
+
 
 New Modules
 ===========

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -341,6 +341,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(endpos)
         STRUCT_FOR_ID(env)
         STRUCT_FOR_ID(errors)
+        STRUCT_FOR_ID(eval)
         STRUCT_FOR_ID(event)
         STRUCT_FOR_ID(eventmask)
         STRUCT_FOR_ID(exc_type)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -850,6 +850,7 @@ extern "C" {
                 INIT_ID(endpos), \
                 INIT_ID(env), \
                 INIT_ID(errors), \
+                INIT_ID(eval), \
                 INIT_ID(event), \
                 INIT_ID(eventmask), \
                 INIT_ID(exc_type), \
@@ -2001,6 +2002,8 @@ _PyUnicode_InitStaticStrings(void) {
     string = &_Py_ID(env);
     PyUnicode_InternInPlace(&string);
     string = &_Py_ID(errors);
+    PyUnicode_InternInPlace(&string);
+    string = &_Py_ID(eval);
     PyUnicode_InternInPlace(&string);
     string = &_Py_ID(event);
     PyUnicode_InternInPlace(&string);
@@ -5925,6 +5928,10 @@ _PyStaticObjects_CheckRefcnt(void) {
     };
     if (Py_REFCNT((PyObject *)&_Py_ID(errors)) < _PyObject_IMMORTAL_REFCNT) {
         _PyObject_Dump((PyObject *)&_Py_ID(errors));
+        Py_FatalError("immortal object has less refcnt than expected _PyObject_IMMORTAL_REFCNT");
+    };
+    if (Py_REFCNT((PyObject *)&_Py_ID(eval)) < _PyObject_IMMORTAL_REFCNT) {
+        _PyObject_Dump((PyObject *)&_Py_ID(eval));
         Py_FatalError("immortal object has less refcnt than expected _PyObject_IMMORTAL_REFCNT");
     };
     if (Py_REFCNT((PyObject *)&_Py_ID(event)) < _PyObject_IMMORTAL_REFCNT) {

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2795,8 +2795,10 @@ class AbstractPickleTests:
             ({1, 2}.__contains__, (2,)),
             # unbound "coexist" method
             (set.__contains__, ({1, 2}, 2)),
-            # built-in class method
+            # built-in bound class method
             (dict.fromkeys, (("a", 1), ("b", 2))),
+            # built-in unbound class method
+            (dict.__dict__["fromkeys"], (dict, ("a", 1), ("b", 2))),
             # built-in static method
             (bytearray.maketrans, (b"abc", b"xyz")),
             # subclass methods

--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-21-22-00-51.gh-issue-95196.MwXQ1l.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-21-22-00-51.gh-issue-95196.MwXQ1l.rst
@@ -1,0 +1,1 @@
+Fixed :class:`types.ClassMethodDescriptorType` being pickled incorrectly.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -640,19 +640,8 @@ classmethoddescr_reduce(PyDescrObject* descr, PyObject* Py_UNUSED(ignored))
     /* Ideally, we would want to use a different callable than eval in
        order to get the descriptor. However, we need to ensure the pickled
        object will not cause errors upon unpickling in older versions. */
-    PyObject* evalFunctionName = PyUnicode_FromString("eval");
-    if (evalFunctionName == NULL) {
-        return NULL;
-    }
-    PyObject* eval = _PyEval_GetBuiltin(evalFunctionName);
-    Py_DECREF(evalFunctionName);
-
-    if (eval == NULL) {
-        return NULL;
-    }
-
     return Py_BuildValue("N(s, N, {s:O, s:O})",
-        eval, "cls.__dict__[name]", Py_None,
+        _PyEval_GetBuiltin(&_Py_ID(eval)), "cls.__dict__[name]", Py_None,
         "cls", PyDescr_TYPE(descr), "name", PyDescr_NAME(descr)
     );
 }


### PR DESCRIPTION
NOTE: I want to apologize for anything that is not up to par in this PR. This is my first time writing to cpython (and writing in python's C-API in general), I would love to learn from any mistakes done here and improve for the next time. I tried my best to look at other examples and guides and derive the correct conventions and workflow from there. 

Previously, instances of types.ClassMethodDescriptorType were reduced
into a wrong set of instructions. Instead of the instructions retrieving 
the descriptor itself (using direct access to the object's `__dict__`),
the instructions retrieved the underlying classmethod (using the normal `getattr`)
which resulted in different object upon unpickling.
This change has replaced the implementation of `__reduce__` for such
instances so it will directly access the owner's `__dict__`.

Since there is no publicly available builtin function (That I could
find) to get an attribute directly from the object's `__dict__`, and in
order for the implmentation to work with older versions of python, I
unfortunately could not avoid the usage of the "eval" builtin in the
implementation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-95196: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
