### PR TITLE
gh-99537: Use Py_SETREF() function in C code

### DIFF
--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2109,9 +2109,7 @@ bytes_translate_impl(PyBytesObject *self, PyObject *table,
                 changed = 1;
         }
         if (!changed && PyBytes_CheckExact(input_obj)) {
-            Py_INCREF(input_obj);
-            Py_DECREF(result);
-            result = input_obj;
+            Py_SETREF(result, Py_NewRef(input_obj));
         }
         PyBuffer_Release(&del_table_view);
         PyBuffer_Release(&table_view);

--- a/Objects/capsule.c
+++ b/Objects/capsule.c
@@ -220,8 +220,7 @@ PyCapsule_Import(const char *name, int no_block)
             }
         } else {
             PyObject *object2 = PyObject_GetAttrString(object, trace);
-            Py_DECREF(object);
-            object = object2;
+            Py_SETREF(object, object2);
         }
         if (!object) {
             goto EXIT;

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -88,8 +88,7 @@ PyFile_GetLine(PyObject *f, int n)
             else {
                 PyObject *v;
                 v = PyBytes_FromStringAndSize(s, len-1);
-                Py_DECREF(result);
-                result = v;
+                Py_SETREF(result, v);
             }
         }
     }
@@ -104,8 +103,7 @@ PyFile_GetLine(PyObject *f, int n)
         else if (PyUnicode_READ_CHAR(result, len-1) == '\n') {
             PyObject *v;
             v = PyUnicode_Substring(result, 0, len-1);
-            Py_DECREF(result);
-            result = v;
+            Py_SETREF(result, v);
         }
     }
     return result;

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -531,20 +531,17 @@ float_richcompare(PyObject *v, PyObject *w, int op)
                 temp = _PyLong_Lshift(ww, 1);
                 if (temp == NULL)
                     goto Error;
-                Py_DECREF(ww);
-                ww = temp;
+                Py_SETREF(ww, temp);
 
                 temp = _PyLong_Lshift(vv, 1);
                 if (temp == NULL)
                     goto Error;
-                Py_DECREF(vv);
-                vv = temp;
+                Py_SETREF(vv, temp);
 
                 temp = PyNumber_Or(vv, _PyLong_GetOne());
                 if (temp == NULL)
                     goto Error;
-                Py_DECREF(vv);
-                vv = temp;
+                Py_SETREF(vv, temp);
             }
 
             r = PyObject_RichCompareBool(vv, ww, op);

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -491,8 +491,7 @@ throw_here:
         }
         else {
             /* Normalize to raise <class>, <instance> */
-            Py_XDECREF(val);
-            val = typ;
+            Py_XSETREF(val, typ);
             typ = Py_NewRef(PyExceptionInstance_Class(typ));
 
             if (tb == NULL)

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1270,8 +1270,7 @@ set_intersection_multi(PySetObject *so, PyObject *args)
             Py_DECREF(result);
             return NULL;
         }
