### PR TITLE
gh-96822: PEP 670: Convert datetime.h macros to functions

### DIFF
--- a/Include/datetime.h
+++ b/Include/datetime.h
@@ -119,39 +119,168 @@ typedef struct
 // o is a pointer to a time or a datetime object.
 #define _PyDateTime_HAS_TZINFO(o)  (((_PyDateTime_BaseTZInfo *)(o))->hastzinfo)
 
-#define PyDateTime_GET_YEAR(o)     ((((PyDateTime_Date*)(o))->data[0] << 8) | \
-                     ((PyDateTime_Date*)(o))->data[1])
-#define PyDateTime_GET_MONTH(o)    (((PyDateTime_Date*)(o))->data[2])
-#define PyDateTime_GET_DAY(o)      (((PyDateTime_Date*)(o))->data[3])
+#define _PyDateTime_Date_CAST(op) ((PyDateTime_Date*)(op))
 
-#define PyDateTime_DATE_GET_HOUR(o)        (((PyDateTime_DateTime*)(o))->data[4])
-#define PyDateTime_DATE_GET_MINUTE(o)      (((PyDateTime_DateTime*)(o))->data[5])
-#define PyDateTime_DATE_GET_SECOND(o)      (((PyDateTime_DateTime*)(o))->data[6])
-#define PyDateTime_DATE_GET_MICROSECOND(o)              \
-    ((((PyDateTime_DateTime*)(o))->data[7] << 16) |       \
-     (((PyDateTime_DateTime*)(o))->data[8] << 8)  |       \
-      ((PyDateTime_DateTime*)(o))->data[9])
-#define PyDateTime_DATE_GET_FOLD(o)        (((PyDateTime_DateTime*)(o))->fold)
-#define PyDateTime_DATE_GET_TZINFO(o)      (_PyDateTime_HAS_TZINFO((o)) ? \
-    ((PyDateTime_DateTime *)(o))->tzinfo : Py_None)
+static inline int PyDateTime_GET_YEAR(PyObject *o) {
+    PyDateTime_Date *date = _PyDateTime_Date_CAST(o);
+    return ((date->data[0] << 8) | date->data[1]);
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_GET_YEAR(ob) PyDateTime_GET_YEAR(_PyObject_CAST(ob))
+#endif
+
+static inline int PyDateTime_GET_MONTH(PyObject *o) {
+    PyDateTime_Date *date = _PyDateTime_Date_CAST(o);
+    return date->data[2];
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_GET_MONTH(ob) PyDateTime_GET_MONTH(_PyObject_CAST(ob))
+#endif
+static inline int PyDateTime_GET_DAY(PyObject *o) {
+    PyDateTime_Date *date = _PyDateTime_Date_CAST(o);
+    return date->data[3];
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_GET_DAY(ob) PyDateTime_GET_DAY(_PyObject_CAST(ob))
+#endif
+
+#define _PyDateTime_DateTime_CAST(op) ((PyDateTime_DateTime*)(op))
+
+static inline int PyDateTime_DATE_GET_HOUR(PyObject *o) {
+    PyDateTime_DateTime *dt = _PyDateTime_DateTime_CAST(o);
+    return dt->data[4];
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_DATE_GET_HOUR(ob) PyDateTime_DATE_GET_HOUR(_PyObject_CAST(ob))
+#endif
+
+static inline int PyDateTime_DATE_GET_MINUTE(PyObject *o) {
+    PyDateTime_DateTime *dt = _PyDateTime_DateTime_CAST(o);
+    return dt->data[5];
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_DATE_GET_MINUTE(ob) PyDateTime_DATE_GET_MINUTE(_PyObject_CAST(ob))
+#endif
+
+static inline int PyDateTime_DATE_GET_SECOND(PyObject *o) {
+    PyDateTime_DateTime *dt = _PyDateTime_DateTime_CAST(o);
+    return dt->data[6];
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_DATE_GET_SECOND(ob) PyDateTime_DATE_GET_SECOND(_PyObject_CAST(ob))
+#endif
+
+static inline int PyDateTime_DATE_GET_MICROSECOND(PyObject *o) {
+    PyDateTime_DateTime *dt = _PyDateTime_DateTime_CAST(o);
+    return ((dt->data[7] << 16) | (dt->data[8] << 8)  | dt->data[9]);
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_DATE_GET_MICROSECOND(ob) PyDateTime_DATE_GET_MICROSECOND(_PyObject_CAST(ob))
+#endif
+
+static inline int PyDateTime_DATE_GET_FOLD(PyObject *o) {
+    PyDateTime_DateTime *dt = _PyDateTime_DateTime_CAST(o);
+    return dt->fold;
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_DATE_GET_FOLD(ob) PyDateTime_DATE_GET_FOLD(_PyObject_CAST(ob))
+#endif
+
+static inline PyObject* PyDateTime_DATE_GET_TZINFO(PyObject *o) {
+    if (_PyDateTime_HAS_TZINFO((o))) {
+        PyDateTime_DateTime *dt = _PyDateTime_DateTime_CAST(o);
+        return dt->tzinfo;
+    }
+    else {
+        return Py_None;
+    }
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_DATE_GET_TZINFO(ob) PyDateTime_DATE_GET_TZINFO(_PyObject_CAST(ob))
+#endif
+
+#define _PyDateTime_Time_CAST(op) ((PyDateTime_Time*)(op))
 
 /* Apply for time instances. */
-#define PyDateTime_TIME_GET_HOUR(o)        (((PyDateTime_Time*)(o))->data[0])
-#define PyDateTime_TIME_GET_MINUTE(o)      (((PyDateTime_Time*)(o))->data[1])
-#define PyDateTime_TIME_GET_SECOND(o)      (((PyDateTime_Time*)(o))->data[2])
-#define PyDateTime_TIME_GET_MICROSECOND(o)              \
-    ((((PyDateTime_Time*)(o))->data[3] << 16) |           \
-     (((PyDateTime_Time*)(o))->data[4] << 8)  |           \
-      ((PyDateTime_Time*)(o))->data[5])
-#define PyDateTime_TIME_GET_FOLD(o)        (((PyDateTime_Time*)(o))->fold)
-#define PyDateTime_TIME_GET_TZINFO(o)      (_PyDateTime_HAS_TZINFO(o) ? \
-    ((PyDateTime_Time *)(o))->tzinfo : Py_None)
+static inline int PyDateTime_TIME_GET_HOUR(PyObject *o) {
+    PyDateTime_Time *time = _PyDateTime_Time_CAST(o);
+    return time->data[0];
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_TIME_GET_HOUR(ob) PyDateTime_TIME_GET_HOUR(_PyObject_CAST(ob))
+#endif
+
+static inline int PyDateTime_TIME_GET_MINUTE(PyObject *o) {
+    PyDateTime_Time *time = _PyDateTime_Time_CAST(o);
+    return time->data[1];
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_TIME_GET_MINUTE(ob) PyDateTime_TIME_GET_MINUTE(_PyObject_CAST(ob))
+#endif
+
+static inline int PyDateTime_TIME_GET_SECOND(PyObject *o) {
+    PyDateTime_Time *time = _PyDateTime_Time_CAST(o);
+    return time->data[2];
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_TIME_GET_SECOND(ob) PyDateTime_TIME_GET_SECOND(_PyObject_CAST(ob))
+#endif
+
+static inline int PyDateTime_TIME_GET_MICROSECOND(PyObject *o) {
+    PyDateTime_Time *time = _PyDateTime_Time_CAST(o);
+    return ((time->data[3] << 16) | (time->data[4] << 8)  | time->data[5]);
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_TIME_GET_MICROSECOND(ob) PyDateTime_TIME_GET_MICROSECOND(_PyObject_CAST(ob))
+#endif
+
+static inline int PyDateTime_TIME_GET_FOLD(PyObject *o) {
+    PyDateTime_Time *time = _PyDateTime_Time_CAST(o);
+    return time->fold;
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_TIME_GET_FOLD(ob) PyDateTime_TIME_GET_FOLD(_PyObject_CAST(ob))
+#endif
+
+static inline PyObject* PyDateTime_TIME_GET_TZINFO(PyObject *o) {
+    if (_PyDateTime_HAS_TZINFO(o)) {
+        PyDateTime_Time *time = _PyDateTime_Time_CAST(o);
+        return time->tzinfo;
+    }
+    else {
+        return Py_None;
+    }
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_TIME_GET_TZINFO(ob) PyDateTime_TIME_GET_TZINFO(_PyObject_CAST(ob))
+#endif
+
+#define _PyDateTime_DELTA_CAST(op) ((PyDateTime_Delta*)(op))
 
 /* Apply for time delta instances */
-#define PyDateTime_DELTA_GET_DAYS(o)         (((PyDateTime_Delta*)(o))->days)
-#define PyDateTime_DELTA_GET_SECONDS(o)      (((PyDateTime_Delta*)(o))->seconds)
-#define PyDateTime_DELTA_GET_MICROSECONDS(o)            \
-    (((PyDateTime_Delta*)(o))->microseconds)
+static inline int PyDateTime_DELTA_GET_DAYS(PyObject *o) {
+    PyDateTime_Delta *delta = _PyDateTime_DELTA_CAST(o);
+    return delta->days;
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_DELTA_GET_DAYS(ob) PyDateTime_DELTA_GET_DAYS(_PyObject_CAST(ob))
+#endif
+
+static inline int PyDateTime_DELTA_GET_SECONDS(PyObject *o){
+    PyDateTime_Delta *delta = _PyDateTime_DELTA_CAST(o);
+    return delta->seconds;
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_DELTA_GET_SECONDS(ob) PyDateTime_DELTA_GET_SECONDS(_PyObject_CAST(ob))
+#endif
+
+static inline int PyDateTime_DELTA_GET_MICROSECONDS(PyObject *o) {
+    PyDateTime_Delta *delta = _PyDateTime_DELTA_CAST(o);
+    return delta->microseconds;
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030c0000
+#  define PyDateTime_DELTA_GET_MICROSECONDS(ob) PyDateTime_DELTA_GET_MICROSECONDS(_PyObject_CAST(ob))
+#endif
 
 
 /* Define structure for C API. */

--- a/Misc/NEWS.d/next/C API/2022-09-14-12-52-52.gh-issue-96822.dSblde.rst
+++ b/Misc/NEWS.d/next/C API/2022-09-14-12-52-52.gh-issue-96822.dSblde.rst
@@ -1,0 +1,4 @@
+:pep:`670`: Convert datetime.h "GET" macros, like
+:c:func:`PyDateTime_TIME_GET_HOUR`, to static inline functions.  These macros
+can no longer be used as l-values to modify structure members. Patch by Victor
+Stinner.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -84,18 +84,18 @@ class datetime.IsoCalendarDate "PyDateTime_IsoCalendarDate *" "&PyDateTime_IsoCa
 /* Date accessors for date and datetime. */
 #define SET_YEAR(o, v)          (((o)->data[0] = ((v) & 0xff00) >> 8), \
                  ((o)->data[1] = ((v) & 0x00ff)))
-#define SET_MONTH(o, v)         (PyDateTime_GET_MONTH(o) = (v))
-#define SET_DAY(o, v)           (PyDateTime_GET_DAY(o) = (v))
+#define SET_MONTH(o, v)         ((o)->data[2] = (v))
+#define SET_DAY(o, v)           ((o)->data[3] = (v))
 
 /* Date/Time accessors for datetime. */
-#define DATE_SET_HOUR(o, v)     (PyDateTime_DATE_GET_HOUR(o) = (v))
-#define DATE_SET_MINUTE(o, v)   (PyDateTime_DATE_GET_MINUTE(o) = (v))
-#define DATE_SET_SECOND(o, v)   (PyDateTime_DATE_GET_SECOND(o) = (v))
+#define DATE_SET_HOUR(o, v)     ((o)->data[4] = (v))
+#define DATE_SET_MINUTE(o, v)   ((o)->data[5] = (v))
+#define DATE_SET_SECOND(o, v)   ((o)->data[6] = (v))
 #define DATE_SET_MICROSECOND(o, v)      \
     (((o)->data[7] = ((v) & 0xff0000) >> 16), \
      ((o)->data[8] = ((v) & 0x00ff00) >> 8), \
      ((o)->data[9] = ((v) & 0x0000ff)))
-#define DATE_SET_FOLD(o, v)   (PyDateTime_DATE_GET_FOLD(o) = (v))
+#define DATE_SET_FOLD(o, v)   (_PyDateTime_DateTime_CAST(o)->fold = (v))
 
 /* Time accessors for time. */
 #define TIME_GET_HOUR           PyDateTime_TIME_GET_HOUR
@@ -103,14 +103,14 @@ class datetime.IsoCalendarDate "PyDateTime_IsoCalendarDate *" "&PyDateTime_IsoCa
 #define TIME_GET_SECOND         PyDateTime_TIME_GET_SECOND
 #define TIME_GET_MICROSECOND    PyDateTime_TIME_GET_MICROSECOND
 #define TIME_GET_FOLD           PyDateTime_TIME_GET_FOLD
-#define TIME_SET_HOUR(o, v)     (PyDateTime_TIME_GET_HOUR(o) = (v))
-#define TIME_SET_MINUTE(o, v)   (PyDateTime_TIME_GET_MINUTE(o) = (v))
-#define TIME_SET_SECOND(o, v)   (PyDateTime_TIME_GET_SECOND(o) = (v))
+#define TIME_SET_HOUR(o, v)     ((o)->data[0] = (v))
+#define TIME_SET_MINUTE(o, v)   ((o)->data[1] = (v))
+#define TIME_SET_SECOND(o, v)   ((o)->data[2] = (v))
 #define TIME_SET_MICROSECOND(o, v)      \
     (((o)->data[3] = ((v) & 0xff0000) >> 16), \
      ((o)->data[4] = ((v) & 0x00ff00) >> 8), \
      ((o)->data[5] = ((v) & 0x0000ff)))
-#define TIME_SET_FOLD(o, v)   (PyDateTime_TIME_GET_FOLD(o) = (v))
+#define TIME_SET_FOLD(o, v)   (_PyDateTime_Time_CAST(o)->fold = (v))
 
 /* Delta accessors for timedelta. */
 #define GET_TD_DAYS(o)          (((PyDateTime_Delta *)(o))->days)
@@ -1515,7 +1515,7 @@ make_somezreplacement(PyObject *object, char *sep, PyObject *tzinfoarg)
     if (tzinfo == Py_None || tzinfo == NULL) {
         return PyBytes_FromStringAndSize(NULL, 0);
     }
-   
+
     assert(tzinfoarg != NULL);
     if (format_utcoffset(buf,
                          sizeof(buf),
@@ -1523,7 +1523,7 @@ make_somezreplacement(PyObject *object, char *sep, PyObject *tzinfoarg)
                          tzinfo,
                          tzinfoarg) < 0)
         return NULL;
-        
+
     return PyBytes_FromStringAndSize(buf, strlen(buf));
 }
 


### PR DESCRIPTION
Convert datetime.h "GET" macros to static inline functions:

* PyDateTime_DATE_GET_FOLD()
* PyDateTime_DATE_GET_HOUR()
* PyDateTime_DATE_GET_MICROSECOND()
* PyDateTime_DATE_GET_MINUTE()
* PyDateTime_DATE_GET_SECOND()
* PyDateTime_DATE_GET_TZINFO()
* PyDateTime_DELTA_GET_DAYS()
* PyDateTime_DELTA_GET_MICROSECONDS()
* PyDateTime_DELTA_GET_SECONDS()
* PyDateTime_GET_DAY()
* PyDateTime_GET_MONTH()
* PyDateTime_GET_YEAR()
* PyDateTime_TIME_GET_FOLD()
* PyDateTime_TIME_GET_HOUR()
* PyDateTime_TIME_GET_MICROSECOND()
* PyDateTime_TIME_GET_MINUTE()
* PyDateTime_TIME_GET_SECOND()
* PyDateTime_TIME_GET_TZINFO()

These macros can no longer be used as l-values to modify structure members.

In the limited C API version 3.12, function arguments are no longer converted to PyObject* implicitly.

Modify internal "SET" macros to access directly directly structure members, rather than using "GET" macros as l-values.

* DATE_SET_FOLD()
* DATE_SET_HOUR()
* DATE_SET_MINUTE()
* DATE_SET_SECOND()
* SET_DAY()
* SET_MONTH()
* TIME_SET_FOLD()
* TIME_SET_HOUR()
* TIME_SET_MINUTE()
* TIME_SET_SECOND()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96822 -->
* Issue: gh-96822
<!-- /gh-issue-number -->
