### PR TITLE
gh-97758: Fix a crash in getpath_joinpath() called without arguments

### DIFF
--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -261,7 +261,7 @@ getpath_joinpath(PyObject *Py_UNUSED(self), PyObject *args)
     }
     Py_ssize_t n = PyTuple_GET_SIZE(args);
     if (n == 0) {
-        return PyUnicode_FromString(NULL);
+        return PyUnicode_FromStringAndSize(NULL, 0);
     }
     /* Convert all parts to wchar and accumulate max final length */
     wchar_t **parts = (wchar_t **)PyMem_Malloc(n * sizeof(wchar_t *));


### PR DESCRIPTION


<!-- gh-issue-number: gh-97758 -->
* Issue: gh-97758
<!-- /gh-issue-number -->
