### PR TITLE
gh-99433: Fix `doctest` failure on `MethodWrapperType`

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -956,7 +956,8 @@ class DocTestFinder:
             return module is inspect.getmodule(object)
         elif inspect.isfunction(object):
             return module.__dict__ is object.__globals__
-        elif inspect.ismethoddescriptor(object):
+        elif (inspect.ismethoddescriptor(object) or
+              inspect.ismethodwrapper(object)):
             if hasattr(object, '__objclass__'):
                 obj_mod = object.__objclass__.__module__
             elif hasattr(object, '__module__'):

--- a/Lib/test/doctest_lineno.py
+++ b/Lib/test/doctest_lineno.py
@@ -48,3 +48,6 @@ class MethodWrapper:
         >>> MethodWrapper.method_with_doctest.__name__
         'method_with_doctest'
         """
+
+# https://github.com/python/cpython/issues/99433
+str_wrapper = object().__str__

--- a/Misc/NEWS.d/next/Library/2022-11-13-15-32-19.gh-issue-99433.Ys6y0A.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-13-15-32-19.gh-issue-99433.Ys6y0A.rst
@@ -1,0 +1,1 @@
+Fix :mod:`doctest` failure on :class:`types.MethodWrapperType` in modules.


### PR DESCRIPTION
Looks like it was failing because `isroutine` now has `ismethodwrapper` check. While `_from_module` was not having one. Refs https://github.com/python/cpython/blame/57be5459593bbd09583317ebdafc4d58ae51dbf4/Lib/inspect.py#L509

New test failure without the code change:

```
======================================================================
FAIL: basics (test.test_doctest.test_DocTestFinder)
Doctest: test.test_doctest.test_DocTestFinder.basics
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/Lib/doctest.py", line 2221, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for test.test_doctest.test_DocTestFinder.basics
  File "/Users/sobolev/Desktop/cpython/Lib/test/test_doctest.py", line 437, in basics

----------------------------------------------------------------------
File "/Users/sobolev/Desktop/cpython/Lib/test/test_doctest.py", line 649, in test.test_doctest.test_DocTestFinder.basics
Failed example:
    tests = doctest.DocTestFinder(exclude_empty=False).find(doctest_lineno)
Exception raised:
    Traceback (most recent call last):
      ...
    ValueError: object must be a class or function
----------------------------------------------------------------------
```

<!-- gh-issue-number: gh-99433 -->
* Issue: gh-99433
<!-- /gh-issue-number -->

This would need a backport to `3.11`