### PR TITLE
gh-44098: Release the GIL during mmap on Unix

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-10-10-09-52-21.gh-issue-44098.okcqJt.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-10-09-52-21.gh-issue-44098.okcqJt.rst
@@ -1,1 +1,1 @@
-Release the GIL when creating :class:`mmap.mmap` objects.
+Release the GIL when creating :class:`mmap.mmap` objects on Unix.

--- a/Misc/NEWS.d/next/Library/2022-10-10-09-52-21.gh-issue-44098.okcqJt.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-10-09-52-21.gh-issue-44098.okcqJt.rst
@@ -1,0 +1,1 @@
+Release the GIL when creating :class:`mmap.mmap` objects.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1318,9 +1318,9 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
         }
     }
 
-    m_obj->data = mmap(NULL, map_size,
-                       prot, flags,
-                       fd, offset);
+    Py_BEGIN_ALLOW_THREADS
+    m_obj->data = mmap(NULL, map_size, prot, flags, fd, offset);
+    Py_END_ALLOW_THREADS
 
     if (devzero != -1) {
         close(devzero);


### PR DESCRIPTION
This seems pretty straightforward. The issue mentions other calls in mmapmodule that we could release the GIL on, but those are in methods where we'd need to be careful to ensure that something sensible happens if those are called concurrently. In prior art, note that #12073 released the GIL for munmap.  In a toy benchmark, I see the speedup you'd expect from doing this.

<!-- gh-issue-number: gh-44098 -->
* Issue: gh-44098
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:gvanrossum