### PR TITLE
[3.11] gh-99016: Make build scripts compatible with Python 3.8 (GH-99017).

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-11-02-19-25-07.gh-issue-99016.R05NkD.rst
+++ b/Misc/NEWS.d/next/Build/2022-11-02-19-25-07.gh-issue-99016.R05NkD.rst
@@ -1,0 +1,1 @@
+Fix build with ``PYTHON_FOR_REGEN=python3.8``.

--- a/Tools/scripts/generate_opcode_h.py
+++ b/Tools/scripts/generate_opcode_h.py
@@ -102,7 +102,7 @@ def main(opcode_py, outfile='Include/opcode.h', internaloutfile='Include/interna
     opname_including_specialized[255] = 'DO_TRACING'
     used[255] = True
 
-    with (open(outfile, 'w') as fobj, open(internaloutfile, 'w') as iobj):
+    with open(outfile, 'w') as fobj, open(internaloutfile, 'w') as iobj:
         fobj.write(header)
         iobj.write(internal_header)
 


### PR DESCRIPTION
(cherry picked from commit f520d720f667c87f7b70ed86ea58d73892d6b969)


<!-- gh-issue-number: gh-99016 -->
* Issue: gh-99016
<!-- /gh-issue-number -->
