### PR TITLE
[3.9] gh-96845: Fix docs around importlib.abc.Traversable (GH-97515)

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -845,6 +845,8 @@ ABC hierarchy::
 
        Read contents of self as text.
 
+    Note: In Python 3.11 and later, this class is found in ``importlib.resources.abc``.
+
 
 .. class:: TraversableResources
 
@@ -855,6 +857,8 @@ ABC hierarchy::
     also supplies ResourceReader.
 
     .. versionadded:: 3.9
+
+    Note: In Python 3.11 and later, this class is found in ``importlib.resources.abc``.
 
 
 :mod:`importlib.resources` -- Resources
@@ -918,7 +922,7 @@ The following functions are available.
 
 .. function:: files(package)
 
-    Returns an :class:`importlib.resources.abc.Traversable` object
+    Returns an :class:`importlib.abc.Traversable` object
     representing the resource container for the package (think directory)
     and its resources (think files). A Traversable may contain other
     containers (think subdirectories).
@@ -930,7 +934,7 @@ The following functions are available.
 
 .. function:: as_file(traversable)
 
-    Given a :class:`importlib.resources.abc.Traversable` object representing
+    Given a :class:`importlib.abc.Traversable` object representing
     a file, typically from :func:`importlib.resources.files`, return
     a context manager for use in a :keyword:`with` statement.
     The context manager provides a :class:`pathlib.Path` object.


### PR DESCRIPTION
* [3.10] gh-96845: Correct reference to Traversable* classes.

* [3.10] gh-96845: Add a note about the pending move of resources.abcs. (cherry picked from commit bead571e6a2752d111f4995bcd4a0c2c3b19c6b6)

Co-authored-by: Jason R. Coombs <jaraco@jaraco.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
