### PR TITLE
Add docs reference to argparse.ArgumentParser.add_argument

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1405,7 +1405,6 @@ class _ActionsContainer(object):
                 return action.default
         return self._defaults.get(dest, None)
 
-
     # =======================
     # Adding argument actions
     # =======================
@@ -1413,6 +1412,8 @@ class _ActionsContainer(object):
         """
         add_argument(dest, ..., name=value, ...)
         add_argument(option_string, option_string, ..., name=value, ...)
+
+        For more details see https://docs.python.org/library/argparse.html?#argparse.ArgumentParser.add_argument
         """
 
         # if no positional args are supplied or only one is supplied and


### PR DESCRIPTION
This is a trivial change. 

In my IPython session I was coding up an argparse CLI, and I forgot the signature for `add_argument`. I got: 

```
In [4]: parser.add_argument?
Signature: parser.add_argument(*args, **kwargs)
Docstring:
add_argument(dest, ..., name=value, ...)
add_argument(option_string, option_string, ..., name=value, ...)
```


I found the current docstring unhelpful. 

I thought to myself: *sigh* now I have to open chrome, navigate to the Python docs (and hope google gives me the official docs as a first result) and look up the details. method signature.

I then thought about how it would be nice if those details were in the docstring itself, but then realized that it might be too much bloat for the standard library.

But then I thought, if they just linked to the docs with all the important info that would've saved me a lot of steps. Just adding a link might not be too much overhead.

So, I decided to put in a small amount of effort to make this PR, explain why I think its a good change, and hope the devs agree with me.

I also removed an extra newline flake8 was complaining about to make the style more locally consistent. (I couldn't help myself; I'll revert it if its a problem but on the flip side if someone gives a go-ahead I'll fix the other 14 minor flake8 issues while I'm here).