### PR TITLE
gh-96959: Update more HTTP links

### DIFF
--- a/Doc/faq/extending.rst
+++ b/Doc/faq/extending.rst
@@ -51,7 +51,7 @@ If you need to interface to some C or C++ library for which no Python extension
 currently exists, you can try wrapping the library's data types and functions
 with a tool such as `SWIG <https://www.swig.org>`_.  `SIP
 <https://riverbankcomputing.com/software/sip/intro>`__, `CXX
-<http://cxx.sourceforge.net/>`_ `Boost
+<https://cxx.sourceforge.net/>`_ `Boost
 <https://www.boost.org/libs/python/doc/index.html>`_, or `Weave
 <https://github.com/scipy/weave>`_ are also
 alternatives for wrapping C++ libraries.

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -329,7 +329,7 @@ Consulting the proceedings for `past Python conferences
 different companies and organizations.
 
 High-profile Python projects include `the Mailman mailing list manager
-<http://www.list.org>`_ and `the Zope application server
+<https://www.list.org>`_ and `the Zope application server
 <https://www.zope.dev>`_.  Several Linux distributions, most notably `Red Hat
 <https://www.redhat.com>`_, have written part or all of their installer and
 system administration software in Python.  Companies that use Python internally

--- a/Doc/faq/gui.rst
+++ b/Doc/faq/gui.rst
@@ -49,7 +49,7 @@ environment variables.
 To get truly stand-alone applications, the Tcl scripts that form the library
 have to be integrated into the application as well. One tool supporting that is
 SAM (stand-alone modules), which is part of the Tix distribution
