### PR TITLE
gh-93738: Documentation C syntax (:c:data:`view->obj` -> :c:expr:`view->obj`)

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -2356,13 +2356,13 @@ Buffer Object Structures
    steps:
 
    (1) Check if the request can be met. If not, raise :c:data:`PyExc_BufferError`,
-       set :c:data:`view->obj` to ``NULL`` and return ``-1``.
+       set :c:expr:`view->obj` to ``NULL`` and return ``-1``.
 
    (2) Fill in the requested fields.
 
    (3) Increment an internal counter for the number of exports.
 
-   (4) Set :c:data:`view->obj` to *exporter* and increment :c:data:`view->obj`.
+   (4) Set :c:expr:`view->obj` to *exporter* and increment :c:expr:`view->obj`.
 
    (5) Return ``0``.
 
@@ -2370,10 +2370,10 @@ Buffer Object Structures
    schemes can be used:
 
    * Re-export: Each member of the tree acts as the exporting object and
-     sets :c:data:`view->obj` to a new reference to itself.
+     sets :c:expr:`view->obj` to a new reference to itself.
 
    * Redirect: The buffer request is redirected to the root object of the
-     tree. Here, :c:data:`view->obj` will be a new reference to the root
+     tree. Here, :c:expr:`view->obj` will be a new reference to the root
      object.
 
    The individual fields of *view* are described in section
@@ -2415,7 +2415,7 @@ Buffer Object Structures
    *view* argument.
 
 
-   This function MUST NOT decrement :c:data:`view->obj`, since that is
+   This function MUST NOT decrement :c:expr:`view->obj`, since that is
    done automatically in :c:func:`PyBuffer_Release` (this scheme is
    useful for breaking reference cycles).
 


### PR DESCRIPTION
Part of #93738. This PR converts references for `view->obj` to the `c:expr` syntax.

A

<!-- gh-issue-number: gh-93738 -->
* Issue: gh-93738
<!-- /gh-issue-number -->
