### PR TITLE
gh-99845: _PySys_GetSizeOf() uses size_t

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1269,6 +1269,15 @@ class SizeofTest(unittest.TestCase):
 
     check_sizeof = test.support.check_sizeof
 
+    def test_sizeof_method(self):
+        class Sizeof(int):
+            def __sizeof__(self):
+                return int(self)
+
+        header_size = self.gc_headsize * 2
+        self.assertEqual(sys.getsizeof(Sizeof(0)), header_size)
+        self.assertEqual(sys.getsizeof(Sizeof(100)), 100 + header_size)
+
     def test_gc_head_size(self):
         # Check that the gc header size is added to objects tracked by the gc.
         vsize = test.support.calcvobjsize
@@ -1299,16 +1308,17 @@ class SizeofTest(unittest.TestCase):
 
         # size_t maximum
         header_size = self.gc_headsize * 2
-        umaxsize = (sys.maxsize * 2 + 1) - header_size
+        maxsize = (sys.maxsize * 2 + 1) - header_size
 
         class OverflowSizeof(int):
             def __sizeof__(self):
                 return int(self)
-        self.assertEqual(sys.getsizeof(OverflowSizeof(umaxsize)),
-                         umaxsize + header_size)
+
+        self.assertEqual(sys.getsizeof(OverflowSizeof(maxsize)),
+                         maxsize + header_size)
         with self.assertRaises(OverflowError):
-            sys.getsizeof(OverflowSizeof(umaxsize + 1))
-        with self.assertRaises((ValueError, OverflowError)):
+            sys.getsizeof(OverflowSizeof(maxsize + 1))
+        with self.assertRaises(OverflowError):
             sys.getsizeof(OverflowSizeof(-1))
 
     def test_default(self):

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1297,17 +1297,19 @@ class SizeofTest(unittest.TestCase):
         self.assertRaises(TypeError, sys.getsizeof, FloatSizeof())
         self.assertIs(sys.getsizeof(FloatSizeof(), sentinel), sentinel)
 
+        # size_t maximum
+        header_size = self.gc_headsize * 2
+        umaxsize = (sys.maxsize * 2 + 1) - header_size
+
         class OverflowSizeof(int):
             def __sizeof__(self):
                 return int(self)
-        self.assertEqual(sys.getsizeof(OverflowSizeof(sys.maxsize)),
-                         sys.maxsize + self.gc_headsize*2)
+        self.assertEqual(sys.getsizeof(OverflowSizeof(umaxsize)),
+                         umaxsize + header_size)
         with self.assertRaises(OverflowError):
-            sys.getsizeof(OverflowSizeof(sys.maxsize + 1))
-        with self.assertRaises(ValueError):
-            sys.getsizeof(OverflowSizeof(-1))
+            sys.getsizeof(OverflowSizeof(umaxsize + 1))
         with self.assertRaises((ValueError, OverflowError)):
-            sys.getsizeof(OverflowSizeof(-sys.maxsize - 1))
+            sys.getsizeof(OverflowSizeof(-1))
 
     def test_default(self):
         size = test.support.calcvobjsize

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1772,7 +1772,7 @@ _PySys_GetSizeOf(PyObject *o)
     size_t header_size = _PyType_PreHeaderSize(Py_TYPE(o));
     if (size > SIZE_MAX - header_size) {
         PyErr_SetString(PyExc_OverflowError,
-                        "size greater than size_t maximum");
+                        "__sizeof__() greater than size_t maximum");
         return (size_t)-1;
     }
     return header_size + size;


### PR DESCRIPTION
The _PySys_GetSizeOf() function now uses an unsigned type (size_t) to compute the size, rather than a signed type (Py_ssize_t).

* _PySys_GetSizeOf() now checks for integer overflow when adding the header size.
* Reformat also _PySys_GetSizeOf().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99845 -->
* Issue: gh-99845
<!-- /gh-issue-number -->
