### PR TITLE
gh-95913: Copyedit & xref FrameInfo in Whatsnew inspect section

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -434,8 +434,10 @@ attributes:
 
    Return ``True`` if the type of object is a :class:`~types.MethodWrapperType`.
 
-   These are instances of :class:`~types.MethodWrapperType`, such as :meth:`~object().__str__`,
-   :meth:`~object().__eq__` and :meth:`~object().__repr__`
+   These are instances of :class:`~types.MethodWrapperType`, such as :meth:`~object.__str__`,
+   :meth:`~object.__eq__` and :meth:`~object.__repr__`.
+
+   .. versionadded:: 3.11
 
 
 .. function:: isroutine(object)

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -1206,12 +1206,13 @@ is considered deprecated and may be removed in the future.
       number, start column offset, and end column offset associated with the
       instruction being executed by the frame this record corresponds to.
 
-.. versionchanged:: 3.5
-   Return a named tuple instead of a tuple.
+   .. versionchanged:: 3.5
+      Return a :term:`named tuple` instead of a :class:`tuple`.
 
-.. versionchanged:: 3.11
-   Changed the return object from a named tuple to a regular object (that is
-   backwards compatible with the previous named tuple).
+   .. versionchanged:: 3.11
+      :class:`!FrameInfo` is now a class instance
+      (that is backwards compatible with the previous :term:`named tuple`).
+
 
 .. class:: Traceback
 
@@ -1244,6 +1245,11 @@ is considered deprecated and may be removed in the future.
       line number, start column offset, and end column offset associated with
       the instruction being executed by the frame this traceback corresponds
       to.
+
+   .. versionchanged:: 3.11
+      :class:`!Traceback` is now a class instance
+      (that is backwards compatible with the previous :term:`named tuple`).
+
 
 .. note::
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -744,8 +744,9 @@ inspect
   (Contributed by Hakan Çelik in :issue:`29418`.)
 
 * Change the frame-related functions in the :mod:`inspect` module to return a
-  regular object (that is backwards compatible with the old tuple-like
-  interface) that include the extended :pep:`657` position information (end
+  :class:`~inspect.FrameInfo` instance
+  (backwards compatible with the old :func:`~collections.namedtuple`-like
+  interface) that includes the extended :pep:`657` position information (end
   line number, column and end column). The affected functions are:
 
   * :func:`inspect.getframeinfo`

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -729,22 +729,32 @@ IDLE and idlelib
 * Include prompts when saving Shell with inputs and outputs.
   (Contributed by Terry Jan Reedy in :gh:`95191`.)
 
+
+.. _whatsnew311-inspect:
+
 inspect
 -------
-* Add :func:`inspect.getmembers_static`: return all members without
+
+* Add :func:`~inspect.getmembers_static` to return all members without
   triggering dynamic lookup via the descriptor protocol. (Contributed by
   Weipeng Hong in :issue:`30533`.)
 
-* Add :func:`inspect.ismethodwrapper` for checking if the type of an object is a
-  :class:`~types.MethodWrapperType`. (Contributed by Hakan Çelik in :issue:`29418`.)
+* Add :func:`~inspect.ismethodwrapper`
+  for checking if the type of an object is a :class:`~types.MethodWrapperType`.
+  (Contributed by Hakan Çelik in :issue:`29418`.)
 
 * Change the frame-related functions in the :mod:`inspect` module to return a
   regular object (that is backwards compatible with the old tuple-like
   interface) that include the extended :pep:`657` position information (end
   line number, column and end column). The affected functions are:
-  :func:`inspect.getframeinfo`, :func:`inspect.getouterframes`, :func:`inspect.getinnerframes`,
-  :func:`inspect.stack` and :func:`inspect.trace`. (Contributed by Pablo Galindo in
-  :gh:`88116`.)
+
+  * :func:`inspect.getframeinfo`
+  * :func:`inspect.getouterframes`
+  * :func:`inspect.getinnerframes`,
+  * :func:`inspect.stack`
+  * :func:`inspect.trace`
+
+  (Contributed by Pablo Galindo in :gh:`88116`.)
 
 locale
 ------

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -743,10 +743,10 @@ inspect
   for checking if the type of an object is a :class:`~types.MethodWrapperType`.
   (Contributed by Hakan Çelik in :issue:`29418`.)
 
-* Change the frame-related functions in the :mod:`inspect` module to return a
-  :class:`~inspect.FrameInfo` instance
-  (backwards compatible with the old :func:`~collections.namedtuple`-like
-  interface) that includes the extended :pep:`657` position information (end
+* Change the frame-related functions in the :mod:`inspect` module to return new
+  :class:`~inspect.FrameInfo` and :class:`~inspect.Traceback` class instances
+  (backwards compatible with the previous :term:`named tuple`-like interfaces)
+  that includes the extended :pep:`657` position information (end
   line number, column and end column). The affected functions are:
 
   * :func:`inspect.getframeinfo`


### PR DESCRIPTION
Part of #95913 

This applies the standard copyediting and formatting to the `inspect` section in the Python 3.11 What's New, as well as explicitly mentions/references the new `inspect.FrameInfo` objects. Specifically:

* Explicitly name and link the new `FrameInfo`/`Traceback` class instances returned by various `inspect` functions and what it replaces (a namedtuple-like object)
* Break prose list of functions into bulleted list for readability
* Don't show redundant module name in `inspect` module APIs
* Other small Sphinx/textual tweaks

Also, it makes a couple directly related fixes in the `inspect` module library documentation:

* Add missing "Changed in 3.11" annotation to `inspect.Traceback`
* Fix indent and wording of that under `inspect.FrameInfo`
* Add missing "New in 3.11" annotation to `inspect.ismethodwrapper` mentioned in What's New, and fix broken cross-references within due to bad Sphinx syntax

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
