### PR TITLE
GH-98363: Presize the list for batched()

### DIFF
--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -149,7 +149,7 @@ batched_next(batchedobject *bo)
     if (it == NULL) {
         return NULL;
     }
-    result = PyList_New(0);
+    result = PyList_New(bo->batch_size);
     if (result == NULL) {
         return NULL;
     }
@@ -158,12 +158,14 @@ batched_next(batchedobject *bo)
         if (item == NULL) {
             break;
         }
-        if (PyList_Append(result, item) < 0) {
-            Py_DECREF(item);
-            Py_DECREF(result);
+        PyList_SET_ITEM(result, i, item);
+    }
+    if (i < bo->batch_size) {
+        PyObject *short_list = PyList_GetSlice(result, 0, i);
+        Py_SETREF(result, short_list);
+        if (result == NULL) {
             return NULL;
         }
-        Py_DECREF(item);
     }
     if (PyList_GET_SIZE(result) > 0) {
         return result;

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -169,9 +169,6 @@ batched_next(batchedobject *bo)
     if (i < bo->batch_size) {
         PyObject *short_list = PyList_GetSlice(result, 0, i);
         Py_SETREF(result, short_list);
-        if (result == NULL) {
-            return NULL;
-        }
     }
     return result;
 }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -166,7 +166,7 @@ batched_next(batchedobject *bo)
         Py_DECREF(result);
         return NULL;
     }
-    if (i < bo->batch_size) {
+    if (i < n) {
         PyObject *short_list = PyList_GetSlice(result, 0, i);
         Py_SETREF(result, short_list);
     }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -160,14 +160,14 @@ batched_next(batchedobject *bo)
         }
         PyList_SET_ITEM(result, i, item);
     }
-    if (i < bo->batch_size) {
+    if (i > 0 && i < bo->batch_size) {
         PyObject *short_list = PyList_GetSlice(result, 0, i);
         Py_SETREF(result, short_list);
         if (result == NULL) {
             return NULL;
         }
     }
-    if (PyList_GET_SIZE(result) > 0) {
+    if (i > 0) {
         return result;
     }
     Py_CLEAR(bo->it);

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -7,6 +7,7 @@
 #include "pycore_object.h"        // _PyObject_GC_TRACK()
 #include "pycore_tuple.h"         // _PyTuple_FromArray()
 #include <stddef.h>
+#include <stdio.h>
 
 /*[clinic input]
 class list "PyListObject *" "&PyList_Type"

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -7,7 +7,6 @@
 #include "pycore_object.h"        // _PyObject_GC_TRACK()
 #include "pycore_tuple.h"         // _PyTuple_FromArray()
 #include <stddef.h>
-#include <stdio.h>
 
 /*[clinic input]
 class list "PyListObject *" "&PyList_Type"


### PR DESCRIPTION
Presizing the result lists saves space from list over-allocation and is faster than the `PyList_Append()` approach.

This is a short PR but it took a while to figure out that `PyList_GetSlice()` would make short work of the problem.  Ideally, we need something like `_PyTuple_Resize()` to resize the list inplace using a `realloc()` and updating the `allocated` field.

<!-- gh-issue-number: gh-98363 -->
* Issue: gh-98363
<!-- /gh-issue-number -->
