### PR TITLE
gh-93738: Documentation C syntax (:c:type:`TYPE` -> :c:expr:`TYPE`)

### DIFF
--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -265,14 +265,14 @@ The following type-oriented macros are provided for convenience.  Note  that
 .. c:function:: TYPE* PyMem_New(TYPE, size_t n)
 
    Same as :c:func:`PyMem_Malloc`, but allocates ``(n * sizeof(TYPE))`` bytes of
-   memory.  Returns a pointer cast to :c:type:`TYPE*`.  The memory will not have
+   memory.  Returns a pointer cast to :c:expr:`TYPE*`.  The memory will not have
    been initialized in any way.
 
 
 .. c:function:: TYPE* PyMem_Resize(void *p, TYPE, size_t n)
 
    Same as :c:func:`PyMem_Realloc`, but the memory block is resized to ``(n *
-   sizeof(TYPE))`` bytes.  Returns a pointer cast to :c:type:`TYPE*`. On return,
+   sizeof(TYPE))`` bytes.  Returns a pointer cast to :c:expr:`TYPE*`. On return,
    *p* will be a pointer to the new memory area, or ``NULL`` in the event of
    failure.
 


### PR DESCRIPTION
Part of #93738. This PR converts references for `TYPE*` to the `c:expr` syntax.

A

<!-- gh-issue-number: gh-93738 -->
* Issue: gh-93738
<!-- /gh-issue-number -->
