### PR TITLE
gh-99726: Add 'fast' argument to os.[l]stat for faster calculation

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -437,6 +437,9 @@ the :mod:`glob` module.)
    :func:`os.lstat`, or :func:`os.stat`.  This function implements the
    underlying comparison used by :func:`samefile` and :func:`sameopenfile`.
 
+   Do not use stat results created with the *fast* argument, as they may be
+   missing information necessary to compare the two files.
+
    .. availability:: Unix, Windows.
 
    .. versionchanged:: 3.4

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1037,16 +1037,26 @@ as internal buffering of data.
    .. availability:: Unix.
 
 
-.. function:: fstat(fd)
+.. function:: fstat(fd, *, fast=False)
 
    Get the status of the file descriptor *fd*. Return a :class:`stat_result`
    object.
 
-   As of Python 3.3, this is equivalent to ``os.stat(fd)``.
+   As of Python 3.3, this is equivalent to ``os.stat(fd, fast=fast)``.
+
+   Passing *fast* as ``True`` may omit some information on some platforms
+   for the sake of performance. These omissions are not guaranteed (that is,
+   the information may be returned anyway), and may change between Python
+   releases without a deprecation period or due to operating system updates
+   without warning. See :class:`stat_result` documentation for the fields
+   that are guaranteed to be present under this option.
 
    .. seealso::
 
       The :func:`.stat` function.
+
+   .. versionchanged:: 3.12
+      Added the *fast* parameter.
 
 
 .. function:: fstatvfs(fd, /)

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2175,7 +2175,7 @@ features:
       Accepts a :term:`path-like object`.
 
 
-.. function:: lstat(path, *, dir_fd=None)
+.. function:: lstat(path, *, dir_fd=None, fast=False)
 
    Perform the equivalent of an :c:func:`lstat` system call on the given path.
    Similar to :func:`~os.stat`, but does not follow symbolic links. Return a
@@ -2184,8 +2184,15 @@ features:
    On platforms that do not support symbolic links, this is an alias for
    :func:`~os.stat`.
 
+   Passing *fast* as ``True`` may omit some information on some platforms
+   for the sake of performance. These omissions are not guaranteed (that is,
+   the information may be returned anyway), and may change between Python
+   releases without a deprecation period or due to operating system updates
+   without warning. See :class:`stat_result` documentation for the fields
+   that are guaranteed to be present under this option.
+
    As of Python 3.3, this is equivalent to ``os.stat(path, dir_fd=dir_fd,
-   follow_symlinks=False)``.
+   follow_symlinks=False, fast=fast)``.
 
    This function can also support :ref:`paths relative to directory descriptors
    <dir_fd>`.
@@ -2208,6 +2215,9 @@ features:
       (name surrogates), including symbolic links and directory junctions.
       Other kinds of reparse points are resolved by the operating system as
       for :func:`~os.stat`.
+
+   .. versionchanged:: 3.12
+      Added the *fast* parameter.
 
 
 .. function:: mkdir(path, mode=0o777, *, dir_fd=None)
@@ -2781,7 +2791,7 @@ features:
       for :class:`bytes` paths on Windows.
 
 
-.. function:: stat(path, *, dir_fd=None, follow_symlinks=True)
+.. function:: stat(path, *, dir_fd=None, follow_symlinks=True, fast=False)
 
    Get the status of a file or a file descriptor. Perform the equivalent of a
    :c:func:`stat` system call on the given path. *path* may be specified as
@@ -2805,6 +2815,13 @@ features:
    :func:`os.path.realpath` function to resolve the path name as far as
    possible and call :func:`lstat` on the result. This does not apply to
    dangling symlinks or junction points, which will raise the usual exceptions.
+
+   Passing *fast* as ``True`` may omit some information on some platforms
+   for the sake of performance. These omissions are not guaranteed (that is,
+   the information may be returned anyway), and may change between Python
+   releases without a deprecation period or due to operating system updates
+   without warning. See :class:`stat_result` documentation for the fields
+   that are guaranteed to be present under this option.
 
    .. index:: module: stat
 
@@ -2838,6 +2855,9 @@ features:
       returns the information for the original path as if
       ``follow_symlinks=False`` had been specified instead of raising an error.
 
