### PR TITLE
gh-58451: Add optional delete_on_close parameter to NamedTemporaryFile

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -75,20 +75,50 @@ The module defines the following user-callable items:
       Added *errors* parameter.
 
 
-.. function:: NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None, newline=None, suffix=None, prefix=None, dir=None, delete=True, *, errors=None)
+.. function:: NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None, newline=None, suffix=None, prefix=None, dir=None, delete=True, *, errors=None, delete_on_close=True)
 
-   This function operates exactly as :func:`TemporaryFile` does, except that
-   the file is guaranteed to have a visible name in the file system (on
-   Unix, the directory entry is not unlinked).  That name can be retrieved
-   from the :attr:`name` attribute of the returned
-   file-like object.  Whether the name can be
-   used to open the file a second time, while the named temporary file is
-   still open, varies across platforms (it can be so used on Unix; it cannot
-   on Windows).  If *delete* is true (the default), the file is
-   deleted as soon as it is closed.
+   This function operates exactly as :func:`TemporaryFile` does, except the
+   following differences:
+
+   * The file is guaranteed to have a visible name in the file system (on Unix,
+     the directory entry is not unlinked).
+
+   * There is more granularity in the deletion behaviour of the file (see
+     ``delete_on_close`` below)
+
    The returned object is always a file-like object whose :attr:`!file`
-   attribute is the underlying true file object. This file-like object can
-   be used in a :keyword:`with` statement, just like a normal file.
+   attribute is the underlying true file object. This file-like object can be
+   used in a :keyword:`with` statement, just like a normal file.  The name of the
+   temporary file can be retrieved from the :attr:`name` attribute of the
+   returned file-like object.
+
+   If *delete* is true (the default) and *delete_on_close* is true (the
+   default), the file is deleted as soon as it is closed. If *delete* is true
+   and *delete_on_close* is false, the file is deleted on context manager exit
+   only. If *delete* is false, the value of *delete_on_close* is ignored.
+
+   While the named temporary file is open, the file can always be opened again
+   on POSIX. On Windows, it can be opened again if *delete* is false, or if
+   *delete_on_close* is false, or if the additional open shares delete access
+   (e.g. by calling :func:`os.open` with the flag ``O_TEMPORARY``).  On
+   Windows, if *delete* is true and *delete_on_close* is false, additional
+   opens that do not share delete access (e.g. via builtin :func:`open`) must
+   be closed before exiting the context manager, else the :func:`os.unlink`
+   call on context manager exit will fail with a :exc:`PermissionError`.
+
+   To use the name of the temporary file to open the closed file second time,
+   either make sure not to delete the file upon closure (set the *delete*
+   parameter to be false) or, in case the temporary file is created in a
+   :keyword:`with` statement, set the *delete_on_close* parameter to be false.
+   The latter approach is recommended as it provides assistance in automatic
+   cleaning of the temporary file upon the context manager exit.
+
+   On Windows, if *delete_on_close* is false, and the file is created in a
+   directory for which the user lacks delete access, then the :func:`os.unlink`
+   call on exit of the context manager will fail with a :exc:`PermissionError`.
+   This cannot happen when *delete_on_close* is true because delete access is
+   requested by the open, which fails immediately if the requested access is not
+   granted.
 
    On POSIX (only), a process that is terminated abruptly with SIGKILL
    cannot automatically delete any NamedTemporaryFiles it created.
@@ -97,6 +127,9 @@ The module defines the following user-callable items:
 
    .. versionchanged:: 3.8
       Added *errors* parameter.
+
+   .. versionchanged:: 3.12
+      Added *delete_on_close* parameter.
 
 
 .. class:: SpooledTemporaryFile(max_size=0, mode='w+b', buffering=-1, encoding=None, newline=None, suffix=None, prefix=None, dir=None, *, errors=None)
@@ -345,6 +378,22 @@ Here are some examples of typical usage of the :mod:`tempfile` module::
     b'Hello world!'
     >>>
     # file is now closed and removed
+
+    # create a temporary file using a context manager, note the name,
+    # close the file, use the name to open the file again
+    >>> with tempfile.TemporaryFile(delete_on_close=False) as fp:
+    ...     fp.write(b'Hello world!')
+    ...     fp_name = fp.name
+    ...     fp.close()
+    # the file is closed, but not removed
+    # open the file again by using its name
+    ...     f = open(fp_name)
+    ...     f.seek(0)
+    ...     f.read()
+    b'Hello world!'
+    ...     f.close()
+    >>>
+    # file is now removed
 
     # create a temporary directory using the context manager
     >>> with tempfile.TemporaryDirectory() as tmpdirname:

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -80,11 +80,10 @@ The module defines the following user-callable items:
    This function operates exactly as :func:`TemporaryFile` does, except the
    following differences:
 
