### PR TITLE
Fix link to Lifecycle of a Pull Request in CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -38,7 +38,7 @@ also suggestions on how you can most effectively help the project.
 
 Please be aware that our workflow does deviate slightly from the typical GitHub
 project. Details on how to properly submit a pull request are covered in
-`Lifecycle of a Pull Request <https://devguide.python.org/getting-started/pull-request-lifecycle.html/>`_.
+`Lifecycle of a Pull Request <https://devguide.python.org/getting-started/pull-request-lifecycle.html>`_.
 We utilize various bots and status checks to help with this, so do follow the
 comments they leave and their "Details" links, respectively. The key points of
 our workflow that are not covered by a bot or status check are:

--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -38,7 +38,7 @@ also suggestions on how you can most effectively help the project.
 
 Please be aware that our workflow does deviate slightly from the typical GitHub
 project. Details on how to properly submit a pull request are covered in
-`Lifecycle of a Pull Request <https://devguide.python.org/pullrequest/>`_.
+`Lifecycle of a Pull Request <https://devguide.python.org/getting-started/pull-request-lifecycle.html/>`_.
 We utilize various bots and status checks to help with this, so do follow the
 comments they leave and their "Details" links, respectively. The key points of
 our workflow that are not covered by a bot or status check are:


### PR DESCRIPTION
The existing link to "Lifecycle of a Pull Request" was broken.