### PR TITLE
gh-99578: Fix refleak in _imp.create_builtin()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-21-11-27-14.gh-issue-99578.DcKoBJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-21-11-27-14.gh-issue-99578.DcKoBJ.rst
@@ -1,0 +1,3 @@
+Fix a reference bug in :func:`_imp.create_builtin()` after the creation of the
+first sub-interpreter for modules ``builtins`` and ``sys``. Patch by Victor
+Stinner.

--- a/Python/import.c
+++ b/Python/import.c
@@ -1035,7 +1035,8 @@ create_builtin(PyThreadState *tstate, PyObject *name, PyObject *spec)
         if (_PyUnicode_EqualToASCIIString(name, p->name)) {
             if (p->initfunc == NULL) {
                 /* Cannot re-init internal module ("sys" or "builtins") */
-                return PyImport_AddModuleObject(name);
+                mod = PyImport_AddModuleObject(name);
+                return Py_XNewRef(mod);
             }
             mod = _PyImport_InitFunc_TrampolineCall(*p->initfunc);
             if (mod == NULL) {


### PR DESCRIPTION
Fix a reference leak in _imp.create_builtin() after the creation of the first sub-interpreter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99578 -->
* Issue: gh-99578
<!-- /gh-issue-number -->
