### PR TITLE
gh-96254: Add new wasm build target and support a pkg_config_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ PCbuild/win32/
 Tools/unicode/data/
 /autom4te.cache
 /build/
+/builddir/
 /config.cache
 /config.log
 /config.status

--- a/Misc/NEWS.d/next/Build/2022-08-24-23-58-06.gh-issue-96254.MWDEJz.rst
+++ b/Misc/NEWS.d/next/Build/2022-08-24-23-58-06.gh-issue-96254.MWDEJz.rst
@@ -1,0 +1,1 @@
+Add support for a pthread and dynamic link version of the emscripten node build

--- a/Tools/wasm/wasm_build.py
+++ b/Tools/wasm/wasm_build.py
@@ -303,6 +303,7 @@ class BuildProfile:
     dynamic_linking: Union[bool, None] = None
     pthreads: Union[bool, None] = None
     testopts: str = "-j2"
+    pkg_config_path: Union[str, None] = None
 
     @property
     def can_execute(self) -> bool:
@@ -360,6 +361,9 @@ class BuildProfile:
 
         if platform.config_site is not None:
             cmd.append(f"CONFIG_SITE={platform.config_site}")
+
+        if self.pkg_config_path is not None:
+            cmd.append(f"PKG_CONFIG_PATH={self.pkg_config_path}")
 
         return cmd
 
@@ -484,6 +488,13 @@ _profiles = [
         pthreads=True,
     ),
     BuildProfile(
+        "emscripten-node-pthreads-dl",
+        host=Host.wasm32_emscripten,
+        target=EmscriptenTarget.node,
+        pthreads=True,
+        dynamic_linking=True
+    ),
+    BuildProfile(
         "emscripten-node-pthreads-debug",
         host=Host.wasm32_emscripten,
         target=EmscriptenTarget.node_debug,
@@ -541,6 +552,11 @@ parser.add_argument(
     nargs="?",
 )
 
+parser.add_argument(
+    "--pkg-config-path",
+    help="PKG_CONFIG_PATH value to pass to configure"
+)
+
 
 def main():
     args = parser.parse_args()
@@ -550,6 +566,7 @@ def main():
         parser.exit(0)
 
     builder = PROFILES[args.platform]
+    builder.pkg_config_path = args.pkg_config_path
     try:
         builder.host.platform.check()
     except ConditionError as e:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

In relation to: https://discuss.python.org/t/get-ctypes-working-in-emscripten-build/18466, this adds the following:
- New build target for pthreads support and dynamic linking at the same time
- Ability to set the PKG_CONFIG_PATH so that submodules can be built too

The PKG_CONFIG_PATH addition seems kinda hacky though. @tiran had suggested another workaround to get this to work. I thought I'd put this out there to see what people thought. It is more explicit than having to find where emscripten has its sysroot though.

<!-- gh-issue-number: gh-96254 -->
* Issue: gh-96254
* Issue: gh-96253
<!-- /gh-issue-number -->
