### PR TITLE
Fix rendering of audioop license in Doc/license.rst

### DIFF
--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -383,6 +383,7 @@ Project, https://www.wide.ad.jp/. ::
    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
    SUCH DAMAGE.
 
+
 Asynchronous socket services
 ----------------------------
 
@@ -988,9 +989,12 @@ https://www.w3.org/TR/xml-c14n2-testcases/ and is distributed under the
    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
 Audioop
 -------
+
 The audioop module uses the code base in g771.c file of the SoX project::
+
     Programming the AdLib/Sound Blaster
     FM Music Chips
     Version 2.0 (24 Feb 1992)


### PR DESCRIPTION
Also some cosmetic blank line additions for consistency with the
formatting of the rest of the file.
