### PR TITLE
gh-98254: Include stdlib module names in error messages for NameErrors

### DIFF
--- a/Lib/idlelib/idle_test/test_run.py
+++ b/Lib/idlelib/idle_test/test_run.py
@@ -39,7 +39,8 @@ class ExceptionTest(unittest.TestCase):
 
     data = (('1/0', ZeroDivisionError, "division by zero\n"),
             ('abc', NameError, "name 'abc' is not defined. "
-                               "Did you mean: 'abs'?\n"),
+                               "Did you mean: 'abs'? "
+                               "Or did you forget to import 'abc'?\n"),
             ('int.reel', AttributeError,
                  "type object 'int' has no attribute 'reel'. "
                  "Did you mean: 'real'?\n"),

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -3184,6 +3184,13 @@ class SuggestionFormattingTestBase:
 
         actual = self.get_suggestion(func)
         self.assertNotIn("something", actual)
+    
+    def test_name_error_for_stdlib_modules(self):
+        def func():
+            stream = io.StringIO()
+
+        actual = self.get_suggestion(func)
+        self.assertIn("forget to import 'io'", actual)
 
 
 class PurePythonSuggestionFormattingTests(

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -3192,6 +3192,14 @@ class SuggestionFormattingTestBase:
         actual = self.get_suggestion(func)
         self.assertIn("forget to import 'io'", actual)
 
+    def test_name_error_for_private_stdlib_modules(self):
+        def func():
+            stream = _io.StringIO()
+
+        actual = self.get_suggestion(func)
+        self.assertIn("forget to import '_io'", actual)
+
+
 
 class PurePythonSuggestionFormattingTests(
     PurePythonExceptionFormattingMixin,

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -3184,7 +3184,7 @@ class SuggestionFormattingTestBase:
 
         actual = self.get_suggestion(func)
         self.assertNotIn("something", actual)
-    
+
     def test_name_error_for_stdlib_modules(self):
         def func():
             stream = io.StringIO()

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -712,6 +712,14 @@ class TracebackException:
             suggestion = _compute_suggestion_error(exc_value, exc_traceback)
             if suggestion:
                 self._str += f". Did you mean: '{suggestion}'?"
+            if issubclass(exc_type, NameError):
+                mod_names = frozenset(mod for mod in sys.stdlib_module_names if not mod.startswith("_"))
+                wrong_name = getattr(exc_value, "name", None)
+                if wrong_name is not None and wrong_name in mod_names:
+                    if suggestion:
+                        self._str += f" Or did you forget to import '{wrong_name}'"
+                    else:
+                        self._str += f". Did you forget to import '{wrong_name}'"
         if lookup_lines:
             self._load_lines()
         self.__suppress_context__ = \

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -713,9 +713,8 @@ class TracebackException:
             if suggestion:
                 self._str += f". Did you mean: '{suggestion}'?"
             if issubclass(exc_type, NameError):
-                mod_names = frozenset(mod for mod in sys.stdlib_module_names if not mod.startswith("_"))
                 wrong_name = getattr(exc_value, "name", None)
-                if wrong_name is not None and wrong_name in mod_names:
+                if wrong_name is not None and wrong_name in sys.stdlib_module_names:
                     if suggestion:
                         self._str += f" Or did you forget to import '{wrong_name}'"
                     else:

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-13-23-23-01.gh-issue-98254.bC8IKt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-13-23-23-01.gh-issue-98254.bC8IKt.rst
@@ -1,0 +1,3 @@
+Modules from the standard library are now potentially suggested as part of the
+error messages displayed by the interpreter when an :exc:`NameError` is raised
+to the top level. Patch by Pablo Galindo

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1107,14 +1107,7 @@ print_exception_suggestions(struct exception_print_context *ctx,
     PyObject *f = ctx->file;
     PyObject *suggestions = _Py_Offer_Suggestions(value);
     if (suggestions) {
-        // Add a trailer ". Did you mean: (...)?"
-        if (PyFile_WriteString(". Did you mean: '", f) < 0) {
-            goto error;
-        }
         if (PyFile_WriteObject(suggestions, f, Py_PRINT_RAW) < 0) {
-            goto error;
-        }
-        if (PyFile_WriteString("'?", f) < 0) {
             goto error;
         }
         Py_DECREF(suggestions);

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -204,7 +204,7 @@ offer_suggestions_for_attribute_error(PyAttributeErrorObject *exc)
         return NULL;
     }
     // Add a trailer ". Did you mean: (...)?"
-    PyObject* result =  PyUnicode_FromFormat(". Did you mean: %R?", suggestion);
+    PyObject* result = PyUnicode_FromFormat(". Did you mean: %R?", suggestion);
     Py_DECREF(suggestion);
     return result;
 }

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -204,7 +204,9 @@ offer_suggestions_for_attribute_error(PyAttributeErrorObject *exc)
         return NULL;
     }
     // Add a trailer ". Did you mean: (...)?"
-    return PyUnicode_FromFormat(". Did you mean %R?", suggestion);
+    PyObject* result =  PyUnicode_FromFormat(". Did you mean %R?", suggestion);
+    Py_DECREF(suggestion);
+    return result;
 }
 
 static PyObject *

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -204,7 +204,7 @@ offer_suggestions_for_attribute_error(PyAttributeErrorObject *exc)
         return NULL;
     }
     // Add a trailer ". Did you mean: (...)?"
-    PyObject* result =  PyUnicode_FromFormat(". Did you mean %R?", suggestion);
+    PyObject* result =  PyUnicode_FromFormat(". Did you mean: %R?", suggestion);
     Py_DECREF(suggestion);
     return result;
 }

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -3,6 +3,7 @@
 
 #include "pycore_pyerrors.h"
 #include "pycore_code.h"        // _PyCode_GetVarnames()
