### PR TITLE
gh-96357: Improve `typing.get_overloads` coverage

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4416,6 +4416,9 @@ class OverloadTests(BaseTestCase):
         other_overload = some_other_func
         def some_other_func(): pass
         self.assertEqual(list(get_overloads(some_other_func)), [other_overload])
+        # Unrelated function still has no overloads:
+        def not_overloaded(): pass
+        self.assertEqual(list(get_overloads(not_overloaded)), [])
 
         # Make sure that after we clear all overloads, the registry is
         # completely empty.


### PR DESCRIPTION
Right now it is fully covered:
<img width="627" alt="Снимок экрана 2022-08-28 в 11 58 38" src="https://user-images.githubusercontent.com/4660275/187066160-53c90c4a-b21a-44b6-8d29-e8b9894519c3.png">


<!-- gh-issue-number: gh-96357 -->
* Issue: gh-96357
<!-- /gh-issue-number -->
