### PR TITLE
[3.11] gh-90814: Correct NEWS wording re. optional C11 features (GH-96309)

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1607,7 +1607,8 @@ Changes in the Python API
 Build Changes
 =============
 
-* Building Python now requires a C11 compiler without optional C11 features.
+* Building Python now requires a C11 compiler. Optional C11 features are not
+  required.
   (Contributed by Victor Stinner in :issue:`46656`.)
 
 * Building Python now requires support of IEEE 754 floating point numbers.

--- a/Misc/NEWS.d/3.11.0a6.rst
+++ b/Misc/NEWS.d/3.11.0a6.rst
@@ -1043,7 +1043,8 @@ Respect `--with-suffix` when building on case-insensitive file systems.
 .. nonce: MD783M
 .. section: Build
 
-Building Python now requires a C11 compiler without optional C11 features.
+Building Python now requires a C11 compiler. Optional C11 features are not
+required.
 Patch by Victor Stinner.
 
 ..


### PR DESCRIPTION
The previous wording of this entry suggests that CPython
won't work if optional compiler features are enabled.
That's not the case. The change is that we require C11 rather
than C89.

Note that PEP 7 does say "Python 3.11 and newer versions use C11
without optional features." It is correct there: that's
not a guide for users who compile Python, but for CPython devs
who must avoid the features.


<!-- gh-issue-number: gh-90814 -->
* Issue: gh-90814
<!-- /gh-issue-number -->
