### PR TITLE
gh-96735: Fix undefined behaviour in struct unpacking functions

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -726,17 +726,6 @@ class StructTest(unittest.TestCase):
         with self.assertRaisesRegex(struct.error, error_msg):
             struct.pack('h', -70000)  # too small
 
-    def test_long_long_unpack_undefined_behaviour(self):
-        # Regression test for python/cpython#96735.
-        self.assertEqual(
-            struct.unpack('<q', b'\xff\xff\xff\xff\xff\xff\xff\xff'),
-            (-1,)
-        )
-        self.assertEqual(
-            struct.unpack('>q', b'\xff\xff\xff\xff\xff\xff\xff\xff'),
-            (-1,)
-        )
-
 
 class UnpackIteratorTest(unittest.TestCase):
     """

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -729,7 +729,11 @@ class StructTest(unittest.TestCase):
     def test_long_long_unpack_undefined_behaviour(self):
         # Regression test for python/cpython#96735.
         self.assertEqual(
-            struct.unpack('!q', b'\xff\xff\xff\xff\xff\xff\xff\xff'),
+            struct.unpack('<q', b'\xff\xff\xff\xff\xff\xff\xff\xff'),
+            (-1,)
+        )
+        self.assertEqual(
+            struct.unpack('>q', b'\xff\xff\xff\xff\xff\xff\xff\xff'),
             (-1,)
         )
 

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -726,6 +726,13 @@ class StructTest(unittest.TestCase):
         with self.assertRaisesRegex(struct.error, error_msg):
             struct.pack('h', -70000)  # too small
 
+    def test_long_long_unpack_undefined_behaviour(self):
+        # Regression test for python/cpython#96735.
+        self.assertEqual(
+            struct.unpack('!q', b'\xff\xff\xff\xff\xff\xff\xff\xff'),
+            (-1,)
+        )
+
 
 class UnpackIteratorTest(unittest.TestCase):
     """

--- a/Misc/NEWS.d/next/Library/2022-09-10-16-46-16.gh-issue-96735.0YzJuG.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-10-16-46-16.gh-issue-96735.0YzJuG.rst
@@ -1,0 +1,1 @@
+Fix undefined behaviour in :func:`struct.unpack`.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -819,7 +819,7 @@ bu_short(_structmodulestate *state, const char *p, const formatdef *f)
     } while (--i > 0);
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
     x = (x ^ 0x8000U) - 0x8000U;
-    return PyLong_FromLong(x & 0x8000U ? -1 - (long)(~x): (long)x);
+    return PyLong_FromLong(x & 0x8000U ? -1 - (long)(~x) : (long)x);
 }
 
 static PyObject *
@@ -836,7 +836,7 @@ bu_int(_structmodulestate *state, const char *p, const formatdef *f)
     } while (--i > 0);
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
     x = (x ^ 0x80000000U) - 0x80000000U;
-    return PyLong_FromLong(x & 0x80000000U ? -1 - (long)(~x): (long)x);
+    return PyLong_FromLong(x & 0x80000000U ? -1 - (long)(~x) : (long)x);
 }
 
 static PyObject *
@@ -866,7 +866,7 @@ bu_longlong(_structmodulestate *state, const char *p, const formatdef *f)
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
     x = (x ^ 0x8000000000000000U) - 0x8000000000000000U;
     return PyLong_FromLongLong(
-        x & 0x8000000000000000U ? -1 - (long long)(~x): (long long)x);
+        x & 0x8000000000000000U ? -1 - (long long)(~x) : (long long)x);
 }
 
 static PyObject *
@@ -1062,7 +1062,7 @@ lu_short(_structmodulestate *state, const char *p, const formatdef *f)
     } while (i > 0);
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
     x = (x ^ 0x8000U) - 0x8000U;
-    return PyLong_FromLong(x & 0x8000U ? -1 - (long)(~x): (long)x);
+    return PyLong_FromLong(x & 0x8000U ? -1 - (long)(~x) : (long)x);
 }
 
 static PyObject *
@@ -1079,7 +1079,7 @@ lu_int(_structmodulestate *state, const char *p, const formatdef *f)
     } while (i > 0);
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
     x = (x ^ 0x80000000U) - 0x80000000U;
