### PR TITLE
gh-99777: TimeoutErrors can now be handled by handle_error()

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -409,20 +409,22 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
             if not self.parse_request():
                 # An error code has been sent, just exit
                 return
-            mname = 'do_' + self.command
-            if not hasattr(self, mname):
-                self.send_error(
-                    HTTPStatus.NOT_IMPLEMENTED,
-                    "Unsupported method (%r)" % self.command)
-                return
-            method = getattr(self, mname)
-            method()
+            
             self.wfile.flush() #actually send the response if not already done.
         except TimeoutError as e:
             #a read or a write timed out.  Discard this connection
             self.log_error("Request timed out: %r", e)
             self.close_connection = True
             return
+        mname = 'do_' + self.command
+        if not hasattr(self, mname):
+            self.send_error(
+                HTTPStatus.NOT_IMPLEMENTED,
+                "Unsupported method (%r)" % self.command)
+            return
+        method = getattr(self, mname)
+        method()
+        return
 
     def handle(self):
         """Handle multiple requests if necessary."""

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1299,7 +1299,7 @@ print_warning.orig_stderr = sys.stderr
 # to check if a test modified the environment. The flag should be set to False
 # before running a new test.
 #
-# For example, threading_helper.threading_cleanup() sets the flag is the function fails
+# For example, threading_helper.threading_cleanup() sets the flag if the function fails
 # to cleanup threads.
 environment_altered = False
 

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -328,6 +328,10 @@ class ErrorHandlerTest(unittest.TestCase):
             self.check_result(handled=False)
 
             self.assertIs(cm.exc_type, SystemExit)
+    
+    def test_timeout_handled(self):
+        BaseErrorTestServer(TimeoutError)
+        self.check_result(handled=True)
 
     @requires_forking
     def test_forking_handled(self):


### PR DESCRIPTION
# gh-99777: Timeout errors can now be handled by handle_error()

This PR addresses gh-99777, allowing TimeoutErrors to be handled by the handle_errors() function when a TimeoutError is thrown in a `do_{METHOD}` function.