### PR TITLE
gh-98831: Clean up and add cache size static_assert to macro

### DIFF
--- a/Tools/cases_generator/test_generator.py
+++ b/Tools/cases_generator/test_generator.py
@@ -383,6 +383,7 @@ def test_macro_instruction():
                 _tmp_3 = res;
             }
             JUMPBY(5);
+            static_assert(INLINE_CACHE_ENTRIES_OP == 5, "incorrect cache size");
             STACK_SHRINK(2);
             POKE(1, _tmp_3);
             DISPATCH();


### PR DESCRIPTION
There's a `static_assert` generated in the first instruction of a family that causes a compile-time error if the cache effect size computed by the generator differs from the cache struct size (given as a macro, `INLINE_CACHE_ENTRIES_XXX`). This wasn't being generated if the head of the family was a macro though. This fixes that, and also blackifies a few places that slipped through the crack.

<!-- gh-issue-number: gh-98831 -->
* Issue: gh-98831
<!-- /gh-issue-number -->
