### PR TITLE
gh-97569: Adds SupportsBool to typing

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2372,6 +2372,10 @@ These protocols are decorated with :func:`runtime_checkable`.
     An ABC with one abstract method ``__abs__`` that is covariant
     in its return type.
 
+.. class:: SupportsBool
+
+    An ABC with one abstract method ``__bool__``.
+
 .. class:: SupportsBytes
 
     An ABC with one abstract method ``__bytes__``.

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2696,6 +2696,11 @@ class ProtocolTests(BaseTestCase):
     def test_supports_float(self):
         self.assertIsSubclass(float, typing.SupportsFloat)
         self.assertNotIsSubclass(str, typing.SupportsFloat)
+    
+    def test_supports_bool(self):
+        self.assertIsSubclass(bool, typing.SupportsBool)
+        self.assertIsSubclass(int, typing.SupportsBool)
+        self.assertNotIsSubclass(str, typing.SupportsBool)
 
     def test_supports_complex(self):
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -89,6 +89,7 @@ __all__ = [
     # Structural checks, a.k.a. protocols.
     'Reversible',
     'SupportsAbs',
+    'SupportsBool',
     'SupportsBytes',
     'SupportsComplex',
     'SupportsFloat',
@@ -2758,6 +2759,16 @@ class SupportsFloat(Protocol):
 
     @abstractmethod
     def __float__(self) -> float:
+        pass
+
+
+@runtime_checkable
+class SupportsBool(Protocol):
+    """An ABC with one abstract method __bool__."""
+    __slots__ = ()
+
+    @abstractmethod
+    def __bool__(self) -> bool:
         pass
 
 

--- a/Misc/NEWS.d/next/Library/2022-09-26-14-51-24.gh-issue-97569.-fbaEl.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-26-14-51-24.gh-issue-97569.-fbaEl.rst
@@ -1,0 +1,1 @@
+New :class:`typing.SupportsBool` protocol to describe objects that implement `__bool__`.


### PR DESCRIPTION
This PR adds SupportsBool to the typing module.

<!-- gh-issue-number: gh-97569 -->
* Issue: gh-97569
<!-- /gh-issue-number -->
