### PR TITLE
gh-98925: Lower marshal recursion depth for WASI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ PCbuild/win32/
 Tools/unicode/data/
 /autom4te.cache
 /build/
+/builddir/
 /config.cache
 /config.log
 /config.status

--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -260,6 +260,8 @@ class BugsTestCase(unittest.TestCase):
         #if os.name == 'nt' and support.Py_DEBUG:
         if os.name == 'nt':
             MAX_MARSHAL_STACK_DEPTH = 1000
+        elif sys.platform == 'wasi':
+            MAX_MARSHAL_STACK_DEPTH = 1500
         else:
             MAX_MARSHAL_STACK_DEPTH = 2000
         for i in range(MAX_MARSHAL_STACK_DEPTH - 2):

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-31-18-03-10.gh-issue-98925.zpdjVd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-31-18-03-10.gh-issue-98925.zpdjVd.rst
@@ -1,0 +1,2 @@
+Lower the recursion depth for marshal on WASI to support (in-development)
+wasmtime 2.0.

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -34,7 +34,7 @@ module marshal
  */
 #if defined(MS_WINDOWS)
 #define MAX_MARSHAL_STACK_DEPTH 1000
-#elif defined(__WASI__)
+#elif defined(__wasi__)
 #define MAX_MARSHAL_STACK_DEPTH 1500
 #else
 #define MAX_MARSHAL_STACK_DEPTH 2000

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -34,6 +34,8 @@ module marshal
  */
 #if defined(MS_WINDOWS)
 #define MAX_MARSHAL_STACK_DEPTH 1000
+#elif defined(__WASI__)
+#define MAX_MARSHAL_STACK_DEPTH 1500
 #else
 #define MAX_MARSHAL_STACK_DEPTH 2000
 #endif


### PR DESCRIPTION
For wasmtime 2.0, the stack depth cost is 6% higher. This causes the default max `marshal` recursion depth to blow the stack.

As the default marshal depth is 2000 and Windows is set to 1000, split the difference and choose 1500 for WASI to be safe.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98925 -->
* Issue: gh-98925
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:brettcannon