### PR TITLE
[3.11] GH-100342: check for allocation failure in AC `*args` parsing (GH-100343).

### DIFF
--- a/Lib/test/clinic.test
+++ b/Lib/test/clinic.test
@@ -3327,6 +3327,9 @@ test_vararg_and_posonly(PyObject *module, PyObject *const *args, Py_ssize_t narg
     }
     a = args[0];
     __clinic_args = PyTuple_New(nargs - 1);
+    if (!__clinic_args) {
+        goto exit;
+    }
     for (Py_ssize_t i = 0; i < nargs - 1; ++i) {
         PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[1 + i]));
     }
@@ -3339,7 +3342,7 @@ exit:
 
 static PyObject *
 test_vararg_and_posonly_impl(PyObject *module, PyObject *a, PyObject *args)
-/*[clinic end generated code: output=081a953b8cbe7617 input=08dc2bf7afbf1613]*/
+/*[clinic end generated code: output=79b75dc07decc8d6 input=08dc2bf7afbf1613]*/
 
 /*[clinic input]
 test_vararg

--- a/Misc/NEWS.d/next/Tools-Demos/2022-12-19-10-08-53.gh-issue-100342.qDFlQG.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2022-12-19-10-08-53.gh-issue-100342.qDFlQG.rst
@@ -1,0 +1,1 @@
+Add missing ``NULL`` check for possible allocation failure in ``*args`` parsing in Argument Clinic.

--- a/Modules/clinic/_testclinic.c.h
+++ b/Modules/clinic/_testclinic.c.h
@@ -2012,6 +2012,9 @@ vararg_and_posonly(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     a = args[0];
     __clinic_args = PyTuple_New(nargs - 1);
+    if (!__clinic_args) {
+        goto exit;
+    }
     for (Py_ssize_t i = 0; i < nargs - 1; ++i) {
         PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[1 + i]));
     }
@@ -2257,6 +2260,9 @@ gh_99233_refcount(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
     __clinic_args = PyTuple_New(nargs - 0);
+    if (!__clinic_args) {
+        goto exit;
+    }
     for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
         PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
     }
@@ -2299,4 +2305,4 @@ gh_99240_double_free(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=fe398ac790310bc4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6b719efc1b8bd2c8 input=a9049054013a1b77]*/

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -903,12 +903,16 @@ class CLanguage(Language):
                     if not new_or_init:
                         parser_code.append(normalize_snippet("""
                             %s = PyTuple_New(%s);
+                            if (!%s) {{
+                                goto exit;
+                            }}
                             for (Py_ssize_t i = 0; i < %s; ++i) {{
                                 PyTuple_SET_ITEM(%s, i, Py_NewRef(args[%d + i]));
                             }}
                             """ % (
                                 p.converter.parser_name,
                                 left_args,
+                                p.converter.parser_name,
                                 left_args,
                                 p.converter.parser_name,
                                 max_pos


### PR DESCRIPTION

(cherry picked from commit 7cf164ad5e3c8c6af5ae8813ad6a784448605418)

Co-authored-by: Kumar Aditya <59607654+kumaraditya303@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-100342 -->
* Issue: gh-100342
<!-- /gh-issue-number -->
