### PR TITLE
gh-97669: Fix test_tools reference leak

### DIFF
--- a/Lib/test/support/import_helper.py
+++ b/Lib/test/support/import_helper.py
@@ -246,3 +246,11 @@ def modules_cleanup(oldmodules):
     # do currently). Implicitly imported *real* modules should be left alone
     # (see issue 10556).
     sys.modules.update(oldmodules)
+
+
+def mock_register_at_fork(func):
+    # bpo-30599: Mock os.register_at_fork() when importing the random module,
+    # since this function doesn't allow to unregister callbacks and would leak
+    # memory.
+    from unittest import mock
+    return mock.patch('os.register_at_fork', create=True)(func)

--- a/Lib/test/test_importlib/test_threaded_import.py
+++ b/Lib/test/test_importlib/test_threaded_import.py
@@ -15,7 +15,7 @@ import threading
 import unittest
 from unittest import mock
 from test.support import verbose
-from test.support.import_helper import forget
+from test.support.import_helper import forget, mock_register_at_fork
 from test.support.os_helper import (TESTFN, unlink, rmtree)
 from test.support import script_helper, threading_helper
 
@@ -40,12 +40,6 @@ def task(N, done, done_tasks, errors):
         finished = len(done_tasks) == N
         if finished:
             done.set()
-
-def mock_register_at_fork(func):
-    # bpo-30599: Mock os.register_at_fork() when importing the random module,
-    # since this function doesn't allow to unregister callbacks and would leak
-    # memory.
-    return mock.patch('os.register_at_fork', create=True)(func)
 
 # Create a circular import structure: A -> C -> B -> D -> A
 # NOTE: `time` is already loaded and therefore doesn't threaten to deadlock.

--- a/Lib/test/test_tools/test_sundry.py
+++ b/Lib/test/test_tools/test_sundry.py
@@ -27,7 +27,11 @@ class TestSundryScripts(unittest.TestCase):
 
     skiplist = denylist + allowlist + other
 
-    def test_sundry(self):
+    # import logging registers "atfork" functions which keep indirectly the
+    # logging module dictionary alive. Mock the function to be able to unload
+    # cleanly the logging module.
+    @import_helper.mock_register_at_fork
+    def test_sundry(self, mock_os):
         old_modules = import_helper.modules_setup()
         try:
             for fn in os.listdir(scriptsdir):


### PR DESCRIPTION
test_tools.test_sundry() now uses an unittest mock to prevent the logging module to register a real "atfork" function which kept the logging module dictionary alive. So the logging module can be properly unloaded. Previously, the logging module was loaded before test_sundry(), but it's no longer the case since recent test_tools sub-tests removals.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97669 -->
* Issue: gh-97669
<!-- /gh-issue-number -->
