### PR TITLE
gh-100689: Revert "bpo-41798: pyexpat: Allocate the expat_CAPI on the…

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
@@ -1,1 +1,1 @@
-Fix crash in ``_elementtree.c`` by reverting :gh:`24061`.
+Fix crash in ``_elementtree.c`` by reverting ``GH-24061``.

--- a/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
@@ -1,0 +1,1 @@
+Fix crash in ``_elementtree.c`` by reverting :gh:`24061`.

--- a/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
@@ -1,1 +1,1 @@
-Fix crash in ``_elementtree.c`` by reverting ``GH-24061``.
+Fix crash in ``_elementtree.c`` by statically allocating ``PyExpat_CAPI`` capsule. 

--- a/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
@@ -1,1 +1,1 @@
-Fix crash in ``_elementtree.c`` by statically allocating ``PyExpat_CAPI`` capsule.
+Fix crash in ``pyexpat`` by statically allocating ``PyExpat_CAPI`` capsule.

--- a/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
@@ -1,1 +1,1 @@
-Fix crash in ``pyexpat`` by statically allocating ``PyExpat_CAPI`` capsule.
+Fix crash in :mod:`pyexpat` by statically allocating ``PyExpat_CAPI`` capsule.

--- a/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-04-12-58-59.gh-issue-100689.Ce0ITG.rst
@@ -1,1 +1,1 @@
-Fix crash in ``_elementtree.c`` by statically allocating ``PyExpat_CAPI`` capsule. 
+Fix crash in ``_elementtree.c`` by statically allocating ``PyExpat_CAPI`` capsule.

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1878,13 +1878,6 @@ error:
 }
 #endif
 
-static void
-pyexpat_destructor(PyObject *op)
-{
-    void *p = PyCapsule_GetPointer(op, PyExpat_CAPSULE_NAME);
-    PyMem_Free(p);
-}
-
 static int
 pyexpat_exec(PyObject *mod)
 {
@@ -1972,46 +1965,40 @@ pyexpat_exec(PyObject *mod)
     MYCONST(XML_PARAM_ENTITY_PARSING_ALWAYS);
 #undef MYCONST
 
-    struct PyExpat_CAPI *capi = PyMem_Calloc(1, sizeof(struct PyExpat_CAPI));
-    if (capi == NULL) {
-        PyErr_NoMemory();
-        return -1;
-    }
+    static struct PyExpat_CAPI capi;
     /* initialize pyexpat dispatch table */
-    capi->size = sizeof(*capi);
-    capi->magic = PyExpat_CAPI_MAGIC;
-    capi->MAJOR_VERSION = XML_MAJOR_VERSION;
-    capi->MINOR_VERSION = XML_MINOR_VERSION;
-    capi->MICRO_VERSION = XML_MICRO_VERSION;
-    capi->ErrorString = XML_ErrorString;
-    capi->GetErrorCode = XML_GetErrorCode;
-    capi->GetErrorColumnNumber = XML_GetErrorColumnNumber;
-    capi->GetErrorLineNumber = XML_GetErrorLineNumber;
-    capi->Parse = XML_Parse;
-    capi->ParserCreate_MM = XML_ParserCreate_MM;
-    capi->ParserFree = XML_ParserFree;
-    capi->SetCharacterDataHandler = XML_SetCharacterDataHandler;
-    capi->SetCommentHandler = XML_SetCommentHandler;
-    capi->SetDefaultHandlerExpand = XML_SetDefaultHandlerExpand;
-    capi->SetElementHandler = XML_SetElementHandler;
-    capi->SetNamespaceDeclHandler = XML_SetNamespaceDeclHandler;
-    capi->SetProcessingInstructionHandler = XML_SetProcessingInstructionHandler;
-    capi->SetUnknownEncodingHandler = XML_SetUnknownEncodingHandler;
-    capi->SetUserData = XML_SetUserData;
-    capi->SetStartDoctypeDeclHandler = XML_SetStartDoctypeDeclHandler;
-    capi->SetEncoding = XML_SetEncoding;
-    capi->DefaultUnknownEncodingHandler = PyUnknownEncodingHandler;
+    capi.size = sizeof(capi);
+    capi.magic = PyExpat_CAPI_MAGIC;
+    capi.MAJOR_VERSION = XML_MAJOR_VERSION;
+    capi.MINOR_VERSION = XML_MINOR_VERSION;
+    capi.MICRO_VERSION = XML_MICRO_VERSION;
+    capi.ErrorString = XML_ErrorString;
+    capi.GetErrorCode = XML_GetErrorCode;
+    capi.GetErrorColumnNumber = XML_GetErrorColumnNumber;
+    capi.GetErrorLineNumber = XML_GetErrorLineNumber;
+    capi.Parse = XML_Parse;
+    capi.ParserCreate_MM = XML_ParserCreate_MM;
+    capi.ParserFree = XML_ParserFree;
+    capi.SetCharacterDataHandler = XML_SetCharacterDataHandler;
+    capi.SetCommentHandler = XML_SetCommentHandler;
+    capi.SetDefaultHandlerExpand = XML_SetDefaultHandlerExpand;
+    capi.SetElementHandler = XML_SetElementHandler;
+    capi.SetNamespaceDeclHandler = XML_SetNamespaceDeclHandler;
+    capi.SetProcessingInstructionHandler = XML_SetProcessingInstructionHandler;
+    capi.SetUnknownEncodingHandler = XML_SetUnknownEncodingHandler;
+    capi.SetUserData = XML_SetUserData;
+    capi.SetStartDoctypeDeclHandler = XML_SetStartDoctypeDeclHandler;
+    capi.SetEncoding = XML_SetEncoding;
+    capi.DefaultUnknownEncodingHandler = PyUnknownEncodingHandler;
 #if XML_COMBINED_VERSION >= 20100
-    capi->SetHashSalt = XML_SetHashSalt;
+    capi.SetHashSalt = XML_SetHashSalt;
 #else
-    capi->SetHashSalt = NULL;
+    capi.SetHashSalt = NULL;
 #endif
 
     /* export using capsule */
-    PyObject *capi_object = PyCapsule_New(capi, PyExpat_CAPSULE_NAME,
-                                          pyexpat_destructor);
+    PyObject *capi_object = PyCapsule_New(&capi, PyExpat_CAPSULE_NAME, NULL);
     if (capi_object == NULL) {
-        PyMem_Free(capi);
         return -1;
     }
 


### PR DESCRIPTION
… heap memory (GH-24061)"

This reverts commit 7c83eaa536d2f436ae46211ca48692f576c732f0.

This would need to be back-ported to 3.10 and 3.11

<!-- gh-issue-number: gh-100689 -->
* Issue: gh-100689
<!-- /gh-issue-number -->
