### PR TITLE
gh-98235: accept file object as initialization argument for netrc class

### DIFF
--- a/Doc/library/netrc.rst
+++ b/Doc/library/netrc.rst
@@ -16,10 +16,13 @@ The :class:`~netrc.netrc` class parses and encapsulates the netrc file format us
 the Unix :program:`ftp` program and other FTP clients.
 
 
-.. class:: netrc([file])
+.. class:: netrc([file[, filename]])
 
    A :class:`~netrc.netrc` instance or subclass instance encapsulates data from  a netrc
-   file.  The initialization argument, if present, specifies the file to parse.  If
+   file.  The initialization argument, if present, specifies the file to parse.  It
+   can be either a file name or an open file object.  In the latter case the second
+   argument can be used as the name of the file for error reporting.  If the second
+   argument is not present, the file name will be derived from the file object.  If
    no argument is given, the file :file:`.netrc` in the user's home directory --
    as determined by :func:`os.path.expanduser` -- will be read.  Otherwise,
    a :exc:`FileNotFoundError` exception will be raised.
@@ -46,6 +49,9 @@ the Unix :program:`ftp` program and other FTP clients.
       can contain arbitrary characters, like whitespace and non-ASCII characters.
       If the login name is anonymous, it won't trigger the security check.
 
+   .. versionchanged:: 3.12
+      :class:`netrc` accepts an instance of an :class:`io.TextIOBase` subclass
+      as the *file* argument. In such case uses *filename* in error messages.
 
 .. exception:: NetrcParseError
 

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -1,5 +1,6 @@
 import netrc, os, unittest, sys, textwrap
 from test.support import os_helper, run_unittest
+from io import StringIO
 
 try:
     import pwd
@@ -22,6 +23,22 @@ class NetrcTestCase(unittest.TestCase):
         finally:
             os.unlink(temp_filename)
         return nrc
+
+    def make_nrc_file(self, test_data, filename=None):
+        test_data = textwrap.dedent(test_data)
+        temp_data = StringIO(test_data)
+        try:
+            nrc = netrc.netrc(temp_data, filename)
+        finally:
+            pass
+        return nrc
+
+    def test_nrc_filename(self):
+        with self.assertRaisesRegex(netrc.NetrcParseError, "bad toplevel token 'spam' \\(eggs, line 1\\)"):
+            self.make_nrc_file("spam", "eggs")
+
+        with self.assertRaisesRegex(netrc.NetrcParseError, "bad toplevel token 'spam' \\(<_io.StringIO object at 0x[0-9a-fA-F]+>, line 1\\)"):
+            self.make_nrc_file("spam")
 
     def test_toplevel_non_ordered_tokens(self):
         nrc = self.make_nrc("""\

--- a/Misc/NEWS.d/next/Library/2022-10-13-09-46-01.gh-issue-98235.3XFRKc.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-13-09-46-01.gh-issue-98235.3XFRKc.rst
@@ -1,0 +1,1 @@
+netrc class accepts open file object as an initialization argument and reads from the file


### PR DESCRIPTION
Add support for accepting an open file object (io.TextIOBase subclass) as an initialization argument of the netrc class.



<!-- gh-issue-number: gh-98235 -->
* Issue: gh-98235
<!-- /gh-issue-number -->
