### PR TITLE
gh-99953: Purge mention of numeric param style from sqlite3 docs

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -501,11 +501,7 @@ Module constants
 
    .. note::
 
-      The :mod:`!sqlite3` module supports ``qmark``, ``numeric``,
-      and ``named`` DB-API parameter styles,
-      because that is what the underlying SQLite library supports.
-      However, the DB-API does not allow multiple values for
-      the ``paramstyle`` attribute.
+      The ``named`` DB-API parameter style is also supported.
 
 .. data:: sqlite_version
 


### PR DESCRIPTION
The PEP-249 numeric style has never been supported.


<!-- gh-issue-number: gh-99953 -->
* Issue: gh-99953
<!-- /gh-issue-number -->
