### PR TITLE
[3.10] gh-90104: avoid RecursionError on recursive dataclass field repr (gh-100756)

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -67,6 +67,24 @@ class TestCase(unittest.TestCase):
 
         self.assertEqual(repr_output, expected_output)
 
+    def test_field_recursive_repr(self):
+        rec_field = field()
+        rec_field.type = rec_field
+        rec_field.name = "id"
+        repr_output = repr(rec_field)
+
+        self.assertIn(",type=...,", repr_output)
+
+    def test_recursive_annotation(self):
+        class C:
+            pass
+
+        @dataclass
+        class D:
+            C: C = field()
+
+        self.assertIn(",type=...,", repr(D.__dataclass_fields__["C"]))
+
     def test_named_init_params(self):
         @dataclass
         class C:

--- a/Misc/NEWS.d/next/Library/2023-01-04-22-10-31.gh-issue-90104.yZk5EX.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-04-22-10-31.gh-issue-90104.yZk5EX.rst
@@ -1,0 +1,1 @@
+Avoid RecursionError on ``repr`` if a dataclass field definition has a cyclic reference.


### PR DESCRIPTION
Avoid RecursionError on recursive dataclass field repr

(cherry picked from commit 0a7936a38f0bab1619ee9fe257880a51c9d839d5)


<!-- gh-issue-number: gh-90104 -->
* Issue: gh-90104
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:ericvsmith