### PR TITLE
gh-99537: Use Py_CLEAR() function in C code

### DIFF
--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2383,8 +2383,7 @@ channel_list_interpreters(PyObject *self, PyObject *args, PyObject *kwds)
     goto finally;
 
 except:
-    Py_XDECREF(ids);
-    ids = NULL;
+    Py_CLEAR(ids);
 
 finally:
     return ids;

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -231,8 +231,7 @@ zoneinfo_new_instance(PyTypeObject *type, PyObject *key)
 
     goto cleanup;
 error:
-    Py_XDECREF(self);
-    self = NULL;
+    Py_CLEAR(self);
 cleanup:
     if (file_obj != NULL) {
         PyObject *exc, *val, *tb;
@@ -2606,14 +2605,9 @@ static PyMethodDef module_methods[] = {{NULL, NULL}};
 static void
 module_free(void *m)
 {
-    Py_XDECREF(_tzpath_find_tzfile);
-    _tzpath_find_tzfile = NULL;
-
-    Py_XDECREF(_common_mod);
-    _common_mod = NULL;
-
-    Py_XDECREF(io_open);
-    io_open = NULL;
+    Py_CLEAR(_tzpath_find_tzfile);
+    Py_CLEAR(_common_mod);
+    Py_CLEAR(io_open);
 
     xdecref_ttinfo(&NO_TTINFO);
 


### PR DESCRIPTION
Replace "Py_XDECREF(var); var = NULL;" with "Py_CLEAR(var);".

Don't replace "Py_DECREF(var); var = NULL;" with "Py_CLEAR(var);". It would add an useless "if (var)" test in code path where var cannot be NULL.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99537 -->
* Issue: gh-99537
<!-- /gh-issue-number -->
