### PR TITLE
gh-87092: reduce redundancy and repetition in compiler's optimization stage

### DIFF
--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -360,13 +360,13 @@ dis_traceback = """\
     -->    BINARY_OP               11 (/)
            POP_TOP
 
-%3d     >> LOAD_FAST_CHECK          1 (tb)
+%3d        LOAD_FAST_CHECK          1 (tb)
            RETURN_VALUE
         >> PUSH_EXC_INFO
 
 %3d        LOAD_GLOBAL              0 (Exception)
            CHECK_EXC_MATCH
-           POP_JUMP_IF_FALSE       22 (to 80)
+           POP_JUMP_IF_FALSE       23 (to 82)
            STORE_FAST               0 (e)
 
 %3d        LOAD_FAST                0 (e)
@@ -376,7 +376,9 @@ dis_traceback = """\
            LOAD_CONST               0 (None)
            STORE_FAST               0 (e)
            DELETE_FAST              0 (e)
-           JUMP_BACKWARD           29 (to 14)
+
+%3d        LOAD_FAST                1 (tb)
+           RETURN_VALUE
         >> LOAD_CONST               0 (None)
            STORE_FAST               0 (e)
            DELETE_FAST              0 (e)
@@ -394,6 +396,7 @@ ExceptionTable:
        TRACEBACK_CODE.co_firstlineno + 5,
        TRACEBACK_CODE.co_firstlineno + 3,
        TRACEBACK_CODE.co_firstlineno + 4,
+       TRACEBACK_CODE.co_firstlineno + 5,
        TRACEBACK_CODE.co_firstlineno + 3)
 
 def _fstring(a, b, c, d):
@@ -440,7 +443,7 @@ dis_with = """\
            CALL                     2
            POP_TOP
 
-%3d     >> LOAD_CONST               2 (2)
+%3d        LOAD_CONST               2 (2)
            STORE_FAST               2 (y)
            LOAD_CONST               0 (None)
            RETURN_VALUE
@@ -453,7 +456,11 @@ dis_with = """\
            POP_EXCEPT
            POP_TOP
            POP_TOP
-           JUMP_BACKWARD           13 (to 30)
+
+%3d        LOAD_CONST               2 (2)
+           STORE_FAST               2 (y)
+           LOAD_CONST               0 (None)
+           RETURN_VALUE
         >> COPY                     3
            POP_EXCEPT
            RERAISE                  1
@@ -465,6 +472,7 @@ ExceptionTable:
        _with.__code__.co_firstlineno + 1,
        _with.__code__.co_firstlineno + 3,
        _with.__code__.co_firstlineno + 1,
+       _with.__code__.co_firstlineno + 3,
        )
 
 async def _asyncwith(c):
@@ -502,7 +510,7 @@ dis_asyncwith = """\
            JUMP_BACKWARD_NO_INTERRUPT     4 (to 48)
         >> POP_TOP
 
-%3d     >> LOAD_CONST               2 (2)
+%3d        LOAD_CONST               2 (2)
            STORE_FAST               2 (y)
            LOAD_CONST               0 (None)
            RETURN_VALUE
@@ -526,7 +534,11 @@ dis_asyncwith = """\
            POP_EXCEPT
            POP_TOP
            POP_TOP
-           JUMP_BACKWARD           24 (to 58)
+
+%3d        LOAD_CONST               2 (2)
+           STORE_FAST               2 (y)
+           LOAD_CONST               0 (None)
+           RETURN_VALUE
         >> COPY                     3
            POP_EXCEPT
            RERAISE                  1
@@ -538,6 +550,7 @@ ExceptionTable:
        _asyncwith.__code__.co_firstlineno + 1,
        _asyncwith.__code__.co_firstlineno + 3,
        _asyncwith.__code__.co_firstlineno + 1,
+       _asyncwith.__code__.co_firstlineno + 3,
        )
 
 

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -344,8 +344,6 @@ class TestTranforms(BytecodeTestCase):
         self.assertEqual(len(returns), 1)
         self.check_lnotab(f)
 
-    @unittest.skip("Following gh-92228 the return has two predecessors "
-                   "and that prevents jump elimination.")
     def test_elim_jump_to_return(self):
         # JUMP_FORWARD to RETURN -->  RETURN
         def f(cond, true_value, false_value):

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -9623,12 +9623,9 @@ duplicate_exits_without_lineno(cfg_builder *g)
             }
         }
     }
