### PR TITLE
gh-64019: Have attribute table in inspect docs link to module attributes instead of listing them

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -32,7 +32,8 @@ The :func:`getmembers` function retrieves the members of an object such as a
 class or module. The functions whose names begin with "is" are mainly
 provided as convenient choices for the second argument to :func:`getmembers`.
 They also help you determine when you can expect to find the following special
-attributes:
+attributes, but note that some module attributes are in the process of being
+depreciated (see `this issue <https://github.com/python/cpython/issues/65961>`_).
 
 .. this function name is too big to fit in the ascii-art table below
 .. |coroutine-origin-link| replace:: :func:`sys.set_coroutine_origin_tracking_depth`

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -61,6 +61,11 @@ attributes:
 |           | __package__       | parent package for the    |
 |           |                   | module/package            |
 +-----------+-------------------+---------------------------+
+|           | __spec__          | specification for the     |
+|           |                   | module's                  |
+|           |                   | import-system-related     |
+|           |                   | state                     |
++-----------+-------------------+---------------------------+
 | class     | __doc__           | documentation string      |
 +-----------+-------------------+---------------------------+
 |           | __name__          | name with which this      |

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -40,10 +40,26 @@ attributes:
 +-----------+-------------------+---------------------------+
 | Type      | Attribute         | Description               |
 +===========+===================+===========================+
-| module    | __doc__           | documentation string      |
+| module    | __cached__        | the path where a compiled |
+|           |                   | version is stored         |
++-----------+-------------------+---------------------------+
+|           | __doc__           | documentation string      |
 +-----------+-------------------+---------------------------+
 |           | __file__          | filename (missing for     |
 |           |                   | built-in modules)         |
++-----------+-------------------+---------------------------+
+|           | __loader__        | loader used to load the   |
+|           |                   | module                    |
++-----------+-------------------+---------------------------+
+|           | __name__          | name of the module        |
++-----------+-------------------+---------------------------+
+|           | __path__          | list of strings specifying|
+|           |                   | the search path within a  |
+|           |                   | package (not set for      |
+|           |                   | modules)                  |
++-----------+-------------------+---------------------------+
+|           | __package__       | parent package for the    |
+|           |                   | module/package            |
 +-----------+-------------------+---------------------------+
 | class     | __doc__           | documentation string      |
 +-----------+-------------------+---------------------------+

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -32,8 +32,7 @@ The :func:`getmembers` function retrieves the members of an object such as a
 class or module. The functions whose names begin with "is" are mainly
 provided as convenient choices for the second argument to :func:`getmembers`.
 They also help you determine when you can expect to find the following special
-attributes, but note that some module attributes are in the process of being
-depreciated (see `this issue <https://github.com/python/cpython/issues/65961>`_).
+attributes (see :ref:`import-mod-attrs` for module attributes):
 
 .. this function name is too big to fit in the ascii-art table below
 .. |coroutine-origin-link| replace:: :func:`sys.set_coroutine_origin_tracking_depth`
@@ -41,32 +40,6 @@ depreciated (see `this issue <https://github.com/python/cpython/issues/65961>`_)
 +-----------+-------------------+---------------------------+
 | Type      | Attribute         | Description               |
 +===========+===================+===========================+
-| module    | __cached__        | the path where a compiled |
-|           |                   | version is stored         |
-+-----------+-------------------+---------------------------+
-|           | __doc__           | documentation string      |
-+-----------+-------------------+---------------------------+
-|           | __file__          | filename (missing for     |
-|           |                   | built-in modules)         |
-+-----------+-------------------+---------------------------+
-|           | __loader__        | loader used to load the   |
-|           |                   | module                    |
-+-----------+-------------------+---------------------------+
-|           | __name__          | name of the module        |
-+-----------+-------------------+---------------------------+
-|           | __path__          | list of strings specifying|
-|           |                   | the search path within a  |
-|           |                   | package (not set for      |
-|           |                   | modules)                  |
-+-----------+-------------------+---------------------------+
-|           | __package__       | parent package for the    |
-|           |                   | module/package            |
-+-----------+-------------------+---------------------------+
-|           | __spec__          | specification for the     |
-|           |                   | module's                  |
-|           |                   | import-system-related     |
-|           |                   | state                     |
-+-----------+-------------------+---------------------------+
 | class     | __doc__           | documentation string      |
 +-----------+-------------------+---------------------------+
 |           | __name__          | name with which this      |


### PR DESCRIPTION
See also https://docs.python.org/dev/library/importlib.html#importlib.machinery.ModuleSpec



<!-- gh-issue-number: gh-64019 -->
* Issue: gh-64019
<!-- /gh-issue-number -->
