### PR TITLE
gh-96538: Move some type-checking out of bisect loops

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-09-03-18-39-05.gh-issue-96538.W156-D.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-03-18-39-05.gh-issue-96538.W156-D.rst
@@ -1,0 +1,1 @@
+Speed up ``bisect.bisect()`` functions by taking advantage of type-stability.

--- a/Modules/_bisectmodule.c
+++ b/Modules/_bisectmodule.c
@@ -77,6 +77,7 @@ internal_bisect_right(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t 
            signed overflow.  (See issue 13496.) */
         mid = ((size_t)lo + hi) / 2;
         assert(mid >= 0);
+        // PySequence_GetItem, but we already checked the types.
         litem = sq_item(list, mid);
         assert((PyErr_Occurred() == NULL) ^ (litem == NULL));
         if (litem == NULL) {
@@ -89,7 +90,13 @@ internal_bisect_right(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t 
             }
             Py_SETREF(litem, newitem);
         }
+        /* if item < key(list[mid]):
+         *     hi = mid
+         * else:
+         *     lo = mid + 1
+         */
         if (compare != NULL && Py_IS_TYPE(litem, tp)) {
+            // A fast path for comparing objects of the same type
             PyObject *res_obj = compare(item, litem, Py_LT);
             if (res_obj == Py_True) {
                 Py_DECREF(res_obj);
@@ -116,6 +123,7 @@ internal_bisect_right(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t 
             }
         }
         else {
+            // A default path for comparing arbitrary objects
             res = PyObject_RichCompareBool(item, litem, Py_LT);
         }
         if (res < 0) {
@@ -248,6 +256,7 @@ internal_bisect_left(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t h
            signed overflow.  (See issue 13496.) */
         mid = ((size_t)lo + hi) / 2;
         assert(mid >= 0);
+        // PySequence_GetItem, but we already checked the types.
         litem = sq_item(list, mid);
         assert((PyErr_Occurred() == NULL) ^ (litem == NULL));
         if (litem == NULL) {
@@ -260,7 +269,13 @@ internal_bisect_left(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t h
             }
             Py_SETREF(litem, newitem);
         }
+        /* if key(list[mid]) < item:
+         *     lo = mid + 1
+         * else:
+         *     hi = mid
+         */
         if (compare != NULL && Py_IS_TYPE(litem, tp)) {
+            // A fast path for comparing objects of the same type
             PyObject *res_obj = compare(litem, item, Py_LT);
             if (res_obj == Py_True) {
                 Py_DECREF(res_obj);
@@ -287,6 +302,7 @@ internal_bisect_left(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t h
             }
         }
         else {
+            // A default path for comparing arbitrary objects
             res = PyObject_RichCompareBool(litem, item, Py_LT);
         }
         if (res < 0) {

--- a/Modules/_bisectmodule.c
+++ b/Modules/_bisectmodule.c
@@ -28,8 +28,8 @@ get_bisect_state(PyObject *module)
 static ssizeargfunc
 get_sq_item(PyObject *s)
 {
+    // The parts of PySequence_GetItem that we only need to do once
     PyTypeObject *tp = Py_TYPE(s);
-    // Inline the important parts of PySequence_GetItem.
     PySequenceMethods *m = tp->tp_as_sequence;
     if (m && m->sq_item) {
         return m->sq_item;

--- a/Modules/_bisectmodule.c
+++ b/Modules/_bisectmodule.c
@@ -25,6 +25,26 @@ get_bisect_state(PyObject *module)
     return (bisect_state *)state;
 }
 
+static ssizeargfunc
+get_sq_item(PyObject *s)
+{
+    PyTypeObject *tp = Py_TYPE(s);
+    // Inline the important parts of PySequence_GetItem.
+    PySequenceMethods *m = tp->tp_as_sequence;
+    if (m && m->sq_item) {
+        return m->sq_item;
+    }
+    const char *msg;
+    if (tp->tp_as_mapping && tp->tp_as_mapping->mp_subscript) {
+        msg = "%.200s is not a sequence";
+    }
+    else {
+        msg = "'%.200s' object does not support indexing";
+    }
+    PyErr_Format(PyExc_TypeError, msg, tp->tp_name);
+    return NULL;
+}
+
 static inline Py_ssize_t
 internal_bisect_right(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t hi,
                       PyObject* key)
@@ -42,32 +62,77 @@ internal_bisect_right(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t 
         if (hi < 0)
             return -1;
     }
+    ssizeargfunc sq_item = get_sq_item(list);
+    if (sq_item == NULL) {
+        return -1;
+    }
+    if (Py_EnterRecursiveCall("in _bisect.bisect_right") < 0) {
+        return -1;
+    }
+    PyTypeObject *tp = Py_TYPE(item);
+    richcmpfunc compare = tp->tp_richcompare;
     while (lo < hi) {
         /* The (size_t)cast ensures that the addition and subsequent division
            are performed as unsigned operations, avoiding difficulties from
            signed overflow.  (See issue 13496.) */
         mid = ((size_t)lo + hi) / 2;
-        litem = PySequence_GetItem(list, mid);
-        if (litem == NULL)
-            return -1;
+        assert(mid >= 0);
+        litem = sq_item(list, mid);
+        assert((PyErr_Occurred() == NULL) ^ (litem == NULL));
+        if (litem == NULL) {
+            goto error;
+        }
         if (key != Py_None) {
             PyObject *newitem = PyObject_CallOneArg(key, litem);
             if (newitem == NULL) {
-                Py_DECREF(litem);
-                return -1;
+                goto error;
             }
             Py_SETREF(litem, newitem);
         }
-        res = PyObject_RichCompareBool(item, litem, Py_LT);
+        if (compare != NULL && Py_IS_TYPE(litem, tp)) {
+            PyObject *res_obj = compare(item, litem, Py_LT);
+            if (res_obj == Py_True) {
+                Py_DECREF(res_obj);
+                Py_DECREF(litem);
+                hi = mid;
+                continue;
+            }
+            if (res_obj == Py_False) {
+                Py_DECREF(res_obj);
+                Py_DECREF(litem);
+                lo = mid + 1;
+                continue;
+            }
+            if (res_obj == NULL) {
+                goto error;
+            }
+            if (res_obj == Py_NotImplemented) {
+                Py_DECREF(res_obj);
+                compare = NULL;
+                res = PyObject_RichCompareBool(item, litem, Py_LT);
+            }
+            else {
+                res = PyObject_IsTrue(res_obj);
+            }
+        }
+        else {
+            res = PyObject_RichCompareBool(item, litem, Py_LT);
+        }
+        if (res < 0) {
+            goto error;
+        }
         Py_DECREF(litem);
-        if (res < 0)
-            return -1;
         if (res)
             hi = mid;
         else
             lo = mid + 1;
     }
+    Py_LeaveRecursiveCall();
     return lo;
+error:
+    Py_LeaveRecursiveCall();
+    Py_DECREF(litem);
+    return -1;
 }
 
 /*[clinic input]
@@ -168,32 +233,77 @@ internal_bisect_left(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t h
         if (hi < 0)
             return -1;
     }
+    ssizeargfunc sq_item = get_sq_item(list);
+    if (sq_item == NULL) {
+        return -1;
+    }
+    if (Py_EnterRecursiveCall("in _bisect.bisect_left") < 0) {
+        return -1;
+    }
+    PyTypeObject *tp = Py_TYPE(item);
+    richcmpfunc compare = tp->tp_richcompare;
     while (lo < hi) {
         /* The (size_t)cast ensures that the addition and subsequent division
            are performed as unsigned operations, avoiding difficulties from
            signed overflow.  (See issue 13496.) */
         mid = ((size_t)lo + hi) / 2;
-        litem = PySequence_GetItem(list, mid);
-        if (litem == NULL)
-            return -1;
+        assert(mid >= 0);
+        litem = sq_item(list, mid);
+        assert((PyErr_Occurred() == NULL) ^ (litem == NULL));
+        if (litem == NULL) {
+            goto error;
+        }
         if (key != Py_None) {
             PyObject *newitem = PyObject_CallOneArg(key, litem);
             if (newitem == NULL) {
-                Py_DECREF(litem);
-                return -1;
+                goto error;
             }
             Py_SETREF(litem, newitem);
         }
-        res = PyObject_RichCompareBool(litem, item, Py_LT);
+        if (compare != NULL && Py_IS_TYPE(litem, tp)) {
+            PyObject *res_obj = compare(litem, item, Py_LT);
+            if (res_obj == Py_True) {
+                Py_DECREF(res_obj);
+                Py_DECREF(litem);
+                lo = mid + 1;
+                continue;
+            }
+            if (res_obj == Py_False) {
+                Py_DECREF(res_obj);
+                Py_DECREF(litem);
+                hi = mid;
+                continue;
+            }
+            if (res_obj == NULL) {
+                goto error;
+            }
+            if (res_obj == Py_NotImplemented) {
+                Py_DECREF(res_obj);
+                compare = NULL;
+                res = PyObject_RichCompareBool(litem, item, Py_LT);
+            }
+            else {
+                res = PyObject_IsTrue(res_obj);
+            }
+        }
+        else {
+            res = PyObject_RichCompareBool(litem, item, Py_LT);
+        }
+        if (res < 0) {
+            goto error;
+        }
         Py_DECREF(litem);
-        if (res < 0)
-            return -1;
         if (res)
             lo = mid + 1;
         else
             hi = mid;
     }
+    Py_LeaveRecursiveCall();
     return lo;
+error:
+    Py_LeaveRecursiveCall();
+    Py_DECREF(litem);
+    return -1;
 }
 
 

--- a/Modules/_bisectmodule.c
+++ b/Modules/_bisectmodule.c
@@ -131,7 +131,7 @@ internal_bisect_right(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t 
     return lo;
 error:
     Py_LeaveRecursiveCall();
-    Py_DECREF(litem);
+    Py_XDECREF(litem);
     return -1;
 }
 
@@ -302,7 +302,7 @@ internal_bisect_left(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t h
     return lo;
 error:
     Py_LeaveRecursiveCall();
-    Py_DECREF(litem);
+    Py_XDECREF(litem);
     return -1;
 }
 


### PR DESCRIPTION
Here's a benchmark program:

```python
from pyperf import Runner, perf_counter
from itertools import repeat
from bisect import bisect
from decimal import Decimal

def bench(loops, size, tp):
    a = sorted(map(tp, range(size)))
    k = tp(size//3)

    t0 = perf_counter()
    for _ in repeat(None, loops):
        bisect(a, k); bisect(a, k); bisect(a, k); bisect(a, k); bisect(a, k);
    t1 = perf_counter()

    return t1 - t0


btf = Runner().bench_time_func
for size in (10, 100, 1_000, 10_000, 100_000, 1_000_000):
    for tp in (int, float, Decimal, str):
        btf(f"[{tp.__name__}]*{size:_}", bench, size, tp, inner_loops=5)
```

And the results:

```
- [Decimal]*10: 102 ns +- 1 ns -> 89.7 ns +- 1.1 ns: 1.14x faster
- [Decimal]*100: 169 ns +- 17 ns -> 139 ns +- 2 ns: 1.21x faster
- [Decimal]*1_000: 249 ns +- 2 ns -> 202 ns +- 4 ns: 1.23x faster
- [Decimal]*10_000: 312 ns +- 6 ns -> 255 ns +- 2 ns: 1.23x faster
- [Decimal]*100_000: 396 ns +- 5 ns -> 321 ns +- 5 ns: 1.23x faster
- [Decimal]*1_000_000: 459 ns +- 10 ns -> 369 ns +- 4 ns: 1.24x faster

- [float]*10: 62.4 ns +- 0.4 ns -> 50.4 ns +- 0.5 ns: 1.24x faster
- [float]*100: 93.4 ns +- 0.8 ns -> 71.1 ns +- 0.8 ns: 1.31x faster
- [float]*1_000: 149 ns +- 1 ns -> 104 ns +- 2 ns: 1.43x faster
- [float]*10_000: 174 ns +- 2 ns -> 121 ns +- 3 ns: 1.44x faster
- [float]*100_000: 223 ns +- 3 ns -> 162 ns +- 15 ns: 1.37x faster
- [float]*1_000_000: 249 ns +- 5 ns -> 180 ns +- 10 ns: 1.38x faster

- [int]*10: 62.8 ns +- 1.5 ns -> 49.0 ns +- 0.6 ns: 1.28x faster
- [int]*100: 96.0 ns +- 5.7 ns -> 69.8 ns +- 3.6 ns: 1.37x faster
- [int]*1_000: 137 ns +- 1 ns -> 102 ns +- 4 ns: 1.35x faster
- [int]*10_000: 183 ns +- 1 ns -> 122 ns +- 7 ns: 1.51x faster
- [int]*100_000: 218 ns +- 2 ns -> 157 ns +- 3 ns: 1.39x faster
- [int]*1_000_000: 251 ns +- 6 ns -> 179 ns +- 2 ns: 1.41x faster

- [str]*10: 76.0 ns +- 1.0 ns -> 64.7 ns +- 4.4 ns: 1.18x faster
- [str]*100: 119 ns +- 1 ns -> 97.2 ns +- 1.9 ns: 1.22x faster
- [str]*1_000: 173 ns +- 5 ns -> 143 ns +- 4 ns: 1.20x faster
- [str]*10_000: 238 ns +- 10 ns -> 187 ns +- 2 ns: 1.27x faster
- [str]*100_000: 322 ns +- 6 ns -> 222 ns +- 6 ns: 1.45x faster
- [str]*1_000_000: 365 ns +- 7 ns -> 252 ns +- 2 ns: 1.45x faster

Geometric mean: 1.31x faster
```


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96538 -->
* Issue: gh-96538
<!-- /gh-issue-number -->
