### PR TITLE
[3.10] gh-97725: Fix documentation for the default file of `asyncio.Task.print_stack` (#101652)

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -1002,7 +1002,7 @@ Task Object
       The *limit* argument is passed to :meth:`get_stack` directly.
 
       The *file* argument is an I/O stream to which the output
-      is written; by default output is written to :data:`sys.stderr`.
+      is written; by default output is written to :data:`sys.stdout`.
 
    .. method:: get_coro()
 

--- a/Misc/NEWS.d/next/Documentation/2023-02-07-21-43-24.gh-issue-97725.cuY7Cd.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-02-07-21-43-24.gh-issue-97725.cuY7Cd.rst
@@ -1,0 +1,2 @@
+Fix :meth:`asyncio.Task.print_stack` description for ``file=None``.
+Patch by Oleg Iarygin.


### PR DESCRIPTION
(cherry picked from commit f87f6e23964d7a4c38b655089cda65538a24ec36)

<!-- gh-issue-number: gh-97725 -->
* Issue: gh-97725
<!-- /gh-issue-number -->
