### PR TITLE
GH-100766: Note that locale.LC_MESSAGES is not universal (GH-100702)

### DIFF
--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -496,6 +496,9 @@ The :mod:`locale` module defines the following exception and functions:
    system, like those returned by :func:`os.strerror` might be affected by this
    category.
 
+   This value may not be available on operating systems not conforming to the
+   POSIX standard, most notably Windows.
+
 
 .. data:: LC_NUMERIC
 


### PR DESCRIPTION
The `LC_MESSAGES` value in `locale` is not universally available. The value is generally imported from C headers through `localemodule.c`. The sourc notes this specifically:

https://github.com/python/cpython/blob/73097d91a64620ae7f620705864b84234d85cc82/Lib/locale.py#L25-L26

This makes the fact more visible to users only reading the documentation.


<!-- gh-issue-number: gh-100766 -->
* Issue: gh-100766
<!-- /gh-issue-number -->
