### PR TITLE
GH-100485: Convert from Fast2Sum to 2Sum

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2847,7 +2847,7 @@ based on ideas from three sources:
 
 The double length routines allow for quite a bit of instruction
 level parallelism.  On a 3.22 Ghz Apple M1 Max, the incremental
-cost of increasing the input vector size by one is 6.25 nsec.
+cost of increasing the input vector size by one is 6.0 nsec.
 
 dl_zero() returns an extended precision zero
 dl_split() exactly splits a double into two half precision components.
@@ -2866,38 +2866,14 @@ dl_zero()
     return (DoubleLength) {0.0, 0.0};
 }
 
-#if 0
-static inline DoubleLength
-fasttwosum(double a, double b)
-{
-    double x = a + b;
-    double y = (a - x) + b;
-    assert (fabs(a) >= fabs(b));
-    return (DoubleLength) {x, y};
-}
-
-static inline DoubleLength
-dl_add(DoubleLength total, double x)
-{
-    DoubleLength s;
-    if (fabs(total.hi) >= fabs(x)) {
-        s = fasttwosum(total.hi, x);
-    } else {
-        s = fasttwosum(x, total.hi);
-    }
-    return (DoubleLength) {s.hi, total.lo + s.lo};
-}
-
-#else
-
 static inline DoubleLength
 twosum(double a, double b)
 {
     double s = a + b;
     double ap = s - b;
     double bp = s - a;
-    double da = (a - ap);
-    double db = (b - bp);
+    double da = a - ap;
+    double db = b - bp;
     double t = da + db;
     return  (DoubleLength) {s, t};
 }
@@ -2908,8 +2884,6 @@ dl_add(DoubleLength total, double x)
     DoubleLength s = twosum(total.hi, x);
     return (DoubleLength) {s.hi, total.lo + s.lo};
 }
-
-#endif
 
 static inline DoubleLength
 dl_split(double x) {

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2866,6 +2866,7 @@ dl_zero()
     return (DoubleLength) {0.0, 0.0};
 }
 
+#if 0
 static inline DoubleLength
 fasttwosum(double a, double b)
 {
@@ -2886,6 +2887,29 @@ dl_add(DoubleLength total, double x)
     }
     return (DoubleLength) {s.hi, total.lo + s.lo};
 }
+
+#else
+
+static inline DoubleLength
+twosum(double a, double b)
+{
+    double s = a + b;
+    double ap = s - b;
+    double bp = s - a;
+    double da = (a - ap);
+    double db = (b - bp);
+    double t = da + db;
+    return  (DoubleLength) {s, t};
+}
+
+static inline DoubleLength
+dl_add(DoubleLength total, double x)
+{
+    DoubleLength s = twosum(total.hi, x);
+    return (DoubleLength) {s.hi, total.lo + s.lo};
+}
+
+#endif
 
 static inline DoubleLength
 dl_split(double x) {

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2860,11 +2860,7 @@ dl_to_d() converts from extended precision to double precision.
 
 typedef struct{ double hi; double lo; } DoubleLength;
 
-static inline DoubleLength
-dl_zero()
-{
-    return (DoubleLength) {0.0, 0.0};
-}
+static const DoubleLength dl_zero = {0.0, 0.0};
 
 static inline DoubleLength
 twosum(double a, double b)
@@ -2948,7 +2944,7 @@ math_sumprod_impl(PyObject *module, PyObject *p, PyObject *q)
     bool int_path_enabled = true, int_total_in_use = false;
     bool flt_path_enabled = true, flt_total_in_use = false;
     long int_total = 0;
-    DoubleLength flt_total = dl_zero();
+    DoubleLength flt_total = dl_zero;
 
     p_it = PyObject_GetIter(p);
     if (p_it == NULL) {
@@ -3108,7 +3104,7 @@ math_sumprod_impl(PyObject *module, PyObject *p, PyObject *q)
                 Py_SETREF(total, new_total);
                 new_total = NULL;
                 Py_CLEAR(term_i);
-                flt_total = dl_zero();
+                flt_total = dl_zero;
                 flt_total_in_use = false;
             }
         }

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2865,17 +2865,26 @@ dl_zero()
 {
     return (DoubleLength) {0.0, 0.0};
 }
+
+static inline DoubleLength
+fasttwosum(double a, double b)
+{
+    double x = a + b;
+    double y = (a - x) + b;
+    assert (fabs(a) >= fabs(b));
+    return (DoubleLength) {x, y};
+}
+
 static inline DoubleLength
 dl_add(DoubleLength total, double x)
 {
-    double s = total.hi + x;
-    double c = total.lo;
+    DoubleLength s;
     if (fabs(total.hi) >= fabs(x)) {
-        c += (total.hi - s) + x;
+        s = fasttwosum(total.hi, x);
     } else {
-        c += (x - s) + total.hi;
+        s = fasttwosum(x, total.hi);
     }
-    return (DoubleLength) {s, c};
+    return (DoubleLength) {s.hi, total.lo + s.lo};
 }
 
 static inline DoubleLength


### PR DESCRIPTION
Baseline for vector size 100 is 692 nsec.  With 2Sum, it is 659 nsec.

Also, converted `dl_zero` from a function to a constant.

<!-- gh-issue-number: gh-100485 -->
* Issue: gh-100485
<!-- /gh-issue-number -->
