### PR TITLE
gh-98724: Fix warnings on Py_SETREF() usage

### DIFF
--- a/Modules/_curses_panel.c
+++ b/Modules/_curses_panel.c
@@ -424,7 +424,7 @@ _curses_panel_panel_replace_impl(PyCursesPanelObject *self,
         PyErr_SetString(state->PyCursesError, "replace_panel() returned ERR");
         return NULL;
     }
-    Py_SETREF(po->wo, Py_NewRef(win));
+    Py_SETREF(po->wo, (PyCursesWindowObject*)Py_NewRef(win));
     Py_RETURN_NONE;
 }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4775,7 +4775,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
          * because we're primarily trying to cut overhead for small powers.
          */
         assert(bi);  /* else there is no significant bit */
-        Py_SETREF(z, Py_NewRef(a));
+        Py_SETREF(z, (PyLongObject*)Py_NewRef(a));
         for (bit = 2; ; bit <<= 1) {
             if (bit > bi) { /* found the first bit */
                 assert((bi & bit) == 0);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -9593,7 +9593,7 @@ super_init_impl(PyObject *self, PyTypeObject *type, PyObject *obj) {
             return -1;
         Py_INCREF(obj);
     }
-    Py_XSETREF(su->type, Py_NewRef(type));
+    Py_XSETREF(su->type, (PyTypeObject*)Py_NewRef(type));
     Py_XSETREF(su->obj, obj);
     Py_XSETREF(su->obj_type, obj_type);
     return 0;


### PR DESCRIPTION
Cast argument to the expected type.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98724 -->
* Issue: gh-98724
<!-- /gh-issue-number -->
