### PR TITLE
GH-92892: Add section about variadic functions to ctypes documentation

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -378,7 +378,7 @@ Calling varadic functions
 
 On a lot of platforms calling variadic functions through ctypes is exactly the same
 as calling functions with a fixed number of parameters. On some platforms, and in
-particular ARM64 for Apple Platforms, the calling convention for variadic functions 
+particular ARM64 for Apple Platforms, the calling convention for variadic functions
 is different than that for regular functions.
 
 On those platforms it is required to specify the *argtypes* attribute for the

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -371,6 +371,26 @@ that they can be converted to the required C data type::
    31
    >>>
 
+.. _ctypes-calling-variadic-functions:
+
+Calling varadic functions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On a lot of platforms calling variadic functions through ctypes is exactly the same
+as calling functions with a fixed number of parameters. On some platforms, and in
+particular ARM64 for Apple Platforms, the calling convention for variadic functions 
+is different than that for regular functions.
+
+On those platforms it is required to specify the *argtypes* attribute for the
+regular, non-variadic, function arguments:
+
+.. code-block:: python3
+
+   libc.printf.argtypes = [ctypes.c_char_p]
+
+Because specifying the attribute does inhibit portability it is adviced to always
+specify ``argtypes`` for all variadic functions.
+
 
 .. _ctypes-calling-functions-with-own-custom-data-types:
 

--- a/Misc/NEWS.d/next/Documentation/2022-11-16-12-52-23.gh-issue-92892.TS-P0j.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-11-16-12-52-23.gh-issue-92892.TS-P0j.rst
@@ -1,0 +1,1 @@
+Document that calling variadic functions with ctypes requires special care on macOS/arm64 (and possibly other platforms).


### PR DESCRIPTION
On some platforms, and in particular macOS/arm64, the calling convention for variadic arguments is different from the regular calling convention. Add a section to the documentation to document this.

<!-- gh-issue-number: gh-92892 -->
* Issue: gh-92892
<!-- /gh-issue-number -->
