### PR TITLE
gh-99645: Fix a bug in handling class cleanups in unittest.TestCase

### DIFF
--- a/Lib/test/test_unittest/test_runner.py
+++ b/Lib/test/test_unittest/test_runner.py
@@ -536,6 +536,44 @@ class TestClassCleanup(unittest.TestCase):
 
         self.assertEqual(TestableTest._class_cleanups, [])
 
+    def test_run_nested_test(self):
+        ordering = []
+
+        class InnerTest(unittest.TestCase):
+            @classmethod
+            def setUpClass(cls):
+                ordering.append('setUpClass2')
+                cls.addClassCleanup(ordering.append, 'cleanup2')
+            def test(self):
+                ordering.append('test2')
+
+        class OuterTest(unittest.TestCase):
+            @classmethod
+            def setUpClass(cls):
+                ordering.append('setUpClass1')
+                cls.addClassCleanup(ordering.append, 'cleanup1')
+            def test(self):
+                ordering.append('start test1')
+                runTests(InnerTest)
+                ordering.append('end test1')
+
+        runTests(OuterTest)
+        self.assertEqual(ordering, ['setUpClass1', 'start test1',
+                                    'setUpClass2', 'test2', 'cleanup2',
+                                    'end test1', 'cleanup1'])
+
+
+    def test_debug_nested_test(self):
+        ordering = []
+
+        class InnerTest(unittest.TestCase):
+            @classmethod
+            def setUpClass(cls):
+                ordering.append('setUpClass2')
+                cls.addClassCleanup(ordering.append, 'cleanup2')
+            def test(self):
+                ordering.append('test2')
+
 
 class TestModuleCleanUp(unittest.TestCase):
     def test_add_and_do_ModuleCleanup(self):

--- a/Lib/test/test_unittest/test_runner.py
+++ b/Lib/test/test_unittest/test_runner.py
@@ -542,37 +542,26 @@ class TestClassCleanup(unittest.TestCase):
         class InnerTest(unittest.TestCase):
             @classmethod
             def setUpClass(cls):
-                ordering.append('setUpClass2')
-                cls.addClassCleanup(ordering.append, 'cleanup2')
+                ordering.append('inner setup')
+                cls.addClassCleanup(ordering.append, 'inner cleanup')
             def test(self):
-                ordering.append('test2')
+                ordering.append('inner test')
 
         class OuterTest(unittest.TestCase):
             @classmethod
             def setUpClass(cls):
-                ordering.append('setUpClass1')
-                cls.addClassCleanup(ordering.append, 'cleanup1')
+                ordering.append('outer setup')
+                cls.addClassCleanup(ordering.append, 'outer cleanup')
             def test(self):
-                ordering.append('start test1')
+                ordering.append('start outer test')
                 runTests(InnerTest)
-                ordering.append('end test1')
+                ordering.append('end outer test')
 
         runTests(OuterTest)
-        self.assertEqual(ordering, ['setUpClass1', 'start test1',
-                                    'setUpClass2', 'test2', 'cleanup2',
-                                    'end test1', 'cleanup1'])
-
-
-    def test_debug_nested_test(self):
-        ordering = []
-
-        class InnerTest(unittest.TestCase):
-            @classmethod
-            def setUpClass(cls):
-                ordering.append('setUpClass2')
-                cls.addClassCleanup(ordering.append, 'cleanup2')
-            def test(self):
-                ordering.append('test2')
+        self.assertEqual(ordering, [
+                'outer setup', 'start outer test',
+                'inner setup', 'inner test', 'inner cleanup',
+                'end outer test', 'outer cleanup'])
 
 
 class TestModuleCleanUp(unittest.TestCase):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -384,11 +384,11 @@ class TestCase(object):
     # of difflib.  See #11763.
     _diffThreshold = 2**16
 
-    # Attribute used by TestSuite for classSetUp
-
-    _classSetupFailed = False
-
-    _class_cleanups = []
+    def __init_subclass__(cls, *args, **kwargs):
+        # Attribute used by TestSuite for classSetUp
+        cls._classSetupFailed = False
+        cls._class_cleanups = []
+        super().__init_subclass__(*args, **kwargs)
 
     def __init__(self, methodName='runTest'):
         """Create an instance of the class that will use the named test

--- a/Misc/NEWS.d/next/Library/2022-11-21-13-49-03.gh-issue-99645.9w1QKq.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-21-13-49-03.gh-issue-99645.9w1QKq.rst
@@ -1,0 +1,3 @@
+Fix a bug in handling class cleanups in :class:`unittest.TestCase`.  Now
+``addClassCleanup()`` uses separate lists for different ``TestCase``
+subclasses, and ``doClassCleanups()`` only cleans up the particular class.


### PR DESCRIPTION
Now addClassCleanup() uses separate lists for different TestCase subclasses, and doClassCleanups() only cleans up the particular class.


<!-- gh-issue-number: gh-99645 -->
* Issue: gh-99645
<!-- /gh-issue-number -->
