### PR TITLE
GH-101195: Update _collections_abc.py collections.abc.MutableSet __iand__ method does not work for some user defined classes inherited from MutableSet

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -746,7 +746,8 @@ class MutableSet(Set):
         return self
 
     def __iand__(self, it):
-        for value in (self - it):
+        values_to_discard = set([v for v in self if v not in it])
+        for value in values_to_discard:
             self.discard(value)
         return self
 

--- a/Misc/NEWS.d/next/Library/2023-01-21-10-04-57.gh-issue-101195.l6HJYL.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-21-10-04-57.gh-issue-101195.l6HJYL.rst
@@ -1,0 +1,1 @@
+Update _collections_abc.py collections.abc.MutableSet __iand__ method does not work for some user defined classes inherited from MutableSet


### PR DESCRIPTION
Update `_collections_abc.py collections.abc.MutableSet __iand__` method does not work for some user defined classes inherited from `MutableSet`


Fixed GH-101195
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
