### PR TITLE
GH-96432 Let fraction literals support optional whitespace around the slash

### DIFF
--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -98,6 +98,9 @@ another rational number, or from a string.
       :class:`Fraction` implements ``__int__`` now to satisfy
       ``typing.SupportsInt`` instance checks.
 
+   .. versionchanged:: 3.12
+      Space is allowed around the slash for string inputs: `Fraction('2 / 3')`.
+
    .. attribute:: numerator
 
       Numerator of the Fraction in lowest term.

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -26,7 +26,7 @@ _RATIONAL_FORMAT = re.compile(r"""
     (?=\d|\.\d)                           # lookahead for digit or .digit
     (?P<num>\d*|\d+(_\d+)*)               # numerator (possibly empty)
     (?:                                   # followed by
-       (?:/(?P<denom>\d+(_\d+)*))?        # an optional denominator
+       (?:\s*/\s*(?P<denom>\d+(_\d+)*))?  # an optional denominator
     |                                     # or
        (?:\.(?P<decimal>d*|\d+(_\d+)*))?  # an optional fractional part
        (?:E(?P<exp>[-+]?\d+(_\d+)*))?     # and optional exponent

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -162,6 +162,7 @@ class FractionTest(unittest.TestCase):
     def testFromString(self):
         self.assertEqual((5, 1), _components(F("5")))
         self.assertEqual((3, 2), _components(F("3/2")))
+        self.assertEqual((3, 2), _components(F("3 / 2")))
         self.assertEqual((3, 2), _components(F(" \n  +3/2")))
         self.assertEqual((-3, 2), _components(F("-3/2  ")))
         self.assertEqual((13, 2), _components(F("    013/02 \n  ")))
@@ -190,9 +191,6 @@ class FractionTest(unittest.TestCase):
         self.assertRaisesMessage(
             ValueError, "Invalid literal for Fraction: '/2'",
             F, "/2")
-        self.assertRaisesMessage(
-            ValueError, "Invalid literal for Fraction: '3 /2'",
-            F, "3 /2")
         self.assertRaisesMessage(
             # Denominators don't need a sign.
             ValueError, "Invalid literal for Fraction: '3/+2'",

--- a/Misc/NEWS.d/next/Documentation/2022-09-01-17-03-04.gh-issue-96432.1EJ1-4.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-09-01-17-03-04.gh-issue-96432.1EJ1-4.rst
@@ -1,0 +1,2 @@
+Fraction literals now support whitespace around the forward slash,
+`Fraction('2 / 3')`.


### PR DESCRIPTION


<!-- gh-issue-number: gh-96432 -->
* Issue: gh-96432
<!-- /gh-issue-number -->
