### PR TITLE
[3.7] gh-96848: Fix -X int_max_str_digits option parsing (#96988)

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -717,6 +717,8 @@ class CmdLineTest(unittest.TestCase):
         assert_python_failure('-X', 'int_max_str_digits', '-c', code)
         assert_python_failure('-X', 'int_max_str_digits=foo', '-c', code)
         assert_python_failure('-X', 'int_max_str_digits=100', '-c', code)
+        assert_python_failure('-X', 'int_max_str_digits', '-c', code,
+                              PYTHONINTMAXSTRDIGITS='4000')
 
         assert_python_failure('-c', code, PYTHONINTMAXSTRDIGITS='foo')
         assert_python_failure('-c', code, PYTHONINTMAXSTRDIGITS='100')

--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-21-14-38-31.gh-issue-96848.WuoLzU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-21-14-38-31.gh-issue-96848.WuoLzU.rst
@@ -1,0 +1,3 @@
+Fix command line parsing: reject :option:`-X int_max_str_digits <-X>` option
+with no value (invalid) when the :envvar:`PYTHONINTMAXSTRDIGITS` environment
+variable is set to a valid limit. Patch by Victor Stinner.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1813,10 +1813,10 @@ static _PyInitError
 config_init_int_max_str_digits(_PyCoreConfig *config)
 {
     int maxdigits;
-    int valid = 0;
 
     const char *env = config_get_env_var("PYTHONINTMAXSTRDIGITS");
     if (env) {
+        int valid = 0;
         if (!pymain_str_to_int(env, &maxdigits)) {
             valid = ((maxdigits == 0) || (maxdigits >= _PY_LONG_MAX_STR_DIGITS_THRESHOLD));
         }
@@ -1834,6 +1834,7 @@ config_init_int_max_str_digits(_PyCoreConfig *config)
     const wchar_t *xoption = config_get_xoption(config, L"int_max_str_digits");
     if (xoption) {
         const wchar_t *sep = wcschr(xoption, L'=');
+        int valid = 0;
         if (sep) {
             if (!pymain_wstr_to_int(sep + 1, &maxdigits)) {
                 valid = ((maxdigits == 0) || (maxdigits >= _PY_LONG_MAX_STR_DIGITS_THRESHOLD));


### PR DESCRIPTION
Fix command line parsing: reject "-X int_max_str_digits" option with no value (invalid) when the PYTHONINTMAXSTRDIGITS environment variable is set to a valid limit.

(cherry picked from commit 41351662bcd21672d8ccfa62fe44d72027e6bcf8)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96848 -->
* Issue: gh-96848
<!-- /gh-issue-number -->
