### PR TITLE
Added asyncio REPL example to docs.

### DIFF
--- a/Doc/library/asyncio.rst
+++ b/Doc/library/asyncio.rst
@@ -56,6 +56,18 @@ Additionally, there are **low-level** APIs for
 * :ref:`bridge <asyncio-futures>` callback-based libraries and code
   with async/await syntax.
 
+You can experiment with an ``asyncio`` concurrent context in the REPL:
+
+.. code-block:: pycon
+
+   $ python -m asyncio
+   asyncio REPL ...
+   Use "await" directly instead of "asyncio.run()".
+   Type "help", "copyright", "credits" or "license" for more information.
+   >>> import asyncio
+   >>> await asyncio.sleep(10, result='hello')
+   hello
+
 .. include:: ../includes/wasm-notavail.rst
 
 .. We use the "rubric" directive here to avoid creating

--- a/Doc/library/asyncio.rst
+++ b/Doc/library/asyncio.rst
@@ -66,7 +66,7 @@ You can experiment with an ``asyncio`` concurrent context in the REPL:
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import asyncio
    >>> await asyncio.sleep(10, result='hello')
-   hello
+   'hello'
 
 .. include:: ../includes/wasm-notavail.rst
 


### PR DESCRIPTION
The ability to run python -m asyncio for a REPL with a concurrent context was previously only mentioned in the What's new in Python 3.8 section. Adding it to the asyncio introduction makes it more discoverable.

Q: This is a small docs change, does it need an issue? Could possibly be ref gh-81209, but not sure of the procedure? 

