### PR TITLE
Trivial Change: Remove unhelpful doc in `datetime.timedelta`

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -587,8 +587,7 @@ class timedelta:
     returning a timedelta, and addition or subtraction of a datetime
     and a timedelta giving a datetime.
 
-    Representation: (days, seconds, microseconds).  Why?  Because I
-    felt like it.
+    Representation: (days, seconds, microseconds).
     """
     __slots__ = '_days', '_seconds', '_microseconds', '_hashcode'
 

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -589,6 +589,10 @@ class timedelta:
 
     Representation: (days, seconds, microseconds).
     """
+    # The representation of (days, seconds, microseconds) was chosen
+    # arbitrarily; the exact rationale originally specified in the docstring
+    # was "Because I felt like it."
+
     __slots__ = '_days', '_seconds', '_microseconds', '_hashcode'
 
     def __new__(cls, days=0, seconds=0, microseconds=0,


### PR DESCRIPTION
I use timedelta's often in my work, and it always makes me a little sad to see this when I mouse over to look at the docstring.