### PR TITLE
gh-99908: Tutorial: Modernize the 'data-record class' example

### DIFF
--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -751,7 +751,7 @@ is to use :mod:`dataclasses` for this purpose::
 
 ::
 
-    >>> john = Employee("john", "computer lab", 1000)
+    >>> john = Employee('john', 'computer lab', 1000)
     >>> john.dept
     'computer lab'
     >>> john.salary

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -737,19 +737,23 @@ to code that is byte-compiled together.  The same restriction applies to
 Odds and Ends
 =============
 
-Sometimes it is useful to have a data type similar to the Pascal "record" or C
-"struct", bundling together a few named data items.  An empty class definition
-will do nicely::
+"struct", bundling together a few named data items. The idiomatic approach
+is to use :mod:`dataclasses` for this purpose::
 
-   class Employee:
-       pass
+    from dataclasses import dataclasses
 
-   john = Employee()  # Create an empty employee record
+    @dataclass
+    class Employee:
+        name: str
+        dept: str
+        salary: int
 
-   # Fill the fields of the record
-   john.name = 'John Doe'
-   john.dept = 'computer lab'
-   john.salary = 1000
+    john = Employee("john", "computer lab", 1000)
+
+    >>> john.dept
+    "computer lab"
+    >>> john.salary
+    1000
 
 A piece of Python code that expects a particular abstract data type can often be
 passed a class that emulates the methods of that data type instead.  For

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -737,6 +737,7 @@ to code that is byte-compiled together.  The same restriction applies to
 Odds and Ends
 =============
 
+Sometimes it is useful to have a data type similar to the Pascal "record" or C
 "struct", bundling together a few named data items. The idiomatic approach
 is to use :mod:`dataclasses` for this purpose::
 
@@ -748,10 +749,11 @@ is to use :mod:`dataclasses` for this purpose::
         dept: str
         salary: int
 
-    john = Employee("john", "computer lab", 1000)
+::
 
+    >>> john = Employee("john", "computer lab", 1000)
     >>> john.dept
-    "computer lab"
+    'computer lab'
     >>> john.salary
     1000
 


### PR DESCRIPTION
Modernize an antiquated example of a 'record' class to use dataclasses.

<!-- gh-issue-number: gh-99908 -->
* Issue: gh-99908
<!-- /gh-issue-number -->
