### PR TITLE
[3.10] gh-96917: link to typing.readthedocs.io from typing.rst (GH-96921)

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -36,6 +36,11 @@ New features are frequently added to the ``typing`` module.
 The `typing_extensions <https://pypi.org/project/typing-extensions/>`_ package
 provides backports of these new features to older versions of Python.
 
+.. seealso::
+
+   The documentation at https://typing.readthedocs.io/ serves as useful reference
+   for type system features, useful typing related tools and typing best practices.
+
 .. _relevant-peps:
 
 Relevant PEPs


### PR DESCRIPTION
See the discussion at https://github.com/python/cpython/issues/91533. (cherry picked from commit 5b3a2569f4b4dfb58a8f90a241f9dac1a7ea4bf6)

Co-authored-by: Shantanu <12621235+hauntsaninja@users.noreply.github.com>

<!-- gh-issue-number: gh-96917 -->
* Issue: gh-96917
<!-- /gh-issue-number -->
