### PR TITLE
raising a BaseException in a multiprocessing worker pool causes process hang

### DIFF
--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -123,7 +123,7 @@ def worker(inqueue, outqueue, initializer=None, initargs=(), maxtasks=None,
         job, i, func, args, kwds = task
         try:
             result = (True, func(*args, **kwds))
-        except Exception as e:
+        except BaseException as e:
             if wrap_exception and func is not _helper_reraises_exception:
                 e = ExceptionWithTraceback(e, e.__traceback__)
             result = (False, e)


### PR DESCRIPTION
raising a BaseException in a worker pool causes us not to put the result in the queue and subsequently for the whole process to hang, catching BaseException alleviates this issue.

A small example reproducing the issue:

```python
from multiprocessing import Pool

def foo():
    raise BaseException()

Pool().apply(foo)
```