### PR TITLE
Fix import in doc for `SimpleHTTPRequestHandler`

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -402,14 +402,12 @@ The :class:`SimpleHTTPRequestHandler` class can be used in the following
 manner in order to create a very basic webserver serving files relative to
 the current directory::
 
-   import http.server
+   from http.server import SimpleHTTPRequestHandler
    import socketserver
 
    PORT = 8000
 
-   Handler = http.server.SimpleHTTPRequestHandler
-
-   with socketserver.TCPServer(("", PORT), Handler) as httpd:
+   with socketserver.TCPServer(("", PORT), SimpleHTTPRequestHandler) as httpd:
        print("serving at port", PORT)
        httpd.serve_forever()
 


### PR DESCRIPTION
# Fix import in doc for `SimpleHTTPRequestHandler`

Since this is a small change, I'm going to avoid creating a GitHub issue for now (but happy to do so if required).