### PR TITLE
gh-96352: Set AttributeError context in _PyObject_GenericGetAttrWithDict

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2099,6 +2099,11 @@ class AttributeErrorTests(unittest.TestCase):
         except AttributeError as exc:
             self.assertEqual("bluch", exc.name)
             self.assertEqual(obj, exc.obj)
+        try:
+            object.__getattribute__(obj, "bluch")
+        except AttributeError as exc:
+            self.assertEqual("bluch", exc.name)
+            self.assertEqual(obj, exc.obj)
 
     def test_getattr_has_name_and_obj_for_method(self):
         class A:

--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-28-10-51-19.gh-issue-96352.jTLD2d.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-28-10-51-19.gh-issue-96352.jTLD2d.rst
@@ -1,0 +1,2 @@
+Fix :exc:`AttributeError` missing ``name`` and ``obj`` attributes in
+:meth:`object.__getattribute__`. Patch by Philip Georgi.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1352,6 +1352,8 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
         PyErr_Format(PyExc_AttributeError,
                      "'%.50s' object has no attribute '%U'",
                      tp->tp_name, name);
+
+        set_attribute_error_context(obj, name);
     }
   done:
     Py_XDECREF(descr);


### PR DESCRIPTION
This causes AttributeErrors's `name` and `obj` to be set in `object.__getattribute__`.

Ping @pablogsal, author of https://github.com/python/cpython/pull/16856

<!-- gh-issue-number: gh-96352 -->
* Issue: gh-96352
<!-- /gh-issue-number -->
