### PR TITLE
gh-96548: argparse: Remove unused name variable when handling ArgumentTypeError

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2523,7 +2523,6 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
         # ArgumentTypeErrors indicate errors
         except ArgumentTypeError as err:
-            name = getattr(action.type, '__name__', repr(action.type))
             msg = str(err)
             raise ArgumentError(action, msg)
 


### PR DESCRIPTION
This removes the unused `name` variable in the block where `ArgumentTypeError` is handled.

`ArgumentTypeError` errors are handled by showing just the string of the exception; unlike `ValueError`, the name (`__name__`) of the function is not included in the error message.

Fixes #96548 

<!-- gh-issue-number: gh-96548 -->
* Issue: gh-96548
<!-- /gh-issue-number -->
