### PR TITLE
gh-97725: Fix documentation for the default file of `Task.print_stack`

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -1097,7 +1097,7 @@ Task Object
       The *limit* argument is passed to :meth:`get_stack` directly.
 
       The *file* argument is an I/O stream to which the output
-      is written; by default output is written to :data:`sys.stderr`.
+      is written; by default output is written to :data:`sys.stdout`.
 
    .. method:: get_coro()
 

--- a/Misc/NEWS.d/next/Documentation/2023-02-07-21-43-24.gh-issue-97725.cuY7Cd.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-02-07-21-43-24.gh-issue-97725.cuY7Cd.rst
@@ -1,0 +1,2 @@
+Fix :meth:`asyncio.Task.print_stack` description for ``file=None``.
+Patch by Oleg Iarygin.


### PR DESCRIPTION
Alternative to gh-97726. Addresses @gvanrossum's [objection](https://github.com/python/cpython/pull/97726#issuecomment-1264710403):

> But do we want to fix the code to match the docs? In cases like this, where the docs and the code have always disagreed (or for many releases), we tend to prefer to fix the docs to match the code, since "fixing" the code may actually break apps that were expecting the observed behavior.
>
> Also, `print_*` kind of suggests that it does the same thing as `print()`. More indication to me that the docs were just wrong (it happens :-).

<!-- gh-issue-number: gh-97725 -->
* Issue: gh-97725
<!-- /gh-issue-number -->
