### PR TITLE
gh-96624: Fix test_dotted_but_module_not_loaded in testpatch.py

### DIFF
--- a/Lib/test/test_unittest/testmock/testpatch.py
+++ b/Lib/test/test_unittest/testmock/testpatch.py
@@ -1923,7 +1923,7 @@ class PatchTest(unittest.TestCase):
             del sys.modules['test.test_unittest.testmock.support']
             del sys.modules['test.test_unittest.testmock']
             del sys.modules['test.test_unittest']
-            del sys.modules['unittest']
+            del sys.modules['test']
 
             # now make sure we can patch based on a dotted path:
             @patch('test.test_unittest.testmock.support.X')

--- a/Misc/NEWS.d/next/Tests/2022-09-08-18-31-26.gh-issue-96624.5cANM1.rst
+++ b/Misc/NEWS.d/next/Tests/2022-09-08-18-31-26.gh-issue-96624.5cANM1.rst
@@ -1,0 +1,1 @@
+Fixed the failure of repeated runs of ``test.test_unittest`` caused by side effects in ``test_dotted_but_module_not_loaded``.


### PR DESCRIPTION
This seems to reflect better the original meaning of the code before c735d545343c3ab002c62596b2fb2cfa4488b0af, and it should fix the consistent warning on most refleak buildbots.

<!-- gh-issue-number: gh-96624 -->
* Issue: gh-96624
<!-- /gh-issue-number -->
