### PR TITLE
Update whatsnew instructions for GitHub

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -37,11 +37,11 @@
    * Credit the author of a patch or bugfix.   Just the name is
    sufficient; the e-mail address isn't necessary.
 
-   * It's helpful to add the bug/patch number as a comment:
+   * It's helpful to add the issue number as a comment:
 
    XXX Describe the transmogrify() function added to the socket
    module.
-   (Contributed by P.Y. Developer in :issue:`12345`.)
+   (Contributed by P.Y. Developer in :gh:`12345`.)
 
    This saves the maintainer the effort of going through the VCS log when
    researching a change.


### PR DESCRIPTION
Since all new changes will have a github issue, recommend `:gh:` rather than `:issue:` in whatsnew instruction block.

Also clarify "bug/patch number" to "issue number" -- this also (subtly) clarifies that it is the issue, not the PR, that should be linked.

I didn't find a "whatsnew template" anywhere (by grepping for text in this header block that is common to all recent whatsnew files), so I assume new ones are created by copying the most recent one, thus editing `3.12.rst` is the right approach.