### PR TITLE
gh-101144: Allow open and read_text encoding to be positional.

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -552,10 +552,10 @@ Path objects are traversable using the ``/`` operator or ``joinpath``.
       mode is now text.
 
    .. versionchanged:: 3.11.2
-      The ``encoding`` parameter can be supplied as the first positional
-      argument again without causing a :exc:`TypeError`. As it could in 3.9 and
-      earlier. Code needing to be compatible with unpatched 3.10 and 3.11
-      versions should always pass ``encoding=`` as a keyword argument.
+      The ``encoding`` parameter can be supplied as a positional argument
+      without causing a :exc:`TypeError`. As it could in 3.9 and earlier. Code
+      needing to be compatible with unpatched 3.10 and 3.11 versions should
+      always pass ``encoding=`` as a keyword argument.
 
 .. method:: Path.iterdir()
 
@@ -603,10 +603,10 @@ Path objects are traversable using the ``/`` operator or ``joinpath``.
    implied by the context).
 
    .. versionchanged:: 3.11.2
-      The ``encoding`` parameter can be supplied as the first positional
-      argument again without causing a :exc:`TypeError`. As it could in 3.9 and
-      earlier. Code needing to be compatible with unpatched 3.10 and 3.11
-      versions should always pass ``encoding=`` as a keyword argument.
+      The ``encoding`` parameter can be supplied as a positional argument
+      without causing a :exc:`TypeError`. As it could in 3.9 and earlier. Code
+      needing to be compatible with unpatched 3.10 and 3.11 versions should
+      always pass ``encoding=`` as a keyword argument.
 
 .. method:: Path.read_bytes()
 

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -551,6 +551,12 @@ Path objects are traversable using the ``/`` operator or ``joinpath``.
       Added support for text and binary modes for open. Default
       mode is now text.
 
+   .. versionchanged:: 3.11.2
+      The ``encoding`` parameter can be supplied as the first positional
+      argument again without causing a :exc:`TypeError`. As it could in 3.9 and
+      earlier. Code needing to be compatible with unpatched 3.10 and 3.11
+      versions should always pass ``encoding=`` as a keyword argument.
+
 .. method:: Path.iterdir()
 
    Enumerate the children of the current directory.
@@ -595,6 +601,12 @@ Path objects are traversable using the ``/`` operator or ``joinpath``.
    keyword arguments are passed through to
    :class:`io.TextIOWrapper` (except ``buffer``, which is
    implied by the context).
+
+   .. versionchanged:: 3.11.2
+      The ``encoding`` parameter can be supplied as the first positional
+      argument again without causing a :exc:`TypeError`. As it could in 3.9 and
+      earlier. Code needing to be compatible with unpatched 3.10 and 3.11
+      versions should always pass ``encoding=`` as a keyword argument.
 
 .. method:: Path.read_bytes()
 

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -553,9 +553,9 @@ Path objects are traversable using the ``/`` operator or ``joinpath``.
 
    .. versionchanged:: 3.11.2
       The ``encoding`` parameter can be supplied as a positional argument
-      without causing a :exc:`TypeError`. As it could in 3.9 and earlier. Code
-      needing to be compatible with unpatched 3.10 and 3.11 versions should
-      always pass ``encoding=`` as a keyword argument.
+      without causing a :exc:`TypeError`. As it could in 3.9. Code needing to
+      be compatible with unpatched 3.10 and 3.11 versions must pass all
+      :class:`io.TextIOWrapper` arguments, ``encoding`` included, as keywords.
 
 .. method:: Path.iterdir()
 
@@ -604,9 +604,9 @@ Path objects are traversable using the ``/`` operator or ``joinpath``.
 
    .. versionchanged:: 3.11.2
       The ``encoding`` parameter can be supplied as a positional argument
-      without causing a :exc:`TypeError`. As it could in 3.9 and earlier. Code
-      needing to be compatible with unpatched 3.10 and 3.11 versions should
-      always pass ``encoding=`` as a keyword argument.
+      without causing a :exc:`TypeError`. As it could in 3.9. Code needing to
+      be compatible with unpatched 3.10 and 3.11 versions must pass all
+      :class:`io.TextIOWrapper` arguments, ``encoding`` included, as keywords.
 
 .. method:: Path.read_bytes()
 

--- a/Lib/test/test_zipfile/test_path.py
+++ b/Lib/test/test_zipfile/test_path.py
@@ -145,7 +145,10 @@ class TestPath(unittest.TestCase):
         a, b, g = root.iterdir()
         with a.open(encoding="utf-8") as strm:
             data = strm.read()
