### PR TITLE
[3.11] gh-96073: Fix installed tests by adding to Makefile.pre.in

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2004,6 +2004,7 @@ TESTSUBDIRS=	ctypes/test \
 		test/test_warnings test/test_warnings/data \
 		test/test_zoneinfo test/test_zoneinfo/data \
 		test/tracedmodules \
+		test/typinganndata \
 		test/xmltestdata test/xmltestdata/c14n-20 \
 		test/ziptestdata \
 		tkinter/test tkinter/test/test_tkinter \


### PR DESCRIPTION
This was broken in #98045 but already fixed on main.

<!-- gh-issue-number: gh-96073 -->
* Issue: gh-96073
<!-- /gh-issue-number -->
