### PR TITLE
gh-101705: Use a range of years for copyright in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -83,10 +83,8 @@ grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
 analyze, test, perform and/or display publicly, prepare derivative works,
 distribute, and otherwise use Python alone or in any derivative version,
 provided, however, that PSF's License Agreement and PSF's notice of copyright,
-i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
-2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Python Software Foundation;
-All Rights Reserved" are retained in Python alone or in any derivative version
-prepared by Licensee.
+i.e., "Copyright (c) 2001-2023 Python Software Foundation; All Rights Reserved"
+are retained in Python alone or in any derivative version prepared by Licensee.
 
 3. In the event Licensee prepares a derivative work that is based on
 or incorporates Python or any part thereof, and wants to make


### PR DESCRIPTION
Uses a range of years for the copyright in LICENSE file. Follows up on #10287 and makes it consistent with other copyright notices.

<!-- gh-issue-number: gh-101705 -->
* Issue: gh-101705
<!-- /gh-issue-number -->
