### PR TITLE
[3.11] gh-89419: gdb: fix bug causing AttributeError in py-locals when no frame is available (GH-100611)

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2022-12-29-19-22-11.bpo-45256.a0ee_H.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2022-12-29-19-22-11.bpo-45256.a0ee_H.rst
@@ -1,0 +1,1 @@
+Fix a bug that caused an :exc:`AttributeError` to be raised in ``python-gdb.py`` when ``py-locals`` is used without a frame.

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -2126,6 +2126,7 @@ class PyLocals(gdb.Command):
         while True:
             if not pyop_frame:
                 print(UNABLE_READ_INFO_PYTHON_FRAME)
+                break
 
             sys.stdout.write('Locals for %s\n' % (pyop_frame.co_name.proxyval(set())))
 


### PR DESCRIPTION
```
Unable to read information on python frame
Python Exception <class 'AttributeError'>: 'NoneType' object has no attribute 'co_name'
```

Regression in commit b4903afd4debbbd71dc49a2c8fefa74a3b6c6832. While refactoring the code into a while loop, the previous early return when no frame exists went missing. We have just printed a message that we cannot get information about this, so the frame will be None, and we cannot attempt to use it.

Discovered on python 3.11, in python 3.12a2 this should error out with `.is_shim()` instead of `co_name`.

(cherry picked from commit 85869498331f7020e18bb243c89cd694f674b911)

<!-- gh-issue-number: gh-89419 -->
* Issue: gh-89419
<!-- /gh-issue-number -->
