### PR TITLE
pythongh-96035: Make urllib.parse.urlparse reject non-numeric ports

### DIFF
--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -167,6 +167,8 @@ class _NetlocResultMixinBase(object):
     def port(self):
         port = self._hostinfo[1]
         if port is not None:
+            if not isdigit(port):
+                raise ValueError(f"Port {port!r} contains non-numeric character(s)")
             try:
                 port = int(port, 10)
             except ValueError:
@@ -1138,6 +1140,8 @@ def _splitnport(host, defport=-1):
     if not delim:
         host = port
     elif port:
+        if not isdigit(port):
+            raise ValueError(f"Port {port!r} contains non-numeric character(s)")
         try:
             nport = int(port)
         except ValueError:

--- a/Misc/NEWS.d/next/Library/2022-10-14-19-57-37.gh-issue-96035.0xcX-p.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-14-19-57-37.gh-issue-96035.0xcX-p.rst
@@ -1,0 +1,3 @@
+Fixes bug in urllib.parse.urlparse that causes certain port numbers
+containing whitespace, underscores, or plus and minus signs to be
+incorrectly accepted.


### PR DESCRIPTION
urllib.parse.urlparse uses `int` to parse port numbers, which means they can contain '+', '-', '_', and whitespace. This patch adds a check that ensures that only numeric port numbers parse without error.

<!-- gh-issue-number: gh-96035 -->
* Issue: gh-96035
<!-- /gh-issue-number -->
