### PR TITLE
gh-65002: Make note that null bytes are used to pad bytes

### DIFF
--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -61,7 +61,6 @@ The module defines the following exception and functions:
    write the packed bytes into the writable buffer *buffer* starting at
    position *offset*.  Note that *offset* is a required argument.
 
-
 .. function:: unpack(format, buffer)
 
    Unpack from the buffer *buffer* (presumably packed by ``pack(format, ...)``)
@@ -194,7 +193,7 @@ platform-dependent.
 +--------+--------------------------+--------------------+----------------+------------+
 | Format | C Type                   | Python type        | Standard size  | Notes      |
 +========+==========================+====================+================+============+
-| ``x``  | pad byte                 | no value           |                |            |
+| ``x``  | pad byte                 | no value           |                | \(7)       |
 +--------+--------------------------+--------------------+----------------+------------+
 | ``c``  | :c:expr:`char`           | bytes of length 1  | 1              |            |
 +--------+--------------------------+--------------------+----------------+------------+
@@ -290,6 +289,9 @@ Notes:
    typical machine, an unsigned short can be used for storage, but not for math
    operations. See the Wikipedia page on the `half-precision floating-point
    format <half precision format_>`_ for more information.
+
+(7)
+   For padding, ``x`` inserts null bytes.
 
 
 A format character may be preceded by an integral repeat count.  For example,

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -61,6 +61,7 @@ The module defines the following exception and functions:
    write the packed bytes into the writable buffer *buffer* starting at
    position *offset*.  Note that *offset* is a required argument.
 
+
 .. function:: unpack(format, buffer)
 
    Unpack from the buffer *buffer* (presumably packed by ``pack(format, ...)``)


### PR DESCRIPTION
https://docs.python.org/dev/library/struct.html#format-characters

<!-- gh-issue-number: gh-65002 -->
* Issue: gh-65002
<!-- /gh-issue-number -->
