### PR TITLE
gh-100692: Add Windows info to `quit()` description

### DIFF
--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -94,6 +94,8 @@ should not be used in programs.
    (i.e. EOF) to exit", and when called, raise :exc:`SystemExit` with the
    specified exit code.
 
+   On Windows, "Use quit() or Ctrl-Z plus Return to exit" is printed instead.
+
 .. data:: copyright
           credits
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Addresses #100692.

Windows uses a `0x1a` byte, or `^Z` in caret notation, as the EOF marker.

<!-- gh-issue-number: gh-100692 -->
* Issue: gh-100692
<!-- /gh-issue-number -->
