### PR TITLE
[3.10] gh-99795: Fix typo in importlib.resources.abc (GH-99796)

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -862,7 +862,7 @@ ABC hierarchy::
     An abstract base class for resource readers capable of serving
     the ``files`` interface. Subclasses ResourceReader and provides
     concrete implementations of the ResourceReader's abstract
-    methods. Therefore, any loader supplying TraversableReader
+    methods. Therefore, any loader supplying TraversableResources
     also supplies ResourceReader.
 
     Loaders that wish to support resource reading are expected to


### PR DESCRIPTION
Changing TraversableReader to TraversableResources at one place of the documentation.

See GH-99795 for more details..
(cherry picked from commit 5f8898216e7b67b7de6b0b1aad9277e88bcebfdb)

Co-authored-by: busywhitespace <busywhitespace@tuta.io>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
