### PR TITLE
gh-99300: Use Py_NewRef() in Modules/ directory

### DIFF
--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -1524,8 +1524,7 @@ ndarray_getbuf(NDArrayObject *self, Py_buffer *view, int flags)
             return -1;
     }
 
-    view->obj = (PyObject *)self;
-    Py_INCREF(view->obj);
+    view->obj = Py_NewRef(self);
     self->head->exports++;
 
     return 0;
@@ -2021,8 +2020,7 @@ ndarray_get_obj(NDArrayObject *self, void *closure)
     if (base->obj == NULL) {
         Py_RETURN_NONE;
     }
-    Py_INCREF(base->obj);
-    return base->obj;
+    return Py_NewRef(base->obj);
 }
 
 static PyObject *
@@ -2559,8 +2557,7 @@ result:
     PyBuffer_Release(&v2);
 
     ret = equal ? Py_True : Py_False;
-    Py_INCREF(ret);
-    return ret;
+    return Py_NewRef(ret);
 }
 
 static PyObject *
@@ -2597,8 +2594,7 @@ is_contiguous(PyObject *self, PyObject *args)
         PyBuffer_Release(&view);
     }
 
-    Py_INCREF(ret);
-    return ret;
+    return Py_NewRef(ret);
 }
 
 static Py_hash_t
@@ -2748,8 +2744,7 @@ staticarray_getbuf(StaticArrayObject *self, Py_buffer *view, int flags)
         view->obj = NULL; /* Don't use this in new code. */
     }
     else {
-        view->obj = (PyObject *)self;
-        Py_INCREF(view->obj);
+        view->obj = Py_NewRef(self);
     }
 
     return 0;

--- a/Modules/_testcapi/vectorcall.c
+++ b/Modules/_testcapi/vectorcall.c
@@ -297,8 +297,7 @@ static PyObject *
 func_descr_get(PyObject *func, PyObject *obj, PyObject *type)
 {
     if (obj == Py_None || obj == NULL) {
-        Py_INCREF(func);
-        return func;
+        return Py_NewRef(func);
     }
     return PyMethod_New(func, obj);
 }
@@ -306,15 +305,13 @@ func_descr_get(PyObject *func, PyObject *obj, PyObject *type)
 static PyObject *
 nop_descr_get(PyObject *func, PyObject *obj, PyObject *type)
 {
-    Py_INCREF(func);
-    return func;
+    return Py_NewRef(func);
 }
 
 static PyObject *
 call_return_args(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    Py_INCREF(args);
-    return args;
+    return Py_NewRef(args);
 }
 
 static PyTypeObject MethodDescriptorBase_Type = {

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -342,8 +342,7 @@ dict_getitem_knownhash(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    Py_XINCREF(result);
-    return result;
+    return Py_XNewRef(result);
 }
 
 /* Issue #4701: Check that PyObject_Hash implicitly calls
@@ -1242,8 +1241,7 @@ get_args(PyObject *self, PyObject *args)
     if (args == NULL) {
         args = Py_None;
     }
-    Py_INCREF(args);
-    return args;
+    return Py_NewRef(args);
 }
 
 static PyObject *
@@ -1252,8 +1250,7 @@ get_kwargs(PyObject *self, PyObject *args, PyObject *kwargs)
     if (kwargs == NULL) {
         kwargs = Py_None;
     }
-    Py_INCREF(kwargs);
-    return kwargs;
+    return Py_NewRef(kwargs);
 }
 
 /* Test tuple argument processing */
@@ -1514,8 +1511,7 @@ getargs_S(PyObject *self, PyObject *args)
     PyObject *obj;
     if (!PyArg_ParseTuple(args, "S", &obj))
         return NULL;
-    Py_INCREF(obj);
-    return obj;
+    return Py_NewRef(obj);
 }
 
 static PyObject *
@@ -1524,8 +1520,7 @@ getargs_Y(PyObject *self, PyObject *args)
     PyObject *obj;
     if (!PyArg_ParseTuple(args, "Y", &obj))
         return NULL;
-    Py_INCREF(obj);
-    return obj;
+    return Py_NewRef(obj);
 }
 
 static PyObject *
@@ -1534,8 +1529,7 @@ getargs_U(PyObject *self, PyObject *args)
     PyObject *obj;
     if (!PyArg_ParseTuple(args, "U", &obj))
         return NULL;
-    Py_INCREF(obj);
-    return obj;
+    return Py_NewRef(obj);
 }
 
 static PyObject *
