### PR TITLE
Add dataclass field default change to 3.11 what's new

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -523,6 +523,13 @@ Added non parallel-safe :func:`~contextlib.chdir` context manager to change
 the current working directory and then restore it on exit. Simple wrapper
 around :func:`~os.chdir`. (Contributed by Filipe Laíns in :issue:`25625`)
 
+dataclasses
+-----------
+
+* Change field default mutability check, allowing only defaults which can be
+   hashed instead of all instances of :class:`dict`, :class:`list` and
+   :class:`set` (Contributed by Eric V. Smith in :gh:`29867`)
+
 datetime
 --------
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -528,7 +528,7 @@ dataclasses
 
 * Change field default mutability check, allowing only defaults which can be
    hashed instead of all instances of :class:`dict`, :class:`list` and
-   :class:`set` (Contributed by Eric V. Smith in :gh:`29867`)
+   :class:`set` (Contributed by Eric V. Smith in :issue:`44674`)
 
 datetime
 --------

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -528,8 +528,8 @@ dataclasses
 
 * Change field default mutability check, allowing only defaults which are
   :term:`hashable` instead of any object which is not an instance of
-  :class:`dict`, :class:`list` or :class:`set` (Contributed by Eric V. Smith in
-  :issue:`44674`)
+  :class:`dict`, :class:`list` or :class:`set`. (Contributed by Eric V. Smith in
+  :issue:`44674`.)
 
 datetime
 --------

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -527,8 +527,8 @@ dataclasses
 -----------
 
 * Change field default mutability check, allowing only defaults which can be
-   hashed instead of all instances of :class:`dict`, :class:`list` and
-   :class:`set` (Contributed by Eric V. Smith in :issue:`44674`)
+  hashed instead of all instances of :class:`dict`, :class:`list` and
+  :class:`set` (Contributed by Eric V. Smith in :issue:`44674`)
 
 datetime
 --------

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -527,8 +527,9 @@ dataclasses
 -----------
 
 * Change field default mutability check, allowing only defaults which are
-  :term:`hashable` instead of all instances of :class:`dict`, :class:`list`
-  and :class:`set` (Contributed by Eric V. Smith in :issue:`44674`)
+  :term:`hashable` instead of any object which is not an instance of
+  :class:`dict`, :class:`list` or :class:`set` (Contributed by Eric V. Smith in
+  :issue:`44674`)
 
 datetime
 --------

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -526,9 +526,9 @@ around :func:`~os.chdir`. (Contributed by Filipe Laíns in :issue:`25625`)
 dataclasses
 -----------
 
-* Change field default mutability check, allowing only defaults which can be
-  hashed instead of all instances of :class:`dict`, :class:`list` and
-  :class:`set` (Contributed by Eric V. Smith in :issue:`44674`)
+* Change field default mutability check, allowing only defaults which are
+  :term:`hashable` instead of all instances of :class:`dict`, :class:`list`
+  and :class:`set` (Contributed by Eric V. Smith in :issue:`44674`)
 
 datetime
 --------


### PR DESCRIPTION
Include dataclass field default mutability check change introduced in #29867. See [discourse discussion](https://discuss.python.org/t/better-communicate-dataclass-mutable-default-check-change-in-python-3-11)