### PR TITLE
Docs: Use PY_VERSION_HEX for version comparison

### DIFF
--- a/Doc/c-api/apiabiversion.rst
+++ b/Doc/c-api/apiabiversion.rst
@@ -58,6 +58,8 @@ See :ref:`stable` for a discussion of API and ABI stability across versions.
    Thus ``3.4.1a2`` is hexversion ``0x030401a2`` and ``3.10.0`` is
    hexversion ``0x030a00f0``.
 
+   Use this for numeric comparisons, e.g. ``#if PY_VERSION_HEX >= ...``
+
    This version is also available via the symbol :data:`Py_Version`.
 
 .. c:var:: const unsigned long Py_Version

--- a/Doc/c-api/apiabiversion.rst
+++ b/Doc/c-api/apiabiversion.rst
@@ -58,7 +58,7 @@ See :ref:`stable` for a discussion of API and ABI stability across versions.
    Thus ``3.4.1a2`` is hexversion ``0x030401a2`` and ``3.10.0`` is
    hexversion ``0x030a00f0``.
 
-   Use this for numeric comparisons, e.g. ``#if PY_VERSION_HEX >= ...``
+   Use this for numeric comparisons, e.g. ``#if PY_VERSION_HEX >= ...``.
 
    This version is also available via the symbol :data:`Py_Version`.
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -2319,7 +2319,7 @@ Porting to Python 3.11
   can define the following macros and use them throughout
   the code (credit: these were copied from the ``mypy`` codebase)::
 
-    #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 8
+    #if PY_VERSION_HEX >= 0x03080000
     #  define CPy_TRASHCAN_BEGIN(op, dealloc) Py_TRASHCAN_BEGIN(op, dealloc)
     #  define CPy_TRASHCAN_END(op) Py_TRASHCAN_END
     #else


### PR DESCRIPTION
`PY_VERSION_HEX` should be used when comparing version numbers, for example `PY_VERSION_HEX >= 0x03080000`.

Avoid `PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 8` because that is true for 3.8-3.12, but also for 4.8-4.12 and so on.

This is already warned in `patchlevel.h` where `PY_VERSION_HEX` is defined:

https://github.com/python/cpython/blob/2e279e85fece187b6058718ac7e82d1692461e26/Include/patchlevel.h#L29-L35

It's a bit hidden there, let's hoist it into docs in `apiabiversion.rst` for visibilty.

# Preview

* https://deploy-preview-100179--python-cpython-preview.netlify.app/c-api/apiabiversion.html#c.PY_VERSION_HEX
* https://deploy-preview-100179--python-cpython-preview.netlify.app/whatsnew/3.11.html#whatsnew311-c-api-porting

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
