### PR TITLE
GH-72384: Add support for start and stop on `range.index()` function

### DIFF
--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -305,6 +305,39 @@ class RangeTest(unittest.TestCase):
 
         self.assertEqual(range(10).index(ALWAYS_EQ), 0)
 
+        a = range(100)
+        self.assertEqual(a.index(20, 10), 20)
+        self.assertEqual(a.index(20, 1, 40), 20)
+        self.assertEqual(a.index(20, 10, 40), 20)
+        self.assertEqual(a.index(20, start=10, stop=40), 20)
+        self.assertEqual(a.index(20, stop=40, start=10), 20)
+        self.assertEqual(a.index(20, 10, -1), 20)
+        self.assertRaises(ValueError, a.index, 20, start=21)
+        self.assertRaises(ValueError, a.index, 20, stop=20)
+        self.assertRaises(TypeError, a.index, 20, start="2")
+        self.assertRaises(TypeError, a.index, 10, stop="20")
+
+        a = range(0, 150, 10)
+        self.assertEqual(a.index(20, 0), 2)
+        self.assertEqual(a.index(20, 0, 5), 2)
+        self.assertEqual(a.index(20, 1, 5), 2)
+        self.assertEqual(a.index(20, 1, -1), 2)
+        self.assertEqual(a.index(20, start=1, stop=10), 2)
+        self.assertEqual(a.index(20, stop=10, start=1), 2)
+        self.assertRaises(ValueError, a.index, 20, start=3)
+        self.assertRaises(ValueError, a.index, 20, stop=2)
+        self.assertRaises(TypeError, a.index, 20, start="1")
+        self.assertRaises(TypeError, a.index, 10, stop="1")
+
+        class AlwaysEqual(object):
+            def __eq__(self, _):
+                return True
+
+        always_equal = AlwaysEqual()
+
+        # start, stop indices with non-integer objects
+        self.assertEqual(range(10).index(always_equal, start=5), 0)
+
     def test_user_index_method(self):
         bignum = 2*sys.maxsize
         smallnum = 42

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -336,7 +336,7 @@ class RangeTest(unittest.TestCase):
         always_equal = AlwaysEqual()
 
         # start, stop indices with non-integer objects
-        self.assertEqual(range(10).index(always_equal, start=5), 0)
+        self.assertEqual(range(10).index(always_equal, start=5), 5)
 
     def test_user_index_method(self):
         bignum = 2*sys.maxsize

--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-25-21-58-21.gh-issue-72384.OCsSbq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-25-21-58-21.gh-issue-72384.OCsSbq.rst
@@ -1,0 +1,1 @@
+Add `start` and `stop` parameters to function :func:`range.index`

--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-25-21-58-21.gh-issue-72384.OCsSbq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-25-21-58-21.gh-issue-72384.OCsSbq.rst
@@ -1,1 +1,1 @@
-Add `start` and `stop` parameters to function :func:`range.index`
+Add ``start`` and ``stop`` parameters to function :func:`range.index`

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -579,37 +579,37 @@ range_index(rangeobject *r, PyObject *args, PyObject *kw)
     PyObject *ob;
     PyObject *start = NULL, *stop = NULL;
 
-    if(!PyArg_ParseTupleAndKeywords(args, kw, "O|OO:range_index",
-                                    keywords, &ob, &start, &stop)){
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "O|OO:range_index",
+                                    keywords, &ob, &start, &stop)) {
       return NULL;
     }
 
-    if(start || stop){
-        if(start && (!PyLong_CheckExact(start))){
+    if (start || stop) {
+        if (start && (!PyLong_CheckExact(start))) {
             PyErr_Format(PyExc_TypeError,
                          "start value must be integer, not %.200s",
                          start->ob_type->tp_name);
             return NULL;
         }
-        if(stop && (!PyLong_CheckExact(stop))){
+        if (stop && (!PyLong_CheckExact(stop))) {
             PyErr_Format(PyExc_TypeError,
                          "stop value must be integer, not %.200s",
                          stop->ob_type->tp_name);
             return NULL;
         }
 
-        if(!start){
+        if (!start) {
             start = _PyLong_GetZero();
         }
 
-        if(!stop){
+        if (!stop) {
             stop = r->length;
         }
 
         PyObject *slice = PySlice_New(start, stop, _PyLong_GetOne());
         r = (rangeobject*) compute_slice(r, slice);
         Py_XDECREF(slice);
-        if(!r){
+        if (!r) {
             Py_XDECREF(r);
             return NULL;
         }
@@ -620,7 +620,14 @@ range_index(rangeobject *r, PyObject *args, PyObject *kw)
         index = _PySequence_IterSearch((PyObject*)r, ob, PY_ITERSEARCH_INDEX);
         if (index == -1)
             return NULL;
-        return PyLong_FromSsize_t(index);
+
+        PyObject *temp = PyLong_FromSsize_t(index);
+        if (start) {
+            return PyNumber_Add(start, temp);
+        }
+        else {
+            return temp;
+        }
     }
 
     contains = range_contains_long(r, ob);
@@ -634,7 +641,7 @@ range_index(rangeobject *r, PyObject *args, PyObject *kw)
         }
 
         if (r->step == _PyLong_GetOne()) {
-            if(start) {
+            if (start) {
                 return PyNumber_Add(idx, start);
             }
             else {
@@ -646,7 +653,7 @@ range_index(rangeobject *r, PyObject *args, PyObject *kw)
         PyObject *sidx = PyNumber_FloorDivide(idx, r->step);
         Py_DECREF(idx);
 
-        if(start){
+        if (start) {
             return PyNumber_Add(sidx, start);
         }
         else {


### PR DESCRIPTION
I mostly took the changes that @nitishch had already pushed to https://github.com/python/cpython/pull/4378 and:

1. Updated them with the latest review feedback from @shreyanavigyan
2. Fixed conflicts with the main branch
3. Added extra tests for ranges with step value different than 1.

This is my first core code contribution so let me know if any improvements or fixes I should make. My C is a bit rusty and, being a first-timer, there were a few things I was unsure about and didn't know where to ask. For example, should I use a) `start = 0;`, b) `start = _PyLong_GetZero();`, or c) `start = PyLong_FromLong(0);`?

I'm also unsure if I should push documentation changes together with this or if they should go as separate PR.

<!-- gh-issue-number: gh-72384 -->
* Issue: gh-72384
<!-- /gh-issue-number -->
