### PR TITLE
gh-95913: Edit, link and sort 3.11 WhatsNew Build section

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1818,40 +1818,66 @@ Porting notes for the C API are
 Build Changes
 =============
 
-* Building Python now requires a
-  `C11 <https://en.cppreference.com/w/c/11>`_ compiler.
-  `Optional C11 features
-  <https://en.wikipedia.org/wiki/C11_(C_standard_revision)#Optional_features>`_
-  are not required.
-  (Contributed by Victor Stinner in :issue:`46656`.)
+* CPython now has :pep:`11` :pep:`Tier 3 support <11#tier-3>` for
+  cross compiling to the `WebAssembly <https://webassembly.org/>`_ platforms
+  `Emscripten <https://emscripten.org/>`_
+  (``wasm32-unknown-emscripten``, i.e. Python in the browser)
+  and `WebAssembly System Interface (WASI) <https://wasi.dev/>`_
+  (``wasm32-unknown-wasi``).
+  The effort is inspired by previous work like `Pyodide <https://pyodide.org/>`_.
+  These platforms provide a limited subset of POSIX APIs; Python standard
+  libraries features and modules related to networking, processes, threading,
+  signals, mmap, and users/groups are not available or don't work.
+  (Emscripten contributed by Christian Heimes and Ethan Smith in :gh:`84461`
+  and WASI contributed by Christian Heimes in :gh:`90473`;
+  platforms promoted in :gh:`95085`)
 
-* Building Python now requires support for
-  `IEEE 754 <https://en.wikipedia.org/wiki/IEEE_754>`_ floating point numbers.
-  (Contributed by Victor Stinner in :issue:`46917`.)
+* Building Python now requires:
+
+  * A `C11 <https://en.cppreference.com/w/c/11>`_ compiler.
+    `Optional C11 features
+    <https://en.wikipedia.org/wiki/C11_(C_standard_revision)#Optional_features>`_
+    are not required.
+    (Contributed by Victor Stinner in :issue:`46656`.)
+
+  * Support for `IEEE 754 <https://en.wikipedia.org/wiki/IEEE_754>`_
+    floating point numbers.
+    (Contributed by Victor Stinner in :issue:`46917`.)
+
+  * Support for `floating point Not-a-Number (NaN)
+    <https://en.wikipedia.org/wiki/NaN#Floating_point>`_,
+    as the :c:macro:`!Py_NO_NAN` macro has been removed.
+    (Contributed by Victor Stinner in :issue:`46656`.)
+
+  * A `C99 <https://en.cppreference.com/w/c/99>`_
+    ``<math.h>`` header file providing the
+    :c:func:`!copysign`, :c:func:`!hypot`, :c:func:`!isfinite`,
+    :c:func:`!isinf`, :c:func:`!isnan`, and :c:func:`!round` functions
+    (contributed by Victor Stinner in :issue:`45440`);
+    and a :c:data:`!NAN` constant or the :c:func:`!__builtin_nan` function
+    (Contributed by Victor Stinner in :issue:`46640`).
+
+* The :mod:`tkinter` package now requires `Tcl/Tk <https://www.tcl.tk>`_
+  version 8.5.12 or newer.
+  (Contributed by Serhiy Storchaka in :issue:`46996`.)
+
+* Build dependencies, compiler flags, and linker flags for most stdlib
+  extension modules are now detected by :program:`configure`. libffi, libnsl,
+  libsqlite3, zlib, bzip2, liblzma, libcrypt, Tcl/Tk, and uuid flags
+  are detected by `pkg-config
+  <https://www.freedesktop.org/wiki/Software/pkg-config/>`_ (when available).
+  :mod:`tkinter` now requires a pkg-config command
+  to detect development settings for `Tcl/Tk`_ headers and libraries.
+  (Contributed by Christian Heimes and Erlend Egeberg Aasland in
+  :issue:`45847`, :issue:`45747`, and :issue:`45763`.)
+
+* libpython is no longer linked against libcrypt.
+  (Contributed by Mike Gilbert in :issue:`45433`.)
 
 * CPython can now be built with the
   `ThinLTO <https://clang.llvm.org/docs/ThinLTO.html>`_ option
   via passing ``thin`` to :option:`--with-lto`, i.e. ``--with-lto=thin``.
   (Contributed by Dong-hee Na and Brett Holman in :issue:`44340`.)
