### PR TITLE
gh-101334: Don't force USTAR format in test_tarfile.

### DIFF
--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -226,8 +226,9 @@ class UstarReadTest(ReadTest, unittest.TestCase):
         self.add_dir_and_getmember('a'*101)
 
     @unittest.skipIf(
-        os.getuid() > 0o777_7777 or os.getgid() > 0o777_7777,
-        f"{os.getuid()=} or {os.getgid()=} too high for USTAR format."
+        (hasattr(os, 'getuid') and os.getuid() > 0o777_7777) or
+        (hasattr(os, 'getgid') and os.getgid() > 0o777_7777),
+        "uid or gid too high for USTAR format."
     )
     def add_dir_and_getmember(self, name):
         with os_helper.temp_cwd():

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -228,7 +228,7 @@ class UstarReadTest(ReadTest, unittest.TestCase):
     @unittest.skipIf(
         os.getuid() > 0o777_7777 or os.getgid() > 0o777_7777,
         f"{os.getuid()=} or {os.getgid()=} too high for USTAR format."
-    ) 
+    )
     def add_dir_and_getmember(self, name):
         with os_helper.temp_cwd():
             with tarfile.open(tmpname, 'w') as tar:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -225,9 +225,14 @@ class UstarReadTest(ReadTest, unittest.TestCase):
         self.add_dir_and_getmember('bar')
         self.add_dir_and_getmember('a'*101)
 
+    @unittest.skipIf(
+        os.getuid() > 0o777_7777 or os.getgid() > 0o777_7777,
+        f"{os.getuid()=} or {os.getgid()=} too high for USTAR format."
+    ) 
     def add_dir_and_getmember(self, name):
         with os_helper.temp_cwd():
             with tarfile.open(tmpname, 'w') as tar:
+                tar.format = tarfile.USTAR_FORMAT
                 try:
                     os.mkdir(name)
                     tar.add(name)

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -228,7 +228,6 @@ class UstarReadTest(ReadTest, unittest.TestCase):
     def add_dir_and_getmember(self, name):
         with os_helper.temp_cwd():
             with tarfile.open(tmpname, 'w') as tar:
-                tar.format = tarfile.USTAR_FORMAT
                 try:
                     os.mkdir(name)
                     tar.add(name)

--- a/Misc/NEWS.d/next/Tests/2023-02-04-17-24-33.gh-issue-101334._yOqwg.rst
+++ b/Misc/NEWS.d/next/Tests/2023-02-04-17-24-33.gh-issue-101334._yOqwg.rst
@@ -1,0 +1,1 @@
+``test_tarfile`` has been updated to pass when run as a high UID.


### PR DESCRIPTION
That causes the test to fail when run using a high UID as that ancient format cannot represent it. The current default (PAX) and the old default (GNU) both support high UIDs.


<!-- gh-issue-number: gh-101334 -->
* Issue: gh-101334
<!-- /gh-issue-number -->
