### PR TITLE
gh-98608: Change _Py_NewInterpreter() to _Py_NewInterpreterFromConfig()

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -1571,8 +1571,6 @@ Private provisional API:
 
 * :c:member:`PyConfig._init_main`: if set to ``0``,
   :c:func:`Py_InitializeFromConfig` stops at the "Core" initialization phase.
-* :c:member:`PyConfig._isolated_interpreter`: if non-zero,
-  disallow threads, subprocesses and fork.
 
 .. c:function:: PyStatus _Py_InitializeMain(void)
 

--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -244,8 +244,17 @@ PyAPI_FUNC(PyStatus) PyConfig_SetWideStringList(PyConfig *config,
 /* --- PyInterpreterConfig ------------------------------------ */
 
 typedef struct {
-    int isolated;
+    int allow_fork;
+    int allow_subprocess;
+    int allow_threads;
 } _PyInterpreterConfig;
+
+#define _PyInterpreterConfig_LEGACY_INIT \
+    { \
+        .allow_fork = 1, \
+        .allow_subprocess = 1, \
+        .allow_threads = 1, \
+    }
 
 /* --- Helper functions --------------------------------------- */
 

--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -245,7 +245,7 @@ PyAPI_FUNC(PyStatus) PyConfig_SetWideStringList(PyConfig *config,
 
 typedef struct {
     int isolated;
-} PyInterpreterConfig;
+} _PyInterpreterConfig;
 
 /* --- Helper functions --------------------------------------- */
 

--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -245,6 +245,12 @@ PyAPI_FUNC(PyStatus) PyConfig_SetWideStringList(PyConfig *config,
     Py_ssize_t length, wchar_t **items);
 
 
+/* --- PyInterpreterConfig ------------------------------------ */
+
+typedef struct {
+    int isolated;
+} PyInterpreterConfig;
+
 /* --- Helper functions --------------------------------------- */
 
 /* Get the original command line arguments, before Python modified them.

--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -213,10 +213,6 @@ typedef struct PyConfig {
     // If equal to 0, stop Python initialization before the "main" phase.
     int _init_main;
 
-    // If non-zero, disallow threads, subprocesses, and fork.
-    // Default: 0.
-    int _isolated_interpreter;
-
     // If non-zero, we believe we're running from a source tree.
     int _is_python_build;
 } PyConfig;

--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -62,4 +62,4 @@ PyAPI_FUNC(int) _Py_CoerceLegacyLocale(int warn);
 PyAPI_FUNC(int) _Py_LegacyLocaleDetected(int warn);
 PyAPI_FUNC(char *) _Py_SetLocaleFromEnv(int category);
 
-PyAPI_FUNC(PyThreadState *) _Py_NewInterpreter(int isolated_subinterpreter);
+PyAPI_FUNC(PyThreadState *) _Py_NewInterpreter(const PyInterpreterConfig *);

--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -62,4 +62,5 @@ PyAPI_FUNC(int) _Py_CoerceLegacyLocale(int warn);
 PyAPI_FUNC(int) _Py_LegacyLocaleDetected(int warn);
 PyAPI_FUNC(char *) _Py_SetLocaleFromEnv(int category);
 
-PyAPI_FUNC(PyThreadState *) _Py_NewInterpreter(const _PyInterpreterConfig *);
+PyAPI_FUNC(PyThreadState *) _Py_NewInterpreterFromConfig(
+    const _PyInterpreterConfig *);

--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -62,4 +62,4 @@ PyAPI_FUNC(int) _Py_CoerceLegacyLocale(int warn);
 PyAPI_FUNC(int) _Py_LegacyLocaleDetected(int warn);
 PyAPI_FUNC(char *) _Py_SetLocaleFromEnv(int category);
 
-PyAPI_FUNC(PyThreadState *) _Py_NewInterpreter(const PyInterpreterConfig *);
+PyAPI_FUNC(PyThreadState *) _Py_NewInterpreter(const _PyInterpreterConfig *);

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -3,10 +3,37 @@
 #endif
 
 
+/*
+Runtime Feature Flags
+
+Each flag indicate whether or not a specific runtime feature
+is available in a given context.  For example, forking the process
+might not be allowed in the current interpreter (i.e. os.fork() would fail).
+*/
+
+// We leave the first 10 for less-specific features.
+
+/* Set if threads are allowed. */
+#define Py_RTFLAGS_THREADS      (1UL << 10)
+
+/* Set if os.fork() is allowed. */
+#define Py_RTFLAGS_FORK         (1UL << 15)
+
+/* Set if subprocesses are allowed. */
+#define Py_RTFLAGS_SUBPROCESS   (1UL << 16)
+
+
+PyAPI_FUNC(int) _PyInterpreterState_HasFeature(PyInterpreterState *interp,
+                                               unsigned long feature);
+
+
+/* private interpreter helpers */
+
 PyAPI_FUNC(int) _PyInterpreterState_RequiresIDRef(PyInterpreterState *);
 PyAPI_FUNC(void) _PyInterpreterState_RequireIDRef(PyInterpreterState *, int);
 
 PyAPI_FUNC(PyObject *) _PyInterpreterState_GetMainModule(PyInterpreterState *);
+
 
 /* State unique per thread */
 

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -143,6 +143,7 @@ struct _is {
 #ifdef HAVE_DLOPEN
     int dlopenflags;
 #endif
+    unsigned long feature_flags;
 
     PyObject *dict;  /* Stores per-interpreter state */
 

--- a/Lib/test/_test_embed_set_config.py
+++ b/Lib/test/_test_embed_set_config.py
@@ -84,7 +84,6 @@ class SetConfigTests(unittest.TestCase):
             'skip_source_first_line',
             '_install_importlib',
             '_init_main',
-            '_isolated_interpreter',
         ]
         if MS_WINDOWS:
             options.append('legacy_windows_stdio')

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1793,6 +1793,22 @@ def run_in_subinterp(code):
     Run code in a subinterpreter. Raise unittest.SkipTest if the tracemalloc
     module is enabled.
     """
+    _check_tracemalloc()
+    import _testcapi
+    return _testcapi.run_in_subinterp(code)
+
+
+def run_in_subinterp_with_config(code, **config):
+    """
+    Run code in a subinterpreter. Raise unittest.SkipTest if the tracemalloc
+    module is enabled.
+    """
+    _check_tracemalloc()
+    import _testcapi
+    return _testcapi.run_in_subinterp_with_config(code, **config)
+
+
+def _check_tracemalloc():
     # Issue #10915, #15751: PyGILState_*() functions don't work with
     # sub-interpreters, the tracemalloc module uses these functions internally
     try:
@@ -1804,8 +1820,6 @@ def run_in_subinterp(code):
             raise unittest.SkipTest("run_in_subinterp() cannot be used "
                                      "if tracemalloc module is tracing "
                                      "memory allocations")
-    import _testcapi
-    return _testcapi.run_in_subinterp(code)
 
 
 def check_free_after_iterating(test, iter, cls, args=()):

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -1084,6 +1084,46 @@ class SubinterpreterTest(unittest.TestCase):
         # test fails, assume that the environment in this process may
         # be altered and suspect.
 
+    def test_configured_settings(self):
+        """
+        The config with which an interpreter is created corresponds
+        1-to-1 with the new interpreter's settings.  This test verifies
+        that they match.
+        """
+        import json
+
+        THREADS = 1<<10
+        FORK = 1<<15
+        SUBPROCESS = 1<<16
+
+        for config, expected in {
+            (True, True, True): THREADS | FORK | SUBPROCESS,
+            (False, False, False): 0,
+            (False, True, True): THREADS | SUBPROCESS,
+        }.items():
+            allow_fork, allow_subprocess, allow_threads = config
+            expected = {
+                'feature_flags': expected,
+            }
+            with self.subTest(config):
+                r, w = os.pipe()
+                with os.fdopen(r) as stdout:
+                    support.run_in_subinterp_with_config(
+                        textwrap.dedent(f'''
+                            import _testinternalcapi, json, os
+                            settings = _testinternalcapi.get_interp_settings()
+                            with os.fdopen({w}, "w") as stdin:
+                                json.dump(settings, stdin)
+                            '''),
+                        allow_fork=allow_fork,
+                        allow_subprocess=allow_subprocess,
+                        allow_threads=allow_threads,
+                    )
+                    out = stdout.read()
+                settings = json.loads(out)
+
+                self.assertEqual(settings, expected)
+
     def test_mutate_exception(self):
         """
         Exceptions saved in global module state get shared between

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1647,6 +1647,25 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 self.check_all_configs("test_init_use_frozen_modules", config,
                                        api=API_PYTHON, env=env)
 
+    def test_init_main_interpreter_settings(self):
+        THREADS = 1<<10
+        FORK = 1<<15
+        SUBPROCESS = 1<<16
+        expected = {
+            # All optional features should be enabled.
+            'feature_flags': THREADS | FORK | SUBPROCESS,
+        }
+        out, err = self.run_embedded_interpreter(
+            'test_init_main_interpreter_settings',
+        )
+        self.assertEqual(err, '')
+        try:
+            out = json.loads(out)
+        except json.JSONDecodeError:
+            self.fail(f'fail to decode stdout: {out!r}')
+
+        self.assertEqual(out, expected)
+
 
 class SetConfigTests(unittest.TestCase):
     def test_set_config(self):

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -496,7 +496,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'check_hash_pycs_mode': 'default',
         'pathconfig_warnings': 1,
         '_init_main': 1,
-        '_isolated_interpreter': 0,
         'use_frozen_modules': not support.Py_DEBUG,
         'safe_path': 0,
         '_is_python_build': IGNORE_CONFIG,
@@ -881,8 +880,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
             'check_hash_pycs_mode': 'always',
             'pathconfig_warnings': 0,
-
-            '_isolated_interpreter': 1,
         }
         self.check_all_configs("test_init_from_config", config, preconfig,
                                api=API_COMPAT)

