### PR TITLE
gh-98963: Add a note to the error for property subclasses without __doc__

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -2359,17 +2359,6 @@ order (MRO) for bases """
             class X(object):
                 p = property(_testcapi.test_with_docstring)
 
-    def test_subclass_with_nonwritable_doc(self):
-        # gh-98963: subclasses must have writable __doc__. A note is added to
-        # the exception in this surprising edge case.
-        class BadProperty(property):
-            __doc__ = property(lambda: None)
-        with self.assertRaises(AttributeError) as cm:
-            p = BadProperty(lambda: 123)
-        notes = cm.exception.__notes__
-        wanted = "subclasses of 'property' need to provide a writable __doc__"
-        self.assertTrue(any(note.startswith(wanted) for note in notes), notes)
-
     def test_properties_plus(self):
         class C(object):
             foo = property(doc="hello")

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -2359,6 +2359,17 @@ order (MRO) for bases """
             class X(object):
                 p = property(_testcapi.test_with_docstring)
 
+    def test_subclass_with_nonwritable_doc(self):
+        # gh-98963: subclasses must have writable __doc__. A note is added to
+        # the exception in this surprising edge case.
+        class BadProperty(property):
+            __doc__ = property(lambda: None)
+        with self.assertRaises(AttributeError) as cm:
+            p = BadProperty(lambda: 123)
+        notes = cm.exception.__notes__
+        wanted = "subclasses of 'property' need to provide a writable __doc__"
+        self.assertTrue(any(note.startswith(wanted) for note in notes), notes)
+
     def test_properties_plus(self):
         class C(object):
             foo = property(doc="hello")

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -229,16 +229,18 @@ class PropertySubSlots(property):
 class PropertySubclassTests(unittest.TestCase):
 
     def test_slots_docstring_copy_exception(self):
-        try:
+        with self.assertRaises(AttributeError) as cm:
             class Foo(object):
                 @PropertySubSlots
                 def spam(self):
                     """Trying to copy this docstring will raise an exception"""
                     return 1
-        except AttributeError:
-            pass
-        else:
-            raise Exception("AttributeError not raised")
+        # gh-98963: A note is added to the exception when we don't have
+        # a writable __doc__.
+        notes = cm.exception.__notes__
+        wanted = "subclasses of 'property' need to provide a writable __doc__"
+        self.assertTrue(any(note.startswith(wanted) for note in notes), notes)
+
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")

--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-03-13-54-54.gh-issue-98963.Z3c6M5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-03-13-54-54.gh-issue-98963.Z3c6M5.rst
@@ -1,0 +1,3 @@
+Add a note to the ``AttributeError`` raised when instantiating a subclass of
+:py:type:`property` that does not have a writable ``__doc__`` attribute.
+(Creating such a subclass is possible via the C API.)

--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-03-13-54-54.gh-issue-98963.Z3c6M5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-03-13-54-54.gh-issue-98963.Z3c6M5.rst
@@ -1,3 +1,3 @@
 Add a note to the ``AttributeError`` raised when instantiating a subclass of
-:py:type:`property` that does not have a writable ``__doc__`` attribute.
+:py:class:`property` that does not have a writable ``__doc__`` attribute.
 (Creating such a subclass is possible via the C API.)


### PR DESCRIPTION
Subclasses created using the C API don't get `__dict__`, which means their `__doc__` can't be set for each property separately. The `__doc__` descriptor from `property` itself is shadowed by the subclass's docstring.

This edge case isn't really worth mentioning in the docs. This adds a note that should guide anyone encountering the issue to the right fix.

The newfangled `__notes__` mechanism is as non-invasive as it gets -- it even retains the original exception object -- while getting the information to the surprised user.
(The message is longer than typical error messages, but IMO it's better to explain here than in the docs, where 99%+ of the readers don't need it.)



<!-- gh-issue-number: gh-98963 -->
* Issue: gh-98963
<!-- /gh-issue-number -->
