### PR TITLE
gh-98831: Modernize the FOR_ITER family of instructions

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2072,13 +2072,13 @@ dummy_func(
         // This is optimized by skipping that instruction and combining
         // its effect (popping 'iter' instead of pushing 'next'.)
 
-        // family(for_iter, INLINE_CACHE_ENTRIES_FOR_ITER) = {
-        //     FOR_ITER,
-        //     FOR_ITER_LIST,
+        family(for_iter, INLINE_CACHE_ENTRIES_FOR_ITER) = {
+            FOR_ITER,
+            FOR_ITER_LIST,
         //     FOR_ITER_TUPLE,
         //     FOR_ITER_RANGE,
         //     FOR_ITER_GEN,
-        // };
+        };
 
         inst(FOR_ITER, (unused/1, iter -- iter, next)) {
             #if ENABLE_SPECIALIZATION
@@ -2115,27 +2115,27 @@ dummy_func(
             // Common case: no jump, leave it to the code generator
         }
 
-        // stack effect: ( -- __0)
-        inst(FOR_ITER_LIST) {
+        inst(FOR_ITER_LIST, (unused/1, iter -- iter, next)) {
             assert(cframe.use_tracing == 0);
-            _PyListIterObject *it = (_PyListIterObject *)TOP();
-            DEOPT_IF(Py_TYPE(it) != &PyListIter_Type, FOR_ITER);
+            DEOPT_IF(Py_TYPE(iter) != &PyListIter_Type, FOR_ITER);
+            _PyListIterObject *it = (_PyListIterObject *)iter;
             STAT_INC(FOR_ITER, hit);
             PyListObject *seq = it->it_seq;
             if (seq) {
                 if (it->it_index < PyList_GET_SIZE(seq)) {
-                    PyObject *next = PyList_GET_ITEM(seq, it->it_index++);
-                    PUSH(Py_NewRef(next));
-                    JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER);
+                    next = Py_NewRef(PyList_GET_ITEM(seq, it->it_index++));
                     goto end_for_iter_list;  // End of this instruction
                 }
                 it->it_seq = NULL;
                 Py_DECREF(seq);
             }
+            Py_DECREF(iter);
             STACK_SHRINK(1);
-            Py_DECREF(it);
+            /* Jump forward oparg, then skip following END_FOR instruction */
             JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER + oparg + 1);
+            DISPATCH();
         end_for_iter_list:
+            // Common case: no jump, leave it to the code generator
         }
 
         // stack effect: ( -- __0)

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2075,7 +2075,7 @@ dummy_func(
         family(for_iter, INLINE_CACHE_ENTRIES_FOR_ITER) = {
             FOR_ITER,
             FOR_ITER_LIST,
-        //     FOR_ITER_TUPLE,
+            FOR_ITER_TUPLE,
         //     FOR_ITER_RANGE,
         //     FOR_ITER_GEN,
         };
@@ -2138,27 +2138,27 @@ dummy_func(
             // Common case: no jump, leave it to the code generator
         }
 
-        // stack effect: ( -- __0)
-        inst(FOR_ITER_TUPLE) {
+        inst(FOR_ITER_TUPLE, (unused/1, iter -- iter, next)) {
             assert(cframe.use_tracing == 0);
-            _PyTupleIterObject *it = (_PyTupleIterObject *)TOP();
+            _PyTupleIterObject *it = (_PyTupleIterObject *)iter;
             DEOPT_IF(Py_TYPE(it) != &PyTupleIter_Type, FOR_ITER);
             STAT_INC(FOR_ITER, hit);
             PyTupleObject *seq = it->it_seq;
             if (seq) {
                 if (it->it_index < PyTuple_GET_SIZE(seq)) {
-                    PyObject *next = PyTuple_GET_ITEM(seq, it->it_index++);
-                    PUSH(Py_NewRef(next));
-                    JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER);
+                    next = Py_NewRef(PyTuple_GET_ITEM(seq, it->it_index++));
                     goto end_for_iter_tuple;  // End of this instruction
                 }
                 it->it_seq = NULL;
                 Py_DECREF(seq);
             }
+            Py_DECREF(iter);
             STACK_SHRINK(1);
-            Py_DECREF(it);
+            /* Jump forward oparg, then skip following END_FOR instruction */
             JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER + oparg + 1);
+            DISPATCH();
         end_for_iter_tuple:
+            // Common case: no jump, leave it to the code generator
         }
 
         // stack effect: ( -- __0)

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2092,7 +2092,7 @@ dummy_func(
             STAT_INC(FOR_ITER, deferred);
             DECREMENT_ADAPTIVE_COUNTER(cache->counter);
             #endif  /* ENABLE_SPECIALIZATION */
-            /* before: [iter]; after: [iter, iter()] *or* [] (and jump an extra instr.) */
+            /* before: [iter]; after: [iter, iter()] *or* [] (and jump over END_FOR.) */
             next = (*Py_TYPE(iter)->tp_iternext)(iter);
             if (next == NULL) {
                 if (_PyErr_Occurred(tstate)) {

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2077,7 +2077,7 @@ dummy_func(
             FOR_ITER_LIST,
             FOR_ITER_TUPLE,
             FOR_ITER_RANGE,
-        //     FOR_ITER_GEN,
+            FOR_ITER_GEN,
         };
 
         inst(FOR_ITER, (unused/1, iter -- iter, next)) {
@@ -2189,9 +2189,10 @@ dummy_func(
             DISPATCH();
         }
 
-        inst(FOR_ITER_GEN) {
+        // This is *not* a super-instruction, unique in the family.
+        inst(FOR_ITER_GEN, (unused/1, iter -- iter, unused)) {
             assert(cframe.use_tracing == 0);
-            PyGenObject *gen = (PyGenObject *)TOP();
+            PyGenObject *gen = (PyGenObject *)iter;
             DEOPT_IF(Py_TYPE(gen) != &PyGen_Type, FOR_ITER);
             DEOPT_IF(gen->gi_frame_state >= FRAME_EXECUTING, FOR_ITER);
             STAT_INC(FOR_ITER, hit);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2746,8 +2746,9 @@
         }
 
         TARGET(FOR_ITER_GEN) {
+            PyObject *iter = PEEK(1);
             assert(cframe.use_tracing == 0);
-            PyGenObject *gen = (PyGenObject *)TOP();
+            PyGenObject *gen = (PyGenObject *)iter;
             DEOPT_IF(Py_TYPE(gen) != &PyGen_Type, FOR_ITER);
             DEOPT_IF(gen->gi_frame_state >= FRAME_EXECUTING, FOR_ITER);
             STAT_INC(FOR_ITER, hit);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2719,8 +2719,9 @@
         }
 
         TARGET(FOR_ITER_RANGE) {
+            PyObject *iter = PEEK(1);
             assert(cframe.use_tracing == 0);
-            _PyRangeIterObject *r = (_PyRangeIterObject *)TOP();
+            _PyRangeIterObject *r = (_PyRangeIterObject *)iter;
             DEOPT_IF(Py_TYPE(r) != &PyRangeIter_Type, FOR_ITER);
             STAT_INC(FOR_ITER, hit);
             _Py_CODEUNIT next = next_instr[INLINE_CACHE_ENTRIES_FOR_ITER];
@@ -2728,6 +2729,7 @@
             if (r->len <= 0) {
                 STACK_SHRINK(1);
                 Py_DECREF(r);
+                // Jump over END_FOR instruction.
                 JUMPBY(INLINE_CACHE_ENTRIES_FOR_ITER + oparg + 1);
             }
             else {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2633,7 +2633,7 @@
             STAT_INC(FOR_ITER, deferred);
             DECREMENT_ADAPTIVE_COUNTER(cache->counter);
             #endif  /* ENABLE_SPECIALIZATION */
-            /* before: [iter]; after: [iter, iter()] *or* [] (and jump an extra instr.) */
+            /* before: [iter]; after: [iter, iter()] *or* [] (and jump over END_FOR.) */
             next = (*Py_TYPE(iter)->tp_iternext)(iter);
             if (next == NULL) {
                 if (_PyErr_Occurred(tstate)) {

--- a/Python/opcode_metadata.h
+++ b/Python/opcode_metadata.h
@@ -261,7 +261,7 @@ _PyOpcode_num_popped(int opcode, int oparg, bool jump) {
         case GET_YIELD_FROM_ITER:
             return 1;
         case FOR_ITER:
-            return -1;
+            return 1;
         case FOR_ITER_LIST:
             return -1;
         case FOR_ITER_TUPLE:
@@ -607,7 +607,7 @@ _PyOpcode_num_pushed(int opcode, int oparg, bool jump) {
         case GET_YIELD_FROM_ITER:
             return 1;
         case FOR_ITER:
-            return -1;
+            return 2;
         case FOR_ITER_LIST:
             return -1;
         case FOR_ITER_TUPLE:
@@ -829,7 +829,7 @@ struct opcode_metadata {
     [MATCH_KEYS] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },
     [GET_ITER] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },
     [GET_YIELD_FROM_ITER] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },
-    [FOR_ITER] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
+    [FOR_ITER] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
     [FOR_ITER_LIST] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
     [FOR_ITER_TUPLE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
     [FOR_ITER_RANGE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },

--- a/Python/opcode_metadata.h
+++ b/Python/opcode_metadata.h
@@ -267,7 +267,7 @@ _PyOpcode_num_popped(int opcode, int oparg, bool jump) {
         case FOR_ITER_TUPLE:
             return 1;
         case FOR_ITER_RANGE:
-            return -1;
+            return 1;
         case FOR_ITER_GEN:
             return -1;
         case BEFORE_ASYNC_WITH:
@@ -613,7 +613,7 @@ _PyOpcode_num_pushed(int opcode, int oparg, bool jump) {
         case FOR_ITER_TUPLE:
             return 2;
         case FOR_ITER_RANGE:
-            return -1;
+            return 2;
         case FOR_ITER_GEN:
             return -1;
         case BEFORE_ASYNC_WITH:
@@ -832,7 +832,7 @@ struct opcode_metadata {
     [FOR_ITER] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
     [FOR_ITER_LIST] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
     [FOR_ITER_TUPLE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
-    [FOR_ITER_RANGE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
+    [FOR_ITER_RANGE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
     [FOR_ITER_GEN] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
     [BEFORE_ASYNC_WITH] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },
     [BEFORE_WITH] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },

--- a/Python/opcode_metadata.h
+++ b/Python/opcode_metadata.h
@@ -269,7 +269,7 @@ _PyOpcode_num_popped(int opcode, int oparg, bool jump) {
         case FOR_ITER_RANGE:
             return 1;
         case FOR_ITER_GEN:
-            return -1;
+            return 1;
         case BEFORE_ASYNC_WITH:
             return 1;
         case BEFORE_WITH:
@@ -615,7 +615,7 @@ _PyOpcode_num_pushed(int opcode, int oparg, bool jump) {
         case FOR_ITER_RANGE:
             return 2;
         case FOR_ITER_GEN:
-            return -1;
+            return 2;
         case BEFORE_ASYNC_WITH:
             return 2;
         case BEFORE_WITH:
@@ -833,7 +833,7 @@ struct opcode_metadata {
     [FOR_ITER_LIST] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
     [FOR_ITER_TUPLE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
     [FOR_ITER_RANGE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
-    [FOR_ITER_GEN] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
+    [FOR_ITER_GEN] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
     [BEFORE_ASYNC_WITH] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },
     [BEFORE_WITH] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },
     [WITH_EXCEPT_START] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },

--- a/Python/opcode_metadata.h
+++ b/Python/opcode_metadata.h
@@ -263,7 +263,7 @@ _PyOpcode_num_popped(int opcode, int oparg, bool jump) {
         case FOR_ITER:
             return 1;
         case FOR_ITER_LIST:
-            return -1;
+            return 1;
         case FOR_ITER_TUPLE:
             return -1;
         case FOR_ITER_RANGE:
@@ -609,7 +609,7 @@ _PyOpcode_num_pushed(int opcode, int oparg, bool jump) {
         case FOR_ITER:
             return 2;
         case FOR_ITER_LIST:
-            return -1;
+            return 2;
         case FOR_ITER_TUPLE:
             return -1;
         case FOR_ITER_RANGE:
@@ -830,7 +830,7 @@ struct opcode_metadata {
     [GET_ITER] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },
     [GET_YIELD_FROM_ITER] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },
     [FOR_ITER] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
-    [FOR_ITER_LIST] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
+    [FOR_ITER_LIST] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
     [FOR_ITER_TUPLE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
     [FOR_ITER_RANGE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
     [FOR_ITER_GEN] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },

--- a/Python/opcode_metadata.h
+++ b/Python/opcode_metadata.h
@@ -265,7 +265,7 @@ _PyOpcode_num_popped(int opcode, int oparg, bool jump) {
         case FOR_ITER_LIST:
             return 1;
         case FOR_ITER_TUPLE:
-            return -1;
+            return 1;
         case FOR_ITER_RANGE:
             return -1;
         case FOR_ITER_GEN:
@@ -611,7 +611,7 @@ _PyOpcode_num_pushed(int opcode, int oparg, bool jump) {
         case FOR_ITER_LIST:
             return 2;
         case FOR_ITER_TUPLE:
-            return -1;
+            return 2;
         case FOR_ITER_RANGE:
             return -1;
         case FOR_ITER_GEN:
@@ -831,7 +831,7 @@ struct opcode_metadata {
     [GET_YIELD_FROM_ITER] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },
     [FOR_ITER] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
     [FOR_ITER_LIST] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
-    [FOR_ITER_TUPLE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
+    [FOR_ITER_TUPLE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IBC },
     [FOR_ITER_RANGE] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
     [FOR_ITER_GEN] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IB },
     [BEFORE_ASYNC_WITH] = { DIR_NONE, DIR_NONE, DIR_NONE, true, INSTR_FMT_IX },


### PR DESCRIPTION
This is somewhat tricky because most of the family members (with the exception of FOR_ITER_GEN) are actually super-instructions that jump over the END_FOR instruction that is the target of the jump (which pops two stack items). In addition, FOR_ITER_RANGE also jumps over the STORE_FAST that follows it when the range is not exhausted.

The cache and stack effects documented in the DSL don't acknowledge the existence of these optimizations. (This will bite us when we try to incorporate these instructions in a level 2 interpreter, we'll have to deal with it then.)

<!-- gh-issue-number: gh-98831 -->
* Issue: gh-98831
<!-- /gh-issue-number -->
