### PR TITLE
gh-99289: Add COMPILEALL_OPTS to Makefile

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -767,6 +767,13 @@ Compiler flags
 
    .. versionadded:: 3.5
 
+.. envvar:: COMPILEALL_OPTS
+
+   Options passed to the :mod:`compileall` command line when building PYC files
+   in ``make install``. Default: ``-j0``.
+
+   .. versionadded:: 3.12
+
 .. envvar:: EXTRA_CFLAGS
 
    Extra C compiler flags.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -669,9 +669,9 @@ Build Changes
   (Contributed by Dong-hee Na in :gh:`89536`.)
 
 * Add ``COMPILEALL_OPTS`` variable in Makefile to override :mod:`compileall`
-  options (default: ``-j0``) in ``make install``. Merge also the 3
-  ``compileall`` commands into a single command building PYC files for the 3
-  optimization levels (0, 1, 2).
+  options (default: ``-j0``) in ``make install``. Also merged the 3
+  ``compileall`` commands into a single command to build .pyc files for all
+  optimization levels (0, 1, 2) at once.
   (Contributed by Victor Stinner in :gh:`99289`.)
 
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -668,6 +668,12 @@ Build Changes
   if the Clang compiler accepts the flag.
   (Contributed by Dong-hee Na in :gh:`89536`.)
 
+* Add ``COMPILEALL_OPTS`` variable in Makefile to override :mod:`compileall`
+  options (default: ``-j0``) in ``make install``. Merge also the 3
+  ``compileall`` commands into a single command building PYC files for the 3
+  optimization levels (0, 1, 2).
+  (Contributed by Victor Stinner in :gh:`99289`.)
+
 
 C API Changes
 =============

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2053,6 +2053,8 @@ TESTSUBDIRS=	idlelib/idle_test \
 		test/xmltestdata test/xmltestdata/c14n-20 \
 		test/ziptestdata
 
+COMPILEALL_OPTS=-j0
+
 TEST_MODULES=@TEST_MODULES@
 libinstall:	all $(srcdir)/Modules/xxmodule.c
 	@for i in $(SCRIPTDIR) $(LIBDEST); \
@@ -2122,32 +2124,15 @@ libinstall:	all $(srcdir)/Modules/xxmodule.c
 	$(INSTALL_DATA) `cat pybuilddir.txt`/_sysconfigdata_$(ABIFLAGS)_$(MACHDEP)_$(MULTIARCH).py \
 		$(DESTDIR)$(LIBDEST); \
 	$(INSTALL_DATA) $(srcdir)/LICENSE $(DESTDIR)$(LIBDEST)/LICENSE.txt
-	-PYTHONPATH=$(DESTDIR)$(LIBDEST)  $(RUNSHARED) \
+	@ # Build PYC files for the 3 optimization levels (0, 1, 2)
+	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
 		$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST) -f \
-		-x 'bad_coding|badsyntax|site-packages|test/test_lib2to3/data' \
-		$(DESTDIR)$(LIBDEST)
-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
-		$(PYTHON_FOR_BUILD) -Wi -O $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST) -f \
-		-x 'bad_coding|badsyntax|site-packages|test/test_lib2to3/data' \
-		$(DESTDIR)$(LIBDEST)
-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
-		$(PYTHON_FOR_BUILD) -Wi -OO $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST) -f \
+		-o 0 -o 1 -o 2 $(COMPILEALL_OPTS) -d $(LIBDEST) -f \
 		-x 'bad_coding|badsyntax|site-packages|test/test_lib2to3/data' \
 		$(DESTDIR)$(LIBDEST)
 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
 		$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST)/site-packages -f \
-		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
-		$(PYTHON_FOR_BUILD) -Wi -O $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST)/site-packages -f \
-		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
-		$(PYTHON_FOR_BUILD) -Wi -OO $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST)/site-packages -f \
+		-o 0 -o 1 -o 2 $(COMPILEALL_OPTS) -d $(LIBDEST)/site-packages -f \
 		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
 		$(PYTHON_FOR_BUILD) -m lib2to3.pgen2.driver $(DESTDIR)$(LIBDEST)/lib2to3/Grammar.txt

--- a/Misc/NEWS.d/next/Build/2022-11-09-14-42-48.gh-issue-99289.X7wFE1.rst
+++ b/Misc/NEWS.d/next/Build/2022-11-09-14-42-48.gh-issue-99289.X7wFE1.rst
@@ -1,0 +1,4 @@
+Add ``COMPILEALL_OPTS`` variable in Makefile to override :mod:`compileall`
+options (default: ``-j0``) in ``make install``. Merge also the 3 ``compileall``
+commands into a single command building PYC files for the 3 optimization levels
+(0, 1, 2). Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Build/2022-11-09-14-42-48.gh-issue-99289.X7wFE1.rst
+++ b/Misc/NEWS.d/next/Build/2022-11-09-14-42-48.gh-issue-99289.X7wFE1.rst
@@ -1,4 +1,4 @@
-Add ``COMPILEALL_OPTS`` variable in Makefile to override :mod:`compileall`
-options (default: ``-j0``) in ``make install``. Merge also the 3 ``compileall``
-commands into a single command building PYC files for the 3 optimization levels
-(0, 1, 2). Patch by Victor Stinner.
+Add a ``COMPILEALL_OPTS`` variable in Makefile to override :mod:`compileall`
+options (default: ``-j0``) in ``make install``. Also merged the ``compileall``
+commands into a single command building .pyc files for the all optimization levels
+(0, 1, 2) at once. Patch by Victor Stinner.


### PR DESCRIPTION
Add COMPILEALL_OPTS variable in Makefile to override compileall options (default: -j0) in "make install". Merge also the 3 compileall commands into a single command building PYC files for the 3 optimization levels (0, 1, 2).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99289 -->
* Issue: gh-99289
<!-- /gh-issue-number -->
