### PR TITLE
gh-94518: Rename `group*` to `extra_group*` to avoid confusion

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-01-15-09-11-30.gh-issue-94518.jvxtxm.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-15-09-11-30.gh-issue-94518.jvxtxm.rst
@@ -1,0 +1,1 @@
+``groups_size`` and ``groups`` variables of ``_posixsubprocess`` module are renamed into ``extra_group_size`` and ``extra_group`` to stress that they add group affinity, not replace it. Patch by Oleg Iarygin.

--- a/Misc/NEWS.d/next/Library/2023-01-15-09-11-30.gh-issue-94518.jvxtxm.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-15-09-11-30.gh-issue-94518.jvxtxm.rst
@@ -1,1 +1,3 @@
-``groups_size`` and ``groups`` variables of ``_posixsubprocess`` module are renamed into ``extra_group_size`` and ``extra_group`` to stress that they add group affinity, not replace it. Patch by Oleg Iarygin.
+Group-related variables of ``_posixsubprocess`` module are renamed to
+stress that supplimentary group affinity is added to a fork, not
+replace the inherited ones. Patch by Oleg Iarygin.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -1079,7 +1079,7 @@ PyDoc_STRVAR(subprocess_fork_exec_doc,
           p2cread, p2cwrite, c2pread, c2pwrite,\n\
           errread, errwrite, errpipe_read, errpipe_write,\n\
           restore_signals, call_setsid, pgid_to_set,\n\
-          gid, extra_groups_packed, uid,\n\
+          gid, extra_groups, uid,\n\
           preexec_fn)\n\
 \n\
 Forks a child process, closes parent file descriptors as appropriate in the\n\

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -519,7 +519,7 @@ child_exec(char *const exec_array[],
            int close_fds, int restore_signals,
            int call_setsid, pid_t pgid_to_set,
            gid_t gid,
-           Py_ssize_t groups_size, const gid_t *groups,
+           Py_ssize_t extra_group_size, const gid_t *extra_groups,
            uid_t uid, int child_umask,
            const void *child_sigmask,
            PyObject *py_fds_to_keep,
@@ -619,8 +619,8 @@ child_exec(char *const exec_array[],
 #endif
 
 #ifdef HAVE_SETGROUPS
-    if (groups_size > 0)
-        POSIX_CALL(setgroups(groups_size, groups));
+    if (extra_group_size > 0)
+        POSIX_CALL(setgroups(extra_group_size, extra_groups));
 #endif /* HAVE_SETGROUPS */
 
 #ifdef HAVE_SETREGID
@@ -725,7 +725,7 @@ do_fork_exec(char *const exec_array[],
              int close_fds, int restore_signals,
              int call_setsid, pid_t pgid_to_set,
              gid_t gid,
-             Py_ssize_t groups_size, const gid_t *groups,
+             Py_ssize_t extra_group_size, const gid_t *extra_groups,
              uid_t uid, int child_umask,
              const void *child_sigmask,
              PyObject *py_fds_to_keep,
@@ -740,7 +740,7 @@ do_fork_exec(char *const exec_array[],
         /* These are checked by our caller; verify them in debug builds. */
         assert(uid == (uid_t)-1);
         assert(gid == (gid_t)-1);
-        assert(groups_size < 0);
+        assert(extra_group_size < 0);
         assert(preexec_fn == Py_None);
 
         pid = vfork();
@@ -777,7 +777,7 @@ do_fork_exec(char *const exec_array[],
                p2cread, p2cwrite, c2pread, c2pwrite,
                errread, errwrite, errpipe_read, errpipe_write,
                close_fds, restore_signals, call_setsid, pgid_to_set,
-               gid, groups_size, groups,
+               gid, extra_group_size, extra_groups,
                uid, child_umask, child_sigmask,
                py_fds_to_keep, preexec_fn, preexec_fn_args_tuple);
     _exit(255);
@@ -799,7 +799,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
     int errpipe_read, errpipe_write, close_fds, restore_signals;
     int call_setsid;
     pid_t pgid_to_set = -1;
-    gid_t *groups = NULL;
+    gid_t *extra_groups = NULL;
     int child_umask;
     PyObject *cwd_obj, *cwd_obj2 = NULL;
     const char *cwd;
@@ -908,14 +908,14 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
             goto cleanup;
 
         if (num_groups > MAX_GROUPS) {
-            PyErr_SetString(PyExc_ValueError, "too many groups");
+            PyErr_SetString(PyExc_ValueError, "too many extra_groups");
             goto cleanup;
         }
 
-        /* Deliberately keep groups == NULL for num_groups == 0 */
+        /* Deliberately keep extra_groups == NULL for num_groups == 0 */
         if (num_groups > 0) {
-            groups = PyMem_RawMalloc(num_groups * sizeof(gid_t));
-            if (groups == NULL) {
+            extra_groups = PyMem_RawMalloc(num_groups * sizeof(gid_t));
+            if (extra_groups == NULL) {
                 PyErr_SetString(PyExc_MemoryError,
                         "failed to allocate memory for group list");
                 goto cleanup;
@@ -929,7 +929,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
                 goto cleanup;
             if (!PyLong_Check(elem)) {
                 PyErr_SetString(PyExc_TypeError,
-                                "groups must be integers");
+                                "extra_groups must be integers");
                 Py_DECREF(elem);
                 goto cleanup;
             } else {
@@ -939,7 +939,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
                     PyErr_SetString(PyExc_ValueError, "invalid group id");
                     goto cleanup;
                 }
-                groups[i] = gid;
+                extra_groups[i] = gid;
             }
             Py_DECREF(elem);
         }
@@ -1014,7 +1014,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
                        p2cread, p2cwrite, c2pread, c2pwrite,
                        errread, errwrite, errpipe_read, errpipe_write,
                        close_fds, restore_signals, call_setsid, pgid_to_set,
-                       gid, num_groups, groups,
+                       gid, num_groups, extra_groups,
                        uid, child_umask, old_sigmask,
                        py_fds_to_keep, preexec_fn, preexec_fn_args_tuple);
 
@@ -1054,7 +1054,7 @@ cleanup:
     }
 
     Py_XDECREF(preexec_fn_args_tuple);
-    PyMem_RawFree(groups);
+    PyMem_RawFree(extra_groups);
     Py_XDECREF(cwd_obj2);
     if (envp)
         _Py_FreeCharPArray(envp);

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -793,7 +793,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
     PyObject *env_list, *preexec_fn;
     PyObject *process_args, *converted_args = NULL, *fast_args = NULL;
     PyObject *preexec_fn_args_tuple = NULL;
-    PyObject *groups_list;
+    PyObject *extra_groups_packed;
     PyObject *uid_object, *gid_object;
     int p2cread, p2cwrite, c2pread, c2pwrite, errread, errwrite;
     int errpipe_read, errpipe_write, close_fds, restore_signals;
@@ -819,7 +819,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
             &p2cread, &p2cwrite, &c2pread, &c2pwrite,
             &errread, &errwrite, &errpipe_read, &errpipe_write,
             &restore_signals, &call_setsid, &pgid_to_set,
-            &gid_object, &groups_list, &uid_object, &child_umask,
+            &gid_object, &extra_groups_packed, &uid_object, &child_umask,
             &preexec_fn, &allow_vfork))
         return NULL;
 
