### PR TITLE
gh-100942: Fix crash on `property` subtypes with weird `__new__`

### DIFF
--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -403,6 +403,16 @@ class PropertySubclassTests(unittest.TestCase):
                 return 2
         self.assertEqual(Foo.spam.__doc__, "a new docstring")
 
+    def test_gh100942(self):
+        # See https://github.com/python/cpython/issues/100942
+        class pro(property):
+            def __new__(typ, *args, **kwargs):
+                return "abcdef"
+
+        p = property.__new__(pro)
+        with self.assertRaises(TypeError):
+            p.getter(lambda self: 1)  # this line was causing a crash
+
 
 class _PropertyUnreachableAttribute:
     msg_format = None

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -410,12 +410,11 @@ class PropertySubclassTests(unittest.TestCase):
                 return "abcdef"
 
         p = property.__new__(pro)
-        with self.assertRaises(TypeError):
-            p.getter(lambda self: 1)  # this line was causing a crash
-        with self.assertRaises(TypeError):
-            p.setter(lambda self, val: 1)  # this line was causing a crash
-        with self.assertRaises(TypeError):
-            p.deleter(lambda self: 1)  # this line was causing a crash
+
+        # These lines were causing crashes:
+        p.getter(lambda self: 1)
+        p.setter(lambda self, val: 1)
+        p.deleter(lambda self: 1)
 
 
 class _PropertyUnreachableAttribute:

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -412,6 +412,10 @@ class PropertySubclassTests(unittest.TestCase):
         p = property.__new__(pro)
         with self.assertRaises(TypeError):
             p.getter(lambda self: 1)  # this line was causing a crash
+        with self.assertRaises(TypeError):
+            p.setter(lambda self, val: 1)  # this line was causing a crash
+        with self.assertRaises(TypeError):
+            p.deleter(lambda self: 1)  # this line was causing a crash
 
 
 class _PropertyUnreachableAttribute:

--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-11-21-41-58.gh-issue-100942._jnwot.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-11-21-41-58.gh-issue-100942._jnwot.rst
@@ -1,0 +1,1 @@
+Fix crash on ``property`` subclasses with weird ``__new__`` methods.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1711,6 +1711,11 @@ property_copy(PyObject *old, PyObject *get, PyObject *set, PyObject *del)
     Py_DECREF(type);
     if (new == NULL)
         return NULL;
+    if (!PyObject_TypeCheck(new, &PyProperty_Type)) {
+        PyErr_Format(PyExc_TypeError, "property instance expected, got %.50s",
+                     Py_TYPE(new)->tp_name);
+        return NULL;
+    }
 
     Py_XSETREF(((propertyobject *) new)->prop_name, Py_XNewRef(pold->prop_name));
     return new;

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1711,13 +1711,11 @@ property_copy(PyObject *old, PyObject *get, PyObject *set, PyObject *del)
     Py_DECREF(type);
     if (new == NULL)
         return NULL;
-    if (!PyObject_TypeCheck(new, &PyProperty_Type)) {
-        PyErr_Format(PyExc_TypeError, "property instance expected, got %.50s",
-                     Py_TYPE(new)->tp_name);
-        return NULL;
+    if (PyObject_TypeCheck(new, &PyProperty_Type)) {
+        Py_XSETREF(((propertyobject *) new)->prop_name,
+                   Py_XNewRef(pold->prop_name));
     }
 
-    Py_XSETREF(((propertyobject *) new)->prop_name, Py_XNewRef(pold->prop_name));
     return new;
 }
 


### PR DESCRIPTION
I went with the easiest solution: just raise a `TypeError` in this case.
What are other options? 🤔 

<!-- gh-issue-number: gh-100942 -->
* Issue: gh-100942
<!-- /gh-issue-number -->
