### PR TITLE
gh-97527: IDLE: protect macosx Tk() call when no GUI

### DIFF
--- a/Lib/idlelib/macosx.py
+++ b/Lib/idlelib/macosx.py
@@ -4,6 +4,7 @@ A number of functions that enhance IDLE on macOS.
 from os.path import expanduser
 import plistlib
 from sys import platform  # Used in _init_tk_type, changed by test.
+from test.support import requires, ResourceDenied
 
 import tkinter
 
@@ -14,23 +15,26 @@ import tkinter
 _tk_type = None
 
 def _init_tk_type():
-    """
-    Initializes OS X Tk variant values for
-    isAquaTk(), isCarbonTk(), isCocoaTk(), and isXQuartz().
+    """ Initialize _tk_type for isXyzTk functions.
     """
     global _tk_type
     if platform == 'darwin':
-        root = tkinter.Tk()
-        ws = root.tk.call('tk', 'windowingsystem')
-        if 'x11' in ws:
-            _tk_type = "xquartz"
-        elif 'aqua' not in ws:
-            _tk_type = "other"
-        elif 'AppKit' in root.tk.call('winfo', 'server', '.'):
-            _tk_type = "cocoa"
+        try:
+            requires('gui')
+        except ResourceDenied:  # Possible when testing.
+            _tk_type = "cocoa"  # Newest and most common.
         else:
-            _tk_type = "carbon"
-        root.destroy()
+            root = tkinter.Tk()
+            ws = root.tk.call('tk', 'windowingsystem')
+            if 'x11' in ws:
+                _tk_type = "xquartz"
+            elif 'aqua' not in ws:
+                _tk_type = "other"
+            elif 'AppKit' in root.tk.call('winfo', 'server', '.'):
+                _tk_type = "cocoa"
+            else:
+                _tk_type = "carbon"
+            root.destroy()
     else:
         _tk_type = "other"
 


### PR DESCRIPTION
Only call tkinter.tk and its follow-up code in _init_tk_type when requires('gui') does not raise.  This function can be called as an unintended side-effect of calling other idlelib code as part of tests on macOS without a GUI enabled.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97527 -->
* Issue: gh-97527
<!-- /gh-issue-number -->
