### PR TITLE
Docs: use Node.findall to avoid a deprecation warning

### DIFF
--- a/Doc/tools/extensions/c_annotations.py
+++ b/Doc/tools/extensions/c_annotations.py
@@ -20,6 +20,7 @@
 """
 
 from os import path
+import docutils
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
@@ -38,6 +39,16 @@ REST_ROLE_MAP = {
     'type': 'type',
     'member': 'member',
 }
+
+
+# Monkeypatch nodes.Node.findall for forwards compatability
+# This patch can be dropped when the minimum Sphinx version is 4.4.0
+# or the minimum Docutils version is 0.18.1.
+if docutils.__version_info__ < (0, 18, 1):
+    def findall(self, *args, **kwargs):
+        return iter(self.traverse(*args, **kwargs))
+
+    nodes.Node.findall = findall
 
 
 class RCEntry:
@@ -86,7 +97,7 @@ class Annotations:
                 self.stable_abi_data[name] = record
 
     def add_annotations(self, app, doctree):
-        for node in doctree.traverse(addnodes.desc_content):
+        for node in doctree.findall(addnodes.desc_content):
             par = node.parent
             if par['domain'] != 'c':
                 continue


### PR DESCRIPTION
As part of the (paused) Sphinx 5.3 work I noticed that we still use `Node.traverse` in `Doc/tools/extensions/c_annotations.py` -- this moves to use the new `findall()` iterator method and adds a patch for still-supported old versions of Sphinx.

A