### PR TITLE
gh-97527: IDLE - fix buggy macosx patch

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -4,6 +4,11 @@ Released on 2022-10-03
 =========================
 
 
+gh-97527: Fix a bug in the previous bugfix that caused IDLE to not
+start when run with 3.10.8, 3.12.0a1, and at least Microsoft Python
+3.10.2288.0 installed without the Lib/test package.  3.11.0 was never
+affected.
+
 gh-65802: Document handling of extensions in Save As dialogs.
 
 gh-95191: Include prompts when saving Shell (interactive input/output).

--- a/Misc/NEWS.d/next/IDLE/2022-10-15-21-20-40.gh-issue-97527.otAHJM.rst
+++ b/Misc/NEWS.d/next/IDLE/2022-10-15-21-20-40.gh-issue-97527.otAHJM.rst
@@ -1,0 +1,3 @@
+Fix a bug in the previous bugfix that caused IDLE to not start when run with
+3.10.8, 3.12.0a1, and at least Microsoft Python 3.10.2288.0 installed
+without the Lib/test package.  3.11.0 was never affected.


### PR DESCRIPTION
#97530 fixed IDLE tests possibly crashing on a Mac without a GUI. But it resulted in IDLE not starting in 3.10.8, 3.12.0a1, and Microsoft Python 3.10.2288.0 when test/* is not installed. After this patch, test.* is only imported when testing on Mac.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97527 -->
* Issue: gh-97527
<!-- /gh-issue-number -->
