### PR TITLE
gh-101609: Fix "‘state’ may be used uninitialized" warning in `_xxinterpchannelsmodule`

### DIFF
--- a/Modules/_xxinterpchannelsmodule.c
+++ b/Modules/_xxinterpchannelsmodule.c
@@ -174,7 +174,9 @@ static int
 clear_module_state(module_state *state)
 {
     /* heap types */
-    (void)_PyCrossInterpreterData_UnregisterClass(state->ChannelIDType);
+    if (state->ChannelIDType != NULL) {
+        (void)_PyCrossInterpreterData_UnregisterClass(state->ChannelIDType);
+    }
     Py_CLEAR(state->ChannelIDType);
 
     /* exceptions */

--- a/Modules/_xxinterpchannelsmodule.c
+++ b/Modules/_xxinterpchannelsmodule.c
@@ -2269,7 +2269,6 @@ module_exec(PyObject *mod)
     return 0;
 
 error:
-    (void)_PyCrossInterpreterData_UnregisterClass(state->ChannelIDType);
     _globals_fini();
     return -1;
 }


### PR DESCRIPTION
I went with the easiest solution: just removing the offending line. See the issue description with my reasoning.

https://github.com/python/cpython/issues/101609

<!-- gh-issue-number: gh-101609 -->
* Issue: gh-101609
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:ericsnowcurrently