### PR TITLE
[3.10] GH-96864: Check for error between line and opcode events (GH-96880)

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -1310,6 +1310,20 @@ class RaisingTraceFuncTestCase(unittest.TestCase):
         finally:
             sys.settrace(existing)
 
+    def test_line_event_raises_before_opcode_event(self):
+        exception = ValueError("BOOM!")
+        def trace(frame, event, arg):
+            if event == "line":
+                raise exception
+            frame.f_trace_opcodes = True
+            return trace
+        def f():
+            pass
+        with self.assertRaises(ValueError) as caught:
+            sys.settrace(trace)
+            f()
+        self.assertIs(caught.exception, exception)
+
 
 # 'Jump' tests: assigning to frame.f_lineno within a trace function
 # moves the execution position - it's how debuggers implement a Jump

--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-16-12-36-13.gh-issue-96864.PLU3i8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-16-12-36-13.gh-issue-96864.PLU3i8.rst
@@ -1,0 +1,2 @@
+Fix a possible assertion failure, fatal error, or :exc:`SystemError` if a
+line tracing event raises an exception while opcode tracing is enabled.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5512,7 +5512,7 @@ maybe_call_line_trace(Py_tracefunc func, PyObject *obj,
         }
     }
     /* Always emit an opcode event if we're tracing all opcodes. */
-    if (frame->f_trace_opcodes) {
+    if (frame->f_trace_opcodes && result == 0) {
         result = call_trace(func, obj, tstate, frame, trace_info, PyTrace_OPCODE, Py_None);
     }
     return result;


### PR DESCRIPTION
(cherry picked from commit c10e33ac119d96c4d88d5ae8b59e65a76ae0ad3c)

<!-- gh-issue-number: gh-96864 -->
* Issue: gh-96864
<!-- /gh-issue-number -->
