### PR TITLE
gh-96828: Add an `ssl.OP_ENABLE_KTLS` option

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -839,6 +839,22 @@ Constants
 
    .. versionadded:: 3.10
 
+.. data:: OP_ENABLE_KTLS
+
+   Enable the use of the kernel TLS. To benefit from the feature, OpenSSL must
+   have been compiled with support for it, and the negotiated cipher suites and
+   extensions must be supported by it (a list of supported ones may vary by
+   platform and kernel version).
+
+   Note that with enabled kernel TLS some cryptographic operations are
+   performed by the kernel directly and not via any available OpenSSL
+   Providers. This might be undesirable if, for example, the application
+   requires all cryptographic operations to be performed by the FIPS provider.
+
+   This option is only available with OpenSSL 3.0.0 and later.
+
+   .. versionadded:: 3.12
+
 .. data:: HAS_ALPN
 
    Whether the OpenSSL library has built-in support for the *Application-Layer

--- a/Misc/NEWS.d/next/Library/2022-09-14-21-56-15.gh-issue-96828.ZoOY5G.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-14-21-56-15.gh-issue-96828.ZoOY5G.rst
@@ -1,0 +1,2 @@
+Add an :data:`~ssl.OP_ENABLE_KTLS` option for enabling the use of the kernel
+TLS (kTLS). Patch by Illia Volochii.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5881,6 +5881,9 @@ sslmodule_init_constants(PyObject *m)
     PyModule_AddIntConstant(m, "OP_IGNORE_UNEXPECTED_EOF",
                             SSL_OP_IGNORE_UNEXPECTED_EOF);
 #endif
+#ifdef SSL_OP_ENABLE_KTLS
+    PyModule_AddIntConstant(m, "OP_ENABLE_KTLS", SSL_OP_ENABLE_KTLS);
+#endif
 
 #ifdef X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT
     PyModule_AddIntConstant(m, "HOSTFLAG_ALWAYS_CHECK_SUBJECT",


### PR DESCRIPTION
Resolves #96828.

<!-- gh-issue-number: gh-96828 -->
* Issue: gh-96828
<!-- /gh-issue-number -->
