### PR TITLE
gh-98878: Use builtins from the bound frame when offering a suggestion

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -7,6 +7,7 @@ import sys
 import types
 import inspect
 import importlib
+import builtins
 import unittest
 import re
 import tempfile
@@ -3206,6 +3207,14 @@ class SuggestionFormattingTestBase:
     def test_name_error_suggestions_from_builtins(self):
         def func():
             print(ZeroDivisionErrrrr)
+        actual = self.get_suggestion(func)
+        self.assertIn("'ZeroDivisionError'?", actual)
+
+    def test_name_error_suggestions_from_builtins_when_builtins_is_module(self):
+        def func():
+            custom_globals = globals().copy()
+            custom_globals["__builtins__"] = builtins
+            print(eval("ZeroDivisionErrrrr", custom_globals))
         actual = self.get_suggestion(func)
         self.assertIn("'ZeroDivisionError'?", actual)
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1035,7 +1035,7 @@ def _compute_suggestion_error(exc_value, tb, wrong_name):
         d = (
             list(frame.f_locals)
             + list(frame.f_globals)
-            + list(frame.f_globals['__builtins__'])
+            + list(frame.f_builtins)
         )
     if len(d) > _MAX_CANDIDATE_ITEMS:
         return None

--- a/Misc/NEWS.d/next/Library/2022-10-30-22-42-48.gh-issue-98878.fgrykp.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-30-22-42-48.gh-issue-98878.fgrykp.rst
@@ -1,0 +1,2 @@
+Use the frame bound builtins when offering a name suggestion in
+:mod:`traceback` to prevent crashing when ``__builtins__`` is not a dict.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The `__builtins__` value in the globals can be either a [dictionary or a module](https://docs.python.org/3/library/builtins.html#module-builtins). This PR allows it to be handled in either way (by actually using the frame builtins instead of the `__builtins__` object).


<!-- gh-issue-number: gh-98878 -->
* Issue: gh-98878
<!-- /gh-issue-number -->
