### PR TITLE
gh-100540: Remove unnecessary '-DMACOSX' for ctypes on macOS

### DIFF
--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -426,7 +426,7 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
         PyErr_Format(PyExc_NotImplementedError, "ffi_prep_closure_loc() is missing");
         goto error;
 #else
-#if defined(__clang__) || defined(MACOSX)
+#if defined(__clang__)
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -436,7 +436,7 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
 #endif
         result = ffi_prep_closure(p->pcl_write, &p->cif, closure_fcn, p);
 
-#if defined(__clang__) || defined(MACOSX)
+#if defined(__clang__)
         #pragma clang diagnostic pop
 #endif
 #if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5)))

--- a/configure
+++ b/configure
@@ -12846,7 +12846,7 @@ if test "x$have_libffi" = xyes; then :
   case $ac_sys_system in #(
   Darwin) :
 
-            as_fn_append LIBFFI_CFLAGS " -I\$(srcdir)/Modules/_ctypes/darwin -DMACOSX"
+            as_fn_append LIBFFI_CFLAGS " -I\$(srcdir)/Modules/_ctypes/darwin"
       ctypes_malloc_closure=yes
      ;; #(
   sunos5) :

--- a/configure.ac
+++ b/configure.ac
@@ -3769,7 +3769,7 @@ AS_VAR_IF([have_libffi], [yes], [
   AS_CASE([$ac_sys_system],
     [Darwin], [
       dnl when do we need USING_APPLE_OS_LIBFFI?
-      AS_VAR_APPEND([LIBFFI_CFLAGS], [" -I\$(srcdir)/Modules/_ctypes/darwin -DMACOSX"])
+      AS_VAR_APPEND([LIBFFI_CFLAGS], [" -I\$(srcdir)/Modules/_ctypes/darwin"])
       ctypes_malloc_closure=yes
     ],
     [sunos5], [AS_VAR_APPEND([LIBFFI_LIBS], [" -mimpure-text"])]


### PR DESCRIPTION
The define was only used to protect a `#pragma clang diagnostic`
setting, which is already better guarded by `__clang__` anwyay.


<!-- gh-issue-number: gh-100540 -->
* Issue: gh-100540
<!-- /gh-issue-number -->
