### PR TITLE
gh-100817: Speed up `copy.deepcopy` calls on `slice` objects

### DIFF
--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -185,6 +185,7 @@ d[str] = _deepcopy_atomic
 d[types.CodeType] = _deepcopy_atomic
 d[type] = _deepcopy_atomic
 d[range] = _deepcopy_atomic
+d[slice] = _deepcopy_atomic
 d[types.BuiltinFunctionType] = _deepcopy_atomic
 d[types.FunctionType] = _deepcopy_atomic
 d[weakref.ref] = _deepcopy_atomic

--- a/Lib/test/test_copy.py
+++ b/Lib/test/test_copy.py
@@ -354,7 +354,7 @@ class TestCopy(unittest.TestCase):
             pass
         tests = [None, 42, 2**100, 3.14, True, False, 1j,
                  "hello", "hello\u1234", f.__code__,
-                 NewStyle, range(10), max, property()]
+                 NewStyle, range(10), max, property(), slice(1, 10, 1)]
         for x in tests:
             self.assertIs(copy.deepcopy(x), x)
 

--- a/Misc/NEWS.d/next/Library/2023-01-07-12-38-22.gh-issue-100817.7iMrim.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-07-12-38-22.gh-issue-100817.7iMrim.rst
@@ -1,0 +1,1 @@
+Speed up ``copy.deepcopy`` calls on ``slice`` instances.


### PR DESCRIPTION
See the original issue for microbenchmarks.

<!-- gh-issue-number: gh-100817 -->
* Issue: gh-100817
<!-- /gh-issue-number -->
