### PR TITLE
`_overload_dummy` raises `NotImplementedError`, not `RuntimeError`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4398,7 +4398,7 @@ class MethodHolder:
 class OverloadTests(BaseTestCase):
 
     def test_overload_fails(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(NotImplementedError):
 
             @overload
             def blah():


### PR DESCRIPTION
Source: https://github.com/python/cpython/blob/eae7dad40255bad42e4abce53ff8143dcbc66af5/Lib/typing.py#L2536-L2542
I've found this while looking for implicit abstract classes / methods in CPython.

Test was checking for `RuntimeError`, it is technically correct:

```python
>>> NotImplementedError.__mro__
(<class 'NotImplementedError'>, <class 'RuntimeError'>, <class 'Exception'>, <class 'BaseException'>, <class 'object'>)
```

But, we can be more precise. It is a good thing.
I am going to skip creating an issue for this, it is like a typo-fix :)
