### PR TITLE
gh-99266: fix wrong exception message in ctypes docs

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -487,7 +487,7 @@ single character Python bytes object into a C char::
    >>> strchr(b"abcdef", b"def")
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
-   ArgumentError: argument 2: TypeError: one character string expected
+   ArgumentError: argument 2: TypeError: wrong type
    >>> print(strchr(b"abcdef", b"x"))
    None
    >>> strchr(b"abcdef", b"d")


### PR DESCRIPTION
This PR fixes the exception message in `ctypes` docs.

Closes #99266.

```python
>>> strchr = libc.strchr
>>> strchr.restype = c_char_p
>>> strchr.argtypes = [c_char_p, c_char]
>>> 
>>> strchr(b"abcdef", b"def")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ctypes.ArgumentError: argument 2: TypeError: wrong type
```

<!-- gh-issue-number: gh-99266 -->
* Issue: gh-99266
<!-- /gh-issue-number -->
