### PR TITLE
gh-99606: consistent empty f-string bytecode

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4931,7 +4931,7 @@ compiler_joined_str(struct compiler *c, expr_ty e)
         _Py_DECLARE_STR(empty, "");
         ADDOP_LOAD_CONST_NEW(c, loc, Py_NewRef(&_Py_STR(empty)));
         if (!value_count) {
-            return 0;
+            return 1;
         }
         ADDOP_NAME(c, loc, LOAD_METHOD, &_Py_ID(join), names);
         ADDOP_I(c, loc, BUILD_LIST, 0);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

In `compiler_joined_str()`, handle empty f-strings by merging logic with the first `if` statement and replace all further references of `asdl_seq_LEN(e->v.JoinedStr.values)` with `value_count`.

<!-- gh-issue-number: gh-99606 -->
* Issue: gh-99606
<!-- /gh-issue-number -->
