### PR TITLE
gh-96272: Replace `test_source_encoding`'s `test_pep263` with `test_import_encoded_module` from `test_imp`

### DIFF
--- a/Lib/test/source_encoding_pep263.py
+++ b/Lib/test/source_encoding_pep263.py
@@ -1,4 +1,0 @@
-# -*- coding: koi8-r -*-
-
-assert "Питон".encode("utf-8") == b'\xd0\x9f\xd0\xb8\xd1\x82\xd0\xbe\xd0\xbd'
-assert "\П".encode("utf-8") == b'\\\xd0\x9f'

--- a/Lib/test/source_encoding_pep263.py
+++ b/Lib/test/source_encoding_pep263.py
@@ -1,11 +1,4 @@
 # -*- coding: koi8-r -*-
 
-def test_pep263(self):
-    self.assertEqual(
-        "Питон".encode("utf-8"),
-        b'\xd0\x9f\xd0\xb8\xd1\x82\xd0\xbe\xd0\xbd'
-    )
-    self.assertEqual(
-        "\П".encode("utf-8"),
-        b'\\\xd0\x9f'
-    )
+assert "Питон".encode("utf-8") == b'\xd0\x9f\xd0\xb8\xd1\x82\xd0\xbe\xd0\xbd'
+assert "\П".encode("utf-8") == b'\\\xd0\x9f'

--- a/Lib/test/source_encoding_pep263.py
+++ b/Lib/test/source_encoding_pep263.py
@@ -1,0 +1,11 @@
+# -*- coding: koi8-r -*-
+
+def test_pep263(self):
+    self.assertEqual(
+        "Питон".encode("utf-8"),
+        b'\xd0\x9f\xd0\xb8\xd1\x82\xd0\xbe\xd0\xbd'
+    )
+    self.assertEqual(
+        "\П".encode("utf-8"),
+        b'\\\xd0\x9f'
+    )

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -66,11 +66,7 @@ class ImportTests(unittest.TestCase):
         self.test_strings = mod.test_strings
         self.test_path = mod.__path__
 
-    def test_import_encoded_module(self):
-        for modname, encoding, teststr in self.test_strings:
-            mod = importlib.import_module('test.encoded_modules.'
-                                          'module_' + modname)
-            self.assertEqual(teststr, mod.test)
+    # test_import_encoded_module moved to test_source_encoding.py
 
     def test_find_module_encoding(self):
         for mod, encoding, _ in self.test_strings:

--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -12,11 +12,6 @@ import tempfile
 
 class MiscSourceEncodingTest(unittest.TestCase):
 
-    def test_pep263(self):
-        # Test moved to its own file because encoding isn't understood by all editors.
-        # See #96272
-        script_helper.assert_python_ok(findfile("source_encoding_pep263.py"))
-
     def test_compilestring(self):
         # see #1882
         c = compile(b"\n# coding: utf-8\nu = '\xc3\xb3'\n", "dummy", "exec")
@@ -298,6 +293,19 @@ class FileSourceEncodingTest(AbstractSourceEncodingTest, unittest.TestCase):
                 fp.write(src)
             res = script_helper.assert_python_ok(fn)
         self.assertEqual(res.out.rstrip(), expected)
+
+
+class ImportTests(unittest.TestCase):
+    def setUp(self):
+        mod = importlib.import_module('test.encoded_modules')
+        self.test_strings = mod.test_strings
+        self.test_path = mod.__path__
+
+    def test_import_encoded_module(self):
+        for modname, encoding, teststr in self.test_strings:
+            mod = importlib.import_module('test.encoded_modules.'
+                                          'module_' + modname)
+            self.assertEqual(teststr, mod.test)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -1,7 +1,7 @@
-# -*- coding: koi8-r -*-
+# -*- coding: utf-8 -*-
 
 import unittest
-from test.support import script_helper, captured_stdout, requires_subprocess
+from test.support import findfile, script_helper, captured_stdout, requires_subprocess
 from test.support.os_helper import TESTFN, unlink, rmtree
 from test.support.import_helper import unload
 import importlib
@@ -13,14 +13,9 @@ import tempfile
 class MiscSourceEncodingTest(unittest.TestCase):
 
     def test_pep263(self):
-        self.assertEqual(
-            "Питон".encode("utf-8"),
-            b'\xd0\x9f\xd0\xb8\xd1\x82\xd0\xbe\xd0\xbd'
-        )
-        self.assertEqual(
-            "\П".encode("utf-8"),
-            b'\\\xd0\x9f'
-        )
+        # Test moved to its own file because encoding isn't understood by all editors.
+        # See #96272
+        script_helper.assert_python_ok(findfile("source_encoding_pep263.py"))
 
     def test_compilestring(self):
         # see #1882

--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from test.support import findfile, script_helper, captured_stdout, requires_subprocess
+from test.support import script_helper, captured_stdout, requires_subprocess
 from test.support.os_helper import TESTFN, unlink, rmtree
 from test.support.import_helper import unload
 import importlib

--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -12,6 +12,15 @@ import tempfile
 
 class MiscSourceEncodingTest(unittest.TestCase):
 
+    def test_import_encoded_module(self):
+        from test.encoded_modules import test_strings
+        # Make sure we're actually testing something
+        self.assertGreaterEqual(len(test_strings), 1)
+        for modname, encoding, teststr in test_strings:
+            mod = importlib.import_module('test.encoded_modules.'
+                                          'module_' + modname)
+            self.assertEqual(teststr, mod.test)
+
     def test_compilestring(self):
         # see #1882
         c = compile(b"\n# coding: utf-8\nu = '\xc3\xb3'\n", "dummy", "exec")
@@ -293,19 +302,6 @@ class FileSourceEncodingTest(AbstractSourceEncodingTest, unittest.TestCase):
                 fp.write(src)
             res = script_helper.assert_python_ok(fn)
         self.assertEqual(res.out.rstrip(), expected)
-
-
-class ImportTests(unittest.TestCase):
-    def setUp(self):
-        mod = importlib.import_module('test.encoded_modules')
-        self.test_strings = mod.test_strings
-        self.test_path = mod.__path__
-
-    def test_import_encoded_module(self):
-        for modname, encoding, teststr in self.test_strings:
-            mod = importlib.import_module('test.encoded_modules.'
-                                          'module_' + modname)
-            self.assertEqual(teststr, mod.test)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Editors don't agree that test_source_encoding.py was valid koi8-r, making it
hard to edit that file without the editor breaking it in some way (see #96272).

Moving the one affected test out to its own file shouldn't change the purpose of
the test, but make editing test_source_encoding.py much easier going forward.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96272 -->
* Issue: gh-96272
<!-- /gh-issue-number -->
