### PR TITLE
Typo: fix DuplicateFreeEnum example docs

### DIFF
--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -1299,7 +1299,7 @@ enumerations)::
 DuplicateFreeEnum
 ^^^^^^^^^^^^^^^^^
 
-Raises an error if a duplicate member name is found instead of creating an
+Raises an error if a duplicate member value is found instead of creating an
 alias::
 
     >>> class DuplicateFreeEnum(Enum):


### PR DESCRIPTION
<!--
Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.
-->

`DuplicateFreeEnum` example code actually raises errors on duplicate values. Docs says it does on duplicate names. Likely a typo.