### PR TITLE
gh-98831: Support conditional effects; use for LOAD_ATTR

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -51,7 +51,7 @@
 
 // Dummy variables for stack effects.
 static PyObject *value, *value1, *value2, *left, *right, *res, *sum, *prod, *sub;
-static PyObject *container, *start, *stop, *v, *lhs, *rhs;
+static PyObject *container, *start, *stop, *v, *lhs, *rhs, *res2;
 static PyObject *list, *tuple, *dict, *owner, *set, *str, *tup, *map, *keys;
 static PyObject *exit_func, *lasti, *val, *retval, *obj, *iter;
 static PyObject *aiter, *awaitable, *iterable, *w, *exc_value, *bc;
@@ -1438,13 +1438,11 @@ dummy_func(
             PREDICT(JUMP_BACKWARD);
         }
 
-        // error: LOAD_ATTR has irregular stack effect
-        inst(LOAD_ATTR) {
+        inst(LOAD_ATTR, (unused/9, owner -- res, res2 if (oparg & 1))) {
             #if ENABLE_SPECIALIZATION
             _PyAttrCache *cache = (_PyAttrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
                 assert(cframe.use_tracing == 0);
-                PyObject *owner = TOP();
                 PyObject *name = GETITEM(names, oparg>>1);
                 next_instr--;
                 _Py_Specialize_LoadAttr(owner, next_instr, name);
@@ -1454,26 +1452,18 @@ dummy_func(
             DECREMENT_ADAPTIVE_COUNTER(cache->counter);
             #endif  /* ENABLE_SPECIALIZATION */
             PyObject *name = GETITEM(names, oparg >> 1);
-            PyObject *owner = TOP();
             if (oparg & 1) {
-                /* Designed to work in tandem with CALL. */
+                /* Designed to work in tandem with CALL, pushes two values. */
                 PyObject* meth = NULL;
-
-                int meth_found = _PyObject_GetMethod(owner, name, &meth);
-
-                if (meth == NULL) {
-                    /* Most likely attribute wasn't found. */
-                    goto error;
-                }
-
-                if (meth_found) {
+                if (_PyObject_GetMethod(owner, name, &meth)) {
                     /* We can bypass temporary bound method object.
                        meth is unbound method and obj is self.
 
                        meth | self | arg1 | ... | argN
                      */
-                    SET_TOP(meth);
-                    PUSH(owner);  // self
+                    assert(meth != NULL);  // No errors on this branch
+                    res = meth;
+                    res2 = owner;  // Transfer ownership
                 }
                 else {
                     /* meth is not an unbound method (but a regular attr, or
@@ -1483,20 +1473,18 @@ dummy_func(
 
                        NULL | meth | arg1 | ... | argN
                     */
-                    SET_TOP(NULL);
                     Py_DECREF(owner);
-                    PUSH(meth);
+                    ERROR_IF(meth == NULL, error);
+                    res = NULL;
+                    res2 = meth;
                 }
             }
             else {
-                PyObject *res = PyObject_GetAttr(owner, name);
-                if (res == NULL) {
-                    goto error;
-                }
+                /* Classic, pushes one value. */
+                res = PyObject_GetAttr(owner, name);
                 Py_DECREF(owner);
-                SET_TOP(res);
+                ERROR_IF(res == NULL, error);
             }
-            JUMPBY(INLINE_CACHE_ENTRIES_LOAD_ATTR);
         }
 
         // error: LOAD_ATTR has irregular stack effect

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1438,7 +1438,7 @@ dummy_func(
             PREDICT(JUMP_BACKWARD);
         }
 
-        inst(LOAD_ATTR, (unused/9, owner -- res, res2 if (oparg & 1))) {
+        inst(LOAD_ATTR, (unused/9, owner -- res2 if (oparg & 1), res)) {
             #if ENABLE_SPECIALIZATION
             _PyAttrCache *cache = (_PyAttrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -1462,8 +1462,8 @@ dummy_func(
                        meth | self | arg1 | ... | argN
                      */
                     assert(meth != NULL);  // No errors on this branch
-                    res = meth;
-                    res2 = owner;  // Transfer ownership
+                    res2 = meth;
+                    res = owner;  // Transfer ownership
                 }
                 else {
                     /* meth is not an unbound method (but a regular attr, or
@@ -1475,8 +1475,8 @@ dummy_func(
                     */
                     Py_DECREF(owner);
                     ERROR_IF(meth == NULL, error);
-                    res = NULL;
-                    res2 = meth;
+                    res2 = NULL;
+                    res = meth;
                 }
             }
             else {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1794,8 +1794,9 @@
                 Py_DECREF(owner);
                 if (res == NULL) goto pop_1_error;
             }
-            POKE(1, res);
-            if (oparg & 1) { PUSH(res2); }
+            STACK_GROW(((oparg & 1) != 0));
+            if (oparg & 1) { POKE(((oparg & 1) != 0), res2); }
+            POKE(1 + ((oparg & 1) != 0), res);
             JUMPBY(9);
             DISPATCH();
         }
@@ -2268,8 +2269,8 @@
             if (!Py_IsNone(match)) {
                 PyErr_SetExcInfo(NULL, Py_NewRef(match), NULL);
             }
-            POKE(2, rest);
             POKE(1, match);
+            POKE(2, rest);
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1794,9 +1794,9 @@
                 Py_DECREF(owner);
                 if (res == NULL) goto pop_1_error;
             }
-            STACK_GROW(((oparg & 1) != 0));
+            STACK_GROW(((oparg & 1) ? 1 : 0));
             POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) != 0), res2); }
