### PR TITLE
gh-95913: Add WhatsNew section for new logging APIs

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -763,6 +763,7 @@ logging
   to return a mapping from logging level names (e.g. ``'CRITICAL'``)
   to the values of their corresponding :ref:`levels` (e.g. ``50``, by default).
   (Contributed by Andrei Kulakovin in :gh:`88024`.)
+
 * Added a :meth:`~logging.handlers.SysLogHandler.createSocket` method
   to :class:`~logging.handlers.SysLogHandler`, to match
   :meth:`SocketHandler.createSocket()

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -753,6 +753,18 @@ locale
   ``locale.getpreferredencoding(False)`` but ignores the
   :ref:`Python UTF-8 Mode <utf8-mode>`.
 
+
+.. _whatsnew311-logging:
+
+logging
+-------
+
+* Added :func:`~logging.getLevelNamesMapping`
+  to return a mapping from logging level names (e.g. ``'CRITICAL'``)
+  to the values of their corresponding :ref:`levels` (e.g. ``50``, by default).
+  (Contributed by Andrei Kulakovin in :gh:`88024`.)
+
+
 math
 ----
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -763,6 +763,13 @@ logging
   to return a mapping from logging level names (e.g. ``'CRITICAL'``)
   to the values of their corresponding :ref:`levels` (e.g. ``50``, by default).
   (Contributed by Andrei Kulakovin in :gh:`88024`.)
+* Added a :meth:`~logging.handlers.SysLogHandler.createSocket` method
+  to :class:`~logging.handlers.SysLogHandler`, to match
+  :meth:`SocketHandler.createSocket()
+  <logging.handlers.SocketHandler.createSocket>`.
+  It is called automatically during handler initialization
+  and when emitting an event, if there is no active socket.
+  (Contributed by Kirill Pinchuk in :gh:`88457`.)
 
 
 math


### PR DESCRIPTION
Part of #95913 and discussed in/related to #98307 .

This PR adds the following to a new Python 3.11 What's New section for the `logging` module:

* The new `logging.getLevelNamesMapping` function mapping level names to their values, added in issue #88024 / PR #26459
* The new `logging.handlers.SysLogHandler.createSocket` method (with preliminary text), added in issue #88457 / PR #26490

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
