### PR TITLE
gh-85858: c-api: Fix padding in PyASCIIObject

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -134,8 +134,8 @@ typedef struct {
            set, use the PyASCIIObject structure. */
         unsigned int ascii:1;
         /* Padding to ensure that PyUnicode_DATA() is always aligned to
-           4 bytes (see issue #19537 on m68k). */
-        unsigned int :25;
+           4 bytes (see issue gh-63736 on m68k). */
+        unsigned int :26;
     } state;
 } PyASCIIObject;
 


### PR DESCRIPTION
This padding was not updated when GH-92579 reduced intern flag bits.

<!-- gh-issue-number: gh-85858 -->
* Issue: gh-85858
<!-- /gh-issue-number -->
