### PR TITLE
gh-95913: Add io support for SpooledTemporaryFile in Whatsnew

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -911,7 +911,7 @@ sysconfig
 tempfile
 --------
 
-* :class:`~tempfile.SpooledTemporaryFile` now fully implements the methods
+* :class:`~tempfile.SpooledTemporaryFile` objects now fully implements the methods
   of :class:`io.BufferedIOBase` or :class:`io.TextIOBase`
   (depending on file mode).
   This lets them work correctly with APIs that expect file-like objects,

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -906,6 +906,18 @@ sysconfig
   (Contributed by Miro Hrončok in :issue:`45413`.)
 
 
+.. _whatsnew311-tempfile:
+
+tempfile
+--------
+
+* :class:`~tempfile.SpooledTemporaryFile` now fully implements the methods
+  of the :class:`io.BufferedIOBase`/:class:`io.TextIOBase` base classes.
+  This lets them work correctly with APIs that expect file-like objects,
+  such as compression modules.
+  (Contributed by Carey Metcalfe in :gh:`70363`.)
+
+
 threading
 ---------
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -912,7 +912,8 @@ tempfile
 --------
 
 * :class:`~tempfile.SpooledTemporaryFile` now fully implements the methods
-  of the :class:`io.BufferedIOBase`/:class:`io.TextIOBase` base classes.
+  of :class:`io.BufferedIOBase` or :class:`io.TextIOBase`
+  (depending on file mode).
   This lets them work correctly with APIs that expect file-like objects,
   such as compression modules.
   (Contributed by Carey Metcalfe in :gh:`70363`.)


### PR DESCRIPTION
Part of #95913 

Adds a section for `tempfile` to the 3.11 What's New, mentioning that `tempfile.SpooledTemporaryFIle` now supports the full range of IO base class methods, as added in issue #70363 / PR #29560 .

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
