### PR TITLE
gh-95913: Edit & expand Deprecated section of 3.11 WhatsNew

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1559,6 +1559,19 @@ Standard Library
   :class:`configparser.ExtendedInterpolation` instead.
   (Contributed by Hugo van Kemenade in :issue:`46607`.)
 
+* The older set of :mod:`importlib.resources` functions were deprecated
+  in favor of the replacements added in Python 3.9
+  and will be removed in a future Python version,
+  due to not supporting resources located within package subdirectories:
+
+  * :func:`importlib.resources.contents`
+  * :func:`importlib.resources.is_resource`
+  * :func:`importlib.resources.open_binary`
+  * :func:`importlib.resources.open_text`
+  * :func:`importlib.resources.read_binary`
+  * :func:`importlib.resources.read_text`
+  * :func:`importlib.resources.path`
+
 * The :func:`locale.getdefaultlocale` function is deprecated and will be
   removed in Python 3.13. Use :func:`locale.setlocale`,
   :func:`locale.getpreferredencoding(False) <locale.getpreferredencoding>` and

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1509,25 +1509,15 @@ Modules
 * :pep:`594` led to the deprecations of the following modules
   slated for removal in Python 3.13:
 
-  * :mod:`aifc`
-  * :mod:`audioop`
-  * :mod:`cgi`
-  * :mod:`cgitb`
-  * :mod:`chunk`
-  * :mod:`crypt`
-  * :mod:`imghdr`
-  * :mod:`mailcap`
-  * :mod:`msilib`
-  * :mod:`nis`
-  * :mod:`nntplib`
-  * :mod:`ossaudiodev`
-  * :mod:`pipes`
-  * :mod:`sndhdr`
-  * :mod:`spwd`
-  * :mod:`sunau`
-  * :mod:`telnetlib`
-  * :mod:`uu`
-  * :mod:`xdrlib`
+  +---------------------+---------------------+---------------------+---------------------+---------------------+
+  | :mod:`aifc`         | :mod:`chunk`        | :mod:`msilib`       | :mod:`pipes`        | :mod:`telnetlib`    |
+  +---------------------+---------------------+---------------------+---------------------+---------------------+
+  | :mod:`audioop`      | :mod:`crypt`        | :mod:`nis`          | :mod:`sndhdr`       | :mod:`uu`           |
+  +---------------------+---------------------+---------------------+---------------------+---------------------+
+  | :mod:`cgi`          | :mod:`imghdr`       | :mod:`nntplib`      | :mod:`spwd`         | :mod:`xdrlib`       |
+  +---------------------+---------------------+---------------------+---------------------+---------------------+
+  | :mod:`cgitb`        | :mod:`mailcap`      | :mod:`ossaudiodev`  | :mod:`sunau`        |                     |
+  +---------------------+---------------------+---------------------+---------------------+---------------------+
 
   (Contributed by Brett Cannon in :issue:`47061` and Victor Stinner in
   :gh:`68966`.)

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1582,9 +1582,9 @@ Standard Library
   removed in Python 3.13. Use ``locale.setlocale(locale.LC_ALL, "")`` instead.
   (Contributed by Victor Stinner in :gh:`90817`.)
 
-* More strict rules will now be applied for numerical group references
+* Stricter rules will now be applied for numerical group references
   and group names in :ref:`regular expressions <re-syntax>`.
-  Only sequences of ASCII digits will be now accepted as a numerical reference,
+  Only sequences of ASCII digits will now be accepted as a numerical reference,
   and the group name in :class:`bytes` patterns and replacement strings
   can only contain ASCII letters, digits and underscores.
   For now, a deprecation warning is raised for syntax violating these rules.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1471,6 +1471,13 @@ This section lists Python APIs that have been deprecated in Python 3.11.
 
 Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
 
