### PR TITLE
gh-59956: Fix Function Groupings in pystate.c

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1456,6 +1456,7 @@ PyThreadState_GetID(PyThreadState *tstate)
    existing async exception.  This raises no exceptions. */
 
 // XXX Move this to Python/ceval_gil.c?
+// XXX Deprecate this.
 int
 PyThreadState_SetAsyncExc(unsigned long id, PyObject *exc)
 {


### PR DESCRIPTION
This is a follow-up to gh-101161.  The objective is to make it easier to read Python/pystate.c by grouping the functions there in a consistent way.  This exclusively involves moving code around and adding various kinds of comments.

The risk of this churn being a problem for other maintainers is relatively low (not many folks work on this part of the runtime code).

<!-- gh-issue-number: gh-59956 -->
* Issue: gh-59956
<!-- /gh-issue-number -->
