### PR TITLE
gh-87604: Avoid publishing list of active per-interpreter audit hooks via the gc module

### DIFF
--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -450,6 +450,17 @@ def test_syslog():
     syslog.closelog()
 
 
+def test_not_in_gc():
+    import gc
+
+    hook = lambda *a: None
+    sys.addaudithook(hook)
+
+    for o in gc.get_objects():
+        if isinstance(o, list):
+            assert hook not in o
+
+
 if __name__ == "__main__":
     from test.support import suppress_msvcrt_asserts
 

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -222,6 +222,11 @@ class AuditTest(unittest.TestCase):
             ('syslog.closelog', '', '')]
         )
 
+    def test_not_in_gc(self):
+        returncode, _, stderr = self.run_python("test_not_in_gc")
+        if returncode:
+            self.fail(stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Security/2022-11-11-12-50-28.gh-issue-87604.OtwH5L.rst
+++ b/Misc/NEWS.d/next/Security/2022-11-11-12-50-28.gh-issue-87604.OtwH5L.rst
@@ -1,0 +1,2 @@
+Avoid publishing list of active per-interpreter audit hooks via the
+:mod:`gc` module

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -431,6 +431,8 @@ sys_addaudithook_impl(PyObject *module, PyObject *hook)
         if (interp->audit_hooks == NULL) {
             return NULL;
         }
+        /* Avoid having our list of hooks show up in the GC module */
+        PyObject_GC_UnTrack(interp->audit_hooks);
     }
 
     if (PyList_Append(interp->audit_hooks, hook) < 0) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-87604 -->
* Issue: gh-87604
<!-- /gh-issue-number -->
