### PR TITLE
gh-100176: venv: Remove redundant compat code for Python <= 3.2

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -497,76 +497,68 @@ subclass which installs setuptools and pip into a created virtual environment::
             url = 'https://bootstrap.pypa.io/get-pip.py'
             self.install_script(context, 'pip', url)
 
-    def main(args=None):
-        compatible = True
-        if sys.version_info < (3, 3):
-            compatible = False
-        elif not hasattr(sys, 'base_prefix'):
-            compatible = False
-        if not compatible:
-            raise ValueError('This script is only for use with '
-                             'Python 3.3 or later')
-        else:
-            import argparse
 
-            parser = argparse.ArgumentParser(prog=__name__,
-                                             description='Creates virtual Python '
-                                                         'environments in one or '
-                                                         'more target '
-                                                         'directories.')
-            parser.add_argument('dirs', metavar='ENV_DIR', nargs='+',
-                                help='A directory in which to create the '
-                                     'virtual environment.')
-            parser.add_argument('--no-setuptools', default=False,
-                                action='store_true', dest='nodist',
-                                help="Don't install setuptools or pip in the "
-                                     "virtual environment.")
-            parser.add_argument('--no-pip', default=False,
-                                action='store_true', dest='nopip',
-                                help="Don't install pip in the virtual "
-                                     "environment.")
-            parser.add_argument('--system-site-packages', default=False,
-                                action='store_true', dest='system_site',
-                                help='Give the virtual environment access to the '
-                                     'system site-packages dir.')
-            if os.name == 'nt':
-                use_symlinks = False
-            else:
-                use_symlinks = True
-            parser.add_argument('--symlinks', default=use_symlinks,
-                                action='store_true', dest='symlinks',
-                                help='Try to use symlinks rather than copies, '
-                                     'when symlinks are not the default for '
-                                     'the platform.')
-            parser.add_argument('--clear', default=False, action='store_true',
-                                dest='clear', help='Delete the contents of the '
-                                                   'virtual environment '
-                                                   'directory if it already '
-                                                   'exists, before virtual '
-                                                   'environment creation.')
-            parser.add_argument('--upgrade', default=False, action='store_true',
-                                dest='upgrade', help='Upgrade the virtual '
-                                                     'environment directory to '
-                                                     'use this version of '
-                                                     'Python, assuming Python '
-                                                     'has been upgraded '
-                                                     'in-place.')
-            parser.add_argument('--verbose', default=False, action='store_true',
-                                dest='verbose', help='Display the output '
-                                                   'from the scripts which '
-                                                   'install setuptools and pip.')
-            options = parser.parse_args(args)
-            if options.upgrade and options.clear:
-                raise ValueError('you cannot supply --upgrade and --clear together.')
-            builder = ExtendedEnvBuilder(system_site_packages=options.system_site,
-                                           clear=options.clear,
-                                           symlinks=options.symlinks,
-                                           upgrade=options.upgrade,
-                                           nodist=options.nodist,
-                                           nopip=options.nopip,
-                                           verbose=options.verbose)
-            for d in options.dirs:
-                builder.create(d)
+    def main(args=None):
+        import argparse
+
+        parser = argparse.ArgumentParser(prog=__name__,
+                                         description='Creates virtual Python '
+                                                     'environments in one or '
+                                                     'more target '
+                                                     'directories.')
+        parser.add_argument('dirs', metavar='ENV_DIR', nargs='+',
+                            help='A directory in which to create the '
+                                 'virtual environment.')
+        parser.add_argument('--no-setuptools', default=False,
+                            action='store_true', dest='nodist',
+                            help="Don't install setuptools or pip in the "
+                                 "virtual environment.")
+        parser.add_argument('--no-pip', default=False,
+                            action='store_true', dest='nopip',
+                            help="Don't install pip in the virtual "
+                                 "environment.")
+        parser.add_argument('--system-site-packages', default=False,
+                            action='store_true', dest='system_site',
+                            help='Give the virtual environment access to the '
+                                 'system site-packages dir.')
+        if os.name == 'nt':
+            use_symlinks = False
+        else:
+            use_symlinks = True
+        parser.add_argument('--symlinks', default=use_symlinks,
+                            action='store_true', dest='symlinks',
+                            help='Try to use symlinks rather than copies, '
+                                 'when symlinks are not the default for '
+                                 'the platform.')
+        parser.add_argument('--clear', default=False, action='store_true',
+                            dest='clear', help='Delete the contents of the '
+                                               'virtual environment '
+                                               'directory if it already '
+                                               'exists, before virtual '
+                                               'environment creation.')
+        parser.add_argument('--upgrade', default=False, action='store_true',
+                            dest='upgrade', help='Upgrade the virtual '
+                                                 'environment directory to '
+                                                 'use this version of '
+                                                 'Python, assuming Python '
+                                                 'has been upgraded '
+                                                 'in-place.')
+        parser.add_argument('--verbose', default=False, action='store_true',
+                            dest='verbose', help='Display the output '
+                                                 'from the scripts which '
+                                                 'install setuptools and pip.')
+        options = parser.parse_args(args)
+        if options.upgrade and options.clear:
+            raise ValueError('you cannot supply --upgrade and --clear together.')
+        builder = ExtendedEnvBuilder(system_site_packages=options.system_site,
+                                       clear=options.clear,
+                                       symlinks=options.symlinks,
+                                       upgrade=options.upgrade,
+                                       nodist=options.nodist,
+                                       nopip=options.nopip,
+                                       verbose=options.verbose)
+        for d in options.dirs:
+            builder.create(d)
 
     if __name__ == '__main__':
         rc = 1

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -223,7 +223,7 @@ class EnvBuilder:
             force_copy = not self.symlinks
             if not force_copy:
                 try:
