### PR TITLE
Make use of TESTFN_ASCII in test_fileio

### DIFF
--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -12,7 +12,9 @@ from functools import wraps
 from test.support import (
     cpython_only, swap_attr, gc_collect, is_emscripten, is_wasi
 )
-from test.support.os_helper import (TESTFN, TESTFN_UNICODE, make_bad_fd)
+from test.support.os_helper import (
+    TESTFN, TESTFN_ASCII, TESTFN_UNICODE, make_bad_fd,
+    )
 from test.support.warnings_helper import check_warnings
 from collections import UserList
 
@@ -431,18 +433,15 @@ class OtherFileTests:
 
     def testBytesOpen(self):
         # Opening a bytes filename
-        try:
-            fn = TESTFN.encode("ascii")
-        except UnicodeEncodeError:
-            self.skipTest('could not encode %r to ascii' % TESTFN)
+        fn = TESTFN_ASCII.encode("ascii")
         f = self.FileIO(fn, "w")
         try:
             f.write(b"abc")
             f.close()
-            with open(TESTFN, "rb") as f:
+            with open(TESTFN_ASCII, "rb") as f:
                 self.assertEqual(f.read(), b"abc")
         finally:
-            os.unlink(TESTFN)
+            os.unlink(TESTFN_ASCII)
 
     @unittest.skipIf(sys.getfilesystemencoding() != 'utf-8',
                      "test only works for utf-8 filesystems")


### PR DESCRIPTION
testBytesOpen requires an ASCII filename, but TESTFN usually isn't ASCII.

Automerge-Triggered-By: GH:zware