-    return PyLong_FromLong(x & 0x80000000U ? -1 - (long)(~x): (long)x);
+    return PyLong_FromLong(x & 0x80000000U ? -1 - (long)(~x) : (long)x);
 }
 
 static PyObject *
@@ -1109,7 +1109,7 @@ lu_longlong(_structmodulestate *state, const char *p, const formatdef *f)
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
     x = (x ^ 0x8000000000000000U) - 0x8000000000000000U;
     return PyLong_FromLongLong(
-        x & 0x8000000000000000U ? -1 - (long long)(~x): (long long)x);
+        x & 0x8000000000000000U ? -1 - (long long)(~x) : (long long)x);
 }
 
 static PyObject *

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -806,18 +806,36 @@ static const formatdef native_table[] = {
 /* Big-endian routines. *****************************************************/
 
 static PyObject *
-bu_int(_structmodulestate *state, const char *p, const formatdef *f)
+bu_short(_structmodulestate *state, const char *p, const formatdef *f)
 {
-    long x = 0;
-    Py_ssize_t i = f->size;
+    unsigned long x = 0;
+
+    /* This function is only ever used in the case f->size == 2. */
+    assert(f->size == 2);
+    Py_ssize_t i = 2;
     const unsigned char *bytes = (const unsigned char *)p;
     do {
         x = (x<<8) | *bytes++;
     } while (--i > 0);
-    /* Extend the sign bit. */
-    if (SIZEOF_LONG > f->size)
-        x |= -(x & (1L << ((8 * f->size) - 1)));
-    return PyLong_FromLong(x);
+    /* Extend sign. */
+    return PyLong_FromLong(x & 0x8000U ? (long)x - 0x10000 : (long)x);
+}
+
+static PyObject *
+bu_int(_structmodulestate *state, const char *p, const formatdef *f)
+{
+    long x = 0;
+
+    /* This function is only ever used in the case f->size == 4. */
+    assert(f->size == 4);
+    Py_ssize_t i = 4;
+    const unsigned char *bytes = (const unsigned char *)p;
+    do {
+        x = (x<<8) | *bytes++;
+    } while (--i > 0);
+    /* Extend sign, avoiding implementation-defined or undefined behaviour. */
+    return PyLong_FromLong(x & 0x80000000U ?
+        -1 - (long)(0xFFFFFFFFU - x) : (long)x);
 }
 
 static PyObject *
@@ -844,10 +862,9 @@ bu_longlong(_structmodulestate *state, const char *p, const formatdef *f)
     do {
         x = (x<<8) | *bytes++;
     } while (--i > 0);
-
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
-    return PyLong_FromLongLong(x & 0x8000000000000000 ?
-        -1 - (long long)(0xFFFFFFFFFFFFFFFF - x) : (long long)x);
+    return PyLong_FromLongLong(x & 0x8000000000000000U ?
+        -1 - (long long)(0xFFFFFFFFFFFFFFFFU - x) : (long long)x);
 }
 
 static PyObject *
