### PR TITLE
Add context for int_max_str_digits setting

### DIFF
--- a/Lib/_pylong.py
+++ b/Lib/_pylong.py
@@ -192,5 +192,7 @@ def str_to_long(s):
             continue
         if not c.isdigit():
             return None, i
+        # FIXME: scanning and creating a list of characters like this is
+        # expensive. Probably should do in C or use regex.
         digits.append(c)
     return _str_to_long_inner(''.join(digits)), None

--- a/Lib/_pylong.py
+++ b/Lib/_pylong.py
@@ -4,6 +4,8 @@ import functools
 
 
 def long_to_decimal(n):
+    if 0:
+        print('long_to_decimal', n.bit_length(), file=sys.stderr)
     # Function due to Tim Peters.  See GH issue #90716 for details.
     # https://github.com/python/cpython/issues/90716
     #
@@ -137,7 +139,7 @@ def _divmod_pos(a, b):
 def divmod_fast(a, b):
     """Asymptotically fast replacement for divmod, for integers."""
     if 0:
-        print('divmod_fast', file=sys.stderr)
+        print('divmod_fast', b.bit_length(), file=sys.stderr)
     if b == 0:
         raise ZeroDivisionError
     elif b < 0:

--- a/Lib/_pylong.py
+++ b/Lib/_pylong.py
@@ -1,0 +1,139 @@
+import sys
+import decimal
+
+
+def long_to_decimal_string(n):
+    # Function due to Tim Peters.  See GH issue #90716 for details.
+    # https://github.com/python/cpython/issues/90716
+    #
+    # The implementation in longobject.c of base conversion algorithms between
+    # power-of-2 and non-power-of-2 bases are quadratic time.  This function
+    # implements a divide-and-conquer algorithm that is faster for large
+    # numbers.  Builds an equal decimal.Decimal in a "clever" recursive way,
+    # and then applies str to _that_.
+
+    D = decimal.Decimal
+    D2 = D(2)
+
+    BITLIM = 128
+
+    def inner(n, w):
+        if w <= BITLIM:
+            return D(n)
+        w2 = w >> 1
+        hi = n >> w2
+        lo = n - (hi << w2)
+        return inner(hi, w - w2) * w2pow[w2] + inner(lo, w2)
+
+    with decimal.localcontext() as ctx:
+        ctx.prec = decimal.MAX_PREC
+        ctx.Emax = decimal.MAX_EMAX
+        ctx.Emin = decimal.MIN_EMIN
+        ctx.traps[decimal.Inexact] = 1
+
+        w2pow = {}
+        w = n.bit_length()
+        while w >= BITLIM:
+            w2 = w >> 1
+            if w & 1:
+                w2pow[w2 + 1] = None
+            w2pow[w2] = None
+            w = w2
+        if w2pow:
+            it = reversed(w2pow.keys())
+            w = next(it)
+            w2pow[w] = D2**w
+            for w in it:
+                if w - 1 in w2pow:
+                    val = w2pow[w - 1] * D2
+                else:
+                    w2 = w >> 1
+                    assert w2 in w2pow
+                    assert w - w2 in w2pow
+                    val = w2pow[w2] * w2pow[w - w2]
+                w2pow[w] = val
+        return str(inner(n, n.bit_length()))
+
+
+# Fast integer division, based on code from mdickinson, fast_div.py GH #47701
+
+DIV_LIMIT = 1000
+
+
+def _div2n1n(a, b, n):
+    """Divide a 2n-bit nonnegative integer a by an n-bit positive integer
+    b, using a recursive divide-and-conquer algorithm.
+
+    Inputs:
+      n is a positive integer
+      b is a positive integer with exactly n bits
+      a is a nonnegative integer such that a < 2**n * b
+
+    Output:
+      (q, r) such that a = b*q+r and 0 <= r < b.
+
+    """
+    if n <= DIV_LIMIT:
+        return divmod(a, b)
+    pad = n & 1
+    if pad:
+        a <<= 1
+        b <<= 1
+        n += 1
+    half_n = n >> 1
+    mask = (1 << half_n) - 1
+    b1, b2 = b >> half_n, b & mask
+    q1, r = _div3n2n(a >> n, (a >> half_n) & mask, b, b1, b2, half_n)
+    q2, r = _div3n2n(r, a & mask, b, b1, b2, half_n)
+    if pad:
+        r >>= 1
+    return q1 << half_n | q2, r
+
+
+def _div3n2n(a12, a3, b, b1, b2, n):
+    """Helper function for _div2n1n; not intended to be called directly."""
+    if a12 >> n == b1:
+        q, r = (1 << n) - 1, a12 - (b1 << n) + b1
+    else:
+        q, r = _div2n1n(a12, b1, n)
+    r = (r << n | a3) - q * b2
+    while r < 0:
+        q -= 1
+        r += b
+    return q, r
+
+
+def _divmod_pos(a, b):
+    """Divide a positive integer a by a positive integer b, giving
+    quotient and remainder."""
+    # Use grade-school algorithm in base 2**n, n = nbits(b)
+    n = len(bin(b)) - 2
+    mask = (1 << n) - 1
+    a_digits = []
+    while a:
+        a_digits.append(a & mask)
+        a >>= n
+    r = 0 if a_digits[-1] >= b else a_digits.pop()
+    q = 0
+    while a_digits:
+        q_digit, r = _div2n1n((r << n) + a_digits.pop(), b, n)
+        q = (q << n) + q_digit
+    return q, r
+
+
+def divmod_fast(a, b):
+    """Asymptotically fast replacement for divmod, for integers."""
+    if 0:
+        print('divmod_fast', file=sys.stderr)
+    if b == 0:
+        raise ZeroDivisionError
+    elif b < 0:
+        q, r = divmod_fast(-a, -b)
+        return q, -r
+    elif a < 0:
+        q, r = divmod_fast(~a, b)
+        return ~q, b + ~r
+    elif a == 0:
+        return 0, 0
+    else:
+        return _divmod_pos(a, b)

