### PR TITLE
gh-96398: python3: use cc_basename instead of CC when checking binary name

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-08-29-19-50-23.gh-issue-96398.mzsP9U.rst
+++ b/Misc/NEWS.d/next/Build/2022-08-29-19-50-23.gh-issue-96398.mzsP9U.rst
@@ -1,0 +1,1 @@
+Use cc_basename instead of CC in configure.ac when checking binary name.

--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,7 @@ AC_CONFIG_HEADERS([pyconfig.h])
 AC_CANONICAL_HOST
 AC_SUBST(build)
 AC_SUBST(host)
+LT_INIT
 
 AS_VAR_IF([cross_compiling], [maybe],
  [AC_MSG_ERROR([Cross compiling required --host=HOST-TUPLE and --build=ARCH])]
@@ -879,7 +880,7 @@ AC_SUBST(CXX)
 preset_cxx="$CXX"
 if test -z "$CXX"
 then
-        case "$CC" in
+        case "$cc_basename" in
         gcc)    AC_PATH_TOOL(CXX, [g++], [g++], [notfound]) ;;
         cc)     AC_PATH_TOOL(CXX, [c++], [c++], [notfound]) ;;
         clang|*/clang)     AC_PATH_TOOL(CXX, [clang++], [clang++], [notfound]) ;;
@@ -1292,7 +1293,7 @@ rmdir CaseSensitiveTestDir
 
 case $ac_sys_system in
 hp*|HP*)
-    case $CC in
+    case $cc_basename in
     cc|*/cc) CC="$CC -Ae";;
     esac;;
 esac
@@ -1826,7 +1827,7 @@ esac
 ],
 [AC_MSG_RESULT(no)])
 if test "$Py_LTO" = 'true' ; then
-  case $CC in
+  case $cc_basename in
     *clang*)
       dnl flag to disable lto during linking
       LDFLAGS_NOLTO="-fno-lto"
@@ -1998,7 +1999,7 @@ then
   fi
 fi
 LLVM_PROF_ERR=no
-case $CC in
+case $cc_basename in
   *clang*)
     # Any changes made here should be reflected in the GCC+Darwin case below
     PGO_PROF_GEN_FLAG="-fprofile-instr-generate"
@@ -2059,7 +2060,7 @@ esac
 # compiler and platform.  BASECFLAGS tweaks need to be made even if the
 # user set OPT.
 
-case $CC in
+case $cc_basename in
     *clang*)
         cc_is_clang=1
         ;;
@@ -2278,7 +2279,7 @@ yes)
 
     # ICC doesn't recognize the option, but only emits a warning
     ## XXX does it emit an unused result warning and can it be disabled?
-    AS_CASE([$CC],
+    AS_CASE([$cc_basename],
             [*icc*], [ac_cv_disable_unused_result_warning=no]
             [PY_CHECK_CC_WARNING([disable], [unused-result])])
     AS_VAR_IF([ac_cv_disable_unused_result_warning], [yes],
@@ -2520,7 +2521,7 @@ yes)
     ;;
 esac
 
-case "$CC" in
+case "$cc_basename" in
 *icc*)
     # ICC needs -fp-model strict or floats behave badly
     CFLAGS_NODIST="$CFLAGS_NODIST -fp-model strict"
@@ -3389,7 +3390,7 @@ then
 		then
 			LINKFORSHARED="-Wl,--export-dynamic"
 		fi;;
-	SunOS/5*) case $CC in
+	SunOS/5*) case $cc_basename in
 		  *gcc*)
 		    if $CC -Xlinker --help 2>&1 | grep export-dynamic >/dev/null
 		    then
@@ -6650,7 +6651,7 @@ if test "$ac_cv_gcc_asm_for_x87" = yes; then
     # Some versions of gcc miscompile inline asm:
     # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46491
     # http://gcc.gnu.org/ml/gcc/2010-11/msg00366.html
-    case $CC in
+    case $cc_basename in
         *gcc*)
             AC_MSG_CHECKING(for gcc ipa-pure-const bug)
             saved_cflags="$CFLAGS"


### PR DESCRIPTION
When paths contain "clang"/"gcc"/"icc", they might be part of $CC
for example because of the "--sysroot" parameter. That could cause
judgement error about clang/gcc/icc compilers. e.g.

when "icc" is containded in working path, below errors are reported when
compiling python3:
x86_64-wrs-linux-gcc: error: strict: No such file or directory
x86_64-wrs-linux-gcc: error: unrecognized command line option '-fp-model'


<!-- gh-issue-number: gh-96398 -->
* Issue: gh-96398
<!-- /gh-issue-number -->
