### PR TITLE
gh-99337: Fix compile errors with gcc 12 on macOS

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-11-15-08-40-22.gh-issue-99337.5LoQDE.rst
+++ b/Misc/NEWS.d/next/Build/2022-11-15-08-40-22.gh-issue-99337.5LoQDE.rst
@@ -1,0 +1,1 @@
+Fix a compilation issue with GCC 12 on macOS.

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -26,6 +26,14 @@
 #include <alloca.h>
 #endif
 
+#ifdef __APPLE__
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_available)
+#define HAVE_BUILTIN_AVAILABLE 1
+#endif
+#endif
+#endif
+
 /**************************************************************/
 
 static void
@@ -403,9 +411,15 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
                      "ffi_prep_cif failed with %d", result);
         goto error;
     }
+
+
 #if HAVE_FFI_PREP_CLOSURE_LOC
 #   ifdef USING_APPLE_OS_LIBFFI
+#    ifdef HAVE_BUILTIN_AVAILABLE
 #      define HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
+#    else
+#      define HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME (ffi_prep_closure_loc != NULL)
+#    endif
 #   else
 #      define HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME 1
 #   endif

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -26,14 +26,6 @@
 #include <alloca.h>
 #endif
 
-#ifdef __APPLE__
-#if defined(__has_builtin)
-#if __has_builtin(__builtin_available)
-#define HAVE_BUILTIN_AVAILABLE 1
-#endif
-#endif
-#endif
-
 /**************************************************************/
 
 static void

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -101,6 +101,13 @@
 
 #define CTYPES_CAPSULE_NAME_PYMEM "_ctypes pymem"
 
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_available)
+#define HAVE_BUILTIN_AVAILABLE 1
+#endif
+#endif
+
+
 static void pymem_destructor(PyObject *ptr)
 {
     void *p = PyCapsule_GetPointer(ptr, CTYPES_CAPSULE_NAME_PYMEM);
@@ -831,7 +838,11 @@ static int _call_function_pointer(int flags,
 #endif
 
 #   ifdef USING_APPLE_OS_LIBFFI
+#    ifdef HAVE_BUILTIN_AVAILABLE
 #      define HAVE_FFI_PREP_CIF_VAR_RUNTIME __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
+#    else
+#      define HAVE_FFI_PREP_CIF_VAR_RUNTIME (ffi_prep_cif_var != NULL)
+#    endif
 #   elif HAVE_FFI_PREP_CIF_VAR
 #      define HAVE_FFI_PREP_CIF_VAR_RUNTIME true
 #   else
@@ -1444,8 +1455,13 @@ copy_com_pointer(PyObject *self, PyObject *args)
 #else
 #ifdef __APPLE__
 #ifdef HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH
-#define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH_RUNTIME \
-    __builtin_available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+#  ifdef HAVE_BUILTIN_AVAILABLE
+#    define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH_RUNTIME \
+        __builtin_available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+#  else
+#    define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH_RUNTIME \
+         (_dyld_shared_cache_contains_path != NULL)
+#  endif
 #else
 // Support the deprecated case of compiling on an older macOS version
 static void *libsystem_b_handle;

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -101,12 +101,6 @@
 
 #define CTYPES_CAPSULE_NAME_PYMEM "_ctypes pymem"
 
-#if defined(__has_builtin)
-#if __has_builtin(__builtin_available)
-#define HAVE_BUILTIN_AVAILABLE 1
-#endif
-#endif
-
 
 static void pymem_destructor(PyObject *ptr)
 {

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -26,6 +26,12 @@
   #endif
 #endif
 
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_available)
+#define HAVE_BUILTIN_AVAILABLE 1
+#endif
+#endif
+
 typedef struct tagPyCArgObject PyCArgObject;
 typedef struct tagCDataObject CDataObject;
 typedef PyObject *(* GETFUNC)(void *, Py_ssize_t size);

--- a/Modules/_ctypes/malloc_closure.c
+++ b/Modules/_ctypes/malloc_closure.c
@@ -23,12 +23,6 @@
 
 /* #define MALLOC_CLOSURE_DEBUG */ /* enable for some debugging output */
 
-#if defined(__has_builtin)
-#if __has_builtin(__builtin_available)
-#define HAVE_BUILTIN_AVAILABLE 1
-#endif
-#endif
-
 
 /******************************************************************/
 

--- a/Modules/_ctypes/malloc_closure.c
+++ b/Modules/_ctypes/malloc_closure.c
@@ -23,6 +23,13 @@
 
 /* #define MALLOC_CLOSURE_DEBUG */ /* enable for some debugging output */
 
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_available)
+#define HAVE_BUILTIN_AVAILABLE 1
+#endif
+#endif
+
+
 /******************************************************************/
 
 typedef union _tagITEM {
@@ -96,7 +103,11 @@ void Py_ffi_closure_free(void *p)
 {
 #ifdef HAVE_FFI_CLOSURE_ALLOC
 #ifdef USING_APPLE_OS_LIBFFI
+# ifdef HAVE_BUILTIN_AVAILABLE
     if (__builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)) {
+#  else
+    if (&ffi_closure_free != NULL) {
+#  endif
 #endif
         ffi_closure_free(p);
         return;
@@ -114,7 +125,11 @@ void *Py_ffi_closure_alloc(size_t size, void** codeloc)
 {
 #ifdef HAVE_FFI_CLOSURE_ALLOC
 #ifdef USING_APPLE_OS_LIBFFI
+# ifdef HAVE_BUILTIN_AVAILABLE
     if (__builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)) {
+# else
+    if (ffi_closure_alloc != NULL) {
+#  endif
 #endif
         return ffi_closure_alloc(size, codeloc);
 #ifdef USING_APPLE_OS_LIBFFI

--- a/Modules/_ctypes/malloc_closure.c
+++ b/Modules/_ctypes/malloc_closure.c
@@ -100,7 +100,7 @@ void Py_ffi_closure_free(void *p)
 # ifdef HAVE_BUILTIN_AVAILABLE
     if (__builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)) {
 #  else
-    if (&ffi_closure_free != NULL) {
+    if (ffi_closure_free != NULL) {
 #  endif
 #endif
         ffi_closure_free(p);

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -154,6 +154,18 @@
 #    define HAVE_SYMLINKAT_RUNTIME (symlinkat != NULL)
 #  endif
 
+#  ifdef HAVE_UTIMENSAT
+#    define HAVE_UTIMENSAT_RUNTIME (utimensat != NULL)
+#  endif
+
+#  ifdef HAVE_FUTIMENS
+#    define HAVE_FUTIMENS_RUNTIME (futimens != NULL)
+#  endif
+
+#  ifdef HAVE_PWRITEV
+#    define HAVE_PWRITEV_RUNTIME (pwritev != NULL)
+#  endif
+
 #endif
 
 #ifdef HAVE_FUTIMESAT
@@ -9842,7 +9854,7 @@ os_preadv_impl(PyObject *module, int fd, PyObject *buffers, Py_off_t offset,
     } while (n < 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
 #else
     do {
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__clang__)
 /* This entire function will be removed from the module dict when the API
  * is not available.
  */
@@ -9857,7 +9869,7 @@ os_preadv_impl(PyObject *module, int fd, PyObject *buffers, Py_off_t offset,
         Py_END_ALLOW_THREADS
     } while (n < 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__clang__)
 #pragma clang diagnostic pop
 #endif
 
@@ -10484,7 +10496,7 @@ os_pwritev_impl(PyObject *module, int fd, PyObject *buffers, Py_off_t offset,
     } while (result < 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
 #else
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__clang__)
 /* This entire function will be removed from the module dict when the API
  * is not available.
  */
@@ -10500,7 +10512,7 @@ os_pwritev_impl(PyObject *module, int fd, PyObject *buffers, Py_off_t offset,
         Py_END_ALLOW_THREADS
     } while (result < 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__clang__)
 #pragma clang diagnostic pop
 #endif
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -83,6 +83,8 @@ int _Py_UnhandledKeyboardInterrupt = 0;
  * found without any external information. This is meant to ease access to the
  * interpreter state for various runtime debugging tools, but is *not* an
  * officially supported feature */
+_Py_COMP_DIAG_PUSH
+_Py_COMP_DIAG_IGNORE_DEPR_DECLS
 
 #if defined(MS_WINDOWS)
 
@@ -98,8 +100,6 @@ __attribute__((
 #endif
 
 /* Suppress deprecation warning for PyBytesObject.ob_shash */
-_Py_COMP_DIAG_PUSH
-_Py_COMP_DIAG_IGNORE_DEPR_DECLS
 _PyRuntimeState _PyRuntime
 #if defined(__linux__) && (defined(__GNUC__) || defined(__clang__))
 __attribute__ ((section (".PyRuntime")))

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -83,6 +83,8 @@ int _Py_UnhandledKeyboardInterrupt = 0;
  * found without any external information. This is meant to ease access to the
  * interpreter state for various runtime debugging tools, but is *not* an
  * officially supported feature */
+
+/* Suppress deprecation warning for PyBytesObject.ob_shash */
 _Py_COMP_DIAG_PUSH
 _Py_COMP_DIAG_IGNORE_DEPR_DECLS
 
@@ -99,7 +101,6 @@ __attribute__((
 
 #endif
 
-/* Suppress deprecation warning for PyBytesObject.ob_shash */
 _PyRuntimeState _PyRuntime
 #if defined(__linux__) && (defined(__GNUC__) || defined(__clang__))
 __attribute__ ((section (".PyRuntime")))


### PR DESCRIPTION
When compiling with GCC 12 on a macOS 12 system I get three groups of errors:

1. In pylifecycle.c the compile rejects _Pragma within a declaration
2. posixmodule.c was missing a number of ..._RUNTIME macros for non-clang on macOS
3. _ctypes assumed that __builtin_available is always present on macOS

<!-- gh-issue-number: gh-99337 -->
* Issue: gh-99337
<!-- /gh-issue-number -->
