### PR TITLE
[document] Add vcpkg instruction step

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,13 +96,24 @@ below.
 
 Package manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-You can also use package manager vcpkg to build cpython with the following step::
+`vcpkg <https://github.com/microsoft/vcpkg>`_ is a package manager that supports
+all platforms (Windows, Linux and MacOS), you can easily use vcpkg to install
+third-party libraries with one command.
+
+Use the following steps to build cpython::
 
     git clone https://github.com/microsoft/vcpkg.git
     ./bootstrap-vcpkg.bat # for powershell
     ./bootstrap-vcpkg.sh # for bash
     ./vcpkg install python3
 
+See `document <https://github.com/microsoft/vcpkg#getting-started>`_ for more usage information.
+Please clone vcpkg in a non-whitespace and no non-ascii path anywhere.
+To remove vcpkg, you just need to remove the vcpkg folder.
+
+Please use `this link 
+<https://github.com/microsoft/vcpkg/issues/new?assignees=&labels=category%3Aport-bug&template=report-package-build-failure.md&title=%5B%3Cport+name%3E%5D+build+failure>`_
+to create an issue to vcpkg if you encounter any issues.
 
 Profile Guided Optimization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,16 @@ Profile Guided Optimization (PGO) and may be used to auto-enable Link Time
 Optimization (LTO) on some platforms.  For more details, see the sections
 below.
 
+Package manager
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+You can also use package manager vcpkg to build cpython with the following step::
+
+    git clone https://github.com/microsoft/vcpkg.git
+    ./bootstrap-vcpkg.bat # for powershell
+    ./bootstrap-vcpkg.sh # for bash
+    ./vcpkg install python3
+
+
 Profile Guided Optimization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
`cpython` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `cpython` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `cpython`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/python3/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)