### PR TITLE
gh-100783: fix os.path.join documentation

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -309,7 +309,7 @@ the :mod:`glob` module.)
    Join one or more path segments intelligently.  The return value is the
    concatenation of *path* and all members of *\*paths*, with exactly one
    directory separator following each non-empty part except the last, meaning
-   that the result will only end in a separator if the last part is empty.  If
+   that the result will end in a separator if the last part is empty.  If
    a segment is an absolute path (which on Windows requires both a drive and a
    root), then all previous segments are ignored and joining continues from the
    absolute path segment.

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -315,7 +315,7 @@ the :mod:`glob` module.)
    absolute path segment.
 
    On Windows, the drive is not reset when a rooted path segment (e.g.,
-   ``r'\foo'``) is encountered. If a segment is from a different drive or is an
+   ``r'\foo'``) is encountered. If a segment is on a different drive or is an
    absolute path, all previous segments are ignored and the drive is reset. Note
    that since there is a current directory for each drive,
    ``os.path.join("c:", "foo")`` represents a path relative to the current

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -306,17 +306,17 @@ the :mod:`glob` module.)
 
 .. function:: join(path, *paths)
 
-   Join one or more path components intelligently.  The return value is the
+   Join one or more path segments intelligently.  The return value is the
    concatenation of *path* and any members of *\*paths* with exactly one
    directory separator following each non-empty part except the last, meaning
    that the result will only end in a separator if the last part is empty.  If
-   a component is an absolute path, all previous components are thrown away
-   and joining continues from the absolute path component.
+   a segment is an absolute path, all previous segments are ignored
+   and joining continues from the absolute path segment.
 
-   On Windows, the drive letter is not reset when an absolute path component
-   (e.g., ``r'\foo'``) is encountered.  If a component contains a drive
-   letter, all previous components are thrown away and the drive letter is
-   reset.  Note that since there is a current directory for each drive,
+   On Windows, the drive is not reset when a rooted path segment (e.g.,
+   ``r'\foo'``) is encountered. If a segment is from a different drive or is an
+   absolute path, all previous segments are ignored and the drive is reset. Note
+   that since there is a current directory for each drive,
    ``os.path.join("c:", "foo")`` represents a path relative to the current
    directory on drive :file:`C:` (:file:`c:foo`), not :file:`c:\\foo`.
 

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -308,8 +308,8 @@ the :mod:`glob` module.)
 
    Join one or more path segments intelligently.  The return value is the
    concatenation of *path* and all members of *\*paths*, with exactly one
-   directory separator following each non-empty part except the last, meaning
-   that the result will end in a separator if the last part is empty.  If
+   directory separator following each non-empty part except the last. That is,
+   if the last part is empty, the result will end in a separator. If
    a segment is an absolute path (which on Windows requires both a drive and a
    root), then all previous segments are ignored and joining continues from the
    absolute path segment.

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -307,7 +307,7 @@ the :mod:`glob` module.)
 .. function:: join(path, *paths)
 
    Join one or more path segments intelligently.  The return value is the
-   concatenation of *path* and any members of *\*paths* with exactly one
+   concatenation of *path* and all members of *\*paths*, with exactly one
    directory separator following each non-empty part except the last, meaning
    that the result will only end in a separator if the last part is empty.  If
    a segment is an absolute path (which on Windows requires both a drive and a

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -310,8 +310,9 @@ the :mod:`glob` module.)
    concatenation of *path* and any members of *\*paths* with exactly one
    directory separator following each non-empty part except the last, meaning
    that the result will only end in a separator if the last part is empty.  If
-   a segment is an absolute path, all previous segments are ignored
-   and joining continues from the absolute path segment.
+   a segment is an absolute path (which on Windows requires both a drive and a
+   root), then all previous segments are ignored and joining continues from the
+   absolute path segment.
 
    On Windows, the drive is not reset when a rooted path segment (e.g.,
    ``r'\foo'``) is encountered. If a segment is from a different drive or is an


### PR DESCRIPTION
- Use "drive", not "drive letter", because of UNC paths
- Previous components are not thrown away from relative drive letters
- Use "segment" instead of "component" for consistency with pathlib

See issue for more details

<!-- gh-issue-number: gh-100783 -->
* Issue: gh-100783
<!-- /gh-issue-number -->
