### PR TITLE
gh-100673: Removed erroneous note in the get_type_hints docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2777,10 +2777,6 @@ Introspection helpers
    .. versionchanged:: 3.9
       Added ``include_extras`` parameter as part of :pep:`593`.
 
-   .. versionchanged:: 3.10
-      Calling ``get_type_hints()`` on a class no longer returns the annotations
-      of its base classes.
-
    .. versionchanged:: 3.11
       Previously, ``Optional[t]`` was added for function and method annotations
       if a default value equal to ``None`` was set.


### PR DESCRIPTION
typing.get_type_hints still includes base class type hints, contrary to a note in the docs claiming this was changed in Python 3.10. The note was a mistake. This PR removes the incorrect note.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-100673 -->
* Issue: gh-100673
<!-- /gh-issue-number -->
