### PR TITLE
[3.7] gh-81435: Fixed an issue that `self.rfile.read` in Windows can't read the complete POST form if the form is big enough.

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -104,6 +104,7 @@ import socketserver
 import sys
 import time
 import urllib.parse
+import tempfile
 from functools import partial
 
 from http import HTTPStatus
@@ -1219,8 +1220,7 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
             chunk_size = 1 * 1024 * 1024
 
             # Receive client POST form in chunks, if the size is more than one chunk, use a temp file to store it.
-            tmpdir = os.path.join(os.path.dirname(scriptfile), f'tmp{os.path.sep}')
-            if not os.path.exists(tmpdir): os.makedirs(tmpdir)
+            tmpdir = tempfile.gettempdir()
             tmpfile = os.path.join(tmpdir, f'{p.pid}.tmp')
 
             # log with frequency limit

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1213,24 +1213,84 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
                                  env = env
                                  )
             if self.command.lower() == "post" and nbytes > 0:
-                data = self.rfile.read(nbytes)
+                to_read = nbytes
             else:
+                to_read = 0
+            chunk_size = 1 * 1024 * 1024
+
+            # Receive client POST form in chunks, if the size is more than one chunk, use a temp file to store it.
+            tmpdir = os.path.join(os.path.dirname(scriptfile), f'tmp{os.path.sep}')
+            if not os.path.exists(tmpdir): os.makedirs(tmpdir)
+            tmpfile = os.path.join(tmpdir, f'{p.pid}.tmp')
+
+            # log with frequency limit
+            last_report = 0
+            def timed_log(content, interval = 0.5):
+                nonlocal last_report
+                thistime = time.time()
+                if thistime - last_report >= interval:
+                    self.log_message(content)
+                    last_report = thistime
+
+            # Receive chunks
+            data = None
+            if nbytes <= chunk_size:
+                usetmpfile = False
+                while to_read:
+                    if data is None:
+                        data = self.rfile.read(to_read)
+                    else:
+                        data += self.rfile.read(to_read)
+                        timed_log(f'Received {len(data)} bytes of {nbytes} bytes data')
+                    to_read = nbytes - len(data)
+                if data is not None:
+                    self.log_message(f'Received {len(data)} bytes of {nbytes} bytes data')
+            else:
+                usetmpfile = True
+                self.log_message(f'Using temp file {tmpfile}')
+                with open(tmpfile, 'wb') as f:
+                    while to_read:
+                        data = self.rfile.read(to_read)
+                        f.write(data)
+                        if len(data):
+                            timed_log(f'Received {nbytes - to_read} bytes of {nbytes} bytes data')
+                        to_read -= len(data)
+                self.log_message(f'Received {nbytes - to_read} bytes of {nbytes} bytes data')
                 data = None
-            # throw away additional data [see bug #427345]
-            while select.select([self.rfile._sock], [], [], 0)[0]:
-                if not self.rfile._sock.recv(1):
-                    break
+
+            if nbytes > 0 and to_read == 0:
+                # throw away additional data [see bug #427345]
+                while select.select([self.rfile._sock], [], [], 0)[0]:
+                    if not self.rfile._sock.recv(1):
+                        break
+
+            # After received all POST form, transfer it to the CGI process
+            if usetmpfile:
+                with open(tmpfile, 'rb') as f:
+                    while True:
+                        data = f.read(chunk_size)
+                        if not data:
+                            data = None
+                            break
+                        try:
+                            p.stdin.write(data)
+                        except BrokenPipeError:
+                            break
+                os.remove(tmpfile)
+                self.log_message(f'Deleted {tmpfile}')
+
             stdout, stderr = p.communicate(data)
             self.wfile.write(stdout)
             if stderr:
                 self.log_error('%s', stderr)
-            p.stderr.close()
-            p.stdout.close()
             status = p.returncode
-            if status:
-                self.log_error("CGI script exit status %#x", status)
-            else:
-                self.log_message("CGI script exited OK")
+            if status is not None:
+                if status:
+                    self.log_error("CGI script exit status %#x", status)
+                else:
+                    self.log_message("CGI script exited OK")
+                p.stdout.close()
+                p.stderr.close()
 
 
 def test(HandlerClass=BaseHTTPRequestHandler,

--- a/Misc/NEWS.d/next/Windows/2023-01-06-13-36-40.gh-issue-81435.pF7otv.rst
+++ b/Misc/NEWS.d/next/Windows/2023-01-06-13-36-40.gh-issue-81435.pF7otv.rst
@@ -1,0 +1,1 @@
+Now `CGIHTTPRequestHandler` is able to handle long POST content especially files uploaded from clients.


### PR DESCRIPTION
# gh-81435: Fixed an issue that `self.rfile.read` in Windows can't read the complete POST form if the form is big enough.

I'm trying to implement a local network service that allows users to upload files to process on the server, but it will fail if the file is bigger than 3 MB.