### PR TITLE
[3.7] gh-79217: Remove empty log line in the suspicious.py tool

### DIFF
--- a/Doc/tools/extensions/suspicious.py
+++ b/Doc/tools/extensions/suspicious.py
@@ -150,7 +150,6 @@ class CheckSuspiciousMarkupBuilder(Builder):
         return False
 
     def report_issue(self, text, lineno, issue):
-        if not self.any_issue: self.logger.info()
         self.any_issue = True
         self.write_log_entry(lineno, issue, text)
         if py3:


### PR DESCRIPTION
Previous to commit ee171a2 the logline was working because of self.info() (now
deprecated) defaults to an empty message.

backport cherry-pick of https://github.com/python/cpython/commit/c3f52a59ce8406d9e59253ad4621e4749abdaeef

this way backports with documentation errors can be diagnosed.


<!-- gh-issue-number: gh-79217 -->
* Issue: gh-79217
<!-- /gh-issue-number -->
