### PR TITLE
gh-87691: add an absolute path pathlib example in / operator docs

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -212,7 +212,10 @@ Paths of a different flavour compare unequal and cannot be ordered::
 Operators
 ^^^^^^^^^
 
-The slash operator helps create child paths, similarly to :func:`os.path.join`::
+The slash operator helps create child paths, mimicking the behaviour of
+:func:`os.path.join`. For instance, when several absolute paths are given, the
+last is taken as an anchor; for a Windows path, changing the local root doesn't
+discard the previous drive setting::
 
    >>> p = PurePath('/etc')
    >>> p
@@ -224,6 +227,8 @@ The slash operator helps create child paths, similarly to :func:`os.path.join`::
    PurePosixPath('/usr/bin')
    >>> p / '/an_absolute_path'
    PurePosixPath('/an_absolute_path')
+   >>> PureWindowsPath('c:/Windows', '/Program Files')
+   PureWindowsPath('c:/Program Files')
 
 A path object can be used anywhere an object implementing :class:`os.PathLike`
 is accepted::

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -222,8 +222,8 @@ The slash operator helps create child paths, similarly to :func:`os.path.join`::
    >>> q = PurePath('bin')
    >>> '/usr' / q
    PurePosixPath('/usr/bin')
-   >>> p / '/another' / 'absolute' / 'path'
-   PurePosixPath('/another/absolute/path')
+   >>> p / '/an_absolute_path'
+   PurePosixPath('/an_absolute_path')
 
 A path object can be used anywhere an object implementing :class:`os.PathLike`
 is accepted::

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -222,6 +222,8 @@ The slash operator helps create child paths, similarly to :func:`os.path.join`::
    >>> q = PurePath('bin')
    >>> '/usr' / q
    PurePosixPath('/usr/bin')
+   >>> p / '/another' / 'absolute' / 'path'
+   PurePosixPath('/another/absolute/path')
 
 A path object can be used anywhere an object implementing :class:`os.PathLike`
 is accepted::


### PR DESCRIPTION
The behaviour is fully explained a couple paragraphs above, but it may be useful to have a brief example to cover the behaviour.

<!-- gh-issue-number: gh-87691 -->
* Issue: gh-87691
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:hauntsaninja