### PR TITLE
gh-94912: Adjusted check for non-standard coroutine function marker.

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -399,8 +399,6 @@ def _has_coroutine_mark(f):
     while ismethod(f):
         f = f.__func__
     f = functools._unwrap_partial(f)
-    if not (isfunction(f) or _signature_is_functionlike(f)):
-        return False
     return getattr(f, "_is_coroutine_marker", None) is _is_coroutine_marker
 
 def markcoroutinefunction(func):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -223,6 +223,10 @@ class TestPredicates(IsTestBase):
         self.assertFalse(inspect.iscoroutinefunction(Cl))
         # instances with async def __call__ are NOT recognised.
         self.assertFalse(inspect.iscoroutinefunction(Cl()))
+        # unless explicitly marked.
+        self.assertTrue(inspect.iscoroutinefunction(
+            inspect.markcoroutinefunction(Cl())
+        ))
 
         class Cl2:
             @inspect.markcoroutinefunction
@@ -232,6 +236,10 @@ class TestPredicates(IsTestBase):
         self.assertFalse(inspect.iscoroutinefunction(Cl2))
         # instances with marked __call__ are NOT recognised.
         self.assertFalse(inspect.iscoroutinefunction(Cl2()))
+        # unless explicitly marked.
+        self.assertTrue(inspect.iscoroutinefunction(
+            inspect.markcoroutinefunction(Cl2())
+        ))
 
         class Cl3:
             @inspect.markcoroutinefunction


### PR DESCRIPTION
The initial implementation did not correctly identify explicitly marked class instances.

Follow up to 532aa4e4e019812d0388920768ede7c04232ebe1 from #99247 
(Bug in Python 3.12.0a4)

Integrating Python 3.12.0a4 with the Django test suite we see that the `_has_coroutine_mark()` is not allowing the key case of a class being marked as an asynchronous callable. (This is my fault: in the discussion with @gvanrossum on #99247 over whether we'd cover the marked and `async def` `__call__` cases automatically, I forgot to add the explicit test for the marked instances.) 

I note the `isfunction(f) or _signature_is_functionlike(f)` restriction is untested, and not, I think, necessary. (If folks applied `markcoroutinefunction`, I think we have to assume that they know what they're up to.) 

<!-- gh-issue-number: gh-94912 -->
* Issue: gh-94912
<!-- /gh-issue-number -->
