### PR TITLE
gh-99901: prepend '/' to url only if netloc is not empty

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -875,6 +875,13 @@ class UrlParseTestCase(unittest.TestCase):
                 self.assertEqual(func(b"path").scheme, b"")
                 self.assertEqual(func(b"path", "").scheme, b"")
 
+    def test_empty_netloc(self):
+        # Issue gh-99901: don't preprend '/' to url if netloc is empty
+        self.assertEqual(urllib.parse.urlunparse(("http", "", "example", "", "", "")),
+                         "http://example")
+        self.assertEqual(urllib.parse.urlunparse((b"http", b"", b"example", b"", b"", b"")),
+                         b"http://example")
+
     def test_parse_fragments(self):
         # Exercise the allow_fragments parameter of urlparse() and urlsplit()
         tests = (

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -526,7 +526,8 @@ def urlunsplit(components):
     scheme, netloc, url, query, fragment, _coerce_result = (
                                           _coerce_args(*components))
     if netloc or (scheme and scheme in uses_netloc and url[:2] != '//'):
-        if url and url[:1] != '/': url = '/' + url
+        if netloc and url and url[:1] != '/':
+            url = '/' + url
         url = '//' + (netloc or '') + url
     if scheme:
         url = scheme + ':' + url

--- a/Misc/NEWS.d/next/Library/2022-11-30-21-19-21.gh-issue-99901.zs8xu9.rst
+++ b/Misc/NEWS.d/next/Library/2022-11-30-21-19-21.gh-issue-99901.zs8xu9.rst
@@ -1,0 +1,1 @@
+Fix :func:`urllib.parse.urlunsplit` to prepend '/' to url only if netloc is not empty.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
#99901

<!-- gh-issue-number: gh-99901 -->
* Issue: gh-99901
<!-- /gh-issue-number -->
