### PR TITLE
fix: bump version tag on HTTP status category indicators

### DIFF
--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -140,7 +140,7 @@ equal to the constant name (i.e. ``http.HTTPStatus.OK`` is also available as
 HTTP status category
 --------------------
 
-.. versionadded:: 3.11
+.. versionadded:: 3.12
 
 The enum values have several properties to indicate the HTTP status category:
 


### PR DESCRIPTION
The HTTP status category indicators were originally set for 3.11 but they didn't make it. Yet https://github.com/python/cpython/pull/95453 got merged with the docs still mentioning 3.11. This is to fix the version tag. See https://github.com/python/cpython/pull/95453#issuecomment-1232000906