-    /* Eliminate empty blocks */
-    for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
-        while (b->b_next && b->b_next->b_iused == 0) {
-            b->b_next = b->b_next->b_next;
-        }
-    }
+
+    assert(no_empty_basic_blocks(g));
+
     /* Any remaining reachable exit blocks without line number can only be reached by
      * fall through, and thus can only have a single predecessor */
     for (basicblock *b = entryblock; b != NULL; b = b->b_next) {

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7364,7 +7364,7 @@ mark_cold(basicblock *entryblock) {
         for (int i = 0; i < b->b_iused; i++) {
             struct instr *instr = &b->b_instr[i];
             if (is_jump(instr)) {
-                assert(i == b->b_iused-1);
+                assert(i == b->b_iused - 1);
                 basicblock *target = b->b_instr[i].i_target;
                 if (!target->b_warm && !target->b_visited) {
                     *sp++ = target;
@@ -8322,7 +8322,7 @@ insert_instruction(basicblock *block, int pos, struct instr *instr) {
     if (basicblock_next_instr(block) < 0) {
         return -1;
     }
-    for (int i = block->b_iused-1; i > pos; i--) {
+    for (int i = block->b_iused - 1; i > pos; i--) {
         block->b_instr[i] = block->b_instr[i-1];
     }
     block->b_instr[pos] = *instr;
@@ -8520,21 +8520,19 @@ remove_redundant_jumps(cfg_builder *g) {
      * of that jump. If it is, then the jump instruction is redundant and
      * can be deleted.
      */
-    int removed = 0;
+    assert(no_empty_basic_blocks(g));
     for (basicblock *b = g->g_entryblock; b != NULL; b = b->b_next) {
         struct instr *last = basicblock_last_instr(b);
-        if (last != NULL) {
-            assert(!IS_ASSEMBLER_OPCODE(last->i_opcode));
-            if (IS_UNCONDITIONAL_JUMP_OPCODE(last->i_opcode)) {
-                if (last->i_target == NULL) {
-                    PyErr_SetString(PyExc_SystemError, "jump with NULL target");
-                    return -1;
-                }
-                if (last->i_target == b->b_next) {
-                    assert(b->b_next->b_iused);
-                    last->i_opcode = NOP;
-                    removed++;
-                }
+        assert(last != NULL);
+        assert(!IS_ASSEMBLER_OPCODE(last->i_opcode));
+        if (IS_UNCONDITIONAL_JUMP_OPCODE(last->i_opcode)) {
+            if (last->i_target == NULL) {
+                PyErr_SetString(PyExc_SystemError, "jump with NULL target");
+                return -1;
+            }
+            if (last->i_target == b->b_next) {
+                assert(b->b_next->b_iused);
+                last->i_opcode = NOP;
             }
         }
     }
@@ -9317,7 +9315,7 @@ check_cfg(cfg_builder *g) {
             int opcode = b->b_instr[i].i_opcode;
             assert(!IS_ASSEMBLER_OPCODE(opcode));
             if (IS_TERMINATOR_OPCODE(opcode)) {
-                if (i != b->b_iused-1) {
+                if (i != b->b_iused - 1) {
                     PyErr_SetString(PyExc_SystemError, "malformed control flow graph.");
                     return -1;
                 }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -8536,7 +8536,6 @@ remove_redundant_jumps(cfg_builder *g) {
             }
         }
     }
-    assert(no_empty_basic_blocks(g));
     return 0;
 }
 


### PR DESCRIPTION
* replace calls to ``eliminate_empty_basic_blocks`` by an assertion that there are no empty blocks
* same for a couple of inlined copies of the ``eliminate_empty_basic_blocks`` logic 
* rename ``clean_basic_block`` --> ``remove_redundant_nops`` for clarity
* rename ``normalize_basic_block`` --> ``check_cfg`` and reduce it to only check (not remove empty blocks).
* rename ``extend_block`` --> ``inline_small_exit_blocks``. Make it inline blocks with linenos too (as it used to until bde06e1b8381f140b296a397ddd1deb1c784ff8e).
* use the ``IS_UNCONDITIONAL_JUMP_OPCODE`` macro in a couple of places instead of checking precise opcodes


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-87092 -->
* Issue: gh-87092
<!-- /gh-issue-number -->
