### PR TITLE
Docs: Add 'as, match statement' to the index

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -593,6 +593,7 @@ The :keyword:`!match` statement
    keyword: if
    keyword: as
    pair: match; case
+   single: as; match statement
    single: : (colon); compound statement
 
 .. versionadded:: 3.10


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

# `match as ...`

Fix for issue identified on Discourse: 

* https://discuss.python.org/t/why-is-there-no-official-python-org-documentation-specifying-all-python-keywords-with-each-being-given-its-own-page-with-links-to-other-areas-of-documentation-that-describe-them/20567/14?u=hugovk

## Before

For "as" in the index, we have:

> except clause
> import statement
> keyword, [1], [2], [3]
> with statement

![image](https://user-images.githubusercontent.com/1324225/199450977-a02c16b6-52d3-482a-9d08-bae8214b0dc1.png)

https://docs.python.org/3.12/genindex-A.html


There's no "match statement" there.

This is the index entry for the `import` statement:

```rst
.. index::
   ! statement: with
   keyword: as
   single: as; with statement
   single: , (comma); with statement
   single: : (colon); compound statement
```

This is the index entry for the `match` statement:

```rst
.. index::
   ! statement: match
   ! keyword: case
   ! single: pattern matching
   keyword: if
   keyword: as
   pair: match; case
   single: : (colon); compound statement
```

## After

So let's add `single: as; match statement`:

> except clause
> import statement
> keyword, [1], [2], [3]
> match statement
> with statement

![image](https://user-images.githubusercontent.com/1324225/199451976-fd1fb01d-1655-4953-86a1-93cd3c5c11a4.png)

---

## `try ... except as ...`

I will note that those keyword links are:

* [keyword](https://docs.python.org/3.12/reference/compound_stmts.html#index-16) itself -> the `with` statement
* [[1]](https://docs.python.org/3.12/reference/compound_stmts.html#index-18) -> the `match` statement
* [[2]](https://docs.python.org/3.12/reference/compound_stmts.html#index-9) -> the `try` statement
* [[3]](https://docs.python.org/3.12/reference/simple_stmts.html#index-34) -> the `import` statement

To be more explicit, we could also add "try statement" to complete the quartet? It's already covered by "except clause" though.



