### PR TITLE
gh-64373: Convert `_functools` to Argument Clinic

### DIFF
--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -468,6 +468,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(modules)
         STRUCT_FOR_ID(mro)
         STRUCT_FOR_ID(msg)
+        STRUCT_FOR_ID(mycmp)
         STRUCT_FOR_ID(n)
         STRUCT_FOR_ID(n_arg)
         STRUCT_FOR_ID(n_fields)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -977,6 +977,7 @@ extern "C" {
                 INIT_ID(modules), \
                 INIT_ID(mro), \
                 INIT_ID(msg), \
+                INIT_ID(mycmp), \
                 INIT_ID(n), \
                 INIT_ID(n_arg), \
                 INIT_ID(n_fields), \
@@ -2259,6 +2260,8 @@ _PyUnicode_InitStaticStrings(void) {
     string = &_Py_ID(mro);
     PyUnicode_InternInPlace(&string);
     string = &_Py_ID(msg);
+    PyUnicode_InternInPlace(&string);
+    string = &_Py_ID(mycmp);
     PyUnicode_InternInPlace(&string);
     string = &_Py_ID(n);
     PyUnicode_InternInPlace(&string);
@@ -6445,6 +6448,10 @@ _PyStaticObjects_CheckRefcnt(void) {
     };
     if (Py_REFCNT((PyObject *)&_Py_ID(msg)) < _PyObject_IMMORTAL_REFCNT) {
         _PyObject_Dump((PyObject *)&_Py_ID(msg));
+        Py_FatalError("immortal object has less refcnt than expected _PyObject_IMMORTAL_REFCNT");
+    };
+    if (Py_REFCNT((PyObject *)&_Py_ID(mycmp)) < _PyObject_IMMORTAL_REFCNT) {
+        _PyObject_Dump((PyObject *)&_Py_ID(mycmp));
         Py_FatalError("immortal object has less refcnt than expected _PyObject_IMMORTAL_REFCNT");
     };
     if (Py_REFCNT((PyObject *)&_Py_ID(n)) < _PyObject_IMMORTAL_REFCNT) {

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -17,6 +17,7 @@ import weakref
 import gc
 from weakref import proxy
 import contextlib
+from inspect import Signature
 
 from test.support import import_helper
 from test.support import threading_helper
@@ -941,6 +942,10 @@ class TestCmpToKey:
         self.assertRaises(TypeError, hash, k)
         self.assertNotIsInstance(k, collections.abc.Hashable)
 
+    def test_cmp_to_signature(self):
+        self.assertEqual(str(Signature.from_callable(self.cmp_to_key)),
+                         '(mycmp)')
+
 
 @unittest.skipUnless(c_functools, 'requires the C _functools module')
 class TestCmpToKeyC(TestCmpToKey, unittest.TestCase):
@@ -1852,6 +1857,13 @@ class TestLRU:
 
         for ref in refs:
             self.assertIsNone(ref())
+
+    def test_common_signatures(self):
+        def orig(): ...
+        lru = self.module.lru_cache(1)(orig)
+
+        self.assertEqual(str(Signature.from_callable(lru.cache_info)), '()')
+        self.assertEqual(str(Signature.from_callable(lru.cache_clear)), '()')
 
 
 @py_functools.lru_cache()

--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-08-20-58-10.gh-issue-64373.AfCi36.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-08-20-58-10.gh-issue-64373.AfCi36.rst
@@ -1,0 +1,1 @@
+Convert :mod:`_functools` to argument clinic.

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -649,7 +649,6 @@ _functools_cmp_to_key_impl(PyObject *module, PyObject *mycmp)
 {
     keyobject *object;
     _functools_state *state;
-    state = get_functools_state(module);
 
     state = get_functools_state(module);
     object = PyObject_GC_New(keyobject, state->keyobject_type);
@@ -661,9 +660,6 @@ _functools_cmp_to_key_impl(PyObject *module, PyObject *mycmp)
     PyObject_GC_Track(object);
     return (PyObject *)object;
 }
-
-PyDoc_STRVAR(functools_cmp_to_key_doc,
-"Convert a cmp= function into a key= function.");
 
 /* reduce (used to be a builtin) ********************************************/
 

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -7,6 +7,13 @@
 #include "pycore_tuple.h"         // _PyTuple_ITEMS()
 #include "structmember.h"         // PyMemberDef
 
+#include "clinic/_functoolsmodule.c.h"
+/*[clinic input]
+module _functools
+class _functools._lru_cache_wrapper "PyObject *" "&lru_cache_type_spec"
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=bece4053896b09c0]*/
+
 /* _functools module written and maintained
    by Hye-Shik Chang <perky@FreeBSD.org>
    with adaptations by Raymond Hettinger <python@rcn.com>
@@ -58,6 +65,7 @@ get_functools_state_by_type(PyTypeObject *type)
     return get_functools_state(module);
 }
 
+// Not converted to argument clinic, because of `*args, **kwargs` arguments.
 static PyObject *
 partial_new(PyTypeObject *type, PyObject *args, PyObject *kw)
 {
@@ -282,6 +290,7 @@ partial_setvectorcall(partialobject *pto)
 }
 
 
+// Not converted to argument clinic, because of `*args, **kwargs` arguments.
 static PyObject *
 partial_call(partialobject *pto, PyObject *args, PyObject *kwargs)
 {
@@ -625,23 +634,29 @@ keyobject_richcompare(PyObject *ko, PyObject *other, int op)
     return answer;
 }
 
+/*[clinic input]
+_functools.cmp_to_key
+
+    mycmp: object
+        Function that compares two objects.
+
+Convert a cmp= function into a key= function.
+[clinic start generated code]*/
+
 static PyObject *
-functools_cmp_to_key(PyObject *self, PyObject *args, PyObject *kwds)
+_functools_cmp_to_key_impl(PyObject *module, PyObject *mycmp)
+/*[clinic end generated code: output=71eaad0f4fc81f33 input=d1b76f231c0dfeb3]*/
 {
-    PyObject *cmp;
-    static char *kwargs[] = {"mycmp", NULL};
     keyobject *object;
     _functools_state *state;
+    state = get_functools_state(module);
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:cmp_to_key", kwargs, &cmp))
-        return NULL;
-
-    state = get_functools_state(self);
+    state = get_functools_state(module);
     object = PyObject_GC_New(keyobject, state->keyobject_type);
     if (!object)
         return NULL;
-    Py_INCREF(cmp);
-    object->cmp = cmp;
+    Py_INCREF(mycmp);
+    object->cmp = mycmp;
     object->object = NULL;
     PyObject_GC_Track(object);
     return (PyObject *)object;
@@ -652,6 +667,8 @@ PyDoc_STRVAR(functools_cmp_to_key_doc,
 
 /* reduce (used to be a builtin) ********************************************/
 
+// Not converted to argument clinic, because of `args` in-place modification.
+// AC will affect performance.
 static PyObject *
 functools_reduce(PyObject *self, PyObject *args)
 {
@@ -1299,25 +1316,41 @@ lru_cache_descr_get(PyObject *self, PyObject *obj, PyObject *type)
     return PyMethod_New(self, obj);
 }
 
-static PyObject *
-lru_cache_cache_info(lru_cache_object *self, PyObject *unused)
-{
-    if (self->maxsize == -1) {
-        return PyObject_CallFunction(self->cache_info_type, "nnOn",
-                                     self->hits, self->misses, Py_None,
-                                     PyDict_GET_SIZE(self->cache));
-    }
-    return PyObject_CallFunction(self->cache_info_type, "nnnn",
-                                 self->hits, self->misses, self->maxsize,
-                                 PyDict_GET_SIZE(self->cache));
-}
+/*[clinic input]
+_functools._lru_cache_wrapper.cache_info
+
+Report cache statistics
+[clinic start generated code]*/
 
 static PyObject *
-lru_cache_cache_clear(lru_cache_object *self, PyObject *unused)
+_functools__lru_cache_wrapper_cache_info_impl(PyObject *self)
+/*[clinic end generated code: output=cc796a0b06dbd717 input=f05e5b6ebfe38645]*/
 {
-    lru_list_elem *list = lru_cache_unlink_list(self);
-    self->hits = self->misses = 0;
-    PyDict_Clear(self->cache);
+    lru_cache_object *_self = (lru_cache_object *) self;
+    if (_self->maxsize == -1) {
+        return PyObject_CallFunction(_self->cache_info_type, "nnOn",
+                                     _self->hits, _self->misses, Py_None,
+                                     PyDict_GET_SIZE(_self->cache));
+    }
+    return PyObject_CallFunction(_self->cache_info_type, "nnnn",
+                                 _self->hits, _self->misses, _self->maxsize,
+                                 PyDict_GET_SIZE(_self->cache));
+}
+
+/*[clinic input]
+_functools._lru_cache_wrapper.cache_clear
+
+Clear the cache and cache statistics
+[clinic start generated code]*/
+
+static PyObject *
+_functools__lru_cache_wrapper_cache_clear_impl(PyObject *self)
+/*[clinic end generated code: output=58423b35efc3e381 input=6ca59dba09b12584]*/
+{
+    lru_cache_object *_self = (lru_cache_object *) self;
+    lru_list_elem *list = lru_cache_unlink_list(_self);
+    _self->hits = _self->misses = 0;
+    PyDict_Clear(_self->cache);
     lru_cache_clear_list(list);
     Py_RETURN_NONE;
 }
@@ -1381,8 +1414,8 @@ cache_info_type:    namedtuple class with the fields:\n\
 );
 
 static PyMethodDef lru_cache_methods[] = {
-    {"cache_info", (PyCFunction)lru_cache_cache_info, METH_NOARGS},
-    {"cache_clear", (PyCFunction)lru_cache_cache_clear, METH_NOARGS},
+    _FUNCTOOLS__LRU_CACHE_WRAPPER_CACHE_INFO_METHODDEF
+    _FUNCTOOLS__LRU_CACHE_WRAPPER_CACHE_CLEAR_METHODDEF
     {"__reduce__", (PyCFunction)lru_cache_reduce, METH_NOARGS},
     {"__copy__", (PyCFunction)lru_cache_copy, METH_VARARGS},
     {"__deepcopy__", (PyCFunction)lru_cache_deepcopy, METH_VARARGS},
@@ -1432,8 +1465,7 @@ PyDoc_STRVAR(_functools_doc,
 
 static PyMethodDef _functools_methods[] = {
     {"reduce",          functools_reduce,     METH_VARARGS, functools_reduce_doc},
-    {"cmp_to_key",      _PyCFunction_CAST(functools_cmp_to_key),
-     METH_VARARGS | METH_KEYWORDS, functools_cmp_to_key_doc},
+    _FUNCTOOLS_CMP_TO_KEY_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 

--- a/Modules/clinic/_functoolsmodule.c.h
+++ b/Modules/clinic/_functoolsmodule.c.h
@@ -1,0 +1,104 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+#if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+#  include "pycore_gc.h"            // PyGC_Head
+#  include "pycore_runtime.h"       // _Py_ID()
+#endif
+
+
+PyDoc_STRVAR(_functools_cmp_to_key__doc__,
+"cmp_to_key($module, /, mycmp)\n"
+"--\n"
+"\n"
+"Convert a cmp= function into a key= function.\n"
+"\n"
+"  mycmp\n"
+"    Function that compares two objects.");
+
+#define _FUNCTOOLS_CMP_TO_KEY_METHODDEF    \
+    {"cmp_to_key", _PyCFunction_CAST(_functools_cmp_to_key), METH_FASTCALL|METH_KEYWORDS, _functools_cmp_to_key__doc__},
+
+static PyObject *
+_functools_cmp_to_key_impl(PyObject *module, PyObject *mycmp);
+
+static PyObject *
+_functools_cmp_to_key(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 1
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_item = { &_Py_ID(mycmp), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"mycmp", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "cmp_to_key",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[1];
+    PyObject *mycmp;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    mycmp = args[0];
+    return_value = _functools_cmp_to_key_impl(module, mycmp);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(_functools__lru_cache_wrapper_cache_info__doc__,
+"cache_info($self, /)\n"
+"--\n"
+"\n"
+"Report cache statistics");
+
+#define _FUNCTOOLS__LRU_CACHE_WRAPPER_CACHE_INFO_METHODDEF    \
+    {"cache_info", (PyCFunction)_functools__lru_cache_wrapper_cache_info, METH_NOARGS, _functools__lru_cache_wrapper_cache_info__doc__},
+
+static PyObject *
+_functools__lru_cache_wrapper_cache_info_impl(PyObject *self);
+
+static PyObject *
+_functools__lru_cache_wrapper_cache_info(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return _functools__lru_cache_wrapper_cache_info_impl(self);
+}
+
+PyDoc_STRVAR(_functools__lru_cache_wrapper_cache_clear__doc__,
+"cache_clear($self, /)\n"
+"--\n"
+"\n"
+"Clear the cache and cache statistics");
+
+#define _FUNCTOOLS__LRU_CACHE_WRAPPER_CACHE_CLEAR_METHODDEF    \
+    {"cache_clear", (PyCFunction)_functools__lru_cache_wrapper_cache_clear, METH_NOARGS, _functools__lru_cache_wrapper_cache_clear__doc__},
+
+static PyObject *
+_functools__lru_cache_wrapper_cache_clear_impl(PyObject *self);
+
+static PyObject *
+_functools__lru_cache_wrapper_cache_clear(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return _functools__lru_cache_wrapper_cache_clear_impl(self);
+}
+/*[clinic end generated code: output=7e7f3bcf9ed61f23 input=a9049054013a1b77]*/


### PR DESCRIPTION
A couple of extra notes:
- `functools.reduce` is not converted, because its `args` parsing / in-place mutation is optimized
- `partial_new` and `partial_call` require `*args, **kwargs`, as far as I know AC does not support that at the moment, they are not converted
- The same for `_lru_cache_wrapper.__call__`
- I've also noticed a couple of other oddities that I will report in two separate issue later

<!-- gh-issue-number: gh-64373 -->
* Issue: gh-64373
<!-- /gh-issue-number -->
