### PR TITLE
gh-95778: remove unneeded doc note on float.as_integer_ratio

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -622,13 +622,6 @@ class`. float also has the following additional methods.
    :exc:`OverflowError` on infinities and a :exc:`ValueError` on
    NaNs.
 
-   .. note::
-
-      The values returned by ``as_integer_ratio()`` can be huge. Attempts
-      to render such integers into decimal strings may bump into the
-      :ref:`integer string conversion length limitation
-      <int_max_str_digits>`.
-
 .. method:: float.is_integer()
 
    Return ``True`` if the float instance is finite with integral


### PR DESCRIPTION
Per mdickinson's comment on the main branch PR https://github.com/python/cpython/pull/96499.

<!-- gh-issue-number: gh-95778 -->
* Issue: gh-95778
<!-- /gh-issue-number -->
