### PR TITLE
gh-101561: Add typing.override decorator

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2750,8 +2750,8 @@ Functions and decorators
 
    The decorator will set the ``__override__`` attribute to ``True`` on
    the decorated object. Thus, a check like
-   ``if getattr(obj, "__final__", False)`` can be used at runtime to determine
-   whether an object ``obj`` has been marked as final.  If the decorated object
+   ``if getattr(obj, "__override__", False)`` can be used at runtime to determine
+   whether an object ``obj`` has been marked as an override.  If the decorated object
    does not support setting attributes, the decorator returns the object unchanged
    without raising an exception.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2732,6 +2732,8 @@ Functions and decorators
    This helps prevent bugs that may occur when a base class is changed without
    an equivalent change to a child class.
 
+   For example::
+
       class Base:
            def log_status(self)
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -91,6 +91,8 @@ annotations. These include:
     *Introducing* :data:`LiteralString`
 * :pep:`681`: Data Class Transforms
     *Introducing* the :func:`@dataclass_transform<dataclass_transform>` decorator
+* :pep:`698`: Adding an override decorator to typing
+    *Introducing* the :func:`@override<override>` decorator
 
 .. _type-aliases:
 
@@ -2721,6 +2723,40 @@ Functions and decorators
 
    This wraps the decorator with something that wraps the decorated
    function in :func:`no_type_check`.
+
+
+.. decorator:: override
+
+   A decorator for methods that indicates to type checkers that this method
+   should override a method or attribute with the same name on a base class.
+   This helps prevent bugs that may occur when a base class is changed without
+   an equivalent change to a child class.
+
+      class Base:
+           def log_status(self)
+
+      class Sub(Base):
+          @override
+          def log_status(self) -> None:  # Okay: overrides Base.log_status
+              ...
+
+          @override
+          def done(self) -> None:  # Error reported by type checker
+              ...
+
+   There is no runtime checking of this property.
+
+   The decorator will set the ``__override__`` attribute to ``True`` on
+   the decorated object. Thus, a check like
+   ``if getattr(obj, "__final__", False)`` can be used at runtime to determine
+   whether an object ``obj`` has been marked as final.  If the decorated object
+   does not support setting attributes, the decorator returns the object unchanged
+   without raising an exception.
+
+   See :pep:`698` for more details.
+
+   .. versionadded:: 3.12
+
 
 .. decorator:: type_check_only
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -355,7 +355,7 @@ typing
 
 * Add :func:`typing.override`, an override decorator telling to static type
   checkers to verify that a method overrides some method or attribute of the
