### PR TITLE
gh-99576: Fix cookiejar file that was not truncated for some classes

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -1891,8 +1891,9 @@ class LWPCookieJar(FileCookieJar):
             else: raise ValueError(MISSING_FILENAME_TEXT)
 
         with os.fdopen(
-            os.open(filename, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600,
-        ), 'w') as f:
+            os.open(filename, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600),
+            'w',
+        ) as f:
             # There really isn't an LWP Cookies 2.0 format, but this indicates
             # that there is extra information in here (domain_dot and
             # port_spec) while still being compatible with libwww-perl, I hope.
@@ -2089,8 +2090,9 @@ class MozillaCookieJar(FileCookieJar):
             else: raise ValueError(MISSING_FILENAME_TEXT)
 
         with os.fdopen(
-            os.open(filename, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600,
-        ), 'w') as f:
+            os.open(filename, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600),
+            'w',
+        ) as f:
             f.write(NETSCAPE_HEADER_TEXT)
             now = time.time()
             for cookie in self:

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -1890,7 +1890,9 @@ class LWPCookieJar(FileCookieJar):
             if self.filename is not None: filename = self.filename
             else: raise ValueError(MISSING_FILENAME_TEXT)
 
-        with os.fdopen(os.open(filename, os.O_CREAT | os.O_WRONLY, 0o600), 'w') as f:
+        with os.fdopen(
+            os.open(filename, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600,
+        ), 'w') as f:
             # There really isn't an LWP Cookies 2.0 format, but this indicates
             # that there is extra information in here (domain_dot and
             # port_spec) while still being compatible with libwww-perl, I hope.
@@ -2086,7 +2088,9 @@ class MozillaCookieJar(FileCookieJar):
             if self.filename is not None: filename = self.filename
             else: raise ValueError(MISSING_FILENAME_TEXT)
 
-        with os.fdopen(os.open(filename, os.O_CREAT | os.O_WRONLY, 0o600), 'w') as f:
+        with os.fdopen(
+            os.open(filename, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600,
+        ), 'w') as f:
             f.write(NETSCAPE_HEADER_TEXT)
             now = time.time()
             for cookie in self:

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -397,6 +397,32 @@ class FileCookieJarTests(unittest.TestCase):
         finally:
             os_helper.unlink(filename)
 
+    @unittest.skipIf(mswindows, "windows file permissions are incompatible with file modes")
+    @os_helper.skip_unless_working_chmod
+    def test_cookie_files_are_truncated(self):
+        filename = os_helper.TESTFN
+        for cookiejar_class in (LWPCookieJar, MozillaCookieJar):
+            c = cookiejar_class(filename)
+
+            req = urllib.request.Request("http://www.acme.com/")
+            headers = ["Set-Cookie: pll_lang=en; Max-Age=31536000; path=/"]
+            res = FakeResponse(headers, "http://www.acme.com/")
+            c.extract_cookies(res, req)
+            self.assertEqual(len(c), 1)
+
+            try:
+                # Save the first version with contents:
+                c.save()
+                # Now, clear cookies and re-save:
+                c.clear()
+                c.save()
+                # Check that file was truncated:
+                c.load()
+            finally:
+                os_helper.unlink(filename)
+
+            self.assertEqual(len(c), 0)
+
     def test_bad_magic(self):
         # OSErrors (eg. file doesn't exist) are allowed to propagate
         filename = os_helper.TESTFN

--- a/Misc/NEWS.d/next/Library/2022-11-20-11-59-54.gh-issue-99576.ZD7jU6.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-20-11-59-54.gh-issue-99576.ZD7jU6.rst
@@ -1,0 +1,2 @@
+Fix ``.save()`` method for ``LWPCookieJar`` and ``MozillaCookieJar``: saved
+file was not truncated on repeated save.


### PR DESCRIPTION
This was changed in https://github.com/python/cpython/pull/93463

CC @ambv and @pSub 

<!-- gh-issue-number: gh-99576 -->
* Issue: gh-99576
<!-- /gh-issue-number -->
