### PR TITLE
gh-99951: Warn if there is an OpenSSL major version mismatch

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -264,6 +264,14 @@ import base64        # for DER-to-PEM translation
 import errno
 import warnings
 
+if not OPENSSL_VERSION_INFO[:2] == _OPENSSL_API_VERSION[:2]:
+    warnings.warn(
+        "Python was compiled against OpenSSL "
+        f"{_OPENSSL_API_VERSION[0]}.{_OPENSSL_API_VERSION[1]}, "
+        "but is using OpenSSL "
+        f"{OPENSSL_VERSION_INFO[0]}.{OPENSSL_VERSION_INFO[1]}. "
+        "OpenSSL does not guarantee compatibility between different major versions.",
+        category=RuntimeWarning, stacklevel=2)
 
 socket_error = OSError  # keep that public name in module namespace
 

--- a/Misc/NEWS.d/next/Core and Builtins/2022-12-31-13-27-16.gh-issue-99951.BGyDJT.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-12-31-13-27-16.gh-issue-99951.BGyDJT.rst
@@ -1,0 +1,1 @@
+Raises :exc:`RuntimeWarning` when there is an OpenSSL major version mismatch between the version python was compiled against and the version python is currently using.


### PR DESCRIPTION
While it is a rare edge case well beyond the average use case, there could be situation where there is an OpenSSL version mismatch between the version python was compiled against, and the version currently loaded. Because OpenSSL states that [major releases can break compatibility with previous versions](https://wiki.openssl.org/index.php/Versioning) and checks are cheap, there seems to be no harm if python warns when it happens.

tl;dr: This PR warns users when importing the `ssl` module when the OpenSSL major version mismatch between the version python was compiled against, and the one it is using.

<!-- gh-issue-number: gh-99951 -->
* Issue: gh-99951
<!-- /gh-issue-number -->
