### PR TITLE
gh-39615: fix warning on return type mismatch

### DIFF
--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -806,7 +806,7 @@ is_filename_to_skip(PyObject *filename, PyTupleObject *skip_file_prefixes)
         for (Py_ssize_t idx = 0; idx < prefixes; ++idx)
         {
             PyObject *prefix = PyTuple_GET_ITEM(skip_file_prefixes, idx);
-            int found = PyUnicode_Tailmatch(filename, prefix, 0, -1, -1);
+            Py_ssize_t found = PyUnicode_Tailmatch(filename, prefix, 0, -1, -1);
             if (found == 1) {
                 return true;
             }


### PR DESCRIPTION
Should fix this:

<img width="931" alt="image" src="https://user-images.githubusercontent.com/1055913/215356997-c698a909-a998-49a3-8d81-28077c78bebd.png">


<!-- gh-issue-number: gh-39615 -->
* Issue: gh-39615
<!-- /gh-issue-number -->
