### PR TITLE
gh-81057: Move _Py_RefTotal to the "Ignored Globals" List

### DIFF
--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -302,10 +302,7 @@ Objects/sliceobject.c	-	_Py_EllipsisObject	-
 ##################################
 ## global non-objects to fix in core code
 
-##-----------------------
-## state
-
-Objects/object.c	-	_Py_RefTotal	-
+# <none>
 
 
 ##################################

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -143,6 +143,12 @@ Modules/syslogmodule.c	-	S_ident_o	-
 Modules/syslogmodule.c	-	S_log_open	-
 
 ##-----------------------
+## kept for stable ABI compatibility
+
+# XXX should be per-interpreter, without impacting stable ABI extensions
+Objects/object.c	-	_Py_RefTotal	-
+
+##-----------------------
 ## one-off temporary state
 
 # used during runtime init


### PR DESCRIPTION
We can't move it to `_PyRuntimeState` because the symbol is exposed in the stable ABI.  We'll have to sort that out before a per-interpreter GIL, but it shouldn't be too hard.

<!-- gh-issue-number: gh-81057 -->
* Issue: gh-81057
<!-- /gh-issue-number -->
