### PR TITLE
gh-100176: Tools/iobench: Remove redundant compat code for Python <= 3.2

### DIFF
--- a/Tools/iobench/iobench.py
+++ b/Tools/iobench/iobench.py
@@ -25,18 +25,22 @@ def get_file_sizes():
         size = int(size) * {'KiB': 1024, 'MiB': 1024 ** 2}[unit]
         yield s.replace(' ', ''), size
 
+
 def get_binary_files():
     return ((name + ".bin", size) for name, size in get_file_sizes())
+
 
 def get_text_files():
     return (("%s-%s-%s.txt" % (name, TEXT_ENCODING, NEWLINES), size)
         for name, size in get_file_sizes())
+
 
 def with_open_mode(mode):
     def decorate(f):
         f.file_open_mode = mode
         return f
     return decorate
+
 
 def with_sizes(*sizes):
     def decorate(f):
@@ -55,6 +59,7 @@ def read_bytewise(f):
     while f.read(1):
         pass
 
+
 @with_open_mode("r")
 @with_sizes("medium")
 def read_small_chunks(f):
@@ -62,6 +67,7 @@ def read_small_chunks(f):
     f.seek(0)
     while f.read(20):
         pass
+
 
 @with_open_mode("r")
 @with_sizes("medium")
@@ -71,6 +77,7 @@ def read_big_chunks(f):
     while f.read(4096):
         pass
 
+
 @with_open_mode("r")
 @with_sizes("small", "medium", "large")
 def read_whole_file(f):
@@ -79,6 +86,7 @@ def read_whole_file(f):
     while f.read():
         pass
 
+
 @with_open_mode("rt")
 @with_sizes("medium")
 def read_lines(f):
@@ -86,6 +94,7 @@ def read_lines(f):
     f.seek(0)
     for line in f:
         pass
+
 
 @with_open_mode("r")
 @with_sizes("medium")
@@ -97,6 +106,7 @@ def seek_forward_bytewise(f):
     for i in range(0, size - 1):
         f.seek(i, 0)
 
+
 @with_open_mode("r")
 @with_sizes("medium")
 def seek_forward_blockwise(f):
@@ -107,6 +117,7 @@ def seek_forward_blockwise(f):
     for i in range(0, size - 1, 1000):
         f.seek(i, 0)
 
+
 @with_open_mode("rb")
 @with_sizes("medium")
 def read_seek_bytewise(f):
@@ -114,6 +125,7 @@ def read_seek_bytewise(f):
     f.seek(0)
     while f.read(1):
         f.seek(1, 1)
+
 
 @with_open_mode("rb")
 @with_sizes("medium")
@@ -131,6 +143,7 @@ def write_bytewise(f, source):
     for i in range(0, len(source)):
         f.write(source[i:i+1])
 
+
 @with_open_mode("w")
 @with_sizes("medium")
 def write_small_chunks(f, source):
@@ -138,12 +151,14 @@ def write_small_chunks(f, source):
     for i in range(0, len(source), 20):
         f.write(source[i:i+20])
 
+
 @with_open_mode("w")
 @with_sizes("medium")
 def write_medium_chunks(f, source):
     """ write 4096 units at a time """
     for i in range(0, len(source), 4096):
         f.write(source[i:i+4096])
+
 
 @with_open_mode("w")
 @with_sizes("large")
@@ -161,6 +176,7 @@ def modify_bytewise(f, source):
     for i in range(0, len(source)):
         f.write(source[i:i+1])
 
+
 @with_open_mode("w+")
 @with_sizes("medium")
 def modify_small_chunks(f, source):
@@ -169,6 +185,7 @@ def modify_small_chunks(f, source):
     for i in range(0, len(source), 20):
         f.write(source[i:i+20])
 
+
 @with_open_mode("w+")
 @with_sizes("medium")
 def modify_medium_chunks(f, source):
@@ -176,6 +193,7 @@ def modify_medium_chunks(f, source):
     f.seek(0)
     for i in range(0, len(source), 4096):
         f.write(source[i:i+4096])
+
 
 @with_open_mode("wb+")
 @with_sizes("medium")
@@ -186,6 +204,7 @@ def modify_seek_forward_bytewise(f, source):
         f.write(source[i:i+1])
         f.seek(i+2)
 
