### PR TITLE
gh-100925: Move array methods under class in array doc

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -85,161 +85,160 @@ The module defines the following type:
    to add initial items to the array.  Otherwise, the iterable initializer is
    passed to the :meth:`extend` method.
 
+   Array objects support the ordinary sequence operations of indexing, slicing,
+   concatenation, and multiplication.  When using slice assignment, the assigned
+   value must be an array object with the same type code; in all other cases,
+   :exc:`TypeError` is raised. Array objects also implement the buffer interface,
+   and may be used wherever :term:`bytes-like objects <bytes-like object>` are supported.
+
    .. audit-event:: array.__new__ typecode,initializer array.array
 
 
-Array objects support the ordinary sequence operations of indexing, slicing,
-concatenation, and multiplication.  When using slice assignment, the assigned
-value must be an array object with the same type code; in all other cases,
-:exc:`TypeError` is raised. Array objects also implement the buffer interface,
-and may be used wherever :term:`bytes-like objects <bytes-like object>` are supported.
+   .. attribute:: typecode
 
-The following data items and methods are also supported:
+      The typecode character used to create the array.
 
-.. attribute:: array.typecode
 
-   The typecode character used to create the array.
+   .. attribute:: itemsize
 
+      The length in bytes of one array item in the internal representation.
 
-.. attribute:: array.itemsize
 
-   The length in bytes of one array item in the internal representation.
+   .. method:: append(x)
 
+      Append a new item with value *x* to the end of the array.
 
-.. method:: array.append(x)
 
-   Append a new item with value *x* to the end of the array.
+   .. method:: buffer_info()
 
+      Return a tuple ``(address, length)`` giving the current memory address and the
+      length in elements of the buffer used to hold array's contents.  The size of the
+      memory buffer in bytes can be computed as ``array.buffer_info()[1] *
+      array.itemsize``.  This is occasionally useful when working with low-level (and
+      inherently unsafe) I/O interfaces that require memory addresses, such as certain
+      :c:func:`ioctl` operations.  The returned numbers are valid as long as the array
+      exists and no length-changing operations are applied to it.
 
-.. method:: array.buffer_info()
+      .. note::
 
-   Return a tuple ``(address, length)`` giving the current memory address and the
-   length in elements of the buffer used to hold array's contents.  The size of the
-   memory buffer in bytes can be computed as ``array.buffer_info()[1] *
-   array.itemsize``.  This is occasionally useful when working with low-level (and
-   inherently unsafe) I/O interfaces that require memory addresses, such as certain
-   :c:func:`ioctl` operations.  The returned numbers are valid as long as the array
-   exists and no length-changing operations are applied to it.
+         When using array objects from code written in C or C++ (the only way to
+         effectively make use of this information), it makes more sense to use the buffer
+         interface supported by array objects.  This method is maintained for backward
+         compatibility and should be avoided in new code.  The buffer interface is
+         documented in :ref:`bufferobjects`.
 
-   .. note::
 
-      When using array objects from code written in C or C++ (the only way to
-      effectively make use of this information), it makes more sense to use the buffer
-      interface supported by array objects.  This method is maintained for backward
-      compatibility and should be avoided in new code.  The buffer interface is
-      documented in :ref:`bufferobjects`.
+   .. method:: byteswap()
 
+      "Byteswap" all items of the array.  This is only supported for values which are
+      1, 2, 4, or 8 bytes in size; for other types of values, :exc:`RuntimeError` is
+      raised.  It is useful when reading data from a file written on a machine with a
+      different byte order.
 
-.. method:: array.byteswap()
 
-   "Byteswap" all items of the array.  This is only supported for values which are
-   1, 2, 4, or 8 bytes in size; for other types of values, :exc:`RuntimeError` is
-   raised.  It is useful when reading data from a file written on a machine with a
-   different byte order.
+   .. method:: count(x)
 
+      Return the number of occurrences of *x* in the array.
 
-.. method:: array.count(x)
 
-   Return the number of occurrences of *x* in the array.
+   .. method:: extend(iterable)
 
+      Append items from *iterable* to the end of the array.  If *iterable* is another
+      array, it must have *exactly* the same type code; if not, :exc:`TypeError` will
+      be raised.  If *iterable* is not an array, it must be iterable and its elements
+      must be the right type to be appended to the array.
 
-.. method:: array.extend(iterable)
 
