### PR TITLE
gh-101614: don't treat python3_d.dll as a Python dll

### DIFF
--- a/Misc/NEWS.d/next/Windows/2023-02-07-18-22-54.gh-issue-101614.NjVP0n.rst
+++ b/Misc/NEWS.d/next/Windows/2023-02-07-18-22-54.gh-issue-101614.NjVP0n.rst
@@ -1,0 +1,1 @@
+Correctly handle extensions built against debug binaries that reference ``python3_d.dll``.

--- a/Python/dynload_win.c
+++ b/Python/dynload_win.c
@@ -125,14 +125,15 @@ static char *GetPythonImport (HINSTANCE hModule)
                 !strncmp(import_name,"python",6)) {
                 char *pch;
 
-#ifndef _DEBUG
-                /* In a release version, don't claim that python3.dll is
-                   a Python DLL. */
+                /* Don't claim that python3.dll is a Python DLL. */
+#ifdef _DEBUG
+                if (strcmp(import_name, "python3_d.dll") == 0) {
+#else
                 if (strcmp(import_name, "python3.dll") == 0) {
+#endif
                     import_data += 20;
                     continue;
                 }
-#endif
 
                 /* Ensure python prefix is followed only
                    by numbers to the end of the basename */


### PR DESCRIPTION
Tentative fix for #101614.

I've verified locally that this fixes the issue for me, I'm unsure what testing strategy may exist in-tree for this.

<!-- gh-issue-number: gh-101614 -->
* Issue: gh-101614
<!-- /gh-issue-number -->
