### PR TITLE
GH-88564: Make sure IDLE keybindings are correctly shown on macOS

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1645,6 +1645,12 @@ def get_accelerator(keydefs, eventname):
     s = re.sub("><", " ", s)
     s = re.sub("<", "", s)
     s = re.sub(">", "", s)
+    if macosx.isCocoaTk():
+        # GH-88564: On macOS the keybindings
+        # for Ctrl+space and Ctrl+backslash need
+        # an adjustment to be shown.
+        s = re.sub('space', 'Space', s)
+        s = re.sub('backslash', '\\\\', s)
     return s
 
 

--- a/Misc/NEWS.d/next/IDLE/2022-11-17-14-27-59.gh-issue-88564.YRJklV.rst
+++ b/Misc/NEWS.d/next/IDLE/2022-11-17-14-27-59.gh-issue-88564.YRJklV.rst
@@ -1,0 +1,1 @@
+Fix the shortcuts shown in the IDLE menu for "Show Completions" and "Show Call Tip" on macOS.


### PR DESCRIPTION
On macOS the Ctrl+space and Ctrl+backslash shortcuts didn't show up correctly in the menu, they were shown as ^S and ^B respectively.

With this changeset they are shown as ^space and ^\ as expected


<!-- gh-issue-number: gh-88564 -->
* Issue: gh-88564
<!-- /gh-issue-number -->
