### PR TITLE
Bump Azure Pipelines to ubuntu-22.04

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -8,7 +8,7 @@ jobs:
   displayName: Pre-build checks
 
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
 
   steps:
   - template: ./prebuild-checks.yml
@@ -20,7 +20,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['docs.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
 
   steps:
   - template: ./docs-steps.yml
@@ -52,7 +52,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
 
   variables:
     testRunTitle: '$(build.sourceBranchName)-linux'
@@ -78,7 +78,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
 
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -8,7 +8,7 @@ jobs:
   displayName: Pre-build checks
 
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
 
   steps:
   - template: ./prebuild-checks.yml
@@ -20,7 +20,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['docs.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
 
   steps:
   - template: ./docs-steps.yml
@@ -52,7 +52,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
 
   variables:
     testRunTitle: '$(system.pullRequest.TargetBranch)-linux'
@@ -78,7 +78,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
 
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Replaces and closes https://github.com/python/cpython/pull/100854.

Should be backported because the 3.7 branch builds on Azure Pipelines are failing, for example:

```
##[warning]An image label with the label ubuntu-16.04 does not exist.
,##[error]The remote provider was unable to process the request.
```

* https://dev.azure.com/Python/cpython/_build/results?buildId=118919&view=logs&j=341b3d8e-0d13-57d4-859b-65d31dcbc29e
* https://github.com/python/cpython/pull/100853

(The `main` and 3.11-3.8 branches were already bumped to `ubuntu-20.04` by https://github.com/python/cpython/issues/89170, which didn't make it back to 3.7.)

* https://github.com/actions/runner-images#available-images
