### PR TITLE
gh-96151: Use a private name for passing builtins to dataclass

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -431,8 +431,8 @@ def _create_fn(name, args, body, *, globals=None, locals=None,
     # worries about external callers.
     if locals is None:
         locals = {}
-    if 'BUILTINS' not in locals:
-        locals['BUILTINS'] = builtins
+    if '_BUILTINS' not in locals:
+        locals['_BUILTINS'] = builtins
     return_annotation = ''
     if return_type is not MISSING:
         locals['_return_type'] = return_type
@@ -462,7 +462,7 @@ def _field_assign(frozen, name, value, self_name):
     # self_name is what "self" is called in this function: don't
     # hard-code "self", since that might be a field name.
     if frozen:
-        return f'BUILTINS.object.__setattr__({self_name},{name!r},{value})'
+        return f'_BUILTINS.object.__setattr__({self_name},{name!r},{value})'
     return f'{self_name}.{name}={value}'
 
 

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -431,8 +431,8 @@ def _create_fn(name, args, body, *, globals=None, locals=None,
     # worries about external callers.
     if locals is None:
         locals = {}
-    if '_BUILTINS' not in locals:
-        locals['_BUILTINS'] = builtins
+    if '__BUILTINS__' not in locals:
+        locals['__BUILTINS__'] = builtins
     return_annotation = ''
     if return_type is not MISSING:
         locals['_return_type'] = return_type
@@ -462,7 +462,7 @@ def _field_assign(frozen, name, value, self_name):
     # self_name is what "self" is called in this function: don't
     # hard-code "self", since that might be a field name.
     if frozen:
-        return f'_BUILTINS.object.__setattr__({self_name},{name!r},{value})'
+        return f'__BUILTINS__.object.__setattr__({self_name},{name!r},{value})'
     return f'{self_name}.{name}={value}'
 
 

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -431,8 +431,6 @@ def _create_fn(name, args, body, *, globals=None, locals=None,
     # worries about external callers.
     if locals is None:
         locals = {}
-    if '__dataclass_builtins__' not in locals:
-        locals['__dataclass_builtins__'] = builtins
     return_annotation = ''
     if return_type is not MISSING:
         locals['_return_type'] = return_type
@@ -462,7 +460,7 @@ def _field_assign(frozen, name, value, self_name):
     # self_name is what "self" is called in this function: don't
     # hard-code "self", since that might be a field name.
     if frozen:
-        return f'__dataclass_builtins__.object.__setattr__({self_name},{name!r},{value})'
+        return f'__dataclass_builtins_object__.__setattr__({self_name},{name!r},{value})'
     return f'{self_name}.{name}={value}'
 
 
@@ -569,6 +567,7 @@ def _init_fn(fields, std_fields, kw_only_fields, frozen, has_post_init,
     locals.update({
         'MISSING': MISSING,
         '_HAS_DEFAULT_FACTORY': _HAS_DEFAULT_FACTORY,
+        '__dataclass_builtins_object__': object,
     })
 
     body_lines = []

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -426,8 +426,8 @@ def _recursive_repr(user_function):
 
 def _create_fn(name, args, body, *, globals=None, locals=None,
                return_type=MISSING):
-    # Note that we mutate locals when exec() is called.  Caller
-    # beware!  The only callers are internal to this module, so no
+    # Note that we may mutate locals. Callers beware!
+    # The only callers are internal to this module, so no
     # worries about external callers.
     if locals is None:
         locals = {}

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -431,8 +431,8 @@ def _create_fn(name, args, body, *, globals=None, locals=None,
     # worries about external callers.
     if locals is None:
         locals = {}
-    if '__BUILTINS__' not in locals:
-        locals['__BUILTINS__'] = builtins
+    if '__dataclass_builtins__' not in locals:
+        locals['__dataclass_builtins__'] = builtins
     return_annotation = ''
     if return_type is not MISSING:
         locals['_return_type'] = return_type
@@ -462,7 +462,7 @@ def _field_assign(frozen, name, value, self_name):
     # self_name is what "self" is called in this function: don't
     # hard-code "self", since that might be a field name.
     if frozen:
-        return f'__BUILTINS__.object.__setattr__({self_name},{name!r},{value})'
+        return f'__dataclass_builtins__.object.__setattr__({self_name},{name!r},{value})'
     return f'{self_name}.{name}={value}'
 
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -254,9 +254,15 @@ class TestCase(unittest.TestCase):
         @dataclass(frozen=True)
         class C:
             object: str
-            BUILTINS: int  # gh-96151
-        c = C('foo', 5)
+        c = C('foo')
         self.assertEqual(c.object, 'foo')
+
+    def test_field_named_BUILTINS_frozen(self):
+        # gh-96151
+        @dataclass(frozen=True)
+        class C:
+            BUILTINS: int
+        c = C(5)
         self.assertEqual(c.BUILTINS, 5)
 
     def test_field_named_like_builtin(self):

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -254,8 +254,10 @@ class TestCase(unittest.TestCase):
         @dataclass(frozen=True)
         class C:
             object: str
-        c = C('foo')
+            BUILTINS: int  # gh-96151
+        c = C('foo', 5)
         self.assertEqual(c.object, 'foo')
+        self.assertEqual(c.BUILTINS, 5)
 
     def test_field_named_like_builtin(self):
         # Attribute names can shadow built-in names

--- a/Misc/NEWS.d/next/Library/2022-10-10-07-07-31.gh-issue-96151.K9fwoq.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-10-07-07-31.gh-issue-96151.K9fwoq.rst
@@ -1,0 +1,1 @@
+Allow ``BUILTINS`` to be a valid field name for frozen dataclasses.


### PR DESCRIPTION
There's no indication that BUILTINS is a special name. Other names that are special to dataclass are all prefixed by an underscore.

As mentioned in the issue, we can also avoid this locals dance altogether by using `().__class__.__base__` instead of `BUILTINS.object`.

<!-- gh-issue-number: gh-96151 -->
* Issue: gh-96151
<!-- /gh-issue-number -->
