### PR TITLE
gh-101656: Fix "conversion from Py_ssize_t to int" warning in `_testcapimodule`

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3185,11 +3185,11 @@ eval_eval_code_ex(PyObject *mod, PyObject *pos_args)
         globals,
         locals,
         c_args,
-        c_args_len,
+        (int)c_args_len,
         c_kwargs,
-        c_kwargs_len,
+        (int)c_kwargs_len,
         c_defaults,
-        c_defaults_len,
+        (int)c_defaults_len,
         kw_defaults,
         closure
     );


### PR DESCRIPTION


<!-- gh-issue-number: gh-101656 -->
* Issue: gh-101656
<!-- /gh-issue-number -->
