### PR TITLE
GH-98363:  Fix exception handling in batched()

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -2012,6 +2012,20 @@ class E:
     def __next__(self):
         3 // 0
 
+class E2:
+    'Test propagation of exceptions after two iterations'
+    def __init__(self, seqn):
+        self.seqn = seqn
+        self.i = 0
+    def __iter__(self):
+        return self
+    def __next__(self):
+        if self.i == 2:
+            raise ZeroDivisionError
+        v = self.seqn[self.i]
+        self.i += 1
+        return v
+
 class S:
     'Test immediate stop'
     def __init__(self, seqn):
@@ -2050,6 +2064,7 @@ class TestVariousIteratorArgs(unittest.TestCase):
         self.assertRaises(TypeError, batched, X(s), 2)
         self.assertRaises(TypeError, batched, N(s), 2)
         self.assertRaises(ZeroDivisionError, list, batched(E(s), 2))
+        self.assertRaises(ZeroDivisionError, list, batched(E2(s), 4))
 
     def test_chain(self):
         for s in ("123", "", range(1000), ('do', 1.2), range(2000,2200,5)):

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -155,8 +155,18 @@ batched_next(batchedobject *bo)
         return NULL;
     }
     for (i=0 ; i < n ; i++) {
-        item = PyIter_Next(it);
+        item = (*Py_TYPE(it)->tp_iternext)(it);
         if (item == NULL) {
+            if (PyErr_Occurred()) {
+                if (PyErr_ExceptionMatches(PyExc_StopIteration)) {
+                    PyErr_Clear();
+                } else {
+                    /* input raised an exception other than StopIteration */
+                    Py_CLEAR(bo->it);
+                    Py_DECREF(result);
+                    return NULL;
+                }
+            }
             break;
         }
         PyList_SET_ITEM(result, i, item);

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -154,8 +154,9 @@ batched_next(batchedobject *bo)
     if (result == NULL) {
         return NULL;
     }
+    iternextfunc iternext = *Py_TYPE(it)->tp_iternext;
     for (i=0 ; i < n ; i++) {
-        item = (*Py_TYPE(it)->tp_iternext)(it);
+        item = iternext(it);
         if (item == NULL) {
             goto null_item;
         }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -155,12 +155,13 @@ batched_next(batchedobject *bo)
         return NULL;
     }
     iternextfunc iternext = *Py_TYPE(it)->tp_iternext;
+    PyObject **items = PySequence_Fast_ITEMS(result);
     for (i=0 ; i < n ; i++) {
         item = iternext(it);
         if (item == NULL) {
             goto null_item;
         }
-        PyList_SET_ITEM(result, i, item);
+        items[i] = item;
     }
     return result;
 


### PR DESCRIPTION
Was erring out when an input iterator raised an exception other than StopIteration.

<!-- gh-issue-number: gh-98363 -->
* Issue: gh-98363
<!-- /gh-issue-number -->
