### PR TITLE
gh-57762: fix misleading tkinter.Tk docstring

### DIFF
--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -2305,7 +2305,7 @@ class Tk(Misc, Wm):
 
     def __init__(self, screenName=None, baseName=None, className='Tk',
                  useTk=True, sync=False, use=None):
-        """Return a new Toplevel widget on screen SCREENNAME. A new Tcl interpreter will
+        """Return a new top level widget on screen SCREENNAME. A new Tcl interpreter will
         be created. BASENAME will be used for the identification of the profile file (see
         readprofile).
         It is constructed from sys.argv[0] without extensions if None is given. CLASSNAME


### PR DESCRIPTION
Mentioned as a desired change by terryjreedy on the corresponding issue, since Tk is not a subclass of Toplevel.

<!-- gh-issue-number: gh-57762 -->
* Issue: gh-57762
<!-- /gh-issue-number -->
