### PR TITLE
GH-91054: Reset static events counts in code watchers tests

### DIFF
--- a/Lib/test/test_capi/test_watchers.py
+++ b/Lib/test/test_capi/test_watchers.py
@@ -383,11 +383,11 @@ class TestCodeObjectWatchers(unittest.TestCase):
                 del co3
                 self.assert_event_counts(2, 2, 1, 1)
 
-        # verify counts remain as they were after both watchers are cleared
+        # verify counts are reset and don't change after both watchers are cleared
         co4 = _testcapi.code_newempty("test_watchers", "dummy4", 0)
-        self.assert_event_counts(2, 2, 1, 1)
+        self.assert_event_counts(0, 0, 0, 0)
         del co4
-        self.assert_event_counts(2, 2, 1, 1)
+        self.assert_event_counts(0, 0, 0, 0)
 
     def test_clear_out_of_range_watcher_id(self):
         with self.assertRaisesRegex(ValueError, r"Invalid code watcher ID -1"):

--- a/Modules/_testcapi/watchers.c
+++ b/Modules/_testcapi/watchers.c
@@ -325,9 +325,13 @@ add_code_watcher(PyObject *self, PyObject *which_watcher)
     long which_l = PyLong_AsLong(which_watcher);
     if (which_l == 0) {
         watcher_id = PyCode_AddWatcher(first_code_object_callback);
+        num_code_object_created_events[0] = 0;
+        num_code_object_destroyed_events[0] = 0;
     }
     else if (which_l == 1) {
         watcher_id = PyCode_AddWatcher(second_code_object_callback);
+        num_code_object_created_events[1] = 0;
+        num_code_object_destroyed_events[1] = 0;
     }
     else {
         return NULL;
@@ -345,6 +349,11 @@ clear_code_watcher(PyObject *self, PyObject *watcher_id)
     long watcher_id_l = PyLong_AsLong(watcher_id);
     if (PyCode_ClearWatcher(watcher_id_l) < 0) {
         return NULL;
+    }
+    // reset static events counters
+    if (watcher_id_l >= 0 && watcher_id_l < NUM_CODE_WATCHERS) {
+        num_code_object_created_events[watcher_id_l] = 0;
+        num_code_object_destroyed_events[watcher_id_l] = 0;
     }
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
GH-99859 introduced new buildbot failures, as reported [here](https://github.com/python/cpython/issues/91054#issuecomment-1336256547).

I was able to reproduce the failures with:

```
./python.exe -m test -v test_capi.test_watchers -m "*TestCodeObjectWatchers*" -R 3:3
```

The root cause appears to be the static events counters used in the tests, when running the tests with repetitions (using the same interpreter state), the counts from the first test run affected the next runs.

This fixes it by resetting the counts when adding and clearing test watchers.

<!-- gh-issue-number: gh-91054 -->
* Issue: gh-91054
<!-- /gh-issue-number -->
