### PR TITLE
Docs: improve accuracy of sqlite3 `check_same_thread` parameter

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -304,8 +304,10 @@ Module functions
    :param bool check_same_thread:
        If ``True`` (default), an exception will be raised if the database connection
        is used by a thread other than the one that created it.
-       This may be helpful in particular when SQLite is not in serialized mode
-       (see :attr:`threadsafety`).
+       If ``False``, the connection may be accessed in multiple threads;
+       write operations may need to be serialized by the user
+       to avoid data corruption.
+       See :attr:`threadsafety` for more information.
 
    :param Connection factory:
        A custom subclass of :class:`Connection` to create the connection with,

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -302,11 +302,10 @@ Module functions
    :type isolation_level: str | None
 
    :param bool check_same_thread:
-       If ``True`` (default), only the creating thread may use the connection.
-       If ``False``, the connection may be shared across multiple threads;
-       if so, write operations may need to be serialized by the user,
-       to avoid data corruption.
-       Please see :attr:`threadsafety` for more information.
+       If ``True`` (default), an exception will be raised if the database connection
+       is used by a thread other than the one that created it.
+       This may be helpful in particular when SQLite is not in serialized mode
+       (see :attr:`threadsafety`).
 
    :param Connection factory:
        A custom subclass of :class:`Connection` to create the connection with,

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -304,8 +304,9 @@ Module functions
    :param bool check_same_thread:
        If ``True`` (default), only the creating thread may use the connection.
        If ``False``, the connection may be shared across multiple threads;
-       users should check :attr:`threadsafety` before setting this value to
-       avoid data corruption.
+       if so, write operations may need to be serialized by the user,
+       to avoid data corruption.
+       Please see :attr:`threadsafety` for more information.
 
    :param Connection factory:
        A custom subclass of :class:`Connection` to create the connection with,

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -302,8 +302,9 @@ Module functions
    :type isolation_level: str | None
 
    :param bool check_same_thread:
-       If ``True`` (default), :exc:`ProgrammingError` will be raised if the database connection
-       is used by a thread other than the one that created it.
+       If ``True`` (default), :exc:`ProgrammingError` will be raised
+       if the database connection is used by a thread
+       other than the one that created it.
        If ``False``, the connection may be accessed in multiple threads;
        write operations may need to be serialized by the user
        to avoid data corruption.

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -302,7 +302,7 @@ Module functions
    :type isolation_level: str | None
 
    :param bool check_same_thread:
-       If ``True`` (default), an exception will be raised if the database connection
+       If ``True`` (default), :exc:`ProgrammingError` will be raised if the database connection
        is used by a thread other than the one that created it.
        If ``False``, the connection may be accessed in multiple threads;
        write operations may need to be serialized by the user

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -304,8 +304,8 @@ Module functions
    :param bool check_same_thread:
        If ``True`` (default), only the creating thread may use the connection.
        If ``False``, the connection may be shared across multiple threads;
-       if so, write operations should be serialized by the user to avoid data
-       corruption.
+       users should check :attr:`threadsafety` before setting this value to
+       avoid data corruption.
 
    :param Connection factory:
        A custom subclass of :class:`Connection` to create the connection with,


### PR DESCRIPTION
Previous information was false: setting `check_same_thread` to `False` does not always require that the user ensure sequentialization themselves, depending on the value of `threadsafety`.