-
-* libpython is no longer linked against libcrypt.
-  (Contributed by Mike Gilbert in :issue:`45433`.)
-
-* Building Python now requires a `C99 <https://en.cppreference.com/w/c/99>`_
-  ``<math.h>`` header file providing the following functions:
-  :c:func:`!copysign`, :c:func:`!hypot`, :c:func:`!isfinite`,
-  :c:func:`!isinf`, :c:func:`!isnan`, and :c:func:`!round`.
-  (Contributed by Victor Stinner in :issue:`45440`.)
-
-* Building Python now requires a `C99 <https://en.cppreference.com/w/c/99>`_
-  ``<math.h>`` header file providing a :c:data:`!NAN` constant,
-  or the :c:func:`!__builtin_nan` built-in function.
-  (Contributed by Victor Stinner in :issue:`46640`.)
-
-* Building Python now requires support for `floating point Not-a-Number (NaN)
-  <https://en.wikipedia.org/wiki/NaN#Floating_point>`_,
-  as the :c:macro:`!Py_NO_NAN` macro has been removed.
-  (Contributed by Victor Stinner in :issue:`46656`.)
 
 * Freelists for object structs can now be disabled. A new :program:`configure`
   option :option:`!--without-freelists` can be used to disable all freelists
@@ -1863,16 +1889,6 @@ Build Changes
   test modules can be linked statically into a main binary or library.
   (Contributed by Brett Cannon and Christian Heimes in :issue:`45548`,
   :issue:`45570`, :issue:`45571`, and :issue:`43974`.)
-
-* Build dependencies, compiler flags, and linker flags for most stdlib
-  extension modules are now detected by :program:`configure`. libffi, libnsl,
-  libsqlite3, zlib, bzip2, liblzma, libcrypt, Tcl/Tk, and uuid flags
-  are detected by `pkg-config
-  <https://www.freedesktop.org/wiki/Software/pkg-config/>`_ (when available).
-  :mod:`tkinter` now requires a pkg-config command
-  to detect development settings for `Tcl/Tk`_ headers and libraries.
-  (Contributed by Christian Heimes and Erlend Egeberg Aasland in
-  :issue:`45847`, :issue:`45747`, and :issue:`45763`.)
 
   .. note::
      Use the environment variables :envvar:`!TCLTK_CFLAGS` and
@@ -1886,23 +1902,6 @@ Build Changes
      The directory ``Misc/rhel7`` contains ``.pc`` files and instructions
      on how to build Python with RHEL 7's and CentOS 7's Tcl/Tk and OpenSSL.
 
-* CPython now has :pep:`11` :pep:`Tier 3 support <11#tier-3>`
-  for cross compiling to the `Emscripten <https://emscripten.org/>`_
-  `WebAssembly <https://webassembly.org/>`_ platform
-  ``wasm32-unknown-emscripten``, i.e. Python in the browser.
-  The effort is inspired by previous work like `Pyodide <https://pyodide.org/>`_.
-  Emscripten provides a limited subset of POSIX APIs; Python standard
-  libraries features and modules related to networking, processes, threading,
-  signals, mmap, and users/groups are not available or don't work.
-  (Contributed by Christian Heimes and Ethan Smith in :gh:`84461`,
-  promoted in :gh:`95085`)
-
-* CPython also now has :pep:`11` :pep:`Tier 3 support <11#tier-3>` for cross
-  compiling to the `WebAssembly System Interface (WASI) <https://wasi.dev/>`_
-  `WebAssembly <https://webassembly.org/>`_ platform ``wasm32-unknown-wasi``.
-  Like Emscripten, only a subset of Python's standard library works on WASI.
-  (Contributed by Christian Heimes in :gh:`90473`, promoted in :gh:`95085`)
-
 * CPython will now use 30-bit digits by default for the Python :class:`int`
   implementation. Previously, the default was to use 30-bit digits on platforms
   with ``SIZEOF_VOID_P >= 8``, and 15-bit digits otherwise. It's still possible
@@ -1911,10 +1910,6 @@ Build Changes
   or (for Windows) the ``PYLONG_BITS_IN_DIGIT`` variable in ``PC/pyconfig.h``,
   but this option may be removed at some point in the future.
   (Contributed by Mark Dickinson in :issue:`45569`.)
-
-* The :mod:`tkinter` package now requires `Tcl/Tk <https://www.tcl.tk>`_
-  version 8.5.12 or newer.
-  (Contributed by Serhiy Storchaka in :issue:`46996`.)
 
 
 .. _whatsnew311-c-api:

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1818,30 +1818,39 @@ Porting notes for the C API are
 Build Changes
 =============
 
