### PR TITLE
gh-96258: move Py_REFCNT and Py_SET_REFCNT to reference counting page

### DIFF
--- a/Doc/c-api/refcounting.rst
+++ b/Doc/c-api/refcounting.rst
@@ -11,6 +11,26 @@ The macros in this section are used for managing reference counts of Python
 objects.
 
 
+.. c:function:: Py_ssize_t Py_REFCNT(PyObject *o)
+
+   Get the reference count of the Python object *o*.
+
+   Use the :c:func:`Py_SET_REFCNT()` function to set an object reference count.
+
+   .. versionchanged:: 3.11
+      The parameter type is no longer :c:expr:`const PyObject*`.
+
+   .. versionchanged:: 3.10
+      :c:func:`Py_REFCNT()` is changed to the inline static function.
+
+
+.. c:function:: void Py_SET_REFCNT(PyObject *o, Py_ssize_t refcnt)
+
+   Set the object *o* reference counter to *refcnt*.
+
+   .. versionadded:: 3.9
+
+
 .. c:function:: void Py_INCREF(PyObject *o)
 
    Increment the reference count for object *o*.

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -121,26 +121,6 @@ the definition of all other Python objects.
    .. versionadded:: 3.9
 
 
-.. c:function:: Py_ssize_t Py_REFCNT(PyObject *o)
-
-   Get the reference count of the Python object *o*.
-
-   Use the :c:func:`Py_SET_REFCNT()` function to set an object reference count.
-
-   .. versionchanged:: 3.11
-      The parameter type is no longer :c:expr:`const PyObject*`.
-
-   .. versionchanged:: 3.10
-      :c:func:`Py_REFCNT()` is changed to the inline static function.
-
-
-.. c:function:: void Py_SET_REFCNT(PyObject *o, Py_ssize_t refcnt)
-
-   Set the object *o* reference counter to *refcnt*.
-
-   .. versionadded:: 3.9
-
-
 .. c:function:: Py_ssize_t Py_SIZE(PyVarObject *o)
 
    Get the size of the Python object *o*.

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -17,7 +17,8 @@ All Python objects ultimately share a small number of fields at the beginning
 of the object's representation in memory.  These are represented by the
 :c:type:`PyObject` and :c:type:`PyVarObject` types, which are defined, in turn,
 by the expansions of some macros also used, whether directly or indirectly, in
-the definition of all other Python objects.
+the definition of all other Python objects.  Additional macros can be found
+under :ref:`reference counting <countingrefs>`.
 
 
 .. c:type:: PyObject


### PR DESCRIPTION
This is I think a relatively trivial change to resolve an issue I ran into, where I briefly and mistakenly thought there was not a macro to check the reference count on a PyObject due to it not being mentioned on the reference counting page.

<!-- gh-issue-number: gh-96258 -->
* Issue: gh-96258
<!-- /gh-issue-number -->
