### PR TITLE
gh-95913: Edit, expand & format Bytecode sect in 3.11 WhatsNew

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1479,35 +1479,27 @@ Replaced opcodes
 +------------------------------------+-----------------------------------+-----------------------------------------+
 
 
-.. _whatsnew311-removed-opcodes:
-
-Removed Opcodes
----------------
-
-* :opcode:`!COPY_DICT_WITHOUT_KEYS`
-* :opcode:`!GEN_START`
-* :opcode:`!POP_BLOCK`
-* :opcode:`!SETUP_FINALLY`
-* :opcode:`!YIELD_FROM`
-
-
 .. _whatsnew311-changed-opcodes:
+.. _whatsnew311-removed-opcodes:
+.. _whatsnew311-changed-removed-opcodes:
 
-Changed Opcodes
----------------
+Changed/removed opcodes
+-----------------------
 
 * Changed :opcode:`JUMP_IF_TRUE_OR_POP` and :opcode:`JUMP_IF_FALSE_OR_POP`
-  to now be relative rather than absolute.
+  to be relative rather than absolute.
 
 * Changed :opcode:`MATCH_CLASS` and :opcode:`MATCH_KEYS`
-  to no longer push an additional boolean value
-  indicating whether the match succeeded or failed.
-  Instead, they indicate failure with ``None``
-  (where a tuple of extracted values would otherwise be).
+  to no longer push an additional boolean value to indicate success/failure.
+  Instead, ``None`` is pushed on failure
+  in place of the tuple of extracted values.
 
 * Changed opcodes that work with exceptions to reflect them
   now being represented as one item on the stack instead of three
   (see :gh:`89874`).
+
+* Removed :opcode:`!COPY_DICT_WITHOUT_KEYS`, :opcode:`!GEN_START`,
+  :opcode:`!POP_BLOCK`, :opcode:`!SETUP_FINALLY` and :opcode:`!YIELD_FROM`.
 
 
 .. _whatsnew311-deprecated:

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1414,51 +1414,54 @@ CPython bytecode changes
   taken when reading or modifying raw, adaptive bytecode containing quickened
   data.
 
-* Replaced all numeric ``BINARY_*`` and ``INPLACE_*`` instructions with a single
-  :opcode:`BINARY_OP` implementation.
+* Replaced all numeric :opcode:`!BINARY_*` and :opcode:`!INPLACE_*` instructions
+  with a single :opcode:`BINARY_OP` implementation.
 
-* Replaced the three call instructions: :opcode:`CALL_FUNCTION`,
-  :opcode:`CALL_FUNCTION_KW` and :opcode:`CALL_METHOD` with
+* Replaced the three call instructions :opcode:`!CALL_FUNCTION`,
+  :opcode:`!CALL_FUNCTION_KW` and :opcode:`!CALL_METHOD` with
   :opcode:`PUSH_NULL`, :opcode:`PRECALL`, :opcode:`CALL`,
   and :opcode:`KW_NAMES`.
   This decouples the argument shifting for methods from the handling of
   keyword arguments and allows better specialization of calls.
 
-* Removed ``COPY_DICT_WITHOUT_KEYS`` and ``GEN_START``.
+* Removed :opcode:`!COPY_DICT_WITHOUT_KEYS` and :opcode:`!GEN_START`.
 
 * :opcode:`MATCH_CLASS` and :opcode:`MATCH_KEYS` no longer push an additional
   boolean value indicating whether the match succeeded or failed. Instead, they
