### PR TITLE
Fix typo :the 'Method 1b' mentioned in longobject.c should be 'Method 1a'.

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1879,7 +1879,7 @@ long_to_decimal_string_internal(PyObject *aa,
 
     /* convert array of base _PyLong_BASE digits in pin to an array of
        base _PyLong_DECIMAL_BASE digits in pout, following Knuth (TAOCP,
-       Volume 2 (3rd edn), section 4.4, Method 1b). */
+       Volume 2 (3rd edn), section 4.4, Method 1a). */
     pin = a->ob_digit;
     pout = scratch->ob_digit;
     size = 0;


### PR DESCRIPTION
According to Knuth (TAOCP, Volume 2 (3rd edn), section 4.4, Page 319), the algorithm of long_to_decimal_string_internal is Method 1a, while long_from_non_binary_base() is Method 1b.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
![TAOCP](https://user-images.githubusercontent.com/64004730/210127271-55167f2d-efab-4d1e-8eee-ea56b3778104.png)
