### PR TITLE
gh-99352: Respect `http.client.HTTPConnection.debuglevel` in `urllib.request.AbstractHTTPHandler` 

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -3,6 +3,7 @@ from test import support
 from test.support import os_helper
 from test.support import warnings_helper
 from test import test_urllib
+from unittest import mock
 
 import os
 import io
@@ -483,6 +484,7 @@ def build_test_opener(*handler_instances):
         opener.add_handler(h)
     return opener
 
+
 class MockHTTPHandler(urllib.request.HTTPHandler):
     # Very simple mock HTTP handler with no special behavior other than using a mock HTTP connection
 
@@ -492,6 +494,7 @@ class MockHTTPHandler(urllib.request.HTTPHandler):
 
     def http_open(self, req):
         return self.do_open(self.httpconn, req)
+
 
 class MockHTTPHandlerRedirect(urllib.request.BaseHandler):
     # useful for testing redirections and auth
@@ -1058,34 +1061,34 @@ class HandlerTests(unittest.TestCase):
             self.assertEqual(int(newreq.get_header('Content-length')),16)
 
     def test_http_handler_global_debuglevel(self):
-        http.client.HTTPConnection.debuglevel = 1
-        o = OpenerDirector()
-        h = MockHTTPHandler()
-        o.add_handler(h)
-        o.open("http://www.example.com")
-        self.assertEqual(h._debuglevel, 1)
+        with mock.patch.object(http.client.HTTPConnection, 'debuglevel', 6):
+            o = OpenerDirector()
+            h = MockHTTPHandler()
+            o.add_handler(h)
+            o.open("http://www.example.com")
+            self.assertEqual(h._debuglevel, 6)
 
     def test_http_handler_local_debuglevel(self):
         o = OpenerDirector()
-        h = MockHTTPHandler(debuglevel=1)
+        h = MockHTTPHandler(debuglevel=5)
         o.add_handler(h)
         o.open("http://www.example.com")
-        self.assertEqual(h._debuglevel, 1)
+        self.assertEqual(h._debuglevel, 5)
 
     def test_https_handler_global_debuglevel(self):
-        http.client.HTTPSConnection.debuglevel = 1
-        o = OpenerDirector()
-        h = MockHTTPSHandler()
-        o.add_handler(h)
-        o.open("https://www.example.com")
-        self.assertEqual(h._debuglevel, 1)
+        with mock.patch.object(http.client.HTTPSConnection, 'debuglevel', 7):
+            o = OpenerDirector()
+            h = MockHTTPSHandler()
+            o.add_handler(h)
+            o.open("https://www.example.com")
+            self.assertEqual(h._debuglevel, 7)
 
     def test_https_handler_local_debuglevel(self):
         o = OpenerDirector()
-        h = MockHTTPSHandler(debuglevel=1)
+        h = MockHTTPSHandler(debuglevel=4)
         o.add_handler(h)
         o.open("https://www.example.com")
-        self.assertEqual(h._debuglevel, 1)
+        self.assertEqual(h._debuglevel, 4)
 
     def test_http_doubleslash(self):
         # Checks the presence of any unnecessary double slash in url does not

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1251,8 +1251,8 @@ class ProxyDigestAuthHandler(BaseHandler, AbstractDigestAuthHandler):
 
 class AbstractHTTPHandler(BaseHandler):
 
-    def __init__(self, debuglevel=0):
-        self._debuglevel = debuglevel
+    def __init__(self, debuglevel=None):
+        self._debuglevel = debuglevel if debuglevel is not None else http.client.HTTPConnection.debuglevel
 
     def set_http_debuglevel(self, level):
         self._debuglevel = level
@@ -1378,7 +1378,8 @@ if hasattr(http.client, 'HTTPSConnection'):
 
     class HTTPSHandler(AbstractHTTPHandler):
 
-        def __init__(self, debuglevel=0, context=None, check_hostname=None):
+        def __init__(self, debuglevel=None, context=None, check_hostname=None):
+            debuglevel = debuglevel if debuglevel is not None else http.client.HTTPSConnection.debuglevel
             AbstractHTTPHandler.__init__(self, debuglevel)
             if context is None:
                 http_version = http.client.HTTPSConnection._http_vsn

