### PR TITLE
gh-101341: Remove unncessary enum._power_of_two function

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1565,11 +1565,6 @@ def unique(enumeration):
                 (enumeration, alias_details))
     return enumeration
 
-def _power_of_two(value):
-    if value < 1:
-        return False
-    return value == 2 ** _high_bit(value)
-
 def _dataclass_repr(self):
     dcf = self.__dataclass_fields__
     return ', '.join(


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101341 -->
* Issue: gh-101341
<!-- /gh-issue-number -->
