### PR TITLE
gh-96397: Document that attributes need not be identifiers

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -144,7 +144,8 @@ Glossary
       It is possible to give an object an attribute whose name is not an
       identifier as defined by :ref:`identifiers`, for example using
       :func:`setattr`, if the object allows it.
-      Such an attribute will not be accessible using a dotted expression.
+      Such an attribute will not be accessible using a dotted expression,
+      and would instead need to be retrieved with :func:`getattr`.
 
    awaitable
       An object that can be used in an :keyword:`await` expression.  Can be

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -136,9 +136,15 @@ Glossary
       :exc:`StopAsyncIteration` exception.  Introduced by :pep:`492`.
 
    attribute
-      A value associated with an object which is referenced by name using
-      dotted expressions.  For example, if an object *o* has an attribute
+      A value associated with an object which is usually referenced by name
+      using dotted expressions.
+      For example, if an object *o* has an attribute
       *a* it would be referenced as *o.a*.
+
+      It is possible to give an object an attribute whose name is not an
+      identifier as defined by :ref:`identifiers`, for example using
+      :func:`setattr`, if the object allows it.
+      Such an attribute will not be accessible using a dotted expression.
 
    awaitable
       An object that can be used in an :keyword:`await` expression.  Can be

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -397,6 +397,7 @@ are always available.  They are listed here in alphabetical order.
    string.  The string must be the name of one of the object's attributes.  The
    function deletes the named attribute, provided the object allows it.  For
    example, ``delattr(x, 'foobar')`` is equivalent to ``del x.foobar``.
+   *name* need not be a Python identifier (see :func:`setattr`).
 
 
 .. _func-dict:
@@ -738,6 +739,7 @@ are always available.  They are listed here in alphabetical order.
    value of that attribute.  For example, ``getattr(x, 'foobar')`` is equivalent to
    ``x.foobar``.  If the named attribute does not exist, *default* is returned if
    provided, otherwise :exc:`AttributeError` is raised.
+   *name* need not be a Python identifier (see :func:`setattr`).
 
    .. note::
 
@@ -1574,6 +1576,12 @@ are always available.  They are listed here in alphabetical order.
    new attribute.  The function assigns the value to the attribute, provided the
    object allows it.  For example, ``setattr(x, 'foobar', 123)`` is equivalent to
    ``x.foobar = 123``.
+
+   *name* need not be a Python identifier as defined in :ref:`identifiers`
+   unless the object chooses to enforce that, for example in a custom
+   :meth:`~object.__getattribute__` or via :attr:`~object.__slots__`.
+   An attribute whose name is not an identifier will not be accessible using
+   the dot notation, but is accessible through :func:`getattr` etc..
 
    .. note::
 


### PR DESCRIPTION
Companion to #96393, and stemming from points made in the discussions at https://discuss.python.org/t/supporting-or-not-invalid-identifiers-in-kwargs/17147/26 and #96397, this proposes extending how we define "attribute" to match the behaviour of implementations and some current user practice.

Needs SC discussion, I believe.



<!-- gh-issue-number: gh-96397 -->
* Issue: gh-96397
<!-- /gh-issue-number -->
