### PR TITLE
GH-100623: Implement singledispatch on type/class arguments

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -871,7 +871,10 @@ def singledispatch(func):
             return True
         from typing import get_args
         return (_is_union_type(cls) and
-                all(isinstance(arg, type) for arg in get_args(cls)))
+                all(isinstance(arg, type) if not _is_type_type(arg)
+                                          else isinstance(get_args(arg)[0],
+                                                          type)
+                    for arg in get_args(cls)))
 
     def register(cls, func=None):
         """generic_func.register(cls, func) -> func
@@ -917,7 +920,10 @@ def singledispatch(func):
             from typing import get_args
 
             for arg in get_args(cls):
-                registry[arg] = func
+                if _is_type_type(arg):
+                    registry[type[get_args(arg)[0]]] = func
+                else:
+                    registry[arg] = func
         elif _is_type_type(cls):
             from typing import get_args
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -939,6 +939,7 @@ def singledispatch(func):
 
     funcname = getattr(func, '__name__', 'singledispatch function')
     registry[object] = func
+    registry[type[object]] = func
     wrapper.register = register
     wrapper.dispatch = dispatch
     wrapper.registry = types.MappingProxyType(registry)

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -786,16 +786,16 @@ def _find_impl(cls, registry):
     if get_origin(cls) is type:
         to_type_like_given = lambda t: type[t]
         class_ = get_args(cls)[0]
-        registry_classes = (
+        registry_classes = {
             get_args(key)[0]
             for key in registry.keys() if get_origin(key) is type
-        )
+        }
     else:
         to_type_like_given = lambda t: t
         class_ = cls
-        registry_classes = (
+        registry_classes = {
             key for key in registry.keys() if get_origin(key) is not type
-        )
+        }
     mro = _compose_mro(class_, registry_classes)
     match = None
     for t in mro:

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -946,8 +946,8 @@ def singledispatch(func):
             raise TypeError(f'{funcname} requires at least '
                             '1 positional argument')
 
-        from inspect import isclass
-        type_arg = type[arg1] if isclass(arg1 := args[0]) else arg1.__class__
+        type_arg = (type[arg1] if isinstance(arg1 := args[0], type)
+                               else arg1.__class__)
         return dispatch(type_arg)(*args, **kw)
 
     funcname = getattr(func, '__name__', 'singledispatch function')

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2945,7 +2945,11 @@ class TestSingleDispatch(unittest.TestCase):
 
         @f.register
         def _(arg: type[list|dict]):
-            return "list|dict"
+            return "type[list|dict]"
+
+        @f.register
+        def _(arg: type[set]|typing.Type[type(None)]):
+            return "type[set]|type[NoneType]"
 
         self.assertEqual(f(int), "type[int]")
         self.assertEqual(f(float), "type[float]")
@@ -2953,7 +2957,8 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(f(bytes), "type[bytes]")
         self.assertEqual(f(B), "type[A]")
         self.assertEqual(f(C), "default")
-        self.assertEqual(f(list), "list|dict")
+        self.assertEqual(f(list), "type[list|dict]")
+        self.assertEqual(f(type(None)), "type[set]|type[NoneType]")
 
 
 class CachedCostItem:

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2943,12 +2943,17 @@ class TestSingleDispatch(unittest.TestCase):
         def _(arg: B):
             return "B"
 
+        @f.register
+        def _(arg: type[list|dict]):
+            return "list|dict"
+
         self.assertEqual(f(int), "type[int]")
         self.assertEqual(f(float), "type[float]")
         self.assertEqual(f(str), "type[str]")
         self.assertEqual(f(bytes), "type[bytes]")
         self.assertEqual(f(B), "type[A]")
         self.assertEqual(f(C), "default")
+        self.assertEqual(f(list), "list|dict")
 
 
 class CachedCostItem:

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2905,6 +2905,47 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(f(""), "default")
         self.assertEqual(f(b""), "default")
 
+    def test_type_argument(self):
+        @functools.singledispatch
+        def f(arg):
+            return "default"
+
+        @f.register
+        def _(arg: type[int]):
+            return "type[int]"
+
+        @f.register
+        def _(arg: typing.Type[float]):
+            return "type[float]"
+
+        @f.register(type[str])
+        def _(arg):
+            return "type[str]"
+
+        @f.register(typing.Type[bytes])
+        def _(arg):
+            return "type[bytes]"
+
+        class A:
+            pass
+
+        class B(A):
+            pass
+
+        @f.register
+        def _(arg: type[A]):
+            return "type[A]"
+
+        @f.register
+        def _(arg: B):
+            return "B"
+
+        self.assertEqual(f(int), "type[int]")
+        self.assertEqual(f(float), "type[float]")
+        self.assertEqual(f(str), "type[str]")
+        self.assertEqual(f(bytes), "type[bytes]")
+        self.assertEqual(f(B), "type[A]")
+
 
 class CachedCostItem:
     _cost = 1

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2960,6 +2960,15 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(f(list), "type[list|dict]")
         self.assertEqual(f(type(None)), "type[set]|type[NoneType]")
 
+        with self.assertRaisesRegex(TypeError, "Invalid annotation for 'arg'"):
+            @f.register
+            def _(arg: type[2]):
+                pass
+
+        with self.assertRaisesRegex(TypeError, "Invalid annotation for 'arg'"):
+            @f.register
+            def _(arg: typing.Type[int]|type[3]):
+                pass
 
 class CachedCostItem:
     _cost = 1

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2932,6 +2932,9 @@ class TestSingleDispatch(unittest.TestCase):
         class B(A):
             pass
 
+        class C:
+            pass
+
         @f.register
         def _(arg: type[A]):
             return "type[A]"
@@ -2945,6 +2948,7 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(f(str), "type[str]")
         self.assertEqual(f(bytes), "type[bytes]")
         self.assertEqual(f(B), "type[A]")
+        self.assertEqual(f(C), "default")
 
 
 class CachedCostItem:

--- a/Misc/NEWS.d/next/Library/2022-12-30-15-21-50.gh-issue-100623.3hdA1o.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-30-15-21-50.gh-issue-100623.3hdA1o.rst
@@ -1,0 +1,1 @@
+Add support for dispatching on ``type[...]`` arguments to :func:`functools.singledispatch`.


### PR DESCRIPTION
# gh-100623: Implement singledispatch on type/class arguments

This implements dispatching on arguments that are themselves types/classes in [`functools.singledispatch`](https://docs.python.org/3/library/functools.html#functools.singledispatch).