### PR TITLE
gh-96577: Fixes buffer overrun in _msi module

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-09-07-00-11-33.gh-issue-96577.kV4K_1.rst
+++ b/Misc/NEWS.d/next/Windows/2022-09-07-00-11-33.gh-issue-96577.kV4K_1.rst
@@ -1,0 +1,1 @@
+Fixes a potential buffer overrun in :mod:`msilib`.

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -360,7 +360,7 @@ msierror(int status)
     int code;
     char buf[2000];
     char *res = buf;
-    DWORD size = sizeof(buf);
+    DWORD size = Py_ARRAY_LENGTH(buf);
     MSIHANDLE err = MsiGetLastErrorRecord();
 
     if (err == 0) {
@@ -484,7 +484,7 @@ _msi_Record_GetString_impl(msiobj *self, unsigned int field)
     unsigned int status;
     WCHAR buf[2000];
     WCHAR *res = buf;
-    DWORD size = sizeof(buf);
+    DWORD size = Py_ARRAY_LENGTH(buf);
     PyObject* string;
 
     status = MsiRecordGetStringW(self->h, field, res, &size);


### PR DESCRIPTION


<!-- gh-issue-number: gh-96577 -->
* Issue: gh-96577
<!-- /gh-issue-number -->
