### PR TITLE
gh-99845: PEP 670: Convert PyObject macros to functions

### DIFF
--- a/Include/cpython/objimpl.h
+++ b/Include/cpython/objimpl.h
@@ -2,7 +2,9 @@
 #  error "this header file must not be included directly"
 #endif
 
-#define _PyObject_SIZE(typeobj) ( (typeobj)->tp_basicsize )
+static inline size_t _PyObject_SIZE(PyTypeObject *type) {
+    return _Py_STATIC_CAST(size_t, type->tp_basicsize);
+}
 
 /* _PyObject_VAR_SIZE returns the number of bytes (as size_t) allocated for a
    vrbl-size object with nitems items, exclusive of gc overhead (if any).  The
@@ -18,10 +20,11 @@
 #   error "_PyObject_VAR_SIZE requires SIZEOF_VOID_P be a power of 2"
 #endif
 
-#define _PyObject_VAR_SIZE(typeobj, nitems)     \
-    _Py_SIZE_ROUND_UP((typeobj)->tp_basicsize + \
-        (nitems)*(typeobj)->tp_itemsize,        \
-        SIZEOF_VOID_P)
+static inline size_t _PyObject_VAR_SIZE(PyTypeObject *type, Py_ssize_t nitems) {
+    size_t size = _Py_STATIC_CAST(size_t, type->tp_basicsize);
+    size += _Py_STATIC_CAST(size_t, nitems) * _Py_STATIC_CAST(size_t, type->tp_itemsize);
+    return _Py_SIZE_ROUND_UP(size, SIZEOF_VOID_P);
+}
 
 
 /* This example code implements an object constructor with a custom


### PR DESCRIPTION
Convert macros to static inline functions to avoid macro pitfalls, like duplication of side effects:

* _PyObject_SIZE()
* _PyObject_VAR_SIZE()

The result type is size_t (unsigned).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99845 -->
* Issue: gh-99845
<!-- /gh-issue-number -->
