### PR TITLE
gh-100428: Make float documentation more accurate

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -658,10 +658,10 @@ are always available.  They are listed here in alphabetical order.
       infinity: "Infinity" | "inf"
       nan: "nan"
       digitpart: `digit` (["_"] `digit`)*
-      floatnumber: [`digitpart`] "." `digitpart` | `digitpart` ["."]
+      number: [`digitpart`] "." `digitpart` | `digitpart` ["."]
       exponent: ("e" | "E") ["+" | "-"] `digitpart`
-      number: floatnumber [`exponent`]
-      numeric_value: `number` | `infinity` | `nan`
+      floatnumber: number [`exponent`]
+      numeric_value: `floatnumber` | `infinity` | `nan`
       numeric_string: [`sign`] `numeric_value`
 
    Case is not significant, so, for example, "inf", "Inf", "INFINITY", and

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -664,9 +664,8 @@ are always available.  They are listed here in alphabetical order.
       numeric_value: `number` | `infinity` | `nan`
       numeric_string: [`sign`] `numeric_value`
 
-   Case is not significant, so, for example,
-   "inf", "Inf", "INFINITY", and "iNfINity" are all acceptable spellings for
-   positive infinity.
+   Case is not significant, so, for example, "inf", "Inf", "INFINITY", and
+   "iNfINity" are all acceptable spellings for positive infinity.
 
    Otherwise, if the argument is an integer or a floating point number, a
    floating point number with the same value (within Python's floating point

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -657,11 +657,16 @@ are always available.  They are listed here in alphabetical order.
       sign: "+" | "-"
       infinity: "Infinity" | "inf"
       nan: "nan"
-      numeric_value: `floatnumber` | `infinity` | `nan`
+
+      number: floatnumber [`exponent`]
+      floatnumber: [`digitpart`] "." `digitpart` | `digitpart` ["."]
+      digitpart: `digit` (["_"] `digit`)*
+      exponent: ("e" | "E") ["+" | "-"] `digitpart`
+
+      numeric_value: `number` | `infinity` | `nan`
       numeric_string: [`sign`] `numeric_value`
 
-   Here ``floatnumber`` is the form of a Python floating-point literal,
-   described in :ref:`floating`.  Case is not significant, so, for example,
+   Case is not significant, so, for example,
    "inf", "Inf", "INFINITY", and "iNfINity" are all acceptable spellings for
    positive infinity.
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -657,12 +657,10 @@ are always available.  They are listed here in alphabetical order.
       sign: "+" | "-"
       infinity: "Infinity" | "inf"
       nan: "nan"
-
       number: floatnumber [`exponent`]
       floatnumber: [`digitpart`] "." `digitpart` | `digitpart` ["."]
       digitpart: `digit` (["_"] `digit`)*
       exponent: ("e" | "E") ["+" | "-"] `digitpart`
-
       numeric_value: `number` | `infinity` | `nan`
       numeric_string: [`sign`] `numeric_value`
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -650,7 +650,7 @@ are always available.  They are listed here in alphabetical order.
    sign may be ``'+'`` or ``'-'``; a ``'+'`` sign has no effect on the value
    produced.  The argument may also be a string representing a NaN
    (not-a-number), or positive or negative infinity.  More precisely, the
-   input must conform to the ``numeric_string`` production rule in the following
+   input must conform to the ``floatvalue`` production rule in the following
    grammar, after leading and trailing whitespace characters are removed:
 
    .. productionlist:: float
@@ -661,10 +661,9 @@ are always available.  They are listed here in alphabetical order.
       number: [`digitpart`] "." `digitpart` | `digitpart` ["."]
       exponent: ("e" | "E") ["+" | "-"] `digitpart`
       floatnumber: number [`exponent`]
-      numeric_value: `floatnumber` | `infinity` | `nan`
-      numeric_string: [`sign`] `numeric_value`
+      floatvalue: [`sign`] (`floatnumber` | `infinity` | `nan`)
 
-   Here ``digit`` is a Unicode decimal digit (characters in the Unicode general
+   Here ``digit`` is a Unicode decimal digit (character in the Unicode general
    category ``Nd``). Case is not significant, so, for example, "inf", "Inf",
    "INFINITY", and "iNfINity" are all acceptable spellings for positive
    infinity.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -657,10 +657,10 @@ are always available.  They are listed here in alphabetical order.
       sign: "+" | "-"
       infinity: "Infinity" | "inf"
       nan: "nan"
-      number: floatnumber [`exponent`]
-      floatnumber: [`digitpart`] "." `digitpart` | `digitpart` ["."]
       digitpart: `digit` (["_"] `digit`)*
+      floatnumber: [`digitpart`] "." `digitpart` | `digitpart` ["."]
       exponent: ("e" | "E") ["+" | "-"] `digitpart`
+      number: floatnumber [`exponent`]
       numeric_value: `number` | `infinity` | `nan`
       numeric_string: [`sign`] `numeric_value`
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -664,8 +664,10 @@ are always available.  They are listed here in alphabetical order.
       numeric_value: `floatnumber` | `infinity` | `nan`
       numeric_string: [`sign`] `numeric_value`
 
-   Case is not significant, so, for example, "inf", "Inf", "INFINITY", and
-   "iNfINity" are all acceptable spellings for positive infinity.
+   Here ``digit`` is a Unicode decimal digit (characters in the Unicode general
+   category ``Nd``). Case is not significant, so, for example, "inf", "Inf",
+   "INFINITY", and "iNfINity" are all acceptable spellings for positive
+   infinity.
 
    Otherwise, if the argument is an integer or a floating point number, a
    floating point number with the same value (within Python's floating point

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -650,8 +650,8 @@ are always available.  They are listed here in alphabetical order.
    sign may be ``'+'`` or ``'-'``; a ``'+'`` sign has no effect on the value
    produced.  The argument may also be a string representing a NaN
    (not-a-number), or positive or negative infinity.  More precisely, the
-   input must conform to the following grammar after leading and trailing
-   whitespace characters are removed:
+   input must conform to the ``numeric_string`` production rule in the following
+   grammar, after leading and trailing whitespace characters are removed:
 
    .. productionlist:: float
       sign: "+" | "-"


### PR DESCRIPTION
Previously, the grammar did not accept `float("10")`. Also implement mdickinson's suggestion of removing the indirection.

<!-- gh-issue-number: gh-100428 -->
* Issue: gh-100428
<!-- /gh-issue-number -->
