### PR TITLE
[3.11] GH-99155: Fix `NormalDist` pickle with `0` and `1` protocols (GH-99156).

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1382,3 +1382,9 @@ class NormalDist:
 
     def __repr__(self):
         return f'{type(self).__name__}(mu={self._mu!r}, sigma={self._sigma!r})'
+
+    def __getstate__(self):
+        return self._mu, self._sigma
+
+    def __setstate__(self, state):
+        self._mu, self._sigma = state

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -2986,14 +2986,19 @@ class TestNormalDist:
         nd = NormalDist(100, 15)
         self.assertNotEqual(nd, lnd)
 
-    def test_pickle_and_copy(self):
+    def test_copy(self):
         nd = self.module.NormalDist(37.5, 5.625)
         nd1 = copy.copy(nd)
         self.assertEqual(nd, nd1)
         nd2 = copy.deepcopy(nd)
         self.assertEqual(nd, nd2)
-        nd3 = pickle.loads(pickle.dumps(nd))
-        self.assertEqual(nd, nd3)
+
+    def test_pickle(self):
+        nd = self.module.NormalDist(37.5, 5.625)
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(proto=proto):
+                pickled = pickle.loads(pickle.dumps(nd, protocol=proto))
+                self.assertEqual(nd, pickled)
 
     def test_hashability(self):
         ND = self.module.NormalDist

--- a/Misc/NEWS.d/next/Library/2022-11-06-12-44-51.gh-issue-99155.vLZOzi.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-06-12-44-51.gh-issue-99155.vLZOzi.rst
@@ -1,0 +1,1 @@
+Fix :class:`statistics.NormalDist` pickle with ``0`` and ``1`` protocols.


### PR DESCRIPTION
(cherry picked from commit d7a00f1e8eee05fc5ae97ea1ef0615feefce887b)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>


<!-- gh-issue-number: gh-99155 -->
* Issue: gh-99155
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:rhettinger