### PR TITLE
gh-99300: Use Py_NewRef() in Modules/_elementtree.c

### DIFF
--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -229,8 +229,7 @@ create_extra(ElementObject* self, PyObject* attrib)
         return -1;
     }
 
-    Py_XINCREF(attrib);
-    self->extra->attrib = attrib;
+    self->extra->attrib = Py_XNewRef(attrib);
 
     self->extra->length = 0;
     self->extra->allocated = STATIC_CHILDREN;
@@ -286,16 +285,9 @@ create_new_element(PyObject* tag, PyObject* attrib)
     if (self == NULL)
         return NULL;
     self->extra = NULL;
-
-    Py_INCREF(tag);
-    self->tag = tag;
-
-    Py_INCREF(Py_None);
-    self->text = Py_None;
-
-    Py_INCREF(Py_None);
-    self->tail = Py_None;
-
+    self->tag = Py_NewRef(tag);
+    self->text = Py_NewRef(Py_None);
+    self->tail = Py_NewRef(Py_None);
     self->weakreflist = NULL;
 
     PyObject_GC_Track(self);
@@ -315,15 +307,9 @@ element_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     ElementObject *e = (ElementObject *)type->tp_alloc(type, 0);
     if (e != NULL) {
-        Py_INCREF(Py_None);
-        e->tag = Py_None;
-
-        Py_INCREF(Py_None);
-        e->text = Py_None;
-
-        Py_INCREF(Py_None);
-        e->tail = Py_None;
-
+        e->tag = Py_NewRef(Py_None);
+        e->text = Py_NewRef(Py_None);
+        e->tail = Py_NewRef(Py_None);
         e->extra = NULL;
         e->weakreflist = NULL;
     }
@@ -514,8 +500,7 @@ element_add_subelement(ElementObject* self, PyObject* element)
     if (element_resize(self, 1) < 0)
         return -1;
 
-    Py_INCREF(element);
-    self->extra->children[self->extra->length] = element;
+    self->extra->children[self->extra->length] = Py_NewRef(element);
 
     self->extra->length++;
 
@@ -747,8 +732,7 @@ _elementtree_Element___copy___impl(ElementObject *self)
         }
 
         for (i = 0; i < self->extra->length; i++) {
-            Py_INCREF(self->extra->children[i]);
-            element->extra->children[i] = self->extra->children[i];
+            element->extra->children[i] = Py_NewRef(self->extra->children[i]);
         }
 
         assert(!element->extra->length);
@@ -863,8 +847,7 @@ deepcopy(PyObject *object, PyObject *memo)
 
     /* Fast paths */
     if (object == Py_None || PyUnicode_CheckExact(object)) {
-        Py_INCREF(object);
-        return object;
+        return Py_NewRef(object);
     }
 
     if (Py_REFCNT(object) == 1) {
@@ -956,8 +939,7 @@ _elementtree_Element___getstate___impl(ElementObject *self)
     }
 
     if (self->extra && self->extra->attrib) {
-        attrib = self->extra->attrib;
-        Py_INCREF(attrib);
+        attrib = Py_NewRef(self->extra->attrib);
     }
     else {
         attrib = PyDict_New();
@@ -1043,8 +1025,7 @@ element_setstate_from_attributes(ElementObject *self,
                 dealloc_extra(oldextra);
                 return NULL;
             }
-            Py_INCREF(child);
-            self->extra->children[i] = child;
+            self->extra->children[i] = Py_NewRef(child);
         }
 
         assert(!self->extra->length);
