### PR TITLE
GH-101112: Specify type of pattern for Path.rglob

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1270,7 +1270,8 @@ call fails (for example because the path doesn't exist).
 .. method:: Path.rglob(pattern)
 
    Glob the given relative *pattern* recursively.  This is like calling
-   :func:`Path.glob` with "``**/``" added in front of the *pattern*::
+   :func:`Path.glob` with "``**/``" added in front of the *pattern*, where
+   *patterns* are the same as for :mod:`fnmatch`::
 
       >>> sorted(Path().rglob("*.py"))
       [PosixPath('build/lib/pathlib.py'),


### PR DESCRIPTION
The documentation for `rglob` did not mention what `pattern` actually is.

Mentioning and linking to `fnmatch` makes this explicit, as the documentation for `fnmatch` both shows the syntax and some explanation.

<!-- gh-issue-number: gh-101112 -->
* Issue: gh-101112
<!-- /gh-issue-number -->
