### PR TITLE
[3.7] Move doc build dependencies to Doc/requirements.txt

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -127,7 +127,8 @@ clean:
 
 venv:
 	$(PYTHON) -m venv $(VENVDIR)
-	$(VENVDIR)/bin/python3 -m pip install -U Sphinx==2.3.1 blurb docutils==0.17.1 Jinja2==3.0.3
+	$(VENVDIR)/bin/python3 -m pip install -U pip setuptools
+	$(VENVDIR)/bin/python3 -m pip install -r requirements.txt
 	@echo "The venv has been created in the $(VENVDIR) directory"
 
 dist:

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -1,0 +1,18 @@
+# Requirements to build the Python documentation
+
+# Sphinx version is pinned so that new versions that introduce new warnings
+# won't suddenly cause build failures. Updating the version is fine as long
+# as no warnings are raised by doing so.
+sphinx==2.3.1
+# Docutils version is pinned to a version compatible with Sphinx
+# version 2.3.1. It can be removed after bumping Sphinx version to at
+# least 3.5.4.
+docutils==0.17.1
+# Jinja version is pinned to a version compatible with Sphinx version 2.3.1.
+jinja2==3.0.3
+
+blurb
+
+# The theme used by the documentation is stored separately, so we need
+# to install that as well.
+python-docs-theme


### PR DESCRIPTION
This makes 3.7 doc builds similar to later releases,
simplifying build tooling.
