### PR TITLE
Use _Py_RVALUE() in macros

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -153,7 +153,7 @@ static inline Py_ssize_t PyCode_GetNumFree(PyCodeObject *op) {
     return op->co_nfreevars;
 }
 
-#define _PyCode_CODE(CO) ((_Py_CODEUNIT *)(CO)->co_code_adaptive)
+#define _PyCode_CODE(CO) _Py_RVALUE((_Py_CODEUNIT *)(CO)->co_code_adaptive)
 #define _PyCode_NBYTES(CO) (Py_SIZE(CO) * (Py_ssize_t)sizeof(_Py_CODEUNIT))
 
 /* Public interface */

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -122,7 +122,7 @@ struct _dictvalues {
     PyObject *values[1];
 };
 
-#define DK_LOG_SIZE(dk)  ((dk)->dk_log2_size)
+#define DK_LOG_SIZE(dk)  _Py_RVALUE((dk)->dk_log2_size)
 #if SIZEOF_VOID_P > 4
 #define DK_SIZE(dk)      (((int64_t)1)<<DK_LOG_SIZE(dk))
 #else

--- a/Include/internal/pycore_hashtable.h
+++ b/Include/internal/pycore_hashtable.h
@@ -18,9 +18,9 @@ typedef struct {
     _Py_slist_item_t *head;
 } _Py_slist_t;
 
-#define _Py_SLIST_ITEM_NEXT(ITEM) (((_Py_slist_item_t *)(ITEM))->next)
+#define _Py_SLIST_ITEM_NEXT(ITEM) _Py_RVALUE(((_Py_slist_item_t *)(ITEM))->next)
 
-#define _Py_SLIST_HEAD(SLIST) (((_Py_slist_t *)(SLIST))->head)
+#define _Py_SLIST_HEAD(SLIST) _Py_RVALUE(((_Py_slist_t *)(SLIST))->head)
 
 
 /* _Py_hashtable: table entry */

--- a/Include/internal/pycore_list.h
+++ b/Include/internal/pycore_list.h
@@ -35,7 +35,7 @@ struct _Py_list_state {
 #endif
 };
 
-#define _PyList_ITEMS(op) (_PyList_CAST(op)->ob_item)
+#define _PyList_ITEMS(op) _Py_RVALUE(_PyList_CAST(op)->ob_item)
 
 extern int
 _PyList_AppendTakeRefListResize(PyListObject *self, PyObject *newitem);

--- a/Include/internal/pycore_tuple.h
+++ b/Include/internal/pycore_tuple.h
@@ -62,7 +62,7 @@ struct _Py_tuple_state {
 #endif
 };
 
-#define _PyTuple_ITEMS(op) (_PyTuple_CAST(op)->ob_item)
+#define _PyTuple_ITEMS(op) _Py_RVALUE(_PyTuple_CAST(op)->ob_item)
 
 extern PyObject *_PyTuple_FromArray(PyObject *const *, Py_ssize_t);
 extern PyObject *_PyTuple_FromArraySteal(PyObject *const *, Py_ssize_t);


### PR DESCRIPTION
The following macros are modified to use _Py_RVALUE(), so they can no longer be used as l-value:

* DK_LOG_SIZE()
* _PyCode_CODE()
* _PyList_ITEMS()
* _PyTuple_ITEMS()
* _Py_SLIST_HEAD()
* _Py_SLIST_ITEM_NEXT()

_PyCode_CODE() is private and other macros are part of the internal C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
