### PR TITLE
gh-94808: Cover `str.rsplit` for UCS1, UCS2 or UCS4

### DIFF
--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -507,7 +507,8 @@ class BaseTest:
     def test_rsplit(self):
         # without arg
         self.checkequal(['a', 'b', 'c', 'd'], 'a b c d', 'rsplit')
-        self.checkequal(['a', 'b', 'c', 'd'], 'a  b  c  d', 'rsplit')
+        self.checkequal(['a', 'b', 'c', 'd'], 'a  b  c d', 'rsplit')
+        self.checkequal([], '', 'rsplit')
 
         # by a char
         self.checkequal(['a', 'b', 'c', 'd'], 'a|b|c|d', 'rsplit', '|')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -505,6 +505,10 @@ class BaseTest:
         self.checkraises(ValueError, 'hello', 'split', '', 0)
 
     def test_rsplit(self):
+        # without arg
+        self.checkequal(['a', 'b', 'c', 'd'], 'a b c d', 'rsplit')
+        self.checkequal(['a', 'b', 'c', 'd'], 'a  b  c  d', 'rsplit')
+
         # by a char
         self.checkequal(['a', 'b', 'c', 'd'], 'a|b|c|d', 'rsplit', '|')
         self.checkequal(['a|b|c', 'd'], 'a|b|c|d', 'rsplit', '|', 1)
@@ -558,6 +562,9 @@ class BaseTest:
 
         # with keyword args
         self.checkequal(['a', 'b', 'c', 'd'], 'a|b|c|d', 'rsplit', sep='|')
+        self.checkequal(['a', 'b', 'c', 'd'], 'a b c d', 'rsplit', sep=None)
+        self.checkequal(['a b c', 'd'],
+                        'a b c d', 'rsplit', sep=None, maxsplit=1)
         self.checkequal(['a|b|c', 'd'],
                         'a|b|c|d', 'rsplit', '|', maxsplit=1)
         self.checkequal(['a|b|c', 'd'],

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -445,10 +445,10 @@ class UnicodeTest(string_tests.CommonTest,
     def test_rsplit(self):
         string_tests.CommonTest.test_rsplit(self)
         # test mixed kinds
-        for left, right in ('ba', '\u0101\u0100', '\U00010301\U00010300'):
+        for left, right in ('ba', 'юё', '\u0101\u0100', '\U00010301\U00010300'):
             left *= 9
             right *= 9
-            for delim in ('c', '\u0102', '\U00010302'):
+            for delim in ('c', 'ы', '\u0102', '\U00010302'):
                 self.checkequal([left + right],
                                 left + right, 'rsplit', delim)
                 self.checkequal([left, right],
@@ -457,6 +457,10 @@ class UnicodeTest(string_tests.CommonTest,
                                 left + right, 'rsplit', delim * 2)
                 self.checkequal([left, right],
                                 left + delim * 2 + right, 'rsplit', delim *2)
+
+            # Check `None` as well:
+            self.checkequal([left + right],
+                             left + right, 'rsplit', None)
 
     def test_partition(self):
         string_tests.MixinStrUnicodeUserStringTest.test_partition(self)


### PR DESCRIPTION
This code was not covered:
<img width="531" alt="Снимок экрана 2022-10-13 в 1 46 36" src="https://user-images.githubusercontent.com/4660275/195461758-b99dbeaa-bb48-49eb-a6b2-ab9a5847ea4e.png">

Now, it is!

@vstinner I got curious and looked into other `asciilib_*` calls. The setup is the same as in https://github.com/python/cpython/pull/98025#issuecomment-1275202297
For example, `asciilib_rsplit_whitespace` also does not give any significant gain:
`./env/bin/python.exe -m pyperf timeit -v '"a b ca b d".rsplit()'`

```
// With asciilib call:
// Mean +- std dev: 134 ns +- 4 ns
// Mean +- std dev: 143 ns +- 5 ns

// Without it:
// Mean +- std dev: 137 ns +- 2 ns
// Mean +- std dev: 140 ns +- 7 ns
```

I will open a new issue about where we can discuss this!

<!-- gh-issue-number: gh-94808 -->
* Issue: gh-94808
<!-- /gh-issue-number -->
