### PR TITLE
gh-100101: Clarify documentation of zip()'s strict option

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1919,11 +1919,6 @@ are always available.  They are listed here in alphabetical order.
      Unlike the default behavior, it raises a :exc:`ValueError` if one iterable
      is exhausted before the others:
 
-        ..
-           This doctest is disabled because doctest does not support capturing
-           output and exceptions in the same code unit.
-           https://github.com/python/cpython/issues/65382
-
         >>> for item in zip(range(3), ['fee', 'fi', 'fo', 'fum'], strict=True):  # doctest: +SKIP
         ...     print(item)
         ...
@@ -1933,6 +1928,11 @@ are always available.  They are listed here in alphabetical order.
         Traceback (most recent call last):
           ...
         ValueError: zip() argument 2 is longer than argument 1
+
+     ..
+        This doctest is disabled because doctest does not support capturing
+        output and exceptions in the same code unit.
+        https://github.com/python/cpython/issues/65382
 
      Without the ``strict=True`` argument, any bug that results in iterables of
      different lengths will be silenced, possibly manifesting as a hard-to-find

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1916,10 +1916,15 @@ are always available.  They are listed here in alphabetical order.
         >>> list(zip(('a', 'b', 'c'), (1, 2, 3), strict=True))
         [('a', 1), ('b', 2), ('c', 3)]
 
-     Unlike the default behavior, it checks that the lengths of iterables are
-     identical, raising a :exc:`ValueError` if they aren't:
+     Unlike the default behavior, it raises a :exc:`ValueError` if one iterable
+     is exhausted before the others:
 
-        >>> list(zip(range(3), ['fee', 'fi', 'fo', 'fum'], strict=True))
+        >>> for item in zip(range(3), ['fee', 'fi', 'fo', 'fum'], strict=True):
+        ...     print(item)
+        ...
+        (0, 'fee')
+        (1, 'fi')
+        (2, 'fo')
         Traceback (most recent call last):
           ...
         ValueError: zip() argument 2 is longer than argument 1

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1919,7 +1919,12 @@ are always available.  They are listed here in alphabetical order.
      Unlike the default behavior, it raises a :exc:`ValueError` if one iterable
      is exhausted before the others:
 
-        >>> for item in zip(range(3), ['fee', 'fi', 'fo', 'fum'], strict=True):
+        ..
+           This doctest is disabled because doctest does not support capturing
+           output and exceptions in the same code unit.
+           https://github.com/python/cpython/issues/65382
+
+        >>> for item in zip(range(3), ['fee', 'fi', 'fo', 'fum'], strict=True):  # doctest: +SKIP
         ...     print(item)
         ...
         (0, 'fee')


### PR DESCRIPTION
Issue: #100101

* Straightforward docs clarification change, no news entry
* Needs application to the 3.10 and 3.11 docs.

<!-- gh-issue-number: gh-100101 -->
* Issue: gh-100101
<!-- /gh-issue-number -->
