### PR TITLE
gh-81057: Fix a Reference Leak in the posix Module

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2242,6 +2242,7 @@ statresult_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
     _posixstate *state = get_posix_state(mod);
+    Py_DECREF(mod);
     if (state == NULL) {
         return NULL;
     }


### PR DESCRIPTION
The leak was introduced in gh-100082.

<!-- gh-issue-number: gh-81057 -->
* Issue: gh-81057
<!-- /gh-issue-number -->
