### PR TITLE
[doc] Make subprocess.wait documentation more precise

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -791,9 +791,10 @@ Instances of the :class:`Popen` class have the following methods:
 
    .. note::
 
-      The function is implemented using a busy loop (non-blocking call and
-      short sleeps). Use the :mod:`asyncio` module for an asynchronous wait:
-      see :class:`asyncio.create_subprocess_exec`.
+      When the ``timeout`` parameter is not ``None``, then (on POSIX) the
+      function is implemented using a busy loop (non-blocking call and short
+      sleeps). Use the :mod:`asyncio` module for an asynchronous wait: see
+      :class:`asyncio.create_subprocess_exec`.
 
    .. versionchanged:: 3.3
       *timeout* was added.


### PR DESCRIPTION
An active loop is only used when the `timeout` parameter is used on POSIX.

When no timeout is used, the code calls `os.waitpid` internally (which puts the process on a sleep status). On Windows, the internal Windows API call accepts a timeout parameter, so that is delegated to the OS.