### PR TITLE
gh-96684: Silently suppress COM security initialization errors in _wmi module

### DIFF
--- a/PC/_wmimodule.cpp
+++ b/PC/_wmimodule.cpp
@@ -63,6 +63,12 @@ _query_thread(LPVOID param)
         RPC_C_IMP_LEVEL_IMPERSONATE,
         NULL, EOAC_NONE, NULL
     );
+    // gh-96684: CoInitializeSecurity will fail if another part of the app has
+    // already called it. Hopefully they passed lenient enough settings that we
+    // can complete the WMI query, so keep going.
+    if (hr == RPC_E_TOO_LATE) {
+        hr = 0;
+    }
     if (SUCCEEDED(hr)) {
         hr = CoCreateInstance(
             CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER,


### PR DESCRIPTION
Such errors indicate that it has already been initialized. We believe that it will typically go on to succeed.
Also updates tests to try and catch threading issues, and to skip the slowest test by default unless the cpu resource is enabled.

<!-- gh-issue-number: gh-96684 -->
* Issue: gh-96684
<!-- /gh-issue-number -->
