### PR TITLE
gh-99944: remove hardcoded check that op is LOAD_CONST

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -363,9 +363,8 @@ def _get_const_value(op, arg, co_consts):
     assert op in hasconst
 
     argval = UNKNOWN
-    if op == LOAD_CONST:
-        if co_consts is not None:
-            argval = co_consts[arg]
+    if co_consts is not None:
+        argval = co_consts[arg]
     return argval
 
 def _get_const_info(op, arg, co_consts):


### PR DESCRIPTION
3.11 adds a new opcode KW_NAMES that has an entry in co_consts, however the hardcoded check here causes dis to not grab the constant

<!-- gh-issue-number: gh-99944 -->
* Issue: gh-99944
<!-- /gh-issue-number -->
