### PR TITLE
implement PY_UNSUPPORTED_OPENSSL_BUILD on macOS

### DIFF
--- a/configure
+++ b/configure
@@ -25262,7 +25262,14 @@ $as_echo_n "checking for unsupported static openssl build... " >&6; }
   -l*) :
 
         libname=$(echo $arg | cut -c3-)
-        new_OPENSSL_LIBS="$new_OPENSSL_LIBS -l:lib${libname}.a -Wl,--exclude-libs,lib${libname}.a"
+        case `uname` in #(
+  Linux) :
+    new_OPENSSL_LIBS="$new_OPENSSL_LIBS -l:lib${libname}.a -Wl,--exclude-libs,lib${libname}.a"n
+          Darwin ;; #(
+  *) :
+    new_OPENSSL_LIBS="$new_OPENSSL_LIBS -Wl,-hidden-l${libname}"
+         ;;
+esac
        ;; #(
   *) :
     new_OPENSSL_LIBS="$new_OPENSSL_LIBS $arg"

--- a/configure
+++ b/configure
@@ -25251,7 +25251,9 @@ $as_echo "$OPENSSL_RPATH" >&6; }
 # This static linking is NOT OFFICIALLY SUPPORTED and not advertised.
 # Requires static OpenSSL build with position-independent code. Some features
 # like DSO engines or external OSSL providers don't work. Only tested with GCC
-# and clang on X86_64.
+# and clang on Linux and Darwin x86_64. On Darwin, ld64 will still prefer the
+# dynamic library if both the static version and the dynamic version are installed in
+# the same directory and have the same name.
 if test "x$PY_UNSUPPORTED_OPENSSL_BUILD" = xstatic; then :
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for unsupported static openssl build" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -6920,7 +6920,10 @@ AS_VAR_IF([PY_UNSUPPORTED_OPENSSL_BUILD], [static], [
     AS_CASE([$arg],
       [-l*], [
         libname=$(echo $arg | cut -c3-)
-        new_OPENSSL_LIBS="$new_OPENSSL_LIBS -l:lib${libname}.a -Wl,--exclude-libs,lib${libname}.a"
+        AS_CASE([`uname`],
+          [Linux], [new_OPENSSL_LIBS="$new_OPENSSL_LIBS -l:lib${libname}.a -Wl,--exclude-libs,lib${libname}.a"]n
+          [Darwin], [new_OPENSSL_LIBS="$new_OPENSSL_LIBS -Wl,-hidden-l${libname}"]
+        )
       ],
       [new_OPENSSL_LIBS="$new_OPENSSL_LIBS $arg"]
     )


### PR DESCRIPTION
This is an extension for the undocumented and untested (on purpose) feature `PY_UNSUPPORTED_OPENSSL_BUILD` feature for macOS

This is something that is possible on macOS too via an obscure `ld64` linker option called `-lhidden-l` which specifies that the static library version is to be included and its symbols are not to be reexported.

The macOS `ld64` option exists at least since OS X 10.11, but `clang` supports it only since 15.0.0, hence the `-Wl` which ensures backwards compatibility

https://releases.llvm.org/15.0.0/tools/lld/docs/ReleaseNotes.html
https://opensource.apple.com/source/ld64/ld64-609/doc/man/man1/ld.1.auto.html

PS Apple's own man-page seems to be slightly misleading - this does not work if both the dynamic and the static libraries are installed at this location - I am still looking for a way to select the static library in this case