### PR TITLE
GH-97696: Initial work on eager tasks

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -458,24 +458,26 @@ class BaseEventLoop(events.AbstractEventLoop):
         Otherwise schedule the resumption and return a task.
         """
         self._check_closed()
-        try:
-            yield_result = coro.send(None)
-        except BaseException as exc:
-            fut = self.create_future()
-            # XXX What about AsyncStopIteration?
-            if isinstance(exc, StopIteration):
-                fut.set_result(exc.value)
-            else:
-                fut.set_exception(exc)
-            return fut
+        # Do not go through the task factory.
+        # This _is_ the task factory.
+        if tasks.Task is not tasks._PyTask:
+            task = tasks.Task(coro, loop=self, name=name, context=context)
         else:
-            # Do not go through the task factory.
-            # This _is_ the task factory.
+            try:
+                yield_result = coro.send(None)
+            except BaseException as exc:
+                fut = self.create_future()
+                # XXX What about AsyncStopIteration?
+                if isinstance(exc, StopIteration):
+                    fut.set_result(exc.value)
+                else:
+                    fut.set_exception(exc)
+                return fut
             task = tasks.Task(coro, loop=self, name=name, context=context,
                                     yield_result=yield_result)
-            if task._source_traceback:
-                del task._source_traceback[-1]
-            return task
+        if task._source_traceback:
+            del task._source_traceback[-1]
+        return task
 
     def set_task_factory(self, factory):
         """Set a task factory that will be used by loop.create_task().

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -75,6 +75,8 @@ def _set_task_name(task, name):
             set_name(name)
 
 
+_NOT_SET = object()
+
 class Task(futures._PyFuture):  # Inherit Python Task implementation
                                 # from a Python Future implementation.
 
@@ -93,7 +95,8 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
     # status is still pending
     _log_destroy_pending = True
 
-    def __init__(self, coro, *, loop=None, name=None, context=None):
+    def __init__(self, coro, *, loop=None, name=None, context=None,
+                                yield_result=_NOT_SET):
         super().__init__(loop=loop)
         if self._source_traceback:
             del self._source_traceback[-1]
@@ -117,7 +120,10 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
         else:
             self._context = context
 
-        self._loop.call_soon(self.__step, context=self._context)
+        if yield_result is _NOT_SET:
+            self._loop.call_soon(self.__step, context=self._context)
+        else:
+            self.__step2(yield_result)
         _register_task(self)
 
     def __del__(self):
@@ -287,6 +293,12 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
         except BaseException as exc:
             super().set_exception(exc)
         else:
+            self.__step2(result)
+        finally:
+            _leave_task(self._loop, self)
+            self = None  # Needed to break cycles when an exception occurs.
+
+    def __step2(self, result):
             blocking = getattr(result, '_asyncio_future_blocking', None)
             if blocking is not None:
                 # Yielded Future must come from Future.__iter__().
@@ -333,9 +345,6 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
                 new_exc = RuntimeError(f'Task got bad yield: {result!r}')
                 self._loop.call_soon(
                     self.__step, new_exc, context=self._context)
-        finally:
-            _leave_task(self._loop, self)
-            self = None  # Needed to break cycles when an exception occurs.
 
     def __wakeup(self, future):
         try:


### PR DESCRIPTION
This defines an event loop method eager_task_factory() that can be made the task factory using loop.set_task_factory(loop.eager_task_factory). It will then return a Future if the coroutine completed (or failed) without ever suspending itself.

As a TEMPORARY demonstration (to be revisited), for now we call this factory from TaskGroup.create_task(), if the loop implementation defines it.

<!-- gh-issue-number: gh-97696 -->
* Issue: gh-97696
<!-- /gh-issue-number -->
