### PR TITLE
gh-100474: Fix handling of dirs named index.html in http.server

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -711,7 +711,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
                 return None
             for index in self.index_pages:
                 index = os.path.join(path, index)
-                if os.path.exists(index):
+                if os.path.isfile(index):
                     path = index
                     break
             else:

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -489,6 +489,9 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         self.check_status_and_reason(response, HTTPStatus.NOT_FOUND)
         response = self.request('/' + 'ThisDoesNotExist' + '/')
         self.check_status_and_reason(response, HTTPStatus.NOT_FOUND)
+        os.makedirs(os.path.join(self.tempdir, 'spam', 'index.html'))
+        response = self.request(self.base_url + '/spam/')
+        self.check_status_and_reason(response, HTTPStatus.OK)
 
         data = b"Dummy index file\r\n"
         with open(os.path.join(self.tempdir_name, 'index.html'), 'wb') as f:

--- a/Misc/NEWS.d/next/Library/2022-12-23-21-02-43.gh-issue-100474.gppA4U.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-23-21-02-43.gh-issue-100474.gppA4U.rst
@@ -1,2 +1,2 @@
-Check that index page is actually a regular file before trying to serve it.
-This avoids issues around directories named "index.html".
+:mod:`http.server` now checks that an index page is actually a regular file before trying
+to serve it.  This avoids issues with directories named `index.html`.

--- a/Misc/NEWS.d/next/Library/2022-12-23-21-02-43.gh-issue-100474.gppA4U.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-23-21-02-43.gh-issue-100474.gppA4U.rst
@@ -1,2 +1,2 @@
 :mod:`http.server` now checks that an index page is actually a regular file before trying
-to serve it.  This avoids issues with directories named `index.html`.
+to serve it.  This avoids issues with directories named ``index.html``.

--- a/Misc/NEWS.d/next/Library/2022-12-23-21-02-43.gh-issue-100474.gppA4U.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-23-21-02-43.gh-issue-100474.gppA4U.rst
@@ -1,0 +1,2 @@
+Check that index page is actually a regular file before trying to serve it.
+This avoids issues around directories named "index.html".


### PR DESCRIPTION
If you had a directory called index.html or index.htm within a directory, it would cause http.server to return a 404 Not Found error instead of the directory listing. This came about due to not checking that the index was a regular file.

I have also added a test case for this situation.

<!-- gh-issue-number: gh-100474 -->
* Issue: gh-100474
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:merwok