### PR TITLE
gh-99266: ctypes: Preserve a more detailed exception in _SimpleCData.from_param

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -466,6 +466,14 @@ integer, string, bytes, a :mod:`ctypes` instance, or an object with an
 Return types
 ^^^^^^^^^^^^
 
+.. testsetup::
+
+   from ctypes import CDLL, c_char, c_char_p
+   from ctypes.util import find_library
+   libc = CDLL(find_library('c'))
+   strchr = libc.strchr
+
+
 By default functions are assumed to return the C :c:expr:`int` type.  Other
 return types can be specified by setting the :attr:`restype` attribute of the
 function object.
@@ -502,18 +510,19 @@ If you want to avoid the ``ord("x")`` calls above, you can set the
 :attr:`argtypes` attribute, and the second argument will be converted from a
 single character Python bytes object into a C char::
 
+.. doctest::
+
    >>> strchr.restype = c_char_p
    >>> strchr.argtypes = [c_char_p, c_char]
    >>> strchr(b"abcdef", b"d")
-   'def'
+   b'def'
    >>> strchr(b"abcdef", b"def")
    Traceback (most recent call last):
-     File "<stdin>", line 1, in <module>
-   ArgumentError: argument 2: TypeError: one character string expected
+   ctypes.ArgumentError: argument 2: TypeError: one character bytes, bytearray or integer expected
    >>> print(strchr(b"abcdef", b"x"))
    None
    >>> strchr(b"abcdef", b"d")
-   'def'
+   b'def'
    >>>
 
 You can also use a callable Python object (a function or a class for example) as

--- a/Lib/test/test_ctypes/test_functions.py
+++ b/Lib/test/test_ctypes/test_functions.py
@@ -65,7 +65,7 @@ class FunctionTestCase(unittest.TestCase):
 
         with self.assertRaises(ArgumentError) as cm:
             callback(b"abc")
-        
+
         self.assertEqual(str(cm.exception),
                          "argument 1: TypeError: one character bytes, "
                          "bytearray or integer expected")

--- a/Lib/test/test_ctypes/test_functions.py
+++ b/Lib/test/test_ctypes/test_functions.py
@@ -79,6 +79,18 @@ class FunctionTestCase(unittest.TestCase):
         self.assertEqual(result, 139)
         self.assertEqual(type(result), int)
 
+        with self.assertRaises(ArgumentError) as cm:
+            f(1, 2, 3, 4, 5.0, 6.0)
+        self.assertEqual(str(cm.exception),
+                         "argument 2: TypeError: unicode string expected "
+                         "instead of int instance")
+
+        with self.assertRaises(ArgumentError) as cm:
+            f(1, "abc", 3, 4, 5.0, 6.0)
+        self.assertEqual(str(cm.exception),
+                         "argument 2: TypeError: one character unicode string "
+                         "expected")
+
     @need_symbol('c_wchar')
     def test_wchar_result(self):
         f = dll._testfunc_i_bhilfd

--- a/Lib/test/test_ctypes/test_functions.py
+++ b/Lib/test/test_ctypes/test_functions.py
@@ -54,6 +54,23 @@ class FunctionTestCase(unittest.TestCase):
             class X(object, Structure):
                 _fields_ = []
 
+    def test_c_char_parm(self):
+        proto = CFUNCTYPE(c_int, c_char)
+        def callback(*args):
+            return 0
+
+        callback = proto(callback)
+
+        self.assertEqual(callback(b"a"), 0)
+
+        with self.assertRaises(ArgumentError) as cm:
+            callback(b"abc")
+        
+        self.assertEqual(str(cm.exception),
+                         "argument 1: TypeError: one character bytes, "
+                         "bytearray or integer expected")
+
+
     @need_symbol('c_wchar')
     def test_wchar_parm(self):
         f = dll._testfunc_i_bhilfd

