### PR TITLE
gh-101440: fix json snippet error in logging-cookbook.rst

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -307,7 +307,7 @@ Suppose you configure logging with the following JSON:
                 "class": "logging.StreamHandler",
                 "level": "INFO",
                 "formatter": "simple",
-                "stream": "ext://sys.stdout",
+                "stream": "ext://sys.stdout"
             },
             "stderr": {
                 "class": "logging.StreamHandler",


### PR DESCRIPTION
remove the extra comma (,)


<!-- gh-issue-number: gh-101440 -->
* Issue: gh-101440
<!-- /gh-issue-number -->
