### PR TITLE
gh-101056: Fix memory leak in `formatfloat()` in `bytesobject.c`

### DIFF
--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -434,8 +434,10 @@ formatfloat(PyObject *v, int flags, int prec, int type,
     len = strlen(p);
     if (writer != NULL) {
         str = _PyBytesWriter_Prepare(writer, str, len);
-        if (str == NULL)
+        if (str == NULL) {
+            PyMem_Free(p);
             return NULL;
+        }
         memcpy(str, p, len);
         PyMem_Free(p);
         str += len;


### PR DESCRIPTION
Docs say:

```
The return value is a pointer to *buffer* with the converted string or
   ``NULL`` if the conversion failed. The caller is responsible for freeing the
   returned string by calling :c:func:`PyMem_Free`.
```

<!-- gh-issue-number: gh-101056 -->
* Issue: gh-101056
<!-- /gh-issue-number -->
