### PR TITLE
gh-96821: Fix undefined behaviour in `_testcapimodule.c`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-18-08-47-40.gh-issue-96821.Co2iOq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-18-08-47-40.gh-issue-96821.Co2iOq.rst
@@ -1,1 +1,1 @@
-Fix undefined behaviour in `_testcapimodule.c`.
+Fix undefined behaviour in ``_testcapimodule.c``.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-18-08-47-40.gh-issue-96821.Co2iOq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-18-08-47-40.gh-issue-96821.Co2iOq.rst
@@ -1,0 +1,1 @@
+Fix undefined behaviour in `_testcapimodule.c`.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4918,6 +4918,7 @@ meth_fastcall_keywords(PyObject* self, PyObject* const* args,
     if (pyargs == NULL) {
         return NULL;
     }
+    assert(args != NULL);
     PyObject *pykwargs = PyObject_Vectorcall((PyObject*)&PyDict_Type,
                                               args + nargs, 0, kwargs);
     return Py_BuildValue("NNN", _null_to_none(self), pyargs, pykwargs);

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4918,9 +4918,10 @@ meth_fastcall_keywords(PyObject* self, PyObject* const* args,
     if (pyargs == NULL) {
         return NULL;
     }
-    assert(args != NULL);
+    assert(args != NULL || nargs == 0);
+    PyObject* const* args_offset = args == NULL ? NULL : args + nargs;
     PyObject *pykwargs = PyObject_Vectorcall((PyObject*)&PyDict_Type,
-                                              args + nargs, 0, kwargs);
+                                              args_offset, 0, kwargs);
     return Py_BuildValue("NNN", _null_to_none(self), pyargs, pykwargs);
 }
 


### PR DESCRIPTION
The first commit demonstrates the undefined behaviour and is meant to fail tests.

The other commits fix it.

<!-- gh-issue-number: gh-96821 -->
* Issue: gh-96821
<!-- /gh-issue-number -->
