### PR TITLE
gh-96280: suppress deprecation warning in test_importlib

### DIFF
--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -322,7 +322,9 @@ class ResourceReader:
 
 class ResourceReaderDefaultsTests(ABCTestHarness):
 
-    SPLIT = make_abc_subclasses(ResourceReader)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        SPLIT = make_abc_subclasses(ResourceReader)
 
     def test_open_resource(self):
         with self.assertRaises(FileNotFoundError):


### PR DESCRIPTION
Fixes #96280.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96280 -->
* Issue: gh-96280
<!-- /gh-issue-number -->
