### PR TITLE
gh-95027: Ensure test runner uses utf-8:surrogateescape for communicating with subprocesses

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -681,6 +681,10 @@ class Regrtest:
 
         self.fix_umask()
 
+        # We may have been launched with a certain IO encoding, but we do not
+        # want children to inherit it, so clear it out now.
+        os.unsetenv('PYTHONIOENCODING')
+
         if self.ns.cleanup:
             self.cleanup()
             sys.exit(0)

--- a/Lib/test/libregrtest/runtest_mp.py
+++ b/Lib/test/libregrtest/runtest_mp.py
@@ -66,7 +66,9 @@ def run_test_in_subprocess(testname: str, ns: Namespace, tmp_dir: str, stdout_fh
            '-m', 'test.regrtest',
            '--worker-args', worker_args]
 
+
     env = dict(os.environ)
+    env['PYTHONIOENCODING'] = 'utf-8:surrogateescape'
     if tmp_dir is not None:
         env['TMPDIR'] = tmp_dir
         env['TEMP'] = tmp_dir
@@ -270,7 +272,7 @@ class TestWorkerProcess(threading.Thread):
         # gh-94026: Write stdout+stderr to a tempfile as workaround for
         # non-blocking pipes on Emscripten with NodeJS.
         with tempfile.TemporaryFile(
-            'w+', encoding=sys.stdout.encoding
+            'w+', encoding=sys.stdout.encoding, errors="surrogateescape",
         ) as stdout_fh:
             # gh-93353: Check for leaked temporary files in the parent process,
             # since the deletion of temporary files can happen late during

--- a/Misc/NEWS.d/next/Tests/2022-09-07-23-44-06.gh-issue-95027.H5xs9o.rst
+++ b/Misc/NEWS.d/next/Tests/2022-09-07-23-44-06.gh-issue-95027.H5xs9o.rst
@@ -1,0 +1,2 @@
+Ensures test runner uses UTF-8 and surrogateescape encoding when
+communicating between multiple processes.


### PR DESCRIPTION


<!-- gh-issue-number: gh-95027 -->
* Issue: gh-95027
<!-- /gh-issue-number -->
