### PR TITLE
gh-95778: `sys` docs: fix `sys.set_int_max_str_digits()` parameter name

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1331,7 +1331,7 @@ always available.
 
    .. availability:: Unix.
 
-.. function:: set_int_max_str_digits(n)
+.. function:: set_int_max_str_digits(maxdigits)
 
    Set the :ref:`integer string conversion length limitation
    <int_max_str_digits>` used by this interpreter. See also


### PR DESCRIPTION
This minor documentation bug was discovered in https://github.com/python/typeshed/pull/8733


<!-- gh-issue-number: gh-95778 -->
* Issue: gh-95778
<!-- /gh-issue-number -->