+#include "stdlib_module_names.h"  // _Py_stdlib_module_names
 
 #define MAX_CANDIDATE_ITEMS 750
 #define MAX_STRING_SIZE 40
@@ -175,7 +176,7 @@ calculate_suggestions(PyObject *dir,
 }
 
 static PyObject *
-offer_suggestions_for_attribute_error(PyAttributeErrorObject *exc)
+get_suggestions_for_attribute_error(PyAttributeErrorObject *exc)
 {
     PyObject *name = exc->name; // borrowed reference
     PyObject *obj = exc->obj; // borrowed reference
@@ -195,35 +196,23 @@ offer_suggestions_for_attribute_error(PyAttributeErrorObject *exc)
     return suggestions;
 }
 
-
 static PyObject *
-offer_suggestions_for_name_error(PyNameErrorObject *exc)
+offer_suggestions_for_attribute_error(PyAttributeErrorObject *exc)
 {
-    PyObject *name = exc->name; // borrowed reference
-    PyTracebackObject *traceback = (PyTracebackObject *) exc->traceback; // borrowed reference
-    // Abort if we don't have a variable name or we have an invalid one
-    // or if we don't have a traceback to work with
-    if (name == NULL || !PyUnicode_CheckExact(name) ||
-        traceback == NULL || !Py_IS_TYPE(traceback, &PyTraceBack_Type)
-    ) {
+    PyObject* suggestion = get_suggestions_for_attribute_error(exc);
+    if (suggestion == NULL) {
         return NULL;
     }
+    // Add a trailer ". Did you mean: (...)?"
+    return PyUnicode_FromFormat(". Did you mean %R?", suggestion);
+}
 
-    // Move to the traceback of the exception
-    while (1) {
-        PyTracebackObject *next = traceback->tb_next;
-        if (next == NULL || !Py_IS_TYPE(next, &PyTraceBack_Type)) {
-            break;
-        }
-        else {
-            traceback = next;
-        }
-    }
-
-    PyFrameObject *frame = traceback->tb_frame;
-    assert(frame != NULL);
+static PyObject *
+get_suggestions_for_name_error(PyObject* name, PyFrameObject* frame)
+{
     PyCodeObject *code = PyFrame_GetCode(frame);
     assert(code != NULL && code->co_localsplusnames != NULL);
+
     PyObject *varnames = _PyCode_GetVarnames(code);
     if (varnames == NULL) {
         return NULL;
@@ -259,6 +248,66 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
     Py_DECREF(dir);
 
     return suggestions;
+}
+
+static bool
+is_name_stdlib_module(PyObject* name)
+{
+    const char* the_name = PyUnicode_AsUTF8(name);
+    Py_ssize_t len = Py_ARRAY_LENGTH(_Py_stdlib_module_names);
+    for (Py_ssize_t i = 0; i < len; i++) {
+        if (strcmp(the_name, _Py_stdlib_module_names[i]) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static PyObject *
+offer_suggestions_for_name_error(PyNameErrorObject *exc)
+{
+    PyObject *name = exc->name; // borrowed reference
+    PyTracebackObject *traceback = (PyTracebackObject *) exc->traceback; // borrowed reference
+    // Abort if we don't have a variable name or we have an invalid one
+    // or if we don't have a traceback to work with
+    if (name == NULL || !PyUnicode_CheckExact(name) ||
+        traceback == NULL || !Py_IS_TYPE(traceback, &PyTraceBack_Type)
+    ) {
+        return NULL;
+    }
+
+    // Move to the traceback of the exception
+    while (1) {
+        PyTracebackObject *next = traceback->tb_next;
+        if (next == NULL || !Py_IS_TYPE(next, &PyTraceBack_Type)) {
+            break;
+        }
+        else {
+            traceback = next;
+        }
+    }
+
+    PyFrameObject *frame = traceback->tb_frame;
+    assert(frame != NULL);
+
+    PyObject* suggestion = get_suggestions_for_name_error(name, frame);
+    bool is_stdlib_module = is_name_stdlib_module(name);
+
+    if (suggestion == NULL && !is_stdlib_module) {
+        return NULL;
+    }
+
+    // Add a trailer ". Did you mean: (...)?"
+    PyObject* result = NULL;
+    if (!is_stdlib_module) {
+        result = PyUnicode_FromFormat(". Did you mean %R?", suggestion);
+    } else if (suggestion == NULL) {
+        result = PyUnicode_FromFormat(". Did you forget to import %R?", name);
+    } else {
+        result = PyUnicode_FromFormat(". Did you mean %R? Or did you forget to import %R?", suggestion, name);
+    }
+    Py_XDECREF(suggestion);
+    return result;
 }
 
 // Offer suggestions for a given exception. Returns a python string object containing the

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -302,11 +302,11 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
     // Add a trailer ". Did you mean: (...)?"
     PyObject* result = NULL;
     if (!is_stdlib_module) {
-        result = PyUnicode_FromFormat(". Did you mean %R?", suggestion);
+        result = PyUnicode_FromFormat(". Did you mean: %R?", suggestion);
     } else if (suggestion == NULL) {
         result = PyUnicode_FromFormat(". Did you forget to import %R?", name);
     } else {
-        result = PyUnicode_FromFormat(". Did you mean %R? Or did you forget to import %R?", suggestion, name);
+        result = PyUnicode_FromFormat(". Did you mean: %R? Or did you forget to import %R?", suggestion, name);
     }
     Py_XDECREF(suggestion);
     return result;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98254 -->
* Issue: gh-98254
<!-- /gh-issue-number -->
