### PR TITLE
gh-100086: Add build info to test.libregrtest

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -17,7 +17,8 @@ from test.libregrtest.runtest import (
     ChildError, DidNotRun)
 from test.libregrtest.setup import setup_tests
 from test.libregrtest.pgo import setup_pgo_tests
-from test.libregrtest.utils import removepy, count, format_duration, printlist
+from test.libregrtest.utils import (removepy, count, format_duration,
+                                    printlist, get_build_info)
 from test import support
 from test.support import os_helper
 from test.support import threading_helper
@@ -491,6 +492,7 @@ class Regrtest:
         print("==", platform.python_implementation(), *sys.version.split())
         print("==", platform.platform(aliased=True),
                       "%s-endian" % sys.byteorder)
+        print("== Python build:", ' '.join(get_build_info()))
         print("== cwd:", os.getcwd())
         cpu_count = os.cpu_count()
         if cpu_count:

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -1,6 +1,7 @@
 import math
 import os.path
 import sys
+import sysconfig
 import textwrap
 from test import support
 
@@ -208,3 +209,87 @@ def clear_caches():
         pass
     else:
         fractions._hash_algorithm.cache_clear()
+
+
+def get_build_info():
+    # Get most important configure and build options as a list of strings.
+    # Example: ['debug', 'ASAN+MSAN'] or ['release', 'LTO+PGO'].
+
+    config_args = sysconfig.get_config_var('CONFIG_ARGS') or ''
+    cflags = sysconfig.get_config_var('PY_CFLAGS') or ''
+    cflags_nodist = sysconfig.get_config_var('PY_CFLAGS_NODIST') or ''
+    ldflags_nodist = sysconfig.get_config_var('PY_LDFLAGS_NODIST') or ''
+
+    build = []
+    if hasattr(sys, 'gettotalrefcount'):
+        # --with-pydebug
+        build.append('debug')
+
+        if '-DNDEBUG' in (cflags + cflags_nodist):
+            build.append('without_assert')
+    else:
+        build.append('release')
+
+        if '--with-assertions' in config_args:
+            build.append('with_assert')
+        elif '-DNDEBUG' not in (cflags + cflags_nodist):
+            build.append('with_assert')
+
+    # --enable-framework=name
+    framework = sysconfig.get_config_var('PYTHONFRAMEWORK')
+    if framework:
+        build.append(f'framework={framework}')
+
+    # --enable-shared
+    shared = int(sysconfig.get_config_var('PY_ENABLE_SHARED') or '0')
+    if shared:
+        build.append('shared')
+
+    # --with-lto
+    optimizations = []
+    if '-flto=thin' in ldflags_nodist:
+        optimizations.append('ThinLTO')
+    elif '-flto' in ldflags_nodist:
+        optimizations.append('LTO')
+
+    # --enable-optimizations
+    pgo_options = (
+        # GCC
+        '-fprofile-use',
+        # clang: -fprofile-instr-use=code.profclangd
+        '-fprofile-instr-use',
+        # ICC
+        "-prof-use",
+    )
+    if any(option in cflags_nodist for option in pgo_options):
+        optimizations.append('PGO')
+    if optimizations:
+        build.append('+'.join(optimizations))
+
+    # --with-address-sanitizer
+    sanitizers = []
+    if support.check_sanitizer(address=True):
+        sanitizers.append("ASAN")
+    # --with-memory-sanitizer
+    if support.check_sanitizer(memory=True):
+        sanitizers.append("MSAN")
+    # --with-undefined-behavior-sanitizer
+    if support.check_sanitizer(ub=True):
+        sanitizers.append("UBSAN")
+    if sanitizers:
+        build.append('+'.join(sanitizers))
+
+    # --with-trace-refs
+    if hasattr(sys, 'getobjects'):
+        build.append("TraceRefs")
+    # --enable-pystats
+    if hasattr(sys, '_stats_on'):
+        build.append("pystats")
+    # --with-valgrind
+    if sysconfig.get_config_var('WITH_VALGRIND'):
+        build.append("valgrind")
+    # --with-dtrace
+    if sysconfig.get_config_var('WITH_DTRACE'):
+        build.append("dtrace")
+
+    return build

--- a/Misc/NEWS.d/next/Tests/2022-12-08-00-03-37.gh-issue-100086.1zYpto.rst
+++ b/Misc/NEWS.d/next/Tests/2022-12-08-00-03-37.gh-issue-100086.1zYpto.rst
@@ -1,0 +1,3 @@
+The Python test runner (libregrtest) now logs Python build information like
+"debug" vs "release" build, or LTO and PGO optimizations. Patch by Victor
+Stinner.


### PR DESCRIPTION
The Python test runner (libregrtest) now logs Python build information like "debug" vs "release" build, or LTO and PGO optimizations.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-100086 -->
* Issue: gh-100086
<!-- /gh-issue-number -->
