### PR TITLE
gh-79932: do not allow to clear a suspended frame

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -949,7 +949,8 @@ frame_clear(PyFrameObject *f, PyObject *Py_UNUSED(ignored))
 {
     if (f->f_frame->owner == FRAME_OWNED_BY_GENERATOR) {
         PyGenObject *gen = _PyFrame_GetGenerator(f->f_frame);
-        if (gen->gi_frame_state == FRAME_EXECUTING) {
+        if (gen->gi_frame_state == FRAME_EXECUTING ||
+            gen->gi_frame_state == FRAME_SUSPENDED) {
             goto running;
         }
         _PyGen_Finalize((PyObject *)gen);


### PR DESCRIPTION
Fixes #79932.

Two pre-existing unit tests are failing. We need to figure out whether this bug is a feature or those tests need to change. 

<!-- gh-issue-number: gh-79932 -->
* Issue: gh-79932
<!-- /gh-issue-number -->
