### PR TITLE
gh-95913: Edit & expand Optimizations in 3.11 WhatsNew

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1138,11 +1138,29 @@ Optimizations
   fast as a corresponding :term:`f-string` expression.
   (Contributed by Serhiy Storchaka in :issue:`28307`.)
 
+* Integer division (``//``) is better tuned for optimization by compilers.
+  It is now around 20% faster on x86-64 when dividing an :class:`int`
+  by a value smaller than ``2**30``.
+  (Contributed by Gregory P. Smith and Tim Peters in :gh:`90564`.)
+
+* :func:`sum` is now nearly 30% faster for integers smaller than ``2**30``.
+  (Contributed by Stefan Behnel in :gh:`68264`.)
+
+* Resizing lists is streamlined for the common case,
+  speeding up :meth:`list.append` by ≈15%
+  and simple :term:`list comprehension`\s by up to 20-30%
+  (Contributed by Dennis Sweeney in :gh:`91165`.)
+
 * Dictionaries don't store hash values when all keys are Unicode objects,
   decreasing :class:`dict` size.
   For example, ``sys.getsizeof(dict.fromkeys("abcdefg"))``
   is reduced from 352 bytes to 272 bytes (23% smaller) on 64-bit platforms.
   (Contributed by Inada Naoki in :issue:`46845`.)
+
+* Using :class:`asyncio.DatagramProtocol` is now orders of magnitude faster
+  when transferring large files over UDP,
+  with speeds over 100 times higher for a ≈60 MiB file.
+  (Contributed by msoxzw in :gh:`91487`.)
 
 * :mod:`math` functions :func:`~math.comb` and :func:`~math.perm` are now
   ≈10 times faster for large arguments (with a larger speedup for larger *k*).
@@ -1153,6 +1171,12 @@ Optimizations
   result, Python 3.11 executes the `pyperformance regular expression benchmarks
   <https://pyperformance.readthedocs.io/benchmarks.html#regex-dna>`_ up to 10%
   faster than Python 3.10.
+
+* The :mod:`statistics` functions :func:`~statistics.mean`,
+  :func:`~statistics.variance` and :func:`~statistics.stdev` now consume
+  iterators in one pass rather than converting them to a :class:`list` first.
+  This is twice as fast and can save substantial memory.
+  (Contributed by Raymond Hettinger in :gh:`90415`.)
 
 * :func:`unicodedata.normalize`
   now normalizes pure-ASCII strings in constant time.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1128,26 +1128,28 @@ fcntl
 Optimizations
 =============
 
-* Compiler now optimizes simple C-style formatting with literal format
-  containing only format codes ``%s``, ``%r`` and ``%a`` and makes it as
-  fast as corresponding f-string expression.
+* The compiler now optimizes simple
+  :ref:`printf-style % formatting <old-string-formatting>` on string literals
+  containing only the format codes ``%s``, ``%r`` and ``%a`` and makes it as
+  fast as a corresponding :term:`f-string` expression.
   (Contributed by Serhiy Storchaka in :issue:`28307`.)
 
-* "Zero-cost" exceptions are implemented. The cost of ``try`` statements is
-  almost eliminated when no exception is raised.
+* "Zero-cost" exceptions are implemented, eliminating the cost
+  of :keyword:`try` statements when no exception is raised.
   (Contributed by Mark Shannon in :issue:`40222`.)
 
-* Pure ASCII strings are now normalized in constant time by :func:`unicodedata.normalize`.
+* Pure ASCII strings are now normalized in constant time by
+  :func:`unicodedata.normalize`.
   (Contributed by Dong-hee Na in :issue:`44987`.)
 
-* :mod:`math` functions :func:`~math.comb` and :func:`~math.perm` are now up
-  to 10 times or more faster for large arguments (the speed up is larger for
-  larger *k*).
+* :mod:`math` functions :func:`~math.comb` and :func:`~math.perm` are now
+  ≈10 times faster for large arguments (with a larger speedup for larger *k*).
   (Contributed by Serhiy Storchaka in :issue:`37295`.)
 
-* Dict don't store hash value when all inserted keys are Unicode objects.
-  This reduces dict size. For example, ``sys.getsizeof(dict.fromkeys("abcdefg"))``
-  becomes 272 bytes from 352 bytes on 64bit platform.
+* Dictionaries don't store hash values when all keys are Unicode objects,
+  decreasing :class:`dict` size.
+  For example, ``sys.getsizeof(dict.fromkeys("abcdefg"))``
+  is reduced from 352 bytes to 272 bytes (23% smaller) on 64-bit platforms.
   (Contributed by Inada Naoki in :issue:`46845`.)
 
 * :mod:`re`'s regular expression matching engine has been partially refactored,

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1131,10 +1131,6 @@ Optimizations
 This section covers specific optimizations independent of the
 :ref:`whatsnew311-faster-cpython` project, which is covered in its own section.
 
-* "Zero-cost" exceptions are implemented, eliminating the cost
-  of :keyword:`try` statements when no exception is raised.
-  (Contributed by Mark Shannon in :issue:`40222`.)
-
 * The compiler now optimizes simple
   :ref:`printf-style % formatting <old-string-formatting>` on string literals
   containing only the format codes ``%s``, ``%r`` and ``%a`` and makes it as

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1169,12 +1169,6 @@ This section covers specific optimizations independent of the
   ≈10 times faster for large arguments (with a larger speedup for larger *k*).
   (Contributed by Serhiy Storchaka in :issue:`37295`.)
 
-* :mod:`re`'s regular expression matching engine has been partially refactored,
-  and now uses computed gotos (or "threaded code") on supported platforms. As a
-  result, Python 3.11 executes the `pyperformance regular expression benchmarks
-  <https://pyperformance.readthedocs.io/benchmarks.html#regex-dna>`_ up to 10%
-  faster than Python 3.10.
-
 * The :mod:`statistics` functions :func:`~statistics.mean`,
   :func:`~statistics.variance` and :func:`~statistics.stdev` now consume
   iterators in one pass rather than converting them to a :class:`list` first.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1128,6 +1128,9 @@ fcntl
 Optimizations
 =============
 
+This section covers specific optimizations independent of the
+:ref:`whatsnew311-faster-cpython` project, which is covered in its own section.
+
 * "Zero-cost" exceptions are implemented, eliminating the cost
   of :keyword:`try` statements when no exception is raised.
   (Contributed by Mark Shannon in :issue:`40222`.)

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1128,23 +1128,15 @@ fcntl
 Optimizations
 =============
 
+* "Zero-cost" exceptions are implemented, eliminating the cost
+  of :keyword:`try` statements when no exception is raised.
+  (Contributed by Mark Shannon in :issue:`40222`.)
+
 * The compiler now optimizes simple
   :ref:`printf-style % formatting <old-string-formatting>` on string literals
   containing only the format codes ``%s``, ``%r`` and ``%a`` and makes it as
   fast as a corresponding :term:`f-string` expression.
   (Contributed by Serhiy Storchaka in :issue:`28307`.)
-
-* "Zero-cost" exceptions are implemented, eliminating the cost
-  of :keyword:`try` statements when no exception is raised.
-  (Contributed by Mark Shannon in :issue:`40222`.)
-
-* Pure ASCII strings are now normalized in constant time by
-  :func:`unicodedata.normalize`.
-  (Contributed by Dong-hee Na in :issue:`44987`.)
-
-* :mod:`math` functions :func:`~math.comb` and :func:`~math.perm` are now
-  ≈10 times faster for large arguments (with a larger speedup for larger *k*).
-  (Contributed by Serhiy Storchaka in :issue:`37295`.)
 
 * Dictionaries don't store hash values when all keys are Unicode objects,
   decreasing :class:`dict` size.
@@ -1152,11 +1144,19 @@ Optimizations
   is reduced from 352 bytes to 272 bytes (23% smaller) on 64-bit platforms.
   (Contributed by Inada Naoki in :issue:`46845`.)
 
+* :mod:`math` functions :func:`~math.comb` and :func:`~math.perm` are now
+  ≈10 times faster for large arguments (with a larger speedup for larger *k*).
+  (Contributed by Serhiy Storchaka in :issue:`37295`.)
+
 * :mod:`re`'s regular expression matching engine has been partially refactored,
   and now uses computed gotos (or "threaded code") on supported platforms. As a
   result, Python 3.11 executes the `pyperformance regular expression benchmarks
   <https://pyperformance.readthedocs.io/benchmarks.html#regex-dna>`_ up to 10%
   faster than Python 3.10.
+
+* :func:`unicodedata.normalize`
+  now normalizes pure-ASCII strings in constant time.
+  (Contributed by Dong-hee Na in :issue:`44987`.)
 
 
 .. _whatsnew311-faster-cpython:


### PR DESCRIPTION
Part of #95913

I've added Sphinx markup and cross references to the Optimizations section of the Python What's New document, copyedited the text to fix grammar errors, read better and be slightly clearer, and sorted it by language, then builtins, then standard library (sorted by module name).

Additionally, I've added a handful of additional optimizations to common functions with documented substantial (>=15%) performance increases mentioned in the changelog (that were unrelated to Faster CPython), and consistent with the existing optimizations mentioned here and in previous verisons. These are:

* #90564 Integer division ``//`` 20% faster 
* #68264 `sum()` 30% faster
* #91165 `list.append` 15% faster / list comprehensions 20-30% faster
* #91487 `asyncio.DatagramProtocol` >100x faster on large files
* #90415 `statistics` functions `mean`, `variance` and `stdev` 2x faster and less memory

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
