### PR TITLE
gh-99300: Use Py_NewRef() in Doc/ directory 

### DIFF
--- a/Doc/includes/custom2.c
+++ b/Doc/includes/custom2.c
@@ -125,9 +125,7 @@ PyInit_custom2(void)
     if (m == NULL)
         return NULL;
 
-    Py_INCREF(&CustomType);
-    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType) < 0) {
-        Py_DECREF(&CustomType);
+    if (PyModule_AddObjectRef(m, "Custom", (PyObject *) &CustomType) < 0) {
         Py_DECREF(m);
         return NULL;
     }

--- a/Doc/includes/custom2.c
+++ b/Doc/includes/custom2.c
@@ -51,14 +51,12 @@ Custom_init(CustomObject *self, PyObject *args, PyObject *kwds)
 
     if (first) {
         tmp = self->first;
-        Py_INCREF(first);
-        self->first = first;
+        self->first = Py_NewRef(first);
         Py_XDECREF(tmp);
     }
     if (last) {
         tmp = self->last;
-        Py_INCREF(last);
-        self->last = last;
+        self->last = Py_NewRef(last);
         Py_XDECREF(tmp);
     }
     return 0;

--- a/Doc/includes/custom3.c
+++ b/Doc/includes/custom3.c
@@ -51,14 +51,12 @@ Custom_init(CustomObject *self, PyObject *args, PyObject *kwds)
 
     if (first) {
         tmp = self->first;
-        Py_INCREF(first);
-        self->first = first;
+        self->first = Py_NewRef(first);
         Py_DECREF(tmp);
     }
     if (last) {
         tmp = self->last;
-        Py_INCREF(last);
-        self->last = last;
+        self->last = Py_NewRef(last);
         Py_DECREF(tmp);
     }
     return 0;
@@ -73,8 +71,7 @@ static PyMemberDef Custom_members[] = {
 static PyObject *
 Custom_getfirst(CustomObject *self, void *closure)
 {
-    Py_INCREF(self->first);
-    return self->first;
+    return Py_NewRef(self->first);
 }
 
 static int
@@ -91,8 +88,7 @@ Custom_setfirst(CustomObject *self, PyObject *value, void *closure)
         return -1;
     }
     tmp = self->first;
-    Py_INCREF(value);
-    self->first = value;
+    self->first = Py_NewRef(value);
     Py_DECREF(tmp);
     return 0;
 }
@@ -100,8 +96,7 @@ Custom_setfirst(CustomObject *self, PyObject *value, void *closure)
 static PyObject *
 Custom_getlast(CustomObject *self, void *closure)
 {
-    Py_INCREF(self->last);
-    return self->last;
+    return Py_NewRef(self->last);
 }
 
 static int
@@ -118,8 +113,7 @@ Custom_setlast(CustomObject *self, PyObject *value, void *closure)
         return -1;
     }
     tmp = self->last;
-    Py_INCREF(value);
-    self->last = value;
+    self->last = Py_NewRef(value);
     Py_DECREF(tmp);
     return 0;
 }

--- a/Doc/includes/custom3.c
+++ b/Doc/includes/custom3.c
@@ -172,9 +172,7 @@ PyInit_custom3(void)
     if (m == NULL)
         return NULL;
 
-    Py_INCREF(&CustomType);
-    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType) < 0) {
-        Py_DECREF(&CustomType);
+    if (PyModule_AddObjectRef(m, "Custom", (PyObject *) &CustomType) < 0) {
         Py_DECREF(m);
         return NULL;
     }

--- a/Doc/includes/custom4.c
+++ b/Doc/includes/custom4.c
@@ -188,9 +188,7 @@ PyInit_custom4(void)
     if (m == NULL)
         return NULL;
 
-    Py_INCREF(&CustomType);
-    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType) < 0) {
-        Py_DECREF(&CustomType);
+    if (PyModule_AddObjectRef(m, "Custom", (PyObject *) &CustomType) < 0) {
         Py_DECREF(m);
         return NULL;
     }

--- a/Doc/includes/custom4.c
+++ b/Doc/includes/custom4.c
@@ -67,14 +67,12 @@ Custom_init(CustomObject *self, PyObject *args, PyObject *kwds)
 
     if (first) {
         tmp = self->first;
-        Py_INCREF(first);
-        self->first = first;
+        self->first = Py_NewRef(first);
         Py_DECREF(tmp);
     }
     if (last) {
         tmp = self->last;
-        Py_INCREF(last);
-        self->last = last;
+        self->last = Py_NewRef(last);
         Py_DECREF(tmp);
     }
     return 0;
@@ -89,8 +87,7 @@ static PyMemberDef Custom_members[] = {
 static PyObject *
 Custom_getfirst(CustomObject *self, void *closure)
 {
-    Py_INCREF(self->first);
-    return self->first;
+    return Py_NewRef(self->first);
 }
 
 static int
@@ -114,8 +111,7 @@ Custom_setfirst(CustomObject *self, PyObject *value, void *closure)
 static PyObject *
 Custom_getlast(CustomObject *self, void *closure)
 {
-    Py_INCREF(self->last);
-    return self->last;
+    return Py_NewRef(self->last);
 }
 
 static int


### PR DESCRIPTION
Replace Py_INCREF() and Py_XINCREF() with Py_NewRef() and Py_XNewRef() in test C files of the Doc/ directory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99300 -->
* Issue: gh-99300
<!-- /gh-issue-number -->
