### PR TITLE
gh-91708: Revert params note in urllib.parse.urlparse table

### DIFF
--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -113,7 +113,8 @@ or on combining URL components into a URL string.
    +------------------+-------+-------------------------+------------------------+
    | :attr:`path`     | 2     | Hierarchical path       | empty string           |
    +------------------+-------+-------------------------+------------------------+
-   | :attr:`params`   | 3     | No longer used          | always an empty string |
+   | :attr:`params`   | 3     | Parameters for last     | empty string           |
+   |                  |       | path element            |                        |
    +------------------+-------+-------------------------+------------------------+
    | :attr:`query`    | 4     | Query component         | empty string           |
    +------------------+-------+-------------------------+------------------------+


### PR DESCRIPTION
https://docs.python.org/dev/library/urllib.parse.html#urllib.parse.urlparse

<!-- gh-issue-number: gh-91708 -->
* Issue: gh-91708
<!-- /gh-issue-number -->
