### PR TITLE
IDLE - fix module browser test

### DIFF
--- a/Lib/idlelib/idle_test/test_browser.py
+++ b/Lib/idlelib/idle_test/test_browser.py
@@ -170,8 +170,7 @@ class ModuleBrowserTreeItemTest(unittest.TestCase):
 
         with mock.patch('os.path.exists', return_value=True):
             mbt.OnDoubleClick()
-            fopen.assert_called()
-            fopen.called_with(fname)
+            fopen.assert_called_once_with(fname)
 
 
 class ChildBrowserTreeItemTest(unittest.TestCase):


### PR DESCRIPTION
Bug reported by Christian Klein on [discuss](https://discuss.python.org/t/include-prefix-called-in-list-of-forbidden-method-prefixes-for-mock-objects-in-unsafe-mode/22249).