### PR TITLE
gh-98172: Fix formatting in `except*` docs

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -365,16 +365,16 @@ one :keyword:`!except*` clause, the first that matches it. ::
        +------------------------------------
    >>>
 
-   Any remaining exceptions that were not handled by any :keyword:`!except*`
-   clause are re-raised at the end, combined into an exception group along with
-   all exceptions that were raised from within :keyword:`!except*` clauses.
+Any remaining exceptions that were not handled by any :keyword:`!except*`
+clause are re-raised at the end, combined into an exception group along with
+all exceptions that were raised from within :keyword:`!except*` clauses.
 
-   An :keyword:`!except*` clause must have a matching type,
-   and this type cannot be a subclass of :exc:`BaseExceptionGroup`.
-   It is not possible to mix :keyword:`except` and :keyword:`!except*`
-   in the same :keyword:`try`.
-   :keyword:`break`, :keyword:`continue` and :keyword:`return`
-   cannot appear in an :keyword:`!except*` clause.
+An :keyword:`!except*` clause must have a matching type,
+and this type cannot be a subclass of :exc:`BaseExceptionGroup`.
+It is not possible to mix :keyword:`except` and :keyword:`!except*`
+in the same :keyword:`try`.
+:keyword:`break`, :keyword:`continue` and :keyword:`return`
+cannot appear in an :keyword:`!except*` clause.
 
 
 .. index::

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -363,7 +363,6 @@ one :keyword:`!except*` clause, the first that matches it. ::
      +-+---------------- 1 ----------------
        | ValueError: 1
        +------------------------------------
-   >>>
 
 Any remaining exceptions that were not handled by any :keyword:`!except*`
 clause are re-raised at the end, combined into an exception group along with


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98172 -->
* Issue: gh-98172
<!-- /gh-issue-number -->
