### PR TITLE
gh-96436: add flag to opt out of sequence index adjustment

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -425,6 +425,9 @@ given type object has a specified feature.
 /* Type is abstract and cannot be instantiated */
 #define Py_TPFLAGS_IS_ABSTRACT (1UL << 20)
 
+/* Do not adjust negative indexes in PySequence_GetItem calls on this type */
+#define Py_TPFLAGS_NO_SEQ_INDEX_ADJUST (1UL << 21)
+
 // This undocumented flag gives certain built-ins their unique pattern-matching
 // behavior, which allows a single positional subpattern to match against the
 // subject itself (rather than a mapped attribute on it):

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -1873,7 +1873,7 @@ PySequence_GetItem(PyObject *s, Py_ssize_t i)
     PySequenceMethods *m = Py_TYPE(s)->tp_as_sequence;
     if (m && m->sq_item) {
         if (i < 0) {
-            if (m->sq_length) {
+            if (!(Py_TYPE(s)->tp_flags & Py_TPFLAGS_NO_SEQ_INDEX_ADJUST) && m->sq_length) {
                 Py_ssize_t l = (*m->sq_length)(s);
                 assert(_Py_CheckSlotResult(s, "__len__", l >= 0));
                 if (l < 0) {

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -363,7 +363,7 @@ tuplecontains(PyTupleObject *a, PyObject *el)
 static PyObject *
 tupleitem(PyTupleObject *a, Py_ssize_t i)
 {
-    if (i < 0 || i >= Py_SIZE(a)) {
+    if (i >= Py_SIZE(a) || (i < 0 && (i += Py_SIZE(a)) < 0)) {
         PyErr_SetString(PyExc_IndexError, "tuple index out of range");
         return NULL;
     }
@@ -777,8 +777,6 @@ tuplesubscript(PyTupleObject* self, PyObject* item)
         Py_ssize_t i = PyNumber_AsSsize_t(item, PyExc_IndexError);
         if (i == -1 && PyErr_Occurred())
             return NULL;
-        if (i < 0)
-            i += PyTuple_GET_SIZE(self);
         return tupleitem(self, i);
     }
     else if (PySlice_Check(item)) {
@@ -876,7 +874,7 @@ PyTypeObject PyTuple_Type = {
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE | Py_TPFLAGS_TUPLE_SUBCLASS |
-        _Py_TPFLAGS_MATCH_SELF | Py_TPFLAGS_SEQUENCE,  /* tp_flags */
+        _Py_TPFLAGS_MATCH_SELF | Py_TPFLAGS_SEQUENCE | Py_TPFLAGS_NO_SEQ_INDEX_ADJUST,  /* tp_flags */
     tuple_new__doc__,                           /* tp_doc */
     (traverseproc)tupletraverse,                /* tp_traverse */
     0,                                          /* tp_clear */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2850,7 +2850,7 @@ type_new_alloc(type_new_ctx *ctx)
     // All heap types need GC, since we can create a reference cycle by storing
     // an instance on one of its parents.
     type->tp_flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE |
-                      Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC);
+                      Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_NO_SEQ_INDEX_ADJUST);
 
     // Initialize essential fields
     type->tp_as_async = &et->as_async;


### PR DESCRIPTION
This is a draft implementation of the proposal in #96436 to add a flag to opt out of sequence index adjustment.

It currently only implements the "Python class" case as well as demonstrates how the `tuple` builtin could also potentially change to make use of this flag (if desired).

<!-- gh-issue-number: gh-96436 -->
* Issue: gh-96436
<!-- /gh-issue-number -->
