### PR TITLE
[3.10] gh-86404: Doc CI: Disable suspicious checks. (GH-26575)

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -43,8 +43,6 @@ jobs:
         cache-dependency-path: 'Doc/requirements.txt'
     - name: 'Install build dependencies'
       run: make -C Doc/ venv
-    - name: 'Check documentation'
-      run: make -C Doc/ suspicious
     - name: 'Build HTML documentation'
       run: make -C Doc/ SPHINXOPTS="-q" SPHINXERRORHANDLING="-W --keep-going" html
     - name: 'Upload'

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
         - cd Doc
         - make venv PYTHON=python
       script:
-        - make check html suspicious SPHINXOPTS="-q -W -j4"
+        - make check html SPHINXOPTS="-q -W -j4"
     - name: "Documentation tests"
       os: linux
       language: c


### PR DESCRIPTION
`make suspicious` is disabled on 3.11 and removed in main, as it has been replaced by sphinx-lint.

Keeping the CI enabled with it here may lead to false positives from `make suspicious` during documentation backports, leading to painfull backports.

<!-- gh-issue-number: gh-86404 -->
* Issue: gh-86404
<!-- /gh-issue-number -->
