### PR TITLE
GH-91079: Decouple C stack overflow checks from Python recursion checks.

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -95,9 +95,12 @@ struct _ts {
     /* Was this thread state statically allocated? */
     int _static;
 
-    int recursion_remaining;
-    int recursion_limit;
-    int recursion_headroom; /* Allow 50 more calls to handle any errors. */
+    int py_recursion_remaining;
+    int py_recursion_limit;
+    int py_recursion_headroom; /* Allow 50 more calls to handle any errors. */
+
+    int c_recursion_remaining;
+    int c_recursion_headroom; /* Allow 50 more calls to handle any errors. */
 
     /* 'tracing' keeps track of the execution depth when tracing/profiling.
        This is to prevent the actual trace/profile code from being recorded in

--- a/Include/internal/pycore_ast_state.h
+++ b/Include/internal/pycore_ast_state.h
@@ -12,8 +12,6 @@ extern "C" {
 
 struct ast_state {
     int initialized;
-    int recursion_depth;
-    int recursion_limit;
     PyObject *AST_type;
     PyObject *Add_singleton;
     PyObject *Add_type;

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -160,7 +160,7 @@ extern PyObject* _Py_MakeCoro(PyFunctionObject *func);
 
 extern int _Py_HandlePending(PyThreadState *tstate);
 
-#define C_RECURSION_LIMT 2500
+#define C_RECURSION_LIMT 2000
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -123,19 +123,14 @@ PyAPI_FUNC(int) _Py_CheckRecursiveCallN(PyThreadState *tstate, int n,
 
 static inline int _Py_EnterRecursiveCallTstate(PyThreadState *tstate,
                                                const char *where) {
-    int remaining = tstate->c_recursion_remaining;
-    if (remaining > 0) {
-        tstate->c_recursion_remaining = remaining - 1;
-        return 0;
-    }
-    return _Py_CheckRecursiveCallN(tstate, 1, where);
+    return (tstate->c_recursion_remaining-- <= 0) &&
+            _Py_CheckRecursiveCallN(tstate, 1, where);
 }
 
 static inline int _Py_EnterRecursiveCallN(PyThreadState *tstate, int n,
                                           const char *where) {
-    int remaining = tstate->c_recursion_remaining;
-    if (remaining >= n) {
-        tstate->c_recursion_remaining = remaining - n;
+    tstate->c_recursion_remaining -= n;
+    if (tstate->c_recursion_remaining < 0) {
         return 0;
     }
     return _Py_CheckRecursiveCallN(tstate, n, where);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -130,7 +130,7 @@ static inline int _Py_EnterRecursiveCallTstate(PyThreadState *tstate,
 static inline int _Py_EnterRecursiveCallN(PyThreadState *tstate, int n,
                                           const char *where) {
     tstate->c_recursion_remaining -= n;
-    if (tstate->c_recursion_remaining < 0) {
+    if (tstate->c_recursion_remaining >= 0) {
         return 0;
     }
     return _Py_CheckRecursiveCallN(tstate, n, where);
@@ -160,7 +160,7 @@ extern PyObject* _Py_MakeCoro(PyFunctionObject *func);
 
 extern int _Py_HandlePending(PyThreadState *tstate);
 
-#define C_RECURSION_LIMT 3000
+#define C_RECURSION_LIMT 2500
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_compile.h
+++ b/Include/internal/pycore_compile.h
@@ -28,9 +28,6 @@ extern PyObject* _Py_Mangle(PyObject *p, PyObject *name);
 typedef struct {
     int optimize;
     int ff_features;
-
-    int recursion_depth;            /* current recursion depth */
-    int recursion_limit;            /* recursion limit */
 } _PyASTOptimizeState;
 
 extern int _PyAST_Optimize(

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -68,7 +68,7 @@ extern "C" {
 #define _PyThreadState_INIT \
     { \
         ._static = 1, \
-        .recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
+        .py_recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
         .context_ver = 1, \
     }
 

--- a/Include/internal/pycore_symtable.h
+++ b/Include/internal/pycore_symtable.h
@@ -37,8 +37,6 @@ struct symtable {
     PyObject *st_private;           /* name of current class or NULL */
     PyFutureFeatures *st_future;    /* module's future features that affect
                                        the symbol table */
-    int recursion_depth;            /* current recursion depth */
-    int recursion_limit;            /* recursion limit */
 };
 
 typedef struct _symtable_entry {

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -61,7 +61,7 @@ class CommonTest(seq_tests.CommonTest):
 
     def test_repr_deep(self):
         a = self.type2test([])
-        for i in range(sys.getrecursionlimit() + 100):
+        for i in range(4000):
             a = self.type2test([a])
         self.assertRaises(RecursionError, repr, a)
 

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -816,9 +816,9 @@ class AST_Tests(unittest.TestCase):
 
     @support.cpython_only
     def test_ast_recursion_limit(self):
-        fail_depth = sys.getrecursionlimit() * 3
-        crash_depth = sys.getrecursionlimit() * 300
-        success_depth = int(fail_depth * 0.75)
+        fail_depth = 3000
+        crash_depth = 100_000
+        success_depth = 1500
 
         def check_limit(prefix, repeated):
             expect_ok = prefix + repeated * success_depth

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -813,6 +813,44 @@ class TestErrorMessagesUseQualifiedName(unittest.TestCase):
         with self.check_raises_type_error(msg):
             A().method_two_args("x", "y", x="oops")
 
+@cpython_only
+class TestRecursion(unittest.TestCase):
+
+    def test_super_deep(self):
+
+        def recurse(n):
+            if n:
+                recurse(n-1)
+
+        def py_recurse(n, m):
+            if n:
+                py_recurse(n-1, m)
+            else:
+                c_py_recurse(m-1)
+
+        def c_recurse(n):
+            if n:
+                _testcapi.pyobject_fastcall(c_recurse, (n-1,))
+
+        def c_py_recurse(m):
+            if m:
+                _testcapi.pyobject_fastcall(py_recurse, (1000, m))
+
+        depth = sys.getrecursionlimit()
+        sys.setrecursionlimit(100_000)
+        try:
+            recurse(90_000)
+            with self.assertRaises(RecursionError):
+                recurse(101_000)
+            c_recurse(100)
+            with self.assertRaises(RecursionError):
+                c_recurse(90_000)
+            c_py_recurse(90)
+            with self.assertRaises(RecursionError):
+                c_py_recurse(100_000)
+        finally:
+            sys.setrecursionlimit(depth)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -111,8 +111,7 @@ class TestSpecifics(unittest.TestCase):
 
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_extended_arg(self):
-        # default: 1000 * 2.5 = 2500 repetitions
-        repeat = int(sys.getrecursionlimit() * 2.5)
+        repeat = 2000
         longexpr = 'x = x or ' + '-x' * repeat
         g = {}
         code = '''

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -111,7 +111,7 @@ class TestSpecifics(unittest.TestCase):
 
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_extended_arg(self):
-        repeat = 2000
+        repeat = 1500
         longexpr = 'x = x or ' + '-x' * repeat
         g = {}
         code = '''
@@ -545,16 +545,9 @@ if 1:
     @support.cpython_only
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_compiler_recursion_limit(self):
-        # Expected limit is sys.getrecursionlimit() * the scaling factor
-        # in symtable.c (currently 3)
-        # We expect to fail *at* that limit, because we use up some of
-        # the stack depth limit in the test suite code
-        # So we check the expected limit and 75% of that
-        # XXX (ncoghlan): duplicating the scaling factor here is a little
-        # ugly. Perhaps it should be exposed somewhere...
-        fail_depth = sys.getrecursionlimit() * 3
-        crash_depth = sys.getrecursionlimit() * 300
-        success_depth = int(fail_depth * 0.75)
+        fail_depth = 3000
+        crash_depth = 100_000
+        success_depth = 1500
 
         def check_limit(prefix, repeated, mode="single"):
             expect_ok = prefix + repeated * success_depth

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -596,7 +596,7 @@ class DictTest(unittest.TestCase):
 
     def test_repr_deep(self):
         d = {}
-        for i in range(sys.getrecursionlimit() + 100):
+        for i in range(4000):
             d = {1: d}
         self.assertRaises(RecursionError, repr, d)
 

--- a/Lib/test/test_exception_group.py
+++ b/Lib/test/test_exception_group.py
@@ -405,7 +405,7 @@ class ExceptionGroupSplitTests(ExceptionGroupTestBase):
 class DeepRecursionInSplitAndSubgroup(unittest.TestCase):
     def make_deep_eg(self):
         e = TypeError(1)
-        for i in range(2000):
+        for i in range(4000):
             e = ExceptionGroup('eg', [e])
         return e
 

--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -8,7 +8,7 @@ import typing
 from test import support
 
 
-
+
 class TestIsInstanceExceptions(unittest.TestCase):
     # Test to make sure that an AttributeError when accessing the instance's
     # class's bases is masked.  This was actually a bug in Python 2.2 and
@@ -97,7 +97,7 @@ class TestIsInstanceExceptions(unittest.TestCase):
         class D: pass
         self.assertRaises(RuntimeError, isinstance, c, D)
 
-
+
 # These tests are similar to above, but tickle certain code paths in
 # issubclass() instead of isinstance() -- really PyObject_IsSubclass()
 # vs. PyObject_IsInstance().
@@ -147,7 +147,7 @@ class TestIsSubclassExceptions(unittest.TestCase):
         self.assertRaises(TypeError, issubclass, B, C())
 
 
-
+
 # meta classes for creating abstract classes and instances
 class AbstractClass(object):
     def __init__(self, bases):
@@ -179,7 +179,7 @@ class Super:
 
 class Child(Super):
     pass
-
+
 class TestIsInstanceIsSubclass(unittest.TestCase):
     # Tests to ensure that isinstance and issubclass work on abstract
     # classes and instances.  Before the 2.2 release, TypeErrors were
@@ -353,10 +353,10 @@ def blowstack(fxn, arg, compare_to):
     # Make sure that calling isinstance with a deeply nested tuple for its
     # argument will raise RecursionError eventually.
     tuple_arg = (compare_to,)
-    for cnt in range(sys.getrecursionlimit()+5):
+    for cnt in range(4000):
         tuple_arg = (tuple_arg,)
         fxn(arg, tuple_arg)
 
-
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-02-11-42-10.gh-issue-91079.32NfD7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-02-11-42-10.gh-issue-91079.32NfD7.rst
@@ -1,0 +1,3 @@
+Decouple C stack overflow checking from Python recursion checking. Allows
+the recursion limit to be increased safely, and reduces the chance of
+segfaults.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -46,7 +46,7 @@ get_recursion_depth(PyObject *self, PyObject *Py_UNUSED(args))
 
     /* subtract one to ignore the frame of the get_recursion_depth() call */
 
-    return PyLong_FromLong(tstate->recursion_limit - tstate->recursion_remaining - 1);
+    return PyLong_FromLong(tstate->py_recursion_limit - tstate->py_recursion_remaining - 1);
 }
 
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -421,12 +421,12 @@ PyObject_Repr(PyObject *v)
 
     /* It is possible for a type to have a tp_repr representation that loops
        infinitely. */
-    if (_Py_EnterRecursiveCallTstate(tstate,
+    if (_Py_EnterRecursiveCallN(tstate, 2,
                                      " while getting the repr of an object")) {
         return NULL;
     }
     res = (*Py_TYPE(v)->tp_repr)(v);
-    _Py_LeaveRecursiveCallTstate(tstate);
+    _Py_LeaveRecursiveCallN(tstate, 2);
 
     if (res == NULL) {
         return NULL;

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1112,8 +1112,6 @@ static int add_ast_fields(struct ast_state *state)
         for dfn in mod.dfns:
             self.visit(dfn)
         self.file.write(textwrap.dedent('''
-                state->recursion_depth = 0;
-                state->recursion_limit = 0;
                 state->initialized = 1;
                 return 1;
             }
@@ -1261,14 +1259,12 @@ class ObjVisitor(PickleVisitor):
         self.emit('if (!o) {', 1)
         self.emit("Py_RETURN_NONE;", 2)
         self.emit("}", 1)
-        self.emit("if (++state->recursion_depth > state->recursion_limit) {", 1)
-        self.emit("PyErr_SetString(PyExc_RecursionError,", 2)
-        self.emit('"maximum recursion depth exceeded during ast construction");', 3)
+        self.emit('if (_Py_EnterRecursiveCall("during ast construction")) {', 1)
         self.emit("return 0;", 2)
         self.emit("}", 1)
 
     def func_end(self):
-        self.emit("state->recursion_depth--;", 1)
+        self.emit("_Py_LeaveRecursiveCall();", 1)
         self.emit("return result;", 1)
         self.emit("failed:", 0)
         self.emit("Py_XDECREF(value);", 1)
@@ -1380,31 +1376,7 @@ PyObject* PyAST_mod2obj(mod_ty t)
         return NULL;
     }
 
-    int recursion_limit = Py_GetRecursionLimit();
-    int starting_recursion_depth;
-    /* Be careful here to prevent overflow. */
-    int COMPILER_STACK_FRAME_SCALE = 3;
-    PyThreadState *tstate = _PyThreadState_GET();
-    if (!tstate) {
-        return 0;
-    }
-    state->recursion_limit = (recursion_limit < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_limit * COMPILER_STACK_FRAME_SCALE : recursion_limit;
-    int recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;
-    starting_recursion_depth = (recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
-    state->recursion_depth = starting_recursion_depth;
-
-    PyObject *result = ast2obj_mod(state, t);
-
-    /* Check that the recursion depth counting balanced correctly */
-    if (result && state->recursion_depth != starting_recursion_depth) {
-        PyErr_Format(PyExc_SystemError,
-            "AST constructor recursion depth mismatch (before=%d, after=%d)",
-            starting_recursion_depth, state->recursion_depth);
-        return 0;
-    }
-    return result;
+    return ast2obj_mod(state, t);
 }
 
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
@@ -1470,8 +1442,6 @@ class ChainOfVisitors:
 def generate_ast_state(module_state, f):
     f.write('struct ast_state {\n')
     f.write('    int initialized;\n')
-    f.write('    int recursion_depth;\n')
-    f.write('    int recursion_limit;\n')
     for s in module_state:
         f.write('    PyObject *' + s + ';\n')
     f.write('};')

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1851,8 +1851,6 @@ init_types(struct ast_state *state)
         "TypeIgnore(int lineno, string tag)");
     if (!state->TypeIgnore_type) return 0;
 
-    state->recursion_depth = 0;
-    state->recursion_limit = 0;
     state->initialized = 1;
     return 1;
 }
@@ -3612,9 +3610,7 @@ ast2obj_mod(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -3672,7 +3668,7 @@ ast2obj_mod(struct ast_state *state, void* _o)
         Py_DECREF(value);
         break;
     }
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -3689,9 +3685,7 @@ ast2obj_stmt(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -4237,7 +4231,7 @@ ast2obj_stmt(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -4254,9 +4248,7 @@ ast2obj_expr(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -4720,7 +4712,7 @@ ast2obj_expr(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -4863,9 +4855,7 @@ ast2obj_comprehension(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->comprehension_type;
@@ -4891,7 +4881,7 @@ ast2obj_comprehension(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->is_async, value) == -1)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -4908,9 +4898,7 @@ ast2obj_excepthandler(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -4956,7 +4944,7 @@ ast2obj_excepthandler(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -4973,9 +4961,7 @@ ast2obj_arguments(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->arguments_type;
@@ -5016,7 +5002,7 @@ ast2obj_arguments(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->defaults, value) == -1)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -5033,9 +5019,7 @@ ast2obj_arg(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->arg_type;
@@ -5076,7 +5060,7 @@ ast2obj_arg(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -5093,9 +5077,7 @@ ast2obj_keyword(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->keyword_type;
@@ -5131,7 +5113,7 @@ ast2obj_keyword(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -5148,9 +5130,7 @@ ast2obj_alias(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->alias_type;
@@ -5186,7 +5166,7 @@ ast2obj_alias(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -5203,9 +5183,7 @@ ast2obj_withitem(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->withitem_type;
@@ -5221,7 +5199,7 @@ ast2obj_withitem(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->optional_vars, value) == -1)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -5238,9 +5216,7 @@ ast2obj_match_case(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     tp = (PyTypeObject *)state->match_case_type;
@@ -5261,7 +5237,7 @@ ast2obj_match_case(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->body, value) == -1)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -5278,9 +5254,7 @@ ast2obj_pattern(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -5422,7 +5396,7 @@ ast2obj_pattern(struct ast_state *state, void* _o)
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -5439,9 +5413,7 @@ ast2obj_type_ignore(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-            "maximum recursion depth exceeded during ast construction");
+    if (_Py_EnterRecursiveCall("during ast construction")) {
         return 0;
     }
     switch (o->kind) {
@@ -5461,7 +5433,7 @@ ast2obj_type_ignore(struct ast_state *state, void* _o)
         Py_DECREF(value);
         break;
     }
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return result;
 failed:
     Py_XDECREF(value);
@@ -12315,31 +12287,7 @@ PyObject* PyAST_mod2obj(mod_ty t)
         return NULL;
     }
 
-    int recursion_limit = Py_GetRecursionLimit();
-    int starting_recursion_depth;
-    /* Be careful here to prevent overflow. */
-    int COMPILER_STACK_FRAME_SCALE = 3;
-    PyThreadState *tstate = _PyThreadState_GET();
-    if (!tstate) {
-        return 0;
-    }
-    state->recursion_limit = (recursion_limit < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_limit * COMPILER_STACK_FRAME_SCALE : recursion_limit;
-    int recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;
-    starting_recursion_depth = (recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
-    state->recursion_depth = starting_recursion_depth;
-
-    PyObject *result = ast2obj_mod(state, t);
-
-    /* Check that the recursion depth counting balanced correctly */
-    if (result && state->recursion_depth != starting_recursion_depth) {
-        PyErr_Format(PyExc_SystemError,
-            "AST constructor recursion depth mismatch (before=%d, after=%d)",
-            starting_recursion_depth, state->recursion_depth);
-        return 0;
-    }
-    return result;
+    return ast2obj_mod(state, t);
 }
 
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -158,7 +158,7 @@ validate_constant(PyObject *value)
         return 1;
 
     if (PyTuple_CheckExact(value) || PyFrozenSet_CheckExact(value)) {
-        if (_Py_EnterRecursiveCall("during compilation")) {
+        if (_Py_EnterRecursiveCall(" during compilation")) {
             return 0;
         }
 
@@ -203,7 +203,7 @@ validate_expr(expr_ty exp, expr_context_ty ctx)
     VALIDATE_POSITIONS(exp);
     int ret = -1;
 
-    if (_Py_EnterRecursiveCall("during compilation")) {
+    if (_Py_EnterRecursiveCall(" during compilation")) {
         return 0;
     }
     int check_ctx = 1;
@@ -524,7 +524,7 @@ validate_pattern(pattern_ty p, int star_ok)
 {
     VALIDATE_POSITIONS(p);
     int ret = -1;
-    if (_Py_EnterRecursiveCall("during compilation")) {
+    if (_Py_EnterRecursiveCall(" during compilation")) {
         return 0;
     }
     switch (p->kind) {
@@ -693,7 +693,7 @@ validate_stmt(stmt_ty stmt)
     VALIDATE_POSITIONS(stmt);
     int ret = -1;
     Py_ssize_t i;
-    if (_Py_EnterRecursiveCall("during compilation")) {
+    if (_Py_EnterRecursiveCall(" during compilation")) {
         return 0;
     }
     switch (stmt->kind) {

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4,14 +4,14 @@
  */
 #include "Python.h"
 #include "pycore_ast.h"           // asdl_stmt_seq
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 
 #include <assert.h>
 #include <stdbool.h>
 
 struct validator {
-    int recursion_depth;            /* current recursion depth */
-    int recursion_limit;            /* recursion limit */
+    int placeholder;
 };
 
 static int validate_stmts(struct validator *, asdl_stmt_seq *);
@@ -161,9 +161,7 @@ validate_constant(struct validator *state, PyObject *value)
         return 1;
 
     if (PyTuple_CheckExact(value) || PyFrozenSet_CheckExact(value)) {
-        if (++state->recursion_depth > state->recursion_limit) {
-            PyErr_SetString(PyExc_RecursionError,
-                            "maximum recursion depth exceeded during compilation");
+        if (_Py_EnterRecursiveCall("during compilation")) {
             return 0;
         }
 
@@ -190,7 +188,7 @@ validate_constant(struct validator *state, PyObject *value)
         }
 
         Py_DECREF(it);
-        --state->recursion_depth;
+        _Py_LeaveRecursiveCall();
         return 1;
     }
 
@@ -207,9 +205,8 @@ validate_expr(struct validator *state, expr_ty exp, expr_context_ty ctx)
 {
     VALIDATE_POSITIONS(exp);
     int ret = -1;
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-                        "maximum recursion depth exceeded during compilation");
+
+    if (_Py_EnterRecursiveCall("during compilation")) {
         return 0;
     }
     int check_ctx = 1;
@@ -387,7 +384,7 @@ validate_expr(struct validator *state, expr_ty exp, expr_context_ty ctx)
         PyErr_SetString(PyExc_SystemError, "unexpected expression");
         ret = 0;
     }
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return ret;
 }
 
@@ -530,9 +527,7 @@ validate_pattern(struct validator *state, pattern_ty p, int star_ok)
 {
     VALIDATE_POSITIONS(p);
     int ret = -1;
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-                        "maximum recursion depth exceeded during compilation");
+    if (_Py_EnterRecursiveCall("during compilation")) {
         return 0;
     }
     switch (p->kind) {
@@ -668,7 +663,7 @@ validate_pattern(struct validator *state, pattern_ty p, int star_ok)
         PyErr_SetString(PyExc_SystemError, "unexpected pattern");
         ret = 0;
     }
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return ret;
 }
 
@@ -701,9 +696,7 @@ validate_stmt(struct validator *state, stmt_ty stmt)
     VALIDATE_POSITIONS(stmt);
     int ret = -1;
     Py_ssize_t i;
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-                        "maximum recursion depth exceeded during compilation");
+    if (_Py_EnterRecursiveCall("during compilation")) {
         return 0;
     }
     switch (stmt->kind) {
@@ -909,7 +902,7 @@ validate_stmt(struct validator *state, stmt_ty stmt)
         PyErr_SetString(PyExc_SystemError, "unexpected statement");
         ret = 0;
     }
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return ret;
 }
 
@@ -975,21 +968,12 @@ _PyAST_Validate(mod_ty mod)
     int res = -1;
     struct validator state;
     PyThreadState *tstate;
-    int recursion_limit = Py_GetRecursionLimit();
-    int starting_recursion_depth;
 
     /* Setup recursion depth check counters */
     tstate = _PyThreadState_GET();
     if (!tstate) {
         return 0;
     }
-    /* Be careful here to prevent overflow. */
-    int recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;
-    starting_recursion_depth = (recursion_depth< INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
-    state.recursion_depth = starting_recursion_depth;
-    state.recursion_limit = (recursion_limit < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_limit * COMPILER_STACK_FRAME_SCALE : recursion_limit;
 
     switch (mod->kind) {
     case Module_kind:
@@ -1010,14 +994,6 @@ _PyAST_Validate(mod_ty mod)
 
     if (res < 0) {
         PyErr_SetString(PyExc_SystemError, "impossible module node");
-        return 0;
-    }
-
-    /* Check that the recursion depth counting balanced correctly */
-    if (res && state.recursion_depth != starting_recursion_depth) {
-        PyErr_Format(PyExc_SystemError,
-            "AST validator recursion depth mismatch (before=%d, after=%d)",
-            starting_recursion_depth, state.recursion_depth);
         return 0;
     }
     return res;

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -706,7 +706,7 @@ astfold_mod(mod_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 static int
 astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 {
-    if (_Py_EnterRecursiveCall("during compilation")) {
+    if (_Py_EnterRecursiveCall(" during compilation")) {
         return 0;
     }
     switch (node_->kind) {
@@ -867,7 +867,7 @@ astfold_arg(arg_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 static int
 astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 {
-    if (_Py_EnterRecursiveCall("during compilation")) {
+    if (_Py_EnterRecursiveCall(" during compilation")) {
         return 0;
     }
     switch (node_->kind) {
@@ -1017,7 +1017,7 @@ astfold_pattern(pattern_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     // Currently, this is really only used to form complex/negative numeric
     // constants in MatchValue and MatchMapping nodes
     // We still recurse into all subexpressions and subpatterns anyway
-    if (_Py_EnterRecursiveCall("during compilation")) {
+    if (_Py_EnterRecursiveCall(" during compilation")) {
         return 0;
     }
     switch (node_->kind) {

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -1,6 +1,7 @@
 /* AST Optimizer */
 #include "Python.h"
 #include "pycore_ast.h"           // _PyAST_GetDocString()
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
 #include "pycore_compile.h"       // _PyASTOptimizeState
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_format.h"        // F_LJUST
@@ -705,9 +706,7 @@ astfold_mod(mod_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 static int
 astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 {
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-                        "maximum recursion depth exceeded during compilation");
+    if (_Py_EnterRecursiveCall("during compilation")) {
         return 0;
     }
     switch (node_->kind) {
@@ -808,7 +807,7 @@ astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     case Name_kind:
         if (node_->v.Name.ctx == Load &&
                 _PyUnicode_EqualToASCIIString(node_->v.Name.id, "__debug__")) {
-            state->recursion_depth--;
+            _Py_LeaveRecursiveCall();
             return make_const(node_, PyBool_FromLong(!state->optimize), ctx_);
         }
         break;
@@ -821,7 +820,7 @@ astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     // No default case, so the compiler will emit a warning if new expression
     // kinds are added without being handled here
     }
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return 1;
 }
 
@@ -868,9 +867,7 @@ astfold_arg(arg_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 static int
 astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 {
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-                        "maximum recursion depth exceeded during compilation");
+    if (_Py_EnterRecursiveCall("during compilation")) {
         return 0;
     }
     switch (node_->kind) {
@@ -988,7 +985,7 @@ astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     // No default case, so the compiler will emit a warning if new statement
     // kinds are added without being handled here
     }
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return 1;
 }
 
@@ -1020,9 +1017,7 @@ astfold_pattern(pattern_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     // Currently, this is really only used to form complex/negative numeric
     // constants in MatchValue and MatchMapping nodes
     // We still recurse into all subexpressions and subpatterns anyway
-    if (++state->recursion_depth > state->recursion_limit) {
-        PyErr_SetString(PyExc_RecursionError,
-                        "maximum recursion depth exceeded during compilation");
+    if (_Py_EnterRecursiveCall("during compilation")) {
         return 0;
     }
     switch (node_->kind) {
@@ -1056,7 +1051,7 @@ astfold_pattern(pattern_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     // No default case, so the compiler will emit a warning if new pattern
     // kinds are added without being handled here
     }
-    state->recursion_depth--;
+    _Py_LeaveRecursiveCall();
     return 1;
 }
 
@@ -1080,32 +1075,15 @@ int
 _PyAST_Optimize(mod_ty mod, PyArena *arena, _PyASTOptimizeState *state)
 {
     PyThreadState *tstate;
-    int recursion_limit = Py_GetRecursionLimit();
-    int starting_recursion_depth;
 
     /* Setup recursion depth check counters */
     tstate = _PyThreadState_GET();
     if (!tstate) {
         return 0;
     }
-    /* Be careful here to prevent overflow. */
-    int recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;
-    starting_recursion_depth = (recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_depth * COMPILER_STACK_FRAME_SCALE : recursion_depth;
-    state->recursion_depth = starting_recursion_depth;
-    state->recursion_limit = (recursion_limit < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
-        recursion_limit * COMPILER_STACK_FRAME_SCALE : recursion_limit;
 
     int ret = astfold_mod(mod, arena, state);
     assert(ret || PyErr_Occurred());
-
-    /* Check that the recursion depth counting balanced correctly */
-    if (ret && state->recursion_depth != starting_recursion_depth) {
-        PyErr_Format(PyExc_SystemError,
-            "AST optimizer recursion depth mismatch (before=%d, after=%d)",
-            starting_recursion_depth, state->recursion_depth);
-        return 0;
-    }
 
     return ret;
 }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -269,7 +269,7 @@ Py_SetRecursionLimit(int new_limit)
 int
 _Py_CheckRecursiveCallN(PyThreadState *tstate, int n, const char *where)
 {
-    assert(tstate->c_recursion_remaining < n);
+    assert(tstate->c_recursion_remaining < 0);
     if (tstate->c_recursion_headroom) {
         if (tstate->c_recursion_remaining < -50) {
             /* Overflowing while handling an overflow. Give up. */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -280,7 +280,7 @@ _Py_CheckRecursiveCallN(PyThreadState *tstate, int n, const char *where)
         if (tstate->c_recursion_remaining < n) {
             tstate->c_recursion_remaining += n;
             _PyErr_Format(tstate, PyExc_RecursionError,
-                        "C stack overflow %s",
+                        "C stack overflow%s",
                         where);
             tstate->c_recursion_remaining -= n;
             return -1;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -277,12 +277,13 @@ _Py_CheckRecursiveCallN(PyThreadState *tstate, int n, const char *where)
         }
     }
     else {
-        if (tstate->c_recursion_remaining < n) {
-            tstate->c_recursion_remaining += n;
+        if (tstate->c_recursion_remaining <= 0) {
+            tstate->c_recursion_headroom++;
             _PyErr_Format(tstate, PyExc_RecursionError,
                         "C stack overflow%s",
                         where);
-            tstate->c_recursion_remaining -= n;
+            tstate->c_recursion_headroom--;
+            tstate->c_recursion_remaining += n;
             return -1;
         }
     }

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -310,14 +310,14 @@ _PyErr_NormalizeException(PyThreadState *tstate, PyObject **exc,
                           PyObject **val, PyObject **tb)
 {
     int recursion_depth = 0;
-    tstate->recursion_headroom++;
+    tstate->c_recursion_headroom++;
     PyObject *type, *value, *initial_tb;
 
   restart:
     type = *exc;
     if (type == NULL) {
         /* There was no exception, so nothing to do. */
-        tstate->recursion_headroom--;
+        tstate->c_recursion_headroom--;
         return;
     }
 
@@ -369,7 +369,7 @@ _PyErr_NormalizeException(PyThreadState *tstate, PyObject **exc,
     }
     *exc = type;
     *val = value;
-    tstate->recursion_headroom--;
+    tstate->c_recursion_headroom--;
     return;
 
   error:

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -792,8 +792,9 @@ init_threadstate(PyThreadState *tstate,
     tstate->native_thread_id = PyThread_get_thread_native_id();
 #endif
 
-    tstate->recursion_limit = interp->ceval.recursion_limit,
-    tstate->recursion_remaining = interp->ceval.recursion_limit,
+    tstate->py_recursion_limit = interp->ceval.recursion_limit;
+    tstate->py_recursion_remaining = interp->ceval.recursion_limit;
+    tstate->c_recursion_remaining = C_RECURSION_LIMT;
 
     tstate->exc_info = &tstate->exc_state;
 

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1164,7 +1164,7 @@ symtable_record_directive(struct symtable *st, identifier name, int lineno,
 static int
 symtable_visit_stmt(struct symtable *st, stmt_ty s)
 {
-    if (_Py_EnterRecursiveCall("during compilation")) {
+    if (_Py_EnterRecursiveCall(" during compilation")) {
         return 0;
     }
     switch (s->kind) {
@@ -1548,7 +1548,7 @@ symtable_handle_namedexpr(struct symtable *st, expr_ty e)
 static int
 symtable_visit_expr(struct symtable *st, expr_ty e)
 {
-    if (_Py_EnterRecursiveCall("during compilation")) {
+    if (_Py_EnterRecursiveCall(" during compilation")) {
         return 0;
     }
     switch (e->kind) {
@@ -1706,7 +1706,7 @@ symtable_visit_expr(struct symtable *st, expr_ty e)
 static int
 symtable_visit_pattern(struct symtable *st, pattern_ty p)
 {
-    if (_Py_EnterRecursiveCall("during compilation")) {
+    if (_Py_EnterRecursiveCall(" during compilation")) {
         return 0;
     }
     switch (p->kind) {

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1217,7 +1217,7 @@ sys_setrecursionlimit_impl(PyObject *module, int new_limit)
 
     /* Reject too low new limit if the current recursion depth is higher than
        the new low-water mark. */
-    int depth = tstate->recursion_limit - tstate->recursion_remaining;
+    int depth = tstate->py_recursion_limit - tstate->py_recursion_remaining;
     if (depth >= new_limit) {
         _PyErr_Format(tstate, PyExc_RecursionError,
                       "cannot set the recursion limit to %i at "


### PR DESCRIPTION
The Python recursion checks work as before.

In addition there is a separate counter for C stack checking which works as follows:
* There is a fixed limit of 3000 "points".
* "Normal" C calls that call ` Py_CheckRecursiveCall()` use 1 point.
* Calls to `PyObject_Repr` use 2 points as they seem to use a bit more stack than most functions.
* Calls to `_PyEval_EvalFrameDefault` use 3 points, as it is a big function and keeps the limit in line with the original limit of 1000
* The ad-hoc recursion checks in the compiler are replaced with calls to `Py_CheckRecursiveCall()`

I intend to add PRs to perform real stack checks for the major platforms, but this seems to offer a reasonable approximation for other platforms.

<!-- gh-issue-number: gh-91079 -->
* Issue: gh-91079
<!-- /gh-issue-number -->
