### PR TITLE
[3.11] gh-100776: Fix misleading default value in help(input) (GH-100788)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-06-02-02-11.gh-issue-100776.pP8xux.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-06-02-02-11.gh-issue-100776.pP8xux.rst
@@ -1,0 +1,1 @@
+Fix misleading default value in :func:`input`'s ``__text_signature__``.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2065,7 +2065,7 @@ builtin_print_impl(PyObject *module, PyObject *args, PyObject *sep,
 /*[clinic input]
 input as builtin_input
 
-    prompt: object(c_default="NULL") = None
+    prompt: object(c_default="NULL") = ""
     /
 
 Read a string from standard input.  The trailing newline is stripped.
@@ -2079,7 +2079,7 @@ On *nix systems, readline is used if available.
 
 static PyObject *
 builtin_input_impl(PyObject *module, PyObject *prompt)
-/*[clinic end generated code: output=83db5a191e7a0d60 input=5e8bb70c2908fe3c]*/
+/*[clinic end generated code: output=83db5a191e7a0d60 input=159c46d4ae40977e]*/
 {
     PyThreadState *tstate = _PyThreadState_GET();
     PyObject *fin = _PySys_GetAttr(

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -843,7 +843,7 @@ exit:
 }
 
 PyDoc_STRVAR(builtin_input__doc__,
-"input($module, prompt=None, /)\n"
+"input($module, prompt=\'\', /)\n"
 "--\n"
 "\n"
 "Read a string from standard input.  The trailing newline is stripped.\n"
@@ -1045,4 +1045,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=cc844ea007c1241f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c45d5fe414f7a8d7 input=a9049054013a1b77]*/


### PR DESCRIPTION
(cherry picked from commit a2141882f259e21bb09fa0b7cba8142147b9e3d7)

Co-authored-by: Shantanu <12621235+hauntsaninja@users.noreply.github.com>

<!-- gh-issue-number: gh-100776 -->
* Issue: gh-100776
<!-- /gh-issue-number -->
