### PR TITLE
gh-99238: Fix crashes caused by lack of checking in subprocess module

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1815,6 +1815,8 @@ class Popen:
                     if env is not None:
                         env_list = []
                         for k, v in env.items():
+                            if v is None:
+                                continue
                             k = os.fsencode(k)
                             if b'=' in k:
                                 raise ValueError("illegal environment variable name")

--- a/Misc/NEWS.d/next/Library/2022-11-07-23-10-51.gh-issue-99238.pj8YXi.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-07-23-10-51.gh-issue-99238.pj8YXi.rst
@@ -1,0 +1,3 @@
+When parsing environment variables passed by caller to subprocess.Popen,
+check the actual value of the variable is not set to None. Lack of this
+checking causes crashes in python programs.


### PR DESCRIPTION
Sometimes application developers set the value of an environment variable to None. This fix adds a guard for mitigating this issue to prevent python from crashing.

Signed-off-by: Tianrui Wei <tianrui@tianruiwei.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99238 -->
* Issue: gh-99238
<!-- /gh-issue-number -->
