### PR TITLE
GH-99205: Mark new interpreters and threads as non-static

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-08-16-35-25.gh-issue-99205.2YOoFT.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-08-16-35-25.gh-issue-99205.2YOoFT.rst
@@ -1,0 +1,2 @@
+Fix an issue that prevented :c:type:`PyThreadState` and
+:c:type:`PyInterpreterState` memory from being freed properly.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -371,6 +371,8 @@ PyInterpreterState_New(void)
         // Set to _PyInterpreterState_INIT.
         memcpy(interp, &initial._main_interpreter,
                sizeof(*interp));
+        // We need to adjust any fields that are different from the initial
+        // interpreter (as defined in _PyInterpreterState_INIT):
         interp->_static = false;
 
         if (id < 0) {
@@ -851,6 +853,8 @@ new_threadstate(PyInterpreterState *interp)
         memcpy(tstate,
                &initial._main_interpreter._initial_thread,
                sizeof(*tstate));
+        // We need to adjust any fields that are different from the initial
+        // thread (as defined in _PyThreadState_INIT):
         tstate->_static = false;
     }
     interp->threads.head = tstate;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -356,6 +356,7 @@ PyInterpreterState_New(void)
         interp = &runtime->_main_interpreter;
         assert(interp->id == 0);
         assert(interp->next == NULL);
+        assert(interp->_static);
 
         interpreters->main = interp;
     }
@@ -368,8 +369,8 @@ PyInterpreterState_New(void)
             goto error;
         }
         // Set to _PyInterpreterState_INIT.
-        memcpy(interp, &initial._main_interpreter,
-               sizeof(*interp));
+        memcpy(interp, &initial._main_interpreter, sizeof(*interp));
+        interp->_static = false;
 
         if (id < 0) {
             /* overflow or Py_Initialize() not called yet! */
@@ -837,6 +838,7 @@ new_threadstate(PyInterpreterState *interp)
         assert(id == 1);
         used_newtstate = 0;
         tstate = &interp->_initial_thread;
+        assert(tstate->_static);
     }
     else {
         // Every valid interpreter must have at least one thread.
@@ -848,6 +850,7 @@ new_threadstate(PyInterpreterState *interp)
         memcpy(tstate,
                &initial._main_interpreter._initial_thread,
                sizeof(*tstate));
+        tstate->_static = false;
     }
     interp->threads.head = tstate;
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -369,7 +369,8 @@ PyInterpreterState_New(void)
             goto error;
         }
         // Set to _PyInterpreterState_INIT.
-        memcpy(interp, &initial._main_interpreter, sizeof(*interp));
+        memcpy(interp, &initial._main_interpreter,
+               sizeof(*interp));
         interp->_static = false;
 
         if (id < 0) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-99205 -->
* Issue: gh-99205
<!-- /gh-issue-number -->
