### PR TITLE
Docs: Bump sphinx-lint and fix unbalanced inline literal markup

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -7,10 +7,7 @@ sphinx==4.5.0
 
 blurb
 
-# sphinx-lint 0.6.2 yields many default role errors due to the new regular
-# expression used for default role detection, so we don't use the version
-# until the errors are fixed.
-sphinx-lint==0.6.5
+sphinx-lint==0.6.7
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.

--- a/Misc/NEWS.d/next/C API/2022-07-12-17-39-32.gh-issue-94731.9CPJNU.rst
+++ b/Misc/NEWS.d/next/C API/2022-07-12-17-39-32.gh-issue-94731.9CPJNU.rst
@@ -1,3 +1,3 @@
 Python again uses C-style casts for most casting operations when compiled
 with C++. This may trigger compiler warnings, if they are enabled with e.g.
-``-Wold-style-cast `` or ``-Wzero-as-null-pointer-constant`` options for ``g++``.
+``-Wold-style-cast`` or ``-Wzero-as-null-pointer-constant`` options for ``g++``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


Bump sphinx-lint and fix its new finding:

```console
$ make -C Doc check
# Check the docs and NEWS files with sphinx-lint.
# Ignore the tools and venv dirs and check that the default role is not used.
PATH=./venv/bin:$PATH sphinx-lint -i tools -i ./venv --enable default-role
No problems found.
PATH=./venv/bin:$PATH sphinx-lint --enable default-role ../Misc/NEWS.d/next/
../Misc/NEWS.d/next/C API/2022-07-12-17-39-32.gh-issue-94731.9CPJNU.rst:3: found an unbalanced inline literal markup. (unbalanced-inline-literals-delimiters)
../Misc/NEWS.d/next/C API/2022-07-12-17-39-32.gh-issue-94731.9CPJNU.rst:3: found an unbalanced inline literal markup. (unbalanced-inline-literals-delimiters)
make: *** [check] Error 1
```

# Before

<img width="806" alt="image" src="https://user-images.githubusercontent.com/1324225/196672899-6fb8c1fd-4e4d-4cb8-8ca1-025b6689efa5.png">

https://docs.python.org/3.12/whatsnew/changelog.html#c-api

# After

<img width="770" alt="image" src="https://user-images.githubusercontent.com/1324225/196673187-1283ee11-6c86-449e-8ac4-c3164d54d455.png">

