### PR TITLE
gh-99377: Revert audit events for thread state creation and free, because the GIL is not properly held at these times

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1239,24 +1239,11 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    The global interpreter lock need not be held, but may be held if it is
    necessary to serialize calls to this function.
 
-   .. audit-event:: cpython.PyThreadState_New id c.PyThreadState_New
-
-      Raise an auditing event ``cpython.PyThreadState_New`` with Python's thread
-      id as the argument. The event will be raised from the thread creating the new
-      ``PyThreadState``, which may not be the new thread.
-
 
 .. c:function:: void PyThreadState_Clear(PyThreadState *tstate)
 
    Reset all information in a thread state object.  The global interpreter lock
    must be held.
-
-   .. audit-event:: cpython.PyThreadState_Clear id c.PyThreadState_Clear
-
-      Raise an auditing event ``cpython.PyThreadState_Clear`` with Python's
-      thread id as the argument. The event may be raised from a different thread
-      than the one being cleared. Exceptions raised from a hook will be treated
-      as unraisable and will not abort the operation.
 
    .. versionchanged:: 3.9
       This function now calls the :c:member:`PyThreadState.on_delete` callback.

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -197,18 +197,10 @@ class AuditTest(unittest.TestCase):
         actual = [(ev[0], ev[2]) for ev in events]
         expected = [
             ("_thread.start_new_thread", "(<test_func>, (), None)"),
-            ("cpython.PyThreadState_New", "(2,)"),
             ("test.test_func", "()"),
-            ("cpython.PyThreadState_Clear", "(2,)"),
         ]
 
         self.assertEqual(actual, expected)
-
-    def test_threading_abort(self):
-        # Ensures that aborting PyThreadState_New raises the correct exception
-        returncode, events, stderr = self.run_python("test_threading_abort")
-        if returncode:
-            self.fail(stderr)
 
 
     def test_wmi_exec_query(self):

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -875,13 +875,6 @@ PyThreadState_New(PyInterpreterState *interp)
     PyThreadState *tstate = new_threadstate(interp);
     if (tstate) {
         _PyThreadState_SetCurrent(tstate);
-        if (_PyThreadState_GET()
-            && PySys_Audit("cpython.PyThreadState_New", "K", tstate->id) < 0
-        ) {
-            PyThreadState_Clear(tstate);
-            _PyThreadState_DeleteCurrent(tstate);
-            return NULL;
-        }
     }
     return tstate;
 }
@@ -889,15 +882,7 @@ PyThreadState_New(PyInterpreterState *interp)
 PyThreadState *
 _PyThreadState_Prealloc(PyInterpreterState *interp)
 {
-    PyThreadState *tstate = new_threadstate(interp);
-    if (tstate) {
-        if (PySys_Audit("cpython.PyThreadState_New", "K", tstate->id) < 0) {
-            PyThreadState_Clear(tstate);
-            _PyThreadState_Delete(tstate, 0);
-            return NULL;
-        }
-    }
-    return tstate;
+    return new_threadstate(interp);
 }
 
 // We keep this around for (accidental) stable ABI compatibility.
@@ -1045,10 +1030,6 @@ _PyInterpreterState_ClearModules(PyInterpreterState *interp)
 void
 PyThreadState_Clear(PyThreadState *tstate)
 {
-    if (PySys_Audit("cpython.PyThreadState_Clear", "K", tstate->id) < 0) {
-        PyErr_WriteUnraisable(NULL);
-    }
-
     int verbose = _PyInterpreterState_GetConfig(tstate->interp)->verbose;
 
     if (verbose && tstate->cframe->current_frame != NULL) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -875,7 +875,9 @@ PyThreadState_New(PyInterpreterState *interp)
     PyThreadState *tstate = new_threadstate(interp);
     if (tstate) {
         _PyThreadState_SetCurrent(tstate);
-        if (PySys_Audit("cpython.PyThreadState_New", "K", tstate->id) < 0) {
+        if (_PyThreadState_GET()
+            && PySys_Audit("cpython.PyThreadState_New", "K", tstate->id) < 0
+        ) {
             PyThreadState_Clear(tstate);
             _PyThreadState_DeleteCurrent(tstate);
             return NULL;


### PR DESCRIPTION
This can occur during initialization. Without the check, later calls to get the interpreter state will cause a fatal error.


<!-- gh-issue-number: gh-99377 -->
* Issue: gh-99377
<!-- /gh-issue-number -->
