### PR TITLE
gh-96296 fix threading.Event.isSet() docstring

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -589,7 +589,7 @@ class Event:
     def isSet(self):
         """Return true if and only if the internal flag is true.
 
-        This method is deprecated, use notify_all() instead.
+        This method is deprecated, use is_set() instead.
 
         """
         import warnings


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This PR updates the docstring for the deprecated method `threading.Event.isSet()` so that the docstring is consistent with the warning message.

Issue: #96296

I'm guessing this change is small enough not to need a news entry.

<!-- gh-issue-number: gh-96296 -->
* Issue: gh-96296
<!-- /gh-issue-number -->
