### PR TITLE
GH-101369: Allow macros as family members

### DIFF
--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -565,11 +565,26 @@ class Analyzer:
         for family in self.families.values():
             for member in family.members:
                 if member_instr := self.instrs.get(member):
-                    member_instr.family = family
+                    if member_instr.family not in (family, None):
+                        self.error(
+                            f"Instruction {member} is a member of multiple families "
+                            f"({member_instr.family.name}, {family.name}).",
+                            family
+                        )
+                    else:
+                        member_instr.family = family
                 elif member_macro := self.macro_instrs.get(member):
                     for part in member_macro.parts:
                         if isinstance(part, Component):
-                            part.instr.family = family
+                            if part.instr.family not in (family, None):
+                                self.error(
+                                    f"Component {part.instr.name} of macro {member} "
+                                    f"is a member of multiple families "
+                                    f"({part.instr.family.name}, {family.name}).",
+                                    family
+                                )
+                            else:
+                                part.instr.family = family
                 else:
                     self.error(
                         f"Unknown instruction {member!r} referenced in family {family.name!r}",

--- a/Tools/cases_generator/test_generator.py
+++ b/Tools/cases_generator/test_generator.py
@@ -343,7 +343,7 @@ def test_macro_instruction():
         inst(OP3, (unused/5, arg2, left, right -- res)) {
             res = op3(arg2, left, right);
         }
-        family(op3, INLINE_CACHE_ENTRIES_OP) = { OP3, OP };
+        family(op, INLINE_CACHE_ENTRIES_OP) = { OP, OP3 };
     """
     output = """
         TARGET(OP1) {
@@ -383,7 +383,6 @@ def test_macro_instruction():
         }
 
         TARGET(OP3) {
-            static_assert(INLINE_CACHE_ENTRIES_OP == 5, "incorrect cache size");
             PyObject *right = PEEK(1);
             PyObject *left = PEEK(2);
             PyObject *arg2 = PEEK(3);


### PR DESCRIPTION
Fixes gh-101369.

@markshannon: You have to use `macro` here:
```
macro(BINARY_OP_ADD_FLOAT) = _BINARY_OP_ADD_FLOAT_CHECK + _BINARY_OP_ADD_FLOAT_ACTION;
```
