### PR TITLE
gh-96463: fix `load_tzdata` raising `OSError`, not  `ZoneInfoNotFound…

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -30,6 +30,9 @@ try:
 except importlib.metadata.PackageNotFoundError:
     HAS_TZDATA_PKG = False
 
+if HAS_TZDATA_PKG:
+    raise ValueError('Fail the test')
+
 ZONEINFO_DATA = None
 ZONEINFO_DATA_V1 = None
 TEMP_DIR = None

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -220,6 +220,7 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
             "America.Los_Angeles",
             "🇨🇦",  # Non-ascii
             "America/New\ud800York",  # Contains surrogate character
+            "a" * 256,  # Too long
         ]
 
         for bad_key in bad_keys:

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -10,7 +10,7 @@ def load_tzdata(key):
 
     try:
         return resources.files(package_name).joinpath(resource_name).open("rb")
-    except (ImportError, FileNotFoundError, UnicodeEncodeError):
+    except (ImportError, FileNotFoundError, UnicodeEncodeError):  # TODO
         # There are three types of exception that can be raised that all amount
         # to "we cannot find this key":
         #
@@ -21,6 +21,8 @@ def load_tzdata(key):
         #   (e.g. Europe/Krasnoy)
         # UnicodeEncodeError: If package_name or resource_name are not UTF-8,
         #   such as keys containing a surrogate character.
+        # OSError: If filename is wrong (too long, has invalid ascii symbols)
+        #   or when there's a permissing error.
         raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
 
 

--- a/Misc/NEWS.d/next/Library/2022-11-19-21-55-06.gh-issue-96463.N6Woyx.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-19-21-55-06.gh-issue-96463.N6Woyx.rst
@@ -1,0 +1,2 @@
+Fix :class:`zoneinfo.ZoneInfo` raising :exc:`OSError` instead of
+``ZoneInfoNotFoundError``.


### PR DESCRIPTION
I expect this to fail at first. This will make sure that we have `tzdata` installed at least somewhere in out test suite.

<!-- gh-issue-number: gh-96463 -->
* Issue: gh-96463
<!-- /gh-issue-number -->
