### PR TITLE
[3.10] gh-97728: Argument Clinic: Fix uninitialized variable in the Py_UNICODE converter (GH-97729)

### DIFF
--- a/Lib/test/clinic.test
+++ b/Lib/test/clinic.test
@@ -1805,12 +1805,12 @@ static PyObject *
 test_Py_UNICODE_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    const Py_UNICODE *a;
-    const Py_UNICODE *b;
-    const Py_UNICODE *c;
-    const Py_UNICODE *d;
+    const Py_UNICODE *a = NULL;
+    const Py_UNICODE *b = NULL;
+    const Py_UNICODE *c = NULL;
+    const Py_UNICODE *d = NULL;
     Py_ssize_clean_t d_length;
-    const Py_UNICODE *e;
+    const Py_UNICODE *e = NULL;
     Py_ssize_clean_t e_length;
 
     if (!_PyArg_ParseStack(args, nargs, "O&O&O&u#Z#:test_Py_UNICODE_converter",
@@ -1843,7 +1843,7 @@ test_Py_UNICODE_converter_impl(PyObject *module, const Py_UNICODE *a,
                                Py_ssize_clean_t d_length,
                                const Py_UNICODE *e,
                                Py_ssize_clean_t e_length)
-/*[clinic end generated code: output=ef45e982fedf0b3d input=064a3b68ad7f04b0]*/
+/*[clinic end generated code: output=e45007c49e77ad4a input=064a3b68ad7f04b0]*/
 
 
 /*[clinic input]

--- a/Misc/NEWS.d/next/Windows/2022-10-02-11-59-23.gh-issue-97728.dIdlPE.rst
+++ b/Misc/NEWS.d/next/Windows/2022-10-02-11-59-23.gh-issue-97728.dIdlPE.rst
@@ -1,0 +1,3 @@
+Fix possible crashes caused by the use of uninitialized variables when pass
+invalid arguments in :func:`os.system` on Windows and in Windows-specific
+modules (like ``winreg``).

--- a/Modules/clinic/_winapi.c.h
+++ b/Modules/clinic/_winapi.c.h
@@ -192,7 +192,7 @@ _winapi_CreateFileMapping(PyObject *module, PyObject *const *args, Py_ssize_t na
     DWORD protect;
     DWORD max_size_high;
     DWORD max_size_low;
-    LPCWSTR name;
+    LPCWSTR name = NULL;
     HANDLE _return_value;
 
     if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "" F_POINTER "kkkO&:CreateFileMapping",
@@ -233,8 +233,8 @@ static PyObject *
 _winapi_CreateJunction(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    LPCWSTR src_path;
-    LPCWSTR dst_path;
+    LPCWSTR src_path = NULL;
+    LPCWSTR dst_path = NULL;
 
     if (!_PyArg_CheckPositional("CreateJunction", nargs, 2, 2)) {
         goto exit;
@@ -394,14 +394,14 @@ static PyObject *
 _winapi_CreateProcess(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    const Py_UNICODE *application_name;
+    const Py_UNICODE *application_name = NULL;
     PyObject *command_line;
     PyObject *proc_attrs;
     PyObject *thread_attrs;
     BOOL inherit_handles;
     DWORD creation_flags;
     PyObject *env_mapping;
-    const Py_UNICODE *current_directory;
+    const Py_UNICODE *current_directory = NULL;
     PyObject *startup_info;
 
     if (!_PyArg_ParseStack(args, nargs, "O&OOOikOO&O:CreateProcess",
@@ -749,7 +749,7 @@ _winapi_OpenFileMapping(PyObject *module, PyObject *const *args, Py_ssize_t narg
     PyObject *return_value = NULL;
     DWORD desired_access;
     BOOL inherit_handle;
-    LPCWSTR name;
+    LPCWSTR name = NULL;
     HANDLE _return_value;
 
     if (!_PyArg_ParseStack(args, nargs, "kiO&:OpenFileMapping",
@@ -1216,4 +1216,4 @@ _winapi__mimetypes_read_windows_registry(PyObject *module, PyObject *const *args
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8e13179bf25bdea5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d76d0a5901db2e2a input=a9049054013a1b77]*/

--- a/Modules/clinic/overlapped.c.h
+++ b/Modules/clinic/overlapped.c.h
@@ -220,7 +220,7 @@ _overlapped_CreateEvent(PyObject *module, PyObject *const *args, Py_ssize_t narg
     PyObject *EventAttributes;
     BOOL ManualReset;
     BOOL InitialState;
-    const Py_UNICODE *Name;
+    const Py_UNICODE *Name = NULL;
 
     if (!_PyArg_ParseStack(args, nargs, "OiiO&:CreateEvent",
         &EventAttributes, &ManualReset, &InitialState, _PyUnicode_WideCharString_Opt_Converter, &Name)) {
@@ -786,7 +786,7 @@ static PyObject *
 _overlapped_Overlapped_ConnectPipe(OverlappedObject *self, PyObject *arg)
 {
     PyObject *return_value = NULL;
-    const Py_UNICODE *Address;
+    const Py_UNICODE *Address = NULL;
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("ConnectPipe", "argument", "str", arg);
@@ -905,4 +905,4 @@ _overlapped_Overlapped_WSARecvFrom(OverlappedObject *self, PyObject *const *args
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ee2ec2f93c8d334b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d3215a6ca589735a input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1717,7 +1717,7 @@ os_system(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *k
     static const char * const _keywords[] = {"command", NULL};
     static _PyArg_Parser _parser = {NULL, _keywords, "system", 0};
     PyObject *argsbuf[1];
-    const Py_UNICODE *command;
+    const Py_UNICODE *command = NULL;
     long _return_value;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
@@ -9291,4 +9291,4 @@ exit:
 #ifndef OS_WAITSTATUS_TO_EXITCODE_METHODDEF
     #define OS_WAITSTATUS_TO_EXITCODE_METHODDEF
 #endif /* !defined(OS_WAITSTATUS_TO_EXITCODE_METHODDEF) */
-/*[clinic end generated code: output=73be33fa0000a6d1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ddc35c3177c3b3ed input=a9049054013a1b77]*/

--- a/PC/clinic/_msi.c.h
+++ b/PC/clinic/_msi.c.h
@@ -195,7 +195,7 @@ _msi_Record_SetString(msiobj *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int field;
-    const Py_UNICODE *value;
+    const Py_UNICODE *value = NULL;
 
     if (!_PyArg_CheckPositional("SetString", nargs, 2, 2)) {
         goto exit;
@@ -244,7 +244,7 @@ _msi_Record_SetStream(msiobj *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int field;
-    const Py_UNICODE *value;
+    const Py_UNICODE *value = NULL;
 
     if (!_PyArg_CheckPositional("SetStream", nargs, 2, 2)) {
         goto exit;
@@ -555,7 +555,7 @@ static PyObject *
 _msi_Database_OpenView(msiobj *self, PyObject *arg)
 {
     PyObject *return_value = NULL;
-    const Py_UNICODE *sql;
+    const Py_UNICODE *sql = NULL;
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("OpenView", "argument", "str", arg);
@@ -650,7 +650,7 @@ static PyObject *
 _msi_OpenDatabase(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    const Py_UNICODE *path;
+    const Py_UNICODE *path = NULL;
     int persist;
 
     if (!_PyArg_CheckPositional("OpenDatabase", nargs, 2, 2)) {
@@ -713,4 +713,4 @@ _msi_CreateRecord(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=49debf733ee5cab2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=19b24ee4e6420dcd input=a9049054013a1b77]*/

--- a/PC/clinic/winreg.c.h
+++ b/PC/clinic/winreg.c.h
@@ -148,7 +148,7 @@ static PyObject *
 winreg_ConnectRegistry(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    const Py_UNICODE *computer_name;
+    const Py_UNICODE *computer_name = NULL;
     HKEY key;
     HKEY _return_value;
 
@@ -220,7 +220,7 @@ winreg_CreateKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
-    const Py_UNICODE *sub_key;
+    const Py_UNICODE *sub_key = NULL;
     HKEY _return_value;
 
     if (!_PyArg_CheckPositional("CreateKey", nargs, 2, 2)) {
@@ -301,7 +301,7 @@ winreg_CreateKeyEx(PyObject *module, PyObject *const *args, Py_ssize_t nargs, Py
     static const char * const _keywords[] = {"key", "sub_key", "reserved", "access", NULL};
     static _PyArg_Parser _parser = {"O&O&|ii:CreateKeyEx", _keywords, 0};
     HKEY key;
-    const Py_UNICODE *sub_key;
+    const Py_UNICODE *sub_key = NULL;
     int reserved = 0;
     REGSAM access = KEY_WRITE;
     HKEY _return_value;
@@ -354,7 +354,7 @@ winreg_DeleteKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
-    const Py_UNICODE *sub_key;
+    const Py_UNICODE *sub_key = NULL;
 
     if (!_PyArg_CheckPositional("DeleteKey", nargs, 2, 2)) {
         goto exit;
@@ -428,7 +428,7 @@ winreg_DeleteKeyEx(PyObject *module, PyObject *const *args, Py_ssize_t nargs, Py
     static const char * const _keywords[] = {"key", "sub_key", "access", "reserved", NULL};
     static _PyArg_Parser _parser = {"O&O&|ii:DeleteKeyEx", _keywords, 0};
     HKEY key;
-    const Py_UNICODE *sub_key;
+    const Py_UNICODE *sub_key = NULL;
     REGSAM access = KEY_WOW64_64KEY;
     int reserved = 0;
 
@@ -469,7 +469,7 @@ winreg_DeleteValue(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
-    const Py_UNICODE *value;
+    const Py_UNICODE *value = NULL;
 
     if (!_PyArg_CheckPositional("DeleteValue", nargs, 2, 2)) {
         goto exit;
@@ -619,7 +619,7 @@ static PyObject *
 winreg_ExpandEnvironmentStrings(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
-    const Py_UNICODE *string;
+    const Py_UNICODE *string = NULL;
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("ExpandEnvironmentStrings", "argument", "str", arg);
@@ -724,8 +724,8 @@ winreg_LoadKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
-    const Py_UNICODE *sub_key;
-    const Py_UNICODE *file_name;
+    const Py_UNICODE *sub_key = NULL;
+    const Py_UNICODE *file_name = NULL;
 
     if (!_PyArg_CheckPositional("LoadKey", nargs, 3, 3)) {
         goto exit;
@@ -805,7 +805,7 @@ winreg_OpenKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObje
     static const char * const _keywords[] = {"key", "sub_key", "reserved", "access", NULL};
     static _PyArg_Parser _parser = {"O&O&|ii:OpenKey", _keywords, 0};
     HKEY key;
-    const Py_UNICODE *sub_key;
+    const Py_UNICODE *sub_key = NULL;
     int reserved = 0;
     REGSAM access = KEY_READ;
     HKEY _return_value;
@@ -862,7 +862,7 @@ winreg_OpenKeyEx(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyOb
     static const char * const _keywords[] = {"key", "sub_key", "reserved", "access", NULL};
     static _PyArg_Parser _parser = {"O&O&|ii:OpenKeyEx", _keywords, 0};
     HKEY key;
-    const Py_UNICODE *sub_key;
+    const Py_UNICODE *sub_key = NULL;
     int reserved = 0;
     REGSAM access = KEY_READ;
     HKEY _return_value;
@@ -953,7 +953,7 @@ winreg_QueryValue(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
-    const Py_UNICODE *sub_key;
+    const Py_UNICODE *sub_key = NULL;
 
     if (!_PyArg_CheckPositional("QueryValue", nargs, 2, 2)) {
         goto exit;
@@ -1016,7 +1016,7 @@ winreg_QueryValueEx(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
-    const Py_UNICODE *name;
+    const Py_UNICODE *name = NULL;
 
     if (!_PyArg_CheckPositional("QueryValueEx", nargs, 2, 2)) {
         goto exit;
@@ -1084,7 +1084,7 @@ winreg_SaveKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
-    const Py_UNICODE *file_name;
+    const Py_UNICODE *file_name = NULL;
 
     if (!_PyArg_CheckPositional("SaveKey", nargs, 2, 2)) {
         goto exit;
@@ -1153,7 +1153,7 @@ winreg_SetValue(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
-    const Py_UNICODE *sub_key;
+    const Py_UNICODE *sub_key = NULL;
     DWORD type;
     PyObject *value_obj;
 
@@ -1228,7 +1228,7 @@ winreg_SetValueEx(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
-    const Py_UNICODE *value_name;
+    const Py_UNICODE *value_name = NULL;
     PyObject *reserved;
     DWORD type;
     PyObject *value;
@@ -1349,4 +1349,4 @@ winreg_QueryReflectionKey(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8ce6fb3b6cd46242 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1c96481d6be5c0d8 input=a9049054013a1b77]*/

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -3449,6 +3449,7 @@ class Py_UNICODE_converter(CConverter):
                 self.converter = '_PyUnicode_WideCharString_Opt_Converter'
             else:
                 fail("Py_UNICODE_converter: illegal 'accept' argument " + repr(accept))
+        self.c_default = "NULL"
 
     def cleanup(self):
         if not self.length:


### PR DESCRIPTION
It affects function os.system() on Windows and Windows-specific modules winreg, _winapi, _overlapped, and _msi.
(cherry picked from commit 0ee9619a4cba58730c45e65d22288fadbf7680de)


<!-- gh-issue-number: gh-97728 -->
* Issue: gh-97728
<!-- /gh-issue-number -->
