### PR TITLE
GH-99298: Clean up attribute specializations

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -213,10 +213,10 @@ extern int _PyLineTable_PreviousAddressRange(PyCodeAddressRange *range);
 
 /* Specialization functions */
 
-extern int _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr,
-                                   PyObject *name);
-extern int _Py_Specialize_StoreAttr(PyObject *owner, _Py_CODEUNIT *instr,
+extern void _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr,
                                     PyObject *name);
+extern void _Py_Specialize_StoreAttr(PyObject *owner, _Py_CODEUNIT *instr,
+                                     PyObject *name);
 extern void _Py_Specialize_LoadGlobal(PyObject *globals, PyObject *builtins,
                                       _Py_CODEUNIT *instr, PyObject *name);
 extern void _Py_Specialize_BinarySubscr(PyObject *sub, PyObject *container,

--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-10-16-53-40.gh-issue-99298.HqRJES.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-10-16-53-40.gh-issue-99298.HqRJES.rst
@@ -1,0 +1,3 @@
+Remove the remaining error paths for attribute specializations, and refuse
+to specialize attribute accesses on types that haven't had
+:c:func:`PyType_Ready` called on them yet.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1138,11 +1138,7 @@ dummy_func(
                 PyObject *owner = TOP();
                 PyObject *name = GETITEM(names, oparg);
                 next_instr--;
-                if (_Py_Specialize_StoreAttr(owner, next_instr, name)) {
-                    // "undo" the rewind so end up in the correct handler:
-                    next_instr++;
-                    goto error;
-                }
+                _Py_Specialize_StoreAttr(owner, next_instr, name);
                 DISPATCH_SAME_OPARG();
             }
             STAT_INC(STORE_ATTR, deferred);
@@ -1714,11 +1710,7 @@ dummy_func(
                 PyObject *owner = TOP();
                 PyObject *name = GETITEM(names, oparg>>1);
                 next_instr--;
-                if (_Py_Specialize_LoadAttr(owner, next_instr, name)) {
-                    // "undo" the rewind so end up in the correct handler:
-                    next_instr++;
-                    goto error;
-                }
+                _Py_Specialize_LoadAttr(owner, next_instr, name);
                 DISPATCH_SAME_OPARG();
             }
             STAT_INC(LOAD_ATTR, deferred);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1141,11 +1141,7 @@
                 PyObject *owner = TOP();
                 PyObject *name = GETITEM(names, oparg);
                 next_instr--;
-                if (_Py_Specialize_StoreAttr(owner, next_instr, name)) {
-                    // "undo" the rewind so end up in the correct handler:
-                    next_instr++;
-                    goto error;
-                }
+                _Py_Specialize_StoreAttr(owner, next_instr, name);
                 DISPATCH_SAME_OPARG();
             }
             STAT_INC(STORE_ATTR, deferred);
@@ -1723,11 +1719,7 @@
                 PyObject *owner = TOP();
                 PyObject *name = GETITEM(names, oparg>>1);
                 next_instr--;
-                if (_Py_Specialize_LoadAttr(owner, next_instr, name)) {
-                    // "undo" the rewind so end up in the correct handler:
-                    next_instr++;
-                    goto error;
-                }
+                _Py_Specialize_LoadAttr(owner, next_instr, name);
                 DISPATCH_SAME_OPARG();
             }
             STAT_INC(LOAD_ATTR, deferred);

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -663,31 +663,32 @@ static int specialize_attr_loadmethod(PyObject* owner, _Py_CODEUNIT* instr, PyOb
     PyObject* descr, DescriptorClassification kind);
 static int specialize_class_load_attr(PyObject* owner, _Py_CODEUNIT* instr, PyObject* name);
 
-int
+void
 _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name)
 {
     assert(_PyOpcode_Caches[LOAD_ATTR] == INLINE_CACHE_ENTRIES_LOAD_ATTR);
     _PyAttrCache *cache = (_PyAttrCache *)(instr + 1);
+    PyTypeObject *type = Py_TYPE(owner);
+    if (!_PyType_IsReady(type)) {
+        // We *might* not really need this check, but we inherited it from
+        // PyObject_GenericGetAttr and friends... and this way we still do the
+        // right thing if someone forgets to call PyType_Ready(type):
+        SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_OTHER);
+        goto fail;
+    }
     if (PyModule_CheckExact(owner)) {
-        int err = specialize_module_load_attr(owner, instr, name, LOAD_ATTR,
-                                              LOAD_ATTR_MODULE);
-        if (err) {
+        if (specialize_module_load_attr(owner, instr, name, LOAD_ATTR,
+                                        LOAD_ATTR_MODULE))
+        {
             goto fail;
         }
         goto success;
     }
     if (PyType_Check(owner)) {
-        int err = specialize_class_load_attr(owner, instr, name);
-        if (err) {
+        if (specialize_class_load_attr(owner, instr, name)) {
             goto fail;
         }
         goto success;
-    }
-    PyTypeObject *type = Py_TYPE(owner);
-    if (type->tp_dict == NULL) {
-        if (PyType_Ready(type) < 0) {
-            return -1;
-        }
     }
     PyObject *descr = NULL;
     DescriptorClassification kind = analyze_descriptor(type, name, &descr, 0);
@@ -803,14 +804,9 @@ _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name)
         case ABSENT:
             break;
     }
