### PR TITLE
Remove `NoneType` redefinition from `clinic.py`

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -27,7 +27,6 @@ import traceback
 import types
 
 from types import *
-NoneType = type(None)
 
 # TODO:
 #
@@ -42,7 +41,6 @@ NoneType = type(None)
 
 version = '1'
 
-NoneType = type(None)
 NO_VARARG = "PY_SSIZE_T_MAX"
 CLINIC_PREFIX = "__clinic_"
 CLINIC_PREFIXED_ARGS = {"args"}


### PR DESCRIPTION
1. It is always definied in `types.py`, we have a star import from it above
2. It was defined twice for some reason

Skipping news and issue for this one.