### PR TITLE
gh-97848: argparse: Disallow misbehaving actions for positional arguments

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1540,6 +1540,11 @@ class _ActionsContainer(object):
             msg = _("'required' is an invalid argument for positionals")
             raise TypeError(msg)
 
+        # make sure 'store_true' action is not specified
+        if 'action' in kwargs and kwargs.get('action') == 'store_true':
+            msg = _("'store_true' is an invalid action for positionals")
+            raise TypeError(msg)
+
         # mark positional arguments as required if at least one is
         # always required
         if kwargs.get('nargs') not in [OPTIONAL, ZERO_OR_MORE]:

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1542,11 +1542,10 @@ class _ActionsContainer(object):
 
         # make sure 'store_true', 'store_false', or 'store_const' action
         # is not specified
-        if 'action' in kwargs:
-            action = kwargs.get('action')
-            if action in ('store_true', 'store_false', 'store_const'):
-                msg = _("{action} is an invalid action for positionals", {'action': action})
-                raise TypeError(msg)
+        action = kwargs.get('action')
+        if action in ('store_true', 'store_false', 'store_const'):
+            msg = _("{action} is an invalid action for positionals", {'action': action})
+            raise TypeError(msg)
 
         # mark positional arguments as required if at least one is
         # always required

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1545,6 +1545,11 @@ class _ActionsContainer(object):
             msg = _("'store_true' is an invalid action for positionals")
             raise TypeError(msg)
 
+        # make sure 'store_false' action is not specified
+        if 'action' in kwargs and kwargs.get('action') == 'store_false':
+            msg = _("'store_false' is an invalid action for positionals")
+            raise TypeError(msg)
+
         # mark positional arguments as required if at least one is
         # always required
         if kwargs.get('nargs') not in [OPTIONAL, ZERO_OR_MORE]:

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1540,20 +1540,18 @@ class _ActionsContainer(object):
             msg = _("'required' is an invalid argument for positionals")
             raise TypeError(msg)
 
-        # make sure 'store_true' action is not specified
-        if 'action' in kwargs and kwargs.get('action') == 'store_true':
-            msg = _("'store_true' is an invalid action for positionals")
-            raise TypeError(msg)
-
-        # make sure 'store_false' action is not specified
-        if 'action' in kwargs and kwargs.get('action') == 'store_false':
-            msg = _("'store_false' is an invalid action for positionals")
-            raise TypeError(msg)
-
-        # make sure 'store_const' action is not specified
-        if 'action' in kwargs and kwargs.get('action') == 'store_const':
-            msg = _("'store_const' is an invalid action for positionals")
-            raise TypeError(msg)
+        # make sure 'store_true', 'store_false', or 'store_const' action
+        # is not specified
+        if 'action' in kwargs:
+            if kwargs.get('action') == 'store_true':
+                msg = _("'store_true' is an invalid action for positionals")
+                raise TypeError(msg)
+            elif kwargs.get('action') == 'store_false':
+                msg = _("'store_false' is an invalid action for positionals")
+                raise TypeError(msg)
+            elif kwargs.get('action') == 'store_const':
+                msg = _("'store_const' is an invalid action for positionals")
+                raise TypeError(msg)
 
         # mark positional arguments as required if at least one is
         # always required

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1550,6 +1550,11 @@ class _ActionsContainer(object):
             msg = _("'store_false' is an invalid action for positionals")
             raise TypeError(msg)
 
+        # make sure 'store_const' action is not specified
+        if 'action' in kwargs and kwargs.get('action') == 'store_const':
+            msg = _("'store_const' is an invalid action for positionals")
+            raise TypeError(msg)
+
         # mark positional arguments as required if at least one is
         # always required
         if kwargs.get('nargs') not in [OPTIONAL, ZERO_OR_MORE]:

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1543,14 +1543,9 @@ class _ActionsContainer(object):
         # make sure 'store_true', 'store_false', or 'store_const' action
         # is not specified
         if 'action' in kwargs:
-            if kwargs.get('action') == 'store_true':
-                msg = _("'store_true' is an invalid action for positionals")
-                raise TypeError(msg)
-            elif kwargs.get('action') == 'store_false':
-                msg = _("'store_false' is an invalid action for positionals")
-                raise TypeError(msg)
-            elif kwargs.get('action') == 'store_const':
-                msg = _("'store_const' is an invalid action for positionals")
+            action = kwargs.get('action')
+            if action in ('store_true', 'store_false', 'store_const'):
+                msg = _("{action} is an invalid action for positionals", {'action': action})
                 raise TypeError(msg)
 
         # mark positional arguments as required if at least one is

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4714,6 +4714,15 @@ class TestInvalidArgumentConstructors(TestCase):
     def test_required_positional(self):
         self.assertTypeError('foo', required=True)
 
+    def test_positionals_with_store_true_action(self):
+        self.assertTypeError('foo', action='store_true')
+
+    def test_positionals_with_store_false_action(self):
+        self.assertTypeError('foo', action='store_false')
+
+    def test_positionals_with_store_const_action(self):
+        self.assertTypeError('foo', action='store_const', const='bar')
+
     def test_user_defined_action(self):
 
         class Success(Exception):

--- a/Misc/NEWS.d/next/Library/2022-10-17-20-20-18.gh-issue-97848.RnkhKZ.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-17-20-20-18.gh-issue-97848.RnkhKZ.rst
@@ -1,0 +1,1 @@
+Disallowed 'store_true', 'store_false', and 'store_const' actions for positional arguments in argparse module.

--- a/Misc/NEWS.d/next/Library/2022-10-17-20-20-18.gh-issue-97848.RnkhKZ.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-17-20-20-18.gh-issue-97848.RnkhKZ.rst
@@ -1,1 +1,1 @@
-Disallowed 'store_true', 'store_false', and 'store_const' actions for positional arguments in argparse module.
+Disallow ``store_true``, ``store_false``, and ``store_const`` actions for positional arguments in :mod:`argparse` module.


### PR DESCRIPTION
Issue #97848

The disallowed actions are: `'store_true'`, `'store_false'` and `'store_const'`, which cause a counterintuitive behaviour.

Tests for new behaviour are included.


<!-- gh-issue-number: gh-97848 -->
* Issue: gh-97848
<!-- /gh-issue-number -->
