### PR TITLE
[3.10] gh-100673: Removed erroneous note in the get_type_hints docs (#100701)

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2233,10 +2233,6 @@ Introspection helpers
    .. versionchanged:: 3.9
       Added ``include_extras`` parameter as part of :pep:`593`.
 
-   .. versionchanged:: 3.10
-      Calling ``get_type_hints()`` on a class no longer returns the annotations
-      of its base classes.
-
 .. function:: get_args(tp)
 .. function:: get_origin(tp)
 


### PR DESCRIPTION
Removed erroneous note in the get_type_hints docs

typing.get_type_hints still includes base class type hints.

(cherry picked from commit deaf090699a7312cccb0637409f44de3f382389b)


<!-- gh-issue-number: gh-100673 -->
* Issue: gh-100673
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:AlexWaygood