### PR TITLE
gh-82052: Don't send partial UTF-8 sequences to the Windows API

### DIFF
--- a/Misc/NEWS.d/next/Windows/2023-01-17-18-17-58.gh-issue-82052.mWyysT.rst
+++ b/Misc/NEWS.d/next/Windows/2023-01-17-18-17-58.gh-issue-82052.mWyysT.rst
@@ -1,0 +1,1 @@
+Fixed an issue where writing more than 32K of Unicode output to the console screen in one go can result in mojibake.


### PR DESCRIPTION
Fixes #82052

This doesn't include a test, as I'm not sure how I would write a test for it. The only reproducer I am aware of involves sending output to the console screen and visually inspecting it. I've validated that this PR fixes the issue by doing that test, but it's not something I know how to automate.

<!-- gh-issue-number: gh-82052 -->
* Issue: gh-82052
<!-- /gh-issue-number -->
