### PR TITLE
gh-96035: [urllib] Enforce that URL port numbers be digit strings

### DIFF
--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -1137,7 +1137,7 @@ def _splitnport(host, defport=-1):
     host, delim, port = host.rpartition(':')
     if not delim:
         host = port
-    elif port:
+    elif port.isdigit():
         try:
             nport = int(port)
         except ValueError:


### PR DESCRIPTION
# gh-96035: [urllib] Enforce that URL port numbers be digit strings

urllib.parse.urlparse currently parses port numbers with `int`, which accepts a lot more than just digit strings. (e.g. `_` between digits, whitespace at the beginning and end, a `'+'` or `'-'` sign in the appropriate place)

This PR adds a check that `port.isdigit()` in the appropriate place, so only digit strings can be accepted as port numbers, as specified in RFC 3986.