### PR TITLE
gh-99941: asyncio.Protocol.data_received now received immutable bytes

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -288,7 +288,8 @@ class _ProactorReadPipeTransport(_ProactorBasePipeTransport,
                         # we got end-of-file so no need to reschedule a new read
                         return
 
-                    data = self._data[:length]
+                    # It's a new slice so make it immutable so protocols upstream don't have problems
+                    data = bytes(memoryview(self._data)[:length])
                 else:
                     # the future will be replaced by next proactor.recv call
                     fut.cancel()

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -688,7 +688,7 @@ class StreamReader:
             await self._wait_for_data('read')
 
         # This will work right even if buffer is less than n bytes
-        data = bytes(self._buffer[:n])
+        data = bytes(memoryview(self._buffer)[:n])
         del self._buffer[:n]
 
         self._maybe_resume_transport()
@@ -730,7 +730,7 @@ class StreamReader:
             data = bytes(self._buffer)
             self._buffer.clear()
         else:
-            data = bytes(self._buffer[:n])
+            data = bytes(memoryview(self._buffer)[:n])
             del self._buffer[:n]
         self._maybe_resume_transport()
         return data

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -75,7 +75,10 @@ class ProactorSocketTransportTests(test_utils.TestCase):
         called_buf = bytearray(self.buffer_size)
         called_buf[:len(buf)] = buf
         self.loop._proactor.recv_into.assert_called_with(self.sock, called_buf)
-        self.protocol.data_received.assert_called_with(bytearray(buf))
+        self.protocol.data_received.assert_called_with(buf)
+        # assert_called_with maps bytearray and bytes to the same thing so check manually
+        # regression test for https://github.com/python/cpython/issues/99941
+        self.assertIsInstance(self.protocol.data_received.call_args.args[0], bytes)
 
     @unittest.skipIf(sys.flags.optimize, "Assertions are disabled in optimized mode")
     def test_loop_reading_no_data(self):

--- a/Misc/NEWS.d/next/Windows/2022-12-06-11-16-46.gh-issue-99941.GmUQ6o.rst
+++ b/Misc/NEWS.d/next/Windows/2022-12-06-11-16-46.gh-issue-99941.GmUQ6o.rst
@@ -1,6 +1,2 @@
-Made :func:`asyncio.Protocol.data_received` receive immutable object
-``bytes`` instead of ``bytearrays`` with regression tests added and opted to
-use ``memoryview`` to take the slices for performance on big buffers.
-Performance test from ``gh-issue:21442`` done on my machine with 10
-repetitions on release build with timings 0.043 (delta: 0.019) before patch
-and 0.041 (delta: 0.010) after so no noticable change in performance.
+Ensure that :func:`asyncio.Protocol.data_received` receives an immutable
+:class:`bytes` object (as documented), instead of :class:`bytearray`.

--- a/Misc/NEWS.d/next/Windows/2022-12-06-11-16-46.gh-issue-99941.GmUQ6o.rst
+++ b/Misc/NEWS.d/next/Windows/2022-12-06-11-16-46.gh-issue-99941.GmUQ6o.rst
@@ -1,0 +1,6 @@
+Made :func:`asyncio.Protocol.data_received` receive immutable object
+``bytes`` instead of ``bytearrays`` with regression tests added and opted to
+use ``memoryview`` to take the slices for performance on big buffers.
+Performance test from ``gh-issue:21442`` done on my machine with 10
+repetitions on release build with timings 0.043 (delta: 0.019) before patch
+and 0.041 (delta: 0.010) after so no noticable change in performance.


### PR DESCRIPTION
Made `asyncio.Protocol.data_received` receive immutable object
`bytes` instead of `bytearrays` (like defined in the docs) with regression tests added
and opted to use `memoryview` to take the slices for performance on big buffers.

Performance test from https://github.com/python/cpython/pull/21442 done on my machine with 10
repetitions on release build with timings 0.043 (delta: 0.019) before patch
and 0.041 (delta: 0.010) after so no noticable change in performance.


<!-- gh-issue-number: gh-99941 -->
* Issue: gh-99941
<!-- /gh-issue-number -->
