### PR TITLE
gh-89381: Fix signature for math.log and cmath.log

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-01-18-00-59-10.gh-issue-89381.AYHxIv.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-18-00-59-10.gh-issue-89381.AYHxIv.rst
@@ -1,0 +1,1 @@
+Fix signature for :func:`math.log` and :func:`cmath.log`.

--- a/Modules/clinic/cmathmodule.c.h
+++ b/Modules/clinic/cmathmodule.c.h
@@ -639,10 +639,10 @@ exit:
 }
 
 PyDoc_STRVAR(cmath_log__doc__,
-"log($module, z, base=<unrepresentable>, /)\n"
+"log($module, z, base=cmath.e, /)\n"
 "--\n"
 "\n"
-"log(z[, base]) -> the logarithm of z to the given base.\n"
+"Return the logarithm of z to the given base.\n"
 "\n"
 "If the base not specified, returns the natural logarithm (base e) of z.");
 
@@ -982,4 +982,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0146c656e67f5d5f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=bbc937dc64f3520b input=a9049054013a1b77]*/

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -187,43 +187,36 @@ exit:
 }
 
 PyDoc_STRVAR(math_log__doc__,
-"log(x, [base=math.e])\n"
+"log($module, x, base=math.e, /)\n"
+"--\n"
+"\n"
 "Return the logarithm of x to the given base.\n"
 "\n"
 "If the base not specified, returns the natural logarithm (base e) of x.");
 
 #define MATH_LOG_METHODDEF    \
-    {"log", (PyCFunction)math_log, METH_VARARGS, math_log__doc__},
+    {"log", _PyCFunction_CAST(math_log), METH_FASTCALL, math_log__doc__},
 
 static PyObject *
-math_log_impl(PyObject *module, PyObject *x, int group_right_1,
-              PyObject *base);
+math_log_impl(PyObject *module, PyObject *x, PyObject *base);
 
 static PyObject *
-math_log(PyObject *module, PyObject *args)
+math_log(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *x;
-    int group_right_1 = 0;
     PyObject *base = NULL;
 
-    switch (PyTuple_GET_SIZE(args)) {
-        case 1:
-            if (!PyArg_ParseTuple(args, "O:log", &x)) {
-                goto exit;
-            }
-            break;
-        case 2:
-            if (!PyArg_ParseTuple(args, "OO:log", &x, &base)) {
-                goto exit;
-            }
-            group_right_1 = 1;
-            break;
-        default:
-            PyErr_SetString(PyExc_TypeError, "math.log requires 1 to 2 arguments");
-            goto exit;
+    if (!_PyArg_CheckPositional("log", nargs, 1, 2)) {
+        goto exit;
     }
-    return_value = math_log_impl(module, x, group_right_1, base);
+    x = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    base = args[1];
+skip_optional:
+    return_value = math_log_impl(module, x, base);
 
 exit:
     return return_value;
@@ -954,4 +947,4 @@ math_ulp(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=899211ec70e4506c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=619aba52da61843d input=a9049054013a1b77]*/

--- a/Modules/cmathmodule.c
+++ b/Modules/cmathmodule.c
@@ -952,17 +952,17 @@ cmath_tanh_impl(PyObject *module, Py_complex z)
 cmath.log
 
     z as x: Py_complex
-    base as y_obj: object = NULL
+    base as y_obj: object(c_default="NULL") = cmath.e
     /
 
-log(z[, base]) -> the logarithm of z to the given base.
+Return the logarithm of z to the given base.
 
 If the base not specified, returns the natural logarithm (base e) of z.
 [clinic start generated code]*/
 
 static PyObject *
 cmath_log_impl(PyObject *module, Py_complex x, PyObject *y_obj)
-/*[clinic end generated code: output=4effdb7d258e0d94 input=230ed3a71ecd000a]*/
+/*[clinic end generated code: output=4effdb7d258e0d94 input=6783d68473d21cf3]*/
 {
     Py_complex y;
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2366,9 +2366,7 @@ loghelper(PyObject* arg, double (*func)(double))
 math.log
 
     x:    object
-    [
     base: object(c_default="NULL") = math.e
-    ]
     /
 
 Return the logarithm of x to the given base.
@@ -2377,9 +2375,8 @@ If the base not specified, returns the natural logarithm (base e) of x.
 [clinic start generated code]*/
 
 static PyObject *
-math_log_impl(PyObject *module, PyObject *x, int group_right_1,
-              PyObject *base)
-/*[clinic end generated code: output=7b5a39e526b73fc9 input=0f62d5726cbfebbd]*/
+math_log_impl(PyObject *module, PyObject *x, PyObject *base)
+/*[clinic end generated code: output=1dead263cbb1e854 input=59b97db7030bb40b]*/
 {
     PyObject *num, *den;
     PyObject *ans;


### PR DESCRIPTION
The optional group in math.log seems unnecessary, as far as I can tell. Once we remove this, Argument Clinic knows what to do.

For `cmath`, we just do what `math` is already doing: use `c_default = NULL` (so the actual runtime logic is unchanged), but mark `cmath.e` as the fake default value.

<!-- gh-issue-number: gh-89381 -->
* Issue: gh-89381
<!-- /gh-issue-number -->
