### PR TITLE
fix: typo

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -157,7 +157,7 @@ Other Language Changes
   in :gh:`96670`.)
 
 * The Garbage Collector now runs only on the eval breaker mechanism of the
-  Python bytecode evaluation loop instead on object allocations. The GC can
+  Python bytecode evaluation loop instead of object allocations. The GC can
   also run when :c:func:`PyErr_CheckSignals` is called so C extensions that
   need to run for a long time without executing any Python code also have a
   chance to execute the GC periodically. (Contributed by Pablo Galindo in


### PR DESCRIPTION
instead on → instead of