### PR TITLE
gh-97943: PyFunction_GetAnnotations should return a borrowed reference.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-05-17-02-22.gh-issue-97943.LYAWlE.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-05-17-02-22.gh-issue-97943.LYAWlE.rst
@@ -1,0 +1,2 @@
+Bugfix: :func:`PyFunction_GetAnnotations` should return a borrowed
+reference. It was returning a new reference.

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -311,7 +311,6 @@ func_get_annotation_dict(PyFunctionObject *op)
         }
         Py_SETREF(op->func_annotations, ann_dict);
     }
-    Py_INCREF(op->func_annotations);
     assert(PyDict_Check(op->func_annotations));
     return op->func_annotations;
 }
@@ -543,7 +542,11 @@ func_get_annotations(PyFunctionObject *op, void *Py_UNUSED(ignored))
         if (op->func_annotations == NULL)
             return NULL;
     }
-    return func_get_annotation_dict(op);
+    PyObject *d = func_get_annotation_dict(op);
+    if (d) {
+        Py_INCREF(d);
+    }
+    return d;
 }
 
 static int


### PR DESCRIPTION
It was returning a new reference, which isn't how it used to work, and isn't how it's documented.

<!-- gh-issue-number: gh-97943 -->
* Issue: gh-97943
<!-- /gh-issue-number -->
