### PR TITLE
gh-96426: Include EMSDK version in SOABI, disable abi3

### DIFF
--- a/Doc/library/intro.rst
+++ b/Doc/library/intro.rst
@@ -112,6 +112,16 @@ DOM APIs as well as limited networking capabilities with JavaScript's
   links are limited and don't support some operations. For example, WASI does
   not permit symlinks with absolute file names.
 
+* ``wasm32-emscripten`` has optional support for shared extensions. Since
+  Emscripten does not provide a stable ABI, yet. Shared libraries include
+  the Emscripten SDK version, for example
+  ``.cpython-312-wasm32-emscripten-3_1_19.so``. Unqualified extensions with
+  ``.abi3.so`` or ``.so`` suffix are not supported.
+
+* ``wasm32-wasi`` does not support shared extensions, yet. All extensions
+  must be compiled into the main WASM binary.
+
+
 .. _WebAssembly: https://webassembly.org/
 .. _Emscripten: https://emscripten.org/
 .. _Emscripten Networking: https://emscripten.org/docs/porting/networking.html>

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -456,5 +456,20 @@ class NullImporterTests(unittest.TestCase):
             os.rmdir(name)
 
 
+@unittest.skipUnless(support.is_emscripten, "Emscripten specific test")
+@requires_load_dynamic
+class EmscriptenSuffixes(unittest.TestCase):
+    def test_extension_suffixes(self):
+        # see gh-96426
+        suffixes = _imp.extension_suffixes()
+        uname = os.uname()
+        release = uname.release.replace(".", "_")
+        shortver = f"{sys.version_info.major}{sys.version_info.minor}"
+        self.assertEqual(
+            suffixes,
+            [f".cpython-{shortver}-{uname.machine}-emscripten-{release}.so"]
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-30-19-57-26.gh-issue-96426.gsLvIy.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-30-19-57-26.gh-issue-96426.gsLvIy.rst
@@ -1,0 +1,5 @@
+``wasm32-emscripten`` platform now include the Emscripten SDK version in
+platform triplet and suffix for shared extension modules (``SOABI``).
+Extensions with `.abi3.so` and `.so` are no longer importable. This avoids
+problems with ABI incompatible builds or accidental mixing of ELF shared
+extensions and WASM shared extensions.

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -42,8 +42,12 @@ const char *_PyImport_DynLoadFiletab[] = {
 #ifdef ALT_SOABI
     "." ALT_SOABI ".so",
 #endif
+#if !defined(__EMSCRIPTEN__)
+    // gh-96426: Emscripten has no stable ABI, only support extensions
+    // with full SOABI, e.g. ".cpython-312-wasm32-emscripten-3_1_19.so".
     ".abi" PYTHON_ABI_STRING ".so",
     ".so",
+#endif // Emscripten
 #endif  /* __CYGWIN__ */
     NULL,
 };

--- a/configure
+++ b/configure
@@ -6236,7 +6236,7 @@ cat > conftest.c <<EOF
         vxworks
 #elif defined(__wasm32__)
 #  if defined(__EMSCRIPTEN__)
-	wasm32-emscripten
+	wasm32-emscripten - __EMSCRIPTEN_major__ _ __EMSCRIPTEN_minor__ _ __EMSCRIPTEN_tiny__
 #  elif defined(__wasi__)
 	wasm32-wasi
 #  else
@@ -6244,7 +6244,7 @@ cat > conftest.c <<EOF
 #  endif
 #elif defined(__wasm64__)
 #  if defined(__EMSCRIPTEN__)
-	wasm64-emscripten
+	wasm64-emscripten - __EMSCRIPTEN_major__ _ __EMSCRIPTEN_minor__ _ __EMSCRIPTEN_tiny__
 #  elif defined(__wasi__)
 	wasm64-wasi
 #  else

--- a/configure.ac
+++ b/configure.ac
@@ -1051,7 +1051,7 @@ cat > conftest.c <<EOF
         vxworks
 #elif defined(__wasm32__)
 #  if defined(__EMSCRIPTEN__)
-	wasm32-emscripten
+	wasm32-emscripten - __EMSCRIPTEN_major__ _ __EMSCRIPTEN_minor__ _ __EMSCRIPTEN_tiny__
 #  elif defined(__wasi__)
 	wasm32-wasi
 #  else
@@ -1059,7 +1059,7 @@ cat > conftest.c <<EOF
 #  endif
 #elif defined(__wasm64__)
 #  if defined(__EMSCRIPTEN__)
-	wasm64-emscripten
+	wasm64-emscripten - __EMSCRIPTEN_major__ _ __EMSCRIPTEN_minor__ _ __EMSCRIPTEN_tiny__
 #  elif defined(__wasi__)
 	wasm64-wasi
 #  else


### PR DESCRIPTION
Emscripten does not provide a stable ABI, yet. Shared libraries include
the Emscripten SDK version, for example
``.cpython-312-wasm32-emscripten-3_1_19.so``. Unqualified extensions with
``.abi3.so`` or ``.so`` suffix are no longer supported.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96426 -->
* Issue: gh-96426
<!-- /gh-issue-number -->
