### PR TITLE
gh-97612: Fix shell injection in get-remote-certificate.py

### DIFF
--- a/Misc/NEWS.d/next/Security/2022-09-28-12-10-57.gh-issue-97612.y6NvOQ.rst
+++ b/Misc/NEWS.d/next/Security/2022-09-28-12-10-57.gh-issue-97612.y6NvOQ.rst
@@ -1,0 +1,3 @@
+Fix a shell code injection vulnerability in the ``get-remote-certificate.py``
+example script. The script no longer uses a shell to run ``openssl`` commands.
+Issue reported and initial fix by Caleb Shortt. Patch by Victor Stinner.

--- a/Tools/scripts/get-remote-certificate.py
+++ b/Tools/scripts/get-remote-certificate.py
@@ -15,8 +15,8 @@ import tempfile
 def fetch_server_certificate (host, port):
 
     def subproc(cmd):
-        from subprocess import Popen, PIPE, STDOUT
-        proc = Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True)
+        from subprocess import Popen, PIPE, STDOUT, DEVNULL
+        proc = Popen(cmd, stdout=PIPE, stderr=STDOUT, stdin=DEVNULL)
         status = proc.wait()
         output = proc.stdout.read()
         return status, output
@@ -33,8 +33,8 @@ def fetch_server_certificate (host, port):
                 fp.write(m.group(1) + b"\n")
             try:
                 tn2 = (outfile or tempfile.mktemp())
-                status, output = subproc(r'openssl x509 -in "%s" -out "%s"' %
-                                         (tn, tn2))
+                cmd = ['openssl', 'x509', '-in', tn, '-out', tn2]
+                status, output = subproc(cmd)
                 if status != 0:
                     raise RuntimeError('OpenSSL x509 failed with status %s and '
                                        'output: %r' % (status, output))
@@ -45,20 +45,9 @@ def fetch_server_certificate (host, port):
             finally:
                 os.unlink(tn)
 
-    if sys.platform.startswith("win"):
-        tfile = tempfile.mktemp()
-        with open(tfile, "w") as fp:
-            fp.write("quit\n")
-        try:
-            status, output = subproc(
-                'openssl s_client -connect "%s:%s" -showcerts < "%s"' %
-                (host, port, tfile))
-        finally:
-            os.unlink(tfile)
-    else:
-        status, output = subproc(
-            'openssl s_client -connect "%s:%s" -showcerts < /dev/null' %
-            (host, port))
+    cmd = ['openssl', 's_client', '-connect', '%s:%s' % (host, port), '-showcerts']
+    status, output = subproc(cmd)
+
     if status != 0:
         raise RuntimeError('OpenSSL connect failed with status %s and '
                            'output: %r' % (status, output))


### PR DESCRIPTION
Fix a shell code injection vulnerability in the
get-remote-certificate.py example script. The script no longer uses a shell to run "openssl" commands. Issue reported and initial fix by Caleb Shortt.

Remove the Windows code path to send "quit" on stdin to the "openssl
s_client" command: use DEVNULL on all platforms instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97612 -->
* Issue: gh-97612
<!-- /gh-issue-number -->
