### PR TITLE
Docs: Fix getstatus() -> getcode() typos

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -532,7 +532,7 @@ statement.
    .. deprecated:: 3.9
       Deprecated in favor of :attr:`~HTTPResponse.headers`.
 
-.. method:: HTTPResponse.getstatus()
+.. method:: HTTPResponse.getcode()
 
    .. deprecated:: 3.9
       Deprecated in favor of :attr:`~HTTPResponse.status`.

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1630,7 +1630,7 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
       .. deprecated:: 3.9
          Deprecated in favor of :attr:`~addinfourl.status`.
 
-   .. method:: getstatus()
+   .. method:: getcode()
 
       .. deprecated:: 3.9
          Deprecated in favor of :attr:`~addinfourl.status`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The docs say `getstatus()` for `http.client.HTTPResponse` and `urllib.response.addinfourl`:

* https://docs.python.org/3/library/http.client.html#http.client.HTTPResponse.getstatus
* https://docs.python.org/3/library/urllib.request.html#urllib.response.addinfourl.getstatus

But they're really `getcode()`:

* https://github.com/python/cpython/blob/f02fa64bf2d03ef7a28650c164e17a5fb5d8543d/Lib/http/client.py#L778-L783
* https://github.com/python/cpython/blob/f02fa64bf2d03ef7a28650c164e17a5fb5d8543d/Lib/urllib/response.py#L80-L81

The documentation (and typos) for these were added as part of https://github.com/python/cpython/pull/11447 for Python 3.9 in 2019, although the methods have been around much longer (2009 and 2008).

Let's backport to at least 3.10.