### PR TITLE
Fix misspell in docs for http.HTTPMethod (introduced in 3.11)

### DIFF
--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -171,16 +171,25 @@ Property             Indicates that           Details
    Usage::
 
       >>> from http import HTTPMethod
-      >>> HTTMethod.GET
-      HTTMethod.GET
-      >>> HTTMethod.GET == 'GET'
+      >>>
+      >>> HTTPMethod.GET
+      <HTTPMethod.GET>
+      >>> HTTPMethod.GET == 'GET'
       True
-      >>> HTTMethod.GET.value
+      >>> HTTPMethod.GET.value
       'GET'
-      >>> HTTMethod.GET.description
+      >>> HTTPMethod.GET.description
       'Transfer a current representation of the target resource.'
       >>> list(HTTPMethod)
-      [HTTPMethod.GET, HTTPMethod.HEAD, ...]
+      [<HTTPMethod.CONNECT>,
+       <HTTPMethod.DELETE>,
+       <HTTPMethod.GET>,
+       <HTTPMethod.HEAD>,
+       <HTTPMethod.OPTIONS>,
+       <HTTPMethod.PATCH>,
+       <HTTPMethod.POST>,
+       <HTTPMethod.PUT>,
+       <HTTPMethod.TRACE>]
 
 .. _http-methods:
 

--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -179,7 +179,7 @@ Property             Indicates that           Details
       >>> HTTPMethod.GET.value
       'GET'
       >>> HTTPMethod.GET.description
-      'Transfer a current representation of the target resource.'
+      'Retrieve the target.'
       >>> list(HTTPMethod)
       [<HTTPMethod.CONNECT>,
        <HTTPMethod.DELETE>,


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
