### PR TITLE
gh-98745: Allow py.exe launcher to install 3.11 by default and 3.12 on request

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-10-27-20-30-16.gh-issue-98745.v06p4r.rst
+++ b/Misc/NEWS.d/next/Windows/2022-10-27-20-30-16.gh-issue-98745.v06p4r.rst
@@ -1,0 +1,1 @@
+Enable the :file:`py.exe` launcher to install 3.12 when requested.

--- a/Misc/NEWS.d/next/Windows/2022-10-27-20-30-16.gh-issue-98745.v06p4r.rst
+++ b/Misc/NEWS.d/next/Windows/2022-10-27-20-30-16.gh-issue-98745.v06p4r.rst
@@ -1,1 +1,1 @@
-Enable the :file:`py.exe` launcher to install 3.12 when requested.
+Update :file:`py.exe` launcher to install 3.11 by default and 3.12 on request.

--- a/PC/launcher2.c
+++ b/PC/launcher2.c
@@ -1673,6 +1673,7 @@ struct AppxSearchInfo {
 
 struct AppxSearchInfo APPX_SEARCH[] = {
     // Releases made through the Store
+    { L"PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0", L"3.12", 10 },
     { L"PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0", L"3.11", 10 },
     { L"PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0", L"3.10", 10 },
     { L"PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0", L"3.9", 10 },
@@ -1681,6 +1682,7 @@ struct AppxSearchInfo APPX_SEARCH[] = {
     // Side-loadable releases. Note that the publisher ID changes whenever we
     // renew our code-signing certificate, so the newer ID has a higher
     // priority (lower sortKey)
+    { L"PythonSoftwareFoundation.Python.3.12_3847v3x7pw1km", L"3.12", 11 },
     { L"PythonSoftwareFoundation.Python.3.11_3847v3x7pw1km", L"3.11", 11 },
     { L"PythonSoftwareFoundation.Python.3.11_hd69rhyc2wevp", L"3.11", 12 },
     { L"PythonSoftwareFoundation.Python.3.10_3847v3x7pw1km", L"3.10", 11 },

--- a/PC/launcher2.c
+++ b/PC/launcher2.c
@@ -1755,7 +1755,8 @@ struct StoreSearchInfo {
 
 
 struct StoreSearchInfo STORE_SEARCH[] = {
-    { L"3", /* 3.10 */ L"9PJPW5LDXLZ5" },
+    { L"3", /* 3.11 */ L"9NRWMJP3717K" },
+    { L"3.12", L"9NCVDN91XZQP" },
     { L"3.11", L"9NRWMJP3717K" },
     { L"3.10", L"9PJPW5LDXLZ5" },
     { L"3.9", L"9P7QFQMJRFP7" },


### PR DESCRIPTION


<!-- gh-issue-number: gh-98745 -->
* Issue: gh-98745
<!-- /gh-issue-number -->
