### PR TITLE
gh-98680: Add PyBUF_* constants to the Limited API listing

### DIFF
--- a/Misc/NEWS.d/next/C API/2022-12-05-17-30-13.gh-issue-98680.FiMCxZ.rst
+++ b/Misc/NEWS.d/next/C API/2022-12-05-17-30-13.gh-issue-98680.FiMCxZ.rst
@@ -1,0 +1,3 @@
+``PyBUF_*`` constants were marked as part of Limiled API of Python 3.11+.
+These were available in 3.11.0 with :c:macro:`Py_LIMITED_API` defined for
+3.11, and are necessary to use the buffer API.

--- a/Misc/NEWS.d/next/C API/2022-12-05-17-30-13.gh-issue-98680.FiMCxZ.rst
+++ b/Misc/NEWS.d/next/C API/2022-12-05-17-30-13.gh-issue-98680.FiMCxZ.rst
@@ -1,3 +1,3 @@
-``PyBUF_*`` constants were marked as part of Limiled API of Python 3.11+.
+``PyBUF_*`` constants were marked as part of Limited API of Python 3.11+.
 These were available in 3.11.0 with :c:macro:`Py_LIMITED_API` defined for
 3.11, and are necessary to use the buffer API.

--- a/Misc/stable_abi.toml
+++ b/Misc/stable_abi.toml
@@ -2271,6 +2271,50 @@
 [function.PyMemoryView_FromBuffer]
     added = '3.11'
 
+# Constants for Py_buffer API added to this list in Python 3.11.1 (https://github.com/python/cpython/issues/98680)
+# (they were available with 3.11.0)
+[const.PyBUF_MAX_NDIM]
+    added = '3.11'
+[const.PyBUF_SIMPLE]
+    added = '3.11'
+[const.PyBUF_WRITABLE]
+    added = '3.11'
+[const.PyBUF_FORMAT]
+    added = '3.11'
+[const.PyBUF_ND]
+    added = '3.11'
+[const.PyBUF_STRIDES]
+    added = '3.11'
+[const.PyBUF_C_CONTIGUOUS]
+    added = '3.11'
+[const.PyBUF_F_CONTIGUOUS]
+    added = '3.11'
+[const.PyBUF_ANY_CONTIGUOUS]
+    added = '3.11'
+[const.PyBUF_INDIRECT]
+    added = '3.11'
+[const.PyBUF_CONTIG]
+    added = '3.11'
+[const.PyBUF_CONTIG_RO]
+    added = '3.11'
+[const.PyBUF_STRIDED]
+    added = '3.11'
+[const.PyBUF_STRIDED_RO]
+    added = '3.11'
+[const.PyBUF_RECORDS]
+    added = '3.11'
+[const.PyBUF_RECORDS_RO]
+    added = '3.11'
+[const.PyBUF_FULL]
+    added = '3.11'
+[const.PyBUF_FULL_RO]
+    added = '3.11'
+[const.PyBUF_READ]
+    added = '3.11'
+[const.PyBUF_WRITE]
+    added = '3.11'
+
+
 # (Detailed comments aren't really needed for further entries: from here on
 #  we can use version control logs.)
 


### PR DESCRIPTION
``PyBUF_*`` constants are marked as part of Limited API of Python 3.11+.
These were available in 3.11.0 with `Py_LIMITED_API` defined for 3.11, and are necessary to use the buffer API. Omitting them in `stable_abi.toml` was a mistake.

(cc @vstinner)

<!-- gh-issue-number: gh-98680 -->
* Issue: gh-98680
<!-- /gh-issue-number -->
