### PR TITLE
gh-99080: Preserve backslash character not used to escape quotes in .netrc files

### DIFF
--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -45,7 +45,10 @@ class _netrclex:
                     if ch == '"':
                         return token
                     elif ch == "\\":
+                        backslash = ch
                         ch = self._read_char()
+                        if ch != '"':
+                            token += backslash
                     token += ch
             else:
                 if ch == "\\":
@@ -54,8 +57,6 @@ class _netrclex:
                 for ch in fiter:
                     if ch in self.whitespace:
                         return token
-                    elif ch == "\\":
-                        ch = self._read_char()
                     token += ch
         return token
 

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -156,6 +156,28 @@ class NetrcTestCase(unittest.TestCase):
             machine host.domain.com login log password \xa1\xa2 account acct
             """, 'password', '\xa1\xa2')
 
+    def test_token_value_with_backslash(self):
+        self._test_token_x("""\
+            machine host.domain.com login lo\gin password pass account acct
+            """, 'login', 'lo\gin')
+        self._test_token_x("""\
+            machine host.domain.com login log password pass account \account
+            """, 'account', '\account')
+        self._test_token_x("""\
+            machine host.domain.com login log password pass\word account acct
+            """, 'password', 'pass\word')
+
+    def test_token_value_with_backslash_enclosed_in_quotes(self):
+        self._test_token_x("""\
+            machine host.domain.com login "lo\gin" password pass account acct
+            """, 'login', 'lo\gin')
+        self._test_token_x("""\
+            machine host.domain.com login log password pass account "acc\ount"
+            """, 'account', 'acc\ount')
+        self._test_token_x("""\
+            machine host.domain.com login log password "pass\word" account acct
+            """, 'password', 'pass\word')
+
     def test_token_value_leading_hash(self):
         self._test_token_x("""\
             machine host.domain.com login #log password pass account acct

--- a/Misc/NEWS.d/next/Library/2022-11-04-08-32-16.gh-issue-99080.-a_SsH.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-04-08-32-16.gh-issue-99080.-a_SsH.rst
@@ -1,0 +1,1 @@
+Treat backslashes in .netrc files as escaping characters only for quotes in quotes


### PR DESCRIPTION
Backslashes can be valid characters in password, they are not always used to escape symbols.
Treat backslash characters as escape symbols only for quotes in quotes when processing .netrc files.

<!-- gh-issue-number: gh-99080 -->
* Issue: gh-99080
<!-- /gh-issue-number -->
