### PR TITLE
gh-100726: optimize construction of range object for medium sized integers

### DIFF
--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -129,6 +129,9 @@ _PyLong_IsPositiveSingleDigit(PyObject* sub) {
     return ((size_t)signed_size) <= 1;
 }
 
+long _PyLong_AsLongAndOverflow(const PyLongObject *v, int *overflow);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -129,6 +129,17 @@ _PyLong_IsPositiveSingleDigit(PyObject* sub) {
     return ((size_t)signed_size) <= 1;
 }
 
+/* Is this PyLong of size 1, 0 or -1? */
+#define IS_MEDIUM_VALUE(x) (((size_t)Py_SIZE(x)) + 1U < 3U)
+
+/* convert a PyLong of size 1, 0 or -1 to a C integer */
+static inline stwodigits
+medium_value(PyLongObject *x)
+{
+    assert(IS_MEDIUM_VALUE(x));
+    return ((stwodigits)Py_SIZE(x)) * x->ob_digit[0];
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -129,17 +129,6 @@ _PyLong_IsPositiveSingleDigit(PyObject* sub) {
     return ((size_t)signed_size) <= 1;
 }
 
-/* Is this PyLong of size 1, 0 or -1? */
-#define IS_MEDIUM_VALUE(x) (((size_t)Py_SIZE(x)) + 1U < 3U)
-
-/* convert a PyLong of size 1, 0 or -1 to a C integer */
-static inline stwodigits
-medium_value(PyLongObject *x)
-{
-    assert(IS_MEDIUM_VALUE(x));
-    return ((stwodigits)Py_SIZE(x)) * x->ob_digit[0];
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-03-20-59-20.gh-issue-100726.W9huFl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-03-20-59-20.gh-issue-100726.W9huFl.rst
@@ -1,0 +1,1 @@
+Optimize construction of `range` object for medium size integers.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-03-20-59-20.gh-issue-100726.W9huFl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-03-20-59-20.gh-issue-100726.W9huFl.rst
@@ -1,1 +1,1 @@
-Optimize construction of `range` object for medium size integers.
+Optimize construction of ``range`` object for medium size integers.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -477,7 +477,7 @@ PyLong_FromDouble(double dval)
 /* Get a C long int from a PyLong object
 
    On overflow, return -1 and set *overflow to 1 or -1 depending on the sign of
-   the result.  Otherwise *overflow is 0.
+   the result.  Otherwise *overflow is unchanged.
 
    Internal version, does not perform error checking
 */
@@ -486,8 +486,6 @@ _PyLong_AsLongAndOverflow(const PyLongObject *v, int *overflow)
 {
     assert(v != NULL);
     assert( PyLong_Check(v) );
-
-    *overflow = 0;
 
     long res = -1;
     Py_ssize_t i = Py_SIZE(v);
@@ -537,6 +535,7 @@ _PyLong_AsLongAndOverflow(const PyLongObject *v, int *overflow)
     return res;
 }
 
+
 /* Get a C long int from an int object or any object that has an __index__
    method.
 
@@ -552,6 +551,7 @@ PyLong_AsLongAndOverflow(PyObject *vv, int *overflow)
     /* This version by Tim Peters */
     PyLongObject *v;
     int do_decref = 0; /* if PyNumber_Index was called */
+    *overflow = 0;
 
     if (vv == NULL) {
         PyErr_BadInternalCall();
@@ -568,7 +568,6 @@ PyLong_AsLongAndOverflow(PyObject *vv, int *overflow)
         do_decref = 1;
     }
 
-    *overflow = 0;
     long res = _PyLong_AsLongAndOverflow(v, overflow);
 
     if (do_decref) {

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -22,6 +22,17 @@ class int "PyObject *" "&PyLong_Type"
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=ec0275e3422a36e3]*/
 
+/* Is this PyLong of size 1, 0 or -1? */
+#define IS_MEDIUM_VALUE(x) (((size_t)Py_SIZE(x)) + 1U < 3U)
+
+/* convert a PyLong of size 1, 0 or -1 to a C integer */
+static inline stwodigits
+medium_value(PyLongObject *x)
+{
+    assert(IS_MEDIUM_VALUE(x));
+    return ((stwodigits)Py_SIZE(x)) * x->ob_digit[0];
+}
+
 #define IS_SMALL_INT(ival) (-_PY_NSMALLNEGINTS <= (ival) && (ival) < _PY_NSMALLPOSINTS)
 #define IS_SMALL_UINT(ival) ((ival) < _PY_NSMALLPOSINTS)
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -474,45 +474,23 @@ PyLong_FromDouble(double dval)
 #define PY_ABS_LONG_MIN         (0-(unsigned long)LONG_MIN)
 #define PY_ABS_SSIZE_T_MIN      (0-(size_t)PY_SSIZE_T_MIN)
 
-/* Get a C long int from an int object or any object that has an __index__
-   method.
+/* Get a C long int from a PyLong object
 
    On overflow, return -1 and set *overflow to 1 or -1 depending on the sign of
    the result.  Otherwise *overflow is 0.
 
-   For other errors (e.g., TypeError), return -1 and set an error condition.
-   In this case *overflow will be 0.
+   Internal version, does not perform error checking
 */
-
-long
-PyLong_AsLongAndOverflow(PyObject *vv, int *overflow)
+inline long
+_PyLong_AsLongAndOverflow(const PyLongObject *v, int *overflow)
 {
-    /* This version by Tim Peters */
-    PyLongObject *v;
-    unsigned long x, prev;
-    long res;
-    Py_ssize_t i;
-    int sign;
-    int do_decref = 0; /* if PyNumber_Index was called */
+    assert(v != NULL);
+    assert( PyLong_Check(v) );
 
     *overflow = 0;
-    if (vv == NULL) {
-        PyErr_BadInternalCall();
-        return -1;
-    }
 
-    if (PyLong_Check(vv)) {
-        v = (PyLongObject *)vv;
-    }
-    else {
-        v = (PyLongObject *)_PyNumber_Index(vv);
-        if (v == NULL)
-            return -1;
-        do_decref = 1;
-    }
-
-    res = -1;
-    i = Py_SIZE(v);
+    long res = -1;
+    Py_ssize_t i = Py_SIZE(v);
 
     switch (i) {
     case -1:
@@ -525,14 +503,15 @@ PyLong_AsLongAndOverflow(PyObject *vv, int *overflow)
         res = v->ob_digit[0];
         break;
     default:
-        sign = 1;
-        x = 0;
+    {
+        int sign = 1;
+        unsigned long x = 0;
         if (i < 0) {
             sign = -1;
             i = -(i);
         }
         while (--i >= 0) {
-            prev = x;
+            unsigned long prev = x;
             x = (x << PyLong_SHIFT) | v->ob_digit[i];
             if ((x >> PyLong_SHIFT) != prev) {
                 *overflow = sign;
@@ -553,7 +532,45 @@ PyLong_AsLongAndOverflow(PyObject *vv, int *overflow)
             /* res is already set to -1 */
         }
     }
+    }
   exit:
+    return res;
+}
+
+/* Get a C long int from an int object or any object that has an __index__
+   method.
+
+   On overflow, return -1 and set *overflow to 1 or -1 depending on the sign of
+   the result.  Otherwise *overflow is 0.
+
+   For other errors (e.g., TypeError), return -1 and set an error condition.
+   In this case *overflow will be 0.
+*/
+long
+PyLong_AsLongAndOverflow(PyObject *vv, int *overflow)
+{
+    /* This version by Tim Peters */
+    PyLongObject *v;
+    int do_decref = 0; /* if PyNumber_Index was called */
+
+    if (vv == NULL) {
+        PyErr_BadInternalCall();
+        return -1;
+    }
+
+    if (PyLong_Check(vv)) {
+        v = (PyLongObject *)vv;
+    }
+    else {
+        v = (PyLongObject *)_PyNumber_Index(vv);
+        if (v == NULL)
+            return -1;
+        do_decref = 1;
+    }
+
+    *overflow = 0;
+    long res = _PyLong_AsLongAndOverflow(v, overflow);
+
     if (do_decref) {
         Py_DECREF(v);
     }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -22,17 +22,6 @@ class int "PyObject *" "&PyLong_Type"
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=ec0275e3422a36e3]*/
 
-/* Is this PyLong of size 1, 0 or -1? */
-#define IS_MEDIUM_VALUE(x) (((size_t)Py_SIZE(x)) + 1U < 3U)
-
-/* convert a PyLong of size 1, 0 or -1 to a C integer */
-static inline stwodigits
-medium_value(PyLongObject *x)
-{
-    assert(IS_MEDIUM_VALUE(x));
-    return ((stwodigits)Py_SIZE(x)) * x->ob_digit[0];
-}
-
 #define IS_SMALL_INT(ival) (-_PY_NSMALLNEGINTS <= (ival) && (ival) < _PY_NSMALLPOSINTS)
 #define IS_SMALL_UINT(ival) ((ival) < _PY_NSMALLPOSINTS)
 

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -175,22 +175,18 @@ static unsigned long
 get_len_of_range(long lo, long hi, long step);
 
 /// Return the length as a long, or -1 on error
-long compute_range_length_long(PyObject *start, PyObject *stop, PyObject *step) {
+long compute_range_length_long(PyLongObject *start, PyLongObject *stop, PyLongObject *step) {
     int overflow = 0;
-    long long_start = PyLong_AsLongAndOverflow(start, &overflow);
-    if (long_start==-1) {
-        // we have either an overflow or another type of error
-        if (overflow || PyErr_Occurred())
+    long long_start = _PyLong_AsLongAndOverflow(start, &overflow);
+    if (overflow) {
             return -1;
     }
-    long long_stop = PyLong_AsLongAndOverflow(stop, &overflow);
-    if (long_stop==-1) {
-        if (overflow || PyErr_Occurred())
+    long long_stop = _PyLong_AsLongAndOverflow(stop, &overflow);
+    if (overflow) {
             return -1;
     }
-    long long_step = PyLong_AsLongAndOverflow(step, &overflow);
-    if (long_step==-1) {
-        if (overflow || PyErr_Occurred())
+    long long_step = _PyLong_AsLongAndOverflow(step, &overflow);
+    if (overflow) {
             return -1;
     }
     return get_len_of_range(long_start, long_stop, long_step);
@@ -209,7 +205,7 @@ compute_range_length(PyObject *start, PyObject *stop, PyObject *step)
     ---------------------------------------------------------------*/
 
     // fast path when all arguments fit into a long integer
-    long len = compute_range_length_long(start, stop, step);
+    long len = compute_range_length_long((PyLongObject*)start, (PyLongObject*)stop, (PyLongObject*)step);
     if (len>=0) {
         return PyLong_FromLong(len);
     }

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -177,6 +177,7 @@ get_len_of_range(long lo, long hi, long step);
 /// Return the length as a long, or -1 on error
 long compute_range_length_long(PyLongObject *start, PyLongObject *stop, PyLongObject *step) {
     int overflow = 0;
+
     long long_start = _PyLong_AsLongAndOverflow(start, &overflow);
     if (overflow) {
             return -1;

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -188,7 +188,7 @@ compute_range_length(PyObject *start, PyObject *stop, PyObject *step)
 
     if (IS_MEDIUM_VALUE(start) && IS_MEDIUM_VALUE(stop) && IS_MEDIUM_VALUE(step) ) {
         // fast path when all arguments fit into a long integer
-        assert( PyLong_Check(start) && PyLong_Check(stop) && PyLong_Check(*step) );
+        assert( PyLong_Check(start) && PyLong_Check(stop) && PyLong_Check(step) );
         long len = get_len_of_range(medium_value((PyLongObject *)start), medium_value((PyLongObject *)stop), medium_value((PyLongObject *)step));
         return PyLong_FromLong(len);
     }

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -175,7 +175,7 @@ static unsigned long
 get_len_of_range(long lo, long hi, long step);
 
 /// Return the length as a long, or -1 on error
-long compute_range_length_long(PyLongObject *start, PyLongObject *stop, PyLongObject *step) {
+static inline long compute_range_length_long(PyLongObject *start, PyLongObject *stop, PyLongObject *step) {
     int overflow = 0;
 
     long long_start = _PyLong_AsLongAndOverflow(start, &overflow);

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -171,6 +171,9 @@ range_dealloc(rangeobject *r)
     PyObject_Free(r);
 }
 
+static unsigned long
+get_len_of_range(long lo, long hi, long step);
+
 /* Return number of items in range (lo, hi, step) as a PyLong object,
  * when arguments are PyLong objects.  Arguments MUST return 1 with
  * PyLong_Check().  Return NULL when there is an error.
@@ -182,6 +185,13 @@ compute_range_length(PyObject *start, PyObject *stop, PyObject *step)
     Algorithm is equal to that of get_len_of_range(), but it operates
     on PyObjects (which are assumed to be PyLong objects).
     ---------------------------------------------------------------*/
+
+    if (IS_MEDIUM_VALUE(start) && IS_MEDIUM_VALUE(stop) && IS_MEDIUM_VALUE(step) ) {
+        // fast path when all arguments fit into a long integer
+        assert( PyLong_Check(start) && PyLong_Check(stop) && PyLong_Check(*step) );
+        long len = get_len_of_range(medium_value((PyLongObject *)start), medium_value((PyLongObject *)stop), medium_value((PyLongObject *)step));
+        return PyLong_FromLong(len);
+    }
     int cmp_result;
     PyObject *lo, *hi;
     PyObject *diff = NULL;


### PR DESCRIPTION
The python `range` object contains code to compute the length from the start, stop and step values. This calculation is performed with PyLong objects which is expensive. This PR adds a fast path for the common case where start, stop and step all fit into a long value.

Benchmark results:
```
range(0, 5): Mean +- std dev: [main_range] 110 ns +- 1 ns -> [pr_range] 56.8 ns +- 1.3 ns: 1.93x faster
list(range(0, 5)): Mean +- std dev: [main_range] 243 ns +- 1 ns -> [pr_range] 181 ns +- 3 ns: 1.34x faster
range(-2, 3): Mean +- std dev: [main_range] 110 ns +- 2 ns -> [pr_range] 56.6 ns +- 1.0 ns: 1.94x faster
list(range(-2, 3)): Mean +- std dev: [main_range] 244 ns +- 3 ns -> [pr_range] 182 ns +- 4 ns: 1.34x faster
range(2, 60): Mean +- std dev: [main_range] 112 ns +- 1 ns -> [pr_range] 57.1 ns +- 1.4 ns: 1.96x faster
list(range(2, 60)): Mean +- std dev: [main_range] 535 ns +- 28 ns -> [pr_range] 472 ns +- 27 ns: 1.13x faster
range(2, 60, 2): Mean +- std dev: [main_range] 115 ns +- 1 ns -> [pr_range] 59.4 ns +- 1.4 ns: 1.94x faster
list(range(2, 60, 2)): Mean +- std dev: [main_range] 382 ns +- 11 ns -> [pr_range] 317 ns +- 5 ns: 1.21x faster
range(73786976294838206464, 73786976294838206469, 2): Mean +- std dev: [main_range] 136 ns +- 1 ns -> [pr_range] 137 ns +- 3 ns: 1.01x slower
list(range(73786976294838206464, 73786976294838206469, 2)): Mean +- std dev: [main_range] 444 ns +- 3 ns -> [pr_range] 440 ns +- 6 ns: 1.01x faster
for loop with range): Mean +- std dev: [main_range] 878 ns +- 12 ns -> [pr_range] 815 ns +- 21 ns: 1.08x faster

Geometric mean: 1.39x faster
```

<details>
<summary>Benchmark script</summary>

```
import pyperf
runner = pyperf.Runner()

cases = [(0,5), (-2, 3), (2, 60)]
for s,t in cases:
    time = runner.timeit(name=f'range({s}, {t})', stmt=f"range({s}, {t})")
    time = runner.timeit(name=f'list(range({s}, {t}))', stmt=f"list(range({s}, {t}))")

time = runner.timeit(name=f'range({s}, {t}, 2)', stmt=f"range({s}, {t}, 2)")
time = runner.timeit(name=f'list(range({s}, {t}, 2))', stmt=f"list(range({s}, {t}, 2))")

big = 2**66
s,t=big, big+5
time = runner.timeit(name=f'range({s}, {t}, 2)', stmt=f"range({s}, {t}, 2)")
time = runner.timeit(name=f'list(range({s}, {t}, 2))', stmt=f"list(range({s}, {t}, 2))")
    
stmt="""
v=0
for ii in range(20):
    v += ii*ii
"""
time = runner.timeit(name='for loop with range)', stmt=stmt)
```
</details>

**Notes**

* The macro and inline method `IS_MEDIUM_VALUE` and `medium_value` have been moved from `longobject.c` to the internal header files. The names have been kept the same to avoid too many changes. But since they are now visible outside `longobject.c` we can rename them to `_PyLong_IsMediumValue` and `_PyLong_MediumValue`.


<!-- gh-issue-number: gh-100726 -->
* Issue: gh-100726
<!-- /gh-issue-number -->