-   Append items from *iterable* to the end of the array.  If *iterable* is another
-   array, it must have *exactly* the same type code; if not, :exc:`TypeError` will
-   be raised.  If *iterable* is not an array, it must be iterable and its elements
-   must be the right type to be appended to the array.
+   .. method:: frombytes(s)
 
+      Appends items from the string, interpreting the string as an array of machine
+      values (as if it had been read from a file using the :meth:`fromfile` method).
 
-.. method:: array.frombytes(s)
+      .. versionadded:: 3.2
+         :meth:`fromstring` is renamed to :meth:`frombytes` for clarity.
 
-   Appends items from the string, interpreting the string as an array of machine
-   values (as if it had been read from a file using the :meth:`fromfile` method).
 
-   .. versionadded:: 3.2
-      :meth:`fromstring` is renamed to :meth:`frombytes` for clarity.
+   .. method:: fromfile(f, n)
 
+      Read *n* items (as machine values) from the :term:`file object` *f* and append
+      them to the end of the array.  If less than *n* items are available,
+      :exc:`EOFError` is raised, but the items that were available are still
+      inserted into the array.
 
-.. method:: array.fromfile(f, n)
 
-   Read *n* items (as machine values) from the :term:`file object` *f* and append
-   them to the end of the array.  If less than *n* items are available,
-   :exc:`EOFError` is raised, but the items that were available are still
-   inserted into the array.
+   .. method:: fromlist(list)
 
+      Append items from the list.  This is equivalent to ``for x in list:
+      a.append(x)`` except that if there is a type error, the array is unchanged.
 
-.. method:: array.fromlist(list)
 
-   Append items from the list.  This is equivalent to ``for x in list:
-   a.append(x)`` except that if there is a type error, the array is unchanged.
+   .. method:: fromunicode(s)
 
+      Extends this array with data from the given unicode string.  The array must
+      be a type ``'u'`` array; otherwise a :exc:`ValueError` is raised.  Use
+      ``array.frombytes(unicodestring.encode(enc))`` to append Unicode data to an
+      array of some other type.
 
-.. method:: array.fromunicode(s)
 
-   Extends this array with data from the given unicode string.  The array must
-   be a type ``'u'`` array; otherwise a :exc:`ValueError` is raised.  Use
-   ``array.frombytes(unicodestring.encode(enc))`` to append Unicode data to an
-   array of some other type.
+   .. method:: index(x[, start[, stop]])
 
+      Return the smallest *i* such that *i* is the index of the first occurrence of
+      *x* in the array.  The optional arguments *start* and *stop* can be
+      specified to search for *x* within a subsection of the array.  Raise
+      :exc:`ValueError` if *x* is not found.
 
-.. method:: array.index(x[, start[, stop]])
+      .. versionchanged:: 3.10
+         Added optional *start* and *stop* parameters.
 
-   Return the smallest *i* such that *i* is the index of the first occurrence of
-   *x* in the array.  The optional arguments *start* and *stop* can be
-   specified to search for *x* within a subsection of the array.  Raise
-   :exc:`ValueError` if *x* is not found.
 
-   .. versionchanged:: 3.10
-      Added optional *start* and *stop* parameters.
+   .. method:: insert(i, x)
 
-.. method:: array.insert(i, x)
+      Insert a new item with value *x* in the array before position *i*. Negative
+      values are treated as being relative to the end of the array.
 
-   Insert a new item with value *x* in the array before position *i*. Negative
-   values are treated as being relative to the end of the array.
 
+   .. method:: pop([i])
 
-.. method:: array.pop([i])
+      Removes the item with the index *i* from the array and returns it. The optional
+      argument defaults to ``-1``, so that by default the last item is removed and
+      returned.
 
-   Removes the item with the index *i* from the array and returns it. The optional
-   argument defaults to ``-1``, so that by default the last item is removed and
-   returned.
 
+   .. method:: remove(x)
 
-.. method:: array.remove(x)
+      Remove the first occurrence of *x* from the array.
 
-   Remove the first occurrence of *x* from the array.
 
+   .. method:: reverse()
 
-.. method:: array.reverse()
+      Reverse the order of the items in the array.
 
-   Reverse the order of the items in the array.
 
+   .. method:: tobytes()
 
-.. method:: array.tobytes()
+      Convert the array to an array of machine values and return the bytes
+      representation (the same sequence of bytes that would be written to a file by
+      the :meth:`tofile` method.)
 
