### PR TITLE
Docs: Create venv if missing

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -21,10 +21,7 @@ PAPEROPT_letter = -D latex_elements.papersize=letterpaper
 ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees $(PAPEROPT_$(PAPER)) -j auto \
                 $(SPHINXOPTS) $(SPHINXERRORHANDLING) . build/$(BUILDER) $(SOURCES)
 
-.PHONY: help build html htmlhelp latex text texinfo epub changes linkcheck \
-	coverage doctest pydoc-topics htmlview clean clean-venv venv dist check serve \
-	autobuild-dev autobuild-dev-html autobuild-stable autobuild-stable-html
-
+.PHONY: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  clean      to remove build files"
@@ -44,6 +41,7 @@ help:
 	@echo "  dist       to create a \"dist\" directory with archived docs for download"
 	@echo "  check      to run a check for frequent markup errors"
 
+.PHONY: build
 build: ensure-venv
 	-mkdir -p build
 # Look first for a Misc/NEWS file (building from a source release tarball
@@ -70,38 +68,46 @@ build: ensure-venv
 	$(SPHINXBUILD) $(ALLSPHINXOPTS)
 	@echo
 
+.PHONY: html
 html: BUILDER = html
 html: build
 	@echo "Build finished. The HTML pages are in build/html."
 
+.PHONY: htmlhelp
 htmlhelp: BUILDER = htmlhelp
 htmlhelp: build
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      "build/htmlhelp/pydoc.hhp project file."
 
+.PHONY: latex
 latex: BUILDER = latex
 latex: build
 	@echo "Build finished; the LaTeX files are in build/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
 	      "run these through (pdf)latex."
 
+.PHONY: text
 text: BUILDER = text
 text: build
 	@echo "Build finished; the text files are in build/text."
 
+.PHONY: texinfo
 texinfo: BUILDER = texinfo
 texinfo: build
 	@echo "Build finished; the python.texi file is in build/texinfo."
 	@echo "Run \`make info' in that directory to run it through makeinfo."
 
+.PHONY: epub
 epub: BUILDER = epub
 epub: build
 	@echo "Build finished; the epub files are in build/epub."
 
+.PHONY: changes
 changes: BUILDER = changes
 changes: build
 	@echo "The overview file is in build/changes."
 
+.PHONY: linkcheck
 linkcheck: BUILDER = linkcheck
 linkcheck:
 	@$(MAKE) build BUILDER=$(BUILDER) || { \
@@ -109,10 +115,12 @@ linkcheck:
 	     "or in build/$(BUILDER)/output.txt"; \
 	false; }
 
+.PHONY: coverage
 coverage: BUILDER = coverage
 coverage: build
 	@echo "Coverage finished; see c.txt and python.txt in build/coverage"
 
+.PHONY: doctest
 doctest: BUILDER = doctest
 doctest:
 	@$(MAKE) build BUILDER=$(BUILDER) || { \
@@ -120,20 +128,25 @@ doctest:
 	     "results in build/doctest/output.txt"; \
 	false; }
 
+.PHONY: pydoc-topics
 pydoc-topics: BUILDER = pydoc-topics
 pydoc-topics: build
 	@echo "Building finished; now run this:" \
 	      "cp build/pydoc-topics/topics.py ../Lib/pydoc_data/topics.py"
 
+.PHONY: htmlview
 htmlview: html
 	$(PYTHON) -c "import os, webbrowser; webbrowser.open('file://' + os.path.realpath('build/html/index.html'))"
 
