### PR TITLE
gh-97545: Make Semaphore run faster.

### DIFF
--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -844,9 +844,8 @@ class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
 
         sem.release()
         sem.release()
-        self.assertEqual(2, sem._value)
+        self.assertEqual(0, sem._value)
 
-        await asyncio.sleep(0)
         await asyncio.sleep(0)
         self.assertEqual(0, sem._value)
         self.assertEqual(3, len(result))

--- a/Misc/NEWS.d/next/Library/2022-09-25-23-24-52.gh-issue-97545.HZLSNt.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-25-23-24-52.gh-issue-97545.HZLSNt.rst
@@ -1,0 +1,1 @@
+Make Semaphore run faster.


### PR DESCRIPTION
gh-97545: Make Semaphore run faster.

For this to be a fifo semaphore, the asyncio loop shall run tasks in their waking order (to be confirmed).

Background:

- Issue https://github.com/python/cpython/issues/90155
- PR https://github.com/python/cpython/pull/93222
- Issue https://github.com/python/cpython/issues/97545
- Issue https://github.com/python/cpython/issues/97028

Tests:

- https://github.com/python/cpython/issues/90155#issuecomment-1093939558
- https://github.com/python/cpython/issues/90155#issuecomment-1137052110
- https://gist.github.com/gvanrossum/02d9e4ef3c4f277050bf18fee0a3f189
- `Lib/test/test_asyncio/test_locks.py`