+
+.. _whatsnew311-deprecated-language:
+.. _whatsnew311-deprecated-builtins:
+
+Language/Builtins
+-----------------
+
 * Chaining :class:`classmethod` descriptors (introduced in :issue:`19072`)
   is now deprecated.  It can no longer be used to wrap other descriptors
   such as :class:`property`.  The core design of this feature was flawed
@@ -1485,76 +1492,17 @@ Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
   eventually a :exc:`SyntaxError`.
   (Contributed by Serhiy Storchaka in :gh:`81548`.)
 
-* The :mod:`lib2to3` package and :ref:`2to3 <2to3-reference>` tool
-  are now deprecated and may not be able to parse Python 3.10 or newer.
-  See :pep:`617`, introducing the new PEG parser, for details.
-  (Contributed by Victor Stinner in :issue:`40360`.)
-
-* Undocumented modules :mod:`!sre_compile`, :mod:`!sre_constants`
-  and :mod:`!sre_parse` are now deprecated.
-  (Contributed by Serhiy Storchaka in :issue:`47152`.)
-
-* :class:`!webbrowser.MacOSX` is deprecated and will be removed in Python 3.13.
-  It is untested, undocumented, and not used by :mod:`webbrowser` itself.
-  (Contributed by Dong-hee Na in :issue:`42255`.)
-
-* The behavior of returning a value from a :class:`~unittest.TestCase` and
-  :class:`~unittest.IsolatedAsyncioTestCase` test methods (other than the
-  default ``None`` value) is now deprecated.
-
-* Deprecated the following not-formally-documented :mod:`unittest` functions,
-  scheduled for removal in Python 3.13:
-
-  * :func:`!unittest.findTestCases`
-  * :func:`!unittest.makeSuite`
-  * :func:`!unittest.getTestCaseNames`
-
-  Use :class:`~unittest.TestLoader` methods instead:
-
-  * :meth:`unittest.TestLoader.loadTestsFromModule`
-  * :meth:`unittest.TestLoader.loadTestsFromTestCase`
-  * :meth:`unittest.TestLoader.getTestCaseNames`
-
-  (Contributed by Erlend E. Aasland in :issue:`5846`.)
-
-* :func:`turtle.settiltangle` has been deprecated since Python 3.1;
-  it now emits a deprecation warning and will be removed in Python 3.13. Use
-  :func:`turtle.tiltangle` instead (it was earlier incorrectly marked
-  as deprecated, and its docstring is now corrected).
-  (Contributed by Hugo van Kemenade in :issue:`45837`.)
-
 * The delegation of :func:`int` to :meth:`~object.__trunc__` is now deprecated.
   Calling ``int(a)`` when ``type(a)`` implements :meth:`!__trunc__` but not
   :meth:`~object.__int__` or :meth:`~object.__index__` now raises
   a :exc:`DeprecationWarning`.
   (Contributed by Zackery Spytz in :issue:`44977`.)
 
-* The following have been deprecated in :mod:`configparser` since Python 3.2.
-  Their deprecation warnings have now been updated to note they will removed in
-  Python 3.12:
 
-  * the :class:`!configparser.SafeConfigParser` class
-  * the :attr:`!configparser.ParsingError.filename` property
-  * the :meth:`configparser.RawConfigParser.readfp` method
+.. _whatsnew311-deprecated-modules:
 
-  (Contributed by Hugo van Kemenade in :issue:`45173`.)
-
-* :class:`!configparser.LegacyInterpolation` has been deprecated in the docstring
-  since Python 3.2, and is not listed in the :mod:`configparser` documentation.
-  It now emits a :exc:`DeprecationWarning` and will be removed
-  in Python 3.13. Use :class:`configparser.BasicInterpolation` or
-  :class:`configparser.ExtendedInterpolation` instead.
-  (Contributed by Hugo van Kemenade in :issue:`46607`.)
-
-* The :func:`locale.getdefaultlocale` function is deprecated and will be
-  removed in Python 3.13. Use :func:`locale.setlocale`,
-  :func:`locale.getpreferredencoding(False) <locale.getpreferredencoding>` and
-  :func:`locale.getlocale` functions instead.
-  (Contributed by Victor Stinner in :gh:`90817`.)
-
-* The :func:`locale.resetlocale` function is deprecated and will be
-  removed in Python 3.13. Use ``locale.setlocale(locale.LC_ALL, "")`` instead.
-  (Contributed by Victor Stinner in :gh:`90817`.)
+Modules
+-------
 
 .. _whatsnew311-pep594:
 
