### PR TITLE
gh-98790: Disable pathconfig warnings except when verbose mode is enabled

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-31-22-53-32.gh-issue-98790.wUAmIZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-31-22-53-32.gh-issue-98790.wUAmIZ.rst
@@ -1,0 +1,2 @@
+Disables path configuration warnings unless verbose mode (``-v``
+or ``PyConfig.verbose``) is enabled.

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -904,7 +904,7 @@ _PyConfig_InitPathConfig(PyConfig *config, int compute_path_config)
         !library_to_dict(dict, "library") ||
         !wchar_to_dict(dict, "executable_dir", NULL) ||
         !wchar_to_dict(dict, "py_setpath", _PyPathConfig_GetGlobalModuleSearchPath()) ||
-        !funcs_to_dict(dict, config->pathconfig_warnings) ||
+        !funcs_to_dict(dict, config->pathconfig_warnings && config->verbose) ||
 #ifndef MS_WINDOWS
         PyDict_SetItemString(dict, "winreg", Py_None) < 0 ||
 #endif


### PR DESCRIPTION


<!-- gh-issue-number: gh-98790 -->
* Issue: gh-98790
<!-- /gh-issue-number -->
