### PR TITLE
gh-93738: Documentation C syntax (Use `c:struct`)

### DIFF
--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -243,7 +243,7 @@ Importing Modules
    UTF-8 encoded string instead of a Unicode object.
 
 
-.. c:type:: struct _frozen
+.. c:struct:: _frozen
 
    .. index:: single: freeze utility
 
@@ -265,7 +265,7 @@ Importing Modules
 
 .. c:var:: const struct _frozen* PyImport_FrozenModules
 
-   This pointer is initialized to point to an array of :c:type:`struct _frozen`
+   This pointer is initialized to point to an array of :c:struct:`_frozen`
    records, terminated by one whose members are all ``NULL`` or zero.  When a frozen
    module is imported, it is searched in this table.  Third-party code could play
    tricks with this to provide a dynamically created collection of frozen modules.
@@ -281,7 +281,7 @@ Importing Modules
    :c:func:`Py_Initialize`.
 
 
-.. c:type:: struct _inittab
+.. c:struct:: _inittab
 
    Structure describing a single entry in the list of built-in modules.  Each of
    these structures gives the name and initialization function for a module built

--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -82,7 +82,7 @@ the same library that the Python runtime is using.
 .. c:function:: int PyRun_SimpleString(const char *command)
 
    This is a simplified interface to :c:func:`PyRun_SimpleStringFlags` below,
-   leaving the :c:type:`PyCompilerFlags`\* argument set to ``NULL``.
+   leaving the :c:struct:`PyCompilerFlags`\* argument set to ``NULL``.
 
 
 .. c:function:: int PyRun_SimpleStringFlags(const char *command, PyCompilerFlags *flags)
@@ -338,7 +338,7 @@ the same library that the Python runtime is using.
    interpreter loop.
 
 
-.. c:type:: struct PyCompilerFlags
+.. c:struct:: PyCompilerFlags
 
    This is the structure used to hold compiler flags.  In cases where code is only
    being compiled, it is passed as ``int flags``, and in cases where code is being

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1088,7 +1088,7 @@ An extended example which also demonstrates the use of pointers accesses the
 
 Quoting the docs for that value:
 
-   This pointer is initialized to point to an array of :c:type:`struct _frozen`
+   This pointer is initialized to point to an array of :c:struct:`_frozen`
    records, terminated by one whose members are all ``NULL`` or zero.  When a frozen
    module is imported, it is searched in this table.  Third-party code could play
    tricks with this to provide a dynamically created collection of frozen modules.
@@ -1107,7 +1107,7 @@ size, we show only how this table can be read with :mod:`ctypes`::
    ...
    >>>
 
-We have defined the :c:type:`struct _frozen` data type, so we can get the pointer
+We have defined the :c:struct:`_frozen` data type, so we can get the pointer
 to the table::
 
    >>> FrozenTable = POINTER(struct_frozen)

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1059,7 +1059,7 @@ The :mod:`socket` module also offers various network-related services:
    Convert an IPv4 address from dotted-quad string format (for example,
    '123.45.67.89') to 32-bit packed binary format, as a bytes object four characters in
    length.  This is useful when conversing with a program that uses the standard C
-   library and needs objects of type :c:type:`struct in_addr`, which is the C type
+   library and needs objects of type :c:struct:`in_addr`, which is the C type
    for the 32-bit packed binary this function returns.
 
    :func:`inet_aton` also accepts strings with less than three dots; see the
@@ -1078,7 +1078,7 @@ The :mod:`socket` module also offers various network-related services:
    Convert a 32-bit packed IPv4 address (a :term:`bytes-like object` four
    bytes in length) to its standard dotted-quad string representation (for example,
    '123.45.67.89').  This is useful when conversing with a program that uses the
-   standard C library and needs objects of type :c:type:`struct in_addr`, which
+   standard C library and needs objects of type :c:struct:`in_addr`, which
    is the C type for the 32-bit packed binary data this function takes as an
    argument.
 
@@ -1095,8 +1095,8 @@ The :mod:`socket` module also offers various network-related services:
 
    Convert an IP address from its family-specific string format to a packed,
    binary format. :func:`inet_pton` is useful when a library or network protocol
-   calls for an object of type :c:type:`struct in_addr` (similar to
-   :func:`inet_aton`) or :c:type:`struct in6_addr`.
+   calls for an object of type :c:struct:`in_addr` (similar to
+   :func:`inet_aton`) or :c:struct:`in6_addr`.
 
    Supported values for *address_family* are currently :const:`AF_INET` and
    :const:`AF_INET6`. If the IP address string *ip_string* is invalid,
@@ -1116,8 +1116,8 @@ The :mod:`socket` module also offers various network-related services:
    bytes) to its standard, family-specific string representation (for
    example, ``'7.10.0.5'`` or ``'5aef:2b::8'``).
    :func:`inet_ntop` is useful when a library or network protocol returns an
-   object of type :c:type:`struct in_addr` (similar to :func:`inet_ntoa`) or
-   :c:type:`struct in6_addr`.
+   object of type :c:struct:`in_addr` (similar to :func:`inet_ntoa`) or
+   :c:struct:`in6_addr`.
 
    Supported values for *address_family* are currently :const:`AF_INET` and
    :const:`AF_INET6`. If the bytes object *packed_ip* is not the correct

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1847,7 +1847,7 @@ Porting to Python 3.11
   fields of the result from the exception instance (the ``value`` field).
   (Contributed by Irit Katriel in :issue:`45711`.)
 
-* :c:type:`_frozen` has a new ``is_package`` field to indicate whether
+* :c:struct:`_frozen` has a new ``is_package`` field to indicate whether
   or not the frozen module is a package.  Previously, a negative value
   in the ``size`` field was the indicator.  Now only non-negative values
   be used for ``size``.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -2015,7 +2015,7 @@ Changes in the Python API
 Changes in the C API
 --------------------
 
-* The :c:type:`PyCompilerFlags` structure got a new *cf_feature_version*
+* The :c:struct:`PyCompilerFlags` structure got a new *cf_feature_version*
   field. It should be initialized to ``PY_MINOR_VERSION``. The field is ignored
   by default, and is used if and only if ``PyCF_ONLY_AST`` flag is set in
   *cf_flags*.


### PR DESCRIPTION
Part of #93738. This PR converts references to struct types to the explicit `c:struct` syntax.

A

<!-- gh-issue-number: gh-93738 -->
* Issue: gh-93738
<!-- /gh-issue-number -->
