### PR TITLE
gh-96359: Fix docs that claimed that int(0|1) doesn't match False

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1122,7 +1122,7 @@ subject value:
 
    These classes accept a single positional argument, and the pattern there is matched
    against the whole object rather than an attribute. For example ``int(0|1)`` matches
-   the value ``0``, but not the values ``0.0`` or ``False``.
+   the value ``0``, but not the value ``0.0``.
 
 In simple terms ``CLS(P1, attr=P2)`` matches only if the following happens:
 


### PR DESCRIPTION
See https://github.com/python/cpython/issues/96359

<!-- gh-issue-number: gh-96359 -->
* Issue: gh-96359
<!-- /gh-issue-number -->
