### PR TITLE
gh-98641: Don't portray asyncio.TaskGroup as a replacement for asyncio.gather in docs

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -248,8 +248,9 @@ Creating Tasks
 
    .. note::
 
-      :meth:`asyncio.TaskGroup.create_task` is a newer alternative
-      that allows for convenient waiting for a group of related tasks.
+      :meth:`asyncio.TaskGroup.create_task` is a new alternative
+      based on `structural concurrency principles <https://en.wikipedia.org/wiki/Structured_concurrency>`_ 
+      that allows for waiting for a group of related tasks with strong safety guarantees.
 
    .. important::
 
@@ -328,7 +329,7 @@ Example::
         async with asyncio.TaskGroup() as tg:
             task1 = tg.create_task(some_coro(...))
             task2 = tg.create_task(another_coro(...))
-        print("Both tasks have completed now.")
+        print(f"Both tasks have completed now: {task1.result()}, {task2.result()}")
 
 The ``async with`` statement will wait for all tasks in the group to finish.
 While waiting, new tasks may still be added to the group
@@ -447,8 +448,11 @@ Running Tasks Concurrently
    Tasks/Futures to be cancelled.
 
    .. note::
-      A more modern way to create and run tasks concurrently and
-      wait for their completion is :class:`asyncio.TaskGroup`.
+      A new alternative to create and run tasks concurrently and
+      wait for their completion is :class:`asyncio.TaskGroup`. While *TaskGroup*
+      provides strong safety guarantees for scheduling a nesting of subtasks, *gather* comes in handy
+      for tasks that do not schedule subtasks and need to have their results consumed eagerly 
+      (i.e. when destructuring the result(s) into a tuple).
 
    .. _asyncio_example_gather:
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -249,7 +249,7 @@ Creating Tasks
    .. note::
 
       :meth:`asyncio.TaskGroup.create_task` is a new alternative
-      based on `structural concurrency principles <https://en.wikipedia.org/wiki/Structured_concurrency>`_ 
+      based on `structural concurrency principles <https://en.wikipedia.org/wiki/Structured_concurrency>`_
       that allows for waiting for a group of related tasks with strong safety guarantees.
 
    .. important::
@@ -449,10 +449,14 @@ Running Tasks Concurrently
 
    .. note::
       A new alternative to create and run tasks concurrently and
-      wait for their completion is :class:`asyncio.TaskGroup`. While *TaskGroup*
-      provides strong safety guarantees for scheduling a nesting of subtasks, *gather* comes in handy
-      for tasks that do not schedule subtasks and need to have their results consumed eagerly 
-      (i.e. when destructuring the result(s) into a tuple).
+      wait for their completion is :class:`asyncio.TaskGroup`. *TaskGroup*
+      provides stronger safety guarantees than *gather* for scheduling a nesting of subtasks.
+      That is, if a task (or a subtask, a task scheduled by a task)
+      raises an exception, *TaskGroup* will, while *gather* will not,
+      cancel the remaining scheduled tasks). However the terser *gather* might be
+      preferred for *Iterable* of tasks which individually handle their own exceptions, or more
+      generally, when having some tasks survive the cancellation
+      of others is an acceptable outcome.
 
    .. _asyncio_example_gather:
 


### PR DESCRIPTION
The purpose of the comments is to rule out the implication that asyncio.TaskGroup is a drop-in replacement / better alternative to asyncio.gather(). Both have their idiomatic uses cases, and asyncio.gather() works well for tasks that do not schedule tasks themselves, especially when the caller needs to consume their result as soon as possible.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98641 -->
* Issue: gh-98641
<!-- /gh-issue-number -->
