### PR TITLE
[3.10] gh-96954: Add tests for unicodedata.name/lookup (GH-96955)

### DIFF
--- a/Lib/test/test_unicodedata.py
+++ b/Lib/test/test_unicodedata.py
@@ -95,6 +95,13 @@ class UnicodeFunctionsTest(UnicodeDatabaseTest):
         result = h.hexdigest()
         self.assertEqual(result, self.expectedchecksum)
 
+    @requires_resource('cpu')
+    def test_name_inverse_lookup(self):
+        for i in range(sys.maxunicode + 1):
+            char = chr(i)
+            if looked_name := self.db.name(char, None):
+                self.assertEqual(self.db.lookup(looked_name), char)
+
     def test_digit(self):
         self.assertEqual(self.db.digit('A', None), None)
         self.assertEqual(self.db.digit('9'), 9)


### PR DESCRIPTION
They were undertested, and since GH-96954 might involve a rewrite of this part of the code we want to ensure that there won't be any behavioral change.

Co-authored-by: Carl Friedrich Bolz-Tereick <cfbolz@gmx.de>
(cherry picked from commit 5a32eeced2c537c13613dd4ff5b2767a37037294)

Co-authored-by: Batuhan Taskaya <isidentical@gmail.com>
