### PR TITLE
gh-99955: use SUCCESS/ERROR return values in optimizer and assembler. Use RETURN_IF_ERROR where appropriate. Fix a couple of bugs.

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3018,7 +3018,7 @@ compiler_lambda(struct compiler *c, expr_ty e)
     location loc = LOC(e);
     funcflags = compiler_default_arguments(c, loc, args);
     if (funcflags == -1) {
-        return 0;
+        return ERROR;
     }
 
     _Py_DECLARE_STR(anon_lambda, "<lambda>");

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7192,12 +7192,12 @@ assemble_init(struct assembler *a, int firstlineno)
     if (a->a_except_table == NULL) {
         goto error;
     }
-    return 0;
+    return SUCCESS;
 error:
     Py_XDECREF(a->a_bytecode);
     Py_XDECREF(a->a_linetable);
     Py_XDECREF(a->a_except_table);
-    return -1;
+    return ERROR;
 }
 
 static void
@@ -7268,13 +7268,13 @@ static int
 label_exception_targets(basicblock *entryblock) {
     basicblock **todo_stack = make_cfg_traversal_stack(entryblock);
     if (todo_stack == NULL) {
-        return -1;
+        return ERROR;
     }
     ExceptStack *except_stack = make_except_stack();
     if (except_stack == NULL) {
         PyMem_Free(todo_stack);
         PyErr_NoMemory();
-        return -1;
+        return ERROR;
     }
     except_stack->depth = 0;
     todo_stack[0] = entryblock;
@@ -7352,11 +7352,11 @@ label_exception_targets(basicblock *entryblock) {
     }
 #endif
     PyMem_Free(todo_stack);
-    return 0;
+    return SUCCESS;
 error:
     PyMem_Free(todo_stack);
     PyMem_Free(except_stack);
-    return -1;
+    return ERROR;
 }
 
 
@@ -7375,14 +7375,14 @@ mark_except_handlers(basicblock *entryblock) {
             }
         }
     }
-    return 0;
+    return SUCCESS;
 }
 
 static int
 mark_warm(basicblock *entryblock) {
     basicblock **stack = make_cfg_traversal_stack(entryblock);
     if (stack == NULL) {
-        return -1;
+        return ERROR;
     }
     basicblock **sp = stack;
 
@@ -7406,7 +7406,7 @@ mark_warm(basicblock *entryblock) {
         }
     }
     PyMem_Free(stack);
-    return 0;
+    return SUCCESS;
 }
 
 static int
@@ -7415,12 +7415,12 @@ mark_cold(basicblock *entryblock) {
         assert(!b->b_cold && !b->b_warm);
     }
     if (mark_warm(entryblock) < 0) {
-        return -1;
+        return ERROR;
     }
 
     basicblock **stack = make_cfg_traversal_stack(entryblock);
     if (stack == NULL) {
-        return -1;
+        return ERROR;
     }
 
     basicblock **sp = stack;
@@ -7455,7 +7455,7 @@ mark_cold(basicblock *entryblock) {
         }
     }
     PyMem_Free(stack);
-    return 0;
+    return SUCCESS;
 }
 
 static int
