### PR TITLE
gh-101100: Fix sphinx warnings in `enum` module

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -52,11 +52,11 @@ are not normal Python classes.  See
 
 .. note:: Nomenclature
 
-   - The class :class:`Color` is an *enumeration* (or *enum*)
-   - The attributes :attr:`Color.RED`, :attr:`Color.GREEN`, etc., are
+   - The class ``Color`` is an *enumeration* (or *enum*)
+   - The attributes ``Color.RED``, ``Color.GREEN``, etc., are
      *enumeration members* (or *members*) and are functionally constants.
    - The enum members have *names* and *values* (the name of
-     :attr:`Color.RED` is ``RED``, the value of :attr:`Color.BLUE` is
+     ``Color.RED`` is ``RED``, the value of ``Color.BLUE`` is
      ``3``, etc.)
 
 ---------------
@@ -165,8 +165,8 @@ Data Types
    to subclass *EnumType* -- see :ref:`Subclassing EnumType <enumtype-examples>`
    for details.
 
-   *EnumType* is responsible for setting the correct :meth:`__repr__`,
-   :meth:`__str__`, :meth:`__format__`, and :meth:`__reduce__` methods on the
+   *EnumType* is responsible for setting the correct *__repr__*,
+   *__str__*, *__format__*, and *__reduce__* methods on the
    final *enum*, as well as creating the enum members, properly handling
    duplicates, providing iteration over the enum class, etc.
 
@@ -424,9 +424,9 @@ Data Types
       Using :class:`auto` with :class:`IntEnum` results in integers of increasing
       value, starting with ``1``.
 
-   .. versionchanged:: 3.11 :meth:`__str__` is now :func:`int.__str__` to
+   .. versionchanged:: 3.11 *__str__* is now ``int.__str__`` to
       better support the *replacement of existing constants* use-case.
-      :meth:`__format__` was already :func:`int.__format__` for that same reason.
+      *__format__* was already ``int.__format__`` for that same reason.
 
 
 .. class:: StrEnum
@@ -761,11 +761,11 @@ Data Types
 Supported ``__dunder__`` names
 """"""""""""""""""""""""""""""
 
-:attr:`__members__` is a read-only ordered mapping of ``member_name``:``member``
+:attr:`!EnumType.__members__` is a read-only ordered mapping of ``member_name``:``member``
 items.  It is only available on the class.
 
-:meth:`__new__`, if specified, must create and return the enum members; it is
-also a very good idea to set the member's :attr:`_value_` appropriately.  Once
+``__new__``, if specified, must create and return the enum members; it is
+also a very good idea to set the member's ``_value_`` appropriately.  Once
 all the members are created it is no longer used.
 
 
@@ -804,7 +804,7 @@ Utilities and Decorators
 .. class:: auto
 
    *auto* can be used in place of a value.  If used, the *Enum* machinery will
-   call an *Enum*'s :meth:`_generate_next_value_` to get an appropriate value.
+   call an *Enum*'s :meth:`!Enum._generate_next_value_` to get an appropriate value.
    For *Enum* and *IntEnum* that appropriate value will be the last value plus
    one; for *Flag* and *IntFlag* it will be the first power-of-two greater
    than the highest value; for *StrEnum* it will be the lower-cased version of
@@ -847,7 +847,7 @@ Utilities and Decorators
 .. decorator:: unique
 
    A :keyword:`class` decorator specifically for enumerations.  It searches an
-   enumeration's :attr:`__members__`, gathering any aliases it finds; if any are
+   enumeration's :attr:`!EnumType.__members__`, gathering any aliases it finds; if any are
    found :exc:`ValueError` is raised with the details::
 
       >>> from enum import Enum, unique

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -424,9 +424,9 @@ Data Types
       Using :class:`auto` with :class:`IntEnum` results in integers of increasing
       value, starting with ``1``.
 