-   Convert the array to an array of machine values and return the bytes
-   representation (the same sequence of bytes that would be written to a file by
-   the :meth:`tofile` method.)
+      .. versionadded:: 3.2
+         :meth:`tostring` is renamed to :meth:`tobytes` for clarity.
 
-   .. versionadded:: 3.2
-      :meth:`tostring` is renamed to :meth:`tobytes` for clarity.
 
+   .. method:: tofile(f)
 
-.. method:: array.tofile(f)
+      Write all items (as machine values) to the :term:`file object` *f*.
 
-   Write all items (as machine values) to the :term:`file object` *f*.
 
+   .. method:: tolist()
 
-.. method:: array.tolist()
+      Convert the array to an ordinary list with the same items.
 
-   Convert the array to an ordinary list with the same items.
 
+   .. method:: tounicode()
 
-.. method:: array.tounicode()
-
-   Convert the array to a unicode string.  The array must be a type ``'u'`` array;
-   otherwise a :exc:`ValueError` is raised. Use ``array.tobytes().decode(enc)`` to
-   obtain a unicode string from an array of some other type.
+      Convert the array to a unicode string.  The array must be a type ``'u'`` array;
+      otherwise a :exc:`ValueError` is raised. Use ``array.tobytes().decode(enc)`` to
+      obtain a unicode string from an array of some other type.
 
 
 When an array object is printed or converted to a string, it is represented as

--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -60,7 +60,7 @@ Notes:
 
 The actual representation of values is determined by the machine architecture
 (strictly speaking, by the C implementation).  The actual size can be accessed
-through the :attr:`itemsize` attribute.
+through the :attr:`array.itemsize` attribute.
 
 The module defines the following item:
 
@@ -116,7 +116,7 @@ The module defines the following type:
       memory buffer in bytes can be computed as ``array.buffer_info()[1] *
       array.itemsize``.  This is occasionally useful when working with low-level (and
       inherently unsafe) I/O interfaces that require memory addresses, such as certain
-      :c:func:`ioctl` operations.  The returned numbers are valid as long as the array
+      :c:func:`!ioctl` operations.  The returned numbers are valid as long as the array
       exists and no length-changing operations are applied to it.
 
       .. note::
@@ -155,7 +155,7 @@ The module defines the following type:
       values (as if it had been read from a file using the :meth:`fromfile` method).
 
       .. versionadded:: 3.2
-         :meth:`fromstring` is renamed to :meth:`frombytes` for clarity.
+         :meth:`!fromstring` is renamed to :meth:`frombytes` for clarity.
 
 
    .. method:: fromfile(f, n)
@@ -221,7 +221,7 @@ The module defines the following type:
       the :meth:`tofile` method.)
 
       .. versionadded:: 3.2
-         :meth:`tostring` is renamed to :meth:`tobytes` for clarity.
+         :meth:`!tostring` is renamed to :meth:`tobytes` for clarity.
 
 
    .. method:: tofile(f)


### PR DESCRIPTION
This fixes the issue reported in #100925 , where the attributes and methods of the `array.array` class are listed under the module rather than the class, and not clearly indicated as such, which is confusing to readers. This supersedes #101239 , which didn't quite solve the right problem; thanks @theWiseAman for your original PR that prompted this.

Also a followup to #98657 , which just fixed this for the one module-level attribute. As both of these are a fix to a docs defect that applies to all supported versions, ensures the stable version will be updated to avoid more reports like the one that prompted this one, and allows future PRs to be cleanly backported, I've queued up backports for both that PR, #98729 and this one, the latter of which should be merged first before this PR is, so that miss-islington can do the backports of this one cleanly:

* #101483
* #101484

To note, since the class name was included in the existing `method`/`attribute` directives, this change doesn't break any internal or Intersphinx links, and also maintains the same fragment ids, so external links will continue to work exactly the same as before. Therefore, I've confirmed it is fully backward-compatible.

|Before|After|
|---|---|
| ![image](https://user-images.githubusercontent.com/17051931/215917423-0d4e2a00-b812-4dc4-b230-f5e8f8bfe621.png) | ![image](https://user-images.githubusercontent.com/17051931/215917325-65175cff-251a-40bd-896b-d70de8cf2a0d.png) |

Closes #101239 