### PR TITLE
gh-98169 dataclasses.astuple support DefaultDict

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1325,15 +1325,15 @@ def _asdict_inner(obj, dict_factory):
         # generator (which is not true for namedtuples, handled
         # above).
         return type(obj)(_asdict_inner(v, dict_factory) for v in obj)
-    elif isinstance(obj, dict) and hasattr(type(obj), 'default_factory'):
-        # obj is a defaultdict, which has a different constructor from
-        # dict as it requires the default_factory as its first arg.
-        # https://bugs.python.org/issue35540
-        result = type(obj)(getattr(obj, 'default_factory'))
-        for k, v in obj.items():
-            result[_asdict_inner(k, dict_factory)] = _asdict_inner(v, dict_factory)
-        return result
     elif isinstance(obj, dict):
+        if hasattr(type(obj), 'default_factory'):
+            # obj is a defaultdict, which has a different constructor from
+            # dict as it requires the default_factory as its first arg.
+            # https://bugs.python.org/issue35540
+            result = type(obj)(getattr(obj, 'default_factory'))
+            for k, v in obj.items():
+                result[_asdict_inner(k, dict_factory)] = _asdict_inner(v, dict_factory)
+            return result
         return type(obj)((_asdict_inner(k, dict_factory),
                           _asdict_inner(v, dict_factory))
                          for k, v in obj.items())
@@ -1386,6 +1386,14 @@ def _astuple_inner(obj, tuple_factory):
         # above).
         return type(obj)(_astuple_inner(v, tuple_factory) for v in obj)
     elif isinstance(obj, dict):
+        if hasattr(type(obj), 'default_factory'):
+            # obj is a defaultdict, which has a different constructor from
+            # dict as it requires the default_factory as its first arg.
+            # https://bugs.python.org/issue35540
+            result = type(obj)(getattr(obj, 'default_factory'))
+            for k, v in obj.items():
+                result[_astuple_inner(k, tuple_factory)] = _asdict_inner(v, tuple_factory)
+            return result
         return type(obj)((_astuple_inner(k, tuple_factory), _astuple_inner(v, tuple_factory))
                           for k, v in obj.items())
     else:

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1329,7 +1329,6 @@ def _asdict_inner(obj, dict_factory):
         if hasattr(type(obj), 'default_factory'):
             # obj is a defaultdict, which has a different constructor from
             # dict as it requires the default_factory as its first arg.
-            # https://bugs.python.org/issue35540
             result = type(obj)(getattr(obj, 'default_factory'))
             for k, v in obj.items():
                 result[_asdict_inner(k, dict_factory)] = _asdict_inner(v, dict_factory)
@@ -1389,7 +1388,6 @@ def _astuple_inner(obj, tuple_factory):
         if hasattr(type(obj), 'default_factory'):
             # obj is a defaultdict, which has a different constructor from
             # dict as it requires the default_factory as its first arg.
-            # https://bugs.python.org/issue35540
             result = type(obj)(getattr(obj, 'default_factory'))
             for k, v in obj.items():
                 result[_astuple_inner(k, tuple_factory)] = _asdict_inner(v, tuple_factory)

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1385,14 +1385,15 @@ def _astuple_inner(obj, tuple_factory):
         # above).
         return type(obj)(_astuple_inner(v, tuple_factory) for v in obj)
     elif isinstance(obj, dict):
-        if hasattr(type(obj), 'default_factory'):
+        obj_type = type(obj)
+        if hasattr(obj_type, 'default_factory'):
             # obj is a defaultdict, which has a different constructor from
             # dict as it requires the default_factory as its first arg.
-            result = type(obj)(getattr(obj, 'default_factory'))
+            result = obj_type(getattr(obj, 'default_factory'))
             for k, v in obj.items():
                 result[_astuple_inner(k, tuple_factory)] = _asdict_inner(v, tuple_factory)
             return result
