### PR TITLE
Doc: Remove title text from internal links

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -2152,8 +2152,7 @@ Porting to Python 3.10
 * The ``PY_SSIZE_T_CLEAN`` macro must now be defined to use
   :c:func:`PyArg_ParseTuple` and :c:func:`Py_BuildValue` formats which use
   ``#``: ``es#``, ``et#``, ``s#``, ``u#``, ``y#``, ``z#``, ``U#`` and ``Z#``.
-  See :ref:`Parsing arguments and building values
-  <arg-parsing>` and the :pep:`353`.
+  See :ref:`arg-parsing` and :pep:`353`.
   (Contributed by Victor Stinner in :issue:`40943`.)
 
 * Since :c:func:`Py_REFCNT()` is changed to the inline static function,
@@ -2184,8 +2183,7 @@ Porting to Python 3.10
   :c:func:`Py_GetProgramFullPath`, :c:func:`Py_GetPythonHome` and
   :c:func:`Py_GetProgramName` functions now return ``NULL`` if called before
   :c:func:`Py_Initialize` (before Python is initialized). Use the new
-  :ref:`Python Initialization Configuration API <init-config>` to get the
-  :ref:`Python Path Configuration.  <init-path-config>`.
+  :ref:`init-config` API to get the :ref:`init-path-config`.
   (Contributed by Victor Stinner in :issue:`42260`.)
 
 * :c:func:`PyList_SET_ITEM`, :c:func:`PyTuple_SET_ITEM` and
@@ -2199,7 +2197,7 @@ Porting to Python 3.10
   ``picklebufobject.h``, ``pyarena.h``, ``pyctype.h``, ``pydebug.h``,
   ``pyfpe.h``, and ``pytime.h`` have been moved to the ``Include/cpython``
   directory. These files must not be included directly, as they are already
-  included in ``Python.h``: :ref:`Include Files <api-includes>`. If they have
+  included in ``Python.h``; see :ref:`api-includes`. If they have
   been included directly, consider including ``Python.h`` instead.
   (Contributed by Nicholas Sim in :issue:`35134`.)
 


### PR DESCRIPTION
Rely on the title of the linked internal page instead of putting the title. Sphinx will render with the title correctly, and this will reduce work for translators

Please backport it to 3.11 and 3.10 as well.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