+   .. versionchanged:: 3.12
+      Added the *fast* parameter.
+
 
 .. class:: stat_result
 
@@ -2845,11 +2865,21 @@ features:
    :c:type:`stat` structure. It is used for the result of :func:`os.stat`,
    :func:`os.fstat` and :func:`os.lstat`.
 
+   When the *fast* argument to these functions is passed ``True``, some
+   information may be reduced or omitted. Those attributes that are
+   guaranteed to be valid, and those currently known to be omitted, are
+   marked in the documentation below. If not specified and you depend on
+   that field, explicitly pass *fast* as ``False`` to ensure it is
+   calculated.
+
    Attributes:
 
    .. attribute:: st_mode
 
       File mode: file type and file mode bits (permissions).
+
+      When *fast* is ``True``, only the file type bits are guaranteed
+      to be valid (the mode bits may be zero).
 
    .. attribute:: st_ino
 
@@ -2864,6 +2894,8 @@ features:
    .. attribute:: st_dev
 
       Identifier of the device on which this file resides.
+
+      On Windows, when *fast* is ``True``, this may be zero.
 
    .. attribute:: st_nlink
 
@@ -2883,6 +2915,8 @@ features:
       The size of a symbolic link is the length of the pathname it contains,
       without a terminating null byte.
 
+      This field is guaranteed to be filled when specifying *fast*.
+
    Timestamps:
 
    .. attribute:: st_atime
@@ -2892,6 +2926,8 @@ features:
    .. attribute:: st_mtime
 
       Time of most recent content modification expressed in seconds.
+
+      This field is guaranteed to be filled when specifying *fast*.
 
    .. attribute:: st_ctime
 
@@ -2908,6 +2944,9 @@ features:
 
       Time of most recent content modification expressed in nanoseconds as an
       integer.
+
+      This field is guaranteed to be filled when specifying *fast*, subject
+      to the note below.
 
    .. attribute:: st_ctime_ns
 
@@ -2998,11 +3037,15 @@ features:
       :c:func:`GetFileInformationByHandle`. See the ``FILE_ATTRIBUTE_*``
       constants in the :mod:`stat` module.
 
+      This field is guaranteed to be filled when specifying *fast*.
+
    .. attribute:: st_reparse_tag
 
       When :attr:`st_file_attributes` has the ``FILE_ATTRIBUTE_REPARSE_POINT``
       set, this field contains the tag identifying the type of reparse point.
       See the ``IO_REPARSE_TAG_*`` constants in the :mod:`stat` module.
