### PR TITLE
[docs] Mention how to get/set a bigint PyLong via the C API

### DIFF
--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -13,6 +13,11 @@ All integers are implemented as "long" integer objects of arbitrary size.
 On error, most ``PyLong_As*`` APIs return ``(return type)-1`` which cannot be
 distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
+.. seealso:: Python methods :meth:`int.to_bytes` and :meth:`int.from_bytes`
+   (called via one of the :c:func:`PyObject_CallMethod` APIs),
+   to convert a :c:type:`PyLongObject` of arbitrary size
+   to or from an array of bytes.
+
 .. c:type:: PyLongObject
 
    This subtype of :c:type:`PyObject` represents a Python integer object.
@@ -318,9 +323,3 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    with :c:func:`PyLong_FromVoidPtr`.
 
    Returns ``NULL`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
-
-
-If you want to convert to or from a binary big integer array of bytes
-representation, call the Python :meth:`int.to_bytes` or :meth:`int.from_bytes`
-methods using one of the :c:func:`PyObject_CallMethod` C APIs.
-

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -318,3 +318,9 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    with :c:func:`PyLong_FromVoidPtr`.
 
    Returns ``NULL`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
+
+
+If you want to convert to or from a binary big integer array of bytes
+representation, call the Python :meth:`int.to_bytes` or :meth:`int.from_bytes`
+methods using one of the :func:`PyObject_CallMethod` C APIs.
+

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -13,11 +13,6 @@ All integers are implemented as "long" integer objects of arbitrary size.
 On error, most ``PyLong_As*`` APIs return ``(return type)-1`` which cannot be
 distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
-.. seealso:: Python methods :meth:`int.to_bytes` and :meth:`int.from_bytes`
-   (called via one of the :c:func:`PyObject_CallMethod` APIs),
-   to convert a :c:type:`PyLongObject` of arbitrary size
-   to or from an array of bytes.
-
 .. c:type:: PyLongObject
 
    This subtype of :c:type:`PyObject` represents a Python integer object.
@@ -98,6 +93,10 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    whitespace and single underscores after a base specifier and between digits are
    ignored.  If there are no digits or *str* is not NULL-terminated following the
    digits and trailing whitespace, :exc:`ValueError` will be raised.
+
+   .. seealso:: Python methods :meth:`int.to_bytes` and :meth:`int.from_bytes`
+      to convert a :c:type:`PyLongObject` to or from an array of bytes in base
+      ``256``. You can call those from C using :c:func:`PyObject_CallMethod`.
 
 
 .. c:function:: PyObject* PyLong_FromUnicodeObject(PyObject *u, int base)

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -322,5 +322,5 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
 If you want to convert to or from a binary big integer array of bytes
 representation, call the Python :meth:`int.to_bytes` or :meth:`int.from_bytes`
-methods using one of the :func:`PyObject_CallMethod` C APIs.
+methods using one of the :c:func:`PyObject_CallMethod` C APIs.
 

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -95,7 +95,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    digits and trailing whitespace, :exc:`ValueError` will be raised.
 
    .. seealso:: Python methods :meth:`int.to_bytes` and :meth:`int.from_bytes`
-      to convert a :c:type:`PyLongObject` to or from an array of bytes in base
+      to convert a :c:type:`PyLongObject` to/from an array of bytes in base
       ``256``. You can call those from C using :c:func:`PyObject_CallMethod`.
 
 


### PR DESCRIPTION
There isn't enough demand for a direct C API to get or set a binary byte array bigint representation of PyLong but we do want the people who need to understand how they can do that.

Background: https://discuss.python.org/t/add-portable-way-to-extract-all-digits-of-a-pylongobject-from-c/20045