### PR TITLE
gh-94808: Add test coverage for PyObject_HasAttrString

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -445,6 +445,19 @@ class ClassTests(unittest.TestCase):
         del testme.cardinal
         self.assertCallStack([('__delattr__', (testme, "cardinal"))])
 
+    def testHasAttrString(self):
+
+        from test.support import import_helper
+        _testcapi = import_helper.import_module('_testcapi')
+
+        class A:
+            def __init__(self):
+                self.attr = 1
+
+        a = A()
+        self.assertEqual(_testcapi.hasattr_string(a, "attr"), True)
+        self.assertEqual(_testcapi.hasattr_string(a, "noattr"), False)
+
     def testDel(self):
         x = []
 

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -446,7 +446,7 @@ class ClassTests(unittest.TestCase):
         self.assertCallStack([('__delattr__', (testme, "cardinal"))])
 
     def testHasAttrString(self):
-
+        import sys
         from test.support import import_helper
         _testcapi = import_helper.import_module('_testcapi')
 
@@ -457,6 +457,7 @@ class ClassTests(unittest.TestCase):
         a = A()
         self.assertEqual(_testcapi.hasattr_string(a, "attr"), True)
         self.assertEqual(_testcapi.hasattr_string(a, "noattr"), False)
+        self.assertEqual(sys.exc_info(), (None, None, None))
 
     def testDel(self):
         x = []

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4852,20 +4852,22 @@ hasattr_string(PyObject *self, PyObject* args)
     PyObject* obj;
     PyObject* attr_name;
 
-    if(!PyArg_UnpackTuple(args, "hasattr_string", 2, 2, &obj, &attr_name))
+    if (!PyArg_UnpackTuple(args, "hasattr_string", 2, 2, &obj, &attr_name)) {
         return NULL;
+    }
 
-    if(!PyUnicode_Check(attr_name))
-    {
+    if (!PyUnicode_Check(attr_name)) {
         PyErr_SetString(PyExc_TypeError, "attribute name must a be string");
         return PyErr_Occurred();
     }
 
     const char *name_str = PyUnicode_AsUTF8(attr_name);
-    if(PyObject_HasAttrString(obj, name_str))
+    if (PyObject_HasAttrString(obj, name_str)) {
         Py_RETURN_TRUE;
-    else
+    }
+    else {
         Py_RETURN_FALSE;
+    }
 }
 
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4846,6 +4846,29 @@ sequence_setitem(PyObject *self, PyObject *args)
 }
 
 
+static PyObject *
+hasattr_string(PyObject *self, PyObject* args)
+{
+    PyObject* obj;
+    PyObject* attr_name;
+
+    if(!PyArg_UnpackTuple(args, "hasattr_string", 2, 2, &obj, &attr_name))
+        return NULL;
+
+    if(!PyUnicode_Check(attr_name))
+    {
+        PyErr_SetString(PyExc_TypeError, "attribute name must a be string");
+        return PyErr_Occurred();
+    }
+
+    const char *name_str = PyUnicode_AsUTF8(attr_name);
+    if(PyObject_HasAttrString(obj, name_str))
+        Py_RETURN_TRUE;
+    else
+        Py_RETURN_FALSE;
+}
+
+
 /* Functions for testing C calling conventions (METH_*) are named meth_*,
  * e.g. "meth_varargs" for METH_VARARGS.
  *
@@ -5705,6 +5728,7 @@ static PyMethodDef TestMethods[] = {
     {"write_unraisable_exc", test_write_unraisable_exc, METH_VARARGS},
     {"sequence_getitem", sequence_getitem, METH_VARARGS},
     {"sequence_setitem", sequence_setitem, METH_VARARGS},
+    {"hasattr_string", hasattr_string, METH_VARARGS},
     {"meth_varargs", meth_varargs, METH_VARARGS},
     {"meth_varargs_keywords", _PyCFunction_CAST(meth_varargs_keywords), METH_VARARGS|METH_KEYWORDS},
     {"meth_o", meth_o, METH_O},


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Add test to cover the function `HasAttrString` of the C API.

<!-- gh-issue-number: gh-94808 -->
* Issue: gh-94808
<!-- /gh-issue-number -->
