### PR TITLE
[3.10] Auto-cancel old builds when new commit pushed to branch (GH-98009)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check_source:
     name: 'Check for source changes'

--- a/.github/workflows/build_msi.yml
+++ b/.github/workflows/build_msi.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build_win32:
     name: 'Windows (x86) Installer'

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build_doc:
     name: 'Docs'

--- a/.github/workflows/verify-ensurepip-wheels.yml
+++ b/.github/workflows/verify-ensurepip-wheels.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* Auto-cancel old builds when new commit pushed to branch

* Add a fallback

Co-authored-by: Ezio Melotti <ezio.melotti@gmail.com>

* Use the same group for all workflows.

Co-authored-by: Ezio Melotti <ezio.melotti@gmail.com>
(cherry picked from commit 75751f4aa5d70f65856645a9128fd42d92d6692c)

Co-authored-by: Hugo van Kemenade <hugovk@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
