### PR TITLE
Make asyncio timeout context decorator

### DIFF
--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -131,6 +131,7 @@ class timeout(Timeout):
         super().__init__(None)
 
     async def __aenter__(self):
+        self._state = _State.ENTERED
         loop = events.get_running_loop()
         self._when = loop.time() + self._delay if self._delay is not None else None
         return await super().__aenter__()

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -24,7 +24,7 @@ class _State(enum.Enum):
     EXITED = "finished"
 
 
-class Timeout:
+class Timeout(contextlib.AsyncContextDecorator):
 
     def __init__(self, when: Optional[float]) -> None:
         self._state = _State.CREATED
@@ -109,7 +109,7 @@ class Timeout:
         self._timeout_handler = None
 
 
-class timeout(Timeout, contextlib.AsyncContextDecorator):
+class timeout(Timeout):
     """Timeout async context manager.
 
     Useful in cases when you want to apply timeout logic around block
@@ -130,7 +130,7 @@ class timeout(Timeout, contextlib.AsyncContextDecorator):
         super().__init__(loop.time() + delay if delay is not None else None)
 
 
-class timeout_at(Timeout, contextlib.AsyncContextDecorator):
+class timeout_at(Timeout):
     """Schedule the timeout at absolute time.
 
     Like timeout() but argument gives absolute time in the same clock system

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -125,9 +125,15 @@ class timeout(Timeout):
     the top-most affected timeout() context manager converts CancelledError
     into TimeoutError.
     """
+
     def __init__(self, delay: Optional[float]):
+        self._delay = delay
+        super().__init__(None)
+
+    async def __aenter__(self):
         loop = events.get_running_loop()
-        super().__init__(loop.time() + delay if delay is not None else None)
+        self._when = loop.time() + self._delay if self._delay is not None else None
+        return await super().__aenter__()
 
 
 class timeout_at(Timeout):


### PR DESCRIPTION

# gh-100283: `asyncio.timeout` and `asyncio.timeout_at` are now `contextlib.AsyncContextDecorators`

closes #100283 