### PR TITLE
`fnmatch` docs: link to `fnmatch.filter()`, not `builtins.filter()`

### DIFF
--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -48,7 +48,7 @@ patterns.
 
 Also note that :func:`functools.lru_cache` with the *maxsize* of 32768 is used to
 cache the compiled regex patterns in the following functions: :func:`fnmatch`,
-:func:`fnmatchcase`, :func:`filter`.
+:func:`fnmatchcase`, :func:`.filter`.
 
 .. function:: fnmatch(filename, pattern)
 


### PR DESCRIPTION
Fix a link that was pointing to the builtin `filter` instead of `fnmatch.filter`

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
