### PR TITLE
gh-100795: Don't call freeaddrinfo on failure.

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-01-21-16-50-22.gh-issue-100795.NPMZf7.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-21-16-50-22.gh-issue-100795.NPMZf7.rst
@@ -1,0 +1,3 @@
+Avoid potential unexpected ``freeaddrinfo`` call (double free) in :mod:`socket`
+when when a libc ``getaddrinfo()`` implementation leaves garbage in an output
+pointer when returning an error. Original patch by Sergey G. Brester.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1085,6 +1085,7 @@ setipaddr(const char *name, struct sockaddr *addr_ret, size_t addr_ret_size, int
            subsequent call to getaddrinfo() does not destroy the
            outcome of the first call. */
         if (error) {
+            res = NULL;  // no-op, remind us that it is invalid; gh-100795
             set_gaierror(error);
             return -1;
         }
@@ -1195,6 +1196,7 @@ setipaddr(const char *name, struct sockaddr *addr_ret, size_t addr_ret_size, int
 #endif
     Py_END_ALLOW_THREADS
     if (error) {
+        res = NULL;  // no-op, remind us that it is invalid; gh-100795
         set_gaierror(error);
         return -1;
     }
@@ -6719,6 +6721,7 @@ socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
     error = getaddrinfo(hptr, pptr, &hints, &res0);
     Py_END_ALLOW_THREADS
     if (error) {
+        res0 = NULL;  // gh-100795
         set_gaierror(error);
         goto err;
     }
@@ -6815,6 +6818,7 @@ socket_getnameinfo(PyObject *self, PyObject *args)
     error = getaddrinfo(hostp, pbuf, &hints, &res);
     Py_END_ALLOW_THREADS
     if (error) {
+        res = NULL;  // gh-100795
         set_gaierror(error);
         goto fail;
     }


### PR DESCRIPTION
When getaddrinfo returns an error, the output pointer is in an unknown state Don't call freeaddrinfo on it.  See the issue for discussion and details with links to reasoning.  _Most_ libc getaddrinfo implementations never modify the output pointer unless they are returning success.

Co-authored-by: Sergey G. Brester <github@sebres.de>
Co-authored-by: Oleg Iarygin <oleg@arhadthedev.net>

This re-does the earlier merged and reverted PR with some additional comments.

<!-- gh-issue-number: gh-100795 -->
* Issue: gh-100795
<!-- /gh-issue-number -->
