### PR TITLE
gh-100210: Correct the comment link for unescaping HTML

### DIFF
--- a/Lib/html/__init__.py
+++ b/Lib/html/__init__.py
@@ -25,7 +25,7 @@ def escape(s, quote=True):
     return s
 
 
-# see http://www.w3.org/TR/html5/syntax.html#tokenizing-character-references
+# see https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state
 
 _invalid_charrefs = {
     0x00: '\ufffd',  # REPLACEMENT CHARACTER


### PR DESCRIPTION
# gh-100210: Correct the comment link for unescaping HTML
