### PR TITLE
[3.10] gh-94808: Cover `PyObject_PyBytes` case with custom `__bytes__` method (GH-96610)

### DIFF
--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1361,10 +1361,14 @@ class LongTest(unittest.TestCase):
             def __bytes__(self):
                 1 / 0
 
-        self.assertEqual(int.from_bytes(ValidBytes()), 1)
-        self.assertRaises(TypeError, int.from_bytes, InvalidBytes())
-        self.assertRaises(TypeError, int.from_bytes, MissingBytes())
-        self.assertRaises(ZeroDivisionError, int.from_bytes, RaisingBytes())
+        for byte_order in ('big', 'little'):
+            self.assertEqual(int.from_bytes(ValidBytes(), byte_order), 1)
+            self.assertRaises(
+                TypeError, int.from_bytes, InvalidBytes(), byte_order)
+            self.assertRaises(
+                TypeError, int.from_bytes, MissingBytes(), byte_order)
+            self.assertRaises(
+                ZeroDivisionError, int.from_bytes, RaisingBytes(), byte_order)
 
     def test_access_to_nonexistent_digit_0(self):
         # http://bugs.python.org/issue14630: A bug in _PyLong_Copy meant that

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1350,6 +1350,22 @@ class LongTest(unittest.TestCase):
         self.assertEqual(i, 1)
         self.assertEqual(getattr(i, 'foo', 'none'), 'bar')
 
+        class ValidBytes:
+            def __bytes__(self):
+                return b'\x01'
+        class InvalidBytes:
+            def __bytes__(self):
+                return 'abc'
+        class MissingBytes: ...
+        class RaisingBytes:
+            def __bytes__(self):
+                1 / 0
+
+        self.assertEqual(int.from_bytes(ValidBytes()), 1)
+        self.assertRaises(TypeError, int.from_bytes, InvalidBytes())
+        self.assertRaises(TypeError, int.from_bytes, MissingBytes())
+        self.assertRaises(ZeroDivisionError, int.from_bytes, RaisingBytes())
+
     def test_access_to_nonexistent_digit_0(self):
         # http://bugs.python.org/issue14630: A bug in _PyLong_Copy meant that
         # ob_digit[0] was being incorrectly accessed for instances of a


### PR DESCRIPTION
Co-authored-by: Jelle Zijlstra <jelle.zijlstra@gmail.com>. (cherry picked from commit e39ae6bef2c357a88e232dcab2e4b4c0f367544b)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>

Backporting https://github.com/python/cpython/pull/96610

<!-- gh-issue-number: gh-94808 -->
* Issue: gh-94808
<!-- /gh-issue-number -->
