### PR TITLE
GH-90043: Handle NaNs in `COMPARE_OP_FLOAT_JUMP`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-12-15-00-50-25.gh-issue-90043.gyoKdx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-12-15-00-50-25.gh-issue-90043.gyoKdx.rst
@@ -1,0 +1,2 @@
+Handle NaNs when specializing :opcode:`COMPARE_OP` for :class:`float`
+values.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2027,11 +2027,8 @@ dummy_func(
             STAT_INC(COMPARE_OP, hit);
             double dleft = PyFloat_AS_DOUBLE(left);
             double dright = PyFloat_AS_DOUBLE(right);
-            // 1 if <, 2 if ==, 4 if >, 8 if unordered; this matches when_to_jump_mask
-            int sign_ish = (+ 6 * (Py_IS_NAN(dleft) | Py_IS_NAN(dright))
-                            + 2 * (dleft > dright)
-                            - 1 * (dleft < dright)
-                            + 2);
+            // 1 if NaN, 2 if <, 4 if >, 8 if ==; this matches when_to_jump_mask
+            int sign_ish = 1 << (2 * (dleft >= dright) + (dleft <= dright));
             _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
             _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
             jump = sign_ish & when_to_jump_mask;
@@ -2058,8 +2055,8 @@ dummy_func(
             assert(Py_ABS(Py_SIZE(left)) <= 1 && Py_ABS(Py_SIZE(right)) <= 1);
             Py_ssize_t ileft = Py_SIZE(left) * ((PyLongObject *)left)->ob_digit[0];
             Py_ssize_t iright = Py_SIZE(right) * ((PyLongObject *)right)->ob_digit[0];
-            // 1 if <, 2 if ==, 4 if >; this matches when _to_jump_mask
-            int sign_ish = 2*(ileft > iright) + 2 - (ileft < iright);
+            // 2 if <, 4 if >, 8 if ==; this matches when_to_jump_mask
+            int sign_ish = 1 << (2 * (ileft >= iright) + (ileft <= iright));
             _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
             _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
             jump = sign_ish & when_to_jump_mask;

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2024,13 +2024,14 @@ dummy_func(
             // Combined: COMPARE_OP (float ? float) + POP_JUMP_IF_(true/false)
             DEOPT_IF(!PyFloat_CheckExact(left), COMPARE_OP);
             DEOPT_IF(!PyFloat_CheckExact(right), COMPARE_OP);
+            STAT_INC(COMPARE_OP, hit);
             double dleft = PyFloat_AS_DOUBLE(left);
             double dright = PyFloat_AS_DOUBLE(right);
-            // 1 if <, 2 if ==, 4 if >; this matches when _to_jump_mask
-            int sign_ish = 2*(dleft > dright) + 2 - (dleft < dright);
-            DEOPT_IF(isnan(dleft), COMPARE_OP);
-            DEOPT_IF(isnan(dright), COMPARE_OP);
-            STAT_INC(COMPARE_OP, hit);
+            // 1 if <, 2 if ==, 4 if >, 8 if unordered; this matches when_to_jump_mask
+            int sign_ish = (+ 6 * (Py_IS_NAN(dleft) | Py_IS_NAN(dright))
+                            + 2 * (dleft > dright)
+                            - 1 * (dleft < dright)
+                            + 2);
             _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
             _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
             jump = sign_ish & when_to_jump_mask;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2217,11 +2217,8 @@
                 STAT_INC(COMPARE_OP, hit);
                 double dleft = PyFloat_AS_DOUBLE(left);
                 double dright = PyFloat_AS_DOUBLE(right);
-                // 1 if <, 2 if ==, 4 if >, 8 if unordered; this matches when_to_jump_mask
-                int sign_ish = (+ 6 * (Py_IS_NAN(dleft) | Py_IS_NAN(dright))
-                                + 2 * (dleft > dright)
-                                - 1 * (dleft < dright)
-                                + 2);
+                // 1 if NaN, 2 if <, 4 if >, 8 if ==; this matches when_to_jump_mask
+                int sign_ish = 1 << (2 * (dleft >= dright) + (dleft <= dright));
                 _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
                 _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
                 jump = sign_ish & when_to_jump_mask;
@@ -2259,8 +2256,8 @@
                 assert(Py_ABS(Py_SIZE(left)) <= 1 && Py_ABS(Py_SIZE(right)) <= 1);
                 Py_ssize_t ileft = Py_SIZE(left) * ((PyLongObject *)left)->ob_digit[0];
                 Py_ssize_t iright = Py_SIZE(right) * ((PyLongObject *)right)->ob_digit[0];
-                // 1 if <, 2 if ==, 4 if >; this matches when _to_jump_mask
-                int sign_ish = 2*(ileft > iright) + 2 - (ileft < iright);
+                // 2 if <, 4 if >, 8 if ==; this matches when_to_jump_mask
+                int sign_ish = 1 << (2 * (ileft >= iright) + (ileft <= iright));
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
                 jump = sign_ish & when_to_jump_mask;

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1924,16 +1924,16 @@ compare_op_fail_kind(PyObject *lhs, PyObject *rhs)
 
 
 static int compare_masks[] = {
-    // 1-bit: jump if less than
-    // 2-bit: jump if equal
+    // 1-bit: jump if unordered
+    // 2-bit: jump if less
     // 4-bit: jump if greater
-    // 8-bit: jump if unordered
-    [Py_LT] = 1 | 0 | 0 | 0,
-    [Py_LE] = 1 | 2 | 0 | 0,
-    [Py_EQ] = 0 | 2 | 0 | 0,
-    [Py_NE] = 1 | 0 | 4 | 8,
+    // 8-bit: jump if equal
+    [Py_LT] = 0 | 2 | 0 | 0,
+    [Py_LE] = 0 | 2 | 0 | 8,
+    [Py_EQ] = 0 | 0 | 0 | 8,
+    [Py_NE] = 1 | 2 | 4 | 0,
     [Py_GT] = 0 | 0 | 4 | 0,
-    [Py_GE] = 0 | 2 | 4 | 0,
+    [Py_GE] = 0 | 0 | 4 | 8,
 };
 
 void
@@ -1983,7 +1983,7 @@ _Py_Specialize_CompareOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
         }
         else {
             _Py_SET_OPCODE(*instr, COMPARE_OP_STR_JUMP);
-            cache->mask = (when_to_jump_mask & 2) == 0;
+            cache->mask = (when_to_jump_mask & 8) == 0;
             goto success;
         }
     }

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1927,12 +1927,13 @@ static int compare_masks[] = {
     // 1-bit: jump if less than
     // 2-bit: jump if equal
     // 4-bit: jump if greater
-    [Py_LT] = 1 | 0 | 0,
-    [Py_LE] = 1 | 2 | 0,
-    [Py_EQ] = 0 | 2 | 0,
-    [Py_NE] = 1 | 0 | 4,
-    [Py_GT] = 0 | 0 | 4,
-    [Py_GE] = 0 | 2 | 4,
+    // 8-bit: jump if unordered
+    [Py_LT] = 1 | 0 | 0 | 0,
+    [Py_LE] = 1 | 2 | 0 | 0,
+    [Py_EQ] = 0 | 2 | 0 | 0,
+    [Py_NE] = 1 | 0 | 4 | 8,
+    [Py_GT] = 0 | 0 | 4 | 0,
+    [Py_GE] = 0 | 2 | 4 | 0,
 };
 
 void
@@ -1953,7 +1954,7 @@ _Py_Specialize_CompareOp(PyObject *lhs, PyObject *rhs, _Py_CODEUNIT *instr,
     assert(oparg <= Py_GE);
     int when_to_jump_mask = compare_masks[oparg];
     if (next_opcode == POP_JUMP_IF_FALSE) {
-        when_to_jump_mask = (1 | 2 | 4) & ~when_to_jump_mask;
+        when_to_jump_mask = (1 | 2 | 4 | 8) & ~when_to_jump_mask;
     }
     if (Py_TYPE(lhs) != Py_TYPE(rhs)) {
         SPECIALIZATION_FAIL(COMPARE_OP, compare_op_fail_kind(lhs, rhs));


### PR DESCRIPTION
`COMPARE_OP_FLOAT_JUMP` contains two `DEOPT_IF` branches for NaN values. This means that `COMPARE_OP` will repeatedly specialize and deoptimize in the presence of NaNs.

The current scheme can be slightly modified to handle unordered operands correctly, and remove these checks entirely.

<!-- gh-issue-number: gh-90043 -->
* Issue: gh-90043
<!-- /gh-issue-number -->
