### PR TITLE
gh-101573 Optimized collections.abc

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -886,7 +886,8 @@ class ItemsView(MappingView, Set):
             return v is value or v == value
 
     def __iter__(self):
-        return ((key, self._mapping[key]) for key in self._mapping)
+        for key in self._mapping:
+            yield (key, self._mapping[key])
 
 
 ItemsView.register(dict_items)
@@ -904,7 +905,8 @@ class ValuesView(MappingView, Collection):
         return False
 
     def __iter__(self):
-        return (self._mapping[key] for key in self._mapping)
+        for key in self._mapping:
+            yield self._mapping[key]
 
 
 ValuesView.register(dict_values)

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -587,7 +587,7 @@ class Set(Collection):
     def __ge__(self, other):
         if not isinstance(other, Set):
             return NotImplemented
-        if len(self) > len(other):
+        if len(self) < len(other):
             return False
         for elem in filterfalse(self.__contains__, other):
             return False

--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-05-16-13-46.gh-issue-101573.9NuZNR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-05-16-13-46.gh-issue-101573.9NuZNR.rst
@@ -1,0 +1,1 @@
+Optimized collections.abc with a few tricks. Some cases may be slower, but most cases should be overall faster. Mostly impacts sets.


### PR DESCRIPTION
These changes mostly impact sets, but also includes some minor changes to `MutableMapping` and `KeysView`.

In several cases, the improved versions are undoubtedly faster by a significant margin, sometimes twice as fast. In most cases, the improved versions were around 15% to 30% faster. In a few cases, my tests showed slower changes caused by either extremely few iterations ran where an initial iterator constructor was noticeable (this is very case dependent), or when `__contains__` was about as fast as `__len__` which I believe is unrealistic in practice.

- Using `filter` or `itertools.filterfalse` for condition testing allows most of the iterations to be ran in C. At most one iteration is ran in Python. This is marginally faster than combining `all` or `any` with `map`, where there is an extra "data passing" step every iteration. This comes with a slight overhead compared to the pure Python loop for the object creation, meaning that if very few iterations are ran, they can be slower. Hard to say if these are an improvement, they're case-dependent.
- Using `filter`, `itertools.filterfalse`, and `itertools.chain` are all consistently and noticeably faster than generator expressions, sometimes more than 2 times faster.
- Some methods require unique items to work and thus cast the input to a set from an iterable. Casting with `self._from_iterable(other)` is unnecessarily slow, `set(other)` should be used instead. This was consistently and noticeably faster, but breaks sets which depend on unhashable items (I think these cases are rare and usually involve specialized implementations anyways). Mappings also do not require casting, since their items are already unique.
- `Set.__xor__` algorithm modified to avoid creating intermediate unnecessary sets. This uses less memory and let's us skip several intermediate constructors, making it consistently and noticeably faster.
- `MutableSet.remove` rewritten to avoid checking `value in self` by using `len(self)` checks instead. In my test, this was slower because the underlying implementations were based on `builtins.set`, making them both very fast. This optimization assumes that a user implementation for `__contains__` is more than 2 times slower than `__len__`, which I think occurs more often in real use cases.
- `MutableSet.pop` simplified to not use `try` block. Tests reveal not much difference, but the code is just cleaner.
- `MutableSet.__ixor__` rewritten to use two previously mentioned changes. The aforementioned `it = set(it)` is used. The just mentioned `len(self)` check to supplement `value in self` is also used. Since only one additional `len(self)` call is needed, this optimization is only slow if `__contains__` is fast and very few items are checked. Additionally, it assumes that using `self.discard(value)` every iteration and only `self.add(value)` when necessary is faster than checking `value in self` every iteration and using either `self.discard(value)` or `self.add(value)`. In my test, this was 2 times faster.
- `KeysView.__iter__` optimized to return the mapping's iterator directly instead of creating an intermediate generator. This is consistently and noticeably faster.
- ~~`ValuesView.__iter__` and `ItemsView.__iter__` optimized to use generator expressions instead of generator functions. This is consistently and noticeably faster.~~
- Many of the `__contains__` could be simplified to `return value in iter(self)`. I think the generator overhead would make this slower, but it might be worth checking.
- `MutableMapping.popitem` same situation as `MutableSet.pop`.

<!-- gh-issue-number: gh-101573 -->
* Issue: gh-101573
<!-- /gh-issue-number -->
