### PR TITLE
gh-97591: In `Exception.__setstate__()`, acquire strong reference before calling `tp_hash` slot.

### DIFF
--- a/Lib/test/test_baseexception.py
+++ b/Lib/test/test_baseexception.py
@@ -114,6 +114,31 @@ class ExceptionClassTests(unittest.TestCase):
                 [repr(exc), exc.__class__.__name__ + '()'])
         self.interface_test_driver(results)
 
+    def test_setstate_refcount_no_crash(self):
+        # gh-97591: Acquire strong reference before calling tp_hash slot
+        # in PyObject_SetAttr.
+        import gc
+        d = {}
+        class HashThisKeyWillClearTheDict(str):
+            def __hash__(self) -> int:
+                d.clear()
+                return super().__hash__()
+        class Value(str):
+            pass
+        exc = Exception()
+
+        d[HashThisKeyWillClearTheDict()] = Value()  # refcount of Value() is 1 now
+
+        # Exception.__setstate__ should aquire a strong reference of key and
+        # value in the dict. Otherwise, Value()'s refcount would go below 
+        # zero in the tp_hash call in PyObject_SetAttr(), and it would cause
+        # crash in GC.
+        exc.__setstate__(d)  # __hash__() is called again here, clearing the dict.
+
+        # This GC would crash if the refcount of Value() goes below zero.
+        gc.collect()
+
+
 class UsageTests(unittest.TestCase):
 
     """Test usage of exceptions"""

--- a/Lib/test/test_baseexception.py
+++ b/Lib/test/test_baseexception.py
@@ -130,7 +130,7 @@ class ExceptionClassTests(unittest.TestCase):
         d[HashThisKeyWillClearTheDict()] = Value()  # refcount of Value() is 1 now
 
         # Exception.__setstate__ should aquire a strong reference of key and
-        # value in the dict. Otherwise, Value()'s refcount would go below 
+        # value in the dict. Otherwise, Value()'s refcount would go below
         # zero in the tp_hash call in PyObject_SetAttr(), and it would cause
         # crash in GC.
         exc.__setstate__(d)  # __hash__() is called again here, clearing the dict.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-01-08-55-09.gh-issue-97591.pw6kkH.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-01-08-55-09.gh-issue-97591.pw6kkH.rst
@@ -1,0 +1,1 @@
+Fixed a missing incref/decref pair in Exception.__setstate__()

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-01-08-55-09.gh-issue-97591.pw6kkH.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-01-08-55-09.gh-issue-97591.pw6kkH.rst
@@ -1,1 +1,2 @@
-Fixed a missing incref/decref pair in Exception.__setstate__()
+Fixed a missing incref/decref pair in `Exception.__setstate__()`.
+Patch by Ofey Chan.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -167,8 +167,14 @@ BaseException_setstate(PyObject *self, PyObject *state)
             return NULL;
         }
         while (PyDict_Next(state, &i, &d_key, &d_value)) {
-            if (PyObject_SetAttr(self, d_key, d_value) < 0)
+            Py_INCREF(d_key);
+            Py_INCREF(d_value);
+            int res = PyObject_SetAttr(self, d_key, d_value);
+            Py_DECREF(d_value);
+            Py_DECREF(d_key);
+            if (res < 0) {
                 return NULL;
+            }
         }
     }
     Py_RETURN_NONE;


### PR DESCRIPTION
Added an `Py_INCREF / Py_DECREF` pair around the call of `tp_hash` slot in `Exception.__setstate__()`.

If the last reference of dict value is cleared (by `dict.clear()`), during the `__setstate__` method call, it would cause gc crash.

A script to reproduce this is in #97591 :

```python
import gc

class Key(str):
    def __hash__(self):
        d.clear()
        return 0

class Value(str):
    pass

d = {}
d[Key()] = Value()

e = Exception()
e.__setstate__(d)

gc.collect() # Segfault happens here
```

Similiar issue: #92930 

<!-- gh-issue-number: gh-97591 -->
* Issue: gh-97591
<!-- /gh-issue-number -->
