### PR TITLE
gh-97850: Remove all known instances of module_repr()

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -412,6 +412,11 @@ Removed
   Validation.
   (Contributed by Victor Stinner in :gh:`94199`.)
 
+* Many previously deprecated cleanups in :mod:`importlib` have now been
+  completed:
+
+  * References to, and support for ``module_repr()`` has been eradicated.
+
 
 Porting to Python 3.12
 ======================

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -728,17 +728,6 @@ class BuiltinImporter:
 
     _ORIGIN = "built-in"
 
-    @staticmethod
-    def module_repr(module):
-        """Return repr for the module.
-
-        The method is deprecated.  The import machinery does the job itself.
-
-        """
-        _warnings.warn("BuiltinImporter.module_repr() is deprecated and "
-                       "slated for removal in Python 3.12", DeprecationWarning)
-        return f'<module {module.__name__!r} ({BuiltinImporter._ORIGIN})>'
-
     @classmethod
     def find_spec(cls, fullname, path=None, target=None):
         if path is not None:
@@ -807,17 +796,6 @@ class FrozenImporter:
     """
 
     _ORIGIN = "frozen"
-
-    @staticmethod
-    def module_repr(m):
-        """Return repr for the module.
-
-        The method is deprecated.  The import machinery does the job itself.
-
-        """
-        _warnings.warn("FrozenImporter.module_repr() is deprecated and "
-                       "slated for removal in Python 3.12", DeprecationWarning)
-        return '<module {!r} ({})>'.format(m.__name__, FrozenImporter._ORIGIN)
 
     @classmethod
     def _fix_up_module(cls, module):

--- a/Lib/test/test_importlib/frozen/test_loader.py
+++ b/Lib/test/test_importlib/frozen/test_loader.py
@@ -103,7 +103,7 @@ class ExecModuleTests(abc.LoaderTests):
                              expected=value))
         self.assertEqual(output, 'Hello world!\n')
 
-    def test_module_repr_indirect(self):
+    def test_module_repr_indirect_through_spec(self):
         name = '__hello__'
         module, output = self.exec_module(name)
         self.assertEqual(repr(module),
@@ -189,13 +189,6 @@ class LoaderTests(abc.LoaderTests):
         self.assertIs(module1, module2)
         self.assertEqual(stdout.getvalue(),
                          'Hello world!\nHello world!\n')
-
-    def test_module_repr(self):
-        with fresh('__hello__', oldapi=True):
-            module = self.machinery.FrozenImporter.load_module('__hello__')
-            repr_str = self.machinery.FrozenImporter.module_repr(module)
-        self.assertEqual(repr_str,
-                         "<module '__hello__' (frozen)>")
 
     # No way to trigger an error in a frozen module.
     test_state_after_failure = None

--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -687,9 +687,6 @@ class SourceOnlyLoader:
     def get_filename(self, fullname):
         return self.path
 
-    def module_repr(self, module):
-        return '<module>'
-
 
 SPLIT_SOL = make_abc_subclasses(SourceOnlyLoader, 'SourceLoader')
 

--- a/Lib/test/test_module.py
+++ b/Lib/test/test_module.py
@@ -239,7 +239,6 @@ a = A(destroyed)"""
             repr(m), "<module 'foo' (<class 'test.test_module.FullLoader'>)>")
 
     def test_module_repr_with_bare_loader_and_filename(self):
-        # Because the loader has no module_repr(), use the file name.
         m = ModuleType('foo')
         # Yes, a class not an instance.
         m.__loader__ = BareLoader
@@ -247,7 +246,6 @@ a = A(destroyed)"""
         self.assertEqual(repr(m), "<module 'foo' from '/tmp/foo.py'>")
 
     def test_module_repr_with_full_loader_and_filename(self):
-        # Even though the module has an __file__, use __loader__.module_repr()
         m = ModuleType('foo')
         # Yes, a class not an instance.
         m.__loader__ = FullLoader

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-04-17-02-18.gh-issue-97850.E3QTRA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-04-17-02-18.gh-issue-97850.E3QTRA.rst
@@ -1,0 +1,1 @@
+Long deprecated, ``module_repr()`` should now be completely eradicated.


### PR DESCRIPTION
As `module_repr()` has long been deprecated, and previously mostly removed from Python 3.12, this completes the process of this obsolete method's removal.


<!-- gh-issue-number: gh-97850 -->
* Issue: gh-97850
<!-- /gh-issue-number -->