+
 @with_open_mode("wb+")
 @with_sizes("medium")
 def modify_seek_forward_blockwise(f, source):
@@ -194,6 +213,7 @@ def modify_seek_forward_blockwise(f, source):
     for i in range(0, len(source), 2000):
         f.write(source[i:i+1000])
         f.seek(i+2000)
+
 
 # XXX the 2 following tests don't work with py3k's text IO
 @with_open_mode("wb+")
@@ -204,6 +224,7 @@ def read_modify_bytewise(f, source):
     for i in range(0, len(source), 2):
         f.read(1)
         f.write(source[i+1:i+2])
+
 
 @with_open_mode("wb+")
 @with_sizes("medium")
@@ -233,6 +254,7 @@ modify_tests = [
     read_modify_bytewise, read_modify_blockwise,
 ]
 
+
 def run_during(duration, func):
     _t = time.time
     n = 0
@@ -247,6 +269,7 @@ def run_during(duration, func):
     end = os.times()
     real = (end[4] if start[4] else time.time()) - real_start
     return n, real, sum(end[0:2]) - sum(start[0:2])
+
 
 def warm_cache(filename):
     with open(filename, "rb") as f:
@@ -322,6 +345,7 @@ def run_all_tests(options):
     # Binary writes
     if "b" in options and "w" in options:
         print("\n** Binary append **\n")
+
         def make_test_source(name, size):
             with open(name, "rb") as f:
                 return f.read()
@@ -331,6 +355,7 @@ def run_all_tests(options):
     # Text writes
     if "t" in options and "w" in options:
         print("\n** Text append **\n")
+
         def make_test_source(name, size):
             with text_open(name, "r") as f:
                 return f.read()
@@ -340,6 +365,7 @@ def run_all_tests(options):
     # Binary overwrites
     if "b" in options and "w" in options:
         print("\n** Binary overwrite **\n")
+
         def make_test_source(name, size):
             with open(name, "rb") as f:
                 return f.read()
@@ -349,6 +375,7 @@ def run_all_tests(options):
     # Text overwrites
     if "t" in options and "w" in options:
         print("\n** Text overwrite **\n")
+
         def make_test_source(name, size):
             with text_open(name, "r") as f:
                 return f.read()
@@ -397,6 +424,7 @@ def prepare_files():
         with open(name, "wb") as f:
             f.write(head)
             f.write(tail)
+
 
 def main():
     global TEXT_ENCODING, NEWLINES
@@ -454,6 +482,7 @@ def main():
 
     prepare_files()
     run_all_tests(test_options)
+
 
 if __name__ == "__main__":
     main()

--- a/Tools/iobench/iobench.py
+++ b/Tools/iobench/iobench.py
@@ -16,9 +16,8 @@ def text_open(fn, mode, encoding=None):
     try:
         return open(fn, mode, encoding=encoding or TEXT_ENCODING)
     except TypeError:
-        if 'r' in mode:
-            mode += 'U' # 'U' mode is needed only in Python 2.x
         return open(fn, mode)
+
 
 def get_file_sizes():
     for s in ['20 KiB', '400 KiB', '10 MiB']:

--- a/Tools/iobench/iobench.py
+++ b/Tools/iobench/iobench.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-# This file should be kept compatible with both Python 2.6 and Python >= 3.0.
-
 import itertools
 import os
 import platform

--- a/Tools/iobench/iobench.py
+++ b/Tools/iobench/iobench.py
@@ -14,11 +14,6 @@ out = sys.stdout
 TEXT_ENCODING = 'utf8'
 NEWLINES = 'lf'
 
-# Compatibility
-try:
-    xrange
-except NameError:
-    xrange = range
 
 def text_open(fn, mode, encoding=None):
     try:
@@ -103,7 +98,7 @@ def seek_forward_bytewise(f):
     f.seek(0, 2)
     size = f.tell()
     f.seek(0, 0)
-    for i in xrange(0, size - 1):
+    for i in range(0, size - 1):
         f.seek(i, 0)
 
 @with_open_mode("r")
@@ -113,7 +108,7 @@ def seek_forward_blockwise(f):
     f.seek(0, 2)
     size = f.tell()
     f.seek(0, 0)
-    for i in xrange(0, size - 1, 1000):
+    for i in range(0, size - 1, 1000):
         f.seek(i, 0)
 
 @with_open_mode("rb")
