### PR TITLE
gh-96276: suppress SyntaxWarning in test_compile

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -8,6 +8,7 @@ import _ast
 import tempfile
 import types
 import textwrap
+import warnings
 from test import support
 from test.support import script_helper, requires_debug_ranges
 from test.support.os_helper import FakePath
@@ -1231,7 +1232,9 @@ f(
             with self.subTest(body):
                 namespace = {}
                 source = textwrap.dedent(source_template.format(body))
-                exec(source, namespace)
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', SyntaxWarning)
+                    exec(source, namespace)
                 code = namespace["f"].__code__
                 self.assertOpcodeSourcePositionIs(
                     code,


### PR DESCRIPTION
Fixes #96276.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96276 -->
* Issue: gh-96276
<!-- /gh-issue-number -->
