### PR TITLE
gh-100585: Fixed a bug where importlib.resources.as_file was leaving file pointers open

### DIFF
--- a/Lib/importlib/resources/_common.py
+++ b/Lib/importlib/resources/_common.py
@@ -155,5 +155,5 @@ def _write_contents(target, source):
         for item in source.iterdir():
             _write_contents(child, item)
     else:
-        child.open('wb').write(source.read_bytes())
+        child.write_bytes(source.read_bytes())
     return child

--- a/Misc/NEWS.d/next/Library/2022-12-28-17-38-39.gh-issue-100585.BiiTlG.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-28-17-38-39.gh-issue-100585.BiiTlG.rst
@@ -1,0 +1,1 @@
+Fixed a bug where importlib.resources.as_file was leaving file pointers open


### PR DESCRIPTION
# gh-100585: Fixed a bug where importlib.resources.as_file was leaving file pointers open

`importlib.resources.as_file` was leaving temporary file pointers open in the `_write_contents` function.
Fixed it by using `Path.write_bytes` instead of `open('wb').write(...)`