### PR TITLE
gh-93738: Documentation C syntax (:c:type:`Py_UNICODE*` -> :c:expr:`Py_UNICODE*`)

### DIFF
--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -2267,7 +2267,7 @@ The :c:type:`Py_UNICODE` has been deprecated by :pep:`393` and will be
 removed in Python 4. All functions using this type are deprecated:
 
 Unicode functions and methods using :c:type:`Py_UNICODE` and
-:c:type:`Py_UNICODE*` types:
+:c:expr:`Py_UNICODE*` types:
 
 * :c:macro:`PyUnicode_FromUnicode`: use :c:func:`PyUnicode_FromWideChar` or
   :c:func:`PyUnicode_FromKindAndData`


### PR DESCRIPTION
Part of #93738. This PR converts references for `Py_UNICODE*` to the `c:expr` syntax.

A

<!-- gh-issue-number: gh-93738 -->
* Issue: gh-93738
<!-- /gh-issue-number -->