+.PHONY: clean
 clean: clean-venv
 	-rm -rf build/*
 
+.PHONY: clean-venv
 clean-venv:
 	rm -rf $(VENVDIR)
 
+.PHONY: venv
 venv:
 	@if [ -d $(VENVDIR) ] ; then \
 		echo "venv already exists."; \
@@ -142,6 +155,7 @@ venv:
 		$(MAKE) ensure-venv; \
 	fi
 
+.PHONY: ensure-venv
 ensure-venv:
 	@if [ ! -d $(VENVDIR) ] ; then \
 		$(PYTHON) -m venv $(VENVDIR); \
@@ -150,6 +164,7 @@ ensure-venv:
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi
 
+.PHONY: dist
 dist:
 	rm -rf dist
 	mkdir -p dist
@@ -204,12 +219,14 @@ dist:
 	rm -r dist/python-$(DISTVERSION)-docs-texinfo
 	rm dist/python-$(DISTVERSION)-docs-texinfo.tar
 
+.PHONY: check
 check:
 	# Check the docs and NEWS files with sphinx-lint.
 	# Ignore the tools and venv dirs and check that the default role is not used.
 	$(SPHINXLINT) -i tools -i $(VENVDIR) --enable default-role
 	$(SPHINXLINT) --enable default-role ../Misc/NEWS.d/next/
 
+.PHONY: serve
 serve:
 	@echo "The serve target was removed, use htmlview instead (see bpo-36329)"
 
@@ -221,15 +238,18 @@ serve:
 # output files)
 
 # for development releases: always build
+.PHONY: autobuild-dev
 autobuild-dev:
 	make dist SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1'
 
 # for quick rebuilds (HTML only)
+.PHONY: autobuild-dev-html
 autobuild-dev-html:
 	make html SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1'
 
 # for stable releases: only build if not in pre-release stage (alpha, beta)
 # release candidate downloads are okay, since the stable tree can be in that stage
+.PHONY: autobuild-stable
 autobuild-stable:
 	@case $(DISTVERSION) in *[ab]*) \
 		echo "Not building; $(DISTVERSION) is not a release version."; \
@@ -237,6 +257,7 @@ autobuild-stable:
 	esac
 	@make autobuild-dev
 
+.PHONY: autobuild-stable-html
 autobuild-stable-html:
 	@case $(DISTVERSION) in *[ab]*) \
 		echo "Not building; $(DISTVERSION) is not a release version."; \

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -220,7 +220,7 @@ dist:
 	rm dist/python-$(DISTVERSION)-docs-texinfo.tar
 
 .PHONY: check
-check:
+check: ensure-venv
 	# Check the docs and NEWS files with sphinx-lint.
 	# Ignore the tools and venv dirs and check that the default role is not used.
 	$(SPHINXLINT) -i tools -i $(VENVDIR) --enable default-role

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -6,9 +6,9 @@
 # You can set these variables from the command line.
 PYTHON       = python3
 VENVDIR      = ./venv
-SPHINXBUILD  = PATH=$(VENVDIR)/bin:$$PATH sphinx-build
-SPHINXLINT   = PATH=$(VENVDIR)/bin:$$PATH sphinx-lint
-BLURB        = PATH=$(VENVDIR)/bin:$$PATH blurb
+SPHINXBUILD  = $(VENVDIR)/bin/sphinx-build
+SPHINXLINT   = $(VENVDIR)/bin/sphinx-lint
+BLURB        = $(VENVDIR)/bin/blurb
 PAPER        =
 SOURCES      =
 DISTVERSION  = $(shell $(PYTHON) tools/extensions/patchlevel.py)

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -44,7 +44,7 @@ help:
 	@echo "  dist       to create a \"dist\" directory with archived docs for download"
 	@echo "  check      to run a check for frequent markup errors"
 
-build:
+build: ensure-venv
 	-mkdir -p build
 # Look first for a Misc/NEWS file (building from a source release tarball
 # or old repo) and use that, otherwise look for a Misc/NEWS.d directory
@@ -139,6 +139,11 @@ venv:
 		echo "venv already exists."; \
 		echo "To recreate it, remove it first with \`make clean-venv'."; \
 	else \
+		$(MAKE) ensure-venv; \
+	fi
+
+ensure-venv:
+	@if [ ! -d $(VENVDIR) ] ; then \
 		$(PYTHON) -m venv $(VENVDIR); \
 		$(VENVDIR)/bin/python3 -m pip install -U pip setuptools; \
 		$(VENVDIR)/bin/python3 -m pip install -r requirements.txt; \


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

# Problem

I started getting this error:

```console
$ make -C Doc clean
rm -rf ./venv
rm -rf build/*
$ make -C Doc html
mkdir -p build
Building NEWS from Misc/NEWS.d with blurb
PATH=./venv/bin:$PATH sphinx-build -b html -d build/doctrees  -j auto  -W . build/html
Running Sphinx v5.1.1
making output directory... done

Theme error:
no theme named 'python_docs_theme' found (missing theme.conf?)
make: *** [build] Error 2
```

That's because I have no venv so it can't find the theme.

The problem is we have this, which looks for Sphinx in the venv _or_ `$PATH`:

```makefile
SPHINXBUILD  = PATH=$(VENVDIR)/bin:$$PATH sphinx-build
```

And in my case it's finding it in my `$PATH`, so this guard passes:

https://github.com/python/cpython/blob/b863b9cd4b8681cf5fff5f121837a1039045783f/Doc/Makefile#L55

But I don't get this warning:

https://github.com/python/cpython/blob/b863b9cd4b8681cf5fff5f121837a1039045783f/Doc/Makefile#L65-L66

# Fix

Two things (aka let's do it like the devguide)

1) let's just use the tools in the venv, not `$PATH` (to make the guard fail, and show the warning):

https://github.com/python/devguide/blob/05f6d0c8d09bd757440e0346190dbd62e06c7251/Makefile#L9-L10

2) and add `ensure-venv` target that will install the venv if the `venv` dir is missing (to avoid the warning in the first place):

https://github.com/python/devguide/blob/05f6d0c8d09bd757440e0346190dbd62e06c7251/Makefile#L58-L64

# Bonus

Whilst we're changing `Docs/Makefile`, PR https://github.com/python/cpython/pull/98189 recently fixed some missing `.PHONY` targets. 👍 

I expect missing `.PHONY` targets will happen again, because it's normal to copy/paste a target, and forget (or not know) to update the long `.PHONY` line right at the top.

Let's do as @zware suggested and define them right next to each target: https://github.com/python/cpython/pull/98189#issuecomment-1276664528

We do this at [Pillow](https://github.com/python-pillow/Pillow/blob/main/Makefile) and at work, it helps a lot. (I'll add it to the devguide and PEPs too.)
