### PR TITLE
gh-99485: Remove PyGen_New() function

### DIFF
--- a/Doc/c-api/coro.rst
+++ b/Doc/c-api/coro.rst
@@ -25,11 +25,3 @@ return.
 
    Return true if *ob*'s type is :c:type:`PyCoro_Type`; *ob* must not be ``NULL``.
    This function always succeeds.
-
-
-.. c:function:: PyObject* PyCoro_New(PyFrameObject *frame, PyObject *name, PyObject *qualname)
-
-   Create and return a new coroutine object based on the *frame* object,
-   with ``__name__`` and ``__qualname__`` set to *name* and *qualname*.
-   A reference to *frame* is stolen by this function.  The *frame* argument
-   must not be ``NULL``.

--- a/Doc/c-api/gen.rst
+++ b/Doc/c-api/gen.rst
@@ -6,8 +6,7 @@ Generator Objects
 -----------------
 
 Generator objects are what Python uses to implement generator iterators. They
-are normally created by iterating over a function that yields values, rather
-than explicitly calling :c:func:`PyGen_New` or :c:func:`PyGen_NewWithQualName`.
+are normally created by iterating over a function that yields values.
 
 
 .. c:type:: PyGenObject
@@ -30,17 +29,3 @@ than explicitly calling :c:func:`PyGen_New` or :c:func:`PyGen_NewWithQualName`.
 
    Return true if *ob*'s type is :c:type:`PyGen_Type`; *ob* must not be
    ``NULL``.  This function always succeeds.
-
-
-.. c:function:: PyObject* PyGen_New(PyFrameObject *frame)
-
-   Create and return a new generator object based on the *frame* object.
-   A reference to *frame* is stolen by this function. The argument must not be
-   ``NULL``.
-
-.. c:function:: PyObject* PyGen_NewWithQualName(PyFrameObject *frame, PyObject *name, PyObject *qualname)
-
-   Create and return a new generator object based on the *frame* object,
-   with ``__name__`` and ``__qualname__`` set to *name* and *qualname*.
-   A reference to *frame* is stolen by this function.  The *frame* argument
-   must not be ``NULL``.

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -959,21 +959,8 @@ PyGen_Check:PyObject*:ob:0:
 PyGen_CheckExact:int:::
 PyGen_CheckExact:PyObject*:ob:0:
 
-PyGen_New:PyObject*::+1:
-PyGen_New:PyFrameObject*:frame:0:
-
-PyGen_NewWithQualName:PyObject*::+1:
-PyGen_NewWithQualName:PyFrameObject*:frame:0:
-PyGen_NewWithQualName:PyObject*:name:0:
-PyGen_NewWithQualName:PyObject*:qualname:0:
-
 PyCoro_CheckExact:int:::
 PyCoro_CheckExact:PyObject*:ob:0:
-
-PyCoro_New:PyObject*::+1:
-PyCoro_New:PyFrameObject*:frame:0:
-PyCoro_New:PyObject*:name:0:
-PyCoro_New:PyObject*:qualname:0:
 
 PyImport_AddModule:PyObject*::0:reference borrowed from sys.modules
 PyImport_AddModule:const char*:name::

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -944,3 +944,18 @@ Removed
 * Remove ``_use_broken_old_ctypes_structure_semantics_`` flag
   from :mod:`ctypes` module.
   (Contributed by Nikita Sobolev in :gh:`99285`.)
+
+* Remove untested functions which were used to create generators and
+  coroutines:
+
+  * ``PyAsyncGen_New()``
+  * ``PyCoro_New()``
+  * ``PyGen_New()``
+  * ``PyGen_NewWithQualName()``
+
+  Since 3.11, these functions can no longer be used in practice, because there
+  is no public C API function creating a frame usable by these functions. In
+  Python 3.10, these functions were called directly by Python, but Python now
+  uses another internal function which create generators and coroutines with no
+  frame ("frame cleared" state).
+  (Contributed by Victor Stinner in :gh:`99485`.)

--- a/Include/cpython/genobject.h
+++ b/Include/cpython/genobject.h
@@ -40,9 +40,6 @@ PyAPI_DATA(PyTypeObject) PyGen_Type;
 #define PyGen_Check(op) PyObject_TypeCheck((op), &PyGen_Type)
 #define PyGen_CheckExact(op) Py_IS_TYPE((op), &PyGen_Type)
 
-PyAPI_FUNC(PyObject *) PyGen_New(PyFrameObject *);
-PyAPI_FUNC(PyObject *) PyGen_NewWithQualName(PyFrameObject *,
-    PyObject *name, PyObject *qualname);
 PyAPI_FUNC(int) _PyGen_SetStopIterationValue(PyObject *);
 PyAPI_FUNC(int) _PyGen_FetchStopIterationValue(PyObject **);
 PyAPI_FUNC(void) _PyGen_Finalize(PyObject *self);
@@ -58,8 +55,6 @@ PyAPI_DATA(PyTypeObject) PyCoro_Type;
 PyAPI_DATA(PyTypeObject) _PyCoroWrapper_Type;
 
 #define PyCoro_CheckExact(op) Py_IS_TYPE((op), &PyCoro_Type)
-PyAPI_FUNC(PyObject *) PyCoro_New(PyFrameObject *,
-    PyObject *name, PyObject *qualname);
 
 
 /* --- Asynchronous Generators -------------------------------------------- */
@@ -72,9 +67,6 @@ PyAPI_DATA(PyTypeObject) PyAsyncGen_Type;
 PyAPI_DATA(PyTypeObject) _PyAsyncGenASend_Type;
 PyAPI_DATA(PyTypeObject) _PyAsyncGenWrappedValue_Type;
 PyAPI_DATA(PyTypeObject) _PyAsyncGenAThrow_Type;
-
-PyAPI_FUNC(PyObject *) PyAsyncGen_New(PyFrameObject *,
-    PyObject *name, PyObject *qualname);
 
 #define PyAsyncGen_CheckExact(op) Py_IS_TYPE((op), &PyAsyncGen_Type)
 

--- a/Misc/NEWS.d/next/C API/2022-12-07-15-13-10.gh-issue-99485.bwn7ef.rst
+++ b/Misc/NEWS.d/next/C API/2022-12-07-15-13-10.gh-issue-99485.bwn7ef.rst
@@ -1,0 +1,13 @@
+Remove untested functions which were used to create generators and
+coroutines:
+
+* ``PyAsyncGen_New()``
+* ``PyCoro_New()``
+* ``PyGen_New()``
+* ``PyGen_NewWithQualName()``
+
+Since 3.11, these functions can no longer be used in practice, because there
+is no public C API function creating a frame usable by these functions. In
+Python 3.10, these functions were called directly by Python, but Python now
+uses another internal function which create generators and coroutines with
+no frame ("frame cleared" state). Patch by Victor Stinner.


### PR DESCRIPTION
Remove untested functions which were used to create generators and coroutines:

* PyAsyncGen_New()
* PyCoro_New()
* PyGen_New()
* PyGen_NewWithQualName()

In Python 3.10, make_coro() of Python/ceval.c creates generators and coroutines from a frame object. In Python 3.11, the function became _Py_MakeCoro() in Python/genobject.c and it takes a function as argument instead of a frame.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99485 -->
* Issue: gh-99485
<!-- /gh-issue-number -->
