### PR TITLE
[3.9] gh-87604: Avoid publishing list of active per-interpreter audit hooks via the gc module (GH-99373)

### DIFF
--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -368,6 +368,17 @@ def test_gc():
     gc.get_referents(y)
 
 
+def test_not_in_gc():
+    import gc
+
+    hook = lambda *a: None
+    sys.addaudithook(hook)
+
+    for o in gc.get_objects():
+        if isinstance(o, list):
+            assert hook not in o
+
+
 if __name__ == "__main__":
     from test.support import suppress_msvcrt_asserts
 

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -132,6 +132,11 @@ class AuditTest(unittest.TestCase):
             ["gc.get_objects", "gc.get_referrers", "gc.get_referents"]
         )
 
+    def test_not_in_gc(self):
+        returncode, _, stderr = self.run_python("test_not_in_gc")
+        if returncode:
+            self.fail(stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Security/2022-11-11-12-50-28.gh-issue-87604.OtwH5L.rst
+++ b/Misc/NEWS.d/next/Security/2022-11-11-12-50-28.gh-issue-87604.OtwH5L.rst
@@ -1,0 +1,2 @@
+Avoid publishing list of active per-interpreter audit hooks via the
+:mod:`gc` module

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -441,7 +441,7 @@ sys_addaudithook_impl(PyObject *module, PyObject *hook)
             return NULL;
         }
         /* Avoid having our list of hooks show up in the GC module */
-        PyObject_GC_UnTrack(interp->audit_hooks);
+        PyObject_GC_UnTrack(is->audit_hooks);
     }
 
     if (PyList_Append(is->audit_hooks, hook) < 0) {

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -440,6 +440,8 @@ sys_addaudithook_impl(PyObject *module, PyObject *hook)
         if (is->audit_hooks == NULL) {
             return NULL;
         }
+        /* Avoid having our list of hooks show up in the GC module */
+        PyObject_GC_UnTrack(interp->audit_hooks);
     }
 
     if (PyList_Append(is->audit_hooks, hook) < 0) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-87604 -->
* Issue: gh-87604
<!-- /gh-issue-number -->
