### PR TITLE
Check callable and where are  truthy values

### DIFF
--- a/Objects/call.c
+++ b/Objects/call.c
@@ -32,7 +32,7 @@ PyObject*
 _Py_CheckFunctionResult(PyThreadState *tstate, PyObject *callable,
                         PyObject *result, const char *where)
 {
-    assert((callable != NULL) ^ (where != NULL));
+    assert((callable) ^ (where));
 
     if (result == NULL) {
         if (!_PyErr_Occurred(tstate)) {


### PR DESCRIPTION
assert `where` and `callable` are valid addresses by removing extra comparison

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
