### PR TITLE
gh-100600: Fix "coroutine was never awaited" warning in `test_coroutines`

### DIFF
--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2214,6 +2214,7 @@ class CoroutineTest(unittest.TestCase):
         gen = f()
         with self.assertWarns(RuntimeWarning):
             gen.cr_frame.clear()
+        gen.close()
 
     def test_stack_in_coroutine_throw(self):
         # Regression test for https://github.com/python/cpython/issues/93592


### PR DESCRIPTION
After:

```
» ./python.exe -m test -v test_coroutines -m test_bpo_45813_2
== CPython 3.12.0a3+ (heads/issue-100577-dirty:43e3659e33, Dec 28 2022, 14:38:55) [Clang 11.0.0 (clang-1100.0.33.16)]
== macOS-10.14.6-x86_64-i386-64bit little-endian
== Python build: debug
== cwd: /Users/sobolev/Desktop/cpython/build/test_python_47299æ
== CPU count: 4
== encodings: locale=UTF-8, FS=utf-8
0:00:00 load avg: 2.26 Run tests sequentially
0:00:00 load avg: 2.26 [1/1] test_coroutines
test_bpo_45813_2 (test.test_coroutines.CoroutineTest.test_bpo_45813_2)
This would crash the interpreter in 3.11a2 ... ok

----------------------------------------------------------------------
Ran 1 test in 0.002s

OK

== Tests result: SUCCESS ==

1 test OK.

Total duration: 402 ms
Tests result: SUCCESS
```

<!-- gh-issue-number: gh-100600 -->
* Issue: gh-100600
<!-- /gh-issue-number -->
