### PR TITLE
[3.10] GH-96187: Prevent _PyCode_GetExtra to return garbage for negat…

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-22-21-33-28.gh-issue-96187.W_6SRG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-22-21-33-28.gh-issue-96187.W_6SRG.rst
@@ -1,0 +1,2 @@
+Fixed a bug that caused ``_PyCode_GetExtra`` to return garbage for negative
+indexes. Patch by Pablo Galindo

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1304,7 +1304,7 @@ _PyCode_GetExtra(PyObject *code, Py_ssize_t index, void **extra)
     PyCodeObject *o = (PyCodeObject*) code;
     _PyCodeObjectExtra *co_extra = (_PyCodeObjectExtra*) o->co_extra;
 
-    if (co_extra == NULL || co_extra->ce_size <= index) {
+    if (co_extra == NULL || index < 0 || co_extra->ce_size <= index) {
         *extra = NULL;
         return 0;
     }


### PR DESCRIPTION
…ive indexes (GH-96188).

(cherry picked from commit 16ebae4cd4029205d932751f26c719c6cb8a6e92)

Co-authored-by: Pablo Galindo Salgado <Pablogsal@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96187 -->
* Issue: gh-96187
<!-- /gh-issue-number -->
