### PR TITLE
gh-96175: add missing self._localName assignment in `xml.dom.minidom.Attr`

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -79,16 +79,16 @@ class MinidomTest(unittest.TestCase):
 
     def testAttrModeSetsParamsAsAttrs(self):
         attr = Attr("qName", "namespaceURI", "localName", "prefix")
-        self.assertEqual(attr._name, "qName")
+        self.assertEqual(attr.name, "qName")
         self.assertEqual(attr.namespaceURI, "namespaceURI")
-        self.assertEqual(attr._prefix, "prefix")
-        self.assertEqual(attr._localName, "localName")
+        self.assertEqual(attr.prefix, "prefix")
+        self.assertEqual(attr.localName, "localName")
 
     def testAttrModeSetsNonOptionalAttrs(self):
         attr = Attr("qName", "namespaceURI", None, "prefix")
-        self.assertEqual(attr._name, "qName")
+        self.assertEqual(attr.name, "qName")
         self.assertEqual(attr.namespaceURI, "namespaceURI")
-        self.assertEqual(attr._prefix, "prefix")
+        self.assertEqual(attr.prefix, "prefix")
         self.assertFalse(hasattr(attr, "_localName"))
 
     def testGetElementsByTagName(self):

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -9,7 +9,7 @@ import unittest
 import pyexpat
 import xml.dom.minidom
 
-from xml.dom.minidom import parse, Node, Document, parseString
+from xml.dom.minidom import parse, Attr, Node, Document, parseString
 from xml.dom.minidom import getDOMImplementation
 from xml.parsers.expat import ExpatError
 

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -79,48 +79,17 @@ class MinidomTest(unittest.TestCase):
 
     def testAttrModeSetsParamsAsAttrs(self):
         attr = Attr("qName", "namespaceURI", "localName", "prefix")
-        self.assertEqual(
-            attr._name,
-            "qName",
-            "testAttrModeSetsParamsAsAttrs -- qName parameter does not match",
-        )
-        self.assertEqual(
-            attr.namespaceURI,
-            "namespaceURI",
-            "testAttrModeSetsParamsAsAttrs -- namespaceURI parameter does not match",
-        )
-        self.assertEqual(
-            attr._prefix,
-            "prefix",
-            "testAttrModeSetsParamsAsAttrs -- prefix parameter does not match",
-        )
-        self.assertEqual(
-            attr._localName,
-            "localName",
-            "testAttrModeSetsParamsAsAttrs -- localName parameter does not match",
-        )
+        self.assertEqual(attr._name, "qName")
+        self.assertEqual(attr.namespaceURI, "namespaceURI")
+        self.assertEqual(attr._prefix, "prefix")
+        self.assertEqual(attr._localName, "localName")
 
     def testAttrModeSetsNonOptionalAttrs(self):
         attr = Attr("qName", "namespaceURI", None, "prefix")
-        self.assertEqual(
-            attr._name,
-            "qName",
-            "testAttrModeSetsParamsAsAttrs -- qName parameter does not match",
-        )
-        self.assertEqual(
-            attr.namespaceURI,
-            "namespaceURI",
-            "testAttrModeSetsParamsAsAttrs -- namespaceURI parameter does not match",
-        )
-        self.assertEqual(
-            attr._prefix,
-            "prefix",
-            "testAttrModeSetsParamsAsAttrs -- prefix parameter does not match",
-        )
-        self.assertFalse(
-            hasattr(attr, "_localName"),
-            "testAttrModeSetsParamsAsAttrs -- localName parameter set when None",
-        )
+        self.assertEqual(attr._name, "qName")
+        self.assertEqual(attr.namespaceURI, "namespaceURI")
+        self.assertEqual(attr._prefix, "prefix")
+        self.assertFalse(hasattr(attr, "_localName"))
 
     def testGetElementsByTagName(self):
         dom = parse(tstfile)

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -89,7 +89,7 @@ class MinidomTest(unittest.TestCase):
         self.assertEqual(attr.name, "qName")
         self.assertEqual(attr.namespaceURI, "namespaceURI")
         self.assertEqual(attr.prefix, "prefix")