--- a/Lib/_pylong.py
+++ b/Lib/_pylong.py
@@ -2,7 +2,7 @@ import sys
 import decimal
 
 
-def long_to_decimal_string(n):
+def long_to_decimal(n):
     # Function due to Tim Peters.  See GH issue #90716 for details.
     # https://github.com/python/cpython/issues/90716
     #
@@ -11,7 +11,6 @@ def long_to_decimal_string(n):
     # implements a divide-and-conquer algorithm that is faster for large
     # numbers.  Builds an equal decimal.Decimal in a "clever" recursive way,
     # and then applies str to _that_.
-
     D = decimal.Decimal
     D2 = D(2)
 
@@ -24,6 +23,12 @@ def long_to_decimal_string(n):
         hi = n >> w2
         lo = n - (hi << w2)
         return inner(hi, w - w2) * w2pow[w2] + inner(lo, w2)
+
+    if n < 0:
+        negate = True
+        n = -n
+    else:
+        negate = False
 
     with decimal.localcontext() as ctx:
         ctx.prec = decimal.MAX_PREC
@@ -52,7 +57,14 @@ def long_to_decimal_string(n):
                     assert w - w2 in w2pow
                     val = w2pow[w2] * w2pow[w - w2]
                 w2pow[w] = val
-        return str(inner(n, n.bit_length()))
+        result = inner(n, n.bit_length())
+        if negate:
+            result = -result
+    return result
+
+
+def long_to_decimal_string(n):
+    return str(long_to_decimal(n))
 
 
 # Fast integer division, based on code from mdickinson, fast_div.py GH #47701

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -802,6 +802,14 @@ class PyLongModuleTests(unittest.TestCase):
         s = str(v1)
         v2 = int(s)
         assert v1 == v2
+        v3 = int(' -' + s)
+        assert -v1 == v3
+        with self.assertRaises(ValueError) as err:
+            int(s + 'z')
+        with self.assertRaises(ValueError) as err:
+            int(s + '_')
+        with self.assertRaises(ValueError) as err:
+            int('_' + s)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -797,6 +797,12 @@ class PyLongModuleTests(unittest.TestCase):
         a, b = divmod(n*3 + 1, n)
         assert a == 3 and b == 1
 
+    def test_pylong_str_to_long(self):
+        v1 = 1 << 1_000_000
+        s = str(v1)
+        v2 = int(s)
+        assert v1 == v2
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -785,19 +785,24 @@ class PyLongModuleTests(unittest.TestCase):
         sys.set_int_max_str_digits(self._previous_limit)
         super().tearDown()
 
-    def test_pylong_long_to_decimal(self):
+    def test_pylong_int_to_decimal(self):
         n = (1 << 1_000_000)
+        suffix = '2747109376'
         s = str(n)
-        assert s[-10:] == '2747109376'
+        assert s[-10:] == suffix
         s = str(-n)
-        assert s[-10:] == '2747109376'
+        assert s[-10:] == suffix
+        s = '%d' % n
+        assert s[-10:] == suffix
+        s = b'%d' % n
+        assert s[-10:] == suffix.encode('ascii')
 
-    def test_pylong_divmod_fast(self):
+    def test_pylong_int_divmod(self):
         n = (1 << 1_000_000)
         a, b = divmod(n*3 + 1, n)
         assert a == 3 and b == 1
 
