### PR TITLE
gh-99724 - wave.py - Support for ALAW and ULAW formats

### DIFF
--- a/Misc/NEWS.d/next/Library/2022-11-23-14-38-15.gh-issue-99724.Oco16k.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-23-14-38-15.gh-issue-99724.Oco16k.rst
@@ -1,0 +1,2 @@
+Support for reading and writing ULAW / ALAW files in wave.py
+Patch by Thibo Rosemplatt.


### PR DESCRIPTION
```python 
>>> import wave
>>> wf1 = wave.open("ulaw08s.wav", "r") # no reading error!
>>> wf2 = wave.open("output.wav", "wb")
>>> 
>>> wf2.setparams(wf1.getparams())
>>> wf2.writeframes(wf1.readframes(-1)) # no writing error!
>>>
>>> wf1.close()
>>> wf2.close()
```

fix #99724

<!-- gh-issue-number: gh-99724 -->
* Issue: gh-99724
<!-- /gh-issue-number -->
