### PR TITLE
gh-98978: Fix Py_SetPythonHome(NULL)

### DIFF
--- a/Misc/NEWS.d/next/C API/2022-11-03-17-46-41.gh-issue-98978.KJjBvv.rst
+++ b/Misc/NEWS.d/next/C API/2022-11-03-17-46-41.gh-issue-98978.KJjBvv.rst
@@ -1,0 +1,3 @@
+Fix use-after-free in ``Py_SetPythonHome(NULL)``,
+``Py_SetProgramName(NULL)`` and ``_Py_SetProgramFullPath(NULL)`` function
+calls. Issue reported by Benedikt Reinartz. Patch by Victor Stinner.

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -261,6 +261,8 @@ Py_SetPythonHome(const wchar_t *home)
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     PyMem_RawFree(_Py_path_config.home);
+    _Py_path_config.home = NULL;
+
     if (has_value) {
         _Py_path_config.home = _PyMem_RawWcsdup(home);
     }
@@ -282,6 +284,8 @@ Py_SetProgramName(const wchar_t *program_name)
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     PyMem_RawFree(_Py_path_config.program_name);
+    _Py_path_config.program_name = NULL;
+
     if (has_value) {
         _Py_path_config.program_name = _PyMem_RawWcsdup(program_name);
     }
@@ -302,6 +306,8 @@ _Py_SetProgramFullPath(const wchar_t *program_full_path)
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     PyMem_RawFree(_Py_path_config.program_full_path);
+    _Py_path_config.program_full_path = NULL;
+
     if (has_value) {
         _Py_path_config.program_full_path = _PyMem_RawWcsdup(program_full_path);
     }


### PR DESCRIPTION
Fix use-after-free in Py_SetPythonHome(NULL), Py_SetProgramName(NULL) and _Py_SetProgramFullPath(NULL) function calls.

Issue reported by Benedikt Reinartz.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98978 -->
* Issue: gh-98978
<!-- /gh-issue-number -->
