### PR TITLE
gh-96805: refactor reprlib

### DIFF
--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -70,23 +70,14 @@ class Repr:
             return self.repr_instance(x, level)
 
     def _join(self, pieces, level):
-        if self.indent is None:
-            return ', '.join(pieces)
         if not pieces:
             return ''
-        indent = self.indent
-        if isinstance(indent, int):
-            if indent < 0:
-                raise ValueError(
-                    f'Repr.indent cannot be negative int (was {indent!r})'
-                )
-            indent *= ' '
-        try:
-            sep = ',\n' + (self.maxlevel - level + 1) * indent
-        except TypeError as error:
-            raise TypeError(
-                f'Repr.indent must be a str, int or None, not {type(indent)}'
-            ) from error
+
+        indent = _validate_indent(self.indent)
+        if indent is None:
+            return ', '.join(pieces)
+
+        sep = ',\n' + (self.maxlevel - level + 1) * indent
         return sep.join(('', *pieces, ''))[1:-len(indent) or None]
 
     def _repr_iterable(self, x, level, *, left, right, maxiter, trail=''):
@@ -213,6 +204,21 @@ class Repr:
             j = max(0, self.maxother-3-i)
             s = s[:i] + self.fillvalue + s[len(s)-j:]
         return s
+
+
+def _validate_indent(indent):
+    if isinstance(indent, int):
+        if indent < 0:
+            raise ValueError(
+                f'Repr.indent cannot be negative int (was {indent!r})'
+            )
+        return ' ' * indent
+
+    if indent is None or isinstance(indent, str):
+        return indent
+
+    msg = f'Repr.indent must be a str, int or None, not {type(indent)}'
+    raise TypeError(msg)
 
 
 def _possibly_sorted(x):

--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -90,19 +90,19 @@ class Repr:
         maxiter,
         trailing_comma=False,
     ):
-        body = self._get_iterable_body(x, level, maxiter, trailing_comma)
+        pieces = list(self._gen_pieces(x, level, maxiter))
+        body = self._get_iterable_body(pieces, level, trailing_comma)
         return f'{left}{body}{right}'
 
-    def _get_iterable_body(self, obj, level, maxiter, trailing_comma):
-        if not obj:
+    def _get_iterable_body(self, pieces, level, trailing_comma):
+        if not pieces:
             return ''
 
         if level <= 0:
             return self.fillvalue
 
-        pieces = self._gen_pieces(obj, level, maxiter)
         result = self._join(pieces, level)
-        if self._need_tailing_comma(obj, trailing_comma):
+        if self._need_tailing_comma(pieces, trailing_comma):
             return result + ','
         return result
 
@@ -113,8 +113,8 @@ class Repr:
         if len(obj) > maxiter:
             yield self.fillvalue
 
-    def _need_tailing_comma(self, obj, trailing_comma):
-        return trailing_comma and len(obj) == 1 and self.indent is None
+    def _need_tailing_comma(self, pieces, trailing_comma):
+        return trailing_comma and len(pieces) == 1 and self.indent is None
 
     def repr_tuple(self, x, level):
         return self._repr_iterable(

--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -138,11 +138,10 @@ class Repr:
     def repr_array(self, x, level):
         if not x:
             return "array('%s')" % x.typecode
-        header = "array('%s', [" % x.typecode
         return self._repr_iterable(
             x,
             level,
-            left=header,
+            left="array('%s', [" % x.typecode,
             right='])',
             maxiter=self.maxarray,
         )

--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -80,7 +80,16 @@ class Repr:
         sep = ',\n' + (self.maxlevel - level + 1) * indent
         return sep.join(('', *pieces, ''))[1:-len(indent) or None]
 
-    def _repr_iterable(self, x, level, *, left, right, maxiter, trail=''):
+    def _repr_iterable(
+        self,
+        x,
+        level,
+        *,
+        left,
+        right,
+        maxiter,
+        trailing_comma=False,
+    ):
         n = len(x)
         if level <= 0 and n:
             s = self.fillvalue
@@ -91,8 +100,8 @@ class Repr:
             if n > maxiter:
                 pieces.append(self.fillvalue)
             s = self._join(pieces, level)
-            if n == 1 and trail and self.indent is None:
-                right = trail + right
+            if n == 1 and trailing_comma and self.indent is None:
+                right = ',' + right
         return '%s%s%s' % (left, s, right)
 
     def repr_tuple(self, x, level):
@@ -102,7 +111,7 @@ class Repr:
             left='(',
             right=')',
             maxiter=self.maxtuple,
-            trail=',',
+            trailing_comma=True,
         )
 
     def repr_list(self, x, level):

