### PR TITLE
gh-97740: Fix bang in Sphinx C domain ref target syntax

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -249,3 +249,18 @@ c_allow_pre_v3 = True
 # bpo-40204: Disable warnings on Sphinx 2 syntax of the C domain since the
 # documentation is built with -W (warnings treated as errors).
 c_warn_on_allowed_pre_v3 = False
+
+# Fix '!' not working with C domain when pre_v3 is enabled
+import sphinx
+
+if sphinx.version_info[:2] < (5, 3):
+    from sphinx.domains.c import CXRefRole
+
+    original_run = CXRefRole.run
+
+    def new_run(self):
+        if self.disabled:
+            return super(CXRefRole, self).run()
+        return original_run(self)
+
+    CXRefRole.run = new_run

--- a/Misc/NEWS.d/next/Documentation/2022-10-02-10-58-52.gh-issue-97741.39l023.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-10-02-10-58-52.gh-issue-97741.39l023.rst
@@ -1,0 +1,2 @@
+Fix ``!`` in c domain ref target syntax via a ``conf.py`` patch, so it works
+as intended to disable ref target resolution.


### PR DESCRIPTION
Presently, `!` doesn't work in Sphinx C domain reference target syntax in the docs due to an issue with `c_allow_pre_v3` causing `.disabled` to be ignored. @AA-Turner developed a workaround to fix that, which I apply here in the `conf.py`.

<!-- gh-issue-number: gh-97740 -->
* Issue: gh-97740
<!-- /gh-issue-number -->
