### PR TITLE
`test_typing`: use all pickle protocols

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2900,7 +2900,7 @@ class ProtocolTests(BaseTestCase):
             self.assertEqual(x.bar, 'abc')
             self.assertEqual(x.x, 1)
             self.assertEqual(x.__dict__, {'foo': 42, 'bar': 'abc'})
-            s = pickle.dumps(P)
+            s = pickle.dumps(P, proto)
             D = pickle.loads(s)
 
             class E:


### PR DESCRIPTION
While working on some other thing, I've noticed that this call does not use `proto` from here: https://github.com/python/cpython/blob/8feb7ab77c80968a6de6079299a39b0494b1701b/Lib/test/test_typing.py#L2896-L2897

I think it is a typo. Fixing it!