### PR TITLE
gh-98230: Add the daemon keyword argument to the Timer constructor

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1628,6 +1628,15 @@ class TimerTests(BaseTestCase):
         timer1.join()
         timer2.join()
 
+    def test_daemon_param(self):
+        # PR 98231: add the daemon parameter to the Timer argument
+        t = threading.Timer(1, print)
+        self.assertFalse(t.daemon)
+        t = threading.Timer(1, print, daemon=False)
+        self.assertFalse(t.daemon)
+        t = threading.Timer(1, print, daemon=True)
+        self.assertTrue(t.daemon)
+
     def _callback_spy(self, *args, **kwargs):
         self.callback_args.append((args[:], kwargs.copy()))
         self.callback_event.set()

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1387,8 +1387,8 @@ class Timer(Thread):
 
     """
 
-    def __init__(self, interval, function, args=None, kwargs=None):
-        Thread.__init__(self)
+    def __init__(self, interval, function, args=None, kwargs=None, *, daemon=None):
+        Thread.__init__(self, daemon=daemon)
         self.interval = interval
         self.function = function
         self.args = args if args is not None else []

--- a/Misc/NEWS.d/next/Library/2022-10-13-13-32-05.gh-issue-98230.oTb1Az.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-13-13-32-05.gh-issue-98230.oTb1Az.rst
@@ -1,1 +1,1 @@
-Add a daemon keyword-only argument to the :func:`threading.Timer` constructor, to pass it to the inherited :func:`Thread` constructor.
+Add a daemon keyword-only argument to the :class:`threading.Timer` constructor, to pass it to the inherited :class:`threading.Thread` constructor.

--- a/Misc/NEWS.d/next/Library/2022-10-13-13-32-05.gh-issue-98230.oTb1Az.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-13-13-32-05.gh-issue-98230.oTb1Az.rst
@@ -1,0 +1,1 @@
+Add a daemon keyword-only argument to the :func:`threading.Timer` constructor, to pass it to the inherited :func:`Thread` constructor.


### PR DESCRIPTION
Very straightforward implementation.
Doc change will be made if and when the idea is approved.

<!-- gh-issue-number: gh-98230 -->
* Issue: gh-98230
<!-- /gh-issue-number -->
