### PR TITLE
gh-97799: use inspect.get_annotations in dataclass

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -920,10 +920,7 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
             if getattr(b, _PARAMS).frozen:
                 any_frozen_base = True
 
-    # Annotations that are defined in this class (not in base
-    # classes).  If __annotations__ isn't present, then this class
-    # adds no new annotations.  We use this to compute fields that are
-    # added by this class.
+    # Annotations defined specifically in this class (not in base classes).
     #
     # Fields are found from cls_annotations, which is guaranteed to be
     # ordered.  Default values are from class attributes, if a field
@@ -932,7 +929,7 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
     # actual default value.  Pseudo-fields ClassVars and InitVars are
     # included, despite the fact that they're not real fields.  That's
     # dealt with later.
-    cls_annotations = cls.__dict__.get('__annotations__', {})
+    cls_annotations = inspect.get_annotations(cls)
 
     # Now find fields in our class.  While doing so, validate some
     # things, and set the default values (as class attributes) where

--- a/Misc/NEWS.d/next/Library/2022-10-03-14-42-13.gh-issue-97799.Y1iJvf.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-03-14-42-13.gh-issue-97799.Y1iJvf.rst
@@ -1,0 +1,2 @@
+:mod:`dataclass` now uses :func:`inspect.get_annotations` to examine the
+annotations on class objects.


### PR DESCRIPTION
`dataclass` used to get the annotations on a class object using `cls.__dict__.get('__annotations__')`.  Now that it always imports `inspect`, it can use `inspect.get_annotations`, which is modern best practice for coping with annotations.

<!-- gh-issue-number: gh-97799 -->
* Issue: gh-97799
<!-- /gh-issue-number -->
