### PR TITLE
gh-96851 Doc: clarify lru_cache on class methods

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -195,7 +195,8 @@ The :mod:`functools` module defines the following functions:
    bypassing the cache, or for rewrapping the function with a different cache.
 
    The cache keeps references to the arguments and return values until they age
-   out of the cache or until the cache is cleared.
+   out of the cache or until the cache is cleared. This includes references 
+   to self, which will prevent class instances from getting garbage collecting.
 
    An `LRU (least recently used) cache
    <https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)>`_


### PR DESCRIPTION
Clarify that when using the lru_cache decorator on class methods the cached function keeps a reference to each instance (self), which prevents the class instance from being garbage collected.

Issue: https://github.com/python/cpython/issues/96851


<!-- gh-issue-number: gh-96851 -->
* Issue: gh-96851
<!-- /gh-issue-number -->
