### PR TITLE
gh-98763: Prefer "python" over "python3" for command line examples in docs.

### DIFF
--- a/Doc/howto/argparse.rst
+++ b/Doc/howto/argparse.rst
@@ -79,16 +79,16 @@ Following is a result of running the code:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py
-   $ python3 prog.py --help
+   $ python prog.py
+   $ python prog.py --help
    usage: prog.py [-h]
 
    options:
      -h, --help  show this help message and exit
-   $ python3 prog.py --verbose
+   $ python prog.py --verbose
    usage: prog.py [-h]
    prog.py: error: unrecognized arguments: --verbose
-   $ python3 prog.py foo
+   $ python prog.py foo
    usage: prog.py [-h]
    prog.py: error: unrecognized arguments: foo
 
@@ -121,10 +121,10 @@ And running the code:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py
+   $ python prog.py
    usage: prog.py [-h] echo
    prog.py: error: the following arguments are required: echo
-   $ python3 prog.py --help
+   $ python prog.py --help
    usage: prog.py [-h] echo
 
    positional arguments:
@@ -132,7 +132,7 @@ And running the code:
 
    options:
      -h, --help  show this help message and exit
-   $ python3 prog.py foo
+   $ python prog.py foo
    foo
 
 Here is what's happening:
@@ -166,7 +166,7 @@ And we get:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py -h
+   $ python prog.py -h
    usage: prog.py [-h] echo
 
    positional arguments:
@@ -187,7 +187,7 @@ Following is a result of running the code:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py 4
+   $ python prog.py 4
    Traceback (most recent call last):
      File "prog.py", line 5, in <module>
        print(args.square**2)
@@ -208,9 +208,9 @@ Following is a result of running the code:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py 4
+   $ python prog.py 4
    16
-   $ python3 prog.py four
+   $ python prog.py four
    usage: prog.py [-h] square
    prog.py: error: argument square: invalid int value: 'four'
 
@@ -235,17 +235,17 @@ And the output:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py --verbosity 1
+   $ python prog.py --verbosity 1
    verbosity turned on
-   $ python3 prog.py
-   $ python3 prog.py --help
+   $ python prog.py
+   $ python prog.py --help
    usage: prog.py [-h] [--verbosity VERBOSITY]
 
    options:
      -h, --help            show this help message and exit
      --verbosity VERBOSITY
                            increase output verbosity
-   $ python3 prog.py --verbosity
+   $ python prog.py --verbosity
    usage: prog.py [-h] [--verbosity VERBOSITY]
    prog.py: error: argument --verbosity: expected one argument
 
@@ -281,12 +281,12 @@ And the output:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py --verbose
+   $ python prog.py --verbose
    verbosity turned on
-   $ python3 prog.py --verbose 1
+   $ python prog.py --verbose 1
    usage: prog.py [-h] [--verbose]
    prog.py: error: unrecognized arguments: 1
-   $ python3 prog.py --help
+   $ python prog.py --help
    usage: prog.py [-h] [--verbose]
 
    options:
@@ -327,9 +327,9 @@ And here goes:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py -v
+   $ python prog.py -v
    verbosity turned on
-   $ python3 prog.py --help
+   $ python prog.py --help
    usage: prog.py [-h] [-v]
 
    options:
@@ -361,14 +361,14 @@ And now the output:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py
+   $ python prog.py
    usage: prog.py [-h] [-v] square
    prog.py: error: the following arguments are required: square
-   $ python3 prog.py 4
+   $ python prog.py 4
    16
-   $ python3 prog.py 4 --verbose
+   $ python prog.py 4 --verbose
    the square of 4 equals 16
-   $ python3 prog.py --verbose 4
+   $ python prog.py --verbose 4
    the square of 4 equals 16
 
 * We've brought back a positional argument, hence the complaint.
@@ -397,16 +397,16 @@ And the output:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py 4
+   $ python prog.py 4
    16
