### PR TITLE
Remove skipped test in test for async mocks.

### DIFF
--- a/Lib/test/test_unittest/testmock/testasync.py
+++ b/Lib/test/test_unittest/testmock/testasync.py
@@ -218,10 +218,6 @@ class AsyncAutospecTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             create_autospec(async_func, instance=True)
 
-    @unittest.skip('Broken test from https://bugs.python.org/issue37251')
-    def test_create_autospec_awaitable_class(self):
-        self.assertIsInstance(create_autospec(AwaitableClass), AsyncMock)
-
     def test_create_autospec(self):
         spec = create_autospec(async_func_args)
         awaitable = spec(1, 2, c=3)


### PR DESCRIPTION
See discussion on https://github.com/python/cpython/pull/25326.
Fix is apparently here, but no-one is confident to review and land: https://github.com/python/cpython/pull/25347.