### PR TITLE
gh-98793: Fix typecheck in `overlapped.c`

### DIFF
--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -239,6 +239,16 @@ class ProactorTests(test_utils.TestCase):
         self.close_loop(self.loop)
         self.assertFalse(self.loop.call_exception_handler.called)
 
+    def test_address_argument_type_error(self):
+        # Regression test for https://github.com/python/cpython/issues/98793
+        ip = asyncio.windows_events.IocpProactor()
+        sock = socket.socket(type=socket.SOCK_DGRAM)
+        bad_address = None
+        with self.assertRaises(TypeError):
+            ip.connect(sock, bad_address)
+        with self.assertRaises(TypeError):
+            ip.sendto(sock, b'abc', addr=bad_address)
+
 
 class WinPolicyTests(test_utils.TestCase):
 

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -241,13 +241,14 @@ class ProactorTests(test_utils.TestCase):
 
     def test_address_argument_type_error(self):
         # Regression test for https://github.com/python/cpython/issues/98793
-        ip = asyncio.windows_events.IocpProactor()
+        proactor = self.loop._proactor
         sock = socket.socket(type=socket.SOCK_DGRAM)
         bad_address = None
         with self.assertRaises(TypeError):
-            ip.connect(sock, bad_address)
+            proactor.connect(sock, bad_address)
         with self.assertRaises(TypeError):
-            ip.sendto(sock, b'abc', addr=bad_address)
+            proactor.sendto(sock, b'abc', addr=bad_address)
+        sock.close()
 
 
 class WinPolicyTests(test_utils.TestCase):

--- a/Misc/NEWS.d/next/Library/2022-10-29-03-40-18.gh-issue-98793.WSPB4A.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-29-03-40-18.gh-issue-98793.WSPB4A.rst
@@ -1,1 +1,1 @@
-Fixes typecheck in :func:`_overlapped.WSAConnect` and :func:`_overlapped.Overlapped.WSASendTo`.
+Fix argument typechecks in :func:`!_overlapped.WSAConnect` and :func:`!_overlapped.Overlapped.WSASendTo` functions. 

--- a/Misc/NEWS.d/next/Library/2022-10-29-03-40-18.gh-issue-98793.WSPB4A.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-29-03-40-18.gh-issue-98793.WSPB4A.rst
@@ -1,1 +1,1 @@
-Fix argument typechecks in :func:`!_overlapped.WSAConnect` and :func:`!_overlapped.Overlapped.WSASendTo` functions. 
+Fix argument typechecks in :func:`!_overlapped.WSAConnect` and :func:`!_overlapped.Overlapped.WSASendTo` functions.

--- a/Misc/NEWS.d/next/Library/2022-10-29-03-40-18.gh-issue-98793.WSPB4A.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-29-03-40-18.gh-issue-98793.WSPB4A.rst
@@ -1,0 +1,1 @@
+Fixes typecheck in :func:`_overlapped.WSAConnect` and :func:`_overlapped.Overlapped.WSASendTo`.

--- a/Modules/clinic/overlapped.c.h
+++ b/Modules/clinic/overlapped.c.h
@@ -1093,6 +1093,10 @@ _overlapped_WSAConnect(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     if (!ConnectSocket && PyErr_Occurred()) {
         goto exit;
     }
+    if (!PyTuple_Check(args[1])) {
+        _PyArg_BadArgument("WSAConnect", "argument 2", "tuple", args[1]);
+        goto exit;
+    }
     AddressObj = args[1];
     return_value = _overlapped_WSAConnect_impl(module, ConnectSocket, AddressObj);
 
@@ -1138,6 +1142,10 @@ _overlapped_Overlapped_WSASendTo(OverlappedObject *self, PyObject *const *args, 
         goto exit;
     }
     if (!_PyLong_UnsignedLong_Converter(args[2], &flags)) {
+        goto exit;
+    }
+    if (!PyTuple_Check(args[3])) {
+        _PyArg_BadArgument("WSASendTo", "argument 4", "tuple", args[3]);
         goto exit;
     }
     AddressObj = args[3];
@@ -1254,4 +1262,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=e0f866222bd5873b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b2e89694b8de3d00 input=a9049054013a1b77]*/

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -1674,7 +1674,7 @@ Overlapped_traverse(OverlappedObject *self, visitproc visit, void *arg)
 _overlapped.WSAConnect
 
     client_handle as ConnectSocket: HANDLE
-    address_as_bytes as AddressObj: object
+    address_as_bytes as AddressObj: object(subclass_of='&PyTuple_Type')
     /
 
 Bind a remote address to a connectionless (UDP) socket.
@@ -1683,7 +1683,7 @@ Bind a remote address to a connectionless (UDP) socket.
 static PyObject *
 _overlapped_WSAConnect_impl(PyObject *module, HANDLE ConnectSocket,
                             PyObject *AddressObj)
-/*[clinic end generated code: output=ea0b4391e94dad63 input=169f8075e9ae7fa4]*/
+/*[clinic end generated code: output=ea0b4391e94dad63 input=7cf65313d49c015a]*/
 {
     char AddressBuf[sizeof(struct sockaddr_in6)];
     SOCKADDR *Address = (SOCKADDR*)AddressBuf;
@@ -1717,7 +1717,7 @@ _overlapped.Overlapped.WSASendTo
     handle: HANDLE
     buf as bufobj: Py_buffer
     flags: DWORD
-    address_as_bytes as AddressObj: object
+    address_as_bytes as AddressObj: object(subclass_of='&PyTuple_Type')
     /
 
 Start overlapped sendto over a connectionless (UDP) socket.
@@ -1727,7 +1727,7 @@ static PyObject *
 _overlapped_Overlapped_WSASendTo_impl(OverlappedObject *self, HANDLE handle,
                                       Py_buffer *bufobj, DWORD flags,
                                       PyObject *AddressObj)
-/*[clinic end generated code: output=3cdedc4cfaeb70cd input=b7c1749a62e2e374]*/
+/*[clinic end generated code: output=3cdedc4cfaeb70cd input=31f44cd4ab92fc33]*/
 {
     char AddressBuf[sizeof(struct sockaddr_in6)];
     SOCKADDR *Address = (SOCKADDR*)AddressBuf;


### PR DESCRIPTION
Fixes typecheck in `_overlapped.WSAConnect` and `_overlapped.Overlapped.WSASendTo`.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98793 -->
* Issue: gh-98793
<!-- /gh-issue-number -->
