### PR TITLE
GH-96179: Fix misleading example on the bisect documentation

### DIFF
--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -216,7 +216,7 @@ records in a table::
     ...     Movie('Aliens', 1986, 'Scott')
     ... ]
 
-    >>> # Find the first movie released on or after 1960
+    >>> # Find the first movie released after 1960
     >>> by_year = attrgetter('released')
     >>> movies.sort(key=by_year)
     >>> movies[bisect(movies, 1960, key=by_year)]

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1419,6 +1419,7 @@ John Popplewell
 Matheus Vieira Portela
 Davin Potts
 Guillaume Pratte
+Pedro Pregueiro
 Florian Preinstorfer
 Alex Prengère
 Amrit Prem

--- a/Misc/NEWS.d/next/Documentation/2022-08-24-10-34-27.gh-issue-96179.qoGS5v.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-08-24-10-34-27.gh-issue-96179.qoGS5v.rst
@@ -1,0 +1,1 @@
+Fix minor error in example for the bisect documentation

--- a/Misc/NEWS.d/next/Documentation/2022-08-24-10-34-27.gh-issue-96179.qoGS5v.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-08-24-10-34-27.gh-issue-96179.qoGS5v.rst
@@ -1,1 +1,0 @@
-Fix minor error in example for the bisect documentation


### PR DESCRIPTION
Fix minor issue with docs for [bisect](https://docs.python.org/3/library/bisect.html#examples) where example could mislead users:

```
>>> # Find the first movie released on or after 1960
>>> by_year = attrgetter('released')
>>> movies.sort(key=by_year)
>>> movies[bisect(movies, 1960, key=by_year)]
Movie(name='The Birds', released=1963, director='Hitchcock')
```

The `movies[bisect(movies, 1960, key=by_year)]` will actually return only movies **after** 1960.


<!-- gh-issue-number: gh-96179 -->
* Issue: gh-96179
<!-- /gh-issue-number -->
