### PR TITLE
gh-99908 Update class documentation to use a modernized example

### DIFF
--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -750,6 +750,7 @@ is to use :mod:`dataclasses` for this purpose::
         salary: int
 
     john = Employee("john", "computer lab", 1000)
+
     >>> john.dept
     # "computer lab"
     >>> john.salary

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -738,18 +738,22 @@ Odds and Ends
 =============
 
 Sometimes it is useful to have a data type similar to the Pascal "record" or C
-"struct", bundling together a few named data items.  An empty class definition
-will do nicely::
+"struct", bundling together a few named data items. The idiomatic approach
+is to use :mod:`dataclasses` for this purpose::
 
-   class Employee:
-       pass
+    from dataclasses import dataclasses
 
-   john = Employee()  # Create an empty employee record
+    @dataclass
+    class Employee:
+        name: str
+        dept: str
+        salary: int
 
-   # Fill the fields of the record
-   john.name = 'John Doe'
-   john.dept = 'computer lab'
-   john.salary = 1000
+    john = Employee("john", "computer lab", 1000)
+    >>> john.dept
+    # "computer lab"
+    >>> john.salary
+    # '1000'
 
 A piece of Python code that expects a particular abstract data type can often be
 passed a class that emulates the methods of that data type instead.  For

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -752,9 +752,9 @@ is to use :mod:`dataclasses` for this purpose::
     john = Employee("john", "computer lab", 1000)
 
     >>> john.dept
-    # "computer lab"
+    "computer lab"
     >>> john.salary
-    # '1000'
+    1000
 
 A piece of Python code that expects a particular abstract data type can often be
 passed a class that emulates the methods of that data type instead.  For


### PR DESCRIPTION
Small update to the docs to improve on an outmoded example from 15 years ago.
The aim of this change is to give readers of the docs a more idiomatic example.

<!-- gh-issue-number: gh-99908 -->
* Issue: gh-99908
<!-- /gh-issue-number -->
