### PR TITLE
 GH-98831: Get rid of super(), just use macro()

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -82,7 +82,7 @@ do { \
 static PyObject *value, *value1, *value2, *left, *right, *res, *sum, *prod, *sub;
 static PyObject *container, *start, *stop, *v, *lhs, *rhs;
 static PyObject *list, *tuple, *dict, *owner;
-static PyObject *exit_func, *lasti, *val;
+static PyObject *exit_func, *lasti, *val, *retval;
 static size_t jump;
 // Dummy variables for cache effects
 static _Py_CODEUNIT when_to_jump_mask, invert, counter, index, hint;
@@ -589,11 +589,10 @@ dummy_func(
             goto error;
         }
 
-        // stack effect: (__0 -- )
-        inst(INTERPRETER_EXIT) {
+        inst(INTERPRETER_EXIT, (retval --)) {
             assert(frame == &entry_frame);
             assert(_PyFrame_IsIncomplete(frame));
-            PyObject *retval = POP();
+            STACK_SHRINK(1);  // Since we're not going to DISPATCH()
             assert(EMPTY());
             /* Restore previous cframe and return. */
             tstate->cframe = cframe.previous;

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -475,15 +475,12 @@ dummy_func(
             PREDICT(JUMP_BACKWARD);
         }
 
-        // stack effect: (__0 -- )
-        inst(SET_ADD) {
-            PyObject *v = POP();
-            PyObject *set = PEEK(oparg);
-            int err;
-            err = PySet_Add(set, v);
+        // Alternative: (set, unused[oparg], v -- set, unused[oparg])
+        inst(SET_ADD, (v --)) {
+            PyObject *set = PEEK(oparg + 1);  // +1 to account for v staying on stack
+            int err = PySet_Add(set, v);
             Py_DECREF(v);
-            if (err != 0)
-                goto error;
+            ERROR_IF(err != 0, error);
             PREDICT(JUMP_BACKWARD);
         }
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -85,7 +85,7 @@ static PyObject *list, *tuple, *dict, *owner;
 static PyObject *exit_func, *lasti, *val;
 static size_t jump;
 // Dummy variables for cache effects
-static _Py_CODEUNIT when_to_jump_mask, invert, counter, index;
+static _Py_CODEUNIT when_to_jump_mask, invert, counter, index, hint;
 static uint32_t type_version;
 // Dummy opcode names for 'op' opcodes
 #define _BINARY_OP_INPLACE_ADD_UNICODE_PART_1 1001
@@ -1966,13 +1966,9 @@ dummy_func(
             Py_DECREF(owner);
         }
 
-        // stack effect: (__0, __1 -- )
-        inst(STORE_ATTR_WITH_HINT) {
+        inst(STORE_ATTR_WITH_HINT, (unused/1, type_version/2, hint/1, value, owner --)) {
             assert(cframe.use_tracing == 0);
-            PyObject *owner = TOP();
             PyTypeObject *tp = Py_TYPE(owner);
-            _PyAttrCache *cache = (_PyAttrCache *)next_instr;
-            uint32_t type_version = read_u32(cache->version);
             assert(type_version != 0);
             DEOPT_IF(tp->tp_version_tag != type_version, STORE_ATTR);
             assert(tp->tp_flags & Py_TPFLAGS_MANAGED_DICT);
@@ -1982,17 +1978,14 @@ dummy_func(
             DEOPT_IF(dict == NULL, STORE_ATTR);
             assert(PyDict_CheckExact((PyObject *)dict));
             PyObject *name = GETITEM(names, oparg);
-            uint16_t hint = cache->index;
             DEOPT_IF(hint >= (size_t)dict->ma_keys->dk_nentries, STORE_ATTR);
-            PyObject *value, *old_value;
+            PyObject *old_value;
             uint64_t new_version;
             if (DK_IS_UNICODE(dict->ma_keys)) {
                 PyDictUnicodeEntry *ep = DK_UNICODE_ENTRIES(dict->ma_keys) + hint;
                 DEOPT_IF(ep->me_key != name, STORE_ATTR);
                 old_value = ep->me_value;
                 DEOPT_IF(old_value == NULL, STORE_ATTR);
-                STACK_SHRINK(1);
-                value = POP();
                 new_version = _PyDict_NotifyEvent(PyDict_EVENT_MODIFIED, dict, name, value);
                 ep->me_value = value;
             }
@@ -2001,8 +1994,6 @@ dummy_func(
                 DEOPT_IF(ep->me_key != name, STORE_ATTR);
                 old_value = ep->me_value;
                 DEOPT_IF(old_value == NULL, STORE_ATTR);
-                STACK_SHRINK(1);
-                value = POP();
                 new_version = _PyDict_NotifyEvent(PyDict_EVENT_MODIFIED, dict, name, value);
                 ep->me_value = value;
             }
@@ -2015,7 +2006,6 @@ dummy_func(
             /* PEP 509 */
             dict->ma_version_tag = new_version;
             Py_DECREF(owner);
-            JUMPBY(INLINE_CACHE_ENTRIES_STORE_ATTR);
         }
 
         // stack effect: (__0, __1 -- )

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1144,15 +1144,11 @@ dummy_func(
             ERROR_IF(err != 0, error);
         }
 
-        // stack effect: (__0 -- )
-        inst(DELETE_ATTR) {
+        inst(DELETE_ATTR, (owner --)) {
             PyObject *name = GETITEM(names, oparg);
-            PyObject *owner = POP();
-            int err;
-            err = PyObject_SetAttr(owner, name, (PyObject *)NULL);
+            int err = PyObject_SetAttr(owner, name, (PyObject *)NULL);
             Py_DECREF(owner);
-            if (err != 0)
-                goto error;
+            ERROR_IF(err != 0, error);
         }
 
         // stack effect: (__0 -- )

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -550,21 +550,19 @@ dummy_func(
             ERROR_IF(err != 0, error);
         }
 
-        // stack effect: (__0 -- )
-        inst(PRINT_EXPR) {
-            PyObject *value = POP();
+        inst(PRINT_EXPR, (value --)) {
             PyObject *hook = _PySys_GetAttr(tstate, &_Py_ID(displayhook));
             PyObject *res;
+            // Can't use ERROR_IF here.
             if (hook == NULL) {
                 _PyErr_SetString(tstate, PyExc_RuntimeError,
                                  "lost sys.displayhook");
                 Py_DECREF(value);
-                goto error;
+                ERROR_IF(1, error);
             }
             res = PyObject_CallOneArg(hook, value);
             Py_DECREF(value);
-            if (res == NULL)
-                goto error;
+            ERROR_IF(res == NULL, error);
             Py_DECREF(res);
         }
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -603,9 +603,8 @@ dummy_func(
             return retval;
         }
 
-        // stack effect: (__0 -- )
-        inst(RETURN_VALUE) {
-            PyObject *retval = POP();
+        inst(RETURN_VALUE, (retval --)) {
+            STACK_SHRINK(1);
             assert(EMPTY());
             _PyFrame_SetStackPointer(frame, stack_pointer);
             TRACE_FUNCTION_EXIT();

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1151,15 +1151,11 @@ dummy_func(
             ERROR_IF(err != 0, error);
         }
 
-        // stack effect: (__0 -- )
-        inst(STORE_GLOBAL) {
+        inst(STORE_GLOBAL, (v --)) {
             PyObject *name = GETITEM(names, oparg);
-            PyObject *v = POP();
-            int err;
-            err = PyDict_SetItem(GLOBALS(), name, v);
+            int err = PyDict_SetItem(GLOBALS(), name, v);
             Py_DECREF(v);
-            if (err != 0)
-                goto error;
+            ERROR_IF(err != 0, error);
         }
 
         inst(DELETE_GLOBAL, (--)) {

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -468,12 +468,10 @@ dummy_func(
             DISPATCH_INLINED(new_frame);
         }
 
-        // stack effect: (__0 -- )
-        inst(LIST_APPEND) {
-            PyObject *v = POP();
-            PyObject *list = PEEK(oparg);
-            if (_PyList_AppendTakeRef((PyListObject *)list, v) < 0)
-                goto error;
+        // Alternative: (list, unused[oparg], v -- list, unused[oparg])
+        inst(LIST_APPEND, (v --)) {
+            PyObject *list = PEEK(oparg + 1);  // +1 to account for v staying on stack
+            ERROR_IF(_PyList_AppendTakeRef((PyListObject *)list, v) < 0, error);
             PREDICT(JUMP_BACKWARD);
         }
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -542,18 +542,12 @@ dummy_func(
             ERROR_IF(err != 0, error);
         }
 
-        // stack effect: (__0, __1 -- )
-        inst(DELETE_SUBSCR) {
-            PyObject *sub = TOP();
-            PyObject *container = SECOND();
-            int err;
-            STACK_SHRINK(2);
+        inst(DELETE_SUBSCR, (container, sub --)) {
             /* del container[sub] */
-            err = PyObject_DelItem(container, sub);
+            int err = PyObject_DelItem(container, sub);
             Py_DECREF(container);
             Py_DECREF(sub);
-            if (err != 0)
-                goto error;
+            ERROR_IF(err != 0, error);
         }
 
         // stack effect: (__0 -- )

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -530,20 +530,21 @@
         }
 
         TARGET(PRINT_EXPR) {
-            PyObject *value = POP();
+            PyObject *value = PEEK(1);
             PyObject *hook = _PySys_GetAttr(tstate, &_Py_ID(displayhook));
             PyObject *res;
+            // Can't use ERROR_IF here.
             if (hook == NULL) {
                 _PyErr_SetString(tstate, PyExc_RuntimeError,
                                  "lost sys.displayhook");
                 Py_DECREF(value);
-                goto error;
+                if (1) goto pop_1_error;
             }
             res = PyObject_CallOneArg(hook, value);
             Py_DECREF(value);
-            if (res == NULL)
-                goto error;
+            if (res == NULL) goto pop_1_error;
             Py_DECREF(res);
+            STACK_SHRINK(1);
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -439,13 +439,12 @@
         }
 
         TARGET(SET_ADD) {
-            PyObject *v = POP();
-            PyObject *set = PEEK(oparg);
-            int err;
-            err = PySet_Add(set, v);
+            PyObject *v = PEEK(1);
+            PyObject *set = PEEK(oparg + 1);  // +1 to account for v staying on stack
+            int err = PySet_Add(set, v);
             Py_DECREF(v);
-            if (err != 0)
-                goto error;
+            if (err != 0) goto pop_1_error;
+            STACK_SHRINK(1);
             PREDICT(JUMP_BACKWARD);
             DISPATCH();
         }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -430,10 +430,10 @@
         }
 
         TARGET(LIST_APPEND) {
-            PyObject *v = POP();
-            PyObject *list = PEEK(oparg);
-            if (_PyList_AppendTakeRef((PyListObject *)list, v) < 0)
-                goto error;
+            PyObject *v = PEEK(1);
+            PyObject *list = PEEK(oparg + 1);  // +1 to account for v staying on stack
+            if (_PyList_AppendTakeRef((PyListObject *)list, v) < 0) goto pop_1_error;
+            STACK_SHRINK(1);
             PREDICT(JUMP_BACKWARD);
             DISPATCH();
         }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3731,7 +3731,7 @@
             {
                 PyObject *right = _tmp_2;
                 PyObject *left = _tmp_1;
-                PyObject *jump;
+                size_t jump;
                 uint16_t when_to_jump_mask = read_u16(next_instr + 1);
                 assert(cframe.use_tracing == 0);
                 // Combined: COMPARE_OP (float ? float) + POP_JUMP_IF_(true/false)
@@ -3746,14 +3746,14 @@
                 STAT_INC(COMPARE_OP, hit);
                 _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
                 _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-                jump = (PyObject *)(size_t)(sign_ish & when_to_jump_mask);
-                _tmp_1 = jump;
+                jump = sign_ish & when_to_jump_mask;
+                _tmp_1 = (PyObject *)jump;
             }
             next_instr += 2;
             NEXTOPARG();
             next_instr++;
             {
-                PyObject *jump = _tmp_1;
+                size_t jump = (size_t)_tmp_1;
                 assert(opcode == POP_JUMP_IF_FALSE || opcode == POP_JUMP_IF_TRUE);
                 if (jump) {
                     JUMPBY(oparg);
@@ -3769,7 +3769,7 @@
             {
                 PyObject *right = _tmp_2;
                 PyObject *left = _tmp_1;
-                PyObject *jump;
+                size_t jump;
                 uint16_t when_to_jump_mask = read_u16(next_instr + 1);
                 assert(cframe.use_tracing == 0);
                 // Combined: COMPARE_OP (int ? int) + POP_JUMP_IF_(true/false)
@@ -3785,14 +3785,14 @@
                 int sign_ish = 2*(ileft > iright) + 2 - (ileft < iright);
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
-                jump = (PyObject *)(size_t)(sign_ish & when_to_jump_mask);
-                _tmp_1 = jump;
+                jump = sign_ish & when_to_jump_mask;
+                _tmp_1 = (PyObject *)jump;
             }
             next_instr += 2;
             NEXTOPARG();
             next_instr++;
             {
-                PyObject *jump = _tmp_1;
+                size_t jump = (size_t)_tmp_1;
                 assert(opcode == POP_JUMP_IF_FALSE || opcode == POP_JUMP_IF_TRUE);
                 if (jump) {
                     JUMPBY(oparg);
@@ -3808,7 +3808,7 @@
             {
                 PyObject *right = _tmp_2;
                 PyObject *left = _tmp_1;
-                PyObject *jump;
+                size_t jump;
                 uint16_t invert = read_u16(next_instr + 1);
                 assert(cframe.use_tracing == 0);
                 // Combined: COMPARE_OP (str == str or str != str) + POP_JUMP_IF_(true/false)
@@ -3821,14 +3821,14 @@
                 _Py_DECREF_SPECIALIZED(right, _PyUnicode_ExactDealloc);
                 assert(res == 0 || res == 1);
                 assert(invert == 0 || invert == 1);
-                jump = (PyObject *)(size_t)(res ^ invert);
-                _tmp_1 = jump;
+                jump = res ^ invert;
+                _tmp_1 = (PyObject *)jump;
             }
             next_instr += 2;
             NEXTOPARG();
             next_instr++;
             {
-                PyObject *jump = _tmp_1;
+                size_t jump = (size_t)_tmp_1;
                 assert(opcode == POP_JUMP_IF_FALSE || opcode == POP_JUMP_IF_TRUE);
                 if (jump) {
                     JUMPBY(oparg);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3567,8 +3567,13 @@
                 Py_INCREF(value);
                 _tmp_2 = value;
             }
-            NEXTOPARG();
-            next_instr++;
+            {
+                uint16_t word = read_u16(next_instr + 0);
+                #ifndef NDEBUG
+                opcode = _Py_OPCODE(word);
+                #endif
+                oparg = _Py_OPARG(word);
+            }
             {
                 PyObject *value;
                 value = GETLOCAL(oparg);
@@ -3576,6 +3581,7 @@
                 Py_INCREF(value);
                 _tmp_1 = value;
             }
+            next_instr += 1;
             STACK_GROW(2);
             POKE(1, _tmp_1);
             POKE(2, _tmp_2);
@@ -3592,14 +3598,20 @@
                 Py_INCREF(value);
                 _tmp_2 = value;
             }
-            NEXTOPARG();
-            next_instr++;
+            {
+                uint16_t word = read_u16(next_instr + 0);
+                #ifndef NDEBUG
+                opcode = _Py_OPCODE(word);
+                #endif
+                oparg = _Py_OPARG(word);
+            }
             {
                 PyObject *value;
                 value = GETITEM(consts, oparg);
                 Py_INCREF(value);
                 _tmp_1 = value;
             }
+            next_instr += 1;
             STACK_GROW(2);
             POKE(1, _tmp_1);
             POKE(2, _tmp_2);
@@ -3612,8 +3624,13 @@
                 PyObject *value = _tmp_1;
                 SETLOCAL(oparg, value);
             }
-            NEXTOPARG();
-            next_instr++;
+            {
+                uint16_t word = read_u16(next_instr + 0);
+                #ifndef NDEBUG
+                opcode = _Py_OPCODE(word);
+                #endif
+                oparg = _Py_OPARG(word);
+            }
             {
                 PyObject *value;
                 value = GETLOCAL(oparg);
@@ -3621,6 +3638,7 @@
                 Py_INCREF(value);
                 _tmp_1 = value;
             }
+            next_instr += 1;
             POKE(1, _tmp_1);
             DISPATCH();
         }
@@ -3632,12 +3650,18 @@
                 PyObject *value = _tmp_1;
                 SETLOCAL(oparg, value);
             }
-            NEXTOPARG();
-            next_instr++;
+            {
+                uint16_t word = read_u16(next_instr + 0);
+                #ifndef NDEBUG
+                opcode = _Py_OPCODE(word);
+                #endif
+                oparg = _Py_OPARG(word);
+            }
             {
                 PyObject *value = _tmp_2;
                 SETLOCAL(oparg, value);
             }
+            next_instr += 1;
             STACK_SHRINK(2);
             DISPATCH();
         }
@@ -3651,8 +3675,13 @@
                 Py_INCREF(value);
                 _tmp_2 = value;
             }
-            NEXTOPARG();
-            next_instr++;
+            {
+                uint16_t word = read_u16(next_instr + 0);
+                #ifndef NDEBUG
+                opcode = _Py_OPCODE(word);
+                #endif
+                oparg = _Py_OPARG(word);
+            }
             {
                 PyObject *value;
                 value = GETLOCAL(oparg);
@@ -3660,9 +3689,25 @@
                 Py_INCREF(value);
                 _tmp_1 = value;
             }
+            next_instr += 1;
             STACK_GROW(2);
             POKE(1, _tmp_1);
             POKE(2, _tmp_2);
+            DISPATCH();
+        }
+
+        TARGET(END_FOR) {
+            PyObject *_tmp_2 = PEEK(2);
+            PyObject *_tmp_1 = PEEK(1);
+            {
+                PyObject *value = _tmp_1;
+                Py_DECREF(value);
+            }
+            {
+                PyObject *value = _tmp_2;
+                Py_DECREF(value);
+            }
+            STACK_SHRINK(2);
             DISPATCH();
         }
 
@@ -3698,12 +3743,17 @@
                 _Py_DECREF_SPECIALIZED(right, _PyUnicode_ExactDealloc);
                 if (*target_local == NULL) goto pop_2_error;
             }
-            next_instr += 1;
-            NEXTOPARG();
-            next_instr++;
+            {
+                uint16_t word = read_u16(next_instr + 1);
+                #ifndef NDEBUG
+                opcode = _Py_OPCODE(word);
+                #endif
+                oparg = _Py_OPARG(word);
+            }
             {
                 // The STORE_FAST is already done; oparg is dead.
             }
+            next_instr += 2;
             STACK_SHRINK(2);
             DISPATCH();
         }
@@ -3732,9 +3782,13 @@
                 jump = sign_ish & when_to_jump_mask;
                 _tmp_2 = (PyObject *)jump;
             }
-            next_instr += 2;
-            NEXTOPARG();
-            next_instr++;
+            {
+                uint16_t word = read_u16(next_instr + 2);
+                #ifndef NDEBUG
+                opcode = _Py_OPCODE(word);
+                #endif
+                oparg = _Py_OPARG(word);
+            }
             {
                 size_t jump = (size_t)_tmp_2;
                 assert(opcode == POP_JUMP_IF_FALSE || opcode == POP_JUMP_IF_TRUE);
@@ -3742,6 +3796,7 @@
                     JUMPBY(oparg);
                 }
             }
+            next_instr += 3;
             STACK_SHRINK(2);
             DISPATCH();
         }
@@ -3771,9 +3826,13 @@
                 jump = sign_ish & when_to_jump_mask;
                 _tmp_2 = (PyObject *)jump;
             }
-            next_instr += 2;
-            NEXTOPARG();
-            next_instr++;
+            {
+                uint16_t word = read_u16(next_instr + 2);
+                #ifndef NDEBUG
+                opcode = _Py_OPCODE(word);
+                #endif
+                oparg = _Py_OPARG(word);
+            }
             {
                 size_t jump = (size_t)_tmp_2;
                 assert(opcode == POP_JUMP_IF_FALSE || opcode == POP_JUMP_IF_TRUE);
@@ -3781,6 +3840,7 @@
                     JUMPBY(oparg);
                 }
             }
+            next_instr += 3;
             STACK_SHRINK(2);
             DISPATCH();
         }
@@ -3807,9 +3867,13 @@
                 jump = res ^ invert;
                 _tmp_2 = (PyObject *)jump;
             }
-            next_instr += 2;
-            NEXTOPARG();
-            next_instr++;
+            {
+                uint16_t word = read_u16(next_instr + 2);
+                #ifndef NDEBUG
+                opcode = _Py_OPCODE(word);
+                #endif
+                oparg = _Py_OPARG(word);
+            }
             {
                 size_t jump = (size_t)_tmp_2;
                 assert(opcode == POP_JUMP_IF_FALSE || opcode == POP_JUMP_IF_TRUE);
@@ -3817,21 +3881,7 @@
                     JUMPBY(oparg);
                 }
             }
-            STACK_SHRINK(2);
-            DISPATCH();
-        }
-
-        TARGET(END_FOR) {
-            PyObject *_tmp_2 = PEEK(2);
-            PyObject *_tmp_1 = PEEK(1);
-            {
-                PyObject *value = _tmp_1;
-                Py_DECREF(value);
-            }
-            {
-                PyObject *value = _tmp_2;
-                Py_DECREF(value);
-            }
+            next_instr += 3;
             STACK_SHRINK(2);
             DISPATCH();
         }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -571,9 +571,10 @@
         }
 
         TARGET(INTERPRETER_EXIT) {
+            PyObject *retval = PEEK(1);
             assert(frame == &entry_frame);
             assert(_PyFrame_IsIncomplete(frame));
-            PyObject *retval = POP();
+            STACK_SHRINK(1);  // Since we're not going to DISPATCH()
             assert(EMPTY());
             /* Restore previous cframe and return. */
             tstate->cframe = cframe.previous;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -518,16 +518,14 @@
         }
 
         TARGET(DELETE_SUBSCR) {
-            PyObject *sub = TOP();
-            PyObject *container = SECOND();
-            int err;
-            STACK_SHRINK(2);
+            PyObject *sub = PEEK(1);
+            PyObject *container = PEEK(2);
             /* del container[sub] */
-            err = PyObject_DelItem(container, sub);
+            int err = PyObject_DelItem(container, sub);
             Py_DECREF(container);
             Py_DECREF(sub);
-            if (err != 0)
-                goto error;
+            if (err != 0) goto pop_2_error;
+            STACK_SHRINK(2);
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2005,22 +2005,22 @@
         }
 
         TARGET(STORE_ATTR_SLOT) {
+            PyObject *owner = PEEK(1);
+            PyObject *value = PEEK(2);
+            uint32_t type_version = read_u32(next_instr + 1);
+            uint16_t index = read_u16(next_instr + 3);
             assert(cframe.use_tracing == 0);
-            PyObject *owner = TOP();
             PyTypeObject *tp = Py_TYPE(owner);
-            _PyAttrCache *cache = (_PyAttrCache *)next_instr;
-            uint32_t type_version = read_u32(cache->version);
             assert(type_version != 0);
             DEOPT_IF(tp->tp_version_tag != type_version, STORE_ATTR);
-            char *addr = (char *)owner + cache->index;
+            char *addr = (char *)owner + index;
             STAT_INC(STORE_ATTR, hit);
-            STACK_SHRINK(1);
-            PyObject *value = POP();
             PyObject *old_value = *(PyObject **)addr;
             *(PyObject **)addr = value;
             Py_XDECREF(old_value);
             Py_DECREF(owner);
-            JUMPBY(INLINE_CACHE_ENTRIES_STORE_ATTR);
+            STACK_SHRINK(2);
+            next_instr += 4;
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3575,14 +3575,14 @@
         }
 
         TARGET(LOAD_FAST__LOAD_FAST) {
-            PyObject *_tmp_1;
             PyObject *_tmp_2;
+            PyObject *_tmp_1;
             {
                 PyObject *value;
                 value = GETLOCAL(oparg);
                 assert(value != NULL);
                 Py_INCREF(value);
-                _tmp_1 = value;
+                _tmp_2 = value;
             }
             NEXTOPARG();
             next_instr++;
@@ -3591,23 +3591,23 @@
                 value = GETLOCAL(oparg);
                 assert(value != NULL);
                 Py_INCREF(value);
-                _tmp_2 = value;
+                _tmp_1 = value;
             }
             STACK_GROW(2);
