### PR TITLE
gh-98783: Fix crashes when `str` subclasses where used in `_PyUnicode_Equal`

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -945,7 +945,7 @@ PyAPI_FUNC(PyObject*) _PyUnicode_FromId(_Py_Identifier*);
    and where the hash values are equal (i.e. a very probable match) */
 PyAPI_FUNC(int) _PyUnicode_EQ(PyObject *, PyObject *);
 
-/* Equality check. Returns -1 on failure. */
+/* Equality check. */
 PyAPI_FUNC(int) _PyUnicode_Equal(PyObject *, PyObject *);
 
 PyAPI_FUNC(int) _PyUnicode_WideCharString_Converter(PyObject *, void *);

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -3605,8 +3605,8 @@ order (MRO) for bases """
         class Some:
             pass
         Some.__module__ = StrSub('example')
-        self.assertEqual(repr(Some), type.__repr__(Some))  # should not crash
-        self.assertEqual(repr(Some()), Some().__repr__())  # should not crash
+        self.assertIsInstance(repr(Some), str)  # should not crash
+        self.assertIsInstance(repr(Some()), str)  # should not crash
 
     def test_keyword_arguments(self):
         # Testing keyword arguments to __init__, __call__...

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1317,6 +1317,15 @@ order (MRO) for bases """
         with self.assertRaisesRegex(AttributeError, "'X' object has no attribute 'a'"):
             X().a
 
+        # Test string subclass in `__slots__`, see gh-98783
+        class SubStr(str):
+            pass
+        class X(object):
+            __slots__ = (SubStr('x'),)
+        X().x = 1
+        with self.assertRaisesRegex(AttributeError, "'X' object has no attribute 'a'"):
+            X().a
+
     def test_slots_special(self):
         # Testing __dict__ and __weakref__ in __slots__...
         class D(object):
@@ -3588,6 +3597,16 @@ order (MRO) for bases """
         self.assertEqual(repr(o), 'A repr')
         self.assertEqual(o.__str__(), '41')
         self.assertEqual(o.__repr__(), 'A repr')
+
+    def test_repr_with_module_str_subclass(self):
+        # gh-98783
+        class StrSub(str):
+            pass
+        class Some:
+            pass
+        Some.__module__ = StrSub('example')
+        self.assertEqual(repr(Some), type.__repr__(Some))  # should not crash
+        self.assertEqual(repr(Some()), Some().__repr__())  # should not crash
 
     def test_keyword_arguments(self):
         # Testing keyword arguments to __init__, __call__...

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1334,6 +1334,12 @@ class LongTest(unittest.TestCase):
                          b'\xff\xff\xff\xff\xff')
         self.assertRaises(OverflowError, (1).to_bytes, 0, 'big')
 
+        # gh-98783
+        class SubStr(str):
+            pass
+        self.assertEqual((0).to_bytes(1, SubStr('big')), b'\x00')
+        self.assertEqual((0).to_bytes(0, SubStr('little')), b'')
+
     def test_from_bytes(self):
         def check(tests, byteorder, signed=False):
             def equivalent_python(byte_array, byteorder, signed=False):
@@ -1533,6 +1539,12 @@ class LongTest(unittest.TestCase):
         self.assertRaises(TypeError, int.from_bytes, InvalidBytes())
         self.assertRaises(TypeError, int.from_bytes, MissingBytes())
         self.assertRaises(ZeroDivisionError, int.from_bytes, RaisingBytes())
+
+        # gh-98783
+        class SubStr(str):
+            pass
+        self.assertEqual(int.from_bytes(b'', SubStr('big')), 0)
+        self.assertEqual(int.from_bytes(b'\x00', SubStr('little')), 0)
 
     @support.cpython_only
     def test_from_bytes_small(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-28-14-52-55.gh-issue-98783.iG0kMs.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-28-14-52-55.gh-issue-98783.iG0kMs.rst
@@ -1,0 +1,2 @@
+Fix multiple crashes when ``str`` subclasses where used instead of ``str``
+itself.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-28-14-52-55.gh-issue-98783.iG0kMs.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-28-14-52-55.gh-issue-98783.iG0kMs.rst
@@ -1,2 +1,2 @@
 Fix multiple crashes in debug mode when ``str`` subclasses
-where used instead of ``str`` itself.
+are used instead of ``str`` itself.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-28-14-52-55.gh-issue-98783.iG0kMs.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-28-14-52-55.gh-issue-98783.iG0kMs.rst
@@ -1,2 +1,2 @@
-Fix multiple crashes when ``str`` subclasses where used instead of ``str``
-itself.
+Fix multiple crashes in debug mode when ``str`` subclasses
+where used instead of ``str`` itself.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -10444,8 +10444,8 @@ unicode_compare_eq(PyObject *str1, PyObject *str2)
 int
 _PyUnicode_Equal(PyObject *str1, PyObject *str2)
 {
-    assert(PyUnicode_CheckExact(str1));
-    assert(PyUnicode_CheckExact(str2));
+    assert(PyUnicode_Check(str1));
+    assert(PyUnicode_Check(str2));
     if (str1 == str2) {
         return 1;
     }


### PR DESCRIPTION
Thanks a lot for your help, @sweeneyde!

<!-- gh-issue-number: gh-98783 -->
* Issue: gh-98783
<!-- /gh-issue-number -->
