### PR TITLE
gh-100221: Fix creating dirs in `make sharedinstall`

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1803,7 +1803,15 @@ commoninstall:  check-clean-src @FRAMEWORKALTINSTALLFIRST@ \
 # Install shared libraries enabled by Setup
 DESTDIRS=	$(exec_prefix) $(LIBDIR) $(BINLIBDEST) $(DESTSHARED)
 
-sharedinstall: $(DESTSHARED) all
+sharedinstall: all
+		@for i in $(DESTDIRS); \
+		do \
+			if test ! -d $(DESTDIR)$$i; then \
+				echo "Creating directory $$i"; \
+				$(INSTALL) -d -m $(DIRMODE) $(DESTDIR)$$i; \
+			else    true; \
+			fi; \
+		done
 		@for i in X $(SHAREDMODS); do \
 		  if test $$i != X; then \
 		    echo $(INSTALL_SHARED) $$i $(DESTSHARED)/`basename $$i`; \
@@ -1813,17 +1821,6 @@ sharedinstall: $(DESTSHARED) all
 				$(DSYMUTIL_PATH) $(DESTDIR)$(DESTSHARED)/`basename $$i`; \
 			fi; \
 		  fi; \
-		done
-
-
-$(DESTSHARED):
-		@for i in $(DESTDIRS); \
-		do \
-			if test ! -d $(DESTDIR)$$i; then \
-				echo "Creating directory $$i"; \
-				$(INSTALL) -d -m $(DIRMODE) $(DESTDIR)$$i; \
-			else    true; \
-			fi; \
 		done
 
 # Install the interpreter with $(VERSION) affixed

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -640,6 +640,7 @@ Tiago Gonçalves
 Chris Gonnerman
 Shelley Gooch
 David Goodger
+Michał Górny
 Elliot Gorokhovsky
 Hans de Graaff
 Tim Graham

--- a/Misc/NEWS.d/next/Build/2022-12-18-08-33-28.gh-issue-100221.K94Ct3.rst
+++ b/Misc/NEWS.d/next/Build/2022-12-18-08-33-28.gh-issue-100221.K94Ct3.rst
@@ -1,0 +1,2 @@
+Fix creating install directories in ``make sharedinstall`` if they exist
+outside ``DESTDIR`` already.


### PR DESCRIPTION
Fix creating install directories in `make sharedinstall` if they exist already outside `DESTDIR`.  The previous make rules assumed that the directories would be created via a dependency on a rule for `$(DESTSHARED)` that did not fire if the directory did exist outside `$(DESTDIR)`.

While technically `$(DESTDIR)` could be prepended to the rule name, moving the rules for creating directories straight into the `sharedinstall` rule seems to fit the common practices better. Since the rule explicitly checks whether the individual directories exist anyway, there seems to be no reason to rely on make determining that implicitly as well.

<!-- gh-issue-number: gh-100221 -->
* Issue: gh-100221
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:zware