### PR TITLE
gh-92584: Remove references to removed _bootsubprocess

### DIFF
--- a/Lib/_aix_support.py
+++ b/Lib/_aix_support.py
@@ -1,14 +1,8 @@
 """Shared AIX support functions."""
 
+import subprocess
 import sys
 import sysconfig
-
-try:
-    import subprocess
-except ImportError:  # pragma: no cover
-    # _aix_support is used in distutils by setup.py to build C extensions,
-    # before subprocess dependencies like _posixsubprocess are available.
-    import _bootsubprocess as subprocess
 
 
 def _aix_tag(vrtl, bd):

--- a/Tools/wasm/wasm_assets.py
+++ b/Tools/wasm/wasm_assets.py
@@ -50,7 +50,6 @@ OMIT_FILES = (
     "xdrlib.py",
     # other platforms
     "_aix_support.py",
-    "_bootsubprocess.py",
     "_osx_support.py",
     # webbrowser
     "antigravity.py",


### PR DESCRIPTION
The _bootsubprocess module was removed in gh-93939 by commit 81dca70d704d0834d8c30580e648a973250b2973.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-92584 -->
* Issue: gh-92584
<!-- /gh-issue-number -->
