### PR TITLE
gh-101400: Fix incorrect lineno in exception message on continue/break which are not in a loop

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -852,8 +852,8 @@ if 1:
                 with self.assertRaises(SyntaxError) as err_ctx:
                     source = f"with object() as obj:\n    {stmt}"
                     compile(source, f"<unloop_{stmt}>", "exec")
-                exc = err_ctx.exception
-                self.assertEqual(exc.lineno, 2)
+                    exc = err_ctx.exception
+                    self.assertEqual(exc.lineno, 2)
 
     def test_consts_in_conditionals(self):
         def and_true(x):

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -846,15 +846,6 @@ if 1:
             self.assertEqual(None, opcodes[1].argval)
             self.assertEqual('RETURN_VALUE', opcodes[2].opname)
 
-    def test_unloop_break_continue(self):
-        for stmt in ('break', 'continue'):
-            with self.subTest(stmt=stmt):
-                with self.assertRaises(SyntaxError) as err_ctx:
-                    source = f"with object() as obj:\n    {stmt}"
-                    compile(source, f"<unloop_{stmt}>", "exec")
-                    exc = err_ctx.exception
-                    self.assertEqual(exc.lineno, 2)
-
     def test_consts_in_conditionals(self):
         def and_true(x):
             return True and x

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -847,14 +847,10 @@ if 1:
             self.assertEqual('RETURN_VALUE', opcodes[2].opname)
 
     def test_unloop_break_continue(self):
-        source_template = "with object() as obj:\n    {}"
-        sources = []
         for stmt in ('break', 'continue'):
-            sources.append((stmt, source_template.format(stmt)))
-
-        for stmt, source in sources:
             with self.subTest(stmt=stmt):
                 with self.assertRaises(SyntaxError) as err_ctx:
+                    source = f"with object() as obj:\n    {stmt}"
                     compile(source, f"<unloop_{stmt}>", "exec")
                 exc = err_ctx.exception
                 self.assertEqual(exc.lineno, 2)

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -846,6 +846,19 @@ if 1:
             self.assertEqual(None, opcodes[1].argval)
             self.assertEqual('RETURN_VALUE', opcodes[2].opname)
 
+    def test_unloop_break_continue(self):
+        source_template = "with object() as obj:\n    {}"
+        sources = []
+        for stmt in ('break', 'continue'):
+            sources.append((stmt, source_template.format(stmt)))
+
+        for stmt, source in sources:
+            with self.subTest(stmt=stmt):
+                with self.assertRaises(SyntaxError) as err_ctx:
+                    compile(source, f"<unloop_{stmt}>", "exec")
+                exc = err_ctx.exception
+                self.assertEqual(exc.lineno, 2)
+
     def test_consts_in_conditionals(self):
         def and_true(x):
             return True and x

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1985,29 +1985,27 @@ class SyntaxTestCase(unittest.TestCase):
                           "outside function")
 
     def test_break_outside_loop(self):
-        self._check_error("break", "outside loop", lineno=1)
-        self._check_error("if 0: break",             "outside loop", lineno=1)
-        self._check_error("if 0: break\nelse:  x=1",  "outside loop", lineno=1)
-        self._check_error("if 1: pass\nelse: break", "outside loop", lineno=2)
-        self._check_error("class C:\n  if 0: break", "outside loop", lineno=2)
+        msg = "outside loop"
+        self._check_error("break", msg, lineno=1)
+        self._check_error("if 0: break", msg, lineno=1)
+        self._check_error("if 0: break\nelse:  x=1", msg, lineno=1)
+        self._check_error("if 1: pass\nelse: break", msg, lineno=2)
+        self._check_error("class C:\n  if 0: break", msg, lineno=2)
         self._check_error("class C:\n  if 1: pass\n  else: break",
-                          "outside loop", lineno=3)
+                          msg, lineno=3)
         self._check_error("with object() as obj:\n break",
-                          "outside loop", lineno=2)
+                          msg, lineno=2)
 
     def test_continue_outside_loop(self):
