### PR TITLE
Docs: Duplicate reference

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -464,7 +464,6 @@ Pending Removal in Python 3.14
 
   Use :mod:`importlib.resources.abc` classes instead:
 
-  * :class:`importlib.resources.abc.TraversableResources`
   * :class:`importlib.resources.abc.Traversable`
   * :class:`importlib.resources.abc.TraversableResources`
 


### PR DESCRIPTION
# Remove duplicate reference 

This PR removes duplicate reference of `importlib.resources.abc.TraversableResources` class.
