### PR TITLE
Fix type annotation of `pstats.FunctionProfile.ncalls`

### DIFF
--- a/Lib/pstats.py
+++ b/Lib/pstats.py
@@ -57,7 +57,7 @@ class SortKey:
 
 @dataclass(unsafe_hash=True)
 class FunctionProfile:
-    ncalls: int
+    ncalls: str
     tottime: float
     percall_tottime: float
     cumtime: float

--- a/Misc/NEWS.d/next/Library/2022-09-10-17-21-41.gh-issue--.xchpJD.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-10-17-21-41.gh-issue--.xchpJD.rst
@@ -1,0 +1,1 @@
+Correctly annotate ``pstats.FunctionProfile.ncalls`` as ``str``

--- a/Misc/NEWS.d/next/Library/2022-09-10-17-21-41.gh-issue--.xchpJD.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-10-17-21-41.gh-issue--.xchpJD.rst
@@ -1,1 +1,0 @@
-Correctly annotate ``pstats.FunctionProfile.ncalls`` as ``str``

--- a/Misc/NEWS.d/next/Library/2022-09-15-00-37-33.gh-issue-96741.4b6czN.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-15-00-37-33.gh-issue-96741.4b6czN.rst
@@ -1,0 +1,1 @@
+Corrected type annotation for dataclass attribute ``pstats.FunctionProfile.ncalls`` to be ``str``.


### PR DESCRIPTION
This PR aligns the type annotation of `pstats.FunctionProfile.ncalls` with its runtime `str` type.

The fact that the runtime type of `pstats.FunctionProfile.ncalls` is `str` can be verified by (1) inspecting the source code for `pstats` and (2) running a small test snippet:

1. in the source code for `pstats`, the only place where `ncalls` is defined seems to be https://github.com/python/cpython/blob/6281affee6423296893b509cd78dc563ca58b196/Lib/pstats.py#L372 where the assigned value is always a string;
2. you can also check that `stats.FunctionProfile.ncalls` is a string by running the following script:

    ```python
    from cProfile import Profile
    from pstats import Stats
    
    # execute random code to generate profile stats
    with Profile() as profile:
        print("foo")
    
    # get a sample function profile
    stats_profile = Stats(profile).get_stats_profile()
    function_profile = next(iter(stats_profile.func_profiles.values()))
    
    # check that the type of `function_profile.ncalls` is indeed `str`
    assert type(function_profile.ncalls) is str
    ```

I also have an open PR in `typeshed` to fix this issue there: https://github.com/python/typeshed/pull/8712.

This change seems small and straightforward enough not to require an issue, but I am happy to open one if you think it is necessary. I also did not include any tests since this is a type annotation fix without any changes to the runtime behavior.