### PR TITLE
gh-98586: add whatsnew entry covering limited-API outgoing vector calls, related documentation fix

### DIFF
--- a/Doc/c-api/call.rst
+++ b/Doc/c-api/call.rst
@@ -93,7 +93,7 @@ This is a pointer to a function with the following signature:
    and they must be unique.
    If there are no keyword arguments, then *kwnames* can instead be *NULL*.
 
-.. c:macro:: PY_VECTORCALL_ARGUMENTS_OFFSET
+.. data:: PY_VECTORCALL_ARGUMENTS_OFFSET
 
    If this flag is set in a vectorcall *nargsf* argument, the callee is allowed
    to temporarily change ``args[-1]``. In other words, *args* points to

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -630,7 +630,7 @@ New Features
   * :c:func:`PyObject_VectorcallMethod`
   * :const:`Py_TPFLAGS_HAVE_VECTORCALL`
 
-  Together with the previous change, this covers both the receiving and outgoing
+  Together with the previous change, this covers both the incoming and outgoing
   ends of the vector call protocol. (Contributed by Wenzel Jakob in
   :gh:`98586`.)
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -622,7 +622,7 @@ New Features
   ``__dict__`` and weakrefs with less bookkeeping,
   using less memory and with faster access.
 
-* API for performing calls using the
+* API for performing calls using
   :ref:`the vectorcall protocol <vectorcall>` was added to the
   :ref:`Limited API <stable>`:
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -630,7 +630,7 @@ New Features
   * :c:func:`PyObject_VectorcallMethod`
   * :const:`Py_TPFLAGS_HAVE_VECTORCALL`
 
-  Together with the previous change, this covers both receiving and outgoing
+  Together with the previous change, this covers both the receiving and outgoing
   ends of the vector call protocol. (Contributed by Wenzel Jakob in
   :gh:`98586`.)
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -623,7 +623,7 @@ New Features
   using less memory and with faster access.
 
 * API for performing calls using
-  :ref:`the vectorcall protocol <vectorcall>` was also added to the
+  :ref:`the vectorcall protocol <vectorcall>` was added to the
   :ref:`Limited API <stable>`:
 
   * :c:func:`PyObject_Vectorcall`

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -623,16 +623,16 @@ New Features
   using less memory and with faster access.
 
 * API for performing calls using
-  :ref:`the vectorcall protocol <vectorcall>` was added to the
+  :ref:`the vectorcall protocol <vectorcall>` was also added to the
   :ref:`Limited API <stable>`:
 
   * :c:func:`PyObject_Vectorcall`
   * :c:func:`PyObject_VectorcallMethod`
   * :const:`PY_VECTORCALL_ARGUMENTS_OFFSET`
 
-  Together with the previous change, this covers both the incoming and outgoing
-  ends of the vector call protocol. (Contributed by Wenzel Jakob in
-  :gh:`98586`.)
+  This means that both the incoming and outgoing ends of the vector call
+  protocol are now available in the :ref:`Limited API <stable>`. (Contributed
+  by Wenzel Jakob in :gh:`98586`.)
 
 * Added two new public functions,
   :c:func:`PyEval_SetProfileAllThreads` and

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -622,6 +622,18 @@ New Features
   ``__dict__`` and weakrefs with less bookkeeping,
   using less memory and with faster access.
 
+* API for performing calls using the
+  :ref:`the vectorcall protocol <vectorcall>` was added to the
+  :ref:`Limited API <stable>`:
+
+  * :c:func:`PyObject_Vectorcall`
+  * :c:func:`PyObject_VectorcallMethod`
+  * :const:`Py_TPFLAGS_HAVE_VECTORCALL`
+
+  Together with the previous change, this covers both receiving and outgoing
+  ends of the vector call protocol. (Contributed by Wenzel Jakob in
+  :gh:`98586`.)
+
 * Added two new public functions,
   :c:func:`PyEval_SetProfileAllThreads` and
   :c:func:`PyEval_SetTraceAllThreads`, that allow to set tracing and profiling

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -628,7 +628,7 @@ New Features
 
   * :c:func:`PyObject_Vectorcall`
   * :c:func:`PyObject_VectorcallMethod`
-  * :const:`Py_TPFLAGS_HAVE_VECTORCALL`
+  * :const:`PY_VECTORCALL_ARGUMENTS_OFFSET`
 
   Together with the previous change, this covers both the incoming and outgoing
   ends of the vector call protocol. (Contributed by Wenzel Jakob in

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-24-10-30-30.gh-issue-98586.Tha5Iy.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-24-10-30-30.gh-issue-98586.Tha5Iy.rst
@@ -1,6 +1,6 @@
 Added the methods :c:func:`PyObject_Vectorcall` and
 :c:func:`PyObject_VectorcallMethod` to the :ref:`Limited API <stable>` along
-with the auxiliary macro constant :c:macro:`PY_VECTORCALL_ARGUMENTS_OFFSET`.
+with the auxiliary macro constant :const:`PY_VECTORCALL_ARGUMENTS_OFFSET`.
 
 The availability of these functions enables more efficient :PEP:`590` vector
 calls from binary extension modules that avoid argument boxing/unboxing


### PR DESCRIPTION
PR #98587 addressing issue #98586 lacked a "what's new" entry.

While making those changes, I noticed an inconsistency in how ``PY_VECTORCALL_ARGUMENTS_OFFSET`` is declared in the underlying Sphinx markup when compared to other macro constants like ``Py_TPFLAGS_HAVE_VECTORCALL``. This PR fixes that as well, which should connect a few currently broken cross-references

<!-- gh-issue-number: gh-98586 -->
* Issue: gh-98586
<!-- /gh-issue-number -->
