### PR TITLE
gh-88267: Avoid exporting functions when a static build is used

### DIFF
--- a/Include/exports.h
+++ b/Include/exports.h
@@ -2,9 +2,15 @@
 #define Py_EXPORTS_H
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-    #define Py_IMPORTED_SYMBOL __declspec(dllimport)
-    #define Py_EXPORTED_SYMBOL __declspec(dllexport)
-    #define Py_LOCAL_SYMBOL
+    #if defined(Py_ENABLE_SHARED)
+        #define Py_IMPORTED_SYMBOL __declspec(dllimport)
+        #define Py_EXPORTED_SYMBOL __declspec(dllexport)
+        #define Py_LOCAL_SYMBOL
+    #else
+        #define Py_IMPORTED_SYMBOL
+        #define Py_EXPORTED_SYMBOL
+        #define Py_LOCAL_SYMBOL
+    #endif
 #else
 /*
  * If we only ever used gcc >= 5, we could use __has_attribute(visibility)

--- a/Misc/NEWS.d/next/Build/2022-12-08-14-00-04.gh-issue-88267.MqtRbm.rst
+++ b/Misc/NEWS.d/next/Build/2022-12-08-14-00-04.gh-issue-88267.MqtRbm.rst
@@ -1,0 +1,1 @@
+Avoid exporting Python symbols in linked Windows applications when the core is built as static.


### PR DESCRIPTION
In a Python core static build scenario (for example: embedding in Windows), MSVC would export the Python symbols for such application as well.
This commit fixes this behavour allowing the application to not export python modules and remove the automatically generated lib file, wichi shouldn't be generated for an executable.

Modules such as _socket.pyd would be disabled in a static build as the linked environment would differ, therefore I don't think there is any use for having an application specifically export modules.

In case where such behavour would be required, I would suggest adding an extra macro to disable such exports (such as Py_NO_EXPORTS).

This behavour has been tested on Windows MSVC2022, on Linux I don't think GCC would automatically export such functions but I'm not an expert on that topic.

(Fixes #88267)

NOTE: I am aware that pythoncore currently doesn't build properly in static, I used vcpkg's https://github.com/microsoft/vcpkg/blob/master/ports/python3/0002-static-library.patch (updated for Py 3.12) along with some changes to PC/dl_nt.c to allow the python interpreter to properly run, I could send a PR for this changes in case.

<!-- gh-issue-number: gh-88267 -->
* Issue: gh-88267
<!-- /gh-issue-number -->
