### PR TITLE
gh-89419: gdb: fix printing AttributeError in py-locals when no frame is available

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2022-12-29-19-22-11.bpo-45256.a0ee_H.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2022-12-29-19-22-11.bpo-45256.a0ee_H.rst
@@ -1,1 +1,1 @@
-Fix confusing AttributeError in python-gdb.py when py-locals is used without a frame.
+Fix a bug that caused an :exc:`AttributeError` to be raised in ``python-gdb.py`` when ``py-locals`` is used without a frame.

--- a/Misc/NEWS.d/next/Tools-Demos/2022-12-29-19-22-11.bpo-45256.a0ee_H.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2022-12-29-19-22-11.bpo-45256.a0ee_H.rst
@@ -1,0 +1,1 @@
+Fix confusing AttributeError in python-gdb.py when py-locals is used without a frame.

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -2108,6 +2108,7 @@ class PyLocals(gdb.Command):
         while True:
             if not pyop_frame:
                 print(UNABLE_READ_INFO_PYTHON_FRAME)
+                break
             if pyop_frame.is_shim():
                 break
 


### PR DESCRIPTION
```
Unable to read information on python frame
Python Exception <class 'AttributeError'>: 'NoneType' object has no attribute 'co_name'
```

Regression in commit b4903afd4debbbd71dc49a2c8fefa74a3b6c6832. While refactoring the code into a while loop, the previous early return when no frame exists went missing. We have just printed a message that we cannot get information about this, so the frame will be None, and we cannot attempt to use it.

Discovered on python 3.11, in python 3.12a2 this should error out with `.is_shim()` instead of `co_name`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-89419 -->
* Issue: gh-89419
<!-- /gh-issue-number -->
