### PR TITLE
[3.11] Fix ref target labels in 3.11 WhatsNew doubled up during merge

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1593,10 +1593,6 @@ Changed/removed opcodes
 .. _whatsnew311-deprecated:
 .. _whatsnew311-python-api-deprecated:
 
-
-.. _whatsnew311-deprecated:
-.. _whatsnew311-python-api-deprecated:
-
 Deprecated
 ==========
 
@@ -1768,9 +1764,6 @@ Standard Library
 
   (Contributed by Erlend E. Aasland in :issue:`5846`.)
 
-
-.. _whatsnew311-pending-removal:
-.. _whatsnew311-python-api-pending-removal:
 
 .. _whatsnew311-pending-removal:
 .. _whatsnew311-python-api-pending-removal:


### PR DESCRIPTION
Related to #95913 

Presumably during the merge of the 3.11.0 release tag with the 3.11 branch, something went wrong and the ref target labels for two sections got doubled up, causing the docs build to fail. This PR fixes that.

@pablogsal Feel free to just pull the change/commit into #98622 if you prefer, of course.