### PR TITLE
gh-99934: test_marshal.py: add more elements in test_deterministic_sets

### DIFF
--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -355,7 +355,7 @@ class BugsTestCase(unittest.TestCase):
             for elements in (
                 "float('nan'), b'a', b'b', b'c', 'x', 'y', 'z'",
                 # Also test for bad interactions with backreferencing:
-                "('Spam', 0), ('Spam', 1), ('Spam', 2)",
+                "('Spam', 0), ('Spam', 1), ('Spam', 2), ('Spam', 3), ('Spam', 4), ('Spam', 5)",
             ):
                 s = f"{kind}([{elements}])"
                 with self.subTest(s):

--- a/Misc/NEWS.d/next/Tests/2022-12-01-18-55-18.gh-issue-99934.Ox3Fqf.rst
+++ b/Misc/NEWS.d/next/Tests/2022-12-01-18-55-18.gh-issue-99934.Ox3Fqf.rst
@@ -1,0 +1,1 @@
+Correct test_marsh on (32 bit) x86: test_deterministic sets was failing.


### PR DESCRIPTION
Existing elements do produce different output on x86_64, but they do not on x86. Let's make the data longer to ensure it differs.


<!-- gh-issue-number: gh-99934 -->
* Issue: gh-99934
<!-- /gh-issue-number -->
