### PR TITLE
Fix potential flakiness in test_run_until_complete_baseexception

### DIFF
--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -868,7 +868,7 @@ class BaseEventLoopTests(test_utils.TestCase):
             self.loop.stop()
             func.called = True
         func.called = False
-        self.loop.call_later(0.01, func)
+        self.loop.call_soon(self.loop.call_soon, func)
         self.loop.run_forever()
         self.assertTrue(func.called)
 


### PR DESCRIPTION
Refs #24477, use a more reliable way to run the test.

If the covering issue happens again, the loop would be requested to stop in the first iteration and got stopped after the first iteration. In that case, our `func()` in the second iteration won't be called.

* skip issue
* skip news
