### PR TITLE
[3.11] GH-100942: Fix incorrect cast in property_copy(). (GH-100965).

### DIFF
--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -214,6 +214,23 @@ class PropertyTests(unittest.TestCase):
             ):
                 p.__set_name__(*([0] * i))
 
+    def test_property_setname_on_property_subclass(self):
+        # https://github.com/python/cpython/issues/100942
+        # Copy was setting the name field without first
+        # verifying that the copy was an actual property
+        # instance.  As a result, the code below was
+        # causing a segfault.
+
+        class pro(property):
+            def __new__(typ, *args, **kwargs):
+                return "abcdef"
+
+        class A:
+            pass
+
+        p = property.__new__(pro)
+        p.__set_name__(A, 1)
+        np = p.getter(lambda self: 1)
 
 # Issue 5890: subclasses of property do not preserve method __doc__ strings
 class PropertySub(property):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-11-22-52-19.gh-issue-100942.ontOy_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-11-22-52-19.gh-issue-100942.ontOy_.rst
@@ -1,0 +1,2 @@
+Fixed segfault in property.getter/setter/deleter that occurred when a property
+subclass overrode the ``__new__`` method to return a non-property instance.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1723,9 +1723,10 @@ property_copy(PyObject *old, PyObject *get, PyObject *set, PyObject *del)
     Py_DECREF(type);
     if (new == NULL)
         return NULL;
-
-    Py_XINCREF(pold->prop_name);
-    Py_XSETREF(((propertyobject *) new)->prop_name, pold->prop_name);
+    if (PyObject_TypeCheck((new), &PyProperty_Type)) {
+        Py_XINCREF(pold->prop_name);
+        Py_XSETREF(((propertyobject *) new)->prop_name, pold->prop_name);
+    }
     return new;
 }
 


### PR DESCRIPTION
(cherry picked from commit 94fc7706b7bc3d57cdd6d15bf8e8c4499ae53a69)

Co-authored-by: Raymond Hettinger <rhettinger@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-100942 -->
* Issue: gh-100942
<!-- /gh-issue-number -->