@@ -1589,6 +1537,48 @@ Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
   warnings have now been updated to note they will removed in Python 3.12.
   (Contributed by Hugo van Kemenade in :issue:`47022`.)
 
+* The :mod:`lib2to3` package and :ref:`2to3 <2to3-reference>` tool
+  are now deprecated and may not be able to parse Python 3.10 or newer.
+  See :pep:`617`, introducing the new PEG parser, for details.
+  (Contributed by Victor Stinner in :issue:`40360`.)
+
+* Undocumented modules :mod:`!sre_compile`, :mod:`!sre_constants`
+  and :mod:`!sre_parse` are now deprecated.
+  (Contributed by Serhiy Storchaka in :issue:`47152`.)
+
+
+.. _whatsnew311-deprecated-stdlib:
+
+Standard Library
+----------------
+
+* The following have been deprecated in :mod:`configparser` since Python 3.2.
+  Their deprecation warnings have now been updated to note they will removed in
+  Python 3.12:
+
+  * the :class:`!configparser.SafeConfigParser` class
+  * the :attr:`!configparser.ParsingError.filename` property
+  * the :meth:`configparser.RawConfigParser.readfp` method
+
+  (Contributed by Hugo van Kemenade in :issue:`45173`.)
+
+* :class:`!configparser.LegacyInterpolation` has been deprecated in the docstring
+  since Python 3.2, and is not listed in the :mod:`configparser` documentation.
+  It now emits a :exc:`DeprecationWarning` and will be removed
+  in Python 3.13. Use :class:`configparser.BasicInterpolation` or
+  :class:`configparser.ExtendedInterpolation` instead.
+  (Contributed by Hugo van Kemenade in :issue:`46607`.)
+
+* The :func:`locale.getdefaultlocale` function is deprecated and will be
+  removed in Python 3.13. Use :func:`locale.setlocale`,
+  :func:`locale.getpreferredencoding(False) <locale.getpreferredencoding>` and
+  :func:`locale.getlocale` functions instead.
+  (Contributed by Victor Stinner in :gh:`90817`.)
+
+* The :func:`locale.resetlocale` function is deprecated and will be
+  removed in Python 3.13. Use ``locale.setlocale(locale.LC_ALL, "")`` instead.
+  (Contributed by Victor Stinner in :gh:`90817`.)
+
 * More strict rules will now be applied for numerical group references
   and group names in :ref:`regular expressions <re-syntax>`.
   Only sequences of ASCII digits will be now accepted as a numerical reference,
@@ -1596,6 +1586,18 @@ Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
   can only contain ASCII letters, digits and underscores.
   For now, a deprecation warning is raised for syntax violating these rules.
   (Contributed by Serhiy Storchaka in :gh:`91760`.)
+
+* In the :mod:`re` module, the :func:`!re.template` function
+  and the corresponding :data:`!re.TEMPLATE` and :data:`!re.T` flags
+  are deprecated, as they were undocumented and lacked an obvious purpose.
+  They will be removed in Python 3.13.
+  (Contributed by Serhiy Storchaka and Miro Hrončok in :gh:`92728`.)
+
+* :func:`turtle.settiltangle` has been deprecated since Python 3.1;
+  it now emits a deprecation warning and will be removed in Python 3.13. Use
+  :func:`turtle.tiltangle` instead (it was earlier incorrectly marked
+  as deprecated, and its docstring is now corrected).
+  (Contributed by Hugo van Kemenade in :issue:`45837`.)
 
 * :class:`typing.Text`, which exists solely to provide compatibility support
   between Python 2 and Python 3 code, is now deprecated. Its removal is
