### PR TITLE
fix(tutorial,venv): replace PyPI description with link

### DIFF
--- a/Doc/tutorial/venv.rst
+++ b/Doc/tutorial/venv.rst
@@ -98,8 +98,8 @@ Managing Packages with pip
 ==========================
 
 You can install, upgrade, and remove packages using a program called
-:program:`pip`.  By default ``pip`` will install packages from the Python
-Package Index, <https://pypi.org>.  You can browse the Python
+:program:`pip`.  By default ``pip`` will install packages from the `Python
+Package Index <https://pypi.org>`_.  You can browse the Python
 Package Index by going to it in your web browser.
 
 ``pip`` has a number of subcommands: "install", "uninstall",


### PR DESCRIPTION
In the venv tutorial, the PyPI link is now attached to its title.