### PR TITLE
signalmodule.c uses _PyErr_WriteUnraisableMsg()

### DIFF
--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -272,9 +272,8 @@ report_wakeup_write_error(void *data)
     errno = (int) (intptr_t) data;
     PyErr_Fetch(&exc, &val, &tb);
     PyErr_SetFromErrno(PyExc_OSError);
-    PySys_WriteStderr("Exception ignored when trying to write to the "
-                      "signal wakeup fd:\n");
-    PyErr_WriteUnraisable(NULL);
+    _PyErr_WriteUnraisableMsg("when trying to write to the signal wakeup fd",
+                              NULL);
     PyErr_Restore(exc, val, tb);
     errno = save_errno;
     return 0;
@@ -284,15 +283,15 @@ report_wakeup_write_error(void *data)
 static int
 report_wakeup_send_error(void* data)
 {
+    int send_errno = (int) (intptr_t) data;
+
     PyObject *exc, *val, *tb;
     PyErr_Fetch(&exc, &val, &tb);
     /* PyErr_SetExcFromWindowsErr() invokes FormatMessage() which
        recognizes the error codes used by both GetLastError() and
        WSAGetLastError */
-    PyErr_SetExcFromWindowsErr(PyExc_OSError, (int) (intptr_t) data);
-    PySys_WriteStderr("Exception ignored when trying to send to the "
-                      "signal wakeup fd:\n");
-    PyErr_WriteUnraisable(NULL);
+    PyErr_SetExcFromWindowsErr(PyExc_OSError, send_errno);
+    _PyErr_WriteUnraisableMsg("when trying to send to the signal wakeup fd", NULL);
     PyErr_Restore(exc, val, tb);
     return 0;
 }


### PR DESCRIPTION
Signal wakeup fd errors are now logged with
_PyErr_WriteUnraisableMsg(), rather than PySys_WriteStderr() and PyErr_WriteUnraisable(), to pass the error message to sys.unraisablehook. By default, it's still written into stderr.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
