### PR TITLE
gh-95913: Edit, sort & expand 3.11 WhatsNew Porting section

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1799,6 +1799,10 @@ Porting notes for the C API are
   is larger than the population size, a :exc:`ValueError` is raised.
   (Contributed by Raymond Hettinger in :issue:`40465`.)
 
+* The *random* optional parameter of :func:`random.shuffle` was removed.
+  It was previously an arbitrary random function to use for the shuffle;
+  now, :func:`random.random` (its previous default) will always be used.
+
 * In :mod:`re` :ref:`re-syntax`, global inline flags (e.g. ``(?i)``)
   can now only be used at the start of regular expressions.
   Using them elsewhere has been deprecated since Python 3.6.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1766,20 +1766,21 @@ Porting notes for the C API are
 :ref:`listed separately <whatsnew311-c-api-porting>`.
 
 * Prohibited passing non-:class:`concurrent.futures.ThreadPoolExecutor`
-  executors to :meth:`loop.set_default_executor` following a deprecation in
-  Python 3.8.
+  executors to :meth:`asyncio.loop.set_default_executor`
+  following a deprecation in Python 3.8.
   (Contributed by Illia Volochii in :issue:`43234`.)
 
 * :func:`open`, :func:`io.open`, :func:`codecs.open` and
   :class:`fileinput.FileInput` no longer accept ``'U'`` ("universal newline")
-  in the file mode. This flag was deprecated since Python 3.3. In Python 3, the
-  "universal newline" is used by default when a file is open in text mode.  The
-  :ref:`newline parameter <open-newline-parameter>` of :func:`open` controls
-  how universal newlines works.
+  in the file mode. In Python 3, "universal newline" mode is used by default
+  whenever a file is opened in text mode,
+  and the ``'U'`` flag has been deprecated since Python 3.3.
+  The :ref:`newline parameter <open-newline-parameter>`
+  to these functions controls how universal newlines work.
   (Contributed by Victor Stinner in :issue:`37330`.)
 
 * The :mod:`pdb` module now reads the :file:`.pdbrc` configuration file with
-  the ``'utf-8'`` encoding.
+  the ``'UTF-8'`` encoding.
   (Contributed by Srinivas Reddy Thatiparthy (శ్రీనివాస్  రెడ్డి తాటిపర్తి) in :issue:`41137`.)
 
 * :mod:`calendar`: The :class:`calendar.LocaleTextCalendar` and
@@ -1788,18 +1789,19 @@ Porting notes for the C API are
   if no locale is specified.
   (Contributed by Victor Stinner in :issue:`46659`.)
 
-* Global inline flags (e.g. ``(?i)``) can now only be used at the start of
-  the regular expressions.  Using them not at the start of expression was
-  deprecated since Python 3.6.
+* In :mod:`re` :ref:`re-syntax`, global inline flags (e.g. ``(?i)``)
+  can now only be used at the start of regular expressions.
+  Using them elsewhere has been deprecated since Python 3.6.
   (Contributed by Serhiy Storchaka in :issue:`47066`.)
 
-* :mod:`re` module: Fix a few long-standing bugs where, in rare cases,
-  capturing group could get wrong result. So the result may be different than
-  before.
+* In the :mod:`re` module, several long-standing bugs where fixed that,
+  in rare cases, could cause capture groups to get the wrong result.
+  Therefore, this could change the captured output in these cases.
   (Contributed by Ma Lin in :issue:`35859`.)
 
-* The *population* parameter of :func:`random.sample` must be a sequence.
-  Automatic conversion of sets to lists is no longer supported. If the sample size
+* The *population* parameter of :func:`random.sample` must be a sequence,
+  and automatic conversion of :class:`set`\s to :class:`list`\s
+  is no longer supported. Also, if the sample size
   is larger than the population size, a :exc:`ValueError` is raised.
   (Contributed by Raymond Hettinger in :issue:`40465`.)
 
@@ -1808,8 +1810,8 @@ Porting notes for the C API are
   a :exc:`ValueError` will be raised. (Contributed by Pablo Galindo in :gh:`93351`)
 
 * :c:member:`~PyTypeObject.tp_dictoffset` should be treated as write-only.
-  It can be set to describe C extension clases to the VM, but should be regarded
-  as meaningless when read. To get the pointer to the object's dictionary call
+  It can be set to describe C extension classwa to the VM, but should be regarded
+  as meaningless when read. To get the pointer to the object's dictionary, call
   :c:func:`PyObject_GenericGetDict` instead.
 
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1765,11 +1765,6 @@ in the Python API that may require changes to your Python code.
 Porting notes for the C API are
 :ref:`listed separately <whatsnew311-c-api-porting>`.
 
