### PR TITLE
Fix typos in `bltinmodule.c`

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -261,8 +261,8 @@ importlib.import_module() to programmatically import a module.
 
 The globals argument is only used to determine the context;
 they are not modified.  The locals argument is unused.  The fromlist
-should be a list of names to emulate ``from name import ...'', or an
-empty list to emulate ``import name''.
+should be a list of names to emulate ``from name import ...``, or an
+empty list to emulate ``import name``.
 When importing a module from a package, note that __import__('A.B', ...)
 returns package A when fromlist is empty, but its submodule B when
 fromlist is not empty.  The level argument is used to determine whether to
@@ -1510,7 +1510,7 @@ setattr as builtin_setattr
 
 Sets the named attribute on the given object to the specified value.
 
-setattr(x, 'y', v) is equivalent to ``x.y = v''
+setattr(x, 'y', v) is equivalent to ``x.y = v``
 [clinic start generated code]*/
 
 static PyObject *
@@ -1533,7 +1533,7 @@ delattr as builtin_delattr
 
 Deletes the named attribute from the given object.
 
-delattr(x, 'y') is equivalent to ``del x.y''
+delattr(x, 'y') is equivalent to ``del x.y``
 [clinic start generated code]*/
 
 static PyObject *

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -273,7 +273,7 @@ is the number of parent directories to search relative to the current module.
 static PyObject *
 builtin___import___impl(PyObject *module, PyObject *name, PyObject *globals,
                         PyObject *locals, PyObject *fromlist, int level)
-/*[clinic end generated code: output=4febeda88a0cd245 input=35e9a6460412430f]*/
+/*[clinic end generated code: output=4febeda88a0cd245 input=73f4b960ea5b9dd6]*/
 {
     return PyImport_ImportModuleLevelObject(name, globals, locals,
                                             fromlist, level);
@@ -1516,7 +1516,7 @@ setattr(x, 'y', v) is equivalent to ``x.y = v``
 static PyObject *
 builtin_setattr_impl(PyObject *module, PyObject *obj, PyObject *name,
                      PyObject *value)
-/*[clinic end generated code: output=dc2ce1d1add9acb4 input=bd2b7ca6875a1899]*/
+/*[clinic end generated code: output=dc2ce1d1add9acb4 input=5e26417f2e8598d4]*/
 {
     if (PyObject_SetAttr(obj, name, value) != 0)
         return NULL;
@@ -1538,7 +1538,7 @@ delattr(x, 'y') is equivalent to ``del x.y``
 
 static PyObject *
 builtin_delattr_impl(PyObject *module, PyObject *obj, PyObject *name)
-/*[clinic end generated code: output=85134bc58dff79fa input=db16685d6b4b9410]*/
+/*[clinic end generated code: output=85134bc58dff79fa input=164865623abe7216]*/
 {
     if (PyObject_SetAttr(obj, name, (PyObject *)NULL) != 0)
         return NULL;

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -21,8 +21,8 @@ PyDoc_STRVAR(builtin___import____doc__,
 "\n"
 "The globals argument is only used to determine the context;\n"
 "they are not modified.  The locals argument is unused.  The fromlist\n"
-"should be a list of names to emulate ``from name import ...\'\', or an\n"
-"empty list to emulate ``import name\'\'.\n"
+"should be a list of names to emulate ``from name import ...``, or an\n"
+"empty list to emulate ``import name``.\n"
 "When importing a module from a package, note that __import__(\'A.B\', ...)\n"
 "returns package A when fromlist is empty, but its submodule B when\n"
 "fromlist is not empty.  The level argument is used to determine whether to\n"
@@ -614,7 +614,7 @@ PyDoc_STRVAR(builtin_setattr__doc__,
 "\n"
 "Sets the named attribute on the given object to the specified value.\n"
 "\n"
-"setattr(x, \'y\', v) is equivalent to ``x.y = v\'\'");
+"setattr(x, \'y\', v) is equivalent to ``x.y = v``");
 
 #define BUILTIN_SETATTR_METHODDEF    \
     {"setattr", _PyCFunction_CAST(builtin_setattr), METH_FASTCALL, builtin_setattr__doc__},
@@ -649,7 +649,7 @@ PyDoc_STRVAR(builtin_delattr__doc__,
 "\n"
 "Deletes the named attribute from the given object.\n"
 "\n"
-"delattr(x, \'y\') is equivalent to ``del x.y\'\'");
+"delattr(x, \'y\') is equivalent to ``del x.y``");
 
 #define BUILTIN_DELATTR_METHODDEF    \
     {"delattr", _PyCFunction_CAST(builtin_delattr), METH_FASTCALL, builtin_delattr__doc__},
@@ -1212,4 +1212,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=919725bf5d400acf input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f3da5510745785af input=a9049054013a1b77]*/


### PR DESCRIPTION
This can even break some `rst` formatter / pretty-printer because of invalid `rst` markup.

No news / issue is needed for this, I guess :)