### PR TITLE
gh-101472: Add nargs='...' to the reference of add_argument in argparse

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1043,6 +1043,17 @@ If the ``nargs`` keyword argument is not provided, the number of arguments consu
 is determined by the action_.  Generally this means a single command-line argument
 will be consumed and a single item (not a list) will be produced.
 
+* ``'...'``. The remaining command-line args are gathered into a list,
+  including optional arguments.  If there are no remaining arguments,
+  an empty list is returned.  For example::
+
+     >>> parser = argparse.ArgumentParser()
+     >>> parser.add_argument('cmd')
+     >>> parser.add_argument('args', nargs='...')
+     >>> parser.parse_args('script.sh -v -n'.split())
+     Namespace(cmd=['script.sh'], args=['-v', '-n'])
+     >>> parser.parse_args('script.sh'.split())
+     Namespace(cmd=['script.sh'], args=[])
 
 .. _const:
 


### PR DESCRIPTION
This provides a fix to improve the documentation.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101472 -->
* Issue: gh-101472
<!-- /gh-issue-number -->
