### PR TITLE
gh-101015: Fix `typing.get_type_hints` with unpacked `*tuple` (PEP 646)

### DIFF
--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -419,6 +419,8 @@ class AnnotationsFutureTestCase(unittest.TestCase):
             """))
 
     def test_get_type_hints_on_func_with_variadic_arg(self):
+        import typing
+
         # `typing.get_type_hints` might break on a function with a variadic
         # annotation (e.g. `f(*args: *Ts)`) if `from __future__ import
         # annotations`, because it could try to evaluate `*Ts` as an expression,
@@ -435,7 +437,8 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         """))
 
         hints = namespace.pop('hints')
-        self.assertIsInstance(hints['args'], namespace['StarredC'])
+        self.assertIsInstance(hints['args'],
+                              typing.Unpack[namespace['StarredC']])
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -437,8 +437,8 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         """))
 
         hints = namespace.pop('hints')
-        self.assertIsInstance(hints['args'],
-                              typing.Unpack[namespace['StarredC']])
+        self.assertEqual(hints['args'].__origin__, typing.Unpack)
+        self.assertIsInstance(hints['args'].__args__[0], namespace['StarredC'])
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -419,8 +419,6 @@ class AnnotationsFutureTestCase(unittest.TestCase):
             """))
 
     def test_get_type_hints_on_func_with_variadic_arg(self):
-        import typing
-
         # `typing.get_type_hints` might break on a function with a variadic
         # annotation (e.g. `f(*args: *Ts)`) if `from __future__ import
         # annotations`, because it could try to evaluate `*Ts` as an expression,

