### PR TITLE
gh-97519: Synchronize links in other copies of HISTORY OF THE SOFTWARE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,12 +2,12 @@ A. HISTORY OF THE SOFTWARE
 ==========================
 
 Python was created in the early 1990s by Guido van Rossum at Stichting
-Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
+Mathematisch Centrum (CWI, see https://www.cwi.nl) in the Netherlands
 as a successor of a language called ABC.  Guido remains Python's
 principal author, although it includes many contributions from others.
 
 In 1995, Guido continued his work on Python at the Corporation for
-National Research Initiatives (CNRI, see http://www.cnri.reston.va.us)
+National Research Initiatives (CNRI, see https://www.cnri.reston.va.us)
 in Reston, Virginia where he released several versions of the
 software.
 
@@ -19,7 +19,7 @@ https://www.python.org/psf/) was formed, a non-profit organization
 created specifically to own Python-related Intellectual Property.
 Zope Corporation was a sponsoring member of the PSF.
 
-All Python releases are Open Source (see http://www.opensource.org for
+All Python releases are Open Source (see https://opensource.org for
 the Open Source Definition).  Historically, most, but not all, Python
 releases have also been GPL-compatible; the table below summarizes
 the various releases.

--- a/Mac/BuildScript/resources/License.rtf
+++ b/Mac/BuildScript/resources/License.rtf
@@ -12,13 +12,13 @@
 HISTORY OF THE SOFTWARE\
 
 \f1\b0 \ulnone \
-Python was created in the early 1990s by Guido van Rossum at Stichting Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands as a successor of a language called ABC. Guido remains Python's principal author, although it includes many contributions from others.\
+Python was created in the early 1990s by Guido van Rossum at Stichting Mathematisch Centrum (CWI, see https://www.cwi.nl) in the Netherlands as a successor of a language called ABC. Guido remains Python's principal author, although it includes many contributions from others.\
 \
-In 1995, Guido continued his work on Python at the Corporation for National Research Initiatives (CNRI, see http://www.cnri.reston.va.us) in Reston, Virginia where he released several versions of the software.\
+In 1995, Guido continued his work on Python at the Corporation for National Research Initiatives (CNRI, see https://www.cnri.reston.va.us) in Reston, Virginia where he released several versions of the software.\
 \
-In May 2000, Guido and the Python core development team moved to BeOpen.com to form the BeOpen PythonLabs team. In October of the same year, the PythonLabs team moved to Digital Creations (now Zope Corporation, see http://www.zope.org). In 2001, the Python Software Foundation (PSF, see https://www.python.org/psf/) was formed, a non-profit organization created specifically to own Python-related Intellectual Property. Zope Corporation is a sponsoring member of the PSF.\
+In May 2000, Guido and the Python core development team moved to BeOpen.com to form the BeOpen PythonLabs team. In October of the same year, the PythonLabs team moved to Digital Creations (now Zope Corporation, see https://www.zope.dev). In 2001, the Python Software Foundation (PSF, see https://www.python.org/psf/) was formed, a non-profit organization created specifically to own Python-related Intellectual Property. Zope Corporation is a sponsoring member of the PSF.\
 \
-All Python releases are Open Source (see http://www.opensource.org for the Open Source Definition). Historically, most, but not all, Python releases have also been GPL-compatible; the table below summarizes the various releases.\
+All Python releases are Open Source (see https://opensource.org for the Open Source Definition). Historically, most, but not all, Python releases have also been GPL-compatible; the table below summarizes the various releases.\
 \
 
 \f2\b Release         Derived     Year        Owner       GPL-\

--- a/Misc/HISTORY
+++ b/Misc/HISTORY
@@ -19610,7 +19610,7 @@ durable way.  For example, some people say they're confused by that
 the Open Source Initiative's entry for the Python Software Foundation
 License::
 
-      http://www.opensource.org/licenses/PythonSoftFoundation.php
+      https://opensource.org/licenses/PythonSoftFoundation.php
 
 says "Python 2.1.1" all over it, wondering whether it applies only
 to Python 2.1.1.


### PR DESCRIPTION
HTTP links in the "HISTORY OF THE SOFTWARE" section of Doc/license.rst were converted to HTTPS in f62ff97f31a775cc7956adeae32c14e7c85bdc15. But there were other copies of these links, which were left HTTP links.


<!-- gh-issue-number: gh-97519 -->
* Issue: gh-97519
<!-- /gh-issue-number -->
