### PR TITLE
gh-101390: Fix docs for `imporlib.util.LazyLoader.factory` to properly call it a class method

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1387,7 +1387,7 @@ an :term:`importer`.
 
    .. classmethod:: factory(loader)
 
-      A static method which returns a callable that creates a lazy loader. This
+      A class method which returns a callable that creates a lazy loader. This
       is meant to be used in situations where the loader is passed by class
       instead of by instance.
       ::


### PR DESCRIPTION
<!-- gh-issue-number: gh-101390 -->
* Issue: gh-101390
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:brettcannon