### PR TITLE
gh-100272: Fix JSON serialization of OrderedDict

### DIFF
--- a/Lib/test/test_json/test_default.py
+++ b/Lib/test/test_json/test_default.py
@@ -1,3 +1,4 @@
+import collections
 from test.test_json import PyTest, CTest
 
 
@@ -6,6 +7,16 @@ class TestDefault:
         self.assertEqual(
             self.dumps(type, default=repr),
             self.dumps(repr(type)))
+
+    def test_ordereddict(self):
+        od = collections.OrderedDict(a=1, b=2)
+        od.move_to_end('a')
+        self.assertEqual(
+            self.dumps(od),
+            '{"b": 2, "a": 1}')
+        self.assertEqual(
+            self.dumps(od, sort_keys=True),
+            '{"a": 1, "b": 2}')
 
 
 class TestPyDefault(TestDefault, PyTest): pass

--- a/Lib/test/test_json/test_default.py
+++ b/Lib/test/test_json/test_default.py
@@ -9,14 +9,14 @@ class TestDefault:
             self.dumps(repr(type)))
 
     def test_ordereddict(self):
-        od = collections.OrderedDict(a=1, b=2)
-        od.move_to_end('a')
+        od = collections.OrderedDict(a=1, b=2, c=3, d=4)
+        od.move_to_end('b')
         self.assertEqual(
             self.dumps(od),
-            '{"b": 2, "a": 1}')
+            '{"a": 1, "c": 3, "d": 4, "b": 2}')
         self.assertEqual(
             self.dumps(od, sort_keys=True),
-            '{"a": 1, "b": 2}')
+            '{"a": 1, "b": 2, "c": 3, "d": 4}')
 
 
 class TestPyDefault(TestDefault, PyTest): pass

--- a/Misc/NEWS.d/next/Library/2022-12-15-18-28-13.gh-issue-100272.D1O9Ey.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-15-18-28-13.gh-issue-100272.D1O9Ey.rst
@@ -1,0 +1,1 @@
+Fix JSON serialization of OrderedDict.  It now preserves the order of keys.

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1570,10 +1570,9 @@ encoder_listencode_dict(PyEncoderObject *s, _PyUnicodeWriter *writer,
         */
     }
 
-    if (s->sort_keys) {
-
-        items = PyDict_Items(dct);
-        if (items == NULL || PyList_Sort(items) < 0)
+    if (s->sort_keys || !PyDict_CheckExact(dct)) {
+        items = PyMapping_Items(dct);
+        if (items == NULL || (s->sort_keys && PyList_Sort(items) < 0))
             goto bail;
 
         for (Py_ssize_t  i = 0; i < PyList_GET_SIZE(items); i++) {


### PR DESCRIPTION
It now preserves the order of keys.


<!-- gh-issue-number: gh-100272 -->
* Issue: gh-100272
<!-- /gh-issue-number -->
