### PR TITLE
gh-96653: Remove duplicate CALL_STAT_INC(inlined_py_calls) in BINARY_SUBSCR_GETITEM

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1659,7 +1659,6 @@ handle_eval_breaker:
             STAT_INC(BINARY_SUBSCR, hit);
             Py_INCREF(getitem);
             _PyInterpreterFrame *new_frame = _PyFrame_PushUnchecked(tstate, getitem);
-            CALL_STAT_INC(inlined_py_calls);
             STACK_SHRINK(2);
             new_frame->localsplus[0] = container;
             new_frame->localsplus[1] = sub;


### PR DESCRIPTION
gh-96653: Remove duplicate CALL_STAT_INC(inlined_py_calls) in BINARY_SUBSCR_GETITEM