### PR TITLE
gh-98178: syslog() is not thread-safe on macOS

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-10-12-10-00-40.gh-issue-98178.hspH51.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-12-10-00-40.gh-issue-98178.hspH51.rst
@@ -1,0 +1,4 @@
+On macOS, fix a crash in :func:`syslog.syslog` in multi-threaded applications.
+On macOS, the libc ``syslog()`` function is not thread-safe, so
+:func:`syslog.syslog` no longer releases the GIL to call it. Patch by Victor
+Stinner.

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -207,9 +207,14 @@ syslog_syslog_impl(PyObject *module, int group_left_1, int priority,
      */
     PyObject *ident = S_ident_o;
     Py_XINCREF(ident);
+#ifdef __APPLE__
+    // gh-98178: On macOS, libc syslog() is not thread-safe
+    syslog(priority, "%s", message);
+#else
     Py_BEGIN_ALLOW_THREADS;
     syslog(priority, "%s", message);
     Py_END_ALLOW_THREADS;
+#endif
     Py_XDECREF(ident);
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
On macOS, fix a crash in syslog.syslog() in multi-threaded applications. On macOS, the libc syslog() function is not thread-safe, so syslog.syslog() no longer releases the GIL to call it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98178 -->
* Issue: gh-98178
<!-- /gh-issue-number -->
