### PR TITLE
gh-91219: http - use subclassing to override index_pages attribute

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -413,6 +413,11 @@ the current directory::
        print("serving at port", PORT)
        httpd.serve_forever()
 
+
+:class:`SimpleHTTPRequestHandler` can also be subclassed to enhance behavior,
+such as using different index file names by overriding the class attribute
+:attr:`index_pages`.
+
 .. _http-server-cli:
 
 :mod:`http.server` can also be invoked directly using the :option:`-m`

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -652,8 +652,8 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
     """
 
-    index_pages = ["index.html", "index.htm"]
     server_version = "SimpleHTTP/" + __version__
+    index_pages = ("index.html", "index.htm")
     extensions_map = _encodings_map_default = {
         '.gz': 'application/gzip',
         '.Z': 'application/octet-stream',
@@ -661,11 +661,9 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         '.xz': 'application/x-xz',
     }
 
-    def __init__(self, *args, directory=None, index_pages=None, **kwargs):
+    def __init__(self, *args, directory=None, **kwargs):
         if directory is None:
             directory = os.getcwd()
-        if index_pages is not None:
-            self.index_pages = index_pages
         self.directory = os.fspath(directory)
         super().__init__(*args, **kwargs)
 

--- a/Misc/NEWS.d/next/Library/2023-01-03-11-06-28.gh-issue-91219.s5IFCw.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-03-11-06-28.gh-issue-91219.s5IFCw.rst
@@ -1,0 +1,2 @@
+Change ``SimpleHTTPRequestHandler`` to support subclassing to provide a
+different set of index file names instead of using ``__init__`` parameters.


### PR DESCRIPTION


<!-- gh-issue-number: gh-91219 -->
* Issue: gh-91219
<!-- /gh-issue-number -->
