### PR TITLE
gh-98414: py.exe launcher does not use defaults for -V:company/ option

### DIFF
--- a/Lib/test/test_launcher.py
+++ b/Lib/test/test_launcher.py
@@ -369,6 +369,13 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
         self.assertEqual(company, data["env.company"])
         self.assertEqual("3.100", data["env.tag"])
 
+    def test_filter_to_company_with_default(self):
+        company = "PythonTestSuite"
+        data = self.run_py([f"-V:{company}/"], env=dict(PY_PYTHON="3.0"))
+        self.assertEqual("X.Y.exe", data["LaunchCommand"])
+        self.assertEqual(company, data["env.company"])
+        self.assertEqual("3.100", data["env.tag"])
+
     def test_filter_to_tag(self):
         company = "PythonTestSuite"
         data = self.run_py([f"-V:3.100"])

--- a/Misc/NEWS.d/next/Windows/2022-10-19-19-35-37.gh-issue-98414.FbHZuS.rst
+++ b/Misc/NEWS.d/next/Windows/2022-10-19-19-35-37.gh-issue-98414.FbHZuS.rst
@@ -1,0 +1,3 @@
+Fix :file:`py.exe` launcher handling of ``-V:<company>/`` option when
+default preferences have been set in environment variables or configuration
+files.

--- a/PC/launcher2.c
+++ b/PC/launcher2.c
@@ -653,6 +653,7 @@ parseCommandLine(SearchInfo *search)
                     search->tag = argStart;
                 }
                 search->tagLength = (int)(tail - search->tag);
+                search->allowDefaults = false;
                 search->restOfCmdLine = tail;
             } else if (MATCHES(L"0") || MATCHES(L"-list")) {
                 search->list = true;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98414 -->
* Issue: gh-98414
<!-- /gh-issue-number -->
