### PR TITLE
gh-97725: Fix default file in `Task.print_stack`

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -14,6 +14,7 @@ import contextvars
 import functools
 import inspect
 import itertools
+import sys
 import types
 import warnings
 import weakref
@@ -183,6 +184,8 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
         to which the output is written; by default output is written
         to sys.stderr.
         """
+        if file is None:
+            file = sys.stderr
         return base_tasks._task_print_stack(self, limit, file)
 
     def cancel(self, msg=None):

--- a/Misc/NEWS.d/next/Library/2022-10-02-06-26-25.gh-issue-97725.icupGE.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-02-06-26-25.gh-issue-97725.icupGE.rst
@@ -1,0 +1,1 @@
+Make :meth:`asyncio.Task.print_task` use ``sys.stderr`` by default, as documented.


### PR DESCRIPTION
`asyncio.Task.print_stack` is described by documentation as having a default output file of `sys.stderr`. However, the default `None` is passed all the way to `print` statements, leading to an actual default of `sys.stdout`.

Fix by setting the file to `sys.stderr` when the default is used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97725 -->
* Issue: gh-97725
<!-- /gh-issue-number -->
