### PR TITLE
gh-99735: Handle no arguments when using sub-commands in argparse

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1852,10 +1852,13 @@ Sub-commands
      >>> parser.parse_args(['co', 'bar'])
      Namespace(foo='bar')
 
-   One particularly effective way of handling sub-commands is to combine the use
-   of the :meth:`add_subparsers` method with calls to :meth:`set_defaults` so
-   that each subparser knows which Python function it should execute.  For
-   example::
+   One particularly effective way of handling sub-commands is to
+   combine the use of the :meth:`add_subparsers` method with calls to
+   :meth:`set_defaults` so that each subparser knows which Python
+   function it should execute.  The :meth:`set_defaults` method of the
+   main parser is called to handle the case when no subcommand is
+   included in the command line. The main parser :meth:`print_help`
+   method is called to display the help in this case.  For example::
 
      >>> # sub-command functions
      >>> def foo(args):

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1889,6 +1889,17 @@ Sub-commands
      >>> args = parser.parse_args('bar XYZYX'.split())
      >>> args.func(args)
      ((XYZYX))
+     >>>
+     >>> # show the help when called without arguments
+     >>> args = parser.parse_args()
+     >>> args.func(args)
+     usage: app.py [-h] {foo,bar} ...
+
+     positional arguments:
+       {foo,bar}
+
+     options:
+       -h, --help  show this help message and exit
 
    This way, you can let :meth:`parse_args` do the job of calling the
    appropriate function after argument parsing is complete.  Associating

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1866,6 +1866,7 @@ Sub-commands
      ...
      >>> # create the top-level parser
      >>> parser = argparse.ArgumentParser()
+     >>> parser.set_defaults(func=lambda args: parser.print_help())
      >>> subparsers = parser.add_subparsers()
      >>>
      >>> # create the parser for the "foo" command


### PR DESCRIPTION
This provides a fix to improve the example in the documentation.

<!-- gh-issue-number: gh-99735 -->
* Issue: gh-99735
<!-- /gh-issue-number -->
