### PR TITLE
include OrderedDict import in TimeBoundedLRU example

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1201,6 +1201,7 @@ variants of :func:`functools.lru_cache`:
 
 .. testcode::
 
+    from collections import OrderedDict
     from time import time
 
     class TimeBoundedLRU:


### PR DESCRIPTION
Currently, the TimeBoundedLRU example in the [OrderedDict recipes](https://docs.python.org/3/library/collections.html#ordereddict-examples-and-recipes) is mostly complete, except for importing OrderedDict itself. Adding this missing import allows readers to copy paste for a fully working example.