### PR TITLE
gh-95913: Prepare remaining Whatsnew sections for editing

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1565,15 +1565,17 @@ Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
   (Contributed by Serhiy Storchaka and Miro Hrončok in :gh:`92728`.)
 
 
-.. _whatsnew311-pending-removal-312:
+.. _whatsnew311-pending-removal:
+.. _whatsnew311-python-api-pending-removal:
 
 Pending Removal in Python 3.12
 ==============================
 
-The following APIs have been deprecated in earlier Python releases,
+The following Python APIs have been deprecated in earlier Python releases,
 and will be removed in Python 3.12.
 
-Python API:
+C APIs pending removal are
+:ref:`listed separately <whatsnew311-c-api-pending-removal>`.
 
 * :class:`pkgutil.ImpImporter`
 * :class:`pkgutil.ImpLoader`
@@ -1601,25 +1603,6 @@ Python API:
 * :func:`cgi.log`
 * :func:`sqlite3.OptimizedUnicode`
 * :func:`sqlite3.enable_shared_cache`
-
-C API:
-
-* :c:func:`PyUnicode_AS_DATA`
-* :c:func:`PyUnicode_AS_UNICODE`
-* :c:func:`PyUnicode_AsUnicodeAndSize`
-* :c:func:`PyUnicode_AsUnicode`
-* :c:func:`PyUnicode_FromUnicode`
-* :c:func:`PyUnicode_GET_DATA_SIZE`
-* :c:func:`PyUnicode_GET_SIZE`
-* :c:func:`PyUnicode_GetSize`
-* :c:func:`PyUnicode_IS_COMPACT`
-* :c:func:`PyUnicode_IS_READY`
-* :c:func:`PyUnicode_READY`
-* :c:func:`Py_UNICODE_WSTR_LENGTH`
-* :c:func:`_PyUnicode_AsUnicode`
-* :c:macro:`PyUnicode_WCHAR_KIND`
-* :c:type:`PyUnicodeObject`
-* :c:func:`PyUnicode_InternImmortal()`
 
 
 .. _whatsnew311-removed:
@@ -2256,6 +2239,32 @@ Deprecated
 
 * Deprecate the ``ob_shash`` member of the :c:type:`PyBytesObject`. Use :c:func:`PyObject_Hash` instead.
   (Contributed by Inada Naoki in :issue:`46864`.)
+
+
+.. _whatsnew311-c-api-pending-removal:
+
+Pending Removal in Python 3.12
+------------------------------
+
+The following C APIs have been deprecated in earlier Python releases,
+and will be removed in Python 3.12.
+
+* :c:func:`PyUnicode_AS_DATA`
+* :c:func:`PyUnicode_AS_UNICODE`
+* :c:func:`PyUnicode_AsUnicodeAndSize`
+* :c:func:`PyUnicode_AsUnicode`
+* :c:func:`PyUnicode_FromUnicode`
+* :c:func:`PyUnicode_GET_DATA_SIZE`
+* :c:func:`PyUnicode_GET_SIZE`
+* :c:func:`PyUnicode_GetSize`
+* :c:func:`PyUnicode_IS_COMPACT`
+* :c:func:`PyUnicode_IS_READY`
+* :c:func:`PyUnicode_READY`
+* :c:func:`Py_UNICODE_WSTR_LENGTH`
+* :c:func:`_PyUnicode_AsUnicode`
+* :c:macro:`PyUnicode_WCHAR_KIND`
+* :c:type:`PyUnicodeObject`
+* :c:func:`PyUnicode_InternImmortal()`
 
 
 .. _whatsnew311-c-api-removed:

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1418,9 +1418,14 @@ CPython bytecode changes
 
 
 .. _whatsnew311-deprecated:
+.. _whatsnew311-python-api-deprecated:
 
 Deprecated
 ==========
+
+This section lists Python APIs that have been deprecated in Python 3.11.
+
+Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
 
 * Chaining :class:`classmethod` descriptors (introduced in :issue:`19072`)
   is now deprecated.  It can no longer be used to wrap other descriptors
@@ -1618,9 +1623,14 @@ C API:
 
 
 .. _whatsnew311-removed:
+.. _whatsnew311-python-api-removed:
 
 Removed
 =======
+
+This section lists Python APIs that have been removed in Python 3.12.
+
+Removed C APIs are :ref:`listed separately <whatsnew311-c-api-removed>`.
 
 * :class:`smtpd.MailmanProxy` is now removed as it is unusable without
   an external module, ``mailman``. (Contributed by Dong-hee Na in :issue:`35800`.)
@@ -1712,18 +1722,16 @@ Removed
 
 
 .. _whatsnew311-porting:
