### PR TITLE
[3.11] gh-99845: _PyObject_DictPointer(): fix dictoffset cast

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1076,8 +1076,9 @@ _PyObject_DictPointer(PyObject *obj)
             tsize = -tsize;
         }
         size_t size = _PyObject_VAR_SIZE(tp, tsize);
+        assert(size <= (size_t)PY_SSIZE_T_MAX);
+        dictoffset += (Py_ssize_t)size;
 
-        dictoffset += (long)size;
         _PyObject_ASSERT(obj, dictoffset > 0);
         _PyObject_ASSERT(obj, dictoffset % SIZEOF_VOID_P == 0);
     }


### PR DESCRIPTION
Cast size_t to Py_ssize_t, rather than casting it to long. On 64-bit Windows, long is 32-bit whereas Py_ssize_t is 64-bit.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99845 -->
* Issue: gh-99845
<!-- /gh-issue-number -->
