### PR TITLE
gh-96652: Fix faulthandler chained signal without sigaction()

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-09-07-22-49-37.gh-issue-96652.YqOKxI.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-07-22-49-37.gh-issue-96652.YqOKxI.rst
@@ -1,0 +1,3 @@
+Fix the faulthandler implementation of ``faulthandler.register(signal,
+chain=True)`` if the ``sigaction()`` function is not available: don't call
+the previous signal handler if it's NULL. Patch by Victor Stinner.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -862,7 +862,7 @@ faulthandler_user(int signum)
         errno = save_errno;
     }
 #else
-    if (user->chain) {
+    if (user->chain && user->previous != NULL) {
         errno = save_errno;
         /* call the previous signal handler */
         user->previous(signum);


### PR DESCRIPTION
Fix the faulthandler implementation of faulthandler.register(signal, chain=True) if the sigaction() function is not available: don't call the previous signal handler if it's NULL.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96652 -->
* Issue: gh-96652
<!-- /gh-issue-number -->
