### PR TITLE
GH-83162: Rename re.error for better clarity.

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -1079,13 +1079,13 @@ Functions
 Exceptions
 ^^^^^^^^^^
 
-.. exception:: error(msg, pattern=None, pos=None)
+.. exception:: ReCompileError(msg, pattern=None, pos=None)
 
    Exception raised when a string passed to one of the functions here is not a
-   valid regular expression (for example, it might contain unmatched parentheses)
-   or when some other error occurs during compilation or matching.  It is never an
-   error if a string contains no match for a pattern.  The error instance has
-   the following additional attributes:
+   valid regular expression (for example, it might contain unmatched
+   parentheses) or when some other error occurs during compilation or matching.
+   It is never an error if a string contains no match for a pattern.  The
+   ``ReCompileError`` instance has the following additional attributes:
 
    .. attribute:: msg
 
@@ -1109,6 +1109,10 @@ Exceptions
 
    .. versionchanged:: 3.5
       Added additional attributes.
+
+   .. versionchanged:: 3.12
+      ``ReCompileError`` was originally named ``error``; the latter is kept as an alias for
+      backward compatibility.
 
 .. _re-objects:
 

--- a/Lib/idlelib/searchengine.py
+++ b/Lib/idlelib/searchengine.py
@@ -84,7 +84,7 @@ class SearchEngine:
             flags = flags | re.IGNORECASE
         try:
             prog = re.compile(pat, flags)
-        except re.error as e:
+        except re.ReCompileError as e:
             self.report_error(pat, e.msg, e.pos)
             return None
         return prog

--- a/Lib/pstats.py
+++ b/Lib/pstats.py
@@ -329,7 +329,7 @@ class Stats:
         if isinstance(sel, str):
             try:
                 rex = re.compile(sel)
-            except re.error:
+            except re.ReCompileError:
                 msg += "   <Invalid regular expression %r>\n" % sel
                 return new_list, msg
             new_list = []

--- a/Lib/re/__init__.py
+++ b/Lib/re/__init__.py
@@ -117,7 +117,8 @@ A, L, and U are mutually exclusive.
     U  UNICODE     For compatibility only. Ignored for string patterns (it
                    is the default), and forbidden for bytes patterns.
 
