### PR TITLE
gh-89047: Fix msecs computation so you never end up with 1000 msecs. (GH-96340)

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -340,7 +340,7 @@ class LogRecord(object):
         self.lineno = lineno
         self.funcName = func
         self.created = ct
-        self.msecs = (ct - int(ct)) * 1000
+        self.msecs = int((ct - int(ct)) * 1000) + 0.0  # see gh-89047
         self.relativeCreated = (self.created - _startTime) * 1000
         if logThreads:
             self.thread = threading.get_ident()

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4261,6 +4261,14 @@ class FormatterTest(unittest.TestCase, AssertErrorMessage):
         f.converter = time.gmtime
         self.assertEqual(f.formatTime(r), '21/04/1993 08:03:00')
 
+    def test_issue_89047(self):
+        f = logging.Formatter(fmt='{asctime}.{msecs:03.0f} {message}', style='{', datefmt="%Y-%m-%d %H:%M:%S")
+        for i in range(2500):
+            time.sleep(0.0004)
+            r = logging.makeLogRecord({'msg': 'Message %d' % (i + 1)})
+            s = f.format(r)
+            self.assertNotIn('.1000', s)
+
 
 class TestBufferingFormatter(logging.BufferingFormatter):
     def formatHeader(self, records):


### PR DESCRIPTION


<!-- gh-issue-number: gh-89047 -->
* Issue: gh-89047
<!-- /gh-issue-number -->
