### PR TITLE
GH-96572: fix use after free in trace refs build mode

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-06-16-54-49.gh-issue-96572.8DRsaW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-06-16-54-49.gh-issue-96572.8DRsaW.rst
@@ -1,0 +1,1 @@
+Fix use after free in trace refs build mode. Patch by Kumar Aditya.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -46,7 +46,7 @@
 #  error "ceval.c must be build with Py_BUILD_CORE define for best performance"
 #endif
 
-#ifndef Py_DEBUG
+#if !defined(Py_DEBUG) && !defined(Py_TRACE_REFS)
 // GH-89279: The MSVC compiler does not inline these static inline functions
 // in PGO build in _PyEval_EvalFrameDefault(), because this function is over
 // the limit of PGO, and that limit cannot be configured.


### PR DESCRIPTION
`--with-trace-refs` requires objects to be explicitly removed from the global list before deallocation but ceval overrides the `Py_DECREF`  for speed and thus skipped this, hence we avoid this optimization in `--with-trace-refs` build mode.

This optimization was introduced in https://github.com/python/cpython/commit/2f233fceae9a0c5e66e439bc0169b36547ba47c3 by @gvanrossum.

Automerge-Triggered-By: GH:gvanrossum