### PR TITLE
GH-93911: Fix `LOAD_ATTR_PROPERTY` caches

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-02-16-47-52.gh-issue-93911.vF-GWe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-02-16-47-52.gh-issue-93911.vF-GWe.rst
@@ -1,0 +1,2 @@
+Fix an issue that could prevent :opcode:`LOAD_ATTR` from specializing
+properly when accessing properties.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -775,8 +775,10 @@ _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name)
                 SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_PROPERTY_NOT_PY_FUNCTION);
                 goto fail;
             }
-            uint32_t version = function_check_args(fget, 1, LOAD_ATTR) &&
-                function_get_version(fget, LOAD_ATTR);
+            if (!function_check_args(fget, 1, LOAD_ATTR)) {
+                goto fail;
+            }
+            uint32_t version = function_get_version(fget, LOAD_ATTR);
             if (version == 0) {
                 goto fail;
             }
@@ -831,9 +833,7 @@ _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name)
             assert(type->tp_getattro == _Py_slot_tp_getattro);
             assert(Py_IS_TYPE(descr, &PyFunction_Type));
             _PyLoadMethodCache *lm_cache = (_PyLoadMethodCache *)(instr + 1);
-            uint32_t func_version = function_check_args(descr, 2, LOAD_ATTR) &&
-                function_get_version(descr, LOAD_ATTR);
-            if (func_version == 0) {
+            if (!function_check_args(descr, 2, LOAD_ATTR)) {
                 goto fail;
             }
             /* borrowed */


### PR DESCRIPTION
Stats show that `LOAD_ATTR_PROPERTY` has a near-100% failure rate. This is because it always sets the cached function version to 1, regardless of the actual value. `LOAD_ATTR_GETATTRIBUTE_OVERRIDDEN` has a similar bug, but it doesn't manifest itself since the incorrect function version is never used.

This fixes both bugs, which brings `LOAD_ATTR` hit rates up from ~80% to ~83% when running the `pyperformance` suite (although `LOAD_ATTR_GETATTRIBUTE_OVERRIDDEN` doesn't actually appear in the suite at all).

<!-- gh-issue-number: gh-93911 -->
* Issue: gh-93911
<!-- /gh-issue-number -->
