### PR TITLE
GH-101097: Switch from standard interval notation to greater or less than signs for random.random()'s documentation

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -294,7 +294,7 @@ be found in any statistics text.
 
 .. function:: random()
 
-   Return the next random floating point number in the range [0.0, 1.0).
+   Return the next random floating point number in the range ``0.0 <= x < 1.0``
 
 
 .. function:: uniform(a, b)

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -21,7 +21,7 @@ lognormal, negative exponential, gamma, and beta distributions. For generating
 distributions of angles, the von Mises distribution is available.
 
 Almost all module functions depend on the basic function :func:`.random`, which
-generates a random float uniformly in the semi-open range ``0.0 <= X < 1.0``.
+generates a random float uniformly in the half-open range ``0.0 <= X < 1.0``.
 Python uses the Mersenne Twister as the core generator.  It produces 53-bit precision
 floats and has a period of 2\*\*19937-1.  The underlying implementation in C is
 both fast and threadsafe.  The Mersenne Twister is one of the most extensively

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -21,8 +21,8 @@ lognormal, negative exponential, gamma, and beta distributions. For generating
 distributions of angles, the von Mises distribution is available.
 
 Almost all module functions depend on the basic function :func:`.random`, which
-generates a random float uniformly in the semi-open range [0.0, 1.0).  Python
-uses the Mersenne Twister as the core generator.  It produces 53-bit precision
+generates a random float uniformly in the semi-open range ``0.0 <= X < 1.0``.
+Python uses the Mersenne Twister as the core generator.  It produces 53-bit precision
 floats and has a period of 2\*\*19937-1.  The underlying implementation in C is
 both fast and threadsafe.  The Mersenne Twister is one of the most extensively
 tested random number generators in existence.  However, being completely
@@ -294,7 +294,7 @@ be found in any statistics text.
 
 .. function:: random()
 
-   Return the next random floating point number in the range ``0.0 <= x < 1.0``
+   Return the next random floating point number in the range ``0.0 <= X < 1.0``
 
 
 .. function:: uniform(a, b)

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -849,7 +849,7 @@ class SystemRandom(Random):
     """
 
     def random(self):
-        """Return the next random floating point number in the range ``0.0 <= X < 1.0``"""
+        """Get the next random number in the range 0.0 <= X < 1.0."""
         return (int.from_bytes(_urandom(7)) >> 3) * RECIP_BPF
 
     def getrandbits(self, k):

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -849,7 +849,7 @@ class SystemRandom(Random):
     """
 
     def random(self):
-        """Get the next random number in the range [0.0, 1.0)."""
+        """Return the next random floating point number in the range ``0.0 <= X < 1.0``"""
         return (int.from_bytes(_urandom(7)) >> 3) * RECIP_BPF
 
     def getrandbits(self, k):


### PR DESCRIPTION
Fixes: https://github.com/python/cpython/issues/101097

<!-- gh-issue-number: gh-101097 -->
* Issue: gh-101097
<!-- /gh-issue-number -->