-    int err = specialize_dict_access(
-        owner, instr, type, kind, name,
-        LOAD_ATTR, LOAD_ATTR_INSTANCE_VALUE, LOAD_ATTR_WITH_HINT
-    );
-    if (err < 0) {
-        return -1;
-    }
-    if (err) {
+    if (specialize_dict_access(owner, instr, type, kind, name, LOAD_ATTR,
+                               LOAD_ATTR_INSTANCE_VALUE, LOAD_ATTR_WITH_HINT))
+    {
         goto success;
     }
 fail:
@@ -818,20 +814,26 @@ fail:
     assert(!PyErr_Occurred());
     _Py_SET_OPCODE(*instr, LOAD_ATTR);
     cache->counter = adaptive_counter_backoff(cache->counter);
-    return 0;
+    return;
 success:
     STAT_INC(LOAD_ATTR, success);
     assert(!PyErr_Occurred());
     cache->counter = adaptive_counter_cooldown();
-    return 0;
 }
 
-int
+void
 _Py_Specialize_StoreAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name)
 {
     assert(_PyOpcode_Caches[STORE_ATTR] == INLINE_CACHE_ENTRIES_STORE_ATTR);
     _PyAttrCache *cache = (_PyAttrCache *)(instr + 1);
     PyTypeObject *type = Py_TYPE(owner);
+    if (!_PyType_IsReady(type)) {
+        // We *might* not really need this check, but we inherited it from
+        // PyObject_GenericSetAttr and friends... and this way we still do the
+        // right thing if someone forgets to call PyType_Ready(type):
+        SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_OTHER);
+        goto fail;
+    }
     if (PyModule_CheckExact(owner)) {
         SPECIALIZATION_FAIL(STORE_ATTR, SPEC_FAIL_OVERRIDDEN);
         goto fail;
@@ -890,15 +892,9 @@ _Py_Specialize_StoreAttr(PyObject *owner, _Py_CODEUNIT *instr, PyObject *name)
         case ABSENT:
             break;
     }
-
-    int err = specialize_dict_access(
-        owner, instr, type, kind, name,
-        STORE_ATTR, STORE_ATTR_INSTANCE_VALUE, STORE_ATTR_WITH_HINT
-    );
-    if (err < 0) {
-        return -1;
-    }
-    if (err) {
+    if (specialize_dict_access(owner, instr, type, kind, name, STORE_ATTR,
+                               STORE_ATTR_INSTANCE_VALUE, STORE_ATTR_WITH_HINT))
+    {
         goto success;
     }
 fail:
@@ -906,12 +902,11 @@ fail:
     assert(!PyErr_Occurred());
     _Py_SET_OPCODE(*instr, STORE_ATTR);
     cache->counter = adaptive_counter_backoff(cache->counter);
-    return 0;
+    return;
 success:
     STAT_INC(STORE_ATTR, success);
     assert(!PyErr_Occurred());
     cache->counter = adaptive_counter_cooldown();
-    return 0;
 }
 
 


### PR DESCRIPTION
It's now impossible for specialization to raise exceptions.

Also, add an overly-cautious-but-inexpensive check for "unready" types when specializing `STORE_ATTR`, as we already do for `LOAD_ATTR`. Probably worth backporting this part manually?

No performance impact:

<details>

