### PR TITLE
Add Pynche's move to the What's new in 3.11

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1667,6 +1667,10 @@ Removed
   Python's test suite."
   (Contributed by Victor Stinner in :issue:`46852`.)
 
+* Pynche - The Pythonically Natural Color and Hue Editor - has been moved out
+  of ``Tools/scripts`` and is `being developed independently
+  <https://gitlab.com/warsaw/pynche/-/tree/main>`_ from the Python source tree.
+
 Porting to Python 3.11
 ======================
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1667,7 +1667,7 @@ Removed
   Python's test suite."
   (Contributed by Victor Stinner in :issue:`46852`.)
 
-* Pynche - The Pythonically Natural Color and Hue Editor - has been moved out
+* Pynche --- The Pythonically Natural Color and Hue Editor --- has been moved out
   of ``Tools/scripts`` and is `being developed independently
   <https://gitlab.com/warsaw/pynche/-/tree/main>`_ from the Python source tree.
 


### PR DESCRIPTION
As described on the tin.

@pablogsal This should be backported to 3.11.0.

Automerge-Triggered-By: GH:warsaw