### PR TITLE
gh-98636: Fix detecting gdbm_compat for _dbm module

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -640,6 +640,7 @@ Tiago Gonçalves
 Chris Gonnerman
 Shelley Gooch
 David Goodger
+Michał Górny
 Elliot Gorokhovsky
 Hans de Graaff
 Tim Graham

--- a/Misc/NEWS.d/next/Build/2022-10-25-11-53-55.gh-issue-98636.e0RPAr.rst
+++ b/Misc/NEWS.d/next/Build/2022-10-25-11-53-55.gh-issue-98636.e0RPAr.rst
@@ -1,0 +1,2 @@
+Fix a regression in detecting ``gdbm_compat`` library for the ``_gdbm``
+module build.

--- a/configure
+++ b/configure
@@ -14703,6 +14703,7 @@ fi
 { ac_cv_header_gdbm_ndbm_h=; unset ac_cv_header_gdbm_ndbm_h;}
 
 if test "$ac_cv_header_gdbm_slash_ndbm_h" = yes -o "$ac_cv_header_gdbm_dash_ndbm_h" = yes; then
+  { ac_cv_search_dbm_open=; unset ac_cv_search_dbm_open;}
   save_CFLAGS=$CFLAGS
 save_CPPFLAGS=$CPPFLAGS
 save_LDFLAGS=$LDFLAGS
@@ -14762,7 +14763,9 @@ $as_echo "$ac_cv_search_dbm_open" >&6; }
 ac_res=$ac_cv_search_dbm_open
 if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
-
+  have_gdbm_compat=yes
+else
+  have_gdbm_compat=no
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -4118,8 +4118,9 @@ AS_VAR_IF([ac_cv_header_gdbm_dash_ndbm_h], [yes], [
 AS_UNSET([ac_cv_header_gdbm_ndbm_h])
 
 if test "$ac_cv_header_gdbm_slash_ndbm_h" = yes -o "$ac_cv_header_gdbm_dash_ndbm_h" = yes; then
+  AS_UNSET([ac_cv_search_dbm_open])
   WITH_SAVE_ENV([
-    AC_SEARCH_LIBS([dbm_open], [gdbm_compat])
+    AC_SEARCH_LIBS([dbm_open], [gdbm_compat], [have_gdbm_compat=yes], [have_gdbm_compat=no])
   ])
 fi
 


### PR DESCRIPTION
Fix the gdbm_compat library detection logic to actually check for
-lgdbm_compat independently of the ndbm detection.  This fixes the build
failure with `--with-dbmliborder=gdbm`, and implicit fallback to ndbm
with the default value.


<!-- gh-issue-number: gh-98636 -->
* Issue: gh-98636
<!-- /gh-issue-number -->
