### PR TITLE
[3.10] gh-100180: Update Windows installer to OpenSSL 1.1.1s (GH-100901)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2023-01-09-23-03-57.gh-issue-100180.b5phrg.rst
+++ b/Misc/NEWS.d/next/Windows/2023-01-09-23-03-57.gh-issue-100180.b5phrg.rst
@@ -1,0 +1,1 @@
+Update Windows installer to OpenSSL 1.1.1s

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -53,7 +53,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.8
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.3.0
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1q
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1s
 set libraries=%libraries%                                       sqlite-3.39.4.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.12.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.12.0
@@ -77,7 +77,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.3.0
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1q
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1s
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.12.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -63,8 +63,8 @@
     <libffiDir>$(ExternalsDir)libffi-3.3.0\</libffiDir>
     <libffiOutDir>$(ExternalsDir)libffi-3.3.0\$(ArchName)\</libffiOutDir>
     <libffiIncludeDir>$(libffiOutDir)include</libffiIncludeDir>
-    <opensslDir>$(ExternalsDir)openssl-1.1.1q\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1q\$(ArchName)\</opensslOutDir>
+    <opensslDir>$(ExternalsDir)openssl-1.1.1s\</opensslDir>
+    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1s\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir>$(ExternalsDir)\zlib-1.2.13\</zlibDir>


### PR DESCRIPTION


<!-- gh-issue-number: gh-100180 -->
* Issue: gh-100180
<!-- /gh-issue-number -->
