### PR TITLE
[3.10] bpo-43564: preserve original exception in args of FTP URLError (GH-24938)

### DIFF
--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1579,8 +1579,7 @@ class FTPHandler(BaseHandler):
             headers = email.message_from_string(headers)
             return addinfourl(fp, headers, req.full_url)
         except ftplib.all_errors as exp:
-            exc = URLError('ftp error: %r' % exp)
-            raise exc.with_traceback(sys.exc_info()[2])
+            raise URLError(exp) from exp
 
     def connect_ftp(self, user, passwd, host, port, dirs, timeout):
         return ftpwrapper(user, passwd, host, port, dirs, timeout,

--- a/Misc/NEWS.d/next/Library/2022-10-09-12-12-38.gh-issue-87730.ClgP3f.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-09-12-12-38.gh-issue-87730.ClgP3f.rst
@@ -1,0 +1,3 @@
+Wrap network errors consistently in urllib FTP support, so the test suite
+doesn't fail when a network is available but the public internet is not
+reachable.


### PR DESCRIPTION
* bpo-43564: preserve original error in args of FTP URLError

* Add NEWS blurb

Co-authored-by: Carl Meyer <carljm@instagram.com>. (cherry picked from commit ad817cd5c44416da3752ebf9baf16d650703275c)

Co-authored-by: Carl Meyer <carl@oddbird.net>
