### PR TITLE
gh-96478: Test `@overload` on C functions

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4391,6 +4391,21 @@ class OverloadTests(BaseTestCase):
 
         blah()
 
+    @patch("typing._overload_registry",
+        defaultdict(lambda: defaultdict(dict)))
+    def test_overload_on_compiled_functions(self):
+        # The registry starts out empty:
+        self.assertEqual(typing._overload_registry, {})
+
+        # This should just not fail:
+        overload(sum)
+        overload(print)
+
+        # No overloads are recorded (but, it still has a side-effect):
+        self.assertEqual(typing.get_overloads(sum), [])
+        self.assertEqual(typing.get_overloads(print), [])
+        self.assertNotEqual(typing._overload_registry, {})
+
     def set_up_overloads(self):
         def blah():
             pass

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4404,7 +4404,6 @@ class OverloadTests(BaseTestCase):
         # No overloads are recorded (but, it still has a side-effect):
         self.assertEqual(typing.get_overloads(sum), [])
         self.assertEqual(typing.get_overloads(print), [])
-        self.assertNotEqual(typing._overload_registry, {})
 
     def set_up_overloads(self):
         def blah():


### PR DESCRIPTION
Now, we have this covered, including a side-effect.

<!-- gh-issue-number: gh-96478 -->
* Issue: gh-96478
<!-- /gh-issue-number -->