@@ -7466,10 +7466,10 @@ push_cold_blocks_to_end(cfg_builder *g, int code_flags) {
     basicblock *entryblock = g->g_entryblock;
     if (entryblock->b_next == NULL) {
         /* single basicblock, no need to reorder */
-        return 0;
+        return SUCCESS;
     }
     if (mark_cold(entryblock) < 0) {
-        return -1;
+        return ERROR;
     }
 
     /* If we have a cold block with fallthrough to a warm block, add */
@@ -7478,7 +7478,7 @@ push_cold_blocks_to_end(cfg_builder *g, int code_flags) {
         if (b->b_cold && BB_HAS_FALLTHROUGH(b) && b->b_next && b->b_next->b_warm) {
             basicblock *explicit_jump = cfg_builder_new_block(g);
             if (explicit_jump == NULL) {
-                return -1;
+                return ERROR;
             }
             basicblock_addop(explicit_jump, JUMP, b->b_next->b_label, NO_LOCATION);
             explicit_jump->b_cold = 1;
@@ -7533,10 +7533,10 @@ push_cold_blocks_to_end(cfg_builder *g, int code_flags) {
 
     if (cold_blocks != NULL) {
         if (remove_redundant_jumps(g) < 0) {
-            return -1;
+            return ERROR;
         }
     }
-    return 0;
+    return SUCCESS;
 }
 
 static void
@@ -7595,7 +7595,7 @@ assemble_emit_exception_table_entry(struct assembler *a, int start, int end, bas
     Py_ssize_t len = PyBytes_GET_SIZE(a->a_except_table);
     if (a->a_except_table_off + MAX_SIZE_OF_ENTRY >= len) {
         if (_PyBytes_Resize(&a->a_except_table, len * 2) < 0) {
-            return -1;
+            return ERROR;
         }
     }
     int size = end-start;
@@ -7611,7 +7611,7 @@ assemble_emit_exception_table_entry(struct assembler *a, int start, int end, bas
     assemble_emit_exception_table_item(a, size, 0);
     assemble_emit_exception_table_item(a, target, 0);
     assemble_emit_exception_table_item(a, depth_lasti, 0);
-    return 0;
+    return SUCCESS;
 }
 
 static int
@@ -7628,7 +7628,7 @@ assemble_exception_table(struct assembler *a, basicblock *entryblock)
             if (instr->i_except != handler) {
                 if (handler != NULL) {
                     if (assemble_emit_exception_table_entry(a, start, ioffset, handler) < 0) {
-                        return -1;
+                        return ERROR;
                     }
                 }
                 start = ioffset;
@@ -7639,10 +7639,10 @@ assemble_exception_table(struct assembler *a, basicblock *entryblock)
     }
     if (handler != NULL) {
         if (assemble_emit_exception_table_entry(a, start, ioffset, handler) < 0) {
-            return -1;
+            return ERROR;
         }
     }
-    return 0;
+    return SUCCESS;
 }
 
 /* Code location emitting code. See locations.md for a description of the format. */
@@ -7745,12 +7745,12 @@ write_location_info_entry(struct assembler* a, location loc, int isize)
     if (a->a_location_off + THEORETICAL_MAX_ENTRY_SIZE >= len) {
         assert(len > THEORETICAL_MAX_ENTRY_SIZE);
         if (_PyBytes_Resize(&a->a_linetable, len*2) < 0) {
-            return -1;
+            return ERROR;
         }
     }
     if (loc.lineno < 0) {
         write_location_info_none(a, isize);
-        return 0;
+        return SUCCESS;
     }
     int line_delta = loc.lineno - a->a_lineno;
     int column = loc.col_offset;
@@ -7761,34 +7761,34 @@ write_location_info_entry(struct assembler* a, location loc, int isize)
         if (loc.end_lineno == loc.lineno || loc.end_lineno == -1) {
             write_location_info_no_column(a, isize, line_delta);
             a->a_lineno = loc.lineno;
-            return 0;
+            return SUCCESS;
         }
     }
     else if (loc.end_lineno == loc.lineno) {
         if (line_delta == 0 && column < 80 && end_column - column < 16 && end_column >= column) {
             write_location_info_short_form(a, isize, column, end_column);
-            return 0;
+            return SUCCESS;
         }
         if (line_delta >= 0 && line_delta < 3 && column < 128 && end_column < 128) {
             write_location_info_oneline_form(a, isize, line_delta, column, end_column);
             a->a_lineno = loc.lineno;
-            return 0;
+            return SUCCESS;
         }
     }
     write_location_info_long_form(a, loc, isize);
     a->a_lineno = loc.lineno;
-    return 0;
+    return SUCCESS;
 }
 
 static int
 assemble_emit_location(struct assembler* a, location loc, int isize)
 {
     if (isize == 0) {
-        return 0;
+        return SUCCESS;
     }
     while (isize > 8) {
         if (write_location_info_entry(a, loc, 8)) {
-            return -1;
+            return ERROR;
         }
         isize -= 8;
     }
@@ -7809,34 +7809,34 @@ assemble_emit(struct assembler *a, struct instr *i)
     int size = instr_size(i);
     if (a->a_offset + size >= len / (int)sizeof(_Py_CODEUNIT)) {
         if (len > PY_SSIZE_T_MAX / 2) {
-            return -1;
+            return ERROR;
         }
         if (_PyBytes_Resize(&a->a_bytecode, len * 2) < 0) {
-            return -1;
+            return ERROR;
         }
     }
     code = (_Py_CODEUNIT *)PyBytes_AS_STRING(a->a_bytecode) + a->a_offset;
     a->a_offset += size;
     write_instr(code, i, size);
-    return 0;
+    return SUCCESS;
 }
 
 static int
 normalize_jumps_in_block(cfg_builder *g, basicblock *b) {
     struct instr *last = basicblock_last_instr(b);
     if (last == NULL || !is_jump(last)) {
-        return 0;
+        return SUCCESS;
     }
     assert(!IS_ASSEMBLER_OPCODE(last->i_opcode));
     bool is_forward = last->i_target->b_visited == 0;
     switch(last->i_opcode) {
         case JUMP:
             last->i_opcode = is_forward ? JUMP_FORWARD : JUMP_BACKWARD;
-            return 0;
+            return SUCCESS;
         case JUMP_NO_INTERRUPT:
             last->i_opcode = is_forward ?
                 JUMP_FORWARD : JUMP_BACKWARD_NO_INTERRUPT;
-            return 0;
+            return SUCCESS;
     }
     int reversed_opcode = 0;
     switch(last->i_opcode) {
@@ -7866,10 +7866,10 @@ normalize_jumps_in_block(cfg_builder *g, basicblock *b) {
                     last->i_opcode == JUMP_IF_TRUE_OR_POP ?
                         "JUMP_IF_TRUE_OR_POP" : "JUMP_IF_FALSE_OR_POP");
             }
-            return 0;
+            return SUCCESS;
     }
     if (is_forward) {
-        return 0;
+        return SUCCESS;
     }
 
     /* transform 'conditional jump T' to
@@ -7879,7 +7879,7 @@ normalize_jumps_in_block(cfg_builder *g, basicblock *b) {
     basicblock *target = last->i_target;
     basicblock *backwards_jump = cfg_builder_new_block(g);
     if (backwards_jump == NULL) {
-        return -1;
+        return ERROR;
     }
     basicblock_addop(backwards_jump, JUMP, target->b_label, NO_LOCATION);
     backwards_jump->b_instr[0].i_target = target;
@@ -7889,7 +7889,7 @@ normalize_jumps_in_block(cfg_builder *g, basicblock *b) {
     backwards_jump->b_cold = b->b_cold;
     backwards_jump->b_next = b->b_next;
     b->b_next = backwards_jump;
-    return 0;
+    return SUCCESS;
 }
 
 static int
@@ -7902,10 +7902,10 @@ normalize_jumps(cfg_builder *g)
     for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
         b->b_visited = 1;
         if (normalize_jumps_in_block(g, b) < 0) {
-            return -1;
+            return ERROR;
         }
     }
-    return 0;
+    return SUCCESS;
 }
 
 static void
@@ -8045,7 +8045,7 @@ fast_scan_many_locals(basicblock *entryblock, int nlocals)
     Py_ssize_t *states = PyMem_Calloc(nlocals - 64, sizeof(Py_ssize_t));
     if (states == NULL) {
         PyErr_NoMemory();
-        return -1;
+        return ERROR;
     }
     Py_ssize_t blocknum = 0;
     // state[i - 64] == blocknum if local i is guaranteed to
@@ -8081,7 +8081,7 @@ fast_scan_many_locals(basicblock *entryblock, int nlocals)
         }
     }
     PyMem_Free(states);
-    return 0;
+    return SUCCESS;
 }
 
 static int
@@ -8090,20 +8090,20 @@ add_checks_for_loads_of_uninitialized_variables(basicblock *entryblock,
 {
     int nlocals = (int)PyDict_GET_SIZE(c->u->u_varnames);
     if (nlocals == 0) {
-        return 0;
+        return SUCCESS;
     }
     if (nlocals > 64) {
         // To avoid O(nlocals**2) compilation, locals beyond the first
         // 64 are only analyzed one basicblock at a time: initialization
         // info is not passed between basicblocks.
         if (fast_scan_many_locals(entryblock, nlocals) < 0) {
-            return -1;
+            return ERROR;
         }
         nlocals = 64;
     }
     basicblock **stack = make_cfg_traversal_stack(entryblock);
     if (stack == NULL) {
-        return -1;
+        return ERROR;
     }
     basicblock **sp = stack;
 
@@ -8132,7 +8132,7 @@ add_checks_for_loads_of_uninitialized_variables(basicblock *entryblock,
         scan_block_for_locals(b, &sp);
     }
     PyMem_Free(stack);
-    return 0;
+    return SUCCESS;
 }
 
 static PyObject *
@@ -8218,17 +8218,17 @@ merge_const_one(PyObject *const_cache, PyObject **obj)
     PyDict_CheckExact(const_cache);
     PyObject *key = _PyCode_ConstantKey(*obj);
     if (key == NULL) {
-        return -1;
+        return ERROR;
     }
 
     // t is borrowed reference
     PyObject *t = PyDict_SetDefault(const_cache, key, key);
     Py_DECREF(key);
     if (t == NULL) {
-        return -1;
+        return ERROR;
     }
     if (t == key) {  // obj is new constant.
-        return 0;
+        return SUCCESS;
     }
 
     if (PyTuple_CheckExact(t)) {
@@ -8237,7 +8237,7 @@ merge_const_one(PyObject *const_cache, PyObject **obj)
     }
 
     Py_SETREF(*obj, Py_NewRef(t));
-    return 0;
+    return SUCCESS;
 }
 
 // This is in codeobject.c.
@@ -8481,7 +8481,7 @@ insert_prefix_instructions(struct compiler *c, basicblock *entryblock,
             .i_target = NULL,
         };
         if (insert_instruction(entryblock, 0, &make_gen) < 0) {
-            return -1;
+            return ERROR;
         }
         struct instr pop_top = {
             .i_opcode = POP_TOP,
@@ -8490,7 +8490,7 @@ insert_prefix_instructions(struct compiler *c, basicblock *entryblock,
             .i_target = NULL,
         };
         if (insert_instruction(entryblock, 1, &pop_top) < 0) {
-            return -1;
+            return ERROR;
         }
     }
 
@@ -8504,7 +8504,7 @@ insert_prefix_instructions(struct compiler *c, basicblock *entryblock,
         int *sorted = PyMem_RawCalloc(nvars, sizeof(int));
         if (sorted == NULL) {
             PyErr_NoMemory();
-            return -1;
+            return ERROR;
         }
         for (int i = 0; i < ncellvars; i++) {
             sorted[fixed[i]] = i + 1;
@@ -8522,7 +8522,7 @@ insert_prefix_instructions(struct compiler *c, basicblock *entryblock,
                 .i_target = NULL,
             };
             if (insert_instruction(entryblock, ncellsused, &make_cell) < 0) {
-                return -1;
+                return ERROR;
             }
             ncellsused += 1;
         }
@@ -8537,12 +8537,12 @@ insert_prefix_instructions(struct compiler *c, basicblock *entryblock,
             .i_target = NULL,
         };
         if (insert_instruction(entryblock, 0, &copy_frees) < 0) {
-            return -1;
+            return ERROR;
         }
 
     }
 
-    return 0;
+    return SUCCESS;
 }
 
 /* Make sure that all returns have a line number, even if early passes
@@ -8823,7 +8823,7 @@ assemble(struct compiler *c, int addNone)
     if (add_checks_for_loads_of_uninitialized_variables(g->g_entryblock, c) < 0) {
         goto error;
     }
-    if (remove_unused_consts(g->g_entryblock, consts)) {
+    if (remove_unused_consts(g->g_entryblock, consts) < 0) {
         goto error;
     }
 
@@ -8965,27 +8965,27 @@ fold_tuple_on_constants(PyObject *const_cache,
 
     for (int i = 0; i < n; i++) {
         if (!HAS_CONST(inst[i].i_opcode)) {
-            return 0;
+            return SUCCESS;
         }
     }
 
     /* Buildup new tuple of constants */
     PyObject *newconst = PyTuple_New(n);
     if (newconst == NULL) {
-        return -1;
+        return ERROR;
     }
     for (int i = 0; i < n; i++) {
         int op = inst[i].i_opcode;
         int arg = inst[i].i_oparg;
         PyObject *constant = get_const_value(op, arg, consts);
         if (constant == NULL) {
-            return -1;
+            return ERROR;
         }
         PyTuple_SET_ITEM(newconst, i, constant);
     }
     if (merge_const_one(const_cache, &newconst) < 0) {
         Py_DECREF(newconst);
-        return -1;
+        return ERROR;
     }
 
     Py_ssize_t index;
@@ -8998,11 +8998,11 @@ fold_tuple_on_constants(PyObject *const_cache,
         if ((size_t)index >= (size_t)INT_MAX - 1) {
             Py_DECREF(newconst);
             PyErr_SetString(PyExc_OverflowError, "too many constants");
-            return -1;
+            return ERROR;
         }
         if (PyList_Append(consts, newconst)) {
             Py_DECREF(newconst);
-            return -1;
+            return ERROR;
         }
     }
     Py_DECREF(newconst);
@@ -9010,7 +9010,7 @@ fold_tuple_on_constants(PyObject *const_cache,
         INSTR_SET_OP0(&inst[i], NOP);
     }
     INSTR_SET_OP1(&inst[n], LOAD_CONST, (int)index);
-    return 0;
+    return SUCCESS;
 }
 
 #define VISITED (-1)