@@ -1012,7 +1029,7 @@ static formatdef bigendian_table[] = {
     {'c',       1,              0,              nu_char,        np_char},
     {'s',       1,              0,              NULL},
     {'p',       1,              0,              NULL},
-    {'h',       2,              0,              bu_int,         bp_int},
+    {'h',       2,              0,              bu_short,       bp_int},
     {'H',       2,              0,              bu_uint,        bp_uint},
     {'i',       4,              0,              bu_int,         bp_int},
     {'I',       4,              0,              bu_uint,        bp_uint},
@@ -1030,18 +1047,36 @@ static formatdef bigendian_table[] = {
 /* Little-endian routines. *****************************************************/
 
 static PyObject *
-lu_int(_structmodulestate *state, const char *p, const formatdef *f)
+lu_short(_structmodulestate *state, const char *p, const formatdef *f)
 {
-    long x = 0;
-    Py_ssize_t i = f->size;
+    unsigned long x = 0;
+
+    /* This function is only ever used in the case f->size == 2. */
+    assert(f->size == 2);
+    Py_ssize_t i = 2;
     const unsigned char *bytes = (const unsigned char *)p;
     do {
         x = (x<<8) | bytes[--i];
     } while (i > 0);
-    /* Extend the sign bit. */
-    if (SIZEOF_LONG > f->size)
-        x |= -(x & (1L << ((8 * f->size) - 1)));
-    return PyLong_FromLong(x);
+    /* Extend sign. */
+    return PyLong_FromLong(x & 0x8000U ? (long)x - 0x10000 : (long)x);
+}
+
+static PyObject *
+lu_int(_structmodulestate *state, const char *p, const formatdef *f)
+{
+    unsigned long x = 0;
+
+    /* This function is only ever used in the case f->size == 4. */
+    assert(f->size == 4);
+    Py_ssize_t i = 4;
+    const unsigned char *bytes = (const unsigned char *)p;
+    do {
+        x = (x<<8) | bytes[--i];
+    } while (i > 0);
+    /* Extend sign, avoiding implementation-defined or undefined behaviour. */
+    return PyLong_FromLong(x & 0x80000000U ?
+        -1 - (long)(0xFFFFFFFFU - x) : (long)x);
 }
 
 static PyObject *
@@ -1068,10 +1103,9 @@ lu_longlong(_structmodulestate *state, const char *p, const formatdef *f)
     do {
         x = (x<<8) | bytes[--i];
     } while (i > 0);
-
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
-    return PyLong_FromLongLong(x & 0x8000000000000000 ?
-        -1 - (long long)(0xFFFFFFFFFFFFFFFF - x) : (long long)x);
+    return PyLong_FromLongLong(x & 0x8000000000000000U ?
+        -1 - (long long)(0xFFFFFFFFFFFFFFFFU - x) : (long long)x);
 }
 
 static PyObject *
@@ -1219,7 +1253,7 @@ static formatdef lilendian_table[] = {
     {'c',       1,              0,              nu_char,        np_char},
     {'s',       1,              0,              NULL},
     {'p',       1,              0,              NULL},
-    {'h',       2,              0,              lu_int,         lp_int},
+    {'h',       2,              0,              lu_short,       lp_int},
     {'H',       2,              0,              lu_uint,        lp_uint},
     {'i',       4,              0,              lu_int,         lp_int},
     {'I',       4,              0,              lu_uint,        lp_uint},

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -824,7 +824,7 @@ bu_short(_structmodulestate *state, const char *p, const formatdef *f)
 static PyObject *
 bu_int(_structmodulestate *state, const char *p, const formatdef *f)
 {
-    long x = 0;
+    unsigned long x = 0;
 
     /* This function is only ever used in the case f->size == 4. */
     assert(f->size == 4);

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -817,8 +817,9 @@ bu_short(_structmodulestate *state, const char *p, const formatdef *f)
     do {
         x = (x<<8) | *bytes++;
     } while (--i > 0);
-    /* Extend sign. */
-    return PyLong_FromLong(x & 0x8000U ? (long)x - 0x10000 : (long)x);
+    /* Extend sign, avoiding implementation-defined or undefined behaviour. */
+    x = (x ^ 0x8000U) - 0x8000U;
+    return PyLong_FromLong(x & 0x8000U ? -1 - (long)(~x): (long)x);
 }
 
 static PyObject *
@@ -834,8 +835,8 @@ bu_int(_structmodulestate *state, const char *p, const formatdef *f)
         x = (x<<8) | *bytes++;
     } while (--i > 0);
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
-    return PyLong_FromLong(x & 0x80000000U ?
-        -1 - (long)(0xFFFFFFFFU - x) : (long)x);
+    x = (x ^ 0x80000000U) - 0x80000000U;
+    return PyLong_FromLong(x & 0x80000000U ? -1 - (long)(~x): (long)x);
 }
 
 static PyObject *
@@ -863,8 +864,9 @@ bu_longlong(_structmodulestate *state, const char *p, const formatdef *f)
         x = (x<<8) | *bytes++;
     } while (--i > 0);
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
-    return PyLong_FromLongLong(x & 0x8000000000000000U ?
-        -1 - (long long)(0xFFFFFFFFFFFFFFFFU - x) : (long long)x);
+    x = (x ^ 0x8000000000000000U) - 0x8000000000000000U;
+    return PyLong_FromLongLong(
+        x & 0x8000000000000000U ? -1 - (long long)(~x): (long long)x);
 }
 
 static PyObject *
