### PR TITLE
Doc: Add summary line to isolation_level & autocommit sqlite3.connect params

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -292,6 +292,7 @@ Module functions
        By default (``0``), type detection is disabled.
 
    :param isolation_level:
+       Control legacy transaction handling behaviour.
        See :attr:`Connection.isolation_level` and
        :ref:`sqlite3-transaction-control-isolation-level` for more information.
        Can be ``"DEFERRED"`` (default), ``"EXCLUSIVE"`` or ``"IMMEDIATE"``;
@@ -325,6 +326,7 @@ Module functions
        enabling various :ref:`sqlite3-uri-tricks`.
 
    :param autocommit:
+       Control :pep:`249` transaction handling behaviour.
        See :attr:`Connection.autocommit` and
        :ref:`sqlite3-transaction-control-autocommit` for more information.
        *autocommit* currently defaults to


### PR DESCRIPTION
As originally [discussed](https://github.com/python/cpython/pull/99825#issuecomment-1332194023) in #99825, the `autocommit` and `isolation_level` parameters to `sqlite3.connect` could benefit from a summary line briefly stating their purpose, before linking elsewhere for more information. This gives the reader at least a basic idea of what it is actually for, and whether it might be prudent to read more about it in the linked references.

Originally implemented by @maggyero .

Co-authored-by: Géry Ogam <gery.ogam@gmail.com>