### PR TITLE
[3.11] gh-101046: Fix a potential memory leak in the parser when raising MemoryError (GH-101051)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-15-03-26-04.gh-issue-101046.g2CM4S.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-15-03-26-04.gh-issue-101046.g2CM4S.rst
@@ -1,0 +1,2 @@
+Fix a possible memory leak in the parser when raising :exc:`MemoryError`.
+Patch by Pablo Galindo

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -23575,6 +23575,7 @@ _loop0_1_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -23644,6 +23645,7 @@ _loop0_2_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -23713,6 +23715,7 @@ _loop1_3_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -23796,6 +23799,7 @@ _loop0_5_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -24379,6 +24383,7 @@ _loop1_14_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -24625,6 +24630,7 @@ _loop0_19_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -24745,6 +24751,7 @@ _loop0_21_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -24961,6 +24968,7 @@ _loop0_24_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -25030,6 +25038,7 @@ _loop1_25_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -25113,6 +25122,7 @@ _loop0_27_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -25280,6 +25290,7 @@ _loop0_30_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -25438,6 +25449,7 @@ _loop1_32_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -25656,6 +25668,7 @@ _loop0_36_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -25725,6 +25738,7 @@ _loop0_37_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -25794,6 +25808,7 @@ _loop0_38_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -25863,6 +25878,7 @@ _loop1_39_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -25937,6 +25953,7 @@ _loop0_40_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26006,6 +26023,7 @@ _loop1_41_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26080,6 +26098,7 @@ _loop1_42_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26154,6 +26173,7 @@ _loop1_43_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26228,6 +26248,7 @@ _loop0_44_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26297,6 +26318,7 @@ _loop1_45_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26371,6 +26393,7 @@ _loop0_46_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26440,6 +26463,7 @@ _loop1_47_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26514,6 +26538,7 @@ _loop0_48_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26583,6 +26608,7 @@ _loop0_49_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26652,6 +26678,7 @@ _loop1_50_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26735,6 +26762,7 @@ _loop0_52_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26855,6 +26883,7 @@ _loop0_54_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -26975,6 +27004,7 @@ _loop0_56_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -27095,6 +27125,7 @@ _loop0_58_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -27283,6 +27314,7 @@ _loop1_60_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -27357,6 +27389,7 @@ _loop1_61_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -27525,6 +27558,7 @@ _loop1_64_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -27608,6 +27642,7 @@ _loop0_66_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -27998,6 +28033,7 @@ _loop0_72_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -28118,6 +28154,7 @@ _loop0_74_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -28296,6 +28333,7 @@ _loop0_77_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -28416,6 +28454,7 @@ _loop0_79_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -28527,6 +28566,7 @@ _loop1_80_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -28601,6 +28641,7 @@ _loop1_81_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -28684,6 +28725,7 @@ _loop0_83_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -28795,6 +28837,7 @@ _loop1_84_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -28869,6 +28912,7 @@ _loop1_85_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -28943,6 +28987,7 @@ _loop1_86_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -29070,6 +29115,7 @@ _loop0_89_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -29517,6 +29563,7 @@ _loop0_95_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -29586,6 +29633,7 @@ _loop0_96_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -29655,6 +29703,7 @@ _loop0_97_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -29724,6 +29773,7 @@ _loop1_98_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -29798,6 +29848,7 @@ _loop0_99_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -29867,6 +29918,7 @@ _loop1_100_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -29941,6 +29993,7 @@ _loop1_101_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30015,6 +30068,7 @@ _loop1_102_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30089,6 +30143,7 @@ _loop0_103_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30158,6 +30213,7 @@ _loop1_104_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30232,6 +30288,7 @@ _loop0_105_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30301,6 +30358,7 @@ _loop1_106_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30375,6 +30433,7 @@ _loop0_107_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30444,6 +30503,7 @@ _loop1_108_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30518,6 +30578,7 @@ _loop1_109_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30651,6 +30712,7 @@ _loop0_112_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30762,6 +30824,7 @@ _loop1_113_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30836,6 +30899,7 @@ _loop0_114_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -30905,6 +30969,7 @@ _loop0_115_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -31043,6 +31108,7 @@ _loop0_118_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -31211,6 +31277,7 @@ _loop0_121_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -31331,6 +31398,7 @@ _loop0_123_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -31451,6 +31519,7 @@ _loop0_125_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -31571,6 +31640,7 @@ _loop0_127_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -31682,6 +31752,7 @@ _loop0_128_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -31760,6 +31831,7 @@ _loop0_130_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -31871,6 +31943,7 @@ _loop1_131_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -31995,6 +32068,7 @@ _loop0_134_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -32115,6 +32189,7 @@ _loop0_136_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -32235,6 +32310,7 @@ _loop0_138_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -32355,6 +32431,7 @@ _loop0_140_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -32475,6 +32552,7 @@ _loop0_142_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -33177,6 +33255,7 @@ _loop0_152_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -33246,6 +33325,7 @@ _loop0_153_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -33315,6 +33395,7 @@ _loop0_154_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -33635,6 +33716,7 @@ _loop0_159_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -33704,6 +33786,7 @@ _loop0_160_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -33773,6 +33856,7 @@ _loop1_161_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -33905,6 +33989,7 @@ _loop0_163_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -34032,6 +34117,7 @@ _loop0_165_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -34159,6 +34245,7 @@ _loop0_167_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -34228,6 +34315,7 @@ _loop1_168_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -34479,6 +34567,7 @@ _loop0_172_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -34683,6 +34772,7 @@ _loop1_175_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -34757,6 +34847,7 @@ _loop0_176_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -34826,6 +34917,7 @@ _loop0_177_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -34904,6 +34996,7 @@ _loop0_179_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -35073,6 +35166,7 @@ _loop0_181_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -35200,6 +35294,7 @@ _loop0_183_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -35327,6 +35422,7 @@ _loop0_185_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -35396,6 +35492,7 @@ _loop1_186_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -35470,6 +35567,7 @@ _loop1_187_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -35663,6 +35761,7 @@ _loop0_190_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -35953,6 +36052,7 @@ _loop0_195_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -36073,6 +36173,7 @@ _loop0_197_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -36193,6 +36294,7 @@ _loop0_199_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -36313,6 +36415,7 @@ _loop0_201_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -36482,6 +36585,7 @@ _loop0_203_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -36551,6 +36655,7 @@ _loop1_204_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -36667,6 +36772,7 @@ _loop0_206_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -36736,6 +36842,7 @@ _loop1_207_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;
@@ -37264,6 +37371,7 @@ _loop0_219_rule(Parser *p)
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
                 if (!_new_children) {
+                    PyMem_Free(_children);
                     p->error_indicator = 1;
                     PyErr_NoMemory();
                     p->level--;

--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -801,7 +801,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
                 self.print(
                     "void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));"
                 )
-                self.out_of_memory_return(f"!_new_children")
+                self.out_of_memory_return(f"!_new_children", cleanup_code="PyMem_Free(_children);")
                 self.print("_children = _new_children;")
             self.print("}")
             self.print("_children[_n++] = _res;")


### PR DESCRIPTION
(cherry picked from commit 1de4395f62bb140563761ef5cbdf46accef3c550)

Co-authored-by: Pablo Galindo Salgado <Pablogsal@gmail.com>

<!-- gh-issue-number: gh-101046 -->
* Issue: gh-101046
<!-- /gh-issue-number -->
