### PR TITLE
gh-99121: Document 'indices' method for 'slice' class

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1617,12 +1617,12 @@ are always available.  They are listed here in alphabetical order.
 .. class:: slice(stop, /)
            slice(start, stop, step=1, /)
 
-   Return a :term:`slice` object representing the set of indices specified by
+   Return a :ref:`slice object <datamodel-slice-objects>` representing the set
+   of indices specified by
    ``range(start, stop, step)``.  The *start* and *step* arguments default to
    ``None``.  Slice objects have read-only data attributes :attr:`~slice.start`,
    :attr:`~slice.stop`, and :attr:`~slice.step` which merely return the argument
-   values (or their default).  They have no other explicit functionality;
-   however, they are used by NumPy and other third-party packages.
+   values (or their default).
    Slice objects are also generated when extended indexing syntax is used.  For
    example: ``a[start:stop:step]`` or ``a[start:stop, i]``.  See
    :func:`itertools.islice` for an alternate version that returns an iterator.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1174,6 +1174,8 @@ Internal types
          Traceback objects can now be explicitly instantiated from Python code,
          and the ``tb_next`` attribute of existing instances can be updated.
 
+   .. _datamodel-slice-objects:
+
    Slice objects
       .. index:: builtin: slice
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Following the suggestion at https://github.com/python/cpython/issues/99121#issuecomment-1304557005, this PR changes the "slice" link from one to the glossary slice entry, to a "slice objects" link to slice objects on the data models page.

It also removes an old reference to NumPy and third-party packages, as suggested at https://github.com/python/cpython/issues/99121#issuecomment-1304495990.

# Before

<img width="826" alt="image" src="https://user-images.githubusercontent.com/1324225/200123416-56a67693-64bf-43f2-a375-b2e5f9e0f7d8.png">

# After

<img width="823" alt="image" src="https://user-images.githubusercontent.com/1324225/200133763-929d5680-8d69-43a0-86f7-e11d2ff122d5.png">


<!-- gh-issue-number: gh-99121 -->
* Issue: gh-99121
<!-- /gh-issue-number -->
