### PR TITLE
gh-101181: Fix `unused-variable` warning in `pystate.c`

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1879,7 +1879,7 @@ _PyGILState_SetTstate(PyThreadState *tstate)
         return _PyStatus_OK();
     }
 
-#ifdef NDEBUG
+#ifndef NDEBUG
     _PyRuntimeState *runtime = tstate->interp->runtime;
 
     assert(runtime->gilstate.autoInterpreterState == tstate->interp);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1878,11 +1878,14 @@ _PyGILState_SetTstate(PyThreadState *tstate)
          * interpreter is responsible to initialize it. */
         return _PyStatus_OK();
     }
+
+#ifdef NDEBUG
     _PyRuntimeState *runtime = tstate->interp->runtime;
 
     assert(runtime->gilstate.autoInterpreterState == tstate->interp);
     assert(current_tss_get(runtime) == tstate);
     assert(tstate->gilstate_counter == 1);
+#endif
 
     return _PyStatus_OK();
 }


### PR DESCRIPTION
CC @kumaraditya303 

<!-- gh-issue-number: gh-101181 -->
* Issue: gh-101181
<!-- /gh-issue-number -->
