### PR TITLE
gh-99368: concurrent.futures: Remove call to mp.util.debug, since mp.util is never imported

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -300,8 +300,6 @@ class _ExecutorManagerThread(threading.Thread):
         def weakref_cb(_,
                        thread_wakeup=self.thread_wakeup,
                        shutdown_lock=self.shutdown_lock):
-            mp.util.debug('Executor collected: triggering callback for'
-                          ' QueueManager wakeup')
             with shutdown_lock:
                 thread_wakeup.wakeup()
 


### PR DESCRIPTION
This is a minor bug fix. The bug is documented in the associated issue: https://github.com/python/cpython/issues/99368

An alternative fix would be to import `mp.util`, but in this case, I don't think we want the extra debug call. 

Note that I made and tested this fix on Python 3.10. I have not tested on the head of `main`. This is my first PR into `cpython`, and I'm not quite sure how your test infrastructure works, or whether this requires manual testing  on `main`. 

<!-- gh-issue-number: gh-99368 -->
* Issue: gh-99368
<!-- /gh-issue-number -->