-        self.assertFalse(hasattr(attr, "_localName"))
+        self.assertEqual(attr.localName, attr.name)
 
     def testGetElementsByTagName(self):
         dom = parse(tstfile)

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -77,6 +77,51 @@ class MinidomTest(unittest.TestCase):
             dom.unlink()
             self.confirm(isinstance(dom, Document))
 
+    def testAttrModeSetsParamsAsAttrs(self):
+        attr = Attr("qName", "namespaceURI", "localName", "prefix")
+        self.assertEqual(
+            attr._name,
+            "qName",
+            "testAttrModeSetsParamsAsAttrs -- qName parameter does not match",
+        )
+        self.assertEqual(
+            attr.namespaceURI,
+            "namespaceURI",
+            "testAttrModeSetsParamsAsAttrs -- namespaceURI parameter does not match",
+        )
+        self.assertEqual(
+            attr._prefix,
+            "prefix",
+            "testAttrModeSetsParamsAsAttrs -- prefix parameter does not match",
+        )
+        self.assertEqual(
+            attr._localName,
+            "localName",
+            "testAttrModeSetsParamsAsAttrs -- localName parameter does not match",
+        )
+
+    def testAttrModeSetsNonOptionalAttrs(self):
+        attr = Attr("qName", "namespaceURI", None, "prefix")
+        self.assertEqual(
+            attr._name,
+            "qName",
+            "testAttrModeSetsParamsAsAttrs -- qName parameter does not match",
+        )
+        self.assertEqual(
+            attr.namespaceURI,
+            "namespaceURI",
+            "testAttrModeSetsParamsAsAttrs -- namespaceURI parameter does not match",
+        )
+        self.assertEqual(
+            attr._prefix,
+            "prefix",
+            "testAttrModeSetsParamsAsAttrs -- prefix parameter does not match",
+        )
+        self.assertFalse(
+            hasattr(attr, "_localName"),
+            "testAttrModeSetsParamsAsAttrs -- localName parameter set when None",
+        )
+
     def testGetElementsByTagName(self):
         dom = parse(tstfile)
         self.confirm(dom.getElementsByTagName("LI") == \

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -358,6 +358,8 @@ class Attr(Node):
         self._name = qName
         self.namespaceURI = namespaceURI
         self._prefix = prefix
+        if localName is not None:
+            self._localName = localName
         self.childNodes = NodeList()
 
         # Add the single child node that represents the value of the attr

--- a/Misc/NEWS.d/next/Library/2022-08-22-13-54-20.gh-issue-96175.bH7zGU.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-22-13-54-20.gh-issue-96175.bH7zGU.rst
@@ -1,1 +1,1 @@
-Fix unused ``localName`` parameter in ``Attr`` minidom node.
+Fix unused ``localName`` parameter in the ``Attr`` class in :mod:`xml.dom.minidom`.

--- a/Misc/NEWS.d/next/Library/2022-08-22-13-54-20.gh-issue-96175.bH7zGU.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-22-13-54-20.gh-issue-96175.bH7zGU.rst
@@ -1,1 +1,1 @@
-Fix unused `localName` parameter in `Attr` minidom node.
+Fix unused ``localName`` parameter in ``Attr`` minidom node.

--- a/Misc/NEWS.d/next/Library/2022-08-22-13-54-20.gh-issue-96175.bH7zGU.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-22-13-54-20.gh-issue-96175.bH7zGU.rst
@@ -1,0 +1,1 @@
+Fix unused `localName` parameter in `Attr` minidom node.


### PR DESCRIPTION
Fixes: #96175 

X-Ref: https://github.com/python/typeshed/pull/8590#discussion_r951473977

This adds a missing assignment to `_localName`

<!-- gh-issue-number: gh-96175 -->
* Issue: gh-96175
<!-- /gh-issue-number -->