@@ -1607,11 +1609,28 @@ Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
   is now deprecated. Support will be removed in Python 3.13. (Contributed by
   Jingchen Ye in :gh:`90224`.)
 
-* In the :mod:`re` module, the :func:`!re.template` function
-  and the corresponding :data:`!re.TEMPLATE` and :data:`!re.T` flags
-  are deprecated, as they were undocumented and lacked an obvious purpose.
-  They will be removed in Python 3.13.
-  (Contributed by Serhiy Storchaka and Miro Hrončok in :gh:`92728`.)
+* :class:`!webbrowser.MacOSX` is deprecated and will be removed in Python 3.13.
+  It is untested, undocumented, and not used by :mod:`webbrowser` itself.
+  (Contributed by Dong-hee Na in :issue:`42255`.)
+
+* The behavior of returning a value from a :class:`~unittest.TestCase` and
+  :class:`~unittest.IsolatedAsyncioTestCase` test methods (other than the
+  default ``None`` value) is now deprecated.
+
+* Deprecated the following not-formally-documented :mod:`unittest` functions,
+  scheduled for removal in Python 3.13:
+
+  * :func:`!unittest.findTestCases`
+  * :func:`!unittest.makeSuite`
+  * :func:`!unittest.getTestCaseNames`
+
+  Use :class:`~unittest.TestLoader` methods instead:
+
+  * :meth:`unittest.TestLoader.loadTestsFromModule`
+  * :meth:`unittest.TestLoader.loadTestsFromTestCase`
+  * :meth:`unittest.TestLoader.getTestCaseNames`
+
+  (Contributed by Erlend E. Aasland in :issue:`5846`.)
 
 
 .. _whatsnew311-pending-removal:

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1475,40 +1475,41 @@ Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
   is now deprecated.  It can no longer be used to wrap other descriptors
   such as :class:`property`.  The core design of this feature was flawed
   and caused a number of downstream problems.  To "pass-through" a
-  :class:`classmethod`, consider using the ``__wrapped__`` attribute
+  :class:`classmethod`, consider using the :attr:`!__wrapped__` attribute
   that was added in Python 3.10.
   (Contributed by Raymond Hettinger in :gh:`89519`.)
 
-* Octal escapes in string and bytes literals with value larger than ``0o377`` now
-  produce :exc:`DeprecationWarning`.
-  In a future Python version they will be a :exc:`SyntaxWarning` and
+* Octal escapes in string and bytes literals with values larger than ``0o377``
+  (255 in decimal) now produce a :exc:`DeprecationWarning`.
+  In a future Python version, they will raise a :exc:`SyntaxWarning` and
   eventually a :exc:`SyntaxError`.
   (Contributed by Serhiy Storchaka in :gh:`81548`.)
 
-* The :mod:`lib2to3` package and ``2to3`` tool are now deprecated and may not
-  be able to parse Python 3.10 or newer. See the :pep:`617` (New PEG parser for
-  CPython).  (Contributed by Victor Stinner in :issue:`40360`.)
+* The :mod:`lib2to3` package and :ref:`2to3 <2to3-reference>` tool
+  are now deprecated and may not be able to parse Python 3.10 or newer.
+  See :pep:`617`, introducing the new PEG parser, for details.
+  (Contributed by Victor Stinner in :issue:`40360`.)
 
-* Undocumented modules ``sre_compile``, ``sre_constants`` and ``sre_parse``
-  are now deprecated.
+* Undocumented modules :mod:`!sre_compile`, :mod:`!sre_constants`
+  and :mod:`!sre_parse` are now deprecated.
   (Contributed by Serhiy Storchaka in :issue:`47152`.)
 
