### PR TITLE
gh-100388: Change undefined __DATE__ to the Unix epoch

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2022-12-21-14-28-01.gh-issue-100388.vne8ky.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2022-12-21-14-28-01.gh-issue-100388.vne8ky.rst
@@ -1,0 +1,2 @@
+Fix the ``platform._sys_version()`` method when ``__DATE__`` is undefined at
+buildtime by changing default buildtime datetime string to the UNIX epoch.

--- a/Modules/getbuildinfo.c
+++ b/Modules/getbuildinfo.c
@@ -13,7 +13,7 @@
 #ifdef __DATE__
 #define DATE __DATE__
 #else
-#define DATE "xx/xx/xx"
+#define DATE "Jan 01 1970"
 #endif
 #endif
 
@@ -21,7 +21,7 @@
 #ifdef __TIME__
 #define TIME __TIME__
 #else
-#define TIME "xx:xx:xx"
+#define TIME "00:00:00"
 #endif
 #endif
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This seems like the most reasonable fix, given the structure of `__DATE__` normally.

Should this fix be backported?

<!-- gh-issue-number: gh-100388 -->
* Issue: gh-100388
<!-- /gh-issue-number -->
