### PR TITLE
Fix incorrectly documented attribute in csv docs

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -458,7 +458,7 @@ Reader objects have the following public attributes:
 
 DictReader objects have the following public attribute:
 
-.. attribute:: csvreader.fieldnames
+.. attribute:: DictReader.fieldnames
 
    If not passed as a parameter when creating the object, this attribute is
    initialized upon first access or when the first record is read from the


### PR DESCRIPTION
The attribute `fieldname` only applies to `DictReader`, but it was incorrectly attributed to `csvreader`.
