### PR TITLE
[3.10] gh-101522: Allow overriding Windows dependencies versions and paths using MSBuild properties (GH-101523)

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-02-02-23-43-46.gh-issue-101522.lnUDta.rst
+++ b/Misc/NEWS.d/next/Build/2023-02-02-23-43-46.gh-issue-101522.lnUDta.rst
@@ -1,0 +1,2 @@
+Allow overriding Windows dependencies versions and paths using MSBuild
+properties.

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -52,23 +52,32 @@
     <BuildPath Condition="'$(BuildPath)' == ''">$(PySourcePath)PCbuild\$(ArchName)\</BuildPath>
     <BuildPath Condition="!HasTrailingSlash($(BuildPath))">$(BuildPath)\</BuildPath>
     <BuildPath Condition="$(Configuration) == 'PGInstrument'">$(BuildPath)instrumented\</BuildPath>
-    
-    <!-- Directories of external projects. tcltk is handled in tcltk.props -->
-    <ExternalsDir>$(EXTERNALS_DIR)</ExternalsDir>
+  </PropertyGroup>
+
+  <!-- Directories of external projects. tcltk is handled in tcltk.props -->
+  <PropertyGroup>
+    <ExternalsDir Condition="$(ExternalsDir) == ''">$(EXTERNALS_DIR)</ExternalsDir>
     <ExternalsDir Condition="$(ExternalsDir) == ''">$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals`))</ExternalsDir>
     <ExternalsDir Condition="!HasTrailingSlash($(ExternalsDir))">$(ExternalsDir)\</ExternalsDir>
-    <sqlite3Dir>$(ExternalsDir)sqlite-3.39.4.0\</sqlite3Dir>
-    <bz2Dir>$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
-    <lzmaDir>$(ExternalsDir)xz-5.2.5\</lzmaDir>
-    <libffiDir>$(ExternalsDir)libffi-3.3.0\</libffiDir>
-    <libffiOutDir>$(ExternalsDir)libffi-3.3.0\$(ArchName)\</libffiOutDir>
-    <libffiIncludeDir>$(libffiOutDir)include</libffiIncludeDir>
-    <opensslDir>$(ExternalsDir)openssl-1.1.1s\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1s\$(ArchName)\</opensslOutDir>
-    <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
-    <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
-    <zlibDir>$(ExternalsDir)\zlib-1.2.13\</zlibDir>
-    
+  </PropertyGroup>
+
+  <Import Project="$(ExternalProps)" Condition="$(ExternalProps) != '' and Exists('$(ExternalProps)')" />
+
+  <PropertyGroup>
+    <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.39.4.0\</sqlite3Dir>
+    <bz2Dir Condition="$(bz2Dir) == ''">$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
+    <lzmaDir Condition="$(lzmaDir) == ''">$(ExternalsDir)xz-5.2.5\</lzmaDir>
+    <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.3.0\</libffiDir>
+    <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
+    <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
+    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1s\</opensslDir>
+    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1s\$(ArchName)\</opensslOutDir>
+    <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
+    <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
+    <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.13\</zlibDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- Suffix for all binaries when building for debug -->
     <PyDebugExt Condition="'$(PyDebugExt)' == '' and $(Configuration) == 'Debug'">_d</PyDebugExt>
     

--- a/PCbuild/tcltk.props
+++ b/PCbuild/tcltk.props
@@ -2,22 +2,26 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="pyproject.props" Condition="$(__PyProject_Props_Imported) != 'true'" />
   <PropertyGroup>
-    <TclMajorVersion>8</TclMajorVersion>
-    <TclMinorVersion>6</TclMinorVersion>
-    <TclPatchLevel>12</TclPatchLevel>
-    <TclRevision>0</TclRevision>
-    <TkMajorVersion>$(TclMajorVersion)</TkMajorVersion>
-    <TkMinorVersion>$(TclMinorVersion)</TkMinorVersion>
-    <TkPatchLevel>$(TclPatchLevel)</TkPatchLevel>
-    <TkRevision>$(TclRevision)</TkRevision>
-    <TixMajorVersion>8</TixMajorVersion>
-    <TixMinorVersion>4</TixMinorVersion>
-    <TixPatchLevel>3</TixPatchLevel>
-    <TixRevision>6</TixRevision>
-    <tclDir>$(ExternalsDir)tcl-core-$(TclMajorVersion).$(TclMinorVersion).$(TclPatchLevel).$(TclRevision)\</tclDir>
-    <tkDir>$(ExternalsDir)tk-$(TkMajorVersion).$(TkMinorVersion).$(TkPatchLevel).$(TkRevision)\</tkDir>
-    <tixDir>$(ExternalsDir)tix-$(TixMajorVersion).$(TixMinorVersion).$(TixPatchLevel).$(TixRevision)\</tixDir>
-    <tcltkDir>$(ExternalsDir)tcltk-$(TclMajorVersion).$(TclMinorVersion).$(TclPatchLevel).$(TclRevision)\$(ArchName)\</tcltkDir>
+    <TclVersion Condition="$(TclVersion) == ''">8.6.12.0</TclVersion>
+    <TkVersion Condition="$(TkVersion) == ''">$(TclVersion)</TkVersion>
+    <TixVersion Condition="$(TixVersion) == ''">8.4.3.6</TixVersion>
+    <TclMajorVersion>$([System.Version]::Parse($(TclVersion)).Major)</TclMajorVersion>
+    <TclMinorVersion>$([System.Version]::Parse($(TclVersion)).Minor)</TclMinorVersion>
+    <TclPatchLevel>$([System.Version]::Parse($(TclVersion)).Build)</TclPatchLevel>
+    <TclRevision>$([System.Version]::Parse($(TclVersion)).Revision)</TclRevision>
+    <TkMajorVersion>$([System.Version]::Parse($(TkVersion)).Major)</TkMajorVersion>
+    <TkMinorVersion>$([System.Version]::Parse($(TkVersion)).Minor)</TkMinorVersion>
+    <TkPatchLevel>$([System.Version]::Parse($(TkVersion)).Build)</TkPatchLevel>
+    <TkRevision>$([System.Version]::Parse($(TkVersion)).Revision)</TkRevision>
+    <TixMajorVersion>$([System.Version]::Parse($(TixVersion)).Major)</TixMajorVersion>
+    <TixMinorVersion>$([System.Version]::Parse($(TixVersion)).Minor)</TixMinorVersion>
+    <TixPatchLevel>$([System.Version]::Parse($(TixVersion)).Build)</TixPatchLevel>
+    <TixRevision>$([System.Version]::Parse($(TixVersion)).Revision)</TixRevision>
+    <tclDir Condition="$(tclDir) == ''">$(ExternalsDir)tcl-core-$(TclVersion)\</tclDir>
+    <tkDir Condition="$(tkDir) == ''">$(ExternalsDir)tk-$(TkVersion)\</tkDir>
+    <tixDir Condition="$(tixDir) == ''">$(ExternalsDir)tix-$(TixVersion)\</tixDir>
+    <tcltkDir Condition="$(tcltkDir) == ''">$(ExternalsDir)tcltk-$(TclVersion)\$(ArchName)\</tcltkDir>
+
     <!--<TclDebugExt Condition="'$(Configuration)' == 'Debug'">g</TclDebugExt>-->
     <tclDLLName>tcl$(TclMajorVersion)$(TclMinorVersion)t$(TclDebugExt).dll</tclDLLName>
     <tclLibName>tcl$(TclMajorVersion)$(TclMinorVersion)t$(TclDebugExt).lib</tclLibName>


### PR DESCRIPTION


<!-- gh-issue-number: gh-101522 -->
* Issue: gh-101522
<!-- /gh-issue-number -->
