### PR TITLE
Docs: Move .PHONY to each section to avoid copy/paste omissions

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -21,10 +21,7 @@ PAPEROPT_letter = -D latex_elements.papersize=letterpaper
 ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees $(PAPEROPT_$(PAPER)) -j auto \
                 $(SPHINXOPTS) $(SPHINXERRORHANDLING) . build/$(BUILDER) $(SOURCES)
 
-.PHONY: help build html htmlhelp latex text texinfo epub changes linkcheck \
-	coverage doctest pydoc-topics htmlview clean clean-venv venv dist check serve \
-	autobuild-dev autobuild-dev-html autobuild-stable autobuild-stable-html
-
+.PHONY: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  clean      to remove build files"
@@ -44,6 +41,7 @@ help:
 	@echo "  dist       to create a \"dist\" directory with archived docs for download"
 	@echo "  check      to run a check for frequent markup errors"
 
+.PHONY: build
 build:
 	-mkdir -p build
 # Look first for a Misc/NEWS file (building from a source release tarball
@@ -70,38 +68,46 @@ build:
 	$(SPHINXBUILD) $(ALLSPHINXOPTS)
 	@echo
 
+.PHONY: html
 html: BUILDER = html
 html: build
 	@echo "Build finished. The HTML pages are in build/html."
 
+.PHONY: htmlhelp
 htmlhelp: BUILDER = htmlhelp
 htmlhelp: build
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      "build/htmlhelp/pydoc.hhp project file."
 
+.PHONY: latex
 latex: BUILDER = latex
 latex: build
 	@echo "Build finished; the LaTeX files are in build/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
 	      "run these through (pdf)latex."
 
+.PHONY: text
 text: BUILDER = text
 text: build
 	@echo "Build finished; the text files are in build/text."
 
+.PHONY: texinfo
 texinfo: BUILDER = texinfo
 texinfo: build
 	@echo "Build finished; the python.texi file is in build/texinfo."
 	@echo "Run \`make info' in that directory to run it through makeinfo."
 
+.PHONY: epub
 epub: BUILDER = epub
 epub: build
 	@echo "Build finished; the epub files are in build/epub."
 
+.PHONY: changes
 changes: BUILDER = changes
 changes: build
 	@echo "The overview file is in build/changes."
 
+.PHONY: linkcheck
 linkcheck: BUILDER = linkcheck
 linkcheck:
 	@$(MAKE) build BUILDER=$(BUILDER) || { \
@@ -109,10 +115,12 @@ linkcheck:
 	     "or in build/$(BUILDER)/output.txt"; \
 	false; }
 
+.PHONY: coverage
 coverage: BUILDER = coverage
 coverage: build
 	@echo "Coverage finished; see c.txt and python.txt in build/coverage"
 
+.PHONY: doctest
 doctest: BUILDER = doctest
 doctest:
 	@$(MAKE) build BUILDER=$(BUILDER) || { \
@@ -120,20 +128,25 @@ doctest:
 	     "results in build/doctest/output.txt"; \
 	false; }
 
+.PHONY: pydoc-topics
 pydoc-topics: BUILDER = pydoc-topics
 pydoc-topics: build
 	@echo "Building finished; now run this:" \
 	      "cp build/pydoc-topics/topics.py ../Lib/pydoc_data/topics.py"
 
+.PHONY: htmlview
 htmlview: html
 	$(PYTHON) -c "import os, webbrowser; webbrowser.open('file://' + os.path.realpath('build/html/index.html'))"
 
+.PHONY: clean
 clean: clean-venv
 	-rm -rf build/*
 
+.PHONY: clean-venv
 clean-venv:
 	rm -rf $(VENVDIR)
 
+.PHONY: venv
 venv:
 	@if [ -d $(VENVDIR) ] ; then \
 		echo "venv already exists."; \
@@ -145,6 +158,7 @@ venv:
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi
 
+.PHONY: dist
 dist:
 	rm -rf dist
 	mkdir -p dist
@@ -199,12 +213,14 @@ dist:
 	rm -r dist/python-$(DISTVERSION)-docs-texinfo
 	rm dist/python-$(DISTVERSION)-docs-texinfo.tar
 
+.PHONY: check
 check:
 	# Check the docs and NEWS files with sphinx-lint.
 	# Ignore the tools and venv dirs and check that the default role is not used.
 	$(SPHINXLINT) -i tools -i $(VENVDIR) --enable default-role
 	$(SPHINXLINT) --enable default-role ../Misc/NEWS.d/next/
 
+.PHONY: serve
 serve:
 	@echo "The serve target was removed, use htmlview instead (see bpo-36329)"
 
@@ -216,15 +232,18 @@ serve:
 # output files)
 
 # for development releases: always build
+.PHONY: autobuild-dev
 autobuild-dev:
 	make dist SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1'
 
 # for quick rebuilds (HTML only)
+.PHONY: autobuild-dev-html
 autobuild-dev-html:
 	make html SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1'
 
 # for stable releases: only build if not in pre-release stage (alpha, beta)
 # release candidate downloads are okay, since the stable tree can be in that stage
+.PHONY: autobuild-stable
 autobuild-stable:
 	@case $(DISTVERSION) in *[ab]*) \
 		echo "Not building; $(DISTVERSION) is not a release version."; \
@@ -232,6 +251,7 @@ autobuild-stable:
 	esac
 	@make autobuild-dev
 
+.PHONY: autobuild-stable-html
 autobuild-stable-html:
 	@case $(DISTVERSION) in *[ab]*) \
 		echo "Not building; $(DISTVERSION) is not a release version."; \


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

(Cherry picked from https://github.com/python/cpython/pull/98266)

PR https://github.com/python/cpython/pull/98189 recently fixed some missing `.PHONY` targets. 👍 

I expect missing `.PHONY` targets will happen again, because it's normal to copy/paste a target, and forget (or not know) to update the long `.PHONY` line right at the top.

Let's do as @zware suggested and define them right next to each target: https://github.com/python/cpython/pull/98189#issuecomment-1276664528

We do this at [Pillow](https://github.com/python-pillow/Pillow/blob/main/Makefile) and at work, it helps a lot, and I've also done it for the [devguide](https://github.com/python/devguide/pull/972) and [PEPs](https://github.com/python/peps/pull/2841).
