### PR TITLE
gh-95913 Add string section to Whatsnew with new Template methods

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -872,6 +872,18 @@ sqlite3
   (Contributed by Aviv Palivoda and Erlend E. Aasland in :issue:`24905`.)
 
 
+.. _whatsnew311-string:
+
+string
+------
+
+* Add :meth:`~string.Template.get_identifiers`
+  and :meth:`~string.Template.is_valid` to :class:`string.Template`,
+  which respectively return all valid placeholders,
+  and whether any invalid placeholders are present.
+  (Contributed by Ben Kehoe in :gh:`90465`.)
+
+
 sys
 ---
 


### PR DESCRIPTION
Part of #95913 . As discussed there, two new methods were added to [string.Template](https://docs.python.org/3.11/library/string.html?highlight=template%20is_valid#template-strings) for 3.11 in issue #90465 / PR #30493 , but were not added to What's New. This PR does just that.

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
