### PR TITLE
GH-88564: IDLE - fix 2 Edit menu hotkey displays

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1624,6 +1624,8 @@ keynames = {
  'bracketleft': '[',
  'bracketright': ']',
  'slash': '/',
+ 'backslash': '\\',
+ 'space': 'Space' if macosx.isCocoaTk() else 'space',  # GH-88564.
 }
 
 def get_accelerator(keydefs, eventname):


### PR DESCRIPTION
On Mac Cocoa, ^+backspace and ^+space were mis-displayed as ^B and ^S. Replace 'backslash' with '\' everywhere, just as 'slash', for example, is replaced with '/'. On Mac Cocoa, change 'space' to 'Space', which then displays as 'Space' instead of 'S'.  ('Space' is also used for the Mac-specific Emoji & Symbols entry.)

Co-authored by [ronaldoussoren](https://github.com/ronaldoussoren)


<!-- gh-issue-number: gh-88564 -->
* Issue: gh-88564
<!-- /gh-issue-number -->