--- a/Misc/NEWS.d/next/C API/2022-10-24-11-26-55.gh-issue-98608._Q2lNV.rst
+++ b/Misc/NEWS.d/next/C API/2022-10-24-11-26-55.gh-issue-98608._Q2lNV.rst
@@ -1,0 +1,4 @@
+A ``_PyInterpreterConfig`` has been added and ``_Py_NewInterpreter()`` has
+been renamed to ``_Py_NewInterpreterFromConfig()``.  The
+"isolated_subinterpreters" argument is now a granular config that captures
+the previous behavior.  Note that this is all "private" API.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -842,8 +842,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
     }
 
     PyInterpreterState *interp = PyInterpreterState_Get();
-    const PyConfig *config = _PyInterpreterState_GetConfig(interp);
-    if (config->_isolated_interpreter) {
+    if (!_PyInterpreterState_HasFeature(interp, Py_RTFLAGS_SUBPROCESS)) {
         PyErr_SetString(PyExc_RuntimeError,
                         "subprocess not supported for isolated subinterpreters");
         return NULL;

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3225,6 +3225,66 @@ run_in_subinterp(PyObject *self, PyObject *args)
     return PyLong_FromLong(r);
 }
 
+/* To run some code in a sub-interpreter. */
+static PyObject *
+run_in_subinterp_with_config(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    const char *code;
+    int allow_fork = -1;
+    int allow_subprocess = -1;
+    int allow_threads = -1;
+    int r;
+    PyThreadState *substate, *mainstate;
+    /* only initialise 'cflags.cf_flags' to test backwards compatibility */
+    PyCompilerFlags cflags = {0};
+
+    static char *kwlist[] = {"code",
+                             "allow_fork", "allow_subprocess", "allow_threads",
+                             NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs,
+                    "s$ppp:run_in_subinterp_with_config", kwlist,
+                    &code, &allow_fork, &allow_subprocess, &allow_threads)) {
+        return NULL;
+    }
+    if (allow_fork < 0) {
+        PyErr_SetString(PyExc_ValueError, "missing allow_fork");
+        return NULL;
+    }
+    if (allow_subprocess < 0) {
+        PyErr_SetString(PyExc_ValueError, "missing allow_subprocess");
+        return NULL;
+    }
+    if (allow_threads < 0) {
+        PyErr_SetString(PyExc_ValueError, "missing allow_threads");
+        return NULL;
+    }
+
+    mainstate = PyThreadState_Get();
+
+    PyThreadState_Swap(NULL);
+
+    _PyInterpreterConfig config = {
+        .allow_fork = allow_fork,
+        .allow_subprocess = allow_subprocess,
+        .allow_threads = allow_threads,
+    };
+    substate = _Py_NewInterpreterFromConfig(&config);
+    if (substate == NULL) {
+        /* Since no new thread state was created, there is no exception to
+           propagate; raise a fresh one after swapping in the old thread
+           state. */
+        PyThreadState_Swap(mainstate);
+        PyErr_SetString(PyExc_RuntimeError, "sub-interpreter creation failed");
+        return NULL;
+    }
+    r = PyRun_SimpleStringFlags(code, &cflags);
+    Py_EndInterpreter(substate);
+
+    PyThreadState_Swap(mainstate);
+
+    return PyLong_FromLong(r);
+}
+
 static int
 check_time_rounding(int round)
 {
@@ -5842,6 +5902,9 @@ static PyMethodDef TestMethods[] = {
      METH_NOARGS},
     {"crash_no_current_thread", crash_no_current_thread,         METH_NOARGS},
     {"run_in_subinterp",        run_in_subinterp,                METH_VARARGS},
+    {"run_in_subinterp_with_config",
+     _PyCFunction_CAST(run_in_subinterp_with_config),
+     METH_VARARGS | METH_KEYWORDS},
     {"pytime_object_to_time_t", test_pytime_object_to_time_t,  METH_VARARGS},
     {"pytime_object_to_timeval", test_pytime_object_to_timeval,  METH_VARARGS},
     {"pytime_object_to_timespec", test_pytime_object_to_timespec,  METH_VARARGS},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3263,7 +3263,7 @@ run_in_subinterp_with_config(PyObject *self, PyObject *args, PyObject *kwargs)
 
     PyThreadState_Swap(NULL);
 
-    _PyInterpreterConfig config = {
+    const _PyInterpreterConfig config = {
         .allow_fork = allow_fork,
         .allow_subprocess = allow_subprocess,
         .allow_threads = allow_threads,

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -550,6 +550,29 @@ _testinternalcapi_optimize_cfg_impl(PyObject *module, PyObject *instructions,
 }
 
 
+static PyObject *
+get_interp_settings(PyObject *self, PyObject *Py_UNUSED(args))
+{
+    PyInterpreterState *interp = _PyInterpreterState_Main();
+    PyObject *flags = PyLong_FromUnsignedLong(interp->feature_flags);
+    if (flags == NULL) {
+        return NULL;
+    }
+    PyObject *settings = PyDict_New();
+    if (settings == NULL) {
+        Py_DECREF(flags);
+        return NULL;
+    }
+    int res = PyDict_SetItemString(settings, "feature_flags", flags);
+    Py_DECREF(flags);
+    if (res != 0) {
+        Py_DECREF(settings);
+        return NULL;
+    }
+    return settings;
+}
+
+
 static PyMethodDef TestMethods[] = {
     {"get_configs", get_configs, METH_NOARGS},
     {"get_recursion_depth", get_recursion_depth, METH_NOARGS},
@@ -569,6 +592,7 @@ static PyMethodDef TestMethods[] = {
     {"set_eval_frame_default", set_eval_frame_default, METH_NOARGS, NULL},
     {"set_eval_frame_record", set_eval_frame_record, METH_O, NULL},
     _TESTINTERNALCAPI_OPTIMIZE_CFG_METHODDEF
+    {"get_interp_settings", get_interp_settings, METH_NOARGS, NULL},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1128,7 +1128,7 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
     }
 
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (interp->config._isolated_interpreter) {
+    if (!_PyInterpreterState_HasFeature(interp, Py_RTFLAGS_THREADS)) {
         PyErr_SetString(PyExc_RuntimeError,
                         "thread is not supported for isolated subinterpreters");
         return NULL;

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1090,8 +1090,7 @@ _winapi_CreateProcess_impl(PyObject *module,
     }
 
     PyInterpreterState *interp = PyInterpreterState_Get();
-    const PyConfig *config = _PyInterpreterState_GetConfig(interp);
-    if (config->_isolated_interpreter) {
+    if (!_PyInterpreterState_HasFeature(interp, Py_RTFLAGS_SUBPROCESS)) {
         PyErr_SetString(PyExc_RuntimeError,
                         "subprocess not supported for isolated subinterpreters");
         return NULL;

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2003,8 +2003,11 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
 
     // Create and initialize the new interpreter.
     PyThreadState *save_tstate = _PyThreadState_GET();
+    PyInterpreterConfig config = {
+        .isolated = isolated,
+    };
     // XXX Possible GILState issues?
-    PyThreadState *tstate = _Py_NewInterpreter(isolated);
+    PyThreadState *tstate = _Py_NewInterpreter(&config);
     PyThreadState_Swap(save_tstate);
     if (tstate == NULL) {
         /* Since no new thread state was created, there is no exception to

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2004,7 +2004,11 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
     // Create and initialize the new interpreter
     // (with all optional features disabled).
     PyThreadState *save_tstate = _PyThreadState_GET();
-    _PyInterpreterConfig config = { 0 };
+    _PyInterpreterConfig config = {
+        .allow_fork = !isolated,
+        .allow_subprocess = !isolated,
+        .allow_threads = !isolated,
+    };
     // XXX Possible GILState issues?
     PyThreadState *tstate = _Py_NewInterpreterFromConfig(&config);
     PyThreadState_Swap(save_tstate);

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2001,11 +2001,10 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    // Create and initialize the new interpreter.
+    // Create and initialize the new interpreter
+    // (with all optional features disabled).
     PyThreadState *save_tstate = _PyThreadState_GET();
-    _PyInterpreterConfig config = {
-        .isolated = isolated,
-    };
+    _PyInterpreterConfig config = { 0 };
     // XXX Possible GILState issues?
     PyThreadState *tstate = _Py_NewInterpreterFromConfig(&config);
     PyThreadState_Swap(save_tstate);

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2007,7 +2007,7 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
         .isolated = isolated,
     };
     // XXX Possible GILState issues?
-    PyThreadState *tstate = _Py_NewInterpreter(&config);
+    PyThreadState *tstate = _Py_NewInterpreterFromConfig(&config);
     PyThreadState_Swap(save_tstate);
     if (tstate == NULL) {
         /* Since no new thread state was created, there is no exception to

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2003,7 +2003,7 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
 
     // Create and initialize the new interpreter.
     PyThreadState *save_tstate = _PyThreadState_GET();
-    PyInterpreterConfig config = {
+    _PyInterpreterConfig config = {
         .isolated = isolated,
     };
     // XXX Possible GILState issues?

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2003,7 +2003,7 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
 
     // Create and initialize the new interpreter.
     PyThreadState *save_tstate = _PyThreadState_GET();
-    _PyInterpreterConfig config = {
+    const _PyInterpreterConfig config = {
         .allow_fork = !isolated,
         .allow_subprocess = !isolated,
         .allow_threads = !isolated,

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2001,8 +2001,7 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    // Create and initialize the new interpreter
-    // (with all optional features disabled).
+    // Create and initialize the new interpreter.
     PyThreadState *save_tstate = _PyThreadState_GET();
     _PyInterpreterConfig config = {
         .allow_fork = !isolated,

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6760,7 +6760,7 @@ os_fork_impl(PyObject *module)
 {
     pid_t pid;
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (interp->config._isolated_interpreter) {
+    if (!_PyInterpreterState_HasFeature(interp, Py_RTFLAGS_FORK)) {
         PyErr_SetString(PyExc_RuntimeError,
                         "fork not supported for isolated subinterpreters");
         return NULL;

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -681,8 +681,6 @@ static int test_init_from_config(void)
 
     config.safe_path = 1;
 
-    config._isolated_interpreter = 1;
-
     putenv("PYTHONINTMAXSTRDIGITS=6666");
     config.int_max_str_digits = 31337;
 

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1899,6 +1899,18 @@ static int test_unicode_id_init(void)
 }
 
 
+static int test_init_main_interpreter_settings(void)
+{
+    _testembed_Py_Initialize();
+    (void) PyRun_SimpleStringFlags(
+        "import _testinternalcapi, json; "
+        "print(json.dumps(_testinternalcapi.get_interp_settings()))",
+        0);
+    Py_Finalize();
+    return 0;
+}
+
+
 #ifndef MS_WINDOWS
 #include "test_frozenmain.h"      // M_test_frozenmain
 
@@ -2085,6 +2097,7 @@ static struct TestCase TestCases[] = {
     {"test_run_main_loop", test_run_main_loop},
     {"test_get_argc_argv", test_get_argc_argv},
     {"test_init_use_frozen_modules", test_init_use_frozen_modules},
+    {"test_init_main_interpreter_settings", test_init_main_interpreter_settings},
 
     // Audit
     {"test_open_code_hook", test_open_code_hook},

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1904,7 +1904,7 @@ static int test_init_main_interpreter_settings(void)
     _testembed_Py_Initialize();
     (void) PyRun_SimpleStringFlags(
         "import _testinternalcapi, json; "
-        "print(json.dumps(_testinternalcapi.get_interp_settings()))",
+        "print(json.dumps(_testinternalcapi.get_interp_settings(0)))",
         0);
     Py_Finalize();
     return 0;

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -780,7 +780,6 @@ _PyConfig_InitCompatConfig(PyConfig *config)
     config->check_hash_pycs_mode = NULL;
     config->pathconfig_warnings = -1;
     config->_init_main = 1;
-    config->_isolated_interpreter = 0;
 #ifdef MS_WINDOWS
     config->legacy_windows_stdio = -1;
 #endif
@@ -1015,7 +1014,6 @@ _PyConfig_Copy(PyConfig *config, const PyConfig *config2)
     COPY_WSTR_ATTR(check_hash_pycs_mode);
     COPY_ATTR(pathconfig_warnings);
     COPY_ATTR(_init_main);
-    COPY_ATTR(_isolated_interpreter);
     COPY_ATTR(use_frozen_modules);
     COPY_ATTR(safe_path);
     COPY_WSTRLIST(orig_argv);
@@ -1123,7 +1121,6 @@ _PyConfig_AsDict(const PyConfig *config)
     SET_ITEM_WSTR(check_hash_pycs_mode);
     SET_ITEM_INT(pathconfig_warnings);
     SET_ITEM_INT(_init_main);
-    SET_ITEM_INT(_isolated_interpreter);
     SET_ITEM_WSTRLIST(orig_argv);
     SET_ITEM_INT(use_frozen_modules);
     SET_ITEM_INT(safe_path);
@@ -1418,7 +1415,6 @@ _PyConfig_FromDict(PyConfig *config, PyObject *dict)
 
     GET_UINT(_install_importlib);
     GET_UINT(_init_main);
-    GET_UINT(_isolated_interpreter);
     GET_UINT(use_frozen_modules);
     GET_UINT(safe_path);
     GET_UINT(_is_python_build);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2027,7 +2027,6 @@ new_interpreter(PyThreadState **tstate_p, const PyInterpreterConfig *config)
     if (_PyStatus_EXCEPTION(status)) {
         goto error;
     }
-    interp->config._isolated_interpreter = config->isolated;
 
     init_interp_settings(interp, config);
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2058,21 +2058,21 @@ error:
 }
 
 PyThreadState *
-_Py_NewInterpreter(int isolated_subinterpreter)
+_Py_NewInterpreter(const PyInterpreterConfig *config)
 {
     PyThreadState *tstate = NULL;
-    PyStatus status = new_interpreter(&tstate, isolated_subinterpreter);
+    PyStatus status = new_interpreter(&tstate, config->isolated);
     if (_PyStatus_EXCEPTION(status)) {
         Py_ExitStatusException(status);
     }
     return tstate;
-
 }
 
 PyThreadState *
 Py_NewInterpreter(void)
 {
-    return _Py_NewInterpreter(0);
+    PyInterpreterConfig config = { 0 };
+    return _Py_NewInterpreter(&config);
 }
 
 /* Delete an interpreter and its last thread.  This requires that the

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2062,7 +2062,7 @@ error:
 }
 
 PyThreadState *
-_Py_NewInterpreter(const _PyInterpreterConfig *config)
+_Py_NewInterpreterFromConfig(const _PyInterpreterConfig *config)
 {
     PyThreadState *tstate = NULL;
     PyStatus status = new_interpreter(&tstate, config);
@@ -2076,7 +2076,7 @@ PyThreadState *
 Py_NewInterpreter(void)
 {
     _PyInterpreterConfig config = { 0 };
-    return _Py_NewInterpreter(&config);
+    return _Py_NewInterpreterFromConfig(&config);
 }
 
 /* Delete an interpreter and its last thread.  This requires that the

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -612,7 +612,7 @@ pycore_init_runtime(_PyRuntimeState *runtime,
 
 
 static void
-init_interp_settings(PyInterpreterState *interp, const PyInterpreterConfig *config)
+init_interp_settings(PyInterpreterState *interp, const _PyInterpreterConfig *config)
 {
     assert(interp->feature_flags == 0);
     if (!config->isolated) {
@@ -670,7 +670,7 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
         return status;
     }
 
-    const PyInterpreterConfig config = {
+    const _PyInterpreterConfig config = {
         .isolated = 0,
     };
     init_interp_settings(interp, &config);
@@ -1978,7 +1978,7 @@ Py_Finalize(void)
 */
 
 static PyStatus
-new_interpreter(PyThreadState **tstate_p, const PyInterpreterConfig *config)
+new_interpreter(PyThreadState **tstate_p, const _PyInterpreterConfig *config)
 {
     PyStatus status;
 
@@ -2062,7 +2062,7 @@ error:
 }
 
 PyThreadState *
-_Py_NewInterpreter(const PyInterpreterConfig *config)
+_Py_NewInterpreter(const _PyInterpreterConfig *config)
 {
     PyThreadState *tstate = NULL;
     PyStatus status = new_interpreter(&tstate, config);
@@ -2075,7 +2075,7 @@ _Py_NewInterpreter(const PyInterpreterConfig *config)
 PyThreadState *
 Py_NewInterpreter(void)
 {
-    PyInterpreterConfig config = { 0 };
+    _PyInterpreterConfig config = { 0 };
     return _Py_NewInterpreter(&config);
 }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -615,9 +615,13 @@ static void
 init_interp_settings(PyInterpreterState *interp, const _PyInterpreterConfig *config)
 {
     assert(interp->feature_flags == 0);
-    if (!config->isolated) {
+    if (config->allow_fork) {
         interp->feature_flags |= Py_RTFLAGS_FORK;
+    }
+    if (config->allow_subprocess) {
         interp->feature_flags |= Py_RTFLAGS_SUBPROCESS;
+    }
+    if (config->allow_threads) {
         interp->feature_flags |= Py_RTFLAGS_THREADS;
     }
 }
@@ -670,9 +674,7 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
         return status;
     }
 
-    const _PyInterpreterConfig config = {
-        .isolated = 0,
-    };
+    const _PyInterpreterConfig config = _PyInterpreterConfig_LEGACY_INIT;
     init_interp_settings(interp, &config);
 
     PyThreadState *tstate = PyThreadState_New(interp);
@@ -2075,7 +2077,7 @@ _Py_NewInterpreterFromConfig(const _PyInterpreterConfig *config)
 PyThreadState *
 Py_NewInterpreter(void)
 {
-    _PyInterpreterConfig config = { 0 };
+    const _PyInterpreterConfig config = _PyInterpreterConfig_LEGACY_INIT;
     return _Py_NewInterpreterFromConfig(&config);
 }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2177,6 +2177,15 @@ _Py_GetConfig(void)
     return _PyInterpreterState_GetConfig(tstate->interp);
 }
 
+
+int
+_PyInterpreterState_HasFeature(PyInterpreterState *interp, unsigned long feature)
+{
+    assert(feature & (Py_RTFLAGS_FORK | Py_RTFLAGS_SUBPROCESS | Py_RTFLAGS_THREADS));
+    return interp->config._isolated_interpreter;
+}
+
+
 #define MINIMUM_OVERHEAD 1000
 
 static PyObject **

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2181,8 +2181,7 @@ _Py_GetConfig(void)
 int
 _PyInterpreterState_HasFeature(PyInterpreterState *interp, unsigned long feature)
 {
-    assert(feature & (Py_RTFLAGS_FORK | Py_RTFLAGS_SUBPROCESS | Py_RTFLAGS_THREADS));
-    return interp->config._isolated_interpreter;
+    return ((interp->feature_flags & feature) != 0);
 }
 
 


### PR DESCRIPTION
(Note that this PR adds "private" symbols.  We'll probably make them public, and add docs, in a separate change.)

We do the following:

1. change the argument to a new `_PyInterpreterConfig` struct
2. rename the function to `_Py_NewInterpreterFromConfig()`, inspired by `Py_InitializeFromConfig()` (takes a `_PyInterpreterConfig`  instead of `isolated_subinterpreter`)
3. split up the boolean `isolated_subinterpreter` into the corresponding multiple granular settings
   * allow_fork
   * allow_subprocess
   * allow_threads
4. add `PyInterpreterState.feature_flags` to store those settings
5. add a function for checking if a feature is enabled on an opaque `PyInterpreterState *`
6. drop `PyConfig._isolated_interpreter`

The current default (`Py_NewInterpeter()` and `Py_Initialize*()`) allows fork, subprocess, and threads and the optional "isolated" interpreter disables all three.  None of that changes here.

Note that the given `_PyInterpreterConfig` will not be used (nor preserved, for now) outside `_Py_NewInterpreterFromConfig()`.  This contrasts with how `PyConfig` is currently preserved, used, and modified outside `Py_InitializeFromConfig()`.  I'd rather just avoid that mess from the start for `_PyInterpreterConfig`.

This change allows us to follow up with a number of improvements (e.g. stop disallowing subprocess and support disallowing exec instead).

<!-- gh-issue-number: gh-98608 -->
* Issue: gh-98608
<!-- /gh-issue-number -->
