### PR TITLE
GH-100485: Tighter accuracy testing of sumprod

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1407,6 +1407,7 @@ class MathTests(unittest.TestCase):
             and calculating yi such that some cancellation occurs. Finally, we permute
             the vectors x, y randomly and calculate the achieved condition number.
             """
+            # Test generator from: https://www.tuhh.de/ti3/paper/rump/OgRuOi05.pdf
 
             assert n >= 6
             n2 = n // 2
@@ -1442,13 +1443,13 @@ class MathTests(unittest.TestCase):
 
         vector_length = 20
         target_condition_number = 1e30
-        for i in range(2000):
+        for i in range(10_000):
             ex = GenDot(n=vector_length, c=target_condition_number)
             if ex.condition > target_condition_number:
                 continue
             res = math.sumprod(ex.x, ex.y)
             relative_error = RelativeError(res, ex)
-            self.assertLess(relative_error, 1e-15,
+            self.assertLessEqual(relative_error, 2.0 ** -53,
                                 (ex, res, relative_error))
 
     def testModf(self):

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1379,7 +1379,7 @@ class MathTests(unittest.TestCase):
         from fractions import Fraction
         from itertools import starmap
         from collections import namedtuple
-        from math import log2, exp2, fabs
+        from math import log2, exp2, fabs, ulp
         from random import choices, uniform, shuffle
         from statistics import median
 
@@ -1436,21 +1436,18 @@ class MathTests(unittest.TestCase):
 
             return DotExample(x, y, DotExact(x, y), Condition(x, y))
 
-        def RelativeError(res, ex):
-            x, y, target_sumprod, condition = ex
-            n = DotExact(list(x) + [-res], list(y) + [1])
-            return fabs(n / target_sumprod)
+        def AbsoluteError(res, ex):
+            return DotExact(list(ex.x) + [-res], list(ex.y) + [1])
 
         vector_length = 20
         target_condition_number = 1e30
-        for i in range(10_000):
-            ex = GenDot(n=vector_length, c=target_condition_number)
+        for i in range(1_000_000):
+            ex = GenDot(n=vector_length, c=target_condition_number / 2)
             if ex.condition > target_condition_number:
                 continue
-            res = math.sumprod(ex.x, ex.y)
-            relative_error = RelativeError(res, ex)
-            self.assertLessEqual(relative_error, 2.0 ** -53,
-                                (ex, res, relative_error))
+            result = math.sumprod(ex.x, ex.y)
+            error = AbsoluteError(result, ex)
+            self.assertLess(fabs(error), ulp(result), (ex, result, error))
 
     def testModf(self):
         self.assertRaises(TypeError, math.modf)

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1442,12 +1442,19 @@ class MathTests(unittest.TestCase):
         vector_length = 20
         target_condition_number = 1e30
         for i in range(1_000_000):
+            # GenDot creates examples whether the condition numbers
+            # are centered about c but can be two orders of magnitude
+            # above or below.  Here, we generate examples centered
+            # around half our target and then reject examples higher
+            # than our target.
             ex = GenDot(n=vector_length, c=target_condition_number / 2)
             if ex.condition > target_condition_number:
                 continue
             result = math.sumprod(ex.x, ex.y)
             error = AbsoluteError(result, ex)
             self.assertLess(fabs(error), ulp(result), (ex, result, error))
+            # XXX Compute the theoretical bound for n=20, K=3, cond=1e30.
+            # ??? Is 1e30 too aggressive (within practical but not theoretical bounds.
 
     def testModf(self):
         self.assertRaises(TypeError, math.modf)

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1441,7 +1441,7 @@ class MathTests(unittest.TestCase):
             return fabs(n / target_sumprod)
 
         def Trial(dotfunc, c, n):
-            ex = GenDot(10, c)
+            ex = GenDot(n, c)
             res = dotfunc(ex.x, ex.y)
             return RelativeError(res, ex)
 

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1440,17 +1440,16 @@ class MathTests(unittest.TestCase):
             n = DotExact(list(x) + [-res], list(y) + [1])
             return fabs(n / target_sumprod)
 
-        def Trial(dotfunc, c, n):
-            ex = GenDot(n, c)
-            res = dotfunc(ex.x, ex.y)
-            return RelativeError(res, ex)
-
-        times = 1000          # Number of trials
-        n = 20                # Length of vectors
-        c = 1e30              # Target condition number
-
-        relative_err = median(Trial(math.sumprod, c, n) for i in range(times))
-        self.assertLess(relative_err, 1e-16)
+        vector_length = 20
+        target_condition_number = 1e30
+        for i in range(2000):
+            ex = GenDot(n=vector_length, c=target_condition_number)
+            if ex.condition > target_condition_number:
+                continue
+            res = math.sumprod(ex.x, ex.y)
+            relative_error = RelativeError(res, ex)
+            self.assertLess(relative_error, 1e-15,
+                                (ex, res, relative_error))
 
     def testModf(self):
         self.assertRaises(TypeError, math.modf)


### PR DESCRIPTION
Run the buildbots to make sure a condition number of 1e28 always passes.  The theoretical limit is 1e25, but the paper indicates that we can get several orders of magnitude better in practice.

<!-- gh-issue-number: gh-100485 -->
* Issue: gh-100485
<!-- /gh-issue-number -->
