### PR TITLE
gh-98689: Update Windows builds to zlib v1.2.13

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-11-01-11-07-33.gh-issue-98689.0f6e_N.rst
+++ b/Misc/NEWS.d/next/Windows/2022-11-01-11-07-33.gh-issue-98689.0f6e_N.rst
@@ -1,0 +1,2 @@
+Update Windows builds to zlib v1.2.13.  v1.2.12 has CVE-2022-37434, but
+the vulnerable ``inflateGetHeader`` API is not used by Python.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -59,7 +59,7 @@ if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.12.
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.12.1
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tix-8.4.3.6
 set libraries=%libraries%                                       xz-5.2.5
-set libraries=%libraries%                                       zlib-1.2.12
+set libraries=%libraries%                                       zlib-1.2.13
 
 for %%e in (%libraries%) do (
     if exist "%EXTERNALS_DIR%\%%e" (

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -71,7 +71,7 @@
     <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1q\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
-    <zlibDir>$(ExternalsDir)\zlib-1.2.12\</zlibDir>
+    <zlibDir>$(ExternalsDir)\zlib-1.2.13\</zlibDir>
     
     <!-- Suffix for all binaries when building for debug -->
     <PyDebugExt Condition="'$(PyDebugExt)' == '' and $(Configuration) == 'Debug'">_d</PyDebugExt>


### PR DESCRIPTION
The tag has now been pushed to cpython-source-deps and this should be ready for merge and backport.


<!-- gh-issue-number: gh-98689 -->
* Issue: gh-98689
<!-- /gh-issue-number -->