-            POKE(1, _tmp_2);
-            POKE(2, _tmp_1);
+            POKE(1, _tmp_1);
+            POKE(2, _tmp_2);
             DISPATCH();
         }
 
         TARGET(LOAD_FAST__LOAD_CONST) {
-            PyObject *_tmp_1;
             PyObject *_tmp_2;
+            PyObject *_tmp_1;
             {
                 PyObject *value;
                 value = GETLOCAL(oparg);
                 assert(value != NULL);
                 Py_INCREF(value);
-                _tmp_1 = value;
+                _tmp_2 = value;
             }
             NEXTOPARG();
             next_instr++;
@@ -3615,11 +3615,11 @@
                 PyObject *value;
                 value = GETITEM(consts, oparg);
                 Py_INCREF(value);
-                _tmp_2 = value;
+                _tmp_1 = value;
             }
             STACK_GROW(2);
-            POKE(1, _tmp_2);
-            POKE(2, _tmp_1);
+            POKE(1, _tmp_1);
+            POKE(2, _tmp_2);
             DISPATCH();
         }
 
@@ -3643,16 +3643,16 @@
         }
 
         TARGET(STORE_FAST__STORE_FAST) {
-            PyObject *_tmp_1 = PEEK(2);
-            PyObject *_tmp_2 = PEEK(1);
+            PyObject *_tmp_2 = PEEK(2);
+            PyObject *_tmp_1 = PEEK(1);
             {
-                PyObject *value = _tmp_2;
+                PyObject *value = _tmp_1;
                 SETLOCAL(oparg, value);
             }
             NEXTOPARG();
             next_instr++;
             {
-                PyObject *value = _tmp_1;
+                PyObject *value = _tmp_2;
                 SETLOCAL(oparg, value);
             }
             STACK_SHRINK(2);
@@ -3660,13 +3660,13 @@
         }
 
         TARGET(LOAD_CONST__LOAD_FAST) {
-            PyObject *_tmp_1;
             PyObject *_tmp_2;
+            PyObject *_tmp_1;
             {
                 PyObject *value;
                 value = GETITEM(consts, oparg);
                 Py_INCREF(value);
-                _tmp_1 = value;
+                _tmp_2 = value;
             }
             NEXTOPARG();
             next_instr++;
@@ -3675,20 +3675,20 @@
                 value = GETLOCAL(oparg);
                 assert(value != NULL);
                 Py_INCREF(value);
-                _tmp_2 = value;
+                _tmp_1 = value;
             }
             STACK_GROW(2);
