### PR TITLE
Fix typos in pystate.c file

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -59,7 +59,7 @@ static void _PyThreadState_Delete(PyThreadState *tstate, int check_current);
 /*
    The stored thread state is set by PyThreadState_Swap().
 
-   For each of these functions, the GIL mus be held by the current thread.
+   For each of these functions, the GIL must be held by the current thread.
  */
 
 static inline PyThreadState *

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -57,9 +57,9 @@ static void _PyThreadState_Delete(PyThreadState *tstate, int check_current);
 //-------------------------------------------------
 
 /*
-   The stored thread state is set by PyThraedState_Swap().
+   The stored thread state is set by PyThreadState_Swap().
 
-   For each of these functions, the GIL must be held by the current thread.
+   For each of these functions, the GIL mus be held by the current thread.
  */
 
 static inline PyThreadState *
@@ -232,7 +232,7 @@ unbind_tstate(PyThreadState *tstate)
         current_tss_clear(runtime);
     }
 
-    // We leave thread_id and native_thraed_id alone
+    // We leave thread_id and native_thread_id alone
     // since they can be useful for debugging.
     // Check the `_status` field to know if these values
     // are still valid.
@@ -1140,7 +1140,7 @@ init_threadstate(PyThreadState *tstate,
     tstate->exc_info = &tstate->exc_state;
 
     // PyGILState_Release must not try to delete this thread state.
-    // This is cleared when PyGILState_Ensure() creates the thread sate.
+    // This is cleared when PyGILState_Ensure() creates the thread state.
     tstate->gilstate_counter = 1;
 
     tstate->cframe = &tstate->root_cframe;
@@ -1220,7 +1220,7 @@ _PyThreadState_Prealloc(PyInterpreterState *interp)
 }
 
 // We keep this around for (accidental) stable ABI compatibility.
-// Realisically, no extensions are using it.
+// Realistically, no extensions are using it.
 void
 _PyThreadState_Init(PyThreadState *tstate)
 {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -59,7 +59,7 @@ static void _PyThreadState_Delete(PyThreadState *tstate, int check_current);
 /*
    The stored thread state is set by PyThraedState_Swap().
 
-   For each of these functions, the GIL mus be held by the current thread.
+   For each of these functions, the GIL must be held by the current thread.
  */
 
 static inline PyThreadState *


### PR DESCRIPTION
Fixed typos in pystate.c file

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