-    def test_pylong_str_to_long(self):
+    def test_pylong_str_to_int(self):
         v1 = 1 << 1_000_000
         s = str(v1)
         v2 = int(s)

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -786,8 +786,8 @@ class PyLongModuleTests(unittest.TestCase):
         super().tearDown()
 
     def test_pylong_int_to_decimal(self):
-        n = (1 << 1_000_000)
-        suffix = '2747109376'
+        n = (1 << 100_000) - 1
+        suffix = '9883109375'
         s = str(n)
         assert s[-10:] == suffix
         s = str(-n)
@@ -798,17 +798,19 @@ class PyLongModuleTests(unittest.TestCase):
         assert s[-10:] == suffix.encode('ascii')
 
     def test_pylong_int_divmod(self):
-        n = (1 << 1_000_000)
+        n = (1 << 100_000)
         a, b = divmod(n*3 + 1, n)
         assert a == 3 and b == 1
 
     def test_pylong_str_to_int(self):
-        v1 = 1 << 1_000_000
+        v1 = 1 << 100_000
         s = str(v1)
         v2 = int(s)
         assert v1 == v2
         v3 = int(' -' + s)
         assert -v1 == v3
+        v4 = int(' +' + s + ' ')
+        assert v1 == v4
         with self.assertRaises(ValueError) as err:
             int(s + 'z')
         with self.assertRaises(ValueError) as err:

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -773,5 +773,30 @@ class IntSubclassStrDigitLimitsTests(IntStrDigitLimitsTests):
     int_class = IntSubclass
 
 
+class PyLongModuleTests(unittest.TestCase):
+    # Tests of the functions in _pylong.py
+
+    def setUp(self):
+        super().setUp()
+        self._previous_limit = sys.get_int_max_str_digits()
+        sys.set_int_max_str_digits(0)
+
+    def tearDown(self):
+        sys.set_int_max_str_digits(self._previous_limit)
+        super().tearDown()
+
+    def test_pylong_long_to_decimal(self):
+        n = (1 << 1_000_000)
+        s = str(n)
+        assert s[-10:] == '2747109376'
+        s = str(-n)
+        assert s[-10:] == '2747109376'
+
+    def test_pylong_divmod_fast(self):
+        n = (1 << 1_000_000)
+        a, b = divmod(n*3 + 1, n)
+        assert a == 3 and b == 1
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-09-16-32-58.gh-issue-90716.z4yuYq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-09-16-32-58.gh-issue-90716.z4yuYq.rst
@@ -1,0 +1,3 @@
+Add _pylong.py module.  It includes asymptotically faster algorithms that
+can be used for operations on integers with many digits.  It is used by
+longobject.c to speed up some operations.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1760,15 +1760,19 @@ py_long_to_decimal_string(PyObject *aa,
         goto success;
     }
     else if (bytes_writer) {
-#if 0
-        *bytes_str = _PyBytesWriter_Prepare(bytes_writer, *bytes_str, strlen);
+        Py_ssize_t size = PyUnicode_GET_LENGTH(s);
+        const void *data = PyUnicode_DATA(s);
+        int kind = PyUnicode_KIND(s);
+        *bytes_str = _PyBytesWriter_Prepare(bytes_writer, *bytes_str, size);
         if (*bytes_str == NULL) {
-            Py_DECREF(s);
-            return -1;
+            goto error;
         }
-#else
-        assert(0); // FIXME: not implemented
-#endif
+        char *p = *bytes_str;
+        for (Py_ssize_t i=0; i < size; i++) {
+            Py_UCS4 ch = PyUnicode_READ(kind, data, i);
+            *p++ = (char) ch;
+        }
+        (*bytes_str) = p;
         goto success;
     }
     else {

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1732,6 +1732,7 @@ rem1(PyLongObject *a, digit n)
     );
 }
 
