### PR TITLE
[3.11] gh-101454: fix documentation for END_ASYNC_FOR (#101455)

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -563,10 +563,9 @@ the original TOS1.
 .. opcode:: END_ASYNC_FOR
 
    Terminates an :keyword:`async for` loop.  Handles an exception raised
-   when awaiting a next item.  If TOS is :exc:`StopAsyncIteration` pop 3
-   values from the stack and restore the exception state using the second
-   of them.  Otherwise re-raise the exception using the value
-   from the stack.  An exception handler block is removed from the block stack.
+   when awaiting a next item. The stack contains the async iterable in
+   TOS1 and the raised exception in TOS. Both are popped.
+   If the exception is not :exc:`StopAsyncIteration`, it is re-raised.
 
    .. versionadded:: 3.8
 


### PR DESCRIPTION
(cherry picked from commit 62251c3da06eb4662502295697f39730565b1717)

Backport of https://github.com/python/cpython/pull/101455.

<!-- gh-issue-number: gh-101454 -->
* Issue: gh-101454
<!-- /gh-issue-number -->
