### PR TITLE
gh-94781: Clean previous instances of ouput files on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-08-30-12-01-51.gh-issue-94781.OxO-Gr.rst
+++ b/Misc/NEWS.d/next/Windows/2022-08-30-12-01-51.gh-issue-94781.OxO-Gr.rst
@@ -1,0 +1,2 @@
+Fix :file:`clean.bat` to clean previous instances of ouput files in ``Python\deepfreeze`` and 
+``Python\frozen_modules`` directories on Windows. Patch by Charlie Zhao.

--- a/Misc/NEWS.d/next/Windows/2022-08-30-12-01-51.gh-issue-94781.OxO-Gr.rst
+++ b/Misc/NEWS.d/next/Windows/2022-08-30-12-01-51.gh-issue-94781.OxO-Gr.rst
@@ -1,2 +1,2 @@
-Fix :file:`clean.bat` to clean previous instances of ouput files in ``Python\deepfreeze`` and
+Fix :file:`pcbuild.proj` to clean previous instances of ouput files in ``Python\deepfreeze`` and
 ``Python\frozen_modules`` directories on Windows. Patch by Charlie Zhao.

--- a/Misc/NEWS.d/next/Windows/2022-08-30-12-01-51.gh-issue-94781.OxO-Gr.rst
+++ b/Misc/NEWS.d/next/Windows/2022-08-30-12-01-51.gh-issue-94781.OxO-Gr.rst
@@ -1,2 +1,2 @@
-Fix :file:`clean.bat` to clean previous instances of ouput files in ``Python\deepfreeze`` and 
+Fix :file:`clean.bat` to clean previous instances of ouput files in ``Python\deepfreeze`` and
 ``Python\frozen_modules`` directories on Windows. Patch by Charlie Zhao.

--- a/PCbuild/_freeze_module.vcxproj
+++ b/PCbuild/_freeze_module.vcxproj
@@ -424,6 +424,10 @@
   <Target Name="_CleanFrozen" BeforeTargets="CoreClean" Condition="$(Configuration) != 'PGUpdate'">
     <ItemGroup>
       <Clean Include="%(None.IntFile)" />
+      <Clean Include="%(None.OutFile)" />
+      <Clean Include="%(GetPath.IntFile)" />
+      <Clean Include="%(GetPath.OutFile)" />
+      <Clean Include="$(PySourcePath)Python\deepfreeze\deepfreeze.c" />
     </ItemGroup>
   </Target>
 </Project>

--- a/PCbuild/clean.bat
+++ b/PCbuild/clean.bat
@@ -2,4 +2,13 @@
 rem A batch program to clean a particular configuration,
 rem just for convenience.
 
-call "%~dp0build.bat" -t Clean %*
+set dir=%~dp0
+
+call "%dir%build.bat" -t Clean %*
+
+rem Clean previous instances of ouput files in `Python\deepfreeze`
+rem and `Python\frozen_modules` directories to ensure successful building
+rem on Windows.
+
+del "%dir%\..\Python\deepfreeze\*.c"
+del "%dir%\..\Python\frozen_modules\*.h"

--- a/PCbuild/clean.bat
+++ b/PCbuild/clean.bat
@@ -2,13 +2,4 @@
 rem A batch program to clean a particular configuration,
 rem just for convenience.
 
-set dir=%~dp0
-
-call "%dir%build.bat" -t Clean %*
-
-rem Clean previous instances of ouput files in `Python\deepfreeze`
-rem and `Python\frozen_modules` directories to ensure successful building
-rem on Windows.
-
-del "%dir%\..\Python\deepfreeze\*.c"
-del "%dir%\..\Python\frozen_modules\*.h"
+call "%~dp0build.bat" -t Clean %*

--- a/PCbuild/pcbuild.proj
+++ b/PCbuild/pcbuild.proj
@@ -125,6 +125,12 @@
              StopOnFirstFailure="false"
              Condition="%(CleanTarget) != ''"
              Targets="%(CleanTarget)" />
+    <MSBuild Projects="@(FreezeProjects)"
+            Properties="Configuration=%(Configuration);Platform=%(Platform);%(Properties)"
+            BuildInParallel="%(BuildInParallel)"
+            StopOnFirstFailure="false"
+            Condition="%(CleanTarget) != ''"
+            Targets="%(CleanTarget)" />
   </Target>
 
   <Target Name="CleanAll">
@@ -140,6 +146,12 @@
              StopOnFirstFailure="false"
              Condition="%(CleanAllTarget) != ''"
              Targets="%(CleanAllTarget)" />
+    <MSBuild Projects="@(FreezeProjects)"
+            Properties="Configuration=%(Configuration);Platform=%(Platform);%(Properties)"
+            BuildInParallel="%(BuildInParallel)"
+            StopOnFirstFailure="false"
+            Condition="%(CleanTarget) != ''"
+            Targets="%(CleanTarget)" />
   </Target>
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />


### PR DESCRIPTION
The files generated by `PCbuild\build.bat` in the `Python\deepfreeze` and `Python\frozen_modules` directories may cause errors when rebuilding after a checkout. 
Now `PCbuild\clean.bat` can correctly remove those previous output files.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94781 -->
* Issue: gh-94781
<!-- /gh-issue-number -->