```
All benchmarks:
===============

Slower (20):
- mdp: 2.51 sec +- 0.02 sec -> 2.61 sec +- 0.01 sec: 1.04x slower
- pickle_list: 4.03 us +- 0.03 us -> 4.17 us +- 0.04 us: 1.04x slower
- scimark_sparse_mat_mult: 4.07 ms +- 0.07 ms -> 4.18 ms +- 0.06 ms: 1.03x slower
- pathlib: 17.3 ms +- 0.2 ms -> 17.7 ms +- 0.4 ms: 1.02x slower
- regex_effbot: 3.34 ms +- 0.02 ms -> 3.42 ms +- 0.03 ms: 1.02x slower
- telco: 6.25 ms +- 0.22 ms -> 6.39 ms +- 0.19 ms: 1.02x slower
- mako: 9.52 ms +- 0.06 ms -> 9.72 ms +- 0.05 ms: 1.02x slower
- regex_dna: 202 ms +- 1 ms -> 206 ms +- 1 ms: 1.02x slower
- django_template: 32.6 ms +- 0.5 ms -> 33.3 ms +- 0.3 ms: 1.02x slower
- float: 71.5 ms +- 0.8 ms -> 72.9 ms +- 1.1 ms: 1.02x slower
- fannkuch: 374 ms +- 11 ms -> 381 ms +- 15 ms: 1.02x slower
- deltablue: 3.19 ms +- 0.04 ms -> 3.25 ms +- 0.04 ms: 1.02x slower
- scimark_lu: 106 ms +- 2 ms -> 107 ms +- 4 ms: 1.01x slower
- coverage: 98.1 ms +- 1.2 ms -> 99.4 ms +- 1.2 ms: 1.01x slower
- nqueens: 81.1 ms +- 1.4 ms -> 82.2 ms +- 1.1 ms: 1.01x slower
- hexiom: 6.06 ms +- 0.02 ms -> 6.14 ms +- 0.03 ms: 1.01x slower
- xml_etree_iterparse: 104 ms +- 2 ms -> 106 ms +- 2 ms: 1.01x slower
- richards: 41.7 ms +- 0.7 ms -> 42.1 ms +- 0.9 ms: 1.01x slower
- scimark_fft: 311 ms +- 3 ms -> 313 ms +- 4 ms: 1.01x slower
- crypto_pyaes: 74.1 ms +- 0.7 ms -> 74.4 ms +- 0.8 ms: 1.00x slower

Faster (28):
- unpack_sequence: 46.1 ns +- 4.1 ns -> 42.5 ns +- 0.8 ns: 1.08x faster
- pidigits: 199 ms +- 0 ms -> 189 ms +- 0 ms: 1.05x faster
- coroutines: 25.5 ms +- 0.2 ms -> 24.6 ms +- 0.2 ms: 1.04x faster
- genshi_text: 21.1 ms +- 0.2 ms -> 20.4 ms +- 0.3 ms: 1.03x faster
- pycparser: 1.08 sec +- 0.02 sec -> 1.05 sec +- 0.02 sec: 1.03x faster
- logging_format: 6.34 us +- 0.10 us -> 6.23 us +- 0.07 us: 1.02x faster
- logging_simple: 5.75 us +- 0.08 us -> 5.66 us +- 0.06 us: 1.02x faster
- deepcopy_reduce: 2.94 us +- 0.04 us -> 2.89 us +- 0.04 us: 1.02x faster
- unpickle_pure_python: 204 us +- 2 us -> 201 us +- 1 us: 1.01x faster
- spectral_norm: 95.9 ms +- 3.8 ms -> 94.6 ms +- 2.6 ms: 1.01x faster
- pickle: 10.3 us +- 0.1 us -> 10.2 us +- 0.1 us: 1.01x faster
- pickle_dict: 31.3 us +- 0.1 us -> 31.0 us +- 0.1 us: 1.01x faster
- sympy_sum: 163 ms +- 1 ms -> 162 ms +- 1 ms: 1.01x faster
- sympy_str: 283 ms +- 4 ms -> 280 ms +- 4 ms: 1.01x faster
- regex_v8: 21.2 ms +- 0.1 ms -> 21.0 ms +- 0.1 ms: 1.01x faster
- generators: 78.7 ms +- 0.5 ms -> 78.0 ms +- 0.4 ms: 1.01x faster
- json_loads: 24.2 us +- 0.4 us -> 24.0 us +- 0.2 us: 1.01x faster
- json_dumps: 9.45 ms +- 0.18 ms -> 9.36 ms +- 0.13 ms: 1.01x faster
- sympy_expand: 457 ms +- 3 ms -> 453 ms +- 7 ms: 1.01x faster
- sympy_integrate: 20.3 ms +- 0.1 ms -> 20.2 ms +- 0.1 ms: 1.01x faster
- sqlglot_transpile: 1.63 ms +- 0.02 ms -> 1.61 ms +- 0.02 ms: 1.01x faster
- xml_etree_process: 53.2 ms +- 0.7 ms -> 52.8 ms +- 0.6 ms: 1.01x faster
- python_startup_no_site: 6.27 ms +- 0.01 ms -> 6.22 ms +- 0.01 ms: 1.01x faster
- genshi_xml: 46.9 ms +- 0.9 ms -> 46.6 ms +- 0.8 ms: 1.01x faster
- sqlglot_normalize: 106 ms +- 1 ms -> 105 ms +- 1 ms: 1.01x faster
- python_startup: 8.60 ms +- 0.01 ms -> 8.55 ms +- 0.01 ms: 1.01x faster
- 2to3: 246 ms +- 1 ms -> 245 ms +- 1 ms: 1.01x faster
- sqlglot_optimize: 50.9 ms +- 0.2 ms -> 50.7 ms +- 0.3 ms: 1.01x faster

Benchmark hidden because not significant (34): aiohttp, async_tree_none, async_tree_cpu_io_mixed, async_tree_io, async_tree_memoization, chameleon, chaos, deepcopy, deepcopy_memo, dulwich_log, go, gunicorn, html5lib, json, logging_silent, meteor_contest, mypy, nbody, pickle_pure_python, pprint_safe_repr, pprint_pformat, pyflate, raytrace, regex_compile, scimark_monte_carlo, scimark_sor, sqlglot_parse, sqlite_synth, thrift, tornado_http, unpickle, unpickle_list, xml_etree_parse, xml_etree_generate

Geometric mean: 1.00x faster
```

</details>

<!-- gh-issue-number: gh-99298 -->
* Issue: gh-99298
<!-- /gh-issue-number -->