+/* asymptotically faster long_to_decimal_string, using _pylong.py */
 static int
 py_long_to_decimal_string(PyObject *aa,
                           PyObject **p_output,
@@ -1765,8 +1766,9 @@ py_long_to_decimal_string(PyObject *aa,
             Py_DECREF(s);
             return -1;
         }
+#else
+        assert(0); // FIXME: not implemented
 #endif
-        assert(0); // not implemented
         goto success;
     }
     else {
@@ -1833,9 +1835,7 @@ long_to_decimal_string_internal(PyObject *aa,
 
 #if 1
     if (size_a > 1000) { // FIXME: what threshold to use?
-        /* Switch to _pylong.long_to_decimal_string().  It asymptotically more
-         * efficient and is faster for large inputs.
-         */
+        /* Switch to _pylong.long_to_decimal_string(). */
         return py_long_to_decimal_string(aa,
                                          p_output,
                                          writer,
@@ -3981,6 +3981,7 @@ fast_floor_div(PyLongObject *a, PyLongObject *b)
     return PyLong_FromLong(div);
 }
 
+/* asymptotically faster divmod, using _pylong.py */
 static int
 py_divmod(PyLongObject *v, PyLongObject *w,
           PyLongObject **pdiv, PyLongObject **pmod)
@@ -4061,8 +4062,7 @@ l_divmod(PyLongObject *v, PyLongObject *w,
     }
 #if 1
     if (Py_ABS(Py_SIZE(w)) > 1000) { // FIXME: what threshold to use?
-        /* Switch to _pylong.divmod_fast().  It asymptotically more efficient
-           and is faster for large inputs. */
+        /* Switch to _pylong.divmod_fast() */
         return py_divmod(v, w, pdiv, pmod);
     }
 #endif

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1833,8 +1833,8 @@ long_to_decimal_string_internal(PyObject *aa,
 
 #if 1
     if (size_a > 1000) { // FIXME: what threshold to use?
-        /* Switch to Python version from the _pylong module.  It is more
-         * efficient for a large number of output digits.
+        /* Switch to _pylong.long_to_decimal_string().  It asymptotically more
+         * efficient and is faster for large inputs.
          */
         return py_long_to_decimal_string(aa,
                                          p_output,
@@ -4022,7 +4022,8 @@ l_divmod(PyLongObject *v, PyLongObject *w,
     }
 #if 1
     if (Py_ABS(Py_SIZE(w)) > 1000) { // FIXME: what threshold to use?
-        /* Use _pylong.divmod_fast(), should be faster. */
+        /* Switch to _pylong.divmod_fast().  It asymptotically more efficient
+           and is faster for large inputs. */
         return py_divmod(v, w, pdiv, pmod);
     }
 #endif

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -2,8 +2,6 @@
 
 /* XXX The functional organization of this file is terrible */
 
-#define NEEDS_PY_IDENTIFIER
-
 #include "Python.h"
 #include "pycore_bitutils.h"      // _Py_popcount32()
 #include "pycore_initconfig.h"    // _PyStatus_OK()
@@ -1734,8 +1732,6 @@ rem1(PyLongObject *a, digit n)
     );
 }
 
-_Py_IDENTIFIER(long_to_decimal_string);
-
 static int
 py_long_to_decimal_string(PyObject *aa,
                           PyObject **p_output,
@@ -1748,9 +1744,7 @@ py_long_to_decimal_string(PyObject *aa,
     if (mod == NULL) {
         return -1;
     }
-    s = _PyObject_CallMethodIdObjArgs(mod,
-                                      &PyId_long_to_decimal_string,
-                                      aa, NULL);
+    s = PyObject_CallMethod(mod, "long_to_decimal_string", "O", aa);
     if (s == NULL) {
         goto error;
     }
@@ -3948,8 +3942,6 @@ fast_floor_div(PyLongObject *a, PyLongObject *b)
     return PyLong_FromLong(div);
 }
 
-_Py_IDENTIFIER(divmod_fast);
-
 static int
 py_divmod(PyLongObject *v, PyLongObject *w,
           PyLongObject **pdiv, PyLongObject **pmod)
@@ -3958,18 +3950,20 @@ py_divmod(PyLongObject *v, PyLongObject *w,
     if (mod == NULL) {
         return -1;
     }
-    PyObject *r = _PyObject_CallMethodIdObjArgs(mod,
-                                                &PyId_divmod_fast,
-                                                v, w, NULL);
+    PyObject *r = PyObject_CallMethod(mod, "divmod_fast", "OO", v, w);
     if (r == NULL) {
         Py_DECREF(mod);
         return -1;
     }
     assert(PyTuple_Check(r));
-    *pdiv = PyTuple_GET_ITEM(r, 0);
-    *pmod = PyTuple_GET_ITEM(r, 1);
-    Py_INCREF(*pdiv);
-    Py_INCREF(*pmod);
+    PyObject *a = PyTuple_GET_ITEM(r, 0);
+    PyObject *b = PyTuple_GET_ITEM(r, 1);
+    Py_INCREF(a);
+    Py_INCREF(b);
+    assert(PyLong_Check(a));
+    assert(PyLong_Check(b));
+    *pdiv = (PyLongObject *)a;
+    *pmod = (PyLongObject *)b;
     Py_DECREF(r);
     Py_DECREF(mod);
     return 0;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -2358,9 +2358,11 @@ long_from_binary_base(const char **str, int base, PyLongObject **res)
     return 0;
 }
 
+static PyObject *long_neg(PyLongObject *v);
+
 /* asymptotically faster str-to-long conversion for base 10, using _pylong.py */
 static PyObject *
-py_str_to_long(const char *str, char **pend, int base)
+py_str_to_long(const char *str, char **pend, int base, int sign)
 {
     PyObject *mod = PyImport_ImportModule("_pylong");
     if (mod == NULL) {
@@ -2384,7 +2386,12 @@ py_str_to_long(const char *str, char **pend, int base)
     else {
         assert(PyLong_Check(v));
         assert(PyTuple_GET_ITEM(result, 1) == Py_None);
-        Py_INCREF(v);
+        if (sign < 0) {
+            v = long_neg((PyLongObject *)v);
+        }
+        else {
+            Py_INCREF(v);
+        }
     }
     Py_DECREF(result);
     return v;
@@ -2625,7 +2632,7 @@ digit beyond the first.
 #if 1
         if (digits > 3000 && base == 10) {
             /* Switch to _pylong.str_to_long() */
-            return py_str_to_long(str, pend, base);
+            return py_str_to_long(str, pend, base, sign);
         }
 #endif
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1755,7 +1755,8 @@ pylong_int_to_decimal_string(PyObject *aa,
     }
     assert(PyUnicode_Check(s));
     if (writer) {
-        if (_PyUnicodeWriter_Prepare(writer, PyUnicode_GET_LENGTH(s), '9') == -1) {
+        Py_ssize_t size = PyUnicode_GET_LENGTH(s);
+        if (_PyUnicodeWriter_Prepare(writer, size, '9') == -1) {
             goto error;
         }
         if (_PyUnicodeWriter_WriteStr(writer, s) < 0) {
@@ -1843,7 +1844,7 @@ long_to_decimal_string_internal(PyObject *aa,
     }
 
 #if WITH_PYLONG_MODULE
-    if (size_a > 1000) { // FIXME: what threshold to use?
+    if (size_a > 1000) {
         /* Switch to _pylong.int_to_decimal_string(). */
         return pylong_int_to_decimal_string(aa,
                                          p_output,
@@ -2641,7 +2642,7 @@ digit beyond the first.
         }
 
 #if WITH_PYLONG_MODULE
-        if (digits > 3000 && base == 10) {
+        if (digits > 6000 && base == 10) {
             /* Switch to _pylong.int_from_string() */
             return pylong_int_from_string(str, pend, base, sign);
         }
@@ -4081,7 +4082,7 @@ l_divmod(PyLongObject *v, PyLongObject *w,
         return 0;
     }
 #if WITH_PYLONG_MODULE
-    if (Py_ABS(Py_SIZE(w)) > 1000) { // FIXME: what threshold to use?
+    if (Py_ABS(Py_SIZE(w)) > 1000) {
         /* Switch to _pylong.int_divmod() */
         return pylong_int_divmod(v, w, pdiv, pmod);
     }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1812,7 +1812,6 @@ long_to_decimal_string_internal(PyObject *aa,
     size_a = Py_ABS(Py_SIZE(a));
     negative = Py_SIZE(a) < 0;
 
-#if 0
     /* quick and dirty pre-check for overflowing the decimal digit limit,
        based on the inequality 10/3 >= log2(10)
 
@@ -1829,14 +1828,9 @@ long_to_decimal_string_internal(PyObject *aa,
             return -1;
         }
     }
-#else
-    /* quick and dirty pre-check for overflowing the decimal digit limit,
-       based on the inequality 10/3 >= log2(10)
 
-       explanation in https://github.com/python/cpython/pull/96537
-    */
-    if (size_a >= 10 * _PY_LONG_MAX_STR_DIGITS_THRESHOLD
-                  / (3 * PyLong_SHIFT) + 2) {
+#if 1
+    if (size_a > 1000) { // FIXME: what threshold to use?
         /* Switch to Python version from the _pylong module.  It is more
          * efficient for a large number of output digits.
          */

--- a/Python/stdlib_module_names.h
+++ b/Python/stdlib_module_names.h
@@ -58,6 +58,7 @@ static const char* _Py_stdlib_module_names[] = {
 "_py_abc",
 "_pydecimal",
 "_pyio",
+"_pylong",
 "_queue",
 "_random",
 "_scproxy",


### PR DESCRIPTION
Draft version: if we have the `_pylong` module, adding a `ContextVar()`  mechanism there for the `int_max_str_digits` setting seems fairly easy. That will be nicer than an interpreter global setting.