### PR TITLE
gh-99502: mention bytes-like objects as input in `secrets.compare_digest`

### DIFF
--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -128,7 +128,8 @@ Other functions
 
 .. function:: compare_digest(a, b)
 
-   Return ``True`` if strings *a* and *b* are equal, otherwise ``False``,
+   Return ``True`` if strings or bytestrings
+   *a* and *b* are equal, otherwise ``False``,
    using a "constant-time compare" to reduce the risk of
    `timing attacks <https://codahale.com/a-lesson-in-timing-attacks/>`_.
    See :func:`hmac.compare_digest` for additional details.

--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -128,7 +128,8 @@ Other functions
 
 .. function:: compare_digest(a, b)
 
-   Return ``True`` if strings or bytestrings
+   Return ``True`` if strings or
+   :term:`bytes-like objects <bytes-like object>`
    *a* and *b* are equal, otherwise ``False``,
    using a "constant-time compare" to reduce the risk of
    `timing attacks <https://codahale.com/a-lesson-in-timing-attacks/>`_.


### PR DESCRIPTION
Now it is in sync with https://docs.python.org/3/library/hmac.html#hmac.compare_digest
It is the same function, just re-exported. So, I guess they should mention the same input types.

<!-- gh-issue-number: gh-99502 -->
* Issue: gh-99502
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:kumaraditya303