--- a/Lib/test/test_ctypes/test_parameters.py
+++ b/Lib/test/test_ctypes/test_parameters.py
@@ -100,7 +100,6 @@ class SimpleTypesTestCase(unittest.TestCase):
             c_wchar.from_param(123)
         self.assertEqual(str(cm.exception),
                          "unicode string expected instead of int instance")
-        
 
     def test_int_pointers(self):
         from ctypes import c_short, c_uint, c_int, c_long, POINTER, pointer

--- a/Lib/test/test_ctypes/test_parameters.py
+++ b/Lib/test/test_ctypes/test_parameters.py
@@ -83,10 +83,24 @@ class SimpleTypesTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError) as cm:
             c_char.from_param(b"abc")
-
         self.assertEqual(str(cm.exception),
                          "one character bytes, bytearray or integer expected")
 
+    @need_symbol('c_wchar')
+    def test_c_wchar(self):
+        from ctypes import c_wchar
+
+        with self.assertRaises(TypeError) as cm:
+            c_wchar.from_param("abc")
+        self.assertEqual(str(cm.exception),
+                         "one character unicode string expected")
+
+
+        with self.assertRaises(TypeError) as cm:
+            c_wchar.from_param(123)
+        self.assertEqual(str(cm.exception),
+                         "unicode string expected instead of int instance")
+        
 
     def test_int_pointers(self):
         from ctypes import c_short, c_uint, c_int, c_long, POINTER, pointer

--- a/Lib/test/test_ctypes/test_parameters.py
+++ b/Lib/test/test_ctypes/test_parameters.py
@@ -78,6 +78,16 @@ class SimpleTypesTestCase(unittest.TestCase):
         pa = c_wchar_p.from_param(c_wchar_p("123"))
         self.assertEqual(type(pa), c_wchar_p)
 
+    def test_c_char(self):
+        from ctypes import c_char
+
+        with self.assertRaises(TypeError) as cm:
+            c_char.from_param(b"abc")
+
+        self.assertEqual(str(cm.exception),
+                         "one character bytes, bytearray or integer expected")
+
+
     def test_int_pointers(self):
         from ctypes import c_short, c_uint, c_int, c_long, POINTER, pointer
         LPINT = POINTER(c_int)

--- a/Misc/NEWS.d/next/Library/2022-11-24-21-52-31.gh-issue-99266.88GcV9.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-24-21-52-31.gh-issue-99266.88GcV9.rst
@@ -1,1 +1,1 @@
-Make ctypes fundamental data types preserve a more detail exception in ```from_param``.
+Make ctypes fundamental data types preserve a more detail exception in ``from_param``.

--- a/Misc/NEWS.d/next/Library/2022-11-24-21-52-31.gh-issue-99266.88GcV9.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-24-21-52-31.gh-issue-99266.88GcV9.rst
@@ -1,1 +1,1 @@
-Make ctypes fundamental data types preserve a more detail exception in ``from_param``.
+Preserve more detailed error messages in :mod:`ctypes`.

--- a/Misc/NEWS.d/next/Library/2022-11-24-21-52-31.gh-issue-99266.88GcV9.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-24-21-52-31.gh-issue-99266.88GcV9.rst
@@ -1,0 +1,1 @@
+Preserve a more detailed exception in ``_ctypes._SimpleCData.from_param``.

--- a/Misc/NEWS.d/next/Library/2022-11-24-21-52-31.gh-issue-99266.88GcV9.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-24-21-52-31.gh-issue-99266.88GcV9.rst
@@ -1,1 +1,1 @@
-Make ctypes fundamental data types preserve a more detail exception in `from_param`.
+Make ctypes fundamental data types preserve a more detail exception in ```from_param``.

