### PR TITLE
gh-99905: Fix output of misses in summarize_stats.py execution counts

### DIFF
--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -317,11 +317,11 @@ def calculate_execution_counts(opcode_stats, total):
     for (count, name, miss) in counts:
         cumulative += count
         if miss:
-            miss =  f"{100*miss/count:0.1f}%"
+            miss = f"{100*miss/count:0.1f}%"
         else:
             miss = ""
-            rows.append((name, count, f"{100*count/total:0.1f}%",
-                         f"{100*cumulative/total:0.1f}%", miss))
+        rows.append((name, count, f"{100*count/total:0.1f}%",
+                     f"{100*cumulative/total:0.1f}%", miss))
     return rows
 
 def emit_execution_counts(opcode_stats, total):


### PR DESCRIPTION
This was an indentation error introduced in 2844aa6a


<!-- gh-issue-number: gh-99905 -->
* Issue: gh-99905
<!-- /gh-issue-number -->
