### PR TITLE
[3.10] gh-85073: Add some missing links to source (GH-99363)

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -18,6 +18,10 @@ and Tasks.
 Coroutines
 ==========
 
+**Source code:** :source:`Lib/asyncio/coroutines.py`
+
+----------------------------------------------------
+
 :term:`Coroutines <coroutine>` declared with the async/await syntax is the
 preferred way of writing asyncio applications.  For example, the following
 snippet of code prints "hello", waits 1 second,
@@ -246,6 +250,10 @@ Running an asyncio Program
 
 Creating Tasks
 ==============
+
+**Source code:** :source:`Lib/asyncio/tasks.py`
+
+-----------------------------------------------
 
 .. function:: create_task(coro, *, name=None)
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -6,6 +6,8 @@
 
 .. moduleauthor:: Thomas Heller <theller@python.net>
 
+**Source code:** :source:`Lib/ctypes`
+
 --------------
 
 :mod:`ctypes` is a foreign function library for Python.  It provides C compatible

--- a/Doc/library/curses.ascii.rst
+++ b/Doc/library/curses.ascii.rst
@@ -7,6 +7,8 @@
 .. moduleauthor:: Eric S. Raymond <esr@thyrsus.com>
 .. sectionauthor:: Eric S. Raymond <esr@thyrsus.com>
 
+**Source code:** :source:`Lib/curses/ascii.py`
+
 --------------
 
 The :mod:`curses.ascii` module supplies name constants for ASCII characters and

--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -9,6 +9,8 @@
 .. sectionauthor:: Moshe Zadka <moshez@zadka.site.co.il>
 .. sectionauthor:: Eric Raymond <esr@thyrsus.com>
 
+**Source code:** :source:`Lib/curses`
+
 --------------
 
 The :mod:`curses` module provides an interface to the curses library, the

--- a/Doc/library/ensurepip.rst
+++ b/Doc/library/ensurepip.rst
@@ -7,6 +7,8 @@
 
 .. versionadded:: 3.4
 
+**Source code:** :source:`Lib/ensurepip`
+
 --------------
 
 The :mod:`ensurepip` package provides support for bootstrapping the ``pip``

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -4,6 +4,8 @@
 .. module:: signal
    :synopsis: Set handlers for asynchronous events.
 
+**Source code:** :source:`Lib/signal.py`
+
 --------------
 
 This module provides mechanisms to use signal handlers in Python.

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -7,6 +7,8 @@
 .. moduleauthor:: Phillip J. Eby <pje@telecommunity.com>
 .. sectionauthor:: Phillip J. Eby <pje@telecommunity.com>
 
+**Source code:** :source:`Lib/wsgiref`
+
 --------------
 
 The Web Server Gateway Interface (WSGI) is a standard interface between web

--- a/Doc/library/zoneinfo.rst
+++ b/Doc/library/zoneinfo.rst
@@ -9,6 +9,8 @@
 .. moduleauthor:: Paul Ganssle <paul@ganssle.io>
 .. sectionauthor:: Paul Ganssle <paul@ganssle.io>
 
+**Source code:** :source:`Lib/zoneinfo`
+
 --------------
 
 The :mod:`zoneinfo` module provides a concrete time zone implementation to


### PR DESCRIPTION
Add some missing links to source from Python docs. (cherry picked from commit 27d8dc2c9d3de886a884f79f0621d4586c0e0f7a)

Co-authored-by: Stanley <46876382+slateny@users.noreply.github.com>


<!-- gh-issue-number: gh-85073 -->
* Issue: gh-85073
<!-- /gh-issue-number -->
