### PR TITLE
gh-99735: Use required=True in argparse subparsers example

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1867,7 +1867,7 @@ Sub-commands
      ...
      >>> # create the top-level parser
      >>> parser = argparse.ArgumentParser()
-     >>> subparsers = parser.add_subparsers()
+     >>> subparsers = parser.add_subparsers(required=True)
      >>>
      >>> # create the parser for the "foo" command
      >>> parser_foo = subparsers.add_parser('foo')


### PR DESCRIPTION
This provides an alternate solution, suggested by @hpaulj to improve the example in the documentation.

<!-- gh-issue-number: gh-99735 -->
* Issue: gh-99735
<!-- /gh-issue-number -->
