### PR TITLE
gh-98724: Fix the Py_CLEAR() macro in the limited C API

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -612,7 +612,13 @@ static inline void Py_DECREF(PyObject *op)
  * and so avoid type punning. Otherwise, use memcpy() which causes type erasure
  * and so prevents the compiler to reuse an old cached 'op' value after
  * Py_CLEAR().
+ *
+ * If _Py_TYPEOF() is not available, the limited C API implementation uses a
+ * function call to hide implementation details. The function uses memcpy() of
+ * <string.h> which is not included by <Python.h>.
  */
+PyAPI_FUNC(void) _Py_Clear(PyObject **pobj);
+
 #ifdef _Py_TYPEOF
 #define Py_CLEAR(op) \
     do { \
@@ -623,6 +629,8 @@ static inline void Py_DECREF(PyObject *op)
             Py_DECREF(_tmp_old_op); \
         } \
     } while (0)
+#elif defined(Py_LIMITED_API)
+#define Py_CLEAR(op) _Py_Clear(_Py_CAST(PyObject**, &(op)))
 #else
 #define Py_CLEAR(op) \
     do { \

--- a/Lib/test/test_stable_abi_ctypes.py
+++ b/Lib/test/test_stable_abi_ctypes.py
@@ -868,6 +868,7 @@ SYMBOL_NAMES = (
     "_PyWeakref_RefType",
     "_Py_BuildValue_SizeT",
     "_Py_CheckRecursiveCall",
+    "_Py_Clear",
     "_Py_Dealloc",
     "_Py_DecRef",
     "_Py_EllipsisObject",

--- a/Misc/stable_abi.toml
+++ b/Misc/stable_abi.toml
@@ -2386,3 +2386,7 @@
     added = '3.12'  # Before 3.12, available in "structmember.h" w/o Py_ prefix
 [const.Py_AUDIT_READ]
     added = '3.12'  # Before 3.12, available in "structmember.h"
+
+[function._Py_Clear]
+    added = '3.12'
+    abi_only = true

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2446,6 +2446,23 @@ int Py_IsFalse(PyObject *x)
     return Py_Is(x, Py_False);
 }
 
+void _Py_Clear(PyObject **pobj)
+{
+    PyObject *old_obj = *pobj;
+    if (old_obj == NULL) {
+        return;
+    }
+
+    // gh-99701: In the limited C API, the Py_CLEAR(obj) macro has a type
+    // punning issue, it casts '&obj' to PyObject** to call _Py_Clear(). Use
+    // memcpy() instead of a simple assignment to cause type erasure and so
+    // prevent the compiler to reuse an old cached 'obj' value after
+    // Py_CLEAR().
+    PyObject *null_ptr = NULL;
+    memcpy(pobj, &null_ptr, sizeof(PyObject*));
+    Py_DECREF(old_obj);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/PC/python3dll.c
+++ b/PC/python3dll.c
@@ -16,6 +16,7 @@
 
 EXPORT_FUNC(_Py_BuildValue_SizeT)
 EXPORT_FUNC(_Py_CheckRecursiveCall)
+EXPORT_FUNC(_Py_Clear)
 EXPORT_FUNC(_Py_Dealloc)
 EXPORT_FUNC(_Py_DecRef)
 EXPORT_FUNC(_Py_IncRef)


### PR DESCRIPTION
If _Py_TYPEOF() is not available, the limited C API now implements the Py_CLEAR() macro as a function call which hides implementation details. The function uses memcpy() of <string.h> which is not included by <Python.h>.

* Add private _Py_Clear() function.
* Add _Py_Clear() to Misc/stable_abi.toml.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98724 -->
* Issue: gh-98724
<!-- /gh-issue-number -->
