### PR TITLE
gh-100176: remove incorrect version compatibility check from clinic

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5212,10 +5212,6 @@ clinic = None
 
 def main(argv):
     import sys
-
-    if sys.version_info.major < 3 or sys.version_info.minor < 3:
-        sys.exit("Error: clinic.py requires Python 3.3 or greater.")
-
     import argparse
     cmdline = argparse.ArgumentParser(
         description="""Preprocessor for CPython C files.


### PR DESCRIPTION
- clinic.py actually requires at least Python 3.6
- This check will fail if there is a 4.0

<!-- gh-issue-number: gh-100176 -->
* Issue: gh-100176
<!-- /gh-issue-number -->
