### PR TITLE
gh-96652: Check previous signal handler to be non-NULL

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-09-07-17-44-08.gh-issue-96652.q51VUj.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-07-17-44-08.gh-issue-96652.q51VUj.rst
@@ -1,0 +1,1 @@
+Check previous signal handler to be non-NULL :func:`faulthandler_user`.

--- a/Misc/NEWS.d/next/Library/2022-09-07-17-44-08.gh-issue-96652.q51VUj.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-07-17-44-08.gh-issue-96652.q51VUj.rst
@@ -1,1 +1,2 @@
-Check previous signal handler to be non-NULL :func:`faulthandler_user`.
+Check the previous signal handler to be non-NULL before its invocation in
+:func:`faulthandler_user`.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -865,7 +865,9 @@ faulthandler_user(int signum)
     if (user->chain) {
         errno = save_errno;
         /* call the previous signal handler */
-        user->previous(signum);
+        if (user->previous) {
+            user->previous(signum);
+        }
     }
 #endif
 }


### PR DESCRIPTION
For systems without `sigaction` (i.e. HAVE_SIGACTION is undefined) `faulthandler_user` has to check previous signal handler to be defined (non-NULL) before calling it. Otherwise the code is subject to segmentation faults.

<!-- gh-issue-number: gh-96652 -->
* Issue: gh-96652
<!-- /gh-issue-number -->
