### PR TITLE
gh-100629: Added a note for implementation-defined behavior in set Documentation

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4341,10 +4341,6 @@ The constructors for both classes work the same:
 
       Add element *elem* to the set.
 
-   .. note::
-      Users are recommended to not to make any assumptions about which element is kept
-      because this behavior is implementation-defined, not specified by python.
-
    .. method:: remove(elem)
 
       Remove element *elem* from the set.  Raises :exc:`KeyError` if *elem* is
@@ -4363,6 +4359,9 @@ The constructors for both classes work the same:
 
       Remove all elements from the set.
 
+   .. note::
+      Users are recommended to not to make any assumptions about which element is kept
+      because this behavior is implementation-defined, not specified by python.   
 
    Note, the non-operator versions of the :meth:`update`,
    :meth:`intersection_update`, :meth:`difference_update`, and

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4360,7 +4360,7 @@ The constructors for both classes work the same:
       Remove all elements from the set.
 
    .. note::
-      Users are recommended to not to make any assumptions about which element is kept
+      It is recommended to not to make any assumptions about which element is kept
       because this behavior is implementation-defined, not specified by python.
 
    Note, the non-operator versions of the :meth:`update`,

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4343,7 +4343,7 @@ The constructors for both classes work the same:
 
    .. note::
       Users are recommended to not to make any assumptions about which element is kept
-      because this behavior is implementation-defined, not specified by python.   
+      because this behavior is implementation-defined, not specified by python.
 
    .. method:: remove(elem)
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4361,7 +4361,7 @@ The constructors for both classes work the same:
 
    .. note::
       Users are recommended to not to make any assumptions about which element is kept
-      because this behavior is implementation-defined, not specified by python.   
+      because this behavior is implementation-defined, not specified by python.
 
    Note, the non-operator versions of the :meth:`update`,
    :meth:`intersection_update`, :meth:`difference_update`, and

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4341,6 +4341,10 @@ The constructors for both classes work the same:
 
       Add element *elem* to the set.
 
+   .. note::
+      Users are recommended to not to make any assumptions about which element is kept
+      because this behavior is implementation-defined, not specified by python.   
+
    .. method:: remove(elem)
 
       Remove element *elem* from the set.  Raises :exc:`KeyError` if *elem* is


### PR DESCRIPTION

gh-100629: Added a note for implementation-defined behavior in Set documentation
