### PR TITLE
gh-96947: Fix comment on `pyruntimestate->pyinterpreters` struct for `next_id`

### DIFF
--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -93,8 +93,8 @@ typedef struct pyruntimestate {
            in the operation of the runtime.  It is also often the only
            interpreter. */
         PyInterpreterState *main;
-        /* _next_interp_id is an auto-numbered sequence of small
-           integers.  It gets initialized in _PyInterpreterState_Init(),
+        /* next_id is an auto-numbered sequence of small
+           integers.  It gets initialized in _PyInterpreterState_Enable(),
            which is called in Py_Initialize(), and used in
            PyInterpreterState_New().  A negative interpreter ID
            indicates an error occurred.  The main interpreter will


### PR DESCRIPTION
 `_next_interp_id` appeared on [this commit](https://github.com/python/cpython/commit/e377416c10eb0bf055b0728cdcdc4488fdfd3b5f#diff-7ac11e526f79b42d6ea9d3592cb99da46775640c69fa5510f4a6de87cced7141R68) renamed to `next_id` ([by this commit](https://github.com/python/cpython/commit/2ebc5ce42a8a9e047e790aefbf9a94811569b2b6#diff-bccfc01bd96b58c022dde77486b8a896cbb31d7581bd4a4156b32c3654afe468R59)). 

Also, now, `next_id` gets initialized in` _PyInterpreterState_Enable()` https://github.com/python/cpython/blob/12c5f328d2479ac3432df5e266adc4e59adeabfe/Python/pystate.c#L241-L244 because `_PyInterpreterState_Init()` function doesn't exist at all.

<!-- gh-issue-number: gh-96947 -->
* Issue: gh-96947
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:ericsnowcurrently