### PR TITLE
Fix minor comment typo in dictobject.c

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4719,7 +4719,7 @@ static PySequenceMethods dictkeys_as_sequence = {
     (objobjproc)dictkeys_contains,      /* sq_contains */
 };
 
-// Create an set object from dictviews object.
+// Create a set object from dictviews object.
 // Returns a new reference.
 // This utility function is used by set operations.
 static PyObject*


### PR DESCRIPTION
Fix a minor comment typo in the Objects/dictobject.c file.

Automerge-Triggered-By: GH:methane