### PR TITLE
gh-101035: Check `fs.st_mtime` before use.

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -378,11 +378,14 @@ provides three different variants:
 
       If the request was mapped to a file, it is opened. Any :exc:`OSError`
       exception in opening the requested file is mapped to a ``404``,
-      ``'File not found'`` error. If there was a ``'If-Modified-Since'``
-      header in the request, and the file was not modified after this time,
-      a ``304``, ``'Not Modified'`` response is sent. Otherwise, the content
-      type is guessed by calling the :meth:`guess_type` method, which in turn
-      uses the *extensions_map* variable, and the file contents are returned.
+      ``'File not found'`` error. If the file's modified timestamp is less then
+      ``-43200``, the return value of the :func:`time.time()` function will be
+      used to avoid :exc:`OSError` exception on ``'win32'`` platform. If there
+      was a ``'If-Modified-Since'`` header in the request, and the file was not
+      modified after this time, a ``304``, ``'Not Modified'`` response is sent.
+      Otherwise, the content type is guessed by calling the :meth:`guess_type`
+      method, which in turn uses the *extensions_map* variable, and the file
+      contents are returned.
 
       A ``'Content-type:'`` header with the guessed content type is output,
       followed by a ``'Content-Length:'`` header with the file's size and a

--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -379,9 +379,9 @@ provides three different variants:
       If the request was mapped to a file, it is opened. Any :exc:`OSError`
       exception in opening the requested file is mapped to a ``404``,
       ``'File not found'`` error. If the file's modified timestamp is less then
-      ``-43200``, the return value of the :func:`time.time()` function will be
-      used to avoid :exc:`OSError` exception on ``'win32'`` platform. If there
-      was a ``'If-Modified-Since'`` header in the request, and the file was not
+      ``-43200``, ``0`` will be used as the modified timestamp to avoid
+      :exc:`OSError` exception on ``'win32'`` platform. If there was a
+      ``'If-Modified-Since'`` header in the request, and the file was not
       modified after this time, a ``304``, ``'Not Modified'`` response is sent.
       Otherwise, the content type is guessed by calling the :meth:`guess_type`
       method, which in turn uses the *extensions_map* variable, and the file

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -731,6 +731,14 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
         try:
             fs = os.fstat(f.fileno())
+            # On Windows, _PyTime_gmtime() only allows timestamps larger or
+            # equal to -43200 (1969-12-31 12:00:00). But os.fstat() will
+            # happily return stat_result with st_mtime less then -43200. See
+            # issue #101035. For files with st_mtime less then -43200, clients
+            # might as well get the "updated" version.
+            mtime = fs.st_mtime
+            if sys.platform == 'win32' and mtime < -43200:
+                mtime = time.time()
             # Use browser cache if possible
             if ("If-Modified-Since" in self.headers
                     and "If-None-Match" not in self.headers):
@@ -749,7 +757,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
                     if ims.tzinfo is datetime.timezone.utc:
                         # compare to UTC datetime of last modification
                         last_modif = datetime.datetime.fromtimestamp(
-                            fs.st_mtime, datetime.timezone.utc)
+                            mtime, datetime.timezone.utc)
                         # remove microseconds, like in If-Modified-Since
                         last_modif = last_modif.replace(microsecond=0)
 
@@ -763,7 +771,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             self.send_header("Content-type", ctype)
             self.send_header("Content-Length", str(fs[6]))
             self.send_header("Last-Modified",
-                self.date_time_string(fs.st_mtime))
+                self.date_time_string(mtime))
             self.end_headers()
             return f
         except:

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -738,7 +738,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             # might as well get the "updated" version.
             mtime = fs.st_mtime
             if sys.platform == 'win32' and mtime < -43200:
-                mtime = time.time()
+                mtime = 0
             # Use browser cache if possible
             if ("If-Modified-Since" in self.headers
                     and "If-None-Match" not in self.headers):

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -342,11 +342,11 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         self.tempdir = tempfile.mkdtemp(dir=basetempdir)
         self.tempdir_name = os.path.basename(self.tempdir)
         self.base_url = '/' + self.tempdir_name
-        tempname = os.path.join(self.tempdir, 'test')
-        with open(tempname, 'wb') as temp:
+        self.tempname = os.path.join(self.tempdir, 'test')
+        with open(self.tempname, 'wb') as temp:
             temp.write(self.data)
             temp.flush()
-        mtime = os.stat(tempname).st_mtime
+        mtime = os.stat(self.tempname).st_mtime
         # compute last modification datetime for browser cache tests
         last_modif = datetime.datetime.fromtimestamp(mtime,
             datetime.timezone.utc)
@@ -573,6 +573,23 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         self.check_status_and_reason(response, HTTPStatus.OK, data=self.data)
         last_modif_header = response.headers['Last-modified']
         self.assertEqual(last_modif_header, self.last_modif_header)
+
+    @unittest.skipUnless(sys.platform == 'win32',
+                         'win32 specific OSError')
+    def test_last_modified_file_with_mtime_12_hour_before_epoch(self):
+        """Check that SimpleHTTPServer can function correctly when file's
+        mtime is less then -43200 (before 1969-12-31 12:00:00+00:00).
+        """
+        stat = os.stat(self.tempname)
+        atime_bak, mtime_bak = stat.st_atime, stat.st_mtime
+
+        os.utime(self.tempname, (-43201., -43201.))
+        try:
+            self.request(self.base_url + '/test')
+        except http.client.RemoteDisconnected as err:
+            raise err
+        finally:
+            os.utime(self.tempname, (atime_bak, mtime_bak))
 
     def test_path_without_leading_slash(self):
         response = self.request(self.tempdir_name + '/test')

--- a/Misc/NEWS.d/next/Library/2023-01-14-16-00-56.gh-issue-101035.S4dWZB.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-14-16-00-56.gh-issue-101035.S4dWZB.rst
@@ -1,2 +1,2 @@
 Check if the timestamp from :func:`os.fstat()` is valid for :func:`datetime.datetime.fromtimestamp()`.
-If the timestamp is not valid, use timestamp from :func:`time.time()` instead to avoid :exc:`OSError`.
+If the timestamp is not valid, use ``0`` instead to avoid :exc:`OSError`.

--- a/Misc/NEWS.d/next/Library/2023-01-14-16-00-56.gh-issue-101035.S4dWZB.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-14-16-00-56.gh-issue-101035.S4dWZB.rst
@@ -1,0 +1,2 @@
+Check if the timestamp from :func:`os.fstat()` is valid for :func:`datetime.datetime.fromtimestamp()`.
+If the timestamp is not valid, use timestamp from :func:`time.time()` instead to avoid :exc:`OSError`.


### PR DESCRIPTION
datetime.datetime.fromtimestamp() will raise `OSError` on `win32` when timestamp is less then `-43200`.
If so, use timestamp from `time.time()`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101035 -->
* Issue: gh-101035
<!-- /gh-issue-number -->
