### PR TITLE
gh-96127: Fix `inspect.signature` call on mocks

### DIFF
--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -3283,6 +3283,25 @@ class TestSignatureObject(unittest.TestCase):
                          ((('a', 10, ..., "positional_or_keyword"),),
                           ...))
 
+    def test_signature_on_mocks(self):
+        # https://github.com/python/cpython/issues/96127
+        for mock in (
+            unittest.mock.Mock(),
+            unittest.mock.AsyncMock(),
+            unittest.mock.MagicMock(),
+        ):
+            with self.subTest(mock=mock):
+                self.assertEqual(str(inspect.signature(mock)), '(*args, **kwargs)')
+
+    def test_signature_on_noncallable_mocks(self):
+        for mock in (
+            unittest.mock.NonCallableMock(),
+            unittest.mock.NonCallableMagicMock(),
+        ):
+            with self.subTest(mock=mock):
+                with self.assertRaises(TypeError):
+                    inspect.signature(mock)
+
     def test_signature_equality(self):
         def foo(a, *, b:int) -> float: pass
         self.assertFalse(inspect.signature(foo) == 42)

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2213,7 +2213,15 @@ class AsyncMockMixin(Base):
         code_mock = NonCallableMock(spec_set=_CODE_ATTRS)
         code_mock.__dict__["_spec_class"] = CodeType
         code_mock.__dict__["_spec_signature"] = _CODE_SIG
-        code_mock.co_flags = inspect.CO_COROUTINE
+        code_mock.co_flags = (
+            inspect.CO_COROUTINE
+            + inspect.CO_VARARGS
+            + inspect.CO_VARKEYWORDS
+        )
+        code_mock.co_argcount = 0
+        code_mock.co_varnames = ('args', 'kwargs')
+        code_mock.co_posonlyargcount = 0
+        code_mock.co_kwonlyargcount = 0
         self.__dict__['__code__'] = code_mock
         self.__dict__['__name__'] = 'AsyncMock'
         self.__dict__['__defaults__'] = tuple()

--- a/Misc/NEWS.d/next/Library/2022-08-27-10-35-50.gh-issue-96127.8RdLre.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-27-10-35-50.gh-issue-96127.8RdLre.rst
@@ -1,0 +1,2 @@
+``inspect.signature`` was raising ``TypeError`` on call with mock objects.
+Now it correctly returns ``(*args, **kwargs)`` as infered signature.


### PR DESCRIPTION
Before:

```pycon
>>> import inspect
>>> from unittest.mock import AsyncMock
>>> inspect.signature(AsyncMock())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/karthikeyan/stuff/python/cpython/Lib/inspect.py", line 3272, in signature
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/cpython/Lib/inspect.py", line 3020, in from_callable
    return _signature_from_callable(obj, sigcls=cls,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/cpython/Lib/inspect.py", line 2507, in _signature_from_callable
    return _signature_from_function(sigcls, obj,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/cpython/Lib/inspect.py", line 2351, in _signature_from_function
    positional = arg_names[:pos_count]
                 ~~~~~~~~~^^^^^^^^^^^^
TypeError: 'Mock' object is not subscriptable
>>> 
```

After:

```pycon
>>> from inspect import signature
>>> from unittest.mock import AsyncMock
>>> 
>>> mock = AsyncMock()
>>> signature(mock)
<Signature (*args, **kwargs)>
```

<!-- gh-issue-number: gh-96127 -->
* Issue: gh-96127
<!-- /gh-issue-number -->

Related https://github.com/python/cpython/pull/94050