### PR TITLE
gh-81057: Fix an ifdef in the time module

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -62,8 +62,7 @@
 #define SEC_TO_NS (1000 * 1000 * 1000)
 
 
-#ifdef HAVE_TIMES
-
+#if defined(HAVE_TIMES) || defined(HAVE_CLOCK)
 static int
 check_ticks_per_second(long tps, const char *context)
 {
@@ -75,6 +74,9 @@ check_ticks_per_second(long tps, const char *context)
     }
     return 0;
 }
+#endif  /* HAVE_TIMES || HAVE_CLOCK */
+
+#ifdef HAVE_TIMES
 
 # define ticks_per_second _PyRuntime.time.ticks_per_second
 


### PR DESCRIPTION
An earlier commit only defined `check_ticks_per_second()` when `HAVE_TIMES` is defined.  However, we also need it when `HAVE_CLOCK` is defined.  This primarily affects Windows.

<!-- gh-issue-number: gh-81057 -->
* Issue: gh-81057
<!-- /gh-issue-number -->
