### PR TITLE
doc: remove a misleading statement.

### DIFF
--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -70,8 +70,8 @@ the ones with a fractional part (e.g. ``5.0``, ``1.6``) have type
 :class:`float`.  We will see more about numeric types later in the tutorial.
 
 Division (``/``) always returns a float.  To do :term:`floor division` and
-get an integer result (discarding any fractional result) you can use the ``//``
-operator; to calculate the remainder you can use ``%``::
+get an integer result you can use the ``//`` operator; to calculate
+the remainder you can use ``%``::
 
    >>> 17 / 3  # classic division returns a float
    5.666666666666667


### PR DESCRIPTION
Fixing an issue reported by Alexandr Mezhelovskiy on a moderated message¹ on the docs@ mailing list. 

1: the message contained no text body.

The `discarding any fractional result` part was misleading for negative number, where `-7.1 // 1 == -8`, as properly explained behind the `` :term:`floor division` `` link.

Alexandr proposed to replace the statement with:

> floor division returns the minimum integer closest to the quotient

But it's a tutorial and should be kept simple, the goal of this paragraph is just to teach user there's two discting division operators.

For the user in need or more information, the link to the glossary already provides a precise explanation with examples.

