### PR TITLE
gh-101021: Document binary parameters as bytes

### DIFF
--- a/Doc/library/email.mime.rst
+++ b/Doc/library/email.mime.rst
@@ -114,9 +114,9 @@ Here are the classes:
 
    A subclass of :class:`~email.mime.nonmultipart.MIMENonMultipart`, the
    :class:`MIMEApplication` class is used to represent MIME message objects of
-   major type :mimetype:`application`.  *_data* is a string containing the raw
-   byte data.  Optional *_subtype* specifies the MIME subtype and defaults to
-   :mimetype:`octet-stream`.
+   major type :mimetype:`application`.  *_data* contains the bytes for the raw
+   application data.  Optional *_subtype* specifies the MIME subtype and defaults
+   to :mimetype:`octet-stream`.
 
    Optional *_encoder* is a callable (i.e. function) which will perform the actual
    encoding of the data for transport.  This callable takes one argument, which is
@@ -145,7 +145,7 @@ Here are the classes:
 
    A subclass of :class:`~email.mime.nonmultipart.MIMENonMultipart`, the
    :class:`MIMEAudio` class is used to create MIME message objects of major type
-   :mimetype:`audio`. *_audiodata* is a string containing the raw audio data.  If
+   :mimetype:`audio`. *_audiodata* contains the bytes for the raw audio data.  If
    this data can be decoded as au, wav, aiff, or aifc, then the
    subtype will be automatically included in the :mailheader:`Content-Type` header.
    Otherwise you can explicitly specify the audio subtype via the *_subtype*
@@ -179,7 +179,7 @@ Here are the classes:
 
    A subclass of :class:`~email.mime.nonmultipart.MIMENonMultipart`, the
    :class:`MIMEImage` class is used to create MIME message objects of major type
-   :mimetype:`image`. *_imagedata* is a string containing the raw image data.  If
+   :mimetype:`image`. *_imagedata* contains the bytes for the raw image data.  If
    this data type can be detected (jpeg, png, gif, tiff, rgb, pbm, pgm, ppm,
    rast, xbm, bmp, webp, and exr attempted), then the subtype will be
    automatically included in the :mailheader:`Content-Type` header. Otherwise

--- a/Lib/email/mime/application.py
+++ b/Lib/email/mime/application.py
@@ -17,7 +17,7 @@ class MIMEApplication(MIMENonMultipart):
                  _encoder=encoders.encode_base64, *, policy=None, **_params):
         """Create an application/* type MIME document.
 
-        _data is a string containing the raw application data.
+        _data contains the bytes for the raw application data.
 
         _subtype is the MIME content type subtype, defaulting to
         'octet-stream'.

--- a/Lib/email/mime/audio.py
+++ b/Lib/email/mime/audio.py
@@ -18,7 +18,7 @@ class MIMEAudio(MIMENonMultipart):
                  _encoder=encoders.encode_base64, *, policy=None, **_params):
         """Create an audio/* type MIME document.
 
-        _audiodata is a string containing the raw audio data.  If this data
+        _audiodata contains the bytes for the raw audio data.  If this data
         can be decoded as au, wav, aiff, or aifc, then the
         subtype will be automatically included in the Content-Type header.
         Otherwise, you can specify  the specific audio subtype via the

--- a/Lib/email/mime/image.py
+++ b/Lib/email/mime/image.py
@@ -17,7 +17,7 @@ class MIMEImage(MIMENonMultipart):
                  _encoder=encoders.encode_base64, *, policy=None, **_params):
         """Create an image/* type MIME document.
 
-        _imagedata is a string containing the raw image data.  If the data
+        _imagedata contains the bytes for the raw image data.  If the data
         type can be detected (jpeg, png, gif, tiff, rgb, pbm, pgm, ppm,
         rast, xbm, bmp, webp, and exr attempted), then the subtype will be
         automatically included in the Content-Type header. Otherwise, you can


### PR DESCRIPTION
The existing documentation refers to binary parameters as "strings" when they are actually bytes.

Fixes #101021

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101021 -->
* Issue: gh-101021
<!-- /gh-issue-number -->
