### PR TITLE
Add re.VERBOSE flag documentation example

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -783,7 +783,8 @@ Flags
    more readable by allowing you to visually separate logical sections of the
    pattern and add comments. Whitespace within the pattern is ignored, except
    when in a character class, or when preceded by an unescaped backslash,
-   or within tokens like ``*?``, ``(?:`` or ``(?P<...>``.
+   or within tokens like ``*?``, ``(?:`` or ``(?P<...>``. For example, ``(? :``
+   and ``* ?`` are not allowed.
    When a line contains a ``#`` that is not in a character class and is not
    preceded by an unescaped backslash, all characters from the leftmost such
    ``#`` through the end of the line are ignored.


### PR DESCRIPTION
The current re.VERBOSE documentation example leaves space for ambiguous interpretation. One may read that spaces within the `(?:` token are spaces inside the non-capturing group (such as `(?: )`). This patch removes the ambiguity by including examples after the statement.