### PR TITLE
gh-97607: a blank line after `.. impl-detail::` in the Docs

### DIFF
--- a/Doc/howto/isolating-extensions.rst
+++ b/Doc/howto/isolating-extensions.rst
@@ -265,6 +265,7 @@ or access. To limit the possible issues, static types are immutable at
 the Python level: for example, you can't set ``str.myattribute = 123``.
 
 .. impl-detail::
+
    Sharing truly immutable objects between interpreters is fine,
    as long as they don't provide access to mutable objects.
    However, in CPython, every Python object has a mutable implementation

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -240,6 +240,7 @@ SimpleQueue Objects
    for compatibility with :meth:`Queue.put`.
 
    .. impl-detail::
+
       This method has a C implementation which is reentrant.  That is, a
       ``put()`` or ``get()`` call can be interrupted by another ``put()``
       call in the same thread without deadlocking or corrupting internal

--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -185,6 +185,7 @@ The following functions operate on a global history list:
    .. versionadded:: 3.6
 
    .. impl-detail::
+
       Auto history is enabled by default, and changes to this do not persist
       across multiple sessions.
 


### PR DESCRIPTION
Add a blank line after `.. impl-detail::` in the documentation for translation work.

If a blank line were missing, Sphinx would not build the paragraph after `.. impl-detail::` during HTML file generation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97607 -->
* Issue: gh-97607
<!-- /gh-issue-number -->
