### PR TITLE
Remove unused variable from `dis._find_imports`

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -666,7 +666,6 @@ def _find_imports(co):
     the corresponding args to __import__.
     """
     IMPORT_NAME = opmap['IMPORT_NAME']
-    LOAD_CONST = opmap['LOAD_CONST']
 
     consts = co.co_consts
     names = co.co_names


### PR DESCRIPTION
It was introduced in https://github.com/python/cpython/commit/04676b69466d2e6d2903f1c6879d2cb292721455
And its usage was removed in https://github.com/python/cpython/commit/40d2ac92f9a28a486156dafdbb613016bb1f6b98

There's now the same global var defined here: https://github.com/python/cpython/blob/79311cbfe718f17c89bab67d7f89da3931bfa2ac/Lib/dis.py#L36

I don't think this needs an issue or news.