### PR TITLE
gh-98724: Fix type punning issue in Py_SETREF()

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -325,9 +325,9 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
  */
 #define Py_SETREF(dst, src)                                     \
     do {                                                        \
-        PyObject **_tmp_dst_ptr = _Py_CAST(PyObject**, &(dst)); \
-        PyObject *_tmp_dst = (*_tmp_dst_ptr);                   \
-        *_tmp_dst_ptr = _PyObject_CAST(src);                    \
+        _PY_TYPEOF(dst)* _tmp_dst_ptr = &(dst);                 \
+        _PY_TYPEOF(dst) _tmp_dst = *_tmp_dst_ptr;               \
+        *_tmp_dst_ptr = (src);                                  \
         Py_DECREF(_tmp_dst);                                    \
     } while (0)
 
@@ -336,9 +336,9 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
  */
 #define Py_XSETREF(dst, src)                                    \
     do {                                                        \
-        PyObject **_tmp_dst_ptr = _Py_CAST(PyObject**, &(dst)); \
-        PyObject *_tmp_dst = (*_tmp_dst_ptr);                   \
-        *_tmp_dst_ptr = _PyObject_CAST(src);                    \
+        _PY_TYPEOF(dst)* _tmp_dst_ptr = &(dst);                 \
+        _PY_TYPEOF(dst) _tmp_dst = *_tmp_dst_ptr;               \
+        *_tmp_dst_ptr = (src);                                  \
         Py_XDECREF(_tmp_dst);                                   \
     } while (0)
 

--- a/Include/object.h
+++ b/Include/object.h
@@ -604,9 +604,9 @@ static inline void Py_DECREF(PyObject *op)
  */
 #define Py_CLEAR(op)                                          \
     do {                                                      \
-        PyObject **_py_tmp_ptr = _Py_CAST(PyObject**, &(op)); \
+        _PY_TYPEOF(op)* _py_tmp_ptr = &(op);                  \
         if (*_py_tmp_ptr != NULL) {                           \
-            PyObject* _py_tmp = (*_py_tmp_ptr);               \
+            _PY_TYPEOF(op) _py_tmp = *_py_tmp_ptr;            \
             *_py_tmp_ptr = NULL;                              \
             Py_DECREF(_py_tmp);                               \
         }                                                     \

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -717,4 +717,7 @@ extern char * _getpty(int *, int, mode_t, int);
 #  endif
 #endif
 
+// Get the type of an expression
+#define _PY_TYPEOF(EXPR) __typeof__(EXPR)
+
 #endif /* Py_PYPORT_H */


### PR DESCRIPTION
Fix type punning issue in Py_CLEAR(), Py_SETREF() and Py_XSETREF() macros. Don't cast pointers to avoid type punning which cause miscompilation of functions using these macros.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98724 -->
* Issue: gh-98724
<!-- /gh-issue-number -->
