### PR TITLE
[3.11] gh-101326: Fix regression when passing None to FutureIter.throw (GH-101327)

### DIFF
--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -607,6 +607,8 @@ class BaseFutureTests:
                           Exception, Exception("elephant"), 32)
         self.assertRaises(TypeError, fi.throw,
                           Exception("elephant"), Exception("elephant"))
+        # https://github.com/python/cpython/issues/101326
+        self.assertRaises(ValueError, fi.throw, ValueError, None, None)
         self.assertRaises(TypeError, fi.throw, list)
 
     def test_future_del_collect(self):

--- a/Misc/NEWS.d/next/Library/2023-01-25-18-07-20.gh-issue-101326.KL4SFv.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-25-18-07-20.gh-issue-101326.KL4SFv.rst
@@ -1,0 +1,1 @@
+Fix regression when passing ``None`` as second or third argument to ``FutureIter.throw``.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1666,7 +1666,12 @@ FutureIter_throw(futureiterobject *self, PyObject *const *args, Py_ssize_t nargs
         val = args[1];
     }
 
-    if (tb != NULL && !PyTraceBack_Check(tb)) {
+    if (val == Py_None) {
+        val = NULL;
+    }
+    if (tb == Py_None ) {
+        tb = NULL;
+    } else if (tb != NULL && !PyTraceBack_Check(tb)) {
         PyErr_SetString(PyExc_TypeError, "throw() third argument must be a traceback");
         return NULL;
     }


### PR DESCRIPTION
(cherry picked from commit a178ba82bfe2f2fb6f6ff0e67cb734fd7c4321e3)

Co-authored-by: Shantanu <12621235+hauntsaninja@users.noreply.github.com>

<!-- gh-issue-number: gh-101326 -->
* Issue: gh-101326
<!-- /gh-issue-number -->
