### PR TITLE
gh-101233: Add part to explain `Py_SETREF` and `Py_NewRef`

### DIFF
--- a/Doc/extending/newtypes_tutorial.rst
+++ b/Doc/extending/newtypes_tutorial.rst
@@ -425,6 +425,18 @@ don't we have to do this?
 * when decrementing a reference count in a :c:member:`~PyTypeObject.tp_dealloc`
   handler on a type which doesn't support cyclic garbage collection [#]_.
 
+There is a much simpler way to reassign to ``self->first`` though, and that is by using :c:func:`Py_XSETREF` and :c:func:`Py_NewRef`::
+
+   if (first) {
+       Py_XSETREF(self->first, Py_NewRef(first));
+   }
+
+:c:func:`Py_XSETREF` automatically handles the assignment to ``self->first`` and the decrementing of its reference count using :c:func:`Py_XDECREF` (in the correct way that was shown earlier). :c:func:`Py_NewRef` automatically handles the incrementing of the reference count for ``first``. We can also apply this to ``self->last`` and ``last``::
+
+   if (last) {
+       Py_XSETREF(self->last, Py_NewRef(last));
+   }
+
 We want to expose our instance variables as attributes. There are a
 number of ways to do that. The simplest way is to define member definitions::
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Add the part right below the "why do we have to do this?" part explaining the correct way of reassigning to an object/attribute.

<!-- gh-issue-number: gh-101233 -->
* Issue: gh-101233
<!-- /gh-issue-number -->
