### PR TITLE
gh-98378: Add small format string example to strftime comments

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1033,7 +1033,11 @@ class date:
             self._day, self._year)
 
     def strftime(self, fmt):
-        "Format using strftime()."
+        """
+        Format using strftime().
+        
+        Example: "%d/%m/%Y, %H:%M:%S"
+        """
         return _wrap_strftime(self, fmt, self.timetuple())
 
     def __format__(self, fmt):

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1035,7 +1035,7 @@ class date:
     def strftime(self, fmt):
         """
         Format using strftime().
-        
+
         Example: "%d/%m/%Y, %H:%M:%S"
         """
         return _wrap_strftime(self, fmt, self.timetuple())


### PR DESCRIPTION
A small example of what a full date and time would look like would help a lot of developers who may not realize that they should investigate `time.h`'s `strftime`, run `man strftime`, or click through a series of docs on the python docs before they get to the actual [definition here](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) which still doesn't have an obvious copy-pastable example of "what the heck format does this thing actually expect?".


<!-- gh-issue-number: gh-98378 -->
* Issue: gh-98378
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:rhettinger