### PR TITLE
[3.10] gh-93738: Documentation C syntax (:c:type: to :c:expr:, misc. cases) (GH-97775)

### DIFF
--- a/Doc/c-api/file.rst
+++ b/Doc/c-api/file.rst
@@ -65,7 +65,7 @@ the :mod:`io` APIs instead.
    Overrides the normal behavior of :func:`io.open_code` to pass its parameter
    through the provided handler.
 
-   The handler is a function of type :c:type:`PyObject *(\*)(PyObject *path,
+   The handler is a function of type :c:expr:`PyObject *(\*)(PyObject *path,
    void *userData)`, where *path* is guaranteed to be :c:type:`PyUnicodeObject`.
 
    The *userData* pointer is passed into the hook function. Since hook

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -99,7 +99,7 @@ the definition of all other Python objects.
 
    Return a :term:`borrowed reference`.
 
-   The :c:func:`Py_SET_TYPE` function must be used to set an object type.
+   Use the :c:func:`Py_SET_TYPE` function to set an object type.
 
 
 .. c:function:: int Py_IS_TYPE(PyObject *o, PyTypeObject *type)
@@ -137,7 +137,7 @@ the definition of all other Python objects.
 
    Get the size of the Python object *o*.
 
-   The :c:func:`Py_SET_SIZE` function must be used to set an object size.
+   Use the :c:func:`Py_SET_SIZE` function to set an object size.
 
 
 .. c:function:: void Py_SET_SIZE(PyVarObject *o, Py_ssize_t size)

--- a/Doc/whatsnew/2.4.rst
+++ b/Doc/whatsnew/2.4.rst
@@ -1453,7 +1453,7 @@ Some of the changes to Python's build process and to the C API are:
   extension functions: :c:macro:`Py_RETURN_NONE`, :c:macro:`Py_RETURN_TRUE`, and
   :c:macro:`Py_RETURN_FALSE`. (Contributed by Brett Cannon.)
 
-* Another new macro, :c:macro:`Py_CLEAR(obj)`,  decreases the reference count of
+* Another new macro, :c:macro:`Py_CLEAR`,  decreases the reference count of
   *obj* and sets *obj* to the null pointer.  (Contributed by Jim Fulton.)
 
 * A new function, ``PyTuple_Pack(N, obj1, obj2, ..., objN)``, constructs
@@ -1464,7 +1464,7 @@ Some of the changes to Python's build process and to the C API are:
   lookups without masking exceptions raised during the look-up process.
   (Contributed by Raymond Hettinger.)
 
-* The :c:macro:`Py_IS_NAN(X)` macro returns 1 if  its float or double argument
+* The :c:expr:`Py_IS_NAN(X)` macro returns 1 if  its float or double argument
   *X* is a NaN.   (Contributed by Tim Peters.)
 
 * C code can avoid unnecessary locking by using the new

--- a/Misc/NEWS.d/3.8.0a4.rst
+++ b/Misc/NEWS.d/3.8.0a4.rst
@@ -1354,7 +1354,7 @@ the function is called twice.
 .. nonce: pz-DIR
 .. section: C API
 
-:c:macro:`PyDoc_VAR(name)` and :c:macro:`PyDoc_STRVAR(name,str)` now create
+:c:expr:`PyDoc_VAR(name)` and :c:expr:`PyDoc_STRVAR(name,str)` now create
 ``static const char name[]`` instead of ``static char name[]``.  Patch by
 Inada Naoki.
 


### PR DESCRIPTION
Co-authored-by: Adam Turner <9087854+AA-Turner@users.noreply.github.com>


<!-- gh-issue-number: gh-93738 -->
* Issue: gh-93738
<!-- /gh-issue-number -->