@@ -1609,8 +1603,7 @@ getargs_z_star(PyObject *self, PyObject *args)
     if (buffer.buf != NULL)
         bytes = PyBytes_FromStringAndSize(buffer.buf, buffer.len);
     else {
-        Py_INCREF(Py_None);
-        bytes = Py_None;
+        bytes = Py_NewRef(Py_None);
     }
     PyBuffer_Release(&buffer);
     return bytes;
@@ -1873,8 +1866,7 @@ parse_tuple_and_keywords(PyObject *self, PyObject *args)
         buffers + 4, buffers + 5, buffers + 6, buffers + 7);
 
     if (result) {
-        return_value = Py_None;
-        Py_INCREF(Py_None);
+        return_value = Py_NewRef(Py_None);
     }
 
 exit:
@@ -2193,11 +2185,9 @@ get_timezone_utc_capi(PyObject* self, PyObject *args) {
         return NULL;
     }
     if (macro) {
-        Py_INCREF(PyDateTime_TimeZone_UTC);
-        return PyDateTime_TimeZone_UTC;
+        return Py_NewRef(PyDateTime_TimeZone_UTC);
     } else {
-        Py_INCREF(PyDateTimeAPI->TimeZone_UTC);
-        return PyDateTimeAPI->TimeZone_UTC;
+        return Py_NewRef(PyDateTimeAPI->TimeZone_UTC);
     }
 }
 
@@ -2984,8 +2974,7 @@ failing_converter(PyObject *obj, void *arg)
 {
     /* Clone str1, then let the conversion fail. */
     assert(str1);
-    str2 = str1;
-    Py_INCREF(str2);
+    str2 = Py_NewRef(str1);
     return 0;
 }
 static PyObject*
@@ -3428,8 +3417,7 @@ with_tp_del(PyObject *self, PyObject *args)
         return NULL;
     }
     tp->tp_del = slot_tp_del;
-    Py_INCREF(obj);
-    return obj;
+    return Py_NewRef(obj);
 }
 
 static PyObject *
@@ -3447,8 +3435,7 @@ without_gc(PyObject *Py_UNUSED(self), PyObject *obj)
         tp->tp_clear = NULL;
     }
     assert(!PyType_IS_GC(tp));
-    Py_INCREF(obj);
-    return obj;
+    return Py_NewRef(obj);
 }
 
 static PyMethodDef ml;
@@ -3469,8 +3456,7 @@ static PyMethodDef ml = {
 static PyObject *
 _test_incref(PyObject *ob)
 {
-    Py_INCREF(ob);
-    return ob;
+    return Py_NewRef(ob);
 }
 
 static PyObject *
@@ -3817,8 +3803,7 @@ test_setallocators(PyMemAllocatorDomain domain)
         goto fail;
     }
 
-    Py_INCREF(Py_None);
-    res = Py_None;
+    res = Py_NewRef(Py_None);
     goto finally;
 
 fail:
@@ -4078,8 +4063,7 @@ call_in_temporary_c_thread(PyObject *self, PyObject *callback)
         goto exit;
     }
 
-    Py_INCREF(callback);
-    test_c_thread.callback = callback;
+    test_c_thread.callback = Py_NewRef(callback);
 
     PyThread_acquire_lock(test_c_thread.start_event, 1);
     PyThread_acquire_lock(test_c_thread.exit_event, 1);
@@ -4100,8 +4084,7 @@ call_in_temporary_c_thread(PyObject *self, PyObject *callback)
         PyThread_release_lock(test_c_thread.exit_event);
     Py_END_ALLOW_THREADS
 
-    Py_INCREF(Py_None);
-    res = Py_None;
+    res = Py_NewRef(Py_None);
 
 exit:
     Py_CLEAR(test_c_thread.callback);
@@ -5037,8 +5020,7 @@ _null_to_none(PyObject* obj)
     if (obj == NULL) {
         Py_RETURN_NONE;
     }
-    Py_INCREF(obj);
-    return obj;
+    return Py_NewRef(obj);
 }
 
 static PyObject*
@@ -5554,8 +5536,7 @@ get_dict_watcher_events(PyObject *self, PyObject *Py_UNUSED(args))
         PyErr_SetString(PyExc_RuntimeError, "no watchers active");
         return NULL;
     }
-    Py_INCREF(g_dict_watch_events);
-    return g_dict_watch_events;
+    return Py_NewRef(g_dict_watch_events);
 }
 
 