--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -437,8 +437,7 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         """))
 
         hints = namespace.pop('hints')
-        self.assertEqual(hints['args'].__origin__, typing.Unpack)
-        self.assertIsInstance(hints['args'].__args__[0], namespace['StarredC'])
+        self.assertIsInstance(hints['args'], namespace['StarredC'])
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1227,6 +1227,20 @@ class TypeVarTupleTests(BaseTestCase):
     def test_get_type_hints_on_unpack_args(self):
         Ts = TypeVarTuple('Ts')
 
+        def func1(*args: *Ts): pass
+        self.assertEqual(gth(func1), {'args': Unpack[Ts]})
+
+        def func2(*args: *tuple[int, str]): pass
+        self.assertEqual(gth(func2), {'args': Unpack[tuple[int, str]]})
+
+        class CustomVariadic(Generic[*Ts]): pass
+
+        def func3(*args: *CustomVariadic[int, str]): pass
+        self.assertEqual(gth(func3), {'args': Unpack[CustomVariadic[int, str]]})
+
+    def test_get_type_hints_on_unpack_args_string(self):
+        Ts = TypeVarTuple('Ts')
+
         def func1(*args: '*Ts'): pass
         self.assertEqual(gth(func1, localns={'Ts': Ts}),
                         {'args': Unpack[Ts]})

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1224,6 +1224,22 @@ class TypeVarTupleTests(BaseTestCase):
         self.assertIs(D[T].__origin__, D)
         self.assertIs(D[Unpack[Ts]].__origin__, D)
 
+    def test_get_type_hints_on_unpack_args(self):
+        Ts = TypeVarTuple('Ts')
+
+        def func1(*args: '*Ts'): pass
+        self.assertEqual(gth(func1, localns={'Ts': Ts}),
+                        {'args': Unpack[Ts]})
+
+        def func2(*args: '*tuple[int, str]'): pass
+        self.assertEqual(gth(func2), {'args': Unpack[tuple[int, str]]})
+
+        class CustomVariadic(Generic[*Ts]): pass
+
+        def func3(*args: '*CustomVariadic[int, str]'): pass
+        self.assertEqual(gth(func3, localns={'CustomVariadic': CustomVariadic}),
+                         {'args': Unpack[CustomVariadic[int, str]]})
+
     def test_tuple_args_are_correct(self):
         Ts = TypeVarTuple('Ts')
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -821,7 +821,7 @@ class ForwardRef(_Final, _root=True):
     __slots__ = ('__forward_arg__', '__forward_code__',
                  '__forward_evaluated__', '__forward_value__',
                  '__forward_is_argument__', '__forward_is_class__',
-                 '__forward_module__', '__forward_is_unpack__')
+                 '__forward_module__')
 
     def __init__(self, arg, is_argument=True, module=None, *, is_class=False):
         if not isinstance(arg, str):
@@ -831,11 +831,9 @@ class ForwardRef(_Final, _root=True):
         # Unfortunately, this isn't a valid expression on its own, so we
         # do the unpacking manually.
         if arg[0] == '*':
-            arg_to_compile = f'({arg},)[0]'  # E.g. (*Ts,)[0] or (tuple[int, int],)[0]
-            is_unpack = True
+            arg_to_compile = f'({arg},)[0]'  # E.g. (*Ts,)[0] or (*tuple[int, int],)[0]
         else:
             arg_to_compile = arg
-            is_unpack = False
         try:
             code = compile(arg_to_compile, '<string>', 'eval')
         except SyntaxError:
@@ -848,7 +846,6 @@ class ForwardRef(_Final, _root=True):
         self.__forward_is_argument__ = is_argument
         self.__forward_is_class__ = is_class
         self.__forward_module__ = module
-        self.__forward_is_unpack__ = is_unpack
 
     def _evaluate(self, globalns, localns, recursive_guard):
         if self.__forward_arg__ in recursive_guard:
@@ -873,11 +870,6 @@ class ForwardRef(_Final, _root=True):
             self.__forward_value__ = _eval_type(
                 type_, globalns, localns, recursive_guard | {self.__forward_arg__}
             )
-            if (
-                self.__forward_is_unpack__ and
-                not isinstance(self.__forward_value__, _UnpackGenericAlias)
-            ):
-                self.__forward_value__ = Unpack[self.__forward_value__]
             self.__forward_evaluated__ = True
         return self.__forward_value__
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -371,10 +371,13 @@ def _eval_type(t, globalns, localns, recursive_guard=frozenset()):
                 ForwardRef(arg) if isinstance(arg, str) else arg
                 for arg in t.__args__
             )
+            is_unpacked = t.__unpacked__
             if _should_unflatten_callable_args(t, args):
                 t = t.__origin__[(args[:-1], args[-1])]
             else:
                 t = t.__origin__[args]
+            if is_unpacked:
+                t = Unpack[t]
         ev_args = tuple(_eval_type(a, globalns, localns, recursive_guard) for a in t.__args__)
         if ev_args == t.__args__:
             return t

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -818,7 +818,7 @@ class ForwardRef(_Final, _root=True):
     __slots__ = ('__forward_arg__', '__forward_code__',
                  '__forward_evaluated__', '__forward_value__',
                  '__forward_is_argument__', '__forward_is_class__',
-                 '__forward_module__')
+                 '__forward_module__', '__forward_is_unpack__')
 
     def __init__(self, arg, is_argument=True, module=None, *, is_class=False):
         if not isinstance(arg, str):
@@ -828,9 +828,11 @@ class ForwardRef(_Final, _root=True):
         # Unfortunately, this isn't a valid expression on its own, so we
         # do the unpacking manually.
         if arg[0] == '*':
-            arg_to_compile = f'({arg},)[0]'  # E.g. (*Ts,)[0]
+            arg_to_compile = f'({arg},)[0]'  # E.g. (*Ts,)[0] or (tuple[int, int],)[0]
+            is_unpack = True
         else:
             arg_to_compile = arg
+            is_unpack = False
         try:
             code = compile(arg_to_compile, '<string>', 'eval')
         except SyntaxError:
@@ -843,6 +845,7 @@ class ForwardRef(_Final, _root=True):
         self.__forward_is_argument__ = is_argument
         self.__forward_is_class__ = is_class
         self.__forward_module__ = module
+        self.__forward_is_unpack__ = is_unpack
 
     def _evaluate(self, globalns, localns, recursive_guard):
         if self.__forward_arg__ in recursive_guard:
@@ -867,6 +870,11 @@ class ForwardRef(_Final, _root=True):
             self.__forward_value__ = _eval_type(
                 type_, globalns, localns, recursive_guard | {self.__forward_arg__}
             )
+            if (
+                self.__forward_is_unpack__ and
+                not isinstance(self.__forward_value__, _UnpackGenericAlias)
+            ):
+                self.__forward_value__ = Unpack[self.__forward_value__]
             self.__forward_evaluated__ = True
         return self.__forward_value__
 

--- a/Misc/NEWS.d/next/Library/2023-01-14-12-58-21.gh-issue-101015.stWFid.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-14-12-58-21.gh-issue-101015.stWFid.rst
@@ -1,2 +1,2 @@
-Fix :class:`typing.ForwardRef` evaluation of ``'*tuple[...]'`` string. It
-must not drop the ``Unpack`` part.
+Fix :func:`typing.get_type_hints` on ``'*tuple[...]'`` and ``*tuple[...]``.
+It must not drop the ``Unpack`` part.

--- a/Misc/NEWS.d/next/Library/2023-01-14-12-58-21.gh-issue-101015.stWFid.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-14-12-58-21.gh-issue-101015.stWFid.rst
@@ -1,0 +1,2 @@
+Fix :class:`typing.ForwardRef` evaluation of ``'*tuple[...]'`` string. It
+must not drop the ``Unpack`` part.


### PR DESCRIPTION
Couple of thoughts:
1. `ForwardRef` has way too many flags
2. This solution feels hacky (just like any other `typing.py` fix 😆), better ideas are welcome


<!-- gh-issue-number: gh-101015 -->
* Issue: gh-101015
<!-- /gh-issue-number -->