@@ -9043,13 +9043,13 @@ swaptimize(basicblock *block, int *ix)
     }
     // It's already optimal if there's only one SWAP:
     if (!more) {
-        return 0;
+        return SUCCESS;
     }
     // Create an array with elements {0, 1, 2, ..., depth - 1}:
     int *stack = PyMem_Malloc(depth * sizeof(int));
     if (stack == NULL) {
         PyErr_NoMemory();
-        return -1;
+        return ERROR;
     }
     for (int i = 0; i < depth; i++) {
         stack[i] = i;
@@ -9110,7 +9110,7 @@ swaptimize(basicblock *block, int *ix)
     }
     PyMem_Free(stack);
     *ix += len - 1;
-    return 0;
+    return SUCCESS;
 }
 
 // This list is pretty small, since it's only okay to reorder opcodes that:
@@ -9416,7 +9416,7 @@ optimize_basic_block(PyObject *const_cache, basicblock *bb, PyObject *consts)
                     INSTR_SET_OP0(inst, NOP);
                     break;
                 }
-                if (swaptimize(bb, &i)) {
+                if (swaptimize(bb, &i) < 0) {
                     goto error;
                 }
                 apply_static_swaps(bb, i);
@@ -9434,9 +9434,9 @@ optimize_basic_block(PyObject *const_cache, basicblock *bb, PyObject *consts)
                 assert (!HAS_CONST(inst->i_opcode));
         }
     }
