### PR TITLE
Remove wrong comment about `repr` in `test_unicode`

### DIFF
--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -94,7 +94,6 @@ class UnicodeTest(string_tests.CommonTest,
         self.assertNotEqual(r"\u0020", " ")
 
     def test_ascii(self):
-        # Test basic sanity of repr()
         self.assertEqual(ascii('abc'), "'abc'")
         self.assertEqual(ascii('ab\\c'), "'ab\\\\c'")
         self.assertEqual(ascii('ab\\'), "'ab\\\\'")


### PR DESCRIPTION
Comment is removed as it was asked in https://github.com/python/cpython/pull/99484 by @JelleZijlstra 

I think that it is worth removing:
- It is a bit misleading
- Test name is good enough to understand what is going on