### PR TITLE
[3.10] GH-98671: bpo-46670: Fix #ifdef in sha3module.c (GH-90828)

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-10-25-14-43-00.gh-issue-98671.a42a6d.rst
+++ b/Misc/NEWS.d/next/Build/2022-10-25-14-43-00.gh-issue-98671.a42a6d.rst
@@ -1,0 +1,3 @@
+Fix ``NO_MISALIGNED_ACCESSES`` being not defined for the SHA3 extension 
+when ``HAVE_ALIGNED_REQUIRED`` is set. Allowing builds on hardware that 
+unaligned memory accesses are not allowed.

--- a/Modules/_sha3/sha3module.c
+++ b/Modules/_sha3/sha3module.c
@@ -65,7 +65,7 @@
 #endif
 
 /* Prevent bus errors on platforms requiring aligned accesses such ARM. */
-#if HAVE_ALIGNED_REQUIRED && !defined(NO_MISALIGNED_ACCESSES)
+#if defined(HAVE_ALIGNED_REQUIRED) && !defined(NO_MISALIGNED_ACCESSES)
 #define NO_MISALIGNED_ACCESSES
 #endif
 


### PR DESCRIPTION
(cherry picked from commit 10a84ffbcb4583e971d1e0266da0ea0a8d4d8551)

<!-- gh-issue-number: gh-98671 -->
* Issue: gh-98671
<!-- /gh-issue-number -->
