### PR TITLE
gh-100098: [Enum] insist on actual tuples, no subclasses, for auto

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -436,7 +436,9 @@ class _EnumDict(dict):
             if isinstance(value, auto):
                 single = True
                 value = (value, )
-            if isinstance(value, tuple):
+            if type(value) is tuple and any(isinstance(v, auto) for v in value):
+                # insist on an actual tuple, no subclasses, in keeping with only supporting
+                # top-level auto() usage (not contained in any other data structure)
                 auto_valued = []
                 for v in value:
                     if isinstance(v, auto):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2841,6 +2841,19 @@ class TestSpecial(unittest.TestCase):
         self.assertEqual(deep, flags)
         self.assertEqual(copied.value, 1 | 2 | 8)
 
+    def test_namedtuple_as_value(self):
+        from collections import namedtuple
+        TTuple = namedtuple('TTuple', 'id a blist')
+        class NTEnum(Enum):
+            NONE = TTuple(0, 0, [])
+            A = TTuple(1, 2, [4])
+            B = TTuple(2, 4, [0, 1, 2])
+        self.assertEqual(repr(NTEnum.NONE), "<NTEnum.NONE: TTuple(id=0, a=0, blist=[])>")
+        self.assertEqual(NTEnum.NONE.value, TTuple(id=0, a=0, blist=[]))
+        self.assertEqual(
+                [x.value for x in NTEnum],
+                [TTuple(id=0, a=0, blist=[]), TTuple(id=1, a=2, blist=[4]), TTuple(id=2, a=4, blist=[0, 1, 2])],
+                )
 
 class TestOrder(unittest.TestCase):
     "test usage of the `_order_` attribute"

--- a/Misc/NEWS.d/next/Library/2022-12-08-06-18-06.gh-issue-100098.uBvPlp.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-08-06-18-06.gh-issue-100098.uBvPlp.rst
@@ -1,0 +1,1 @@
+Fix ``tuple`` subclasses being cast to ``tuple`` when used as enum values.


### PR DESCRIPTION
When checking for auto() instances, only top-level usage is supported, which means either alone or as part of a regular tuple. Other containers, such as lists, dicts, or namedtuples, are not supported.

<!-- gh-issue-number: gh-100098 -->
* Issue: gh-100098
<!-- /gh-issue-number -->
