### PR TITLE
gh-100637: Fix int and bool __sizeof__ calculation to include the 1 element ob_digit array for 0 and False

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1459,7 +1459,7 @@ class SizeofTest(unittest.TestCase):
         # listreverseiterator (list)
         check(reversed([]), size('nP'))
         # int
-        check(0, vsize(''))
+        check(0, vsize('') + self.longdigit)
         check(1, vsize('') + self.longdigit)
         check(-1, vsize('') + self.longdigit)
         PyLong_BASE = 2**sys.int_info.bits_per_digit

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1322,6 +1322,7 @@ class SizeofTest(unittest.TestCase):
         check = self.check_sizeof
         # bool
         check(True, vsize('') + self.longdigit)
+        check(False, vsize('') + self.longdigit)
         # buffer
         # XXX
         # builtin_function_or_method

--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-01-15-59-48.gh-issue-100637.M2n6Kg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-01-15-59-48.gh-issue-100637.M2n6Kg.rst
@@ -1,0 +1,1 @@
+Fix :func:`int.__sizeof__` calculation to include the 1 element ob_digit array for 0 and False.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5879,7 +5879,10 @@ int___sizeof___impl(PyObject *self)
 {
     Py_ssize_t res;
 
-    res = offsetof(PyLongObject, ob_digit) + Py_MAX(Py_ABS(Py_SIZE(self)), 1)*sizeof(digit);
+    res = offsetof(PyLongObject, ob_digit)
+        /* using Py_MAX(..., 1) because we always allocate space for at least
+           one digit, even though the integer zero has a Py_SIZE of 0 */
+        + Py_MAX(Py_ABS(Py_SIZE(self)), 1)*sizeof(digit);
     return res;
 }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5879,7 +5879,7 @@ int___sizeof___impl(PyObject *self)
 {
     Py_ssize_t res;
 
-    res = offsetof(PyLongObject, ob_digit) + Py_ABS(Py_SIZE(self))*sizeof(digit);
+    res = offsetof(PyLongObject, ob_digit) + Py_MAX(Py_ABS(Py_SIZE(self)), 1)*sizeof(digit);
     return res;
 }
 


### PR DESCRIPTION
Fixes behavior where `int` and `bool` `__sizeof__` under-reports true size by 4 bytes as it did not take into account the size 1 `ob_digit` array for `0` and `False`.

## Changes

- 88e249bf0048a83e15ac9883737d1abf0ab7cea9 Use `Py_MAX` to use the maximum of 1 or the absolute `ob_size` size.
```c
offsetof(PyLongObject, ob_digit) + Py_MAX(Py_ABS(Py_SIZE(self)), 1)*sizeof(digit)
```

## Testing
- 391ec873612fde1a5ebc8957e527d0b2c59dcf6d Update sys.getsizeof unit test for int 0 to use the same size as the cases for -1 and 1 
- 88e249bf0048a83e15ac9883737d1abf0ab7cea9 Add a sys.getsizeof unit test for False matching the previous test case for True

<!-- gh-issue-number: gh-100637 -->
* Issue: gh-100637
<!-- /gh-issue-number -->
