### PR TITLE
Add upstream openssl 1.1.1q patch for trivial build error on macOS

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -249,6 +249,7 @@ def library_recipes():
               name="OpenSSL 1.1.1q",
               url="https://www.openssl.org/source/openssl-1.1.1q.tar.gz",
               checksum='d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca',
+              patches=['openssl1.1.1q-pr-18719.patch'],
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Mac/BuildScript/openssl1.1.1q-pr-18719.patch
+++ b/Mac/BuildScript/openssl1.1.1q-pr-18719.patch
@@ -1,0 +1,17 @@
+https://github.com/openssl/openssl/commit/60f011f584d80447e86cae1d1bd3ae24bc13235b
+This fixes a regression in 1.1.1q:
+
+test/v3ext.c:201:24: error: implicitly declaring library function 'memcmp' with type 'int (const void *, const void *, unsigned long)' [-Werror,-Wimplicit-function-declaration]
+        if (!TEST_true(memcmp(ip1->data, ip2->data, ip1->length) <= 0))
+
+diff -Naur openssl-1.1.1q/test/v3ext.c openssl-1.1.1q-patched/test/v3ext.c
+--- openssl-1.1.1q/test/v3ext.c	2022-07-05 09:08:33.000000000 +0000
++++ openssl-1.1.1q-patched/test/v3ext.c	2022-09-05 16:54:45.740859256 +0000
+@@ -8,6 +8,7 @@
+  */
+ 
+ #include <stdio.h>
++#include <string.h>
+ #include <openssl/x509.h>
+ #include <openssl/x509v3.h>
+ #include <openssl/pem.h>


### PR DESCRIPTION
Fix OpenSSL 1.1.1q build error in macOS installer by including [a post-1.1.1q fix from upstream](https://github.com/openssl/openssl/commit/60f011f584d80447e86cae1d1bd3ae24bc13235):

```
This fixes a regression in 1.1.1q:

test/v3ext.c:201:24: error: implicitly declaring library function 'memcmp' with type 'int (const void *, const void *, unsigned long)' [-Werror,-Wimplicit-function-declaration]
        if (!TEST_true(memcmp(ip1->data, ip2->data, ip1->length) <= 0))


```