### PR TITLE
[3.11] gh-98548: Fix `-ne` shell operator spelling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Check for changes in the ABI
         run: |
           make check-abidump
-          if [ $? -neq 0 ] ; then
+          if [ $? -ne 0 ] ; then
             echo "Generated ABI file is not up to date."
             echo "Please, add the release manager of this branch as a reviewer of this PR."
             echo ""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,7 @@ jobs:
           make -j4
       - name: Check for changes in the ABI
         run: |
-          make check-abidump
-          if [ $? -ne 0 ] ; then
+          if ! make check-abidump; then
             echo "Generated ABI file is not up to date."
             echo "Please, add the release manager of this branch as a reviewer of this PR."
             echo ""


### PR DESCRIPTION
# gh-98548: Workflow not equal operator spelling

This shell operator should be spelled as -ne, not as -neq. All shell binary operators are two symbols long.

This bug is present on 3.10 and 3.11 branches only. 

This follows #98555 for another affected branch.