### PR TITLE
Fix `test_recursion_direct` failure on Windows buildbot

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1249,7 +1249,7 @@ Module(
         e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0)
         e.operand = e
         with self.assertRaises(RecursionError):
-            with support.infinite_recursion():
+            with support.infinite_recursion(max_depth=30):
                 compile(ast.Expression(e), "<test>", "eval")
 
     def test_recursion_indirect(self):
@@ -1258,7 +1258,7 @@ Module(
         e.operand = f
         f.operand = e
         with self.assertRaises(RecursionError):
-            with support.infinite_recursion():
+            with support.infinite_recursion(max_depth=30):
                 compile(ast.Expression(e), "<test>", "eval")
 
 

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1246,6 +1246,7 @@ Module(
         self.assertIn('sleep', ns)
 
     def test_recursion_direct(self):
+        self.skipTest('for now')
         e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0)
         e.operand = e
         with self.assertRaises(RecursionError):


### PR DESCRIPTION
My plan is to just decrease the recursion limit value, so it won't crash.
But first, I need to know what the value is (it is `75` by default now).
Example logs: https://buildbot.python.org/all/#/builders/729/builds/3229