### PR TITLE
gh-90814: Correct NEWS wording re. optional C11 features

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1619,7 +1619,8 @@ Changes in the Python API
 Build Changes
 =============
 
-* Building Python now requires a C11 compiler without optional C11 features.
+* Building Python now requires a C11 compiler. Optional C11 features are not
+  required.
   (Contributed by Victor Stinner in :issue:`46656`.)
 
 * Building Python now requires support of IEEE 754 floating point numbers.

--- a/Misc/NEWS.d/3.11.0a6.rst
+++ b/Misc/NEWS.d/3.11.0a6.rst
@@ -1043,7 +1043,8 @@ Respect `--with-suffix` when building on case-insensitive file systems.
 .. nonce: MD783M
 .. section: Build
 
-Building Python now requires a C11 compiler without optional C11 features.
+Building Python now requires a C11 compiler. Optional C11 features are not
+required.
 Patch by Victor Stinner.
 
 ..


### PR DESCRIPTION
The current wording of this entry suggests that CPython
won't work if optional compiler features are enabled.
That's not the case. The real change is that we require C11
rather than C89.

Note that PEP-7 says "Python 3.11 and newer versions use C11
without optional features." That is correct: CPython devs
must avoid the features, so that they're not required to build Python.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-90814 -->
* Issue: gh-90814
<!-- /gh-issue-number -->
