### PR TITLE
gh-97825: fix AttributeError when calling subprocess.check_output(input=None) with encoding or errors args

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -456,7 +456,8 @@ def check_output(*popenargs, timeout=None, **kwargs):
     if 'input' in kwargs and kwargs['input'] is None:
         # Explicitly passing input=None was previously equivalent to passing an
         # empty string. That is maintained here for backwards compatibility.
-        if kwargs.get('universal_newlines') or kwargs.get('text'):
+        if kwargs.get('universal_newlines') or kwargs.get('text') or kwargs.get('encoding') \
+                or kwargs.get('errors'):
             empty = ''
         else:
             empty = b''

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -238,6 +238,12 @@ class ProcessTestCase(BaseTestCase):
                 input=None, universal_newlines=True)
         self.assertNotIn('XX', output)
 
+    def test_check_output_input_none_encoding_errors(self):
+        output = subprocess.check_output(
+                [sys.executable, "-c", "print('foo')"],
+                input=None, encoding='utf-8', errors='ignore')
+        self.assertIn('foo', output)
+
     def test_check_output_stdout_arg(self):
         # check_output() refuses to accept 'stdout' argument
         with self.assertRaises(ValueError) as c:

--- a/Misc/NEWS.d/next/Library/2022-10-04-07-55-19.gh-issue-97825.mNdv1l.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-04-07-55-19.gh-issue-97825.mNdv1l.rst
@@ -1,1 +1,1 @@
-Fixes :exc:`AttributeError` when :meth:`subprocess.check_output` is used with argument `input=None` and either of the arguments *encoding* or *errors* are used.
+Fixes :exc:`AttributeError` when :meth:`subprocess.check_output` is used with argument ``input=None`` and either of the arguments *encoding* or *errors* are used.

--- a/Misc/NEWS.d/next/Library/2022-10-04-07-55-19.gh-issue-97825.mNdv1l.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-04-07-55-19.gh-issue-97825.mNdv1l.rst
@@ -1,0 +1,1 @@
+Fixes :exc:`AttributeError` when :meth:`subprocess.check_output` is used with argument `input=None` and either of the arguments *encoding* or *errors* are used.


### PR DESCRIPTION


<!-- gh-issue-number: gh-97825 -->
* Issue: gh-97825
<!-- /gh-issue-number -->
