### PR TITLE
gh-99925: Fix inconsistency in `json.dumps()` error messages

### DIFF
--- a/Lib/test/test_json/test_float.py
+++ b/Lib/test/test_json/test_float.py
@@ -26,7 +26,8 @@ class TestFloat:
                 res = self.loads(out)
                 self.assertEqual(len(res), 1)
                 self.assertNotEqual(res[0], res[0])
-            self.assertRaises(ValueError, self.dumps, [val], allow_nan=False)
+            msg = f'Out of range float values are not JSON compliant: {val}'
+            self.assertRaisesRegex(ValueError, msg, self.dumps, [val], allow_nan=False)
 
 
 class TestPyFloat(TestFloat, PyTest): pass

--- a/Misc/NEWS.d/next/Library/2022-12-01-15-26-42.gh-issue-99925.vXya8e.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-01-15-26-42.gh-issue-99925.vXya8e.rst
@@ -1,2 +1,0 @@
-Unify error messages in :meth:`json.dumps(float('nan'), allow_nan=False)`
-between `indent=None` and `indent=<SOMETHING>`

--- a/Misc/NEWS.d/next/Library/2022-12-01-15-26-42.gh-issue-99925.vXya8e.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-01-15-26-42.gh-issue-99925.vXya8e.rst
@@ -1,0 +1,2 @@
+Unify error messages in :meth:`json.dumps(float('nan'), allow_nan=False)`
+between `indent=None` and `indent=<SOMETHING>`

--- a/Misc/NEWS.d/next/Library/2022-12-01-15-44-58.gh-issue-99925.x4y6pF.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-01-15-44-58.gh-issue-99925.x4y6pF.rst
@@ -1,0 +1,4 @@
+Unify error messages in JSON serialization between
+``json.dumps(float('nan'), allow_nan=False)`` and ``json.dumps(float('nan'),
+allow_nan=False, indent=<SOMETHING>)``. Now both include the representation
+of the value that could not be serialized.

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1321,8 +1321,8 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
         if (!s->allow_nan) {
             PyErr_Format(
                     PyExc_ValueError,
-                    "Out of range float values are not JSON compliant: %s",
-                    PyOS_double_to_string(i, 'r', 0, 0, NULL)
+                    "Out of range float values are not JSON compliant: %R",
+                    obj
                     );
             return NULL;
         }

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1319,9 +1319,10 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
     double i = PyFloat_AS_DOUBLE(obj);
     if (!Py_IS_FINITE(i)) {
         if (!s->allow_nan) {
-            PyErr_SetString(
+            PyErr_Format(
                     PyExc_ValueError,
-                    "Out of range float values are not JSON compliant"
+                    "Out of range float values are not JSON compliant: %s",
+                    PyOS_double_to_string(i, 'r', 0, 0, NULL)
                     );
             return NULL;
         }


### PR DESCRIPTION
Fixes #99925.

When you try to serialize a `NaN`, `inf` or `-inf` with `json.dumps(..., allow_nan=False)`, the error messages are inconsistent, depending on whether you use `indent` or not.

```python
>>> json.dumps(float('nan'), allow_nan=False)
ValueError: Out of range float values are not JSON compliant

>>> json.dumps(float('nan'), allow_nan=False, indent=4)
ValueError: Out of range float values are not JSON compliant: nan
```

That is because if you don't use `indent`, the encoding is done in C code [here](https://github.com/python/cpython/blob/0563be23a557917228a8b48cbb31bda285a3a815/Modules/_json.c#L1321-L1327),
but if you use `indent`, the encoding is done in pure Python code [here](https://github.com/python/cpython/blob/0563be23a557917228a8b48cbb31bda285a3a815/Lib/json/encoder.py#L239-L242), and the error messages are different between the two.

This PR unifies the error messages, so that both now include the representation of the invalid value.

<!-- gh-issue-number: gh-99925 -->
* Issue: gh-99925
<!-- /gh-issue-number -->
