### PR TITLE
Fix memory leaks in test_capi

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -1495,6 +1495,9 @@ class TestDictWatchers(unittest.TestCase):
         unraisable = unraisables[0]
         self.assertIs(unraisable.object, d)
         self.assertEqual(str(unraisable.exc_value), "boom!")
+        # avoid leaking reference cycles
+        del unraisable
+        del unraisables
 
     def test_two_watchers(self):
         d1 = {}

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -5210,6 +5210,7 @@ dict_watch_callback(PyDict_WatchEvent event,
         Py_DECREF(msg);
         return -1;
     }
+    Py_DECREF(msg);
     return 0;
 }
 
@@ -5224,8 +5225,10 @@ dict_watch_callback_second(PyDict_WatchEvent event,
         return -1;
     }
     if (PyList_Append(g_dict_watch_events, msg) < 0) {
+        Py_DECREF(msg);
         return -1;
     }
+    Py_DECREF(msg);
     return 0;
 }
 


### PR DESCRIPTION
These memory leaks were recently introduced in #31787. Not sure if this fix qualifies as "trivial" or requires an issue also.

Before this fix, `./python -m test test_capi -R 3:3` reports a memory leak; after this fix it passes.


