### PR TITLE
gh-92216: improve performance of hasattr for type objects

### DIFF
--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -80,6 +80,7 @@ extern static_builtin_state * _PyStaticType_GetState(PyTypeObject *);
 extern void _PyStaticType_ClearWeakRefs(PyTypeObject *type);
 extern void _PyStaticType_Dealloc(PyTypeObject *type);
 
+PyObject *_Py_type_getattro(PyTypeObject *type, PyObject *name, int supress);
 
 PyObject *_Py_slot_tp_getattro(PyObject *self, PyObject *name);
 PyObject *_Py_slot_tp_getattr_hook(PyObject *self, PyObject *name);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -980,6 +980,20 @@ int
 PyObject_HasAttr(PyObject *v, PyObject *name)
 {
     PyObject *res;
+
+    if (Py_IS_TYPE(v, &PyType_Type)) // exact type object
+    {
+        PyObject *result = _Py_type_getattro((PyTypeObject*)v, name, 1);
+        if (result != NULL) {
+            return 1;
+        }
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+            return 0;
+        }
+        return 0;
+    }
+
     if (_PyObject_LookupAttr(v, name, &res) < 0) {
         PyErr_Clear();
         return 0;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4328,7 +4328,7 @@ _Py_type_getattro(PyTypeObject *type, PyObject *name, int suppress_exception)
 
 /* This is similar to PyObject_GenericGetAttr(),
    but uses _PyType_Lookup() instead of just looking in type->tp_dict. */
-PyObject *
+static PyObject *
 type_getattro(PyTypeObject *type, PyObject *name)
 {
     return _Py_type_getattro(type, name, 0);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4237,8 +4237,8 @@ is_dunder_name(PyObject *name)
 
 /* This is similar to PyObject_GenericGetAttr(),
    but uses _PyType_Lookup() instead of just looking in type->tp_dict. */
-static PyObject *
-type_getattro(PyTypeObject *type, PyObject *name)
+PyObject *
+_Py_type_getattro(PyTypeObject *type, PyObject *name, int suppress_exception)
 {
     PyTypeObject *metatype = Py_TYPE(type);
     PyObject *meta_attribute, *attribute;
@@ -4318,10 +4318,20 @@ type_getattro(PyTypeObject *type, PyObject *name)
     }
 
     /* Give up */
+    if (!suppress_exception) {
     PyErr_Format(PyExc_AttributeError,
                  "type object '%.50s' has no attribute '%U'",
                  type->tp_name, name);
+    }
     return NULL;
+}
+
+/* This is similar to PyObject_GenericGetAttr(),
+   but uses _PyType_Lookup() instead of just looking in type->tp_dict. */
+PyObject *
+type_getattro(PyTypeObject *type, PyObject *name)
+{
+    return _Py_type_getattro(type, name, 0);
 }
 
 static int


### PR DESCRIPTION
Improve performance of `hasattr` for type objects by eliminating the generation of an exception.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-92216 -->
* Issue: gh-92216
<!-- /gh-issue-number -->
