### PR TITLE
Fix capitalization of Unix in multiprocessing documentation

### DIFF
--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -83,7 +83,7 @@ Here are the methods of the :class:`Message` class:
       Note that this method is provided as a convenience and may not always
       format the message the way you want.  For example, by default it does
       not do the mangling of lines that begin with ``From`` that is
-      required by the unix mbox format.  For more flexibility, instantiate a
+      required by the Unix mbox format.  For more flexibility, instantiate a
       :class:`~email.generator.Generator` instance and use its
       :meth:`~email.generator.Generator.flatten` method directly.  For example::
 
@@ -125,7 +125,7 @@ Here are the methods of the :class:`Message` class:
       Note that this method is provided as a convenience and may not always
       format the message the way you want.  For example, by default it does
       not do the mangling of lines that begin with ``From`` that is
-      required by the unix mbox format.  For more flexibility, instantiate a
+      required by the Unix mbox format.  For more flexibility, instantiate a
       :class:`~email.generator.BytesGenerator` instance and use its
       :meth:`~email.generator.BytesGenerator.flatten` method directly.
       For example::

--- a/Doc/library/email.generator.rst
+++ b/Doc/library/email.generator.rst
@@ -55,7 +55,7 @@ To accommodate reproducible processing of SMIME-signed messages
    defaults to the value of the :attr:`~email.policy.Policy.mangle_from_`
    setting of the *policy* (which is ``True`` for the
    :data:`~email.policy.compat32` policy and ``False`` for all others).
-   *mangle_from_* is intended for use when messages are stored in unix mbox
+   *mangle_from_* is intended for use when messages are stored in Unix mbox
    format (see :mod:`mailbox` and `WHY THE CONTENT-LENGTH FORMAT IS BAD
    <https://www.jwz.org/doc/content-length.html>`_).
 
@@ -156,7 +156,7 @@ to be using :class:`BytesGenerator`, and not :class:`Generator`.
    defaults to the value of the :attr:`~email.policy.Policy.mangle_from_`
    setting of the *policy* (which is ``True`` for the
    :data:`~email.policy.compat32` policy and ``False`` for all others).
-   *mangle_from_* is intended for use when messages are stored in unix mbox
+   *mangle_from_* is intended for use when messages are stored in Unix mbox
    format (see :mod:`mailbox` and `WHY THE CONTENT-LENGTH FORMAT IS BAD
    <https://www.jwz.org/doc/content-length.html>`_).
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -144,8 +144,8 @@ to start a process.  These *start methods* are
    subprocess. See :issue:`33725`.
 
 .. versionchanged:: 3.4
-   *spawn* added on all unix platforms, and *forkserver* added for
-   some unix platforms.
+   *spawn* added on all Unix platforms, and *forkserver* added for
+   some Unix platforms.
    Child processes no longer inherit all of the parents inheritable
    handles on Windows.
 

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -16,7 +16,7 @@ files see :func:`open`, and for accessing the filesystem see the :mod:`os`
 module. The path parameters can be passed as strings, or bytes, or any object
 implementing the :class:`os.PathLike` protocol.
 
-Unlike a unix shell, Python does not do any *automatic* path expansions.
+Unlike a Unix shell, Python does not do any *automatic* path expansions.
 Functions such as :func:`expanduser` and :func:`expandvars` can be invoked
 explicitly when an application desires shell-like path expansion.  (See also
 the :mod:`glob` module.)

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -1128,7 +1128,7 @@ The :mod:`test.support.socket_helper` module provides support for socket tests.
 
 .. function:: bind_unix_socket(sock, addr)
 
-   Bind a unix socket, raising :exc:`unittest.SkipTest` if
+   Bind a Unix socket, raising :exc:`unittest.SkipTest` if
    :exc:`PermissionError` is raised.
 
 

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -1898,7 +1898,7 @@ socket
   family on OS X.  (Contributed by Michael Goderbauer in :issue:`13777`.)
 
 * New function :func:`~socket.sethostname` allows the hostname to be set
-  on unix systems if the calling process has sufficient privileges.
+  on Unix systems if the calling process has sufficient privileges.
   (Contributed by Ross Lagerwall in :issue:`10866`.)
 
 


### PR DESCRIPTION
Fix capitalization of Unix in multiprocessing documentation