### PR TITLE
gh-98879: Remove unreachable error case from COMPARE_OP_STR_JUMP

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3420,9 +3420,6 @@ handle_eval_breaker:
             DEOPT_IF(!PyUnicode_CheckExact(right), COMPARE_OP);
             STAT_INC(COMPARE_OP, hit);
             int res = _PyUnicode_Equal(left, right);
-            if (res < 0) {
-                goto error;
-            }
             assert(oparg == Py_EQ || oparg == Py_NE);
             JUMPBY(INLINE_CACHE_ENTRIES_COMPARE_OP);
             NEXTOPARG();


### PR DESCRIPTION
f9c9354a7a173eaca2aa19e667b5cf12167b7fed made errors impossible, since PyUnicode_READY() no longer exists.

<!-- gh-issue-number: gh-98879 -->
* Issue: gh-98879
<!-- /gh-issue-number -->
