### PR TITLE
gh-99509: Add `__class_getitem__` to `multiprocessing.Queue`

### DIFF
--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -280,6 +280,8 @@ class Queue(object):
         import traceback
         traceback.print_exc()
 
+    __class_getitem__ = classmethod(types.GenericAlias)
+
 
 _sentinel = object()
 

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -31,11 +31,15 @@ try:
     from multiprocessing.managers import ValueProxy
     from multiprocessing.pool import ApplyResult
     from multiprocessing.queues import SimpleQueue as MPSimpleQueue
+    from multiprocessing.queues import Queue as MPQueue
+    from multiprocessing.queues import JoinableQueue as MPJoinableQueue
 except ImportError:
     # _multiprocessing module is optional
     ValueProxy = None
     ApplyResult = None
     MPSimpleQueue = None
+    MPQueue = None
+    MPJoinableQueue = None
 try:
     from multiprocessing.shared_memory import ShareableList
 except ImportError:
@@ -130,7 +134,8 @@ class BaseTest(unittest.TestCase):
     if ctypes is not None:
         generic_types.extend((ctypes.Array, ctypes.LibraryLoader))
     if ValueProxy is not None:
-        generic_types.extend((ValueProxy, ApplyResult, MPSimpleQueue))
+        generic_types.extend((ValueProxy, ApplyResult,
+                              MPSimpleQueue, MPQueue, MPJoinableQueue))
 
     def test_subscriptable(self):
         for t in self.generic_types:

--- a/Misc/NEWS.d/next/Library/2022-11-15-18-45-01.gh-issue-99509.FLK0xU.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-15-18-45-01.gh-issue-99509.FLK0xU.rst
@@ -1,0 +1,1 @@
+Add :pep:`585` support for :class:`multiprocessing.queues.Queue`.


### PR DESCRIPTION
It is generic in typeshed as well: https://github.com/python/typeshed/blob/72d1597de2dee8be369d448efc71e62922a813cc/stdlib/multiprocessing/queues.pyi#L12-L22

<!-- gh-issue-number: gh-99509 -->
* Issue: gh-99509
<!-- /gh-issue-number -->