-    return 0;
+    return SUCCESS;
 error:
-    return -1;
+    return ERROR;
 }
 
 /* If this block ends with an unconditional jump to a small exit block, then
@@ -9526,19 +9526,19 @@ check_cfg(cfg_builder *g) {
             if (IS_TERMINATOR_OPCODE(opcode)) {
                 if (i != b->b_iused - 1) {
                     PyErr_SetString(PyExc_SystemError, "malformed control flow graph.");
-                    return -1;
+                    return ERROR;
                 }
             }
         }
     }
-    return 0;
+    return SUCCESS;
 }
 
 static int
 mark_reachable(basicblock *entryblock) {
     basicblock **stack = make_cfg_traversal_stack(entryblock);
     if (stack == NULL) {
-        return -1;
+        return ERROR;
     }
     basicblock **sp = stack;
     entryblock->b_predecessors = 1;
@@ -9567,7 +9567,7 @@ mark_reachable(basicblock *entryblock) {
         }
     }
     PyMem_Free(stack);
-    return 0;
+    return SUCCESS;
 }
 
 static void
@@ -9656,7 +9656,7 @@ translate_jump_labels_to_targets(basicblock *entryblock)
     basicblock **label2block = (basicblock **)PyMem_Malloc(mapsize);
     if (!label2block) {
         PyErr_NoMemory();
-        return -1;
+        return ERROR;
     }
     memset(label2block, 0, mapsize);
     for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
@@ -9678,7 +9678,7 @@ translate_jump_labels_to_targets(basicblock *entryblock)
         }
     }
     PyMem_Free(label2block);
-    return 0;
+    return SUCCESS;
 }
 
 /* Perform optimizations on a control flow graph.
@@ -9694,29 +9694,29 @@ optimize_cfg(cfg_builder *g, PyObject *consts, PyObject *const_cache)
 {
     assert(PyDict_CheckExact(const_cache));
     if (check_cfg(g) < 0) {
-        return -1;
+        return ERROR;
     }
     eliminate_empty_basic_blocks(g);
     for (basicblock *b = g->g_entryblock; b != NULL; b = b->b_next) {
         if (inline_small_exit_blocks(b) < 0) {
-            return -1;
+            return ERROR;
         }
     }
     assert(no_empty_basic_blocks(g));
     for (basicblock *b = g->g_entryblock; b != NULL; b = b->b_next) {
         if (optimize_basic_block(const_cache, b, consts)) {
-            return -1;
+            return ERROR;
         }
         remove_redundant_nops(b);
         assert(b->b_predecessors == 0);
     }
     for (basicblock *b = g->g_entryblock; b != NULL; b = b->b_next) {
         if (inline_small_exit_blocks(b) < 0) {
-            return -1;
+            return ERROR;
         }
     }
     if (mark_reachable(g->g_entryblock)) {
-        return -1;
+        return ERROR;
     }
     /* Delete unreachable instructions */
     for (basicblock *b = g->g_entryblock; b != NULL; b = b->b_next) {
@@ -9730,9 +9730,9 @@ optimize_cfg(cfg_builder *g, PyObject *consts, PyObject *const_cache)
     eliminate_empty_basic_blocks(g);
     assert(no_redundant_nops(g));
     if (remove_redundant_jumps(g) < 0) {
-        return -1;
+        return ERROR;
     }
-    return 0;
+    return SUCCESS;
 }
 
 
