### PR TITLE
Fix typo in sorting HOWTO

### DIFF
--- a/Doc/howto/sorting.rst
+++ b/Doc/howto/sorting.rst
@@ -247,7 +247,7 @@ To accommodate those situations, Python provides
 :class:`functools.cmp_to_key` to wrap the comparison function
 to make it usable as a key function::
 
-    sorted(words, key=cmp_to_key(strcoll)
+    sorted(words, key=cmp_to_key(strcoll))  # locale-aware sort order
 
 Odds and Ends
 =============


### PR DESCRIPTION
there is a missing close parenthesis. I also added the comment available here: 

https://docs.python.org/3.12/library/functools.html#functools.cmp_to_key

from where this example was probably copied

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
