### PR TITLE
gh-98390: Fix source locations of boolean sub-expressions

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1208,6 +1208,32 @@ f(
         self.assertOpcodeSourcePositionIs(compiled_code, 'CALL',
             line=1, end_line=3, column=0, end_column=1)
 
+    def test_multiline_boolean_expression(self):
+        snippet = """\
+if (a or
+    (b and not c) or
+    not (
+        d > 0)):
+    x = 42
+"""
+
+        compiled_code, _ = self.check_positions_against_ast(snippet)
+        # jump if a is true:
+        self.assertOpcodeSourcePositionIs(compiled_code, 'POP_JUMP_IF_TRUE',
+            line=1, end_line=1, column=4, end_column=5, occurrence=1)
+        # jump if b is false:
+        self.assertOpcodeSourcePositionIs(compiled_code, 'POP_JUMP_IF_FALSE',
+            line=2, end_line=2, column=5, end_column=6, occurrence=1)
+        # jump if c is false:
+        self.assertOpcodeSourcePositionIs(compiled_code, 'POP_JUMP_IF_FALSE',
+            line=2, end_line=2, column=15, end_column=16, occurrence=2)
+        # compare d and 0
+        self.assertOpcodeSourcePositionIs(compiled_code, 'COMPARE_OP',
+            line=4, end_line=4, column=8, end_column=13, occurrence=1)
+        # jump if comparison it True
+        self.assertOpcodeSourcePositionIs(compiled_code, 'POP_JUMP_IF_TRUE',
+            line=4, end_line=4, column=8, end_column=13, occurrence=2)
+
     def test_very_long_line_end_offset(self):
         # Make sure we get the correct column offset for offsets
         # too large to store in a byte.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-18-14-11-32.gh-issue-98390.H1sxJu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-18-14-11-32.gh-issue-98390.H1sxJu.rst
@@ -1,0 +1,1 @@
+Fix location of sub-expressions of boolean expressions, by reducing their scope to that of the sub-expression.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2953,7 +2953,7 @@ compiler_jump_if(struct compiler *c, location *ploc,
 
     /* general implementation */
     VISIT(c, expr, e);
-    ADDOP_JUMP(c, *ploc, cond ? POP_JUMP_IF_TRUE : POP_JUMP_IF_FALSE, next);
+    ADDOP_JUMP(c, LOC(e), cond ? POP_JUMP_IF_TRUE : POP_JUMP_IF_FALSE, next);
     return 1;
 }
 


### PR DESCRIPTION
Fixes #98390.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98390 -->
* Issue: gh-98390
<!-- /gh-issue-number -->
