### PR TITLE
gh-100340: Allows -Wno-int-conversion for wasm

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-01-17-21-32-51.gh-issue-100340.i9zRGM.rst
+++ b/Misc/NEWS.d/next/Build/2023-01-17-21-32-51.gh-issue-100340.i9zRGM.rst
@@ -1,0 +1,2 @@
+Allows -Wno-int-conversion for wasm-sdk 17 and onwards, thus enables
+building WASI builds once against the latest sdk.

--- a/Tools/wasm/config.site-wasm32-wasi
+++ b/Tools/wasm/config.site-wasm32-wasi
@@ -37,3 +37,6 @@ ac_cv_header_netpacket_packet_h=no
 # disable accept for WASM runtimes without sock_accept
 #ac_cv_func_accept=no
 #ac_cv_func_accept4=no
+
+# Disable int-conversion for wask-sdk as it triggers an error from version 17.
+ac_cv_disable_int_conversion=yes

--- a/configure
+++ b/configure
@@ -8743,6 +8743,44 @@ fi
 
 
 
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC int-conversion warning" >&5
+$as_echo_n "checking if we can disable $CC int-conversion warning... " >&6; }
+if ${ac_cv_disable_int_conversion_warning+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+    py_cflags=$CFLAGS
+    as_fn_append CFLAGS "-Wint-conversion -Werror"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_disable_int_conversion_warning=yes
+else
+  ac_cv_disable_int_conversion_warning=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CFLAGS=$py_cflags
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_int_conversion_warning" >&5
+$as_echo "$ac_cv_disable_int_conversion_warning" >&6; }
+
+
+    if test "x$ac_cv_disable_int_conversion" = xyes; then :
+  CFLAGS_NODIST="$CFLAGS_NODIST -Wno-int-conversion"
+fi
+
+
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC missing-field-initializers warning" >&5
 $as_echo_n "checking if we can disable $CC missing-field-initializers warning... " >&6; }
 if ${ac_cv_disable_missing_field_initializers_warning+:} false; then :

--- a/configure.ac
+++ b/configure.ac
@@ -2288,6 +2288,10 @@ yes)
     AS_VAR_IF([ac_cv_disable_unused_parameter_warning], [yes],
               [CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-parameter"])
 
+    PY_CHECK_CC_WARNING([disable], [int-conversion])
+    AS_VAR_IF([ac_cv_disable_int_conversion], [yes],
+              [CFLAGS_NODIST="$CFLAGS_NODIST -Wno-int-conversion"])
+
     PY_CHECK_CC_WARNING([disable], [missing-field-initializers])
     AS_VAR_IF([ac_cv_disable_missing_field_initializers_warning], [yes],
               [CFLAGS_NODIST="$CFLAGS_NODIST -Wno-missing-field-initializers"])


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Adds new configuration directive to disable `int-conversion` and then using it for the `wasm32-wasi` build only. This allows us to build on the version 17 of the wasm-sdk.

## How to test manually?

Install the [version 17](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-17) of the SDK and then run the following command:

```
./Tools/wasm/wasm_build.py wasi
```


<!-- gh-issue-number: gh-100340 -->
* Issue: gh-100340
<!-- /gh-issue-number -->
