### PR TITLE
gh-95914: Add What's New item describing PEP 670 changes

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1884,16 +1884,16 @@ New Features
 Porting to Python 3.11
 ----------------------
 
-* Many macros have been converted to functions in the Python C API,
-  making them usable from other programming languages and avoiding
-  `macro pitfalls <https://gcc.gnu.org/onlinedocs/cpp/Macro-Pitfalls.html>`_
+* Some macros have been converted to static inline functions to avoid
+  `macro pitfalls <https://gcc.gnu.org/onlinedocs/cpp/Macro-Pitfalls.html>`_.
   The change should be mostly transparent to users,
   as the replacement functions will cast their arguments to the expected types
   to avoid compiler warnings due to static type checks.
-  However, when the limited C API is set to >=3.11, these casts are not done,
-  and callers will need to cast arguments to their expected values.
+  However, when the limited C API is set to >=3.11,
+  these casts are not done,
+  and callers will need to cast arguments to their expected types.
   See :pep:`670` for more details.
-  (Contributed by Victor Stinner in :gh:`89653`.)
+  (Contributed by Victor Stinner and Erlend E. Aasland in :gh:`89653`.)
 
 * :c:func:`PyErr_SetExcInfo()` no longer uses the ``type`` and ``traceback``
   arguments, the interpreter now derives those values from the exception

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1884,6 +1884,17 @@ New Features
 Porting to Python 3.11
 ----------------------
 
+* Many macros have been converted to functions in the Python C API,
+  making them usable from other programming languages and avoiding
+  `macro pitfalls <https://gcc.gnu.org/onlinedocs/cpp/Macro-Pitfalls.html>`_
+  The change should be mostly transparent to users,
+  as the replacement functions will cast their arguments to the expected types
+  to avoid compiler warnings due to static type checks.
+  However, when the limited C API is set to >=3.11, these casts are not done,
+  and callers will need to cast arguments to their expected values.
+  See :pep:`670` for more details.
+  (Contributed by Victor Stinner in :gh:`89653`.)
+
 * :c:func:`PyErr_SetExcInfo()` no longer uses the ``type`` and ``traceback``
   arguments, the interpreter now derives those values from the exception
   instance (the ``value`` argument). The function still steals references


### PR DESCRIPTION
Part of #95914 (and in turn, #95913).

As discussed with @erlend-aasland , adds an item to the C API -> Porting section of the Python 3.11 What's New document summarizing the changes proposed in PEP 670 (PEP-670), *Converting macros to functions in the Python C API*, and implemented by @vstinner in issue #89653 (and many linked PRs) and their impact on users. This is the last chunk needed before I can link every Summary item with a more detailed What's New entry, and then #95914 will finally be complete.

<!-- gh-issue-number: gh-95914 -->
* Issue: gh-95914
<!-- /gh-issue-number -->
