### PR TITLE
Doctest: Pin sphinxext-opengraph==0.7.5 to prevent importing NumPy

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -8,7 +8,7 @@ sphinx==4.5.0
 blurb
 
 sphinx-lint==0.6.7
-sphinxext-opengraph>=0.7.1
+sphinxext-opengraph==0.7.5
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

We use a Sphinx extension to help with SEO metadata. They recently added (in 0.8.0) support for generating images for social media cards (https://github.com/wpilibsuite/sphinxext-opengraph/pull/88). We're not using that feature, but it still attempts to install and import Matplotlib and its dependency NumPy, which can fail the doctest for 3.12/`main` due to incompatibilities.

For now, let's pin to the previous version, sphinxext-opengraph==0.7.5, and make another fix later (see: https://github.com/python/cpython/issues/101639#issuecomment-1420782050).