@@ -1276,8 +1257,7 @@ _elementtree_Element_findtext_impl(ElementObject *self, PyObject *path,
             );
 
     if (!self->extra) {
-        Py_INCREF(default_value);
-        return default_value;
+        return Py_NewRef(default_value);
     }
 
     for (i = 0; i < self->extra->length; i++) {
@@ -1301,8 +1281,7 @@ _elementtree_Element_findtext_impl(ElementObject *self, PyObject *path,
             return NULL;
     }
 
-    Py_INCREF(default_value);
-    return default_value;
+    return Py_NewRef(default_value);
 }
 
 /*[clinic input]
@@ -1396,8 +1375,7 @@ _elementtree_Element_get_impl(ElementObject *self, PyObject *key,
         }
     }
 
-    Py_INCREF(default_value);
-    return default_value;
+    return Py_NewRef(default_value);
 }
 
 static PyObject *
@@ -1456,8 +1434,7 @@ element_getitem(PyObject* self_, Py_ssize_t index)
         return NULL;
     }
 
-    Py_INCREF(self->extra->children[index]);
-    return self->extra->children[index];
+    return Py_NewRef(self->extra->children[index]);
 }
 
 /*[clinic input]
@@ -1495,8 +1472,7 @@ _elementtree_Element_insert_impl(ElementObject *self, Py_ssize_t index,
     for (i = self->extra->length; i > index; i--)
         self->extra->children[i] = self->extra->children[i-1];
 
-    Py_INCREF(subelement);
-    self->extra->children[index] = subelement;
+    self->extra->children[index] = Py_NewRef(subelement);
 
     self->extra->length++;
 
@@ -1697,8 +1673,7 @@ element_setitem(PyObject* self_, Py_ssize_t index, PyObject* item)
             raise_type_error(item);
             return -1;
         }
-        Py_INCREF(item);
-        self->extra->children[index] = item;
+        self->extra->children[index] = Py_NewRef(item);
     } else {
         self->extra->length--;
         for (i = index; i < self->extra->length; i++)
@@ -1929,8 +1904,7 @@ element_ass_subscr(PyObject* self_, PyObject* item, PyObject* value)
         for (cur = start, i = 0; i < newlen;
              cur += step, i++) {
             PyObject* element = PySequence_Fast_GET_ITEM(seq, i);
-            Py_INCREF(element);
-            self->extra->children[cur] = element;
+            self->extra->children[cur] = Py_NewRef(element);
         }
 
         self->extra->length += newlen - slicelen;
@@ -1953,24 +1927,21 @@ static PyObject*
 element_tag_getter(ElementObject *self, void *closure)
 {
     PyObject *res = self->tag;
-    Py_INCREF(res);
-    return res;
+    return Py_NewRef(res);
 }
 
 static PyObject*
 element_text_getter(ElementObject *self, void *closure)
 {
     PyObject *res = element_get_text(self);
-    Py_XINCREF(res);
-    return res;
+    return Py_XNewRef(res);
 }
 
 static PyObject*
 element_tail_getter(ElementObject *self, void *closure)
 {
     PyObject *res = element_get_tail(self);
-    Py_XINCREF(res);
-    return res;
+    return Py_XNewRef(res);
 }
 
 static PyObject*
@@ -1982,8 +1953,7 @@ element_attrib_getter(ElementObject *self, void *closure)
             return NULL;
     }
     res = element_get_attrib(self);
-    Py_XINCREF(res);
-    return res;
+    return Py_XNewRef(res);
 }
 
 /* macro for setter validation */
@@ -2123,8 +2093,7 @@ parent_stack_push_new(ElementIterObject *it, ElementObject *parent)
         it->parent_stack_size = new_size;
     }
     item = it->parent_stack + it->parent_stack_used++;
-    Py_INCREF(parent);
-    item->parent = parent;
+    item->parent = (ElementObject*)Py_NewRef(parent);
     item->child_index = 0;
     return 0;
 }
@@ -2291,11 +2260,9 @@ create_elementiter(ElementObject *self, PyObject *tag, int gettext)
     if (!it)
         return NULL;
 
-    Py_INCREF(tag);
-    it->sought_tag = tag;
+    it->sought_tag = Py_NewRef(tag);
     it->gettext = gettext;