-        Py_DECREF(result);
-        result = newresult;
+        Py_SETREF(result, newresult);
     }
     return result;
 }

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -448,8 +448,7 @@ _PySlice_GetLongIndices(PySliceObject *self, PyObject *length,
         if (_PyLong_Sign(start) < 0) {
             /* start += length */
             PyObject *tmp = PyNumber_Add(start, length);
-            Py_DECREF(start);
-            start = tmp;
+            Py_SETREF(start, tmp);
             if (start == NULL)
                 goto error;
 
@@ -457,9 +456,7 @@ _PySlice_GetLongIndices(PySliceObject *self, PyObject *length,
             if (cmp_result < 0)
                 goto error;
             if (cmp_result) {
-                Py_INCREF(lower);
-                Py_DECREF(start);
-                start = lower;
+                Py_SETREF(start, Py_NewRef(lower));
             }
         }
         else {
@@ -467,9 +464,7 @@ _PySlice_GetLongIndices(PySliceObject *self, PyObject *length,
             if (cmp_result < 0)
                 goto error;
             if (cmp_result) {
-                Py_INCREF(upper);
-                Py_DECREF(start);
-                start = upper;
+                Py_SETREF(start, Py_NewRef(upper));
             }
         }
     }
@@ -486,8 +481,7 @@ _PySlice_GetLongIndices(PySliceObject *self, PyObject *length,
         if (_PyLong_Sign(stop) < 0) {
             /* stop += length */
             PyObject *tmp = PyNumber_Add(stop, length);
-            Py_DECREF(stop);
-            stop = tmp;
+            Py_SETREF(stop, tmp);
             if (stop == NULL)
                 goto error;
 
@@ -495,9 +489,7 @@ _PySlice_GetLongIndices(PySliceObject *self, PyObject *length,
             if (cmp_result < 0)
                 goto error;
             if (cmp_result) {
-                Py_INCREF(lower);
-                Py_DECREF(stop);
-                stop = lower;
+                Py_SETREF(stop, Py_NewRef(lower));
             }
         }
         else {
@@ -505,9 +497,7 @@ _PySlice_GetLongIndices(PySliceObject *self, PyObject *length,
             if (cmp_result < 0)
                 goto error;
             if (cmp_result) {
-                Py_INCREF(upper);
-                Py_DECREF(stop);
-                stop = upper;
+                Py_SETREF(stop, Py_NewRef(upper));
             }
         }
     }

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -473,8 +473,7 @@ get_field_object(SubString *input, PyObject *args, PyObject *kwargs,
             goto error;
 
         /* assign to obj */
-        Py_DECREF(obj);
-        obj = tmp;
+        Py_SETREF(obj, tmp);
     }
     /* end of iterator, this is the non-error case */
     if (ok == 1)
@@ -825,8 +824,7 @@ output_markup(SubString *field_name, SubString *format_spec,
             goto done;
 
         /* do the assignment, transferring ownership: fieldobj = tmp */
-        Py_DECREF(fieldobj);
-        fieldobj = tmp;
+        Py_SETREF(fieldobj, tmp);
         tmp = NULL;
     }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5968,8 +5968,7 @@ object___dir___impl(PyObject *self)
     else {
         /* Copy __dict__ to avoid mutating it. */
         PyObject *temp = PyDict_Copy(dict);
-        Py_DECREF(dict);
-        dict = temp;
+        Py_SETREF(dict, temp);
     }
 
     if (dict == NULL)
@@ -9377,8 +9376,7 @@ super_getattro(PyObject *self, PyObject *name)
                        (See SF ID #743627)  */
                     (su->obj == (PyObject *)starttype) ? NULL : su->obj,
                     (PyObject *)starttype);
-                Py_DECREF(res);
-                res = res2;
+                Py_SETREF(res, res2);
             }
 
             Py_DECREF(mro);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -13572,8 +13572,7 @@ _PyUnicode_FormatLong(PyObject *val, int alt, int prec, int type)
         for (i = 0; i < numdigits; i++)
             *b1++ = *buf++;
         *b1 = '\0';
-        Py_DECREF(result);
-        result = r1;
+        Py_SETREF(result, r1);
         buf = PyBytes_AS_STRING(result);
         len = numnondigits + prec;
     }
@@ -13590,8 +13589,7 @@ _PyUnicode_FormatLong(PyObject *val, int alt, int prec, int type)
         || buf != PyUnicode_DATA(result)) {
         PyObject *unicode;
         unicode = _PyUnicode_FromASCII(buf, len);
-        Py_DECREF(result);
-        result = unicode;
+        Py_SETREF(result, unicode);
     }
     else if (len != PyUnicode_GET_LENGTH(result)) {
         if (PyUnicode_Resize(&result, len) < 0)

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -824,8 +824,7 @@ PyWeakref_NewRef(PyObject *ob, PyObject *callback)
                        during GC.  Return that one instead of this one
                        to avoid violating the invariants of the list
                        of weakrefs for ob. */
-                    Py_DECREF(result);
-                    result = (PyWeakReference*)Py_NewRef(ref);
+                    Py_SETREF(result, (PyWeakReference*)Py_NewRef(ref));
                 }
             }
             else {
@@ -888,8 +887,7 @@ PyWeakref_NewProxy(PyObject *ob, PyObject *callback)
                        during GC.  Return that one instead of this one
                        to avoid violating the invariants of the list
                        of weakrefs for ob. */
-                    Py_DECREF(result);
-                    result = (PyWeakReference*)Py_NewRef(proxy);
+                    Py_SETREF(result, (PyWeakReference*)Py_NewRef(proxy));
                     goto skip_insert;
                 }
                 prev = ref;

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -801,8 +801,7 @@ next_external_frame(PyFrameObject *frame)
 {
     do {
         PyFrameObject *back = PyFrame_GetBack(frame);
-        Py_DECREF(frame);
-        frame = back;
+        Py_SETREF(frame, back);
     } while (frame != NULL && is_internal_frame(frame));
 
     return frame;
@@ -828,8 +827,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
     if (stack_level <= 0 || is_internal_frame(f)) {
         while (--stack_level > 0 && f != NULL) {
             PyFrameObject *back = PyFrame_GetBack(f);
-            Py_DECREF(f);
-            f = back;
+            Py_SETREF(f, back);
         }
     }
     else {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -168,8 +168,7 @@ builtin___build_class__(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
             goto error;
         }
         if (winner != meta) {
-            Py_DECREF(meta);
-            meta = Py_NewRef(winner);
+            Py_SETREF(meta, Py_NewRef(winner));
         }
     }
     /* else: meta is not a class, so we cannot do the metaclass

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -8280,9 +8280,7 @@ merge_const_one(PyObject *const_cache, PyObject **obj)
         t = PyTuple_GET_ITEM(t, 1);
     }
 
-    Py_INCREF(t);
-    Py_DECREF(*obj);
-    *obj = t;
+    Py_SETREF(*obj, Py_NewRef(t));
     return 1;
 }
 

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -353,16 +353,13 @@ _PyErr_NormalizeException(PyThreadState *tstate, PyObject **exc,
             if (fixed_value == NULL) {
                 goto error;
             }
-            Py_DECREF(value);
-            value = fixed_value;
+            Py_SETREF(value, fixed_value);
         }
         /* If the class of the instance doesn't exactly match the
            class of the type, believe the instance.
         */
         else if (inclass != type) {
-            Py_INCREF(inclass);
-            Py_DECREF(type);
-            type = inclass;
+            Py_SETREF(type, Py_NewRef(inclass));
         }
     }
     *exc = type;

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -1354,8 +1354,7 @@ hamt_node_collision_assoc(PyHamtNode_Collision *self,
                 }
 
                 /* Replace the old value with the new value for the our key. */