--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -102,7 +102,7 @@ class Repr:
 
         pieces = self._gen_pieces(obj, level, maxiter)
         result = self._join(pieces, level)
-        if trailing_comma and len(obj) == 1 and self.indent is None:
+        if self._need_tailing_comma(obj, trailing_comma):
             return result + ','
         return result
 
@@ -112,6 +112,9 @@ class Repr:
 
         if len(obj) > maxiter:
             yield self.fillvalue
+
+    def _need_tailing_comma(self, obj, trailing_comma):
+        return trailing_comma and len(obj) == 1 and self.indent is None
 
     def repr_tuple(self, x, level):
         return self._repr_iterable(

--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -6,6 +6,7 @@ import builtins
 from itertools import islice
 from _thread import get_ident
 
+
 def recursive_repr(fillvalue='...'):
     'Decorator to make a repr function return fillvalue for a recursive call'
 
@@ -32,6 +33,7 @@ def recursive_repr(fillvalue='...'):
         return wrapper
 
     return decorating_function
+
 
 class Repr:
 
@@ -87,7 +89,7 @@ class Repr:
             ) from error
         return sep.join(('', *pieces, ''))[1:-len(indent) or None]
 
-    def _repr_iterable(self, x, level, left, right, maxiter, trail=''):
+    def _repr_iterable(self, x, level, *, left, right, maxiter, trail=''):
         n = len(x)
         if level <= 0 and n:
             s = self.fillvalue
@@ -103,32 +105,66 @@ class Repr:
         return '%s%s%s' % (left, s, right)
 
     def repr_tuple(self, x, level):
-        return self._repr_iterable(x, level, '(', ')', self.maxtuple, ',')
+        return self._repr_iterable(
+            x,
+            level,
+            left='(',
+            right=')',
+            maxiter=self.maxtuple,
+            trail=',',
+        )
 
     def repr_list(self, x, level):
-        return self._repr_iterable(x, level, '[', ']', self.maxlist)
+        return self._repr_iterable(
+            x,
+            level,
+            left='[',
+            right=']',
+            maxiter=self.maxlist,
+        )
 
     def repr_array(self, x, level):
         if not x:
             return "array('%s')" % x.typecode
         header = "array('%s', [" % x.typecode
-        return self._repr_iterable(x, level, header, '])', self.maxarray)
+        return self._repr_iterable(
+            x,
+            level,
+            left=header,
+            right='])',
+            maxiter=self.maxarray,
+        )
 
     def repr_set(self, x, level):
         if not x:
             return 'set()'
-        x = _possibly_sorted(x)
-        return self._repr_iterable(x, level, '{', '}', self.maxset)
+        return self._repr_iterable(
+            _possibly_sorted(x),
+            level,
+            left='{',
+            right='}',
+            maxiter=self.maxset,
+        )
 
     def repr_frozenset(self, x, level):
         if not x:
             return 'frozenset()'
-        x = _possibly_sorted(x)
-        return self._repr_iterable(x, level, 'frozenset({', '})',
-                                   self.maxfrozenset)
+        return self._repr_iterable(
+            _possibly_sorted(x),
+            level,
+            left='frozenset({',
+            right='})',
+            maxiter=self.maxfrozenset,
+        )
 
     def repr_deque(self, x, level):
-        return self._repr_iterable(x, level, 'deque([', '])', self.maxdeque)
+        return self._repr_iterable(
+            x,
+            level,
+            left='deque([',
+            right='])',
+            maxiter=self.maxdeque,
+        )
 
     def repr_dict(self, x, level):
         n = len(x)