+
+      This field is guaranteed to be filled when specifying *fast*.
 
    The standard module :mod:`stat` defines functions and constants that are
    useful for extracting information from a :c:type:`stat` structure. (On
@@ -3038,6 +3081,10 @@ features:
       On Windows, the :attr:`st_mode` member now identifies special
       files as :const:`S_IFCHR`, :const:`S_IFIFO` or :const:`S_IFBLK`
       as appropriate.
+
+   .. versionchanged:: 3.12
+      Added the *fast* argument and defined the minimum set of returned
+      fields.
 
 .. function:: statvfs(path)
 

--- a/Include/internal/pycore_fileutils_windows.h
+++ b/Include/internal/pycore_fileutils_windows.h
@@ -1,0 +1,77 @@
+#ifndef Py_INTERNAL_FILEUTILS_WINDOWS_H
+#define Py_INTERNAL_FILEUTILS_WINDOWS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "Py_BUILD_CORE must be defined to include this header"
+#endif
+
+#ifdef MS_WINDOWS
+
+#if !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI)
+typedef struct _FILE_STAT_BASIC_INFORMATION {
+    LARGE_INTEGER FileId;
+    LARGE_INTEGER CreationTime;
+    LARGE_INTEGER LastAccessTime;
+    LARGE_INTEGER LastWriteTime;
+    LARGE_INTEGER ChangeTime;
+    LARGE_INTEGER AllocationSize;
+    LARGE_INTEGER EndOfFile;
+    ULONG FileAttributes;
+    ULONG ReparseTag;
+    ULONG NumberOfLinks;
+    ULONG DeviceType;
+    ULONG DeviceCharacteristics;
+} FILE_STAT_BASIC_INFORMATION;
+
+typedef enum _FILE_INFO_BY_NAME_CLASS {
+    FileStatByNameInfo,
+    FileStatLxByNameInfo,
+    FileCaseSensitiveByNameInfo,
+    FileStatBasicByNameInfo,
+    MaximumFileInfoByNameClass
+} FILE_INFO_BY_NAME_CLASS;
+#endif
+
+typedef BOOL (WINAPI *PGetFileInformationByName)(
+    PCWSTR FileName,
+    FILE_INFO_BY_NAME_CLASS FileInformationClass,
+    PVOID FileInfoBuffer,
+    ULONG FileInfoBufferSize
+);
+
+static inline BOOL GetFileInformationByName(
+    PCWSTR FileName,
+    FILE_INFO_BY_NAME_CLASS FileInformationClass,
+    PVOID FileInfoBuffer,
+    ULONG FileInfoBufferSize
+) {
+    static PGetFileInformationByName GetFileInformationByName = NULL;
+    static int GetFileInformationByName_init = -1;
+
+    if (GetFileInformationByName_init < 0) {
+        HMODULE hMod = LoadLibraryW(L"api-ms-win-core-file-l2-1-4");
+        GetFileInformationByName_init = 0;
+        if (hMod) {
+            GetFileInformationByName = (PGetFileInformationByName)GetProcAddress(
+                hMod, "GetFileInformationByName");
+            if (GetFileInformationByName) {
+                GetFileInformationByName_init = 1;
+            } else {
+                FreeLibrary(hMod);
+            }
+        }
+    }
+
+    if (GetFileInformationByName_init <= 0) {
+        SetLastError(ERROR_NOT_SUPPORTED);
+        return FALSE;
+    }
+    return GetFileInformationByName(FileName, FileInformationClass, FileInfoBuffer, FileInfoBufferSize);
+}
+
+#endif
+
+#endif

--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -903,6 +903,7 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(false));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(family));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(fanout));
+    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(fast));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(fd));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(fd2));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(fdel));

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -389,6 +389,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(false)
         STRUCT_FOR_ID(family)
         STRUCT_FOR_ID(fanout)