@@ -9742,12 +9742,12 @@ remove_unused_consts(basicblock *entryblock, PyObject *consts)
     assert(PyList_CheckExact(consts));
     Py_ssize_t nconsts = PyList_GET_SIZE(consts);
     if (nconsts == 0) {
-        return 0;  /* nothing to do */
+        return SUCCESS;  /* nothing to do */
     }
 
     Py_ssize_t *index_map = NULL;
     Py_ssize_t *reverse_index_map = NULL;
-    int err = 1;
+    int err = ERROR;
 
     index_map = PyMem_Malloc(nconsts * sizeof(Py_ssize_t));
     if (index_map == NULL) {
@@ -9782,7 +9782,7 @@ remove_unused_consts(basicblock *entryblock, PyObject *consts)
     }
     if (n_used_consts == nconsts) {
         /* nothing to do */
-        err = 0;
+        err = SUCCESS;
         goto end;
     }
 
@@ -9830,7 +9830,7 @@ remove_unused_consts(basicblock *entryblock, PyObject *consts)
         }
     }
 
-    err = 0;
+    err = SUCCESS;
 end:
     PyMem_Free(index_map);
     PyMem_Free(reverse_index_map);
@@ -9874,7 +9874,7 @@ duplicate_exits_without_lineno(cfg_builder *g)
             if (is_exit_without_lineno(target) && target->b_predecessors > 1) {
                 basicblock *new_target = copy_basicblock(g, target);
                 if (new_target == NULL) {
-                    return -1;
+                    return ERROR;
                 }
                 new_target->b_instr[0].i_loc = last->i_loc;
                 last->i_target = new_target;
@@ -9897,7 +9897,7 @@ duplicate_exits_without_lineno(cfg_builder *g)
             }
         }
     }
