### PR TITLE
gh-99970 Adding missing `optionflags` parameter in the documentation of `doctest`

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -1055,7 +1055,7 @@ from text files and modules with doctests:
    from a text file using :func:`DocFileSuite`.
 
 
-.. function:: DocTestSuite(module=None, globs=None, extraglobs=None, test_finder=None, setUp=None, tearDown=None, checker=None)
+.. function:: DocTestSuite(module=None, globs=None, extraglobs=None, test_finder=None, setUp=None, tearDown=None, optionflags=0, checker=None)
 
    Convert doctest tests for a module to a :class:`unittest.TestSuite`.
 


### PR DESCRIPTION
Adding **optionflags** parameter into the signature of **DocTestSuite** function.

See #99970 for more details.

<!-- gh-issue-number: gh-99970 -->
* Issue: gh-99970
<!-- /gh-issue-number -->
