### PR TITLE
gh-80667: Fix Tangut ideographs names in unicodedata

### DIFF
--- a/Lib/test/test_unicodedata.py
+++ b/Lib/test/test_unicodedata.py
@@ -71,7 +71,7 @@ class UnicodeFunctionsTest(UnicodeDatabaseTest):
 
     # Update this if the database changes. Make sure to do a full rebuild
     # (e.g. 'make distclean && make') to get the correct checksum.
-    expectedchecksum = '26ff0d31c14194b4606a5b3a81ac36df3a14e331'
+    expectedchecksum = '95cc75e49b140c61b884c16d0a9fbbb0b93a7fa9'
 
     @requires_resource('cpu')
     def test_function_checksum(self):

--- a/Misc/NEWS.d/next/Library/2023-02-05-20-02-30.gh-issue-80667.7LmzeA.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-05-20-02-30.gh-issue-80667.7LmzeA.rst
@@ -1,0 +1,1 @@
+unicodedata: Fix missing Tangut Ideographs names.


### PR DESCRIPTION
Fix Tangut ideographs names in unicodedata.

Partially fixes #80667.

<!-- gh-issue-number: gh-80667 -->
* Issue: gh-80667
<!-- /gh-issue-number -->
