### PR TITLE
gh-90716: bugfixes and more tests for _pylong.

### DIFF
--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -857,7 +857,8 @@ class PyLongModuleTests(unittest.TestCase):
             mock_int_to_str.return_value = None  # not a str
             with self.assertRaises(TypeError) as ctx:
                 str(big_value)
-            self.assertIn('non-string', str(ctx.exception))
+            self.assertIn('_pylong.int_to_decimal_string did not',
+                          str(ctx.exception))
             mock_int_to_str.side_effect = RuntimeError("testABC")
             with self.assertRaises(RuntimeError):
                 str(big_value)
@@ -872,7 +873,8 @@ class PyLongModuleTests(unittest.TestCase):
             mock_int_from_str.return_value = b'not an int'
             with self.assertRaises(TypeError) as ctx:
                 int(big_value)
-            self.assertIn('_pylong.int_from_string', str(ctx.exception))
+            self.assertIn('_pylong.int_from_string did not',
+                          str(ctx.exception))
 
             mock_int_from_str.side_effect = RuntimeError("test123")
             with self.assertRaises(RuntimeError):

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -2,9 +2,12 @@ import sys
 import time
 
 import unittest
+from unittest import mock
 from test import support
 from test.test_grammar import (VALID_UNDERSCORE_LITERALS,
                                INVALID_UNDERSCORE_LITERALS)
+
+import _pylong
 
 L = [
         ('0', 0),
@@ -840,6 +843,34 @@ class PyLongModuleTests(unittest.TestCase):
             int(s + '_')
         with self.assertRaises(ValueError) as err:
             int('_' + s)
+
+    @mock.patch.object(_pylong, "int_to_decimal_string")
+    def test_pylong_misbehavior_error_path_to_str(
+            self, mock_int_to_str):
+        with support.adjust_int_max_str_digits(20_000):
+            big_value = int('7'*19_999)
+            mock_int_to_str.return_value = None  # not a str
+            with self.assertRaises(TypeError) as ctx:
+                str(big_value)
+            self.assertIn('non-string', str(ctx.exception))
+            mock_int_to_str.side_effect = RuntimeError("testABC")
+            with self.assertRaises(RuntimeError):
+                str(big_value)
+
+    @mock.patch.object(_pylong, "int_from_string")
+    def test_pylong_misbehavior_error_path_from_str(
+            self, mock_int_from_str):
+        big_value = '7'*19_999
+        with support.adjust_int_max_str_digits(20_000):
+            mock_int_from_str.return_value = b'not an int'
+            with self.assertRaises(TypeError) as ctx:
+                int(big_value)
+            self.assertIn('_pylong.int_from_string', str(ctx.exception))
+
+            mock_int_from_str.side_effect = RuntimeError("test123")
+            with self.assertRaises(RuntimeError):
+                int(big_value)
+
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -7,7 +7,10 @@ from test import support
 from test.test_grammar import (VALID_UNDERSCORE_LITERALS,
                                INVALID_UNDERSCORE_LITERALS)
 
-import _pylong
+try:
+    import _pylong
+except ImportError:
+    _pylong = None
 
 L = [
         ('0', 0),
@@ -844,6 +847,8 @@ class PyLongModuleTests(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             int('_' + s)
 
+    @support.cpython_only  # tests implementation details of CPython.
+    @unittest.skipUnless(_pylong, "_pylong module required")
     @mock.patch.object(_pylong, "int_to_decimal_string")
     def test_pylong_misbehavior_error_path_to_str(
             self, mock_int_to_str):
@@ -857,6 +862,8 @@ class PyLongModuleTests(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 str(big_value)
 
+    @support.cpython_only  # tests implementation details of CPython.
+    @unittest.skipUnless(_pylong, "_pylong module required")
     @mock.patch.object(_pylong, "int_from_string")
     def test_pylong_misbehavior_error_path_from_str(
             self, mock_int_from_str):
@@ -870,7 +877,6 @@ class PyLongModuleTests(unittest.TestCase):
             mock_int_from_str.side_effect = RuntimeError("test123")
             with self.assertRaises(RuntimeError):
                 int(big_value)
-
 
 
 if __name__ == "__main__":

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1753,7 +1753,11 @@ pylong_int_to_decimal_string(PyObject *aa,
     if (s == NULL) {
         goto error;
     }
-    assert(PyUnicode_Check(s));
+    if (!PyUnicode_Check(s)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "_pylong.int_to_decimal_string did not return a str");
+        goto error;
+    }
     if (writer) {
         Py_ssize_t size = PyUnicode_GET_LENGTH(s);
         if (_PyUnicodeWriter_Prepare(writer, size, '9') == -1) {
@@ -2372,7 +2376,8 @@ pylong_int_from_string(const char *start, const char *end, PyLongObject **res)
         goto error;
     }
     if (!PyLong_Check(result)) {
-        PyErr_SetString(PyExc_TypeError, "_pylong.int_from_string did not return an int");
+        PyErr_SetString(PyExc_TypeError,
+                        "_pylong.int_from_string did not return an int");
         goto error;
     }
     *res = (PyLongObject *)result;


### PR DESCRIPTION
* Properly decref on _pylong import error.
* Improve the error message on _pylong TypeError.
* Tie the return value comments together.

These are minor followups to issues not caught among the reviewers on https://github.com/python/cpython/pull/96673.


<!-- gh-issue-number: gh-90716 -->
* Issue: gh-90716
<!-- /gh-issue-number -->
