### PR TITLE
gh-94808: improve coverage of number formatting

### DIFF
--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -1570,7 +1570,7 @@ class UnicodeTest(string_tests.CommonTest,
         self.assertRaisesRegex(TypeError, '%u format: a real number is required, not complex', operator.mod, '%u', 3j)
         self.assertRaisesRegex(TypeError, '%i format: a real number is required, not complex', operator.mod, '%i', 2j)
         self.assertRaisesRegex(TypeError, '%d format: a real number is required, not complex', operator.mod, '%d', 1j)
-        self.assertRaises(TypeError, operator.mod, '%c', pi)
+        self.assertRaisesRegex(TypeError, '%c requires int or char', operator.mod, '%c', pi)
 
         class RaisingNumber:
             def __int__(self):

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -1311,6 +1311,20 @@ class UnicodeTest(string_tests.CommonTest,
         self.assertRaises(ValueError, ("{" + big + "}").format)
         self.assertRaises(ValueError, ("{[" + big + "]}").format, [0])
 
+        # test number formatter errors:
+        self.assertRaises(ValueError, '{0:x}'.format, 1j)
+        self.assertRaises(ValueError, '{0:x}'.format, 1.0)
+        self.assertRaises(ValueError, '{0:X}'.format, 1j)
+        self.assertRaises(ValueError, '{0:X}'.format, 1.0)
+        self.assertRaises(ValueError, '{0:o}'.format, 1j)
+        self.assertRaises(ValueError, '{0:o}'.format, 1.0)
+        self.assertRaises(ValueError, '{0:u}'.format, 1j)
+        self.assertRaises(ValueError, '{0:u}'.format, 1.0)
+        self.assertRaises(ValueError, '{0:i}'.format, 1j)
+        self.assertRaises(ValueError, '{0:i}'.format, 1.0)
+        self.assertRaises(ValueError, '{0:d}'.format, 1j)
+        self.assertRaises(ValueError, '{0:d}'.format, 1.0)
+
         # issue 6089
         self.assertRaises(ValueError, "{0[0]x}".format, [None])
         self.assertRaises(ValueError, "{0[0](10)}".format, [None])
@@ -1546,11 +1560,31 @@ class UnicodeTest(string_tests.CommonTest,
         self.assertEqual('%X' % letter_m, '6D')
         self.assertEqual('%o' % letter_m, '155')
         self.assertEqual('%c' % letter_m, 'm')
-        self.assertRaisesRegex(TypeError, '%x format: an integer is required, not float', operator.mod, '%x', 3.14),
-        self.assertRaisesRegex(TypeError, '%X format: an integer is required, not float', operator.mod, '%X', 2.11),
-        self.assertRaisesRegex(TypeError, '%o format: an integer is required, not float', operator.mod, '%o', 1.79),
-        self.assertRaisesRegex(TypeError, '%x format: an integer is required, not PseudoFloat', operator.mod, '%x', pi),
-        self.assertRaises(TypeError, operator.mod, '%c', pi),
+        self.assertRaisesRegex(TypeError, '%x format: an integer is required, not float', operator.mod, '%x', 3.14)
+        self.assertRaisesRegex(TypeError, '%X format: an integer is required, not float', operator.mod, '%X', 2.11)
+        self.assertRaisesRegex(TypeError, '%o format: an integer is required, not float', operator.mod, '%o', 1.79)
+        self.assertRaisesRegex(TypeError, '%x format: an integer is required, not PseudoFloat', operator.mod, '%x', pi)
+        self.assertRaisesRegex(TypeError, '%x format: an integer is required, not complex', operator.mod, '%x', 3j)
+        self.assertRaisesRegex(TypeError, '%X format: an integer is required, not complex', operator.mod, '%X', 2j)
+        self.assertRaisesRegex(TypeError, '%o format: an integer is required, not complex', operator.mod, '%o', 1j)
+        self.assertRaisesRegex(TypeError, '%u format: a real number is required, not complex', operator.mod, '%u', 3j)
+        self.assertRaisesRegex(TypeError, '%i format: a real number is required, not complex', operator.mod, '%i', 2j)
+        self.assertRaisesRegex(TypeError, '%d format: a real number is required, not complex', operator.mod, '%d', 1j)
+        self.assertRaises(TypeError, operator.mod, '%c', pi)
+
+        class RaisingNumber:
+            def __int__(self):
+                raise RuntimeError('int')  # should be not `TypeErorr`
+            def __index__(self):
+                raise RuntimeError('index')  # should be not `TypeErorr`
+
+        rn = RaisingNumber()
+        self.assertRaisesRegex(RuntimeError, 'int', operator.mod, '%d', rn)
+        self.assertRaisesRegex(RuntimeError, 'int', operator.mod, '%i', rn)
+        self.assertRaisesRegex(RuntimeError, 'int', operator.mod, '%u', rn)
+        self.assertRaisesRegex(RuntimeError, 'index', operator.mod, '%x', rn)
+        self.assertRaisesRegex(RuntimeError, 'index', operator.mod, '%X', rn)
+        self.assertRaisesRegex(RuntimeError, 'index', operator.mod, '%o', rn)
 
     def test_formatting_with_enum(self):
         # issue18780

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -1574,9 +1574,9 @@ class UnicodeTest(string_tests.CommonTest,
 
         class RaisingNumber:
             def __int__(self):
-                raise RuntimeError('int')  # should be not `TypeErorr`
+                raise RuntimeError('int')  # should not be `TypeError`
             def __index__(self):
-                raise RuntimeError('index')  # should be not `TypeErorr`
+                raise RuntimeError('index')  # should not be `TypeError`
 
         rn = RaisingNumber()
         self.assertRaisesRegex(RuntimeError, 'int', operator.mod, '%d', rn)


### PR DESCRIPTION
There are two major changes:
1. `PyNumber_Check` in `mainformatlong` is now covered with `complex` numbers
2. I've covered this line that were responsible for re-raising exceptions:
<img width="507" alt="Снимок экрана 2022-11-14 в 15 38 23" src="https://user-images.githubusercontent.com/4660275/201662535-bdb747a2-503f-4da3-83c6-30698540f128.png">

I can add lots of other cases in other PRs, including:
- subclassing of primitives
- returning subclasses from `__int__`, `__index__`, etc (some of which is deprecated)
- more values and more `%` formatters

But, this PR is minimal to just increase the phisycal coveraged.

<!-- gh-issue-number: gh-94808 -->
* Issue: gh-94808
<!-- /gh-issue-number -->