-  same name on a base class, as per :pep:698 (Contributed by Steven Troxler in
+  same name on a base class, as per :pep:`698` (Contributed by Steven Troxler in
   :gh:`101564`).
 
 sys

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -350,6 +350,14 @@ tempfile
 The :class:`tempfile.NamedTemporaryFile` function has a new optional parameter
 *delete_on_close* (Contributed by Evgeny Zorin in :gh:`58451`.)
 
+typing
+-----
+
+* Add :func:`typing.override`, an override decorator telling to static type
+  checkers to verify that a method overrides some method or attribute of the
+  same name on a base class, as per :pep:698 (Contributed by Steven Troxler in
+  :gh:`101564`).
+
 sys
 ---
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -351,7 +351,7 @@ The :class:`tempfile.NamedTemporaryFile` function has a new optional parameter
 *delete_on_close* (Contributed by Evgeny Zorin in :gh:`58451`.)
 
 typing
------
+------
 
 * Add :func:`typing.override`, an override decorator telling to static type
   checkers to verify that a method overrides some method or attribute of the

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -355,8 +355,8 @@ typing
 
 * Add :func:`typing.override`, an override decorator telling to static type
   checkers to verify that a method overrides some method or attribute of the
-  same name on a base class, as per :pep:`698` (Contributed by Steven Troxler in
-  :gh:`101564`).
+  same name on a base class, as per :pep:`698`. (Contributed by Steven Troxler in
+  :gh:`101564`.)
 
 sys
 ---

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -138,6 +138,7 @@ __all__ = [
     'NoReturn',
     'NotRequired',
     'overload',
+    'override',
     'ParamSpecArgs',
     'ParamSpecKwargs',
     'Required',
@@ -2657,6 +2658,7 @@ T_contra = TypeVar('T_contra', contravariant=True)  # Ditto contravariant.
 # Internal type variable used for Type[].
 CT_co = TypeVar('CT_co', covariant=True, bound=type)
 
+
 # A useful type variable with constraints.  This represents string types.
 # (This one *is* for export!)
 AnyStr = TypeVar('AnyStr', bytes, str)
@@ -2748,6 +2750,8 @@ Type.__doc__ = \
     At this point the type checker knows that joe has type BasicUser.
     """
 
+# Internal type variable for callables. Not for export.
+F = TypeVar("F", bound=Callable[..., Any])
 
 @runtime_checkable
 class SupportsInt(Protocol):
@@ -3448,3 +3452,40 @@ def dataclass_transform(
         }
         return cls_or_fn
     return decorator
+
+
+
+def override(__arg: F) -> F:
+    """Indicate that a method is intended to override a method in a base class.
+
+    Usage:
+
+        class Base:
+            def method(self) -> None: ...
+                pass
+
+        class Child(Base):
+            @override
+            def method(self) -> None:
+                super().method()
+
+    When this decorator is applied to a method, the type checker will
+    validate that it overrides a method or attribute with the same name on a
+    base class.  This helps prevent bugs that may occur when a base class is
+    changed without an equivalent change to a child class.
+
+    There is no runtime checking of this property. The decorator sets the
+    ``__override__`` attribute to ``True`` on the decorated object to allow
+    runtime introspection.
+
+    See PEP 698 for details.
+
+    """
+    try:
+        __arg.__override__ = True
+    except (AttributeError, TypeError):
+        # Skip the attribute silently if it is not writable.
+        # AttributeError happens if the object has __slots__ or a
+        # read-only property, TypeError if it's a builtin class.
+        pass
+    return __arg

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3455,7 +3455,7 @@ def dataclass_transform(
 
 
 
-def override(__arg: F) -> F:
+def override(method: F, /) -> F:
     """Indicate that a method is intended to override a method in a base class.
 
     Usage:
@@ -3482,10 +3482,10 @@ def override(__arg: F) -> F:
 
     """
     try:
-        __arg.__override__ = True
+        method.__override__ = True
     except (AttributeError, TypeError):
         # Skip the attribute silently if it is not writable.
         # AttributeError happens if the object has __slots__ or a
         # read-only property, TypeError if it's a builtin class.
         pass
-    return __arg
+    return method

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1848,6 +1848,7 @@ Tom Tromey
 John Tromp
 Diane Trout
 Jason Trowbridge
+Steven Troxler
 Brent Tubbs
 Anthony Tuininga
 Erno Tukia

--- a/Misc/NEWS.d/next/Library/2023-02-04-16-35-46.gh-issue-101561.Xo6pIZ.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-04-16-35-46.gh-issue-101561.Xo6pIZ.rst
@@ -1,0 +1,5 @@
+Add a new decorator ``typing.override``.
+
+This decorator indicates to static type checkers that they should verify the method overrides an attribute or method of the same name in a base class. This is useful for catching bugs when base class methods are renamed but some children are not updated accordingly.
+
+See :pep:698 for details.

--- a/Misc/NEWS.d/next/Library/2023-02-04-16-35-46.gh-issue-101561.Xo6pIZ.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-04-16-35-46.gh-issue-101561.Xo6pIZ.rst
@@ -1,5 +1,1 @@
-Add a new decorator ``typing.override``.
-
-This decorator indicates to static type checkers that they should verify the method overrides an attribute or method of the same name in a base class. This is useful for catching bugs when base class methods are renamed but some children are not updated accordingly.
-
-See :pep:`698` for details. Patch by Steven Troxler.
+Add a new decorator :func:`typing.override`. See :pep:`698` for details. Patch by Steven Troxler.

--- a/Misc/NEWS.d/next/Library/2023-02-04-16-35-46.gh-issue-101561.Xo6pIZ.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-04-16-35-46.gh-issue-101561.Xo6pIZ.rst
@@ -2,4 +2,4 @@ Add a new decorator ``typing.override``.
 
 This decorator indicates to static type checkers that they should verify the method overrides an attribute or method of the same name in a base class. This is useful for catching bugs when base class methods are renamed but some children are not updated accordingly.
 
-See :pep:`698` for details.
+See :pep:`698` for details. Patch by Steven Troxler.

--- a/Misc/NEWS.d/next/Library/2023-02-04-16-35-46.gh-issue-101561.Xo6pIZ.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-04-16-35-46.gh-issue-101561.Xo6pIZ.rst
@@ -2,4 +2,4 @@ Add a new decorator ``typing.override``.
 
 This decorator indicates to static type checkers that they should verify the method overrides an attribute or method of the same name in a base class. This is useful for catching bugs when base class methods are renamed but some children are not updated accordingly.
 
-See :pep:698 for details.
+See :pep:`698` for details.


### PR DESCRIPTION
The code is pulled almost unchanged from `typing_extensions`:

- [decorator implementation](https://github.com/python/typing_extensions/blob/main/src/test_typing_extensions.py#L168-L202)
- [tests](https://github.com/python/typing_extensions/blob/main/src/test_typing_extensions.py#L168-L202)

Question that came up was where to put the type variable and what to name it:
- In `typing_extensions` the type variables use underscore prefixes to indicate that they are not public, but `typing` doesn't appear to use that convention so I named the type variable `F`.
- I couldn't put the type variable next to all of the other ones (used in generic container definitions) because it relies on `Callable` which is defined below. If this is a problem I could correct it using a forward reference, or we could try to rearrange the module to put special forms above type variables.

## Testing the code:

First set up the repo, following instructions
at https://devguide.python.org/ by running:
```
./configure --with-pydebug && make -j
```

Then run the typing tests:
```
./python -m test test_typing -v
```

I ran the full test suite with
```
./python -m test -j3
```
and it came back clean except for a `test_grp` failure which I seem to get on trunk as well - likely something in my build is misconfigured but I'm pretty sure it is unrelated to the changes here.

<!-- gh-issue-number: gh-101561 -->
* Issue: gh-101561
<!-- /gh-issue-number -->


## Make sure the docs build:

```
cd Doc
make venv
make html
```