-* :class:`webbrowser.MacOSX` is deprecated and will be removed in Python 3.13.
-  It is untested and undocumented and also not used by webbrowser itself.
+* :class:`!webbrowser.MacOSX` is deprecated and will be removed in Python 3.13.
+  It is untested, undocumented, and not used by :mod:`webbrowser` itself.
   (Contributed by Dong-hee Na in :issue:`42255`.)
 
 * The behavior of returning a value from a :class:`~unittest.TestCase` and
   :class:`~unittest.IsolatedAsyncioTestCase` test methods (other than the
-  default ``None`` value), is now deprecated.
+  default ``None`` value) is now deprecated.
 
-* Deprecated the following :mod:`unittest` functions, scheduled for removal in
-  Python 3.13:
+* Deprecated the following not-formally-documented :mod:`unittest` functions,
+  scheduled for removal in Python 3.13:
 
-  * :func:`unittest.findTestCases`
-  * :func:`unittest.makeSuite`
-  * :func:`unittest.getTestCaseNames`
+  * :func:`!unittest.findTestCases`
+  * :func:`!unittest.makeSuite`
+  * :func:`!unittest.getTestCaseNames`
 
-  Use :class:`~unittest.TestLoader` method instead:
+  Use :class:`~unittest.TestLoader` methods instead:
 
   * :meth:`unittest.TestLoader.loadTestsFromModule`
   * :meth:`unittest.TestLoader.loadTestsFromTestCase`
@@ -1516,29 +1517,31 @@ Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
 
   (Contributed by Erlend E. Aasland in :issue:`5846`.)
 
-* The :meth:`turtle.RawTurtle.settiltangle` is deprecated since Python 3.1,
+* :func:`turtle.settiltangle` has been deprecated since Python 3.1;
   it now emits a deprecation warning and will be removed in Python 3.13. Use
-  :meth:`turtle.RawTurtle.tiltangle` instead (it was earlier incorrectly marked
-  as deprecated, its docstring is now corrected).
+  :func:`turtle.tiltangle` instead (it was earlier incorrectly marked
+  as deprecated, and its docstring is now corrected).
   (Contributed by Hugo van Kemenade in :issue:`45837`.)
 
-* The delegation of :func:`int` to :meth:`__trunc__` is now deprecated. Calling
-  ``int(a)`` when ``type(a)`` implements :meth:`__trunc__` but not
-  :meth:`__int__` or :meth:`__index__` now raises a :exc:`DeprecationWarning`.
+* The delegation of :func:`int` to :meth:`~object.__trunc__` is now deprecated.
+  Calling ``int(a)`` when ``type(a)`` implements :meth:`!__trunc__` but not
+  :meth:`~object.__int__` or :meth:`~object.__index__` now raises
+  a :exc:`DeprecationWarning`.
   (Contributed by Zackery Spytz in :issue:`44977`.)
 
 * The following have been deprecated in :mod:`configparser` since Python 3.2.
   Their deprecation warnings have now been updated to note they will removed in
   Python 3.12:
 
-  * the :class:`configparser.SafeConfigParser` class
-  * the :attr:`configparser.ParsingError.filename` property
+  * the :class:`!configparser.SafeConfigParser` class
+  * the :attr:`!configparser.ParsingError.filename` property
   * the :meth:`configparser.RawConfigParser.readfp` method
 
   (Contributed by Hugo van Kemenade in :issue:`45173`.)
 
-* :class:`configparser.LegacyInterpolation` has been deprecated in the docstring
-  since Python 3.2. It now emits a :exc:`DeprecationWarning` and will be removed
+* :class:`!configparser.LegacyInterpolation` has been deprecated in the docstring
+  since Python 3.2, and is not listed in the :mod:`configparser` documentation.
+  It now emits a :exc:`DeprecationWarning` and will be removed
   in Python 3.13. Use :class:`configparser.BasicInterpolation` or
   :class:`configparser.ExtendedInterpolation` instead.
   (Contributed by Hugo van Kemenade in :issue:`46607`.)
