### PR TITLE
docs(typing): add "see PEP 675" to LiteralString

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -631,6 +631,8 @@ These can be used as types in annotations and do not support ``[]``.
    that generate type checker errors could be vulnerable to an SQL
    injection attack.
 
+   See :pep:`675` for more details.
+
    .. versionadded:: 3.11
 
 .. data:: Never


### PR DESCRIPTION
Other newly introduced classes also reference the corresponding PEP (e.g. TypeAlias).