-* Building Python now requires a C11 compiler. Optional C11 features are not
-  required.
+* Building Python now requires a
+  `C11 <https://en.cppreference.com/w/c/11>`_ compiler.
+  `Optional C11 features
+  <https://en.wikipedia.org/wiki/C11_(C_standard_revision)#Optional_features>`_
+  are not required.
   (Contributed by Victor Stinner in :issue:`46656`.)
 
-* Building Python now requires support of IEEE 754 floating point numbers.
+* Building Python now requires support for
+  `IEEE 754 <https://en.wikipedia.org/wiki/IEEE_754>`_ floating point numbers.
   (Contributed by Victor Stinner in :issue:`46917`.)
 
-* CPython can now be built with the ThinLTO option via ``--with-lto=thin``.
+* CPython can now be built with the
+  `ThinLTO <https://clang.llvm.org/docs/ThinLTO.html>`_ option
+  via passing ``thin`` to :option:`--with-lto`, i.e. ``--with-lto=thin``.
   (Contributed by Dong-hee Na and Brett Holman in :issue:`44340`.)
 
 * libpython is no longer linked against libcrypt.
   (Contributed by Mike Gilbert in :issue:`45433`.)
 
-* Building Python now requires a C99 ``<math.h>`` header file providing
-  the following functions: ``copysign()``, ``hypot()``, ``isfinite()``,
-  ``isinf()``, ``isnan()``, ``round()``.
+* Building Python now requires a `C99 <https://en.cppreference.com/w/c/99>`_
+  ``<math.h>`` header file providing the following functions:
+  :c:func:`!copysign`, :c:func:`!hypot`, :c:func:`!isfinite`,
+  :c:func:`!isinf`, :c:func:`!isnan`, and :c:func:`!round`.
   (Contributed by Victor Stinner in :issue:`45440`.)
 
-* Building Python now requires a C99 ``<math.h>`` header file providing
-  a ``NAN`` constant, or the ``__builtin_nan()`` built-in function.
+* Building Python now requires a `C99 <https://en.cppreference.com/w/c/99>`_
+  ``<math.h>`` header file providing a :c:data:`!NAN` constant,
+  or the :c:func:`!__builtin_nan` built-in function.
   (Contributed by Victor Stinner in :issue:`46640`.)
 
-* Building Python now requires support for floating point Not-a-Number (NaN):
-  remove the ``Py_NO_NAN`` macro.
+* Building Python now requires support for `floating point Not-a-Number (NaN)
+  <https://en.wikipedia.org/wiki/NaN#Floating_point>`_,
+  as the :c:macro:`!Py_NO_NAN` macro has been removed.
   (Contributed by Victor Stinner in :issue:`46656`.)
 
 * Freelists for object structs can now be disabled. A new :program:`configure`
@@ -1851,54 +1860,60 @@ Build Changes
 
 * ``Modules/Setup`` and ``Modules/makesetup`` have been improved and tied up.
   Extension modules can now be built through ``makesetup``. All except some
-  test modules can be linked statically into main binary or library.
+  test modules can be linked statically into a main binary or library.
   (Contributed by Brett Cannon and Christian Heimes in :issue:`45548`,
   :issue:`45570`, :issue:`45571`, and :issue:`43974`.)
 
 * Build dependencies, compiler flags, and linker flags for most stdlib
   extension modules are now detected by :program:`configure`. libffi, libnsl,
   libsqlite3, zlib, bzip2, liblzma, libcrypt, Tcl/Tk, and uuid flags
-  are detected by ``pkg-config`` (when available). :mod:`tkinter` now
-  requires ``pkg-config`` command to detect development settings for Tcl/Tk
-  headers and libraries.
+  are detected by `pkg-config
+  <https://www.freedesktop.org/wiki/Software/pkg-config/>`_ (when available).
+  :mod:`tkinter` now requires a pkg-config command
+  to detect development settings for `Tcl/Tk`_ headers and libraries.
   (Contributed by Christian Heimes and Erlend Egeberg Aasland in
   :issue:`45847`, :issue:`45747`, and :issue:`45763`.)
 
   .. note::
-     Use the environment variables :envvar:`TCLTK_CFLAGS` and
-     :envvar:`TCLTK_LIBS` to manually specify the location of Tcl/Tk headers
-     and libraries. The :program:`configure` options ``--with-tcltk-includes``
-     and ``--with-tcltk-libs`` have been removed.
+     Use the environment variables :envvar:`!TCLTK_CFLAGS` and
+     :envvar:`!TCLTK_LIBS` to manually specify the location of Tcl/Tk headers
+     and libraries. The :program:`configure` options
+     :option:`!--with-tcltk-includes` and :option:`!--with-tcltk-libs`
+     have been removed.
 
      On RHEL 7 and CentOS 7 the development packages do not provide ``tcl.pc``
