### PR TITLE
GH-96754: Check whether the interpreter frame is complete before creating frame object.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-12-16-58-22.gh-issue-96754.0GRme5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-12-16-58-22.gh-issue-96754.0GRme5.rst
@@ -1,0 +1,3 @@
+Make sure that all frame objects created are created from valid interpreter
+frames. Prevents the possibility of invalid frames in backtraces and signal
+handlers.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -1832,6 +1832,9 @@ _PyErr_CheckSignalsTstate(PyThreadState *tstate)
     _Py_atomic_store(&is_tripped, 0);
 
     _PyInterpreterFrame *frame = tstate->cframe->current_frame;
+    while (frame && _PyFrame_IsIncomplete(frame)) {
+        frame = frame->previous;
+    }
     signal_state_t *state = &signal_global_state;
     for (int i = 1; i < Py_NSIG; i++) {
         if (!_Py_atomic_load_relaxed(&Handlers[i].tripped)) {

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5113,9 +5113,11 @@ error:
 #endif
 
         /* Log traceback info. */
-        PyFrameObject *f = _PyFrame_GetFrameObject(frame);
-        if (f != NULL) {
-            PyTraceBack_Here(f);
+        if (!_PyFrame_IsIncomplete(frame)) {
+            PyFrameObject *f = _PyFrame_GetFrameObject(frame);
+            if (f != NULL) {
+                PyTraceBack_Here(f);
+            }
         }
 
         if (tstate->c_tracefunc != NULL) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1406,6 +1406,9 @@ _PyThread_CurrentFrames(void)
         PyThreadState *t;
         for (t = i->threads.head; t != NULL; t = t->next) {
             _PyInterpreterFrame *frame = t->cframe->current_frame;
+            while (frame && _PyFrame_IsIncomplete(frame)) {
+                frame = frame->previous;
+            }
             if (frame == NULL) {
                 continue;
             }


### PR DESCRIPTION
Fixes three possible cases of frame objects being created from incomplete frames.

<!-- gh-issue-number: gh-96754 -->
* Issue: gh-96754
<!-- /gh-issue-number -->
