### PR TITLE
[3.11] Docs: Bump sphinx-lint and use double backticks for inline literals (GH-98441)

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1800,7 +1800,7 @@ is not possible due to its implementation being opaque at build time.
 
    .. note::
       A freed key becomes a dangling pointer. You should reset the key to
-      `NULL`.
+      ``NULL``.
 
 
 Methods

--- a/Doc/library/asyncio-api-index.rst
+++ b/Doc/library/asyncio-api-index.rst
@@ -57,7 +57,7 @@ await on multiple things with timeouts.
       - Monitor for completion.
 
     * - :func:`timeout`
-      - Run with a timeout. Useful in cases when `wait_for` is not suitable.
+      - Run with a timeout. Useful in cases when ``wait_for`` is not suitable.
 
     * - :func:`to_thread`
       - Asynchronously run a function in a separate OS thread.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -391,7 +391,7 @@ Pure paths provide the following methods and properties:
 
       If you want to walk an arbitrary filesystem path upwards, it is
       recommended to first call :meth:`Path.resolve` so as to resolve
-      symlinks and eliminate `".."` components.
+      symlinks and eliminate ``".."`` components.
 
 
 .. data:: PurePath.name

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -829,7 +829,7 @@ Instances of the :class:`Popen` class have the following methods:
 
       On Windows, SIGTERM is an alias for :meth:`terminate`. CTRL_C_EVENT and
       CTRL_BREAK_EVENT can be sent to processes started with a *creationflags*
-      parameter which includes `CREATE_NEW_PROCESS_GROUP`.
+      parameter which includes ``CREATE_NEW_PROCESS_GROUP``.
 
 
 .. method:: Popen.terminate()

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -7,10 +7,7 @@ sphinx==4.5.0
 
 blurb
 
-# sphinx-lint 0.6.2 yields many default role errors due to the new regular
-# expression used for default role detection, so we don't use the version
-# until the errors are fixed.
-sphinx-lint==0.6.4
+sphinx-lint==0.6.7
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Backport of https://github.com/python/cpython/pull/98441 for 3.11.

The RST change from that PR isn't needed in 3.11 because the news fragment has already been moved into `Misc/NEWS.d/3.11.0b5.rst` and fixed.

However, there were a few uses of default roles to fix.
