### PR TITLE
gh-60580: Fix a wrong type of `ctypes.wintypes.BYTE`

### DIFF
--- a/Lib/ctypes/wintypes.py
+++ b/Lib/ctypes/wintypes.py
@@ -1,7 +1,7 @@
 # The most useful windows datatypes
 import ctypes
 
-BYTE = ctypes.c_byte
+BYTE = ctypes.c_ubyte
 WORD = ctypes.c_ushort
 DWORD = ctypes.c_ulong
 

--- a/Lib/test/test_ctypes/test_wintypes.py
+++ b/Lib/test/test_ctypes/test_wintypes.py
@@ -48,14 +48,14 @@ class WinTypesTest(unittest.TestCase):
         self.assertGreater(ctype(-1).value, 0)
 
     def test_signedness(self):
-        for type in (wintypes.BYTE, wintypes.WORD, wintypes.DWORD,
+        for ctype in (wintypes.BYTE, wintypes.WORD, wintypes.DWORD,
                      wintypes.BOOLEAN, wintypes.UINT, wintypes.ULONG):
-            with self.subTest(type=type):
-                self.assertIsUnsigned(type)
+            with self.subTest(ctype=ctype):
+                self.assertIsUnsigned(ctype)
 
-        for type in (wintypes.BOOL, wintypes.INT, wintypes.LONG):
-            with self.subTest(type=type):
-                self.assertIsSigned(type)
+        for ctype in (wintypes.BOOL, wintypes.INT, wintypes.LONG):
+            with self.subTest(ctype=ctype):
+                self.assertIsSigned(ctype)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_ctypes/test_wintypes.py
+++ b/Lib/test/test_ctypes/test_wintypes.py
@@ -41,7 +41,7 @@ class WinTypesTest(unittest.TestCase):
         vb.value = []
         self.assertIs(vb.value, False)
 
-    def test_signess(self):
+    def test_signedness(self):
         # Unsigned aliases with octet size in their names
         for type in (wintypes.BYTE, wintypes.WORD, wintypes.DWORD):
             with self.subTest(type=type):

--- a/Lib/test/test_ctypes/test_wintypes.py
+++ b/Lib/test/test_ctypes/test_wintypes.py
@@ -44,15 +44,18 @@ class WinTypesTest(unittest.TestCase):
     def assertIsSigned(self, ctype):
         self.assertLess(ctype(-1).value, 0)
 
+    def assertIsUnsigned(self, ctype):
+        self.assertGreater(ctype(-1).value, 0)
+
     def test_signedness(self):
         for type in (wintypes.BYTE, wintypes.WORD, wintypes.DWORD,
                      wintypes.BOOLEAN, wintypes.UINT, wintypes.ULONG):
             with self.subTest(type=type):
-                self.assertFalse(assertIsSigned(type))
+                self.assertIsUnsigned(type)
 
         for type in (wintypes.BOOL, wintypes.INT, wintypes.LONG):
             with self.subTest(type=type):
-                self.assertTrue(assertIsSigned(type))
+                self.assertIsSigned(type)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_ctypes/test_wintypes.py
+++ b/Lib/test/test_ctypes/test_wintypes.py
@@ -1,3 +1,6 @@
+# See <https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types>
+# for reference.
+
 import unittest
 
 # also work on POSIX
@@ -37,6 +40,22 @@ class WinTypesTest(unittest.TestCase):
         self.assertIs(vb.value, True)
         vb.value = []
         self.assertIs(vb.value, False)
+
+    def test_signess(self):
+        # Unsigned aliases with octet sie in their name
+        for type in (wintypes.BYTE, wintypes.WORD, wintypes.DWORD):
+            with self.subTest(type=type):
+                self.assertEqual(type(200).value, 128)
+
+        # Unsigned aliases with generic name
+        for type in (wintypes.BOOLEAN, wintypes.UINT, wintypes.ULONG):
+            with self.subTest(type=type):
+                self.assertLess(type(200).value, 200)
+
+        #Signed types with generic names
+        for type in (wintypes.BOOL, wintypes.INT, wintypes.LONG):
+            with self.subTest(type=type):
+                self.assertLess(type(200).value, 200)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_ctypes/test_wintypes.py
+++ b/Lib/test/test_ctypes/test_wintypes.py
@@ -42,20 +42,20 @@ class WinTypesTest(unittest.TestCase):
         self.assertIs(vb.value, False)
 
     def test_signess(self):
-        # Unsigned aliases with octet sizw in their name
+        # Unsigned aliases with octet size in their names
         for type in (wintypes.BYTE, wintypes.WORD, wintypes.DWORD):
             with self.subTest(type=type):
-                self.assertEqual(type(200).value, 128)
+                self.assertEqual(type(200).value, 200)
 
         # Unsigned aliases with generic names
         for type in (wintypes.BOOLEAN, wintypes.UINT, wintypes.ULONG):
             with self.subTest(type=type):
-                self.assertEqual(type(200).value, 128)
+                self.assertEqual(type(200).value, 200)
 
         # Signed types with generic names
         for type in (wintypes.BOOL, wintypes.INT, wintypes.LONG):
             with self.subTest(type=type):
-                self.assertLess(type(200).value, 200)
+                self.assertLess(type(200).value, 128)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_ctypes/test_wintypes.py
+++ b/Lib/test/test_ctypes/test_wintypes.py
@@ -41,21 +41,18 @@ class WinTypesTest(unittest.TestCase):
         vb.value = []
         self.assertIs(vb.value, False)
 
+    def assertIsSigned(self, ctype):
+        self.assertLess(ctype(-1).value, 0)
+
     def test_signedness(self):
-        # Unsigned aliases with octet size in their names
-        for type in (wintypes.BYTE, wintypes.WORD, wintypes.DWORD):
+        for type in (wintypes.BYTE, wintypes.WORD, wintypes.DWORD,
+                     wintypes.BOOLEAN, wintypes.UINT, wintypes.ULONG):
             with self.subTest(type=type):
-                self.assertEqual(type(200).value, 200)
+                self.assertFalse(assertIsSigned(type))
 
-        # Unsigned aliases with generic names
-        for type in (wintypes.BOOLEAN, wintypes.UINT, wintypes.ULONG):
-            with self.subTest(type=type):
-                self.assertEqual(type(200).value, 200)
-
-        # Signed types with generic names
         for type in (wintypes.BOOL, wintypes.INT, wintypes.LONG):
             with self.subTest(type=type):
-                self.assertLess(type(200).value, 128)
+                self.assertTrue(assertIsSigned(type))
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_ctypes/test_wintypes.py
+++ b/Lib/test/test_ctypes/test_wintypes.py
@@ -42,17 +42,17 @@ class WinTypesTest(unittest.TestCase):
         self.assertIs(vb.value, False)
 
     def test_signess(self):
-        # Unsigned aliases with octet sie in their name
+        # Unsigned aliases with octet sizw in their name
         for type in (wintypes.BYTE, wintypes.WORD, wintypes.DWORD):
             with self.subTest(type=type):
                 self.assertEqual(type(200).value, 128)
 
-        # Unsigned aliases with generic name
+        # Unsigned aliases with generic names
         for type in (wintypes.BOOLEAN, wintypes.UINT, wintypes.ULONG):
             with self.subTest(type=type):
-                self.assertLess(type(200).value, 200)
+                self.assertEqual(type(200).value, 128)
 
-        #Signed types with generic names
+        # Signed types with generic names
         for type in (wintypes.BOOL, wintypes.INT, wintypes.LONG):
             with self.subTest(type=type):
                 self.assertLess(type(200).value, 200)

--- a/Misc/NEWS.d/next/Library/2022-09-26-21-18-47.gh-issue-60580.0hBgde.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-26-21-18-47.gh-issue-60580.0hBgde.rst
@@ -1,0 +1,3 @@
+:data:`ctypes.wintypes.BYTE` definition changed from
+:data:`~ctypes.c_byte` to :data:`~ctypes.c_ubyte` to match Windows
+SDK. Patch by Anatoly Techtonik.

--- a/Misc/NEWS.d/next/Library/2022-09-26-21-18-47.gh-issue-60580.0hBgde.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-26-21-18-47.gh-issue-60580.0hBgde.rst
@@ -1,3 +1,3 @@
 :data:`ctypes.wintypes.BYTE` definition changed from
 :data:`~ctypes.c_byte` to :data:`~ctypes.c_ubyte` to match Windows
-SDK. Patch by Anatoly Techtonik.
+SDK. Patch by Anatoly Techtonik and Oleg Iarygin.


### PR DESCRIPTION
This PR is created from a .diff file attached to the issue, by Anatoly Techtonik (@techtonik on GitHub).

<!-- gh-issue-number: gh-60580 -->
* Issue: gh-60580
<!-- /gh-issue-number -->
