### PR TITLE
gh-99300: Use Py_NewRef() in Modules/_datetimemodule.c

### DIFF
--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -189,8 +189,7 @@ divide_nearest(PyObject *m, PyObject *n)
     temp = _PyLong_DivmodNear(m, n);
     if (temp == NULL)
         return NULL;
-    result = PyTuple_GET_ITEM(temp, 0);
-    Py_INCREF(result);
+    result = Py_NewRef(PyTuple_GET_ITEM(temp, 0));
     Py_DECREF(temp);
 
     return result;
@@ -1005,8 +1004,7 @@ new_datetime_ex2(int year, int month, int day, int hour, int minute,
         DATE_SET_SECOND(self, second);
         DATE_SET_MICROSECOND(self, usecond);
         if (aware) {
-            Py_INCREF(tzinfo);
-            self->tzinfo = tzinfo;
+            self->tzinfo = Py_NewRef(tzinfo);
         }
         DATE_SET_FOLD(self, fold);
     }
@@ -1083,8 +1081,7 @@ new_time_ex2(int hour, int minute, int second, int usecond,
         TIME_SET_SECOND(self, second);
         TIME_SET_MICROSECOND(self, usecond);
         if (aware) {
-            Py_INCREF(tzinfo);
-            self->tzinfo = tzinfo;
+            self->tzinfo = Py_NewRef(tzinfo);
         }
         TIME_SET_FOLD(self, fold);
     }
@@ -1165,10 +1162,8 @@ create_timezone(PyObject *offset, PyObject *name)
     if (self == NULL) {
         return NULL;
     }
-    Py_INCREF(offset);
-    self->offset = offset;
-    Py_XINCREF(name);
-    self->name = name;
+    self->offset = Py_NewRef(offset);
+    self->name = Py_XNewRef(name);
     return (PyObject *)self;
 }
 
@@ -1182,8 +1177,7 @@ new_timezone(PyObject *offset, PyObject *name)
     assert(name == NULL || PyUnicode_Check(name));
 
     if (name == NULL && delta_bool((PyDateTime_Delta *)offset) == 0) {
-        Py_INCREF(PyDateTime_TimeZone_UTC);
-        return PyDateTime_TimeZone_UTC;
+        return Py_NewRef(PyDateTime_TimeZone_UTC);
     }
     if ((GET_TD_DAYS(offset) == -1 &&
             GET_TD_SECONDS(offset) == 0 &&
@@ -1397,8 +1391,7 @@ tzinfo_from_isoformat_results(int rv, int tzoffset, int tz_useconds)
     if (rv == 1) {
         // Create a timezone from offset in seconds (0 returns UTC)
         if (tzoffset == 0) {
-            Py_INCREF(PyDateTime_TimeZone_UTC);
-            return PyDateTime_TimeZone_UTC;
+            return Py_NewRef(PyDateTime_TimeZone_UTC);
         }
 
         PyObject *delta = new_delta(0, tzoffset, tz_useconds, 1);
@@ -1409,8 +1402,7 @@ tzinfo_from_isoformat_results(int rv, int tzoffset, int tz_useconds)
         Py_DECREF(delta);
     }
     else {
-        tzinfo = Py_None;
-        Py_INCREF(Py_None);
+        tzinfo = Py_NewRef(Py_None);
     }
 
     return tzinfo;
@@ -1943,8 +1935,7 @@ microseconds_to_delta_ex(PyObject *pyus, PyTypeObject *type)
         goto BadDivmod;
     }
 
-    num = PyTuple_GET_ITEM(tuple, 0);           /* leftover seconds */
-    Py_INCREF(num);
+    num = Py_NewRef(PyTuple_GET_ITEM(tuple, 0));        /* leftover seconds */
     Py_DECREF(tuple);
 
     tuple = checked_divmod(num, seconds_per_day);
@@ -1962,8 +1953,7 @@ microseconds_to_delta_ex(PyObject *pyus, PyTypeObject *type)
         goto BadDivmod;
     }
 
-    num = PyTuple_GET_ITEM(tuple, 0);           /* leftover days */
-    Py_INCREF(num);
+    num = Py_NewRef(PyTuple_GET_ITEM(tuple, 0));           /* leftover days */
     d = _PyLong_AsInt(num);
     if (d == -1 && PyErr_Occurred()) {
         goto Done;
@@ -3346,8 +3336,7 @@ iso_calendar_date_year(PyDateTime_IsoCalendarDate *self, void *unused)
     if (year == NULL) {
         return NULL;
     }
-    Py_INCREF(year);
-    return year;
+    return Py_NewRef(year);
 }
 
 static PyObject *