-   $ python3 prog.py 4 -v
+   $ python prog.py 4 -v
    usage: prog.py [-h] [-v VERBOSITY] square
    prog.py: error: argument -v/--verbosity: expected one argument
-   $ python3 prog.py 4 -v 1
+   $ python prog.py 4 -v 1
    4^2 == 16
-   $ python3 prog.py 4 -v 2
+   $ python prog.py 4 -v 2
    the square of 4 equals 16
-   $ python3 prog.py 4 -v 3
+   $ python prog.py 4 -v 3
    16
 
 These all look good except the last one, which exposes a bug in our program.
@@ -431,10 +431,10 @@ And the output:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py 4 -v 3
+   $ python prog.py 4 -v 3
    usage: prog.py [-h] [-v {0,1,2}] square
    prog.py: error: argument -v/--verbosity: invalid choice: 3 (choose from 0, 1, 2)
-   $ python3 prog.py 4 -h
+   $ python prog.py 4 -h
    usage: prog.py [-h] [-v {0,1,2}] square
 
    positional arguments:
@@ -473,18 +473,18 @@ to count the number of occurrences of specific options.
 
 .. code-block:: shell-session
 
-   $ python3 prog.py 4
+   $ python prog.py 4
    16
-   $ python3 prog.py 4 -v
+   $ python prog.py 4 -v
    4^2 == 16
-   $ python3 prog.py 4 -vv
+   $ python prog.py 4 -vv
    the square of 4 equals 16
-   $ python3 prog.py 4 --verbosity --verbosity
+   $ python prog.py 4 --verbosity --verbosity
    the square of 4 equals 16
-   $ python3 prog.py 4 -v 1
+   $ python prog.py 4 -v 1
    usage: prog.py [-h] [-v] square
    prog.py: error: unrecognized arguments: 1
-   $ python3 prog.py 4 -h
+   $ python prog.py 4 -h
    usage: prog.py [-h] [-v] square
 
    positional arguments:
@@ -493,7 +493,7 @@ to count the number of occurrences of specific options.
    options:
      -h, --help       show this help message and exit
      -v, --verbosity  increase output verbosity
-   $ python3 prog.py 4 -vvv
+   $ python prog.py 4 -vvv
    16
 
 * Yes, it's now more of a flag (similar to ``action="store_true"``) in the
@@ -540,11 +540,11 @@ And this is what it gives:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py 4 -vvv
+   $ python prog.py 4 -vvv
    the square of 4 equals 16
-   $ python3 prog.py 4 -vvvv
+   $ python prog.py 4 -vvvv
    the square of 4 equals 16
-   $ python3 prog.py 4
+   $ python prog.py 4
    Traceback (most recent call last):
      File "prog.py", line 11, in <module>
        if args.verbosity >= 2:
@@ -584,7 +584,7 @@ And:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py 4
+   $ python prog.py 4
    16
 
 You can go quite far just with what we've learned so far,
@@ -617,10 +617,10 @@ Output:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py
+   $ python prog.py
    usage: prog.py [-h] [-v] x y
    prog.py: error: the following arguments are required: x, y
-   $ python3 prog.py -h
+   $ python prog.py -h
    usage: prog.py [-h] [-v] x y
 
    positional arguments:
@@ -630,7 +630,7 @@ Output:
    options:
      -h, --help       show this help message and exit
      -v, --verbosity
-   $ python3 prog.py 4 2 -v
+   $ python prog.py 4 2 -v
    4^2 == 16
 
 
@@ -655,11 +655,11 @@ Output:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py 4 2
+   $ python prog.py 4 2
    16
-   $ python3 prog.py 4 2 -v
+   $ python prog.py 4 2 -v
    4^2 == 16
-   $ python3 prog.py 4 2 -vv
+   $ python prog.py 4 2 -vv
    Running 'prog.py'
    4^2 == 16
 
@@ -727,16 +727,16 @@ demonstration. Anyways, here's the output:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py 4 2
+   $ python prog.py 4 2
    4^2 == 16
-   $ python3 prog.py 4 2 -q
+   $ python prog.py 4 2 -q
    16
