### PR TITLE
gh-96665: Fixes build break on older MSVC versions due to C++20 features in argument clinic

### DIFF
--- a/PC/_wmimodule.cpp
+++ b/PC/_wmimodule.cpp
@@ -15,7 +15,17 @@
 #include <propvarutil.h>
 
 #include <Python.h>
+
+
+#if _MSC_VER >= 1929
+// We can use clinic directly when the C++ compiler supports C++20
 #include "clinic/_wmimodule.cpp.h"
+#else
+// Cannot use clinic because of missing C++20 support, so create a simpler
+// API instead. This won't impact releases, so fine to omit the docstring.
+static PyObject *_wmi_exec_query_impl(PyObject *module, PyObject *query);
+#define _WMI_EXEC_QUERY_METHODDEF {"exec_query", _wmi_exec_query_impl, METH_O, NULL},
+#endif
 
 
 /*[clinic input]


### PR DESCRIPTION


<!-- gh-issue-number: gh-96665 -->
* Issue: gh-96665
<!-- /gh-issue-number -->
