### PR TITLE
gh-80678: Add comment on preferred csv delimiters

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -276,7 +276,7 @@ The :mod:`csv` module defines the following classes:
       is given, it is interpreted as a string containing possible valid
       delimiter characters.
       If not excluded by the *delimiters* parameter, and if there is ambiguity,
-      then delimiter choice will be bias towards ``[',', '\t', ';', ' ', ':']``.
+      then delimiter choice will be biased towards ``[',', '\t', ';', ' ', ':']``.
 
 
    .. method:: has_header(sample)

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -275,6 +275,8 @@ The :mod:`csv` module defines the following classes:
       reflecting the parameters found.  If the optional *delimiters* parameter
       is given, it is interpreted as a string containing possible valid
       delimiter characters.
+      If not excluded by the *delimiters* parameter, and if there is ambiguity,
+      then delimiter choice will be bias towards ``[',', '\t', ';', ' ', ':']``.
 
 
    .. method:: has_header(sample)


### PR DESCRIPTION
https://docs.python.org/dev/library/csv.html#csv.Sniffer.sniff

See https://github.com/python/cpython/blob/1499d73b3e02878850c007fa7298bb62f6c5a9a1/Lib/csv.py#L177 for the list of preferred delimiters, and see https://github.com/python/cpython/blob/1499d73b3e02878850c007fa7298bb62f6c5a9a1/Lib/csv.py#L369-L375 for choosing the preferred delimiters

<!-- gh-issue-number: gh-80678 -->
* Issue: gh-80678
<!-- /gh-issue-number -->
