### PR TITLE
gh-95913: Fix PEP number in PEP 678 What's New ref label

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -191,7 +191,7 @@ See :pep:`654` for more details.
 Irit Katriel, Yury Selivanov and Guido van Rossum.)
 
 
-.. _whatsnew311-pep670:
+.. _whatsnew311-pep678:
 
 PEP 678: Exceptions can be enriched with notes
 ----------------------------------------------


### PR DESCRIPTION
Followup to #95915 ; nominally part of #95913 

The ref target label for the PEP 678 "New Features" section in the 3.11 What's New, just added in #95915, contained the number for PEP 670 instead, which is confusing and will clash when that is added shortly. This fixes that.

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
