### PR TITLE
GH-99298: Don't perform jumps before error handling

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-09-12-07-24.gh-issue-99298.NeArAJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-09-12-07-24.gh-issue-99298.NeArAJ.rst
@@ -1,0 +1,2 @@
+Fix an issue that could potentially cause incorrect error handling for some
+bytecode instructions.


### PR DESCRIPTION
My next steps:
- This will need a manual backport to 3.11 (3.10 seems unaffected).
- For 3.12, `_Py_Specialize_LoadAttr` and `_Py_Specialize_StoreAttr` don't actually need to handle errors (we can just fail to specialize "unready" types, which are probably super rare in practice).

<!-- gh-issue-number: gh-99298 -->
* Issue: gh-99298
<!-- /gh-issue-number -->
