### PR TITLE
[3.7] Bump Azure Pipelines to ubuntu-20.04

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -12,7 +12,7 @@ jobs:
   displayName: Pre-build checks
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
   steps:
   - template: ./prebuild-checks.yml
@@ -24,7 +24,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['docs.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
   steps:
   - template: ./docs-steps.yml
@@ -56,7 +56,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
   variables:
     testRunTitle: '$(build.sourceBranchName)-linux'
@@ -82,7 +82,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
   container: manylinux1
 
@@ -113,7 +113,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -1,11 +1,7 @@
 variables:
-  manylinux: false
   coverage: false
 
-resources:
-  containers:
-  - container: manylinux1
-    image: pyca/cryptography-manylinux1:x86_64
+trigger: ['main', '3.11', '3.10', '3.9', '3.8', '3.7']
 
 jobs:
 - job: Prebuild
@@ -67,37 +63,6 @@ jobs:
   - template: ./posix-steps.yml
     parameters:
       dependencies: apt
-
-
-- job: ManyLinux1_CI_Tests
-  displayName: ManyLinux1 CI Tests
-  dependsOn: Prebuild
-  condition: |
-    and(
-        and(
-            succeeded(),
-            eq(variables['manylinux'], 'true')
-        ),
-        eq(dependencies.Prebuild.outputs['tests.run'], 'true')
-    )
-
-  pool:
-    vmImage: ubuntu-20.04
-
-  container: manylinux1
-
-  variables:
-    testRunTitle: '$(build.sourceBranchName)-manylinux1'
-    testRunPlatform: manylinux1
-    openssl_version: ''
-
-  steps:
-  - template: ./posix-steps.yml
-    parameters:
-      dependencies: yum
-      sudo_dependencies: ''
-      xvfb: false
-      patchcheck: false
 
 
 - job: Ubuntu_Coverage_CI_Tests

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -12,7 +12,7 @@ jobs:
   displayName: Pre-build checks
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
   steps:
   - template: ./prebuild-checks.yml
@@ -24,7 +24,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['docs.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
   steps:
   - template: ./docs-steps.yml
@@ -56,7 +56,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
   variables:
     testRunTitle: '$(system.pullRequest.TargetBranch)-linux'
@@ -82,7 +82,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
   container: manylinux1
 
@@ -113,7 +113,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -1,11 +1,7 @@
 variables:
-  manylinux: false
   coverage: false
 
-resources:
-  containers:
-  - container: manylinux1
-    image: pyca/cryptography-manylinux1:x86_64
+pr: ['main', '3.11', '3.10', '3.9', '3.8', '3.7']
 
 jobs:
 - job: Prebuild
@@ -67,37 +63,6 @@ jobs:
   - template: ./posix-steps.yml
     parameters:
       dependencies: apt
-
-
-- job: ManyLinux1_PR_Tests
-  displayName: ManyLinux1 PR Tests
-  dependsOn: Prebuild
-  condition: |
-    and(
-        and(
-            succeeded(),
-            eq(variables['manylinux'], 'true')
-        ),
-        eq(dependencies.Prebuild.outputs['tests.run'], 'true')
-    )
-
-  pool:
-    vmImage: ubuntu-20.04
-
-  container: manylinux1
-
-  variables:
-    testRunTitle: '$(system.pullRequest.TargetBranch)-manylinux1'
-    testRunPlatform: manylinux1
-    openssl_version: ''
-
-  steps:
-  - template: ./posix-steps.yml
-    parameters:
-      dependencies: yum
-      sudo_dependencies: ''
-      xvfb: false
-      patchcheck: false
 
 
 - job: Ubuntu_Coverage_PR_Tests


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The 3.7 branch builds on Azure Pipelines is failing, for example:

```
##[warning]An image label with the label ubuntu-16.04 does not exist.
,##[error]The remote provider was unable to process the request.
```

* https://dev.azure.com/Python/cpython/_build/results?buildId=118919&view=logs&j=341b3d8e-0d13-57d4-859b-65d31dcbc29e
* https://github.com/python/cpython/pull/100853

The `main` and 3.11-3.8 branches were already bumped to `ubuntu-20.04` by https://github.com/python/cpython/issues/89170, which didn't make it back to 3.7.

---

Alternatively, we could use `ubuntu-22.04` for all branches, or the `ubuntu-latest` alias which is now pointing to `ubuntu-22.04`.

* https://github.com/actions/runner-images#available-images