### PR TITLE
gh-98354: Add unicode check for 'name' attribute in _imp_create_builtin

### DIFF
--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -397,21 +397,20 @@ class ImportTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             create_builtin(spec)
 
+        import builtins
         class UnicodeSubclass(str):
             pass
         class GoodSpec:
-            name = UnicodeSubclass("sys")
+            name = UnicodeSubclass("builtins")
         spec = GoodSpec()
         bltin = create_builtin(spec)
-        import sys
-        self.assertEqual(bltin, sys)
+        self.assertEqual(bltin, builtins)
 
         class UnicodeSubclassFakeSpec(str):
             def __init__(self, name):
                 self.name = self
         spec = UnicodeSubclassFakeSpec("builtins")
         bltin = create_builtin(spec)
-        import builtins
         self.assertEqual(bltin, builtins)
 
 class ReloadTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-19-18-03-28.gh-issue-98354.GRGta3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-19-18-03-28.gh-issue-98354.GRGta3.rst
@@ -1,0 +1,1 @@
+Added unicode check for ``name`` attribute of ``spec`` argument passed in :func:`_imp.create_builtin` function.

--- a/Python/import.c
+++ b/Python/import.c
@@ -1021,6 +1021,13 @@ _imp_create_builtin(PyObject *module, PyObject *spec)
         return NULL;
     }
 
+    if (!PyUnicode_Check(name)) {
+        PyErr_Format(PyExc_TypeError,
+                     "name must be string, not %.200s",
+                     Py_TYPE(name)->tp_name);
+        return NULL;
+    }
+
     PyObject *mod = create_builtin(tstate, name, spec);
     Py_DECREF(name);
     return mod;

--- a/Python/import.c
+++ b/Python/import.c
@@ -1025,6 +1025,7 @@ _imp_create_builtin(PyObject *module, PyObject *spec)
         PyErr_Format(PyExc_TypeError,
                      "name must be string, not %.200s",
                      Py_TYPE(name)->tp_name);
+        Py_DECREF(name);
         return NULL;
     }
 


### PR DESCRIPTION
Fixes #98354 

<!-- gh-issue-number: gh-98354 -->
* Issue: gh-98354
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:ericsnowcurrently