### PR TITLE
gh-98978: Fix use-after-free in apps that call pathconfig global functions multiple times

### DIFF
--- a/Misc/NEWS.d/next/Security/2022-11-02-15-11-29.gh-issue-98978.Yl_gFA.rst
+++ b/Misc/NEWS.d/next/Security/2022-11-02-15-11-29.gh-issue-98978.Yl_gFA.rst
@@ -1,0 +1,3 @@
+Fixed a potential use-after-free in applications that call configuration
+functions :c:func:`Py_SetPythonHome`, :c:func:`Py_SetProgramName` or
+(private) ``_Py_SetProgramFullPath`` multiple times.

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -261,9 +261,7 @@ Py_SetPythonHome(const wchar_t *home)
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     PyMem_RawFree(_Py_path_config.home);
-    if (has_value) {
-        _Py_path_config.home = _PyMem_RawWcsdup(home);
-    }
+    _Py_path_config.home = has_value ? _PyMem_RawWcsdup(home) : NULL;
 
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
@@ -282,9 +280,7 @@ Py_SetProgramName(const wchar_t *program_name)
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     PyMem_RawFree(_Py_path_config.program_name);
-    if (has_value) {
-        _Py_path_config.program_name = _PyMem_RawWcsdup(program_name);
-    }
+    _Py_path_config.program_name = has_value ? _PyMem_RawWcsdup(program_name) : NULL;
 
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
@@ -302,9 +298,7 @@ _Py_SetProgramFullPath(const wchar_t *program_full_path)
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     PyMem_RawFree(_Py_path_config.program_full_path);
-    if (has_value) {
-        _Py_path_config.program_full_path = _PyMem_RawWcsdup(program_full_path);
-    }
+    _Py_path_config.program_full_path = has_value ? _PyMem_RawWcsdup(program_full_path) : NULL;
 
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-98978 -->
* Issue: gh-98978
<!-- /gh-issue-number -->
