### PR TITLE
gh-86018 Inconsistent errors for JSON-encoding NaNs with allow_nan=False

### DIFF
--- a/Lib/test/test_json/test_float.py
+++ b/Lib/test/test_json/test_float.py
@@ -26,8 +26,9 @@ class TestFloat:
                 res = self.loads(out)
                 self.assertEqual(len(res), 1)
                 self.assertNotEqual(res[0], res[0])
-            self.assertRaises(ValueError, self.dumps, [val], allow_nan=False)
-
+            self.assertRaisesRegex(
+                ValueError, str(val), self.dumps, [val], allow_nan=False
+            )
 
 class TestPyFloat(TestFloat, PyTest): pass
 class TestCFloat(TestFloat, CTest): pass

--- a/Misc/NEWS.d/next/Library/2022-11-06-19-59-56.gh-issue-86018.xAt6g2.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-06-19-59-56.gh-issue-86018.xAt6g2.rst
@@ -1,1 +1,1 @@
-+ Fix issue where the error messages for :func:`json.dump` and :func:`json.dumps` were inconsistent when serializing non-finite values with ``allow_nan=False``
++ Fix issue where the error messages for :meth:`json.dump` and :meth:`json.dumps` were inconsistent when serializing non-finite values with ``allow_nan=False``

--- a/Misc/NEWS.d/next/Library/2022-11-06-19-59-56.gh-issue-86018.xAt6g2.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-06-19-59-56.gh-issue-86018.xAt6g2.rst
@@ -1,0 +1,1 @@
++ Fix issue where the error messages for :func:`json.dump` and :func:`json.dumps` were inconsistent when serializing non-finite values with ``allow_nan=False``

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1324,22 +1324,21 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
     /* Return the JSON representation of a PyFloat. */
     double i = PyFloat_AS_DOUBLE(obj);
     if (!Py_IS_FINITE(i)) {
-        char* value;
-        if (i > 0) {
-          value = "Infinity";
-        } else if (i < 0) {
-          value = "-Infinity";
-        } else {
-          value = "NaN";
-        }
-
         if (!s->allow_nan) {
-            PyErr_Format(PyExc_ValueError,
-                           "Out of range float values are not JSON compliant: %S",
-                           obj);
+            PyErr_Format(
+                    PyExc_ValueError,
+                    "Out of range float values are not JSON compliant: %S", obj
+                    );
             return NULL;
-        } else {
-          return PyUnicode_FromString(value);
+        }
+        if (i > 0) {
+            return PyUnicode_FromString("Infinity");
+        }
+        else if (i < 0) {
+            return PyUnicode_FromString("-Infinity");
+        }
+        else {
+            return PyUnicode_FromString("NaN");
         }
     }
     return PyFloat_Type.tp_repr(obj);

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1324,21 +1324,25 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
     /* Return the JSON representation of a PyFloat. */
     double i = PyFloat_AS_DOUBLE(obj);
     if (!Py_IS_FINITE(i)) {
-        if (!s->allow_nan) {
-            PyErr_SetString(
-                    PyExc_ValueError,
-                    "Out of range float values are not JSON compliant"
-                    );
-            return NULL;
-        }
+        char* value;
+        char *py_value;
         if (i > 0) {
-            return PyUnicode_FromString("Infinity");
+          value = "Infinity";
+          py_value = "inf";
+        } else if (i < 0) {
+          value = "-Infinity";
+          py_value = "-inf";
+        } else {
+          value = "NaN";
+          py_value = "nan";
         }
-        else if (i < 0) {
-            return PyUnicode_FromString("-Infinity");
-        }
-        else {
-            return PyUnicode_FromString("NaN");
+
+        if (!s->allow_nan) {
+            char message[55] = "Out of range float values are not JSON compliant: ";
+            PyErr_SetString(PyExc_ValueError, strcat(message, py_value));
+            return NULL;
+        } else {
+          return PyUnicode_FromString(value);
         }
     }
     return PyFloat_Type.tp_repr(obj);

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1325,21 +1325,18 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
     double i = PyFloat_AS_DOUBLE(obj);
     if (!Py_IS_FINITE(i)) {
         char* value;
-        char *py_value;
         if (i > 0) {
           value = "Infinity";
-          py_value = "inf";
         } else if (i < 0) {
           value = "-Infinity";
-          py_value = "-inf";
         } else {
           value = "NaN";
-          py_value = "nan";
         }
 
         if (!s->allow_nan) {
-            char message[55] = "Out of range float values are not JSON compliant: ";
-            PyErr_SetString(PyExc_ValueError, strcat(message, py_value));
+            PyErr_Format(PyExc_ValueError,
+                           "Out of range float values are not JSON compliant: %S",
+                           obj);
             return NULL;
         } else {
           return PyUnicode_FromString(value);


### PR DESCRIPTION
Fix issue where json.dumps provided a different error message than json.dump with non-finite values


<!-- gh-issue-number: gh-86018 -->
* Issue: gh-86018
<!-- /gh-issue-number -->
