### PR TITLE
gh-99597: Better error message for assignment in f-strings

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1114,6 +1114,8 @@ x = (
                              "f'x{<'",  # See bpo-46762.
                              "f'x{>'",
                              "f'{i='",  # See gh-93418.
+                             "f'{i=!r'",
+                             "f'{i=!r:10 '",
                              ])
 
         # But these are just normal strings.

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1367,5 +1367,17 @@ x = (
         with self.assertRaisesRegex(SyntaxError, error_msg):
             compile("f'{**a}'", "?", "exec")
 
+    def test_syntax_error_for_assignment_statements(self):
+        self.assertAllRaise(
+            SyntaxError,
+            "expected expression, not assignment statement",
+            [
+                """f'{a = bcde}'""",
+                """f'{a = 1!r}'""",
+                """f'{a = b, 1, !r }'""",
+                """f'{a = b !r :5 }'""",
+            ]
+        )
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-21-07-57-38.gh-issue-99597.vReuZx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-21-07-57-38.gh-issue-99597.vReuZx.rst
@@ -1,0 +1,1 @@
+Provide a better error message for use of an assignment statement inside an f-string.

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -829,6 +829,13 @@ fstring_find_expr(Parser *p, const char **str, const char *end, int raw, int rec
     }
 
     if (*str >= end || **str != '}') {
+        /* If we're in = mode (detected by non-NULL expr_text),
+           provide a more helpful error */
+        if (*expr_text) {
+            RAISE_SYNTAX_ERROR("f-string: expected expression, "
+                               "not assignment statement");
+            goto error;
+        }
         goto unexpected_end_of_string;
     }
 


### PR DESCRIPTION
The introduction of debug f-strings in 3.8 regressed the error message users would get here.

```
$ python3.7 -c 'f"{x = 5}"'
  File "<fstring>", line 1
    (x = 5)
       ^
SyntaxError: invalid syntax
```

```
$ python3.9 -c 'f"{x = 5}"'
  File "<string>", line 1
    f"{x = 5}"
              ^
SyntaxError: f-string: expecting '}'
```

This adds a little bit of special casing to the f-string specific logic in order to provide a better error message:

```
$ ./python.exe -c 'f"{x = 5}"'
  File "<string>", line 1
    f"{x = 5}"
              ^
SyntaxError: f-string: expected expression, not assignment statement
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99597 -->
* Issue: gh-99597
<!-- /gh-issue-number -->