-This module also defines an exception 'error'.
+This module also defines exception 'ReCompileError', aliased to 'error' for
+backward compatibility.
 
 """
 
@@ -133,7 +134,7 @@ __all__ = [
     "findall", "finditer", "compile", "purge", "template", "escape",
     "error", "Pattern", "Match", "A", "I", "L", "M", "S", "X", "U",
     "ASCII", "IGNORECASE", "LOCALE", "MULTILINE", "DOTALL", "VERBOSE",
-    "UNICODE", "NOFLAG", "RegexFlag",
+    "UNICODE", "NOFLAG", "RegexFlag", "ReCompileError"
 ]
 
 __version__ = "2.2.1"
@@ -156,7 +157,7 @@ class RegexFlag:
     _numeric_repr_ = hex
 
 # sre exception
-error = _compiler.error
+ReCompileError = error = sre_compile.ReCompileError
 
 # --------------------------------------------------------------------
 # public interface

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -47,7 +47,7 @@ class ReTests(unittest.TestCase):
         recurse(actual, expect)
 
     def checkPatternError(self, pattern, errmsg, pos=None):
-        with self.assertRaises(re.error) as cm:
+        with self.assertRaises(re.ReCompileError) as cm:
             re.compile(pattern)
         with self.subTest(pattern=pattern):
             err = cm.exception
@@ -56,13 +56,16 @@ class ReTests(unittest.TestCase):
                 self.assertEqual(err.pos, pos)
 
     def checkTemplateError(self, pattern, repl, string, errmsg, pos=None):
-        with self.assertRaises(re.error) as cm:
+        with self.assertRaises(re.ReCompileError) as cm:
             re.sub(pattern, repl, string)
         with self.subTest(pattern=pattern, repl=repl):
             err = cm.exception
             self.assertEqual(err.msg, errmsg)
             if pos is not None:
                 self.assertEqual(err.pos, pos)
+
+    def test_error_is_ReCompileError_alias(self):
+        assert re.error is re.ReCompileError
 
     def test_keep_buffer(self):
         # See bug 14212
@@ -152,7 +155,7 @@ class ReTests(unittest.TestCase):
                          (chr(9)+chr(10)+chr(11)+chr(13)+chr(12)+chr(7)+chr(8)))
         for c in 'cdehijklmopqsuwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ':
             with self.subTest(c):
-                with self.assertRaises(re.error):
+                with self.assertRaises(re.ReCompileError):
                     self.assertEqual(re.sub('a', '\\' + c, 'a'), '\\' + c)
 
         self.assertEqual(re.sub(r'^\s*', 'X', 'test'), 'Xtest')
@@ -775,10 +778,10 @@ class ReTests(unittest.TestCase):
         re.purge()  # for warnings
         for c in 'ceghijklmopqyzCEFGHIJKLMNOPQRTVXY':
             with self.subTest(c):
-                self.assertRaises(re.error, re.compile, '\\%c' % c)
+                self.assertRaises(re.ReCompileError, re.compile, '\\%c' % c)
         for c in 'ceghijklmopqyzABCEFGHIJKLMNOPQRTVXYZ':
             with self.subTest(c):
-                self.assertRaises(re.error, re.compile, '[\\%c]' % c)
+                self.assertRaises(re.ReCompileError, re.compile, '[\\%c]' % c)
 
     def test_named_unicode_escapes(self):
         # test individual Unicode named escapes
@@ -909,14 +912,14 @@ class ReTests(unittest.TestCase):
         self.assertIsNone(re.match(r'(?:(a)|(x))b(?<=(?(1)c|x))c', 'abc'))
         self.assertTrue(re.match(r'(?:(a)|(x))b(?<=(?(1)b|x))c', 'abc'))
         # Group used before defined.
-        self.assertRaises(re.error, re.compile, r'(a)b(?<=(?(2)b|x))(c)')
+        self.assertRaises(re.ReCompileError, re.compile, r'(a)b(?<=(?(2)b|x))(c)')
         self.assertIsNone(re.match(r'(a)b(?<=(?(1)c|x))(c)', 'abc'))
         self.assertTrue(re.match(r'(a)b(?<=(?(1)b|x))(c)', 'abc'))
         # Group defined in the same lookbehind pattern
-        self.assertRaises(re.error, re.compile, r'(a)b(?<=(.)\2)(c)')
-        self.assertRaises(re.error, re.compile, r'(a)b(?<=(?P<a>.)(?P=a))(c)')
-        self.assertRaises(re.error, re.compile, r'(a)b(?<=(a)(?(2)b|x))(c)')
-        self.assertRaises(re.error, re.compile, r'(a)b(?<=(.)(?<=\2))(c)')
+        self.assertRaises(re.ReCompileError, re.compile, r'(a)b(?<=(.)\2)(c)')
+        self.assertRaises(re.ReCompileError, re.compile, r'(a)b(?<=(?P<a>.)(?P=a))(c)')
+        self.assertRaises(re.ReCompileError, re.compile, r'(a)b(?<=(a)(?(2)b|x))(c)')
+        self.assertRaises(re.ReCompileError, re.compile, r'(a)b(?<=(.)(?<=\2))(c)')
 
     def test_ignore_case(self):
         self.assertEqual(re.match("abc", "ABC", re.I).group(0), "ABC")
@@ -1284,8 +1287,8 @@ class ReTests(unittest.TestCase):
             self.assertTrue(re.match((r"\x%02x" % i).encode(), bytes([i])))
             self.assertTrue(re.match((r"\x%02x0" % i).encode(), bytes([i])+b"0"))
             self.assertTrue(re.match((r"\x%02xz" % i).encode(), bytes([i])+b"z"))
-        self.assertRaises(re.error, re.compile, br"\u1234")
-        self.assertRaises(re.error, re.compile, br"\U00012345")
+        self.assertRaises(re.ReCompileError, re.compile, br"\u1234")
+        self.assertRaises(re.ReCompileError, re.compile, br"\U00012345")
         self.assertTrue(re.match(br"\0", b"\000"))
         self.assertTrue(re.match(br"\08", b"\0008"))
         self.assertTrue(re.match(br"\01", b"\001"))
@@ -1307,8 +1310,8 @@ class ReTests(unittest.TestCase):
             self.assertTrue(re.match((r"[\x%02x]" % i).encode(), bytes([i])))
             self.assertTrue(re.match((r"[\x%02x0]" % i).encode(), bytes([i])))
             self.assertTrue(re.match((r"[\x%02xz]" % i).encode(), bytes([i])))
-        self.assertRaises(re.error, re.compile, br"[\u1234]")
-        self.assertRaises(re.error, re.compile, br"[\U00012345]")
+        self.assertRaises(re.ReCompileError, re.compile, br"[\u1234]")
+        self.assertRaises(re.ReCompileError, re.compile, br"[\U00012345]")
         self.checkPatternError(br"[\567]",
                                r'octal escape value \567 outside of '
                                r'range 0-0o377', 1)
@@ -1640,11 +1643,11 @@ class ReTests(unittest.TestCase):
             self.assertIsNone(pat.match(b'\xe0'))
         # Incompatibilities
         self.assertRaises(ValueError, re.compile, br'\w', re.UNICODE)
-        self.assertRaises(re.error, re.compile, br'(?u)\w')
+        self.assertRaises(re.ReCompileError, re.compile, br'(?u)\w')
         self.assertRaises(ValueError, re.compile, r'\w', re.UNICODE | re.ASCII)
         self.assertRaises(ValueError, re.compile, r'(?u)\w', re.ASCII)
         self.assertRaises(ValueError, re.compile, r'(?a)\w', re.UNICODE)
-        self.assertRaises(re.error, re.compile, r'(?au)\w')
+        self.assertRaises(re.ReCompileError, re.compile, r'(?au)\w')
 
     def test_locale_flag(self):
         enc = locale.getpreferredencoding()
@@ -1685,11 +1688,11 @@ class ReTests(unittest.TestCase):
             self.assertIsNone(pat.match(bletter))
         # Incompatibilities
         self.assertRaises(ValueError, re.compile, '', re.LOCALE)
-        self.assertRaises(re.error, re.compile, '(?L)')
+        self.assertRaises(re.ReCompileError, re.compile, '(?L)')
         self.assertRaises(ValueError, re.compile, b'', re.LOCALE | re.ASCII)
         self.assertRaises(ValueError, re.compile, b'(?L)', re.ASCII)
         self.assertRaises(ValueError, re.compile, b'(?a)', re.LOCALE)
-        self.assertRaises(re.error, re.compile, b'(?aL)')
+        self.assertRaises(re.ReCompileError, re.compile, b'(?aL)')
 
     def test_scoped_flags(self):
         self.assertTrue(re.match(r'(?i:a)b', 'Ab'))
@@ -2031,7 +2034,7 @@ class ReTests(unittest.TestCase):
         self.assertIsNone(p4.match(b'\xc5\xc5'))
 
     def test_error(self):
-        with self.assertRaises(re.error) as cm:
+        with self.assertRaises(re.ReCompileError) as cm:
             re.compile('(\u20ac))')
         err = cm.exception
         self.assertIsInstance(err.pattern, str)
@@ -2043,14 +2046,14 @@ class ReTests(unittest.TestCase):
         self.assertIn(' at position 3', str(err))
         self.assertNotIn(' at position 3', err.msg)
         # Bytes pattern
-        with self.assertRaises(re.error) as cm:
+        with self.assertRaises(re.ReCompileError) as cm:
             re.compile(b'(\xa4))')
         err = cm.exception
         self.assertIsInstance(err.pattern, bytes)
         self.assertEqual(err.pattern, b'(\xa4))')
         self.assertEqual(err.pos, 3)
         # Multiline pattern
-        with self.assertRaises(re.error) as cm:
+        with self.assertRaises(re.ReCompileError) as cm:
             re.compile("""
                 (
                     abc
@@ -2717,7 +2720,7 @@ class ExternalTests(unittest.TestCase):
 
             with self.subTest(pattern=pattern, string=s):
                 if outcome == SYNTAX_ERROR:  # Expected a syntax error
-                    with self.assertRaises(re.error):
+                    with self.assertRaises(re.ReCompileError):
                         re.compile(pattern)
                     continue
 

--- a/Misc/NEWS.d/next/Library/2023-02-08-00-43-29.gh-issue-83162.ufdI9F.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-08-00-43-29.gh-issue-83162.ufdI9F.rst
@@ -1,0 +1,3 @@
+Renamed :exc:`re.error` to :exc:`ReCompileError` for clarity, and kept
+:exc:`re.error` for backward compatibility. Patch by Matthias Bussonnier and
+Adam Chhina.

--- a/Modules/_xxtestfuzz/fuzzer.c
+++ b/Modules/_xxtestfuzz/fuzzer.c
@@ -193,7 +193,7 @@ PyObject* sre_error_exception = NULL;
 int SRE_FLAG_DEBUG = 0;
 /* Called by LLVMFuzzerTestOneInput for initialization */
 static int init_sre_compile(void) {
-    /* Import sre_compile.compile and sre.error */
+    /* Import sre_compile.compile and sre_constants.ReCompileError */
     PyObject* sre_compile_module = PyImport_ImportModule("sre_compile");
     if (sre_compile_module == NULL) {
         return 0;
@@ -207,7 +207,7 @@ static int init_sre_compile(void) {
     if (sre_constants == NULL) {
         return 0;
     }
-    sre_error_exception = PyObject_GetAttrString(sre_constants, "error");
+    sre_error_exception = PyObject_GetAttrString(sre_constants, "ReCompileError");
     if (sre_error_exception == NULL) {
         return 0;
     }
@@ -261,7 +261,7 @@ static int fuzz_sre_compile(const char* data, size_t size) {
     ) {
         PyErr_Clear();
     }
-    /* Ignore re.error */
+    /* Ignore re.ReCompileError */
     if (compiled == NULL && PyErr_ExceptionMatches(sre_error_exception)) {
         PyErr_Clear();
     }


### PR DESCRIPTION
Follow-up of rebased/squashed [PR-1751](https://github.com/python/cpython/pull/17501) - renaming `re.error` for better clarity.

<ins>TODO</ins>
- [ ] Settle on new exception name
- [ ] Re-run tests
- [ ] [Follow-up](https://github.com/python/cpython/pull/17501#discussion_r355159029) on whether we rename the exception in `idlelib/replace.py`
- [ ] Ask whether this should also be added `Python 3.12 What's New`

<!-- gh-issue-number: gh-83612 -->
* Issue: gh-83612
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-83162 -->
* Issue: gh-83162
<!-- /gh-issue-number -->
