### PR TITLE
GH-90352: fix _SelectorDatagramTransport to inherit from DatagramTransport

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -1126,7 +1126,7 @@ class _SelectorSocketTransport(_SelectorTransport):
         self._empty_waiter = None
 
 
-class _SelectorDatagramTransport(_SelectorTransport):
+class _SelectorDatagramTransport(_SelectorTransport, transports.DatagramTransport):
 
     _buffer_factory = collections.deque
 

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -1081,6 +1081,10 @@ class SelectorDatagramTransportTests(test_utils.TestCase):
         self.protocol.datagram_received.assert_called_with(
             b'data', ('0.0.0.0', 1234))
 
+    def test_transport_inheritance(self):
+        transport = self.datagram_transport()
+        self.assertIsInstance(transport, asyncio.DatagramTransport)
+
     def test_read_ready_tryagain(self):
         transport = self.datagram_transport()
 

--- a/Misc/NEWS.d/next/Library/2022-10-29-09-42-20.gh-issue-90352.t8QEPt.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-29-09-42-20.gh-issue-90352.t8QEPt.rst
@@ -1,0 +1,1 @@
+Fix ``_SelectorDatagramTransport`` to inherit from :class:`~asyncio.DatagramTransport` in :mod:`asyncio`. Patch by Kumar Aditya.


### PR DESCRIPTION
Closes https://github.com/python/cpython/issues/90352

<!-- gh-issue-number: gh-90352 -->
* Issue: gh-90352
<!-- /gh-issue-number -->
