### PR TITLE
gh-99533: Fix issue where email.generator.Generator ignores policy when using multipart/signed

### DIFF
--- a/Lib/email/generator.py
+++ b/Lib/email/generator.py
@@ -313,17 +313,6 @@ class Generator:
                 epilogue = msg.epilogue
             self._write_lines(epilogue)
 
-    def _handle_multipart_signed(self, msg):
-        # The contents of signed parts has to stay unmodified in order to keep
-        # the signature intact per RFC1847 2.1, so we disable header wrapping.
-        # RDM: This isn't enough to completely preserve the part, but it helps.
-        p = self.policy
-        self.policy = p.clone(max_line_length=0)
-        try:
-            self._handle_multipart(msg)
-        finally:
-            self.policy = p
-
     def _handle_message_delivery_status(self, msg):
         # We can't just write the headers directly to self's file object
         # because this will leave an extra newline between the last header

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -5564,6 +5564,13 @@ class TestSigned(TestEmailBase):
         result = fp.getvalue()
         self._signed_parts_eq(original, result)
 
+    def test_multipart_signed(self):
+        inner = Message()
+        outer = Message()
+        outer.set_type("multipart/signed")
+        outer.attach(inner)
+        self.assertTrue(inner.as_string() in outer.as_string())
+
 class TestHeaderRegistry(TestEmailBase):
     # See issue gh-93010.
     def test_HeaderRegistry(self):

--- a/Misc/NEWS.d/next/Build/2022-12-13-00-31-01.gh-issue-99533.cEDd71.rst
+++ b/Misc/NEWS.d/next/Build/2022-12-13-00-31-01.gh-issue-99533.cEDd71.rst
@@ -1,0 +1,2 @@
+Fix issue where email.generator.Generator ignores policy when using multipart/signed due to old functions in generator.py
+:func:`_handle_multipart_signed`. Patch by Jack Pendley.


### PR DESCRIPTION
Provides fix for Issue https://github.com/python/cpython/issues/99533

The requested fix in the original issue report was implemented.

Removed _handle_multipart_signed from generator.py altogether so the headers folding no longer changes when accessing the whole message at once

<!-- gh-issue-number: gh-99533 -->
* Issue: gh-99533
<!-- /gh-issue-number -->
