### PR TITLE
gh-98766: Lazier ChainMap methods

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -32,7 +32,7 @@ import sys as _sys
 from itertools import chain as _chain
 from itertools import repeat as _repeat
 from itertools import starmap as _starmap
-from itertools import islice as _isclice
+from itertools import islice as _islice
 from keyword import iskeyword as _iskeyword
 from operator import eq as _eq
 from operator import itemgetter as _itemgetter
@@ -1032,7 +1032,7 @@ class ChainMap(_collections_abc.MutableMapping):
 
     def copy(self):
         'New ChainMap or subclass with a new copy of maps[0] and refs to maps[1:]'
-        return self.__class__(self.maps[0].copy(), *_isclice(self.maps, 1, None))
+        return self.__class__(self.maps[0].copy(), *_islice(self.maps, 1, None))
 
     __copy__ = copy
 
@@ -1050,7 +1050,7 @@ class ChainMap(_collections_abc.MutableMapping):
     @property
     def parents(self):                          # like Django's Context.pop()
         'New ChainMap from maps[1:].'
-        return self.__class__(*_isclice(self.maps, 1, None))
+        return self.__class__(*_islice(self.maps, 1, None))
 
     def __setitem__(self, key, value):
         self.maps[0][key] = value

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1011,7 +1011,7 @@ class ChainMap(_collections_abc.MutableMapping):
         return len(set().union(*self.maps))     # reuses stored hash values if possible
 
     def __iter__(self):
-        lazy_views = (keyview.keys() for keyview in reversed(self.maps))
+        lazy_views = (key_view.keys() for key_view in reversed(self.maps))
         d = dict.fromkeys(_chain.from_iterable(lazy_views))
         return iter(d)
 


### PR DESCRIPTION
This was the best I was able to get performance without making any new methods on dict to prevent multiple hashes being calculated. I can take a stab at adding a new function to dict if there is desire to get back to the original performance of set unions. I imagine chainmap is one of the most heavily used types in the Collections module and iter is probably one of the most heavily called functions from it due to ABC.Mapping using it internally. The changes should be safe to backport to anywhere https://github.com/python/cpython/pull/23569 was merged as it makes no outward behavioral changes. 

I can take a stab at making a better function in either c that can be imported or as a method on the dict class later. I have been working with a lot of custom dictionary like objects late and have run into this ordering breaking issue a bunch of times so I imagine some kind of standard library solution to it would be helpful for anyone making something along these lines. 

<!-- gh-issue-number: gh-98766 -->
* Issue: gh-98766
<!-- /gh-issue-number -->