@@ -895,14 +895,14 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
         cwd = NULL;
     }
 
-    if (groups_list != Py_None) {
+    if (extra_groups_packed != Py_None) {
 #ifdef HAVE_SETGROUPS
-        if (!PyList_Check(groups_list)) {
+        if (!PyList_Check(extra_groups_packed)) {
             PyErr_SetString(PyExc_TypeError,
                     "setgroups argument must be a list");
             goto cleanup;
         }
-        extra_group_size = PySequence_Size(groups_list);
+        extra_group_size = PySequence_Size(extra_groups_packed);
 
         if (extra_group_size < 0)
             goto cleanup;
@@ -924,7 +924,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
 
         for (Py_ssize_t i = 0; i < extra_group_size; i++) {
             PyObject *elem;
-            elem = PySequence_GetItem(groups_list, i);
+            elem = PySequence_GetItem(extra_groups_packed, i);
             if (!elem)
                 goto cleanup;
             if (!PyLong_Check(elem)) {
@@ -1079,7 +1079,7 @@ PyDoc_STRVAR(subprocess_fork_exec_doc,
           p2cread, p2cwrite, c2pread, c2pwrite,\n\
           errread, errwrite, errpipe_read, errpipe_write,\n\
           restore_signals, call_setsid, pgid_to_set,\n\
-          gid, groups_list, uid,\n\
+          gid, extra_groups_packed, uid,\n\
           preexec_fn)\n\
 \n\
 Forks a child process, closes parent file descriptors as appropriate in the\n\


### PR DESCRIPTION
This PR addresses https://github.com/python/cpython/pull/94687#issuecomment-1269264285:

> Todo: replace `groups_size`/`groups` parameter names with `extra_group_size`/`extra_groups` across the whole file to avoid confusion of passers-by. It's necessary to mitigate a misleading name of `setgroups` that supposes replacement of not supplimentary group affinities, but all ones. The mislead results in seeing the omission of `setgroups` call for `groups_size == 0` as a bug (like we should reset the inherited affinities but do nothing instead).
>
> I'll do it in a separate PR because both this PR and gh-94519 are already big enough to clobber them with extra details.

Edit: this PR also unifies terminology by further renaming `groups_list` parameter and `num_groups` variable into `extra_groups_packed` and `extra_group_size`.

cc @gpshead

<!-- gh-issue-number: gh-94518 -->
* Issue: gh-94518
<!-- /gh-issue-number -->
