### PR TITLE
CODEOWNERS: add myself to sysconfig and importlib.resources

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,7 +63,7 @@ Python/traceback.c            @iritkatriel
 # bytecode.
 **/*import*.c                 @brettcannon @encukou @ericsnowcurrently @ncoghlan @warsaw
 **/*import*.py                @brettcannon @encukou @ericsnowcurrently @ncoghlan @warsaw
-**/*importlib/resources/*      @jaraco @warsaw @brettcannon
+**/*importlib/resources/*      @jaraco @warsaw @brettcannon @FFY00
 **/importlib/metadata/*       @jaraco @warsaw
 
 # Dates and times
@@ -147,6 +147,8 @@ Lib/ast.py                    @isidentical
 **/*tarfile*                  @ethanfurman
 
 **/*tomllib*                  @encukou
+
+**/*sysconfig*                @FFY00
 
 # macOS
 /Mac/                         @python/macos-team


### PR DESCRIPTION
`sysconfig` as per https://github.com/python/devguide/pull/974 (probably wait until/if that gets merged)
`importlib.resources` as I have been co-maintaining https://github.com/python/importlib_resources for a while