### PR TITLE
gh-97514: Don't use Linux abstract sockets for multiprocessing

### DIFF
--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -17,6 +17,7 @@ import struct
 import time
 import tempfile
 import itertools
+import warnings
 
 import _multiprocessing
 
@@ -73,11 +74,6 @@ def arbitrary_address(family):
     if family == 'AF_INET':
         return ('localhost', 0)
     elif family == 'AF_UNIX':
-        # Prefer abstract sockets if possible to avoid problems with the address
-        # size.  When coding portable applications, some implementations have
-        # sun_path as short as 92 bytes in the sockaddr_un struct.
-        if util.abstract_sockets_supported:
-            return f"\0listener-{os.getpid()}-{next(_mmap_counter)}"
         return tempfile.mktemp(prefix='listener-', dir=util.get_temp_dir())
     elif family == 'AF_PIPE':
         return tempfile.mktemp(prefix=r'\\.\pipe\pyc-%d-%d-' %
@@ -601,11 +597,22 @@ class SocketListener(object):
         self._family = family
         self._last_accepted = None
 
-        if family == 'AF_UNIX' and not util.is_abstract_socket_namespace(address):
-            # Linux abstract socket namespaces do not need to be explicitly unlinked
-            self._unlink = util.Finalize(
-                self, os.unlink, args=(address,), exitpriority=0
-                )
+        if family == 'AF_UNIX':
+            if util.is_abstract_socket_namespace(address):
+                self._unlink = None
+                warnings.warn(
+                    'Security: This application\'s use of an abstract socket '
+                    f'{address!r} for a multiprocessing Listener may allow '
+                    'anyone on the system to inject code into the process.',
+                    RuntimeWarning)
+                # XXX The stacklevel= `address` came from is not reasonably
+                # known because this could be constructed from multiple
+                # different levels based on how people use multiprocessing.
+            else:
+                # Linux abstract socket namespaces do not need to be explicitly unlinked
+                self._unlink = util.Finalize(
+                    self, os.unlink, args=(address,), exitpriority=0
+                    )
         else:
             self._unlink = None
 

--- a/Misc/NEWS.d/next/Security/2022-09-07-10-42-00.gh-issue-97514.Yggdsl.rst
+++ b/Misc/NEWS.d/next/Security/2022-09-07-10-42-00.gh-issue-97514.Yggdsl.rst
@@ -1,13 +1,13 @@
-On Linux the :mod:`multiprocessing` module when configured to use the
-``"forkserver"`` start method has switched back to using filesystem backed unix
-domain sockets by default for communication with the fork server. No longer
-using Linux's abstract socket namespace by default. Abstract sockets have no
-permissions and could thus allow any user on the system in the same `network
+On Linux the :mod:`multiprocessing` module, when configured by code to use the
+``"forkserver"`` start method, has switched back to using filesystem backed
+unix domain sockets by default for communication with the *forkserver* process.
+No longer using Linux's abstract socket namespace by default. Abstract sockets
+have no permissions and could allow any user on the system in the same `network
 namespace <https://man7.org/linux/man-pages/man7/network_namespaces.7.html>`_
 (often the whole system) to inject code into the multiprocessing *forkserver*
 process as a potential privilege escalation. Filesystem based socket
-permissions are restricted to the forkserver user as with Python 3.8 and
-earlier.
+permissions are restricted to the *forkserver* process user as in Python 3.8
+and earlier.
 
 This prevents Linux `CVE-2022-42919
 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42919>`_ in code that

--- a/Misc/NEWS.d/next/Security/2022-09-07-10-42-00.gh-issue-97514.Yggdsl.rst
+++ b/Misc/NEWS.d/next/Security/2022-09-07-10-42-00.gh-issue-97514.Yggdsl.rst
@@ -1,16 +1,15 @@
-On Linux the :mod:`multiprocessing` module, when configured by code to use the
-``"forkserver"`` start method, has switched back to using filesystem backed
-unix domain sockets by default for communication with the *forkserver* process.
-No longer using Linux's abstract socket namespace by default. Abstract sockets
-have no permissions and could allow any user on the system in the same `network
-namespace <https://man7.org/linux/man-pages/man7/network_namespaces.7.html>`_
-(often the whole system) to inject code into the multiprocessing *forkserver*
-process as a potential privilege escalation. Filesystem based socket
-permissions are restricted to the *forkserver* process user as in Python 3.8
+On Linux the :mod:`multiprocessing` module returns to using filesystem backed
+unix domain sockets for communication with the *forkserver* process instead of
+the Linux abstract socket namespace.  Only code that chooses to use the
+:ref:`"forkserver" start method <multiprocessing-start-methods>` is affected.
+
+Abstract sockets have no permissions and could allow any user on the system in
+the same `network namespace
+<https://man7.org/linux/man-pages/man7/network_namespaces.7.html>`_ (often the
+whole system) to inject code into the multiprocessing *forkserver* process.
+This was a potential privilege escalation. Filesystem based socket permissions
+restrict this to the *forkserver* process user as was the default in Python 3.8
 and earlier.
 
 This prevents Linux `CVE-2022-42919
-<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42919>`_ in code that
-chooses to use the *forkserver* start method as documented in
-:ref:`multiprocessing contexts and start methods
-<multiprocessing-start-methods>`.
+<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42919>`_.

--- a/Misc/NEWS.d/next/Security/2022-09-07-10-42-00.gh-issue-97514.Yggdsl.rst
+++ b/Misc/NEWS.d/next/Security/2022-09-07-10-42-00.gh-issue-97514.Yggdsl.rst
@@ -1,0 +1,4 @@
+On Linux :mod:`multiprocessing` no longer uses Linux specific abstract socket
+namespace sockets by default for inter-process communication as they have no
+permissions and thus allowed anyone on the system to inject code into the
+multiprocessing server process.

--- a/Misc/NEWS.d/next/Security/2022-09-07-10-42-00.gh-issue-97514.Yggdsl.rst
+++ b/Misc/NEWS.d/next/Security/2022-09-07-10-42-00.gh-issue-97514.Yggdsl.rst
@@ -1,4 +1,16 @@
-On Linux :mod:`multiprocessing` no longer uses Linux specific abstract socket
-namespace sockets by default for inter-process communication as they have no
-permissions and thus allowed anyone on the system to inject code into the
-multiprocessing server process.
+On Linux the :mod:`multiprocessing` module when configured to use the
+``"forkserver"`` start method has switched back to using filesystem backed unix
+domain sockets by default for communication with the fork server. No longer
+using Linux's abstract socket namespace by default. Abstract sockets have no
+permissions and could thus allow any user on the system in the same `network
+namespace <https://man7.org/linux/man-pages/man7/network_namespaces.7.html>`_
+(often the whole system) to inject code into the multiprocessing *forkserver*
+process as a potential privilege escalation. Filesystem based socket
+permissions are restricted to the forkserver user as with Python 3.8 and
+earlier.
+
+This prevents Linux `CVE-2022-42919
+<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42919>`_ in code that
+chooses to use the *forkserver* start method as documented in
+:ref:`multiprocessing contexts and start methods
+<multiprocessing-start-methods>`.


### PR DESCRIPTION
Linux abstract sockets lack any form of permissions so their use allows any process in the same host-local network namespace (which means any user on the system in many default configurations) to inject code into the process. A "same machine Remote Code Execution RCE" vulnerability.

This removes the default preference for abstract sockets in multiprocessing introduced in Python 3.9+ via
https://github.com/python/cpython/pull/18866 while fixing https://github.com/python/cpython/issues/84031.

This issue was reported to the PSRT on 2022-09-07 by Devin Jeanpierre @ssbr from Google. @gpshead requested the CVE.

More good reasoning on why to avoid abstract AF_UNIX sockets on Linux: https://web.archive.org/web/20220107100548/https://utcc.utoronto.ca/~cks/space/blog/linux/SocketAbstractNamespace?showcomments#comments

This is intended for backporting to apply to 3.9 - 3.12.

---

**Urgency**: The Release Manager @pablogsal has approved having this in 3.11.0. As the issue is Linux only, **there is NO urgent need for new Windows or macOS package builds**. So even if a new 3.10.x and 3.9.x release is not officially cut while making it public, this small change is trivially back-ported by all involved Linux Python binary package distributors whom we assume will be _very interested_ in having it.

---

PSRT report & discussion: https://mail.python.org/archives/list/psrt@python.org/thread/WMFW2T2I4P3I7SQHYJEBZTSHRVJT44F6/

<!-- gh-issue-number: gh-97514 -->
* Issue: gh-97514
<!-- /gh-issue-number -->
