### PR TITLE
gh-42127 Expand child process console opening comments.

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -271,7 +271,8 @@ default values. The arguments that are most commonly needed are:
    the child's file handles will be inherited from the parent for console
    applications, if the child can connect to the console.  Otherwise it will
    allocate a new console. For non-console applications, the window manager
-   and graphical shell will determine behavior.  Additionally, *stderr* can be
+   and graphical shell will determine behavior.
+   Additionally, *stderr* can be
    :data:`STDOUT`, which indicates that the stderr data from the child process
    should be captured into the same file handle as for *stdout*.
 
@@ -493,7 +494,8 @@ functions.
    no redirection will occur; the child's file handles will be inherited from
    the parent for console applications, if the child can connect to the console.
    Otherwise it will allocate a new console.  For non-console applications, the
-   window manager and graphical shell will determine behavior.  Additionally,
+   window manager and graphical shell will determine behavior.
+   Additionally,
    *stderr* can be :data:`STDOUT`, which indicates that the stderr data from
    the applications should be captured into the same file handle as for stdout.
 

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -268,10 +268,12 @@ default values. The arguments that are most commonly needed are:
    :data:`PIPE` indicates that a new pipe to the child should be created.
    :data:`DEVNULL` indicates that the special file :data:`os.devnull` will
    be used.  With the default settings of ``None``, no redirection will occur;
-   the child's file handles will be inherited from the parent.
-   Additionally, *stderr* can be :data:`STDOUT`, which indicates that the
-   stderr data from the child process should be captured into the same file
-   handle as for *stdout*.
+   the child's file handles will be inherited from the parent for console
+   applications, if the child can connect to the console.  Otherwise it will
+   allocate a new console. For non-console applications, the window manager
+   and graphical shell will determine behavior.  Additionally, *stderr* can be
+   :data:`STDOUT`, which indicates that the stderr data from the child process
+   should be captured into the same file handle as for *stdout*.
 
    .. index::
       single: universal newlines; subprocess module
@@ -489,9 +491,11 @@ functions.
    be created.  :data:`DEVNULL` indicates that the special file
    :data:`os.devnull` will be used. With the default settings of ``None``,
    no redirection will occur; the child's file handles will be inherited from
-   the parent.  Additionally, *stderr* can be :data:`STDOUT`, which indicates
-   that the stderr data from the applications should be captured into the same
-   file handle as for stdout.
+   the parent for console applications, if the child can connect to the console.
+   Otherwise it will allocate a new console.  For non-console applications, the
+   window manager and graphical shell will determine behavior.  Additionally,
+   *stderr* can be :data:`STDOUT`, which indicates that the stderr data from
+   the applications should be captured into the same file handle as for stdout.
 
    If *preexec_fn* is set to a callable object, this object will be called in the
    child process just before the child is executed.

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -272,9 +272,9 @@ default values. The arguments that are most commonly needed are:
    applications, if the child can connect to the console.  Otherwise it will
    allocate a new console. For non-console applications, the window manager
    and graphical shell will determine behavior.
-   Additionally, *stderr* can be
-   :data:`STDOUT`, which indicates that the stderr data from the child process
-   should be captured into the same file handle as for *stdout*.
+   Additionally, *stderr* can be :data:`STDOUT`, which indicates that the
+   stderr data from the child process should be captured into the same file
+   handle as for *stdout*.
 
    .. index::
       single: universal newlines; subprocess module
@@ -495,9 +495,9 @@ functions.
    the parent for console applications, if the child can connect to the console.
    Otherwise it will allocate a new console.  For non-console applications, the
    window manager and graphical shell will determine behavior.
-   Additionally,
-   *stderr* can be :data:`STDOUT`, which indicates that the stderr data from
-   the applications should be captured into the same file handle as for stdout.
+   Additionally, *stderr* can be :data:`STDOUT`, which indicates
+   that the stderr data from the applications should be captured into the same
+   file handle as for stdout.
 
    If *preexec_fn* is set to a callable object, this object will be called in the
    child process just before the child is executed.


### PR DESCRIPTION
This expands the child process console opening in Doc/library/subprocess.rst. This PR is compatible with branch 3.11, but not with branch 3.10.

<!-- gh-issue-number: gh-42127 -->
* Issue: gh-42127
<!-- /gh-issue-number -->