-        assert data == "content of a"
+        self.assertEqual(data, "content of a")
+        with a.open('r', "utf-8") as strm:  # No gh-101144 TypeError
+            data = strm.read()
+        self.assertEqual(data, "content of a")
 
     def test_open_write(self):
         """
@@ -187,6 +190,7 @@ class TestPath(unittest.TestCase):
         root = zipfile.Path(alpharep)
         a, b, g = root.iterdir()
         assert a.read_text(encoding="utf-8") == "content of a"
+        a.read_text("utf-8")  # No TypeError per gh-101144.
         assert a.read_bytes() == b"content of a"
 
     @pass_alpharep

--- a/Lib/test/test_zipfile/test_path.py
+++ b/Lib/test/test_zipfile/test_path.py
@@ -146,9 +146,24 @@ class TestPath(unittest.TestCase):
         with a.open(encoding="utf-8") as strm:
             data = strm.read()
         self.assertEqual(data, "content of a")
-        with a.open('r', "utf-8") as strm:  # No gh-101144 TypeError
+        with a.open('r', "utf-8") as strm:  # not a kw, no gh-101144 TypeError
             data = strm.read()
         self.assertEqual(data, "content of a")
+
+    def test_open_encoding_utf16(self):
+        in_memory_file = io.BytesIO()
+        zf = zipfile.ZipFile(in_memory_file, "w")
+        zf.writestr("path/16.txt", "This was utf-16".encode("utf-16"))
+        zf.filename = "test_open_utf16.zip"
+        root = zipfile.Path(zf)
+        path, = root.iterdir()
+        u16 = path.joinpath("16.txt")
+        with u16.open('r', "utf-16") as strm:
+            data = strm.read()
+        self.assertEqual(data, "This was utf-16")
+        with u16.open(encoding="utf-16") as strm:
+            data = strm.read()
+        self.assertEqual(data, "This was utf-16")
 
     def test_open_write(self):
         """
@@ -190,7 +205,7 @@ class TestPath(unittest.TestCase):
         root = zipfile.Path(alpharep)
         a, b, g = root.iterdir()
         assert a.read_text(encoding="utf-8") == "content of a"
-        a.read_text("utf-8")  # No TypeError per gh-101144.
+        a.read_text("utf-8")  # No positional arg TypeError per gh-101144.
         assert a.read_bytes() == b"content of a"
 
     @pass_alpharep

--- a/Lib/test/test_zipfile/test_path.py
+++ b/Lib/test/test_zipfile/test_path.py
@@ -157,7 +157,7 @@ class TestPath(unittest.TestCase):
         zf.writestr("path/16.txt", "This was utf-16".encode("utf-16"))
         zf.filename = "test_open_utf16.zip"
         root = zipfile.Path(zf)
-        path, = root.iterdir()
+        (path,) = root.iterdir()
         u16 = path.joinpath("16.txt")
         with u16.open('r', "utf-16") as strm:
             data = strm.read()
@@ -172,7 +172,7 @@ class TestPath(unittest.TestCase):
         zf.writestr("path/bad-utf8.bin", b"invalid utf-8: \xff\xff.")
         zf.filename = "test_read_text_encoding_errors.zip"
         root = zipfile.Path(zf)
-        path, = root.iterdir()
+        (path,) = root.iterdir()
         u16 = path.joinpath("bad-utf8.bin")
 
         # encoding= as a positional argument for gh-101144.
@@ -199,7 +199,7 @@ with zipfile.ZipFile(io.BytesIO(), "w") as zf:
     zf.filename = '<test_encoding_warnings in memory zip file>'
     zf.writestr("path/file.txt", b"Spanish Inquisition")
     root = zipfile.Path(zf)
-    path, = root.iterdir()
+    (path,) = root.iterdir()
     file_path = path.joinpath("file.txt")
     unused = file_path.read_text()  # should warn
     file_path.open("r").close()  # should warn

--- a/Lib/zipfile/_path.py
+++ b/Lib/zipfile/_path.py
@@ -258,7 +258,8 @@ class Path:
                 raise ValueError("encoding args invalid for binary operation")
             return stream
         else:
-            kwargs["encoding"] = io.text_encoding(kwargs.get("encoding"))
+            if "encoding" in kwargs:
+                kwargs["encoding"] = io.text_encoding(kwargs["encoding"])
         return io.TextIOWrapper(stream, *args, **kwargs)
 
     @property
@@ -282,7 +283,8 @@ class Path:
         return pathlib.Path(self.root.filename).joinpath(self.at)
 
     def read_text(self, *args, **kwargs):
-        kwargs["encoding"] = io.text_encoding(kwargs.get("encoding"))
+        if "encoding" in kwargs:
+            kwargs["encoding"] = io.text_encoding(kwargs["encoding"])
         with self.open('r', *args, **kwargs) as strm:
             return strm.read()
 

