### PR TITLE
gh-93738: Documentation C syntax (:c:type:`PyBytesObject*` -> :c:expr:`PyBytesObject*`)

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -711,7 +711,7 @@ conversion function:
    ParseTuple converter: encode :class:`str` objects -- obtained directly or
    through the :class:`os.PathLike` interface -- to :class:`bytes` using
    :c:func:`PyUnicode_EncodeFSDefault`; :class:`bytes` objects are output as-is.
-   *result* must be a :c:type:`PyBytesObject*` which must be released when it is
+   *result* must be a :c:expr:`PyBytesObject*` which must be released when it is
    no longer used.
 
    .. versionadded:: 3.1


### PR DESCRIPTION
Part of #93738. This PR converts references for `PyBytesObject*` to the `c:expr` syntax.

A

<!-- gh-issue-number: gh-93738 -->
* Issue: gh-93738
<!-- /gh-issue-number -->