-        self._check_error("if 0: continue",             "not properly in loop",
-                          lineno=1)
-        self._check_error("if 0: continue\nelse:  x=1", "not properly in loop",
-                          lineno=1)
-        self._check_error("if 1: pass\nelse: continue", "not properly in loop",
-                          lineno=2)
-        self._check_error("class C:\n  if 0: continue", "not properly in loop",
-                          lineno=2)
+        msg = "not properly in loop"
+        self._check_error("if 0: continue", msg, lineno=1)
+        self._check_error("if 0: continue\nelse:  x=1", msg, lineno=1)
+        self._check_error("if 1: pass\nelse: continue", msg, lineno=2)
+        self._check_error("class C:\n  if 0: continue", msg, lineno=2)
         self._check_error("class C:\n  if 1: pass\n  else: continue",
-                          "not properly in loop", lineno=3)
+                          msg, lineno=3)
         self._check_error("with object() as obj:\n    continue",
-                          "not properly in loop", lineno=2)
+                          msg, lineno=2)
 
     def test_unexpected_indent(self):
         self._check_error("foo()\n bar()\n", "unexpected indent",

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1957,9 +1957,6 @@ class SyntaxTestCase(unittest.TestCase):
             """
         self._check_error(source, "parameter and nonlocal", lineno=3)
 
-    def test_break_outside_loop(self):
-        self._check_error("break", "outside loop")
-
     def test_yield_outside_function(self):
         self._check_error("if 0: yield",                "outside function")
         self._check_error("if 0: yield\nelse:  x=1",    "outside function")
@@ -1988,20 +1985,29 @@ class SyntaxTestCase(unittest.TestCase):
                           "outside function")
 
     def test_break_outside_loop(self):
-        self._check_error("if 0: break",             "outside loop")
-        self._check_error("if 0: break\nelse:  x=1",  "outside loop")
-        self._check_error("if 1: pass\nelse: break", "outside loop")
-        self._check_error("class C:\n  if 0: break", "outside loop")
+        self._check_error("break", "outside loop", lineno=1)
+        self._check_error("if 0: break",             "outside loop", lineno=1)
+        self._check_error("if 0: break\nelse:  x=1",  "outside loop", lineno=1)
+        self._check_error("if 1: pass\nelse: break", "outside loop", lineno=2)
+        self._check_error("class C:\n  if 0: break", "outside loop", lineno=2)
         self._check_error("class C:\n  if 1: pass\n  else: break",
-                          "outside loop")
+                          "outside loop", lineno=3)
+        self._check_error("with object() as obj:\n break",
+                          "outside loop", lineno=2)
 
     def test_continue_outside_loop(self):
-        self._check_error("if 0: continue",             "not properly in loop")
-        self._check_error("if 0: continue\nelse:  x=1", "not properly in loop")
-        self._check_error("if 1: pass\nelse: continue", "not properly in loop")
-        self._check_error("class C:\n  if 0: continue", "not properly in loop")
+        self._check_error("if 0: continue",             "not properly in loop",
+                          lineno=1)
+        self._check_error("if 0: continue\nelse:  x=1", "not properly in loop",
+                          lineno=1)
+        self._check_error("if 1: pass\nelse: continue", "not properly in loop",
+                          lineno=2)
+        self._check_error("class C:\n  if 0: continue", "not properly in loop",
+                          lineno=2)
         self._check_error("class C:\n  if 1: pass\n  else: continue",
-                          "not properly in loop")
+                          "not properly in loop", lineno=3)
+        self._check_error("with object() as obj:\n    continue",
+                          "not properly in loop", lineno=2)
 
     def test_unexpected_indent(self):
         self._check_error("foo()\n bar()\n", "unexpected indent",

--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-30-08-59-47.gh-issue-101400.Di_ZFm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-30-08-59-47.gh-issue-101400.Di_ZFm.rst
@@ -1,1 +1,2 @@
-Restore continue/break loc for the non-loop case. Patch by Dong-hee Na.
+Fix wrong lineno in exception message on continue/break
+which are not in a loop. Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-30-08-59-47.gh-issue-101400.Di_ZFm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-30-08-59-47.gh-issue-101400.Di_ZFm.rst
@@ -1,2 +1,2 @@
-Fix wrong lineno in exception message on continue/break
-which are not in a loop. Patch by Dong-hee Na.
+Fix wrong lineno in exception message on :keyword:`continue` or
+:keyword:`break` which are not in a loop. Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-30-08-59-47.gh-issue-101400.Di_ZFm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-30-08-59-47.gh-issue-101400.Di_ZFm.rst
@@ -1,0 +1,1 @@
+Restore continue/break loc for the non-loop case. Patch by Dong-hee Na.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3246,11 +3246,12 @@ static int
 compiler_break(struct compiler *c, location loc)
 {
     struct fblockinfo *loop = NULL;
+    location origin_loc = loc;
     /* Emit instruction with line number */
     ADDOP(c, loc, NOP);
     RETURN_IF_ERROR(compiler_unwind_fblock_stack(c, &loc, 0, &loop));
     if (loop == NULL) {
-        return compiler_error(c, loc, "'break' outside loop");
+        return compiler_error(c, origin_loc, "'break' outside loop");
     }
     RETURN_IF_ERROR(compiler_unwind_fblock(c, &loc, loop, 0));
     ADDOP_JUMP(c, loc, JUMP, loop->fb_exit);
@@ -3261,11 +3262,12 @@ static int
 compiler_continue(struct compiler *c, location loc)
 {
     struct fblockinfo *loop = NULL;
+    location origin_loc = loc;
     /* Emit instruction with line number */
     ADDOP(c, loc, NOP);
     RETURN_IF_ERROR(compiler_unwind_fblock_stack(c, &loc, 0, &loop));
     if (loop == NULL) {
-        return compiler_error(c, loc, "'continue' not properly in loop");
+        return compiler_error(c, origin_loc, "'continue' not properly in loop");
     }
     ADDOP_JUMP(c, loc, JUMP, loop->fb_block);
     return SUCCESS;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101400 -->
* Issue: gh-101400
<!-- /gh-issue-number -->