--- a/Lib/zipfile/_path.py
+++ b/Lib/zipfile/_path.py
@@ -281,9 +281,8 @@ class Path:
     def filename(self):
         return pathlib.Path(self.root.filename).joinpath(self.at)
 
-    def read_text(self, encoding=None, *args, **kwargs):
-        encoding = io.text_encoding(encoding)
-        with self.open('r', *args, encoding=encoding, **kwargs) as strm:
+    def read_text(self, *args, **kwargs):
+        with self.open('r', *args, **kwargs) as strm:
             return strm.read()
 
     def read_bytes(self):

--- a/Lib/zipfile/_path.py
+++ b/Lib/zipfile/_path.py
@@ -241,7 +241,7 @@ class Path:
         self.root = FastLookup.make(root)
         self.at = at
 
-    def open(self, mode='r', *args, pwd=None, **kwargs):
+    def open(self, mode='r', encoding=None, *args, pwd=None, **kwargs):
         """
         Open this entry as text or binary following the semantics
         of ``pathlib.Path.open()`` by passing arguments through
@@ -254,13 +254,12 @@ class Path:
             raise FileNotFoundError(self)
         stream = self.root.open(self.at, zip_mode, pwd=pwd)
         if 'b' in mode:
-            if args or kwargs:
+            if encoding is not None or args or kwargs:
                 raise ValueError("encoding args invalid for binary operation")
             return stream
         else:
-            if "encoding" in kwargs:
-                kwargs["encoding"] = io.text_encoding(kwargs["encoding"])
-        return io.TextIOWrapper(stream, *args, **kwargs)
+            encoding = io.text_encoding(encoding)
+        return io.TextIOWrapper(stream, *args, encoding=encoding, **kwargs)
 
     @property
     def name(self):
@@ -282,10 +281,9 @@ class Path:
     def filename(self):
         return pathlib.Path(self.root.filename).joinpath(self.at)
 
-    def read_text(self, *args, **kwargs):
-        if "encoding" in kwargs:
-            kwargs["encoding"] = io.text_encoding(kwargs["encoding"])
-        with self.open('r', *args, **kwargs) as strm:
+    def read_text(self, encoding=None, *args, **kwargs):
+        encoding = io.text_encoding(encoding)
+        with self.open('r', *args, encoding=encoding, **kwargs) as strm:
             return strm.read()
 
     def read_bytes(self):

--- a/Lib/zipfile/_path.py
+++ b/Lib/zipfile/_path.py
@@ -149,6 +149,7 @@ class FastLookup(CompleteDirs):
 
 
 def _extract_text_encoding(encoding=None, *args, **kwargs):
+    # stacklevel=3 so that the caller of the caller see any warning.
     return io.text_encoding(encoding, 3), args, kwargs
 
 

--- a/Misc/NEWS.d/next/Library/2023-01-18-17-58-50.gh-issue-101144.FHd8Un.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-18-17-58-50.gh-issue-101144.FHd8Un.rst
@@ -1,4 +1,4 @@
-:func:`zipfile.Path.open` and :func:`zipfile.Path.read_text` accept
+Make :func:`zipfile.Path.open` and :func:`zipfile.Path.read_text` also accept
 ``encoding`` as a positional argument. This was the behavior in Python 3.9 and
 earlier.  3.10 introduced a regression where supplying it as a positional
 argument would lead to a :exc:`TypeError`.

--- a/Misc/NEWS.d/next/Library/2023-01-18-17-58-50.gh-issue-101144.FHd8Un.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-18-17-58-50.gh-issue-101144.FHd8Un.rst
@@ -1,4 +1,4 @@
 :func:`zipfile.Path.open` and :func:`zipfile.Path.read_text` accept
 ``encoding`` as a positional argument. This was the behavior in Python 3.9 and
-earlier.  3.10 introduced an unintended regression where supplying it as a
-positional argument would lead to a :exc:`TypeError`.
+earlier.  3.10 introduced a regression where supplying it as a positional
+argument would lead to a :exc:`TypeError`.

--- a/Misc/NEWS.d/next/Library/2023-01-18-17-58-50.gh-issue-101144.FHd8Un.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-18-17-58-50.gh-issue-101144.FHd8Un.rst
@@ -1,0 +1,4 @@
+:func:`zipfile.Path.open` and :func:`zipfile.Path.read_text` accept
+``encoding`` as a positional argument. This was the behavior in Python 3.9 and
+earlier.  3.10 introduced an unintended regression where supplying it as a
+positional argument would lead to a :exc:`TypeError`.


### PR DESCRIPTION
This was the behavior in 3.9 and earlier.  The fix for https://github.com/python/cpython/issues/87817 introduced an API regression in 3.10.0b1.

<!-- gh-issue-number: gh-101144 -->
* Issue: gh-101144
<!-- /gh-issue-number -->
