### PR TITLE
gh-101536: [docs] Improve attributes of `urllib.error.HTTPError`

### DIFF
--- a/Doc/library/urllib.error.rst
+++ b/Doc/library/urllib.error.rst
@@ -31,13 +31,18 @@ The following exceptions are raised by :mod:`urllib.error` as appropriate:
       of :exc:`IOError`.
 
 
-.. exception:: HTTPError
+.. exception:: HTTPError(url, code, msg, hdrs, fp)
 
    Though being an exception (a subclass of :exc:`URLError`), an
    :exc:`HTTPError` can also function as a non-exceptional file-like return
    value (the same thing that :func:`~urllib.request.urlopen` returns).  This
    is useful when handling exotic HTTP errors, such as requests for
    authentication.
+
+   .. attribute:: url
+
+      Contains the request URL.
+      Is an alias for *filename* attribute.
 
    .. attribute:: code
 
@@ -48,13 +53,19 @@ The following exceptions are raised by :mod:`urllib.error` as appropriate:
    .. attribute:: reason
 
       This is usually a string explaining the reason for this error.
+      Is an alias for *msg* attribute.
 
    .. attribute:: headers
 
       The HTTP response headers for the HTTP request that caused the
       :exc:`HTTPError`.
+      Is an alias for *hdrs* attribute.
 
       .. versionadded:: 3.4
+
+   .. attribute:: fp
+
+      A file-like object with the HTTP error body.
 
 .. exception:: ContentTooShortError(msg, content)
 

--- a/Doc/library/urllib.error.rst
+++ b/Doc/library/urllib.error.rst
@@ -42,7 +42,7 @@ The following exceptions are raised by :mod:`urllib.error` as appropriate:
    .. attribute:: url
 
       Contains the request URL.
-      Is an alias for *filename* attribute.
+      An alias for *filename* attribute.
 
    .. attribute:: code
 
@@ -53,19 +53,19 @@ The following exceptions are raised by :mod:`urllib.error` as appropriate:
    .. attribute:: reason
 
       This is usually a string explaining the reason for this error.
-      Is an alias for *msg* attribute.
+      An alias for *msg* attribute.
 
    .. attribute:: headers
 
       The HTTP response headers for the HTTP request that caused the
       :exc:`HTTPError`.
-      Is an alias for *hdrs* attribute.
+      An alias for *hdrs* attribute.
 
       .. versionadded:: 3.4
 
    .. attribute:: fp
 
-      A file-like object with the HTTP error body.
+      A file-like object where the HTTP error body can be read from.
 
 .. exception:: ContentTooShortError(msg, content)
 


### PR DESCRIPTION
There are several tricky parts:
1. The are multiple aliases. `url` and `filename`, `hdrs` and `headers`, `code` and `status`, `msg` and readonly `reason`. Which ones should we document? My idea was that we should try to stick to the same names we use in constructor. But, with some exceptions. For example: `filename` does not make much sense here: I changed it to be `url`. And the same with `msg` and `hdrs`: I use `reason` and `headers`
2. Do we need to list aliases? I think so, because otherwise it would be hard to understand that `msg` and `reason` are the same thing

CC @facundobatista @orsenthil 

<!-- gh-issue-number: gh-101536 -->
* Issue: gh-101536
<!-- /gh-issue-number -->
