### PR TITLE
gh-101167: fix bug in the new test.support.requires_specialization decorator

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1079,7 +1079,8 @@ def requires_limited_api(test):
         _testcapi.LIMITED_API_AVAILABLE, 'needs Limited API support')(test)
 
 def requires_specialization(test):
-    return unittest.skipUnless(opcode.ENABLE_SPECIALIZATION, "requires specialization")
+    return unittest.skipUnless(
+        opcode.ENABLE_SPECIALIZATION, "requires specialization")(test)
 
 def _filter_suite(suite, pred):
     """Recursively filter test cases in a suite based on a predicate."""


### PR DESCRIPTION
Fixes #101167.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101167 -->
* Issue: gh-101167
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:iritkatriel