### PR TITLE
Skip py.exe launcher tests in full layout CI test

### DIFF
--- a/.azure-pipelines/windows-layout-steps.yml
+++ b/.azure-pipelines/windows-layout-steps.yml
@@ -12,7 +12,7 @@ steps:
   displayName: Show layout info (${{ parameters.kind }})
 
 - ${{ if eq(parameters.fulltest, 'true') }}:
-  - script: .\python.exe -m test -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0 --junit-xml="$(Build.BinariesDirectory)\test-results-${{ parameters.kind }}.xml" --tempdir "$(Build.BinariesDirectory)\tmp-${{ parameters.kind }}-$(arch)"
+  - script: .\python.exe -m test -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0 --junit-xml="$(Build.BinariesDirectory)\test-results-${{ parameters.kind }}.xml" --tempdir "$(Build.BinariesDirectory)\tmp-${{ parameters.kind }}-$(arch)" -i test_launcher
     workingDirectory: $(Build.BinariesDirectory)\layout-${{ parameters.kind }}-$(arch)
     displayName: ${{ parameters.kind }} Tests
     env:


### PR DESCRIPTION
These tests become flaky when py.exe exists on the test machine but isn't the one that was just built. They also don't provide any useful information for this scenario, so easiest to just skip them.