@@ -1555,7 +1558,7 @@ Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
 
 .. _whatsnew311-pep594:
 
-* :pep:`594` led to the deprecations of the following modules which are
+* :pep:`594` led to the deprecations of the following modules
   slated for removal in Python 3.13:
 
   * :mod:`aifc`
@@ -1586,12 +1589,12 @@ Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
   warnings have now been updated to note they will removed in Python 3.12.
   (Contributed by Hugo van Kemenade in :issue:`47022`.)
 
-* More strict rules will be applied now applied for numerical group references
-  and group names in regular expressions in future Python versions.
-  Only sequence of ASCII digits will be now accepted as a numerical reference.
-  The group name in bytes patterns and replacement strings could only
-  contain ASCII letters and digits and underscore.
-  For now, a deprecation warning is raised for such syntax.
+* More strict rules will now be applied for numerical group references
+  and group names in :ref:`regular expressions <re-syntax>`.
+  Only sequences of ASCII digits will be now accepted as a numerical reference,
+  and the group name in :class:`bytes` patterns and replacement strings
+  can only contain ASCII letters, digits and underscores.
+  For now, a deprecation warning is raised for syntax violating these rules.
   (Contributed by Serhiy Storchaka in :gh:`91760`.)
 
 * :class:`typing.Text`, which exists solely to provide compatibility support
@@ -1600,13 +1603,14 @@ Deprecated C APIs are :ref:`listed separately <whatsnew311-c-api-deprecated>`.
   wherever possible.
   (Contributed by Alex Waygood in :gh:`92332`.)
 
-* The keyword argument syntax for constructing :data:`~typing.TypedDict` types
+* The keyword argument syntax for constructing :data:`typing.TypedDict` types
   is now deprecated. Support will be removed in Python 3.13. (Contributed by
   Jingchen Ye in :gh:`90224`.)
 
-* The :func:`re.template` function and the corresponding :const:`re.TEMPLATE`
-  and :const:`re.T` flags are deprecated, as they were undocumented and
-  lacked an obvious purpose. They will be removed in Python 3.13.
+* In the :mod:`re` module, the :func:`!re.template` function
+  and the corresponding :data:`!re.TEMPLATE` and :data:`!re.T` flags
+  are deprecated, as they were undocumented and lacked an obvious purpose.
+  They will be removed in Python 3.13.
   (Contributed by Serhiy Storchaka and Miro Hrončok in :gh:`92728`.)
 
 


### PR DESCRIPTION
Part of #95913 

This PR copyedits, Sphinxifies, organizes and formats the Deprecated (Python) section in the Python 3.11 What's New. Specifically, it:

* Organizes the section from a long, flat, essentially arbitrary list of items to be ordered by Language/Builtin deprecations, then whole Module deprecation, and finally deprecations in the stdlib, sorted alphabetically. This puts the broader-reaching changes nearer the top and makes it much easier for readers to navigate and find particular areas/deprecations they are interested in.
* Formats the listing of PEP 594-removed modules from a long thin bulleted list to a table, to take up much less space while being easier to skim at a glance
* Tweaks the text to fix grammar and phrasing errors and issues
* Fixes and enhances the Sphinx cross-references and reST syntax used

Also, searching through deprecation warnings in the docs, I found one set of deprecations that weren't documented in the What's New, and did so:

* `importlib.resources` [deprecated its original set of functions added in 3.7](https://docs.python.org/3.11/library/importlib.resources.html#deprecated-functions) and supplanted by improved alternatives in 3.9. However, that hadn't been mentioned in the What's New anywhere I could find, so I added a short description and enumerated the relevant functions.

There may be more in the changelog that aren't properly documented in the docs, but if so that can wait for a followup.

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