+            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), res2); }
             JUMPBY(9);
             DISPATCH();
         }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1746,8 +1746,8 @@
         TARGET(LOAD_ATTR) {
             PREDICTED(LOAD_ATTR);
             PyObject *owner = PEEK(1);
-            PyObject *res;
             PyObject *res2;
+            PyObject *res;
             #if ENABLE_SPECIALIZATION
             _PyAttrCache *cache = (_PyAttrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -1771,8 +1771,8 @@
                        meth | self | arg1 | ... | argN
                      */
                     assert(meth != NULL);  // No errors on this branch
-                    res = meth;
-                    res2 = owner;  // Transfer ownership
+                    res2 = meth;
+                    res = owner;  // Transfer ownership
                 }
                 else {
                     /* meth is not an unbound method (but a regular attr, or
@@ -1784,8 +1784,8 @@
                     */
                     Py_DECREF(owner);
                     if (meth == NULL) goto pop_1_error;
-                    res = NULL;
-                    res2 = meth;
+                    res2 = NULL;
+                    res = meth;
                 }
             }
             else {
@@ -1795,8 +1795,8 @@
                 if (res == NULL) goto pop_1_error;
             }
             STACK_GROW(((oparg & 1) != 0));
-            if (oparg & 1) { POKE(((oparg & 1) != 0), res2); }
-            POKE(1 + ((oparg & 1) != 0), res);
+            POKE(1, res);
+            if (oparg & 1) { POKE(1 + ((oparg & 1) != 0), res2); }
             JUMPBY(9);
             DISPATCH();
         }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2273,8 +2273,8 @@
             if (!Py_IsNone(match)) {
                 PyErr_SetExcInfo(NULL, Py_NewRef(match), NULL);
             }
-            POKE(1, match);
             POKE(2, rest);
