### PR TITLE
gh-96377: Update asyncio policy doc intro paras to be clear and accurate

### DIFF
--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -109,7 +109,7 @@ that the event loop runs in.
 
 There is currently no way to schedule coroutines or callbacks directly
 from a different process (such as one started with
-:mod:`multiprocessing`). The :ref:`Event Loop Methods <asyncio-event-loop>`
+:mod:`multiprocessing`). The :ref:`asyncio-event-loop-methods`
 section lists APIs that can read from pipes and watch file descriptors
 without blocking the event loop. In addition, asyncio's
 :ref:`Subprocess <asyncio-subprocess>` APIs provide a way to start a

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1,6 +1,8 @@
 .. currentmodule:: asyncio
 
 
+.. _asyncio-event-loop:
+
 ==========
 Event Loop
 ==========
@@ -92,7 +94,7 @@ This documentation page contains the following sections:
   loop APIs.
 
 
-.. _asyncio-event-loop:
+.. _asyncio-event-loop-methods:
 
 Event Loop Methods
 ==================
@@ -1598,6 +1600,7 @@ Do not instantiate the class directly.
 
 
 .. _asyncio-event-loops:
+.. _asyncio-event-loop-implementations:
 
 Event Loop Implementations
 ==========================
@@ -1644,7 +1647,7 @@ on Unix and :class:`ProactorEventLoop` on Windows.
 
    Abstract base class for asyncio-compliant event loops.
 
-   The :ref:`Event Loop Methods <asyncio-event-loop>` section lists all
+   The :ref:`asyncio-event-loop-methods` section lists all
    methods that an alternative implementation of ``AbstractEventLoop``
    should have defined.
 

--- a/Doc/library/asyncio-llapi-index.rst
+++ b/Doc/library/asyncio-llapi-index.rst
@@ -37,7 +37,7 @@ Event Loop Methods
 ==================
 
 See also the main documentation section about the
-:ref:`event loop methods <asyncio-event-loop>`.
+:ref:`asyncio-event-loop-methods`.
 
 .. rubric:: Lifecycle
 .. list-table::

--- a/Doc/library/asyncio-policy.rst
+++ b/Doc/library/asyncio-policy.rst
@@ -8,7 +8,7 @@ Policies
 ========
 
 An event loop policy is a global (per-interpreter) object
-used to get and set the current event loop,
+used to get and set the current :ref:`event loop <asyncio-event-loop>`,
 as well as create new event loops.
 The default policy can be :ref:`replaced <asyncio-policy-get-set>` with
 :ref:`built-in alternatives <asyncio-policy-builtin>`

--- a/Doc/library/asyncio-policy.rst
+++ b/Doc/library/asyncio-policy.rst
@@ -7,17 +7,18 @@
 Policies
 ========
 
-An event loop policy is a global per-process object that controls
-the management of the event loop. Each event loop has a default
-policy, which can be changed and customized using the policy API.
+An event loop policy is a global (per-interpreter) object
+used to get and set the current event loop, as well as create new event loops.
+The default policy can be replaced with built-in alternatives
+to use different event loop implementations,
+or substituted by a custom policy class that can override these behaviors.
 
-A policy defines the notion of *context* and manages a
-separate event loop per context. The default policy
-defines *context* to be the current thread.
+The policy object gets and sets a separate event loop per *context*.
+This is per-thread by default,
+though custom policies could define *context* differently.
 
-By using a custom event loop policy, the behavior of
-:func:`get_event_loop`, :func:`set_event_loop`, and
-:func:`new_event_loop` functions can be customized.
+Custom event loop policies can control the behavior of
+:func:`get_event_loop`, :func:`set_event_loop`, and :func:`new_event_loop`.
 
 Policy objects should implement the APIs defined
 in the :class:`AbstractEventLoopPolicy` abstract base class.

--- a/Doc/library/asyncio-policy.rst
+++ b/Doc/library/asyncio-policy.rst
@@ -8,12 +8,16 @@ Policies
 ========
 
 An event loop policy is a global (per-interpreter) object
-used to get and set the current event loop, as well as create new event loops.
-The default policy can be replaced with built-in alternatives
+used to get and set the current event loop,
+as well as create new event loops.
+The default policy can be :ref:`replaced <asyncio-policy-get-set>` with
+:ref:`built-in alternatives <asyncio-policy-builtin>`
 to use different event loop implementations,
-or substituted by a custom policy class that can override these behaviors.
+or substituted by a :ref:`custom policy <asyncio-custom-policies>`
+that can override these behaviors.
 
-The policy object gets and sets a separate event loop per *context*.
+The :ref:`policy object <asyncio-policy-objects>`
+gets and sets a separate event loop per *context*.
 This is per-thread by default,
 though custom policies could define *context* differently.
 
@@ -23,6 +27,8 @@ Custom event loop policies can control the behavior of
 Policy objects should implement the APIs defined
 in the :class:`AbstractEventLoopPolicy` abstract base class.
 
+
+.. _asyncio-policy-get-set:
 
 Getting and Setting the Policy
 ==============================
@@ -40,6 +46,8 @@ for the current process:
 
    If *policy* is set to ``None``, the default policy is restored.
 
+
+.. _asyncio-policy-objects:
 
 Policy Objects
 ==============
@@ -87,6 +95,8 @@ The abstract event loop policy base class is defined as follows:
       This function is Unix specific.
 
 
+.. _asyncio-policy-builtin:
+
 asyncio ships with the following built-in policies:
 
 
@@ -117,6 +127,7 @@ asyncio ships with the following built-in policies:
    :class:`ProactorEventLoop` event loop implementation.
 
    .. availability:: Windows.
+
 
 .. _asyncio-watchers:
 
@@ -270,6 +281,8 @@ implementation used by the asyncio event loop:
 
    .. versionadded:: 3.9
 
+
+.. _asyncio-custom-policies:
 
 Custom Policies
 ===============


### PR DESCRIPTION
As reported in #96377 , the introductory paragraphs of the [Asyncio Policies doc](https://docs.python.org/3.12/library/asyncio-policy.html) are confusing and not particularly accurate. Therefore, as discussed there, I've rewritten them to better reflect and explain the current reality, per the guidance of @gvanrossum . I've also added refs to the various relevant sections as they are mentioned, and also linked the [doc explaining what an event loop is](https://docs.python.org/3.12/library/asyncio-eventloop.html) to begin with when mentioned.

To note, the previous `asyncio-event-loop` ref target label actually pointed to the [table of low-level event loop methods](https://docs.python.org/3.12/library/asyncio-eventloop.html#event-loop-methods), instead of pointing to the top-level summary of what an event loop actually is as you'd expect and also what most actual usages treated it as, which was in fact missing a ref target label entirely. Therefore, I moved it up a bit to point to that top-level document heading so I could use such, and added a new `asyncio-event-loop-methods` ref pointing specifically to the section with the table, updating the few instances that actually did treat the previous as the methods table to point to that instead.

Preview:

![image](https://user-images.githubusercontent.com/17051931/192652278-e9f4f640-8e4d-499c-80dc-3854ac539b15.png)


<!-- gh-issue-number: gh-96377 -->
* Issue: gh-96377
<!-- /gh-issue-number -->