-* Prohibited passing non-:class:`concurrent.futures.ThreadPoolExecutor`
-  executors to :meth:`asyncio.loop.set_default_executor`
-  following a deprecation in Python 3.8.
-  (Contributed by Illia Volochii in :issue:`43234`.)
-
 * :func:`open`, :func:`io.open`, :func:`codecs.open` and
   :class:`fileinput.FileInput` no longer accept ``'U'`` ("universal newline")
   in the file mode. In Python 3, "universal newline" mode is used by default
@@ -1779,15 +1774,30 @@ Porting notes for the C API are
   to these functions controls how universal newlines work.
   (Contributed by Victor Stinner in :issue:`37330`.)
 
-* The :mod:`pdb` module now reads the :file:`.pdbrc` configuration file with
-  the ``'UTF-8'`` encoding.
-  (Contributed by Srinivas Reddy Thatiparthy (శ్రీనివాస్  రెడ్డి తాటిపర్తి) in :issue:`41137`.)
+* :class:`ast.AST` node positions are now validated when provided to
+  :func:`compile` and other related functions. If invalid positions are detected,
+  a :exc:`ValueError` will be raised. (Contributed by Pablo Galindo in :gh:`93351`)
+
+* Prohibited passing non-:class:`concurrent.futures.ThreadPoolExecutor`
+  executors to :meth:`asyncio.loop.set_default_executor`
+  following a deprecation in Python 3.8.
+  (Contributed by Illia Volochii in :issue:`43234`.)
 
 * :mod:`calendar`: The :class:`calendar.LocaleTextCalendar` and
   :class:`calendar.LocaleHTMLCalendar` classes now use
   :func:`locale.getlocale`, instead of using :func:`locale.getdefaultlocale`,
   if no locale is specified.
   (Contributed by Victor Stinner in :issue:`46659`.)
+
+* The :mod:`pdb` module now reads the :file:`.pdbrc` configuration file with
+  the ``'UTF-8'`` encoding.
+  (Contributed by Srinivas Reddy Thatiparthy (శ్రీనివాస్  రెడ్డి తాటిపర్తి) in :issue:`41137`.)
+
+* The *population* parameter of :func:`random.sample` must be a sequence,
+  and automatic conversion of :class:`set`\s to :class:`list`\s
+  is no longer supported. Also, if the sample size
+  is larger than the population size, a :exc:`ValueError` is raised.
+  (Contributed by Raymond Hettinger in :issue:`40465`.)
 
 * In :mod:`re` :ref:`re-syntax`, global inline flags (e.g. ``(?i)``)
   can now only be used at the start of regular expressions.
@@ -1798,16 +1808,6 @@ Porting notes for the C API are
   in rare cases, could cause capture groups to get the wrong result.
   Therefore, this could change the captured output in these cases.
   (Contributed by Ma Lin in :issue:`35859`.)
-
-* The *population* parameter of :func:`random.sample` must be a sequence,
-  and automatic conversion of :class:`set`\s to :class:`list`\s
-  is no longer supported. Also, if the sample size
-  is larger than the population size, a :exc:`ValueError` is raised.
-  (Contributed by Raymond Hettinger in :issue:`40465`.)
-
-* :class:`ast.AST` node positions are now validated when provided to
-  :func:`compile` and other related functions. If invalid positions are detected,
-  a :exc:`ValueError` will be raised. (Contributed by Pablo Galindo in :gh:`93351`)
 
 * :c:member:`~PyTypeObject.tp_dictoffset` should be treated as write-only.
   It can be set to describe C extension classwa to the VM, but should be regarded

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1809,11 +1809,6 @@ Porting notes for the C API are
   Therefore, this could change the captured output in these cases.
   (Contributed by Ma Lin in :issue:`35859`.)
 
-* :c:member:`~PyTypeObject.tp_dictoffset` should be treated as write-only.
-  It can be set to describe C extension classwa to the VM, but should be regarded
-  as meaningless when read. To get the pointer to the object's dictionary, call
-  :c:func:`PyObject_GenericGetDict` instead.
-
 
 .. _whatsnew311-build-changes:
 


### PR DESCRIPTION
Part of #95913 

This PR copyedits, sorts and fixes the syntax of the Porting section of the What's New in Python 3.11 document. In particular, it:

* Orders the list alphabetically by module, with builtins at the top
* Adds, fixes and refines Sphinx cross references
* Adds appropriate Sphinx roles and other constructs
* Tweaks the text to fix grammar/wording issues
* Uses consistent, direct phrasing for easier/quicker readability

One item was added with this PR, based on grepping the docs, and one was removed:

* The *random* parameter to `random.shuffle` being removed was added
* A C API change mistakenly included in this section was removed, and will be added to the Porting section of the C API in a followup PR

There are likely a number of others that could be found by scouring the docs and changelog in detail, but I decided it was most pragmatic to defer that at least until later.

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
