### PR TITLE
GH-101362: Call join() only when >1 argument supplied to pathlib.PurePath()

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -275,9 +275,12 @@ class PurePath(object):
     def _parse_parts(cls, parts):
         if not parts:
             return '', '', []
+        elif len(parts) == 1:
+            path = os.fspath(parts[0])
+        else:
+            path = cls._flavour.join(*parts)
         sep = cls._flavour.sep
         altsep = cls._flavour.altsep
-        path = cls._flavour.join(*parts)
         if altsep:
             path = path.replace(altsep, sep)
         drv, root, rel = cls._flavour.splitroot(path)

--- a/Misc/NEWS.d/next/Library/2023-02-07-21-16-41.gh-issue-101362.KMQllM.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-07-21-16-41.gh-issue-101362.KMQllM.rst
@@ -1,0 +1,2 @@
+Speed up :class:`pathlib.PurePath` construction by calling
+:func:`os.path.join` only when two or more arguments are given.


### PR DESCRIPTION
This reduces the time taken to run `PurePath("foo")` by ~15%