@@ -137,28 +132,28 @@ def read_seek_blockwise(f):
 @with_sizes("small")
 def write_bytewise(f, source):
     """ write one unit at a time """
-    for i in xrange(0, len(source)):
+    for i in range(0, len(source)):
         f.write(source[i:i+1])
 
 @with_open_mode("w")
 @with_sizes("medium")
 def write_small_chunks(f, source):
     """ write 20 units at a time """
-    for i in xrange(0, len(source), 20):
+    for i in range(0, len(source), 20):
         f.write(source[i:i+20])
 
 @with_open_mode("w")
 @with_sizes("medium")
 def write_medium_chunks(f, source):
     """ write 4096 units at a time """
-    for i in xrange(0, len(source), 4096):
+    for i in range(0, len(source), 4096):
         f.write(source[i:i+4096])
 
 @with_open_mode("w")
 @with_sizes("large")
 def write_large_chunks(f, source):
     """ write 1e6 units at a time """
-    for i in xrange(0, len(source), 1000000):
+    for i in range(0, len(source), 1000000):
         f.write(source[i:i+1000000])
 
 
@@ -167,7 +162,7 @@ def write_large_chunks(f, source):
 def modify_bytewise(f, source):
     """ modify one unit at a time """
     f.seek(0)
-    for i in xrange(0, len(source)):
+    for i in range(0, len(source)):
         f.write(source[i:i+1])
 
 @with_open_mode("w+")
@@ -175,7 +170,7 @@ def modify_bytewise(f, source):
 def modify_small_chunks(f, source):
     """ modify 20 units at a time """
     f.seek(0)
-    for i in xrange(0, len(source), 20):
+    for i in range(0, len(source), 20):
         f.write(source[i:i+20])
 
 @with_open_mode("w+")
@@ -183,7 +178,7 @@ def modify_small_chunks(f, source):
 def modify_medium_chunks(f, source):
     """ modify 4096 units at a time """
     f.seek(0)
-    for i in xrange(0, len(source), 4096):
+    for i in range(0, len(source), 4096):
         f.write(source[i:i+4096])
 
 @with_open_mode("wb+")
@@ -191,7 +186,7 @@ def modify_medium_chunks(f, source):
 def modify_seek_forward_bytewise(f, source):
     """ alternate write & seek one unit """
     f.seek(0)
-    for i in xrange(0, len(source), 2):
+    for i in range(0, len(source), 2):
         f.write(source[i:i+1])
         f.seek(i+2)
 
@@ -200,7 +195,7 @@ def modify_seek_forward_bytewise(f, source):
 def modify_seek_forward_blockwise(f, source):
     """ alternate write & seek 1000 units """
     f.seek(0)
-    for i in xrange(0, len(source), 2000):
+    for i in range(0, len(source), 2000):
         f.write(source[i:i+1000])
         f.seek(i+2000)
 
@@ -210,7 +205,7 @@ def modify_seek_forward_blockwise(f, source):
 def read_modify_bytewise(f, source):
     """ alternate read & write one unit """
     f.seek(0)
-    for i in xrange(0, len(source), 2):
+    for i in range(0, len(source), 2):
         f.read(1)
         f.write(source[i+1:i+2])
 
@@ -219,7 +214,7 @@ def read_modify_bytewise(f, source):
 def read_modify_blockwise(f, source):
     """ alternate read & write 1000 units """
     f.seek(0)
-    for i in xrange(0, len(source), 2000):
+    for i in range(0, len(source), 2000):
         f.read(1000)
         f.write(source[i+1000:i+2000])
 

--- a/Tools/iobench/iobench.py
+++ b/Tools/iobench/iobench.py
@@ -31,7 +31,7 @@ def get_binary_files():
 
 
 def get_text_files():
-    return (("%s-%s-%s.txt" % (name, TEXT_ENCODING, NEWLINES), size)
+    return ((f"{name}-{TEXT_ENCODING}-{NEWLINES}.txt", size)
         for name, size in get_file_sizes())
 
 
@@ -280,9 +280,7 @@ def run_all_tests(options):
     def print_label(filename, func):
         name = re.split(r'[-.]', filename)[0]
         out.write(
-            ("[%s] %s... "
-                % (name.center(7), func.__doc__.strip())
-            ).ljust(52))
+            f"[{name.center(7)}] {func.__doc__.strip()}... ".ljust(52))
         out.flush()
 
     def print_results(size, n, real, cpu):
