### PR TITLE
Use more precise exception types in `assertRaises` in typing tests

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3575,11 +3575,11 @@ class GenericTests(BaseTestCase):
 
         self.assertEqual(D.__parameters__, ())
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(TypeError):
             D[int]
-        with self.assertRaises(Exception):
+        with self.assertRaises(TypeError):
             D[Any]
-        with self.assertRaises(Exception):
+        with self.assertRaises(TypeError):
             D[T]
 
     def test_new_with_args(self):


### PR DESCRIPTION
`Exception` base-class is too broad, literally anything can be thrown.
We can be more precise with using `TypeError` instead: this is exactly what is thrown.

Going to skip issue for this, it is very minor.