### PR TITLE
gh-91485: Avoid unnecessary use of non-Python syntax in io docs

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -1021,8 +1021,8 @@ Text I/O
 
       .. versionadded:: 3.7
 
-   .. method:: reconfigure(*[, encoding][, errors][, newline][, \
-                           line_buffering][, write_through])
+   .. method:: reconfigure(*, encoding=None, errors=None, newline=None, \
+                           line_buffering=None, write_through=None)
 
       Reconfigure this text stream using new settings for *encoding*,
       *errors*, *newline*, *line_buffering* and *write_through*.


### PR DESCRIPTION


<!-- gh-issue-number: gh-91485 -->
* Issue: gh-91485
<!-- /gh-issue-number -->
