### PR TITLE
gh-85432: Harmonise parameter names between C and pure-Python implementations of `datetime.time.strftime`, `datetime.datetime.fromtimestamp`

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1553,8 +1553,7 @@ class time:
         except Exception:
             raise ValueError(f'Invalid isoformat string: {time_string!r}')
 
-
-    def strftime(self, fmt):
+    def strftime(self, format):
         """Format using strftime().  The date part of the timestamp passed
         to underlying strftime should not be used.
         """
@@ -1563,7 +1562,7 @@ class time:
         timetuple = (1900, 1, 1,
                      self._hour, self._minute, self._second,
                      0, 1, -1)
-        return _wrap_strftime(self, fmt, timetuple)
+        return _wrap_strftime(self, format, timetuple)
 
     def __format__(self, fmt):
         if not isinstance(fmt, str):
@@ -1787,14 +1786,14 @@ class datetime(date):
         return result
 
     @classmethod
-    def fromtimestamp(cls, t, tz=None):
+    def fromtimestamp(cls, timestamp, tz=None):
         """Construct a datetime from a POSIX timestamp (like time.time()).
 
         A timezone info object may be passed in as well.
         """
         _check_tzinfo_arg(tz)
 
-        return cls._fromtimestamp(t, tz is not None, tz)
+        return cls._fromtimestamp(timestamp, tz is not None, tz)
 
     @classmethod
     def utcfromtimestamp(cls, t):

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -2426,6 +2426,12 @@ class TestDateTime(TestDate):
         got = self.theclass.fromtimestamp(ts)
         self.verify_field_equality(expected, got)
 
+    def test_fromtimestamp_keyword_arg(self):
+        import time
+
+        # gh-85432: The parameter was named "t" in the pure-Python impl.
+        self.theclass.fromtimestamp(timestamp=time.time())
+
     def test_utcfromtimestamp(self):
         import time
 
@@ -3527,6 +3533,9 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
             t.strftime('%H\ud800%M')
         except UnicodeEncodeError:
             pass
+
+        # gh-85432: The parameter was named "fmt" in the pure-Python impl.
+        t.strftime(format="%f")
 
     def test_format(self):
         t = self.theclass(1, 2, 3, 4)

--- a/Misc/NEWS.d/next/Library/2022-12-04-16-12-04.gh-issue-85432.l_ehmI.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-04-16-12-04.gh-issue-85432.l_ehmI.rst
@@ -1,0 +1,5 @@
+Rename the *fmt* parameter of the pure-Python implementation of
+:meth:`datetime.time.strftime` to *format*. Rename the *t* parameter of
+:meth:`datetime.datetime.fromtimestamp` to *timestamp*. These changes mean
+the parameter names in the pure-Python implementation now match the
+parameter names in the C implementation. Patch by Alex Waygood.


### PR DESCRIPTION
#85432 was closed _slightly_ prematurely in my view. While #21712 fixes things for `datetime.date.strftime`, as mentioned in https://github.com/python/cpython/issues/85432#issuecomment-1093876867, the problem also exists for `datetime.time.strftime`, as well as `datetime.datetime.fromtimestamp`:

Works with the C implementation:

```pycon
>>> import time, datetime
>>> datetime.time().strftime(format="%f")
'000000'
>>> datetime.datetime.fromtimestamp(timestamp=time.time())
datetime.datetime(2022, 12, 4, 16, 23, 25, 69430)
>>> exit()
```

Not with the pure-Python implementation:

```pycon
>>> import sys
>>> sys.modules["_datetime"] = None
>>> import time, datetime
>>> datetime.time().strftime(format="%f")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: time.strftime() got an unexpected keyword argument 'format'
>>> datetime.datetime.fromtimestamp(timestamp=time.time())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: datetime.fromtimestamp() got an unexpected keyword argument 'timestamp'
```