### PR TITLE
gh-97731: fix distclean target to clean docs

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1863,7 +1863,7 @@ altbininstall: $(BUILDPYTHON) @FRAMEWORKPYTHONW@
       $(DSYMUTIL_PATH) $(DESTDIR)$(PYTHONFRAMEWORKPREFIX)/$(INSTSONAME); \
 		fi \
 	fi
-	
+
 
 bininstall: altbininstall
 	if test ! -d $(DESTDIR)$(LIBPC); then \
@@ -2432,8 +2432,7 @@ rmtestturds:
 	-rm -f gb-18030-2000.xml
 
 docclean:
-	-rm -rf Doc/build
-	-rm -rf Doc/tools/sphinx Doc/tools/pygments Doc/tools/docutils
+	$(MAKE) -C Doc clean
 
 # like the 'clean' target but retain the profile guided optimization (PGO)
 # data.  The PGO data is only valid if source code remains unchanged.
@@ -2485,7 +2484,7 @@ clobber: clean
 # Make things extra clean, before making a distribution:
 # remove all generated files, even Makefile[.pre]
 # Keep configure and Python-ast.[ch], it's possible they can't be generated
-distclean: clobber
+distclean: clobber docclean
 	for file in $(srcdir)/Lib/test/data/* ; do \
 	    if test "$$file" != "$(srcdir)/Lib/test/data/README"; then rm "$$file"; fi; \
 	done


### PR DESCRIPTION
This change makes the `distclean` target in `Makefile.pre.in` rely on the `clean` target in `Doc/Makefile` to do that part of its job. 

<!-- gh-issue-number: gh-97731 -->
* Issue: gh-97731
<!-- /gh-issue-number -->
