### PR TITLE
gh-95913: Move py.exe to appropriate What's New section & refine text

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -207,8 +207,10 @@ See :pep:`678` for more details.
 PEP written by Zac Hatfield-Dodds.)
 
 
-Windows py.exe launcher improvements
-------------------------------------
+.. _whatsnew311-windows-launcher:
+
+Windows ``py.exe`` launcher improvements
+----------------------------------------
 
 The copy of :ref:`launcher` included with Python 3.11 has been significantly
 updated. It now supports company/tag syntax as defined in :pep:`514` using the

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -212,24 +212,24 @@ PEP written by Zac Hatfield-Dodds.)
 Windows ``py.exe`` launcher improvements
 ----------------------------------------
 
-The copy of :ref:`launcher` included with Python 3.11 has been significantly
+The copy of the :ref:`launcher` included with Python 3.11 has been significantly
 updated. It now supports company/tag syntax as defined in :pep:`514` using the
-``-V:<company>/<tag>`` argument instead of the limited ``-<major>.<minor>`` argument.
-This allows launching distributions other than ``PythonCore``, which is the one
-obtained from `python.org <https://python.org>`_.
+``-V:<company>/<tag>`` argument instead of the limited ``-<major>.<minor>``.
+This allows launching distributions other than ``PythonCore``,
+the one hosted on `python.org <https://python.org>`_.
 
 When using ``-V:`` selectors, either company or tag can be omitted, but all
 installs will be searched. For example, ``-V:OtherPython/`` will select the
 "best" tag registered for ``OtherPython``, while ``-V:3.11`` or ``-V:/3.11``
 will select the "best" distribution with tag ``3.11``.
 
-When using legacy ``-<major>``, ``-<major>.<minor>``,
+When using the legacy ``-<major>``, ``-<major>.<minor>``,
 ``-<major>-<bitness>`` or ``-<major>.<minor>-<bitness>`` arguments,
 all existing behaviour should be preserved from past versions.
 Only releases from ``PythonCore`` will be selected.
-However, the ``-64`` suffix now implies "not 32-bit",
+However, the ``-64`` suffix now implies "not 32-bit" (not necessarily x86-64),
 as there are multiple supported 64-bit platforms.
-32-bit runtimes are detected by checking its tag for a ``-32`` suffix.
+32-bit runtimes are detected by checking the runtime's tag for a ``-32`` suffix.
 All releases of Python since 3.5 have included this in their 32-bit builds.
 
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -207,6 +207,28 @@ See :pep:`678` for more details.
 PEP written by Zac Hatfield-Dodds.)
 
 
+Windows py.exe launcher improvements
+------------------------------------
+
+The copy of :ref:`launcher` included with Python 3.11 has been significantly
+updated. It now supports company/tag syntax as defined in :pep:`514` using the
+``-V:<company>/<tag>`` argument instead of the limited ``-x.y`` argument. This
+allows launching distributions other than ``PythonCore``, which is the one
+obtained from `python.org <https://python.org>`_.
+
+When using ``-V:`` selectors, either company or tag can be omitted, but all
+installs will be searched. For example, ``-V:OtherPython/`` will select the
+"best" tag registered for ``OtherPython``, while ``-V:3.11`` or ``-V:/3.11``
+will select the "best" distribution with tag ``3.11``.
+
+When using legacy ``-x``, ``-x.y``, ``-x-ZZ`` or ``-x.y-ZZ`` arguments, all
+existing behaviour should be preserved from past versions. Only releases from
+``PythonCore`` will be selected. However, the ``-64`` suffix now implies "not
+32-bit", as there are multiple supported 64-bit platforms. 32-bit runtimes are
+detected by checking its tag for a ``-32`` suffix. All releases of Python
+since 3.5 have included this in their 32-bit builds.
+
+
 .. _new-feat-related-type-hints-311:
 .. _whatsnew311-typing-features:
 
@@ -399,28 +421,6 @@ that was originally planned for release in Python 3.10
 has been put on hold indefinitely.
 See `this message from the Steering Council <https://mail.python.org/archives/list/python-dev@python.org/message/VIZEBX5EYMSYIJNDBF6DMUMZOCWHARSO/>`__
 for more information.
