### PR TITLE
[3.11] gh-101400: Fix incorrect lineno in exception message on contin…

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1907,9 +1907,6 @@ class SyntaxTestCase(unittest.TestCase):
             """
         self._check_error(source, "parameter and nonlocal", lineno=3)
 
-    def test_break_outside_loop(self):
-        self._check_error("break", "outside loop")
-
     def test_yield_outside_function(self):
         self._check_error("if 0: yield",                "outside function")
         self._check_error("if 0: yield\nelse:  x=1",    "outside function")
@@ -1938,20 +1935,27 @@ class SyntaxTestCase(unittest.TestCase):
                           "outside function")
 
     def test_break_outside_loop(self):
-        self._check_error("if 0: break",             "outside loop")
-        self._check_error("if 0: break\nelse:  x=1",  "outside loop")
-        self._check_error("if 1: pass\nelse: break", "outside loop")
-        self._check_error("class C:\n  if 0: break", "outside loop")
+        msg = "outside loop"
+        self._check_error("break", msg, lineno=1)
+        self._check_error("if 0: break", msg, lineno=1)
+        self._check_error("if 0: break\nelse:  x=1", msg, lineno=1)
+        self._check_error("if 1: pass\nelse: break", msg, lineno=2)
+        self._check_error("class C:\n  if 0: break", msg, lineno=2)
         self._check_error("class C:\n  if 1: pass\n  else: break",
-                          "outside loop")
+                          msg, lineno=3)
+        self._check_error("with object() as obj:\n break",
+                          msg, lineno=2)
 
     def test_continue_outside_loop(self):
-        self._check_error("if 0: continue",             "not properly in loop")
-        self._check_error("if 0: continue\nelse:  x=1", "not properly in loop")
-        self._check_error("if 1: pass\nelse: continue", "not properly in loop")
-        self._check_error("class C:\n  if 0: continue", "not properly in loop")
+        msg = "not properly in loop"
+        self._check_error("if 0: continue", msg, lineno=1)
+        self._check_error("if 0: continue\nelse:  x=1", msg, lineno=1)
+        self._check_error("if 1: pass\nelse: continue", msg, lineno=2)
+        self._check_error("class C:\n  if 0: continue", msg, lineno=2)
         self._check_error("class C:\n  if 1: pass\n  else: continue",
-                          "not properly in loop")
+                          msg, lineno=3)
+        self._check_error("with object() as obj:\n    continue",
+                          msg, lineno=2)
 
     def test_unexpected_indent(self):
         self._check_error("foo()\n bar()\n", "unexpected indent",

--- a/Misc/NEWS.d/next/Core and Builtins/2023-01-30-08-59-47.gh-issue-101400.Di_ZFm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-01-30-08-59-47.gh-issue-101400.Di_ZFm.rst
@@ -1,0 +1,2 @@
+Fix wrong lineno in exception message on :keyword:`continue` or
+:keyword:`break` which are not in a loop. Patch by Dong-hee Na.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -929,8 +929,7 @@ compiler_next_instr(basicblock *b)
     (new)->u_lineno = (old)->u_lineno;                    \
     (new)->u_col_offset = (old)->u_col_offset;            \
     (new)->u_end_lineno = (old)->u_end_lineno;            \
-    (new)->u_end_col_offset = (old)->u_end_col_offset;    \
-
+    (new)->u_end_col_offset = (old)->u_end_col_offset;
 
 #define COPY_INSTR_LOC(old, new)                         \
     (new).i_lineno = (old).i_lineno;                     \

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3259,14 +3259,20 @@ static int
 compiler_break(struct compiler *c)
 {
     struct fblockinfo *loop = NULL;
-    int origin_lineno = c->u->u_lineno;
+    int u_lineno = c->u->u_lineno;
+    int u_col_offset = c->u->u_col_offset;
+    int u_end_lineno = c->u->u_end_lineno;
+    int u_end_col_offset = c->u->u_end_col_offset;
     /* Emit instruction with line number */
     ADDOP(c, NOP);
     if (!compiler_unwind_fblock_stack(c, 0, &loop)) {
         return 0;
     }
     if (loop == NULL) {
-        c->u->u_lineno = origin_lineno;
+        c->u->u_lineno = u_lineno;
+        c->u->u_col_offset = u_col_offset;
+        c->u->u_end_lineno = u_end_lineno;
+        c->u->u_end_col_offset = u_end_col_offset;
         return compiler_error(c, "'break' outside loop");
     }
     if (!compiler_unwind_fblock(c, loop, 0)) {
@@ -3280,14 +3286,20 @@ static int
 compiler_continue(struct compiler *c)
 {
     struct fblockinfo *loop = NULL;
-    int origin_lineno = c->u->u_lineno;
+    int u_lineno = c->u->u_lineno;
+    int u_col_offset = c->u->u_col_offset;
+    int u_end_lineno = c->u->u_end_lineno;
+    int u_end_col_offset = c->u->u_end_col_offset;
     /* Emit instruction with line number */
     ADDOP(c, NOP);
     if (!compiler_unwind_fblock_stack(c, 0, &loop)) {
         return 0;
     }
     if (loop == NULL) {
-        c->u->u_lineno = origin_lineno;
+        c->u->u_lineno = u_lineno;
+        c->u->u_col_offset = u_col_offset;
+        c->u->u_end_lineno = u_end_lineno;
+        c->u->u_end_col_offset = u_end_col_offset;
         return compiler_error(c, "'continue' not properly in loop");
     }
     ADDOP_JUMP(c, JUMP, loop->fb_block);

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -925,12 +925,6 @@ compiler_next_instr(basicblock *b)
     (c)->u->u_end_lineno = -1;                  \
     (c)->u->u_end_col_offset = -1;
 
-#define COPY_COMPILER_UNIT_LOC(old, new)                  \
-    (new)->u_lineno = (old)->u_lineno;                    \
-    (new)->u_col_offset = (old)->u_col_offset;            \
-    (new)->u_end_lineno = (old)->u_end_lineno;            \
-    (new)->u_end_col_offset = (old)->u_end_col_offset;
-
 #define COPY_INSTR_LOC(old, new)                         \
     (new).i_lineno = (old).i_lineno;                     \
     (new).i_col_offset = (old).i_col_offset;             \
@@ -3265,15 +3259,14 @@ static int
 compiler_break(struct compiler *c)
 {
     struct fblockinfo *loop = NULL;
-    struct compiler_unit origin_loc;
-    COPY_COMPILER_UNIT_LOC(c->u, &origin_loc);
+    int origin_lineno = c->u->u_lineno;
     /* Emit instruction with line number */
     ADDOP(c, NOP);
     if (!compiler_unwind_fblock_stack(c, 0, &loop)) {
         return 0;
     }
     if (loop == NULL) {
-        COPY_COMPILER_UNIT_LOC(&origin_loc, c->u);
+        c->u->u_lineno = origin_lineno;
         return compiler_error(c, "'break' outside loop");
     }
     if (!compiler_unwind_fblock(c, loop, 0)) {
@@ -3287,15 +3280,14 @@ static int
 compiler_continue(struct compiler *c)
 {
     struct fblockinfo *loop = NULL;
-    struct compiler_unit origin_loc;
-    COPY_COMPILER_UNIT_LOC(c->u, &origin_loc);
+    int origin_lineno = c->u->u_lineno;
     /* Emit instruction with line number */
     ADDOP(c, NOP);
     if (!compiler_unwind_fblock_stack(c, 0, &loop)) {
         return 0;
     }
     if (loop == NULL) {
-        COPY_COMPILER_UNIT_LOC(&origin_loc, c->u);
+        c->u->u_lineno = origin_lineno;
         return compiler_error(c, "'continue' not properly in loop");
     }
     ADDOP_JUMP(c, JUMP, loop->fb_block);

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -925,6 +925,13 @@ compiler_next_instr(basicblock *b)
     (c)->u->u_end_lineno = -1;                  \
     (c)->u->u_end_col_offset = -1;
 
+#define COPY_COMPILER_UNIT_LOC(old, new)                  \
+    (new)->u_lineno = (old)->u_lineno;                    \
+    (new)->u_col_offset = (old)->u_col_offset;            \
+    (new)->u_end_lineno = (old)->u_end_lineno;            \
+    (new)->u_end_col_offset = (old)->u_end_col_offset;    \
+
+
 #define COPY_INSTR_LOC(old, new)                         \
     (new).i_lineno = (old).i_lineno;                     \
     (new).i_col_offset = (old).i_col_offset;             \
@@ -3259,12 +3266,15 @@ static int
 compiler_break(struct compiler *c)
 {
     struct fblockinfo *loop = NULL;
+    struct compiler_unit origin_loc;
+    COPY_COMPILER_UNIT_LOC(c->u, &origin_loc);
     /* Emit instruction with line number */
     ADDOP(c, NOP);
     if (!compiler_unwind_fblock_stack(c, 0, &loop)) {
         return 0;
     }
     if (loop == NULL) {
+        COPY_COMPILER_UNIT_LOC(&origin_loc, c->u);
         return compiler_error(c, "'break' outside loop");
     }
     if (!compiler_unwind_fblock(c, loop, 0)) {
@@ -3278,12 +3288,15 @@ static int
 compiler_continue(struct compiler *c)
 {
     struct fblockinfo *loop = NULL;
+    struct compiler_unit origin_loc;
+    COPY_COMPILER_UNIT_LOC(c->u, &origin_loc);
     /* Emit instruction with line number */
     ADDOP(c, NOP);
     if (!compiler_unwind_fblock_stack(c, 0, &loop)) {
         return 0;
     }
     if (loop == NULL) {
+        COPY_COMPILER_UNIT_LOC(&origin_loc, c->u);
         return compiler_error(c, "'continue' not properly in loop");
     }
     ADDOP_JUMP(c, JUMP, loop->fb_block);


### PR DESCRIPTION
…ue/break which are not in a loop (GH-101413).

(cherry picked from commit e867c1b753424d8d3f9c9ba0b431d007fd958c80)

Co-authored-by: Dong-hee Na <donghee.na@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101400 -->
* Issue: gh-101400
<!-- /gh-issue-number -->
