### PR TITLE
gh-100227: Port dup3_works to the module state variable.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-12-15-15-46-30.gh-issue-100227.ae9uXR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-12-15-15-46-30.gh-issue-100227.ae9uXR.rst
@@ -1,0 +1,2 @@
+Port dup3_works of :mod:`posix` module to the module state variable. Patch
+by Dong-hee Na.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -9457,8 +9457,9 @@ os_dup2_impl(PyObject *module, int fd, int fd2, int inheritable)
         res = dup3(fd, fd2, O_CLOEXEC);
         Py_END_ALLOW_THREADS
         if (res < 0) {
-            if (state->dup3_works == -1)
-                dup3_works = (errno != ENOSYS);
+            if (state->dup3_works == -1) {
+                state->dup3_works = (errno != ENOSYS);
+            }
             if (state->dup3_works) {
                 posix_error();
                 return -1;

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -18,7 +18,6 @@ filename	funcname	name	reason
 Python/bootstrap_hash.c	py_getrandom	getrandom_works	-
 Python/fileutils.c	-	_Py_open_cloexec_works	-
 Python/fileutils.c	set_inheritable	ioctl_works	-
-# (set lazily, *after* first init)
 
 ## guards around resource init
 Python/thread_pthread.h	PyThread__init_thread	lib_initialized	-

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -19,8 +19,6 @@ Python/bootstrap_hash.c	py_getrandom	getrandom_works	-
 Python/fileutils.c	-	_Py_open_cloexec_works	-
 Python/fileutils.c	set_inheritable	ioctl_works	-
 # (set lazily, *after* first init)
-# XXX Is this thread-safe?
-Modules/posixmodule.c	os_dup2_impl	dup3_works	-
 
 ## guards around resource init
 Python/thread_pthread.h	PyThread__init_thread	lib_initialized	-


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

`dup3_works` is safe to be ported as the module state variable since there is just one writing accessing in L9462.
Even if there are duplicated updatings for the `dup3_works` due to the race condition, `dup3_works` will not be updated anymore after the initial trial.

<!-- gh-issue-number: gh-100227 -->
* Issue: gh-100227
<!-- /gh-issue-number -->
