### PR TITLE
gh-97913 Docs: Add walrus operator to the index

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1742,10 +1742,11 @@ returns a boolean value regardless of the type of its argument
 
 
 .. index::
-  single: := (colon equals)
-  single: assignment expression
-  single: walrus operator
-  single: named expression
+   single: := (colon equals)
+   single: assignment expression
+   single: walrus operator
+   single: named expression
+
 Assignment expressions
 ======================
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1745,7 +1745,7 @@ returns a boolean value regardless of the type of its argument
   single: := (colon equals)
   single: assignment expression
   single: walrus operator
-
+  single: named expression
 Assignment expressions
 ======================
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1741,6 +1741,11 @@ returns a boolean value regardless of the type of its argument
 (for example, ``not 'foo'`` produces ``False`` rather than ``''``.)
 
 
+.. index::
+  single: := (colon equals)
+  single: assignment expression
+  single: walrus operator
+
 Assignment expressions
 ======================
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The walrus operator for assignment expressions isn't in the indices:

* https://docs.python.org/3/genindex-all.html
* https://docs.python.org/3/genindex-Symbols.html

Let's add it.

# Preview

<img width="431" alt="image" src="https://user-images.githubusercontent.com/1324225/194130226-26875df2-661b-4a4d-8246-81d54625e057.png">

<img width="260" alt="image" src="https://user-images.githubusercontent.com/1324225/194130796-78db6ab6-ab11-4ad3-9539-45fd0c4b9a4d.png">

<img width="340" alt="image" src="https://user-images.githubusercontent.com/1324225/194130723-421f54e3-44e8-42a5-9ef1-cc6b4ea9cb08.png">


<!-- gh-issue-number: gh-97913 -->
* Issue: gh-97913
<!-- /gh-issue-number -->
