### PR TITLE
GH-96582: fix possible NULL pointer dereference in _PyThread_CurrentFrames 

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-05-15-07-25.gh-issue-96582.HEsL5s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-05-15-07-25.gh-issue-96582.HEsL5s.rst
@@ -1,0 +1,1 @@
+Fix possible ``NULL`` pointer dereference in ``_PyThread_CurrentFrames``. Patch by Kumar Aditya.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1413,7 +1413,12 @@ _PyThread_CurrentFrames(void)
             if (id == NULL) {
                 goto fail;
             }
-            int stat = PyDict_SetItem(result, id, (PyObject *)_PyFrame_GetFrameObject(frame));
+            PyObject *frameobj = (PyObject *)_PyFrame_GetFrameObject(frame);
+            if (frameobj == NULL) {
+                Py_DECREF(id);
+                goto fail;
+            }
+            int stat = PyDict_SetItem(result, id, frameobj);
             Py_DECREF(id);
             if (stat < 0) {
                 goto fail;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96582 -->
* Issue: gh-96582
<!-- /gh-issue-number -->
