### PR TITLE
Fix copy-paste error in `Tools/clinic.py`

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2828,7 +2828,7 @@ class CConverter(metaclass=CConverterAutoRegister):
         """
         The C statements required to modify this variable after parsing.
         Returns a string containing this code indented at column 0.
-        If no initialization is necessary, returns an empty string.
+        If no modification is necessary, returns an empty string.
         """
         return ""
 


### PR DESCRIPTION
While working on https://github.com/python/cpython/issues/100550 I've noticed that there's a copy-pasted phrase from https://github.com/python/cpython/blob/b0ea28913e3bf684ef847a71afcdfa8224bab63d/Tools/clinic/clinic.py#L2819-L2833

Skipping news and issue for a trivial change.