### PR TITLE
Add `sprint` issues to the Sprint 2022 project.

### DIFF
--- a/.github/workflows/project-updater.yml
+++ b/.github/workflows/project-updater.yml
@@ -18,6 +18,7 @@ jobs:
           - { project:  2, label: "release-blocker, deferred-blocker" }
           - { project:  3, label: expert-subinterpreters }
           - { project: 29, label: expert-asyncio }
+          - { project: 32, label: sprint }
     
     steps:
       - uses: actions/add-to-project@v0.1.0


### PR DESCRIPTION
This PR automatically adds issues with the `sprint` label to the [Sprint 2022 project](https://github.com/orgs/python/projects/32/views/1).