### PR TITLE
gh-99300: Use Py_NewRef() in Modules/_ctypes/

### DIFF
--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -374,8 +374,7 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
     }
     p->atypes[i] = NULL;
 
-    Py_INCREF(restype);
-    p->restype = restype;
+    p->restype = Py_NewRef(restype);
     if (restype == Py_None) {
         p->setfunc = NULL;
         p->ffi_restype = &ffi_type_void;
@@ -446,10 +445,8 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
         goto error;
     }
 
-    Py_INCREF(converters);
-    p->converters = converters;
-    Py_INCREF(callable);
-    p->callable = callable;
+    p->converters = Py_NewRef(converters);
+    p->callable = Py_NewRef(callable);
     return p;
 
   error:

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -671,8 +671,7 @@ static int ConvParam(PyObject *obj, Py_ssize_t index, struct argument *pa)
     if (PyCArg_CheckExact(obj)) {
         PyCArgObject *carg = (PyCArgObject *)obj;
         pa->ffi_type = carg->pffi_type;
-        Py_INCREF(obj);
-        pa->keep = obj;
+        pa->keep = Py_NewRef(obj);
         memcpy(&pa->value, &carg->value, sizeof(pa->value));
         return 0;
     }
@@ -702,8 +701,7 @@ static int ConvParam(PyObject *obj, Py_ssize_t index, struct argument *pa)
     if (PyBytes_Check(obj)) {
         pa->ffi_type = &ffi_type_pointer;
         pa->value.p = PyBytes_AsString(obj);
-        Py_INCREF(obj);
-        pa->keep = obj;
+        pa->keep = Py_NewRef(obj);
         return 0;
     }
 
@@ -1733,8 +1731,7 @@ byref(PyObject *self, PyObject *args)
 
     parg->tag = 'P';
     parg->pffi_type = &ffi_type_pointer;
-    Py_INCREF(obj);
-    parg->obj = obj;
+    parg->obj = Py_NewRef(obj);
     parg->value.p = (char *)((CDataObject *)obj)->b_ptr + offset;
     return (PyObject *)parg;
 }
@@ -1774,8 +1771,7 @@ My_PyObj_FromPtr(PyObject *self, PyObject *args)
     if (PySys_Audit("ctypes.PyObj_FromPtr", "(O)", ob) < 0) {
         return NULL;
     }
-    Py_INCREF(ob);
-    return ob;
+    return Py_NewRef(ob);
 }
 
 static PyObject *
@@ -1888,8 +1884,7 @@ POINTER(PyObject *self, PyObject *cls)
 
     result = PyDict_GetItemWithError(_ctypes_ptrtype_cache, cls);
     if (result) {
-        Py_INCREF(result);
-        return result;
+        return Py_NewRef(result);
     }
     else if (PyErr_Occurred()) {
         return NULL;
@@ -1928,8 +1923,7 @@ POINTER(PyObject *self, PyObject *cls)
         PyMem_Free(buf);
         if (result == NULL)
             return result;
-        Py_INCREF(cls);
-        key = cls;
+        key = Py_NewRef(cls);
     } else {
         PyErr_SetString(PyExc_TypeError, "must be a ctypes type");
         return NULL;

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -144,8 +144,7 @@ PyCField_FromDesc(PyObject *desc, Py_ssize_t index,
     self->getfunc = getfunc;
     self->index = index;
 
-    Py_INCREF(proto);
-    self->proto = proto;
+    self->proto = Py_NewRef(proto);
 
     switch (fieldtype) {
     case NEW_BITFIELD:
@@ -1097,8 +1096,7 @@ O_get(void *ptr, Py_ssize_t size)
                             "PyObject is NULL");
         return NULL;
     }
-    Py_INCREF(ob);
-    return ob;
+    return Py_NewRef(ob);
 }
 
 static PyObject *
@@ -1106,8 +1104,7 @@ O_set(void *ptr, PyObject *value, Py_ssize_t size)
 {
     /* Hm, does the memory block need it's own refcount or not? */
     *(PyObject **)ptr = value;
-    Py_INCREF(value);
-    return value;
+    return Py_NewRef(value);
 }
 
 
@@ -1233,8 +1230,7 @@ U_set(void *ptr, PyObject *value, Py_ssize_t length)
         return NULL;
     }
 
-    Py_INCREF(value);
-    return value;
+    return Py_NewRef(value);
 }
 
 
@@ -1292,13 +1288,11 @@ z_set(void *ptr, PyObject *value, Py_ssize_t size)
 {
     if (value == Py_None) {
         *(char **)ptr = NULL;
-        Py_INCREF(value);
-        return value;
+        return Py_NewRef(value);
     }
     if (PyBytes_Check(value)) {
         *(const char **)ptr = PyBytes_AsString(value);
-        Py_INCREF(value);
-        return value;
+        return Py_NewRef(value);
     } else if (PyLong_Check(value)) {
 #if SIZEOF_VOID_P == SIZEOF_LONG_LONG
         *(char **)ptr = (char *)PyLong_AsUnsignedLongLongMask(value);
@@ -1334,8 +1328,7 @@ Z_set(void *ptr, PyObject *value, Py_ssize_t size)
 
     if (value == Py_None) {
         *(wchar_t **)ptr = NULL;
-        Py_INCREF(value);
-        return value;
+        return Py_NewRef(value);
     }
     if (PyLong_Check(value)) {
 #if SIZEOF_VOID_P == SIZEOF_LONG_LONG

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -267,8 +267,7 @@ MakeFields(PyObject *type, CFieldObject *descr,
         new_descr->size = fdescr->size;
         new_descr->offset = fdescr->offset + offset;
         new_descr->index = fdescr->index + index;
-        new_descr->proto = fdescr->proto;
-        Py_XINCREF(new_descr->proto);
+        new_descr->proto = Py_XNewRef(fdescr->proto);
         new_descr->getfunc = fdescr->getfunc;
         new_descr->setfunc = fdescr->setfunc;
 


### PR DESCRIPTION
Replace Py_INCREF() and Py_XINCREF() with Py_NewRef() and Py_XNewRef() in C files of the Modules/_ctypes/ directory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99300 -->
* Issue: gh-99300
<!-- /gh-issue-number -->
