### PR TITLE
gh-98713: Use `@cpython_only` for a test that fails on PyPy

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -42,7 +42,7 @@ import typing
 import weakref
 import types
 
-from test.support import import_helper, captured_stderr
+from test.support import import_helper, captured_stderr, cpython_only
 from test import mod_generics_cache
 from test import _typed_dict_helper
 
@@ -4635,6 +4635,7 @@ class OverloadTests(BaseTestCase):
 
         blah()
 
+    @cpython_only  # gh-98713
     def test_overload_on_compiled_functions(self):
         with patch("typing._overload_registry",
                    defaultdict(lambda: defaultdict(dict))):

--- a/Misc/NEWS.d/next/Tests/2022-10-26-15-19-20.gh-issue-98713.Lnu32R.rst
+++ b/Misc/NEWS.d/next/Tests/2022-10-26-15-19-20.gh-issue-98713.Lnu32R.rst
@@ -1,0 +1,3 @@
+Fix a bug in test suite when cpython-specific implementation details were
+not covered by ``@cpython_only`` and were not skipped on other
+implementations.

--- a/Misc/NEWS.d/next/Tests/2022-10-26-15-19-20.gh-issue-98713.Lnu32R.rst
+++ b/Misc/NEWS.d/next/Tests/2022-10-26-15-19-20.gh-issue-98713.Lnu32R.rst
@@ -1,3 +1,3 @@
-Fix a bug in test suite when cpython-specific implementation details were
-not covered by ``@cpython_only`` and were not skipped on other
-implementations.
+Fix a bug in the :mod:`typing` tests where a test relying on CPython-specific
+implementation details was not decorated with ``@cpython_only`` and was not
+skipped on other implementations.


### PR DESCRIPTION


<!-- gh-issue-number: gh-98713 -->
* Issue: gh-98713
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:AlexWaygood