### PR TITLE
gh-100465: Set metaclass of importlib.metadata.Distribution to abc.ABCMeta

### DIFF
--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -341,7 +341,7 @@ class FileHash:
         return f'<FileHash mode: {self.mode} value: {self.value}>'
 
 
-class Distribution:
+class Distribution(metaclass=abc.ABCMeta):
     """A Python distribution package."""
 
     @abc.abstractmethod


### PR DESCRIPTION
See issue python/importlib_metadata#419 for more details.

<!-- gh-issue-number: python/importlib_metadata#419 -->
* Issue: python/importlib_metadata#419
<!-- /gh-issue-number -->
