### PR TITLE
GH-96678: Fix undefined behavior in ceval.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-09-13-13-27.gh-issue-96678.vMxi9F.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-09-13-13-27.gh-issue-96678.vMxi9F.rst
@@ -1,0 +1,1 @@
+Fix case of undefined behavior in ceval.c

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5535,7 +5535,13 @@ initialize_locals(PyThreadState *tstate, PyFunctionObject *func,
     /* Pack other positional arguments into the *args argument */
     if (co->co_flags & CO_VARARGS) {
         PyObject *u = NULL;
-        u = _PyTuple_FromArraySteal(args + n, argcount - n);
+        if (argcount == n) {
+            u = Py_NewRef(&_Py_SINGLETON(tuple_empty));
+        }
+        else {
+            assert(args != NULL);
+            u = _PyTuple_FromArraySteal(args + n, argcount - n);
+        }
         if (u == NULL) {
             goto fail_post_positional;
         }


### PR DESCRIPTION
A minimal fix for easy porting to 3.11.

<!-- gh-issue-number: gh-96678 -->
* Issue: gh-96678
<!-- /gh-issue-number -->