+.. _whatsnew311-python-api-porting:
 
 Porting to Python 3.11
 ======================
 
 This section lists previously described changes and other bugfixes
-that may require changes to your code.
+in the Python API that may require changes to your Python code.
 
-
-.. _whatsnew311-porting-python-api:
-
-Changes in the Python API
--------------------------
+Porting notes for the C API are
+:ref:`listed separately <whatsnew311-c-api-porting>`.
 
 * Prohibited passing non-:class:`concurrent.futures.ThreadPoolExecutor`
   executors to :meth:`loop.set_default_executor` following a deprecation in

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1136,7 +1136,7 @@ Faster Startup
 .. _whatsnew311-faster-imports:
 
 Frozen imports / Static code objects
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Python caches bytecode in the :ref:`__pycache__<tut-pycache>` directory to
 speed up module loading.
@@ -1169,7 +1169,7 @@ Faster Runtime
 .. _whatsnew311-lazy-python-frames:
 
 Cheaper, lazy Python frames
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Python frames are created whenever Python calls a Python function. This frame
 holds execution information. The following are new frame optimizations:
@@ -1192,7 +1192,7 @@ up significantly. We measured a 3-7% speedup in pyperformance.
 .. _whatsnew311-inline-calls:
 
 Inlined Python function calls
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 During a Python function call, Python will call an evaluating C function to
 interpret that function's code. This effectively limits pure Python recursion to
@@ -1214,7 +1214,7 @@ We measured a 1-3% improvement in pyperformance.
 .. _whatsnew311-pep659:
 
 PEP 659: Specializing Adaptive Interpreter
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :pep:`659` is one of the key parts of the faster CPython project. The general
 idea is that while Python is a dynamic language, most code has regions where

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -545,6 +545,8 @@ New Modules
   (Contributed by Sebastian Rittau in :issue:`42012`.)
 
 
+.. _whatsnew311-improved-modules:
+
 Improved Modules
 ================
 
@@ -1077,6 +1079,8 @@ fcntl
   the ``FD_CLOEXEC`` flag in addition.
 
 
+.. _whatsnew311-optimizations:
+
 Optimizations
 =============
 
@@ -1109,6 +1113,8 @@ Optimizations
   faster than Python 3.10.
 
 
+.. _whatsnew311-faster-cpython:
+
 Faster CPython
 ==============
 
@@ -1121,8 +1127,13 @@ could be up to 10-60% faster.
 This project focuses on two major areas in Python: faster startup and faster
 runtime. Other optimizations not under this project are listed in `Optimizations`_.
 
+
+.. _whatsnew311-faster-startup:
+
 Faster Startup
 --------------
+
+.. _whatsnew311-faster-imports:
 
 Frozen imports / Static code objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1150,11 +1161,16 @@ impact for short-running programs using Python.
 (Contributed by Eric Snow, Guido van Rossum and Kumar Aditya in numerous issues.)
 
 
+.. _whatsnew311-faster-runtime:
+
 Faster Runtime
 --------------
 
+.. _whatsnew311-lazy-python-frames:
+
 Cheaper, lazy Python frames
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Python frames are created whenever Python calls a Python function. This frame
 holds execution information. The following are new frame optimizations:
 
@@ -1171,10 +1187,13 @@ up significantly. We measured a 3-7% speedup in pyperformance.
 
 (Contributed by Mark Shannon in :issue:`44590`.)
 
+
 .. _inline-calls:
+.. _whatsnew311-inline-calls:
 
 Inlined Python function calls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 During a Python function call, Python will call an evaluating C function to
 interpret that function's code. This effectively limits pure Python recursion to
 what's safe for the C stack.
@@ -1191,8 +1210,12 @@ We measured a 1-3% improvement in pyperformance.
 
 (Contributed by Pablo Galindo and Mark Shannon in :issue:`45256`.)
 
+
+.. _whatsnew311-pep659:
+
 PEP 659: Specializing Adaptive Interpreter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 :pep:`659` is one of the key parts of the faster CPython project. The general
 idea is that while Python is a dynamic language, most code has regions where
 objects and types rarely change. This concept is known as *type stability*.
@@ -1274,6 +1297,8 @@ Bucher, with additional help from Irit Katriel and Dennis Sweeney.)
        be sped up by :issue:`45947`.
 
 
+.. _whatsnew311-faster-cpython-misc:
+
 Misc
 ----
 
@@ -1284,6 +1309,9 @@ Misc
 * A more concise representation of exceptions in the interpreter reduced the
   time required for catching an exception by about 10%.
   (Contributed by Irit Katriel in :issue:`45711`.)
