### PR TITLE
gh-100213: `ERROR` macro is reported to be implictly redefined

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -56,6 +56,7 @@
 #define STACK_USE_GUIDELINE 30
 
 #define SUCCESS 0
+#undef ERROR
 #define ERROR -1
 
 #define RETURN_IF_ERROR(X)  \


### PR DESCRIPTION
So, it is explicit now.

Also, changing `ERROR` to some other name is an option, if we some reason still need old `ERROR` macro.

<!-- gh-issue-number: gh-100213 -->
* Issue: gh-100213
<!-- /gh-issue-number -->