-   $ python3 prog.py 4 2 -v
+   $ python prog.py 4 2 -v
    4 to the power 2 equals 16
-   $ python3 prog.py 4 2 -vq
+   $ python prog.py 4 2 -vq
    usage: prog.py [-h] [-v | -q] x y
    prog.py: error: argument -q/--quiet: not allowed with argument -v/--verbose
-   $ python3 prog.py 4 2 -v --quiet
+   $ python prog.py 4 2 -v --quiet
    usage: prog.py [-h] [-v | -q] x y
    prog.py: error: argument -q/--quiet: not allowed with argument -v/--verbose
 
@@ -771,7 +771,7 @@ but not both at the same time:
 
 .. code-block:: shell-session
 
-   $ python3 prog.py --help
+   $ python prog.py --help
    usage: prog.py [-h] [-v | -q] x y
 
    calculate X to the power of Y

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -86,7 +86,7 @@ If you run that script, specifying a C file as an argument:
 
 .. code-block:: shell-session
 
-    $ python3 Tools/clinic/clinic.py foo.c
+    $ python Tools/clinic/clinic.py foo.c
 
 Argument Clinic will scan over the file looking for lines that
 look exactly like this:

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -449,7 +449,7 @@ When run, this outputs:
 
 .. code-block:: shell-session
 
-    $ python3 compare-strs.py
+    $ python compare-strs.py
     length of first string= 1
     length of second string= 2
     True

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -61,7 +61,7 @@ The top-level code environment can be:
 
     .. code-block:: shell-session
 
-       $ python3 helloworld.py
+       $ python helloworld.py
        Hello, world!
 
 * the Python module or package passed to the Python interpreter with the
@@ -69,14 +69,14 @@ The top-level code environment can be:
 
     .. code-block:: shell-session
 
-       $ python3 -m tarfile
+       $ python -m tarfile
        usage: tarfile.py [-h] [-v] (...)
 
 * Python code read by the Python interpreter from standard input:
 
     .. code-block:: shell-session
 
-       $ echo "import this" | python3
+       $ echo "import this" | python
        The Zen of Python, by Tim Peters
 
        Beautiful is better than ugly.
@@ -87,7 +87,7 @@ The top-level code environment can be:
 
     .. code-block:: shell-session
 
-       $ python3 -c "import this"
+       $ python -c "import this"
        The Zen of Python, by Tim Peters
 
        Beautiful is better than ugly.
@@ -178,7 +178,7 @@ that your function will return some value acceptable as an input to
 returned if your function does not have a return statement).
 
 By proactively following this convention ourselves, our module will have the
-same behavior when run directly (i.e. ``python3 echo.py``) as it will have if
+same behavior when run directly (i.e. ``python echo.py``) as it will have if
 we later package it as a console script entry-point in a pip-installable
 package.
 
@@ -215,7 +215,7 @@ directly from the command line using the :option:`-m` flag. For example:
 
 .. code-block:: shell-session
 
-   $ python3 -m bandclass
+   $ python -m bandclass
 
 This command will cause ``__main__.py`` to run. How you utilize this mechanism
 will depend on the nature of the package you are writing, but in this
@@ -320,7 +320,7 @@ Now, if we started our program, the result would look like this:
 
 .. code-block:: shell-session
 
-   $ python3 start.py
+   $ python start.py
    Define the variable `my_name`!
 
 The exit code of the program would be 1, indicating an error. Uncommenting the
@@ -329,7 +329,7 @@ status code 0, indicating success:
 
 .. code-block:: shell-session
 
-   $ python3 start.py
+   $ python start.py
    Dinsdale found in file /path/to/start.py
 
 Note that importing ``__main__`` doesn't cause any issues with unintentionally

--- a/Doc/library/devmode.rst
+++ b/Doc/library/devmode.rst
@@ -21,7 +21,7 @@ Effects of the Python Development Mode
 Enabling the Python Development Mode is similar to the following command, but
 with additional effects described below::
 
