### PR TITLE
Refactor a test

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5719,14 +5719,10 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertNotIsInstance(g, G)
 
     def test_subclassing_subclasshook(self):
-
-        class Base(typing.Iterable):
+        class Base(abc.ABC):
             @classmethod
             def __subclasshook__(cls, other):
-                if other.__name__ == 'Foo':
-                    return True
-                else:
-                    return False
+                return other.__name__ == 'Foo'
 
         class C(Base): ...
         class Foo: ...

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5719,7 +5719,7 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertNotIsInstance(g, G)
 
     def test_subclassing_subclasshook(self):
-        class Base(abc.ABC):
+        class Base(typing.Iterable):
             @classmethod
             def __subclasshook__(cls, other):
                 return other.__name__ == 'Foo'


### PR DESCRIPTION
Changes:
- Refactors out the 'if bool: return True; else: return False` anti-pattern.
- ~~Makes `Base` inherit from `abc.ABC` instead of `typing.Iterable`, which is a clearer statement of intent.~~ (Edit: this was a misunderstanding on my part).
------------------------------------------
Not creating an issue as I don't think this warrants one.
Not creating a News entry as I don't think this warrants one.