### PR TITLE
gh-101128: Fix ambiguity in description of random.choices arguments

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -175,13 +175,12 @@ Functions for sequences
    If the *population* is empty, raises :exc:`IndexError`.
 
    If a *weights* sequence is specified, selections are made according to the
-   relative weights.  Alternatively, if a *cum_weights* sequence is given, the
-   selections are made according to the cumulative weights (perhaps computed
-   using :func:`itertools.accumulate`).  For example, the relative weights
-   ``[10, 5, 30, 5]`` are equivalent to the cumulative weights
-   ``[10, 15, 45, 50]``.  Internally, the relative weights are converted to
-   cumulative weights before making selections, so supplying the cumulative
-   weights saves work.
+   relative weights.  Alternatively, if a *cum_weights* sequence is given
+   (perhaps computed using :func:`itertools.accumulate`), the selections
+   are made according to the cumulative weights. For example, the relative weights
+   ``[10, 5, 30, 5]`` are equivalent to the cumulative weights ``[10, 15, 45, 50]``.
+   Internally, the relative weights are converted to cumulative weights before making
+   selections, so supplying the cumulative weights saves work.
 
    If neither *weights* nor *cum_weights* are specified, selections are made
    with equal probability.  If a weights sequence is supplied, it must be


### PR DESCRIPTION
Hello.

I've moved the comment about using `itertools.accumulate` in the description of `random.choices` to the beginning of the sentence to make it clearer that it should be used for the `cum_weights` argument itself. Details are in the issue: gh-101128.

Thanks in advance.