### PR TITLE
gh-100755: Use SHA512 for multiprocessing HMAC digests

### DIFF
--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -803,7 +803,7 @@ def deliver_challenge(connection, authkey):
             "Authkey must be bytes, not {0!s}".format(type(authkey)))
     message = os.urandom(MESSAGE_LENGTH)
     connection.send_bytes(CHALLENGE + message)
-    digest = hmac.new(authkey, message, 'md5').digest()
+    digest = hmac.new(authkey, message, 'sha512').digest()
     response = connection.recv_bytes(256)        # reject large message
     if response == digest:
         connection.send_bytes(WELCOME)
@@ -819,7 +819,7 @@ def answer_challenge(connection, authkey):
     message = connection.recv_bytes(256)         # reject large message
     assert message[:len(CHALLENGE)] == CHALLENGE, 'message = %r' % message
     message = message[len(CHALLENGE):]
-    digest = hmac.new(authkey, message, 'md5').digest()
+    digest = hmac.new(authkey, message, 'sha512').digest()
     connection.send_bytes(digest)
     response = connection.recv_bytes(256)        # reject large message
     if response != WELCOME:


### PR DESCRIPTION
Specifically for the `deliver_challenge` and `answer_challenge` methods.

<!-- gh-issue-number: gh-100755 -->
* Issue: gh-100755
<!-- /gh-issue-number -->
