### PR TITLE
docs: Fix enum reassign `str` documentation

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -922,6 +922,6 @@ Notes
 
    or you can reassign the appropriate :meth:`str`, etc., in your enum::
 
-       >>> from enum import IntEnum
+       >>> from enum import Enum, IntEnum
        >>> class MyIntEnum(IntEnum):
-       ...     __str__ = IntEnum.__str__
+       ...     __str__ = Enum.__str__


### PR DESCRIPTION
Previous documentation didn't show correct reassignment to restore 3.10 enum str behavior.
