### PR TITLE
[3.11] gh-95987: Fix `repr` of `Any` type subclasses (GH-96412)

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -109,6 +109,12 @@ class AnyTests(BaseTestCase):
     def test_repr(self):
         self.assertEqual(repr(Any), 'typing.Any')
 
+        class Sub(Any): pass
+        self.assertEqual(
+            repr(Sub),
+            "<class 'test.test_typing.AnyTests.test_repr.<locals>.Sub'>",
+        )
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             issubclass(42, Any)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -493,7 +493,9 @@ class _AnyMeta(type):
         return super().__instancecheck__(obj)
 
     def __repr__(self):
-        return "typing.Any"
+        if self is Any:
+            return "typing.Any"
+        return super().__repr__()  # respect to subclasses
 
 
 class Any(metaclass=_AnyMeta):

--- a/Misc/NEWS.d/next/Library/2022-08-30-11-46-36.gh-issue-95987.CV7_u4.rst
+++ b/Misc/NEWS.d/next/Library/2022-08-30-11-46-36.gh-issue-95987.CV7_u4.rst
@@ -1,0 +1,1 @@
+Fix ``repr`` of ``Any`` subclasses.


### PR DESCRIPTION
(cherry picked from commit 4217393)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>

<!-- gh-issue-number: gh-95987 -->
* Issue: gh-95987
<!-- /gh-issue-number -->
