### PR TITLE
simplified conditions in dict_richcompare

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3155,20 +3155,12 @@ static PyObject *
 dict_richcompare(PyObject *v, PyObject *w, int op)
 {
     int cmp;
-    PyObject *res;
 
-    if (!PyDict_Check(v) || !PyDict_Check(w)) {
-        res = Py_NotImplemented;
-    }
-    else if (op == Py_EQ || op == Py_NE) {
-        cmp = dict_equal((PyDictObject *)v, (PyDictObject *)w);
-        if (cmp < 0)
-            return NULL;
-        res = (cmp == (op == Py_EQ)) ? Py_True : Py_False;
-    }
-    else
-        res = Py_NotImplemented;
-    return Py_NewRef(res);
+    if (!PyDict_Check(v) || !PyDict_Check(w) || (op != Py_EQ && op != Py_NE))
+        return Py_NewRef(Py_NotImplemented);
+    if ((cmp = dict_equal((PyDictObject *)v, (PyDictObject *)w)) < 0)
+        return NULL;
+    return Py_NewRef((cmp == (op == Py_EQ)) ? Py_True : Py_False);
 }
 
 /*[clinic input]


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
`dict_richcompare` function in `dictobject.c` file uses redundant condition branching.