### PR TITLE
gh-97647: Update activate.bat for a dynamic VIRTUAL_ENV

### DIFF
--- a/Lib/venv/scripts/nt/activate.bat
+++ b/Lib/venv/scripts/nt/activate.bat
@@ -8,7 +8,8 @@ if defined _OLD_CODEPAGE (
     "%SystemRoot%\System32\chcp.com" 65001 > nul
 )
 
-set VIRTUAL_ENV=__VENV_DIR__
+rem Set VIRTUAL_ENV dynamically as parent of this dir so we can move / rename the tree
+for %%I in ("%~dp0..") do set VIRTUAL_ENV=%%~fI
 
 if not defined PROMPT set PROMPT=$P$G
 


### PR DESCRIPTION
Issue #97647 

Sets VIRTUAL_ENV dynamically as parent of this bat's dir so we can move / rename the venv tree
(Activate.ps1 already does this.)


<!-- gh-issue-number: gh-97647 -->
* Issue: gh-97647
<!-- /gh-issue-number -->
