### PR TITLE
gh-97016: Convert PyBytes_AS_STRING() to function

### DIFF
--- a/Include/cpython/bytearrayobject.h
+++ b/Include/cpython/bytearrayobject.h
@@ -11,24 +11,12 @@ typedef struct {
     Py_ssize_t ob_exports; /* How many buffer exports */
 } PyByteArrayObject;
 
-PyAPI_DATA(char) _PyByteArray_empty_string[];
-
 /* Macros and static inline functions, trading safety for speed */
 #define _PyByteArray_CAST(op) \
     (assert(PyByteArray_Check(op)), _Py_CAST(PyByteArrayObject*, op))
 
-static inline char* PyByteArray_AS_STRING(PyObject *op)
-{
-    PyByteArrayObject *self = _PyByteArray_CAST(op);
-    if (Py_SIZE(self)) {
-        return self->ob_start;
-    }
-    return _PyByteArray_empty_string;
-}
+PyAPI_DATA(char*) PyByteArray_AS_STRING(PyObject *op);
 #define PyByteArray_AS_STRING(self) PyByteArray_AS_STRING(_PyObject_CAST(self))
 
-static inline Py_ssize_t PyByteArray_GET_SIZE(PyObject *op) {
-    PyByteArrayObject *self = _PyByteArray_CAST(op);
-    return Py_SIZE(self);
-}
+PyAPI_DATA(Py_ssize_t) PyByteArray_GET_SIZE(PyObject *op);
 #define PyByteArray_GET_SIZE(self) PyByteArray_GET_SIZE(_PyObject_CAST(self))

--- a/Include/cpython/bytesobject.h
+++ b/Include/cpython/bytesobject.h
@@ -28,20 +28,10 @@ PyAPI_FUNC(PyObject*) _PyBytes_FromHex(
 PyAPI_FUNC(PyObject *) _PyBytes_DecodeEscape(const char *, Py_ssize_t,
                                              const char *, const char **);
 
-/* Macros and static inline functions, trading safety for speed */
-#define _PyBytes_CAST(op) \
-    (assert(PyBytes_Check(op)), _Py_CAST(PyBytesObject*, op))
-
-static inline char* PyBytes_AS_STRING(PyObject *op)
-{
-    return _PyBytes_CAST(op)->ob_sval;
-}
+PyAPI_FUNC(char*) PyBytes_AS_STRING(PyObject *op);
 #define PyBytes_AS_STRING(op) PyBytes_AS_STRING(_PyObject_CAST(op))
 
-static inline Py_ssize_t PyBytes_GET_SIZE(PyObject *op) {
-    PyBytesObject *self = _PyBytes_CAST(op);
-    return Py_SIZE(self);
-}
+PyAPI_FUNC(Py_ssize_t) PyBytes_GET_SIZE(PyObject *op);
 #define PyBytes_GET_SIZE(self) PyBytes_GET_SIZE(_PyObject_CAST(self))
 
 /* _PyBytes_Join(sep, x) is like sep.join(x).  sep must be PyBytesObject*,

--- a/Misc/NEWS.d/next/C API/2022-09-22-17-43-33.gh-issue-97016.d5iveG.rst
+++ b/Misc/NEWS.d/next/C API/2022-09-22-17-43-33.gh-issue-97016.d5iveG.rst
@@ -1,0 +1,9 @@
+Convert the following static inline functions to regular functions:
+
+* :c:func:`PyByteArray_AS_STRING()`
+* :c:func:`PyByteArray_GET_SIZE()`
+* :c:func:`PyBytes_AS_STRING()`
+* :c:func:`PyBytes_GET_SIZE()`
+
+Remove the ``_PyByteArray_empty_string`` variable. It was excluded from the
+limited C API. Patch by Victor Stinner.


### PR DESCRIPTION
Convert the following static inline functions to regular functions:

* PyByteArray_AS_STRING()
* PyByteArray_GET_SIZE()
* PyBytes_AS_STRING()
* PyBytes_GET_SIZE()

Remove the _PyByteArray_empty_string variable. It was excluded from the limited C API.

In bytesobject.c and bytearrayobject.c, add static inline functions and use them for best performance:

* _PyByteArray_AS_STRING()
* _PyByteArray_GET_SIZE()
* _PyBytes_AS_STRING()
* _PyBytes_GET_SIZE()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97016 -->
* Issue: gh-97016
<!-- /gh-issue-number -->
