### PR TITLE
[3.7] gh-97612: Fix shell injection in get-remote-certificate.py (#97613)

### DIFF
--- a/Misc/NEWS.d/next/Security/2022-09-28-12-10-57.gh-issue-97612.y6NvOQ.rst
+++ b/Misc/NEWS.d/next/Security/2022-09-28-12-10-57.gh-issue-97612.y6NvOQ.rst
@@ -1,0 +1,3 @@
+Fix a shell code injection vulnerability in the ``get-remote-certificate.py``
+example script. The script no longer uses a shell to run ``openssl`` commands.
+Issue reported and initial fix by Caleb Shortt. Patch by Victor Stinner.


### PR DESCRIPTION
Fix a shell code injection vulnerability in the
get-remote-certificate.py example script. The script no longer uses a shell to run "openssl" commands. Issue reported and initial fix by Caleb Shortt.

Remove the Windows code path to send "quit" on stdin to the "openssl s_client" command: use DEVNULL on all platforms instead.

Co-authored-by: Caleb Shortt <caleb@rgauge.com>
(cherry picked from commit 83a0f44ffd8b398673ae56c310cf5768d359c341)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97612 -->
* Issue: gh-97612
<!-- /gh-issue-number -->
