### PR TITLE
gh-98233: Fix `Annotated[int, ...].__mro__` access

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6768,9 +6768,20 @@ class AnnotatedTests(BaseTestCase):
         self.assertEqual(X[int], List[Annotated[int, 5]])
 
     def test_annotated_mro(self):
-        class X(Annotated[int, (1, 10)]): ...
+        A = Annotated[int, (1, 10)]
+        class X(A): ...
         self.assertEqual(X.__mro__, (X, int, object),
                          "Annotated should be transparent.")
+
+        # But, __mro__ of the annotation itself should be concrete:
+        class_mro = A.__mro__
+        # We don't want to fix all implementation details of mro here:
+        self.assertIn(typing._AnnotatedAlias, class_mro)
+        self.assertIn(typing._GenericAlias, class_mro)
+        self.assertIn(object, class_mro)
+
+        # __class__ must be concrete:
+        self.assertEqual(A.__class__, typing._AnnotatedAlias)
 
 
 class TypeAliasTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2132,6 +2132,8 @@ class _AnnotatedAlias(_NotIterable, _GenericAlias, _root=True):
     def __getattr__(self, attr):
         if attr in {'__name__', '__qualname__'}:
             return 'Annotated'
+        if attr == '__mro__':
+            return self.__class__.__mro__
         return super().__getattr__(attr)
 
     def __mro_entries__(self, bases):

--- a/Misc/NEWS.d/next/Library/2022-10-13-11-11-54.gh-issue-98233.aPI2Ar.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-13-11-11-54.gh-issue-98233.aPI2Ar.rst
@@ -1,0 +1,1 @@
+Fix ``Annotated[int, ...].__mro__`` access.


### PR DESCRIPTION


<!-- gh-issue-number: gh-98233 -->
* Issue: gh-98233
<!-- /gh-issue-number -->
