### PR TITLE
gh-100739: Respect mock spec when checking for unsafe prefixes

### DIFF
--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -1652,6 +1652,22 @@ class MockTest(unittest.TestCase):
         m.aseert_foo_call()
         m.assrt_foo_call()
 
+    # gh-100739
+    def test_mock_safe_with_spec(self):
+        class Foo(object):
+            def assert_bar(self):
+                pass
+
+            def assertSome(self):
+                pass
+
+        m = Mock(spec=Foo)
+        m.assert_bar()
+        m.assertSome()
+
+        m.assert_bar.assert_called_once()
+        m.assertSome.assert_called_once()
+
     #Issue21262
     def test_assert_not_called(self):
         m = Mock()

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -652,7 +652,7 @@ class NonCallableMock(Base):
                 raise AttributeError("Mock object has no attribute %r" % name)
         elif _is_magic(name):
             raise AttributeError(name)
-        if not self._mock_unsafe:
+        if not self._mock_unsafe and (not self._mock_methods or name not in self._mock_methods):
             if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')):
                 raise AttributeError(
                     f"{name!r} is not a valid assertion. Use a spec "

--- a/Misc/NEWS.d/next/Library/2023-01-04-09-53-38.gh-issue-100740.-j5UjI.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-04-09-53-38.gh-issue-100740.-j5UjI.rst
@@ -1,0 +1,1 @@
+Fix Mock not respecting the spec for attribute names prefixed with assert

--- a/Misc/NEWS.d/next/Library/2023-01-04-09-53-38.gh-issue-100740.-j5UjI.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-04-09-53-38.gh-issue-100740.-j5UjI.rst
@@ -1,1 +1,1 @@
-Fix Mock not respecting the spec for attribute names prefixed with assert
+Fix ``unittest.mock.Mock`` not respecting the spec for attribute names prefixed with ``assert``.


### PR DESCRIPTION
Respect Mock spec for attribute names starting with assert (and typos)

<!-- gh-issue-number: gh-100739 -->
* Issue: gh-100739
<!-- /gh-issue-number -->
