### PR TITLE
gh-101322: Ensure test_zlib.ZlibDecompressorTest runs, fix errors in ZlibDecompressor

### DIFF
--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -944,13 +944,18 @@ LAERTES
 """
 
 
-class ZlibDecompressorTest():
+class ZlibDecompressorTest(unittest.TestCase):
     # Test adopted from test_bz2.py
     TEXT = HAMLET_SCENE
     DATA = zlib.compress(HAMLET_SCENE)
     BAD_DATA = b"Not a valid deflate block"
+    BIG_TEXT = DATA * ((128 * 1024 // len(DATA)) + 1)
+    BIG_DATA = zlib.compress(BIG_TEXT)
+
     def test_Constructor(self):
-        self.assertRaises(TypeError, zlib._ZlibDecompressor, 42)
+        self.assertRaises(TypeError, zlib._ZlibDecompressor, "ASDA")
+        self.assertRaises(TypeError, zlib._ZlibDecompressor, -15, "notbytes")
+        self.assertRaises(TypeError, zlib._ZlibDecompressor, -15, b"bytes", 5)
 
     def testDecompress(self):
         zlibd = zlib._ZlibDecompressor()

--- a/Misc/NEWS.d/next/Library/2023-01-26-06-44-35.gh-issue-101323.h8Hk11.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-26-06-44-35.gh-issue-101323.h8Hk11.rst
@@ -1,0 +1,2 @@
+Fix a bug where errors where not thrown by zlib._ZlibDecompressor if
+encountered during decompressing.

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -1519,6 +1519,7 @@ decompress_buf(ZlibDecompressor *self, Py_ssize_t max_length)
         }
     } else if (err != Z_OK && err != Z_BUF_ERROR) {
         zlib_error(state, self->zst, err, "while decompressing data");
+        goto error;
     }
 
     self->avail_in_real += self->zst.avail_in;


### PR DESCRIPTION
Turns out that when I made https://github.com/python/cpython/pull/97664 I added test but these are actually not run at test time.

I also found a small error in the code that is now fixed. 

<!-- gh-issue-number: gh-101322 -->
* Issue: gh-101322
<!-- /gh-issue-number -->
