### PR TITLE
gh-97607: Fix content parsing in the impl-detail reST directive

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -116,10 +116,8 @@ class ImplementationDetail(Directive):
         content.source = pnode[0].source
         content.line = pnode[0].line
         content += pnode[0].children
-        pnode[0].replace_self(
-            nodes.paragraph('', '', content, translatable=False))
-        pnode[0].insert(0, add_text)
-        pnode[0].insert(1, nodes.Text(' '))
+        pnode[0].replace_self(nodes.paragraph(
+            '', '', add_text, nodes.Text(' '), content, translatable=False))
         return [pnode]
 
 

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -106,22 +106,20 @@ class ImplementationDetail(Directive):
     label_text = 'CPython implementation detail:'
 
     def run(self):
+        self.assert_has_content()
         pnode = nodes.compound(classes=['impl-detail'])
         label = translators['sphinx'].gettext(self.label_text)
         content = self.content
         add_text = nodes.strong(label, label)
         self.state.nested_parse(content, self.content_offset, pnode)
-        if pnode.children and isinstance(pnode[0], nodes.paragraph):
-            content = nodes.inline(pnode[0].rawsource, translatable=True)
-            content.source = pnode[0].source
-            content.line = pnode[0].line
-            content += pnode[0].children
-            pnode[0].replace_self(nodes.paragraph('', '', content,
-                                                  translatable=False))
-            pnode[0].insert(0, add_text)
-            pnode[0].insert(1, nodes.Text(' '))
-        else:
-            pnode.insert(0, nodes.paragraph('', '', add_text))
+        content = nodes.inline(pnode[0].rawsource, translatable=True)
+        content.source = pnode[0].source
+        content.line = pnode[0].line
+        content += pnode[0].children
+        pnode[0].replace_self(
+            nodes.paragraph('', '', content, translatable=False))
+        pnode[0].insert(0, add_text)
+        pnode[0].insert(1, nodes.Text(' '))
         return [pnode]
 
 

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -100,8 +100,6 @@ def source_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
 class ImplementationDetail(Directive):
 
     has_content = True
-    required_arguments = 0
-    optional_arguments = 1
     final_argument_whitespace = True
 
     # This text is copied to templates/dummy.html
@@ -112,9 +110,6 @@ class ImplementationDetail(Directive):
         label = translators['sphinx'].gettext(self.label_text)
         content = self.content
         add_text = nodes.strong(label, label)
-        if self.arguments:
-            n, m = self.state.inline_text(self.arguments[0], self.lineno)
-            pnode.append(nodes.paragraph('', '', *(n + m)))
         self.state.nested_parse(content, self.content_offset, pnode)
         if pnode.children and isinstance(pnode[0], nodes.paragraph):
             content = nodes.inline(pnode[0].rawsource, translatable=True)


### PR DESCRIPTION
This fixes #97607 with the [custom `impl-detail` reST directive in the docs](https://github.com/python/cpython/blob/4652093e1b816b78e9a585d671a807ce66427417/Doc/tools/extensions/pyspecific.py#L100), that results in the text being untranslated in translations (e.g. python/python-docs-zh-tw#187 ) when it isn't written as a separate content paragraph under the directive (as opposed to with no or one line break after the directive start `::`, as opposed to two). 

In particular, currently the directive treats text in the same paragraph as the directive start by capturing it in an optional argument and manually processing it, which results in missing metadata (e.g. raw source, file and line number) in the parsed doctree nodes (that in turn breaks the translation code that requires this metadata). This PR fixes the directive to use the same internal logic as the similar builtin docutils/Sphinx directives (e.g. the various admonition types), taking no arguments and just treating that text as directive content by default, regardless of the number of line breaks.

All three forms (0, 1, and 2 line breaks) are used for e.g. `note::` in the [`os` module doc source](https://github.com/python/cpython/blob/main/Doc/library/os.rst), and all three render correctly in the [translated `os` module docs](https://docs.python.org/zh-tw/3.12/library/os.html), and I also confirmed that the parsed doctree structure, content and attributes are now identical for all three to that previously generated for separate paragraphs, and the untranslated HTML is byte-identical both between source forms and before and after this change. In addition to fixing the issue, this also simplifies the directive code and logic.

Additionally, I also was able to eliminate the related unused branch from the directive code that handled the situation where the directive is used alone with no content at all. This isn't used anywhere in the docs and seems to lack a clear use case, and its use would be more likely to just an unintentional mistake (e.g. due to an indentation mismatch). The behavior is now likewise consistent with the aforementioned built-in directive, being flagged as an error at build time, and the code/logic is further simplified from two (originally three) code paths to one.

@StevenHsuYL , could you test to confirm that this PR fixes the issue you experienced in  python/python-docs-zh-tw#187 and reported in #97607 ? Thanks!

Fixes #97607
Closes #97635 

<!-- gh-issue-number: gh-97607 -->
* Issue: gh-97607
<!-- /gh-issue-number -->
