### PR TITLE
glossary.rst: Fix typo in package definition

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -882,7 +882,7 @@ Glossary
 
    package
       A Python :term:`module` which can contain submodules or recursively,
-      subpackages.  Technically, a package is a Python module with an
+      subpackages.  Technically, a package is a Python module with a
       ``__path__`` attribute.
 
       See also :term:`regular package` and :term:`namespace package`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This is a tiny typo fix of package definition in glossary. 
According to https://devguide.python.org/documentation/help-documenting/ simple typos don’t require issues of their own, but, instead, a pull request can by submitted directly.

Automerge-Triggered-By: GH:AlexWaygood