### PR TITLE
gh-59956:  Clarify Runtime State Status Expectations

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -130,6 +130,8 @@ struct _ts {
         unsigned int bound:1;
         /* Has been unbound from its OS thread. */
         unsigned int unbound:1;
+        /* Currently in use (maybe holds the GIL). */
+        unsigned int active:1;
 
         /* various stages of finalization */
         unsigned int finalizing:1;

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -119,7 +119,22 @@ struct _ts {
     PyThreadState *next;
     PyInterpreterState *interp;
 
-    int _status;
+    struct {
+        /* Has been initialized to a safe state.
+
+           In order to be effective, this must be set to 0 during or right
+           after allocation. */
+        unsigned int initialized:1;
+        /* Has been bound to an OS thread. */
+        unsigned int bound:1;
+        /* Has been unbound from its OS thread. */
+        unsigned int unbound:1;
+        // XXX finalizing
+        // XXX cleared
+        // XXX finalized
+        /* padding to align to 4 bytes */
+        unsigned int :29;
+    } _status;
 
     int py_recursion_remaining;
     int py_recursion_limit;

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -268,6 +268,10 @@ struct _ts {
 // Alias for backward compatibility with Python 3.8
 #define _PyInterpreterState_Get PyInterpreterState_Get
 
+/* An alias for the internal _PyThreadState_New(),
+   kept for stable ABI compatibility. */
+PyAPI_FUNC(PyThreadState *) _PyThreadState_Prealloc(PyInterpreterState *);
+
 /* Similar to PyThreadState_Get(), but don't issue a fatal error
  * if it is NULL. */
 PyAPI_FUNC(PyThreadState *) _PyThreadState_UncheckedGet(void);

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -130,6 +130,8 @@ struct _ts {
         unsigned int bound:1;
         /* Has been unbound from its OS thread. */
         unsigned int unbound:1;
+        /* Has been bound aa current for the GILState API. */
+        unsigned int bound_gilstate:1;
         /* Currently in use (maybe holds the GIL). */
         unsigned int active:1;
 
@@ -139,7 +141,7 @@ struct _ts {
         unsigned int finalized:1;
 
         /* padding to align to 4 bytes */
-        unsigned int :26;
+        unsigned int :25;
     } _status;
 
     int py_recursion_remaining;

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -141,7 +141,7 @@ struct _ts {
         unsigned int finalized:1;
 
         /* padding to align to 4 bytes */
-        unsigned int :25;
+        unsigned int :24;
     } _status;
 
     int py_recursion_remaining;

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -266,8 +266,6 @@ struct _ts {
 // Alias for backward compatibility with Python 3.8
 #define _PyInterpreterState_Get PyInterpreterState_Get
 
-PyAPI_FUNC(PyThreadState *) _PyThreadState_Prealloc(PyInterpreterState *);
-
 /* Similar to PyThreadState_Get(), but don't issue a fatal error
  * if it is NULL. */
 PyAPI_FUNC(PyThreadState *) _PyThreadState_UncheckedGet(void);

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -125,15 +125,19 @@ struct _ts {
            In order to be effective, this must be set to 0 during or right
            after allocation. */
         unsigned int initialized:1;
+
         /* Has been bound to an OS thread. */
         unsigned int bound:1;
         /* Has been unbound from its OS thread. */
         unsigned int unbound:1;
-        // XXX finalizing
-        // XXX cleared
-        // XXX finalized
+
+        /* various stages of finalization */
+        unsigned int finalizing:1;
+        unsigned int cleared:1;
+        unsigned int finalized:1;
+
         /* padding to align to 4 bytes */
-        unsigned int :29;
+        unsigned int :26;
     } _status;
 
     int py_recursion_remaining;

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -124,9 +124,7 @@ PyAPI_FUNC(void) _PyThreadState_Bind(PyThreadState *tstate);
 // We keep this around exclusively for stable ABI compatibility.
 PyAPI_FUNC(void) _PyThreadState_Init(
     PyThreadState *tstate);
-PyAPI_FUNC(void) _PyThreadState_DeleteExcept(
-    _PyRuntimeState *runtime,
-    PyThreadState *tstate);
+PyAPI_FUNC(void) _PyThreadState_DeleteExcept(PyThreadState *tstate);
 
 
 static inline void

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -120,6 +120,7 @@ static inline PyInterpreterState* _PyInterpreterState_GET(void) {
 
 // PyThreadState functions
 
+PyAPI_FUNC(PyThreadState *) _PyThreadState_New(PyInterpreterState *interp);
 PyAPI_FUNC(void) _PyThreadState_Bind(PyThreadState *tstate);
 // We keep this around exclusively for stable ABI compatibility.
 PyAPI_FUNC(void) _PyThreadState_Init(

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -137,18 +137,6 @@ _PyThreadState_UpdateTracingState(PyThreadState *tstate)
 }
 
 
-/* PyThreadState status */
-
-#define PyThreadState_UNINITIALIZED 0
-/* Has been initialized to a safe state.
-
-   In order to be effective, this must be set to 0 during or right
-   after allocation. */
-#define PyThreadState_INITIALIZED 1
-#define PyThreadState_BOUND 2
-#define PyThreadState_UNBOUND 3
-
-
 /* Other */
 
 PyAPI_FUNC(PyThreadState *) _PyThreadState_Swap(

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1161,7 +1161,7 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
         return PyErr_NoMemory();
     }
     boot->interp = _PyInterpreterState_GET();
-    boot->tstate = _PyThreadState_Prealloc(boot->interp);
+    boot->tstate = _PyThreadState_New(boot->interp);
     if (boot->tstate == NULL) {
         PyMem_Free(boot);
         if (!PyErr_Occurred()) {

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -624,7 +624,7 @@ _PyEval_ReInitThreads(PyThreadState *tstate)
     }
 
     /* Destroy all threads except the current one */
-    _PyThreadState_DeleteExcept(runtime, tstate);
+    _PyThreadState_DeleteExcept(tstate);
     return _PyStatus_OK();
 }
 #endif

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1867,7 +1867,7 @@ Py_FinalizeEx(void)
        _PyRuntimeState_SetFinalizing() has been called, no other Python thread
        can take the GIL at this point: if they try, they will exit
        immediately. */
-    _PyThreadState_DeleteExcept(runtime, tstate);
+    _PyThreadState_DeleteExcept(tstate);
 
     /* Flush sys.stdout and sys.stderr */
     if (flush_std_files() < 0) {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1824,6 +1824,9 @@ Py_FinalizeEx(void)
     // XXX assert(_Py_IsMainInterpreter(tstate->interp));
     // XXX assert(_Py_IsMainThread());
 
+    // Block some operations.
+    tstate->interp->finalizing = 1;
+
     // Wrap up existing "threading"-module-created, non-daemon threads.
     wait_for_thread_shutdown(tstate);
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -696,10 +696,11 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
     const _PyInterpreterConfig config = _PyInterpreterConfig_LEGACY_INIT;
     init_interp_settings(interp, &config);
 
-    PyThreadState *tstate = PyThreadState_New(interp);
+    PyThreadState *tstate = _PyThreadState_New(interp);
     if (tstate == NULL) {
         return _PyStatus_ERR("can't make first thread");
     }
+    _PyThreadState_Bind(tstate);
     (void) PyThreadState_Swap(tstate);
 
     status = init_interp_create_gil(tstate);
@@ -2074,12 +2075,13 @@ new_interpreter(PyThreadState **tstate_p, const _PyInterpreterConfig *config)
         return _PyStatus_OK();
     }
 
-    PyThreadState *tstate = PyThreadState_New(interp);
+    PyThreadState *tstate = _PyThreadState_New(interp);
     if (tstate == NULL) {
         PyInterpreterState_Delete(interp);
         *tstate_p = NULL;
         return _PyStatus_OK();
     }
+    _PyThreadState_Bind(tstate);
 
     PyThreadState *save_tstate = PyThreadState_Swap(tstate);
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -773,13 +773,12 @@ PyInterpreterState_Delete(PyInterpreterState *interp)
     _PyRuntimeState *runtime = interp->runtime;
     struct pyinterpreters *interpreters = &runtime->interpreters;
 
+    /* Unset current thread.  After this, many C API calls become crashy. */
+    _PyThreadState_Swap(runtime, NULL);
+
     zapthreads(interp, 0);
 
     _PyEval_FiniState(&interp->ceval);
-
-    // XXX Move this above zapthreads().
-    /* Unset current thread.  After this, many C API calls become crashy. */
-    _PyThreadState_Swap(runtime, NULL);
 
     HEAD_LOCK(runtime);
     PyInterpreterState **p;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -283,13 +283,17 @@ bind_gilstate_tstate(PyThreadState *tstate)
     assert(tstate_is_alive(tstate));
     assert(tstate_is_bound(tstate));
     // XXX assert(!tstate->_status.active);
-    // XXX assert(!tstate->_status.bound_gilstate);
-    _PyRuntimeState *runtime = tstate->interp->runtime;
+    assert(!tstate->_status.bound_gilstate);
 
-    // XXX Skipping like this does not play nice with multiple interpreters.
-    if (gilstate_tss_get(runtime) == NULL) {
-        gilstate_tss_set(runtime, tstate);
+    _PyRuntimeState *runtime = tstate->interp->runtime;
+    PyThreadState *tcur = gilstate_tss_get(runtime);
+    assert(tstate != tcur);
+
+    if (tcur != NULL) {
+        // XXX Skipping like this does not play nice with multiple interpreters.
+        return;
     }
+    gilstate_tss_set(runtime, tstate);
     tstate->_status.bound_gilstate = 1;
 }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -190,6 +190,7 @@ bind_tstate(PyThreadState *tstate)
     assert(tstate != NULL);
     assert(tstate_is_alive(tstate) && !tstate->_status.bound);
     assert(!tstate->_status.unbound);  // just in case
+    assert(!tstate->_status.active);
     assert(tstate->thread_id == 0);
     assert(tstate->native_thread_id == 0);
     _PyRuntimeState *runtime = tstate->interp->runtime;
@@ -231,6 +232,7 @@ unbind_tstate(PyThreadState *tstate)
     assert(tstate != NULL);
     assert(tstate_is_bound(tstate));
     // XXX assert(tstate_is_alive(tstate) && tstate_is_bound(tstate));
+    // XXX assert(!tstate->_status.active);
     assert(tstate->thread_id > 0);
 #ifdef PY_HAVE_THREAD_NATIVE_ID
     assert(tstate->native_thread_id > 0);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1610,7 +1610,8 @@ static inline void
 tstate_activate(PyThreadState *tstate)
 {
     assert(tstate != NULL);
-    assert(tstate_is_alive(tstate) && tstate_is_bound(tstate));
+    // XXX assert(tstate_is_alive(tstate));
+    assert(tstate_is_bound(tstate));
     assert(!tstate->_status.active);
 
     if (!tstate->_status.bound_gilstate) {
@@ -1719,7 +1720,8 @@ _PyThreadState_Swap(_PyRuntimeState *runtime, PyThreadState *newts)
         tstate_deactivate(oldts);
     }
     if (newts != NULL) {
-        assert(tstate_is_alive(newts) && tstate_is_bound(newts));
+        // XXX assert(tstate_is_alive(newts));
+        assert(tstate_is_bound(newts));
         current_fast_set(runtime, newts);
         tstate_activate(newts);
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1730,6 +1730,7 @@ _PyThreadState_Swap(_PyRuntimeState *runtime, PyThreadState *newts)
         // XXX assert(tstate_is_alive(oldts) && tstate_is_bound(oldts));
         tstate_deactivate(oldts);
     }
+
     if (newts != NULL) {
         // XXX assert(tstate_is_alive(newts));
         assert(tstate_is_bound(newts));

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -308,12 +308,9 @@ unbind_gilstate_tstate(PyThreadState *tstate)
     assert(tstate_is_bound(tstate));
     // XXX assert(!tstate->_status.active);
     assert(tstate->_status.bound_gilstate);
-    // XXX assert(tstate == gilstate_tss_get(tstate->interp->runtime));
+    assert(tstate == gilstate_tss_get(tstate->interp->runtime));
 
-    // XXX This check *should* always succeed.
-    if (tstate == gilstate_tss_get(tstate->interp->runtime)) {
-        gilstate_tss_clear(tstate->interp->runtime);
-    }
+    gilstate_tss_clear(tstate->interp->runtime);
     tstate->_status.bound_gilstate = 0;
 }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -290,8 +290,11 @@ bind_gilstate_tstate(PyThreadState *tstate)
     assert(tstate != tcur);
 
     if (tcur != NULL) {
+        // The original gilstate implementation only respects the
+        // first thread state set.
         // XXX Skipping like this does not play nice with multiple interpreters.
         return;
+        tcur->_status.bound_gilstate = 0;
     }
     gilstate_tss_set(runtime, tstate);
     tstate->_status.bound_gilstate = 1;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -243,10 +243,6 @@ unbind_tstate(PyThreadState *tstate)
     assert(tstate->native_thread_id > 0);
 #endif
 
-    if (tstate->_status.bound_gilstate) {
-        unbind_gilstate_tstate(tstate);
-    }
-
     // We leave thread_id and native_thraed_id alone
     // since they can be useful for debugging.
     // Check the `_status` field to know if these values
@@ -1440,7 +1436,11 @@ tstate_delete_common(PyThreadState *tstate)
     }
     HEAD_UNLOCK(runtime);
 
-    // XXX Do this in PyThreadState_Swap() (and assert not-equal here)?
+    // XXX Unbind in PyThreadState_Clear(), or earlier
+    // (and assert not-equal here)?
+    if (tstate->_status.bound_gilstate) {
+        unbind_gilstate_tstate(tstate);
+    }
     unbind_tstate(tstate);
 
     // XXX Move to PyThreadState_Clear()?

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -229,12 +229,6 @@ bind_tstate(PyThreadState *tstate)
 #endif
 
     tstate->_status.bound = 1;
-
-    // This make sure there's a gilstate tstate bound
-    // as soon as possible.
-    if (gilstate_tss_get(tstate->interp->runtime) == NULL) {
-        bind_gilstate_tstate(tstate);
-    }
 }
 
 static void
@@ -1310,6 +1304,11 @@ PyThreadState_New(PyInterpreterState *interp)
     PyThreadState *tstate = new_threadstate(interp);
     if (tstate) {
         bind_tstate(tstate);
+        // This make sure there's a gilstate tstate bound
+        // as soon as possible.
+        if (gilstate_tss_get(tstate->interp->runtime) == NULL) {
+            bind_gilstate_tstate(tstate);
+        }
     }
     return tstate;
 }
@@ -1762,6 +1761,11 @@ void
 _PyThreadState_Bind(PyThreadState *tstate)
 {
     bind_tstate(tstate);
+    // This make sure there's a gilstate tstate bound
+    // as soon as possible.
+    if (gilstate_tss_get(tstate->interp->runtime) == NULL) {
+        bind_gilstate_tstate(tstate);
+    }
 }
 
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1266,7 +1266,7 @@ void
 PyThreadState_Clear(PyThreadState *tstate)
 {
     assert(tstate->_status.initialized && !tstate->_status.cleared);
-    // XXX !tstate->_status.bound || tstate->_status.unbound
+    // XXX assert(!tstate->_status.bound || tstate->_status.unbound);
     tstate->_status.finalizing = 1;  // just in case
 
     /* XXX Conditions we need to enforce:

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1251,7 +1251,7 @@ PyThreadState_New(PyInterpreterState *interp)
 
 // This must be followed by a call to _PyThreadState_Bind();
 PyThreadState *
-_PyThreadState_Prealloc(PyInterpreterState *interp)
+_PyThreadState_New(PyInterpreterState *interp)
 {
     return new_threadstate(interp);
 }
@@ -2066,10 +2066,11 @@ PyGILState_Ensure(void)
     int has_gil;
     if (tcur == NULL) {
         /* Create a new Python thread state for this thread */
-        tcur = PyThreadState_New(runtime->gilstate.autoInterpreterState);
+        tcur = new_threadstate(runtime->gilstate.autoInterpreterState);
         if (tcur == NULL) {
             Py_FatalError("Couldn't create thread-state for new thread");
         }
+        bind_tstate(tcur);
 
         /* This is our thread state!  We'll need to delete it in the
            matching call to PyGILState_Release(). */

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1304,7 +1304,7 @@ PyThreadState_New(PyInterpreterState *interp)
     PyThreadState *tstate = new_threadstate(interp);
     if (tstate) {
         bind_tstate(tstate);
-        // This make sure there's a gilstate tstate bound
+        // This makes sure there's a gilstate tstate bound
         // as soon as possible.
         if (gilstate_tss_get(tstate->interp->runtime) == NULL) {
             bind_gilstate_tstate(tstate);
@@ -1768,7 +1768,7 @@ void
 _PyThreadState_Bind(PyThreadState *tstate)
 {
     bind_tstate(tstate);
-    // This make sure there's a gilstate tstate bound
+    // This makes sure there's a gilstate tstate bound
     // as soon as possible.
     if (gilstate_tss_get(tstate->interp->runtime) == NULL) {
         bind_gilstate_tstate(tstate);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1613,6 +1613,8 @@ tstate_activate(PyThreadState *tstate)
     assert(tstate_is_bound(tstate));
     assert(!tstate->_status.active);
 
+    assert(!tstate->_status.bound_gilstate ||
+           tstate == gilstate_tss_get((tstate->interp->runtime)));
     if (!tstate->_status.bound_gilstate) {
         bind_gilstate_tstate(tstate);
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1321,6 +1321,13 @@ _PyThreadState_New(PyInterpreterState *interp)
     return new_threadstate(interp);
 }
 
+// We keep this for stable ABI compabibility.
+PyThreadState *
+_PyThreadState_Prealloc(PyInterpreterState *interp)
+{
+    return _PyThreadState_New(interp);
+}
+
 // We keep this around for (accidental) stable ABI compatibility.
 // Realisically, no extensions are using it.
 void

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1359,9 +1359,11 @@ PyThreadState_DeleteCurrent(void)
  * be kept in those other interpreters.
  */
 void
-_PyThreadState_DeleteExcept(_PyRuntimeState *runtime, PyThreadState *tstate)
+_PyThreadState_DeleteExcept(PyThreadState *tstate)
 {
+    assert(tstate != NULL);
     PyInterpreterState *interp = tstate->interp;
+    _PyRuntimeState *runtime = interp->runtime;
 
     HEAD_LOCK(runtime);
     /* Remove all thread states, except tstate, from the linked list of

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -773,8 +773,11 @@ PyInterpreterState_Delete(PyInterpreterState *interp)
     _PyRuntimeState *runtime = interp->runtime;
     struct pyinterpreters *interpreters = &runtime->interpreters;
 
-    /* Unset current thread.  After this, many C API calls become crashy. */
-    _PyThreadState_Swap(runtime, NULL);
+    PyThreadState *tcur = current_fast_get(runtime);
+    if (tcur != NULL && interp == tcur->interp) {
+        /* Unset current thread.  After this, many C API calls become crashy. */
+        _PyThreadState_Swap(runtime, NULL);
+    }
 
     zapthreads(interp, 0);
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -866,6 +866,8 @@ _PyInterpreterState_DeleteExceptMain(_PyRuntimeState *runtime)
             continue;
         }
 
+        // XXX Won't this fail since PyInterpreterState_Clear() requires
+        // the "current" tstate to be set?
         PyInterpreterState_Clear(interp);  // XXX must activate?
         zapthreads(interp);
         if (interp->id_mutex != NULL) {


### PR DESCRIPTION
A `PyThreadState` can be in one of many states in its lifecycle, represented by some status value.  Those statuses haven't been particularly clear, so we're addressing that here.  Specifically:

* made the distinct lifecycle statuses clear on `PyThreadState`
* identified expectations of how various lifecycle-related functions relate to status
* noted the various places where those expectations don't match the actual behavior

At some point we'll need to address the mismatches.

(This change also includes some cleanup.)

<!-- gh-issue-number: gh-59956 -->
* Issue: gh-59956
<!-- /gh-issue-number -->