-    PYTHONMALLOC=debug PYTHONASYNCIODEBUG=1 python3 -W default -X faulthandler
+    PYTHONMALLOC=debug PYTHONASYNCIODEBUG=1 python -W default -X faulthandler
 
 Effects of the Python Development Mode:
 
@@ -128,14 +128,14 @@ any warning. Example using README.txt, which has 269 lines:
 
 .. code-block:: shell-session
 
-    $ python3 script.py README.txt
+    $ python script.py README.txt
     269
 
 Enabling the Python Development Mode displays a :exc:`ResourceWarning` warning:
 
 .. code-block:: shell-session
 
-    $ python3 -X dev script.py README.txt
+    $ python -X dev script.py README.txt
     269
     script.py:10: ResourceWarning: unclosed file <_io.TextIOWrapper name='README.rst' mode='r' encoding='UTF-8'>
       main()
@@ -146,7 +146,7 @@ opened:
 
 .. code-block:: shell-session
 
-    $ python3 -X dev -X tracemalloc=5 script.py README.rst
+    $ python -X dev -X tracemalloc=5 script.py README.rst
     269
     script.py:10: ResourceWarning: unclosed file <_io.TextIOWrapper name='README.rst' mode='r' encoding='UTF-8'>
       main()
@@ -190,7 +190,7 @@ By default, Python does not emit any warning:
 
 .. code-block:: shell-session
 
-    $ python3 script.py
+    $ python script.py
     import os
 
 The Python Development Mode shows a :exc:`ResourceWarning` and logs a "Bad file
@@ -198,7 +198,7 @@ descriptor" error when finalizing the file object:
 
 .. code-block:: shell-session
 
-    $ python3 script.py
+    $ python script.py
     import os
     script.py:10: ResourceWarning: unclosed file <_io.TextIOWrapper name='script.py' mode='r' encoding='UTF-8'>
       main()

--- a/Doc/library/faulthandler.rst
+++ b/Doc/library/faulthandler.rst
@@ -166,10 +166,10 @@ handler:
 
 .. code-block:: shell-session
 
-    $ python3 -c "import ctypes; ctypes.string_at(0)"
+    $ python -c "import ctypes; ctypes.string_at(0)"
     Segmentation fault
 
-    $ python3 -q -X faulthandler
+    $ python -q -X faulthandler
     >>> import ctypes
     >>> ctypes.string_at(0)
     Fatal Python error: Segmentation fault

--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -250,8 +250,8 @@ command line:
 
 .. code-block:: shell-session
 
-   $ python3 -m site --user-site
-   /home/user/.local/lib/python3.3/site-packages
+   $ python -m site --user-site
+   /home/user/.local/lib/python3.11/site-packages
 
 If it is called without arguments, it will print the contents of
 :data:`sys.path` on the standard output, followed by the value of

--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -27,11 +27,11 @@ can be used to compare three different expressions:
 
 .. code-block:: shell-session
 
-   $ python3 -m timeit '"-".join(str(n) for n in range(100))'
+   $ python -m timeit '"-".join(str(n) for n in range(100))'
    10000 loops, best of 5: 30.2 usec per loop
-   $ python3 -m timeit '"-".join([str(n) for n in range(100)])'
+   $ python -m timeit '"-".join([str(n) for n in range(100)])'
    10000 loops, best of 5: 27.5 usec per loop
-   $ python3 -m timeit '"-".join(map(str, range(100)))'
+   $ python -m timeit '"-".join(map(str, range(100)))'
    10000 loops, best of 5: 23.2 usec per loop
 
 This can be achieved from the :ref:`python-interface` with::


### PR DESCRIPTION
Currently docs are not consistent in using `python` vs. `python3` for command line examples. As far as I'm aware, we should prefer `python`, see https://peps.python.org/pep-0394/#for-end-users-of-python

I can create a new issue, if required for such cleanup.

<!-- gh-issue-number: gh-98763 -->
* Issue: gh-98763
<!-- /gh-issue-number -->
