### PR TITLE
gh-96397: Document that keywords in calls need not be identifiers

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1059,7 +1059,7 @@ given a value (by an explicit keyword argument, or from another unpacking),
 a :exc:`TypeError` exception is raised.
 
 When ``**expression`` is used, each key in this mapping must be
-an instance of :class:`str`.
+a string.
 Each value from the mapping is assigned to the first formal parameter
 eligible for keyword assignment whose name is equal to the key.
 A key need not be a Python identifier (e.g. ``"max-temp °F"`` is acceptable,

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1061,7 +1061,7 @@ a :exc:`TypeError` exception is raised.
 When ``**expression`` is used, each key in this mapping must be
 an instance of :class:`str` or a :term:`hashable` sub-class of it.
 Each value from the mapping is assigned to the first formal parameter
-eligible for keyword assignment, where the name is equal to the key.
+eligible for keyword assignment whose name is equal to the key.
 A key need not be a Python identifier (e.g. ``"max-temp °F"`` is acceptable,
 although it will not match any formal parameter that could be declared).
 If there is no match to a formal parameter

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1054,9 +1054,19 @@ used in the same call, so in practice this confusion does not often arise.
 
 If the syntax ``**expression`` appears in the function call, ``expression`` must
 evaluate to a :term:`mapping`, the contents of which are treated as
-additional keyword arguments.  If a keyword is already present
-(as an explicit keyword argument, or from another unpacking),
+additional keyword arguments. If a parameter matching a key has already been
+given a value (by an explicit keyword argument, or from another unpacking),
 a :exc:`TypeError` exception is raised.
+
+When ``**expression`` is used, each key in this mapping must be
+an instance of :class:`str` or a :term:`hashable` sub-class of it.
+Each value from the mapping is assigned to the first formal parameter
+eligible for keyword assignment, where the name is equal to the key.
+A key need not be a Python identifier (e.g. ``"max-temp °F"`` is acceptable,
+although it will not match any formal parameter that could be declared).
+If there is no match to a formal parameter
+the key-value pair is collected by the ``**`` parameter, if there is one,
+or if there is not, a :exc:`TypeError` exception is raised.
 
 Formal parameters using the syntax ``*identifier`` or ``**identifier`` cannot be
 used as positional argument slots or as keyword argument names.

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1059,7 +1059,7 @@ given a value (by an explicit keyword argument, or from another unpacking),
 a :exc:`TypeError` exception is raised.
 
 When ``**expression`` is used, each key in this mapping must be
-an instance of :class:`str` or a :term:`hashable` sub-class of it.
+an instance of :class:`str`.
 Each value from the mapping is assigned to the first formal parameter
 eligible for keyword assignment whose name is equal to the key.
 A key need not be a Python identifier (e.g. ``"max-temp °F"`` is acceptable,


### PR DESCRIPTION
This is to clarify that the keys of keyword arguments (necessarily given as
a mapping) are acceptable in a call even if they would not be valid
as the identifiers of formal parameters. It responds to the discussion at:

https://discuss.python.org/t/supporting-or-not-invalid-identifiers-in-kwargs/17147/31

Respectfully note the continuing desire of some participants there there to debate this further.

Also, I may not have done full justice to @ChrisBarker-NOAA's contribution. In particular, I think it is worth documenting, as a further changeset here or on another PR, the apparent acceptability of non-identifier names in the `__dict__` of objects, supported by `(get|set)attr`, which he pointed out.

<!-- gh-issue-number: gh-96397 -->
* Issue: gh-96397
<!-- /gh-issue-number -->
