### PR TITLE
Fix: Mac/Extras.install.py，Can not filter osx .DS_store file

### DIFF
--- a/Mac/Extras.install.py
+++ b/Mac/Extras.install.py
@@ -12,6 +12,7 @@ def isclean(name):
     if name == 'CVS': return 0
     if name == '.cvsignore': return 0
     if name == '.DS_store': return 0
+    if name == '.DS_Store': return 0
     if name == '.svn': return 0
     if name.endswith('~'): return 0
     if name.endswith('.BAK'): return 0


### PR DESCRIPTION
Mac/Extras.install.py，Can not filter osx DS_store file

As 

```python
if name == '.DS_store': return 0
```

But in OSX, Real File Name is ` .DS_Store`, like this

```shell
(venv) zhangbo@zhangbodeMacBook-Pro a2 % ll -a
total 16
drwxr-xr-x  4 zhangbo  staff   128 Oct 22 17:34 .
drwxr-xr-x  8 zhangbo  staff   256 Oct 22 17:18 ..
-rw-r--r--@ 1 zhangbo  staff  6148 Oct 22 17:17 .DS_Store
drwxr-xr-x  3 zhangbo  staff    96 Oct 22 17:23 123
```

So we need update `.DS_store` to `.DS_Store`
