### PR TITLE
[3.10] gh-100050: Fix an assertion error when raising unclosed parenthesis errors in the tokenizer (GH-100065)

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1587,6 +1587,22 @@ def func2():
         for paren in ")]}":
             self._check_error(paren + "1 + 2", f"unmatched '\\{paren}'")
 
+        # Some more complex examples:
+        code = """\
+func(
+    a=["unclosed], # Need a quote in this comment: "
+    b=2,
+)
+"""
+        self._check_error(code, "parenthesis '\\)' does not match opening parenthesis '\\['")
+
+    def test_error_string_literal(self):
+
+        self._check_error("'blech", "unterminated string literal")
+        self._check_error('"blech', "unterminated string literal")
+        self._check_error("'''blech", "unterminated triple-quoted string literal")
+        self._check_error('"""blech', "unterminated triple-quoted string literal")
+
     def test_match_call_does_not_raise_syntax_error(self):
         code = """
 def match(x):

--- a/Misc/NEWS.d/next/Core and Builtins/2022-12-06-22-24-01.gh-issue-100050.lcrPqQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-12-06-22-24-01.gh-issue-100050.lcrPqQ.rst
@@ -1,0 +1,2 @@
+Honor existing errors obtained when searching for mismatching parentheses in
+the tokenizer. Patch by Pablo Galindo

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -1328,6 +1328,10 @@ _PyPegen_check_tokenizer_errors(Parser *p) {
         const char *end;
         switch (PyTokenizer_Get(p->tok, &start, &end)) {
             case ERRORTOKEN:
+                if (PyErr_Occurred()) {
+                    ret = -1;
+                    goto exit;
+                }
                 if (p->tok->level != 0) {
                     int error_lineno = p->tok->parenlinenostack[p->tok->level-1];
                     if (current_err_line > error_lineno) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-100050 -->
* Issue: gh-100050
<!-- /gh-issue-number -->