-
-
-Windows py.exe launcher improvements
-------------------------------------
-
-The copy of :ref:`launcher` included with Python 3.11 has been significantly
-updated. It now supports company/tag syntax as defined in :pep:`514` using the
-``-V:<company>/<tag>`` argument instead of the limited ``-x.y`` argument. This
-allows launching distributions other than ``PythonCore``, which is the one
-obtained from `python.org <https://python.org>`_.
-
-When using ``-V:`` selectors, either company or tag can be omitted, but all
-installs will be searched. For example, ``-V:OtherPython/`` will select the
-"best" tag registered for ``OtherPython``, while ``-V:3.11`` or ``-V:/3.11``
-will select the "best" distribution with tag ``3.11``.
-
-When using legacy ``-x``, ``-x.y``, ``-x-ZZ`` or ``-x.y-ZZ`` arguments, all
-existing behaviour should be preserved from past versions. Only releases from
-``PythonCore`` will be selected. However, the ``-64`` suffix now implies "not
-32-bit", as there are multiple supported 64-bit platforms. 32-bit runtimes are
-detected by checking its tag for a ``-32`` suffix. All releases of Python
-since 3.5 have included this in their 32-bit builds.
 
 
 Other Language Changes

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -214,8 +214,8 @@ Windows ``py.exe`` launcher improvements
 
 The copy of :ref:`launcher` included with Python 3.11 has been significantly
 updated. It now supports company/tag syntax as defined in :pep:`514` using the
-``-V:<company>/<tag>`` argument instead of the limited ``-x.y`` argument. This
-allows launching distributions other than ``PythonCore``, which is the one
+``-V:<company>/<tag>`` argument instead of the limited ``-<major>.<minor>`` argument.
+This allows launching distributions other than ``PythonCore``, which is the one
 obtained from `python.org <https://python.org>`_.
 
 When using ``-V:`` selectors, either company or tag can be omitted, but all
@@ -223,12 +223,14 @@ installs will be searched. For example, ``-V:OtherPython/`` will select the
 "best" tag registered for ``OtherPython``, while ``-V:3.11`` or ``-V:/3.11``
 will select the "best" distribution with tag ``3.11``.
 
-When using legacy ``-x``, ``-x.y``, ``-x-ZZ`` or ``-x.y-ZZ`` arguments, all
-existing behaviour should be preserved from past versions. Only releases from
-``PythonCore`` will be selected. However, the ``-64`` suffix now implies "not
-32-bit", as there are multiple supported 64-bit platforms. 32-bit runtimes are
-detected by checking its tag for a ``-32`` suffix. All releases of Python
-since 3.5 have included this in their 32-bit builds.
+When using legacy ``-<major>``, ``-<major>.<minor>``,
+``-<major>-<bitness>`` or ``-<major>.<minor>-<bitness>`` arguments,
+all existing behaviour should be preserved from past versions.
+Only releases from ``PythonCore`` will be selected.
+However, the ``-64`` suffix now implies "not 32-bit",
+as there are multiple supported 64-bit platforms.
+32-bit runtimes are detected by checking its tag for a ``-32`` suffix.
+All releases of Python since 3.5 have included this in their 32-bit builds.
 
 
 .. _new-feat-related-type-hints-311:

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -225,8 +225,8 @@ will select the "best" distribution with tag ``3.11``.
 
 When using the legacy ``-<major>``, ``-<major>.<minor>``,
 ``-<major>-<bitness>`` or ``-<major>.<minor>-<bitness>`` arguments,
-all existing behaviour should be preserved from past versions.
-Only releases from ``PythonCore`` will be selected.
+all existing behaviour should be preserved from past versions,
+and only releases from ``PythonCore`` will be selected.
 However, the ``-64`` suffix now implies "not 32-bit" (not necessarily x86-64),
 as there are multiple supported 64-bit platforms.
 32-bit runtimes are detected by checking the runtime's tag for a ``-32`` suffix.


### PR DESCRIPTION
Part of #95913 

Discussion of the improvements to the `py.exe` Windows launcher was mistakenly added to the "New Features Related to Type Hints" section of the What's New in #96595 , which clearly doesn't seem to be the right place. I moved it to what seemed to be the most appropriate existing section, New Features (since there wasn't a section specific to ancillary utilities or Windows-specific changes, and I didn't want to introduce a whole new section just for it especially at this late hour, and because that was the most likely section it was intended to go under).

In addition, I made some minor refinements to the text/syntax consistent with the other What's New changes, including:

* Be more explicit to clarify what the legacy version arg components represent, as I was initially somewhat confused (especially on `-ZZ`)
* Add a ref target label and using a literal for `py.exe`, consistent with general convention and its specific usage elsewhere
* Apply other minor grammar, clarity and readability fixes

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
