### PR TITLE
gh-99153: set location on SyntaxError for try with both except and except*

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -1254,7 +1254,7 @@ invalid_try_stmt:
     | a='try' ':' NEWLINE !INDENT {
         RAISE_INDENTATION_ERROR("expected an indented block after 'try' statement on line %d", a->lineno) }
     | 'try' ':' block !('except' | 'finally') { RAISE_SYNTAX_ERROR("expected 'except' or 'finally' block") }
-    | a='try' ':' block* ((except_block+ a=except_star_block) | (except_star_block+ a=except_block)) block* {
+    | a='try' ':' block* ((except_block+ except_star_block) | (except_star_block+ except_block)) block* {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "cannot have both 'except' and 'except*' on the same 'try'") }
 invalid_except_stmt:
     | 'except' '*'? a=expression ',' expressions ['as' NAME ] ':' {

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -1254,8 +1254,8 @@ invalid_try_stmt:
     | a='try' ':' NEWLINE !INDENT {
         RAISE_INDENTATION_ERROR("expected an indented block after 'try' statement on line %d", a->lineno) }
     | 'try' ':' block !('except' | 'finally') { RAISE_SYNTAX_ERROR("expected 'except' or 'finally' block") }
-    | 'try' ':' block* ((except_block+ except_star_block) | (except_star_block+ except_block)) block* {
-        RAISE_SYNTAX_ERROR("cannot have both 'except' and 'except*' on the same 'try'") }
+    | a='try' ':' block* ((except_block+ a=except_star_block) | (except_star_block+ a=except_block)) block* {
+        RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "cannot have both 'except' and 'except*' on the same 'try'") }
 invalid_except_stmt:
     | 'except' '*'? a=expression ',' expressions ['as' NAME ] ':' {
         RAISE_SYNTAX_ERROR_STARTING_FROM(a, "multiple exception types must be parenthesized") }

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2014,6 +2014,16 @@ class SyntaxTestCase(unittest.TestCase):
                           "Generator expression must be parenthesized",
                           lineno=1, end_lineno=1, offset=11, end_offset=53)
 
