### PR TITLE
gh-98950: Pass through -X options to test.bisect_cmd

### DIFF
--- a/Lib/test/bisect_cmd.py
+++ b/Lib/test/bisect_cmd.py
@@ -51,6 +51,12 @@ def python_cmd():
     cmd = [sys.executable]
     cmd.extend(subprocess._args_from_interpreter_flags())
     cmd.extend(subprocess._optim_args_from_interpreter_flags())
+    for key, value in sys._xoptions.items():
+        cmd.append("-X")
+        if value == True:
+            cmd.append(key)
+        else:
+            cmd.append(f"{key}={value}")
     return cmd
 
 

--- a/Lib/test/bisect_cmd.py
+++ b/Lib/test/bisect_cmd.py
@@ -53,7 +53,7 @@ def python_cmd():
     cmd.extend(subprocess._optim_args_from_interpreter_flags())
     for key, value in sys._xoptions.items():
         cmd.append("-X")
-        if value == True:
+        if value is True:
             cmd.append(key)
         else:
             cmd.append(f"{key}={value}")

--- a/Misc/NEWS.d/next/Library/2022-11-06-22-48-29.gh-issue-98950.2R2ALh.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-06-22-48-29.gh-issue-98950.2R2ALh.rst
@@ -1,0 +1,1 @@
+Pass through nonstandard -X options too when running test.bisect_cmd.


### PR DESCRIPTION
Some -X options are not known to CPython and are
implementation-specific. Other VMs or extensions might want to pass through options that affect runtime behavior.

For example, the Cinder JIT uses `-X jit` and friends to indicate that the runtime should enable the JIT. Without this patch, bisect runs do not pass that through.

<!-- gh-issue-number: gh-98950 -->
* Issue: gh-98950
<!-- /gh-issue-number -->
