### PR TITLE
Update link to supported versions table in security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 The Python team applies security fixes according to the table
 in [the devguide](
-https://devguide.python.org/#status-of-python-branches
+https://devguide.python.org/versions/#supported-versions
 ).
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
Since python/devguide#901, the existing link has just gone to a placeholder pointer to the new link.

(See also python/pythondotorg#2162, which made this top of mind when I happened to look at this file just now.)
