### PR TITLE
gh-85988: Change documentation for sys.float_info.rounds

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -607,11 +607,11 @@ always available.
    | :const:`rounds`     | FLT_ROUNDS     | The rounding mode for floating-point addition is |
    |                     |                | characterized by the implementation defined value|
    |                     |                | of FLT_ROUNDS:                                   |
-   |                     |                | -1  indeterminable                               |
-   |                     |                | 0   toward zero                                  |
-   |                     |                | 1   to nearest                                   |
-   |                     |                | 2   toward positive infinity                     |
-   |                     |                | 3   toward negative infinity                     |
+   |                     |                | ``-1`` indeterminable,                           |
+   |                     |                | ``0`` toward zero,                               |
+   |                     |                | ``1`` to nearest,                                |
+   |                     |                | ``2`` toward positive infinity,                  |
+   |                     |                | ``3`` toward negative infinity                   |
    |                     |                |                                                  |
    |                     |                | All other values for FLT_ROUNDS characterize     |
    |                     |                | implementation-defined rounding behavior.        |

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -604,12 +604,17 @@ always available.
    +---------------------+----------------+--------------------------------------------------+
    | :const:`radix`      | FLT_RADIX      | radix of exponent representation                 |
    +---------------------+----------------+--------------------------------------------------+
-   | :const:`rounds`     | FLT_ROUNDS     | integer constant representing the rounding mode  |
-   |                     |                | used for arithmetic operations.  This reflects   |
-   |                     |                | the value of the system FLT_ROUNDS macro at      |
-   |                     |                | interpreter startup time.  See section 5.2.4.2.2 |
-   |                     |                | of the C99 standard for an explanation of the    |
-   |                     |                | possible values and their meanings.              |
+   | :const:`rounds`     | FLT_ROUNDS     | The rounding mode for floating-point addition is |
+   |                     |                | characterized by the implementation defined value|
+   |                     |                | of FLT_ROUNDS:                                   |
+   |                     |                | -1  indeterminable                               |
+   |                     |                | 0   toward zero                                  |
+   |                     |                | 1   to nearest                                   |
+   |                     |                | 2   toward positive infinity                     |
+   |                     |                | 3   toward negative infinity                     |
+   |                     |                |                                                  |
+   |                     |                | All other values for FLT_ROUNDS characterize     |
+   |                     |                | implementation-defined rounding behavior.        |
    +---------------------+----------------+--------------------------------------------------+
 
    The attribute :attr:`sys.float_info.dig` needs further explanation.  If

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -604,9 +604,10 @@ always available.
    +---------------------+----------------+--------------------------------------------------+
    | :const:`radix`      | FLT_RADIX      | radix of exponent representation                 |
    +---------------------+----------------+--------------------------------------------------+
-   | :const:`rounds`     | FLT_ROUNDS     | The rounding mode for floating-point addition is |
-   |                     |                | characterized by the implementation defined value|
-   |                     |                | of FLT_ROUNDS:                                   |
+   | :const:`rounds`     | FLT_ROUNDS     | integer representing the rounding mode for       |
+   |                     |                | floating-point arithmetic. This reflects the     |
+   |                     |                | value of the system FLT_ROUNDS macro at          |
+   |                     |                | interpreter startup time:                        |
    |                     |                | ``-1`` indeterminable,                           |
    |                     |                | ``0`` toward zero,                               |
    |                     |                | ``1`` to nearest,                                |


### PR DESCRIPTION
Change the documentation for sys.float_info.rounds to remove references to C99 section 5.2.4.2.2 and instead place the available values inline.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-85988 -->
* Issue: gh-85988
<!-- /gh-issue-number -->
