### PR TITLE
gh-99772: Do not ignore utc offset microseconds

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1466,10 +1466,16 @@ class time:
                 return 2 # arbitrary non-zero value
             else:
                 raise TypeError("cannot compare naive and aware times")
-        myhhmm = self._hour * 60 + self._minute - myoff//timedelta(minutes=1)
-        othhmm = other._hour * 60 + other._minute - otoff//timedelta(minutes=1)
-        return _cmp((myhhmm, self._second, self._microsecond),
-                    (othhmm, other._second, other._microsecond))
+
+        mydelta = timedelta(
+            seconds=self._hour * 3600 + self._minute * 60 + self._second,
+            microseconds=self._microsecond
+            ) - myoff
+        otdelta = timedelta(
+            seconds=other._hour * 3600 + other._minute * 60 + other._second,
+            microseconds=other._microsecond
+            ) - otoff
+        return _cmp(mydelta, otdelta)
 
     def __hash__(self):
         """Hash."""

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3861,6 +3861,22 @@ class TZInfoBase:
                         expected = 1
                     self.assertEqual(got, expected)
 
+        # Test tz offset with microseconds
+        d0 = base.replace(minute=5, tzinfo=timezone(timedelta(microseconds=3)))
+        d1 = base.replace(
+            minute=5, tzinfo=timezone(timedelta(microseconds=456)))
+        d2 = base.replace(
+            minute=5, tzinfo=timezone(timedelta(microseconds=98764)))
+        for x in d0, d1, d2:
+            for y in d0, d1, d2:
+                for op in lt, le, gt, ge, eq, ne:
+                    got = op(x, y)
+                    expected = op(
+                        -x.utcoffset().microseconds,
+                        -y.utcoffset().microseconds)
+                    self.assertEqual(got, expected)
+
+
 
 # Testing time objects with a non-None tzinfo.
 class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2022-11-25-12-25-29.gh-issue-99772.ZO23Uc.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-25-12-25-29.gh-issue-99772.ZO23Uc.rst
@@ -1,0 +1,1 @@
+Fix compare operations for datetime.time values with microseconds resolution in utcoffset.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4473,22 +4473,24 @@ time_richcompare(PyObject *self, PyObject *other, int op)
     }
     /* The hard case: both aware with different UTC offsets */
     else if (offset1 != Py_None && offset2 != Py_None) {
-        int offsecs1, offsecs2;
+        int64_t offusecs1, offusecs2, diff64;
         assert(offset1 != offset2); /* else last "if" handled it */
-        offsecs1 = TIME_GET_HOUR(self) * 3600 +
-                   TIME_GET_MINUTE(self) * 60 +
-                   TIME_GET_SECOND(self) -
-                   GET_TD_DAYS(offset1) * 86400 -
-                   GET_TD_SECONDS(offset1);
-        offsecs2 = TIME_GET_HOUR(other) * 3600 +
-                   TIME_GET_MINUTE(other) * 60 +
-                   TIME_GET_SECOND(other) -
-                   GET_TD_DAYS(offset2) * 86400 -
-                   GET_TD_SECONDS(offset2);
-        diff = offsecs1 - offsecs2;
-        if (diff == 0)
-            diff = TIME_GET_MICROSECOND(self) -
-                   TIME_GET_MICROSECOND(other);
+        offusecs1 = TIME_GET_HOUR(self) * 3600000000 +
+                    TIME_GET_MINUTE(self) * INT64_C(60000000) +
+                    TIME_GET_SECOND(self) * 1000000 +
+                    TIME_GET_MICROSECOND(self) -
+                    GET_TD_DAYS(offset1) * 86400000000 -
+                    GET_TD_SECONDS(offset1) * INT64_C(1000000) -
+                    GET_TD_MICROSECONDS(offset1);
+        offusecs2 = TIME_GET_HOUR(other) * 3600000000 +
+                    TIME_GET_MINUTE(other) * INT64_C(60000000) +
+                    TIME_GET_SECOND(other) * 1000000 +
+                    TIME_GET_MICROSECOND(other) -
+                    GET_TD_DAYS(offset2) * 86400000000 -
+                    GET_TD_SECONDS(offset2) * INT64_C(1000000) -
+                    GET_TD_MICROSECONDS(offset2);
+        diff64 = offusecs1 - offusecs2;
+        diff = diff64 ? diff64 < 0 ? -1 : 1 : 0;  /* diff_to_bool needs int */
         result = diff_to_bool(diff, op);
     }
     else if (op == Py_EQ) {

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4475,14 +4475,14 @@ time_richcompare(PyObject *self, PyObject *other, int op)
     else if (offset1 != Py_None && offset2 != Py_None) {
         int64_t offusecs1, offusecs2, diff64;
         assert(offset1 != offset2); /* else last "if" handled it */
-        offusecs1 = TIME_GET_HOUR(self) * 3600000000 +
+        offusecs1 = TIME_GET_HOUR(self) * INT64_C(3600000000) +
                     TIME_GET_MINUTE(self) * INT64_C(60000000) +
                     TIME_GET_SECOND(self) * 1000000 +
                     TIME_GET_MICROSECOND(self) -
                     GET_TD_DAYS(offset1) * 86400000000 -
                     GET_TD_SECONDS(offset1) * INT64_C(1000000) -
                     GET_TD_MICROSECONDS(offset1);
-        offusecs2 = TIME_GET_HOUR(other) * 3600000000 +
+        offusecs2 = TIME_GET_HOUR(other) * INT64_C(3600000000) +
                     TIME_GET_MINUTE(other) * INT64_C(60000000) +
                     TIME_GET_SECOND(other) * 1000000 +
                     TIME_GET_MICROSECOND(other) -


### PR DESCRIPTION
<!--

Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Fixes the compare operations for datetime.time values with microseconds in the utc offset.


<!-- gh-issue-number: gh-99772 -->
* Issue: gh-99772
<!-- /gh-issue-number -->
