### PR TITLE
gh-90889: Deprecate pathlib methods when required functions are missing.

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -887,6 +887,8 @@ call fails (for example because the path doesn't exist).
    Return the name of the group owning the file.  :exc:`KeyError` is raised
    if the file's gid isn't found in the system database.
 
+   .. availability:: Unix.
+
 
 .. method:: Path.is_dir()
 
@@ -1145,6 +1147,8 @@ call fails (for example because the path doesn't exist).
    Return the name of the user owning the file.  :exc:`KeyError` is raised
    if the file's uid isn't found in the system database.
 
+   .. availability:: Unix.
+
 
 .. method:: Path.read_bytes()
 
@@ -1184,6 +1188,8 @@ call fails (for example because the path doesn't exist).
       >>> p.symlink_to('setup.py')
       >>> p.readlink()
       PosixPath('setup.py')
+
+   .. availability:: Unix, Windows.
 
    .. versionadded:: 3.9
 
@@ -1333,6 +1339,9 @@ call fails (for example because the path doesn't exist).
       The order of arguments (link, target) is the reverse
       of :func:`os.symlink`'s.
 
+   .. availability:: Unix, Windows.
+
+
 .. method:: Path.hardlink_to(target)
 
    Make this path a hard link to the same file as *target*.
@@ -1342,6 +1351,8 @@ call fails (for example because the path doesn't exist).
       of :func:`os.link`'s.
 
    .. versionadded:: 3.10
+
+   .. availability:: Unix, Windows.
 
 
 .. method:: Path.touch(mode=0o666, exist_ok=True)

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -20,6 +20,11 @@ from operator import attrgetter
 from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO
 from urllib.parse import quote_from_bytes as urlquote_from_bytes
 
+try:
+    import pwd, grp
+except ImportError:
+    pwd = grp = None
+
 
 __all__ = [
     "PurePath", "PurePosixPath", "PureWindowsPath",
@@ -861,22 +866,26 @@ class Path(PurePath):
         """
         Return the login name of the file owner.
         """
-        try:
-            import pwd
-            return pwd.getpwuid(self.stat().st_uid).pw_name
-        except ImportError:
+        if not pwd:
+            msg = ("From Python {remove}, pathlib.Path.owner() will "
+                   "not be available in builds lacking the pwd module.")
+            warnings._deprecated("pathlib.Path.owner()", msg,
+                                 remove=(3, 14))
             raise NotImplementedError("Path.owner() is unsupported on this system")
+        return pwd.getpwuid(self.stat().st_uid).pw_name
 
     def group(self):
         """
         Return the group name of the file gid.
         """
 
-        try:
-            import grp
-            return grp.getgrgid(self.stat().st_gid).gr_name
-        except ImportError:
+        if not grp:
+            msg = ("From Python {remove}, pathlib.Path.group() will "
+                   "not be available in builds lacking the grp module.")
+            warnings._deprecated("pathlib.Path.group()", msg,
+                                 remove=(3, 14))
             raise NotImplementedError("Path.group() is unsupported on this system")
+        return grp.getgrgid(self.stat().st_gid).gr_name
 
     def open(self, mode='r', buffering=-1, encoding=None,
              errors=None, newline=None):
@@ -928,6 +937,10 @@ class Path(PurePath):
         Return the path to which the symbolic link points.
         """
         if not hasattr(os, "readlink"):
+            msg = ("From Python {remove}, pathlib.Path.readlink() will "
+                   "not be available in builds lacking os.readlink().")
+            warnings._deprecated("pathlib.Path.readlink()", msg,
+                                 remove=(3, 14))
             raise NotImplementedError("os.readlink() not available on this system")
         return self._from_parts((os.readlink(self),))
 
@@ -1039,6 +1052,10 @@ class Path(PurePath):
         Note the order of arguments (link, target) is the reverse of os.symlink.
         """
         if not hasattr(os, "symlink"):
+            msg = ("From Python {remove}, pathlib.Path.symlink_to() will "
+                   "not be available in builds lacking os.symlink().")
+            warnings._deprecated("pathlib.Path.symlink_to()", msg,
+                                 remove=(3, 14))
             raise NotImplementedError("os.symlink() not available on this system")
         os.symlink(target, self, target_is_directory)
 
@@ -1049,6 +1066,10 @@ class Path(PurePath):
         Note the order of arguments (self, target) is the reverse of os.link's.
         """
         if not hasattr(os, "link"):
+            msg = ("From Python {remove}, pathlib.Path.hardlink_to() will "
+                   "not be available in builds lacking os.link().")
+            warnings._deprecated("pathlib.Path.hardlink_to()", msg,
+                                 remove=(3, 14))
             raise NotImplementedError("os.link() not available on this system")
         os.link(target, self)
 

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2078,8 +2078,40 @@ class _BasePathTest(object):
         p = P / 'fileA'
         # linking to another path.
         q = P / 'dirA' / 'fileAA'
-        with self.assertRaises(NotImplementedError):
-            q.hardlink_to(p)
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                p.hardlink_to(q)
+
+    @unittest.skipIf(hasattr(os, "symlink"), "os.symlink() is present")
+    def test_symlink_to_not_implemented(self):
+        P = self.cls(BASE)
+        p = P / 'fileA'
+        # linking to another path.
+        q = P / 'dirA' / 'fileAA'
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                p.symlink_to(q)
+
+    @unittest.skipIf(hasattr(os, "readlink"), "os.readlink() is present")
+    def test_readlink_not_implemented(self):
+        p = self.cls(BASE) / 'fileA'
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                p.readlink()
+
+    @unittest.skipIf(pwd, "the pwd module is present")
+    def test_owner_not_implemented(self):
+        p = self.cls(BASE) / 'fileA'
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                p.owner()
+
+    @unittest.skipIf(grp, "the grp module is present")
+    def test_group_not_implemented(self):
+        p = self.cls(BASE) / 'fileA'
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                p.group()
 
     def test_rename(self):
         P = self.cls(BASE)

--- a/Misc/NEWS.d/next/Library/2023-02-01-21-11-42.gh-issue-90889.wC7C7H.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-01-21-11-42.gh-issue-90889.wC7C7H.rst
@@ -1,0 +1,13 @@
+Deprecate use of some pathlib methods when low-level functions or modules
+they require are missing. The affected methods are:
+:meth:`pathlib.Path.readlink` (when :func:`os.readlink` is missing),
+:meth:`~pathlib.Path.symlink_to` (likewise :func:`os.symlink`),
+:meth:`~pathlib.Path.hardlink_to` (:func:`os.link`),
+:meth:`~pathlib.Path.owner` (:mod:`pwd`) and :meth:`~pathlib.Path.group`
+(:mod:`grp`). From Python 3.14, these methods will not be present when
+corresponding low-level functions or modules are not available; this will
+facilitate feature detection like
+``if hasattr(p, 'symlink_to'): p.symlink_to(...)``. In Python 3.13 and
+prior, users may check for the existence of the underlying functions like
+``if hasattr(os, 'symlink'): p.symlink_to(...)``, or check for a
+POSIX-flavoured path like ``if isinstance(p, PosixPath):  u = p.owner()``.


### PR DESCRIPTION
Emit a deprecation warning (in addition to raising `NotImplementedError`) if a pathlib method is called that relies on a missing function. Affects:

- `Path.readlink()` (when `os.readlink()` is missing)
- `Path.symlink_to()` (when `os.symlink()` is missing)
- `Path.hardlink_to()` (when `os.link()` is missing)
- `Path.owner()` (when `pwd.getpwuid()` is missing)
- `Path.group()` (when `grp.getgrgid()` is missing)

From Python 3.14, these methods will only be present if their required low-level functions are present, which will allow users to perform feature detection: `if hasattr(p, 'symlink_to'): p.symlink_to(...)`

To support versions prior to Python 3.14, users can first check for the low-level functions, like: `if hasattr(os, 'symlink'): p.symlink_to(...)`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-90889 -->
* Issue: gh-90889
<!-- /gh-issue-number -->
