### PR TITLE
Correct CVE-2020-10735 documentation

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5480,7 +5480,7 @@ to mitigate denial of service attacks. This limit *only* applies to decimal or
 other non-power-of-two number bases. Hexadecimal, octal, and binary conversions
 are unlimited. The limit can be configured.
 
-The :class:`int` type in CPython is an abitrary length number stored in binary
+The :class:`int` type in CPython is an arbitrary length number stored in binary
 form (commonly known as a "bignum"). There exists no algorithm that can convert
 a string to a binary integer or a binary integer to a string in linear time,
 *unless* the base is a power of 2. Even the best known algorithms for base 10
@@ -5544,7 +5544,7 @@ and :class:`str` or :class:`bytes`:
 * ``int(string)`` with default base 10.
 * ``int(string, base)`` for all bases that are not a power of 2.
 * ``str(integer)``.
-* ``repr(integer)``
+* ``repr(integer)``.
 * any other string conversion to base 10, for example ``f"{integer}"``,
   ``"{}".format(integer)``, or ``b"%d" % integer``.
 
@@ -5572,7 +5572,7 @@ command line flag to configure the limit:
   :envvar:`PYTHONINTMAXSTRDIGITS` or :option:`-X int_max_str_digits <-X>`.
   If both the env var and the ``-X`` option are set, the ``-X`` option takes
   precedence. A value of *-1* indicates that both were unset, thus a value of
-  :data:`sys.int_info.default_max_str_digits` was used during initilization.
+  :data:`sys.int_info.default_max_str_digits` was used during initialization.
 
 From code, you can inspect the current limit and set a new one using these
 :mod:`sys` APIs:

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -548,11 +548,6 @@ Convenience Functions
    .. versionchanged:: 3.3
       The *use_builtin_types* flag was added.
 
-   .. versionchanged:: 3.11
-      Conversion to :class:`int` now limits the maximum length of the integer
-      string via the interpreter's :ref:`integer string conversion length
-      limitation <int_max_str_digits>` to help avoid denial of service attacks.
-
 
 .. _xmlrpc-client-example:
 

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -548,6 +548,11 @@ Convenience Functions
    .. versionchanged:: 3.3
       The *use_builtin_types* flag was added.
 
+   .. versionchanged:: 3.12
+      Conversion to :class:`int` now limits the maximum length of the integer
+      string via the interpreter's :ref:`integer string conversion length
+      limitation <int_max_str_digits>` to help avoid denial of service attacks.
+
 
 .. _xmlrpc-client-example:
 

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -548,7 +548,7 @@ Convenience Functions
    .. versionchanged:: 3.3
       The *use_builtin_types* flag was added.
 
-   .. versionchanged:: 3.12
+   .. versionchanged:: 3.11
       Conversion to :class:`int` now limits the maximum length of the integer
       string via the interpreter's :ref:`integer string conversion length
       limitation <int_max_str_digits>` to help avoid denial of service attacks.

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -749,7 +749,7 @@ PyDoc_STRVAR(sys_get_int_max_str_digits__doc__,
 "get_int_max_str_digits($module, /)\n"
 "--\n"
 "\n"
-"Set the maximum string digits limit for non-binary int<->str conversions.");
+"Return the maximum string digits limit for non-binary int<->str conversions.");
 
 #define SYS_GET_INT_MAX_STR_DIGITS_METHODDEF    \
     {"get_int_max_str_digits", (PyCFunction)sys_get_int_max_str_digits, METH_NOARGS, sys_get_int_max_str_digits__doc__},
@@ -1318,4 +1318,4 @@ sys_is_stack_trampoline_active(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=79228e569529129c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b32b444538dfd354 input=a9049054013a1b77]*/

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1699,12 +1699,12 @@ sys_mdebug_impl(PyObject *module, int flag)
 /*[clinic input]
 sys.get_int_max_str_digits
 
-Set the maximum string digits limit for non-binary int<->str conversions.
+Return the maximum string digits limit for non-binary int<->str conversions.
 [clinic start generated code]*/
 
 static PyObject *
 sys_get_int_max_str_digits_impl(PyObject *module)
-/*[clinic end generated code: output=0042f5e8ae0e8631 input=8dab13e2023e60d5]*/
+/*[clinic end generated code: output=0042f5e8ae0e8631 input=61bf9f99bc8b112d]*/
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
     return PyLong_FromLong(interp->long_state.max_str_digits);


### PR DESCRIPTION
I was reviewing the changes made to address CVE-2020-10735 originally addressed in #96499 and noticed a few documentation hiccups.