### PR TITLE
Fix typo in 3.11.0a7.rst

### DIFF
--- a/Misc/NEWS.d/3.11.0a7.rst
+++ b/Misc/NEWS.d/3.11.0a7.rst
@@ -1099,7 +1099,7 @@ wrong.
 .. section: Library
 
 Fix handling of the ``stacklevel`` argument to logging functions in the
-:mod:`logging` module so that it is consistent accross all logging functions
+:mod:`logging` module so that it is consistent across all logging functions
 and, as advertised, similar to the ``stacklevel`` argument used in
 :meth:`~warnings.warn`.
 


### PR DESCRIPTION
accross -> across

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
