### PR TITLE
gh-96859: [argparse] Avoid O(N^2) behavior while consuming optionals

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1933,7 +1933,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                     arg_string_pattern_parts.append('A')
 
             # otherwise, add the arg to the arg strings
-            # and note the index if it was an option
+            # and record parsed optionals together with their indices
             else:
                 option_tuple = self._parse_optional(arg_string)
                 if option_tuple is None:
@@ -1971,11 +1971,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 action(self, namespace, argument_values, option_string)
 
         # function to convert arg_strings into an optional action
-        def consume_optional(start_index, option_tuple):
-
-            # get the optional identified at this index
-            action, option_string, explicit_arg = option_tuple
-
+        def consume_optional(start_index, action, option_string, explicit_arg):
             # identify additional optionals in the same arg string
             # (e.g. -xyz is the same as -x -y -z if no args are required)
             match_argument = self._match_argument
@@ -2091,7 +2087,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 start_index = option_tuple_index
 
             # consume the next optional and any arguments for it
-            start_index = consume_optional(start_index, option_tuple)
+            start_index = consume_optional(start_index, *option_tuple)
 
         # consume any positionals following the last Optional
         stop_index = consume_positionals(start_index)

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1918,9 +1918,10 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 conflicts.extend(group_actions[:i])
                 conflicts.extend(group_actions[i + 1:])
 
-        # find all option indices, and determine the arg_string_pattern
-        # which has an 'O' if there is an option at an index,
-        # an 'A' if there is an argument, or a '-' if there is a '--'
+        # determine the arg_string_pattern which has an 'O' if there is
+        # an option at an index, an 'A' if there is an argument, or a '-' if
+        # there is a '--'. record parsed optionals so that they could be
+        # later passed to consume_optional().
         option_tuples = []
         arg_string_pattern_parts = []
         arg_strings_iter = iter(arg_strings)

--- a/Misc/NEWS.d/next/Library/2022-09-18-01-11-02.gh-issue-96859.G6Uusx.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-18-01-11-02.gh-issue-96859.G6Uusx.rst
@@ -1,0 +1,1 @@
+Improved performance of :class:`argparse.ArgumentParser` when parsing very long argument lists.


### PR DESCRIPTION
The loop consuming optional and positional arguments in ArgumentParser._parse_known_args() rescans option_string_indices on every iteration of the loop in order to compute the next option index:

```py
next_option_string_index = min([
    index
    for index in option_string_indices
    if index >= start_index])
```

This becomes very slow when parsing a very long list of arguments, e.g. when parsing a response file.

This commit refactors the loop to scan the option indices list only once.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96859 -->
* Issue: gh-96859
<!-- /gh-issue-number -->
