### PR TITLE
gh-96159: Fix significant performance degradation in logging.TimedRotat… (GH-96182)

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -348,11 +348,15 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
         record is not used, as we are just comparing times, but it is needed so
         the method signatures are the same
         """
-        # See bpo-45401: Never rollover anything other than regular files
-        if os.path.exists(self.baseFilename) and not os.path.isfile(self.baseFilename):
-            return False
         t = int(time.time())
         if t >= self.rolloverAt:
+            # See #89564: Never rollover anything other than regular files
+            if os.path.exists(self.baseFilename) and not os.path.isfile(self.baseFilename):
+                # The file is not a regular file, so do not rollover, but do
+                # set the next rollover time to avoid repeated checks.
+                self.rolloverAt = self.computeRollover(t)
+                return False
+
             return True
         return False
 

--- a/Misc/NEWS.d/next/Library/2022-08-22-18-42-17.gh-issue-96159.3bFU39.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-22-18-42-17.gh-issue-96159.3bFU39.rst
@@ -1,0 +1,1 @@
+Fix a performance regression in logging TimedRotatingFileHandler. Only check for special files when the rollover time has passed.


### PR DESCRIPTION
This is a simple fix for #96159. The cost of checking for non-regular files is now only incurred when the rollover time is reached, rather than on every single log message.

A similar change could be made to RotatingFileHandler, but does seek() and tell() calls on the file, which are probably bad to do on special files, so I thought it was safer to leave it with the file type check on every call.

<!-- gh-issue-number: gh-96159 -->
* Issue: gh-96159
<!-- /gh-issue-number -->
