### PR TITLE
gh-94808: Cover `LOAD_GLOBAL` for custom dict subtypes

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -780,19 +780,19 @@ class BuiltinTest(unittest.TestCase):
             pass
 
         # globals' `__getitem__` raises
-        code = compile("print(globalname)", "test", "exec")
+        code = compile("globalname", "test", "exec")
         self.assertRaises(setonlyerror,
                           exec, code, setonlydict({'globalname': 1}))
 
         # builtins' `__getitem__` raises
-        code = compile("print(superglobal)", "test", "exec")
+        code = compile("superglobal", "test", "exec")
         self.assertRaises(setonlyerror, exec, code,
                           {'__builtins__': setonlydict({'superglobal': 1})})
 
         # custom builtins dict subclass is missing key
-        code = compile("print(superglobal)", "test", "exec")
-        self.assertRaises(NameError, exec, code,
-                          {'__builtins__': customdict()})
+        code = compile("superglobal", "test", "exec")
+        self.assertRaisesRegex(NameError, "name 'superglobal' is not defined",
+                               exec, code, {'__builtins__': customdict()})
 
     def test_exec_redirected(self):
         savestdout = sys.stdout

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -737,6 +737,7 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(TypeError,
                           exec, code, {'__builtins__': 123})
 
+    def test_exec_globals_frozen(self):
         class frozendict_error(Exception):
             pass
 
@@ -768,6 +769,7 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(frozendict_error,
                           exec, code, namespace)
 
+    def test_exec_globals_error_on_get(self):
         # custom `globals` or `builtins` can raise errors on item access
         class setonlyerror(Exception):
             pass
@@ -775,9 +777,6 @@ class BuiltinTest(unittest.TestCase):
         class setonlydict(dict):
             def __getitem__(self, key):
                 raise setonlyerror
-
-        class customdict(dict):  # this one should not do anything fancy
-            pass
 
         # globals' `__getitem__` raises
         code = compile("globalname", "test", "exec")
@@ -789,8 +788,14 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(setonlyerror, exec, code,
                           {'__builtins__': setonlydict({'superglobal': 1})})
 
-        # custom builtins dict subclass is missing key
+    def test_exec_globals_dict_subclass(self):
+        class customdict(dict):  # this one should not do anything fancy
+            pass
+
         code = compile("superglobal", "test", "exec")
+        # works correctly
+        exec(code, {'__builtins__': customdict({'superglobal': 1})})
+        # custom builtins dict subclass is missing key
         self.assertRaisesRegex(NameError, "name 'superglobal' is not defined",
                                exec, code, {'__builtins__': customdict()})
 


### PR DESCRIPTION
I've covered several missing conditions in `TARGET(LOAD_GLOBAL)`:
- The one where custom `globals()` dict subtype raises non `KeyError`: https://github.com/python/cpython/blob/53a54b781d1f05f2d0b40ce88b3da92d5d23e9d2/Python/ceval.c#L2445-L2447
- Similar case where `__builtins__` dict subtype raises non `KeyError`: https://github.com/python/cpython/blob/53a54b781d1f05f2d0b40ce88b3da92d5d23e9d2/Python/ceval.c#L2458
- Regular `NameError` in a custom `__builtins__` dict subtype: https://github.com/python/cpython/blob/53a54b781d1f05f2d0b40ce88b3da92d5d23e9d2/Python/ceval.c#L2453-L2457

<!-- gh-issue-number: gh-94808 -->
* Issue: gh-94808
<!-- /gh-issue-number -->
