### PR TITLE
gh-98657: [docs] `array.typecodes` is a module-level attribute

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -62,6 +62,14 @@ The actual representation of values is determined by the machine architecture
 (strictly speaking, by the C implementation).  The actual size can be accessed
 through the :attr:`itemsize` attribute.
 
+The module defines the following items:
+
+
+.. data:: typecodes
+
+   A string with all available type codes.
+
+
 The module defines the following type:
 
 
@@ -79,9 +87,6 @@ The module defines the following type:
 
    .. audit-event:: array.__new__ typecode,initializer array.array
 
-.. data:: typecodes
-
-   A string with all available type codes.
 
 Array objects support the ordinary sequence operations of indexing, slicing,
 concatenation, and multiplication.  When using slice assignment, the assigned

--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -62,7 +62,7 @@ The actual representation of values is determined by the machine architecture
 (strictly speaking, by the C implementation).  The actual size can be accessed
 through the :attr:`itemsize` attribute.
 
-The module defines the following items:
+The module defines the following item:
 
 
 .. data:: typecodes


### PR DESCRIPTION
It is defined on a module-level and should be documented as such:

```
>>> import array
>>> array.typecodes
'bBuhHiIlLqQfd'
>>> 
```

Typeshed definition: https://github.com/python/typeshed/blob/fd75bc21fca7d62235bdd2063ce65cdddbd40a1a/stdlib/array.pyi#L16

<!-- gh-issue-number: gh-98657 -->
* Issue: gh-98657
<!-- /gh-issue-number -->
