### PR TITLE
gh-97646: Change `.js` and `.mjs` files mimetype to conform to RFC 9239

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -427,8 +427,8 @@ def _default_mime_types():
     # Make sure the entry with the preferred file extension for a particular mime type
     # appears before any others of the same mimetype.
     types_map = _types_map_default = {
-        '.js'     : 'application/javascript',
-        '.mjs'    : 'application/javascript',
+        '.js'     : 'text/javascript',
+        '.mjs'    : 'text/javascript',
         '.json'   : 'application/json',
         '.webmanifest': 'application/manifest+json',
         '.doc'    : 'application/msword',

--- a/Misc/NEWS.d/next/Library/2022-10-05-20-52-17.gh-issue-97646.Q4fVww.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-05-20-52-17.gh-issue-97646.Q4fVww.rst
@@ -1,0 +1,1 @@
+Replace deprecated ``application/javascript`` with ``text/javascript`` in :mod:`mimetypes`. See :rfc:`9239`. Patch by Noam Cohen.


### PR DESCRIPTION


<!-- gh-issue-number: gh-97646 -->
* Issue: gh-97646
<!-- /gh-issue-number -->
