### PR TITLE
GH-99729: Unlink frames before clearing them

### DIFF
--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -2,6 +2,7 @@ import gc
 import re
 import sys
 import textwrap
+import threading
 import types
 import unittest
 import weakref
@@ -329,6 +330,45 @@ class TestIncompleteFrameAreInvisible(unittest.TestCase):
             if old_enabled:
                 gc.enable()
 
+    @support.cpython_only
+    def test_sneaky_frame_object_teardown(self):
+
+        class SneakyDel:
+            def __del__(self):
+                """
+                Stash a reference to the entire stack for walking later.
+
+                It may look crazy, but you'd be surprised how common this is
+                when using a test runner (like pytest). The typical recipe is:
+                ResourceWarning + -Werror + a custom sys.unraisablehook.
+                """
+                nonlocal sneaky_frame_object
+                sneaky_frame_object = sys._getframe()
+
+        class SneakyThread(threading.Thread):
+            """
+            A separate thread isn't needed to make this code crash, but it does
+            make crashes more consistent, since it means sneaky_frame_object is
+            backed by freed memory after the thread completes!
+            """
+
+            def run(self):
+                """Run SneakyDel.__del__ as this frame is popped."""
+                ref = SneakyDel()
+
+        sneaky_frame_object = None
+        t = SneakyThread()
+        t.start()
+        t.join()
+        # sneaky_frame_object can be anything, really, but it's crucial that
+        # SneakyThread.run's frame isn't anywhere on the stack while it's being
+        # torn down:
+        self.assertIsNotNone(sneaky_frame_object)
+        while sneaky_frame_object is not None:
+            self.assertIsNot(
+                sneaky_frame_object.f_code, SneakyThread.run.__code__
+            )
+            sneaky_frame_object = sneaky_frame_object.f_back
 
 @unittest.skipIf(_testcapi is None, 'need _testcapi')
 class TestCAPI(unittest.TestCase):

--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -12,6 +12,7 @@ except ImportError:
     _testcapi = None
 
 from test import support
+from test.support import threading_helper
 from test.support.script_helper import assert_python_ok
 
 
@@ -331,6 +332,7 @@ class TestIncompleteFrameAreInvisible(unittest.TestCase):
                 gc.enable()
 
     @support.cpython_only
+    @threading_helper.requires_working_threading()
     def test_sneaky_frame_object_teardown(self):
 
         class SneakyDel:

--- a/Misc/NEWS.d/next/Core and Builtins/2022-11-26-04-00-41.gh-issue-99729.A3ovwQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-11-26-04-00-41.gh-issue-99729.A3ovwQ.rst
@@ -1,0 +1,3 @@
+Fix an issue that could cause frames to be visible to Python code as they
+are being torn down, possibly leading to memory corruption or hard crashes
+of the interpreter.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -619,7 +619,10 @@ dummy_func(
             DTRACE_FUNCTION_EXIT();
             _Py_LeaveRecursiveCallPy(tstate);
             assert(frame != &entry_frame);
-            frame = cframe.current_frame = pop_frame(tstate, frame);
+            // GH-99729: We need to unlink the frame *before* clearing it:
+            _PyInterpreterFrame *dying = frame;
+            frame = cframe.current_frame = dying->previous;
+            _PyEvalFrameClearAndPop(tstate, dying);
             _PyFrame_StackPush(frame, retval);
             goto resume_frame;
         }

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -127,6 +127,9 @@ _PyFrame_Clear(_PyInterpreterFrame *frame)
      * to have cleared the enclosing generator, if any. */
     assert(frame->owner != FRAME_OWNED_BY_GENERATOR ||
         _PyFrame_GetGenerator(frame)->gi_frame_state == FRAME_CLEARED);
+    // GH-99729: Clearing this frame can expose the stack (via finalizers). It's
+    // crucial that this frame has been unlinked, and is no longer visible:
+    assert(_PyThreadState_GET()->cframe->current_frame != frame);
     if (frame->frame_obj) {
         PyFrameObject *f = frame->frame_obj;
         frame->frame_obj = NULL;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -628,7 +628,10 @@
             DTRACE_FUNCTION_EXIT();
             _Py_LeaveRecursiveCallPy(tstate);
             assert(frame != &entry_frame);
-            frame = cframe.current_frame = pop_frame(tstate, frame);
+            // GH-99729: We need to unlink the frame *before* clearing it:
+            _PyInterpreterFrame *dying = frame;
+            frame = cframe.current_frame = dying->previous;
+            _PyEvalFrameClearAndPop(tstate, dying);
             _PyFrame_StackPush(frame, retval);
             goto resume_frame;
         }


### PR DESCRIPTION
Thanks for your patience with this.

I decided to switch strategies mid-fix after a discussion with @markshannon this morning: instead of hacking the frame to look "incomplete" just before teardown, I think unlinking the frame *before* clearing it (instead of after) is a better approach that is easier to reason about and keeps extra code out of the hot path when popping frames.

This is going to need a manual backport to 3.11. I'll start on it now to hopefully unblock releases.

CC: @pablogsal 

<!-- gh-issue-number: gh-99729 -->
* Issue: gh-99729
<!-- /gh-issue-number -->