@@ -1058,8 +1060,9 @@ lu_short(_structmodulestate *state, const char *p, const formatdef *f)
     do {
         x = (x<<8) | bytes[--i];
     } while (i > 0);
-    /* Extend sign. */
-    return PyLong_FromLong(x & 0x8000U ? (long)x - 0x10000 : (long)x);
+    /* Extend sign, avoiding implementation-defined or undefined behaviour. */
+    x = (x ^ 0x8000U) - 0x8000U;
+    return PyLong_FromLong(x & 0x8000U ? -1 - (long)(~x): (long)x);
 }
 
 static PyObject *
@@ -1075,8 +1078,8 @@ lu_int(_structmodulestate *state, const char *p, const formatdef *f)
         x = (x<<8) | bytes[--i];
     } while (i > 0);
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
-    return PyLong_FromLong(x & 0x80000000U ?
-        -1 - (long)(0xFFFFFFFFU - x) : (long)x);
+    x = (x ^ 0x80000000U) - 0x80000000U;
+    return PyLong_FromLong(x & 0x80000000U ? -1 - (long)(~x): (long)x);
 }
 
 static PyObject *
@@ -1104,8 +1107,9 @@ lu_longlong(_structmodulestate *state, const char *p, const formatdef *f)
         x = (x<<8) | bytes[--i];
     } while (i > 0);
     /* Extend sign, avoiding implementation-defined or undefined behaviour. */
-    return PyLong_FromLongLong(x & 0x8000000000000000U ?
-        -1 - (long long)(0xFFFFFFFFFFFFFFFFU - x) : (long long)x);
+    x = (x ^ 0x8000000000000000U) - 0x8000000000000000U;
+    return PyLong_FromLongLong(
+        x & 0x8000000000000000U ? -1 - (long long)(~x): (long long)x);
 }
 
 static PyObject *

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -835,16 +835,19 @@ bu_uint(_structmodulestate *state, const char *p, const formatdef *f)
 static PyObject *
 bu_longlong(_structmodulestate *state, const char *p, const formatdef *f)
 {
-    long long x = 0;
-    Py_ssize_t i = f->size;
+    unsigned long long x = 0;
+
+    /* This function is only ever used in the case f->size == 8. */
+    assert(f->size == 8);
+    Py_ssize_t i = 8;
     const unsigned char *bytes = (const unsigned char *)p;
     do {
         x = (x<<8) | *bytes++;
     } while (--i > 0);
-    /* Extend the sign bit. */
-    if (SIZEOF_LONG_LONG > f->size)
-        x |= -(x & ((long long)1 << ((8 * f->size) - 1)));
-    return PyLong_FromLongLong(x);
+
+    /* Extend sign, avoiding implementation-defined or undefined behaviour. */
+    return PyLong_FromLongLong(x & 0x8000000000000000 ?
+        -1 - (long long)(0xFFFFFFFFFFFFFFFF - x) : (long long)x);
 }
 
 static PyObject *


### PR DESCRIPTION
This PR fixes undefined behaviour in the struct module unpacking support functions `bu_longlong`, `lu_longlong`, `bu_int` and `lu_int`; thanks to @kumaraditya303 for finding these.

The fix is to accumulate the bytes in an unsigned integer type instead of a signed integer type, then to convert to the appropriate signed type. In cases where the width matches, that conversion will typically be compiled away to a no-op.
(Evidence from Godbolt: https://godbolt.org/z/5zvxodj64 .)

To make the conversions efficient, I've specialised the relevant functions for their output size: for `bu_longlong` and `lu_longlong`, this only entails checking that the output size is indeed `8`. But `bu_int` and `lu_int` were used for format sizes `2` and `4` - I've split those into two separate functions each.

No tests, because all of the affected cases are already exercised by the test suite.

<!-- gh-issue-number: gh-96735 -->
* Issue: gh-96735
<!-- /gh-issue-number -->
