### PR TITLE
gh-95778: Add pre-check for int-to-str conversion

### DIFF
--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -18,9 +18,9 @@ extern "C" {
  * everyone's existing deployed numpy test suite passes before
  * https://github.com/numpy/numpy/issues/22098 is widely available.
  *
- * $ python -m timeit -s 's = * "1"*4300' 'int(s)'
+ * $ python -m timeit -s 's = "1"*4300' 'int(s)'
  * 2000 loops, best of 5: 125 usec per loop
- * $ python -m timeit -s 's = * "1"*4300; v = int(s)' 'str(v)'
+ * $ python -m timeit -s 's = "1"*4300; v = int(s)' 'str(v)'
  * 1000 loops, best of 5: 311 usec per loop
  * (zen2 cloud VM)
  *

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -651,10 +651,13 @@ class IntStrDigitLimitsTests(unittest.TestCase):
         self.assertGreater(seconds_to_convert, 0.02,
                            msg="'We're gonna need a bigger boat (int).'")
 
-        with self.assertRaises(ValueError) as err:
-            start = process_time()
-            str(huge_int)
-        seconds_to_fail_huge = process_time() - start
+        # We test with the limit almost at the size needed to check performance.
+        # The performant limit check is slightly fuzzy, give it a some room.
+        with support.adjust_int_max_str_digits(int(.995 * 120_412)):
+            with self.assertRaises(ValueError) as err:
+                start = process_time()
+                str(huge_int)
+            seconds_to_fail_huge = process_time() - start
         self.assertIn('conversion', str(err.exception))
         self.assertLess(seconds_to_fail_huge, seconds_to_convert/8)
 
@@ -686,10 +689,11 @@ class IntStrDigitLimitsTests(unittest.TestCase):
         self.assertGreater(seconds_to_convert, 0.02,
                            msg="'We're gonna need a bigger boat (str).'")
 
-        with self.assertRaises(ValueError) as err:
-            start = process_time()
-            int(huge)
-        seconds_to_fail_huge = process_time() - start
+        with support.adjust_int_max_str_digits(200_000 - 1):
+            with self.assertRaises(ValueError) as err:
+                start = process_time()
+                int(huge)
+            seconds_to_fail_huge = process_time() - start
         self.assertIn('conversion', str(err.exception))
         self.assertLess(seconds_to_fail_huge, seconds_to_convert/8)
 

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -636,24 +636,25 @@ class IntStrDigitLimitsTests(unittest.TestCase):
     def test_denial_of_service_prevented_int_to_str(self):
         """Regression test: ensure we fail before performing O(N**2) work."""
         maxdigits = sys.get_int_max_str_digits()
-        assert maxdigits < 100_000, maxdigits  # A test prerequisite.
+        assert maxdigits < 50_000, maxdigits  # A test prerequisite.
         process_time = time.process_time
 
-        huge_int = int(f'0x{"c"*100_000}', base=16)  # 120412 decimal digits.
-        with support.adjust_int_max_str_digits(120_412):
+        huge_int = int(f'0x{"c"*65_000}', base=16)  # 78268 decimal digits.
+        digits = 78_268
+        with support.adjust_int_max_str_digits(digits):
             start = process_time()
             huge_decimal = str(huge_int)
         seconds_to_convert = process_time() - start
-        self.assertEqual(len(huge_decimal), 120_412)
+        self.assertEqual(len(huge_decimal), digits)
         # Ensuring that we chose a slow enough conversion to time.
         # Unlikely any CPU core will ever be faster than the assertion.
-        # It takes 0.25 seconds on a Zen based cloud VM in an opt build.
-        self.assertGreater(seconds_to_convert, 0.02,
+        # It takes 0.10 seconds on a Zen based cloud VM in an opt build.
+        self.assertGreater(seconds_to_convert, 0.005,
                            msg="'We're gonna need a bigger boat (int).'")
 
         # We test with the limit almost at the size needed to check performance.
         # The performant limit check is slightly fuzzy, give it a some room.
-        with support.adjust_int_max_str_digits(int(.995 * 120_412)):
+        with support.adjust_int_max_str_digits(int(.995 * digits)):
             with self.assertRaises(ValueError) as err:
                 start = process_time()
                 str(huge_int)

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -638,7 +638,7 @@ class IntStrDigitLimitsTests(unittest.TestCase):
         maxdigits = sys.get_int_max_str_digits()
         assert maxdigits < 50_000, maxdigits  # A test prerequisite.
         get_time = time.process_time
-        if get_time() <= 0:  # some platforms like WASM lacks process_time()
+        if get_time() <= 0:  # some platforms like WASM lack process_time()
             get_time = time.monotonic
 
         huge_int = int(f'0x{"c"*65_000}', base=16)  # 78268 decimal digits.
@@ -682,7 +682,7 @@ class IntStrDigitLimitsTests(unittest.TestCase):
         maxdigits = sys.get_int_max_str_digits()
         assert maxdigits < 100_000, maxdigits  # A test prerequisite.
         get_time = time.process_time
-        if get_time() <= 0:  # some platforms like WASM lacks process_time()
+        if get_time() <= 0:  # some platforms like WASM lack process_time()
             get_time = time.monotonic
 
         huge = '8'*200_000

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -648,13 +648,11 @@ class IntStrDigitLimitsTests(unittest.TestCase):
             huge_decimal = str(huge_int)
         seconds_to_convert = get_time() - start
         self.assertEqual(len(huge_decimal), digits)
-        # Ensuring that we chose a slow enough conversion to time.
-        # Unlikely any CPU core will ever be faster than the assertion.
-        # It takes 0.10 seconds on a Zen based cloud VM in an opt build.
+        # Ensuring that we chose a slow enough conversion to measure.
+        # It takes 0.1 seconds on a Zen based cloud VM in an opt build.
         if seconds_to_convert < 0.005:
-            raise unittest.SkipTest(f'')
-        self.assertGreater(seconds_to_convert, 0.005,
-                           msg="'We're gonna need a bigger boat (int).'")
+            raise unittest.SkipTest('"slow" conversion took only '
+                                    f'{seconds_to_convert} seconds.')
 
         # We test with the limit almost at the size needed to check performance.
         # The performant limit check is slightly fuzzy, give it a some room.
@@ -685,18 +683,19 @@ class IntStrDigitLimitsTests(unittest.TestCase):
         if get_time() <= 0:  # some platforms like WASM lack process_time()
             get_time = time.monotonic
 
-        huge = '8'*200_000
-        with support.adjust_int_max_str_digits(200_000):
+        digits = 133700
+        huge = '8'*digits
+        with support.adjust_int_max_str_digits(digits):
             start = get_time()
             int(huge)
         seconds_to_convert = get_time() - start
-        # Ensuring that we chose a slow enough conversion to time.
-        # Unlikely any CPU core will ever be faster than the assertion.
-        # It takes 0.25 seconds on a Zen based cloud VM in an opt build.
-        self.assertGreater(seconds_to_convert, 0.02,
-                           msg="'We're gonna need a bigger boat (str).'")
+        # Ensuring that we chose a slow enough conversion to measure.
+        # It takes 0.1 seconds on a Zen based cloud VM in an opt build.
+        if seconds_to_convert < 0.005:
+            raise unittest.SkipTest('"slow" conversion took only '
+                                    f'{seconds_to_convert} seconds.')
 
-        with support.adjust_int_max_str_digits(200_000 - 1):
+        with support.adjust_int_max_str_digits(digits - 1):
             with self.assertRaises(ValueError) as err:
                 start = get_time()
                 int(huge)
@@ -709,7 +708,7 @@ class IntStrDigitLimitsTests(unittest.TestCase):
         extra_huge = '7'*1_200_000
         with self.assertRaises(ValueError) as err:
             start = get_time()
-            # If not limited, 8 seconds said Zen based cloud VM.
+            # If not limited, 8 seconds in the Zen based cloud VM.
             int(extra_huge)
         seconds_to_fail_extra_huge = get_time() - start
         self.assertIn('conversion', str(err.exception))

--- a/Misc/NEWS.d/next/Security/2022-08-07-16-53-38.gh-issue-95778.ch010gps.rst
+++ b/Misc/NEWS.d/next/Security/2022-08-07-16-53-38.gh-issue-95778.ch010gps.rst
@@ -11,4 +11,4 @@ limitation <int_max_str_digits>` documentation.  The default limit is 4300
 digits in string form.
 
 Patch by Gregory P. Smith [Google] and Christian Heimes [Red Hat] with feedback
-from Victor Stinner, Thomas Wouters, Steve Dower, and Ned Deily.
+from Victor Stinner, Thomas Wouters, Steve Dower, Ned Deily, and Mark Dickinson.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1759,8 +1759,11 @@ long_to_decimal_string_internal(PyObject *aa,
     size_a = Py_ABS(Py_SIZE(a));
     negative = Py_SIZE(a) < 0;
 
-    /* quick and dirty pre-check for overflowing the digit limit,
-       based on the inequality 10/3 >= log2(10) */
+    /* quick and dirty pre-check for overflowing the decimal digit limit,
+       based on the inequality 10/3 >= log2(10)
+
+       explanation in https://github.com/python/cpython/pull/96537
+    */
     if (size_a >= 10 * _PY_LONG_MAX_STR_DIGITS_THRESHOLD
                   / (3 * PyLong_SHIFT) + 2) {
         PyInterpreterState *interp = _PyInterpreterState_GET();

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -37,6 +37,7 @@ medium_value(PyLongObject *x)
 #define IS_SMALL_UINT(ival) ((ival) < _PY_NSMALLPOSINTS)
 
 #define _MAX_STR_DIGITS_ERROR_FMT "Exceeds the limit (%d) for integer string conversion: value has %zd digits"
+#define _MAX_STR_DIGITS_ERROR_FMT2 "Exceeds the limit (%d) for integer string conversion"
 
 static inline void
 _Py_DECREF_INT(PyLongObject *op)
@@ -1758,6 +1759,20 @@ long_to_decimal_string_internal(PyObject *aa,
     size_a = Py_ABS(Py_SIZE(a));
     negative = Py_SIZE(a) < 0;
 
+    /* quick and dirty pre-check for overflowing the digit limit,
+       based on the inequality 10/3 >= log2(10) */
+    if (size_a >= 10 * _PY_LONG_MAX_STR_DIGITS_THRESHOLD
+                  / (3 * PyLong_SHIFT) + 2) {
+        PyInterpreterState *interp = _PyInterpreterState_GET();
+        int max_str_digits = interp->int_max_str_digits;
+        if ((max_str_digits > 0) && (size_a >= 10 * max_str_digits
+                                     / (3 * PyLong_SHIFT) + 2)) {
+            PyErr_Format(PyExc_ValueError, _MAX_STR_DIGITS_ERROR_FMT2,
+                         max_str_digits);
+            return -1;
+        }
+    }
+
     /* quick and dirty upper bound for the number of digits
        required to express a in base _PyLong_DECIMAL_BASE:
 
@@ -1823,8 +1838,8 @@ long_to_decimal_string_internal(PyObject *aa,
         Py_ssize_t strlen_nosign = strlen - negative;
         if ((max_str_digits > 0) && (strlen_nosign > max_str_digits)) {
             Py_DECREF(scratch);
-            PyErr_Format(PyExc_ValueError, _MAX_STR_DIGITS_ERROR_FMT,
-                         max_str_digits, strlen_nosign);
+            PyErr_Format(PyExc_ValueError, _MAX_STR_DIGITS_ERROR_FMT2,
+                         max_str_digits);
             return -1;
         }
     }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -36,8 +36,8 @@ medium_value(PyLongObject *x)
 #define IS_SMALL_INT(ival) (-_PY_NSMALLNEGINTS <= (ival) && (ival) < _PY_NSMALLPOSINTS)
 #define IS_SMALL_UINT(ival) ((ival) < _PY_NSMALLPOSINTS)
 
-#define _MAX_STR_DIGITS_ERROR_FMT "Exceeds the limit (%d) for integer string conversion: value has %zd digits"
-#define _MAX_STR_DIGITS_ERROR_FMT2 "Exceeds the limit (%d) for integer string conversion"
+#define _MAX_STR_DIGITS_ERROR_FMT_TO_INT "Exceeds the limit (%d) for integer string conversion: value has %zd digits"
+#define _MAX_STR_DIGITS_ERROR_FMT_TO_STR "Exceeds the limit (%d) for integer string conversion"
 
 static inline void
 _Py_DECREF_INT(PyLongObject *op)
@@ -1767,7 +1767,7 @@ long_to_decimal_string_internal(PyObject *aa,
         int max_str_digits = interp->int_max_str_digits;
         if ((max_str_digits > 0) &&
             (max_str_digits / (3 * PyLong_SHIFT) <= (size_a - 11) / 10)) {
-            PyErr_Format(PyExc_ValueError, _MAX_STR_DIGITS_ERROR_FMT2,
+            PyErr_Format(PyExc_ValueError, _MAX_STR_DIGITS_ERROR_FMT_TO_STR,
                          max_str_digits);
             return -1;
         }
@@ -1838,7 +1838,7 @@ long_to_decimal_string_internal(PyObject *aa,
         Py_ssize_t strlen_nosign = strlen - negative;
         if ((max_str_digits > 0) && (strlen_nosign > max_str_digits)) {
             Py_DECREF(scratch);
-            PyErr_Format(PyExc_ValueError, _MAX_STR_DIGITS_ERROR_FMT2,
+            PyErr_Format(PyExc_ValueError, _MAX_STR_DIGITS_ERROR_FMT_TO_STR,
                          max_str_digits);
             return -1;
         }
@@ -2513,7 +2513,7 @@ digit beyond the first.
             PyInterpreterState *interp = _PyInterpreterState_GET();
             int max_str_digits = interp->int_max_str_digits;
             if ((max_str_digits > 0) && (digits > max_str_digits)) {
-                PyErr_Format(PyExc_ValueError, _MAX_STR_DIGITS_ERROR_FMT,
+                PyErr_Format(PyExc_ValueError, _MAX_STR_DIGITS_ERROR_FMT_TO_INT,
                              max_str_digits, digits);
                 return NULL;
             }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1766,9 +1766,7 @@ long_to_decimal_string_internal(PyObject *aa,
         PyInterpreterState *interp = _PyInterpreterState_GET();
         int max_str_digits = interp->int_max_str_digits;
         if ((max_str_digits > 0) &&
-            /* avoid overflow in 10 * max_str_digits */
-            (max_str_digits <= INT_MAX / 10) &&
-            (size_a >= 10 * max_str_digits / (3 * PyLong_SHIFT) + 2)) {
+            (max_str_digits / (3 * PyLong_SHIFT) <= (size_a - 11) / 10)) {
             PyErr_Format(PyExc_ValueError, _MAX_STR_DIGITS_ERROR_FMT2,
                          max_str_digits);
             return -1;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1765,8 +1765,10 @@ long_to_decimal_string_internal(PyObject *aa,
                   / (3 * PyLong_SHIFT) + 2) {
         PyInterpreterState *interp = _PyInterpreterState_GET();
         int max_str_digits = interp->int_max_str_digits;
-        if ((max_str_digits > 0) && (size_a >= 10 * max_str_digits
-                                     / (3 * PyLong_SHIFT) + 2)) {
+        if ((max_str_digits > 0) &&
+            /* avoid overflow in 10 * max_str_digits */
+            (max_str_digits <= INT_MAX / 10) &&
+            (size_a >= 10 * max_str_digits / (3 * PyLong_SHIFT) + 2)) {
             PyErr_Format(PyExc_ValueError, _MAX_STR_DIGITS_ERROR_FMT2,
                          max_str_digits);
             return -1;


### PR DESCRIPTION
On current `main`, converting a large enough `int` to a decimal string raises `ValueError` as expected. However, the raise comes _after_ the quadratic-time base-conversion algorithm has run to completion. For effective DOS prevention, we need some kind of check before entering the quadratic-time loop.

This PR gives a proof-of-concept quick fix: essentially we catch _most_ values that exceed the threshold up front. Those that slip through will still be on the small side, and will get caught by the existing check.

For the record, here's the justification for the current check. The C code check is:
```c
max_str_digits / (3 * PyLong_SHIFT) <= (size_a - 11) / 10
```

In math-speak, writing $M$ for `max_str_digits`, $L$ for `PyLong_SHIFT` and $s$ for `size_a`, that check is:
$$\left\lfloor\frac{M}{3L}\right\rfloor \le \left\lfloor\frac{s - 11}{10}\right\rfloor$$

From this it follows that
$$\frac{M}{3L} < \frac{s-1}{10}$$
hence that
$$\frac{L(s-1)}{M} > \frac{10}{3} > \log_2(10).$$
So
$$2^{L(s-1)} > 10^M.$$
But our input integer $a$ satisfies $|a| \ge 2^{L(s-1)}$, so $|a|$ is larger than $10^M$. This shows that we don't accidentally capture anything _below_ the intended limit in the check.

~I don't think this is ready to merge as-is - there are some details to figure out, and I'll add line-by-line comments for those.~

<!-- gh-issue-number: gh-95778 -->
* Issue: gh-95778
<!-- /gh-issue-number -->
