### PR TITLE
gh-96488: Fix build failure with older versions of GCC

### DIFF
--- a/Lib/distutils/tests/test_unixccompiler.py
+++ b/Lib/distutils/tests/test_unixccompiler.py
@@ -90,7 +90,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
         sys.platform = 'bar'
         def gcv(v):
             if v == 'CC':
-                return 'cc'
+                return 'icc'
             elif v == 'GNULD':
                 return 'yes'
         sysconfig.get_config_var = gcv
@@ -100,7 +100,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
         sys.platform = 'bar'
         def gcv(v):
             if v == 'CC':
-                return 'cc'
+                return 'icc'
             elif v == 'GNULD':
                 return 'no'
         sysconfig.get_config_var = gcv

--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -13,7 +13,7 @@ the "typical" Unix-style command-line C compiler:
   * link shared library handled by 'cc -shared'
 """
 
-import os, sys, re
+import os, sys, re, shutil
 
 from distutils import sysconfig
 from distutils.dep_util import newer
@@ -216,7 +216,27 @@ class UnixCCompiler(CCompiler):
 
     def _is_gcc(self, compiler_name):
         # clang uses same syntax for rpath as gcc
-        return any(name in compiler_name for name in ("gcc", "g++", "clang"))
+        valid_compiler_names = ("gcc", "g++", "clang")
+        is_gcc = any(name in compiler_name for name in valid_compiler_names)
+        # On Linux systems, the compiler name may be, e.g., "cc -pthread".
+        # The executable "cc" is in this case a symlink to the true compiler.
+        if not is_gcc and "cc" in compiler_name:
+            # We need to make sure that this is not another compiler with "cc"
+            # at the end of its name, like "icc". For this, it is checked
+            # whether "cc" is the first word, or separated by a space or path
+            # delimiter before the "cc" substring.
+            cc_string_location = compiler_name.find("cc")
+            if cc_string_location == 0 \
+                    or compiler_name[cc_string_location - 1] == ' ' \
+                    or compiler_name[cc_string_location - 1] == '/' \
+                    or compiler_name[cc_string_location - 1] == '\\':
+                cc_path = shutil.which("cc")
+                if cc_path is not None:
+                    real_compiler_path = os.path.realpath(cc_path)
+                    is_gcc = any(
+                        name in real_compiler_path \
+                        for name in valid_compiler_names)
+        return is_gcc
 
     def runtime_library_dir_option(self, dir):
         # XXX Hackish, at the very least.  See Python bug #445902:

--- a/Misc/NEWS.d/next/Build/2022-10-12-15-35-37.gh-issue-96488.s7h7up.rst
+++ b/Misc/NEWS.d/next/Build/2022-10-12-15-35-37.gh-issue-96488.s7h7up.rst
@@ -1,0 +1,1 @@
+Fix build failures with older versions of GCC when using runtime_library_dirs with distutils. Older versions of GCC only support the flag "-Wl,-R" instead of "-R". distutils now also handles this correctly with the compiler alias "cc".


### PR DESCRIPTION
This PR fixes #96488, https://github.com/microsoft/vcpkg/issues/26573, https://github.com/rbgirshick/py-faster-rcnn/issues/706, https://github.com/LSSTDESC/CCL/issues/270. These issues happended when `runtime_library_dirs` was used with distutils on systems with older versions of GCC not supporting the `-R` flag.

In https://github.com/rbgirshick/py-faster-rcnn/issues/706, it was proposed to fix the problem by replacing the string "-R" in https://github.com/python/cpython/blob/main/Lib/distutils/unixccompiler.py#L261 by "-Wl,-R". However, the problem comes not from the fact that this line is wrong, but from `_is_gcc(compiler)` not accepting the compiler name `cc` as a possibly valid alias for GCC. On Linux, `cc` is a symlink to the default C++ compiler. In this PR, `cc` is now resolved to the actually used compiler. Thus, `_is_gcc` works correctly now for the compiler alias `cc`, and using `runtime_library_dirs` no longer results in compiler errors on older versions of GCC.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96488 -->
* Issue: gh-96488
<!-- /gh-issue-number -->
