### PR TITLE
gh-65496: Correct wording on csv's skipinitialspace

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -416,7 +416,7 @@ Dialects support the following attributes:
 
 .. attribute:: Dialect.skipinitialspace
 
-   When :const:`True`, whitespace immediately following the *delimiter* is ignored.
+   When :const:`True`, spaces immediately following the *delimiter* are ignored.
    The default is :const:`False`.
 
 

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -362,6 +362,11 @@ class Test_Csv(unittest.TestCase):
         self._read_test(['1,@,3,@,5'], [['1', ',3,', '5']], quotechar='@')
         self._read_test(['1,\0,3,\0,5'], [['1', ',3,', '5']], quotechar='\0')
 
+    def test_read_skipinitialspace(self):
+        self._read_test(['no space, space,  spaces,\ttab'],
+                        [['no space', 'space', 'spaces', '\ttab']],
+                        skipinitialspace=True)
+
     def test_read_bigfield(self):
         # This exercises the buffer realloc functionality and field size
         # limits.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -704,7 +704,7 @@ parse_process_char(ReaderObj *self, _csvstate *module_state, Py_UCS4 c)
             self->state = ESCAPED_CHAR;
         }
         else if (c == ' ' && dialect->skipinitialspace)
-            /* ignore space at start of field */
+            /* ignore spaces at start of field */
             ;
         else if (c == dialect->delimiter) {
             /* save empty field */
@@ -1647,9 +1647,9 @@ PyDoc_STRVAR(csv_module_doc,
 "        quoting character.  It defaults to '\"'.\n"
 "    * delimiter - specifies a one-character string to use as the\n"
 "        field separator.  It defaults to ','.\n"
-"    * skipinitialspace - specifies how to interpret whitespace which\n"
-"        immediately follows a delimiter.  It defaults to False, which\n"
-"        means that whitespace immediately following a delimiter is part\n"
+"    * skipinitialspace - specifies how to interpret spaces which\n"
+"        immediately follow a delimiter.  It defaults to False, which\n"
+"        means that spaces immediately following a delimiter is part\n"
 "        of the following field.\n"
 "    * lineterminator -  specifies the character sequence which should\n"
 "        terminate rows.\n"


### PR DESCRIPTION
https://docs.python.org/dev/library/csv.html#csv.Dialect.skipinitialspace

Co-authored-by: Brandon Milam

<!-- gh-issue-number: gh-65496 -->
* Issue: gh-65496
<!-- /gh-issue-number -->
