### PR TITLE
gh-93357: Port test cases to IsolatedAsyncioTestCase, part 2

### DIFF
--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -944,8 +944,7 @@ os.close(fd)
 class NewStreamTests2(unittest.IsolatedAsyncioTestCase):
     async def test_wait_closed_on_close(self):
         with test_utils.run_test_server() as httpd:
-            rd, wr = self.loop.run_until_complete(
-                asyncio.open_connection(*httpd.address))
+            rd, wr = await asyncio.open_connection(*httpd.address)
 
             wr.write(b'GET / HTTP/1.0\r\n\r\n')
             data = await rd.readline()
@@ -962,8 +961,7 @@ class NewStreamTests2(unittest.IsolatedAsyncioTestCase):
             rd, wr = await asyncio.open_connection(*httpd.address)
 
             wr.write(b'GET / HTTP/1.0\r\n\r\n')
-            f = rd.readline()
-            data = self.loop.run_until_complete(f)
+            data = await rd.readline()
             self.assertEqual(data, b'HTTP/1.0 200 OK\r\n')
             wr.close()
             await wr.wait_closed()
@@ -1005,11 +1003,9 @@ class NewStreamTests2(unittest.IsolatedAsyncioTestCase):
         with test_utils.run_test_server() as httpd:
             rd, wr = await asyncio.open_connection(*httpd.address)
             wr.close()
-            f = wr.wait_closed()
-            self.loop.run_until_complete(f)
+            await wr.wait_closed()
             self.assertTrue(rd.at_eof())
-            f = rd.read()
-            data = self.loop.run_until_complete(f)
+            data = await rd.read()
             self.assertEqual(data, b'')
 
 

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -997,13 +997,8 @@ class NewStreamTests2(unittest.IsolatedAsyncioTestCase):
                 wr.write(b'data')
                 await wr.drain()
 
-        messages = []
-        self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
-
         with test_utils.run_test_server() as httpd:
             await inner(httpd)
-
-        self.assertEqual(messages, [])
 
     async def test_eof_feed_when_closing_writer(self):
         # See http://bugs.python.org/issue35065

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -980,13 +980,8 @@ class NewStreamTests2(unittest.IsolatedAsyncioTestCase):
             wr.close()
             await wr.wait_closed()
 
-        messages = []
-        self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
-
         with test_utils.run_test_server() as httpd:
             await inner(httpd)
-
-        self.assertEqual(messages, [])
 
     async def test_async_writer_api_exception_after_close(self):
         async def inner(httpd):

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -943,7 +943,7 @@ os.close(fd)
 
 class NewStreamTests2(unittest.IsolatedAsyncioTestCase):
     async def test_wait_closed_on_close(self):
-        async with test_utils.run_test_server() as httpd:
+        with test_utils.run_test_server() as httpd:
             rd, wr = self.loop.run_until_complete(
                 asyncio.open_connection(*httpd.address))
 
@@ -1002,7 +1002,7 @@ class NewStreamTests2(unittest.IsolatedAsyncioTestCase):
 
     async def test_eof_feed_when_closing_writer(self):
         # See http://bugs.python.org/issue35065
-        async with test_utils.run_test_server() as httpd:
+        with test_utils.run_test_server() as httpd:
             rd, wr = await asyncio.open_connection(*httpd.address)
             wr.close()
             f = wr.wait_closed()

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -949,7 +949,7 @@ class NewStreamTests2(unittest.IsolatedAsyncioTestCase):
             wr.write(b'GET / HTTP/1.0\r\n\r\n')
             data = await rd.readline()
             self.assertEqual(data, b'HTTP/1.0 200 OK\r\n')
-            await rd.read()
+            data = await rd.read()
             self.assertTrue(data.endswith(b'\r\n\r\nTest message'))
             self.assertFalse(wr.is_closing())
             wr.close()


### PR DESCRIPTION
This PR is a follow-up to gh-93369 to fix broken [Ubuntu SSL tests with OpenSSL](https://github.com/python/cpython/actions/runs/3184337370/jobs/5192630200) and [Ubuntu SSL tests with OpenSSL (3.0.5)](https://github.com/python/cpython/actions/runs/3184337370/jobs/5192630297) tests.

The break is caused by `async`-isation of a few tests in `class StreamTests2(test_utils.TestCase)` not designed for this. Since they happen to be grouped in the end of a file, it's easier to group them under an unplanned `class NewStreamTests2(unittest.IsolatedAsyncioTestCase)` and make three in-between tests `async` too rather that partially roll the changes back.

Thanks to @kumaraditya303 for [noticing the issue](https://github.com/python/cpython/pull/93369#issuecomment-1267363937).

Closes gh-97894.

<!-- gh-issue-number: gh-93357 -->
* Issue: gh-93357
<!-- /gh-issue-number -->