-   .. versionchanged:: 3.11 :meth:`!__str__` is now :meth:`!int.__str__` to
+   .. versionchanged:: 3.11 :meth:`~object.__str__` is now :meth:`!int.__str__` to
       better support the *replacement of existing constants* use-case.
-      :meth:`!__format__` was already :meth:`!int.__format__` for that same reason.
+      :meth:`~object.__format__` was already :meth:`!int.__format__` for that same reason.
 
 
 .. class:: StrEnum
@@ -761,10 +761,10 @@ Data Types
 Supported ``__dunder__`` names
 """"""""""""""""""""""""""""""
 
-:attr:`!__members__` is a read-only ordered mapping of ``member_name``:``member``
+:attr:`~EnumType.__members__` is a read-only ordered mapping of ``member_name``:``member``
 items.  It is only available on the class.
 
-:meth:`!__new__`, if specified, must create and return the enum members; it is
+:meth:`~object.__new__`, if specified, must create and return the enum members; it is
 also a very good idea to set the member's :attr:`!_value_` appropriately.  Once
 all the members are created it is no longer used.
 
@@ -847,7 +847,7 @@ Utilities and Decorators
 .. decorator:: unique
 
    A :keyword:`class` decorator specifically for enumerations.  It searches an
-   enumeration's :attr:`!__members__`, gathering any aliases it finds; if any are
+   enumeration's :attr:`~EnumType.__members__`, gathering any aliases it finds; if any are
    found :exc:`ValueError` is raised with the details::
 
       >>> from enum import Enum, unique

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -52,11 +52,11 @@ are not normal Python classes.  See
 
 .. note:: Nomenclature
 
-   - The class ``Color`` is an *enumeration* (or *enum*)
-   - The attributes ``Color.RED``, ``Color.GREEN``, etc., are
+   - The class :class:`!Color` (or *enum*)
+   - The attributes :attr:`!Color.RED`, :attr:`!Color.GREEN`, etc., are
      *enumeration members* (or *members*) and are functionally constants.
    - The enum members have *names* and *values* (the name of
-     ``Color.RED`` is ``RED``, the value of ``Color.BLUE`` is
+     :attr:`!Color.RED` is ``RED``, the value of :attr:`!Color.BLUE` is
      ``3``, etc.)
 
 ---------------
@@ -165,8 +165,8 @@ Data Types
    to subclass *EnumType* -- see :ref:`Subclassing EnumType <enumtype-examples>`
    for details.
 
-   *EnumType* is responsible for setting the correct *__repr__*,
-   *__str__*, *__format__*, and *__reduce__* methods on the
+   *EnumType* is responsible for setting the correct :meth:`!__repr__`,
+   :meth:`!__str__`, :meth:`!__format__`, and :meth:`!__reduce__` methods on the
    final *enum*, as well as creating the enum members, properly handling
    duplicates, providing iteration over the enum class, etc.
 
@@ -424,9 +424,9 @@ Data Types
       Using :class:`auto` with :class:`IntEnum` results in integers of increasing
       value, starting with ``1``.
 
-   .. versionchanged:: 3.11 *__str__* is now ``int.__str__`` to
+   .. versionchanged:: 3.11 :meth:`!__str__` is now :meth:`!int.__str__` to
       better support the *replacement of existing constants* use-case.
-      *__format__* was already ``int.__format__`` for that same reason.
+      :meth:`!__format__` was already :meth:`!int.__format__` for that same reason.
 
 
 .. class:: StrEnum
@@ -761,11 +761,11 @@ Data Types
 Supported ``__dunder__`` names
 """"""""""""""""""""""""""""""
 
-:attr:`!EnumType.__members__` is a read-only ordered mapping of ``member_name``:``member``
+:attr:`!__members__` is a read-only ordered mapping of ``member_name``:``member``
 items.  It is only available on the class.
 
-``__new__``, if specified, must create and return the enum members; it is
-also a very good idea to set the member's ``_value_`` appropriately.  Once
+:meth:`!__new__`, if specified, must create and return the enum members; it is
+also a very good idea to set the member's :attr:`!_value_` appropriately.  Once
 all the members are created it is no longer used.
 
 
