### PR TITLE
gh-97669: Move difflib examples to Doc/includes/

### DIFF
--- a/Doc/includes/diff.py
+++ b/Doc/includes/diff.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """ Command line interface to difflib.py providing diffs in four formats:
 
 * ndiff:    lists every line and highlights interline changes.

--- a/Doc/includes/ndiff.py
+++ b/Doc/includes/ndiff.py
@@ -1,16 +1,3 @@
-#! /usr/bin/env python3
-
-# Module ndiff version 1.7.0
-# Released to the public domain 08-Dec-2000,
-# by Tim Peters (tim.one@home.com).
-
-# Provided as-is; use at your own risk; no warranty; no promises; enjoy!
-
-# ndiff.py is now simply a front-end to the difflib.ndiff() function.
-# Originally, it contained the difflib.SequenceMatcher class as well.
-# This completes the raiding of reusable code from this formerly
-# self-contained script.
-
 """ndiff [-q] file1 file2
     or
 ndiff (-r1 | -r2) < ndiff_output > file1_or_file2
@@ -121,13 +108,4 @@ def restore(which):
     sys.stdout.writelines(restored)
 
 if __name__ == '__main__':
-    args = sys.argv[1:]
-    if "-profile" in args:
-        import profile, pstats
-        args.remove("-profile")
-        statf = "ndiff.pro"
-        profile.run("main(args)", statf)
-        stats = pstats.Stats(statf)
-        stats.strip_dirs().sort_stats('time').print_stats()
-    else:
-        main(args)
+    main(sys.argv[1:])

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -145,8 +145,6 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
       The arguments for this method are the same as those for the :meth:`make_file`
       method.
 
-   :file:`Tools/scripts/diff.py` is a command-line front-end to this class and
-   contains a good example of its use.
 
 
 .. function:: context_diff(a, b, fromfile='', tofile='', fromfiledate='', tofiledate='', n=3, lineterm='\n')
@@ -239,8 +237,6 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
    returns if the character is junk, or false if not. The default is module-level
    function :func:`IS_CHARACTER_JUNK`, which filters out whitespace characters (a
    blank or tab; it's a bad idea to include newline in this!).
-
-   :file:`Tools/scripts/ndiff.py` is a command-line front-end to this function.
 
       >>> diff = ndiff('one\ntwo\nthree\n'.splitlines(keepends=True),
       ...              'ore\ntree\nemu\n'.splitlines(keepends=True))
@@ -759,7 +755,12 @@ A command-line interface to difflib
 -----------------------------------
 
 This example shows how to use difflib to create a ``diff``-like utility.
-It is also contained in the Python source distribution, as
-:file:`Tools/scripts/diff.py`.
 
-.. literalinclude:: ../../Tools/scripts/diff.py
+.. literalinclude:: ../includes/diff.py
+
+ndiff example
+-------------
+
+This example shows how to use :func:`difflib.ndiff`.
+
+.. literalinclude:: ../includes/ndiff.py


### PR DESCRIPTION
Remove diff.py and ndiff.py scripts of Tools/scripts/: move them to Doc/includes/.

* diff.py and ndiff.py files are no longer executable. Remove also their shebang ("#!/usr/bin/env python3").
* Remove the -profile command from ndiff.py to simply the code.
* Remove ndiff.py copyright and history command. The Python documentation examples are distributed under the "Zero Clause BSD License".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97669 -->
* Issue: gh-97669
<!-- /gh-issue-number -->
