### PR TITLE
GH-100485: Create an alternative code path when an accurate fma() implementation is not available

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1450,6 +1450,11 @@ class MathTests(unittest.TestCase):
         n = 20                # Length of vectors
         c = 1e30              # Target condition number
 
+        # If the following test fails, it means that the C math library
+        # implementation of fma() is not compliant with the C99 standard
+        # and is inaccurate.  To solve this problem, make a new build
+        # with the symbol NO_C99_FMA defined.  That will enable a slower
+        # but more accurate code path that avoids the fma() call.
         relative_err = median(Trial(math.sumprod, c, n) for i in range(times))
         self.assertLess(relative_err, 1e-16)
 

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1453,8 +1453,8 @@ class MathTests(unittest.TestCase):
         # If the following test fails, it means that the C math library
         # implementation of fma() is not compliant with the C99 standard
         # and is inaccurate.  To solve this problem, make a new build
-        # with the symbol NO_C99_FMA defined.  That will enable a slower
-        # but more accurate code path that avoids the fma() call.
+        # with the symbol UNRELIABLE_FMA defined.  That will enable a
+        # slower but accurate code path that avoids the fma() call.
         relative_err = median(Trial(math.sumprod, c, n) for i in range(times))
         self.assertLess(relative_err, 1e-16)
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2851,7 +2851,6 @@ dl_sum(double a, double b)
     return (DoubleLength) {x, y};
 }
 
-#ifdef NO_C99_FMA
 /*
    Our default implementation of dl_mul() depends on the C math library
    having an accurate fma() function as required by § 7.12.13.1 of the
@@ -2866,6 +2865,8 @@ dl_sum(double a, double b)
    A Floating-Point Technique for Extending the Available Precision
    https://csclub.uwaterloo.ca/~pbarfuss/dekker1971.pdf
 */
+
+#ifdef NO_C99_FMA
 
 static DoubleLength
 dl_split(double x) {

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2851,6 +2851,46 @@ dl_sum(double a, double b)
     return (DoubleLength) {x, y};
 }
 
+#ifdef NO_C99_FMA
+/*
+   Our default implementation of dl_mul() depends on the C math library
+   having an accurate fma() function as required by § 7.12.13.1 of the
+   C99 standard.
+
+   The NO_C99_FMA option is provided as a slower, but fully accurate
+   alternative for builds where the fma() function is found wanting.
+   The speed penalty may be modest (17% slower on an Apple M1 Max),
+   so don't hesitate to enable this build option.
+
+   The algorithms are from the T. J. Dekker paper:
+   A Floating-Point Technique for Extending the Available Precision
+   https://csclub.uwaterloo.ca/~pbarfuss/dekker1971.pdf
+*/
+
+static DoubleLength
+dl_split(double x) {
+    // Dekker (5.5) and (5.6).
+    double t = x * 134217729.0;  // Veltkamp constant = 2.0 ** 27 + 1
+    double hi = t - (t - x);
+    double lo = x - hi;
+    return (DoubleLength) {hi, lo};
+}
+
+static DoubleLength
+dl_mul(double x, double y)
+{
+    // Dekker (5.12) and mul12()
+    DoubleLength xx = dl_split(x);
+    DoubleLength yy = dl_split(y);
+    double p = xx.hi * yy.hi;
+    double q = xx.hi * yy.lo + xx.lo * yy.hi;
+    double z = p + q;
+    double zz = p - z + q + xx.lo * yy.lo;
+    return (DoubleLength) {z, zz};
+}
+
+#else
+
 static DoubleLength
 dl_mul(double x, double y)
 {
@@ -2859,6 +2899,8 @@ dl_mul(double x, double y)
     double zz = fma(x, y, -z);
     return (DoubleLength) {z, zz};
 }
+
+#endif
 
 typedef struct { double hi; double lo; double tiny; } TripleLength;
 


### PR DESCRIPTION
Provide a workaround for older compilers where fma() was not implemented accurately as required by the C99 standard.

<!-- gh-issue-number: gh-100485 -->
* Issue: gh-100485
<!-- /gh-issue-number -->
