### PR TITLE
gh-81057: Move PyImport_Inittab to _PyRuntimeState

### DIFF
--- a/Include/cpython/import.h
+++ b/Include/cpython/import.h
@@ -25,6 +25,7 @@ struct _inittab {
     const char *name;           /* ASCII encoded string */
     PyObject* (*initfunc)(void);
 };
+// This is not used after Py_Initialize() is called.
 PyAPI_DATA(struct _inittab *) PyImport_Inittab;
 PyAPI_FUNC(int) PyImport_ExtendInittab(struct _inittab *newtab);
 

--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -7,6 +7,8 @@ extern "C" {
 
 
 struct _import_runtime_state {
+    /* The builtin modules (defined in config.c). */
+    struct _inittab *inittab;
     /* The most recent value assigned to a PyModuleDef.m_base.m_index.
        This is incremented each time PyModuleDef_Init() is called,
        which is just about every time an extension module is imported.

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -33,6 +33,7 @@ PyAPI_FUNC(int) _Py_IsLocaleCoercionTarget(const char *ctype_loc);
 
 /* Various one-time initializers */
 
+extern PyStatus _PyImport_Init(void);
 extern PyStatus _PyFaulthandler_Init(int enable);
 extern int _PyTraceMalloc_Init(int enable);
 extern PyObject * _PyBuiltin_Init(PyInterpreterState *interp);

--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-11-14-48-17.gh-issue-81057.ik4iOv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-11-14-48-17.gh-issue-81057.ik4iOv.rst
@@ -1,0 +1,5 @@
+The docs clearly say that ``PyImport_Inittab``,
+:c:api:`PyImport_AppendInittab`, and :c:api:`PyImport_ExtendInittab` should
+not be used after :c:api:`Py_Initialize` has been called.  We now enforce
+this for the two functions.  Additionally, the runtime now uses an internal
+copy of ``PyImport_Inittab``, to guard against modification.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-11-14-48-17.gh-issue-81057.ik4iOv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-11-14-48-17.gh-issue-81057.ik4iOv.rst
@@ -1,5 +1,6 @@
 The docs clearly say that ``PyImport_Inittab``,
-:c:api:`PyImport_AppendInittab`, and :c:api:`PyImport_ExtendInittab` should
-not be used after :c:api:`Py_Initialize` has been called.  We now enforce
-this for the two functions.  Additionally, the runtime now uses an internal
-copy of ``PyImport_Inittab``, to guard against modification.
+:c:func:`PyImport_AppendInittab`, and :c:func:`PyImport_ExtendInittab`
+should not be used after :c:func:`Py_Initialize` has been called.
+We now enforce this for the two functions.  Additionally, the runtime
+now uses an internal copy of ``PyImport_Inittab``,
+to guard against modification.

--- a/Python/import.c
+++ b/Python/import.c
@@ -33,6 +33,8 @@ extern struct _inittab _PyImport_Inittab[];
 // This is not used after Py_Initialize() is called.
 // (See _PyRuntimeState.imports.inittab.)
 struct _inittab *PyImport_Inittab = _PyImport_Inittab;
+// When we dynamically allocate a larger table for PyImport_ExtendInittab(),
+// we track the pointer here so we can deallocate it during finalization.
 static struct _inittab *inittab_copy = NULL;
 
 /*[clinic input]

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -605,6 +605,11 @@ pycore_init_runtime(_PyRuntimeState *runtime,
         return status;
     }
 
+    status = _PyImport_Init();
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     status = _PyInterpreterState_Enable(runtime);
     if (_PyStatus_EXCEPTION(status)) {
         return status;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2252,8 +2252,9 @@ list_builtin_module_names(void)
     if (list == NULL) {
         return NULL;
     }
-    for (Py_ssize_t i = 0; PyImport_Inittab[i].name != NULL; i++) {
-        PyObject *name = PyUnicode_FromString(PyImport_Inittab[i].name);
+    struct _inittab *inittab = _PyRuntime.imports.inittab;
+    for (Py_ssize_t i = 0; inittab[i].name != NULL; i++) {
+        PyObject *name = PyUnicode_FromString(inittab[i].name);
         if (name == NULL) {
             goto error;
         }

--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -392,7 +392,6 @@ Python/frozen.c	-	_PyImport_FrozenAliases	-
 Python/frozen.c	-	_PyImport_FrozenBootstrap	-
 Python/frozen.c	-	_PyImport_FrozenStdlib	-
 Python/frozen.c	-	_PyImport_FrozenTest	-
-Python/import.c	-	inittab_copy	-
 Python/preconfig.c	-	Py_FileSystemDefaultEncoding	-
 Python/preconfig.c	-	Py_HasFileSystemDefaultEncoding	-
 Python/preconfig.c	-	Py_FileSystemDefaultEncodeErrors	-

--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -393,7 +393,6 @@ Python/frozen.c	-	_PyImport_FrozenBootstrap	-
 Python/frozen.c	-	_PyImport_FrozenStdlib	-
 Python/frozen.c	-	_PyImport_FrozenTest	-
 Python/import.c	-	inittab_copy	-
-Python/import.c	-	PyImport_Inittab	-
 Python/preconfig.c	-	Py_FileSystemDefaultEncoding	-
 Python/preconfig.c	-	Py_HasFileSystemDefaultEncoding	-
 Python/preconfig.c	-	Py_FileSystemDefaultEncodeErrors	-

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -4,6 +4,7 @@ filename	funcname	name	reason
 ##################################
 # mutable but known to be safe
 
+Python/import.c	-	PyImport_Inittab	-
 Python/pylifecycle.c	-	_PyRuntime	-
 
 # All uses of _PyArg_Parser are handled in c-analyzr/cpython/_analyzer.py.

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -4,6 +4,7 @@ filename	funcname	name	reason
 ##################################
 # mutable but known to be safe
 
+Python/import.c	-	inittab_copy	-
 Python/import.c	-	PyImport_Inittab	-
 Python/pylifecycle.c	-	_PyRuntime	-
 


### PR DESCRIPTION
We actually don't move `PyImport_Inittab`.  Instead, we make a copy that we keep on `_PyRuntimeState` and use only that after `Py_Initialize()`.  We also prevent folks from modifying `PyImport_Inittab` (the best we can) after that point.

<!-- gh-issue-number: gh-81057 -->
* Issue: gh-81057
<!-- /gh-issue-number -->
