### PR TITLE
gh-98718: re-use already calculated is_python_build from getpath

### DIFF
--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -197,6 +197,7 @@ typedef struct PyConfig {
     wchar_t *base_prefix;
     wchar_t *exec_prefix;
     wchar_t *base_exec_prefix;
+    wchar_t *build_prefix;
 
     /* --- Parameter only used by Py_Main() ---------- */
     int skip_source_first_line;

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -226,12 +226,9 @@ def is_python_build(check_home=None):
         import warnings
         warnings.warn("check_home argument is deprecated and ignored.",
                       DeprecationWarning, stacklevel=2)
-    for fn in ("Setup", "Setup.local"):
-        if os.path.isfile(os.path.join(_PROJECT_BASE, "Modules", fn)):
-            return True
-    return False
+    return bool(sys.build_prefix)
 
-_PYTHON_BUILD = is_python_build()
+_PYTHON_BUILD = bool(sys.build_prefix)
 
 if _PYTHON_BUILD:
     for scheme in ('posix_prefix', 'posix_home'):

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -509,6 +509,9 @@ if ((not home_was_set and real_executable_dir and not py_setpath)
         config['_is_python_build'] = 1
 
 
+config['build_prefix'] = build_prefix
+
+
 # ******************************************************************************
 # CALCULATE prefix AND exec_prefix
 # ******************************************************************************

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -731,6 +731,7 @@ PyConfig_Clear(PyConfig *config)
     CLEAR(config->base_prefix);
     CLEAR(config->exec_prefix);
     CLEAR(config->base_exec_prefix);
+    CLEAR(config->build_prefix);
     CLEAR(config->platlibdir);
 
     CLEAR(config->filesystem_encoding);
@@ -985,6 +986,7 @@ _PyConfig_Copy(PyConfig *config, const PyConfig *config2)
     COPY_WSTR_ATTR(base_prefix);
     COPY_WSTR_ATTR(exec_prefix);
     COPY_WSTR_ATTR(base_exec_prefix);
+    COPY_WSTR_ATTR(build_prefix);
     COPY_WSTR_ATTR(platlibdir);
 
     COPY_ATTR(site_import);
@@ -1094,6 +1096,7 @@ _PyConfig_AsDict(const PyConfig *config)
     SET_ITEM_WSTR(base_prefix);
     SET_ITEM_WSTR(exec_prefix);
     SET_ITEM_WSTR(base_exec_prefix);
+    SET_ITEM_WSTR(build_prefix);
     SET_ITEM_WSTR(platlibdir);
     SET_ITEM_INT(site_import);
     SET_ITEM_INT(bytes_warning);
@@ -1407,6 +1410,7 @@ _PyConfig_FromDict(PyConfig *config, PyObject *dict)
     GET_WSTR_OPT(base_prefix);
     GET_WSTR_OPT(exec_prefix);
     GET_WSTR_OPT(base_exec_prefix);
+    GET_WSTR_OPT(build_prefix);
 
     GET_UINT(skip_source_first_line);
     GET_WSTR_OPT(run_command);
@@ -3172,6 +3176,7 @@ _Py_DumpPathConfig(PyThreadState *tstate)
     DUMP_SYS(_base_executable);
     DUMP_SYS(base_prefix);
     DUMP_SYS(base_exec_prefix);
+    DUMP_SYS(build_prefix);
     DUMP_SYS(platlibdir);
     DUMP_SYS(executable);
     DUMP_SYS(prefix);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3306,6 +3306,9 @@ _PySys_UpdateConfig(PyThreadState *tstate)
         SET_SYS_FROM_WSTR(SYS_ATTR, WSTR); \
     }
 
+#define COPY_BOOL(KEY, VALUE) \
+        SET_SYS(KEY, PyBool_FromLong(VALUE));
+
     if (config->module_search_paths_set) {
         COPY_LIST("path", config->module_search_paths);
     }
@@ -3317,6 +3320,7 @@ _PySys_UpdateConfig(PyThreadState *tstate)
     COPY_WSTR("exec_prefix", config->exec_prefix);
     COPY_WSTR("base_exec_prefix", config->base_exec_prefix);
     COPY_WSTR("platlibdir", config->platlibdir);
+    COPY_WSTR("build_prefix", config->build_prefix);
 
     if (config->pycache_prefix != NULL) {
         SET_SYS_FROM_WSTR("pycache_prefix", config->pycache_prefix);


### PR DESCRIPTION
This also gets rid of the duplicated logic.

<!-- gh-issue-number: gh-98718 -->
* Issue: gh-98718
<!-- /gh-issue-number -->
