### PR TITLE
gh-100072: only trigger netlify builds for doc changes

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -21,10 +21,9 @@ on:
     - '3.8'
     - '3.7'
     paths:
-    - '.github/workflows/doc.yml'
-    # Should be in sync with `netlify.toml`:
     - 'Doc/**'
     - 'Misc/**'
+    - '.github/workflows/doc.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -21,9 +21,10 @@ on:
     - '3.8'
     - '3.7'
     paths:
+    - '.github/workflows/doc.yml'
+    # Should be in sync with `netlify.toml`:
     - 'Doc/**'
     - 'Misc/**'
-    - '.github/workflows/doc.yml'
 
 permissions:
   contents: read

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "build/html"
     # Do not trigger netlify builds if docs were not changed.
     # Changed files should be in sync with `.github/workflows/doc.yml`
-    ignore = "git diff --name-only $CACHED_COMMIT_REF $COMMIT_REF | grep -q '^(Doc\/|netlify\.toml)' && exit 1 || exit 0"
+    ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../netlify.toml"
 
 [build.environment]
   PYTHON_VERSION = "3.8"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
     base = "Doc/"
     command = "make html"
     publish = "build/html"
+    # Do not trigger netlify builds if docs were not changed.
+    # Changed files should be in sync with `.github/workflows/doc.yml`
+    ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./Doc ./Misc ./netlify.toml"
 
 [build.environment]
   PYTHON_VERSION = "3.8"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "build/html"
     # Do not trigger netlify builds if docs were not changed.
     # Changed files should be in sync with `.github/workflows/doc.yml`
-    ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF Doc/ netlify.toml"
+    ignore = "git diff --name-only $CACHED_COMMIT_REF $COMMIT_REF | grep -q '^(Doc\/|netlify\.toml)' && exit 1 || exit 0"
 
 [build.environment]
   PYTHON_VERSION = "3.8"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "build/html"
     # Do not trigger netlify builds if docs were not changed.
     # Changed files should be in sync with `.github/workflows/doc.yml`
-    ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./Doc ./Misc ./netlify.toml"
+    ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF Doc/ netlify.toml"
 
 [build.environment]
   PYTHON_VERSION = "3.8"


### PR DESCRIPTION
This PR will trigger the netlify build because of `netlify.toml` change, but hopefully it won't trigger changes anymore for other builds without `./Doc` or `./Misc` changes.

Open question: do we need `./Misc` here? All `NEWS` go there, many PRs have it. But, I don't think we are really interested in rendering news. Opinions?

CC @Mariatta @hugovk @epicfaace 

<!-- gh-issue-number: gh-100072 -->
* Issue: gh-100072
<!-- /gh-issue-number -->
