### PR TITLE
gh-98083 Fix URLs in `README.rst`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Building a complete Python installation requires the use of various
 additional third-party libraries, depending on your build platform and
 configure options.  Not all standard library modules are buildable or
 useable on all platforms.  Refer to the
-`Install dependencies <https://devguide.python.org/setup/#install-dependencies>`_
+`Install dependencies <https://devguide.python.org/getting-started/setup-building.html#build-dependencies>`_
 section of the `Developer Guide`_ for current detailed information on
 dependencies for various Linux distributions and macOS.
 
@@ -135,7 +135,7 @@ What's New
 We have a comprehensive overview of the changes in the `What's New in Python
 3.12 <https://docs.python.org/3.12/whatsnew/3.12.html>`_ document.  For a more
 detailed change log, read `Misc/NEWS
-<https://github.com/python/cpython/blob/main/Misc/NEWS.d>`_, but a full
+<https://github.com/python/cpython/tree/main/Misc/NEWS.d>`_, but a full
 accounting of changes can only be gleaned from the `commit history
 <https://github.com/python/cpython/commits/main>`_.
 
@@ -189,7 +189,7 @@ your environment, you can `file a bug report
 <https://github.com/python/cpython/issues>`_ and include relevant output from
 that command to show the issue.
 
-See `Running & Writing Tests <https://devguide.python.org/runtests/>`_
+See `Running & Writing Tests <https://devguide.python.org/testing/run-write-tests.html>`_
 for more on running tests.
 
 Installing multiple versions


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

There were 2 broken links in `README.rst`: 
* Link to [Install dependencies](https://devguide.python.org/getting-started/setup-building.html#build-dependencies) in the devguide
* Link to [Running & Writing Tests](https://devguide.python.org/testing/run-write-tests.html)

Another link to the [NEWS.d](https://github.com/python/cpython/tree/main/Misc/NEWS.d) directory was causing a 301 redirect (since it's a directory and github uses `tree` instead of `blob` in the URL), so I fixed that too.

<!-- gh-issue-number: gh-98083 -->
* Issue: gh-98083
<!-- /gh-issue-number -->