-     and ``tk.pc``, use :envvar:`TCLTK_LIBS="-ltk8.5 -ltkstub8.5 -ltcl8.5"`.
+     and ``tk.pc``; use ``TCLTK_LIBS="-ltk8.5 -ltkstub8.5 -ltcl8.5"``.
      The directory ``Misc/rhel7`` contains ``.pc`` files and instructions
-     how to build Python with RHEL 7's and CentOS 7's Tcl/Tk and OpenSSL.
+     on how to build Python with RHEL 7's and CentOS 7's Tcl/Tk and OpenSSL.
 
-* CPython now has :pep:`11` tier 3 support for cross compiling to WebAssembly
-  platform ``wasm32-unknown-emscripten`` (Python in the browser). The effort
-  is inspired by previous work like `Pyodide <https://pyodide.org/>`_.
-  Emscripten provides a limited subset of POSIX APIs. Python standard
+* CPython now has :pep:`11` :pep:`Tier 3 support <11#tier-3>`
+  for cross compiling to the `Emscripten <https://emscripten.org/>`_
+  `WebAssembly <https://webassembly.org/>`_ platform
+  ``wasm32-unknown-emscripten``, i.e. Python in the browser.
+  The effort is inspired by previous work like `Pyodide <https://pyodide.org/>`_.
+  Emscripten provides a limited subset of POSIX APIs; Python standard
   libraries features and modules related to networking, processes, threading,
   signals, mmap, and users/groups are not available or don't work.
   (Contributed by Christian Heimes and Ethan Smith in :gh:`84461`,
   promoted in :gh:`95085`)
 
-* CPython now has :pep:`11` tier 3 support for cross compiling to WebAssembly
-  platform ``wasm32-unknown-wasi`` (WebAssembly System Interface). Like on
-  Emscripten, only a subset of Python's standard library is available on WASI.
+* CPython also now has :pep:`11` :pep:`Tier 3 support <11#tier-3>` for cross
+  compiling to the `WebAssembly System Interface (WASI) <https://wasi.dev/>`_
+  `WebAssembly <https://webassembly.org/>`_ platform ``wasm32-unknown-wasi``.
+  Like Emscripten, only a subset of Python's standard library works on WASI.
   (Contributed by Christian Heimes in :gh:`90473`, promoted in :gh:`95085`)
 
 * CPython will now use 30-bit digits by default for the Python :class:`int`
   implementation. Previously, the default was to use 30-bit digits on platforms
   with ``SIZEOF_VOID_P >= 8``, and 15-bit digits otherwise. It's still possible
   to explicitly request use of 15-bit digits via either the
-  ``--enable-big-digits`` option to the configure script or (for Windows) the
-  ``PYLONG_BITS_IN_DIGIT`` variable in ``PC/pyconfig.h``, but this option may
-  be removed at some point in the future. (Contributed by Mark Dickinson in
-  :issue:`45569`.)
+  :option:`--enable-big-digits` option to the configure script
+  or (for Windows) the ``PYLONG_BITS_IN_DIGIT`` variable in ``PC/pyconfig.h``,
+  but this option may be removed at some point in the future.
+  (Contributed by Mark Dickinson in :issue:`45569`.)
 
-* The :mod:`tkinter` package now requires Tcl/Tk version 8.5.12 or newer.
+* The :mod:`tkinter` package now requires `Tcl/Tk <https://www.tcl.tk>`_
+  version 8.5.12 or newer.
   (Contributed by Serhiy Storchaka in :issue:`46996`.)
 
 


### PR DESCRIPTION
Part of #95913 

This PR copyedits, sorts and fixes/improves the syntax, cross references and links of the Build section of the What's New in Python 3.11 document. In particular, it:

* Orders the list of items more sensitively to group similar/related topics together, e.g. new build requirements, new configure flags, etc.
* Consolidates several items that contained mostly redundant/closely related information
* Adds, fixes and refines Sphinx cross references and links to external references as appropriate
* Adds appropriate Sphinx roles and other constructs
* Tweaks the text to fix grammar/wording issues
* Uses consistent, direct phrasing for easier/quicker readability

While I did read through the various Build changes in the changelog, and quite a few appeared to be of a similar magnitude to those added here, given this is not an area of my expertise and it would substantially delay the review of this PR, I elected to defer that until later.

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->
