### PR TITLE
Docs: Fix ambiguous pronoun

### DIFF
--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -678,8 +678,8 @@ Private Variables
 object don't exist in Python.  However, there is a convention that is followed
 by most Python code: a name prefixed with an underscore (e.g. ``_spam``) should
 be treated as a non-public part of the API (whether it is a function, a method
-or a data member).  It should be considered an implementation detail and subject
-to change without notice.
+or a data member).  Users of such an API should consider variables so named
+to be implementation details subject to change without notice.
 
 .. index::
    pair: name; mangling


### PR DESCRIPTION
"It" could be taken to refer to the 'name with a leading underscore' convention itself, rather than to the variable whose name follows that convention.

No issue as it's a trivial change.