-                Py_DECREF(new_node->c_array[val_idx]);
-                new_node->c_array[val_idx] = Py_NewRef(val);
+                Py_SETREF(new_node->c_array[val_idx], Py_NewRef(val));
 
                 return (PyHamtNode *)new_node;
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -718,8 +718,7 @@ _Py_HandleSystemExit(int *exitcode_p)
         /* The error code should be in the `code' attribute. */
         PyObject *code = PyObject_GetAttr(value, &_Py_ID(code));
         if (code) {
-            Py_DECREF(value);
-            value = code;
+            Py_SETREF(value, code);
             if (value == Py_None)
                 goto done;
         }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -198,8 +198,7 @@ sys_audit_tstate(PyThreadState *ts, const char *event,
         eventArgs = _Py_VaBuildValue_SizeT(argFormat, vargs);
         if (eventArgs && !PyTuple_Check(eventArgs)) {
             PyObject *argTuple = PyTuple_Pack(1, eventArgs);
-            Py_DECREF(eventArgs);
-            eventArgs = argTuple;
+            Py_SETREF(eventArgs, argTuple);
         }
     }
     else {

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -136,9 +136,7 @@ tb_next_set(PyTracebackObject *self, PyObject *new_next, void *Py_UNUSED(_))
         cursor = cursor->tb_next;
     }
 
-    PyObject *old_next = (PyObject*)self->tb_next;
-    self->tb_next = (PyTracebackObject *)Py_XNewRef(new_next);
-    Py_XDECREF(old_next);
+    Py_XSETREF(self->tb_next, (PyTracebackObject *)Py_XNewRef(new_next));
 
     return 0;
 }
@@ -533,8 +531,7 @@ display_source_line_with_margin(PyObject *f, PyObject *filename, int lineno, int
         PyObject *truncated;
         truncated = PyUnicode_Substring(lineobj, i, PyUnicode_GET_LENGTH(lineobj));
         if (truncated) {
-            Py_DECREF(lineobj);
-            lineobj = truncated;
+            Py_SETREF(lineobj, truncated);
         } else {
             PyErr_Clear();
         }


### PR DESCRIPTION
Fix potential race condition in code patterns:

* Replace "Py_DECREF(var); var = new;" with "Py_SETREF(var, new);"
* Replace "Py_XDECREF(var); var = new;" with "Py_XSETREF(var, new);"
* Replace "Py_CLEAR(var); var = new;" with "Py_XSETREF(var, new);"

Other changes:

* Replace "old = var; var = new; Py_DECREF(var)" with "Py_SETREF(var, new);"
* Replace "old = var; var = new; Py_XDECREF(var)" with "Py_XSETREF(var, new);"
* And remove the "old" variable.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99537 -->
* Issue: gh-99537
<!-- /gh-issue-number -->
