### PR TITLE
gh-98253: Break potential reference cycles in external code worsened by typing.py lru_cache

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -352,6 +352,11 @@ def _tp_cache(func=None, /, *, typed=False):
     original function for non-hashable arguments.
     """
     def decorator(func):
+        # The callback 'inner' references the newly created lru_cache
+        # indirectly by performing a lookup in the global '_caches' dictionary.
+        # This breaks a reference that can be problematic when combined with
+        # C API extensions that leak references to types. See GH-98253.
+
         cache = functools.lru_cache(typed=typed)(func)
         _caches[func] = cache
         _cleanups.append(cache.cache_clear)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -344,7 +344,7 @@ def _flatten_literal_params(parameters):
 
 
 _cleanups = []
-_caches = { }
+_caches = {}
 
 
 def _tp_cache(func=None, /, *, typed=False):

--- a/Misc/NEWS.d/next/Library/2022-10-24-11-01-05.gh-issue-98253.HVd5v4.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-24-11-01-05.gh-issue-98253.HVd5v4.rst
@@ -1,0 +1,10 @@
+The implementation of the typing module is now more resilient to reference
+leaks in binary extension modules.
+
+Previously, a reference leak in a typed C API-based extension module could leak
+internals of the typing module, which could in turn introduce leaks in
+essentially any other package with typed function signatures. Although the
+typing package is not the original source of the problem, such non-local
+dependences exacerbate debugging of large-scale projects, and the
+implementation was therefore changed to reduce harm by providing better
+isolation.


### PR DESCRIPTION
The ``typing`` module internally uses LRU caches to memoize the result of type-related computations. These LRU caches have the potential to introduce difficult-to-find reference leaks spanning multiple extension modules. 

Suppose that a binary extension module ``a`` leaks a reference to a type ``a.A`` with typed function signatures.

The leaked type ``a.A`` will induce a secondary refleak of the ``typing`` LRU caches, which will at this point cause tertiary leaks in entirely unrelated extension modules. In this way, a benign refleak in any extension can cause difficult-to-debug leaks everywhere else.

This commit fixes this by removing the direct reference from ``a.A`` to ``typing`` implementation details.

<!-- gh-issue-number: gh-98253 -->
* Issue: gh-98253
<!-- /gh-issue-number -->
