### PR TITLE
gh-95913: Edit zipfile Whatsnew section & add new APIs

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1071,6 +1071,10 @@ zipfile
 * Added support for specifying member name encoding for reading metadata
   in a :class:`~zipfile.ZipFile`'s directory and file headers.
   (Contributed by Stephen J. Turnbull and Serhiy Storchaka in :issue:`28080`.)
+* Added :meth:`ZipFile.mkdir <zipfile.ZipFile.mkdir>`
+  for creating new directories inside ZIP archives.
+  (Contributed by Sam Ezeh in :gh:`49083`.)
+
 
 fcntl
 -----

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1071,9 +1071,11 @@ zipfile
 * Added support for specifying member name encoding for reading metadata
   in a :class:`~zipfile.ZipFile`'s directory and file headers.
   (Contributed by Stephen J. Turnbull and Serhiy Storchaka in :issue:`28080`.)
+
 * Added :meth:`ZipFile.mkdir() <zipfile.ZipFile.mkdir>`
   for creating new directories inside ZIP archives.
   (Contributed by Sam Ezeh in :gh:`49083`.)
+
 * Added :attr:`~zipfile.Path.stem`, :attr:`~zipfile.Path.suffix`
   and :attr:`~zipfile.Path.suffixes` to :class:`zipfile.Path`.
   (Contributed by Miguel Brito in :gh:`88261`.)

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1071,9 +1071,12 @@ zipfile
 * Added support for specifying member name encoding for reading metadata
   in a :class:`~zipfile.ZipFile`'s directory and file headers.
   (Contributed by Stephen J. Turnbull and Serhiy Storchaka in :issue:`28080`.)
-* Added :meth:`ZipFile.mkdir <zipfile.ZipFile.mkdir>`
+* Added :meth:`ZipFile.mkdir() <zipfile.ZipFile.mkdir>`
   for creating new directories inside ZIP archives.
   (Contributed by Sam Ezeh in :gh:`49083`.)
+* Added :attr:`~zipfile.Path.stem`, :attr:`~zipfile.Path.suffix`
+  and :attr:`~zipfile.Path.suffixes` to :class:`zipfile.Path`.
+  (Contributed by Miguel Brito in :gh:`88261`.)
 
 
 fcntl

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1062,11 +1062,14 @@ warnings
   providing a more concise way to locally ignore warnings or convert them to errors.
   (Contributed by Zac Hatfield-Dodds in :issue:`47074`.)
 
+
+.. _whatsnew311-zipfile:
+
 zipfile
 -------
 
-* Added support for specifying member name encoding for reading
-  metadata in the zipfile's directory and file headers.
+* Added support for specifying member name encoding for reading metadata
+  in a :class:`~zipfile.ZipFile`'s directory and file headers.
   (Contributed by Stephen J. Turnbull and Serhiy Storchaka in :issue:`28080`.)
 
 fcntl


### PR DESCRIPTION
Part of #95913 

Performs basic editing and formatting on the existing `zipfile` section of the Python 3.11 What's New document, and adds two new items:

* `ZipFile.mkdir` added in issue #49083 / PR #32160
* `zipfile.Path` attributes `stem`, `suffix` and `suffixes`, added in issue #88261 / PR #26129

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
