### PR TITLE
gh-99708: fix bug where compiler crashes on if expression with an empty body block

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1146,6 +1146,17 @@ if 1:
                 with self.subTest(source):
                     self.assertEqual(actual_positions, expected_positions)
 
+    def test_if_expression_expression_empty_block(self):
+        # See regression in gh-99708
+        exprs = [
+            "assert (False if 1 else True)",
+            "def f():\n\tif not (False if 1 else True): raise AssertionError",
+            "def f():\n\tif not (False if 1 else True): return 12",
+        ]
+        for expr in exprs:
+            with self.subTest(expr=expr):
+                compile(expr, "<single>", "exec")
+
 
 @requires_debug_ranges()
 class TestSourcePositions(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-23-18-16-18.gh-issue-99708.7MuaiR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-23-18-16-18.gh-issue-99708.7MuaiR.rst
@@ -1,0 +1,1 @@
+Fix bug where compiler crashes on an if expression with an empty body block.


### PR DESCRIPTION
Fixes #99708.

The crash comes from a cleanup sequence where we call `eliminate_empty_basic_blocks()` followed by `remove_redundant_nops()`. Later we assert that there are no empty blocks, but removing a redundant NOP can create an empty basic block.

I don't think that removing empty blocks can create new redundant NOPs. So this PR reverses the order, and add a debug assertion afterwards that there are no redundant NOPs.


<!-- gh-issue-number: gh-99708 -->
* Issue: gh-99708
<!-- /gh-issue-number -->
