### PR TITLE
GH-90230: Fix warnings and failures with `--enable-pystats`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-06-11-19-03.gh-issue-90230.YOtzs5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-06-11-19-03.gh-issue-90230.YOtzs5.rst
@@ -1,0 +1,2 @@
+Fix compiler warnings and test failures when building with
+``--enable-pystats``.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -121,6 +121,7 @@ _Py_GetSpecializationStats(void) {
     err += add_stat_dict(stats, BINARY_OP, "binary_op");
     err += add_stat_dict(stats, COMPARE_OP, "compare_op");
     err += add_stat_dict(stats, UNPACK_SEQUENCE, "unpack_sequence");
+    err += add_stat_dict(stats, FOR_ITER, "for_iter");
     if (err < 0) {
         Py_DECREF(stats);
         return NULL;
@@ -975,6 +976,7 @@ load_attr_fail_kind(DescriptorClassification kind)
         case MUTABLE:
             return SPEC_FAIL_ATTR_MUTABLE_CLASS;
         case GETSET_OVERRIDDEN:
+        case GETATTRIBUTE_IS_PYTHON_FUNCTION:
             return SPEC_FAIL_OVERRIDDEN;
         case BUILTIN_CLASSMETHOD:
             return SPEC_FAIL_ATTR_BUILTIN_CLASS_METHOD;


### PR DESCRIPTION
This fixes one compiler warning and one test failure that appear when compiling with `--enable-pystats`.