### PR TITLE
gh-98930: improve the docstring of signal.strsignal

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -362,9 +362,9 @@ The :mod:`signal` module defines the following functions:
 
 .. function:: strsignal(signalnum)
 
-   Return the system description of the signal *signalnum*, such as
-   "Interrupt", "Segmentation fault", etc. Returns :const:`None` if the signal
-   is not recognized.
+   Returns the description of signal *signalnum*, such as "Interrupt"
+   for :const:`SIGINT`. Returns :const:`None` if *signalnum* has no
+   description. Raises :exc:`ValueError` if *signalnum* is invalid.
 
    .. versionadded:: 3.8
 

--- a/Misc/NEWS.d/next/Documentation/2022-11-09-13-51-57.gh-issue-98930.Qj67r0.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-11-09-13-51-57.gh-issue-98930.Qj67r0.rst
@@ -1,1 +1,0 @@
-Changed the doc of signalmodule for making it understandable to users when it raises ValueError, when it returns None etc.

--- a/Misc/NEWS.d/next/Documentation/2022-11-09-13-51-57.gh-issue-98930.Qj67r0.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-11-09-13-51-57.gh-issue-98930.Qj67r0.rst
@@ -1,0 +1,1 @@
+Changed the doc of signalmodule for making it understandable to users when it raises ValueError, when it returns None etc.

--- a/Modules/clinic/signalmodule.c.h
+++ b/Modules/clinic/signalmodule.c.h
@@ -211,8 +211,9 @@ PyDoc_STRVAR(signal_strsignal__doc__,
 "\n"
 "Return the system description of the given signal.\n"
 "\n"
-"The return values can be such as \"Interrupt\", \"Segmentation fault\", etc.\n"
-"Returns None if the signal is not recognized.");
+"Returns the description of signal *signalnum*, such as \"Interrupt\"\n"
+"for :const:`SIGINT`. Returns :const:`None` if *signalnum* has no\n"
+"description. Raises :exc:`ValueError` if *signalnum* is invalid.");
 
 #define SIGNAL_STRSIGNAL_METHODDEF    \
     {"strsignal", (PyCFunction)signal_strsignal, METH_O, signal_strsignal__doc__},
@@ -704,4 +705,4 @@ exit:
 #ifndef SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF
     #define SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF
 #endif /* !defined(SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF) */
-/*[clinic end generated code: output=f2a3321b32b0637c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2b54dc607f6e3146 input=a9049054013a1b77]*/

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -626,10 +626,9 @@ signal.strsignal
 
 Return the system description of the given signal.
 
-The return values can be such as "Interrupt", "Segmentation fault", etc.
-Return the system description of the signal *signalnum*, such as
-"Interrupt" for :const:`SIGINT`. Returns :const:`None` if *signalnum* has
-no description. Raises :exc:`ValueError` if *signalnum* is invalid.
+Returns the description of signal *signalnum*, such as "Interrupt"
+for :const:`SIGINT`. Returns :const:`None` if *signalnum* has no
+description. Raises :exc:`ValueError` if *signalnum* is invalid.
 [clinic start generated code]*/
 
 static PyObject *

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -633,7 +633,7 @@ description. Raises :exc:`ValueError` if *signalnum* is invalid.
 
 static PyObject *
 signal_strsignal_impl(PyObject *module, int signalnum)
-/*[clinic end generated code: output=44e12e1e3b666261 input=b77914b03f856c74]*/
+/*[clinic end generated code: output=44e12e1e3b666261 input=238b335847778bc0]*/
 {
     const char *res;
 

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -627,7 +627,9 @@ signal.strsignal
 Return the system description of the given signal.
 
 The return values can be such as "Interrupt", "Segmentation fault", etc.
-Returns None if the signal is not recognized.
+Return the system description of the signal *signalnum*, such as
+"Interrupt" for :const:`SIGINT`. Returns :const:`None` if *signalnum* has
+no description. Raises :exc:`ValueError` if *signalnum* is invalid.
 [clinic start generated code]*/
 
 static PyObject *


### PR DESCRIPTION
gh-98930: Improved the docstring on signal.strsignal to make it explain when it returns a message, None, or when it raises ValueError.

Closes #98930 