### PR TITLE
[3.10] gh-98552: Fix preloading '__main__' with forkserver being broken

### DIFF
--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -177,12 +177,18 @@ class BaseContext(object):
         from .spawn import set_executable
         set_executable(executable)
 
-    def set_forkserver_preload(self, module_names):
+    def set_forkserver_preload(self, module_names, raise_exceptions=False):
         '''Set list of module names to try to load in forkserver process.
-        This is really just a hint.
+
+        If this method is not called, the default list of modules_names is
+        ['__main__']. In most scenarios, callers will want to specify '__main__'
+        as the first entry in modules_names when calling this method.
+
+        By default, any exceptions from importing the specified module names
+        are suppressed. Set raise_exceptions = True to not suppress.
         '''
         from .forkserver import set_forkserver_preload
-        set_forkserver_preload(module_names)
+        set_forkserver_preload(module_names, raise_exceptions)
 
     def get_context(self, method=None):
         if method is None:

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5216,9 +5216,11 @@ class TestStartMethod(unittest.TestCase):
         rc, out, err = test.support.script_helper.assert_python_ok(name)
         out = out.decode()
         err = err.decode()
-        if out.rstrip() != 'ok' or err != '':
-            print(out)
-            print(err)
+        expected = "mp_preload\nmp_preload\nmp_preload_import\nf\nf\nf"
+        if out.rstrip() != expected or err != '':
+            print("expected out: " + expected)
+            print("actual out  : " + out)
+            print("err         : " + err)
             self.fail("failed spawning forkserver or grandchild")
 
 

--- a/Lib/test/mp_preload.py
+++ b/Lib/test/mp_preload.py
@@ -2,17 +2,32 @@ import multiprocessing
 
 multiprocessing.Lock()
 
-
+#
+# This test verifies that preload is behaving as expected. By preloading
+# both __main__ and mp_preload_import, both this module and mp_preload_import
+# should be loaded in the forkserver process when it serves new processes.
+# This means that each new process and call to f() will not cause additional
+# module loading.
+#
+# The expected output is then:
+# mp_preload
+# mp_preload
+# mp_preload_import
+# f
+# f
+# f
+#
+# Any deviation from this means something is broken.
+#
 def f():
-    print("ok")
+    import test.mp_preload_import
+    print('f')
 
-
+print("mp_preload")
 if __name__ == "__main__":
     ctx = multiprocessing.get_context("forkserver")
-    modname = "test.mp_preload"
-    # Make sure it's importable
-    __import__(modname)
-    ctx.set_forkserver_preload([modname])
-    proc = ctx.Process(target=f)
-    proc.start()
-    proc.join()
+    ctx.set_forkserver_preload(["__main__","test.mp_preload_import"], True)
+    for i in range(3):
+        proc = ctx.Process(target=f)
+        proc.start()
+        proc.join()

--- a/Lib/test/mp_preload_import.py
+++ b/Lib/test/mp_preload_import.py
@@ -1,0 +1,1 @@
+print('mp_preload_import')

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1248,6 +1248,7 @@ Trent Nelson
 Andrew Nester
 Osvaldo Santana Neto
 Chad Netzer
+Nick Neumann
 Max Neunhöffer
 Anthon van der Neut
 George Neville-Neil

--- a/Misc/NEWS.d/next/Library/2022-10-31-14-57-37.gh-issue-98552.dfHWph.rst
+++ b/Misc/NEWS.d/next/Library/2022-10-31-14-57-37.gh-issue-98552.dfHWph.rst
@@ -1,0 +1,2 @@
+Fix preloading ``__main__`` with forkserver, and other related forkserver
+issues


### PR DESCRIPTION
This has been broken for a long time (9 years).

We do this by using spawn.get_preparation_data() and then using the values in that dictionary appropriately. This lets us also fix the setting of sys.path (which never worked) and other minor properties of the forkserver process.

While updating the test to verify these fixes, we also discovered that forkserver was not flushing stdout/stderr before it forked to create a new process. This caused the updated test to fail because unflushed output in the forkserver would then be printed by the forked process as well. This is now fixed too.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98552 -->
* Issue: gh-98552
<!-- /gh-issue-number -->
