### PR TITLE
gh-100546: Remove incorrect positional-only marker from eval

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -513,7 +513,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. _func-eval:
 
-.. function:: eval(expression, /, globals=None, locals=None)
+.. function:: eval(expression, globals=None, locals=None)
 
    The arguments are a string and optional globals and locals.  If provided,
    *globals* must be a dictionary.  If provided, *locals* can be any mapping


### PR DESCRIPTION
All the arguments are positional-only.

The current status after #99476 seems to be to not use positional-only markers in documentation, hence I've simply removed it.

That said, there are still three other positional-only markers in this file).  I asked for clarification in
https://github.com/python/cpython/issues/100546#issuecomment-1365565055.
See also https://github.com/python/cpython/issues/98340

<!-- gh-issue-number: gh-100546 -->
* Issue: gh-100546
<!-- /gh-issue-number -->
