### PR TITLE
gh-87597: Document TimeoutExpired.stdout & .stderr types.

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -193,7 +193,10 @@ underlying :class:`Popen` interface can be used directly.
     .. attribute:: output
 
         Output of the child process if it was captured by :func:`run` or
-        :func:`check_output`.  Otherwise, ``None``.
+        :func:`check_output`.  Otherwise, ``None``.  This is always
+        :class:`bytes` when any output was captured regardless of the
+        ``text=True`` setting.  It may be ``None`` when there was no output
+        captured.
 
     .. attribute:: stdout
 
@@ -202,7 +205,9 @@ underlying :class:`Popen` interface can be used directly.
     .. attribute:: stderr
 
         Stderr output of the child process if it was captured by :func:`run`.
-        Otherwise, ``None``.
+        Otherwise, ``None``.  This is always :class:`bytes` when stderr output
+        was captured regardless of the ``text=True`` setting.  It may be
+        ``None`` when there was no stderr output captured.
 
     .. versionadded:: 3.3
 

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -195,8 +195,8 @@ underlying :class:`Popen` interface can be used directly.
         Output of the child process if it was captured by :func:`run` or
         :func:`check_output`.  Otherwise, ``None``.  This is always
         :class:`bytes` when any output was captured regardless of the
-        ``text=True`` setting.  It may be ``None`` when there was no output
-        captured.
+        ``text=True`` setting.  It may remain ``None`` instead of ``b''``
+        when no output was observed.
 
     .. attribute:: stdout
 
@@ -206,8 +206,8 @@ underlying :class:`Popen` interface can be used directly.
 
         Stderr output of the child process if it was captured by :func:`run`.
         Otherwise, ``None``.  This is always :class:`bytes` when stderr output
-        was captured regardless of the ``text=True`` setting.  It may be
-        ``None`` when there was no stderr output captured.
+        was captured regardless of the ``text=True`` setting.  It may remain
+        ``None`` instead of ``b''`` when no stderr output was observed.
 
     .. versionadded:: 3.3
 


### PR DESCRIPTION
This documents the behavior that has always been the case since timeout support was introduced in Python 3.3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-87597 -->
* Issue: gh-87597
<!-- /gh-issue-number -->