-(http://tix.sourceforge.net/).
+(https://tix.sourceforge.net/).
 
 Build Tix with SAM enabled, perform the appropriate call to
 :c:func:`Tclsam_init`, etc. inside Python's

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -180,7 +180,7 @@ How do I create documentation from doc strings?
 
 The :mod:`pydoc` module can create HTML from the doc strings in your Python
 source code.  An alternative for creating API documentation purely from
-docstrings is `epydoc <http://epydoc.sourceforge.net/>`_.  `Sphinx
+docstrings is `epydoc <https://epydoc.sourceforge.net/>`_.  `Sphinx
 <https://www.sphinx-doc.org>`_ can also include docstring content.
 
 

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -35,7 +35,7 @@ debugging non-PythonWin programs.  PythonWin is available as part of
 as a part of the
 `ActivePython <https://www.activestate.com/products/python/>`_ distribution.
 
-`Eric <http://eric-ide.python-projects.org/>`_ is an IDE built on PyQt
+`Eric <https://eric-ide.python-projects.org/>`_ is an IDE built on PyQt
 and the Scintilla editing component.
 
 `trepan3k <https://github.com/rocky/python3-trepan/>`_ is a gdb-like debugger.
@@ -99,7 +99,7 @@ executables:
 * `PyOxidizer <https://pyoxidizer.readthedocs.io/en/stable/>`_ (Cross-platform)
 * `cx_Freeze <https://marcelotduarte.github.io/cx_Freeze/>`_ (Cross-platform)
 * `py2app <https://github.com/ronaldoussoren/py2app>`_ (macOS only)
-* `py2exe <http://www.py2exe.org/>`_ (Windows only)
+* `py2exe <https://www.py2exe.org/>`_ (Windows only)
 
 Are there coding standards or a style guide for Python programs?
 ----------------------------------------------------------------

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2269,7 +2269,7 @@ to stdout.  Otherwise, the content is read from stdin.
     code that generated them. This is helpful for tools that make source code
     transformations.
 
-    `leoAst.py <http://leoeditor.com/appendices.html#leoast-py>`_ unifies the
+    `leoAst.py <https://leoeditor.com/appendices.html#leoast-py>`_ unifies the
     token-based and parse-tree-based views of python programs by inserting
     two-way links between tokens and ast nodes.
 

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -125,7 +125,7 @@ See :ref:`json-commandline` for detailed documentation.
 
 .. note::
 
-   JSON is a subset of `YAML <http://yaml.org/>`_ 1.2.  The JSON produced by
+   JSON is a subset of `YAML <https://yaml.org/>`_ 1.2.  The JSON produced by
    this module's default settings (in particular, the default *separators*
    value) is also a subset of YAML 1.0 and 1.1.  This module can thus also be
    used as a YAML serializer.

--- a/Doc/library/mailbox.rst
+++ b/Doc/library/mailbox.rst
@@ -426,7 +426,7 @@ Supported mailbox formats are Maildir, mbox, MH, Babyl, and MMDF.
 
 .. seealso::
 
-   `maildir man page from Courier <http://www.courier-mta.org/maildir.html>`_
+   `maildir man page from Courier <https://www.courier-mta.org/maildir.html>`_
       A specification of the format. Describes a common extension for
       supporting folders.
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -568,13 +568,13 @@ Simulation of arrival times and service deliveries for a multiserver queue::
    `Economics Simulation
    <https://nbviewer.jupyter.org/url/norvig.com/ipython/Economics.ipynb>`_
    a simulation of a marketplace by
-   `Peter Norvig <http://norvig.com/bio.html>`_ that shows effective
+   `Peter Norvig <https://norvig.com/bio.html>`_ that shows effective
    use of many of the tools and distributions provided by this module
    (gauss, uniform, sample, betavariate, choice, triangular, and randrange).
 
    `A Concrete Introduction to Probability (using Python)
    <https://nbviewer.jupyter.org/url/norvig.com/ipython/Probability.ipynb>`_
-   a tutorial by `Peter Norvig <http://norvig.com/bio.html>`_ covering
+   a tutorial by `Peter Norvig <https://norvig.com/bio.html>`_ covering
    the basics of probability theory, how to write simulations, and
    how to perform data analysis using Python.
 

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -38,7 +38,7 @@ details that are unchanged.
 
 .. seealso::
 
-   * `TkDocs <http://tkdocs.com/>`_
+   * `TkDocs <https://tkdocs.com/>`_
       Extensive tutorial on creating user interfaces with Tkinter.  Explains key concepts,
       and illustrates recommended approaches using the modern API.
 

--- a/Doc/library/tkinter.tix.rst
+++ b/Doc/library/tkinter.tix.rst
@@ -33,17 +33,17 @@ special needs of your application and users.
 
 .. seealso::
 
-   `Tix Homepage <http://tix.sourceforge.net/>`_
+   `Tix Homepage <https://tix.sourceforge.net/>`_
       The home page for :mod:`Tix`.  This includes links to additional documentation
       and downloads.
 
-   `Tix Man Pages <http://tix.sourceforge.net/dist/current/man/>`_
+   `Tix Man Pages <https://tix.sourceforge.net/dist/current/man/>`_
       On-line version of the man pages and reference material.
 
-   `Tix Programming Guide <http://tix.sourceforge.net/dist/current/docs/tix-book/tix.book.html>`_
+   `Tix Programming Guide <https://tix.sourceforge.net/dist/current/docs/tix-book/tix.book.html>`_
       On-line version of the programmer's reference material.
 
-   `Tix Development Applications <http://tix.sourceforge.net/Tixapps/src/Tide.html>`_
+   `Tix Development Applications <https://tix.sourceforge.net/Tixapps/src/Tide.html>`_
       Tix applications for development of Tix and Tkinter programs. Tide applications
       work under Tk or Tkinter, and include :program:`TixInspect`, an inspector to
       remotely modify and debug Tix/Tk/Tkinter applications.
@@ -80,7 +80,7 @@ the following::
 Tix Widgets
 -----------
 
-`Tix <http://tix.sourceforge.net/dist/current/man/html/TixCmd/TixIntro.htm>`_
+`Tix <https://tix.sourceforge.net/dist/current/man/html/TixCmd/TixIntro.htm>`_
 introduces over 40 widget classes to the :mod:`tkinter` repertoire.
 
 
@@ -91,125 +91,125 @@ Basic Widgets
 .. class:: Balloon()
 
    A `Balloon
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixBalloon.htm>`_ that
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixBalloon.htm>`_ that
    pops up over a widget to provide help.  When the user moves the cursor inside a
    widget to which a Balloon widget has been bound, a small pop-up window with a
    descriptive message will be shown on the screen.
 
 .. Python Demo of:
-.. \ulink{Balloon}{http://tix.sourceforge.net/dist/current/demos/samples/Balloon.tcl}
+.. \ulink{Balloon}{https://tix.sourceforge.net/dist/current/demos/samples/Balloon.tcl}
 
 
 .. class:: ButtonBox()
 
    The `ButtonBox
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixButtonBox.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixButtonBox.htm>`_
    widget creates a box of buttons, such as is commonly used for ``Ok Cancel``.
 
 .. Python Demo of:
-.. \ulink{ButtonBox}{http://tix.sourceforge.net/dist/current/demos/samples/BtnBox.tcl}
+.. \ulink{ButtonBox}{https://tix.sourceforge.net/dist/current/demos/samples/BtnBox.tcl}
 
 
 .. class:: ComboBox()
 
    The `ComboBox
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixComboBox.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixComboBox.htm>`_
    widget is similar to the combo box control in MS Windows. The user can select a
    choice by either typing in the entry subwidget or selecting from the listbox
    subwidget.
 
 .. Python Demo of:
-.. \ulink{ComboBox}{http://tix.sourceforge.net/dist/current/demos/samples/ComboBox.tcl}
+.. \ulink{ComboBox}{https://tix.sourceforge.net/dist/current/demos/samples/ComboBox.tcl}
 
 
 .. class:: Control()
 
    The `Control
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixControl.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixControl.htm>`_
    widget is also known as the :class:`SpinBox` widget. The user can adjust the
    value by pressing the two arrow buttons or by entering the value directly into
    the entry. The new value will be checked against the user-defined upper and
    lower limits.
 
 .. Python Demo of:
-.. \ulink{Control}{http://tix.sourceforge.net/dist/current/demos/samples/Control.tcl}
+.. \ulink{Control}{https://tix.sourceforge.net/dist/current/demos/samples/Control.tcl}
 
 
 .. class:: LabelEntry()
 
    The `LabelEntry
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixLabelEntry.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixLabelEntry.htm>`_
    widget packages an entry widget and a label into one mega widget. It can
    be used to simplify the creation of "entry-form" type of interface.
 
 .. Python Demo of:
-.. \ulink{LabelEntry}{http://tix.sourceforge.net/dist/current/demos/samples/LabEntry.tcl}
+.. \ulink{LabelEntry}{https://tix.sourceforge.net/dist/current/demos/samples/LabEntry.tcl}
 
 
 .. class:: LabelFrame()
 
    The `LabelFrame
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixLabelFrame.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixLabelFrame.htm>`_
    widget packages a frame widget and a label into one mega widget.  To create
    widgets inside a LabelFrame widget, one creates the new widgets relative to the
    :attr:`frame` subwidget and manage them inside the :attr:`frame` subwidget.
 
 .. Python Demo of:
-.. \ulink{LabelFrame}{http://tix.sourceforge.net/dist/current/demos/samples/LabFrame.tcl}
+.. \ulink{LabelFrame}{https://tix.sourceforge.net/dist/current/demos/samples/LabFrame.tcl}
 
 
 .. class:: Meter()
 
    The `Meter
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixMeter.htm>`_ widget
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixMeter.htm>`_ widget
    can be used to show the progress of a background job which may take a long time
    to execute.
 
 .. Python Demo of:
-.. \ulink{Meter}{http://tix.sourceforge.net/dist/current/demos/samples/Meter.tcl}
+.. \ulink{Meter}{https://tix.sourceforge.net/dist/current/demos/samples/Meter.tcl}
 
 
 .. class:: OptionMenu()
 
    The `OptionMenu
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixOptionMenu.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixOptionMenu.htm>`_
    creates a menu button of options.
 
 .. Python Demo of:
-.. \ulink{OptionMenu}{http://tix.sourceforge.net/dist/current/demos/samples/OptMenu.tcl}
+.. \ulink{OptionMenu}{https://tix.sourceforge.net/dist/current/demos/samples/OptMenu.tcl}
 
 
 .. class:: PopupMenu()
 
    The `PopupMenu
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixPopupMenu.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixPopupMenu.htm>`_
    widget can be used as a replacement of the ``tk_popup`` command. The advantage
    of the :mod:`Tix` :class:`PopupMenu` widget is it requires less application code
    to manipulate.
 
 .. Python Demo of:
-.. \ulink{PopupMenu}{http://tix.sourceforge.net/dist/current/demos/samples/PopMenu.tcl}
+.. \ulink{PopupMenu}{https://tix.sourceforge.net/dist/current/demos/samples/PopMenu.tcl}
 
 
 .. class:: Select()
 
    The `Select
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixSelect.htm>`_ widget
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixSelect.htm>`_ widget
    is a container of button subwidgets. It can be used to provide radio-box or
    check-box style of selection options for the user.
 
 .. Python Demo of:
-.. \ulink{Select}{http://tix.sourceforge.net/dist/current/demos/samples/Select.tcl}
+.. \ulink{Select}{https://tix.sourceforge.net/dist/current/demos/samples/Select.tcl}
 
 
 .. class:: StdButtonBox()
 
    The `StdButtonBox
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixStdButtonBox.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixStdButtonBox.htm>`_
    widget is a group of standard buttons for Motif-like dialog boxes.
 
 .. Python Demo of:
-.. \ulink{StdButtonBox}{http://tix.sourceforge.net/dist/current/demos/samples/StdBBox.tcl}
+.. \ulink{StdButtonBox}{https://tix.sourceforge.net/dist/current/demos/samples/StdBBox.tcl}
 
 
 File Selectors
@@ -219,37 +219,37 @@ File Selectors
 .. class:: DirList()
 
    The `DirList
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixDirList.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixDirList.htm>`_
    widget displays a list view of a directory, its previous directories and its
    sub-directories. The user can choose one of the directories displayed in the
    list or change to another directory.
 
 .. Python Demo of:
-.. \ulink{DirList}{http://tix.sourceforge.net/dist/current/demos/samples/DirList.tcl}
+.. \ulink{DirList}{https://tix.sourceforge.net/dist/current/demos/samples/DirList.tcl}
 
 
 .. class:: DirTree()
 
    The `DirTree
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixDirTree.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixDirTree.htm>`_
    widget displays a tree view of a directory, its previous directories and its
    sub-directories. The user can choose one of the directories displayed in the
    list or change to another directory.
 
 .. Python Demo of:
-.. \ulink{DirTree}{http://tix.sourceforge.net/dist/current/demos/samples/DirTree.tcl}
+.. \ulink{DirTree}{https://tix.sourceforge.net/dist/current/demos/samples/DirTree.tcl}
 
 
 .. class:: DirSelectDialog()
 
    The `DirSelectDialog
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixDirSelectDialog.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixDirSelectDialog.htm>`_
    widget presents the directories in the file system in a dialog window.  The user
    can use this dialog window to navigate through the file system to select the
    desired directory.
 
 .. Python Demo of:
-.. \ulink{DirSelectDialog}{http://tix.sourceforge.net/dist/current/demos/samples/DirDlg.tcl}
+.. \ulink{DirSelectDialog}{https://tix.sourceforge.net/dist/current/demos/samples/DirDlg.tcl}
 
 
 .. class:: DirSelectBox()
@@ -263,39 +263,39 @@ File Selectors
 .. class:: ExFileSelectBox()
 
    The `ExFileSelectBox
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixExFileSelectBox.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixExFileSelectBox.htm>`_
    widget is usually embedded in a tixExFileSelectDialog widget. It provides a
    convenient method for the user to select files. The style of the
    :class:`ExFileSelectBox` widget is very similar to the standard file dialog on
    MS Windows 3.1.
 
 .. Python Demo of:
-.. \ulink{ExFileSelectDialog}{http://tix.sourceforge.net/dist/current/demos/samples/EFileDlg.tcl}
+.. \ulink{ExFileSelectDialog}{https://tix.sourceforge.net/dist/current/demos/samples/EFileDlg.tcl}
 
 
 .. class:: FileSelectBox()
 
    The `FileSelectBox
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixFileSelectBox.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixFileSelectBox.htm>`_
    is similar to the standard Motif(TM) file-selection box. It is generally used
    for the user to choose a file. FileSelectBox stores the files mostly recently
    selected into a :class:`ComboBox` widget so that they can be quickly selected
    again.
 
 .. Python Demo of:
-.. \ulink{FileSelectDialog}{http://tix.sourceforge.net/dist/current/demos/samples/FileDlg.tcl}
+.. \ulink{FileSelectDialog}{https://tix.sourceforge.net/dist/current/demos/samples/FileDlg.tcl}
 
 
 .. class:: FileEntry()
 
    The `FileEntry
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixFileEntry.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixFileEntry.htm>`_
    widget can be used to input a filename. The user can type in the filename
    manually. Alternatively, the user can press the button widget that sits next to
    the entry, which will bring up a file selection dialog.
 
 .. Python Demo of:
-.. \ulink{FileEntry}{http://tix.sourceforge.net/dist/current/demos/samples/FileEnt.tcl}
+.. \ulink{FileEntry}{https://tix.sourceforge.net/dist/current/demos/samples/FileEnt.tcl}
 
 
 Hierarchical ListBox
@@ -305,42 +305,42 @@ Hierarchical ListBox
 .. class:: HList()
 
    The `HList
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixHList.htm>`_ widget
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixHList.htm>`_ widget
    can be used to display any data that have a hierarchical structure, for example,
    file system directory trees. The list entries are indented and connected by
    branch lines according to their places in the hierarchy.
 
 .. Python Demo of:
-.. \ulink{HList}{http://tix.sourceforge.net/dist/current/demos/samples/HList1.tcl}
+.. \ulink{HList}{https://tix.sourceforge.net/dist/current/demos/samples/HList1.tcl}
 
 
 .. class:: CheckList()
 
    The `CheckList
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixCheckList.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixCheckList.htm>`_
    widget displays a list of items to be selected by the user. CheckList acts
    similarly to the Tk checkbutton or radiobutton widgets, except it is capable of
    handling many more items than checkbuttons or radiobuttons.
 
 .. Python Demo of:
-.. \ulink{ CheckList}{http://tix.sourceforge.net/dist/current/demos/samples/ChkList.tcl}
+.. \ulink{ CheckList}{https://tix.sourceforge.net/dist/current/demos/samples/ChkList.tcl}
 .. Python Demo of:
-.. \ulink{ScrolledHList (1)}{http://tix.sourceforge.net/dist/current/demos/samples/SHList.tcl}
+.. \ulink{ScrolledHList (1)}{https://tix.sourceforge.net/dist/current/demos/samples/SHList.tcl}
 .. Python Demo of:
-.. \ulink{ScrolledHList (2)}{http://tix.sourceforge.net/dist/current/demos/samples/SHList2.tcl}
+.. \ulink{ScrolledHList (2)}{https://tix.sourceforge.net/dist/current/demos/samples/SHList2.tcl}
 
 
 .. class:: Tree()
 
    The `Tree
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixTree.htm>`_ widget
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixTree.htm>`_ widget
    can be used to display hierarchical data in a tree form. The user can adjust the
    view of the tree by opening or closing parts of the tree.
 
 .. Python Demo of:
-.. \ulink{Tree}{http://tix.sourceforge.net/dist/current/demos/samples/Tree.tcl}
+.. \ulink{Tree}{https://tix.sourceforge.net/dist/current/demos/samples/Tree.tcl}
 .. Python Demo of:
-.. \ulink{Tree (Dynamic)}{http://tix.sourceforge.net/dist/current/demos/samples/DynTree.tcl}
+.. \ulink{Tree (Dynamic)}{https://tix.sourceforge.net/dist/current/demos/samples/DynTree.tcl}
 
 
 Tabular ListBox
@@ -350,7 +350,7 @@ Tabular ListBox
 .. class:: TList()
 
    The `TList
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixTList.htm>`_ widget
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixTList.htm>`_ widget
    can be used to display data in a tabular format. The list entries of a
    :class:`TList` widget are similar to the entries in the Tk listbox widget.  The
    main differences are (1) the :class:`TList` widget can display the list entries
@@ -358,17 +358,17 @@ Tabular ListBox
    multiple colors and fonts for the list entries.
 
 .. Python Demo of:
-.. \ulink{ScrolledTList (1)}{http://tix.sourceforge.net/dist/current/demos/samples/STList1.tcl}
+.. \ulink{ScrolledTList (1)}{https://tix.sourceforge.net/dist/current/demos/samples/STList1.tcl}
 .. Python Demo of:
-.. \ulink{ScrolledTList (2)}{http://tix.sourceforge.net/dist/current/demos/samples/STList2.tcl}
+.. \ulink{ScrolledTList (2)}{https://tix.sourceforge.net/dist/current/demos/samples/STList2.tcl}
 .. Grid has yet to be added to Python
 .. \subsubsection{Grid Widget}
 .. Python Demo of:
-.. \ulink{Simple Grid}{http://tix.sourceforge.net/dist/current/demos/samples/SGrid0.tcl}
+.. \ulink{Simple Grid}{https://tix.sourceforge.net/dist/current/demos/samples/SGrid0.tcl}
 .. Python Demo of:
-.. \ulink{ScrolledGrid}{http://tix.sourceforge.net/dist/current/demos/samples/SGrid1.tcl}
+.. \ulink{ScrolledGrid}{https://tix.sourceforge.net/dist/current/demos/samples/SGrid1.tcl}
 .. Python Demo of:
-.. \ulink{Editable Grid}{http://tix.sourceforge.net/dist/current/demos/samples/EditGrid.tcl}
+.. \ulink{Editable Grid}{https://tix.sourceforge.net/dist/current/demos/samples/EditGrid.tcl}
 
 
 Manager Widgets
@@ -378,19 +378,19 @@ Manager Widgets
 .. class:: PanedWindow()
 
    The `PanedWindow
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixPanedWindow.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixPanedWindow.htm>`_
    widget allows the user to interactively manipulate the sizes of several panes.
    The panes can be arranged either vertically or horizontally.  The user changes
    the sizes of the panes by dragging the resize handle between two panes.
 
 .. Python Demo of:
-.. \ulink{PanedWindow}{http://tix.sourceforge.net/dist/current/demos/samples/PanedWin.tcl}
+.. \ulink{PanedWindow}{https://tix.sourceforge.net/dist/current/demos/samples/PanedWin.tcl}
 
 
 .. class:: ListNoteBook()
 
    The `ListNoteBook
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixListNoteBook.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixListNoteBook.htm>`_
    widget is very similar to the :class:`TixNoteBook` widget: it can be used to
    display many windows in a limited space using a notebook metaphor. The notebook
    is divided into a stack of pages (windows). At one time only one of these pages
@@ -398,30 +398,30 @@ Manager Widgets
    the desired page in the :attr:`hlist` subwidget.
 
 .. Python Demo of:
-.. \ulink{ListNoteBook}{http://tix.sourceforge.net/dist/current/demos/samples/ListNBK.tcl}
+.. \ulink{ListNoteBook}{https://tix.sourceforge.net/dist/current/demos/samples/ListNBK.tcl}
 
 
 .. class:: NoteBook()
 
    The `NoteBook
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixNoteBook.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixNoteBook.htm>`_
    widget can be used to display many windows in a limited space using a notebook
    metaphor. The notebook is divided into a stack of pages. At one time only one of
    these pages can be shown. The user can navigate through these pages by choosing
    the visual "tabs" at the top of the NoteBook widget.
 
 .. Python Demo of:
-.. \ulink{NoteBook}{http://tix.sourceforge.net/dist/current/demos/samples/NoteBook.tcl}
+.. \ulink{NoteBook}{https://tix.sourceforge.net/dist/current/demos/samples/NoteBook.tcl}
 
 .. \subsubsection{Scrolled Widgets}
 .. Python Demo of:
-.. \ulink{ScrolledListBox}{http://tix.sourceforge.net/dist/current/demos/samples/SListBox.tcl}
+.. \ulink{ScrolledListBox}{https://tix.sourceforge.net/dist/current/demos/samples/SListBox.tcl}
 .. Python Demo of:
-.. \ulink{ScrolledText}{http://tix.sourceforge.net/dist/current/demos/samples/SText.tcl}
+.. \ulink{ScrolledText}{https://tix.sourceforge.net/dist/current/demos/samples/SText.tcl}
 .. Python Demo of:
-.. \ulink{ScrolledWindow}{http://tix.sourceforge.net/dist/current/demos/samples/SWindow.tcl}
+.. \ulink{ScrolledWindow}{https://tix.sourceforge.net/dist/current/demos/samples/SWindow.tcl}
 .. Python Demo of:
-.. \ulink{Canvas Object View}{http://tix.sourceforge.net/dist/current/demos/samples/CObjView.tcl}
+.. \ulink{Canvas Object View}{https://tix.sourceforge.net/dist/current/demos/samples/CObjView.tcl}
 
 
 Image Types
@@ -429,17 +429,17 @@ Image Types
 
 The :mod:`tkinter.tix` module adds:
 
-* `pixmap <http://tix.sourceforge.net/dist/current/man/html/TixCmd/pixmap.htm>`_
+* `pixmap <https://tix.sourceforge.net/dist/current/man/html/TixCmd/pixmap.htm>`_
   capabilities to all :mod:`tkinter.tix` and :mod:`tkinter` widgets to create
   color images from XPM files.
 
   .. Python Demo of:
-  .. \ulink{XPM Image In Button}{http://tix.sourceforge.net/dist/current/demos/samples/Xpm.tcl}
+  .. \ulink{XPM Image In Button}{https://tix.sourceforge.net/dist/current/demos/samples/Xpm.tcl}
   .. Python Demo of:
-  .. \ulink{XPM Image In Menu}{http://tix.sourceforge.net/dist/current/demos/samples/Xpm1.tcl}
+  .. \ulink{XPM Image In Menu}{https://tix.sourceforge.net/dist/current/demos/samples/Xpm1.tcl}
 
 * `Compound
-  <http://tix.sourceforge.net/dist/current/man/html/TixCmd/compound.htm>`_ image
+  <https://tix.sourceforge.net/dist/current/man/html/TixCmd/compound.htm>`_ image
   types can be used to create images that consists of multiple horizontal lines;
   each line is composed of a series of items (texts, bitmaps, images or spaces)
   arranged from left to right. For example, a compound image can be used to
@@ -447,13 +447,13 @@ The :mod:`tkinter.tix` module adds:
   widget.
 
   .. Python Demo of:
-  .. \ulink{Compound Image In Buttons}{http://tix.sourceforge.net/dist/current/demos/samples/CmpImg.tcl}
+  .. \ulink{Compound Image In Buttons}{https://tix.sourceforge.net/dist/current/demos/samples/CmpImg.tcl}
   .. Python Demo of:
-  .. \ulink{Compound Image In NoteBook}{http://tix.sourceforge.net/dist/current/demos/samples/CmpImg2.tcl}
+  .. \ulink{Compound Image In NoteBook}{https://tix.sourceforge.net/dist/current/demos/samples/CmpImg2.tcl}
   .. Python Demo of:
-  .. \ulink{Compound Image Notebook Color Tabs}{http://tix.sourceforge.net/dist/current/demos/samples/CmpImg4.tcl}
+  .. \ulink{Compound Image Notebook Color Tabs}{https://tix.sourceforge.net/dist/current/demos/samples/CmpImg4.tcl}
   .. Python Demo of:
-  .. \ulink{Compound Image Icons}{http://tix.sourceforge.net/dist/current/demos/samples/CmpImg3.tcl}
+  .. \ulink{Compound Image Icons}{https://tix.sourceforge.net/dist/current/demos/samples/CmpImg3.tcl}
 
 
 Miscellaneous Widgets
@@ -463,7 +463,7 @@ Miscellaneous Widgets
 .. class:: InputOnly()
 
    The `InputOnly
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixInputOnly.htm>`_
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixInputOnly.htm>`_
    widgets are to accept inputs from the user, which can be done with the ``bind``
    command (Unix only).
 
@@ -477,7 +477,7 @@ In addition, :mod:`tkinter.tix` augments :mod:`tkinter` by providing:
 .. class:: Form()
 
    The `Form
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tixForm.htm>`_ geometry
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tixForm.htm>`_ geometry
    manager based on attachment rules for all Tk widgets.
 
 
@@ -488,7 +488,7 @@ Tix Commands
 .. class:: tixCommand()
 
    The `tix commands
-   <http://tix.sourceforge.net/dist/current/man/html/TixCmd/tix.htm>`_ provide
+   <https://tix.sourceforge.net/dist/current/man/html/TixCmd/tix.htm>`_ provide
    access to miscellaneous elements of :mod:`Tix`'s internal state and the
    :mod:`Tix` application context.  Most of the information manipulated by these
    methods pertains to the application as a whole, or to a screen or display,

--- a/Doc/library/tkinter.ttk.rst
+++ b/Doc/library/tkinter.ttk.rst
@@ -56,7 +56,7 @@ for improved styling effects.
 
 .. seealso::
 
-   `Converting existing applications to use Tile widgets <http://tktable.sourceforge.net/tile/doc/converting.txt>`_
+   `Converting existing applications to use Tile widgets <https://tktable.sourceforge.net/tile/doc/converting.txt>`_
      A monograph (using Tcl terminology) about differences typically
      encountered when moving applications to use the new widgets.
 
@@ -1272,7 +1272,7 @@ option. If you don't know the class name of a widget, use the method
 
 .. seealso::
 
-   `Tcl'2004 conference presentation <http://tktable.sourceforge.net/tile/tile-tcl2004.pdf>`_
+   `Tcl'2004 conference presentation <https://tktable.sourceforge.net/tile/tile-tcl2004.pdf>`_
       This document explains how the theme engine works
 
 

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -165,7 +165,7 @@ between conformable Python objects and XML on the wire.
       A good description of XML-RPC operation and client software in several languages.
       Contains pretty much everything an XML-RPC client developer needs to know.
 
-   `XML-RPC Introspection <http://xmlrpc-c.sourceforge.net/introspection.html>`_
+   `XML-RPC Introspection <https://xmlrpc-c.sourceforge.net/introspection.html>`_
       Describes the XML-RPC protocol extension for introspection.
 
    `XML-RPC Specification <http://xmlrpc.scripting.com/spec.html>`_

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -1226,7 +1226,7 @@ With ongoing development of Python, some platforms that used to be supported
 earlier are no longer supported (due to the lack of users or developers).
 Check :pep:`11` for details on all unsupported platforms.
 
-* `Windows CE <http://pythonce.sourceforge.net/>`_ is
+* `Windows CE <https://pythonce.sourceforge.net/>`_ is
   `no longer supported <https://github.com/python/cpython/issues/71542>`__
   since Python 3 (if it ever was).
 * The `Cygwin <https://cygwin.com/>`_ installer offers to install the

--- a/Doc/whatsnew/2.0.rst
+++ b/Doc/whatsnew/2.0.rst
@@ -572,7 +572,7 @@ Work has been done on porting Python to 64-bit Windows on the Itanium processor,
 mostly by Trent Mick of ActiveState.  (Confusingly, ``sys.platform`` is still
 ``'win32'`` on Win64 because it seems that for ease of porting, MS Visual C++
 treats code as 32 bit on Itanium.) PythonWin also supports Windows CE; see the
-Python CE page at http://pythonce.sourceforge.net/ for more information.
+Python CE page at https://pythonce.sourceforge.net/ for more information.
 
 Another new platform is Darwin/MacOS X; initial support for it is in Python 2.0.
 Dynamic loading works, if you specify "configure --with-dyld --with-suffix=.x".

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -1231,7 +1231,7 @@ complete list of changes, or look through the CVS logs for all the details.
   repeat an array. (Contributed by Jason Orendorff.)
 
 * The :mod:`bsddb` module has been replaced by version 4.1.6 of the `PyBSDDB
-  <http://pybsddb.sourceforge.net>`_ package, providing a more complete interface
+  <https://pybsddb.sourceforge.net>`_ package, providing a more complete interface
   to the transactional features of the BerkeleyDB library.
 
   The old version of the module has been renamed to  :mod:`bsddb185` and is no

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -973,7 +973,7 @@ sites do not finish before midnight, the barrier times-out and the ballots are
 sealed and deposited in a queue for later handling.
 
 See `Barrier Synchronization Patterns
-<http://osl.cs.illinois.edu/media/papers/karmani-2009-barrier_synchronization_pattern.pdf>`_
+<https://osl.cs.illinois.edu/media/papers/karmani-2009-barrier_synchronization_pattern.pdf>`_
 for more examples of how barriers can be used in parallel computing.  Also, there is
 a simple but thorough explanation of barriers in `The Little Book of Semaphores
 <https://greenteapress.com/semaphores/LittleBookOfSemaphores.pdf>`_, *section 3.6*.
@@ -2418,7 +2418,7 @@ Unicode
 =======
 
 Python has been updated to `Unicode 6.0.0
-<http://unicode.org/versions/Unicode6.0.0/>`_.  The update to the standard adds
+<https://unicode.org/versions/Unicode6.0.0/>`_.  The update to the standard adds
 over 2,000 new characters including `emoji <https://en.wikipedia.org/wiki/Emoji>`_
 symbols which are important for mobile phones.
 
@@ -2426,7 +2426,7 @@ In addition, the updated standard has altered the character properties for two
 Kannada characters (U+0CF1, U+0CF2) and one New Tai Lue numeric character
 (U+19DA), making the former eligible for use in identifiers while disqualifying
 the latter.  For more information, see `Unicode Character Database Changes
-<http://www.unicode.org/versions/Unicode6.0.0/#Database_Changes>`_.
+<https://www.unicode.org/versions/Unicode6.0.0/#Database_Changes>`_.
 
 
 Codecs

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -1963,7 +1963,7 @@ Other Improvements
   <https://devguide.python.org/coverage/#measuring-coverage-of-c-code-with-gcov-and-lcov>`_
   will build python, run the test suite, and generate an HTML coverage report
   for the C codebase using ``gcov`` and `lcov
-  <http://ltp.sourceforge.net/coverage/lcov.php>`_.
+  <https://ltp.sourceforge.net/coverage/lcov.php>`_.
 
 * The ``-R`` option to the :ref:`python regression test suite <regrtest>` now
   also checks for memory allocation leaks, using

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -1977,7 +1977,7 @@ unicodedata
 -----------
 
 The :mod:`unicodedata` module now uses data from `Unicode 8.0.0
-<http://unicode.org/versions/Unicode8.0.0/>`_.
+<https://unicode.org/versions/Unicode8.0.0/>`_.
 
 
 unittest

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -1644,7 +1644,7 @@ unicodedata
 -----------
 
 The :mod:`unicodedata` module now uses data from `Unicode 9.0.0
-<http://unicode.org/versions/Unicode9.0.0/>`_.
+<https://unicode.org/versions/Unicode9.0.0/>`_.
 (Contributed by Benjamin Peterson.)
 
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1507,7 +1507,7 @@ unicodedata
 -----------
 
 The internal :mod:`unicodedata` database has been upgraded to use `Unicode 11
-<http://www.unicode.org/versions/Unicode11.0.0/>`_. (Contributed by Benjamin
+<https://www.unicode.org/versions/Unicode11.0.0/>`_. (Contributed by Benjamin
 Peterson.)
 
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1351,7 +1351,7 @@ unicodedata
 -----------
 
 The :mod:`unicodedata` module has been upgraded to use the `Unicode 12.1.0
-<http://blog.unicode.org/2019/05/unicode-12-1-en.html>`_ release.
+<https://blog.unicode.org/2019/05/unicode-12-1-en.html>`_ release.
 
 New function :func:`~unicodedata.is_normalized` can be used to verify a string
 is in a specific normal form, often much faster than by actually normalizing


### PR DESCRIPTION
Use HTTPS for documents which are available by both HTTP and HTTPS links, but there is no redirection from HTTP to HTTPS or vice versa.


<!-- gh-issue-number: gh-96959 -->
* Issue: gh-96959
<!-- /gh-issue-number -->
