### PR TITLE
gh-100407: Improve __subclasshook__ docs

### DIFF
--- a/Doc/library/abc.rst
+++ b/Doc/library/abc.rst
@@ -109,28 +109,27 @@ a helper class :class:`ABC` to alternatively define ABCs through inheritance:
 
       .. XXX explain the "usual mechanism"
 
-
-   For a demonstration of these concepts, look at this example ABC definition::
+      ::
       
-      from abc import ABC, abstractmethod
+         from abc import ABC, abstractmethod
 
-      class MyIterable(ABC):
-          @abstractmethod
-          def __iter__(self):
-              return NotImplemented
-          
-          @classmethod
-          def __subclasshook__(cls, subclass: type) -> bool:
-              return hasattr(subclass, "__iter__")
-       
-       >>> MyIterable in list.__bases__
-       False
-       >>> issubclass(list, MyIterable)
-       True
+         class MyIterable(ABC):
+            @abstractmethod
+            def __iter__(self):
+               return NotImplemented
+            
+            @classmethod
+            def __subclasshook__(cls, subclass: type) -> bool:
+               return hasattr(subclass, "__iter__")
+         
+         >>> MyIterable in list.__bases__
+         False
+         >>> issubclass(list, MyIterable)
+         True
 
-   :class:`list` doesn't inherit from ``MyIterable``, nor is it registered as a subclass.
-   Using ``__subclasshook__`` it was possible to make not only :class:`list` but **all**
-   classes which define an ``__iter__`` method virtual subclasses of ``MyIterable``.
+      :class:`list` doesn't inherit from ``MyIterable``, nor is it registered as a subclass.
+      Using ``__subclasshook__`` it was possible to make not only :class:`list` but **all**
+      classes which define an ``__iter__`` method virtual subclasses of ``MyIterable``.
 
 
 The :mod:`abc` module also provides the following decorator:

--- a/Doc/library/abc.rst
+++ b/Doc/library/abc.rst
@@ -109,7 +109,7 @@ a helper class :class:`ABC` to alternatively define ABCs through inheritance:
 
       .. XXX explain the "usual mechanism"
 
-      ::
+      **Example use**::
       
          from abc import ABC, abstractmethod
 

--- a/Doc/library/abc.rst
+++ b/Doc/library/abc.rst
@@ -95,10 +95,10 @@ a helper class :class:`ABC` to alternatively define ABCs through inheritance:
 
       (Must be defined as a class method.)
       
-      Check whether *subclass* is considered a subclass of this ABC.  This allows
-      for *virtual* subclassing, where a class is considered a subclass of an
-      ABC by virtue of fulfilling some criteria, as opposed to by calling
-      :meth:`register` on *subclass* or having it inherit from the ABC.
+      Check whether *subclass* is considered a subclass of this ABC.
+      This mechanism allows customizing the behaviour of ``issubclass``
+      without needing to call :meth:`register` on classes that you want
+      to be considered subclasses of an ABC.
 
       This method should return ``True``, ``False`` or ``NotImplemented``.  If
       it returns ``True``, the *subclass* is considered a subclass of this ABC.


### PR DESCRIPTION
1. Provides a more concise example of `__subclasshook__` using `list` as opposed to a custom `Foo` class.
2. Removes `.register` from the example; IMO it obscured the purpose of the example unclear.
3. Explains the reason for the important `if cls is <ABCType>` pattern (used in most stdlib subclasshooks).

![image](https://user-images.githubusercontent.com/48555120/209444709-6cb8d2eb-6d98-4101-b3c8-07b69b2eb936.png)

<!-- gh-issue-number: gh-100407 -->
* Issue: gh-100407
<!-- /gh-issue-number -->
