### PR TITLE
gh-90111: Minor Cleanup for Runtime-Global Objects

### DIFF
--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -29,7 +29,7 @@ extern "C" {
 struct _Py_cached_objects {
     PyObject *str_replace_inf;
 
-    PyObject *interned;
+    PyObject *interned_strings;
 };
 
 #define _Py_GLOBAL_OBJECT(NAME) \

--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -28,6 +28,8 @@ extern "C" {
 
 struct _Py_cached_objects {
     PyObject *str_replace_inf;
+
+    PyObject *interned;
 };
 
 #define _Py_GLOBAL_OBJECT(NAME) \
@@ -59,8 +61,6 @@ struct _Py_global_objects {
         PyHamtNode_Bitmap hamt_bitmap_node_empty;
         _PyContextTokenMissing context_token_missing;
     } singletons;
-
-    PyObject *interned;
 };
 
 #define _Py_INTERP_CACHED_OBJECT(interp, NAME) \

--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -33,11 +33,11 @@ struct _Py_cached_objects {
 };
 
 #define _Py_GLOBAL_OBJECT(NAME) \
-    _PyRuntime.global_objects.NAME
+    _PyRuntime.static_objects.NAME
 #define _Py_SINGLETON(NAME) \
     _Py_GLOBAL_OBJECT(singletons.NAME)
 
-struct _Py_global_objects {
+struct _Py_static_objects {
     struct {
         /* Small integers are preallocated in this array so that they
          * can be shared.

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -163,7 +163,7 @@ typedef struct pyruntimestate {
 
     /* All the objects that are shared by the runtime's interpreters. */
     struct _Py_cached_objects cached_objects;
-    struct _Py_global_objects global_objects;
+    struct _Py_static_objects static_objects;
 
     /* The following fields are here to avoid allocation during init.
        The data is exposed through _PyRuntimeState pointer fields.

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -70,7 +70,7 @@ extern "C" {
         .types = { \
             .next_version_tag = 1, \
         }, \
-        .global_objects = { \
+        .static_objects = { \
             .singletons = { \
                 .small_ints = _Py_small_ints_INIT, \
                 .bytes_empty = _PyBytes_SIMPLE_INIT(0, 0), \

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -233,12 +233,12 @@ static inline PyObject* unicode_new_empty(void)
 */
 static inline PyObject *get_interned_dict(void)
 {
-    return _PyRuntime.global_objects.interned;
+    return _PyRuntime.cached_objects.interned;
 }
 
 static inline void set_interned_dict(PyObject *dict)
 {
-    _PyRuntime.global_objects.interned = dict;
+    _PyRuntime.cached_objects.interned = dict;
 }
 
 #define _Py_RETURN_UNICODE_EMPTY()   \

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -233,12 +233,12 @@ static inline PyObject* unicode_new_empty(void)
 */
 static inline PyObject *get_interned_dict(void)
 {
-    return _Py_CACHED_OBJECT(interned);
+    return _Py_CACHED_OBJECT(interned_strings);
 }
 
 static inline void set_interned_dict(PyObject *dict)
 {
-    _Py_CACHED_OBJECT(interned) = dict;
+    _Py_CACHED_OBJECT(interned_strings) = dict;
 }
 
 #define _Py_RETURN_UNICODE_EMPTY()   \

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -233,12 +233,12 @@ static inline PyObject* unicode_new_empty(void)
 */
 static inline PyObject *get_interned_dict(void)
 {
-    return _PyRuntime.cached_objects.interned;
+    return _Py_CACHED_OBJECT(interned);
 }
 
 static inline void set_interned_dict(PyObject *dict)
 {
-    _PyRuntime.cached_objects.interned = dict;
+    _Py_CACHED_OBJECT(interned) = dict;
 }
 
 #define _Py_RETURN_UNICODE_EMPTY()   \


### PR DESCRIPTION
* move `_PyRuntime.global_objects.interned` to `_PyRuntime.cached_objects.interned_strings` (and use `_Py_CACHED_OBJECT()`)
* rename `_PyRuntime.global_objects` to `_PyRuntime.static_objects`

(This also relates to gh-96075.)

<!-- gh-issue-number: gh-90111 -->
* Issue: gh-90111
<!-- /gh-issue-number -->
