### PR TITLE
gh-96587: Raise `SyntaxError` for PEP654 on older `feature_version`

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -412,7 +412,9 @@ try_stmt[stmt_ty]:
     | invalid_try_stmt
     | 'try' &&':' b=block f=finally_block { _PyAST_Try(b, NULL, NULL, f, EXTRA) }
     | 'try' &&':' b=block ex[asdl_excepthandler_seq*]=except_block+ el=[else_block] f=[finally_block] { _PyAST_Try(b, ex, el, f, EXTRA) }
-    | 'try' &&':' b=block ex[asdl_excepthandler_seq*]=except_star_block+ el=[else_block] f=[finally_block] { _PyAST_TryStar(b, ex, el, f, EXTRA) }
+    | 'try' &&':' b=block ex[asdl_excepthandler_seq*]=except_star_block+ el=[else_block] f=[finally_block] { 
+        CHECK_VERSION(stmt_ty, 11, "Exception groups are", 
+                      _PyAST_TryStar(b, ex, el, f, EXTRA)) }
 
 
 # Except statement

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -771,6 +771,15 @@ class AST_Tests(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             ast.parse('(x := 0)', feature_version=(3, 7))
 
+    def test_exception_groups_feature_version(self):
+        code = dedent('''
+        try: ...
+        except* Exception: ...
+        ''')
+        ast.parse(code)
+        with self.assertRaises(SyntaxError):
+            ast.parse(code, feature_version=(3, 10))
+
     def test_invalid_major_feature_version(self):
         with self.assertRaises(ValueError):
             ast.parse('pass', feature_version=(2, 7))

--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-05-19-20-44.gh-issue-96587.bVxhX2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-05-19-20-44.gh-issue-96587.bVxhX2.rst
@@ -1,0 +1,2 @@
+Correctly raise ``SyntaxError`` on exception groups (:pep:`654`) on python
+versions prior to 3.11

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -6970,7 +6970,7 @@ try_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_TryStar ( b , ex , el , f , EXTRA );
+            _res = CHECK_VERSION ( stmt_ty , 11 , "Exception groups are" , _PyAST_TryStar ( b , ex , el , f , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;


### PR DESCRIPTION


<!-- gh-issue-number: gh-96587 -->
* Issue: gh-96587
<!-- /gh-issue-number -->