-    return 0;
+    return SUCCESS;
 }
 
 
@@ -9926,54 +9926,54 @@ instructions_to_cfg(PyObject *instructions, cfg_builder *g)
         if (PyLong_Check(item)) {
             int lbl_id = PyLong_AsLong(item);
             if (PyErr_Occurred()) {
-                return -1;
+                return ERROR;
             }
             if (lbl_id <= 0 || lbl_id > instr_size) {
                 /* expect label in a reasonable range */
                 PyErr_SetString(PyExc_ValueError, "label out of range");
-                return -1;
+                return ERROR;
             }
             jump_target_label lbl = {lbl_id};
             if (cfg_builder_use_label(g, lbl) < 0) {
-                return -1;
+                return ERROR;
             }
         }
         else {
             if (!PyTuple_Check(item) || PyTuple_GET_SIZE(item) != 6) {
                 PyErr_SetString(PyExc_ValueError, "expected a 6-tuple");
-                return -1;
+                return ERROR;
             }
             int opcode = PyLong_AsLong(PyTuple_GET_ITEM(item, 0));
             if (PyErr_Occurred()) {
-                return -1;
+                return ERROR;
             }
             int oparg = PyLong_AsLong(PyTuple_GET_ITEM(item, 1));
             if (PyErr_Occurred()) {
-                return -1;
+                return ERROR;
             }
             location loc;
             loc.lineno = PyLong_AsLong(PyTuple_GET_ITEM(item, 2));
             if (PyErr_Occurred()) {
-                return -1;
+                return ERROR;
             }
             loc.end_lineno = PyLong_AsLong(PyTuple_GET_ITEM(item, 3));
             if (PyErr_Occurred()) {
-                return -1;
+                return ERROR;
             }
             loc.col_offset = PyLong_AsLong(PyTuple_GET_ITEM(item, 4));
             if (PyErr_Occurred()) {
-                return -1;
+                return ERROR;
             }
             loc.end_col_offset = PyLong_AsLong(PyTuple_GET_ITEM(item, 5));
             if (PyErr_Occurred()) {
-                return -1;
+                return ERROR;
             }
             if (cfg_builder_addop(g, opcode, oparg, loc) < 0) {
-                return -1;
+                return ERROR;
             }
         }
     }
-    return 0;
+    return SUCCESS;
 }
 
 static PyObject *


### PR DESCRIPTION
Fixes #99955.

This should be the last sweep of the error handling code. 

Also fixes bugs in NEW_JUMP_TARGET_LABEL, USE_LABEL which returned 0 for error, and in compiler_lambda which did the same in one place.

<!-- gh-issue-number: gh-99955 -->
* Issue: gh-99955
<!-- /gh-issue-number -->
