### PR TITLE
gh-99948: Add emscripten platform support to ctypes.util.find_library

### DIFF
--- a/Lib/ctypes/util.py
+++ b/Lib/ctypes/util.py
@@ -80,6 +80,30 @@ elif os.name == "posix" and sys.platform == "darwin":
                 continue
         return None
 
+elif os.name == "posix" and sys.platform == "emscripten":
+    def _is_wasm(filename):
+        # Return True if the given file is an WASM module
+        wasm_header = b'\x00asm'
+        with open(filename, 'br') as thefile:
+            return thefile.read(4) == wasm_header
+
+    def find_library(name):
+        possible = ['lib%s.so' % name,
+                    'lib%s.wasm' % name]
+
+        paths = os.environ.get('LD_LIBRARY_PATH', '')
+        for dir in paths.split(":"):
+            for name in possible:
+                libfile = os.path.join(dir, name)
+
+                if os.path.isfile(libfile):
+                    if not _is_wasm(libfile):
+                        continue
+
+                    return libfile
+
+        return None
+
 elif sys.platform.startswith("aix"):
     # AIX has two styles of storing shared libraries
     # GNU auto_tools refer to these as svr4 and aix

--- a/Lib/test/test_ctypes/test_find.py
+++ b/Lib/test/test_ctypes/test_find.py
@@ -123,5 +123,37 @@ class FindLibraryLinux(unittest.TestCase):
             self.assertNotEqual(find_library('c'), None)
 
 
+@unittest.skipUnless(sys.platform.startswith('emscripten'),
+                     'Test only valid for Emscripten')
+class FindLibraryEmscripten(unittest.TestCase):
+    def test_find_on_libpath(self):
+        import tempfile
+
+        # A very simple wasm module
+        # In WAT format: (module)
+        wasm_module = b'\x00asm\x01\x00\x00\x00\x00\x08\x04name\x02\x01\x00'
+
+        with tempfile.TemporaryDirectory() as d:
+            libname = 'dummy'
+            dstname = os.path.join(d, 'lib%s.so' % libname)
+            with open(dstname, 'wb') as f:
+                f.write(wasm_module)
+
+            # now check that the .so can't be found (since not in
+            # LD_LIBRARY_PATH)
+            self.assertIsNone(find_library(libname))
+            # now add the location to LD_LIBRARY_PATH
+            with os_helper.EnvironmentVarGuard() as env:
+                KEY = 'LD_LIBRARY_PATH'
+                if KEY not in env:
+                    v = d
+                else:
+                    v = '%s:%s' % (env[KEY], d)
+                env.set(KEY, v)
+                # now check that the .so can be found (since in
+                # LD_LIBRARY_PATH)
+                self.assertEqual(find_library(libname), dstname)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2022-12-02-12-06-40.gh-issue-99948.2zXKx9.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-02-12-06-40.gh-issue-99948.2zXKx9.rst
@@ -1,0 +1,1 @@
+Add emscripten platform support to ctypes.util.find_library.


### PR DESCRIPTION
This adds `ctypes.util.find_library` function for emscripten platform.

Emscripten [internally uses `LD_LIBRARY_PATH` env variable](https://github.com/emscripten-core/emscripten/blob/2d7743702107236b09a66cef4ce017e1ecf6c3f3/src/library_dylink.js#L962-L965) to search libraries.

<!-- gh-issue-number: gh-99948 -->
* Issue: gh-99948
<!-- /gh-issue-number -->
