### PR TITLE
Remove unused arrange_output_buffer function from zlibmodule.c.

### DIFF
--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -1440,22 +1440,6 @@ arrange_output_buffer_with_maximum(uint32_t *avail_out,
     return length;
 }
 
-static inline Py_ssize_t
-arrange_output_buffer(uint32_t *avail_out,
-                      uint8_t **next_out,
-                      PyObject **buffer,
-                      Py_ssize_t length)
-{
-    Py_ssize_t ret;
-
-    ret = arrange_output_buffer_with_maximum(avail_out, next_out, buffer,
-                                             length,
-                                             PY_SSIZE_T_MAX);
-    if (ret == -2)
-        PyErr_NoMemory();
-    return ret;
-}
-
 /* Decompress data of length self->avail_in_real in self->state.next_in. The 
    output buffer is allocated dynamically and returned. If the max_length is 
    of sufficiently low size, max_length is allocated immediately. At most 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
