### PR TITLE
GH-91079: Raise recursion error on C stack overflow, instead of crashing.

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -74,6 +74,7 @@ PyAPI_FUNC(int) Py_MakePendingCalls(void);
 PyAPI_FUNC(void) Py_SetRecursionLimit(int);
 PyAPI_FUNC(int) Py_GetRecursionLimit(void);
 
+PyAPI_FUNC(int) Py_StackOverflowCheck(const char *where);
 PyAPI_FUNC(int) Py_EnterRecursiveCall(const char *where);
 PyAPI_FUNC(void) Py_LeaveRecursiveCall(void);
 

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -74,7 +74,6 @@ PyAPI_FUNC(int) Py_MakePendingCalls(void);
 PyAPI_FUNC(void) Py_SetRecursionLimit(int);
 PyAPI_FUNC(int) Py_GetRecursionLimit(void);
 
-PyAPI_FUNC(int) Py_StackOverflowCheck(const char *where);
 PyAPI_FUNC(int) Py_EnterRecursiveCall(const char *where);
 PyAPI_FUNC(void) Py_LeaveRecursiveCall(void);
 

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -95,9 +95,17 @@ struct _ts {
     /* Was this thread state statically allocated? */
     int _static;
 
-    int recursion_remaining;
+    /* Python recursion limit handling */
+    int py_recursion_remaining;
     int recursion_limit;
-    int recursion_headroom; /* Allow 50 more calls to handle any errors. */
+    int py_recursion_headroom; /* Allow 50 more calls to handle any errors. */
+
+    /* C stack overflow handling */
+    intptr_t stack_limit;
+    intptr_t yellow_stack_limit;
+    intptr_t red_stack_limit;
+    int stack_in_yellow;
+    int stack_grows;
 
     /* 'tracing' keeps track of the execution depth when tracing/profiling.
        This is to prevent the actual trace/profile code from being recorded in
@@ -367,3 +375,6 @@ typedef int (*crossinterpdatafunc)(PyObject *, _PyCrossInterpreterData *);
 
 PyAPI_FUNC(int) _PyCrossInterpreterData_RegisterClass(PyTypeObject *, crossinterpdatafunc);
 PyAPI_FUNC(crossinterpdatafunc) _PyCrossInterpreterData_Lookup(PyObject *);
+
+
+PyAPI_FUNC(int) _Py_OS_GetStackLimits(void** low, void** high);

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -101,9 +101,9 @@ struct _ts {
     int py_recursion_headroom; /* Allow 50 more calls to handle any errors. */
 
     /* C stack overflow handling */
+    intptr_t stack_base;
     intptr_t stack_limit;
-    intptr_t yellow_stack_limit;
-    intptr_t red_stack_limit;
+    intptr_t stack_top;
     int stack_in_yellow;
     int stack_grows;
 

--- a/Include/internal/pycore_ast_state.h
+++ b/Include/internal/pycore_ast_state.h
@@ -12,8 +12,6 @@ extern "C" {
 
 struct ast_state {
     int initialized;
-    int recursion_depth;
-    int recursion_limit;
     PyObject *AST_type;
     PyObject *Add_singleton;
     PyObject *Add_type;

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -119,7 +119,7 @@ PyAPI_FUNC(int) _Py_CheckRecursiveCall(
     const char *where);
 
 
-PyAPI_FUNC(int) _Py_StackOverflowCheckCall(
+int _Py_StackOverflowCheckCall(
     PyThreadState *tstate,
     const char *where,
     intptr_t scaled_location);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -140,7 +140,12 @@ _Py_StackOverflowCheck(PyThreadState *tstate, const char *where)
 
 static inline int _Py_EnterRecursiveCall(const char *where) {
     PyThreadState *tstate = _PyThreadState_GET();
-    return _Py_EnterRecursiveCallTstate(tstate, where);
+    return _Py_StackOverflowCheck(tstate, where);
+}
+
+static inline int Py_StackOverflowCheck(const char *where) {
+    PyThreadState *tstate = _PyThreadState_GET();
+    return _Py_StackOverflowCheck(tstate, where);
 }
 
 static inline void _Py_LeaveRecursiveCallTstate(PyThreadState *tstate)  {

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -119,7 +119,7 @@ PyAPI_FUNC(int) _Py_CheckRecursiveCall(
     const char *where);
 
 
-int _Py_StackOverflowCheckCall(
+PyAPI_FUNC(int) _Py_StackOverflowCheckCall(
     PyThreadState *tstate,
     const char *where,
     intptr_t scaled_location);

--- a/Include/internal/pycore_compile.h
+++ b/Include/internal/pycore_compile.h
@@ -29,8 +29,6 @@ typedef struct {
     int optimize;
     int ff_features;
 
-    int recursion_depth;            /* current recursion depth */
-    int recursion_limit;            /* recursion limit */
 } _PyASTOptimizeState;
 
 extern int _PyAST_Optimize(

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -162,6 +162,8 @@ PyAPI_FUNC(int) _PyState_AddModule(
 
 PyAPI_FUNC(int) _PyOS_InterruptOccurred(PyThreadState *tstate);
 
+int _Py_UpdateStackLimits(PyThreadState *tstate);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_symtable.h
+++ b/Include/internal/pycore_symtable.h
@@ -37,8 +37,6 @@ struct symtable {
     PyObject *st_private;           /* name of current class or NULL */
     PyFutureFeatures *st_future;    /* module's future features that affect
                                        the symbol table */
-    int recursion_depth;            /* current recursion depth */
-    int recursion_limit;            /* recursion limit */
 };
 
 typedef struct _symtable_entry {

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -61,7 +61,7 @@ class CommonTest(seq_tests.CommonTest):
 
     def test_repr_deep(self):
         a = self.type2test([])
-        for i in range(sys.getrecursionlimit() + 100):
+        for i in range(100_000):
             a = self.type2test([a])
         self.assertRaises(RecursionError, repr, a)
 

--- a/Lib/test/mapping_tests.py
+++ b/Lib/test/mapping_tests.py
@@ -624,7 +624,7 @@ class TestHashMappingProtocol(TestMappingProtocol):
 
     def test_repr_deep(self):
         d = self._empty_mapping()
-        for i in range(sys.getrecursionlimit() + 100):
+        for i in range(100_000):
             d0 = d
             d = self._empty_mapping()
             d[1] = d0

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -816,19 +816,17 @@ class AST_Tests(unittest.TestCase):
 
     @support.cpython_only
     def test_ast_recursion_limit(self):
-        fail_depth = sys.getrecursionlimit() * 3
-        crash_depth = sys.getrecursionlimit() * 300
-        success_depth = int(fail_depth * 0.75)
+        crash_depth = 100_000
+        success_depth = 5_000
 
         def check_limit(prefix, repeated):
             expect_ok = prefix + repeated * success_depth
             ast.parse(expect_ok)
-            for depth in (fail_depth, crash_depth):
-                broken = prefix + repeated * depth
-                details = "Compiling ({!r} + {!r} * {})".format(
-                            prefix, repeated, depth)
-                with self.assertRaises(RecursionError, msg=details):
-                    ast.parse(broken)
+            broken = prefix + repeated * crash_depth
+            details = "Compiling ({!r} + {!r} * {})".format(
+                        prefix, repeated, crash_depth)
+            with self.assertRaises(RecursionError, msg=details):
+                ast.parse(broken)
 
         check_limit("a", "()")
         check_limit("a", ".b")

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -817,7 +817,7 @@ class AST_Tests(unittest.TestCase):
     @support.cpython_only
     def test_ast_recursion_limit(self):
         crash_depth = 100_000
-        success_depth = 1500
+        success_depth = 1000
 
         def check_limit(prefix, repeated):
             expect_ok = prefix + repeated * success_depth

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -817,7 +817,7 @@ class AST_Tests(unittest.TestCase):
     @support.cpython_only
     def test_ast_recursion_limit(self):
         crash_depth = 100_000
-        success_depth = 2_000
+        success_depth = 1500
 
         def check_limit(prefix, repeated):
             expect_ok = prefix + repeated * success_depth

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -817,7 +817,7 @@ class AST_Tests(unittest.TestCase):
     @support.cpython_only
     def test_ast_recursion_limit(self):
         crash_depth = 100_000
-        success_depth = 5_000
+        success_depth = 2_000
 
         def check_limit(prefix, repeated):
             expect_ok = prefix + repeated * success_depth

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -813,6 +813,44 @@ class TestErrorMessagesUseQualifiedName(unittest.TestCase):
         with self.check_raises_type_error(msg):
             A().method_two_args("x", "y", x="oops")
 
+@cpython_only
+class TestRecursion(unittest.TestCase):
+
+    def test_super_deep(self):
+
+        def recurse(n):
+            if n:
+                recurse(n-1)
+
+        def py_recurse(n, m):
+            if n:
+                py_recurse(n-1, m)
+            else:
+                c_py_recurse(m-1)
+
+        def c_recurse(n):
+            if n:
+                _testcapi.pyobject_fastcall(c_recurse, (n-1,))
+
+        def c_py_recurse(m):
+            if m:
+                _testcapi.pyobject_fastcall(py_recurse, (1000, m))
+
+        depth = sys.getrecursionlimit()
+        sys.setrecursionlimit(100_000)
+        try:
+            recurse(90_000)
+            with self.assertRaises(RecursionError):
+                recurse(101_000)
+            c_recurse(100)
+            with self.assertRaises(RecursionError):
+                c_recurse(90_000)
+            c_py_recurse(90)
+            with self.assertRaises(RecursionError):
+                c_py_recurse(100_000)
+        finally:
+            sys.setrecursionlimit(depth)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -111,7 +111,7 @@ class TestSpecifics(unittest.TestCase):
 
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_extended_arg(self):
-        repeat = 1000
+        repeat = 700
         longexpr = 'x = x or ' + '-x' * repeat
         g = {}
         code = '''

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -547,7 +547,7 @@ if 1:
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_compiler_recursion_limit(self):
         crash_depth = 100_000
-        success_depth = 1500
+        success_depth = 1000
 
         def check_limit(prefix, repeated, mode="single"):
             expect_ok = prefix + repeated * success_depth

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -547,7 +547,7 @@ if 1:
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_compiler_recursion_limit(self):
         crash_depth = 100_000
-        success_depth = 5_000
+        success_depth = 2_000
 
         def check_limit(prefix, repeated, mode="single"):
             expect_ok = prefix + repeated * success_depth

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -547,7 +547,7 @@ if 1:
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_compiler_recursion_limit(self):
         crash_depth = 100_000
-        success_depth = 2_000
+        success_depth = 1500
 
         def check_limit(prefix, repeated, mode="single"):
             expect_ok = prefix + repeated * success_depth

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -544,9 +544,11 @@ if 1:
 
     @support.cpython_only
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
+    @support.skip_if_sanitizer(memory=True, address=True,
+                               reason= "sanitizer consumes too much stack space")
     def test_compiler_recursion_limit(self):
         crash_depth = 100_000
-        success_depth = 700
+        success_depth = 1000
 
         def check_limit(prefix, repeated, mode="single"):
             expect_ok = prefix + repeated * success_depth

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -111,8 +111,7 @@ class TestSpecifics(unittest.TestCase):
 
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_extended_arg(self):
-        # default: 1000 * 2.5 = 2500 repetitions
-        repeat = int(sys.getrecursionlimit() * 2.5)
+        repeat = 1000
         longexpr = 'x = x or ' + '-x' * repeat
         g = {}
         code = '''

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -546,26 +546,17 @@ if 1:
     @support.cpython_only
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_compiler_recursion_limit(self):
-        # Expected limit is sys.getrecursionlimit() * the scaling factor
-        # in symtable.c (currently 3)
-        # We expect to fail *at* that limit, because we use up some of
-        # the stack depth limit in the test suite code
-        # So we check the expected limit and 75% of that
-        # XXX (ncoghlan): duplicating the scaling factor here is a little
-        # ugly. Perhaps it should be exposed somewhere...
-        fail_depth = sys.getrecursionlimit() * 3
-        crash_depth = sys.getrecursionlimit() * 300
-        success_depth = int(fail_depth * 0.75)
+        crash_depth = 100_000
+        success_depth = 5_000
 
         def check_limit(prefix, repeated, mode="single"):
             expect_ok = prefix + repeated * success_depth
             compile(expect_ok, '<test>', mode)
-            for depth in (fail_depth, crash_depth):
-                broken = prefix + repeated * depth
-                details = "Compiling ({!r} + {!r} * {})".format(
-                            prefix, repeated, depth)
-                with self.assertRaises(RecursionError, msg=details):
-                    compile(broken, '<test>', mode)
+            broken = prefix + repeated * crash_depth
+            details = "Compiling ({!r} + {!r} * {})".format(
+                        prefix, repeated, crash_depth)
+            with self.assertRaises(RecursionError, msg=details):
+                compile(broken, '<test>', mode)
 
         check_limit("a", "()")
         check_limit("a", ".b")

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -546,7 +546,7 @@ if 1:
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_compiler_recursion_limit(self):
         crash_depth = 100_000
-        success_depth = 1000
+        success_depth = 700
 
         def check_limit(prefix, repeated, mode="single"):
             expect_ok = prefix + repeated * success_depth

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -596,7 +596,7 @@ class DictTest(unittest.TestCase):
 
     def test_repr_deep(self):
         d = {}
-        for i in range(sys.getrecursionlimit() + 100):
+        for i in range(100_000):
             d = {1: d}
         self.assertRaises(RecursionError, repr, d)
 

--- a/Lib/test/test_dynamic.py
+++ b/Lib/test/test_dynamic.py
@@ -142,7 +142,7 @@ class RebindBuiltinsTests(unittest.TestCase):
 
         code = "lambda: " + "+".join(f"_number_{i}" for i in range(700))
         sum_func = eval(code, MyGlobals())
-        expected = sum(range(limit))
+        expected = sum(range(700))
         # Warm up the the function for quickening (PEP 659)
         for _ in range(30):
             self.assertEqual(sum_func(), expected)

--- a/Lib/test/test_dynamic.py
+++ b/Lib/test/test_dynamic.py
@@ -140,9 +140,7 @@ class RebindBuiltinsTests(unittest.TestCase):
             def __missing__(self, key):
                 return int(key.removeprefix("_number_"))
 
-        # 1,000 on most systems
-        limit = sys.getrecursionlimit()
-        code = "lambda: " + "+".join(f"_number_{i}" for i in range(limit))
+        code = "lambda: " + "+".join(f"_number_{i}" for i in range(700))
         sum_func = eval(code, MyGlobals())
         expected = sum(range(limit))
         # Warm up the the function for quickening (PEP 659)

--- a/Lib/test/test_exception_group.py
+++ b/Lib/test/test_exception_group.py
@@ -405,7 +405,7 @@ class ExceptionGroupSplitTests(ExceptionGroupTestBase):
 class DeepRecursionInSplitAndSubgroup(unittest.TestCase):
     def make_deep_eg(self):
         e = TypeError(1)
-        for i in range(2000):
+        for i in range(100_000):
             e = ExceptionGroup('eg', [e])
         return e
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1375,16 +1375,6 @@ class ExceptionTests(unittest.TestCase):
 
             class MyException(Exception): pass
 
-            def setrecursionlimit(depth):
-                while 1:
-                    try:
-                        sys.setrecursionlimit(depth)
-                        return depth
-                    except RecursionError:
-                        # sys.setrecursionlimit() raises a RecursionError if
-                        # the new recursion limit is too low (issue #25274).
-                        depth += 1
-
             def recurse(cnt):
                 cnt -= 1
                 if cnt:
@@ -1405,9 +1395,8 @@ class ExceptionTests(unittest.TestCase):
                 # tstate->recursion_depth is equal to (recursion_limit - 1)
                 # and is equal to recursion_limit when _gen_throw() calls
                 # PyErr_NormalizeException().
-                recurse(setrecursionlimit(depth + 2) - depth)
+                recurse(1000)
             finally:
-                sys.setrecursionlimit(recursionlimit)
                 print('Done.')
         """ % __file__
         rc, out, err = script_helper.assert_python_failure("-Wd", "-c", code)

--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -8,7 +8,7 @@ import typing
 from test import support
 
 
-
+
 class TestIsInstanceExceptions(unittest.TestCase):
     # Test to make sure that an AttributeError when accessing the instance's
     # class's bases is masked.  This was actually a bug in Python 2.2 and
@@ -97,7 +97,7 @@ class TestIsInstanceExceptions(unittest.TestCase):
         class D: pass
         self.assertRaises(RuntimeError, isinstance, c, D)
 
-
+
 # These tests are similar to above, but tickle certain code paths in
 # issubclass() instead of isinstance() -- really PyObject_IsSubclass()
 # vs. PyObject_IsInstance().
@@ -147,7 +147,7 @@ class TestIsSubclassExceptions(unittest.TestCase):
         self.assertRaises(TypeError, issubclass, B, C())
 
 
-
+
 # meta classes for creating abstract classes and instances
 class AbstractClass(object):
     def __init__(self, bases):
@@ -179,7 +179,7 @@ class Super:
 
 class Child(Super):
     pass
-
+
 class TestIsInstanceIsSubclass(unittest.TestCase):
     # Tests to ensure that isinstance and issubclass work on abstract
     # classes and instances.  Before the 2.2 release, TypeErrors were
@@ -353,10 +353,10 @@ def blowstack(fxn, arg, compare_to):
     # Make sure that calling isinstance with a deeply nested tuple for its
     # argument will raise RecursionError eventually.
     tuple_arg = (compare_to,)
-    for cnt in range(sys.getrecursionlimit()+5):
+    for cnt in range(100_000):
         tuple_arg = (tuple_arg,)
         fxn(arg, tuple_arg)
 
-
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2751,16 +2751,17 @@ class TestExtendedArgs(unittest.TestCase):
         self.assertEqual(counts, {'call': 1, 'line': 301, 'return': 1})
 
     def test_trace_lots_of_globals(self):
+        COUNT = 700
         code = """if 1:
             def f():
                 return (
                     {}
                 )
-        """.format("\n+\n".join(f"var{i}\n" for i in range(1000)))
-        ns = {f"var{i}": i for i in range(1000)}
+        """.format("\n+\n".join(f"var{i}\n" for i in range(700)))
+        ns = {f"var{i}": i for i in range(700)}
         exec(code, ns)
         counts = self.count_traces(ns["f"])
-        self.assertEqual(counts, {'call': 1, 'line': 2000, 'return': 1})
+        self.assertEqual(counts, {'call': 1, 'line': 1400, 'return': 1})
 
 
 class TestEdgeCases(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2022-08-31-19-35-19.gh-issue-91079.K0A-QO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-08-31-19-35-19.gh-issue-91079.K0A-QO.rst
@@ -1,0 +1,3 @@
+Recursion that would have overflowed the C stack is prevented and a
+RecursionError raised. Prevents VM crashes when the recursion limit is set
+too high.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -44,9 +44,7 @@ get_recursion_depth(PyObject *self, PyObject *Py_UNUSED(args))
 {
     PyThreadState *tstate = _PyThreadState_GET();
 
-    /* subtract one to ignore the frame of the get_recursion_depth() call */
-
-    return PyLong_FromLong(tstate->recursion_limit - tstate->recursion_remaining - 1);
+    return PyLong_FromLong(tstate->recursion_limit - tstate->py_recursion_remaining);
 }
 
 

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1112,8 +1112,6 @@ static int add_ast_fields(struct ast_state *state)
         for dfn in mod.dfns:
             self.visit(dfn)
         self.file.write(textwrap.dedent('''
-                state->recursion_depth = 0;
-                state->recursion_limit = 0;
                 state->initialized = 1;
                 return 1;
             }
@@ -1261,14 +1259,11 @@ class ObjVisitor(PickleVisitor):
         self.emit('if (!o) {', 1)
         self.emit("Py_RETURN_NONE;", 2)
         self.emit("}", 1)
-        self.emit("if (++state->recursion_depth > state->recursion_limit) {", 1)
-        self.emit("PyErr_SetString(PyExc_RecursionError,", 2)
-        self.emit('"maximum recursion depth exceeded during ast construction");', 3)
+        self.emit('if (Py_StackOverflowCheck("during ast construction")) {', 1)
         self.emit("return 0;", 2)
         self.emit("}", 1)
 
     def func_end(self):
-        self.emit("state->recursion_depth--;", 1)
         self.emit("return result;", 1)
         self.emit("failed:", 0)
         self.emit("Py_XDECREF(value);", 1)
@@ -1380,31 +1375,7 @@ PyObject* PyAST_mod2obj(mod_ty t)
         return NULL;
     }
 
-    int recursion_limit = Py_GetRecursionLimit();
-    int starting_recursion_depth;
-    /* Be careful here to prevent overflow. */
-    int COMPILER_STACK_FRAME_SCALE = 3;
-    PyThreadState *tstate = _PyThreadState_GET();
-    if (!tstate) {
-        return 0;
-    }
-    state->recursion_limit = (recursion_limit < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_limit * COMPILER_STACK_FRAME_SCALE : recursion_limit;
-    int recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;
-    starting_recursion_depth = (recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
-    state->recursion_depth = starting_recursion_depth;
-
-    PyObject *result = ast2obj_mod(state, t);
-
-    /* Check that the recursion depth counting balanced correctly */
-    if (result && state->recursion_depth != starting_recursion_depth) {
-        PyErr_Format(PyExc_SystemError,
-            "AST constructor recursion depth mismatch (before=%d, after=%d)",
-            starting_recursion_depth, state->recursion_depth);
-        return 0;
-    }
-    return result;
+    return ast2obj_mod(state, t);
 }
 
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
@@ -1470,8 +1441,6 @@ class ChainOfVisitors:
 def generate_ast_state(module_state, f):
     f.write('struct ast_state {\n')
     f.write('    int initialized;\n')
-    f.write('    int recursion_depth;\n')
-    f.write('    int recursion_limit;\n')
     for s in module_state:
         f.write('    PyObject *' + s + ';\n')
     f.write('};')

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1851,8 +1851,6 @@ init_types(struct ast_state *state)
         "TypeIgnore(int lineno, string tag)");
     if (!state->TypeIgnore_type) return 0;
 
-    state->recursion_depth = 0;
-    state->recursion_limit = 0;
     state->initialized = 1;
     return 1;
 }
@@ -3612,9 +3610,7 @@ ast2obj_mod(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -3672,7 +3668,6 @@ ast2obj_mod(struct ast_state *state, void* _o)
         Py_DECREF(value);
         break;
     }
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -3689,9 +3684,7 @@ ast2obj_stmt(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -4237,7 +4230,6 @@ ast2obj_stmt(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -4254,9 +4246,7 @@ ast2obj_expr(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -4720,7 +4710,6 @@ ast2obj_expr(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -4863,9 +4852,7 @@ ast2obj_comprehension(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->comprehension_type;
@@ -4891,7 +4878,6 @@ ast2obj_comprehension(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->is_async, value) == -1)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -4908,9 +4894,7 @@ ast2obj_excepthandler(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -4956,7 +4940,6 @@ ast2obj_excepthandler(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -4973,9 +4956,7 @@ ast2obj_arguments(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->arguments_type;
@@ -5016,7 +4997,6 @@ ast2obj_arguments(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->defaults, value) == -1)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -5033,9 +5013,7 @@ ast2obj_arg(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->arg_type;
@@ -5076,7 +5054,6 @@ ast2obj_arg(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -5093,9 +5070,7 @@ ast2obj_keyword(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->keyword_type;
@@ -5131,7 +5106,6 @@ ast2obj_keyword(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -5148,9 +5122,7 @@ ast2obj_alias(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->alias_type;
@@ -5186,7 +5158,6 @@ ast2obj_alias(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -5203,9 +5174,7 @@ ast2obj_withitem(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->withitem_type;
@@ -5221,7 +5190,6 @@ ast2obj_withitem(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->optional_vars, value) == -1)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -5238,9 +5206,7 @@ ast2obj_match_case(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->match_case_type;
@@ -5261,7 +5227,6 @@ ast2obj_match_case(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->body, value) == -1)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -5278,9 +5243,7 @@ ast2obj_pattern(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -5422,7 +5385,6 @@ ast2obj_pattern(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -5439,9 +5401,7 @@ ast2obj_type_ignore(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (Py_StackOverflowCheck("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -5461,7 +5421,6 @@ ast2obj_type_ignore(struct ast_state *state, void* _o)
         Py_DECREF(value);
         break;
     }
-    state->recursion_depth--;
     return result;
 failed:
     Py_XDECREF(value);
@@ -12315,31 +12274,7 @@ PyObject* PyAST_mod2obj(mod_ty t)
         return NULL;
     }
 
-    int recursion_limit = Py_GetRecursionLimit();
-    int starting_recursion_depth;
-    /* Be careful here to prevent overflow. */
-    int COMPILER_STACK_FRAME_SCALE = 3;
-    PyThreadState *tstate = _PyThreadState_GET();
-    if (!tstate) {
-        return 0;
-    }
-    state->recursion_limit = (recursion_limit < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_limit * COMPILER_STACK_FRAME_SCALE : recursion_limit;
-    int recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;
-    starting_recursion_depth = (recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
-    state->recursion_depth = starting_recursion_depth;
-
-    PyObject *result = ast2obj_mod(state, t);
-
-    /* Check that the recursion depth counting balanced correctly */
-    if (result && state->recursion_depth != starting_recursion_depth) {
-        PyErr_Format(PyExc_SystemError,
-            "AST constructor recursion depth mismatch (before=%d, after=%d)",
-            starting_recursion_depth, state->recursion_depth);
-        return 0;
-    }
-    return result;
+    return ast2obj_mod(state, t);
 }
 
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -1,6 +1,7 @@
 /* AST Optimizer */
 #include "Python.h"
 #include "pycore_ast.h"           // _PyAST_GetDocString()
+#include "pycore_ceval.h"         // Py_StackOverflowCheck
 #include "pycore_compile.h"       // _PyASTOptimizeState
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_format.h"        // F_LJUST

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -7464,7 +7464,8 @@ maybe_dtrace_line(_PyInterpreterFrame *frame,
 
 int Py_EnterRecursiveCall(const char *where)
 {
-    return _Py_EnterRecursiveCall(where);
+    PyThreadState *tstate = _PyThreadState_GET();
+    return _Py_StackOverflowCheck(tstate, where);
 }
 
 #undef Py_LeaveRecursiveCall
@@ -7472,11 +7473,4 @@ int Py_EnterRecursiveCall(const char *where)
 void Py_LeaveRecursiveCall(void)
 {
     _Py_LeaveRecursiveCall();
-}
-
-
-int Py_StackOverflowCheck(const char *where)
-{
-    PyThreadState *tstate = _PyThreadState_GET();
-    return _Py_StackOverflowCheck(tstate, where);
 }

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -310,14 +310,14 @@ _PyErr_NormalizeException(PyThreadState *tstate, PyObject **exc,
                           PyObject **val, PyObject **tb)
 {
     int recursion_depth = 0;
-    tstate->recursion_headroom++;
+    tstate->py_recursion_headroom++;
     PyObject *type, *value, *initial_tb;
 
   restart:
     type = *exc;
     if (type == NULL) {
         /* There was no exception, so nothing to do. */
-        tstate->recursion_headroom--;
+        tstate->py_recursion_headroom--;
         return;
     }
 
@@ -369,7 +369,7 @@ _PyErr_NormalizeException(PyThreadState *tstate, PyObject **exc,
     }
     *exc = type;
     *val = value;
-    tstate->recursion_headroom--;
+    tstate->py_recursion_headroom--;
     return;
 
   error:

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -830,7 +830,7 @@ _Py_UpdateStackLimits(PyThreadState *tstate)
         here > tstate->stack_top + 8*BLOCK_SIZE)
     {
         /* Either uninitialized or,
-         * sufficiently out of bounds that we must have the wrong thread. */
+         * sufficiently out of bounds that we must be in a new thread. */
         tstate->stack_base = here - BLOCK_SIZE;
         tstate->stack_top = tstate->stack_base + DEFAULT_STACK_ALLOWANCE;
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -785,9 +785,10 @@ stack_grows(void) {
          return -1;
      }
 }
-#define DEFAULT_STACK_ALLOWANCE (1<<16)
-#define SIZE_OF_RED_ZONE (1<<10)
-#define SIZE_OF_YELLOW_ZONE (3<<10)
+#define BLOCK_SIZE (1 << 10)
+#define DEFAULT_STACK_ALLOWANCE (100 * BLOCK_SIZE)
+#define SIZE_OF_RED_ZONE BLOCK_SIZE
+#define SIZE_OF_YELLOW_ZONE (3 * BLOCK_SIZE)
 
 int
 _Py_OS_GetStackLimits(void** low, void** high);

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1,5 +1,6 @@
 #include "Python.h"
 #include "pycore_ast.h"           // identifier, stmt_ty
+#include "pycore_ceval.h"         // Py_StackOverflowCheck
 #include "pycore_compile.h"       // _Py_Mangle(), _PyFuture_FromAST()
 #include "pycore_parser.h"        // _PyParser_ASTFromString()
 #include "pycore_pystate.h"       // _PyThreadState_GET()

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1217,7 +1217,7 @@ sys_setrecursionlimit_impl(PyObject *module, int new_limit)
 
     /* Reject too low new limit if the current recursion depth is higher than
        the new low-water mark. */
-    int depth = tstate->recursion_limit - tstate->recursion_remaining;
+    int depth = tstate->recursion_limit - tstate->py_recursion_remaining;
     if (depth >= new_limit) {
         _PyErr_Format(tstate, PyExc_RecursionError,
                       "cannot set the recursion limit to %i at "


### PR DESCRIPTION
This is the first stage in implementing #91079.
It does not ask the O/S for stack size, instead using a fixed stack size of 100k words (800k bytes for 64 bit machines, 400k bytes for 32 bit machines).

This provides a base implementation for platforms other than the main three or four.

Full stack support for the major platforms will be added in subsequent PRs.

<!-- gh-issue-number: gh-91079 -->
* Issue: gh-91079
<!-- /gh-issue-number -->
