### PR TITLE
gh-99518: Fix escape symbol in `test_enum`

### DIFF
--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1478,7 +1478,7 @@ class TestSpecial(unittest.TestCase):
             class EvenMoreColor(Color, IntEnum):
                 chartruese = 7
         #
-        with self.assertRaisesRegex(ValueError, "\(.Foo., \(.pink., .black.\)\) is not a valid .*Color"):
+        with self.assertRaisesRegex(ValueError, r"\(.Foo., \(.pink., .black.\)\) is not a valid .*Color"):
             Color('Foo', ('pink', 'black'))
 
     def test_exclude_methods(self):


### PR DESCRIPTION
It should be fine now :)

CC @ethanfurman 

<!-- gh-issue-number: gh-99518 -->
* Issue: gh-99518
<!-- /gh-issue-number -->
