### PR TITLE
_io.BufferedReader: Actually use cached position in tell

### DIFF
--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1182,7 +1182,7 @@ buffered_tell(buffered *self, PyObject *Py_UNUSED(ignored))
     Py_off_t pos;
 
     CHECK_INITIALIZED(self)
-    pos = _buffered_raw_tell(self);
+    pos = RAW_TELL(self);
     if (pos == -1)
         return NULL;
     pos -= RAW_OFFSET(self);


### PR DESCRIPTION
I might be completely wrong about this but it seems like `tell` is supposed to use the cached value, but doesn't seem to actually do so, making it quite slow in my testing.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
