### PR TITLE
gh-45108: Improve docstring and testing of ZipFile.testfile()

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -124,8 +124,9 @@ class AbstractTestsWithSourceFile:
                 self.assertEqual(info.filename, nm)
                 self.assertEqual(info.file_size, len(self.data))
 
-            # Check that testzip doesn't raise an exception
-            zipfp.testzip()
+            # Check that testzip thinks the archive is ok
+            # (it returns None if all contents could be read properly)
+            self.assertIsNone(zipfp.testzip())
 
     def test_basic(self):
         for f in get_files(self):
@@ -748,8 +749,8 @@ class AbstractTestZip64InSmallFiles:
                 self.assertEqual(info.filename, nm)
                 self.assertEqual(info.file_size, len(self.data))
 
-            # Check that testzip doesn't raise an exception
-            zipfp.testzip()
+            # Check that testzip thinks the archive is valid
+            self.assertIsNone(zipfp.testzip())
 
     def test_basic(self):
         for f in get_files(self):

--- a/Lib/test/test_zipfile64.py
+++ b/Lib/test/test_zipfile64.py
@@ -32,10 +32,6 @@ class TestsWithSourceFile(unittest.TestCase):
         line_gen = ("Test of zipfile line %d." % i for i in range(1000000))
         self.data = '\n'.join(line_gen).encode('ascii')
 
-        # And write it to a file.
-        with open(TESTFN, "wb") as fp:
-            fp.write(self.data)
-
     def zipTest(self, f, compression):
         # Create the ZIP archive.
         with zipfile.ZipFile(f, "w", compression) as zipfp:
@@ -67,6 +63,9 @@ class TestsWithSourceFile(unittest.TestCase):
                     (num, filecount)), file=sys.__stdout__)
                     sys.__stdout__.flush()
 
+            # Check that testzip thinks the archive is valid
+            self.assertIsNone(zipfp.testzip())
+
     def testStored(self):
         # Try the temp file first.  If we do TESTFN2 first, then it hogs
         # gigabytes of disk space for the duration of the test.
@@ -85,9 +84,7 @@ class TestsWithSourceFile(unittest.TestCase):
         self.zipTest(TESTFN2, zipfile.ZIP_DEFLATED)
 
     def tearDown(self):
-        for fname in TESTFN, TESTFN2:
-            if os.path.exists(fname):
-                os.remove(fname)
+        os_helper.unlink(TESTFN2)
 
 
 class OtherTests(unittest.TestCase):

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1468,7 +1468,10 @@ class ZipFile:
                   file=file)
 
     def testzip(self):
-        """Read all the files and check the CRC."""
+        """Read all the files and check the CRC.
+
+        Return None if all files could be read successfully, or the name
+        of the offending file otherwise."""
         chunk_size = 2 ** 20
         for zinfo in self.filelist:
             try:


### PR DESCRIPTION
Based on patches proposed in #45108.

Differences with the last version of the patch:
* The docstring has been reformatted. The first line should be a short summary.
* Fixed multiple conflicts.
* Added yet one assert.
* Removed testziptest. Corresponding asserts are already included in other tests.
* Changes related to `close()` was already made.
* File TESTFN no longer used in test_zipfile64.TestsWithSourceFile.


<!-- gh-issue-number: gh-45108 -->
* Issue: gh-45108
<!-- /gh-issue-number -->
