### PR TITLE
Docs: add `named` to the note describing the sqlite3.paramstyle attribute

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -478,9 +478,9 @@ Module constants
 
    .. note::
 
-      The :mod:`!sqlite3` module supports both ``qmark`` and ``numeric`` DB-API
-      parameter styles, because that is what the underlying SQLite library
-      supports. However, the DB-API does not allow multiple values for
+      The :mod:`!sqlite3` module supports ``qmark``, ``numeric``, and ``named``
+      DB-API parameter styles, because that is what the underlying SQLite
+      library supports. However, the DB-API does not allow multiple values for
       the ``paramstyle`` attribute.
 
 .. data:: sqlite_version

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -478,9 +478,10 @@ Module constants
 
    .. note::
 
-      The :mod:`!sqlite3` module supports ``qmark``, ``numeric``, and ``named``
-      DB-API parameter styles, because that is what the underlying SQLite
-      library supports. However, the DB-API does not allow multiple values for
+      The :mod:`!sqlite3` module supports ``qmark``, ``numeric``,
+      and ``named`` DB-API parameter styles,
+      because that is what the underlying SQLite library supports.
+      However, the DB-API does not allow multiple values for
       the ``paramstyle`` attribute.
 
 .. data:: sqlite_version


### PR DESCRIPTION
The documentation for `sqlite3.paramstyle` states that only `qmark` and `numeric` styles are supported for parameter placeholders but, according to the SQLite documentation, the `named` style is also supported.

See the following links for more details:

- https://docs.python.org/3/library/sqlite3.html#sqlite3.paramstyle
- https://peps.python.org/pep-0249/#paramstyle
- https://www.sqlite.org/lang_expr.html#parameters

A simple example confirms that this is supported:

```pycon
>>> import sqlite3
>>> con = sqlite3.connect(":memory:")
>>> cur = con.execute("CREATE TEMPORARY TABLE t (name TEXT)")
>>> cur.execute("INSERT INTO t (name) VALUES ('Bob'), ('Cat'), ('Joe')")
<sqlite3.Cursor object at 0x7fcbe373b940>
>>> cur.execute("SELECT * FROM t WHERE name = :name", {"name": "Cat"})
<sqlite3.Cursor object at 0x7fcbe373b940>
>>> print(cur.fetchone()[0])
Cat
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
