### PR TITLE
gh-100463: Add handling for extensionless URLs in http.server

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -376,13 +376,16 @@ provides three different variants:
       :func:`os.listdir` to scan the directory, and returns a ``404`` error
       response if the :func:`~os.listdir` fails.
 
-      If the request was mapped to a file, it is opened. Any :exc:`OSError`
-      exception in opening the requested file is mapped to a ``404``,
-      ``'File not found'`` error. If there was a ``'If-Modified-Since'``
-      header in the request, and the file was not modified after this time,
-      a ``304``, ``'Not Modified'`` response is sent. Otherwise, the content
-      type is guessed by calling the :meth:`guess_type` method, which in turn
-      uses the *extensions_map* variable, and the file contents are returned.
+      If the request was mapped to a file, it is opened. If the file does not
+      exist, and the URL does not contain an extension, the path is instead
+      checked for the file with the additional extension ``.html`` or ``.htm``
+      (in that order) and that is opened. Any :exc:`OSError` exception in
+      opening the requested file is mapped to a ``404``, ``'File not found'``
+      error. If there was a ``'If-Modified-Since'`` header in the request, and
+      the file was not modified after this time, a ``304``, ``'Not Modified'``
+      response is sent. Otherwise, the content type is guessed by calling the
+      :meth:`guess_type` method, which in turn uses the *extensions_map*
+      variable, and the file contents are returned.
 
       A ``'Content-type:'`` header with the guessed content type is output,
       followed by a ``'Content-Length:'`` header with the file's size and a
@@ -397,6 +400,9 @@ provides three different variants:
 
       .. versionchanged:: 3.7
          Support of the ``'If-Modified-Since'`` header.
+
+      .. versionchanged:: 3.12
+         Checks for presence of HTML file in absence of an extension.
 
 The :class:`SimpleHTTPRequestHandler` class can be used in the following
 manner in order to create a very basic webserver serving files relative to

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -587,6 +587,21 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         self.assertEqual(response.getheader("Location"),
                          self.tempdir_name + "/?hi=1")
 
+    def test_default_extension(self):
+        """Checks an extensionless path finds a HMTL file, and finds an
+        extensionless file with priority.
+        """
+        data1 = b"SPAM SPAM SPAM!\r\n"
+        with open(os.path.join(self.tempdir_name, 'spam.html'), 'wb') as f:
+            f.write(data1)
+        response = self.request(self.tempdir_name + '/spam')
+        self.check_status_and_reason(response, HTTPStatus.OK, data1)
+        data2 = b"The one true spam.\r\n"
+        with open(os.path.join(self.tempdir_name, 'spam'), 'wb') as f:
+            f.write(data2)
+        response = self.request(self.tempdir_name + '/spam')
+        self.check_status_and_reason(response, HTTPStatus.OK, data2)
+
     def test_html_escape_filename(self):
         filename = '<test&>.txt'
         fullpath = os.path.join(self.tempdir, filename)


### PR DESCRIPTION
Adds handling for extensionless URLs in http.server, where they will translated into the same filename with the `.html` extension. This PR adds a special case for URLs without any extension that will check common extensions before returning a 404 error.

Extensionless files are checked first for an exact match, then sequentially for the defined default_extensions (which unless overridden are .html and .htm), before returning a Not Found error if none exist.

The list of default extensions can be changed at runtime my passing a list of extensions to SimpleHTTPRequestHandler initiation.

Fixes #100463

<!-- gh-issue-number: gh-100463 -->
* Issue: gh-100463
<!-- /gh-issue-number -->
