### PR TITLE
gh-96661: Ensure default action for warnings is restored in the interpreter's state

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -729,6 +729,13 @@ class _WarningsTests(BaseTest, unittest.TestCase):
                 self.assertEqual(len(w), 0)
         finally:
             self.module.defaultaction = original
+            # Emit and catch one more warning to propagate just restored default
+            # action into the state structure of the interpreter
+            with original_warnings.catch_warnings(record=True,
+                    module=self.module) as w:
+                self.module.resetwarnings()
+                self.module.warn_explicit(message, UserWarning, "<test>", 45)
+                del w[:]
 
     def test_showwarning_missing(self):
         # Test that showwarning() missing is okay.

--- a/Misc/NEWS.d/next/Tests/2022-09-07-18-46-16.gh-issue-96661.HV1FBv.rst
+++ b/Misc/NEWS.d/next/Tests/2022-09-07-18-46-16.gh-issue-96661.HV1FBv.rst
@@ -1,1 +1,2 @@
-Ensure `test.test_warnings._WarningsTests.test_default_action` restores default action for warnings in the interpreter's state.
+Ensure :meth:`_WarningsTests.test_default_action` from :mod:`test_warnings`
+restores default action for warnings in the interpreter's state.

--- a/Misc/NEWS.d/next/Tests/2022-09-07-18-46-16.gh-issue-96661.HV1FBv.rst
+++ b/Misc/NEWS.d/next/Tests/2022-09-07-18-46-16.gh-issue-96661.HV1FBv.rst
@@ -1,0 +1,1 @@
+Ensure `test.test_warnings._WarningsTests.test_default_action` restores default action for warnings in the interpreter's state.


### PR DESCRIPTION
On the first run all the tests from `test_warnings` suite pass.
On every subsequent run several tests fail because warnings being emitted via `module.warn`/`module.warn_explicit` functions are ignored by default and not caught by the `catch_warnings` class object.

It turns out that failures are caused by `test_warnings._WarningsTests.test_default_action` that changes default action for warnings to `ignore` but fails to restore it back to `default`.
Even though the code of `test_warnings._WarningsTests.test_default_action` contains the following `finally` block which sets module's default action member to its original value, this value is never propagated to the interpreter's state structure.
```python
        finally:
            self.module.defaultaction = original
```

The quirk is in the broken reference chain.
At the very beginning of the test this chain looks perfectly correct: `original -> module.defaultaction -> module._defaultaction -> interp.warnings.default_action`.
However, test deletes `module.defaultaction` and assigns a different string literal (i.e. `ignore`) to it thus taking `module.defaultaction` away from the aforementioned chain:
```python
                # Test removal.
                del self.module.defaultaction
                ...
                # Test setting.
                self.module.defaultaction = "ignore"
```
Furthermore, as soon as a warning is fired after `module.defaultaction` value has been updated, `interp.warnings.default_action` is set to reference new `module.defaultaction`.
The bottom line result is two separate reference chains: `original -> module._defaultaction` and `module.defaultaction -> interp.warnings.default_action`.
The assignment `self.module.defaultaction = original` in the test's `finally` block (see above) can by no means change `interp.warnings.default_action` value despite partially restoring the original reference chain: `original -> module.defaultaction -> module._defaultaction`.

The `warnings` C module interface is pretty terse containing only two functions: `warn_explicit` and `_filters_mutated`.
The latter one has nothing to do with `interp.warnings.default_action` value whereas the former does exactly what we need: sets `interp.warnings.default_action` to reference `module.defaultaction`.

<!-- gh-issue-number: gh-96661 -->
* Issue: gh-96661
<!-- /gh-issue-number -->
