### PR TITLE
gh-100795: avoid unexpected `freeaddrinfo` after failed `getaddrinfo`

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-01-21-16-50-22.gh-issue-100795.NPMZf7.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-21-16-50-22.gh-issue-100795.NPMZf7.rst
@@ -1,2 +1,2 @@
-Avoid unexpected ``freeaddrinfo`` when :mod:`socket.socket.getaddrinfo`
+Avoid unexpected ``freeaddrinfo`` when :meth:`socket.socket.getaddrinfo`
 fails. Patch by Sergey G. Brester.

--- a/Misc/NEWS.d/next/Library/2023-01-21-16-50-22.gh-issue-100795.NPMZf7.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-21-16-50-22.gh-issue-100795.NPMZf7.rst
@@ -1,0 +1,2 @@
+Avoid unexpected ``freeaddrinfo`` when :mod:`socket.socket.getaddrinfo`
+fails. Patch by Sergey G. Brester.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -6719,6 +6719,7 @@ socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
     error = getaddrinfo(hptr, pptr, &hints, &res0);
     Py_END_ALLOW_THREADS
     if (error) {
+        res0 = NULL;  /* avoid unexpected free if res0 becomes not NULL */
         set_gaierror(error);
         goto err;
     }
@@ -6815,6 +6816,7 @@ socket_getnameinfo(PyObject *self, PyObject *args)
     error = getaddrinfo(hostp, pbuf, &hints, &res);
     Py_END_ALLOW_THREADS
     if (error) {
+        res = NULL;  /* avoid unexpected free if res0 becomes not NULL */
         set_gaierror(error);
         goto fail;
     }

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -6816,7 +6816,7 @@ socket_getnameinfo(PyObject *self, PyObject *args)
     error = getaddrinfo(hostp, pbuf, &hints, &res);
     Py_END_ALLOW_THREADS
     if (error) {
-        res = NULL;  /* avoid unexpected free if res0 becomes not NULL */
+        res = NULL;  /* avoid unexpected free if res becomes not NULL */
         set_gaierror(error);
         goto fail;
     }


### PR DESCRIPTION
This is rebased #101010 to main.

Proposed PR fixes segfault gh-100795 - avoid unexpected `freeaddrinfo` if `res` becomes not NULL during invocation of `getaddrinfo` if it fails.
Previously this could cause double freeing and other hardly reproducible aftereffects, especially in multithreaded environment.

One could surely do `return -1` instead of `res = NULL` & `goto fail` (in second case), like in https://github.com/python/cpython/blob/5ef90eebfd90147c7e774cd5335ad4fe69a7227c/Modules/socketmodule.c#L1095
but this way it is minimal invasive (more consistent, remains safe against some merges or future implementations expecting goto fail to free some other handles, etc).