### PR TITLE
gh-99191: Use correct check for MSVC C++ version support in _wmimodule.cpp

### DIFF
--- a/Misc/NEWS.d/next/Windows/2022-12-20-18-36-17.gh-issue-99191.0cfRja.rst
+++ b/Misc/NEWS.d/next/Windows/2022-12-20-18-36-17.gh-issue-99191.0cfRja.rst
@@ -1,0 +1,2 @@
+Use ``_MSVC_LANG >= 202002L`` instead of less-precise ``_MSC_VER >=1929``
+to more accurately test for C++20 support in :file:`PC/_wmimodule.cpp`.

--- a/PC/_wmimodule.cpp
+++ b/PC/_wmimodule.cpp
@@ -17,7 +17,7 @@
 #include <Python.h>
 
 
-#if _MSC_VER >= 1929
+#if _MSVC_LANG >= 202002L
 // We can use clinic directly when the C++ compiler supports C++20
 #include "clinic/_wmimodule.cpp.h"
 #else
@@ -96,9 +96,9 @@ _query_thread(LPVOID param)
     }
     if (SUCCEEDED(hr)) {
         hr = services->ExecQuery(
-            bstr_t("WQL"), 
+            bstr_t("WQL"),
             bstrQuery,
-            WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, 
+            WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
             NULL,
             &enumerator
         );


### PR DESCRIPTION
As discussed in #99191 , in [PC/_wmimodule.cpp](https://github.com/python/cpython/blob/c18d83118881333b9a0afd0add83afb2ba7300f7/PC/_wmimodule.cpp#L20) it currently uses the check ``#if _MSC_VER >= 1929`` to determine if the compiler supports C++20 designated initializers. However, the `/std:c++20` flag was only introduced in VS 2019 16.11, but `1929` is also the version reported in VS 2019 16.10, which doesn't support that flag. Therefore, the current check will break (resulting in the unsupported C++20 branch being taken and presumably resulting in a compiler error) on VS 16.10 and also if the build is invoked such that `\std:c++20` is overridden or not passed.

However, we can instead use `_MSVC_LANG >= 202002L` to check whether C++20 or greater is actually being targeted.

Fixes #99191 

<!-- gh-issue-number: gh-99191 -->
* Issue: gh-99191
<!-- /gh-issue-number -->
