### PR TITLE
gh-89727: Improve os.walk complexity and speed

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -279,7 +279,6 @@ def renames(old, new):
 
 __all__.extend(["makedirs", "removedirs", "renames"])
 
-
 def walk(top, topdown=True, onerror=None, followlinks=False):
     """Directory tree generator.
 

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -279,6 +279,7 @@ def renames(old, new):
 
 __all__.extend(["makedirs", "removedirs", "renames"])
 
+
 def walk(top, topdown=True, onerror=None, followlinks=False):
     """Directory tree generator.
 
@@ -341,11 +342,11 @@ def walk(top, topdown=True, onerror=None, followlinks=False):
     """
     sys.audit("os.walk", top, topdown, onerror, followlinks)
 
-    stack = [(False, fspath(top))]
+    stack = [fspath(top)]
     islink, join = path.islink, path.join
     while stack:
-        must_yield, top = stack.pop()
-        if must_yield:
+        top = stack.pop()
+        if isinstance(top, tuple):
             yield top
             continue
 
@@ -422,13 +423,13 @@ def walk(top, topdown=True, onerror=None, followlinks=False):
                 # the caller can replace the directory entry during the "yield"
                 # above.
                 if followlinks or not islink(new_path):
-                    stack.append((False, new_path))
+                    stack.append(new_path)
         else:
             # Yield after sub-directory traversal if going bottom up
-            stack.append((True, (top, dirs, nondirs)))
+            stack.append((top, dirs, nondirs))
             # Traverse into sub-directories
             for new_path in reversed(walk_dirs):
-                stack.append((False, new_path))
+                stack.append(new_path)
 
 __all__.append("walk")
 

--- a/Misc/NEWS.d/next/Library/2023-01-01-23-57-00.gh-issue-89727.ojedHN.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-01-23-57-00.gh-issue-89727.ojedHN.rst
@@ -1,1 +1,1 @@
-Simplify and optimize os.walk by using isinstance checks to check the top of the stack.
+Simplify and optimize :func:`os.walk` by using :func:`isinstance` checks to check the top of the stack.

--- a/Misc/NEWS.d/next/Library/2023-01-01-23-57-00.gh-issue-89727.ojedHN.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-01-23-57-00.gh-issue-89727.ojedHN.rst
@@ -1,0 +1,1 @@
+Simplify and optimize os.walk by using isinstance checks to check the top of the stack.


### PR DESCRIPTION
Use isinstance for checking the top of the stack in `os.walk` to simplify it and speed it up.

<!-- gh-issue-number: gh-89727 -->
* Issue: gh-89727
<!-- /gh-issue-number -->

A small benchmark below. `"."` is this repository.
![image](https://user-images.githubusercontent.com/17561586/210187800-a8a3572e-024b-4cef-b9e8-5484fcc22191.png)