+            POKE(1, match);
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1745,11 +1745,13 @@
 
         TARGET(LOAD_ATTR) {
             PREDICTED(LOAD_ATTR);
+            PyObject *owner = PEEK(1);
+            PyObject *res;
+            PyObject *res2;
             #if ENABLE_SPECIALIZATION
             _PyAttrCache *cache = (_PyAttrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
                 assert(cframe.use_tracing == 0);
-                PyObject *owner = TOP();
                 PyObject *name = GETITEM(names, oparg>>1);
                 next_instr--;
                 _Py_Specialize_LoadAttr(owner, next_instr, name);
@@ -1759,26 +1761,18 @@
             DECREMENT_ADAPTIVE_COUNTER(cache->counter);
             #endif  /* ENABLE_SPECIALIZATION */
             PyObject *name = GETITEM(names, oparg >> 1);
-            PyObject *owner = TOP();
             if (oparg & 1) {
-                /* Designed to work in tandem with CALL. */
+                /* Designed to work in tandem with CALL, pushes two values. */
                 PyObject* meth = NULL;
-
-                int meth_found = _PyObject_GetMethod(owner, name, &meth);
-
-                if (meth == NULL) {
-                    /* Most likely attribute wasn't found. */
-                    goto error;
-                }
-
-                if (meth_found) {
+                if (_PyObject_GetMethod(owner, name, &meth)) {
                     /* We can bypass temporary bound method object.
                        meth is unbound method and obj is self.
 
                        meth | self | arg1 | ... | argN
                      */
-                    SET_TOP(meth);
-                    PUSH(owner);  // self
+                    assert(meth != NULL);  // No errors on this branch
+                    res = meth;
+                    res2 = owner;  // Transfer ownership
                 }
                 else {
                     /* meth is not an unbound method (but a regular attr, or
@@ -1788,20 +1782,21 @@
 
                        NULL | meth | arg1 | ... | argN
                     */
-                    SET_TOP(NULL);
                     Py_DECREF(owner);
-                    PUSH(meth);
+                    if (meth == NULL) goto pop_1_error;
+                    res = NULL;
+                    res2 = meth;
                 }
             }
             else {
-                PyObject *res = PyObject_GetAttr(owner, name);
-                if (res == NULL) {
-                    goto error;
-                }
+                /* Classic, pushes one value. */
+                res = PyObject_GetAttr(owner, name);
                 Py_DECREF(owner);
-                SET_TOP(res);
+                if (res == NULL) goto pop_1_error;
             }
-            JUMPBY(INLINE_CACHE_ENTRIES_LOAD_ATTR);
+            POKE(1, res);
+            if (oparg & 1) { PUSH(res2); }
+            JUMPBY(9);
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1746,7 +1746,7 @@
         TARGET(LOAD_ATTR) {
             PREDICTED(LOAD_ATTR);
             PyObject *owner = PEEK(1);
-            PyObject *res2;
+            PyObject *res2 = NULL;
             PyObject *res;
             #if ENABLE_SPECIALIZATION
             _PyAttrCache *cache = (_PyAttrCache *)next_instr;

--- a/Python/opcode_metadata.h
+++ b/Python/opcode_metadata.h
@@ -531,7 +531,7 @@ _PyOpcode_num_pushed(int opcode, int oparg) {
         case MAP_ADD:
             return 0;
         case LOAD_ATTR:
-            return 2;
+            return ((oparg & 1) != 0) + 1;
         case LOAD_ATTR_INSTANCE_VALUE:
             return -1;
         case LOAD_ATTR_MODULE:

--- a/Python/opcode_metadata.h
+++ b/Python/opcode_metadata.h
@@ -185,7 +185,7 @@ _PyOpcode_num_popped(int opcode, int oparg) {
         case MAP_ADD:
             return 2;
         case LOAD_ATTR:
-            return -1;
+            return 1;
         case LOAD_ATTR_INSTANCE_VALUE:
             return -1;
         case LOAD_ATTR_MODULE:
@@ -531,7 +531,7 @@ _PyOpcode_num_pushed(int opcode, int oparg) {
         case MAP_ADD:
             return 0;
         case LOAD_ATTR:
-            return -1;
+            return 2;
         case LOAD_ATTR_INSTANCE_VALUE:
             return -1;
         case LOAD_ATTR_MODULE:
@@ -694,7 +694,7 @@ _PyOpcode_num_pushed(int opcode, int oparg) {
 }
 #endif
 enum Direction { DIR_NONE, DIR_READ, DIR_WRITE };
-enum InstructionFormat { INSTR_FMT_IB, INSTR_FMT_IBC, INSTR_FMT_IBC0, INSTR_FMT_IBC000, INSTR_FMT_IBIB, INSTR_FMT_IX, INSTR_FMT_IXC, INSTR_FMT_IXC000 };
+enum InstructionFormat { INSTR_FMT_IB, INSTR_FMT_IBC, INSTR_FMT_IBC0, INSTR_FMT_IBC000, INSTR_FMT_IBC00000000, INSTR_FMT_IBIB, INSTR_FMT_IX, INSTR_FMT_IXC, INSTR_FMT_IXC000 };
 struct opcode_metadata {
     enum Direction dir_op1;
     enum Direction dir_op2;
@@ -791,7 +791,7 @@ struct opcode_metadata {
     [DICT_UPDATE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
     [DICT_MERGE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
     [MAP_ADD] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
-    [LOAD_ATTR] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
+    [LOAD_ATTR] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC00000000 },
     [LOAD_ATTR_INSTANCE_VALUE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
     [LOAD_ATTR_MODULE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
     [LOAD_ATTR_WITH_HINT] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },

--- a/Python/opcode_metadata.h
+++ b/Python/opcode_metadata.h
@@ -531,7 +531,7 @@ _PyOpcode_num_pushed(int opcode, int oparg) {
         case MAP_ADD:
             return 0;
         case LOAD_ATTR:
-            return ((oparg & 1) != 0) + 1;
+            return ((oparg & 1) ? 1 : 0) + 1;
         case LOAD_ATTR_INSTANCE_VALUE:
             return -1;
         case LOAD_ATTR_MODULE:

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -736,7 +736,7 @@ class Analyzer:
 
     def get_stack_effect_info(
         self, thing: parser.InstDef | parser.Super | parser.Macro
-    ) -> tuple[Instruction, str, str]:
+    ) -> tuple[Instruction|None, str, str]:
 
         def effect_str(effect: list[StackEffect]) -> str:
             if getattr(thing, 'kind', None) == 'legacy':
@@ -752,6 +752,9 @@ class Analyzer:
                     instr = self.instrs[thing.name]
                     popped = effect_str(instr.input_effects)
                     pushed = effect_str(instr.output_effects)
+                else:
+                    instr = None
+                    popped = pushed = "", ""
             case parser.Super():
                 instr = self.super_instrs[thing.name]
                 popped = '+'.join(effect_str(comp.instr.input_effects) for comp in instr.parts)
@@ -770,8 +773,9 @@ class Analyzer:
         pushed_data = []
         for thing in self.everything:
             instr, popped, pushed = self.get_stack_effect_info(thing)
-            popped_data.append( (instr, popped) )
-            pushed_data.append( (instr, pushed) )
+            if instr is not None:
+                popped_data.append( (instr, popped) )
+                pushed_data.append( (instr, pushed) )
 
         def write_function(direction: str, data: list[tuple[Instruction, str]]) -> None:
             self.out.emit("\n#ifndef NDEBUG");

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -59,7 +59,10 @@ def effect_size(effect: StackEffect) -> tuple[int, str]:
     At most one of these will be non-zero / non-empty.
     """
     if effect.size:
+        assert not effect.cond, "Manual effects should be conditional"
         return 0, effect.size
+    elif effect.cond:
+        return 0, f"{maybe_parenthesize(effect.cond)} != 0"
     else:
         return 1, ""
 
@@ -778,10 +781,10 @@ class Analyzer:
         self, thing: parser.InstDef | parser.Super | parser.Macro
     ) -> tuple[Instruction, str, str]:
 
-        def effect_str(effect: list[StackEffect]) -> str:
+        def effect_str(effects: list[StackEffect]) -> str:
             if getattr(thing, 'kind', None) == 'legacy':
                 return str(-1)
-            n_effect, sym_effect = list_effect_size(effect)
+            n_effect, sym_effect = list_effect_size(effects)
             if sym_effect:
                 return f"{sym_effect} + {n_effect}" if n_effect else sym_effect
             return str(n_effect)

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -64,7 +64,7 @@ def effect_size(effect: StackEffect) -> tuple[int, str]:
         assert not effect.cond, "Array effects cannot have a condition"
         return 0, effect.size
     elif effect.cond:
-        return 0, f"{maybe_parenthesize(effect.cond)} != 0"
+        return 0, f"{maybe_parenthesize(effect.cond)} ? 1 : 0"
     else:
         return 1, ""
 

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -160,10 +160,13 @@ class Formatter:
         if dst.name == UNUSED:
             return
         typ = f"{dst.type}" if dst.type else "PyObject *"
-        init = ""
         if src:
             cast = self.cast(dst, src)
             init = f" = {cast}{src.name}"
+        elif dst.cond:
+            init = " = NULL"
+        else:
+            init = ""
         sepa = "" if typ.endswith("*") else " "
         self.emit(f"{typ}{sepa}{dst.name}{init};")
 

--- a/Tools/cases_generator/parser.py
+++ b/Tools/cases_generator/parser.py
@@ -74,6 +74,8 @@ class StackEffect(Node):
     cond: str = ""  # Optional `if (cond)`
     size: str = ""  # Optional `[size]`
     # Note: size cannot be combined with type or cond
+    # 'manual' is used to decide between PEEK() and POP()
+    manual: bool = field(init=False, compare=False, default=False)
 
 
 @dataclass

--- a/Tools/cases_generator/parser.py
+++ b/Tools/cases_generator/parser.py
@@ -74,8 +74,6 @@ class StackEffect(Node):
     cond: str = ""  # Optional `if (cond)`
     size: str = ""  # Optional `[size]`
     # Note: size cannot be combined with type or cond
-    # 'manual' is used to decide between PEEK() and POP()
-    manual: bool = field(init=False, compare=False, default=False)
 
 
 @dataclass

--- a/Tools/cases_generator/test_generator.py
+++ b/Tools/cases_generator/test_generator.py
@@ -358,8 +358,7 @@ def test_macro_instruction():
             {
                 PyObject *arg1 = _tmp_1;
                 PyObject *interim;
-                uint16_t counter = re
-                ad_u16(&next_instr[0].cache);
+                uint16_t counter = read_u16(&next_instr[0].cache);
                 interim = op1(arg1);
                 _tmp_1 = interim;
             }

--- a/Tools/cases_generator/test_generator.py
+++ b/Tools/cases_generator/test_generator.py
@@ -9,19 +9,19 @@ from parser import StackEffect
 
 def test_effect_sizes():
     input_effects = [
-        x := StackEffect("x", "", ""),
-        y := StackEffect("y", "", "oparg"),
-        z := StackEffect("z", "", "oparg*2"),
+        x := StackEffect("x", "", "", ""),
+        y := StackEffect("y", "", "", "oparg"),
+        z := StackEffect("z", "", "", "oparg*2"),
     ]
     output_effects = [
-        a := StackEffect("a", "", ""),
-        b := StackEffect("b", "", "oparg*4"),
-        c := StackEffect("c", "", ""),
+        StackEffect("a", "", "", ""),
+        StackEffect("b", "", "", "oparg*4"),
+        StackEffect("c", "", "", ""),
     ]
     other_effects = [
-        p := StackEffect("p", "", "oparg<<1"),
-        q := StackEffect("q", "", ""),
-        r := StackEffect("r", "", ""),
+        StackEffect("p", "", "", "oparg<<1"),
+        StackEffect("q", "", "", ""),
+        StackEffect("r", "", "", ""),
     ]
     assert generate_cases.effect_size(x) == (1, "")
     assert generate_cases.effect_size(y) == (0, "oparg")
@@ -472,6 +472,24 @@ def test_register():
             result = op(left, right);
             Py_XSETREF(REG(oparg3), result);
             JUMPBY(1);
+            DISPATCH();
+        }
+    """
+    run_cases_test(input, output)
+
+def test_cond_effect():
+    input = """
+        inst(OP, (input if (oparg & 1) -- output if (oparg & 2))) {
+            output = spam(oparg, input);
+        }
+    """
+    output = """
+        TARGET(OP) {
+            PyObject *input = NULL;
+            if (oparg & 1) { input = POP(); }
+            PyObject *output;
+            output = spam(oparg, input);
+            if (oparg & 2) { PUSH(output); }
             DISPATCH();
         }
     """

--- a/Tools/cases_generator/test_generator.py
+++ b/Tools/cases_generator/test_generator.py
@@ -494,7 +494,7 @@ def test_cond_effect():
             PyObject *input = (oparg & 1) ? PEEK(1 + ((oparg & 1) != 0)) : NULL;
             PyObject *aa = PEEK(2 + ((oparg & 1) != 0));
             PyObject *xx;
-            PyObject *output;
+            PyObject *output = NULL;
             PyObject *zz;
             output = spam(oparg, input);
             STACK_SHRINK(((oparg & 1) != 0));

--- a/Tools/cases_generator/test_generator.py
+++ b/Tools/cases_generator/test_generator.py
@@ -491,17 +491,17 @@ def test_cond_effect():
     output = """
         TARGET(OP) {
             PyObject *cc = PEEK(1);
-            PyObject *input = (oparg & 1) ? PEEK(1 + ((oparg & 1) != 0)) : NULL;
-            PyObject *aa = PEEK(2 + ((oparg & 1) != 0));
+            PyObject *input = (oparg & 1) ? PEEK(1 + ((oparg & 1) ? 1 : 0)) : NULL;
+            PyObject *aa = PEEK(2 + ((oparg & 1) ? 1 : 0));
             PyObject *xx;
             PyObject *output = NULL;
             PyObject *zz;
             output = spam(oparg, input);
-            STACK_SHRINK(((oparg & 1) != 0));
-            STACK_GROW(((oparg & 2) != 0));
+            STACK_SHRINK(((oparg & 1) ? 1 : 0));
+            STACK_GROW(((oparg & 2) ? 1 : 0));
             POKE(1, zz);
-            if (oparg & 2) { POKE(1 + ((oparg & 2) != 0), output); }
-            POKE(2 + ((oparg & 2) != 0), xx);
+            if (oparg & 2) { POKE(1 + ((oparg & 2) ? 1 : 0), output); }
+            POKE(2 + ((oparg & 2) ? 1 : 0), xx);
             DISPATCH();
         }
     """


### PR DESCRIPTION
We can now write
```
inst(OP, (foo if (oparg & 1) -- bar if (oparg & 2)) {
    ...
}
```
which pops `foo` off the stack if `oparg & 1`, otherwise setting it to `NULL`, and pushes `bar` onto the stack if `oparg & 2` (otherwise ignoring it).

This syntax cannot be combined with an array size on the same effect, but it can be combined with a type (untested). In addition, it is incompatible with an array size closer to the stack top, e.g. `foo if (oparg&1), bar[oparg>>1]` is not supported (I don't think it's used, and generating code for it would be slightly awkward, but could be done if needed).

The implementation switches to using `POP()` and `PUSH()` (from `PEEK()` and `POKE()`) for those variables that are either conditional or whose position relative to the bottom (!) of the stack depends on a condition. (See the added test for details.)

To demonstrate this, I converted `LOAD_ATTR` (but not its specializations).

<!-- gh-issue-number: gh-98831 -->
* Issue: gh-98831
<!-- /gh-issue-number -->
