### PR TITLE
gh-79218: Define `MS_WIN64` macro for Mingw-w64 64bit on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-12-09-22-47-42.gh-issue-79218.Yiot2e.rst
+++ b/Misc/NEWS.d/next/Windows/2022-12-09-22-47-42.gh-issue-79218.Yiot2e.rst
@@ -1,0 +1,1 @@
+Define ``MS_WIN64`` for Mingw-w64 64bit, fix cython compilation failure.

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -210,6 +210,24 @@ typedef int pid_t;
 #endif /* _MSC_VER */
 
 /* ------------------------------------------------------------------------*/
+/* mingw and mingw-w64 define __MINGW32__ */
+#ifdef __MINGW32__
+
+#if !defined(MS_WIN64) && defined(_WIN64)
+#define MS_WIN64
+#endif
+
+#if !defined(MS_WIN32) && defined(_WIN32)
+#define MS_WIN32
+#endif
+
+#if !defined(MS_WINDOWS) && defined(MS_WIN32)
+#define MS_WINDOWS
+#endif
+
+#endif /* __MINGW32__*/
+
+/* ------------------------------------------------------------------------*/
 /* egcs/gnu-win32 defines __GNUC__ and _WIN32 */
 #if defined(__GNUC__) && defined(_WIN32)
 /* XXX These defines are likely incomplete, but should be easy to fix.

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -213,16 +213,8 @@ typedef int pid_t;
 /* mingw and mingw-w64 define __MINGW32__ */
 #ifdef __MINGW32__
 
-#if !defined(MS_WIN64) && defined(_WIN64)
+#ifdef _WIN64
 #define MS_WIN64
-#endif
-
-#if !defined(MS_WIN32) && defined(_WIN32)
-#define MS_WIN32
-#endif
-
-#if !defined(MS_WINDOWS) && defined(MS_WIN32)
-#define MS_WINDOWS
 #endif
 
 #endif /* __MINGW32__*/


### PR DESCRIPTION
Replace gh-19326.

[Msys2](https://www.msys2.org/) has fixed it for some time:

 - https://github.com/msys2-contrib/cpython-mingw/commit/43133b521e79f62d4d473a2c5ad9a1b8dafacbdf
 - https://github.com/python/cpython/compare/v3.10.8...msys2-contrib:cpython-mingw:mingw-v3.10.8

Co-authored-by: Алексей <alexey.pawlow@gmail.com>
Co-authored-by: Christoph Reiter <reiter.christoph@gmail.com>

<!-- gh-issue-number: gh-79218 -->
* Issue: gh-79218
<!-- /gh-issue-number -->
