### PR TITLE
Fix nesting of 'Pending Removal in Python 3.14'

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -479,7 +479,7 @@ APIs:
 * :class:`webbrowser.MacOSX` (:gh:`86421`)
 
 Pending Removal in Python 3.14
-==============================
+------------------------------
 
 * Deprecated the following :mod:`importlib.abc` classes, scheduled for removal in
   Python 3.14:


### PR DESCRIPTION
In [What’s New In Python 3.12](https://docs.python.org/3.12/whatsnew/3.12.html#deprecated), subsections of *Pending Removal in Python [...]* must be children of *Deprecated*.

However, *[...] 3.13* breaks this being a sibling instead and making the following *[...] Future Versions* its own child:

![](https://user-images.githubusercontent.com/4881073/217229671-13e4dc9d-b23a-4299-ab9c-a6f9764695c2.png)

