### PR TITLE
GH-100807: 🔥 Drop unused `BADF` def from stdlib `socket`

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -59,7 +59,6 @@ try:
     import errno
 except ImportError:
     errno = None
-EBADF = getattr(errno, 'EBADF', 9)
 EAGAIN = getattr(errno, 'EAGAIN', 11)
 EWOULDBLOCK = getattr(errno, 'EWOULDBLOCK', 11)
 


### PR DESCRIPTION
This variable is unused and is leftover from the decade-old cleanup/refactoring. It was initially hardcoded in Python 2.2 via https://github.com/python/cpython/commit/e5e50591. Then, almost two years later, in Python 2.3, it was replaced with this constant via https://github.com/python/cpython/commit/70d566be. Four years after that, Python 2.7 had a substantial refactoring of the `socket` module which removed the use of this constant in
https://github.com/python/cpython/commit/7d0a8264 and during almost 16 following years it remained unused.

This patch removes it as it's not really necessary to keep it — it shouldn't be exposed via `socket.EBADF` in addition to `errno.EBADF`.