+        STRUCT_FOR_ID(fast)
         STRUCT_FOR_ID(fd)
         STRUCT_FOR_ID(fd2)
         STRUCT_FOR_ID(fdel)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -895,6 +895,7 @@ extern "C" {
     INIT_ID(false), \
     INIT_ID(family), \
     INIT_ID(fanout), \
+    INIT_ID(fast), \
     INIT_ID(fd), \
     INIT_ID(fd2), \
     INIT_ID(fdel), \

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -684,6 +684,8 @@ _PyUnicode_InitStaticStrings(void) {
     PyUnicode_InternInPlace(&string);
     string = &_Py_ID(fanout);
     PyUnicode_InternInPlace(&string);
+    string = &_Py_ID(fast);
+    PyUnicode_InternInPlace(&string);
     string = &_Py_ID(fd);
     PyUnicode_InternInPlace(&string);
     string = &_Py_ID(fd2);

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -734,7 +734,7 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         except (AttributeError, io.UnsupportedOperation) as err:
             raise exceptions.SendfileNotAvailableError("not a regular file")
         try:
-            fsize = os.fstat(fileno).st_size
+            fsize = os.fstat(fileno, fast=True).st_size
         except OSError:
             raise exceptions.SendfileNotAvailableError("not a regular file")
         blocksize = count if count else fsize

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -307,7 +307,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
             # Check for abstract socket. `str` and `bytes` paths are supported.
             if path[0] not in (0, '\x00'):
                 try:
-                    if stat.S_ISSOCK(os.stat(path).st_mode):
+                    if stat.S_ISSOCK(os.stat(path, fast=True).st_mode):
                         os.remove(path)
                 except FileNotFoundError:
                     pass
@@ -363,7 +363,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
         except (AttributeError, io.UnsupportedOperation) as err:
             raise exceptions.SendfileNotAvailableError("not a regular file")
         try:
-            fsize = os.fstat(fileno).st_size
+            fsize = os.fstat(fileno, fast=True).st_size
         except OSError:
             raise exceptions.SendfileNotAvailableError("not a regular file")
         blocksize = count if count else fsize
@@ -472,7 +472,7 @@ class _UnixReadPipeTransport(transports.ReadTransport):
         self._closing = False
         self._paused = False
 
-        mode = os.fstat(self._fileno).st_mode
+        mode = os.fstat(self._fileno, fast=True).st_mode
         if not (stat.S_ISFIFO(mode) or
                 stat.S_ISSOCK(mode) or
                 stat.S_ISCHR(mode)):
@@ -607,7 +607,7 @@ class _UnixWritePipeTransport(transports._FlowControlMixin,
         self._conn_lost = 0
         self._closing = False  # Set when close() or write_eof() called.
 
-        mode = os.fstat(self._fileno).st_mode
+        mode = os.fstat(self._fileno, fast=True).st_mode
         is_char = stat.S_ISCHR(mode)
         is_fifo = stat.S_ISFIFO(mode)
         is_socket = stat.S_ISSOCK(mode)

--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -220,7 +220,7 @@ def compile_file(fullname, ddir=None, force=False, rx=None, quiet=0,
         if tail == '.py':
             if not force:
                 try:
-                    mtime = int(os.stat(fullname).st_mtime)
+                    mtime = int(os.stat(fullname, fast=True).st_mtime)
                     expect = struct.pack('<4sLL', importlib.util.MAGIC_NUMBER,
                                          0, mtime & 0xFFFF_FFFF)
                     for cfile in opt_cfiles.values():

--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -50,8 +50,8 @@ def cmp(f1, f2, shallow=True):
 
     """
 
-    s1 = _sig(os.stat(f1))
-    s2 = _sig(os.stat(f2))
+    s1 = _sig(os.stat(f1, fast=True))
+    s2 = _sig(os.stat(f2, fast=True))
     if s1[0] != stat.S_IFREG or s2[0] != stat.S_IFREG:
         return False
     if shallow and s1 == s2:
@@ -159,12 +159,12 @@ class dircmp:
 
             ok = True
             try:
-                a_stat = os.stat(a_path)
+                a_stat = os.stat(a_path, fast=True)
             except OSError:
                 # print('Can\'t stat', a_path, ':', why.args[1])
                 ok = False
             try:
-                b_stat = os.stat(b_path)
+                b_stat = os.stat(b_path, fast=True)
             except OSError:
                 # print('Can\'t stat', b_path, ':', why.args[1])
                 ok = False

--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -193,7 +193,7 @@ def _lexists(pathname, dir_fd):
     if dir_fd is None:
         return os.path.lexists(pathname)
     try:
-        os.lstat(pathname, dir_fd=dir_fd)
+        os.lstat(pathname, dir_fd=dir_fd, fast=True)
     except (OSError, ValueError):
         return False
     else:
@@ -204,7 +204,7 @@ def _isdir(pathname, dir_fd):
     if dir_fd is None:
         return os.path.isdir(pathname)
     try:
-        st = os.stat(pathname, dir_fd=dir_fd)
+        st = os.stat(pathname, dir_fd=dir_fd, fast=True)
     except (OSError, ValueError):
         return False
     else:

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -722,7 +722,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             return None
 
         try:
-            fs = os.fstat(f.fileno())
+            fs = os.fstat(f.fileno(), fast=True)
             # Use browser cache if possible
             if ("If-Modified-Since" in self.headers
                     and "If-None-Match" not in self.headers):

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -137,20 +137,20 @@ def _path_split(path):
     return path[:i], path[i + 1:]
 
 
-def _path_stat(path):
+def _path_stat(path, *, fast=False):
     """Stat the path.
 
     Made a separate function to make it easier to override in experiments
     (e.g. cache stat results).
 
     """
-    return _os.stat(path)
+    return _os.stat(path, fast=fast)
 
 
 def _path_is_mode_type(path, mode):
     """Test whether the path is the specified mode type."""
     try:
-        stat_info = _path_stat(path)
+        stat_info = _path_stat(path, fast=True)
     except OSError:
         return False
     return (stat_info.st_mode & 0o170000) == mode
@@ -955,7 +955,7 @@ class WindowsRegistryFinder:
         if filepath is None:
             return None
         try:
-            _path_stat(filepath)
+            _path_stat(filepath, fast=True)
         except OSError:
             return None
         for loader, suffixes in _get_supported_file_loaders():
@@ -1212,7 +1212,7 @@ class SourceFileLoader(FileLoader, SourceLoader):
 
     def path_stats(self, path):
         """Return the metadata for the path."""
-        st = _path_stat(path)
+        st = _path_stat(path, fast=True)
         return {'mtime': st.st_mtime, 'size': st.st_size}
 
     def _cache_bytecode(self, source_path, bytecode_path, data):
@@ -1663,7 +1663,7 @@ class FileFinder:
         is_namespace = False
         tail_module = fullname.rpartition('.')[2]
         try:
-            mtime = _path_stat(self.path or _os.getcwd()).st_mtime
+            mtime = _path_stat(self.path or _os.getcwd(), fast=True).st_mtime
         except OSError:
             mtime = -1
         if mtime != self._path_mtime:

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -263,7 +263,7 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
         # path object (see Issue #27493), but self.baseFilename will be a string
         filename = self.baseFilename
         if os.path.exists(filename):
-            t = os.stat(filename)[ST_MTIME]
+            t = os.stat(filename, fast=True)[ST_MTIME]
         else:
             t = int(time.time())
         self.rolloverAt = self.computeRollover(t)

--- a/Lib/multiprocessing/shared_memory.py
+++ b/Lib/multiprocessing/shared_memory.py
@@ -110,7 +110,7 @@ class SharedMemory:
             try:
                 if create and size:
                     os.ftruncate(self._fd, size)
-                stats = os.fstat(self._fd)
+                stats = os.fstat(self._fd, fast=True)
                 size = stats.st_size
                 self._mmap = mmap.mmap(self._fd, size)
             except OSError:

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -262,7 +262,7 @@ def islink(path):
     This will always return false for Windows prior to 6.0.
     """
     try:
-        st = os.lstat(path)
+        st = os.lstat(path, fast=True)
     except (OSError, ValueError, AttributeError):
         return False
     return stat.S_ISLNK(st.st_mode)
@@ -274,7 +274,7 @@ if hasattr(os.stat_result, 'st_reparse_tag'):
     def isjunction(path):
         """Test whether a path is a junction"""
         try:
-            st = os.lstat(path)
+            st = os.lstat(path, fast=True)
         except (OSError, ValueError, AttributeError):
             return False
         return bool(st.st_reparse_tag == stat.IO_REPARSE_TAG_MOUNT_POINT)
@@ -290,7 +290,7 @@ else:
 def lexists(path):
     """Test whether a path exists.  Returns True for broken symbolic links"""
     try:
-        st = os.lstat(path)
+        st = os.lstat(path, fast=True)
     except (OSError, ValueError):
         return False
     return True

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -130,7 +130,7 @@ def _fastcopy_sendfile(fsrc, fdst):
     # should not make any difference, also in case the file content
     # changes while being copied.
     try:
-        blocksize = max(os.fstat(infd).st_size, 2 ** 23)  # min 8MiB
+        blocksize = max(os.fstat(infd, fast=True).st_size, 2 ** 23)  # min 8MiB
     except OSError:
         blocksize = 2 ** 27  # 128MiB
     # On 32-bit architectures truncate to 1GiB to avoid OverflowError,
@@ -219,7 +219,7 @@ def _samefile(src, dst):
             os.path.normcase(os.path.abspath(dst)))
 
 def _stat(fn):
-    return fn.stat() if isinstance(fn, os.DirEntry) else os.stat(fn)
+    return fn.stat() if isinstance(fn, os.DirEntry) else os.stat(fn, fast=True)
 
 def _islink(fn):
     return fn.is_symlink() if isinstance(fn, os.DirEntry) else os.path.islink(fn)
@@ -567,7 +567,7 @@ def copytree(src, dst, symlinks=False, ignore=None, copy_function=copy2,
 if hasattr(os.stat_result, 'st_file_attributes'):
     def _rmtree_islink(path):
         try:
-            st = os.lstat(path)
+            st = os.lstat(path, fast=True)
             return (stat.S_ISLNK(st.st_mode) or
                 (st.st_file_attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT
                  and st.st_reparse_tag == stat.IO_REPARSE_TAG_MOUNT_POINT))

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -354,7 +354,7 @@ class socket(_socket.socket):
             except (AttributeError, io.UnsupportedOperation) as err:
                 raise _GiveupOnSendfile(err)  # not a regular file
             try:
-                fsize = os.fstat(fileno).st_size
+                fsize = os.fstat(fileno, fast=True).st_size
             except OSError as err:
                 raise _GiveupOnSendfile(err)  # not a regular file
             if not fsize:

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -1004,8 +1004,8 @@ class TestClassesAndFunctions(unittest.TestCase):
         self.assertFullArgSpecEquals(
              os.stat,
              args_e=['path'],
-             kwonlyargs_e=['dir_fd', 'follow_symlinks'],
-             kwonlydefaults_e={'dir_fd': None, 'follow_symlinks': True})
+             kwonlyargs_e=['dir_fd', 'follow_symlinks', 'fast'],
+             kwonlydefaults_e={'dir_fd': None, 'follow_symlinks': True, 'fast': False})
 
     @cpython_only
     @unittest.skipIf(MISSING_C_DOCSTRINGS,

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -613,6 +613,18 @@ class StatAttributeTests(unittest.TestCase):
             unpickled = pickle.loads(p)
             self.assertEqual(result, unpickled)
 
+    def test_stat_result_fast(self):
+        # Minimum guaranteed fields when requesting incomplete info
+        result_1 = os.stat(self.fname, fast=True)
+        result_2 = os.stat(self.fname, fast=False)
+        result_3 = os.stat(self.fname)
+        self.assertEqual(stat.S_IFMT(result_1.st_mode),
+                         stat.S_IFMT(result_2.st_mode))
+        self.assertEqual(result_1.st_size, result_2.st_size)
+        self.assertEqual(result_1.st_mtime, result_2.st_mtime)
+        # Ensure the default matches fast=False
+        self.assertEqual(result_2, result_3)
+
     @unittest.skipUnless(hasattr(os, 'statvfs'), 'test needs os.statvfs()')
     def test_statvfs_attributes(self):
         result = os.statvfs(self.fname)

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -209,7 +209,7 @@ class PosixPathTest(unittest.TestCase):
         # Simulate the path being on a different device from its parent by
         # mocking out st_dev.
         save_lstat = os.lstat
-        def fake_lstat(path):
+        def fake_lstat(path, fast=False):
             st_ino = 0
             st_dev = 0
             if path == ABSTFN:
@@ -227,7 +227,7 @@ class PosixPathTest(unittest.TestCase):
         # issue #2466: Simulate ismount run on a directory that is not
         # readable, which used to return False.
         save_lstat = os.lstat
-        def fake_lstat(path):
+        def fake_lstat(path, fast=False):
             st_ino = 0
             st_dev = 0
             if path.startswith(ABSTFN) and path != ABSTFN:

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -1162,7 +1162,7 @@ class TestDescriptions(unittest.TestCase):
     @requires_docstrings
     def test_module_level_callable(self):
         self.assertEqual(self._get_summary_line(os.stat),
-            "stat(path, *, dir_fd=None, follow_symlinks=True)")
+            "stat(path, *, dir_fd=None, follow_symlinks=True, fast=False)")
 
     @requires_docstrings
     def test_staticmethod(self):

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1505,7 +1505,7 @@ class FileHandler(BaseHandler):
         filename = req.selector
         localfile = url2pathname(filename)
         try:
-            stats = os.stat(localfile)
+            stats = os.stat(localfile, fast=True)
             size = stats.st_size
             modified = email.utils.formatdate(stats.st_mtime, usegmt=True)
             mtype = mimetypes.guess_type(filename)[0]
@@ -2022,7 +2022,7 @@ class URLopener:
         host, file = _splithost(url)
         localname = url2pathname(file)
         try:
-            stats = os.stat(localname)
+            stats = os.stat(localname, fast=True)
         except OSError as e:
             raise URLError(e.strerror, e.filename)
         size = stats.st_size

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -525,7 +525,7 @@ class ZipInfo (object):
         """
         if isinstance(filename, os.PathLike):
             filename = os.fspath(filename)
-        st = os.stat(filename)
+        st = os.stat(filename, fast=True)
         isdir = stat.S_ISDIR(st.st_mode)
         mtime = time.localtime(st.st_mtime)
         date_time = mtime[0:6]
@@ -2129,23 +2129,23 @@ class PyZipFile(ZipFile):
         if self._optimize == -1:
             # legacy mode: use whatever file is present
             if (os.path.isfile(file_pyc) and
-                  os.stat(file_pyc).st_mtime >= os.stat(file_py).st_mtime):
+                  os.stat(file_pyc, fast=True).st_mtime >= os.stat(file_py, fast=True).st_mtime):
                 # Use .pyc file.
                 arcname = fname = file_pyc
             elif (os.path.isfile(pycache_opt0) and
-                  os.stat(pycache_opt0).st_mtime >= os.stat(file_py).st_mtime):
+                  os.stat(pycache_opt0, fast=True).st_mtime >= os.stat(file_py, fast=True).st_mtime):
                 # Use the __pycache__/*.pyc file, but write it to the legacy pyc
                 # file name in the archive.
                 fname = pycache_opt0
                 arcname = file_pyc
             elif (os.path.isfile(pycache_opt1) and
-                  os.stat(pycache_opt1).st_mtime >= os.stat(file_py).st_mtime):
+                  os.stat(pycache_opt1, fast=True).st_mtime >= os.stat(file_py, fast=True).st_mtime):
                 # Use the __pycache__/*.pyc file, but write it to the legacy pyc
                 # file name in the archive.
                 fname = pycache_opt1
                 arcname = file_pyc
             elif (os.path.isfile(pycache_opt2) and
-                  os.stat(pycache_opt2).st_mtime >= os.stat(file_py).st_mtime):
+                  os.stat(pycache_opt2, fast=True).st_mtime >= os.stat(file_py, fast=True).st_mtime):
                 # Use the __pycache__/*.pyc file, but write it to the legacy pyc
                 # file name in the archive.
                 fname = pycache_opt2
@@ -2177,7 +2177,7 @@ class PyZipFile(ZipFile):
                     msg = "invalid value for 'optimize': {!r}".format(self._optimize)
                     raise ValueError(msg)
             if not (os.path.isfile(fname) and
-                    os.stat(fname).st_mtime >= os.stat(file_py).st_mtime):
+                    os.stat(fname, fast=True).st_mtime >= os.stat(file_py, fast=True).st_mtime):
                 if not _compile(file_py, optimize=self._optimize):
                     fname = arcname = file_py
         archivename = os.path.split(arcname)[1]

--- a/Misc/NEWS.d/next/Library/2022-11-23-15-15-59.gh-issue-99726.6m-YhG.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-23-15-15-59.gh-issue-99726.6m-YhG.rst
@@ -1,2 +1,2 @@
-Adds `fast` argument to :func:`os.stat` and :func:`os.lstat` to enable
+Adds ``fast`` argument to :func:`os.stat` and :func:`os.lstat` to enable
 performance optimizations by skipping some fields in the result.

--- a/Misc/NEWS.d/next/Library/2022-11-23-15-15-59.gh-issue-99726.6m-YhG.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-23-15-15-59.gh-issue-99726.6m-YhG.rst
@@ -1,0 +1,2 @@
+Adds `fast` argument to :func:`os.stat` and :func:`os.lstat` to enable
+performance optimizations by skipping some fields in the result.

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -6756,19 +6756,23 @@ exit:
 #endif /* defined(__APPLE__) */
 
 PyDoc_STRVAR(os_fstat__doc__,
-"fstat($module, /, fd)\n"
+"fstat($module, /, fd, *, fast=False)\n"
 "--\n"
 "\n"
 "Perform a stat system call on the given file descriptor.\n"
 "\n"
+"  fast\n"
+"    If True, certain data may be omitted on some platforms to\n"
+"    allow faster results. See the documentation for specific cases.\n"
+"\n"
 "Like stat(), but for an open file descriptor.\n"
-"Equivalent to os.stat(fd).");
+"Equivalent to os.stat(fd, fast=fast).");
 
 #define OS_FSTAT_METHODDEF    \
     {"fstat", _PyCFunction_CAST(os_fstat), METH_FASTCALL|METH_KEYWORDS, os_fstat__doc__},
 
 static PyObject *
-os_fstat_impl(PyObject *module, int fd);
+os_fstat_impl(PyObject *module, int fd, int fast);
 
 static PyObject *
 os_fstat(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -6776,14 +6780,14 @@ os_fstat(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
 
-    #define NUM_KEYWORDS 1
+    #define NUM_KEYWORDS 2
     static struct {
         PyGC_Head _this_is_not_used;
         PyObject_VAR_HEAD
         PyObject *ob_item[NUM_KEYWORDS];
     } _kwtuple = {
         .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
-        .ob_item = { &_Py_ID(fd), },
+        .ob_item = { &_Py_ID(fd), &_Py_ID(fast), },
     };
     #undef NUM_KEYWORDS
     #define KWTUPLE (&_kwtuple.ob_base.ob_base)
@@ -6792,15 +6796,17 @@ os_fstat(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
     #  define KWTUPLE NULL
     #endif  // !Py_BUILD_CORE
 
-    static const char * const _keywords[] = {"fd", NULL};
+    static const char * const _keywords[] = {"fd", "fast", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
         .fname = "fstat",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
-    PyObject *argsbuf[1];
+    PyObject *argsbuf[2];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     int fd;
+    int fast = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
     if (!args) {
@@ -6810,7 +6816,15 @@ os_fstat(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
     if (fd == -1 && PyErr_Occurred()) {
         goto exit;
     }
-    return_value = os_fstat_impl(module, fd);
+    if (!noptargs) {
+        goto skip_optional_kwonly;
+    }
+    fast = PyObject_IsTrue(args[1]);
+    if (fast < 0) {
+        goto exit;
+    }
+skip_optional_kwonly:
+    return_value = os_fstat_impl(module, fd, fast);
 
 exit:
     return return_value;
@@ -11577,4 +11591,4 @@ exit:
 #ifndef OS_WAITSTATUS_TO_EXITCODE_METHODDEF
     #define OS_WAITSTATUS_TO_EXITCODE_METHODDEF
 #endif /* !defined(OS_WAITSTATUS_TO_EXITCODE_METHODDEF) */
-/*[clinic end generated code: output=8653c0259a7b7c5e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8ac51554262db9eb input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -10254,19 +10254,27 @@ os.fstat
 
     fd : int
 
+    *
+
+    fast: bool = False
+        If True, certain data may be omitted on some platforms to
+        allow faster results. See the documentation for specific cases.
+
 Perform a stat system call on the given file descriptor.
 
 Like stat(), but for an open file descriptor.
-Equivalent to os.stat(fd).
+Equivalent to os.stat(fd, fast=fast).
 [clinic start generated code]*/
 
 static PyObject *
-os_fstat_impl(PyObject *module, int fd)
-/*[clinic end generated code: output=efc038cb5f654492 input=27e0e0ebbe5600c9]*/
+os_fstat_impl(PyObject *module, int fd, int fast)
+/*[clinic end generated code: output=7bd835f9da58993a input=a21b5b699d3a18c7]*/
 {
     STRUCT_STAT st;
     int res;
     int async_err = 0;
+    /* Currently we do not do anything with the fast option. */
+    (void)fast;
 
     do {
         Py_BEGIN_ALLOW_THREADS


### PR DESCRIPTION
When passed as True, only st_mode's type bits, st_size and st_mtime[_nsec] are guaranteed to be set. Other fields may also be set for a given Python version on a given platform version, but may change without warning (in the case of OS changes - Python will try to keep them stable).
This first implementation uses a new Windows API that is significantly faster, provided the volume identifier is not required. Other optimizations may be added later.

<!-- gh-issue-number: gh-99726 -->
* Issue: gh-99726
<!-- /gh-issue-number -->
