### PR TITLE
gh-101432: Update the docs for inspect.getcoroutinestate

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -1464,8 +1464,8 @@ generator to be determined easily.
 
    Get current state of a coroutine object.  The function is intended to be
    used with coroutine objects created by :keyword:`async def` functions, but
-   will accept any coroutine-like object that has ``cr_running`` and
-   ``cr_frame`` attributes.
+   will accept any coroutine-like object that has ``cr_running``,
+   ``cr_suspended`` and ``cr_frame`` attributes.
 
    Possible states are:
     * CORO_CREATED: Waiting to start execution.
@@ -1474,6 +1474,9 @@ generator to be determined easily.
     * CORO_CLOSED: Execution has completed.
 
    .. versionadded:: 3.5
+
+   .. versionchanged:: 3.11
+      Added requirement on ``cr_suspended`` attribute.
 
 The current internal state of the generator can also be queried. This is
 mostly useful for testing purposes, to ensure that internal state is being


### PR DESCRIPTION
Coroutine-like objects now additionally need a ``cr_suspended`` attribute to be supported by the `inspect.getcoroutinestate` method.

<!-- gh-issue-number: gh-101432 -->
* Issue: gh-101432
<!-- /gh-issue-number -->
