### PR TITLE
gh-85735: Add PYTHONHISTFILE and PYTHONHISTSIZE to control Python history file

### DIFF
--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -144,11 +144,17 @@ Readline configuration
 On systems that support :mod:`readline`, this module will also import and
 configure the :mod:`rlcompleter` module, if Python is started in
 :ref:`interactive mode <tut-interactive>` and without the :option:`-S` option.
-The default behavior is enable tab-completion and to use
-:file:`~/.python_history` as the history save file.  To disable it, delete (or
-override) the :data:`sys.__interactivehook__` attribute in your
+The default behavior is enable tab-completion and to use the
+:envvar:`PYTHONHISTFILE` file (defaults to :file:`~/.python_history`) as the
+history save file for up to :envvar:`PYTHONHISTSIZE` lines (defaults to 131072
+or ~4MB). To disable it, set :envvar:`PYTHONHISTFILE` to an empty string,
+or delete (or override) the :data:`sys.__interactivehook__` attribute in your
 :mod:`sitecustomize` or :mod:`usercustomize` module or your
 :envvar:`PYTHONSTARTUP` file.
+
+.. versionchanged:: 3.xx
+   Added :envvar:`PYTHONHISTFILE` and :envvar:`PYTHONHISTSIZE` to control
+   the location and size of the history file.
 
 .. versionchanged:: 3.4
    Activation of rlcompleter and history was made automatic.

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -612,6 +612,28 @@ before the command-line switches other than -E or -I.  It is customary that
 command-line switches override environmental variables where there is a
 conflict.
 
+.. envvar:: PYTHONHISTFILE
+
+   Change the location of the Python history file. By default, the history is
+   saved to :file:`~/.python_history`.
+
+   If the environment variable is defined but has not value, the history will
+   not be saved upon interpreter's exit.
+
+   .. versionadded:: 3.xx
+
+
+.. envvar:: PYTHONHISTSIZE
+
+   Change the maximum number of lines preserved by the :envvar:`PYTHONHISTFILE`
+   file. By default, Python preserves 131072 lines (~4MB).
+
+   This value controls truncation of the history file size upon exit only.
+   Upon start the history file will be read fully, regardless of its size.
+
+   .. versionadded:: 3.xx
+
+
 .. envvar:: PYTHONHOME
 
    Change the location of the standard Python libraries.  By default, the


### PR DESCRIPTION
TBD:
- [ ] What sensible default should be used for `PYTHONHISTSIZE` (currently 131072 or ~4MB per my usage)

<!-- gh-issue-number: gh-85735 -->
* Issue: gh-85735
<!-- /gh-issue-number -->
