### PR TITLE
GH-93143: Don't turn `LOAD_FAST` into `LOAD_FAST_CHECK`

### DIFF
--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -815,7 +815,7 @@ class TestMarkingVariablesAsUnKnown(BytecodeTestCase):
         self.assertInBytecode(f, 'LOAD_FAST_CHECK', "a73")
         self.assertInBytecode(f, 'LOAD_FAST', "a73")
 
-    def test_setting_lineno_warns_and_assigns_none_0(self):
+    def test_setting_lineno_no_undefined(self):
         code = textwrap.dedent(f"""\
             def f():
                 x = y = 2
@@ -847,7 +847,7 @@ class TestMarkingVariablesAsUnKnown(BytecodeTestCase):
         self.assertNotInBytecode(f, "LOAD_FAST_CHECK")
         self.assertEqual(f.__code__.co_code, co_code)
 
-    def test_setting_lineno_warns_and_assigns_none_1(self):
+    def test_setting_lineno_one_undefined(self):
         code = textwrap.dedent(f"""\
             def f():
                 x = y = 2
@@ -881,7 +881,7 @@ class TestMarkingVariablesAsUnKnown(BytecodeTestCase):
         self.assertNotInBytecode(f, "LOAD_FAST_CHECK")
         self.assertEqual(f.__code__.co_code, co_code)
 
-    def test_setting_lineno_warns_and_assigns_none_2(self):
+    def test_setting_lineno_two_undefined(self):
         code = textwrap.dedent(f"""\
             def f():
                 x = y = 2

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-19-23-54-43.gh-issue-93143.1wCYub.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-19-23-54-43.gh-issue-93143.1wCYub.rst
@@ -1,0 +1,4 @@
+Rather than changing :attr:`~types.CodeType.co_code`, the interpreter will
+now display a :exc:`RuntimeWarning` and assign :const:`None` to any fast
+locals that are incorrectly left unbound after jumps or :keyword:`del`
+statements executed while tracing.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-10-19-23-54-43.gh-issue-93143.1wCYub.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-10-19-23-54-43.gh-issue-93143.1wCYub.rst
@@ -1,4 +1,4 @@
 Rather than changing :attr:`~types.CodeType.co_code`, the interpreter will
 now display a :exc:`RuntimeWarning` and assign :const:`None` to any fast
-locals that are incorrectly left unbound after jumps or :keyword:`del`
+locals that are left unbound after jumps or :keyword:`del`
 statements executed while tracing.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1182,7 +1182,7 @@ _PyFrame_FastToLocalsWithError(_PyInterpreterFrame *frame) {
                 // run yet.
                 if (value != NULL) {
                     if (PyCell_Check(value) &&
-                        _PyFrame_OpAlreadyRan(frame, MAKE_CELL, i)) {
+                            _PyFrame_OpAlreadyRan(frame, MAKE_CELL, i)) {
                         // (likely) MAKE_CELL must have executed already.
                         value = PyCell_GET(value);
                     }
@@ -1303,7 +1303,7 @@ _PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear)
         else if (value != oldvalue) {
             if (value == NULL) {
                 // Probably can't delete this, since the compiler's flow
-                // analysis may have already "proved" that it exists here:
+                // analysis may have already "proven" that it exists here:
                 const char *e = "assigning None to unbound local %R";
                 if (PyErr_WarnFormat(PyExc_RuntimeWarning, 0, e, name)) {
                     // It's okay if frame_obj is NULL, just try anyways:

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1311,7 +1311,7 @@ _PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear)
                 }
                 value = Py_NewRef(Py_None);
             }
-            Py_XINCREF(value);
+            Py_INCREF(value);
             Py_XSETREF(fast[i], value);
         }
         Py_XDECREF(value);


### PR DESCRIPTION
The compiler's dataflow analysis for fast locals can be invalidated by jumps or deletions while tracing. When this happens, rather than changing `co_code` (which users assume to be constant) to use the less-efficient `LOAD_FAST_CHECK` everywhere, just display a `RuntimeWarning` and set any problematic locals to `None` instead.

<!-- gh-issue-number: gh-93143 -->
* Issue: gh-93143
<!-- /gh-issue-number -->