-                    if not os.path.islink(dst): # can't link to itself!
+                    if not os.path.islink(dst):  # can't link to itself!
                         if relative_symlinks_ok:
                             assert os.path.dirname(src) == os.path.dirname(dst)
                             os.symlink(os.path.basename(src), dst)
@@ -418,11 +418,11 @@ class EnvBuilder:
         binpath = context.bin_path
         plen = len(path)
         for root, dirs, files in os.walk(path):
-            if root == path: # at top-level, remove irrelevant dirs
+            if root == path:  # at top-level, remove irrelevant dirs
                 for d in dirs[:]:
                     if d not in ('common', os.name):
                         dirs.remove(d)
-                continue # ignore files in top level
+                continue  # ignore files in top level
             for f in files:
                 if (os.name == 'nt' and f.startswith('python')
                         and f.endswith(('.exe', '.pdb'))):
@@ -468,83 +468,76 @@ def create(env_dir, system_site_packages=False, clear=False,
                          prompt=prompt, upgrade_deps=upgrade_deps)
     builder.create(env_dir)
 
-def main(args=None):
-    compatible = True
-    if sys.version_info < (3, 3):
-        compatible = False
-    elif not hasattr(sys, 'base_prefix'):
-        compatible = False
-    if not compatible:
-        raise ValueError('This script is only for use with Python >= 3.3')
-    else:
-        import argparse
 