@@ -290,8 +288,9 @@ def run_all_tests(options):
         bw = ("%4d MiB/s" if bw > 100 else "%.3g MiB/s") % bw
         out.write(bw.rjust(12) + "\n")
         if cpu < 0.90 * real:
-            out.write("   warning: test above used only %d%% CPU, "
-                "result may be flawed!\n" % (100.0 * cpu / real))
+            out.write("   warning: test above used only "
+                      f"{100.0 * cpu / real}% CPU, "
+                      "result may be flawed!\n")
 
     def run_one_test(name, size, open_func, test_func, *args):
         mode = test_func.file_open_mode
@@ -322,7 +321,7 @@ def run_all_tests(options):
         "large": 2,
     }
 
-    print("Python %s" % sys.version)
+    print(f"Python {sys.version}")
     print("Unicode: PEP 393")
     print(platform.platform())
     binary_files = list(get_binary_files())
@@ -330,7 +329,7 @@ def run_all_tests(options):
     if "b" in options:
         print("Binary unit = one byte")
     if "t" in options:
-        print("Text unit = one character (%s-decoded)" % TEXT_ENCODING)
+        print(f"Text unit = one character ({TEXT_ENCODING}-decoded)")
 
     # Binary reads
     if "b" in options and "r" in options:
@@ -399,7 +398,7 @@ def prepare_files():
                 break
         else:
             raise RuntimeError(
-                "Couldn't find chunk marker in %s !" % __file__)
+                f"Couldn't find chunk marker in {__file__} !")
         if NEWLINES == "all":
             it = itertools.cycle(["\n", "\r", "\r\n"])
         else:
@@ -445,7 +444,7 @@ def main():
                       help="run write & modify tests")
     parser.add_option("-E", "--encoding",
                       action="store", dest="encoding", default=None,
-                      help="encoding for text tests (default: %s)" % TEXT_ENCODING)
+                      help=f"encoding for text tests (default: {TEXT_ENCODING})")
     parser.add_option("-N", "--newlines",
                       action="store", dest="newlines", default='lf',
                       help="line endings for text tests "
@@ -458,7 +457,7 @@ def main():
         parser.error("unexpected arguments")
     NEWLINES = options.newlines.lower()
     if NEWLINES not in ('lf', 'cr', 'crlf', 'all'):
-        parser.error("invalid 'newlines' option: %r" % NEWLINES)
+        parser.error(f"invalid 'newlines' option: {NEWLINES!r}")
 
     test_options = ""
     if options.read:

--- a/Tools/iobench/iobench.py
+++ b/Tools/iobench/iobench.py
@@ -289,7 +289,7 @@ def run_all_tests(options):
         out.write(bw.rjust(12) + "\n")
         if cpu < 0.90 * real:
             out.write("   warning: test above used only "
-                      f"{100.0 * cpu / real}% CPU, "
+                      f"{cpu / real:%} CPU, "
                       "result may be flawed!\n")
 
     def run_one_test(name, size, open_func, test_func, *args):

--- a/Tools/iobench/iobench.py
+++ b/Tools/iobench/iobench.py
@@ -309,14 +309,7 @@ def run_all_tests(options):
     }
 
     print("Python %s" % sys.version)
-    if sys.version_info < (3, 3):
-        if sys.maxunicode > 0xffff:
-            text = "UCS-4 (wide build)"
-        else:
-            text = "UTF-16 (narrow build)"
-    else:
-        text = "PEP 393"
-    print("Unicode: %s" % text)
+    print("Unicode: PEP 393")
     print(platform.platform())
     binary_files = list(get_binary_files())
     text_files = list(get_text_files())


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Python 3.2 has been EOL since 2016-02-20 and 2.7 since 2020-01-01, so we can remove these old compatibility checks.

https://devguide.python.org/versions/

Also use f-strings and adjust some whitespace.

---

Ping also @pitrou who created this file with this note in 2010 in https://github.com/python/cpython/commit/a69ba65fdce3be6f55634b47cc56cf1f962f6cbc:

> This file should be kept compatible with both Python 2.6 and Python >= 3.0.

---

<!-- gh-issue-number: gh-100176 -->
* Issue: gh-100176
<!-- /gh-issue-number -->
