### PR TITLE
Fix typos in Doc folder

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -615,7 +615,7 @@ Defining Getters and Setters
 
    .. c:member:: getter PyGetSetDef.get
 
-      C funtion to get the attribute.
+      C function to get the attribute.
 
    .. c:member:: setter PyGetSetDef.set
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -390,7 +390,7 @@ regular, non-variadic, function arguments:
 
    libc.printf.argtypes = [ctypes.c_char_p]
 
-Because specifying the attribute does inhibit portability it is adviced to always
+Because specifying the attribute does inhibit portability it is advised to always
 specify ``argtypes`` for all variadic functions.
 
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -2463,7 +2463,7 @@ Transaction control via the ``autocommit`` attribute
 
 The recommended way of controlling transaction behaviour is through
 the :attr:`Connection.autocommit` attribute,
-which should preferrably be set using the *autocommit* parameter
+which should preferably be set using the *autocommit* parameter
 of :func:`connect`.
 
 It is suggested to set *autocommit* to ``False``,


### PR DESCRIPTION
Addressed issue: https://github.com/python/cpython/issues/100879

Fixed typos:
adviced -> advised
funtion -> function
preferrably -> preferably

Found with: https://github.com/ss18/grep-typos