+    def test_except_then_except_star(self):
+        self._check_error("try: pass\nexcept ValueError: pass\nexcept* TypeError: pass",
+                          r"cannot have both 'except' and 'except\*' on the same 'try'",
+                          lineno=1, end_lineno=1, offset=1, end_offset=4)
+
+    def test_except_star_then_except(self):
+        self._check_error("try: pass\nexcept* ValueError: pass\nexcept TypeError: pass",
+                          r"cannot have both 'except' and 'except\*' on the same 'try'",
+                          lineno=1, end_lineno=1, offset=1, end_offset=4)
+
     def test_empty_line_after_linecont(self):
         # See issue-40847
         s = r"""\

--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-06-13-25-01.gh-issue-99153.uE3CVL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-06-13-25-01.gh-issue-99153.uE3CVL.rst
@@ -1,1 +1,1 @@
-Fix location of :exc:`SyntaxError` for a :keyword:`try` block with both  :keyword:`except` and  :keyword:`except*`.
+Fix location of :exc:`SyntaxError` for a :keyword:`try` block with both  :keyword:`except` and :keyword:`except* <except_star>`.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-06-13-25-01.gh-issue-99153.uE3CVL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-06-13-25-01.gh-issue-99153.uE3CVL.rst
@@ -1,0 +1,1 @@
+Fix location of :exc:`SyntaxError` for a :keyword:`try` block with both  :keyword:`except` and  :keyword:`except*`.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -38401,15 +38401,15 @@ _tmp_241_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> _tmp_241[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "except_block+ except_star_block"));
         asdl_seq * _loop1_248_var;
-        excepthandler_ty a;
+        excepthandler_ty except_star_block_var;
         if (
             (_loop1_248_var = _loop1_248_rule(p))  // except_block+
             &&
-            (a = except_star_block_rule(p))  // except_star_block
+            (except_star_block_var = except_star_block_rule(p))  // except_star_block
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_241[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "except_block+ except_star_block"));
-            _res = _PyPegen_dummy_name(p, _loop1_248_var, a);
+            _res = _PyPegen_dummy_name(p, _loop1_248_var, except_star_block_var);
             goto done;
         }
         p->mark = _mark;
@@ -38443,15 +38443,15 @@ _tmp_242_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> _tmp_242[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "except_star_block+ except_block"));
         asdl_seq * _loop1_249_var;
-        excepthandler_ty a;
+        excepthandler_ty except_block_var;
         if (
             (_loop1_249_var = _loop1_249_rule(p))  // except_star_block+
             &&
-            (a = except_block_rule(p))  // except_block
+            (except_block_var = except_block_rule(p))  // except_block
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_242[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "except_star_block+ except_block"));
-            _res = _PyPegen_dummy_name(p, _loop1_249_var, a);
+            _res = _PyPegen_dummy_name(p, _loop1_249_var, except_block_var);
             goto done;
         }
         p->mark = _mark;

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -21974,13 +21974,13 @@ invalid_try_stmt_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_try_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'try' ':' block* ((except_block+ except_star_block) | (except_star_block+ except_block)) block*"));
-        Token * _keyword;
         Token * _literal;
         asdl_seq * _loop0_203_var;
         asdl_seq * _loop0_205_var;
         void *_tmp_204_var;
+        Token * a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 620))  // token='try'
+            (a = _PyPegen_expect_token(p, 620))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -21992,7 +21992,7 @@ invalid_try_stmt_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ invalid_try_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'try' ':' block* ((except_block+ except_star_block) | (except_star_block+ except_block)) block*"));
-            _res = RAISE_SYNTAX_ERROR ( "cannot have both 'except' and 'except*' on the same 'try'" );
+            _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "cannot have both 'except' and 'except*' on the same 'try'" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;
@@ -38401,15 +38401,15 @@ _tmp_241_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> _tmp_241[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "except_block+ except_star_block"));
         asdl_seq * _loop1_248_var;
-        excepthandler_ty except_star_block_var;
+        excepthandler_ty a;
         if (
             (_loop1_248_var = _loop1_248_rule(p))  // except_block+
             &&
-            (except_star_block_var = except_star_block_rule(p))  // except_star_block
+            (a = except_star_block_rule(p))  // except_star_block
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_241[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "except_block+ except_star_block"));
-            _res = _PyPegen_dummy_name(p, _loop1_248_var, except_star_block_var);
+            _res = _PyPegen_dummy_name(p, _loop1_248_var, a);
             goto done;
         }
         p->mark = _mark;
@@ -38443,15 +38443,15 @@ _tmp_242_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> _tmp_242[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "except_star_block+ except_block"));
         asdl_seq * _loop1_249_var;
-        excepthandler_ty except_block_var;
+        excepthandler_ty a;
         if (
             (_loop1_249_var = _loop1_249_rule(p))  // except_star_block+
             &&
-            (except_block_var = except_block_rule(p))  // except_block
+            (a = except_block_rule(p))  // except_block
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_242[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "except_star_block+ except_block"));
-            _res = _PyPegen_dummy_name(p, _loop1_249_var, except_block_var);
+            _res = _PyPegen_dummy_name(p, _loop1_249_var, a);
             goto done;
         }
         p->mark = _mark;


### PR DESCRIPTION
Fixes #99153.

I made it point to the `try` because we don't know which `except` or `except*` is incorrect.

```
% ./python.exe f.py 
  File "/Users/iritkatriel/src/cpython-1/f.py", line 4
    try:
    ^^^
SyntaxError: cannot have both 'except' and 'except*' on the same 'try'
```


<!-- gh-issue-number: gh-99153 -->
* Issue: gh-99153
<!-- /gh-issue-number -->
