### PR TITLE
gh-94808: Cover `PyObject_PyBytes` case with custom `__bytes__` method

### DIFF
--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1530,9 +1530,9 @@ class LongTest(unittest.TestCase):
                 1 / 0
 
         self.assertEqual(int.from_bytes(ValidBytes()), 1)
-        self.assertRaises(TypeError, int.from_bytes, InvalidBytes)
-        self.assertRaises(TypeError, int.from_bytes, MissingBytes)
-        self.assertRaises(TypeError, int.from_bytes, RaisingBytes)
+        self.assertRaises(TypeError, int.from_bytes, InvalidBytes())
+        self.assertRaises(TypeError, int.from_bytes, MissingBytes())
+        self.assertRaises(ZeroDivisionError, int.from_bytes, RaisingBytes())
 
     @support.cpython_only
     def test_from_bytes_small(self):

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1518,6 +1518,22 @@ class LongTest(unittest.TestCase):
         self.assertEqual(i, 1)
         self.assertEqual(getattr(i, 'foo', 'none'), 'bar')
 
+        class ValidBytes:
+            def __bytes__(self):
+                return b'\x01'
+        class InvalidBytes:
+            def __bytes__(self):
+                return 'abc'
+        class MissingBytes: ...
+        class RaisingBytes:
+            def __bytes__(self):
+                1 / 0
+
+        self.assertEqual(int.from_bytes(ValidBytes()), 1)
+        self.assertRaises(TypeError, int.from_bytes, InvalidBytes)
+        self.assertRaises(TypeError, int.from_bytes, MissingBytes)
+        self.assertRaises(TypeError, int.from_bytes, RaisingBytes)
+
     @support.cpython_only
     def test_from_bytes_small(self):
         # bpo-46361


### PR DESCRIPTION
There were two options:
1. Add a new `_testcapimodule.c` function to test `PyObject_PyBytes` directly. But, there's already `pyobject_bytes_from_null` which only covers `NULL` case. So, it is somewhat covered
2. Add a test for some call that uses `PyObject_Bytes`, like `int_from_bytes_impl`. In this case we not only test C-API itself, but also do something useful for the end implementation (in this case `int.from_bytes`)

So, I went with `2.`
Probably it is still possible to add a new `_testcapimodule.c` function in the next PR.

<!-- gh-issue-number: gh-94808 -->
* Issue: gh-94808
<!-- /gh-issue-number -->