@@ -5924,8 +5905,7 @@ function_get_code(PyObject *self, PyObject *func)
 {
     PyObject *code = PyFunction_GetCode(func);
     if (code != NULL) {
-        Py_INCREF(code);
-        return code;
+        return Py_NewRef(code);
     } else {
         return NULL;
     }
@@ -5936,8 +5916,7 @@ function_get_globals(PyObject *self, PyObject *func)
 {
     PyObject *globals = PyFunction_GetGlobals(func);
     if (globals != NULL) {
-        Py_INCREF(globals);
-        return globals;
+        return Py_NewRef(globals);
     } else {
         return NULL;
     }
@@ -5948,8 +5927,7 @@ function_get_module(PyObject *self, PyObject *func)
 {
     PyObject *module = PyFunction_GetModule(func);
     if (module != NULL) {
-        Py_INCREF(module);
-        return module;
+        return Py_NewRef(module);
     } else {
         return NULL;
     }
@@ -5960,8 +5938,7 @@ function_get_defaults(PyObject *self, PyObject *func)
 {
     PyObject *defaults = PyFunction_GetDefaults(func);
     if (defaults != NULL) {
-        Py_INCREF(defaults);
-        return defaults;
+        return Py_NewRef(defaults);
     } else if (PyErr_Occurred()) {
         return NULL;
     } else {
@@ -5987,8 +5964,7 @@ function_get_kw_defaults(PyObject *self, PyObject *func)
 {
     PyObject *defaults = PyFunction_GetKwDefaults(func);
     if (defaults != NULL) {
-        Py_INCREF(defaults);
-        return defaults;
+        return Py_NewRef(defaults);
     } else if (PyErr_Occurred()) {
         return NULL;
     } else {
@@ -6099,8 +6075,7 @@ get_type_modified_events(PyObject *self, PyObject *Py_UNUSED(args))
         PyErr_SetString(PyExc_RuntimeError, "no watchers active");
         return NULL;
     }
-    Py_INCREF(g_type_modified_events);
-    return g_type_modified_events;
+    return Py_NewRef(g_type_modified_events);
 }
 
 static PyObject *
@@ -6729,8 +6704,7 @@ awaitObject_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    Py_INCREF(v);
-    ao->ao_iterator = v;
+    ao->ao_iterator = Py_NewRef(v);
 
     return (PyObject *)ao;
 }
@@ -6747,8 +6721,7 @@ awaitObject_dealloc(awaitObject *ao)
 static PyObject *
 awaitObject_await(awaitObject *ao)
 {
-    Py_INCREF(ao->ao_iterator);
-    return ao->ao_iterator;
+    return Py_NewRef(ao->ao_iterator);
 }
 
 static PyAsyncMethods awaitType_as_async = {
@@ -6969,8 +6942,7 @@ generic_alias_new(PyObject *item)
     if (o == NULL) {
         return NULL;
     }
-    Py_INCREF(item);
-    o->item = item;
+    o->item = Py_NewRef(item);
     return (PyObject*) o;
 }
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -524,8 +524,7 @@ set_eval_frame_record(PyObject *self, PyObject *list)
         return NULL;
     }
     Py_CLEAR(record_list);
-    Py_INCREF(list);
-    record_list = list;
+    record_list = Py_NewRef(list);
     _PyInterpreterState_SetEvalFrameFunc(PyInterpreterState_Get(), record_eval);
     Py_RETURN_NONE;
 }

--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -57,8 +57,7 @@ Example_demo(ExampleObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "|O:demo", &o))
         return NULL;
     if (o != NULL && PyUnicode_Check(o)) {
-        Py_INCREF(o);
-        return o;
+        return Py_NewRef(o);
     }
     Py_RETURN_NONE;
 }
@@ -77,8 +76,7 @@ Example_getattro(ExampleObject *self, PyObject *name)
     if (self->x_attr != NULL) {
         PyObject *v = PyDict_GetItemWithError(self->x_attr, name);
         if (v != NULL) {
-            Py_INCREF(v);
-            return v;
+            return Py_NewRef(v);
         }
         else if (PyErr_Occurred()) {
             return NULL;
@@ -151,8 +149,7 @@ _testmultiphase_StateAccessType_get_defining_module_impl(StateAccessTypeObject *
         return NULL;
     }
     assert(PyType_GetModuleByDef(Py_TYPE(self), &def_meth_state_access) == retval);
-    Py_INCREF(retval);
-    return retval;
+    return Py_NewRef(retval);
 }
 
 /*[clinic input]

--- a/Modules/testcapi_long.h
+++ b/Modules/testcapi_long.h
@@ -202,6 +202,5 @@ TESTNAME(PyObject *error(const char*))
         Py_DECREF(Py_None);
     }
 
-    Py_INCREF(Py_None);
-    return Py_None;
+    return Py_NewRef(Py_None);
 }


### PR DESCRIPTION
Replace Py_INCREF() and Py_XINCREF() with Py_NewRef() and Py_XNewRef() in test C files of the Modules/ directory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99300 -->
* Issue: gh-99300
<!-- /gh-issue-number -->
