### PR TITLE
gh-96448: fix documentation for _thread.lock.acquire

### DIFF
--- a/Doc/library/_thread.rst
+++ b/Doc/library/_thread.rst
@@ -171,7 +171,7 @@ Lock objects have the following methods:
    If the floating-point *timeout* argument is present and positive, it
    specifies the maximum wait time in seconds before returning.  A negative
    *timeout* argument specifies an unbounded wait.  You cannot specify
-   a *timeout* if blocking is False.
+   a *timeout* if *blocking* is False.
 
    The return value is ``True`` if the lock is acquired successfully,
    ``False`` if not.

--- a/Doc/library/_thread.rst
+++ b/Doc/library/_thread.rst
@@ -157,21 +157,21 @@ This module defines the following constants and functions:
 Lock objects have the following methods:
 
 
-.. method:: lock.acquire(waitflag=1, timeout=-1)
+.. method:: lock.acquire(blocking=True, timeout=-1)
 
    Without any optional argument, this method acquires the lock unconditionally, if
    necessary waiting until it is released by another thread (only one thread at a
    time can acquire a lock --- that's their reason for existence).
 
-   If the integer *waitflag* argument is present, the action depends on its
-   value: if it is zero, the lock is only acquired if it can be acquired
-   immediately without waiting, while if it is nonzero, the lock is acquired
+   If the *blocking* argument is present, the action depends on its
+   value: if it is False, the lock is only acquired if it can be acquired
+   immediately without waiting, while if it is True, the lock is acquired
    unconditionally as above.
 
    If the floating-point *timeout* argument is present and positive, it
    specifies the maximum wait time in seconds before returning.  A negative
    *timeout* argument specifies an unbounded wait.  You cannot specify
-   a *timeout* if *waitflag* is zero.
+   a *timeout* if blocking is False.
 
    The return value is ``True`` if the lock is acquired successfully,
    ``False`` if not.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This change is fairly trivial, so I think it probably doesn't need a news entry.  This PR updates the documentation for `_thread.lock.acquire()` to use the correct name for its first parameter.  

I also switched to saying `True` and `False` instead of `1` and `0`, which is consistent with the function's `PyDoc_STRVAR`.


<!-- gh-issue-number: gh-96448 -->
* Issue: gh-96448
<!-- /gh-issue-number -->
