### PR TITLE
gh-59956: Clarify GILState-related Code

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -114,11 +114,7 @@ struct _ts {
     PyThreadState *next;
     PyInterpreterState *interp;
 
-    /* Has been initialized to a safe state.
-
-       In order to be effective, this must be set to 0 during or right
-       after allocation. */
-    int _initialized;
+    int _status;
 
     int py_recursion_remaining;
     int py_recursion_limit;

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -69,7 +69,7 @@ extern void _PyThread_FiniType(PyInterpreterState *interp);
 extern void _Py_Deepfreeze_Fini(void);
 extern void _PyArg_Fini(void);
 
-extern PyStatus _PyGILState_Init(_PyRuntimeState *runtime);
+extern PyStatus _PyGILState_Init(PyInterpreterState *interp);
 extern PyStatus _PyGILState_SetTstate(PyThreadState *tstate);
 extern void _PyGILState_Fini(PyInterpreterState *interp);
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -142,7 +142,7 @@ _PyThreadState_UpdateTracingState(PyThreadState *tstate)
 /* Other */
 
 PyAPI_FUNC(PyThreadState *) _PyThreadState_Swap(
-    struct _gilstate_runtime_state *gilstate,
+    _PyRuntimeState *runtime,
     PyThreadState *newts);
 
 PyAPI_FUNC(PyStatus) _PyInterpreterState_Enable(_PyRuntimeState *runtime);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -149,7 +149,6 @@ PyAPI_FUNC(PyStatus) _PyInterpreterState_Enable(_PyRuntimeState *runtime);
 
 #ifdef HAVE_FORK
 extern PyStatus _PyInterpreterState_DeleteExceptMain(_PyRuntimeState *runtime);
-extern PyStatus _PyGILState_Reinit(_PyRuntimeState *runtime);
 extern void _PySignal_AfterFork(void);
 #endif
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -67,12 +67,12 @@ _Py_ThreadCanHandlePendingCalls(void)
 static inline PyThreadState*
 _PyRuntimeState_GetThreadState(_PyRuntimeState *runtime)
 {
-    return (PyThreadState*)_Py_atomic_load_relaxed(&runtime->gilstate.tstate_current);
+    return (PyThreadState*)_Py_atomic_load_relaxed(&runtime->tstate_current);
 }
 
 /* Get the current Python thread state.
 
-   Efficient macro reading directly the 'gilstate.tstate_current' atomic
+   Efficient macro reading directly the 'tstate_current' atomic
    variable. The macro is unsafe: it does not check for error and it can
    return NULL.
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -139,6 +139,18 @@ _PyThreadState_UpdateTracingState(PyThreadState *tstate)
 }
 
 
+/* PyThreadState status */
+
+#define PyThreadState_UNINITIALIZED 0
+/* Has been initialized to a safe state.
+
+   In order to be effective, this must be set to 0 during or right
+   after allocation. */
+#define PyThreadState_INITIALIZED 1
+#define PyThreadState_BOUND 2
+#define PyThreadState_UNBOUND 3
+
+
 /* Other */
 
 PyAPI_FUNC(PyThreadState *) _PyThreadState_Swap(

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -120,7 +120,7 @@ static inline PyInterpreterState* _PyInterpreterState_GET(void) {
 
 // PyThreadState functions
 
-PyAPI_FUNC(void) _PyThreadState_SetCurrent(PyThreadState *tstate);
+PyAPI_FUNC(void) _PyThreadState_Bind(PyThreadState *tstate);
 // We keep this around exclusively for stable ABI compatibility.
 PyAPI_FUNC(void) _PyThreadState_Init(
     PyThreadState *tstate);

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -41,9 +41,6 @@ struct _gilstate_runtime_state {
     /* bpo-26558: Flag to disable PyGILState_Check().
        If set to non-zero, PyGILState_Check() always return 1. */
     int check_enabled;
-    /* Assuming the current thread holds the GIL, this is the
-       PyThreadState for the current thread. */
-    _Py_atomic_address tstate_current;
     /* The single PyInterpreterState used by this process'
        GILState implementation
     */
@@ -123,6 +120,10 @@ typedef struct pyruntimestate {
     } xidregistry;
 
     unsigned long main_thread;
+
+    /* Assuming the current thread holds the GIL, this is the
+       PyThreadState for the current thread. */
+    _Py_atomic_address tstate_current;
 
     PyWideStringList orig_argv;
 

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -46,7 +46,6 @@ struct _gilstate_runtime_state {
     */
     /* TODO: Given interp_main, it may be possible to kill this ref */
     PyInterpreterState *autoInterpreterState;
-    Py_tss_t autoTSSkey;
 };
 
 /* Runtime audit hook state */
@@ -124,6 +123,8 @@ typedef struct pyruntimestate {
     /* Assuming the current thread holds the GIL, this is the
        PyThreadState for the current thread. */
     _Py_atomic_address tstate_current;
+    /* Used for the thread state bound to the current thread. */
+    Py_tss_t autoTSSkey;
 
     PyWideStringList orig_argv;
 

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -33,6 +33,9 @@ extern "C" {
               until _PyInterpreterState_Enable() is called. */ \
             .next_id = -1, \
         }, \
+        /* A TSS key must be initialized with Py_tss_NEEDS_INIT \
+           in accordance with the specification. */ \
+        .autoTSSkey = Py_tss_NEEDS_INIT, \
         .parser = _parser_runtime_state_INIT, \
         .imports = { \
             .lock = { \
@@ -49,9 +52,6 @@ extern "C" {
         }, \
         .gilstate = { \
             .check_enabled = 1, \
-            /* A TSS key must be initialized with Py_tss_NEEDS_INIT \
-               in accordance with the specification. */ \
-            .autoTSSkey = Py_tss_NEEDS_INIT, \
         }, \
         .dtoa = _dtoa_runtime_state_INIT(runtime), \
         .fileutils = { \

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1074,13 +1074,7 @@ thread_run(void *boot_raw)
     PyThreadState *tstate;
 
     tstate = boot->tstate;
-    tstate->thread_id = PyThread_get_thread_ident();
-#ifdef PY_HAVE_THREAD_NATIVE_ID
-    tstate->native_thread_id = PyThread_get_thread_native_id();
-#else
-    tstate->native_thread_id = 0;
-#endif
-    _PyThreadState_SetCurrent(tstate);
+    _PyThreadState_Bind(tstate);
     PyEval_AcquireThread(tstate);
     tstate->interp->threads.count++;
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -587,7 +587,7 @@ PyOS_AfterFork_Child(void)
     PyStatus status;
     _PyRuntimeState *runtime = &_PyRuntime;
 
-    status = _PyGILState_Reinit(runtime);
+    status = _PyRuntimeState_ReInitThreads(runtime);
     if (_PyStatus_EXCEPTION(status)) {
         goto fatal_error;
     }
@@ -610,11 +610,6 @@ PyOS_AfterFork_Child(void)
     }
 
     _PySignal_AfterFork();
-
-    status = _PyRuntimeState_ReInitThreads(runtime);
-    if (_PyStatus_EXCEPTION(status)) {
-        goto fatal_error;
-    }
 
     status = _PyInterpreterState_DeleteExceptMain(runtime);
     if (_PyStatus_EXCEPTION(status)) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1111,11 +1111,14 @@ tstate_delete_common(PyThreadState *tstate,
     }
     HEAD_UNLOCK(runtime);
 
+    // XXX Do this in PyThreadState_Swap() (and assert not-equal here)?
     if (gilstate->autoInterpreterState &&
         PyThread_tss_get(&gilstate->autoTSSkey) == tstate)
     {
         PyThread_tss_set(&gilstate->autoTSSkey, NULL);
     }
+
+    // XXX Move to PyThreadState_Clear()?
     _PyStackChunk *chunk = tstate->datastack_chunk;
     tstate->datastack_chunk = NULL;
     while (chunk != NULL) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -70,14 +70,14 @@ current_fast_clear(_PyRuntimeState *runtime)
 static int
 current_tss_initialized(_PyRuntimeState *runtime)
 {
-    return PyThread_tss_is_created(&runtime->gilstate.autoTSSkey);
+    return PyThread_tss_is_created(&runtime->autoTSSkey);
 }
 
 static PyStatus
 current_tss_init(_PyRuntimeState *runtime)
 {
     assert(!current_tss_initialized(runtime));
-    if (PyThread_tss_create(&runtime->gilstate.autoTSSkey) != 0) {
+    if (PyThread_tss_create(&runtime->autoTSSkey) != 0) {
         return _PyStatus_NO_MEMORY();
     }
     return _PyStatus_OK();
@@ -87,14 +87,14 @@ static void
 current_tss_fini(_PyRuntimeState *runtime)
 {
     assert(current_tss_initialized(runtime));
-    PyThread_tss_delete(&runtime->gilstate.autoTSSkey);
+    PyThread_tss_delete(&runtime->autoTSSkey);
 }
 
 static inline PyThreadState *
 current_tss_get(_PyRuntimeState *runtime)
 {
     assert(current_tss_initialized(runtime));
-    return (PyThreadState *)PyThread_tss_get(&runtime->gilstate.autoTSSkey);
+    return (PyThreadState *)PyThread_tss_get(&runtime->autoTSSkey);
 }
 
 static inline int
@@ -102,7 +102,7 @@ _current_tss_set(_PyRuntimeState *runtime, PyThreadState *tstate)
 {
     assert(tstate != NULL);
     assert(current_tss_initialized(runtime));
-    return PyThread_tss_set(&runtime->gilstate.autoTSSkey, (void *)tstate);
+    return PyThread_tss_set(&runtime->autoTSSkey, (void *)tstate);
 }
 static inline void
 current_tss_set(_PyRuntimeState *runtime, PyThreadState *tstate)
@@ -116,7 +116,7 @@ static inline void
 current_tss_clear(_PyRuntimeState *runtime)
 {
     assert(current_tss_initialized(runtime));
-    if (PyThread_tss_set(&runtime->gilstate.autoTSSkey, NULL) != 0) {
+    if (PyThread_tss_set(&runtime->autoTSSkey, NULL) != 0) {
         Py_FatalError("failed to clear current tstate (TSS)");
     }
 }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -74,21 +74,21 @@ current_tss_fini(_PyRuntimeState *runtime)
     PyThread_tss_delete(&runtime->gilstate.autoTSSkey);
 }
 
-static PyThreadState *
+static inline PyThreadState *
 current_tss_get(_PyRuntimeState *runtime)
 {
     assert(current_tss_initialized(runtime));
     return (PyThreadState *)PyThread_tss_get(&runtime->gilstate.autoTSSkey);
 }
 
-static int
+static inline int
 _current_tss_set(_PyRuntimeState *runtime, PyThreadState *tstate)
 {
     assert(tstate != NULL);
     assert(current_tss_initialized(runtime));
     return PyThread_tss_set(&runtime->gilstate.autoTSSkey, (void *)tstate);
 }
-static void
+static inline void
 current_tss_set(_PyRuntimeState *runtime, PyThreadState *tstate)
 {
     if (_current_tss_set(runtime, tstate) != 0) {
@@ -96,7 +96,7 @@ current_tss_set(_PyRuntimeState *runtime, PyThreadState *tstate)
     }
 }
 
-static void
+static inline void
 current_tss_clear(_PyRuntimeState *runtime)
 {
     assert(current_tss_initialized(runtime));

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -48,8 +48,7 @@ static inline PyThreadState *
 current_fast_get(_PyRuntimeState *runtime)
 {
     // The GIL must be held by the current thread.
-    return (PyThreadState*)_Py_atomic_load_relaxed(
-                &runtime->gilstate.tstate_current);
+    return (PyThreadState*)_Py_atomic_load_relaxed(&runtime->tstate_current);
 }
 
 static inline void
@@ -57,16 +56,14 @@ current_fast_set(_PyRuntimeState *runtime, PyThreadState *tstate)
 {
     // The GIL must be held by the current thread.
     assert(tstate != NULL);
-    _Py_atomic_store_relaxed(&runtime->gilstate.tstate_current,
-                             (uintptr_t)tstate);
+    _Py_atomic_store_relaxed(&runtime->tstate_current, (uintptr_t)tstate);
 }
 
 static inline void
 current_fast_clear(_PyRuntimeState *runtime)
 {
     // The GIL must be held by the current thread.
-    _Py_atomic_store_relaxed(&runtime->gilstate.tstate_current,
-                             (uintptr_t)NULL);
+    _Py_atomic_store_relaxed(&runtime->tstate_current, (uintptr_t)NULL);
 }
 
 


### PR DESCRIPTION
The objective of this change is to help make the GILState-related code easier to understand.  This mostly involves moving code around and some semantically equivalent refactors.  However, there are a also a small number of slight changes in structure and behavior:

* `tstate_current` is moved out of `_PyRuntimeState.gilstate` (6281edb2c5d42150b413ae89df9d0e4b68eaf8f3)
* `autoTSSkey` is moved out of `_PyRuntimeState.gilstate` (4af2ecbe2e2881d003ef59645271850230bc8d75)
* `autoTSSkey` is initialized earlier (7bdf5a41afee01fd20c26ef2237c8fe6d261c245)
* `autoTSSkey` is re-initialized (after fork) earlier (7bdf5a41afee01fd20c26ef2237c8fe6d261c245)

<!-- gh-issue-number: gh-59956 -->
* Issue: gh-59956
<!-- /gh-issue-number -->
