### PR TITLE
gh-99677: Deduplicate self-type in `mro` in `inspect._getmembers`

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -537,7 +537,7 @@ def _getmembers(object, predicate, getter):
     processed = set()
     names = dir(object)
     if isclass(object):
-        mro = (object,) + getmro(object)
+        mro = getmro(object)
         # add any DynamicClassAttributes to the list of names if object is a class;
         # this may result in duplicate entries if, for example, a virtual
         # attribute with the same name as a DynamicClassAttribute exists


### PR DESCRIPTION
I am not adding news, because there are no user-facing changes.

<!-- gh-issue-number: gh-99677 -->
* Issue: gh-99677
<!-- /gh-issue-number -->
