### PR TITLE
gh-97928: Fix handling options starting with "-" in tkinter.Text.count()

### DIFF
--- a/Lib/test/test_tkinter/test_text.py
+++ b/Lib/test/test_tkinter/test_text.py
@@ -76,9 +76,7 @@ class TextTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(text.count('1.0', 'end'), (124,)  # 'indices' by default
                          if self.wantobjects else ('124',))
         self.assertRaises(tkinter.TclError, text.count, '1.0', 'end', 'spam')
-        # '-lines' is ignored, 'indices' is used by default
-        self.assertEqual(text.count('1.0', 'end', '-lines'), (124,)
-                         if self.wantobjects else ('124',))
+        self.assertRaises(tkinter.TclError, text.count, '1.0', 'end', '-lines')
 
         self.assertIsInstance(text.count('1.3', '1.5', 'ypixels'), tuple)
         self.assertIsInstance(text.count('1.3', '1.5', 'update', 'ypixels'), int

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3648,7 +3648,7 @@ class Text(Widget, XView, YView):
         "lines", "xpixels" and "ypixels". There is an additional possible
         option "update", which if given then all subsequent options ensure
         that any possible out of date information is recalculated."""
-        args = ['-%s' % arg for arg in args if not arg.startswith('-')]
+        args = ['-%s' % arg for arg in args]
         args += [index1, index2]
         res = self.tk.call(self._w, 'count', *args) or None
         if res is not None and len(args) <= 3:

--- a/Misc/NEWS.d/next/Library/2022-10-19-09-29-12.gh-issue-97928.xj3im7.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-19-09-29-12.gh-issue-97928.xj3im7.rst
@@ -1,0 +1,2 @@
+:meth:`tkinter.Text.count` raises now an exception for options starting with
+"-" instead of silently ignoring them.


### PR DESCRIPTION
Previously they were silently ignored. Now they are errors.


<!-- gh-issue-number: gh-97928 -->
* Issue: gh-97928
<!-- /gh-issue-number -->
