### PR TITLE
gh-96192: fix os.ismount() to use a path that is str or bytes

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -195,6 +195,7 @@ def ismount(path):
         if stat.S_ISLNK(s1.st_mode):
             return False
 
+    path = os.fspath(path)
     if isinstance(path, bytes):
         parent = join(path, b'..')
     else:

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -178,6 +178,8 @@ class PosixPathTest(unittest.TestCase):
     def test_ismount(self):
         self.assertIs(posixpath.ismount("/"), True)
         self.assertIs(posixpath.ismount(b"/"), True)
+        self.assertIs(posixpath.ismount(FakePath("/")), True)
+        self.assertIs(posixpath.ismount(FakePath(b"/")), True)
 
     def test_ismount_non_existent(self):
         # Non-existent mountpoint.

--- a/Misc/NEWS.d/next/Library/2022-08-23-03-13-18.gh-issue-96192.TJywOF.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-23-03-13-18.gh-issue-96192.TJywOF.rst
@@ -1,0 +1,1 @@
+Fix handling of ``bytes`` :term:`path-like objects <path-like object>` in :func:`os.ismount()`.


### PR DESCRIPTION
Co-authored-by: Eryk Sun <eryksun@gmail.com>
Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>

<!-- gh-issue-number: gh-96192 -->
* Issue: gh-96192
<!-- /gh-issue-number -->
