### PR TITLE
gh-96641: Do not expose `KeyWrapper` in `_functoolsmodule.c`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-07-13-38-37.gh-issue-96641.wky0Fc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-07-13-38-37.gh-issue-96641.wky0Fc.rst
@@ -1,0 +1,1 @@
+Do not expose ``KeyWrapper`` in :mod:`_functools`.

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1471,9 +1471,8 @@ _functools_exec(PyObject *module)
     if (state->keyobject_type == NULL) {
         return -1;
     }
-    if (PyModule_AddType(module, state->keyobject_type) < 0) {
-        return -1;
-    }
+    // keyobject_type is used only internally.
+    // So we don't expose it in module namespace.
 
     state->lru_list_elem_type = (PyTypeObject *)PyType_FromModuleAndSpec(
         module, &lru_list_elem_type_spec, NULL);


### PR DESCRIPTION
After:

```
Python 3.12.0a0 (heads/main-dirty:0d04b8d9e1, Sep  7 2022, 13:35:21) [Clang 11.0.0 (clang-1100.0.33.16)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from _functools import KeyWrapper
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'KeyWrapper' from '_functools' (unknown location)
>>> 
```

<!-- gh-issue-number: gh-96641 -->
* Issue: gh-96641
<!-- /gh-issue-number -->
