### PR TITLE
gh-100873: Fix "‘lo’ may be used uninitialized in this function" warning in `mathmodule.c`

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1467,7 +1467,7 @@ math_fsum(PyObject *module, PyObject *seq)
     Py_ssize_t i, j, n = 0, m = NUM_PARTIALS;
     double x, y, t, ps[NUM_PARTIALS], *p = ps;
     double xsave, special_sum = 0.0, inf_sum = 0.0;
-    double hi, yr, lo;
+    double hi, yr, lo = 0.0;
 
     iter = PyObject_GetIter(seq);
     if (iter == NULL)


### PR DESCRIPTION
Applying suggestion from https://github.com/python/cpython/issues/100873#issuecomment-1375569838

<!-- gh-issue-number: gh-100873 -->
* Issue: gh-100873
<!-- /gh-issue-number -->
