### PR TITLE
gh-98174: Handle EPROTOTYPE under macOS in test_sendfile_fallback_close_peer_in_the_middle_of_receiving

### DIFF
--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -1,6 +1,7 @@
 """Tests for sendfile functionality."""
 
 import asyncio
+import errno
 import os
 import socket
 import sys
@@ -484,8 +485,17 @@ class SendfileMixin(SendfileBase):
 
         srv_proto, cli_proto = self.prepare_sendfile(close_after=1024)
         with self.assertRaises(ConnectionError):
-            self.run_loop(
-                self.loop.sendfile(cli_proto.transport, self.file))
+            try:
+                self.run_loop(
+                    self.loop.sendfile(cli_proto.transport, self.file))
+            except OSError as e:
+                # macOS may raise OSError of EPROTOTYPE when writing to a
+                # socket that is in the process of closing down.
+                if e.errno == errno.EPROTOTYPE and sys.platform == "darwin":
+                    raise ConnectionError from e
+                else:
+                    raise
+
         self.run_loop(srv_proto.done)
 
         self.assertTrue(1024 <= srv_proto.nbytes < len(self.DATA),

--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -492,7 +492,7 @@ class SendfileMixin(SendfileBase):
                 # macOS may raise OSError of EPROTOTYPE when writing to a
                 # socket that is in the process of closing down.
                 if e.errno == errno.EPROTOTYPE and sys.platform == "darwin":
-                    raise ConnectionError from e
+                    raise ConnectionError
                 else:
                     raise
 

--- a/Misc/NEWS.d/next/Tests/2022-10-16-06-42-01.gh-issue-98174.msZY0C.rst
+++ b/Misc/NEWS.d/next/Tests/2022-10-16-06-42-01.gh-issue-98174.msZY0C.rst
@@ -1,0 +1,1 @@
+Update test case `test_sendfile_fallback_close_peer_in_the_middle_of_receiving` to handle `OSError` of `EPROTOTYPE` on macOS.

--- a/Misc/NEWS.d/next/Tests/2022-10-16-06-42-01.gh-issue-98174.msZY0C.rst
+++ b/Misc/NEWS.d/next/Tests/2022-10-16-06-42-01.gh-issue-98174.msZY0C.rst
@@ -1,1 +1,0 @@
-Update test case `test_sendfile_fallback_close_peer_in_the_middle_of_receiving` to handle `OSError` of `EPROTOTYPE` on macOS.


### PR DESCRIPTION
macOS may raise `OSError` of `EPROTOTYPE` when writing to a socket that is in the middle of closing down. See also http://erickt.github.io/blog/2014/11/19/adventures-in-debugging-a-potential-osx-kernel-bug/

This PR updates the test case `test_sendfile_fallback_close_peer_in_the_middle_of_receiving` to handle this possibility in addition to `ConnectionError`.

<!-- gh-issue-number: gh-98174 -->
* Issue: gh-98174
<!-- /gh-issue-number -->
