### PR TITLE
GH-90699: Clear interned strings in _elementtree

### DIFF
--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -122,6 +122,16 @@ elementtree_clear(PyObject *m)
     Py_CLEAR(st->elementpath_obj);
     Py_CLEAR(st->comment_factory);
     Py_CLEAR(st->pi_factory);
+
+    // Interned strings
+    Py_CLEAR(st->str_append);
+    Py_CLEAR(st->str_find);
+    Py_CLEAR(st->str_findall);
+    Py_CLEAR(st->str_findtext);
+    Py_CLEAR(st->str_iterfind);
+    Py_CLEAR(st->str_tail);
+    Py_CLEAR(st->str_text);
+    Py_CLEAR(st->str_doctype);
     return 0;
 }
 


### PR DESCRIPTION
Interned strings were added in GH-99012


<!-- gh-issue-number: gh-90699 -->
* Issue: gh-90699
<!-- /gh-issue-number -->
