### PR TITLE
gh-96364: Fix text signatures of `__getitem__` for `list` and `dict`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-29-00-37-21.gh-issue-96364.c-IVyb.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-29-00-37-21.gh-issue-96364.c-IVyb.rst
@@ -1,0 +1,1 @@
+Fix text signatures of ``list.__getitem__`` and ``dict.__getitem__``.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3591,7 +3591,8 @@ dict_ior(PyObject *self, PyObject *other)
     return self;
 }
 
-PyDoc_STRVAR(getitem__doc__, "x.__getitem__(y) <==> x[y]");
+PyDoc_STRVAR(getitem__doc__,
+"__getitem__($self, key, /)\n--\n\nReturn self[key].");
 
 PyDoc_STRVAR(sizeof__doc__,
 "D.__sizeof__() -> size of D in memory, in bytes");

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2824,7 +2824,8 @@ static PyObject *list_iter(PyObject *seq);
 static PyObject *list_subscript(PyListObject*, PyObject*);
 
 static PyMethodDef list_methods[] = {
-    {"__getitem__", (PyCFunction)list_subscript, METH_O|METH_COEXIST, "x.__getitem__(y) <==> x[y]"},
+    {"__getitem__", (PyCFunction)list_subscript, METH_O|METH_COEXIST,
+     "__getitem__($self, key, /)\n--\n\nReturn self[key]."},
     LIST___REVERSED___METHODDEF
     LIST___SIZEOF___METHODDEF
     LIST_CLEAR_METHODDEF

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2825,7 +2825,7 @@ static PyObject *list_subscript(PyListObject*, PyObject*);
 
 static PyMethodDef list_methods[] = {
     {"__getitem__", (PyCFunction)list_subscript, METH_O|METH_COEXIST,
-     "__getitem__($self, index, /)\n--\n\nReturn self[index]."},
+     PyDoc_STR("__getitem__($self, index, /)\n--\n\nReturn self[index].")},
     LIST___REVERSED___METHODDEF
     LIST___SIZEOF___METHODDEF
     LIST_CLEAR_METHODDEF

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2825,7 +2825,7 @@ static PyObject *list_subscript(PyListObject*, PyObject*);
 
 static PyMethodDef list_methods[] = {
     {"__getitem__", (PyCFunction)list_subscript, METH_O|METH_COEXIST,
-     "__getitem__($self, key, /)\n--\n\nReturn self[key]."},
+     "__getitem__($self, index, /)\n--\n\nReturn self[index]."},
     LIST___REVERSED___METHODDEF
     LIST___SIZEOF___METHODDEF
     LIST_CLEAR_METHODDEF


### PR DESCRIPTION
After this change:

```python
Python 3.12.0a0 (heads/main-dirty:e860e521ec, Aug 28 2022, 21:36:18) [Clang 11.0.0 (clang-1100.0.33.16)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> help(list.__getitem__)
Help on method_descriptor:

__getitem__(self, key, /)
    Return self[key].

>>> help(dict.__getitem__)
Help on method_descriptor:

__getitem__(self, key, /)
    Return self[key].

```

<!-- gh-issue-number: gh-96364 -->
* Issue: gh-96364
<!-- /gh-issue-number -->
