### PR TITLE
gh-59956: Add a Test to Verify GILState Matches the "Current" Thread State

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1413,6 +1413,9 @@ class TestThreadState(unittest.TestCase):
         ret = assert_python_ok('-X', 'tracemalloc', '-c', code)
         self.assertIn(b'callback called', ret.out)
 
+    def test_gilstate_matches_current(self):
+        _testcapi.test_current_tstate_matches()
+
 
 class Test_testcapi(unittest.TestCase):
     locals().update((name, getattr(_testcapi, name))


### PR DESCRIPTION
This test should have been in gh-101431.

<!-- gh-issue-number: gh-59956 -->
* Issue: gh-59956
<!-- /gh-issue-number -->
