### PR TITLE
Fix name of removed inspect.Signature method in 3.11.0a2 changelog

### DIFF
--- a/Misc/NEWS.d/3.11.0a2.rst
+++ b/Misc/NEWS.d/3.11.0a2.rst
@@ -618,7 +618,7 @@ Removed from the :mod:`inspect` module:
   use the :func:`inspect.signature` function and :class:`Signature` object
   directly.
 
-* the undocumented ``Signature.from_callable`` and ``Signature.from_function``
+* the undocumented ``Signature.from_builtin`` and ``Signature.from_function``
   functions, deprecated since Python 3.5; use the
   :meth:`Signature.from_callable() <inspect.Signature.from_callable>` method
   instead.


### PR DESCRIPTION
Noticed this while looking through removed and deprecated items in Python 3.11.

`skip issue` label needed