### PR TITLE
gh-81057: Move the Cached Parser Dummy Name to _PyRuntimeState

### DIFF
--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -8,6 +8,7 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+#include "pycore_ast.h"             // struct _expr
 #include "pycore_gc.h"              // PyGC_Head
 #include "pycore_global_strings.h"  // struct _Py_global_strings
 #include "pycore_hamt.h"            // PyHamtNode_Bitmap
@@ -60,6 +61,8 @@ struct _Py_static_objects {
         _PyGC_Head_UNUSED _hamt_bitmap_node_empty_gc_not_used;
         PyHamtNode_Bitmap hamt_bitmap_node_empty;
         _PyContextTokenMissing context_token_missing;
+
+        struct _expr parser_dummy_name;
     } singletons;
 };
 

--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -8,7 +8,6 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "pycore_ast.h"             // struct _expr
 #include "pycore_gc.h"              // PyGC_Head
 #include "pycore_global_strings.h"  // struct _Py_global_strings
 #include "pycore_hamt.h"            // PyHamtNode_Bitmap
@@ -61,8 +60,6 @@ struct _Py_static_objects {
         _PyGC_Head_UNUSED _hamt_bitmap_node_empty_gc_not_used;
         PyHamtNode_Bitmap hamt_bitmap_node_empty;
         _PyContextTokenMissing context_token_missing;
-
-        struct _expr parser_dummy_name;
     } singletons;
 };
 

--- a/Include/internal/pycore_parser.h
+++ b/Include/internal/pycore_parser.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 
-#include "pycore_ast.h"             // Name_kind
+#include "pycore_ast.h"             // struct _expr
 #include "pycore_global_strings.h"  // _Py_DECLARE_STR()
 #include "pycore_pyarena.h"         // PyArena
 
@@ -24,20 +24,21 @@ struct _parser_runtime_state {
 #else
     int _not_used;
 #endif
+    struct _expr dummy_name;
 };
 
-
 _Py_DECLARE_STR(empty, "")
-
-#define _Py_parser_dummy_name_INIT \
+#define _parser_runtime_state_INIT \
     { \
-        .kind = Name_kind, \
-        .v.Name.id = &_Py_STR(empty), \
-        .v.Name.ctx = Load, \
-        .lineno = 1, \
-        .col_offset = 0, \
-        .end_lineno = 1, \
-        .end_col_offset = 0, \
+        .dummy_name = { \
+            .kind = Name_kind, \
+            .v.Name.id = &_Py_STR(empty), \
+            .v.Name.ctx = Load, \
+            .lineno = 1, \
+            .col_offset = 0, \
+            .end_lineno = 1, \
+            .end_col_offset = 0, \
+        }, \
     }
 
 extern struct _mod* _PyParser_ASTFromString(

--- a/Include/internal/pycore_parser.h
+++ b/Include/internal/pycore_parser.h
@@ -9,6 +9,8 @@ extern "C" {
 #endif
 
 
+#include "pycore_ast.h"             // Name_kind
+#include "pycore_global_strings.h"  // _Py_DECLARE_STR()
 #include "pycore_pyarena.h"         // PyArena
 
 
@@ -25,6 +27,18 @@ struct _parser_runtime_state {
 };
 
 
+_Py_DECLARE_STR(empty, "")
+
+#define _Py_parser_dummy_name_INIT \
+    { \
+        .kind = Name_kind, \
+        .v.Name.id = &_Py_STR(empty), \
+        .v.Name.ctx = Load, \
+        .lineno = 1, \
+        .col_offset = 0, \
+        .end_lineno = 1, \
+        .end_col_offset = 0, \
+    }
 
 extern struct _mod* _PyParser_ASTFromString(
     const char *str,

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -9,6 +9,7 @@ extern "C" {
 #endif
 
 #include "pycore_object.h"
+#include "pycore_parser.h"
 #include "pycore_pymem_init.h"
 #include "pycore_obmalloc_init.h"
 
@@ -90,6 +91,7 @@ extern "C" {
                 .context_token_missing = { \
                     .ob_base = _PyObject_IMMORTAL_INIT(&_PyContextTokenMissing_Type), \
                 }, \
+                .parser_dummy_name = _Py_parser_dummy_name_INIT, \
             }, \
         }, \
         ._main_interpreter = _PyInterpreterState_INIT, \

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -33,6 +33,7 @@ extern "C" {
               until _PyInterpreterState_Enable() is called. */ \
             .next_id = -1, \
         }, \
+        .parser = _parser_runtime_state_INIT, \
         .imports = { \
             .lock = { \
                 .mutex = NULL, \
@@ -91,7 +92,6 @@ extern "C" {
                 .context_token_missing = { \
                     .ob_base = _PyObject_IMMORTAL_INIT(&_PyContextTokenMissing_Type), \
                 }, \
-                .parser_dummy_name = _Py_parser_dummy_name_INIT, \
             }, \
         }, \
         ._main_interpreter = _PyInterpreterState_INIT, \

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -3,12 +3,11 @@
 #include "pegen.h"
 #include "string_parser.h"
 #include "pycore_runtime.h"         // _PyRuntime
-#include "pycore_global_objects.h"  // _Py_SINGLETON()
 
 void *
 _PyPegen_dummy_name(Parser *p, ...)
 {
-    return &_Py_SINGLETON(parser_dummy_name);
+    return &_PyRuntime.parser.dummy_name;
 }
 
 /* Creates a single-element asdl_seq* that contains a */

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -2,30 +2,13 @@
 
 #include "pegen.h"
 #include "string_parser.h"
-
-static PyObject *
-_create_dummy_identifier(Parser *p)
-{
-    return _PyPegen_new_identifier(p, "");
-}
+#include "pycore_runtime.h"         // _PyRuntime
+#include "pycore_global_objects.h"  // _Py_SINGLETON()
 
 void *
 _PyPegen_dummy_name(Parser *p, ...)
 {
-    // XXX This leaks memory from the initial arena.
-    // Use a statically allocated variable instead of a pointer?
-    static void *cache = NULL;
-
-    if (cache != NULL) {
-        return cache;
-    }
-
-    PyObject *id = _create_dummy_identifier(p);
-    if (!id) {
-        return NULL;
-    }
-    cache = _PyAST_Name(id, Load, 1, 0, 1, 0, p->arena);
-    return cache;
+    return &_Py_SINGLETON(parser_dummy_name);
 }
 
 /* Creates a single-element asdl_seq* that contains a */

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -50,10 +50,6 @@ Python/getversion.c	-	version	-
 Python/bootstrap_hash.c	-	_Py_HashSecret_Initialized	-
 Python/pyhash.c	-	_Py_HashSecret	-
 
-## internal state - set lazily (*after* first init)
-# XXX Move to _PyRuntimeState (i.e. tie to init/fini cycle)?
-Parser/action_helpers.c	_PyPegen_dummy_name	cache	-
-
 
 ##################################
 ## state tied to Py_Main()


### PR DESCRIPTION
We have been lazily creating a singleton parser node in `_PyPegen_dummy_name()` and cached it in a static variable.  Here we instead statically define/initialize the node as part of `_PyRuntimeState`.  This eliminates one of the remaining global variables, reduces run-time CPU time (and memory usage), and eliminates a minor memory leak.

<!-- gh-issue-number: gh-81057 -->
* Issue: gh-81057
<!-- /gh-issue-number -->
