### PR TITLE
Fix parameter name in equivalent code snippet of `enumerate`

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -505,9 +505,9 @@ are always available.  They are listed here in alphabetical order.
 
    Equivalent to::
 
-      def enumerate(sequence, start=0):
+      def enumerate(iterable, start=0):
           n = start
-          for elem in sequence:
+          for elem in iterable:
               yield n, elem
               n += 1
 


### PR DESCRIPTION
The parameter name was changed from `sequence` to `iterable` in commit d11ae5d6. However, when the equivalent code snippet was added a couple of years later in commits 690d4ae8 / 90289281, it accidentally used the old name.

Trivial docs change, no issue exists, and no news entry needed.