### PR TITLE
ceval.c's GETITEM should have asserts, not set exceptions

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -733,9 +733,14 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
 /* Tuple access macros */
 
 #ifndef Py_DEBUG
-#define GETITEM(v, i) PyTuple_GET_ITEM((PyTupleObject *)(v), (i))
+#define GETITEM(v, i) PyTuple_GET_ITEM((v), (i))
 #else
-#define GETITEM(v, i) PyTuple_GetItem((v), (i))
+static inline PyObject *
+GETITEM(PyObject *v, Py_ssize_t i) {
+    assert(i >= 0);
+    assert(i < PyTuple_GET_SIZE(v));
+    return PyTuple_GET_ITEM(v, i);
+}
 #endif
 
 /* Code access macros */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -737,6 +737,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
 #else
 static inline PyObject *
 GETITEM(PyObject *v, Py_ssize_t i) {
+    assert(PyTuple_Check(v));
     assert(i >= 0);
     assert(i < PyTuple_GET_SIZE(v));
     return PyTuple_GET_ITEM(v, i);


### PR DESCRIPTION
Before this change: the following segfaults at `Py_INCREF(value)` in `LOAD_CONST`:

```
>>> f = lambda: 42
>>> f.__code__ = f.__code__.replace(co_consts=())
>>> f()
```

This is because `PyTuple_GetItem` raises and returns NULL, which is never checked for.

After the change:

```
>>> f = lambda: 42
>>> f.__code__ = f.__code__.replace(co_consts=())
>>> f()
Assertion failed: i < PyTuple_GET_SIZE(v), file C:\Users\sween\Source\Repos\cpython2\cpython\Python\ceval.c, line 740
```

Also, `PyTuple_GET_ITEM` already casts.

This is a change that only applies in debug mode to malformed code, so skipping issue/news.