### PR TITLE
gh-84747: Add async for comment for StreamReader

### DIFF
--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -183,7 +183,8 @@ StreamReader
 .. class:: StreamReader
 
    Represents a reader object that provides APIs to read data
-   from the IO stream.
+   from the IO stream. As an :term:`asynchronous iterable`, the
+   object supports the :keyword:`async for` statement.
 
    It is not recommended to instantiate *StreamReader* objects
    directly; use :func:`open_connection` and :func:`start_server`


### PR DESCRIPTION
https://docs.python.org/dev/library/asyncio-stream.html#asyncio.StreamReader

Perhaps the example under https://docs.python.org/dev/library/asyncio-stream.html#tcp-echo-client-using-streams can be adjusted to look like

```
    ...
    data = await reader.read(100)
    print(f'Received: {data.decode()!r}')

    async for line in reader:
        print(line)

    print('Close the connection')
    writer.close()
    ...
```

but it's optional

<!-- gh-issue-number: gh-84747 -->
* Issue: gh-84747
<!-- /gh-issue-number -->
