### PR TITLE
decimal: A missing special case from IEEE 854-1987?

### DIFF
--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -1307,7 +1307,8 @@ class Decimal(object):
 
         # Special case for multiplying by zero
         if not self or not other:
-            return Decimal(0)
+            ans = _dec_from_triple(resultsign, '0', 0)
+            return ans
 
         # Special case for multiplying by power of 10
         if self._int == '1':

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -1307,10 +1307,7 @@ class Decimal(object):
 
         # Special case for multiplying by zero
         if not self or not other:
-            ans = _dec_from_triple(resultsign, '0', resultexp)
-            # Fixing in case the exponent is out of bounds
-            ans = ans._fix(context)
-            return ans
+            return Decimal(0)
 
         # Special case for multiplying by power of 10
         if self._int == '1':


### PR DESCRIPTION
I don't think I'm qualified enough to reason about these things, so using this PR to continue a conversation started here: https://stackoverflow.com/questions/74500614/python-decimal-multiplication-by-zero

Why does the following code:

```
from decimal import Decimal
result = Decimal('0') * Decimal('0.8881783462119193534061639577') print(result)
```

return 0E-28 ?

I've traced it to the following code in this file:

```
if not self or not other:
    ans = _dec_from_triple(resultsign, '0', resultexp)
    # Fixing in case the exponent is out of bounds
    ans = ans._fix(context)
    return ans
```

The code appears to follow Decimal Arithmetic Specification, which doesn't explicitly suggest what to do when we multiply by zero, referring to 'special cases/numbers' from IEEE 854-1987, which also doesn't specify what we do when we multiply an integer by zero - that obvious case seems to be missing from both documents. So the decimal library does the thing that is explicitly specified:

- The coefficient of the result, before rounding, is computed by multiplying together the coefficients of the operands.
- The exponent of the result, before rounding, is the sum of the exponents of the two operands.
- The sign of the result is the exclusive or of the signs of the operands.

Question: what is the need to return the coefficient and exponent (i.e, 0E-28) if one of the operands is a zero? We already know what that coefficient is when calling the multiplication function. Why not just return a signed zero?

EDIT: apparently it's important to retain the sign (in signed zero), for functions like [atan2](https://docs.python.org/3/library/math.html#math.atan2)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
