### PR TITLE
gh-9886c: Fixed hls colors going out of bounds 0.0-1.0

### DIFF
--- a/Lib/colorsys.py
+++ b/Lib/colorsys.py
@@ -94,7 +94,7 @@ def rgb_to_hls(r, g, b):
     else:
         h = 4.0+gc-rc
     h = (h/6.0) % 1.0
-    return h, l, s
+    return round(h, 14), round(l, 14), round(s, 14)
 
 def hls_to_rgb(h, l, s):
     if s == 0.0:


### PR DESCRIPTION
Return values of this function were going out of bounds of 0.0 - 1.0, fixed that.
[Parent PR from where this issue is coming from](https://github.com/matplotlib/matplotlib/pull/24885).