@@ -158,7 +194,7 @@ class Repr:
         return s
 
     def repr_int(self, x, level):
-        s = builtins.repr(x) # XXX Hope this isn't too slow...
+        s = builtins.repr(x)  # XXX Hope this isn't too slow...
         if len(s) > self.maxlong:
             i = max(0, (self.maxlong-3)//2)
             j = max(0, self.maxlong-3-i)
@@ -187,6 +223,7 @@ def _possibly_sorted(x):
         return sorted(x)
     except Exception:
         return list(x)
+
 
 aRepr = Repr()
 repr = aRepr.repr

--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -90,7 +90,7 @@ class Repr:
         maxiter,
         trailing_comma=False,
     ):
-        pieces = list(self._gen_pieces(x, level, maxiter))
+        pieces = list(self._gen_pieces(x, level - 1, maxiter))
         body = self._get_iterable_body(pieces, level, trailing_comma)
         return f'{left}{body}{right}'
 
@@ -108,7 +108,7 @@ class Repr:
 
     def _gen_pieces(self, obj, level, maxiter):
         for elem in islice(obj, maxiter):
-            yield self.repr1(elem, level - 1)
+            yield self.repr1(elem, level)
 
         if len(obj) > maxiter:
             yield self.fillvalue
@@ -180,14 +180,14 @@ class Repr:
     def repr_dict(self, x, level):
         left = '{'
         right = '}'
-        pieces = list(self._gen_dict_pieces(x, level, self.maxdict))
+        pieces = list(self._gen_dict_pieces(x, level - 1, self.maxdict))
         body = self._get_iterable_body(pieces, level, trailing_comma=False)
         return f'{left}{body}{right}'
 
     def _gen_dict_pieces(self, obj, level, maxiter):
         for key in islice(_possibly_sorted(obj), maxiter):
-            keyrepr = self.repr1(key, level - 1)
-            valrepr = self.repr1(obj[key], level - 1)
+            keyrepr = self.repr1(key, level)
+            valrepr = self.repr1(obj[key], level)
             yield f'{keyrepr}: {valrepr}'
 
         if len(obj) > maxiter:

--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -179,22 +179,20 @@ class Repr:
         )
 
     def repr_dict(self, x, level):
-        n = len(x)
-        if n == 0:
-            return '{}'
-        if level <= 0:
-            return '{' + self.fillvalue + '}'
-        newlevel = level - 1
-        repr1 = self.repr1
-        pieces = []
-        for key in islice(_possibly_sorted(x), self.maxdict):
-            keyrepr = repr1(key, newlevel)
-            valrepr = repr1(x[key], newlevel)
-            pieces.append('%s: %s' % (keyrepr, valrepr))
-        if n > self.maxdict:
-            pieces.append(self.fillvalue)
-        s = self._join(pieces, level)
-        return '{%s}' % (s,)
+        left = '{'
+        right = '}'
+        pieces = list(self._gen_dict_pieces(x, level, self.maxdict))
+        body = self._get_iterable_body(pieces, level, trailing_comma=False)
+        return f'{left}{body}{right}'
+
+    def _gen_dict_pieces(self, obj, level, maxiter):
+        for key in islice(_possibly_sorted(obj), maxiter):
+            keyrepr = self.repr1(key, level - 1)
+            valrepr = self.repr1(obj[key], level - 1)
+            yield f'{keyrepr}: {valrepr}'
+
+        if len(obj) > maxiter:
+            yield self.fillvalue
 
     def repr_str(self, x, level):
         s = builtins.repr(x[:self.maxstring])


### PR DESCRIPTION
In an attempt to find similarities between ``pprint`` and ``reprlib`` functionality,
I performed a refactoring of ``reprlib.py`` by extracting helper methods:
 - indent validation
 - common functionality for iterables

<!-- gh-issue-number: gh-96805 -->
* Issue: gh-96805
<!-- /gh-issue-number -->