@@ -3357,8 +3346,7 @@ iso_calendar_date_week(PyDateTime_IsoCalendarDate *self, void *unused)
     if (week == NULL) {
         return NULL;
     }
-    Py_INCREF(week);
-    return week;
+    return Py_NewRef(week);
 }
 
 static PyObject *
@@ -3368,8 +3356,7 @@ iso_calendar_date_weekday(PyDateTime_IsoCalendarDate *self, void *unused)
     if (weekday == NULL) {
         return NULL;
     }
-    Py_INCREF(weekday);
-    return weekday;
+    return Py_NewRef(weekday);
 }
 
 static PyGetSetDef iso_calendar_date_getset[] = {
@@ -3980,8 +3967,7 @@ timezone_str(PyDateTime_TimeZone *self)
     char sign;
 
     if (self->name != NULL) {
-        Py_INCREF(self->name);
-        return self->name;
+        return Py_NewRef(self->name);
     }
     if ((PyObject *)self == PyDateTime_TimeZone_UTC ||
            (GET_TD_DAYS(self->offset) == 0 &&
@@ -3997,8 +3983,7 @@ timezone_str(PyDateTime_TimeZone *self)
     }
     else {
         sign = '+';
-        offset = self->offset;
-        Py_INCREF(offset);
+        offset = Py_NewRef(self->offset);
     }
     /* Offset is not negative here. */
     microseconds = GET_TD_MICROSECONDS(offset);
@@ -4033,8 +4018,7 @@ timezone_utcoffset(PyDateTime_TimeZone *self, PyObject *dt)
     if (_timezone_check_argument(dt, "utcoffset") == -1)
         return NULL;
 
-    Py_INCREF(self->offset);
-    return self->offset;
+    return Py_NewRef(self->offset);
 }
 
 static PyObject *
@@ -4171,8 +4155,7 @@ static PyObject *
 time_tzinfo(PyDateTime_Time *self, void *unused)
 {
     PyObject *result = HASTZINFO(self) ? self->tzinfo : Py_None;
-    Py_INCREF(result);
-    return result;
+    return Py_NewRef(result);
 }
 
 static PyObject *
@@ -4217,8 +4200,7 @@ time_from_pickle(PyTypeObject *type, PyObject *state, PyObject *tzinfo)
         me->hashcode = -1;
         me->hastzinfo = aware;
         if (aware) {
-            Py_INCREF(tzinfo);
-            me->tzinfo = tzinfo;
+            me->tzinfo = Py_NewRef(tzinfo);
         }
         if (pdata[0] & (1 << 7)) {
             me->data[0] -= 128;
@@ -4514,12 +4496,10 @@ time_richcompare(PyObject *self, PyObject *other, int op)
         result = diff_to_bool(diff, op);
     }
     else if (op == Py_EQ) {
-        result = Py_False;
-        Py_INCREF(result);
+        result = Py_NewRef(Py_False);
     }
     else if (op == Py_NE) {
-        result = Py_True;
-        Py_INCREF(result);
+        result = Py_NewRef(Py_True);
     }
     else {
         PyErr_SetString(PyExc_TypeError,
@@ -4548,8 +4528,7 @@ time_hash(PyDateTime_Time *self)
                 return -1;
         }
         else {
-            self0 = (PyObject *)self;
-            Py_INCREF(self0);
+            self0 = Py_NewRef(self);
         }
         offset = time_utcoffset(self0, NULL);
         Py_DECREF(self0);
@@ -4846,8 +4825,7 @@ static PyObject *
 datetime_tzinfo(PyDateTime_DateTime *self, void *unused)
 {
     PyObject *result = HASTZINFO(self) ? self->tzinfo : Py_None;
-    Py_INCREF(result);
-    return result;
+    return Py_NewRef(result);
 }
 
 static PyObject *
@@ -4894,8 +4872,7 @@ datetime_from_pickle(PyTypeObject *type, PyObject *state, PyObject *tzinfo)
         me->hashcode = -1;
         me->hastzinfo = aware;
         if (aware) {
-            Py_INCREF(tzinfo);
-            me->tzinfo = tzinfo;
+            me->tzinfo = Py_NewRef(tzinfo);
         }
         if (pdata[2] & (1 << 7)) {
             me->data[2] -= 128;
@@ -5307,8 +5284,7 @@ _sanitize_isoformat_str(PyObject *dtstr)
     }
 
     if (surrogate_separator == 0) {
-        Py_INCREF(dtstr);
-        return dtstr;
+        return Py_NewRef(dtstr);
     }
 
     PyObject *str_out = _PyUnicode_Copy(dtstr);
@@ -5622,9 +5598,8 @@ datetime_subtract(PyObject *left, PyObject *right)
             int delta_d, delta_s, delta_us;
 
             if (GET_DT_TZINFO(left) == GET_DT_TZINFO(right)) {
-                offset2 = offset1 = Py_None;
-                Py_INCREF(offset1);
-                Py_INCREF(offset2);
+                offset1 = Py_NewRef(Py_None);
+                offset2 = Py_NewRef(Py_None);
             }
             else {
                 offset1 = datetime_utcoffset(left, NULL);
@@ -5969,12 +5944,10 @@ datetime_richcompare(PyObject *self, PyObject *other, int op)
         result = diff_to_bool(diff, op);
     }
     else if (op == Py_EQ) {
-        result = Py_False;
-        Py_INCREF(result);
+        result = Py_NewRef(Py_False);
     }
     else if (op == Py_NE) {
-        result = Py_True;
-        Py_INCREF(result);
+        result = Py_NewRef(Py_True);
     }
     else {
         PyErr_SetString(PyExc_TypeError,
@@ -6006,8 +5979,7 @@ datetime_hash(PyDateTime_DateTime *self)
                 return -1;
         }
         else {
-            self0 = (PyObject *)self;
-            Py_INCREF(self0);
+            self0 = Py_NewRef(self);
         }
         offset = datetime_utcoffset(self0, NULL);
         Py_DECREF(self0);
@@ -6224,15 +6196,13 @@ datetime_astimezone(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
         if (self_tzinfo == NULL)
             return NULL;
     } else {
-        self_tzinfo = self->tzinfo;
-        Py_INCREF(self_tzinfo);
+        self_tzinfo = Py_NewRef(self->tzinfo);
     }
 
     /* Conversion to self's own time zone is a NOP. */
     if (self_tzinfo == tzinfo) {
         Py_DECREF(self_tzinfo);
-        Py_INCREF(self);
-        return self;
+        return (PyDateTime_DateTime*)Py_NewRef(self);
     }
 
     /* Convert self to UTC. */
@@ -6278,8 +6248,7 @@ datetime_astimezone(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
     else {
         /* Result is already aware - just replace tzinfo. */
         temp = result->tzinfo;
-        result->tzinfo = PyDateTime_TimeZone_UTC;
-        Py_INCREF(result->tzinfo);
+        result->tzinfo = Py_NewRef(PyDateTime_TimeZone_UTC);
         Py_DECREF(temp);
     }
 
@@ -6449,8 +6418,7 @@ datetime_utctimetuple(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 
     tzinfo = GET_DT_TZINFO(self);
     if (tzinfo == Py_None) {
-        utcself = self;
-        Py_INCREF(utcself);
+        utcself = (PyDateTime_DateTime*)Py_NewRef(self);
     }
     else {
         PyObject *offset;
@@ -6459,8 +6427,7 @@ datetime_utctimetuple(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
             return NULL;
         if (offset == Py_None) {
             Py_DECREF(offset);
-            utcself = self;
-            Py_INCREF(utcself);
+            utcself = (PyDateTime_DateTime*)Py_NewRef(self);
         }
         else {
             utcself = (PyDateTime_DateTime *)add_datetime_timedelta(self,

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -227,8 +227,7 @@ zoneinfo_new_instance(PyTypeObject *type, PyObject *key)
     }
     Py_DECREF(rv);
 
-    ((PyZoneInfo_ZoneInfo *)self)->key = key;
-    Py_INCREF(key);
+    ((PyZoneInfo_ZoneInfo *)self)->key = Py_NewRef(key);
 
     goto cleanup;
 error:
@@ -381,10 +380,9 @@ zoneinfo_ZoneInfo_from_file_impl(PyTypeObject *type, PyObject *file_obj,
 
     self->source = SOURCE_FILE;
     self->file_repr = file_repr;
-    self->key = key;
-    Py_INCREF(key);
-
+    self->key = Py_NewRef(key);
     return obj_self;
+
 error:
     Py_XDECREF(file_repr);
     Py_XDECREF(self);
@@ -484,8 +482,7 @@ zoneinfo_utcoffset(PyObject *self, PyObject *dt)
     if (tti == NULL) {
         return NULL;
     }
-    Py_INCREF(tti->utcoff);
-    return tti->utcoff;
+    return Py_NewRef(tti->utcoff);
 }
 
 static PyObject *
@@ -495,8 +492,7 @@ zoneinfo_dst(PyObject *self, PyObject *dt)
     if (tti == NULL) {
         return NULL;
     }
-    Py_INCREF(tti->dstoff);
-    return tti->dstoff;
+    return Py_NewRef(tti->dstoff);
 }
 
 static PyObject *
@@ -506,8 +502,7 @@ zoneinfo_tzname(PyObject *self, PyObject *dt)
     if (tti == NULL) {
         return NULL;
     }
-    Py_INCREF(tti->tzname);
-    return tti->tzname;
+    return Py_NewRef(tti->tzname);
 }
 
 #define GET_DT_TZINFO PyDateTime_DATE_GET_TZINFO
@@ -651,8 +646,7 @@ static PyObject *
 zoneinfo_str(PyZoneInfo_ZoneInfo *self)
 {
     if (!(self->key == Py_None)) {
-        Py_INCREF(self->key);
-        return self->key;
+        return Py_NewRef(self->key);
     }
     else {
         return zoneinfo_repr(self);
@@ -793,8 +787,7 @@ build_ttinfo(long utcoffset, long dstoffset, PyObject *tzname, _ttinfo *out)
         return -1;
     }
 
-    out->tzname = tzname;
-    Py_INCREF(tzname);
+    out->tzname = Py_NewRef(tzname);
 
     return 0;
 }
@@ -1082,8 +1075,7 @@ load_data(PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
         if (PyObject_IsTrue(tti->dstoff)) {
             _ttinfo *tti_after = &(self->tzrule_after.std);
             Py_DECREF(tti_after->dstoff);
-            tti_after->dstoff = tti->dstoff;
-            Py_INCREF(tti_after->dstoff);
+            tti_after->dstoff = Py_NewRef(tti->dstoff);
         }
     }
 
@@ -2285,13 +2277,10 @@ strong_cache_node_new(PyObject *key, PyObject *zone)
         return NULL;
     }
 
-    Py_INCREF(key);
-    Py_INCREF(zone);
-
     node->next = NULL;
     node->prev = NULL;
-    node->key = key;
-    node->zone = zone;
+    node->key = Py_NewRef(key);
+    node->zone = Py_NewRef(zone);
 
     return node;
 }
@@ -2443,8 +2432,7 @@ zone_from_strong_cache(const PyTypeObject *const type, PyObject *const key)
 
     if (node != NULL) {
         move_strong_cache_node_to_front(&ZONEINFO_STRONG_CACHE, node);
-        Py_INCREF(node->zone);
-        return node->zone;
+        return Py_NewRef(node->zone);
     }
 
     return NULL;  // Cache miss
@@ -2679,13 +2667,9 @@ zoneinfomodule_exec(PyObject *m)
     }
 
     if (NO_TTINFO.utcoff == NULL) {
-        NO_TTINFO.utcoff = Py_None;
-        NO_TTINFO.dstoff = Py_None;
-        NO_TTINFO.tzname = Py_None;
-
-        for (size_t i = 0; i < 3; ++i) {
-            Py_INCREF(Py_None);
-        }
+        NO_TTINFO.utcoff = Py_NewRef(Py_None);
+        NO_TTINFO.dstoff = Py_NewRef(Py_None);
+        NO_TTINFO.tzname = Py_NewRef(Py_None);
     }
 
     if (initialize_caches()) {


### PR DESCRIPTION
Replace Py_INCREF() and Py_XINCREF() with Py_NewRef() and Py_XNewRef() in Modules/_datetimemodule.c and Modules/_zoneinfo.c

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99300 -->
* Issue: gh-99300
<!-- /gh-issue-number -->
