### PR TITLE
[3.10] [3.11] gh-100160: Remove any deprecation warnings in asyncio.g…

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -48,7 +48,7 @@ an event loop:
    running event loop.
 
    If there is no running event loop set, the function will return
-   the result of ``get_event_loop_policy().get_event_loop()`` call.
+   the result of the ``get_event_loop_policy().get_event_loop()`` call.
 
    Because this function has rather complex behavior (especially
    when custom event loop policies are in use), using the
@@ -59,15 +59,15 @@ an event loop:
    instead of using these lower level functions to manually create and close an
    event loop.
 
-   .. deprecated:: 3.10
-      Deprecation warning is emitted if there is no current event loop.
-      In Python 3.12 it will be an error.
-
    .. note::
-      In Python versions 3.10.0--3.10.8 this function
-      (and other functions which used it implicitly) emitted a
+      In Python versions 3.10.0--3.10.8 and 3.11.0 this function
+      (and other functions which use it implicitly) emitted a
       :exc:`DeprecationWarning` if there was no running event loop, even if
-      the current loop was set.
+      the current loop was set on the policy.
+      In Python versions 3.10.9, 3.11.1 and 3.12 they emit a
+      :exc:`DeprecationWarning` if there is no running event loop and no
+      current loop is set.
+      In some future Python release this will become an error.
 
 .. function:: set_event_loop(loop)
 

--- a/Doc/library/asyncio-policy.rst
+++ b/Doc/library/asyncio-policy.rst
@@ -112,10 +112,11 @@ asyncio ships with the following built-in policies:
 
       On Windows, :class:`ProactorEventLoop` is now used by default.
 
-   .. deprecated:: 3.10.9
-      :meth:`get_event_loop` now emits a :exc:`DeprecationWarning` if there
-      is no current event loop set and a new event loop has been implicitly
-      created. In Python 3.12 it will be an error.
+   .. note::
+      In Python versions 3.10.9, 3.11.1 and 3.12 the :meth:`get_event_loop`
+      method of the default asyncio policy emits a :exc:`DeprecationWarning`
+      if there is no running event loop and no current loop is set.
+      In some future Python release this will become an error.
 
 
 .. class:: WindowsSelectorEventLoopPolicy

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1706,19 +1706,6 @@ Deprecated
   scheduled for removal in Python 3.12.
   (Contributed by Erlend E. Aasland in :issue:`42264`.)
 
-* :func:`asyncio.get_event_loop` now emits a deprecation warning if there is
-  no running event loop. In the future it will be an alias of
-  :func:`~asyncio.get_running_loop`.
-  :mod:`asyncio` functions which implicitly create :class:`~asyncio.Future`
-  or :class:`~asyncio.Task` objects now emit
-  a deprecation warning if there is no running event loop and no explicit
-  *loop* argument is passed: :func:`~asyncio.ensure_future`,
-  :func:`~asyncio.wrap_future`, :func:`~asyncio.gather`,
-  :func:`~asyncio.shield`, :func:`~asyncio.as_completed` and constructors of
-  :class:`~asyncio.Future`, :class:`~asyncio.Task`,
-  :class:`~asyncio.StreamReader`, :class:`~asyncio.StreamReaderProtocol`.
-  (Contributed by Serhiy Storchaka in :issue:`39529`.)
-
 * The undocumented built-in function ``sqlite3.enable_shared_cache`` is now
   deprecated, scheduled for removal in Python 3.12.  Its use is strongly
   discouraged by the SQLite3 documentation.  See `the SQLite3 docs

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -650,21 +650,6 @@ class BaseDefaultEventLoopPolicy(AbstractEventLoopPolicy):
         if (self._local._loop is None and
                 not self._local._set_called and
                 threading.current_thread() is threading.main_thread()):
-            stacklevel = 2
-            try:
-                f = sys._getframe(1)
-            except AttributeError:
-                pass
-            else:
-                while f:
-                    module = f.f_globals.get('__name__')
-                    if not (module == 'asyncio' or module.startswith('asyncio.')):
-                        break
-                    f = f.f_back
-                    stacklevel += 1
-            import warnings
-            warnings.warn('There is no current event loop',
-                          DeprecationWarning, stacklevel=stacklevel)
             self.set_event_loop(self.new_event_loop())
 
         if self._local._loop is None:

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2602,9 +2602,7 @@ class PolicyTests(unittest.TestCase):
     def test_get_event_loop(self):
         policy = asyncio.DefaultEventLoopPolicy()
         self.assertIsNone(policy._local._loop)
-        with self.assertWarns(DeprecationWarning) as cm:
-            loop = policy.get_event_loop()
-        self.assertEqual(cm.filename, __file__)
+        loop = policy.get_event_loop()
         self.assertIsInstance(loop, asyncio.AbstractEventLoop)
 
         self.assertIs(policy._local._loop, loop)
@@ -2618,10 +2616,8 @@ class PolicyTests(unittest.TestCase):
                 policy, "set_event_loop",
                 wraps=policy.set_event_loop) as m_set_event_loop:
 
-            with self.assertWarns(DeprecationWarning) as cm:
-                loop = policy.get_event_loop()
+            loop = policy.get_event_loop()
             self.addCleanup(loop.close)
-            self.assertEqual(cm.filename, __file__)
 
             # policy._local._loop must be set through .set_event_loop()
             # (the unix DefaultEventLoopPolicy needs this call to attach
@@ -2810,10 +2806,8 @@ class GetEventLoopTestsMixin:
             loop = asyncio.new_event_loop()
             self.addCleanup(loop.close)
 
-            with self.assertWarns(DeprecationWarning) as cm:
-                loop2 = asyncio.get_event_loop()
+            loop2 = asyncio.get_event_loop()
             self.addCleanup(loop2.close)
-            self.assertEqual(cm.warnings[0].filename, __file__)
             asyncio.set_event_loop(None)
             with self.assertRaisesRegex(RuntimeError, 'no current'):
                 asyncio.get_event_loop()

--- a/Lib/test/test_json/test_default.py
+++ b/Lib/test/test_json/test_default.py
@@ -1,3 +1,4 @@
+import collections
 from test.test_json import PyTest, CTest
 
 
@@ -6,6 +7,16 @@ class TestDefault:
         self.assertEqual(
             self.dumps(type, default=repr),
             self.dumps(repr(type)))
+
+    def test_ordereddict(self):
+        od = collections.OrderedDict(a=1, b=2)
+        od.move_to_end('a')
+        self.assertEqual(
+            self.dumps(od),
+            '{"b": 2, "a": 1}')
+        self.assertEqual(
+            self.dumps(od, sort_keys=True),
+            '{"a": 1, "b": 2}')
 
 
 class TestPyDefault(TestDefault, PyTest): pass

--- a/Misc/NEWS.d/next/Library/2022-12-21-18-29-24.gh-issue-100160.isBmL5.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-21-18-29-24.gh-issue-100160.isBmL5.rst
@@ -1,0 +1,2 @@
+Remove any deprecation warnings in :func:`asyncio.get_event_loop`. They are
+deferred to Python 3.12.


### PR DESCRIPTION
…et_event_loop() (GH-100412)

Some deprecation warnings will reappear (in a slightly different form) in 3.12.

Co-authored-by: Guido van Rossum <guido@python.org>. (cherry picked from commit 1b2459dc64b1c3eea89312ea9bf422f8d7c75bb2)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>


<!-- gh-issue-number: gh-100160 -->
* Issue: gh-100160
<!-- /gh-issue-number -->
