### PR TITLE
gh-96611: Fix error message for invalid UTF-8 in mid-multiline string

### DIFF
--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -147,6 +147,16 @@ class MiscSourceEncodingTest(unittest.TestCase):
         self.assertTrue(c.exception.args[0].startswith(expected),
                         msg=c.exception.args[0])
 
+    def test_file_parse_error_multiline(self):
+        # gh96611:
+        with open(TESTFN, "wb") as fd:
+            fd.write(b'print("""\n\xb1""")\n')
+
+        retcode, stdout, stderr = script_helper.assert_python_failure(TESTFN)
+
+        self.assertGreater(retcode, 0)
+        self.assertIn(b"Non-UTF-8 code starting with '\\xb1'", stderr)
+
 
 class AbstractSourceEncodingTest:
 

--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -152,11 +152,13 @@ class MiscSourceEncodingTest(unittest.TestCase):
         with open(TESTFN, "wb") as fd:
             fd.write(b'print("""\n\xb1""")\n')
 
-        retcode, stdout, stderr = script_helper.assert_python_failure(TESTFN)
+        try:
+            retcode, stdout, stderr = script_helper.assert_python_failure(TESTFN)
 
-        self.assertGreater(retcode, 0)
-        self.assertIn(b"Non-UTF-8 code starting with '\\xb1'", stderr)
-
+            self.assertGreater(retcode, 0)
+            self.assertIn(b"Non-UTF-8 code starting with '\\xb1'", stderr)
+        finally:
+            os.unlink(TESTFN)
 
 class AbstractSourceEncodingTest:
 

--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-06-16-22-13.gh-issue-96611.14wIX8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-06-16-22-13.gh-issue-96611.14wIX8.rst
@@ -1,0 +1,2 @@
+When loading a file with invalid UTF-8 inside a multi-line string, a correct
+SyntaxError is emitted.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1936,6 +1936,8 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
         /* Get rest of string */
         while (end_quote_size != quote_size) {
             c = tok_nextc(tok);
+            if (tok->done == E_DECODE)
+                break;
             if (c == EOF || (quote_size == 1 && c == '\n')) {
                 assert(tok->multi_line_start != NULL);
                 // shift the tok_state's location into


### PR DESCRIPTION
This now emits:

```
SyntaxError: Non-UTF-8 code starting with '\xb1' in file /home/mdboom/tmp/x.py on line 3, but no encoding declared; see https://peps.python.org/pep-0263/ for details
```

rather than 

```
SystemError: Negative size passed to PyUnicode_New
```

<!-- gh-issue-number: gh-96611 -->
* Issue: gh-96611
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:pablogsal