### PR TITLE
gh-96385: Correctly raise error on `[*T, *V]` substitution

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -596,6 +596,7 @@ class GenericAliasSubstitutionTests(BaseTestCase):
     def test_one_parameter(self):
         T = TypeVar('T')
         Ts = TypeVarTuple('Ts')
+        Ts2 = TypeVarTuple('Ts2')
 
         class C(Generic[T]): pass
 
@@ -621,6 +622,8 @@ class GenericAliasSubstitutionTests(BaseTestCase):
             # Should definitely raise TypeError: list only takes one argument.
             ('list[T, *tuple_type[int, ...]]',    '[int]',                   'list[int, *tuple_type[int, ...]]'),
             ('List[T, *tuple_type[int, ...]]',    '[int]',                   'TypeError'),
+            # Should raise, because more than one `TypeVarTuple` is not supported.
+            ('generic[*Ts, *Ts2]',                '[int]',                   'TypeError'),
         ]
 
         for alias_template, args_template, expected_template in tests:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1074,7 +1074,7 @@ class TypeVarTuple(_Final, _Immutable, _PickleUsingNameMixin, _root=True):
     def __typing_prepare_subst__(self, alias, args):
         params = alias.__parameters__
         typevartuple_index = params.index(self)
-        for param in enumerate(params[typevartuple_index + 1:]):
+        for param in params[typevartuple_index + 1:]:
             if isinstance(param, TypeVarTuple):
                 raise TypeError(f"More than one TypeVarTuple parameter in {alias}")
 

--- a/Misc/NEWS.d/next/Library/2022-08-29-15-28-39.gh-issue-96385.uLRTsf.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-29-15-28-39.gh-issue-96385.uLRTsf.rst
@@ -1,3 +1,3 @@
-Fix ``TypeVarTuple.__typing_prepare_subst__``. ``TypeError` was not raised
+Fix ``TypeVarTuple.__typing_prepare_subst__``. ``TypeError`` was not raised
 when using more than one ``TypeVarTuple``, like ``[*T, *V]`` in type alias
 substitutions.

--- a/Misc/NEWS.d/next/Library/2022-08-29-15-28-39.gh-issue-96385.uLRTsf.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-29-15-28-39.gh-issue-96385.uLRTsf.rst
@@ -1,0 +1,3 @@
+Fix ``TypeVarTuple.__typing_prepare_subst__``. ``TypeError` was not raised
+when using more than one ``TypeVarTuple``, like ``[*T, *V]`` in type alias
+substitutions.


### PR DESCRIPTION
I think that this was the original intent.

The path is now fully covered:
<img width="769" alt="Снимок экрана 2022-08-29 в 15 32 10" src="https://user-images.githubusercontent.com/4660275/187201652-f9547273-5067-47e9-a596-0a0eba8a67b8.png">


<!-- gh-issue-number: gh-96385 -->
* Issue: gh-96385
<!-- /gh-issue-number -->