-        return type(obj)((_astuple_inner(k, tuple_factory), _astuple_inner(v, tuple_factory))
+        return obj_type((_astuple_inner(k, tuple_factory), _astuple_inner(v, tuple_factory))
                           for k, v in obj.items())
     else:
         return copy.deepcopy(obj)

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1391,7 +1391,7 @@ def _astuple_inner(obj, tuple_factory):
             # dict as it requires the default_factory as its first arg.
             result = obj_type(getattr(obj, 'default_factory'))
             for k, v in obj.items():
-                result[_astuple_inner(k, tuple_factory)] = _asdict_inner(v, tuple_factory)
+                result[_astuple_inner(k, tuple_factory)] = _astuple_inner(v, tuple_factory)
             return result
         return obj_type((_astuple_inner(k, tuple_factory), _astuple_inner(v, tuple_factory))
                           for k, v in obj.items())

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1680,19 +1680,17 @@ class TestCase(unittest.TestCase):
     def test_helper_asdict_defaultdict(self):
         # Ensure asdict() does not throw exceptions when a
         # defaultdict is a member of a dataclass
-
         @dataclass
         class C:
             mp: DefaultDict[str, List]
-
 
         dd = defaultdict(list)
         dd["x"].append(12)
         c = C(mp=dd)
         d = asdict(c)
 
-        assert d == {"mp": {"x": [12]}}
-        assert d["mp"] is not c.mp  # make sure defaultdict is copied
+        self.assertEqual(d, {"mp": {"x": [12]}})
+        self.assertTrue(d["mp"] is not c.mp)  # make sure defaultdict is copied
 
     def test_helper_astuple(self):
         # Basic tests for astuple(), it should return a new tuple.
@@ -1820,6 +1818,21 @@ class TestCase(unittest.TestCase):
         # Now, using a tuple_factory.  list is convenient here.
         t = astuple(c, tuple_factory=list)
         self.assertEqual(t, ['outer', T(1, ['inner', T(11, 12, 13)], 2)])
+
+    def test_helper_astuple_defaultdict(self):
+        # Ensure astuple() does not throw exceptions when a
+        # defaultdict is a member of a dataclass
+        @dataclass
+        class C:
+            mp: DefaultDict[str, List]
+
+        dd = defaultdict(list)
+        dd["x"].append(12)
+        c = C(mp=dd)
+        t = astuple(c)
+
+        self.assertEqual(t, ({"x": [12]},))
+        self.assertTrue(t[0] is not dd) # make sure defaultdict is copied
 
     def test_dynamic_class_creation(self):
         cls_dict = {'__annotations__': {'x': int, 'y': int},

--- a/Misc/NEWS.d/next/Library/2022-10-10-19-14-51.gh-issue-98169.DBWIxL.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-10-19-14-51.gh-issue-98169.DBWIxL.rst
@@ -1,0 +1,2 @@
+Fix :func:`dataclasses.astuple` crash when :class:`collections.defaultdict`
+is present in the attributes.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Basically applying the same fix for `asdict` from https://github.com/python/cpython/pull/32056 to `astuple`. These two should've been the same PR, but I didn't know about `astuple` previously.

Also modified the handling of `DefaultDict` in `asdict` a little so that we only call `isinstance(obj, dict)` once. This results in a ~3% speed up on my machine on this example:

```python
# benchmark
from dataclasses import dataclass, asdict
from collections import defaultdict
from typing import DefaultDict, Dict, List, NamedTuple
import time


class NT(NamedTuple):
    x: int
    y: float

@dataclass
class C:
    dd: DefaultDict[str, List]
    nt: NT
    d1: Dict[str, List]
    d2: Dict[str, int]

def get_instance():
    instance = C(dd=defaultdict(list), nt=NT(1, 1.), d1={}, d2={})
    instance.dd["x"].append(12)
    instance.dd["x"].append(13)
    instance.d1["y"] = [1, 2, 3]
    instance.d2["z"] = 1
    return instance

instance = get_instance()

def timeit(callable, n_runs = 100_000, name=""):
    t1 = time.perf_counter_ns()
    for _ in range(n_runs):
        callable()

    elapsed_ms = round(1e-6 * (time.perf_counter_ns() - t1), 2)
    print(f"{name}\t{n_runs} runs: {elapsed_ms} ms")

timeit(lambda: asdict(instance), name="asdict")
timeit(lambda: astuple(instance), name="astuple")
```


<!-- gh-issue-number: gh-98169 -->
* Issue: gh-98169
<!-- /gh-issue-number -->
