### PR TITLE
GH-96421: Introduce cleanup contexts for inlined frames

### DIFF
--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -45,6 +45,14 @@ enum _frameowner {
     FRAME_OWNED_BY_FRAME_OBJECT = 2
 };
 
+enum _frame_cleanup {
+    FRAME_CLEANUP_INVALID = 0,
+    FRAME_CLEANUP_ENTRY = 1,
+    FRAME_CLEANUP_INLINED_CLASS = 2,
+    FRAME_CLEANUP_INLINED_FUNCTION = 3,
+    FRAME_CLEANUP_INLINED_GENERATOR = 4,
+};
+
 typedef struct _PyInterpreterFrame {
     /* "Specials" section */
     PyObject *f_funcobj; /* Strong reference */
@@ -61,7 +69,7 @@ typedef struct _PyInterpreterFrame {
     // over, or (in the case of a newly-created frame) a totally invalid value:
     _Py_CODEUNIT *prev_instr;
     int stacktop;     /* Offset of TOS from localsplus  */
-    bool is_entry;  // Whether this is the "root" frame for the current _PyCFrame.
+    char cleanup;
     char owner;
     /* Locals and stack */
     PyObject *localsplus[1];
@@ -109,7 +117,7 @@ _PyFrame_InitializeSpecials(
     frame->stacktop = code->co_nlocalsplus;
     frame->frame_obj = NULL;
     frame->prev_instr = _PyCode_CODE(code) - 1;
-    frame->is_entry = false;
+    frame->cleanup = FRAME_CLEANUP_INVALID;
     frame->owner = FRAME_OWNED_BY_THREAD;
 }
 

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -48,9 +48,7 @@ enum _frameowner {
 enum _frame_cleanup {
     FRAME_CLEANUP_INVALID = 0,
     FRAME_CLEANUP_ENTRY = 1,
-    FRAME_CLEANUP_INLINED_CLASS = 2,
-    FRAME_CLEANUP_INLINED_FUNCTION = 3,
-    FRAME_CLEANUP_INLINED_GENERATOR = 4,
+    FRAME_CLEANUP_INLINED_FUNCTION = 2,
 };
 
 typedef struct _PyInterpreterFrame {

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1342,7 +1342,7 @@ int _PyFrame_IsEntryFrame(PyFrameObject *frame)
 {
     assert(frame != NULL);
     assert(!_PyFrame_IsIncomplete(frame->f_frame));
-    return frame->f_frame->is_entry;
+    return frame->f_frame->cleanup = FRAME_CLEANUP_ENTRY;
 }
 
 

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1078,7 +1078,7 @@ class PyFramePtr:
         return int(prev_instr - first_instr)
 
     def is_entry(self):
-        return self._f_special("is_entry", bool)
+        return self._f_special("cleanup", int) == 1
 
     def previous(self):
         return self._f_special("previous", PyFramePtr)


### PR DESCRIPTION
This is intended as an alternative to #96319. I personally find that this is a bit simpler, more scalable, and easier to reason about.

Rather than pushing "shim" frames, give `_PyInterpreterFrame` a `cleanup` member that tells the interpreter how to handle its two exit paths (the old `exit_unwind` label on error, and the new `cleanup` label on success).

This proof-of-concept sketches out how inlining generators and class constructions would work under this new scheme by implementing their cleanup code in `exit_unwind` and `cleanup`. However, the specializations themselves are still unimplemented.

<!-- gh-issue-number: gh-96421 -->
* Issue: gh-96421
<!-- /gh-issue-number -->
