### PR TITLE
Provided better example for logging cookbook (GH-101164)

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1982,7 +1982,7 @@ Using a rotator and namer to customize log rotation processing
 --------------------------------------------------------------
 
 An example of how you can define a namer and rotator is given in the following
-snippet, which shows gzip compression of the log file::
+runnable script, which shows gzip compression of the log file::
 
     import gzip
     import logging

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1987,7 +1987,7 @@ snippet, which shows zlib-based compression of the log file::
     def namer(name):
         return name + ".gz"
 
-    def rotator(source, dest):        
+    def rotator(source, dest):
         with open(source, 'rb') as f_in:
             with gzip.open(dest, 'wb') as f_out:
                 shutil.copyfileobj(f_in, f_out)

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1984,6 +1984,12 @@ Using a rotator and namer to customize log rotation processing
 An example of how you can define a namer and rotator is given in the following
 snippet, which shows gzip compression of the log file::
 
+    import gzip
+    import logging
+    import logging.handlers
+    import os
+    import shutil
+
     def namer(name):
         return name + ".gz"
 
@@ -1993,9 +1999,30 @@ snippet, which shows gzip compression of the log file::
                 shutil.copyfileobj(f_in, f_out)
         os.remove(source)
 
-    rh = logging.handlers.RotatingFileHandler(...)
+
+    rh = logging.handlers.RotatingFileHandler('rotated.log', maxBytes=1024, backupCount=5)
     rh.rotator = rotator
     rh.namer = namer
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(rh)
+    f = logging.Formatter('%(asctime)s %(message)s')
+    rh.setFormatter(f)
+    for i in range(1000):
+        root.info(f'Message no. {i + 1}')
+
+After running this, you will see six new files, five of which are compressed:
+
+.. code-block:: shell-session
+
+    $ ls rotated.log*
+    rotated.log       rotated.log.2.gz  rotated.log.4.gz
+    rotated.log.1.gz  rotated.log.3.gz  rotated.log.5.gz
+    $ zcat rotated.log.1.gz
+    2023-01-20 02:02:39,673 Message no. 984
+    2023-01-20 02:02:39,674 Message no. 985
+    2023-01-20 02:02:39,674 Message no. 986
+    2023-01-20 02:02:39,674 Message no. 987
 
 A more elaborate multiprocessing example
 ----------------------------------------

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1982,7 +1982,7 @@ Using a rotator and namer to customize log rotation processing
 --------------------------------------------------------------
 
 An example of how you can define a namer and rotator is given in the following
-snippet, which shows zlib-based compression of the log file::
+snippet, which shows gzip compression of the log file::
 
     def namer(name):
         return name + ".gz"

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1987,21 +1987,15 @@ snippet, which shows zlib-based compression of the log file::
     def namer(name):
         return name + ".gz"
 
-    def rotator(source, dest):
-        with open(source, "rb") as sf:
-            data = sf.read()
-            compressed = zlib.compress(data, 9)
-            with open(dest, "wb") as df:
-                df.write(compressed)
+    def rotator(source, dest):        
+        with open(source, 'rb') as f_in:
+            with gzip.open(dest, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
         os.remove(source)
 
     rh = logging.handlers.RotatingFileHandler(...)
     rh.rotator = rotator
     rh.namer = namer
-
-These are not "true" .gz files, as they are bare compressed data, with no
-"container" such as you’d find in an actual gzip file. This snippet is just
-for illustration purposes.
 
 A more elaborate multiprocessing example
 ----------------------------------------

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -2000,9 +2000,10 @@ snippet, which shows gzip compression of the log file::
         os.remove(source)
 
 
-    rh = logging.handlers.RotatingFileHandler('rotated.log', maxBytes=1024, backupCount=5)
+    rh = logging.handlers.RotatingFileHandler('rotated.log', maxBytes=128, backupCount=5)
     rh.rotator = rotator
     rh.namer = namer
+
     root = logging.getLogger()
     root.setLevel(logging.INFO)
     root.addHandler(rh)
@@ -2019,10 +2020,9 @@ After running this, you will see six new files, five of which are compressed:
     rotated.log       rotated.log.2.gz  rotated.log.4.gz
     rotated.log.1.gz  rotated.log.3.gz  rotated.log.5.gz
     $ zcat rotated.log.1.gz
-    2023-01-20 02:02:39,673 Message no. 984
-    2023-01-20 02:02:39,674 Message no. 985
-    2023-01-20 02:02:39,674 Message no. 986
-    2023-01-20 02:02:39,674 Message no. 987
+    2023-01-20 02:28:17,767 Message no. 996
+    2023-01-20 02:28:17,767 Message no. 997
+    2023-01-20 02:28:17,767 Message no. 998
 
 A more elaborate multiprocessing example
 ----------------------------------------


### PR DESCRIPTION
This change is trivial, so, according to guidelines, i haven't created an issue.

I just made a small fix to the code from logging cookbook. The rotator function should compress file. And, to compress file, you need to use gzib library, not zlib.

To save you some time, this fact is clearly stated in [zlib docs](https://docs.python.org/3.11/library/zlib.html)
> For reading and writing `.gz` files see the [gzip](https://docs.python.org/3.11/library/gzip.html#module-gzip) module.