### PR TITLE
gh-100379: Fix usage of unset variable during configure when --enable-framework is  not used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2978,7 +2978,10 @@ case $ac_sys_system/$ac_sys_release in
     else
         LIBTOOL_CRUFT="${LIBTOOL_CRUFT} -arch_only `/usr/bin/arch`"
     fi
-    LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -install_name $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+    if test "$enable_framework"
+    then
+        LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -install_name $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+    fi
     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
   Darwin/*)
     gcc_version=`gcc -dumpversion`
@@ -3031,7 +3034,10 @@ case $ac_sys_system/$ac_sys_release in
     fi
 
     LIBTOOL_CRUFT=$LIBTOOL_CRUFT" -lSystem -lSystemStubs -arch_only ${MACOSX_DEFAULT_ARCH}"
-    LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -install_name $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+    if test "$enable_framework"
+    then
+        LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -install_name $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+    fi
     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
 esac
 AC_MSG_CHECKING(for --enable-framework)


### PR DESCRIPTION

PYTHONFRAMEWORKINSTALLDIR is only set upon --enable-framework. Guard all its usage accordingly.



<!-- gh-issue-number: gh-100379 -->
* Issue: gh-100379
<!-- /gh-issue-number -->
