### PR TITLE
GH-100573: Fix server hang caused by os.stat() on named pipe (Windows)

### DIFF
--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -366,6 +366,10 @@ class ProactorEventLoop(proactor_events.BaseProactorEventLoop):
                     return
 
                 f = self._proactor.accept_pipe(pipe)
+            except BrokenPipeError:
+                if pipe and pipe.fileno() != -1:
+                    pipe.close()
+                self.call_soon(loop_accept_pipe)
             except OSError as exc:
                 if pipe and pipe.fileno() != -1:
                     self.call_exception_handler({
@@ -377,6 +381,7 @@ class ProactorEventLoop(proactor_events.BaseProactorEventLoop):
                 elif self._debug:
                     logger.warning("Accept pipe failed on pipe %r",
                                    pipe, exc_info=True)
+                self.call_soon(loop_accept_pipe)
             except exceptions.CancelledError:
                 if pipe:
                     pipe.close()

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -255,6 +255,7 @@ class ProactorTests(test_utils.TestCase):
         self.assertEqual(res, 'done')
 
     async def _test_client_pipe_stat(self):
+        # Regression test for https://github.com/python/cpython/issues/100573
         ADDRESS = r'\\.\pipe\test_client_pipe_stat-%s' % os.getpid()
 
         async def probe():

--- a/Misc/NEWS.d/next/Library/2023-01-12-01-18-13.gh-issue-100573.KDskqo.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-12-01-18-13.gh-issue-100573.KDskqo.rst
@@ -1,0 +1,1 @@
+Fix a Windows asyncio bug with named pipes where a client doing `os.stat()` on the pipe would cause an error in the server that disabled serving future requests.

--- a/Misc/NEWS.d/next/Library/2023-01-12-01-18-13.gh-issue-100573.KDskqo.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-12-01-18-13.gh-issue-100573.KDskqo.rst
@@ -1,1 +1,1 @@
-Fix a Windows asyncio bug with named pipes where a client doing ``os.stat()`` on the pipe would cause an error in the server that disabled serving future requests.
+Fix a Windows :mod:`asyncio` bug with named pipes where a client doing ``os.stat()`` on the pipe would cause an error in the server that disabled serving future requests.

--- a/Misc/NEWS.d/next/Library/2023-01-12-01-18-13.gh-issue-100573.KDskqo.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-12-01-18-13.gh-issue-100573.KDskqo.rst
@@ -1,1 +1,1 @@
-Fix a Windows asyncio bug with named pipes where a client doing `os.stat()` on the pipe would cause an error in the server that disabled serving future requests.
+Fix a Windows asyncio bug with named pipes where a client doing ``os.stat()`` on the pipe would cause an error in the server that disabled serving future requests.


### PR DESCRIPTION


<!-- gh-issue-number: gh-100573 -->
* Issue: gh-100573
<!-- /gh-issue-number -->
