### PR TITLE
GH-91432: Remove the `iterator_exhausted_no_error` label

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3811,7 +3811,8 @@ handle_eval_breaker:
                 _PyErr_Clear(tstate);
             }
             /* iterator ended normally */
-            Py_DECREF(POP());
+            STACK_SHRINK(1);
+            Py_DECREF(iter);
             JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER + oparg);
             DISPATCH();
         }
@@ -3848,9 +3849,10 @@ handle_eval_breaker:
                 it->it_seq = NULL;
                 Py_DECREF(seq);
             }
-            Py_DECREF(POP());
+            STACK_SHRINK(1);
+            Py_DECREF(it);
             JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER + oparg);
-            DISPATCH();
+            NOTRACE_DISPATCH();
         }
 
         TARGET(FOR_ITER_RANGE) {
@@ -3861,9 +3863,10 @@ handle_eval_breaker:
             _Py_CODEUNIT next = next_instr[INLINE_CACHE_ENTRIES_FOR_ITER];
             assert(_PyOpcode_Deopt[_Py_OPCODE(next)] == STORE_FAST);
             if (r->index >= r->len) {
-                Py_DECREF(POP());
+                STACK_SHRINK(1);
+                Py_DECREF(r);
                 JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER + oparg);
-                DISPATCH();
+                NOTRACE_DISPATCH();
             }
             long value = (long)(r->start +
                                 (unsigned long)(r->index++) * r->step);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3810,9 +3810,7 @@ handle_eval_breaker:
                 }
                 _PyErr_Clear(tstate);
             }
-        iterator_exhausted_no_error:
             /* iterator ended normally */
-            assert(!_PyErr_Occurred(tstate));
             Py_DECREF(POP());
             JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER + oparg);
             DISPATCH();
@@ -3839,19 +3837,20 @@ handle_eval_breaker:
             DEOPT_IF(Py_TYPE(it) != &PyListIter_Type, FOR_ITER);
             STAT_INC(FOR_ITER, hit);
             PyListObject *seq = it->it_seq;
-            if (seq == NULL) {
-                goto iterator_exhausted_no_error;
+            if (seq) {
+                if (it->it_index < PyList_GET_SIZE(seq)) {
+                    PyObject *next = PyList_GET_ITEM(seq, it->it_index++);
+                    Py_INCREF(next);
+                    PUSH(next);
+                    JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER);
+                    NOTRACE_DISPATCH();
+                }
+                it->it_seq = NULL;
+                Py_DECREF(seq);
             }
-            if (it->it_index < PyList_GET_SIZE(seq)) {
-                PyObject *next = PyList_GET_ITEM(seq, it->it_index++);
-                Py_INCREF(next);
-                PUSH(next);
-                JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER);
-                NOTRACE_DISPATCH();
-            }
-            it->it_seq = NULL;
-            Py_DECREF(seq);
-            goto iterator_exhausted_no_error;
+            Py_DECREF(POP());
+            JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER + oparg);
+            DISPATCH();
         }
 
         TARGET(FOR_ITER_RANGE) {
@@ -3862,7 +3861,9 @@ handle_eval_breaker:
             _Py_CODEUNIT next = next_instr[INLINE_CACHE_ENTRIES_FOR_ITER];
             assert(_PyOpcode_Deopt[_Py_OPCODE(next)] == STORE_FAST);
             if (r->index >= r->len) {
-                goto iterator_exhausted_no_error;
+                Py_DECREF(POP());
+                JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER + oparg);
+                DISPATCH();
             }
             long value = (long)(r->start +
                                 (unsigned long)(r->index++) * r->step);


### PR DESCRIPTION
There's not a very good reason why this tiny region of code needs to be shared between three different instructions. I find it impairs readability, and creates a dependency between the logic of the three opcodes that doesn't really need to be there.

<!-- gh-issue-number: gh-91432 -->
* Issue: gh-91432
<!-- /gh-issue-number -->
