### PR TITLE
[3.11] GH-93354: Fix `PRECALL`'s adaptive backoff

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-06-05-41-01.gh-issue-93354.6BpHl2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-06-05-41-01.gh-issue-93354.6BpHl2.rst
@@ -1,0 +1,2 @@
+Fix an issue that could delay the specialization of :opcode:`PRECALL`
+instructions.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4793,7 +4793,7 @@ handle_eval_breaker:
 
         TARGET(PRECALL_ADAPTIVE) {
             _PyPrecallCache *cache = (_PyPrecallCache *)next_instr;
-            if (cache->counter == 0) {
+            if (ADAPTIVE_COUNTER_IS_ZERO(cache)) {
                 next_instr--;
                 int is_meth = is_method(stack_pointer, oparg);
                 int nargs = oparg + is_meth;
@@ -4807,7 +4807,7 @@ handle_eval_breaker:
             }
             else {
                 STAT_INC(PRECALL, deferred);
-                cache->counter--;
+                DECREMENT_ADAPTIVE_COUNTER(cache);
                 JUMP_TO_INSTRUCTION(PRECALL);
             }
         }


### PR DESCRIPTION
This was probably missed in #93379.

<!-- gh-issue-number: gh-93354 -->
* Issue: gh-93354
<!-- /gh-issue-number -->
