### PR TITLE
GH-85724: Ignore the MAC from the Touch Bar interface on macOS in uuid

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -830,6 +830,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
             print(hex, end=' ')
         self.assertTrue(0 < node < (1 << 48),
                         "%s is not an RFC 4122 node ID" % hex)
+        self.assertNotEqual(node, int("ac:de:48:00:11:22".replace(":", ""), 16))
 
     @unittest.skipUnless(_uuid._ifconfig_getnode in _uuid._GETTERS,
         "ifconfig is not used for introspection on this platform")

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -805,10 +805,13 @@ lo0       - 127.0.0.0/8   127.0.0.1           259955     -     -   259955     - 
         data = '''
 fake      Link encap:UNSPEC  hwaddr 00-00
 cscotun0  Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00
+en5       Link encap:UNSPEC  HWaddr ac:de:48:00:11:22
 eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
 '''
 
         # The above data will only be parsed properly on non-AIX unixes.
+        # The value for 'en5' is the single MAC address used by Touch Bar Mac laptops
+        # and should be ignored.
         with mock.patch.multiple(self.uuid,
                                  _MAC_DELIM=b':',
                                  _MAC_OMITS_LEADING_ZEROES=False,
@@ -830,7 +833,10 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
             print(hex, end=' ')
         self.assertTrue(0 < node < (1 << 48),
                         "%s is not an RFC 4122 node ID" % hex)
-        self.assertNotEqual(node, int("ac:de:48:00:11:22".replace(":", ""), 16))
+
+        # GH-85724: Ensure that the MAC address of the TouchBar interface
+        # on Intel Macbooks is not used in a UUID.
+        self.assertNotEqual(node, self.uuid._MACOS_TOUCHBAR_MAC_AS_INT)
 
     @unittest.skipUnless(_uuid._ifconfig_getnode in _uuid._GETTERS,
         "ifconfig is not used for introspection on this platform")

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -407,12 +407,9 @@ def _get_command_stdout(command, *args):
 def _is_universal(mac):
     return not (mac & (1 << 41))
 
-# MAC adresses that are blacklisted for finding a node id
-_MAC_BLACKLIST={
-    # (GH-85724) Hardcoded MAC adres for all Intel MacBook's with Touch Bar.
-    int("ac:de:48:00:11:22".replace(":", ""), 16),
-}
-
+# (GH-85724) Hardcoded MAC adres for all Intel MacBook's with Touch Bar.
+_MACOS_TOUCHBAR_MAC="ac:de:48:00:11:22"
+_MACOS_TOUCHBAR_MAC_AS_INT=int(_MACOS_TOUCHBAR_MAC.replace(":", ""), 16)
 
 def _find_mac_near_keyword(command, args, keywords, get_word_index):
     """Searches a command's output for a MAC address near a keyword.
@@ -443,7 +440,7 @@ def _find_mac_near_keyword(command, args, keywords, get_word_index):
                     # real MAC address
                     pass
                 else:
-                    if mac in _MAC_BLACKLIST:
+                    if mac == _MACOS_TOUCHBAR_MAC_AS_INT:
                         continue
                     if _is_universal(mac):
                         return mac
@@ -507,7 +504,7 @@ def _find_mac_under_heading(command, args, heading):
         mac = _parse_mac(word)
         if mac is None:
             continue
-        if mac in _MAC_BLACKLIST:
+        if mac == _MACOS_TOUCHBAR_MAC_AS_INT:
             continue
         if _is_universal(mac):
             return mac
@@ -599,7 +596,7 @@ try:
         # if it does because this is a single MAC adress for all 
         # devices. See GH-85724
         _x = _generate_time_safe()[0]
-        if _x.endswith(bytes.fromhex("ac:de:48:00:11:22".replace(":", ""))):
+        if _x.endswith(bytes.fromhex(_MACOS_TOUCHBAR_MAC.replace(":", ""))):
             _has_uuid_generate_time_safe = False
             _generate_time_safe = None
         del _x

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -403,8 +403,15 @@ def _get_command_stdout(command, *args):
 #
 # See https://en.wikipedia.org/wiki/MAC_address#Universal_vs._local
 
+
 def _is_universal(mac):
     return not (mac & (1 << 41))
+
+# MAC adresses that are blacklisted for finding a node id
+_MAC_BLACKLIST={
+    # (GH-85724) Hardcoded MAC adres for all Intel MacBook's with Touch Bar.
+    int("ac:de:48:00:11:22".replace(":", ""), 16),
+}
 
 
 def _find_mac_near_keyword(command, args, keywords, get_word_index):
@@ -436,6 +443,8 @@ def _find_mac_near_keyword(command, args, keywords, get_word_index):
                     # real MAC address
                     pass
                 else:
+                    if mac in _MAC_BLACKLIST:
+                        continue
                     if _is_universal(mac):
                         return mac
                     first_local_mac = first_local_mac or mac
@@ -497,6 +506,8 @@ def _find_mac_under_heading(command, args, heading):
 
         mac = _parse_mac(word)
         if mac is None:
+            continue
+        if mac in _MAC_BLACKLIST:
             continue
         if _is_universal(mac):
             return mac
@@ -581,6 +592,18 @@ try:
     _generate_time_safe = getattr(_uuid, "generate_time_safe", None)
     _UuidCreate = getattr(_uuid, "UuidCreate", None)
     _has_uuid_generate_time_safe = _uuid.has_uuid_generate_time_safe
+
+    if sys.platform == "darwin" and _generate_time_safe is not None:
+        # On macOS check if generate_time_safe uses the MAC adddress
+        # of the Touch Bar on Intel Macbooks and ignore the function
+        # if it does because this is a single MAC adress for all 
+        # devices. See GH-85724
+        _x = _generate_time_safe()[0]
+        if _x.endswith(bytes.fromhex("ac:de:48:00:11:22".replace(":", ""))):
+            _has_uuid_generate_time_safe = False
+            _generate_time_safe = None
+        del _x
+
 except ImportError:
     _uuid = None
     _generate_time_safe = None

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -407,7 +407,7 @@ def _get_command_stdout(command, *args):
 def _is_universal(mac):
     return not (mac & (1 << 41))
 
-# (GH-85724) Hardcoded MAC adres for all Intel MacBook's with Touch Bar.
+# (GH-85724) Hardcoded MAC address for all Intel MacBook's with Touch Bar.
 _MACOS_TOUCHBAR_MAC="ac:de:48:00:11:22"
 _MACOS_TOUCHBAR_MAC_AS_INT=int(_MACOS_TOUCHBAR_MAC.replace(":", ""), 16)
 


### PR DESCRIPTION
All Intel MacBook Pro devices with a Touch Bar have a network interface connected to a controller for that device that has the same MAC address for all MacBooks.

Ignore these MAC adresses in the UUID library.

<!-- gh-issue-number: gh-85724 -->
* Issue: gh-85724
<!-- /gh-issue-number -->
