### PR TITLE
gh-93738: Documentation C syntax (:c:type:`PyTupleObject*` -> :c:expr:`PyTupleObject*`)

### DIFF
--- a/Doc/c-api/typehints.rst
+++ b/Doc/c-api/typehints.rst
@@ -16,7 +16,7 @@ two types exist -- :ref:`GenericAlias <types-genericalias>` and
    :class:`types.GenericAlias`.  The *origin* and *args* arguments set the
    ``GenericAlias``\ 's ``__origin__`` and ``__args__`` attributes respectively.
    *origin* should be a :c:type:`PyTypeObject*`, and *args* can be a
-   :c:type:`PyTupleObject*` or any ``PyObject*``.  If *args* passed is
+   :c:expr:`PyTupleObject*` or any ``PyObject*``.  If *args* passed is
    not a tuple, a 1-tuple is automatically constructed and ``__args__`` is set
    to ``(args,)``.
    Minimal checking is done for the arguments, so the function will succeed even


### PR DESCRIPTION
Part of #93738. This PR converts references for `PyTupleObject*` to the `c:expr` syntax.

A

<!-- gh-issue-number: gh-93738 -->
* Issue: gh-93738
<!-- /gh-issue-number -->
