### PR TITLE
gh-88057: in compile.c, assertion that stackdepth is alway >=0 is missing in one place

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7075,6 +7075,7 @@ stackdepth(basicblock *entryblock, int code_flags)
                 return -1;
             }
             int new_depth = depth + effect;
+            assert(new_depth >= 0); /* invalid code or bug in stackdepth() */
             if (new_depth > maxdepth) {
                 maxdepth = new_depth;
             }


### PR DESCRIPTION

I believe this assertion would have helped @larryhastings with the crash described in #88057.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-88057 -->
* Issue: gh-88057
<!-- /gh-issue-number -->
