### PR TITLE
[3.11] gh-101656: Fix "conversion from Py_ssize_t to int" warning in …

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -6179,11 +6179,11 @@ eval_eval_code_ex(PyObject *mod, PyObject *pos_args)
         globals,
         locals,
         c_args,
-        c_args_len,
+        (int)c_args_len,
         c_kwargs,
-        c_kwargs_len,
+        (int)c_kwargs_len,
         c_defaults,
-        c_defaults_len,
+        (int)c_defaults_len,
         kw_defaults,
         closure
     );


### PR DESCRIPTION
…`_testcapimodule` (GH-101657).

(cherry picked from commit acc2f3b19d28d4bf3f8fb32357f581cba5ba24c7)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101656 -->
* Issue: gh-101656
<!-- /gh-issue-number -->
