### PR TITLE
gh-99300: Use Py_NewRef() in PC/ directory

### DIFF
--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -701,8 +701,7 @@ _msi_SummaryInformation_GetProperty_impl(msiobj *self, int field)
             result = PyBytes_FromStringAndSize(sval, ssize);
             break;
         case VT_EMPTY:
-            Py_INCREF(Py_None);
-            result = Py_None;
+            result = Py_NewRef(Py_None);
             break;
         default:
             PyErr_Format(PyExc_NotImplementedError, "result of type %d", type);

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -308,7 +308,7 @@ static PyHKEYObject *
 winreg_HKEYType___enter___impl(PyHKEYObject *self)
 /*[clinic end generated code: output=52c34986dab28990 input=c40fab1f0690a8e2]*/
 {
-    return Py_XNewRef(self);
+    return (PyHKEYObject*)Py_XNewRef(self);
 }
 
 

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -308,8 +308,7 @@ static PyHKEYObject *
 winreg_HKEYType___enter___impl(PyHKEYObject *self)
 /*[clinic end generated code: output=52c34986dab28990 input=c40fab1f0690a8e2]*/
 {
-    Py_XINCREF(self);
-    return self;
+    return Py_XNewRef(self);
 }
 
 
@@ -784,8 +783,7 @@ Reg2Py(BYTE *retDataBuf, DWORD retDataSize, DWORD typ)
            support it natively, we should handle the bits. */
         default:
             if (retDataSize == 0) {
-                Py_INCREF(Py_None);
-                obData = Py_None;
+                obData = Py_NewRef(Py_None);
             }
             else
                 obData = PyBytes_FromStringAndSize(


### PR DESCRIPTION
Replace Py_INCREF() and Py_XINCREF() with Py_NewRef() and Py_XNewRef() in test C files of the PC/ directory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99300 -->
* Issue: gh-99300
<!-- /gh-issue-number -->