@@ -804,7 +804,7 @@ Utilities and Decorators
 .. class:: auto
 
    *auto* can be used in place of a value.  If used, the *Enum* machinery will
-   call an *Enum*'s :meth:`!Enum._generate_next_value_` to get an appropriate value.
+   call an *Enum*'s :meth:`~Enum._generate_next_value_` to get an appropriate value.
    For *Enum* and *IntEnum* that appropriate value will be the last value plus
    one; for *Flag* and *IntFlag* it will be the first power-of-two greater
    than the highest value; for *StrEnum* it will be the lower-cased version of
@@ -847,7 +847,7 @@ Utilities and Decorators
 .. decorator:: unique
 
    A :keyword:`class` decorator specifically for enumerations.  It searches an
-   enumeration's :attr:`!EnumType.__members__`, gathering any aliases it finds; if any are
+   enumeration's :attr:`!__members__`, gathering any aliases it finds; if any are
    found :exc:`ValueError` is raised with the details::
 
       >>> from enum import Enum, unique

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -52,7 +52,7 @@ are not normal Python classes.  See
 
 .. note:: Nomenclature
 
-   - The class :class:`!Color` (or *enum*)
+   - The class :class:`!Color` is an *enumeration* (or *enum*)
    - The attributes :attr:`!Color.RED`, :attr:`!Color.GREEN`, etc., are
      *enumeration members* (or *members*) and are functionally constants.
    - The enum members have *names* and *values* (the name of


### PR DESCRIPTION
There were several warnings before:

```

/Users/sobolev/Desktop/cpython/Doc/library/enum.rst:428: WARNING: py:meth reference target not found: __str__
/Users/sobolev/Desktop/cpython/Doc/library/enum.rst:428: WARNING: py:func reference target not found: int.__str__
/Users/sobolev/Desktop/cpython/Doc/library/enum.rst:428: WARNING: py:meth reference target not found: __format__
/Users/sobolev/Desktop/cpython/Doc/library/enum.rst:428: WARNING: py:func reference target not found: int.__format__
/Users/sobolev/Desktop/cpython/Doc/library/enum.rst:764: WARNING: py:attr reference target not found: __members__
/Users/sobolev/Desktop/cpython/Doc/library/enum.rst:767: WARNING: py:meth reference target not found: __new__
/Users/sobolev/Desktop/cpython/Doc/library/enum.rst:767: WARNING: py:attr reference target not found: _value_
/Users/sobolev/Desktop/cpython/Doc/library/enum.rst:806: WARNING: py:meth reference target not found: _generate_next_value_
/Users/sobolev/Desktop/cpython/Doc/library/enum.rst:849: WARNING: py:attr reference target not found: __members__
```

Here's how these places were rendered:


1. 

<img width="811" alt="Снимок экрана 2023-01-18 в 11 18 28" src="https://user-images.githubusercontent.com/4660275/213121303-207ef28f-2df2-46bc-b530-e2d1ae54b262.png">

2. 

<img width="742" alt="Снимок экрана 2023-01-18 в 11 18 38" src="https://user-images.githubusercontent.com/4660275/213121300-5c8113c4-8f61-481e-bc89-42b13e28b53a.png">

3.
<img width="779" alt="Снимок экрана 2023-01-18 в 11 19 57" src="https://user-images.githubusercontent.com/4660275/213121297-7e893672-ab58-4477-b3d6-e5bc9605502e.png">

4.

<img width="808" alt="Снимок экрана 2023-01-18 в 11 21 18" src="https://user-images.githubusercontent.com/4660275/213121284-64ce7b08-4037-4fd5-a379-e34ebd61b03a.png">


After the fix, there are no warnings:

<img width="752" alt="Снимок экрана 2023-01-18 в 11 27 00" src="https://user-images.githubusercontent.com/4660275/213121657-9858bd52-9e5a-4bef-b22b-87cf93234529.png">


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
