### PR TITLE
gh-97639: Remove `tokenize.NL` check from `tabnanny`

### DIFF
--- a/Lib/tabnanny.py
+++ b/Lib/tabnanny.py
@@ -23,8 +23,6 @@ __version__ = "6"
 import os
 import sys
 import tokenize
-if not hasattr(tokenize, 'NL'):
-    raise ValueError("tokenize.NL doesn't exist -- tokenize module too old")
 
 __all__ = ["check", "NannyNag", "process_tokens"]
 

--- a/Misc/NEWS.d/next/Library/2022-09-29-08-15-55.gh-issue-97639.JSjWYW.rst
+++ b/Misc/NEWS.d/next/Library/2022-09-29-08-15-55.gh-issue-97639.JSjWYW.rst
@@ -1,0 +1,1 @@
+Remove ``tokenize.NL`` check from :mod:`tabnanny`.


### PR DESCRIPTION
As said in https://github.com/python/cpython/issues/97639, `tokenize.NL` is always there for a long time.

<!-- gh-issue-number: gh-97639 -->
* Issue: gh-97639
<!-- /gh-issue-number -->
