### PR TITLE
gh-99728: correct typo in datetime format codes

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2602,7 +2602,7 @@ Notes:
 (9)
    When used with the :meth:`strptime` method, the leading zero is optional
    for  formats ``%d``, ``%m``, ``%H``, ``%I``, ``%M``, ``%S``, ``%j``, ``%U``,
-   ``%V``, and ``%W``. Format ``%y`` does require a leading zero.
+   ``%W``, and ``%V``. Format ``%y`` does require a leading zero.
 
 .. rubric:: Footnotes
 

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2601,8 +2601,8 @@ Notes:
 
 (9)
    When used with the :meth:`strptime` method, the leading zero is optional
-   for  formats ``%d``, ``%m``, ``%H``, ``%I``, ``%M``, ``%S``, ``%J``, ``%U``,
-   ``%W``, and ``%V``. Format ``%y`` does require a leading zero.
+   for  formats ``%d``, ``%j``, ``%m``, ``%H``, ``%I``, ``%M``, ``%S``, ``%U``,
+   ``%V``, and ``%W``. Format ``%y`` does require a leading zero.
 
 .. rubric:: Footnotes
 

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2601,7 +2601,7 @@ Notes:
 
 (9)
    When used with the :meth:`strptime` method, the leading zero is optional
-   for  formats ``%d``, ``%j``, ``%m``, ``%H``, ``%I``, ``%M``, ``%S``, ``%U``,
+   for  formats ``%d``, ``%m``, ``%H``, ``%I``, ``%M``, ``%S``, ``%j``, ``%U``,
    ``%V``, and ``%W``. Format ``%y`` does require a leading zero.
 
 .. rubric:: Footnotes


### PR DESCRIPTION
The documentation referenced '%J', which is not a valid datetime format code. The documentation was changed to reference '%j' instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99728 -->
* Issue: gh-99728
<!-- /gh-issue-number -->