-        parser = argparse.ArgumentParser(prog=__name__,
-                                         description='Creates virtual Python '
-                                                     'environments in one or '
-                                                     'more target '
-                                                     'directories.',
-                                         epilog='Once an environment has been '
-                                                'created, you may wish to '
-                                                'activate it, e.g. by '
-                                                'sourcing an activate script '
-                                                'in its bin directory.')
-        parser.add_argument('dirs', metavar='ENV_DIR', nargs='+',
-                            help='A directory to create the environment in.')
-        parser.add_argument('--system-site-packages', default=False,
-                            action='store_true', dest='system_site',
-                            help='Give the virtual environment access to the '
-                                 'system site-packages dir.')
-        if os.name == 'nt':
-            use_symlinks = False
-        else:
-            use_symlinks = True
-        group = parser.add_mutually_exclusive_group()
-        group.add_argument('--symlinks', default=use_symlinks,
-                           action='store_true', dest='symlinks',
-                           help='Try to use symlinks rather than copies, '
-                                'when symlinks are not the default for '
-                                'the platform.')
-        group.add_argument('--copies', default=not use_symlinks,
-                           action='store_false', dest='symlinks',
-                           help='Try to use copies rather than symlinks, '
-                                'even when symlinks are the default for '
-                                'the platform.')
-        parser.add_argument('--clear', default=False, action='store_true',
-                            dest='clear', help='Delete the contents of the '
-                                               'environment directory if it '
-                                               'already exists, before '
-                                               'environment creation.')
-        parser.add_argument('--upgrade', default=False, action='store_true',
-                            dest='upgrade', help='Upgrade the environment '
-                                               'directory to use this version '
-                                               'of Python, assuming Python '
-                                               'has been upgraded in-place.')
-        parser.add_argument('--without-pip', dest='with_pip',
-                            default=True, action='store_false',
-                            help='Skips installing or upgrading pip in the '
-                                 'virtual environment (pip is bootstrapped '
-                                 'by default)')
-        parser.add_argument('--prompt',
-                            help='Provides an alternative prompt prefix for '
-                                 'this environment.')
-        parser.add_argument('--upgrade-deps', default=False, action='store_true',
-                            dest='upgrade_deps',
-                            help='Upgrade core dependencies: {} to the latest '
-                                 'version in PyPI'.format(
-                                 ' '.join(CORE_VENV_DEPS)))
-        options = parser.parse_args(args)
-        if options.upgrade and options.clear:
-            raise ValueError('you cannot supply --upgrade and --clear together.')
-        builder = EnvBuilder(system_site_packages=options.system_site,
-                             clear=options.clear,
-                             symlinks=options.symlinks,
-                             upgrade=options.upgrade,
-                             with_pip=options.with_pip,
-                             prompt=options.prompt,
-                             upgrade_deps=options.upgrade_deps)
-        for d in options.dirs:
-            builder.create(d)
+def main(args=None):
+    import argparse
+
+    parser = argparse.ArgumentParser(prog=__name__,
+                                     description='Creates virtual Python '
+                                                 'environments in one or '
+                                                 'more target '
+                                                 'directories.',
+                                     epilog='Once an environment has been '
+                                            'created, you may wish to '
+                                            'activate it, e.g. by '
+                                            'sourcing an activate script '
+                                            'in its bin directory.')
+    parser.add_argument('dirs', metavar='ENV_DIR', nargs='+',
+                        help='A directory to create the environment in.')
+    parser.add_argument('--system-site-packages', default=False,
+                        action='store_true', dest='system_site',
+                        help='Give the virtual environment access to the '
+                             'system site-packages dir.')
+    if os.name == 'nt':
+        use_symlinks = False
+    else:
+        use_symlinks = True
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--symlinks', default=use_symlinks,
+                       action='store_true', dest='symlinks',
+                       help='Try to use symlinks rather than copies, '
+                            'when symlinks are not the default for '
+                            'the platform.')
+    group.add_argument('--copies', default=not use_symlinks,
+                       action='store_false', dest='symlinks',
+                       help='Try to use copies rather than symlinks, '
+                            'even when symlinks are the default for '
+                            'the platform.')
+    parser.add_argument('--clear', default=False, action='store_true',
+                        dest='clear', help='Delete the contents of the '
+                                           'environment directory if it '
+                                           'already exists, before '
+                                           'environment creation.')
+    parser.add_argument('--upgrade', default=False, action='store_true',
+                        dest='upgrade', help='Upgrade the environment '
+                                             'directory to use this version '
+                                             'of Python, assuming Python '
+                                             'has been upgraded in-place.')
+    parser.add_argument('--without-pip', dest='with_pip',
+                        default=True, action='store_false',
+                        help='Skips installing or upgrading pip in the '
+                             'virtual environment (pip is bootstrapped '
+                             'by default)')
+    parser.add_argument('--prompt',
+                        help='Provides an alternative prompt prefix for '
+                             'this environment.')
+    parser.add_argument('--upgrade-deps', default=False, action='store_true',
+                        dest='upgrade_deps',
+                        help=f'Upgrade core dependencies: {" ".join(CORE_VENV_DEPS)} '
+                             'to the latest version in PyPI')
+    options = parser.parse_args(args)
+    if options.upgrade and options.clear:
+        raise ValueError('you cannot supply --upgrade and --clear together.')
+    builder = EnvBuilder(system_site_packages=options.system_site,
+                         clear=options.clear,
+                         symlinks=options.symlinks,
+                         upgrade=options.upgrade,
+                         with_pip=options.with_pip,
+                         prompt=options.prompt,
+                         upgrade_deps=options.upgrade_deps)
+    for d in options.dirs:
+        builder.create(d)
+
 
 if __name__ == '__main__':
     rc = 1


### PR DESCRIPTION
Python 3.2 has been EOL since 2016-02-20 and 2.7 since 2020-01-01, so we can remove this old compatibility check and unindent the old `else` block.

https://devguide.python.org/versions/

In the unindented block, replace a `.format()` call with an f-string.

And similar changes in the documentation.

Finally, some whitespace adjustments, can drop these if you wish.

Does this need a news file?


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-100176 -->
* Issue: gh-100176
<!-- /gh-issue-number -->
