### PR TITLE
GH-94597: add deprecation warnings for subclassing `AbstractChildWatcher`

### DIFF
--- a/Doc/library/asyncio-policy.rst
+++ b/Doc/library/asyncio-policy.rst
@@ -222,6 +222,9 @@ implementation used by the asyncio event loop:
       This method has to be called to ensure that underlying
       resources are cleaned-up.
 
+   .. deprecated:: 3.12
+
+
 .. class:: ThreadedChildWatcher
 
    This implementation starts a new waiting thread for every subprocess spawn.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -203,8 +203,8 @@ asyncio
   (Contributed by Kumar Aditya in :gh:`98024`.)
 
 * The child watcher classes :class:`~asyncio.MultiLoopChildWatcher`,
-  :class:`~asyncio.FastChildWatcher` and
-  :class:`~asyncio.SafeChildWatcher` are deprecated and
+  :class:`~asyncio.FastChildWatcher`, :class:`~asyncio.AbstractChildWatcher`
+  and :class:`~asyncio.SafeChildWatcher` are deprecated and
   will be removed in Python 3.14. It is recommended to not manually
   configure a child watcher as the event loop now uses the best available
   child watcher for each platform (:class:`~asyncio.PidfdChildWatcher`

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -846,6 +846,13 @@ class AbstractChildWatcher:
         waitpid(-1), there should be only one active object per process.
     """
 
+    def __init_subclass__(cls) -> None:
+        if cls.__module__ != __name__:
+            warnings._deprecated("AbstractChildWatcher",
+                             "{name!r} is deprecated as of Python 3.12 and will be "
+                             "removed in Python {remove}.",
+                              remove=(3, 14))
+
     def add_child_handler(self, pid, callback, *args):
         """Register a new child handler.
 

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -1108,6 +1108,11 @@ class UnixWritePipeTransportTests(test_utils.TestCase):
 
 class AbstractChildWatcherTests(unittest.TestCase):
 
+    def test_warns_on_subclassing(self):
+        with self.assertWarns(DeprecationWarning):
+            class MyWatcher(asyncio.AbstractChildWatcher):
+                pass
+
     def test_not_implemented(self):
         f = mock.Mock()
         watcher = asyncio.AbstractChildWatcher()
@@ -1747,7 +1752,9 @@ class PolicyTests(unittest.TestCase):
 
             self.assertIsInstance(policy.get_event_loop(),
                                   asyncio.AbstractEventLoop)
-            watcher = policy.get_child_watcher()
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                watcher = policy.get_child_watcher()
 
             self.assertIsInstance(watcher, asyncio.SafeChildWatcher)
             self.assertIsNone(watcher._loop)

--- a/Misc/NEWS.d/next/Library/2022-11-11-18-23-41.gh-issue-94597.m6vMDK.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-11-18-23-41.gh-issue-94597.m6vMDK.rst
@@ -1,0 +1,1 @@
+Deprecate :class:`asyncio.AbstractChildWatcher` to be removed in Python 3.14. Patch by Kumar Aditya.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94597 -->
* Issue: gh-94597
<!-- /gh-issue-number -->
