### PR TITLE
venv commands

### DIFF
--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -110,21 +110,23 @@ script in the virtual environment's binary directory. The invocation of the
 script is platform-specific (`<venv>` must be replaced by the path of the
 directory containing the virtual environment):
 
-+-------------+-----------------+-----------------------------------------+
-| Platform    | Shell           | Command to activate virtual environment |
-+=============+=================+=========================================+
-| POSIX       | bash/zsh        | $ source <venv>/bin/activate            |
-+-------------+-----------------+-----------------------------------------+
-|             | fish            | $ source <venv>/bin/activate.fish       |
-+-------------+-----------------+-----------------------------------------+
-|             | csh/tcsh        | $ source <venv>/bin/activate.csh        |
-+-------------+-----------------+-----------------------------------------+
-|             | PowerShell Core | $ <venv>/bin/Activate.ps1               |
-+-------------+-----------------+-----------------------------------------+
-| Windows     | cmd.exe         | C:\\> <venv>\\Scripts\\activate.bat     |
-+-------------+-----------------+-----------------------------------------+
-|             | PowerShell      | PS C:\\> <venv>\\Scripts\\Activate.ps1  |
-+-------------+-----------------+-----------------------------------------+
++-------------+-------------------+-----------------------------------------+
+| Platform    | Shell             | Command to activate virtual environment |
++=============+===================+=========================================+
+| POSIX       | Bourne compatible | $ . <venv>/bin/activate                 |
++-------------+-------------------+-----------------------------------------+
+|             | csh               | % source <venv>/bin/activate.csh        |
++-------------+-------------------+-----------------------------------------+
+|             | fish              | user@host /> . <venv>/bin/activate.fish |
++-------------+-------------------+-----------------------------------------+
+|             | PowerShell Core   | PS /> <venv>/bin/Activate.ps1           |
++-------------+-------------------+-----------------------------------------+
+|             | tcsh              | > source <venv>/bin/activate.csh        |
++-------------+-------------------+-----------------------------------------+
+| Windows     | cmd.exe           | C:\\> <venv>\\Scripts\\activate.bat     |
++-------------+-------------------+-----------------------------------------+
+|             | PowerShell        | PS C:\\> <venv>\\Scripts\\Activate.ps1  |
++-------------+-------------------+-----------------------------------------+
 
 When a virtual environment is active, the :envvar:`VIRTUAL_ENV` environment
 variable is set to the path of the virtual environment. This can be used to

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -110,23 +110,23 @@ script in the virtual environment's binary directory. The invocation of the
 script is platform-specific (`<venv>` must be replaced by the path of the
 directory containing the virtual environment):
 
-+-------------+-------------------+-----------------------------------------+
-| Platform    | Shell             | Command to activate virtual environment |
-+=============+===================+=========================================+
-| POSIX       | Bourne compatible | $ . <venv>/bin/activate                 |
-+-------------+-------------------+-----------------------------------------+
-|             | csh               | % source <venv>/bin/activate.csh        |
-+-------------+-------------------+-----------------------------------------+
-|             | fish              | user@host /> . <venv>/bin/activate.fish |
-+-------------+-------------------+-----------------------------------------+
-|             | PowerShell Core   | PS /> <venv>/bin/Activate.ps1           |
-+-------------+-------------------+-----------------------------------------+
-|             | tcsh              | > source <venv>/bin/activate.csh        |
-+-------------+-------------------+-----------------------------------------+
-| Windows     | cmd.exe           | C:\\> <venv>\\Scripts\\activate.bat     |
-+-------------+-------------------+-----------------------------------------+
-|             | PowerShell        | PS C:\\> <venv>\\Scripts\\Activate.ps1  |
-+-------------+-------------------+-----------------------------------------+
++-------------+-------------------+----------------------------------------------+
+| Platform    | Shell             | Command to activate virtual environment      |
++=============+===================+==============================================+
+| POSIX       | Bourne compatible | $ . <venv>/bin/activate                      |
++-------------+-------------------+----------------------------------------------+
+|             | csh               | % source <venv>/bin/activate.csh             |
++-------------+-------------------+----------------------------------------------+
+|             | fish              | user@host /> source <venv>/bin/activate.fish |
++-------------+-------------------+----------------------------------------------+
+|             | PowerShell Core   | PS /> <venv>/bin/Activate.ps1                |
++-------------+-------------------+----------------------------------------------+
+|             | tcsh              | > source <venv>/bin/activate.csh             |
++-------------+-------------------+----------------------------------------------+
+| Windows     | cmd.exe           | C:\\> <venv>\\Scripts\\activate.bat          |
++-------------+-------------------+----------------------------------------------+
+|             | PowerShell        | PS C:\\> <venv>\\Scripts\\Activate.ps1       |
++-------------+-------------------+----------------------------------------------+
 
 When a virtual environment is active, the :envvar:`VIRTUAL_ENV` environment
 variable is set to the path of the virtual environment. This can be used to

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -88,7 +88,7 @@ The command, if run with ``-h``, will show the available options::
    script by setting the execution policy for the user. You can do this by
    issuing the following PowerShell command:
 
-   PS C:\> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+   PS C:\\> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
    See `About Execution Policies
    <https://go.microsoft.com/fwlink/?LinkID=135170>`_

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -144,8 +144,7 @@ The exact mechanism is platform-specific and is an internal implementation
 detail (typically a script or shell function will be used).
 
 .. versionadded:: 3.4
-   ``fish`` and ``csh`` activation scripts.
+   ``.fish`` and ``.csh`` activation scripts.
 
 .. versionadded:: 3.8
-   PowerShell activation scripts installed under POSIX for PowerShell Core
-   support.
+   ``.ps1`` activation script for PowerShell Core.


### PR DESCRIPTION
fix prompts for POSIX shells

replaced `bash/zsh` with `Bourne compatible` (Almquist shell also works with the command)

replaced `source` with its shortcut `.` where available

third commit reverts my change using `.` instead of `source` for fish 

evidently the fish [documentation](https://fishshell.com/docs/current/cmds/source.html#cmd-source) authors don't know the history of bash; where `source` wasn't an "alias"

". (a single period) is an alias for the `source` command. The use of . is deprecated in favour of `source`, and  
. will be removed in a future version of fish."