### PR TITLE
gh-96415: Remove `types._cell_factory` from a module namespace

### DIFF
--- a/Lib/types.py
+++ b/Lib/types.py
@@ -60,7 +60,7 @@ except TypeError as exc:
 GetSetDescriptorType = type(FunctionType.__code__)
 MemberDescriptorType = type(FunctionType.__globals__)
 
-del sys, _f, _g, _C, _c, _ag  # Not for export
+del sys, _f, _g, _C, _c, _ag, _cell_factory  # Not for export
 
 
 # Provide a PEP 3115 compliant mechanism for class creation

--- a/Misc/NEWS.d/next/Library/2022-08-30-12-32-00.gh-issue-96415.6W7ORH.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-30-12-32-00.gh-issue-96415.6W7ORH.rst
@@ -1,0 +1,1 @@
+Remove ``types._cell_factory`` from module namespace.


### PR DESCRIPTION
This is now in line with other `types.py` helpers.

<!-- gh-issue-number: gh-96415 -->
* Issue: gh-96415
<!-- /gh-issue-number -->
