### PR TITLE
Add note on capture_output arg to subprocess.run() docstring

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -508,7 +508,8 @@ def run(*popenargs,
 
     The returned instance will have attributes args, returncode, stdout and
     stderr. By default, stdout and stderr are not captured, and those attributes
-    will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them.
+    will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them,
+    or pass capture_output=True to capture both.
 
     If check is True and the exit code was non-zero, it raises a
     CalledProcessError. The CalledProcessError object will have the return code


### PR DESCRIPTION
It may be worth to have a separate paragraph for this argument, I'm not sure.