### PR TITLE
gh-101543: Ensure Windows registry path is only used when stdlib can't be found

### DIFF
--- a/Misc/NEWS.d/next/Windows/2023-02-03-17-53-06.gh-issue-101543.cORAT4.rst
+++ b/Misc/NEWS.d/next/Windows/2023-02-03-17-53-06.gh-issue-101543.cORAT4.rst
@@ -1,0 +1,2 @@
+Ensure the install path in the registry is only used when the standard
+library hasn't been located in any other way.

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -784,5 +784,6 @@ config['base_prefix'] = base_prefix or prefix
 config['base_exec_prefix'] = base_exec_prefix or exec_prefix
 
 config['platlibdir'] = platlibdir
-config['stdlib_dir'] = stdlib_dir
-config['platstdlib_dir'] = platstdlib_dir
+# test_embed expects empty strings, not None
+config['stdlib_dir'] = stdlib_dir or ''
+config['platstdlib_dir'] = platstdlib_dir or ''

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -582,7 +582,7 @@ else:
     # Detect prefix by searching from our executable location for the stdlib_dir
     if STDLIB_SUBDIR and STDLIB_LANDMARKS and executable_dir and not prefix:
         prefix = search_up(executable_dir, *STDLIB_LANDMARKS)
-        if prefix:
+        if prefix and not stdlib_dir:
             stdlib_dir = joinpath(prefix, STDLIB_SUBDIR)
 
     if PREFIX and not prefix:
@@ -629,20 +629,6 @@ else:
 
     if not prefix or not exec_prefix:
         warn('Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]')
-
-
-# If we haven't set [plat]stdlib_dir already, set them now
-if not stdlib_dir:
-    if prefix:
-        stdlib_dir = joinpath(prefix, STDLIB_SUBDIR)
-    else:
-        stdlib_dir = ''
-
-if not platstdlib_dir:
-    if exec_prefix:
-        platstdlib_dir = joinpath(exec_prefix, PLATSTDLIB_LANDMARK)
-    else:
-        platstdlib_dir = ''
 
 
 # For a venv, update the main prefix/exec_prefix but leave the base ones unchanged
@@ -706,8 +692,9 @@ elif not pythonpath_was_set:
                             pythonpath.extend(v.split(DELIM))
                         i += 1
                     # Paths from the core key get appended last, but only
-                    # when home was not set and we aren't in a build dir
-                    if not home_was_set and not venv_prefix and not build_prefix:
+                    # when home was not set and we haven't found our stdlib
+                    # some other way.
+                    if not home and not stdlib_dir:
                         v = winreg.QueryValue(key, None)
                         if isinstance(v, str):
                             pythonpath.extend(v.split(DELIM))
@@ -722,6 +709,11 @@ elif not pythonpath_was_set:
             pythonpath.append(joinpath(prefix, p))
 
     # Then add stdlib_dir and platstdlib_dir
+    if not stdlib_dir and prefix:
+        stdlib_dir = joinpath(prefix, STDLIB_SUBDIR)
+    if not platstdlib_dir and exec_prefix:
+        platstdlib_dir = joinpath(exec_prefix, PLATSTDLIB_LANDMARK)
+
     if os_name == 'nt':
         # QUIRK: Windows generates paths differently
         if platstdlib_dir:


### PR DESCRIPTION


<!-- gh-issue-number: gh-101543 -->
* Issue: gh-101543
<!-- /gh-issue-number -->
