### PR TITLE
gh-101143: Remove references to TimerHandle from asyncio.base_events.BaseEventLoop._add_callback

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1857,12 +1857,10 @@ class BaseEventLoop(events.AbstractEventLoop):
                                  exc_info=True)
 
     def _add_callback(self, handle):
-        """Add a Handle to _scheduled (TimerHandle) or _ready."""
+        """Add a Handle to _ready."""
         assert isinstance(handle, events.Handle), 'A Handle is required here'
-        if handle._cancelled:
-            return
-        assert not isinstance(handle, events.TimerHandle)
-        self._ready.append(handle)
+        if not handle._cancelled:
+            self._ready.append(handle)
 
     def _add_callback_signalsafe(self, handle):
         """Like _add_callback() but called from a signal handler."""

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1858,7 +1858,6 @@ class BaseEventLoop(events.AbstractEventLoop):
 
     def _add_callback(self, handle):
         """Add a Handle to _ready."""
-        assert isinstance(handle, events.Handle), 'A Handle is required here'
         if not handle._cancelled:
             self._ready.append(handle)
 

--- a/Misc/NEWS.d/next/Library/2023-01-20-10-46-59.gh-issue-101143.hJo8hu.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-20-10-46-59.gh-issue-101143.hJo8hu.rst
@@ -1,2 +1,2 @@
-Remove unused references to TimerHandle in
-asyncio.base_events.BaseEventLoop._add_callback
+Remove unused references to :class:`~asyncio.TimerHandle` in
+``asyncio.base_events.BaseEventLoop._add_callback``.

--- a/Misc/NEWS.d/next/Library/2023-01-20-10-46-59.gh-issue-101143.hJo8hu.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-20-10-46-59.gh-issue-101143.hJo8hu.rst
@@ -1,0 +1,2 @@
+Remove unused references to TimerHandle in
+asyncio.base_events.BaseEventLoop._add_callback


### PR DESCRIPTION
gh-101143: Remove references to TimerHandle from asyncio.base_events.BaseEventLoop._add_callback

After 592ada9b4b08ad57037e365b9c462d71c96e4453 it appears this function no longer cares about `self._scheduled` or `TimerHandle` but the docstring seems to imply otherwise

fixes #101143
