### PR TITLE
gh-99185: Copy python executable (python.exe) to python3.exe

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -279,6 +279,7 @@ LIBOBJDIR=	Python/
 LIBOBJS=	@LIBOBJS@
 
 PYTHON=		python$(EXE)
+PYTHON3=	python3$(EXE)
 BUILDPYTHON=	python$(BUILDEXE)
 
 HOSTRUNNER= @HOSTRUNNER@
@@ -580,6 +581,7 @@ LIBEXPAT_HEADERS= \
 all:		@DEF_MAKE_ALL_RULE@
 build_all:	check-clean-src $(BUILDPYTHON) platform sharedmods \
 		gdbhooks Programs/_testembed scripts checksharedmods rundsymutil
+		cp $(PYTHON) $(PYTHON3)
 build_wasm: check-clean-src $(BUILDPYTHON) platform sharedmods \
 		python-config checksharedmods
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -176,6 +176,7 @@ EXPORTSFROM=	@EXPORTSFROM@
 # Executable suffix (.exe on Windows and Mac OS X)
 EXE=		@EXEEXT@
 BUILDEXE=	@BUILDEXEEXT@
+WINDOWSEXE=.exe
 
 # Short name and location for Mac OS X Python framework
 UNIVERSALSDK=@UNIVERSALSDK@
@@ -581,7 +582,9 @@ LIBEXPAT_HEADERS= \
 all:		@DEF_MAKE_ALL_RULE@
 build_all:	check-clean-src $(BUILDPYTHON) platform sharedmods \
 		gdbhooks Programs/_testembed scripts checksharedmods rundsymutil
-		cp $(BUILDPYTHON) $(BUILDPYTHON3)
+	@if test "$(BUILDEXE)" = "$(WINDOWSEXE)" ; then \
+		cp $(BUILDPYTHON) $(BUILDPYTHON3) ; \
+	fi
 build_wasm: check-clean-src $(BUILDPYTHON) platform sharedmods \
 		python-config checksharedmods
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -279,8 +279,8 @@ LIBOBJDIR=	Python/
 LIBOBJS=	@LIBOBJS@
 
 PYTHON=		python$(EXE)
-PYTHON3=	python3$(EXE)
 BUILDPYTHON=	python$(BUILDEXE)
+BUILDPYTHON3=	python3$(BUILDEXE)
 
 HOSTRUNNER= @HOSTRUNNER@
 
@@ -581,7 +581,7 @@ LIBEXPAT_HEADERS= \
 all:		@DEF_MAKE_ALL_RULE@
 build_all:	check-clean-src $(BUILDPYTHON) platform sharedmods \
 		gdbhooks Programs/_testembed scripts checksharedmods rundsymutil
-		cp $(PYTHON) $(PYTHON3)
+		cp $(BUILDPYTHON) $(BUILDPYTHON3)
 build_wasm: check-clean-src $(BUILDPYTHON) platform sharedmods \
 		python-config checksharedmods
 

--- a/Misc/NEWS.d/next/Build/2022-12-12-04-46-29.gh-issue-99185.bQm_Wd.rst
+++ b/Misc/NEWS.d/next/Build/2022-12-12-04-46-29.gh-issue-99185.bQm_Wd.rst
@@ -1,0 +1,1 @@
+Copy python executable (python.exe) to python3.exe


### PR DESCRIPTION
# Provides fix for Issue #99185

The requested fix in the original issue report was implemented.
```
gh-99185: Copy python executable (python.exe) to python3.exe
```
