### PR TITLE
gh-100008: Require Two's complement to build Python

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -16,6 +16,9 @@ Features required to build CPython:
   point numbers and `floating point Not-a-Number (NaN)
   <https://en.wikipedia.org/wiki/NaN#Floating_point>`_.
 
+* `Two's complement <https://en.wikipedia.org/wiki/Two%27s_complement>`_
+  integer representation.
+
 * Support for threads.
 
 * OpenSSL 1.1.1 or newer for the :mod:`ssl` and :mod:`hashlib` modules.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -711,6 +711,12 @@ Build Changes
   optimization levels (0, 1, 2) at once.
   (Contributed by Victor Stinner in :gh:`99289`.)
 
+* Building Python now requires `two's complement
+  <https://en.wikipedia.org/wiki/Two%27s_complement>`_ integer representation:
+  drop support for platforms with other `signed number representations
+  <https://en.wikipedia.org/wiki/Signed_number_representations>`_.
+  (Contributed by Victor Stinner in :gh:`100008`.)
+
 
 C API Changes
 =============

--- a/Misc/NEWS.d/next/Build/2022-12-05-17-07-49.gh-issue-100008.dlTVxs.rst
+++ b/Misc/NEWS.d/next/Build/2022-12-05-17-07-49.gh-issue-100008.dlTVxs.rst
@@ -1,0 +1,5 @@
+Building Python now requires `two's complement
+<https://en.wikipedia.org/wiki/Two%27s_complement>`_ integer representation:
+drop support for platforms with other `signed number representations
+<https://en.wikipedia.org/wiki/Signed_number_representations>`_.
+Patch by Victor Stinner.


### PR DESCRIPTION
Building Python now requires two's complement integer representation: drop support for platforms with other signed number representations.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-100008 -->
* Issue: gh-100008
<!-- /gh-issue-number -->
