### PR TITLE
gh-96279: fix typo in pathlib documentation

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1038,7 +1038,7 @@ call fails (for example because the path doesn't exist).
       # Delete everything reachable from the directory "top".
       # CAUTION:  This is dangerous! For example, if top == Path('/'),
       # it could delete all of your files.
-      for root, dirs, files in top.walk(topdown=False):
+      for root, dirs, files in top.walk(top_down=False):
           for name in files:
               (root / name).unlink()
           for name in dirs:


### PR DESCRIPTION
 Documentation typo for pathlib.Path.walk in Python 3.12 #96279




<!-- gh-issue-number: gh-96279 -->
* Issue: gh-96279
<!-- /gh-issue-number -->
