### PR TITLE
gh-99086: Fix implicit int warning in configure check for PTHREAD_SCOPE_SYSTEM (#99085)

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-11-04-02-58-10.gh-issue-99086.DV_4Br.rst
+++ b/Misc/NEWS.d/next/Build/2022-11-04-02-58-10.gh-issue-99086.DV_4Br.rst
@@ -1,1 +1,1 @@
-Fix ``-Wimplicit-int`` compiler warning n :program:`configure` check for ``PTHREAD_SCOPE_SYSTEM``.
+Fix ``-Wimplicit-int`` compiler warning in :program:`configure` check for ``PTHREAD_SCOPE_SYSTEM``.

--- a/Misc/NEWS.d/next/Build/2022-11-04-02-58-10.gh-issue-99086.DV_4Br.rst
+++ b/Misc/NEWS.d/next/Build/2022-11-04-02-58-10.gh-issue-99086.DV_4Br.rst
@@ -1,0 +1,1 @@
+Fix ``-Wimplicit-int`` warning in configure.ac when testing for PTHREAD_SCOPE_SYSTEM.

--- a/Misc/NEWS.d/next/Build/2022-11-04-02-58-10.gh-issue-99086.DV_4Br.rst
+++ b/Misc/NEWS.d/next/Build/2022-11-04-02-58-10.gh-issue-99086.DV_4Br.rst
@@ -1,1 +1,1 @@
-Fix ``-Wimplicit-int`` warning in configure.ac when testing for PTHREAD_SCOPE_SYSTEM.
+Fix ``-Wimplicit-int`` compiler warning n :program:`configure` check for ``PTHREAD_SCOPE_SYSTEM``.

--- a/configure
+++ b/configure
@@ -11134,7 +11134,7 @@ else
       void *foo(void *parm) {
         return NULL;
       }
-      main() {
+      int main() {
         pthread_attr_t attr;
         pthread_t id;
         if (pthread_attr_init(&attr)) return (-1);

--- a/configure.ac
+++ b/configure.ac
@@ -3367,7 +3367,7 @@ if test "$posix_threads" = "yes"; then
       void *foo(void *parm) {
         return NULL;
       }
-      main() {
+      int main() {
         pthread_attr_t attr;
         pthread_t id;
         if (pthread_attr_init(&attr)) return (-1);


### PR DESCRIPTION
Clang 16 makes -Wimplicit-int fatal by default.

Avoids errors like:
```
conftest.c:142:7: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
```

Signed-off-by: Sam James <sam@gentoo.org>


<!-- gh-issue-number: gh-99086 -->
* Issue: gh-99086
<!-- /gh-issue-number -->
