### PR TITLE
gh-95243: Mitigate the race condition in testSockName

### DIFF
--- a/Misc/NEWS.d/next/Tests/2022-08-22-14-59-42.gh-issue-95243.DeD66V.rst
+++ b/Misc/NEWS.d/next/Tests/2022-08-22-14-59-42.gh-issue-95243.DeD66V.rst
@@ -1,0 +1,3 @@
+Mitigate the inherent race condition from using find_unused_port() in
+testSockName() by trying to find an unused port a few times before failing.
+Patch by Ross Burton.


### PR DESCRIPTION
find_unused_port() has an inherent race condition, but we can't use
bind_port() as that uses .getsockname() which this test is exercising.

Try binding to unused ports a few times before failing.

<!-- gh-issue-number: gh-95243 -->
* Issue: gh-95243
<!-- /gh-issue-number -->
