### PR TITLE
gh-94445: add compiler test for another case of excessive stack use

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1645,6 +1645,13 @@ class TestExpressionStackSize(unittest.TestCase):
         # This raised on 3.10.0 to 3.10.5
         compile(code, "<foo>", "single")
 
+    def test_stack_3050_2(self):
+        M = 3050
+        args = ", ".join(f"arg{i}:type{i}" for i in range(M))
+        code = f"def f({args}):\n  pass"
+        # This raised on 3.10.0 to 3.10.5
+        compile(code, "<foo>", "single")
+
 
 class TestStackSizeStability(unittest.TestCase):
     # Check that repeating certain snippets doesn't increase the stack size


### PR DESCRIPTION
In GH-94329 the `MAX_ALLOWED_STACK_SIZE` check in the compiler (added in 3.10.0) was reverted,
because it was discovered that a large sequence unpacking could use more than the allowed stack size.
A todo comment was left in the code to re-add this check in future, and GH-94445 was created to track
the todo item.

I've found another case in which unbounded stack can be consumed: a function with a very large number
of type-annotated arguments. This PR simply adds a test for that case, to ensure that if in future the
stack-size check is again enforced, the case won't be missed and cause another breakage for valid (if
pathological) code.