-    Py_INCREF(self);
-    it->root_element = self;
+    it->root_element = (ElementObject*)Py_NewRef(self);
 
     it->parent_stack = PyMem_New(ParentLocator, INIT_PARENT_STACK_SIZE);
     if (it->parent_stack == NULL) {
@@ -2357,12 +2324,8 @@ treebuilder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     TreeBuilderObject *t = (TreeBuilderObject *)type->tp_alloc(type, 0);
     if (t != NULL) {
         t->root = NULL;
-
-        Py_INCREF(Py_None);
-        t->this = Py_None;
-        Py_INCREF(Py_None);
-        t->last = Py_None;
-
+        t->this = Py_NewRef(Py_None);
+        t->last = Py_NewRef(Py_None);
         t->data = NULL;
         t->element_factory = NULL;
         t->comment_factory = NULL;
@@ -2705,8 +2668,7 @@ treebuilder_handle_start(TreeBuilderObject* self, PyObject* tag,
                 );
             goto error;
         }
-        Py_INCREF(node);
-        self->root = node;
+        self->root = Py_NewRef(node);
     }
 
     if (self->index < PyList_GET_SIZE(self->stack)) {
@@ -2743,7 +2705,7 @@ treebuilder_handle_data(TreeBuilderObject* self, PyObject* data)
             Py_RETURN_NONE;
         }
         /* store the first item as is */
-        Py_INCREF(data); self->data = data;
+        self->data = Py_NewRef(data);
     } else {
         /* more than one item; use a list to collect items */
         if (PyBytes_CheckExact(self->data) && Py_REFCNT(self->data) == 1 &&
@@ -2789,8 +2751,7 @@ treebuilder_handle_end(TreeBuilderObject* self, PyObject* tag)
     }
 
     item = self->last;
-    self->last = self->this;
-    Py_INCREF(self->last);
+    self->last = Py_NewRef(self->this);
     Py_XSETREF(self->last_for_tail, self->last);
     self->index--;
     self->this = PyList_GET_ITEM(self->stack, self->index);
@@ -2827,8 +2788,7 @@ treebuilder_handle_comment(TreeBuilderObject* self, PyObject* text)
             Py_XSETREF(self->last_for_tail, comment);
         }
     } else {
-        Py_INCREF(text);
-        comment = text;
+        comment = Py_NewRef(text);
     }
 
     if (self->events_append && self->comment_event_obj) {
@@ -2996,8 +2956,7 @@ treebuilder_done(TreeBuilderObject* self)
     else
         res = Py_None;
 
-    Py_INCREF(res);
-    return res;
+    return Py_NewRef(res);
 }
 
 /*[clinic input]
@@ -3115,8 +3074,7 @@ makeuniversal(XMLParserObject* self, const char* string)
             size++;
         } else {
             /* plain name; use key as tag */
-            Py_INCREF(key);
-            tag = key;
+            tag = Py_NewRef(key);
         }
 
         /* decode universal name */
@@ -3505,8 +3463,7 @@ expat_start_doctype_handler(XMLParserObject *self,
             return;
         }
     } else {
-        Py_INCREF(Py_None);
-        sysid_obj = Py_None;
+        sysid_obj = Py_NewRef(Py_None);
     }
 
     if (pubid) {
@@ -3517,8 +3474,7 @@ expat_start_doctype_handler(XMLParserObject *self,
             return;
         }
     } else {
-        Py_INCREF(Py_None);
-        pubid_obj = Py_None;
+        pubid_obj = Py_NewRef(Py_None);
     }
 
     elementtreestate *st = ET_STATE_GLOBAL;
@@ -4377,8 +4333,7 @@ PyInit__elementtree(void)
 
     m = PyState_FindModule(&elementtreemodule);
     if (m) {
-        Py_INCREF(m);
-        return m;
+        return Py_NewRef(m);
     }
 
     /* Initialize object types */


### PR DESCRIPTION
Replace Py_INCREF() and Py_XINCREF() with Py_NewRef() and Py_XNewRef() in Modules/_elementtree.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99300 -->
* Issue: gh-99300
<!-- /gh-issue-number -->
