### PR TITLE
GH-95815: Document less specific error for os.remove

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2421,7 +2421,7 @@ features:
 .. function:: remove(path, *, dir_fd=None)
 
    Remove (delete) the file *path*.  If *path* is a directory, an
-   :exc:`IsADirectoryError` is raised.  Use :func:`rmdir` to remove directories.
+   :exc:`OSError` is raised.  Use :func:`rmdir` to remove directories.
    If the file does not exist, a :exc:`FileNotFoundError` is raised.
 
    This function can support :ref:`paths relative to directory descriptors


### PR DESCRIPTION
os.remove can raise PermissionError instead of IsADirectoryError, when the object to be removed is a directory (in particular on macOS).

This reverts a change done in #14262.


<!-- gh-issue-number: gh-95815 -->
* Issue: gh-95815
<!-- /gh-issue-number -->