-  indicate failure with :const:`None` (where a tuple of extracted values would
+  indicate failure with ``None`` (where a tuple of extracted values would
   otherwise be).
 
-* Replace several stack manipulation instructions (``DUP_TOP``, ``DUP_TOP_TWO``,
-  ``ROT_TWO``, ``ROT_THREE``, ``ROT_FOUR``, and ``ROT_N``) with new
-  :opcode:`COPY` and :opcode:`SWAP` instructions.
+* Replaced several stack manipulation instructions
+  (:opcode:`!DUP_TOP`, :opcode:`!DUP_TOP_TWO`, :opcode:`!ROT_TWO`,
+  :opcode:`!ROT_THREE`, :opcode:`!ROT_FOUR`, and :opcode:`!ROT_N`)
+  with new :opcode:`COPY` and :opcode:`SWAP` instructions.
 
-* Replaced :opcode:`JUMP_IF_NOT_EXC_MATCH` by :opcode:`CHECK_EXC_MATCH` which
+* Replaced :opcode:`!JUMP_IF_NOT_EXC_MATCH` by :opcode:`CHECK_EXC_MATCH`, which
   performs the check but does not jump.
 
-* Replaced :opcode:`JUMP_IF_NOT_EG_MATCH` by :opcode:`CHECK_EG_MATCH` which
+* Replaced :opcode:`!JUMP_IF_NOT_EG_MATCH` by :opcode:`CHECK_EG_MATCH` which
   performs the check but does not jump.
 
-* Replaced :opcode:`JUMP_ABSOLUTE` by the relative :opcode:`JUMP_BACKWARD`.
+* Replaced :opcode:`!JUMP_ABSOLUTE` by the relative :opcode:`JUMP_BACKWARD`.
 
-* Added :opcode:`JUMP_BACKWARD_NO_INTERRUPT`, which is used in certain loops where it
-  is undesirable to handle interrupts.
+* Added :opcode:`JUMP_BACKWARD_NO_INTERRUPT`,
+  which is used in certain loops where it is undesirable to handle interrupts.
 
-* Replaced :opcode:`POP_JUMP_IF_TRUE` and :opcode:`POP_JUMP_IF_FALSE` by
-  the relative :opcode:`POP_JUMP_FORWARD_IF_TRUE`, :opcode:`POP_JUMP_BACKWARD_IF_TRUE`,
+* Replaced :opcode:`!POP_JUMP_IF_TRUE` and :opcode:`!POP_JUMP_IF_FALSE` by
+  the relative :opcode:`POP_JUMP_FORWARD_IF_TRUE`,
+  :opcode:`POP_JUMP_BACKWARD_IF_TRUE`,
   :opcode:`POP_JUMP_FORWARD_IF_FALSE` and :opcode:`POP_JUMP_BACKWARD_IF_FALSE`.
 
-* Added :opcode:`POP_JUMP_FORWARD_IF_NOT_NONE`, :opcode:`POP_JUMP_BACKWARD_IF_NOT_NONE`,
+* Added :opcode:`POP_JUMP_FORWARD_IF_NOT_NONE`,
+  :opcode:`POP_JUMP_BACKWARD_IF_NOT_NONE`,
   :opcode:`POP_JUMP_FORWARD_IF_NONE` and :opcode:`POP_JUMP_BACKWARD_IF_NONE`
   opcodes to speed up conditional jumps.
 
 * :opcode:`JUMP_IF_TRUE_OR_POP` and :opcode:`JUMP_IF_FALSE_OR_POP` are now
   relative rather than absolute.
 
-* :opcode:`RESUME` has been added. It is a no-op. Performs internal tracing,
-  debugging and optimization checks.
+* :opcode:`RESUME` has been added. It is a no-op,
+  and performs internal tracing, debugging and optimization checks.
 
 
 .. _whatsnew311-deprecated:

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1468,15 +1468,20 @@ Replaced opcodes
 | | :opcode:`!JUMP_IF_NOT_EXC_MATCH` | | :opcode:`CHECK_EXC_MATCH`       | Now performs check but doesn't jump     |
 | | :opcode:`!JUMP_IF_NOT_EG_MATCH`  | | :opcode:`CHECK_EG_MATCH`        |                                         |
 +------------------------------------+-----------------------------------+-----------------------------------------+
-| | :opcode:`!JUMP_ABSOLUTE`         | | :opcode:`JUMP_BACKWARD`         | All jump opcodes now relative;          |
-| | :opcode:`!POP_JUMP_IF_FALSE`     | | :opcode:`POP_JUMP_BACKWARD_IF_* | arg is offset from current instruction  |
-| | :opcode:`!POP_JUMP_IF_TRUE`      |   <POP_JUMP_BACKWARD_IF_TRUE>`    | rather than absolute location;          |
-|                                    | | :opcode:`POP_JUMP_FORWARD_IF_*  | added ``NONE`` & ``NOT_NONE`` variants  |
+| | :opcode:`!JUMP_ABSOLUTE`         | | :opcode:`JUMP_BACKWARD`         | See [#bytecode-jump]_;                  |
+| | :opcode:`!POP_JUMP_IF_FALSE`     | | :opcode:`POP_JUMP_BACKWARD_IF_* | ``TRUE``, ``FALSE``,                    |
+| | :opcode:`!POP_JUMP_IF_TRUE`      |   <POP_JUMP_BACKWARD_IF_TRUE>`    | ``NONE`` and ``NOT_NONE`` variants      |
+|                                    | | :opcode:`POP_JUMP_FORWARD_IF_*  | for each direction                      |
 |                                    |   <POP_JUMP_FORWARD_IF_TRUE>`     |                                         |
 +------------------------------------+-----------------------------------+-----------------------------------------+
 | | :opcode:`!SETUP_WITH`            | :opcode:`BEFORE_WITH`             | :keyword:`with` block setup             |
 | | :opcode:`!SETUP_ASYNC_WITH`      |                                   |                                         |
 +------------------------------------+-----------------------------------+-----------------------------------------+
+
+.. [#bytecode-jump] All jump opcodes are now relative, including the
+   existing :opcode:`JUMP_IF_TRUE_OR_POP` and :opcode:`JUMP_IF_FALSE_OR_POP`.
+   The argument is now an offset from the current instruction
+   rather than an absolute location.
 
 
 .. _whatsnew311-changed-opcodes:
@@ -1485,9 +1490,6 @@ Replaced opcodes
 
 Changed/removed opcodes
 -----------------------
-
-* Changed :opcode:`JUMP_IF_TRUE_OR_POP` and :opcode:`JUMP_IF_FALSE_OR_POP`
-  to be relative rather than absolute.
 
 * Changed :opcode:`MATCH_CLASS` and :opcode:`MATCH_KEYS`
   to no longer push an additional boolean value to indicate success/failure.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1407,44 +1407,65 @@ contributors are volunteers from the community.
 CPython bytecode changes
 ========================
 
-
-
 .. _whatsnew311-added-opcodes:
+.. _whatsnew311-replaced-opcodes:
+.. _whatsnew311-added-replaced-opcodes:
 
-Added Opcodes
--------------
+Added/Replaced Opcodes
+----------------------
 
-+-------------------------------------------+-------------------------------------------------------------------------+
-| New Opcode(s)                             | Notes                                                                   |
-+===========================================+=========================================================================+
-| | :opcode:`ASYNC_GEN_WRAP`                | Used in generators and co-routines                                      |
-| | :opcode:`RETURN_GENERATOR`              |                                                                         |
-| | :opcode:`SEND`                          |                                                                         |
-+-------------------------------------------+-------------------------------------------------------------------------+
-| :opcode:`CACHE`                           | Inline cache entries [#opcode-cache]_                                   |
-+-------------------------------------------+-------------------------------------------------------------------------+
-| :opcode:`COPY_FREE_VARS`                  | Avoids needing special caller-side code                                 |
-|                                           | to handle calling closures                                              |
-+-------------------------------------------+-------------------------------------------------------------------------+
-| :opcode:`JUMP_BACKWARD_NO_INTERRUPT`      | Used in certain loops where                                             |
-|                                           | it is undesirable to handle interrupts                                  |
-+-------------------------------------------+-------------------------------------------------------------------------+
-| :opcode:`MAKE_CELL`                       | Creates new :ref:`cell-objects`                                         |
-+-------------------------------------------+-------------------------------------------------------------------------+
-| | :opcode:`POP_JUMP_BACKWARD_IF_NONE`     | Speeds up conditional jumps                                             |
-| | :opcode:`POP_JUMP_BACKWARD_IF_NOT_NONE` |                                                                         |
-| | :opcode:`POP_JUMP_FORWARD_IF_NOT_NONE`  |                                                                         |
-| | :opcode:`POP_JUMP_FORWARD_IF_NONE`      |                                                                         |
-+-------------------------------------------+-------------------------------------------------------------------------+
-| :opcode:`PREP_RERAISE_STAR`               | Handles the new                                                         |
-|                                           | :ref:`exception groups and except*                                      |
-|                                           | <whatsnew311-pep654>`                                                   |
-+-------------------------------------------+-------------------------------------------------------------------------+
-| :opcode:`PUSH_EXC_INFO`                   | For use in exception handlers                                           |
-+-------------------------------------------+-------------------------------------------------------------------------+
-| :opcode:`RESUME`                          | No-op; performs internal tracing,                                       |
-|                                           | debugging and optimization checks                                       |
-+-------------------------------------------+-------------------------------------------------------------------------+
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| New Opcode(s)                             | Replaced Opcode(s)                 | Notes                                   |
++===========================================+====================================+=========================================+
+| | :opcode:`ASYNC_GEN_WRAP`                |                                    | Used in generators and co-routines      |
+| | :opcode:`RETURN_GENERATOR`              |                                    |                                         |
+| | :opcode:`SEND`                          |                                    |                                         |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| :opcode:`BEFORE_WITH`                     | | :opcode:`!SETUP_WITH`            | :keyword:`with` block setup             |
+|                                           | | :opcode:`!SETUP_ASYNC_WITH`      |                                         |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| :opcode:`BINARY_OP`                       | | :opcode:`!BINARY_*`              | Replaced all numeric binary/in-place    |
+|                                           | | :opcode:`!INPLACE_*`             | opcodes with a single opcode            |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| :opcode:`CACHE`                           |                                    | Inline cache entries [#opcode-cache]_   |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`CALL`                          | | :opcode:`!CALL_FUNCTION`         | Decouples argument shifting for methods |
+| | :opcode:`KW_NAMES`                      | | :opcode:`!CALL_FUNCTION_KW`      | from handling of keyword arguments;     |
+| | :opcode:`PRECALL`                       | | :opcode:`!CALL_METHOD`           | allows better specialization of calls   |
+| | :opcode:`PUSH_NULL`                     |                                    |                                         |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`CHECK_EXC_MATCH`               | | :opcode:`!JUMP_IF_NOT_EXC_MATCH` | Now performs check                      |
+| | :opcode:`CHECK_EG_MATCH`                | | :opcode:`!JUMP_IF_NOT_EG_MATCH`  | but doesn't jump                        |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`COPY`                          | | :opcode:`!DUP_TOP`               | Stack manipulation instructions         |
+| | :opcode:`SWAP`                          | | :opcode:`!DUP_TOP_TWO`           |                                         |
+|                                           | | :opcode:`!ROT_TWO`               |                                         |
+|                                           | | :opcode:`!ROT_THREE`             |                                         |
+|                                           | | :opcode:`!ROT_FOUR`              |                                         |
+|                                           | | :opcode:`!ROT_N`                 |                                         |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| :opcode:`COPY_FREE_VARS`                  |                                    | Avoids needing special caller-side code |
+|                                           |                                    | for closures                            |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| :opcode:`JUMP_BACKWARD_NO_INTERRUPT`      |                                    | For certain loops where                 |
+|                                           |                                    | handling interrupts is undesirable      |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`JUMP_BACKWARD`                 | | :opcode:`!JUMP_ABSOLUTE`         | All jump opcodes now relative;          |
+| | :opcode:`POP_JUMP_BACKWARD_IF_*         | | :opcode:`!POP_JUMP_IF_FALSE`     | arg is offset from current instruction  |
+|   <POP_JUMP_BACKWARD_IF_TRUE>`            | | :opcode:`!POP_JUMP_IF_TRUE`      | rather than absolute location           |
+| | :opcode:`POP_JUMP_FORWARD_IF_*          |                                    | and most op names contain direction;    |
+|   <POP_JUMP_FORWARD_IF_TRUE>`             |                                    | added ``NONE`` & ``NOT_NONE`` variants  |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| :opcode:`MAKE_CELL`                       |                                    | Creates new :ref:`cell-objects`         |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| :opcode:`PREP_RERAISE_STAR`               |                                    | Handles the :ref:`new exception groups  |
+|                                           |                                    | <whatsnew311-pep654>`                   |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| :opcode:`PUSH_EXC_INFO`                   |                                    | For use in exception handlers           |
++-------------------------------------------+------------------------------------+-----------------------------------------+
+| :opcode:`RESUME`                          |                                    | No-op; performs internal tracing,       |
+|                                           |                                    | debugging and optimization checks       |
++-------------------------------------------+------------------------------------+-----------------------------------------+
 
 .. [#opcode-cache] The bytecode now contains inline cache entries,
    which take the form of :opcode:`CACHE` instructions.
@@ -1453,52 +1474,6 @@ Added Opcodes
    Populated caches can look like arbitrary instructions,
    so great care should be taken when reading or modifying
    raw, adaptive bytecode containing quickened data.
-
-
-.. _whatsnew311-replaced-opcodes:
-
-Replaced Opcodes
-----------------
-
-+------------------------------------+----------------------------------------+--------------------+
-| Removed Opcode(s)                  | New Opcode(s)                          | Notes              |
-+===============+====================+========================================+====================+
-| | :opcode:`!BINARY_*`              | :opcode:`BINARY_OP`                    | [#opcode-binary]_  |
-| | :opcode:`!INPLACE_*`             |                                        |                    |
-+------------------------------------+----------------------------------------+--------------------+
-| | :opcode:`!CALL_FUNCTION`         | | :opcode:`CALL`                       | [#opcode-call]_    |
-| | :opcode:`!CALL_FUNCTION_KW`      | | :opcode:`KW_NAMES`                   |                    |
-| | :opcode:`!CALL_METHOD`           | | :opcode:`PRECALL`                    |                    |
-|                                    | | :opcode:`PUSH_NULL`                  |                    |
-+------------------------------------+----------------------------------------+--------------------+
-| | :opcode:`!DUP_TOP`               | | :opcode:`COPY`                       | Stack manipulation |
-| | :opcode:`!DUP_TOP_TWO`           | | :opcode:`SWAP`                       |                    |
-| | :opcode:`!ROT_TWO`               |                                        |                    |
-| | :opcode:`!ROT_THREE`             |                                        |                    |
-| | :opcode:`!ROT_FOUR`              |                                        |                    |
-| | :opcode:`!ROT_N`                 |                                        |                    |
-+------------------------------------+----------------------------------------+--------------------+
-| :opcode:`!JUMP_ABSOLUTE`           | :opcode:`JUMP_BACKWARD`                | Now relative       |
-+------------------------------------+----------------------------------------+--------------------+
-| | :opcode:`!JUMP_IF_NOT_EXC_MATCH` | | :opcode:`CHECK_EXC_MATCH`            | Now performs check |
-| | :opcode:`!JUMP_IF_NOT_EG_MATCH`  | | :opcode:`CHECK_EG_MATCH`             | but doesn't jump   |
-+------------------------------------+----------------------------------------+--------------------+
-| | :opcode:`!POP_JUMP_IF_FALSE`     | | :opcode:`POP_JUMP_BACKWARD_IF_FALSE` | Now relative       |
-| |                                  | | :opcode:`POP_JUMP_FORWARD_IF_FALSE`  |                    |
-| | :opcode:`!POP_JUMP_IF_TRUE`      | | :opcode:`POP_JUMP_BACKWARD_IF_TRUE`  |                    |
-| |                                  | | :opcode:`POP_JUMP_FORWARD_IF_TRUE`   |                    |
-+------------------------------------+----------------------------------------+--------------------+
-| | :opcode:`!SETUP_WITH`            | :opcode:`BEFORE_WITH`                  | :keyword:`with`    |
-| | :opcode:`!SETUP_ASYNC_WITH`      |                                        | block setup        |
-+------------------------------------+----------------------------------------+--------------------+
-
-.. [#opcode-binary] Replaced all numeric :opcode:`!BINARY_*`
-   and :opcode:`!INPLACE_*` instructions
-   with a single :opcode:`BINARY_OP` implementation.
-
-.. [#opcode-call] Decouples the argument shifting for methods
-   from the handling of keyword arguments
-   and allows better specialization of calls.
 
 
 .. _whatsnew311-removed-opcodes:

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1432,7 +1432,7 @@ New opcodes
 
 * :opcode:`MAKE_CELL`, to create :ref:`cell-objects`.
 
-* :opcode:`PREP_RERAISE_STAR`,
+* :opcode:`CHECK_EG_MATCH`  and  :opcode:`PREP_RERAISE_STAR`,
   to handle the :ref:`new exception groups and except* <whatsnew311-pep654>`
   added in :pep:`654`.
 
@@ -1466,7 +1466,6 @@ Replaced opcodes
 | | :opcode:`!ROT_N`                 |                                   |                                         |
 +------------------------------------+-----------------------------------+-----------------------------------------+
 | | :opcode:`!JUMP_IF_NOT_EXC_MATCH` | | :opcode:`CHECK_EXC_MATCH`       | Now performs check but doesn't jump     |
-| | :opcode:`!JUMP_IF_NOT_EG_MATCH`  | | :opcode:`CHECK_EG_MATCH`        |                                         |
 +------------------------------------+-----------------------------------+-----------------------------------------+
 | | :opcode:`!JUMP_ABSOLUTE`         | | :opcode:`JUMP_BACKWARD`         | See [#bytecode-jump]_;                  |
 | | :opcode:`!POP_JUMP_IF_FALSE`     | | :opcode:`POP_JUMP_BACKWARD_IF_* | ``TRUE``, ``FALSE``,                    |

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1407,73 +1407,76 @@ contributors are volunteers from the community.
 CPython bytecode changes
 ========================
 
+The bytecode now contains inline cache entries,
+which take the form of the newly-added :opcode:`CACHE` instructions.
+Many opcodes expect to be followed by an exact number of caches,
+and instruct the interpreter to skip over them at runtime.
+Populated caches can look like arbitrary instructions,
+so great care should be taken when reading or modifying
+raw, adaptive bytecode containing quickened data.
+
+
 .. _whatsnew311-added-opcodes:
+
+New opcodes
+-----------
+
+* :opcode:`ASYNC_GEN_WRAP`, :opcode:`RETURN_GENERATOR` and :opcode:`SEND`,
+  used in generators and co-routines.
+
+* :opcode:`COPY_FREE_VARS`,
+  which avoids needing special caller-side code for closures.
+
+* :opcode:`JUMP_BACKWARD_NO_INTERRUPT`,
+  for use in certain loops where handling interrupts is undesirable.
+
+* :opcode:`MAKE_CELL`, to create :ref:`cell-objects`.
+
+* :opcode:`PREP_RERAISE_STAR`,
+  to handle the :ref:`new exception groups and except* <whatsnew311-pep654>`
+  added in :pep:`654`.
+
+* :opcode:`PUSH_EXC_INFO`, for use in exception handlers.
+
+* :opcode:`RESUME`, a no-op,
+  for internal tracing, debugging and optimization checks.
+
+
 .. _whatsnew311-replaced-opcodes:
-.. _whatsnew311-added-replaced-opcodes:
 
-Added/Replaced Opcodes
-----------------------
+Replaced opcodes
+----------------
 
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| New Opcode(s)                             | Replaced Opcode(s)                 | Notes                                   |
-+===========================================+====================================+=========================================+
-| | :opcode:`ASYNC_GEN_WRAP`                |                                    | Used in generators and co-routines      |
-| | :opcode:`RETURN_GENERATOR`              |                                    |                                         |
-| | :opcode:`SEND`                          |                                    |                                         |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| :opcode:`BEFORE_WITH`                     | | :opcode:`!SETUP_WITH`            | :keyword:`with` block setup             |
-|                                           | | :opcode:`!SETUP_ASYNC_WITH`      |                                         |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| :opcode:`BINARY_OP`                       | | :opcode:`!BINARY_*`              | Replaced all numeric binary/in-place    |
-|                                           | | :opcode:`!INPLACE_*`             | opcodes with a single opcode            |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| :opcode:`CACHE`                           |                                    | Inline cache entries [#opcode-cache]_   |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| | :opcode:`CALL`                          | | :opcode:`!CALL_FUNCTION`         | Decouples argument shifting for methods |
-| | :opcode:`KW_NAMES`                      | | :opcode:`!CALL_FUNCTION_KW`      | from handling of keyword arguments;     |
-| | :opcode:`PRECALL`                       | | :opcode:`!CALL_METHOD`           | allows better specialization of calls   |
-| | :opcode:`PUSH_NULL`                     |                                    |                                         |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| | :opcode:`CHECK_EXC_MATCH`               | | :opcode:`!JUMP_IF_NOT_EXC_MATCH` | Now performs check                      |
-| | :opcode:`CHECK_EG_MATCH`                | | :opcode:`!JUMP_IF_NOT_EG_MATCH`  | but doesn't jump                        |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| | :opcode:`COPY`                          | | :opcode:`!DUP_TOP`               | Stack manipulation instructions         |
-| | :opcode:`SWAP`                          | | :opcode:`!DUP_TOP_TWO`           |                                         |
-|                                           | | :opcode:`!ROT_TWO`               |                                         |
-|                                           | | :opcode:`!ROT_THREE`             |                                         |
-|                                           | | :opcode:`!ROT_FOUR`              |                                         |
-|                                           | | :opcode:`!ROT_N`                 |                                         |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| :opcode:`COPY_FREE_VARS`                  |                                    | Avoids needing special caller-side code |
-|                                           |                                    | for closures                            |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| :opcode:`JUMP_BACKWARD_NO_INTERRUPT`      |                                    | For certain loops where                 |
-|                                           |                                    | handling interrupts is undesirable      |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| | :opcode:`JUMP_BACKWARD`                 | | :opcode:`!JUMP_ABSOLUTE`         | All jump opcodes now relative;          |
-| | :opcode:`POP_JUMP_BACKWARD_IF_*         | | :opcode:`!POP_JUMP_IF_FALSE`     | arg is offset from current instruction  |
-|   <POP_JUMP_BACKWARD_IF_TRUE>`            | | :opcode:`!POP_JUMP_IF_TRUE`      | rather than absolute location           |
-| | :opcode:`POP_JUMP_FORWARD_IF_*          |                                    | and most op names contain direction;    |
-|   <POP_JUMP_FORWARD_IF_TRUE>`             |                                    | added ``NONE`` & ``NOT_NONE`` variants  |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| :opcode:`MAKE_CELL`                       |                                    | Creates new :ref:`cell-objects`         |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| :opcode:`PREP_RERAISE_STAR`               |                                    | Handles the :ref:`new exception groups  |
-|                                           |                                    | <whatsnew311-pep654>`                   |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| :opcode:`PUSH_EXC_INFO`                   |                                    | For use in exception handlers           |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-| :opcode:`RESUME`                          |                                    | No-op; performs internal tracing,       |
-|                                           |                                    | debugging and optimization checks       |
-+-------------------------------------------+------------------------------------+-----------------------------------------+
-
-.. [#opcode-cache] The bytecode now contains inline cache entries,
-   which take the form of :opcode:`CACHE` instructions.
-   Many opcodes expect to be followed by an exact number of caches,
-   and instruct the interpreter to skip over them at runtime.
-   Populated caches can look like arbitrary instructions,
-   so great care should be taken when reading or modifying
-   raw, adaptive bytecode containing quickened data.
++-----------------------------------+------------------------------------+-----------------------------------------+
+| New Opcode(s)                     | Replaced Opcode(s)                 | Notes                                   |
++===================================+====================================+=========================================+
+| :opcode:`BEFORE_WITH`             | | :opcode:`!SETUP_WITH`            | :keyword:`with` block setup             |
+|                                   | | :opcode:`!SETUP_ASYNC_WITH`      |                                         |
++-----------------------------------+------------------------------------+-----------------------------------------+
+| :opcode:`BINARY_OP`               | | :opcode:`!BINARY_*`              | Replaced all numeric binary/in-place    |
+|                                   | | :opcode:`!INPLACE_*`             | opcodes with a single opcode            |
++-----------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`CALL`                  | | :opcode:`!CALL_FUNCTION`         | Decouples argument shifting for methods |
+| | :opcode:`KW_NAMES`              | | :opcode:`!CALL_FUNCTION_KW`      | from handling of keyword arguments;     |
+| | :opcode:`PRECALL`               | | :opcode:`!CALL_METHOD`           | allows better specialization of calls   |
+| | :opcode:`PUSH_NULL`             |                                    |                                         |
++-----------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`CHECK_EXC_MATCH`       | | :opcode:`!JUMP_IF_NOT_EXC_MATCH` | Now performs check                      |
+| | :opcode:`CHECK_EG_MATCH`        | | :opcode:`!JUMP_IF_NOT_EG_MATCH`  | but doesn't jump                        |
++-----------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`COPY`                  | | :opcode:`!DUP_TOP`               | Stack manipulation instructions         |
+| | :opcode:`SWAP`                  | | :opcode:`!DUP_TOP_TWO`           |                                         |
+|                                   | | :opcode:`!ROT_TWO`               |                                         |
+|                                   | | :opcode:`!ROT_THREE`             |                                         |
+|                                   | | :opcode:`!ROT_FOUR`              |                                         |
+|                                   | | :opcode:`!ROT_N`                 |                                         |
++-----------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`JUMP_BACKWARD`         | | :opcode:`!JUMP_ABSOLUTE`         | All jump opcodes now relative;          |
+| | :opcode:`POP_JUMP_BACKWARD_IF_* | | :opcode:`!POP_JUMP_IF_FALSE`     | arg is offset from current instruction  |
+|   <POP_JUMP_BACKWARD_IF_TRUE>`    | | :opcode:`!POP_JUMP_IF_TRUE`      | rather than absolute location           |
+| | :opcode:`POP_JUMP_FORWARD_IF_*  |                                    | and most op names contain direction;    |
+|   <POP_JUMP_FORWARD_IF_TRUE>`     |                                    | added ``NONE`` & ``NOT_NONE`` variants  |
++-----------------------------------+------------------------------------+-----------------------------------------+
 
 
 .. _whatsnew311-removed-opcodes:

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1407,6 +1407,59 @@ contributors are volunteers from the community.
 CPython bytecode changes
 ========================
 
++-------------------------------------------+-------------------------------------------+
+| Old Opcode(s)                             | New Opcode(s)                             |
++===============+===========================+===========================================+
+|                                           | | :opcode:`ASYNC_GEN_WRAP`                |
+|                                           | | :opcode:`CACHE`                         |
+|                                           | | :opcode:`COPY_FREE_VARS`                |
+|                                           | | :opcode:`JUMP_BACKWARD_NO_INTERRUPT`    |
+|                                           | | :opcode:`MAKE_CELL`                     |
+|                                           | | :opcode:`POP_JUMP_BACKWARD_IF_NONE`     |
+|                                           | | :opcode:`POP_JUMP_BACKWARD_IF_NOT_NONE` |
+|                                           | | :opcode:`POP_JUMP_FORWARD_IF_NOT_NONE`  |
+|                                           | | :opcode:`POP_JUMP_FORWARD_IF_NONE`      |
+|                                           | | :opcode:`PREP_RERAISE_STAR`             |
+|                                           | | :opcode:`PUSH_EXC_INFO`                 |
+|                                           | | :opcode:`RESUME`                        |
+|                                           | | :opcode:`RETURN_GENERATOR`              |
+|                                           | | :opcode:`SEND`                          |
++-------------------------------------------+-------------------------------------------+
+| | :opcode:`!BINARY_*`                     | :opcode:`BINARY_OP`                       |
+| | :opcode:`!INPLACE_*`                    |                                           |
++-------------------------------------------+-------------------------------------------+
+| | :opcode:`!CALL_FUNCTION`                | | :opcode:`CALL`                          |
+| | :opcode:`!CALL_FUNCTION_KW`             | | :opcode:`KW_NAMES`                      |
+| | :opcode:`!CALL_METHOD`                  | | :opcode:`PRECALL`                       |
+|                                           | | :opcode:`PUSH_NULL`                     |
++-------------------------------------------+-------------------------------------------+
+| | :opcode:`!DUP_TOP`                      | | :opcode:`COPY`                          |
+| | :opcode:`!DUP_TOP_TWO`                  | | :opcode:`SWAP`                          |
+| | :opcode:`!ROT_TWO`                      |                                           |
+| | :opcode:`!ROT_THREE`                    |                                           |
+| | :opcode:`!ROT_FOUR`                     |                                           |
+| | :opcode:`!ROT_N`                        |                                           |
++-------------------------------------------+-------------------------------------------+
+| :opcode:`!JUMP_ABSOLUTE`                  | :opcode:`JUMP_BACKWARD`                   |
++-------------------------------------------+-------------------------------------------+
+| :opcode:`!JUMP_IF_NOT_EXC_MATCH`          | :opcode:`CHECK_EXC_MATCH`                 |
++-------------------------------------------+-------------------------------------------+
+| :opcode:`!JUMP_IF_NOT_EG_MATCH`           | :opcode:`CHECK_EG_MATCH`                  |
++-------------------------------------------+-------------------------------------------+
+| :opcode:`!POP_JUMP_IF_FALSE`              | | :opcode:`POP_JUMP_BACKWARD_IF_FALSE`    |
+|                                           | | :opcode:`POP_JUMP_FORWARD_IF_FALSE`     |
++-------------------------------------------+-------------------------------------------+
+| :opcode:`!POP_JUMP_IF_TRUE`               | | :opcode:`POP_JUMP_BACKWARD_IF_TRUE`     |
+|                                           | | :opcode:`POP_JUMP_FORWARD_IF_TRUE`      |
++-------------------------------------------+-------------------------------------------+
+| | :opcode:`!COPY_DICT_WITHOUT_KEYS`       |                                           |
+| | :opcode:`!GEN_START`                    |                                           |
+| | :opcode:`!POP_BLOCK`                    |                                           |
+| | :opcode:`!SETUP_FINALLY`                |                                           |
+| | :opcode:`!YIELD_FROM`                   |                                           |
++-------------------------------------------+-------------------------------------------+
+
+
 * The bytecode now contains inline cache entries, which take the form of
   :opcode:`CACHE` instructions. Many opcodes expect to be followed by an exact
   number of caches, and instruct the interpreter to skip over them at runtime.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1447,36 +1447,36 @@ New opcodes
 Replaced opcodes
 ----------------
 
-+-----------------------------------+------------------------------------+-----------------------------------------+
-| New Opcode(s)                     | Replaced Opcode(s)                 | Notes                                   |
-+===================================+====================================+=========================================+
-| :opcode:`BEFORE_WITH`             | | :opcode:`!SETUP_WITH`            | :keyword:`with` block setup             |
-|                                   | | :opcode:`!SETUP_ASYNC_WITH`      |                                         |
-+-----------------------------------+------------------------------------+-----------------------------------------+
-| :opcode:`BINARY_OP`               | | :opcode:`!BINARY_*`              | Replaced all numeric binary/in-place    |
-|                                   | | :opcode:`!INPLACE_*`             | opcodes with a single opcode            |
-+-----------------------------------+------------------------------------+-----------------------------------------+
-| | :opcode:`CALL`                  | | :opcode:`!CALL_FUNCTION`         | Decouples argument shifting for methods |
-| | :opcode:`KW_NAMES`              | | :opcode:`!CALL_FUNCTION_KW`      | from handling of keyword arguments;     |
-| | :opcode:`PRECALL`               | | :opcode:`!CALL_METHOD`           | allows better specialization of calls   |
-| | :opcode:`PUSH_NULL`             |                                    |                                         |
-+-----------------------------------+------------------------------------+-----------------------------------------+
-| | :opcode:`CHECK_EXC_MATCH`       | | :opcode:`!JUMP_IF_NOT_EXC_MATCH` | Now performs check                      |
-| | :opcode:`CHECK_EG_MATCH`        | | :opcode:`!JUMP_IF_NOT_EG_MATCH`  | but doesn't jump                        |
-+-----------------------------------+------------------------------------+-----------------------------------------+
-| | :opcode:`COPY`                  | | :opcode:`!DUP_TOP`               | Stack manipulation instructions         |
-| | :opcode:`SWAP`                  | | :opcode:`!DUP_TOP_TWO`           |                                         |
-|                                   | | :opcode:`!ROT_TWO`               |                                         |
-|                                   | | :opcode:`!ROT_THREE`             |                                         |
-|                                   | | :opcode:`!ROT_FOUR`              |                                         |
-|                                   | | :opcode:`!ROT_N`                 |                                         |
-+-----------------------------------+------------------------------------+-----------------------------------------+
-| | :opcode:`JUMP_BACKWARD`         | | :opcode:`!JUMP_ABSOLUTE`         | All jump opcodes now relative;          |
-| | :opcode:`POP_JUMP_BACKWARD_IF_* | | :opcode:`!POP_JUMP_IF_FALSE`     | arg is offset from current instruction  |
-|   <POP_JUMP_BACKWARD_IF_TRUE>`    | | :opcode:`!POP_JUMP_IF_TRUE`      | rather than absolute location           |
-| | :opcode:`POP_JUMP_FORWARD_IF_*  |                                    | and most op names contain direction;    |
-|   <POP_JUMP_FORWARD_IF_TRUE>`     |                                    | added ``NONE`` & ``NOT_NONE`` variants  |
-+-----------------------------------+------------------------------------+-----------------------------------------+
++------------------------------------+-----------------------------------+-----------------------------------------+
+| Replaced Opcode(s)                 | New Opcode(s)                     | Notes                                   |
++====================================+===================================+=========================================+
+| | :opcode:`!BINARY_*`              | :opcode:`BINARY_OP`               | Replaced all numeric binary/in-place    |
+| | :opcode:`!INPLACE_*`             |                                   | opcodes with a single opcode            |
++------------------------------------+-----------------------------------+-----------------------------------------+
+| | :opcode:`!CALL_FUNCTION`         | | :opcode:`CALL`                  | Decouples argument shifting for methods |
+| | :opcode:`!CALL_FUNCTION_KW`      | | :opcode:`KW_NAMES`              | from handling of keyword arguments;     |
+| | :opcode:`!CALL_METHOD`           | | :opcode:`PRECALL`               | allows better specialization of calls   |
+|                                    | | :opcode:`PUSH_NULL`             |                                         |
++------------------------------------+-----------------------------------+-----------------------------------------+
+| | :opcode:`!DUP_TOP`               | | :opcode:`COPY`                  | Stack manipulation instructions         |
+| | :opcode:`!DUP_TOP_TWO`           | | :opcode:`SWAP`                  |                                         |
+| | :opcode:`!ROT_TWO`               |                                   |                                         |
+| | :opcode:`!ROT_THREE`             |                                   |                                         |
+| | :opcode:`!ROT_FOUR`              |                                   |                                         |
+| | :opcode:`!ROT_N`                 |                                   |                                         |
++------------------------------------+-----------------------------------+-----------------------------------------+
+| | :opcode:`!JUMP_IF_NOT_EXC_MATCH` | | :opcode:`CHECK_EXC_MATCH`       | Now performs check but doesn't jump     |
+| | :opcode:`!JUMP_IF_NOT_EG_MATCH`  | | :opcode:`CHECK_EG_MATCH`        |                                         |
++------------------------------------+-----------------------------------+-----------------------------------------+
+| | :opcode:`!JUMP_ABSOLUTE`         | | :opcode:`JUMP_BACKWARD`         | All jump opcodes now relative;          |
+| | :opcode:`!POP_JUMP_IF_FALSE`     | | :opcode:`POP_JUMP_BACKWARD_IF_* | arg is offset from current instruction  |
+| | :opcode:`!POP_JUMP_IF_TRUE`      |   <POP_JUMP_BACKWARD_IF_TRUE>`    | rather than absolute location;          |
+|                                    | | :opcode:`POP_JUMP_FORWARD_IF_*  | added ``NONE`` & ``NOT_NONE`` variants  |
+|                                    |   <POP_JUMP_FORWARD_IF_TRUE>`     |                                         |
++------------------------------------+-----------------------------------+-----------------------------------------+
+| | :opcode:`!SETUP_WITH`            | :opcode:`BEFORE_WITH`             | :keyword:`with` block setup             |
+| | :opcode:`!SETUP_ASYNC_WITH`      |                                   |                                         |
++------------------------------------+-----------------------------------+-----------------------------------------+
 
 
 .. _whatsnew311-removed-opcodes:

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1527,6 +1527,10 @@ Changed Opcodes
   Instead, they indicate failure with ``None``
   (where a tuple of extracted values would otherwise be).
 
+* Changed opcodes that work with exceptions to reflect them
+  now being represented as one item on the stack instead of three
+  (see :gh:`89874`).
+
 
 .. _whatsnew311-deprecated:
 .. _whatsnew311-python-api-deprecated:

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1414,6 +1414,17 @@ CPython bytecode changes
   taken when reading or modifying raw, adaptive bytecode containing quickened
   data.
 
+* Added :opcode:`JUMP_BACKWARD_NO_INTERRUPT`,
+  which is used in certain loops where it is undesirable to handle interrupts.
+
+* Added :opcode:`POP_JUMP_FORWARD_IF_NOT_NONE`,
+  :opcode:`POP_JUMP_BACKWARD_IF_NOT_NONE`,
+  :opcode:`POP_JUMP_FORWARD_IF_NONE` and :opcode:`POP_JUMP_BACKWARD_IF_NONE`
+  opcodes to speed up conditional jumps.
+
+* Added the :opcode:`RESUME` opcode. It is a no-op,
+  and performs internal tracing, debugging and optimization checks.
+
 * Replaced all numeric :opcode:`!BINARY_*` and :opcode:`!INPLACE_*` instructions
   with a single :opcode:`BINARY_OP` implementation.
 
@@ -1423,14 +1434,6 @@ CPython bytecode changes
   and :opcode:`KW_NAMES`.
   This decouples the argument shifting for methods from the handling of
   keyword arguments and allows better specialization of calls.
-
-* Removed :opcode:`!COPY_DICT_WITHOUT_KEYS` and :opcode:`!GEN_START`.
-
-* Changed :opcode:`MATCH_CLASS` and :opcode:`MATCH_KEYS`
-  to no longer push an additional boolean value
-  indicating whether the match succeeded or failed.
-  Instead, they indicate failure with ``None``
-  (where a tuple of extracted values would otherwise be).
 
 * Replaced several stack manipulation instructions
   (:opcode:`!DUP_TOP`, :opcode:`!DUP_TOP_TWO`, :opcode:`!ROT_TWO`,
@@ -1443,24 +1446,21 @@ CPython bytecode changes
 
 * Replaced :opcode:`!JUMP_ABSOLUTE` by the relative :opcode:`JUMP_BACKWARD`.
 
-* Added :opcode:`JUMP_BACKWARD_NO_INTERRUPT`,
-  which is used in certain loops where it is undesirable to handle interrupts.
-
 * Replaced :opcode:`!POP_JUMP_IF_TRUE` and :opcode:`!POP_JUMP_IF_FALSE` by
   the relative :opcode:`POP_JUMP_FORWARD_IF_TRUE`,
   :opcode:`POP_JUMP_BACKWARD_IF_TRUE`,
   :opcode:`POP_JUMP_FORWARD_IF_FALSE` and :opcode:`POP_JUMP_BACKWARD_IF_FALSE`.
 
-* Added :opcode:`POP_JUMP_FORWARD_IF_NOT_NONE`,
-  :opcode:`POP_JUMP_BACKWARD_IF_NOT_NONE`,
-  :opcode:`POP_JUMP_FORWARD_IF_NONE` and :opcode:`POP_JUMP_BACKWARD_IF_NONE`
-  opcodes to speed up conditional jumps.
+* Removed :opcode:`!COPY_DICT_WITHOUT_KEYS` and :opcode:`!GEN_START`.
 
 * Changed :opcode:`JUMP_IF_TRUE_OR_POP` and :opcode:`JUMP_IF_FALSE_OR_POP`
   to now be relative rather than absolute.
 
-* Added the :opcode:`RESUME` opcode. It is a no-op,
-  and performs internal tracing, debugging and optimization checks.
+* Changed :opcode:`MATCH_CLASS` and :opcode:`MATCH_KEYS`
+  to no longer push an additional boolean value
+  indicating whether the match succeeded or failed.
+  Instead, they indicate failure with ``None``
+  (where a tuple of extracted values would otherwise be).
 
 
 .. _whatsnew311-deprecated:

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1426,21 +1426,20 @@ CPython bytecode changes
 
 * Removed :opcode:`!COPY_DICT_WITHOUT_KEYS` and :opcode:`!GEN_START`.
 
-* :opcode:`MATCH_CLASS` and :opcode:`MATCH_KEYS` no longer push an additional
-  boolean value indicating whether the match succeeded or failed. Instead, they
-  indicate failure with ``None`` (where a tuple of extracted values would
-  otherwise be).
+* Changed :opcode:`MATCH_CLASS` and :opcode:`MATCH_KEYS`
+  to no longer push an additional boolean value
+  indicating whether the match succeeded or failed.
+  Instead, they indicate failure with ``None``
+  (where a tuple of extracted values would otherwise be).
 
 * Replaced several stack manipulation instructions
   (:opcode:`!DUP_TOP`, :opcode:`!DUP_TOP_TWO`, :opcode:`!ROT_TWO`,
   :opcode:`!ROT_THREE`, :opcode:`!ROT_FOUR`, and :opcode:`!ROT_N`)
   with new :opcode:`COPY` and :opcode:`SWAP` instructions.
 
-* Replaced :opcode:`!JUMP_IF_NOT_EXC_MATCH` by :opcode:`CHECK_EXC_MATCH`, which
-  performs the check but does not jump.
-
-* Replaced :opcode:`!JUMP_IF_NOT_EG_MATCH` by :opcode:`CHECK_EG_MATCH` which
-  performs the check but does not jump.
+* Replaced :opcode:`!JUMP_IF_NOT_EXC_MATCH` with :opcode:`CHECK_EXC_MATCH`
+  and :opcode:`!JUMP_IF_NOT_EG_MATCH` with :opcode:`CHECK_EG_MATCH`,
+  which perform the check but do not jump.
 
 * Replaced :opcode:`!JUMP_ABSOLUTE` by the relative :opcode:`JUMP_BACKWARD`.
 
@@ -1457,10 +1456,10 @@ CPython bytecode changes
   :opcode:`POP_JUMP_FORWARD_IF_NONE` and :opcode:`POP_JUMP_BACKWARD_IF_NONE`
   opcodes to speed up conditional jumps.
 
-* :opcode:`JUMP_IF_TRUE_OR_POP` and :opcode:`JUMP_IF_FALSE_OR_POP` are now
-  relative rather than absolute.
+* Changed :opcode:`JUMP_IF_TRUE_OR_POP` and :opcode:`JUMP_IF_FALSE_OR_POP`
+  to now be relative rather than absolute.
 
-* :opcode:`RESUME` has been added. It is a no-op,
+* Added the :opcode:`RESUME` opcode. It is a no-op,
   and performs internal tracing, debugging and optimization checks.
 
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1407,120 +1407,116 @@ contributors are volunteers from the community.
 CPython bytecode changes
 ========================
 
-+-------------------------------------------+-------------------------------------------+
-| Old Opcode(s)                             | New Opcode(s)                             |
-+===============+===========================+===========================================+
-|                                           | | :opcode:`ASYNC_GEN_WRAP`                |
-|                                           | | :opcode:`CACHE`                         |
-|                                           | | :opcode:`COPY_FREE_VARS`                |
-|                                           | | :opcode:`JUMP_BACKWARD_NO_INTERRUPT`    |
-|                                           | | :opcode:`MAKE_CELL`                     |
-|                                           | | :opcode:`POP_JUMP_BACKWARD_IF_NONE`     |
-|                                           | | :opcode:`POP_JUMP_BACKWARD_IF_NOT_NONE` |
-|                                           | | :opcode:`POP_JUMP_FORWARD_IF_NOT_NONE`  |
-|                                           | | :opcode:`POP_JUMP_FORWARD_IF_NONE`      |
-|                                           | | :opcode:`PREP_RERAISE_STAR`             |
-|                                           | | :opcode:`PUSH_EXC_INFO`                 |
-|                                           | | :opcode:`RESUME`                        |
-|                                           | | :opcode:`RETURN_GENERATOR`              |
-|                                           | | :opcode:`SEND`                          |
-+-------------------------------------------+-------------------------------------------+
-| | :opcode:`!BINARY_*`                     | :opcode:`BINARY_OP`                       |
-| | :opcode:`!INPLACE_*`                    |                                           |
-+-------------------------------------------+-------------------------------------------+
-| | :opcode:`!CALL_FUNCTION`                | | :opcode:`CALL`                          |
-| | :opcode:`!CALL_FUNCTION_KW`             | | :opcode:`KW_NAMES`                      |
-| | :opcode:`!CALL_METHOD`                  | | :opcode:`PRECALL`                       |
-|                                           | | :opcode:`PUSH_NULL`                     |
-+-------------------------------------------+-------------------------------------------+
-| | :opcode:`!DUP_TOP`                      | | :opcode:`COPY`                          |
-| | :opcode:`!DUP_TOP_TWO`                  | | :opcode:`SWAP`                          |
-| | :opcode:`!ROT_TWO`                      |                                           |
-| | :opcode:`!ROT_THREE`                    |                                           |
-| | :opcode:`!ROT_FOUR`                     |                                           |
-| | :opcode:`!ROT_N`                        |                                           |
-+-------------------------------------------+-------------------------------------------+
-| :opcode:`!JUMP_ABSOLUTE`                  | :opcode:`JUMP_BACKWARD`                   |
-+-------------------------------------------+-------------------------------------------+
-| :opcode:`!JUMP_IF_NOT_EXC_MATCH`          | :opcode:`CHECK_EXC_MATCH`                 |
-+-------------------------------------------+-------------------------------------------+
-| :opcode:`!JUMP_IF_NOT_EG_MATCH`           | :opcode:`CHECK_EG_MATCH`                  |
-+-------------------------------------------+-------------------------------------------+
-| :opcode:`!POP_JUMP_IF_FALSE`              | | :opcode:`POP_JUMP_BACKWARD_IF_FALSE`    |
-|                                           | | :opcode:`POP_JUMP_FORWARD_IF_FALSE`     |
-+-------------------------------------------+-------------------------------------------+
-| :opcode:`!POP_JUMP_IF_TRUE`               | | :opcode:`POP_JUMP_BACKWARD_IF_TRUE`     |
-|                                           | | :opcode:`POP_JUMP_FORWARD_IF_TRUE`      |
-+-------------------------------------------+-------------------------------------------+
-| | :opcode:`!COPY_DICT_WITHOUT_KEYS`       |                                           |
-| | :opcode:`!GEN_START`                    |                                           |
-| | :opcode:`!POP_BLOCK`                    |                                           |
-| | :opcode:`!SETUP_FINALLY`                |                                           |
-| | :opcode:`!YIELD_FROM`                   |                                           |
-+-------------------------------------------+-------------------------------------------+
 
 
-* The bytecode now contains inline cache entries, which take the form of
-  :opcode:`CACHE` instructions. Many opcodes expect to be followed by an exact
-  number of caches, and instruct the interpreter to skip over them at runtime.
-  Populated caches can look like arbitrary instructions, so great care should be
-  taken when reading or modifying raw, adaptive bytecode containing quickened
-  data.
+.. _whatsnew311-added-opcodes:
 
-* Added :opcode:`COPY_FREE_VARS` to avoid needing special caller-side code
-  to handle calling closures.
+Added Opcodes
+-------------
 
-* Added :opcode:`JUMP_BACKWARD_NO_INTERRUPT`,
-  which is used in certain loops where it is undesirable to handle interrupts.
++-------------------------------------------+-------------------------------------------------------------------------+
+| New Opcode(s)                             | Notes                                                                   |
++===========================================+=========================================================================+
+| | :opcode:`ASYNC_GEN_WRAP`                | Used in generators and co-routines                                      |
+| | :opcode:`RETURN_GENERATOR`              |                                                                         |
+| | :opcode:`SEND`                          |                                                                         |
++-------------------------------------------+-------------------------------------------------------------------------+
+| :opcode:`CACHE`                           | Inline cache entries [#opcode-cache]_                                   |
++-------------------------------------------+-------------------------------------------------------------------------+
+| :opcode:`COPY_FREE_VARS`                  | Avoids needing special caller-side code                                 |
+|                                           | to handle calling closures                                              |
++-------------------------------------------+-------------------------------------------------------------------------+
+| :opcode:`JUMP_BACKWARD_NO_INTERRUPT`      | Used in certain loops where                                             |
+|                                           | it is undesirable to handle interrupts                                  |
++-------------------------------------------+-------------------------------------------------------------------------+
+| :opcode:`MAKE_CELL`                       | Creates new :ref:`cell-objects`                                         |
++-------------------------------------------+-------------------------------------------------------------------------+
+| | :opcode:`POP_JUMP_BACKWARD_IF_NONE`     | Speeds up conditional jumps                                             |
+| | :opcode:`POP_JUMP_BACKWARD_IF_NOT_NONE` |                                                                         |
+| | :opcode:`POP_JUMP_FORWARD_IF_NOT_NONE`  |                                                                         |
+| | :opcode:`POP_JUMP_FORWARD_IF_NONE`      |                                                                         |
++-------------------------------------------+-------------------------------------------------------------------------+
+| :opcode:`PREP_RERAISE_STAR`               | Handles the new                                                         |
+|                                           | :ref:`exception groups and except*                                      |
+|                                           | <whatsnew311-pep654>`                                                   |
++-------------------------------------------+-------------------------------------------------------------------------+
+| :opcode:`PUSH_EXC_INFO`                   | For use in exception handlers                                           |
++-------------------------------------------+-------------------------------------------------------------------------+
+| :opcode:`RESUME`                          | No-op; performs internal tracing,                                       |
+|                                           | debugging and optimization checks                                       |
++-------------------------------------------+-------------------------------------------------------------------------+
 
-* Added :opcode:`MAKE_CELL` to create a new :ref:`cell object <cell-objects>`.
+.. [#opcode-cache] The bytecode now contains inline cache entries,
+   which take the form of :opcode:`CACHE` instructions.
+   Many opcodes expect to be followed by an exact number of caches,
+   and instruct the interpreter to skip over them at runtime.
+   Populated caches can look like arbitrary instructions,
+   so great care should be taken when reading or modifying
+   raw, adaptive bytecode containing quickened data.
 
-* Added :opcode:`POP_JUMP_FORWARD_IF_NOT_NONE`,
-  :opcode:`POP_JUMP_BACKWARD_IF_NOT_NONE`,
-  :opcode:`POP_JUMP_FORWARD_IF_NONE` and :opcode:`POP_JUMP_BACKWARD_IF_NONE`
-  opcodes to speed up conditional jumps.
 
-* Added :opcode:`PUSH_EXC_INFO` for use in exception handlers
-  and :opcode:`PREP_RERAISE_STAR` for the new
-  :ref:`exception groups and except* <whatsnew311-pep654>`.
+.. _whatsnew311-replaced-opcodes:
 
-* Added the :opcode:`RESUME` opcode. It is a no-op,
-  and performs internal tracing, debugging and optimization checks.
+Replaced Opcodes
+----------------
 
-* Added :opcode:`RETURN_GENERATOR`, :opcode:`SEND` and :opcode:`ASYNC_GEN_WRAP`,
-  used in generators and co-routines.
++------------------------------------+----------------------------------------+--------------------+
+| Removed Opcode(s)                  | New Opcode(s)                          | Notes              |
++===============+====================+========================================+====================+
+| | :opcode:`!BINARY_*`              | :opcode:`BINARY_OP`                    | [#opcode-binary]_  |
+| | :opcode:`!INPLACE_*`             |                                        |                    |
++------------------------------------+----------------------------------------+--------------------+
+| | :opcode:`!CALL_FUNCTION`         | | :opcode:`CALL`                       | [#opcode-call]_    |
+| | :opcode:`!CALL_FUNCTION_KW`      | | :opcode:`KW_NAMES`                   |                    |
+| | :opcode:`!CALL_METHOD`           | | :opcode:`PRECALL`                    |                    |
+|                                    | | :opcode:`PUSH_NULL`                  |                    |
++------------------------------------+----------------------------------------+--------------------+
+| | :opcode:`!DUP_TOP`               | | :opcode:`COPY`                       | Stack manipulation |
+| | :opcode:`!DUP_TOP_TWO`           | | :opcode:`SWAP`                       |                    |
+| | :opcode:`!ROT_TWO`               |                                        |                    |
+| | :opcode:`!ROT_THREE`             |                                        |                    |
+| | :opcode:`!ROT_FOUR`              |                                        |                    |
+| | :opcode:`!ROT_N`                 |                                        |                    |
++------------------------------------+----------------------------------------+--------------------+
+| :opcode:`!JUMP_ABSOLUTE`           | :opcode:`JUMP_BACKWARD`                | Now relative       |
++------------------------------------+----------------------------------------+--------------------+
+| | :opcode:`!JUMP_IF_NOT_EXC_MATCH` | | :opcode:`CHECK_EXC_MATCH`            | Now performs check |
+| | :opcode:`!JUMP_IF_NOT_EG_MATCH`  | | :opcode:`CHECK_EG_MATCH`             | but doesn't jump   |
++------------------------------------+----------------------------------------+--------------------+
+| | :opcode:`!POP_JUMP_IF_FALSE`     | | :opcode:`POP_JUMP_BACKWARD_IF_FALSE` | Now relative       |
+| |                                  | | :opcode:`POP_JUMP_FORWARD_IF_FALSE`  |                    |
+| | :opcode:`!POP_JUMP_IF_TRUE`      | | :opcode:`POP_JUMP_BACKWARD_IF_TRUE`  |                    |
+| |                                  | | :opcode:`POP_JUMP_FORWARD_IF_TRUE`   |                    |
++------------------------------------+----------------------------------------+--------------------+
+| | :opcode:`!SETUP_WITH`            | :opcode:`BEFORE_WITH`                  | :keyword:`with`    |
+| | :opcode:`!SETUP_ASYNC_WITH`      |                                        | block setup        |
++------------------------------------+----------------------------------------+--------------------+
 
-* Replaced all numeric :opcode:`!BINARY_*` and :opcode:`!INPLACE_*` instructions
-  with a single :opcode:`BINARY_OP` implementation.
+.. [#opcode-binary] Replaced all numeric :opcode:`!BINARY_*`
+   and :opcode:`!INPLACE_*` instructions
+   with a single :opcode:`BINARY_OP` implementation.
 
-* Replaced the three call instructions :opcode:`!CALL_FUNCTION`,
-  :opcode:`!CALL_FUNCTION_KW` and :opcode:`!CALL_METHOD` with
-  :opcode:`PUSH_NULL`, :opcode:`PRECALL`, :opcode:`CALL`,
-  and :opcode:`KW_NAMES`.
-  This decouples the argument shifting for methods from the handling of
-  keyword arguments and allows better specialization of calls.
+.. [#opcode-call] Decouples the argument shifting for methods
+   from the handling of keyword arguments
+   and allows better specialization of calls.
 
-* Replaced several stack manipulation instructions
-  (:opcode:`!DUP_TOP`, :opcode:`!DUP_TOP_TWO`, :opcode:`!ROT_TWO`,
-  :opcode:`!ROT_THREE`, :opcode:`!ROT_FOUR`, and :opcode:`!ROT_N`)
-  with new :opcode:`COPY` and :opcode:`SWAP` instructions.
 
-* Replaced :opcode:`!JUMP_IF_NOT_EXC_MATCH` with :opcode:`CHECK_EXC_MATCH`
-  and :opcode:`!JUMP_IF_NOT_EG_MATCH` with :opcode:`CHECK_EG_MATCH`,
-  which perform the check but do not jump.
+.. _whatsnew311-removed-opcodes:
 
-* Replaced :opcode:`!JUMP_ABSOLUTE` by the relative :opcode:`JUMP_BACKWARD`.
+Removed Opcodes
+---------------
 
-* Replaced :opcode:`!POP_JUMP_IF_TRUE` and :opcode:`!POP_JUMP_IF_FALSE` by
-  the relative :opcode:`POP_JUMP_FORWARD_IF_TRUE`,
-  :opcode:`POP_JUMP_BACKWARD_IF_TRUE`,
-  :opcode:`POP_JUMP_FORWARD_IF_FALSE` and :opcode:`POP_JUMP_BACKWARD_IF_FALSE`.
+* :opcode:`!COPY_DICT_WITHOUT_KEYS`
+* :opcode:`!GEN_START`
+* :opcode:`!POP_BLOCK`
+* :opcode:`!SETUP_FINALLY`
+* :opcode:`!YIELD_FROM`
 
-* Replaced :opcode:`!SETUP_WITH` and :opcode:`!SETUP_ASYNC_WITH`
-  with :opcode:`BEFORE_WITH`.
 
-* Removed opcodes :opcode:`!COPY_DICT_WITHOUT_KEYS`, :opcode:`!GEN_START`,
-  :opcode:`!POP_BLOCK`, :opcode:`!SETUP_FINALLY` and :opcode:`!YIELD_FROM`.
+.. _whatsnew311-changed-opcodes:
+
+Changed Opcodes
+---------------
 
 * Changed :opcode:`JUMP_IF_TRUE_OR_POP` and :opcode:`JUMP_IF_FALSE_OR_POP`
   to now be relative rather than absolute.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1414,16 +1414,28 @@ CPython bytecode changes
   taken when reading or modifying raw, adaptive bytecode containing quickened
   data.
 
+* Added :opcode:`COPY_FREE_VARS` to avoid needing special caller-side code
+  to handle calling closures.
+
 * Added :opcode:`JUMP_BACKWARD_NO_INTERRUPT`,
   which is used in certain loops where it is undesirable to handle interrupts.
+
+* Added :opcode:`MAKE_CELL` to create a new :ref:`cell object <cell-objects>`.
 
 * Added :opcode:`POP_JUMP_FORWARD_IF_NOT_NONE`,
   :opcode:`POP_JUMP_BACKWARD_IF_NOT_NONE`,
   :opcode:`POP_JUMP_FORWARD_IF_NONE` and :opcode:`POP_JUMP_BACKWARD_IF_NONE`
   opcodes to speed up conditional jumps.
 
+* Added :opcode:`PUSH_EXC_INFO` for use in exception handlers
+  and :opcode:`PREP_RERAISE_STAR` for the new
+  :ref:`exception groups and except* <whatsnew311-pep654>`.
+
 * Added the :opcode:`RESUME` opcode. It is a no-op,
   and performs internal tracing, debugging and optimization checks.
+
+* Added :opcode:`RETURN_GENERATOR`, :opcode:`SEND` and :opcode:`ASYNC_GEN_WRAP`,
+  used in generators and co-routines.
 
 * Replaced all numeric :opcode:`!BINARY_*` and :opcode:`!INPLACE_*` instructions
   with a single :opcode:`BINARY_OP` implementation.
@@ -1451,7 +1463,11 @@ CPython bytecode changes
   :opcode:`POP_JUMP_BACKWARD_IF_TRUE`,
   :opcode:`POP_JUMP_FORWARD_IF_FALSE` and :opcode:`POP_JUMP_BACKWARD_IF_FALSE`.
 
-* Removed :opcode:`!COPY_DICT_WITHOUT_KEYS` and :opcode:`!GEN_START`.
+* Replaced :opcode:`!SETUP_WITH` and :opcode:`!SETUP_ASYNC_WITH`
+  with :opcode:`BEFORE_WITH`.
+
+* Removed opcodes :opcode:`!COPY_DICT_WITHOUT_KEYS`, :opcode:`!GEN_START`,
+  :opcode:`!POP_BLOCK`, :opcode:`!SETUP_FINALLY` and :opcode:`!YIELD_FROM`.
 
 * Changed :opcode:`JUMP_IF_TRUE_OR_POP` and :opcode:`JUMP_IF_FALSE_OR_POP`
   to now be relative rather than absolute.


### PR DESCRIPTION
Part of #95913 

This PR expands, edits and formats the CPython Bytecode Changes section in the What's New in Python 3.11 document.

On the editing side, like with the other PRs, it:

* Uses clear, consistent phrasing on all bytecode entries, making them easier to scan and read
* Orders them more consistently (Added, Replaced, Removed, Changed, roughly alphabetical by opcode name within each, aside from special cases), for the same reasons
* Fixes and improves the Sphinx syntax and semantics

Likewise, it adds some missing additional opcodes that were added, replaced or removed in 3.11:

* Added `COPY_FREE_VARS`, `MAKE_CELL`, `PUSH_EXC_INFO`, `PREP_RE_RAISE_STAR`, `RETURN_GENERATOR`, `SEND` and `ASYNC_GEN_WRAP`
* Replaced `SETUP_WITH` and `SETUP_ASYNC_WITH` with `BEFORE_WITH`
* Removed `POP_BLOCK`, `SETUP_FINALLY` and `YIELD_FROM`

Finally, it consolidates the sets of replaced opcodes into a much quicker and easier to navigate table.

## Rendered Preview

<details>

<summary> --> Rendered Preview (click to expand) <--- </summary>

![image](https://user-images.githubusercontent.com/17051931/197420114-a212be6c-cc4b-485d-b8d9-bafd16658bbd.png)

</details>

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