+
+
+.. _whatsnew311-faster-cpython-faq:
 
 FAQ
 ---
@@ -1319,6 +1347,8 @@ FAQ
 | A: No. We're still exploring other optimizations.
 
 
+.. _whatsnew311-faster-cpython-about:
+
 About
 -----
 
@@ -1327,6 +1357,8 @@ funded by Microsoft to work on this full-time. Pablo Galindo Salgado is also
 funded by Bloomberg LP to work on the project part-time. Finally, many
 contributors are volunteers from the community.
 
+
+.. _whatsnew311-bytecode-changes:
 
 CPython bytecode changes
 ========================
@@ -1383,6 +1415,9 @@ CPython bytecode changes
 
 * :opcode:`RESUME` has been added. It is a no-op. Performs internal tracing,
   debugging and optimization checks.
+
+
+.. _whatsnew311-deprecated:
 
 Deprecated
 ==========
@@ -1525,6 +1560,8 @@ Deprecated
   (Contributed by Serhiy Storchaka and Miro Hrončok in :gh:`92728`.)
 
 
+.. _whatsnew311-pending-removal-312:
+
 Pending Removal in Python 3.12
 ==============================
 
@@ -1579,6 +1616,8 @@ C API:
 * :c:type:`PyUnicodeObject`
 * :c:func:`PyUnicode_InternImmortal()`
 
+
+.. _whatsnew311-removed:
 
 Removed
 =======
@@ -1671,12 +1710,17 @@ Removed
   of ``Tools/scripts`` and is `being developed independently
   <https://gitlab.com/warsaw/pynche/-/tree/main>`_ from the Python source tree.
 
+
+.. _whatsnew311-porting:
+
 Porting to Python 3.11
 ======================
 
 This section lists previously described changes and other bugfixes
 that may require changes to your code.
 
+
+.. _whatsnew311-porting-python-api:
 
 Changes in the Python API
 -------------------------
@@ -1727,6 +1771,9 @@ Changes in the Python API
   It can be set to describe C extension clases to the VM, but should be regarded
   as meaningless when read. To get the pointer to the object's dictionary call
   :c:func:`PyObject_GenericGetDict` instead.
+
+
+.. _whatsnew311-build-changes:
 
 Build Changes
 =============
@@ -1815,8 +1862,12 @@ Build Changes
   (Contributed by Serhiy Storchaka in :issue:`46996`.)
 
 
+.. _whatsnew311-c-api:
+
 C API Changes
 =============
+
+.. _whatsnew311-c-api-new-features:
 
 New Features
 ------------
@@ -1880,6 +1931,9 @@ New Features
 
 * Added the :c:member:`PyConfig.safe_path` member.
   (Contributed by Victor Stinner in :gh:`57684`.)
+
+
+.. _whatsnew311-c-api-porting:
 
 Porting to Python 3.11
 ----------------------
@@ -2167,6 +2221,9 @@ Porting to Python 3.11
   paths and then modify them, finish initialization and use :c:func:`PySys_GetObject`
   to retrieve :data:`sys.path` as a Python list object and modify it directly.
 
+
+.. _whatsnew311-c-api-deprecated:
+
 Deprecated
 ----------
 
@@ -2191,6 +2248,9 @@ Deprecated
 
 * Deprecate the ``ob_shash`` member of the :c:type:`PyBytesObject`. Use :c:func:`PyObject_Hash` instead.
   (Contributed by Inada Naoki in :issue:`46864`.)
+
+
+.. _whatsnew311-c-api-removed:
 
 Removed
 -------


### PR DESCRIPTION
Part of #95913

To ensure PRs to edit the remaining sections can all be submitted in parallel and don't introduce any merge conflicts with each other, this preliminary PR (which can hopefully be merged quickly) ensures there are two line breaks between each section (per standard convention), and adds the same standard ref target labels to each section as the previous to enable stable cross-referencing.

To note, this PR does _not_ do so for any of the ``Improved Modules`` subsections, which will be done in a separate PR once the current batch of PRs adding/editing those are merged, so the rest can safely proceed in parallel without conflicts.

Additionally, it makes a few other straightforward but cross-cutting changes:

* Elide the redundant "Python API changes" subsection heading in the Porting section, given all the C API changes are discussed under the C API section
* Move the list of C APIs pending deprecation from the top-level Pending Removal section to a subsection of the C API section, to match all the others (Deprecated/Removed/Porting), and mention/link it accordingly
* Explicitly clarify that the top-level Deprecated/Pending Removal/Removed/Porting-section changes are referring to the Python API, and link the C API equivalents
* Use the standard H4 heading underbar symbols as [stated in the devguide](https://devguide.python.org/documentation/markup/#sections)

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
