### PR TITLE
gh-101386: fix typos found by codespell

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -839,7 +839,7 @@ PyConfig
       will produce an error.
 
       Configured by the :option:`-X int_max_str_digits <-X>` command line
-      flag or the :envvar:`PYTHONINTMAXSTRDIGITS` environment varable.
+      flag or the :envvar:`PYTHONINTMAXSTRDIGITS` environment variable.
 
       Default: ``-1`` in Python mode.  4300
       (:data:`sys.int_info.default_max_str_digits`) in isolated mode.
@@ -1582,7 +1582,7 @@ applied during the "Main" phase. It may allow to customize Python in Python to
 override or tune the :ref:`Path Configuration <init-path-config>`, maybe
 install a custom :data:`sys.meta_path` importer or an import hook, etc.
 
-It may become possible to calculatin the :ref:`Path Configuration
+It may become possible to calculate the :ref:`Path Configuration
 <init-path-config>` in Python, after the Core phase and before the Main phase,
 which is one of the :pep:`432` motivation.
 

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -3628,7 +3628,7 @@ refer to the comments in the code snippet for more detailed information.
 Logging to syslog with RFC5424 support
 --------------------------------------
 
-Although :rfc:`5424` dates from 2009, most syslog servers are configured by detault to
+Although :rfc:`5424` dates from 2009, most syslog servers are configured by default to
 use the older :rfc:`3164`, which hails from 2001. When ``logging`` was added to Python
 in 2003, it supported the earlier (and only existing) protocol at the time. Since
 RFC5424 came out, as there has not been widespread deployment of it in syslog
@@ -3819,7 +3819,7 @@ then running the script results in
     WARNING:demo:division by zero
 
 As you can see, this output isn't ideal. That's because the underlying code
-which writes to ``sys.stderr`` makes mutiple writes, each of which results in a
+which writes to ``sys.stderr`` makes multiple writes, each of which results in a
 separate logged line (for example, the last three lines above). To get around
 this problem, you need to buffer things and only output log lines when newlines
 are seen. Let's use a slghtly better implementation of ``LoggerWriter``:

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -2207,7 +2207,7 @@ This section shows recipes for common adapters and converters.
    assert convert_datetime(b"2019-05-18T15:17:08.123456") == dt
 
    # Using current time as fromtimestamp() returns local date/time.
-   # Droping microseconds as adapt_datetime_epoch truncates fractional second part.
+   # Dropping microseconds as adapt_datetime_epoch truncates fractional second part.
    now = datetime.datetime.now().replace(microsecond=0)
    current_timestamp = int(now.timestamp())
 

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -462,7 +462,7 @@ In such cases, the ``@`` format character should be used to specify
 native byte ordering and data sizes.  Internal pad bytes are normally inserted
 automatically.  It is possible that a zero-repeat format code will be
 needed at the end of a format string to round up to the correct
-byte boundary for proper alignment of consective chunks of data.
+byte boundary for proper alignment of consecutive chunks of data.
 
 Consider these two simple examples (on a 64-bit, little-endian
 machine)::


### PR DESCRIPTION
Fix the following typos by codespell (https://github.com/codespell-project/codespell):
```
./c-api/init_config.rst:842: varable ==> variable
./c-api/init_config.rst:1585: calculatin ==> calculate
./howto/logging-cookbook.rst:3631: detault ==> default
./howto/logging-cookbook.rst:3822: mutiple ==> multiple
./library/sqlite3.rst:2210: Droping ==> Dropping
./library/struct.rst:465: consective ==> consecutive
```

<!-- gh-issue-number: gh-101386 -->
* Issue: gh-101386
<!-- /gh-issue-number -->
