### PR TITLE
gh-99659: Use correct exceptions in sqlite3 bigmem tests

### DIFF
--- a/Lib/test/test_sqlite3/test_types.py
+++ b/Lib/test/test_sqlite3/test_types.py
@@ -106,9 +106,9 @@ class SqliteTypeTests(unittest.TestCase):
     @unittest.skipUnless(sys.maxsize > 2**32, 'requires 64bit platform')
     @support.bigmemtest(size=2**31, memuse=4, dry_run=False)
     def test_too_large_string(self, maxsize):
-        with self.assertRaises(sqlite.InterfaceError):
+        with self.assertRaises(sqlite.DataError):
             self.cur.execute("insert into test(s) values (?)", ('x'*(2**31-1),))
-        with self.assertRaises(OverflowError):
+        with self.assertRaises(sqlite.DataError):
             self.cur.execute("insert into test(s) values (?)", ('x'*(2**31),))
         self.cur.execute("select 1 from test")
         row = self.cur.fetchone()
@@ -117,9 +117,9 @@ class SqliteTypeTests(unittest.TestCase):
     @unittest.skipUnless(sys.maxsize > 2**32, 'requires 64bit platform')
     @support.bigmemtest(size=2**31, memuse=3, dry_run=False)
     def test_too_large_blob(self, maxsize):
-        with self.assertRaises(sqlite.InterfaceError):
+        with self.assertRaises(sqlite.DataError):
             self.cur.execute("insert into test(s) values (?)", (b'x'*(2**31-1),))
-        with self.assertRaises(OverflowError):
+        with self.assertRaises(sqlite.DataError):
             self.cur.execute("insert into test(s) values (?)", (b'x'*(2**31),))
         self.cur.execute("select 1 from test")
         row = self.cur.fetchone()

--- a/Misc/NEWS.d/next/Tests/2022-11-21-19-21-30.gh-issue-99659.4gP0nm.rst
+++ b/Misc/NEWS.d/next/Tests/2022-11-21-19-21-30.gh-issue-99659.4gP0nm.rst
@@ -1,0 +1,3 @@
+Optional big memory tests in ``test_sqlite3`` now catch the correct
+:exc:`sqlite.DataError` exception type in case of too large strings and/or
+blobs passed.


### PR DESCRIPTION
The tests in question were added in 0eec6276fdcd by Serhiy. Apparently, sqlite3 changed exceptions raised in those cases in the mean time but the tests never ran because they require a high `-M` setting in the test runner.


<!-- gh-issue-number: gh-99659 -->
* Issue: gh-99659
<!-- /gh-issue-number -->
