### PR TITLE
gh-100188: Reduce misses in BINARY_SUBSCR_LIST_INT

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-12-12-05-30-12.gh-issue-100188.sGCSMR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-12-12-05-30-12.gh-issue-100188.sGCSMR.rst
@@ -1,0 +1,1 @@
+The ``BINARY_SUBSCR_LIST_INT`` instruction is no longer used for negative ``int``s, since that instruction always misses when encountering negative integers.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-12-12-05-30-12.gh-issue-100188.sGCSMR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-12-12-05-30-12.gh-issue-100188.sGCSMR.rst
@@ -1,1 +1,3 @@
-The ``BINARY_SUBSCR_LIST_INT`` instruction is no longer used for negative integers because that instruction always misses when encountering negative integers.
+The ``BINARY_SUBSCR_LIST_INT`` and ``BINARY_SUBSCR_TUPLE_INT``
+instruction are no longer used for negative integers because
+those instruction always miss when encountering negative integers.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-12-12-05-30-12.gh-issue-100188.sGCSMR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-12-12-05-30-12.gh-issue-100188.sGCSMR.rst
@@ -1,3 +1,3 @@
 The ``BINARY_SUBSCR_LIST_INT`` and ``BINARY_SUBSCR_TUPLE_INT``
-instruction are no longer used for negative integers because
-those instruction always miss when encountering negative integers.
+instructions are no longer used for negative integers because
+those instructions always miss when encountering negative integers.

--- a/Misc/NEWS.d/next/Core and Builtins/2022-12-12-05-30-12.gh-issue-100188.sGCSMR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-12-12-05-30-12.gh-issue-100188.sGCSMR.rst
@@ -1,1 +1,1 @@
-The ``BINARY_SUBSCR_LIST_INT`` instruction is no longer used for negative ``int``s, since that instruction always misses when encountering negative integers.
+The ``BINARY_SUBSCR_LIST_INT`` instruction is no longer used for negative integers because that instruction always misses when encountering negative integers.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1262,8 +1262,12 @@ _Py_Specialize_BinarySubscr(
     PyTypeObject *container_type = Py_TYPE(container);
     if (container_type == &PyList_Type) {
         if (PyLong_CheckExact(sub)) {
-            _Py_SET_OPCODE(*instr, BINARY_SUBSCR_LIST_INT);
-            goto success;
+            if (Py_SIZE(sub) == 0 || Py_SIZE(sub) == 1) {
+                _Py_SET_OPCODE(*instr, BINARY_SUBSCR_LIST_INT);
+                goto success;
+            }
+            SPECIALIZATION_FAIL(BINARY_SUBSCR, SPEC_FAIL_OUT_OF_RANGE);
+            goto fail;
         }
         SPECIALIZATION_FAIL(BINARY_SUBSCR,
             PySlice_Check(sub) ? SPEC_FAIL_SUBSCR_LIST_SLICE : SPEC_FAIL_OTHER);

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1275,8 +1275,12 @@ _Py_Specialize_BinarySubscr(
     }
     if (container_type == &PyTuple_Type) {
         if (PyLong_CheckExact(sub)) {
-            _Py_SET_OPCODE(*instr, BINARY_SUBSCR_TUPLE_INT);
-            goto success;
+            if (Py_SIZE(sub) == 0 || Py_SIZE(sub) == 1) {
+                _Py_SET_OPCODE(*instr, BINARY_SUBSCR_TUPLE_INT);
+                goto success;
+            }
+            SPECIALIZATION_FAIL(BINARY_SUBSCR, SPEC_FAIL_OUT_OF_RANGE);
+            goto fail;
         }
         SPECIALIZATION_FAIL(BINARY_SUBSCR,
             PySlice_Check(sub) ? SPEC_FAIL_SUBSCR_TUPLE_SLICE : SPEC_FAIL_OTHER);


### PR DESCRIPTION
Comparing `./python -m pyperf timeit -s "a = [0]" "a[-1]" --duplicate=100`:
```
Mean +- std dev: [main100] 12.4 ns +- 0.5 ns -> [pr100] 11.6 ns +- 0.3 ns: 1.07x faster
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-100188 -->
* Issue: gh-100188
<!-- /gh-issue-number -->
