### PR TITLE
gh-96628: remove deprecated and ignored arg of sysconfig.is_python_build()

### DIFF
--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -323,7 +323,7 @@ class install(Command):
             self.config_vars['userbase'] = self.install_userbase
             self.config_vars['usersite'] = self.install_usersite
 
-        if sysconfig.is_python_build(True):
+        if sysconfig.is_python_build():
             self.config_vars['srcdir'] = sysconfig.get_config_var('srcdir')
 
         self.expand_basedirs()


### PR DESCRIPTION
Fixes #96628.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96628 -->
* Issue: gh-96628
<!-- /gh-issue-number -->
