### PR TITLE
gh-101558: Add time.sleep_until()

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -388,6 +388,22 @@ Functions
       by a signal, except if the signal handler raises an exception (see
       :pep:`475` for the rationale).
 
+.. function:: sleep_until(secs)
+
+   Like :func:`sleep`, but sleep until the specified time of the system clock (as
+   returned by :func:`time`). This can be used, for example, to schedule events
+   at a specific timestamp obtained from
+   :meth:`datetime.timestamp <datetime.datetime.timestamp>`.
+
+   See the notes in :func:`sleep` on the behavior when interrupted and on accuracy.
+   Additional potential sources of inaccuracies include:
+
+   * Because this function uses the system clock as a reference, this means the
+     reference clock is adjustable and may jump backwards.
+   * On Unix, if ``clock_nanosleep()`` is not available, the absolute timeout
+     is emulated using ``nanosleep()`` or ``select()``.
+
+   .. versionadded:: 3.12
 
 .. index::
    single: % (percent); datetime format

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -159,6 +159,18 @@ class TimeTestCase(unittest.TestCase):
         self.assertRaises(ValueError, time.sleep, -1)
         time.sleep(1.2)
 
+    def test_sleep_until(self):
+        start = time.time()
+        deadline = start + 2
+        time.sleep_until(deadline)
+        stop = time.time()
+        delta = stop - deadline
+        # cargo-cult these 50ms from test_monotonic (bpo-20101)
+        self.assertGreater(delta, -0.050)
+        # allow sleep_until to take up to 1s longer than planned
+        # (e.g. in case the system is under heavy load during testing)
+        self.assertLess(delta, 1.000)
+
     def test_epoch(self):
         # bpo-43869: Make sure that Python use the same Epoch on all platforms:
         # January 1, 1970, 00:00:00 (UTC).

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -403,6 +403,7 @@ Lisandro Dalcin
 Darren Dale
 Andrew Dalke
 Lars Damerow
+Hauke Dämpfling
 Evan Dandrea
 Eric Daniel
 Scott David Daniels

--- a/Misc/NEWS.d/next/Library/2023-02-04-15-35-47.gh-issue-101558.ocOYkj.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-04-15-35-47.gh-issue-101558.ocOYkj.rst
@@ -1,0 +1,2 @@
+Added the :func:`time.sleep_until` function, which allows sleeping until the
+specified absolute time.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -438,8 +438,9 @@ static PyObject *
 time_sleep_until(PyObject *self, PyObject *deadline_obj)
 {
     _PyTime_t deadline;
-    if (_PyTime_FromSecondsObject(&deadline, deadline_obj, _PyTime_ROUND_TIMEOUT))
+    if (_PyTime_FromSecondsObject(&deadline, deadline_obj, _PyTime_ROUND_TIMEOUT)) {
         return NULL;
+    }
     if (deadline < 0) {
         PyErr_SetString(PyExc_ValueError,
                         "sleep_until deadline must be non-negative");


### PR DESCRIPTION
This modifies `pysleep` to give it an "`absolute`" argument, and adds a `time.sleep_until()` function.

~~(I haven't been able to test this on Windows yet, I hope the GitHub Actions will take care of that)~~ ✓

<!-- gh-issue-number: gh-101558 -->
* Issue: gh-101558
<!-- /gh-issue-number -->
