### PR TITLE
gh-64921: Clarify wording for open()'s newline arg

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1243,8 +1243,8 @@ are always available.  They are listed here in alphabetical order.
 
    .. _open-newline-parameter:
 
-   *newline* controls how :term:`universal newlines` mode works (it only
-   applies to text mode).  It can be ``None``, ``''``, ``'\n'``, ``'\r'``, and
+   *newline* determines how to parse newline characters from the stream.
+   It can be ``None``, ``''``, ``'\n'``, ``'\r'``, and
    ``'\r\n'``.  It works as follows:
 
    * When reading input from the stream, if *newline* is ``None``, universal


### PR DESCRIPTION
https://docs.python.org/dev/library/functions.html#open

Comment on `U` mode deprecation resolved by https://github.com/python/cpython/pull/11646

<!-- gh-issue-number: gh-64921 -->
* Issue: gh-64921
<!-- /gh-issue-number -->
