### PR TITLE
gh-101140: Add free list for generators and async functions

### DIFF
--- a/Include/cpython/genobject.h
+++ b/Include/cpython/genobject.h
@@ -78,6 +78,7 @@ PyAPI_FUNC(PyObject *) PyAsyncGen_New(PyFrameObject *,
 
 #define PyAsyncGen_CheckExact(op) Py_IS_TYPE((op), &PyAsyncGen_Type)
 
+PyAPI_FUNC(void) _PyGen_ClearFreeList(void);
 
 #undef _PyGenObject_HEAD
 

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -80,6 +80,9 @@ static inline int _PyGCHead_FINALIZED(PyGC_Head *gc) {
 static inline void _PyGCHead_SET_FINALIZED(PyGC_Head *gc) {
     gc->_gc_prev |= _PyGC_PREV_MASK_FINALIZED;
 }
+static inline void _PyGCHead_UNSET_FINALIZED(PyGC_Head *gc) {
+    gc->_gc_prev &= !_PyGC_PREV_MASK_FINALIZED;
+}
 
 static inline int _PyGC_FINALIZED(PyObject *op) {
     PyGC_Head *gc = _Py_AS_GC(op);
@@ -88,6 +91,10 @@ static inline int _PyGC_FINALIZED(PyObject *op) {
 static inline void _PyGC_SET_FINALIZED(PyObject *op) {
     PyGC_Head *gc = _Py_AS_GC(op);
     _PyGCHead_SET_FINALIZED(gc);
+}
+static inline void _PyGC_SET_UNFINALIZED(PyObject *op) {
+    PyGC_Head *gc = _Py_AS_GC(op);
+    _PyGCHead_UNSET_FINALIZED(gc);
 }
 
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-19-01-35-36.gh-issue-101140.2OOJZp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-19-01-35-36.gh-issue-101140.2OOJZp.rst
@@ -1,0 +1,1 @@
+Optimize generator, coroutine, and async generator creation using a free list.

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -30,6 +30,7 @@
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"     // _PyThreadState_GET()
+#include "cpython/genobject.h"
 #include "pydtrace.h"
 
 typedef struct _gc_runtime_state GCState;
@@ -1043,6 +1044,7 @@ clear_freelists(PyInterpreterState *interp)
     _PyDict_ClearFreeList(interp);
     _PyAsyncGen_ClearFreeLists(interp);
     _PyContext_ClearFreeList(interp);
+    _PyGen_ClearFreeList();
 }
 
 // Show stats for objects in each generations

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -2356,3 +2356,20 @@ async_gen_athrow_new(PyAsyncGenObject *gen, PyObject *args)
     _PyObject_GC_TRACK((PyObject*)o);
     return (PyObject*)o;
 }
+
+void
+_PyGen_ClearFreeList(void)
+{
+    for (int i = 0; i < FREE_LIST_MAX; i++) {
+        for (int j = 0; j < MAX_SLOTS; j++) {
+            gen_free_list *free_list = &freelists[i][j];
+
+            while (free_list->free_list != NULL) {
+                PyGenObject *gen = free_list->free_list;
+                free_list->free_list = (PyGenObject *)gen->gi_code;
+                PyObject_GC_Del(gen);
+                --free_list->numfree;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a free list for generator functions, async generators, and co-routines.  On Instagram's workload a similar change has yielded a .25% - .46% perf win on the production workload.  This differs from that slightly in that since 3.10 generators are now variable sized objects.  Therefore the cache is a little bit bigger to accommodate the different sizes, but has a smaller number of entries per-size, and is arbitrarily limited at a certain size (currently 20).  These numbers could likely be tuned further.


<!-- gh-issue-number: gh-101140 -->
* Issue: gh-101140
<!-- /gh-issue-number -->
