### PR TITLE
gh-99706: unicodeobject: Fix padding in `PyASCIIObject.state`

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -135,7 +135,7 @@ typedef struct {
         unsigned int ascii:1;
         /* Padding to ensure that PyUnicode_DATA() is always aligned to
            4 bytes (see issue #19537 on m68k). */
-        unsigned int :25;
+        unsigned int :26;
     } state;
 } PyASCIIObject;
 


### PR DESCRIPTION
Increase padding by 1 bit so that total bitfield size is 32 bits, as the fact the fields currently sum to 31 looks potentially unintended to me.

<!-- gh-issue-number: gh-99706 -->
* Issue: gh-99706
<!-- /gh-issue-number -->