-            POKE(1, _tmp_2);
-            POKE(2, _tmp_1);
+            POKE(1, _tmp_1);
+            POKE(2, _tmp_2);
             DISPATCH();
         }
 
         TARGET(BINARY_OP_INPLACE_ADD_UNICODE) {
-            PyObject *_tmp_1 = PEEK(2);
-            PyObject *_tmp_2 = PEEK(1);
+            PyObject *_tmp_2 = PEEK(2);
+            PyObject *_tmp_1 = PEEK(1);
             {
-                PyObject *right = _tmp_2;
-                PyObject *left = _tmp_1;
+                PyObject *right = _tmp_1;
+                PyObject *left = _tmp_2;
                 assert(cframe.use_tracing == 0);
                 DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
                 DEOPT_IF(Py_TYPE(right) != Py_TYPE(left), BINARY_OP);
@@ -3726,11 +3726,11 @@
         }
 
         TARGET(COMPARE_OP_FLOAT_JUMP) {
-            PyObject *_tmp_1 = PEEK(2);
-            PyObject *_tmp_2 = PEEK(1);
+            PyObject *_tmp_2 = PEEK(2);
+            PyObject *_tmp_1 = PEEK(1);
             {
-                PyObject *right = _tmp_2;
-                PyObject *left = _tmp_1;
+                PyObject *right = _tmp_1;
+                PyObject *left = _tmp_2;
                 size_t jump;
                 uint16_t when_to_jump_mask = read_u16(next_instr + 1);
                 assert(cframe.use_tracing == 0);
@@ -3747,13 +3747,13 @@
                 _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
                 _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
                 jump = sign_ish & when_to_jump_mask;
-                _tmp_1 = (PyObject *)jump;
+                _tmp_2 = (PyObject *)jump;
             }
             next_instr += 2;
             NEXTOPARG();
             next_instr++;
             {
-                size_t jump = (size_t)_tmp_1;
+                size_t jump = (size_t)_tmp_2;
                 assert(opcode == POP_JUMP_IF_FALSE || opcode == POP_JUMP_IF_TRUE);
                 if (jump) {
                     JUMPBY(oparg);
@@ -3764,11 +3764,11 @@
         }
 
         TARGET(COMPARE_OP_INT_JUMP) {
-            PyObject *_tmp_1 = PEEK(2);
-            PyObject *_tmp_2 = PEEK(1);
+            PyObject *_tmp_2 = PEEK(2);
+            PyObject *_tmp_1 = PEEK(1);
             {
-                PyObject *right = _tmp_2;
-                PyObject *left = _tmp_1;
+                PyObject *right = _tmp_1;
+                PyObject *left = _tmp_2;
                 size_t jump;
                 uint16_t when_to_jump_mask = read_u16(next_instr + 1);
                 assert(cframe.use_tracing == 0);
@@ -3786,13 +3786,13 @@
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
                 jump = sign_ish & when_to_jump_mask;
-                _tmp_1 = (PyObject *)jump;
+                _tmp_2 = (PyObject *)jump;
             }
             next_instr += 2;
             NEXTOPARG();
             next_instr++;
             {
-                size_t jump = (size_t)_tmp_1;
+                size_t jump = (size_t)_tmp_2;
                 assert(opcode == POP_JUMP_IF_FALSE || opcode == POP_JUMP_IF_TRUE);
                 if (jump) {
                     JUMPBY(oparg);
@@ -3803,11 +3803,11 @@
         }
 
         TARGET(COMPARE_OP_STR_JUMP) {
-            PyObject *_tmp_1 = PEEK(2);
-            PyObject *_tmp_2 = PEEK(1);
+            PyObject *_tmp_2 = PEEK(2);
+            PyObject *_tmp_1 = PEEK(1);
             {
-                PyObject *right = _tmp_2;
-                PyObject *left = _tmp_1;
+                PyObject *right = _tmp_1;
+                PyObject *left = _tmp_2;
                 size_t jump;
                 uint16_t invert = read_u16(next_instr + 1);
                 assert(cframe.use_tracing == 0);
@@ -3822,13 +3822,13 @@
                 assert(res == 0 || res == 1);
                 assert(invert == 0 || invert == 1);
                 jump = res ^ invert;
-                _tmp_1 = (PyObject *)jump;
+                _tmp_2 = (PyObject *)jump;
             }
             next_instr += 2;
             NEXTOPARG();
             next_instr++;
             {
-                size_t jump = (size_t)_tmp_1;
+                size_t jump = (size_t)_tmp_2;
                 assert(opcode == POP_JUMP_IF_FALSE || opcode == POP_JUMP_IF_TRUE);
                 if (jump) {
                     JUMPBY(oparg);
@@ -3839,14 +3839,14 @@
         }
 
         TARGET(END_FOR) {
-            PyObject *_tmp_1 = PEEK(2);
-            PyObject *_tmp_2 = PEEK(1);
+            PyObject *_tmp_2 = PEEK(2);
+            PyObject *_tmp_1 = PEEK(1);
             {
-                PyObject *value = _tmp_2;
+                PyObject *value = _tmp_1;
                 Py_DECREF(value);
             }
             {
-                PyObject *value = _tmp_1;
+                PyObject *value = _tmp_2;
                 Py_DECREF(value);
             }
             STACK_SHRINK(2);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1118,13 +1118,12 @@
         }
 
         TARGET(DELETE_ATTR) {
+            PyObject *owner = PEEK(1);
             PyObject *name = GETITEM(names, oparg);
-            PyObject *owner = POP();
-            int err;
-            err = PyObject_SetAttr(owner, name, (PyObject *)NULL);
+            int err = PyObject_SetAttr(owner, name, (PyObject *)NULL);
             Py_DECREF(owner);
-            if (err != 0)
-                goto error;
+            if (err != 0) goto pop_1_error;
+            STACK_SHRINK(1);
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -600,46 +600,39 @@
         }
 
         TARGET(GET_AITER) {
+            PyObject *obj = PEEK(1);
+            PyObject *iter;
             unaryfunc getter = NULL;
-            PyObject *iter = NULL;
-            PyObject *obj = TOP();
             PyTypeObject *type = Py_TYPE(obj);
 
             if (type->tp_as_async != NULL) {
                 getter = type->tp_as_async->am_aiter;
             }
 
-            if (getter != NULL) {
-                iter = (*getter)(obj);
-                Py_DECREF(obj);
-                if (iter == NULL) {
-                    SET_TOP(NULL);
-                    goto error;
-                }
-            }
-            else {
-                SET_TOP(NULL);
+            if (getter == NULL) {
                 _PyErr_Format(tstate, PyExc_TypeError,
                               "'async for' requires an object with "
                               "__aiter__ method, got %.100s",
                               type->tp_name);
                 Py_DECREF(obj);
-                goto error;
+                if (1) goto pop_1_error;
             }
+
+            iter = (*getter)(obj);
+            Py_DECREF(obj);
+            if (iter == NULL) goto pop_1_error;
 
             if (Py_TYPE(iter)->tp_as_async == NULL ||
                     Py_TYPE(iter)->tp_as_async->am_anext == NULL) {
 
-                SET_TOP(NULL);
                 _PyErr_Format(tstate, PyExc_TypeError,
                               "'async for' received an object from __aiter__ "
                               "that does not implement __anext__: %.100s",
                               Py_TYPE(iter)->tp_name);
                 Py_DECREF(iter);
-                goto error;
+                if (1) goto pop_1_error;
             }
-
-            SET_TOP(iter);
+            POKE(1, iter);
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1128,13 +1128,12 @@
         }
 
         TARGET(STORE_GLOBAL) {
+            PyObject *v = PEEK(1);
             PyObject *name = GETITEM(names, oparg);
-            PyObject *v = POP();
-            int err;
-            err = PyDict_SetItem(GLOBALS(), name, v);
+            int err = PyDict_SetItem(GLOBALS(), name, v);
             Py_DECREF(v);
-            if (err != 0)
-                goto error;
+            if (err != 0) goto pop_1_error;
+            STACK_SHRINK(1);
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -218,40 +218,6 @@
             DISPATCH();
         }
 
-        TARGET(BINARY_OP_INPLACE_ADD_UNICODE) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
-            assert(cframe.use_tracing == 0);
-            DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
-            DEOPT_IF(Py_TYPE(right) != Py_TYPE(left), BINARY_OP);
-            _Py_CODEUNIT true_next = next_instr[INLINE_CACHE_ENTRIES_BINARY_OP];
-            assert(_Py_OPCODE(true_next) == STORE_FAST ||
-                   _Py_OPCODE(true_next) == STORE_FAST__LOAD_FAST);
-            PyObject **target_local = &GETLOCAL(_Py_OPARG(true_next));
-            DEOPT_IF(*target_local != left, BINARY_OP);
-            STAT_INC(BINARY_OP, hit);
-            /* Handle `left = left + right` or `left += right` for str.
-             *
-             * When possible, extend `left` in place rather than
-             * allocating a new PyUnicodeObject. This attempts to avoid
-             * quadratic behavior when one neglects to use str.join().
-             *
-             * If `left` has only two references remaining (one from
-             * the stack, one in the locals), DECREFing `left` leaves
-             * only the locals reference, so PyUnicode_Append knows
-             * that the string is safe to mutate.
-             */
-            assert(Py_REFCNT(left) >= 2);
-            _Py_DECREF_NO_DEALLOC(left);
-            PyUnicode_Append(target_local, right);
-            _Py_DECREF_SPECIALIZED(right, _PyUnicode_ExactDealloc);
-            if (*target_local == NULL) goto pop_2_error;
-            // The STORE_FAST is already done.
-            JUMPBY(INLINE_CACHE_ENTRIES_BINARY_OP + 1);
-            STACK_SHRINK(2);
-            DISPATCH();
-        }
-
         TARGET(BINARY_OP_ADD_FLOAT) {
             PyObject *right = PEEK(1);
             PyObject *left = PEEK(2);
@@ -3809,6 +3775,48 @@
             STACK_GROW(2);
             POKE(1, _tmp_2);
             POKE(2, _tmp_1);
+            DISPATCH();
+        }
+
+        TARGET(BINARY_OP_INPLACE_ADD_UNICODE) {
+            PyObject *_tmp_1 = PEEK(2);
+            PyObject *_tmp_2 = PEEK(1);
+            {
+                PyObject *right = _tmp_2;
+                PyObject *left = _tmp_1;
+                assert(cframe.use_tracing == 0);
+                DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
+                DEOPT_IF(Py_TYPE(right) != Py_TYPE(left), BINARY_OP);
+                _Py_CODEUNIT true_next = next_instr[INLINE_CACHE_ENTRIES_BINARY_OP];
+                assert(_Py_OPCODE(true_next) == STORE_FAST ||
+                       _Py_OPCODE(true_next) == STORE_FAST__LOAD_FAST);
+                PyObject **target_local = &GETLOCAL(_Py_OPARG(true_next));
+                DEOPT_IF(*target_local != left, BINARY_OP);
+                STAT_INC(BINARY_OP, hit);
+                /* Handle `left = left + right` or `left += right` for str.
+                 *
+                 * When possible, extend `left` in place rather than
+                 * allocating a new PyUnicodeObject. This attempts to avoid
+                 * quadratic behavior when one neglects to use str.join().
+                 *
+                 * If `left` has only two references remaining (one from
+                 * the stack, one in the locals), DECREFing `left` leaves
+                 * only the locals reference, so PyUnicode_Append knows
+                 * that the string is safe to mutate.
+                 */
+                assert(Py_REFCNT(left) >= 2);
+                _Py_DECREF_NO_DEALLOC(left);
+                PyUnicode_Append(target_local, right);
+                _Py_DECREF_SPECIALIZED(right, _PyUnicode_ExactDealloc);
+                if (*target_local == NULL) goto pop_2_error;
+            }
+            next_instr += 1;
+            NEXTOPARG();
+            next_instr++;
+            {
+                // The STORE_FAST is already done; oparg is dead.
+            }
+            STACK_SHRINK(2);
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -586,7 +586,8 @@
         }
 
         TARGET(RETURN_VALUE) {
-            PyObject *retval = POP();
+            PyObject *retval = PEEK(1);
+            STACK_SHRINK(1);
             assert(EMPTY());
             _PyFrame_SetStackPointer(frame, stack_pointer);
             TRACE_FUNCTION_EXIT();

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -552,7 +552,7 @@ class Analyzer:
         # and 'lowest' and 'highest' are the extremes.
         # Note that 'lowest' may be negative.
         # TODO: Reverse the numbering.
-        stack = [StackEffect(f"_tmp_{i+1}", "") for i in range(highest - lowest)]
+        stack = [StackEffect(f"_tmp_{i+1}", "") for i in reversed(range(highest - lowest))]
         return stack, -lowest
 
     def write_instructions(self) -> None:
@@ -629,6 +629,11 @@ class Analyzer:
     @contextlib.contextmanager
     def wrap_super_or_macro(self, up: SuperOrMacroInstruction):
         """Shared boilerplate for super- and macro instructions."""
+        # TODO: Somewhere (where?) make it so that if one instruction
+        # has an output that is input to another, and the variable names
+        # and types match and don't conflict with other instructions,
+        # that variable is declared with the right name and type in the
+        # outer block, rather than trusting the compiler to optimize it.
         self.out.emit("")
         with self.out.block(f"TARGET({up.name})"):
             for i, var in enumerate(up.stack):

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -260,27 +260,13 @@ class Component:
 
 
 @dataclasses.dataclass
-class SuperOrMacroInstruction:
-    """Common fields for super- and macro instructions."""
+class MacroInstruction:
+    """A macro instruction."""
 
     name: str
     stack: list[StackEffect]
     initial_sp: int
     final_sp: int
-
-
-@dataclasses.dataclass
-class SuperInstruction(SuperOrMacroInstruction):
-    """A super-instruction."""
-
-    super: parser.Super
-    parts: list[Component]
-
-
-@dataclasses.dataclass
-class MacroInstruction(SuperOrMacroInstruction):
-    """A macro instruction."""
-
     macro: parser.Macro
     parts: list[Component | parser.CacheEffect]
 
@@ -312,8 +298,6 @@ class Analyzer:
         self.errors += 1
 
     instrs: dict[str, Instruction]  # Includes ops
-    supers: dict[str, parser.Super]
-    super_instrs: dict[str, SuperInstruction]
     macros: dict[str, parser.Macro]
     macro_instrs: dict[str, MacroInstruction]
     families: dict[str, parser.Family]
@@ -345,15 +329,12 @@ class Analyzer:
         # Parse from start
         psr.setpos(start)
         self.instrs = {}
-        self.supers = {}
         self.macros = {}
         self.families = {}
         while thing := psr.definition():
             match thing:
                 case parser.InstDef(name=name):
                     self.instrs[name] = Instruction(thing)
-                case parser.Super(name):
-                    self.supers[name] = thing
                 case parser.Macro(name):
                     self.macros[name] = thing
                 case parser.Family(name):
@@ -365,7 +346,7 @@ class Analyzer:
 
         print(
             f"Read {len(self.instrs)} instructions/ops, "
-            f"{len(self.supers)} supers, {len(self.macros)} macros, "
+            f"{len(self.macros)} macros, "
             f"and {len(self.families)} families from {self.filename}",
             file=sys.stderr,
         )
@@ -378,7 +359,7 @@ class Analyzer:
         self.find_predictions()
         self.map_families()
         self.check_families()
-        self.analyze_supers_and_macros()
+        self.analyze_macros()
 
     def find_predictions(self) -> None:
         """Find the instructions that need PREDICTED() labels."""
@@ -444,25 +425,11 @@ class Analyzer:
                         family,
                     )
 
-    def analyze_supers_and_macros(self) -> None:
-        """Analyze each super- and macro instruction."""
-        self.super_instrs = {}
+    def analyze_macros(self) -> None:
+        """Analyze each macro instruction."""
         self.macro_instrs = {}
-        for name, super in self.supers.items():
-            self.super_instrs[name] = self.analyze_super(super)
         for name, macro in self.macros.items():
             self.macro_instrs[name] = self.analyze_macro(macro)
-
-    def analyze_super(self, super: parser.Super) -> SuperInstruction:
-        components = self.check_super_components(super)
-        stack, initial_sp = self.stack_analysis(components)
-        sp = initial_sp
-        parts: list[Component] = []
-        for instr in components:
-            part, sp = self.analyze_instruction(instr, stack, sp)
-            parts.append(part)
-        final_sp = sp
-        return SuperInstruction(super.name, stack, initial_sp, final_sp, super, parts)
 
     def analyze_macro(self, macro: parser.Macro) -> MacroInstruction:
         components = self.check_macro_components(macro)
@@ -494,15 +461,6 @@ class Analyzer:
             sp += 1
         return Component(instr, input_mapping, output_mapping), sp
 
-    def check_super_components(self, super: parser.Super) -> list[Instruction]:
-        components: list[Instruction] = []
-        for op in super.ops:
-            if op.name not in self.instrs:
-                self.error(f"Unknown instruction {op.name!r}", super)
-            else:
-                components.append(self.instrs[op.name])
-        return components
-
     def check_macro_components(
         self, macro: parser.Macro
     ) -> list[InstructionOrCacheEffect]:
@@ -522,9 +480,7 @@ class Analyzer:
     def stack_analysis(
         self, components: typing.Iterable[InstructionOrCacheEffect]
     ) -> tuple[list[StackEffect], int]:
-        """Analyze a super-instruction or macro.
-
-        Print an error if there's a cache effect (which we don't support yet).
+        """Analyze a macro.
 
         Return the list of variable names and the initial stack pointer.
         """
@@ -576,12 +532,6 @@ class Analyzer:
                             self.out.emit(f"PREDICT({prediction});")
                         self.out.emit(f"DISPATCH();")
 
-            # Write and count super-instructions
-            n_supers = 0
-            for sup in self.super_instrs.values():
-                n_supers += 1
-                self.write_super(sup)
-
             # Write and count macro instructions
             n_macros = 0
             for macro in self.macro_instrs.values():
@@ -589,27 +539,14 @@ class Analyzer:
                 self.write_macro(macro)
 
         print(
-            f"Wrote {n_instrs} instructions, {n_supers} supers, "
+            f"Wrote {n_instrs} instructions "
             f"and {n_macros} macros to {self.output_filename}",
             file=sys.stderr,
         )
 
-    def write_super(self, sup: SuperInstruction) -> None:
-        """Write code for a super-instruction."""
-        with self.wrap_super_or_macro(sup):
-            first = True
-            for comp in sup.parts:
-                if not first:
-                    self.out.emit("NEXTOPARG();")
-                    self.out.emit("next_instr++;")
-                first = False
-                comp.write_body(self.out, 0)
-                if comp.instr.cache_offset:
-                    self.out.emit(f"next_instr += {comp.instr.cache_offset};")
-
     def write_macro(self, mac: MacroInstruction) -> None:
         """Write code for a macro instruction."""
-        with self.wrap_super_or_macro(mac):
+        with self.wrap_macro(mac):
             cache_adjust = 0
             for part in mac.parts:
                 match part:
@@ -623,8 +560,8 @@ class Analyzer:
                 self.out.emit(f"next_instr += {cache_adjust};")
 
     @contextlib.contextmanager
-    def wrap_super_or_macro(self, up: SuperOrMacroInstruction):
-        """Shared boilerplate for super- and macro instructions."""
+    def wrap_macro(self, up: MacroInstruction):
+        """Boilerplate for macro instructions."""
         # TODO: Somewhere (where?) make it so that if one instruction
         # has an output that is input to another, and the variable names
         # and types match and don't conflict with other instructions,

--- a/Tools/cases_generator/parser.py
+++ b/Tools/cases_generator/parser.py
@@ -63,7 +63,7 @@ class Block(Node):
 class StackEffect(Node):
     name: str
     type: str = ""
-    # TODO: type, condition
+    # TODO: array, condition
 
 
 @dataclass

--- a/Tools/cases_generator/parser.py
+++ b/Tools/cases_generator/parser.py
@@ -62,6 +62,7 @@ class Block(Node):
 @dataclass
 class StackEffect(Node):
     name: str
+    type: str = ""
     # TODO: type, condition
 
 
@@ -147,7 +148,7 @@ class Parser(PLexer):
             if self.expect(lx.LPAREN) and (tkn := self.expect(lx.IDENTIFIER)):
                 name = tkn.text
                 if self.expect(lx.COMMA):
-                    inp, outp = self.stack_effect()
+                    inp, outp = self.io_effect()
                     if self.expect(lx.RPAREN):
                         if (tkn := self.peek()) and tkn.kind == lx.LBRACE:
                             return InstHeader(kind, name, inp, outp)
@@ -156,7 +157,7 @@ class Parser(PLexer):
                     return InstHeader(kind, name, [], [])
         return None
 
-    def stack_effect(self) -> tuple[list[InputEffect], list[OutputEffect]]:
+    def io_effect(self) -> tuple[list[InputEffect], list[OutputEffect]]:
         # '(' [inputs] '--' [outputs] ')'
         if self.expect(lx.LPAREN):
             inputs = self.inputs() or []
@@ -181,23 +182,7 @@ class Parser(PLexer):
 
     @contextual
     def input(self) -> InputEffect | None:
-        # IDENTIFIER '/' INTEGER (CacheEffect)
-        # IDENTIFIER (StackEffect)
-        if tkn := self.expect(lx.IDENTIFIER):
-            if self.expect(lx.DIVIDE):
-                if num := self.expect(lx.NUMBER):
-                    try:
-                        size = int(num.text)
-                    except ValueError:
-                        raise self.make_syntax_error(
-                            f"Expected integer, got {num.text!r}"
-                        )
-                    else:
-                        return CacheEffect(tkn.text, size)
-                raise self.make_syntax_error("Expected integer")
-            else:
-                # TODO: Arrays, conditions
-                return StackEffect(tkn.text)
+        return self.cache_effect() or self.stack_effect()
 
     def outputs(self) -> list[OutputEffect] | None:
         # output (, output)*
@@ -214,8 +199,30 @@ class Parser(PLexer):
 
     @contextual
     def output(self) -> OutputEffect | None:
+        return self.stack_effect()
+
+    @contextual
+    def cache_effect(self) -> CacheEffect | None:
+        # IDENTIFIER '/' NUMBER
         if tkn := self.expect(lx.IDENTIFIER):
-            return StackEffect(tkn.text)
+            if self.expect(lx.DIVIDE):
+                num = self.require(lx.NUMBER).text
+                try:
+                    size = int(num)
+                except ValueError:
+                    raise self.make_syntax_error(f"Expected integer, got {num!r}")
+                else:
+                    return CacheEffect(tkn.text, size)
+
+    @contextual
+    def stack_effect(self) -> StackEffect | None:
+        # IDENTIFIER [':' IDENTIFIER]
+        # TODO: Arrays, conditions
+        if tkn := self.expect(lx.IDENTIFIER):
+            type = ""
+            if self.expect(lx.COLON):
+                type = self.require(lx.IDENTIFIER).text
+            return StackEffect(tkn.text, type)
 
     @contextual
     def super_def(self) -> Super | None:

--- a/Tools/cases_generator/parser.py
+++ b/Tools/cases_generator/parser.py
@@ -100,12 +100,6 @@ class InstDef(Node):
 
 
 @dataclass
-class Super(Node):
-    name: str
-    ops: list[OpName]
-
-
-@dataclass
 class Macro(Node):
     name: str
     uops: list[UOp]
@@ -120,11 +114,9 @@ class Family(Node):
 
 class Parser(PLexer):
     @contextual
-    def definition(self) -> InstDef | Super | Macro | Family | None:
+    def definition(self) -> InstDef | Macro | Family | None:
         if inst := self.inst_def():
             return inst
-        if super := self.super_def():
-            return super
         if macro := self.macro_def():
             return macro
         if family := self.family_def():
@@ -223,18 +215,6 @@ class Parser(PLexer):
             if self.expect(lx.COLON):
                 type = self.require(lx.IDENTIFIER).text
             return StackEffect(tkn.text, type)
-
-    @contextual
-    def super_def(self) -> Super | None:
-        if (tkn := self.expect(lx.IDENTIFIER)) and tkn.text == "super":
-            if self.expect(lx.LPAREN):
-                if tkn := self.expect(lx.IDENTIFIER):
-                    if self.expect(lx.RPAREN):
-                        if self.expect(lx.EQUALS):
-                            if ops := self.ops():
-                                self.require(lx.SEMI)
-                                res = Super(tkn.text, ops)
-                                return res
 
     def ops(self) -> list[OpName] | None:
         if op := self.op():


### PR DESCRIPTION
Instead of `super(X) = Y + Z` write `macro(X) = Y + JOIN + Z` and get rid of the code duplication for super and macro.

<!-- gh-issue-number: gh-98831 -->
* Issue: gh-98831
<!-- /gh-issue-number -->