--- a/Misc/NEWS.d/next/Library/2022-11-10-16-26-47.gh-issue-99353.DQFjnt.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-10-16-26-47.gh-issue-99353.DQFjnt.rst
@@ -1,0 +1,3 @@
+Respect http.client.HTTPConnection.debuglevel flag in
+urllib.request.AbstractHTTPHandler when the AbstractHTTPHandler's
+constructor parameter 'debuglevel' is not set.

--- a/Misc/NEWS.d/next/Library/2022-11-10-16-26-47.gh-issue-99353.DQFjnt.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-10-16-26-47.gh-issue-99353.DQFjnt.rst
@@ -1,3 +1,3 @@
-Respect http.client.HTTPConnection.debuglevel flag in
-urllib.request.AbstractHTTPHandler when the AbstractHTTPHandler's
-constructor parameter 'debuglevel' is not set.
+Respect the :class:`http.client.HTTPConnection` ``.debuglevel`` flag
+in :class:`urllib.request.AbstractHTTPHandler` when its constructor
+parameter ``debuglevel`` is not set. And do the same for ``*HTTPS*``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Fixes #99352.

Some proposed changes to allow the `AbstractHTTPHandler` use the value of `http.client.HTTPConnection.debuglevel` if no `debuglevel` is passed to `AbstractHTTPHandler`'s constructor. This has to be done in the constructor body because argument default values are evaluated at function definition evaluation time and `http.client.HTTPConnection.debuglevel` could be set after `urllib.request` is imported. 

With these proposed changes, `AbstractHTTPHandler` and `HTTPSHandler` now respect both sources of `debuglevel`. If the value is not set in the constructor arguments, the constructor will source the value from `http.client.HTTPConnection.debuglevel`.

Using the global `http.client.HTTPConnection.debuglevel`:

```pycon
wheeler@fedora:~/cpython$ python
Python 3.10.7 (main, Sep  7 2022, 00:00:00) [GCC 12.2.1 20220819 (Red Hat 12.2.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import http.client
>>> import urllib.request
>>> http.client.HTTPConnection.debuglevel=1
>>> urllib.request.urlopen("http://example.com")
send: b'GET / HTTP/1.1\r\nAccept-Encoding: identity\r\nHost: example.com\r\nUser-Agent: Python-urllib/3.10\r\nConnection: close\r\n\r\n'
reply: 'HTTP/1.1 200 OK\r\n'
header: Age: 486527
header: Cache-Control: max-age=604800
header: Content-Type: text/html; charset=UTF-8
header: Date: Thu, 10 Nov 2022 22:00:09 GMT
header: Etag: "3147526947+gzip+ident"
header: Expires: Thu, 17 Nov 2022 22:00:09 GMT
header: Last-Modified: Thu, 17 Oct 2019 07:18:26 GMT
header: Server: ECS (cha/80C2)
header: Vary: Accept-Encoding
header: X-Cache: HIT
header: Content-Length: 1256
header: Connection: close
<http.client.HTTPResponse object at 0x7f322c674a00>
>>> 
```

Using the `debuglevel` constructor parameter:

```pycon
wheeler@fedora:~/cpython$ python
Python 3.10.7 (main, Sep  7 2022, 00:00:00) [GCC 12.2.1 20220819 (Red Hat 12.2.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import urllib.request
>>> handler = urllib.request.HTTPHandler(debuglevel=1)
>>> opener = urllib.request.build_opener(handler)
>>> opener.open("http://example.com")
send: b'GET / HTTP/1.1\r\nAccept-Encoding: identity\r\nHost: example.com\r\nUser-Agent: Python-urllib/3.10\r\nConnection: close\r\n\r\n'
reply: 'HTTP/1.1 200 OK\r\n'
header: Age: 567191
header: Cache-Control: max-age=604800
header: Content-Type: text/html; charset=UTF-8
header: Date: Thu, 10 Nov 2022 22:06:43 GMT
header: Etag: "3147526947+ident"
header: Expires: Thu, 17 Nov 2022 22:06:43 GMT
header: Last-Modified: Thu, 17 Oct 2019 07:18:26 GMT
header: Server: ECS (cha/8096)
header: Vary: Accept-Encoding
header: X-Cache: HIT
header: Content-Length: 1256
header: Connection: close
<http.client.HTTPResponse object at 0x7ff801e373d0>
>>> 
```


<!-- gh-issue-number: gh-99352 -->
* Issue: gh-99352
<!-- /gh-issue-number -->