-   * The file is guaranteed to have a visible name in the file system (on Unix,
-     the directory entry is not unlinked).
-
-   * There is more granularity in the deletion behaviour of the file (see
-     ``delete_on_close`` below)
+   * The file is guaranteed to have a visible name in the file system
+     (on Unix, the directory entry is not unlinked).
+   * There is more granularity in the deletion behaviour of the file
+     (see *delete_on_close* below)
 
    The returned object is always a :term:`file-like object` whose :attr:`!file`
    attribute is the underlying true file object. This :term:`file-like object` can be

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -101,8 +101,8 @@ The module defines the following user-callable items:
    always guaranteed in this case (see :meth:`object.__del__`). If *delete* is
    false, the value of *delete_on_close* is ignored.
 
-   Therefore to use the name of the temporary file to open the closed file
-   second time, either make sure not to delete the file upon closure (set the
+   Therefore to use the name of the temporary file to reopen the file after
+   closing it, either make sure not to delete the file upon closure (set the
    *delete* parameter to be false) or, in case the temporary file is created in
    a :keyword:`with` statement, set the *delete_on_close* parameter to be false.
    The latter approach is recommended as it provides assistance in automatic
@@ -112,8 +112,8 @@ The module defines the following user-callable items:
    follows:
 
    * On POSIX the file can always be opened again.
-   * On Windows to open the file again while it is open make sure that at least
-     one of the following conditions are fulfilled:
+   * On Windows, make sure that at least one of the following conditions are
+     fulfilled:
 
          * *delete* is false
          * additional open shares delete access (e.g. by calling :func:`os.open`

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -80,16 +80,19 @@ The module defines the following user-callable items:
    This function operates exactly as :func:`TemporaryFile` does, except the
    following differences:
 
-   * The file is guaranteed to have a visible name in the file system
-     (on Unix, the directory entry is not unlinked).
-   * There is more granularity in the deletion behaviour of the file
-     (see *delete_on_close* below)
+   * This function returns a file that is guaranteed to have a visible name in
+     the file system.
+   * To manage the named file, it extends the parameters of
+     :func:`TemporaryFile` with *delete* and *delete_on_close* parameters that
+     determine whether and how the named file should be automatically deleted.
 
    The returned object is always a :term:`file-like object` whose :attr:`!file`
-   attribute is the underlying true file object. This :term:`file-like object` can be
-   used in a :keyword:`with` statement, just like a normal file.  The name of the
-   temporary file can be retrieved from the :attr:`name` attribute of the
-   returned file-like object.
+   attribute is the underlying true file object. This :term:`file-like object`
+   can be used in a :keyword:`with` statement, just like a normal file.  The
+   name of the temporary file can be retrieved from the :attr:`name` attribute
+   of the returned file-like object. On Unix, unlike with the
+   :func:`TemporaryFile`, the directory entry does not get unlinked immediately
+   after the file creation.
 
    If *delete* is true (the default) and *delete_on_close* is true (the
    default), the file is deleted as soon as it is closed. If *delete* is true

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -97,8 +97,8 @@ The module defines the following user-callable items:
    and *delete_on_close* is false, the file is deleted on context manager exit
    only, if no context manager was used, then the file is deleted only when the
    :term:`file-like object` is finalized and hence deletion is not always
-   guaranteed (see :meth:`object.__del__`). If *delete* is false, the value of
-   *delete_on_close* is ignored.
+   guaranteed in this case (see :meth:`object.__del__`). If *delete* is false,
+   the value of *delete_on_close* is ignored.
 
    While the named temporary file is open, the file can always be opened again
    on POSIX. On Windows, it can be opened again if *delete* is false, or if

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -96,8 +96,9 @@ The module defines the following user-callable items:
    default), the file is deleted as soon as it is closed. If *delete* is true
    and *delete_on_close* is false, the file is deleted on context manager exit
    only, if no context manager was used, then the file is deleted only when the
-   :term:`file-like object` is finalized (see :meth:`object.__del__`). If
-   *delete* is false, the value of *delete_on_close* is ignored.
+   :term:`file-like object` is finalized and hence deletion is not always
+   guaranteed (see :meth:`object.__del__`). If *delete* is false, the value of
+   *delete_on_close* is ignored.
 
    While the named temporary file is open, the file can always be opened again
    on POSIX. On Windows, it can be opened again if *delete* is false, or if

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -94,26 +94,32 @@ The module defines the following user-callable items:
    If *delete* is true (the default) and *delete_on_close* is true (the
    default), the file is deleted as soon as it is closed. If *delete* is true
    and *delete_on_close* is false, the file is deleted on context manager exit
-   only, if no context manager was used, then the file is deleted only when the
-   :term:`file-like object` is finalized and hence deletion is not always
-   guaranteed in this case (see :meth:`object.__del__`). If *delete* is false,
-   the value of *delete_on_close* is ignored.
+   only, or else when the :term:`file-like object` is finalized. Deletion is not
+   always guaranteed in this case (see :meth:`object.__del__`). If *delete* is
+   false, the value of *delete_on_close* is ignored.
 
-   While the named temporary file is open, the file can always be opened again
-   on POSIX. On Windows, it can be opened again if *delete* is false, or if
-   *delete_on_close* is false, or if the additional open shares delete access
-   (e.g. by calling :func:`os.open` with the flag ``O_TEMPORARY``).  On
-   Windows, if *delete* is true and *delete_on_close* is false, additional
-   opens that do not share delete access (e.g. via builtin :func:`open`) must
-   be closed before exiting the context manager, else the :func:`os.unlink`
-   call on context manager exit will fail with a :exc:`PermissionError`.
-
-   To use the name of the temporary file to open the closed file second time,
-   either make sure not to delete the file upon closure (set the *delete*
-   parameter to be false) or, in case the temporary file is created in a
-   :keyword:`with` statement, set the *delete_on_close* parameter to be false.
+   Therefore to use the name of the temporary file to open the closed file
+   second time, either make sure not to delete the file upon closure (set the
+   *delete* parameter to be false) or, in case the temporary file is created in
+   a :keyword:`with` statement, set the *delete_on_close* parameter to be false.
    The latter approach is recommended as it provides assistance in automatic
    cleaning of the temporary file upon the context manager exit.
+
+   Opening the temporary file again by its name while it is still open works as
+   follows:
+
+   * On POSIX the file can always be opened again.
+   * On Windows to open the file again while it is open make sure that at least
+     one of the following conditions are fulfilled:
+
+         * *delete* is false
+         * additional open shares delete access (e.g. by calling :func:`os.open`
+           with the flag ``O_TEMPORARY``)
+         * *delete* is true but *delete_on_close* is false. Note, that in this
+           case the additional opens that do not share delete access (e.g.
+           created via builtin :func:`open`) must be closed before exiting the
+           context manager, else the :func:`os.unlink` call on context manager
+           exit will fail with a :exc:`PermissionError`.
 
    On Windows, if *delete_on_close* is false, and the file is created in a
    directory for which the user lacks delete access, then the :func:`os.unlink`
@@ -381,19 +387,16 @@ Here are some examples of typical usage of the :mod:`tempfile` module::
     >>>
     # file is now closed and removed
 
-    # create a temporary file using a context manager, note the name,
+    # create a temporary file using a context manager
     # close the file, use the name to open the file again
     >>> with tempfile.TemporaryFile(delete_on_close=False) as fp:
-    ...     fp.write(b'Hello world!')
-    ...     fp_name = fp.name
-    ...     fp.close()
+    ...    fp.write(b'Hello world!')
+    ...    fp.close()
     # the file is closed, but not removed
     # open the file again by using its name
-    ...     f = open(fp_name)
-    ...     f.seek(0)
-    ...     f.read()
+    ...    with open(fp.name) as f
+    ...        f.read()
     b'Hello world!'
-    ...     f.close()
     >>>
     # file is now removed
 

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -86,8 +86,8 @@ The module defines the following user-callable items:
    * There is more granularity in the deletion behaviour of the file (see
      ``delete_on_close`` below)
 
-   The returned object is always a file-like object whose :attr:`!file`
-   attribute is the underlying true file object. This file-like object can be
+   The returned object is always a :term:`file-like object` whose :attr:`!file`
+   attribute is the underlying true file object. This :term:`file-like object` can be
    used in a :keyword:`with` statement, just like a normal file.  The name of the
    temporary file can be retrieved from the :attr:`name` attribute of the
    returned file-like object.
@@ -95,7 +95,9 @@ The module defines the following user-callable items:
    If *delete* is true (the default) and *delete_on_close* is true (the
    default), the file is deleted as soon as it is closed. If *delete* is true
    and *delete_on_close* is false, the file is deleted on context manager exit
-   only. If *delete* is false, the value of *delete_on_close* is ignored.
+   only, if no context manager was used, then the file is deleted only when the
+   :term:`file-like object` is finalized (see :meth:`object.__del__`). If
+   *delete* is false, the value of *delete_on_close* is ignored.
 
    While the named temporary file is open, the file can always be opened again
    on POSIX. On Windows, it can be opened again if *delete* is false, or if

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -145,7 +145,7 @@ unicodedata
 tempfile
 --------
 
-The :class:`tempfile.NamedTemporaryFile` class has a new optional parameter
+The :class:`tempfile.NamedTemporaryFile` function has a new optional parameter
 *delete_on_close* (Contributed by Evgeny Zorin in :gh:`58451`.)
 
 Optimizations

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -142,6 +142,11 @@ unicodedata
 * The Unicode database has been updated to version 15.0.0. (Contributed by
   Benjamin Peterson in :gh:`96734`).
 
+tempfile
+--------
+
+The :class:`tempfile.NamedTemporaryFile` class has a new optional parameter
+*delete_on_close* (Contributed by Evgeny Zorin in :gh:`58451`.)
 
 Optimizations
 =============

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -527,7 +527,7 @@ def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
     'newline' -- the newline argument to io.open (default None)
     'delete' -- whether the file is automatically deleted (default True).
     'delete_on_close' -- if 'delete', whether the file is deleted on close
-       (default True) or otherwise either on context manager exit 
+       (default True) or otherwise either on context manager exit
        (if context manager was used) or on object finalization. .
     'errors' -- the errors argument to io.open (default None)
     The file is created as mkstemp() would do it.

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -542,9 +542,6 @@ class _TemporaryFileWrapper:
         for line in self.file:
             yield line
 
-    def __del__(self):
-        self._cleanup()
-
 def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
                        newline=None, suffix=None, prefix=None,
                        dir=None, delete=True, *, errors=None,

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -501,7 +501,7 @@ class _TemporaryFileWrapper:
         self.file.__enter__()
         return self
 
-    def _cleanup(self):
+    def _cleanup(self, unlink=_os.unlink):
         if self._cleanup_called or self.name is None:
             return
         self._cleanup_called = True
@@ -511,7 +511,7 @@ class _TemporaryFileWrapper:
             # If the file is to be deleted, but not on close, delete it now.
             if self.delete and not self.delete_on_close:
                 try:
-                    _os.unlink(self.name)
+                    unlink(self.name)
                 except FileNotFoundError:
                     # The file may have been deleted already.
                     pass
@@ -543,16 +543,7 @@ class _TemporaryFileWrapper:
             yield line
 
     def __del__(self):
-        # This is to delete the temporary file in case delete = True,
-        # delete_on_close = False and no context manager was used
-        if self.delete:
-            try:
-                _os.unlink(self.name)
-            # It is okay to ignore FileNotFoundError. The file may have
-            # been deleted already.
-            except FileNotFoundError:
-                pass
-
+        self._cleanup()
 
 def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
                        newline=None, suffix=None, prefix=None,

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -421,11 +421,10 @@ class _TemporaryFileCloser:
     file = None  # Set here since __del__ checks it
     close_called = False
 
-    def __init__(self, file, name, delete=True, delete_on_close=True):
+    def __init__(self, file, name, delete=True):
         self.file = file
         self.name = name
         self.delete = delete
-        self.delete_on_close = delete_on_close
 
     # NT provides delete-on-close as a primitive, so we don't need
     # the wrapper to do anything special.  We still use it so that
@@ -443,9 +442,8 @@ class _TemporaryFileCloser:
                 try:
                     self.file.close()
                 finally:
-                    if self.delete and self.delete_on_close:
-                        if _os.path.exists(self.name):
-                            unlink(self.name)
+                    if self.delete and _os.path.exists(self.name):
+                        unlink(self.name)
 
         # Need to ensure the file is deleted on __del__
         def __del__(self):
@@ -473,8 +471,8 @@ class _TemporaryFileWrapper:
         self.name = name
         self.delete = delete
         self.delete_on_close = delete_on_close
-        self._closer = _TemporaryFileCloser(file, name, delete,
-                                            delete_on_close)
+        self._closer = _TemporaryFileCloser(file, name,
+                                            delete and delete_on_close)
 
     def __getattr__(self, name):
         # Attribute lookups are delegated to the underlying file

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -527,7 +527,8 @@ def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
     'newline' -- the newline argument to io.open (default None)
     'delete' -- whether the file is automatically deleted (default True).
     'delete_on_close' -- if 'delete', whether the file is deleted on close
-       or on context exit (default True).
+       (default True) or otherwise either on context manager exit 
+       (if context manager was used) or on object finalization. .
     'errors' -- the errors argument to io.open (default None)
     The file is created as mkstemp() would do it.
 

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -444,7 +444,8 @@ class _TemporaryFileCloser:
                     self.file.close()
                 finally:
                     if self.delete and self.delete_on_close:
-                        unlink(self.name)
+                        if _os.path.exists(self.name):
+                            unlink(self.name)
 
         # Need to ensure the file is deleted on __del__
         def __del__(self):

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -435,6 +435,8 @@ class _TemporaryFileCloser:
                     self.close_called = True
                     self.file.close()
             finally:
+                # Windows provides delete-on-close as a primitive, in which
+                # case the file was deleted by self.file.close().
                 if self.delete and not (self.delete_on_close and windows):
                     try:
                         unlink(self.name)

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -530,6 +530,17 @@ class _TemporaryFileWrapper:
         for line in self.file:
             yield line
 
+    def __del__(self):
+        # This is to delete the temporary file in case delete = True,
+        # delete_on_close = False and no context manager was used
+        if self.delete:
+            try:
+                _os.unlink(self.name)
+            # It is okay to ignore FileNotFoundError. The file may have
+            # been deleted already.
+            except FileNotFoundError:
+                pass
+
 
 def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
                        newline=None, suffix=None, prefix=None,

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -437,7 +437,7 @@ class _TemporaryFileCloser:
             finally:
                 # Windows provides delete-on-close as a primitive, in which
                 # case the file was deleted by self.file.close().
-                if self.delete and not (self.delete_on_close and windows):
+                if self.delete and not (windows and self.delete_on_close):
                     try:
                         unlink(self.name)
                     except FileNotFoundError:

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -575,7 +575,8 @@ def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
             file.close()
             raise
     except:
-        if name is not None and not (_os.name == 'nt' and delete):
+        if name is not None and not (
+            _os.name == 'nt' and delete and delete_on_close):
             _os.unlink(name)
         raise
 

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -452,6 +452,8 @@ class _TemporaryFileCloser:
 
     def __del__(self):
         self.cleanup()
+
+
 class _TemporaryFileWrapper:
     """Temporary file wrapper
 

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1077,7 +1077,7 @@ class TestNamedTemporaryFile(BaseTestCase):
     def test_del_by_finalizer(self):
         # A NamedTemporaryFile is deleted by fanalizer in case delete = True
         # delete_on_close = False and no context manager is used
-        def my_func(dir)->str:
+        def my_func(dir):
             f = tempfile.NamedTemporaryFile(dir=dir, delete=True,
                                             delete_on_close=False)
             tmp_name = f.name

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1018,7 +1018,7 @@ class TestNamedTemporaryFile(BaseTestCase):
         # Issue gh-58451: tempfile.NamedTemporaryFile is not particulary useful
         # on Windows
         # A NamedTemporaryFile is NOT deleted when closed if
-        # delete_on_close= False, but is deleted on content manager exit
+        # delete_on_close=False, but is deleted on context manager exit
         dir = tempfile.mkdtemp()
         try:
             with tempfile.NamedTemporaryFile(dir=dir,
@@ -1030,21 +1030,21 @@ class TestNamedTemporaryFile(BaseTestCase):
                 with self.subTest():
                     # Testing that file is not deleted on close
                     self.assertTrue(os.path.exists(f.name),
-                            "NamedTemporaryFile %s is incorrectly deleted\
-                             on closure when delete_on_close= False" % f_name)
+                            f"NamedTemporaryFile {f.name!r} is incorrectly deleted "
+                            f"on closure when delete_on_close=False")
 
             with self.subTest():
-                # Testing that file is deleted on content manager exit
+                # Testing that file is deleted on context manager exit
                 self.assertFalse(os.path.exists(f.name),
-                                 "NamedTemporaryFile %s exists\
-                                  after content manager exit" % f.name)
+                                 f"NamedTemporaryFile {f.name!r} exists "
+                                 f"after context manager exit")
 
         finally:
             os.rmdir(dir)
 
     def test_context_man_ok_to_delete_manually(self):
-        # A NamedTemporaryFile can be deleted by a user before content manager
-        # comes to it. This will not generate an error
+        # A NamedTemporaryFile can be deleted by a user before
+        # context manager comes to it. This will not generate an error
         dir = tempfile.mkdtemp()
         try:
             with tempfile.NamedTemporaryFile(dir=dir,
@@ -1069,7 +1069,7 @@ class TestNamedTemporaryFile(BaseTestCase):
                 f.write(b'blat')
                 f_name = f.name
             self.assertTrue(os.path.exists(f.name),
-                        "NamedTemporaryFile %s exists after close" % f.name)
+                        f"NamedTemporaryFile {f.name!r} exists after close")
         finally:
             os.unlink(f_name)
             os.rmdir(dir)
@@ -1091,8 +1091,7 @@ class TestNamedTemporaryFile(BaseTestCase):
         try:
             tmp_name = my_func(dir)
             self.assertFalse(os.path.exists(tmp_name),
-                        "NamedTemporaryFile %s exists after finalizer "\
-                            % tmp_name)
+                        f"NamedTemporaryFile {tmp_name!r} exists after finalizer ")
         finally:
             os.rmdir(dir)
 

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1043,8 +1043,8 @@ class TestNamedTemporaryFile(BaseTestCase):
             os.rmdir(dir)
 
     def test_context_man_ok_to_delete_manually(self):
-        # A NamedTemporaryFile can be deleted by a user before
-        # context manager comes to it. This will not generate an error
+        # In the case of delete=True, a NamedTemporaryFile can be manually
+        # deleted in a with-statement context without causing an error.
         dir = tempfile.mkdtemp()
         try:
             with tempfile.NamedTemporaryFile(dir=dir,
@@ -1062,8 +1062,7 @@ class TestNamedTemporaryFile(BaseTestCase):
         dir = tempfile.mkdtemp()
         f_name = ""
         try:
-            # setting delete_on_close = True to test, that this does not have
-            # an effect, if delete = False
+            # Test that delete_on_close=True has no effect if delete=False.
             with tempfile.NamedTemporaryFile(dir=dir, delete=False,
                                              delete_on_close=True) as f:
                 f.write(b'blat')
@@ -1075,8 +1074,8 @@ class TestNamedTemporaryFile(BaseTestCase):
             os.rmdir(dir)
 
     def test_del_by_finalizer(self):
-        # A NamedTemporaryFile is deleted by fanalizer in case delete = True
-        # delete_on_close = False and no context manager is used
+        # A NamedTemporaryFile is deleted when finalized in the case of
+        # delete=True, delete_on_close=False, and no with-statement is used.
         def my_func(dir):
             f = tempfile.NamedTemporaryFile(dir=dir, delete=True,
                                             delete_on_close=False)
@@ -1085,7 +1084,7 @@ class TestNamedTemporaryFile(BaseTestCase):
             # Testing extreme case, where the file is not explicitly closed
             # f.close()
             return tmp_name
-        # Making sure that Garbage Collector has finalized the file object
+        # Make sure that the garbage collector has finalized the file object.
         gc.collect()
         dir = tempfile.mkdtemp()
         try:
@@ -1097,9 +1096,9 @@ class TestNamedTemporaryFile(BaseTestCase):
             os.rmdir(dir)
 
     def test_correct_finalizer_work_if_already_deleted(self):
-        # There should be No errors in case delete = True
-        # delete_on_close = False and no context manager is used, but file is
-        # deleted manually
+        # There should be no error in the case of delete=True,
+        # delete_on_close=False, no with-statement is used, and the file is
+        # deleted manually.
         def my_func(dir)->str:
             f = tempfile.NamedTemporaryFile(dir=dir, delete=True,
                                             delete_on_close=False)
@@ -1108,7 +1107,7 @@ class TestNamedTemporaryFile(BaseTestCase):
             f.close()
             os.unlink(tmp_name)
             return tmp_name
-        # Making sure that Garbage Collector has finalized the file object
+        # Make sure that the garbage collector has finalized the file object.
         gc.collect()
 
     def test_bad_mode(self):

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1030,8 +1030,8 @@ class TestNamedTemporaryFile(BaseTestCase):
                 with self.subTest():
                     # Testing that file is not deleted on close
                     self.assertTrue(os.path.exists(f.name),
-                            f"NamedTemporaryFile {f.name!r} is incorrectly deleted "
-                            f"on closure when delete_on_close=False")
+                            f"NamedTemporaryFile {f.name!r} is incorrectly "
+                            f"deleted on closure when delete_on_close=False")
 
             with self.subTest():
                 # Testing that file is deleted on context manager exit
@@ -1082,7 +1082,7 @@ class TestNamedTemporaryFile(BaseTestCase):
                                             delete_on_close=False)
             tmp_name = f.name
             f.write(b'blat')
-            # Testing extreme case, where the file is not even explicitly closed
+            # Testing extreme case, where the file is not explicitly closed
             # f.close()
             return tmp_name
         # Making sure that Garbage Collector has finalized the file object
@@ -1091,7 +1091,8 @@ class TestNamedTemporaryFile(BaseTestCase):
         try:
             tmp_name = my_func(dir)
             self.assertFalse(os.path.exists(tmp_name),
-                        f"NamedTemporaryFile {tmp_name!r} exists after finalizer ")
+                        f"NamedTemporaryFile {tmp_name!r} "
+                        f"exists after finalizer ")
         finally:
             os.rmdir(dir)
 
@@ -1178,7 +1179,8 @@ class TestSpooledTemporaryFile(BaseTestCase):
         missing_attrs = iobase_attrs - spooledtempfile_attrs
         self.assertFalse(
             missing_attrs,
-            'SpooledTemporaryFile missing attributes from IOBase/BufferedIOBase/TextIOBase'
+            'SpooledTemporaryFile missing attributes from '
+            'IOBase/BufferedIOBase/TextIOBase'
         )
 
     def test_del_on_close(self):

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -980,91 +980,6 @@ class TestNamedTemporaryFile(BaseTestCase):
         finally:
             os.rmdir(dir)
 
-    def test_not_del_on_close_if_delete_on_close_false(self):
-        # Issue gh-58451: tempfile.NamedTemporaryFile is not particulary useful on Windows
-        # A NamedTemporaryFile is NOT deleted when closed if
-        # delete_on_close= False, but is deleted on content manager exit
-        dir = tempfile.mkdtemp()
-        try:
-            with tempfile.NamedTemporaryFile(dir=dir,
-                                             delete=True,
-                                             delete_on_close=False) as f:
-                f.write(b'blat')
-                f_name = f.name
-                f.close()
-                with self.subTest():
-                    # Testing that file is not deleted on close
-                    self.assertTrue(os.path.exists(f.name),
-                            "NamedTemporaryFile %s is incorrectly deleted\
-                             on closure when delete_on_close= False" % f_name)
-
-            with self.subTest():
-                # Testing that file is deleted on content manager exit
-                self.assertFalse(os.path.exists(f.name),
-                                 "NamedTemporaryFile %s exists\
-                                  after content manager exit" % f.name)
-
-        finally:
-            os.rmdir(dir)
-
-    def test_ok_to_delete_manually(self):
-        # A NamedTemporaryFile can be deleted by a user before content manager
-        # comes to it. This will not generate an error
-        dir = tempfile.mkdtemp()
-        try:
-            with tempfile.NamedTemporaryFile(dir=dir,
-                                             delete=True,
-                                             delete_on_close=False) as f:
-                f.write(b'blat')
-                f.close()
-                os.unlink(f.name)
-
-        finally:
-            os.rmdir(dir)
-
-    def test_not_del_if_delete_false(self):
-        # A NamedTemporaryFile is not deleted if delete = False
-        dir = tempfile.mkdtemp()
-        f_name = ""
-        try:
-            # setting delete_on_close = True to test, that this does not have
-            # an effect, if delete = False
-            with tempfile.NamedTemporaryFile(dir=dir, delete=False,
-                                             delete_on_close=True) as f:
-                f.write(b'blat')
-                f_name = f.name
-            self.assertTrue(os.path.exists(f.name),
-                        "NamedTemporaryFile %s exists after close" % f.name)
-        finally:
-            os.unlink(f_name)
-            os.rmdir(dir)
-
-    def test_del_by_finalizer_if_no_with(self):
-        # A NamedTemporaryFile is deleted by fanalizer in case delete = True
-        # delete_on_close = False and no context manager is used
-        def my_func(dir):
-            f = tempfile.NamedTemporaryFile(dir=dir, delete=True,
-                                            delete_on_close=False)
-            tmp_name = f.name
-            f.write(b'blat')
-            f.close()
-            with self.subTest():
-                self.assertTrue(os.path.exists(tmp_name),
-                            "NamedTemporaryFile %s missing after close"\
-                                % tmp_name)
-            return tmp_name
-        # Making sure that Garbage Collector has finalyzed the file object
-        gc.collect()
-        dir = tempfile.mkdtemp()
-        try:
-            tmp_name = my_func(dir)
-            with self.subTest():
-                self.assertFalse(os.path.exists(tmp_name),
-                            "NamedTemporaryFile %s exists after finalizer "\
-                                % tmp_name)
-        finally:
-            os.rmdir(dir)
-
     def test_dis_del_on_close(self):
         # Tests that delete-on-close can be disabled
         dir = tempfile.mkdtemp()
@@ -1098,6 +1013,103 @@ class TestNamedTemporaryFile(BaseTestCase):
             with f:
                 pass
         self.assertRaises(ValueError, use_closed)
+
+    def test_context_man_not_del_on_close_if_delete_on_close_false(self):
+        # Issue gh-58451: tempfile.NamedTemporaryFile is not particulary useful
+        # on Windows
+        # A NamedTemporaryFile is NOT deleted when closed if
+        # delete_on_close= False, but is deleted on content manager exit
+        dir = tempfile.mkdtemp()
+        try:
+            with tempfile.NamedTemporaryFile(dir=dir,
+                                             delete=True,
+                                             delete_on_close=False) as f:
+                f.write(b'blat')
+                f_name = f.name
+                f.close()
+                with self.subTest():
+                    # Testing that file is not deleted on close
+                    self.assertTrue(os.path.exists(f.name),
+                            "NamedTemporaryFile %s is incorrectly deleted\
+                             on closure when delete_on_close= False" % f_name)
+
+            with self.subTest():
+                # Testing that file is deleted on content manager exit
+                self.assertFalse(os.path.exists(f.name),
+                                 "NamedTemporaryFile %s exists\
+                                  after content manager exit" % f.name)
+
+        finally:
+            os.rmdir(dir)
+
+    def test_context_man_ok_to_delete_manually(self):
+        # A NamedTemporaryFile can be deleted by a user before content manager
+        # comes to it. This will not generate an error
+        dir = tempfile.mkdtemp()
+        try:
+            with tempfile.NamedTemporaryFile(dir=dir,
+                                             delete=True,
+                                             delete_on_close=False) as f:
+                f.write(b'blat')
+                f.close()
+                os.unlink(f.name)
+
+        finally:
+            os.rmdir(dir)
+
+    def test_context_man_not_del_if_delete_false(self):
+        # A NamedTemporaryFile is not deleted if delete = False
+        dir = tempfile.mkdtemp()
+        f_name = ""
+        try:
+            # setting delete_on_close = True to test, that this does not have
+            # an effect, if delete = False
+            with tempfile.NamedTemporaryFile(dir=dir, delete=False,
+                                             delete_on_close=True) as f:
+                f.write(b'blat')
+                f_name = f.name
+            self.assertTrue(os.path.exists(f.name),
+                        "NamedTemporaryFile %s exists after close" % f.name)
+        finally:
+            os.unlink(f_name)
+            os.rmdir(dir)
+
+    def test_del_by_finalizer(self):
+        # A NamedTemporaryFile is deleted by fanalizer in case delete = True
+        # delete_on_close = False and no context manager is used
+        def my_func(dir)->str:
+            f = tempfile.NamedTemporaryFile(dir=dir, delete=True,
+                                            delete_on_close=False)
+            tmp_name = f.name
+            f.write(b'blat')
+            # Testing extreme case, where the file is not even explicitly closed
+            # f.close()
+            return tmp_name
+        # Making sure that Garbage Collector has finalized the file object
+        gc.collect()
+        dir = tempfile.mkdtemp()
+        try:
+            tmp_name = my_func(dir)
+            self.assertFalse(os.path.exists(tmp_name),
+                        "NamedTemporaryFile %s exists after finalizer "\
+                            % tmp_name)
+        finally:
+            os.rmdir(dir)
+
+    def test_correct_finalizer_work_if_already_deleted(self):
+        # There should be No errors in case delete = True
+        # delete_on_close = False and no context manager is used, but file is
+        # deleted manually
+        def my_func(dir)->str:
+            f = tempfile.NamedTemporaryFile(dir=dir, delete=True,
+                                            delete_on_close=False)
+            tmp_name = f.name
+            f.write(b'blat')
+            f.close()
+            os.unlink(tmp_name)
+            return tmp_name
+        # Making sure that Garbage Collector has finalized the file object
+        gc.collect()
 
     def test_bad_mode(self):
         dir = tempfile.mkdtemp()

--- a/Misc/NEWS.d/next/Library/2020-09-28-04-56-04.bpo-14243.YECnxv.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-28-04-56-04.bpo-14243.YECnxv.rst
@@ -1,1 +1,1 @@
-The :class:`tempfile.NamedTemporaryFile` has a new optional parameter *delete_on_close*
+The :class:`tempfile.NamedTemporaryFile` function has a new optional parameter *delete_on_close*

--- a/Misc/NEWS.d/next/Library/2020-09-28-04-56-04.bpo-14243.YECnxv.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-28-04-56-04.bpo-14243.YECnxv.rst
@@ -1,0 +1,1 @@
+The :class:`tempfile.NamedTemporaryFile` has a new optional parameter *delete_on_close*


### PR DESCRIPTION
This is a reincarnation of the already marked as **awaiting merge** [PR 22431](https://github.com/python/cpython/pull/22431), which was subsequently closed due to some [ git mistake](https://github.com/python/cpython/pull/22431#issuecomment-1250404118).

This PR fixes issue [58451](https://github.com/python/cpython/issues/58451): **tempfile.NamedTemporaryFile not particularly useful on Windows**

```tempfile.NamedTemporaryFile``` is too hard to use portably when you need to open the file by name after writing it.  To do that, you need to close the file first (on Windows), which means you have to pass ```delete=False```, which in turn means that you get no help in cleaning up the actual file resource,

Hence at the moment there is no out of the box solution to use  tempfile.NamedTemporaryFile on Windows in such scenario (which is often used in unit testing):

* in test module:
1) create and open temporary file
2) write data to it
3) pass name of the temporary file to the operational code

* In operational code, being tested
1) open file, using name of the temporary file 
2) read data from this temporary file 

In this Pull Request the issue is solved by adding an additional optional argument to ```NamedTemporaryFile() 'delete_on_close' ``` (default is True). It works in combination with already existing argument ```'delete'```, and determines the deletion behaviour.

If _delete_ is true (the default) and _delete_on_close_ is true (the default), the file is deleted as soon as it is closed. If _delete_ is true and _delete_on_close_ is false, the file is deleted on context manager exit only, if no context manager was used, then the file is deleted only when the file-like object is finalized.  If __delete__ is false, the value of _delete_on_close_ is ignored.

So, the change shall be fully backwards compatible.

<!-- gh-issue-number: gh-58451 -->
* Issue: gh-58451
<!-- /gh-issue-number -->
