### PR TITLE
gh-96349: Fix minor performance regression initializing threading.Event

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -262,18 +262,12 @@ class Condition:
         # If the lock defines _release_save() and/or _acquire_restore(),
         # these override the default implementations (which just call
         # release() and acquire() on the lock).  Ditto for _is_owned().
-        try:
+        if hasattr(lock, '_release_save'):
             self._release_save = lock._release_save
-        except AttributeError:
-            pass
-        try:
+        if hasattr(lock, '_acquire_restore'):
             self._acquire_restore = lock._acquire_restore
-        except AttributeError:
-            pass
-        try:
+        if hasattr(lock, '_is_owned'):
             self._is_owned = lock._is_owned
-        except AttributeError:
-            pass
         self._waiters = _deque()
 
     def _at_fork_reinit(self):

--- a/Misc/NEWS.d/next/Library/2022-08-27-21-26-52.gh-issue-96349.XyYLlO.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-27-21-26-52.gh-issue-96349.XyYLlO.rst
@@ -1,0 +1,1 @@
+Fixed a minor performance regression in :func:`threading.Event.__init__`


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
There was a minor performance regression making it slightly slower to initialize a `threading.Event` on the main branch than it was in 3.10.  I think the slowdown may have been related to zero-cost exceptions.

This PR removes the slowdown (and makes it faster than it was before).

Here's a simple benchmark with pyperf:

3.10:
```
../cpython3.10/python -m pyperf timeit -s 'from threading import Event' 'e = Event()'
.....................
Mean +- std dev: 1.52 us +- 0.02 us
```
Main branch:
```
../cpython/python -m pyperf timeit -s 'from threading import Event' 'e = Event()'
.....................
Mean +- std dev: 1.59 us +- 0.02 us
```
With this PR:
```
../cpython/python -m pyperf timeit -s 'from threading import Event' 'e = Event()'
.....................
Mean +- std dev: 462 ns +- 10 ns
```


<!-- gh-issue-number: gh-96349 -->
* Issue: gh-96349
<!-- /gh-issue-number -->