--- a/Misc/NEWS.d/next/Library/2022-11-24-21-52-31.gh-issue-99266.88GcV9.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-24-21-52-31.gh-issue-99266.88GcV9.rst
@@ -1,1 +1,1 @@
-Preserve a more detailed exception in ``_ctypes._SimpleCData.from_param``.
+Make ctypes fundamental data types preserve a more detail exception in `from_param`.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2240,6 +2240,9 @@ PyCSimpleType_from_param(PyObject *type, PyObject *value)
     if (as_parameter) {
         if (_Py_EnterRecursiveCall("while processing _as_parameter_")) {
             Py_DECREF(as_parameter);
+            Py_XDECREF(exc);
+            Py_XDECREF(val);
+            Py_XDECREF(tb);
             return NULL;
         }
         value = PyCSimpleType_from_param(type, as_parameter);

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2197,6 +2197,7 @@ PyCSimpleType_from_param(PyObject *type, PyObject *value)
     struct fielddesc *fd;
     PyObject *as_parameter;
     int res;
+    PyObject *exc, *val, *tb;
 
     /* If the value is already an instance of the requested type,
        we can use it as is */
@@ -2230,6 +2231,8 @@ PyCSimpleType_from_param(PyObject *type, PyObject *value)
     parg->obj = fd->setfunc(&parg->value, value, 0);
     if (parg->obj)
         return (PyObject *)parg;
+
+    PyErr_Fetch(&exc, &val, &tb);
     PyErr_Clear();
     Py_DECREF(parg);
 
@@ -2244,10 +2247,12 @@ PyCSimpleType_from_param(PyObject *type, PyObject *value)
         value = PyCSimpleType_from_param(type, as_parameter);
         _Py_LeaveRecursiveCall();
         Py_DECREF(as_parameter);
+        Py_DECREF(exc);
+        Py_DECREF(val);
+        Py_DECREF(tb);
         return value;
     }
-    PyErr_SetString(PyExc_TypeError,
-                    "wrong type");
+    PyErr_Restore(exc, val, tb);
     return NULL;
 }
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2235,6 +2235,9 @@ PyCSimpleType_from_param(PyObject *type, PyObject *value)
     Py_DECREF(parg);
 
     if (_PyObject_LookupAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {
+        Py_XDECREF(exc);
+        Py_XDECREF(val);
+        Py_XDECREF(tb);
         return NULL;
     }
     if (as_parameter) {

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2256,11 +2256,12 @@ PyCSimpleType_from_param(PyObject *type, PyObject *value)
         Py_XDECREF(tb);
         return value;
     }
-    if (exc)
+    if (exc) {
         PyErr_Restore(exc, val, tb);
-    else
-        PyErr_SetString(PyExc_TypeError,
-                        "wrong type");
+    }
+    else {
+        PyErr_SetString(PyExc_TypeError, "wrong type");
+    }
     return NULL;
 }
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2231,9 +2231,7 @@ PyCSimpleType_from_param(PyObject *type, PyObject *value)
     parg->obj = fd->setfunc(&parg->value, value, 0);
     if (parg->obj)
         return (PyObject *)parg;
-
     PyErr_Fetch(&exc, &val, &tb);
-    PyErr_Clear();
     Py_DECREF(parg);
 
     if (_PyObject_LookupAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2247,12 +2247,16 @@ PyCSimpleType_from_param(PyObject *type, PyObject *value)
         value = PyCSimpleType_from_param(type, as_parameter);
         _Py_LeaveRecursiveCall();
         Py_DECREF(as_parameter);
-        Py_DECREF(exc);
-        Py_DECREF(val);
-        Py_DECREF(tb);
+        Py_XDECREF(exc);
+        Py_XDECREF(val);
+        Py_XDECREF(tb);
         return value;
     }
-    PyErr_Restore(exc, val, tb);
+    if (exc)
+        PyErr_Restore(exc, val, tb);
+    else
+        PyErr_SetString(PyExc_TypeError,
+                        "wrong type");
     return NULL;
 }
 


### PR DESCRIPTION
Closes #99266.

The exception from `fd->setfunc` is now saved and then restored if the object doesn't have an `_as_parameter_`.

<!-- gh-issue-number: gh-99266 -->
* Issue: gh-99266
<!-- /gh-issue-number -->
