### PR TITLE
[3.7] gh-101283: Improved fallback logic for subprocess with shell=True on Windows (GH-101286)

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -111,6 +111,14 @@ compatibility with older versions, see the :ref:`call-function-trio` section.
       Added the *text* parameter, as a more understandable alias of *universal_newlines*.
       Added the *capture_output* parameter.
 
+   .. versionchanged:: 3.11.2
+
+      Changed Windows shell search order for ``shell=True``. The current
+      directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
+      ``%SystemRoot%\System32\cmd.exe``. As a result, dropping a
+      malicious program named ``cmd.exe`` into a current directory no
+      longer works.
+
 .. class:: CompletedProcess
 
    The return value from :func:`run`, representing a process that has finished.
@@ -441,6 +449,17 @@ functions.
    becomes the display name for the executable in utilities such as
    :program:`ps`.  If ``shell=True``, on POSIX the *executable* argument
    specifies a replacement shell for the default :file:`/bin/sh`.
+
+   .. versionchanged:: 3.6
+      *executable* parameter accepts a :term:`path-like object` on POSIX.
+
+   .. versionchanged:: 3.11.2
+
+      Changed Windows shell search order for ``shell=True``. The current
+      directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
+      ``%SystemRoot%\System32\cmd.exe``. As a result, dropping a
+      malicious program named ``cmd.exe`` into a current directory no
+      longer works.
 
    *stdin*, *stdout* and *stderr* specify the executed program's standard input,
    standard output and standard error file handles, respectively.  Valid values
@@ -1032,6 +1051,14 @@ calls these functions.
    .. versionchanged:: 3.3
       *timeout* was added.
 
+   .. versionchanged:: 3.11.2
+
+      Changed Windows shell search order for ``shell=True``. The current
+      directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
+      ``%SystemRoot%\System32\cmd.exe``. As a result, dropping a
+      malicious program named ``cmd.exe`` into a current directory no
+      longer works.
+
 .. function:: check_call(args, *, stdin=None, stdout=None, stderr=None, \
                          shell=False, cwd=None, timeout=None, \
                          **other_popen_kwargs)
@@ -1061,6 +1088,14 @@ calls these functions.
 
    .. versionchanged:: 3.3
       *timeout* was added.
+
+   .. versionchanged:: 3.11.2
+
+      Changed Windows shell search order for ``shell=True``. The current
+      directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
+      ``%SystemRoot%\System32\cmd.exe``. As a result, dropping a
+      malicious program named ``cmd.exe`` into a current directory no
+      longer works.
 
 
 .. function:: check_output(args, *, stdin=None, stderr=None, shell=False, \
@@ -1115,6 +1150,14 @@ calls these functions.
 
    .. versionadded:: 3.7
       *text* was added as a more readable alias for *universal_newlines*.
+
+   .. versionchanged:: 3.11.2
+
+      Changed Windows shell search order for ``shell=True``. The current
+      directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
+      ``%SystemRoot%\System32\cmd.exe``. As a result, dropping a
+      malicious program named ``cmd.exe`` into a current directory no
+      longer works.
 
 
 .. _subprocess-replacements:

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -111,7 +111,7 @@ compatibility with older versions, see the :ref:`call-function-trio` section.
       Added the *text* parameter, as a more understandable alias of *universal_newlines*.
       Added the *capture_output* parameter.
 
-   .. versionchanged:: 3.11.2
+   .. versionchanged:: 3.7.17
 
       Changed Windows shell search order for ``shell=True``. The current
       directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
@@ -453,7 +453,7 @@ functions.
    .. versionchanged:: 3.6
       *executable* parameter accepts a :term:`path-like object` on POSIX.
 
-   .. versionchanged:: 3.11.2
+   .. versionchanged:: 3.7.17
 
       Changed Windows shell search order for ``shell=True``. The current
       directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
@@ -1051,7 +1051,7 @@ calls these functions.
    .. versionchanged:: 3.3
       *timeout* was added.
 
-   .. versionchanged:: 3.11.2
+   .. versionchanged:: 3.7.17
 
       Changed Windows shell search order for ``shell=True``. The current
       directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
@@ -1089,7 +1089,7 @@ calls these functions.
    .. versionchanged:: 3.3
       *timeout* was added.
 
-   .. versionchanged:: 3.11.2
+   .. versionchanged:: 3.7.17
 
       Changed Windows shell search order for ``shell=True``. The current
       directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
@@ -1151,7 +1151,7 @@ calls these functions.
    .. versionadded:: 3.7
       *text* was added as a more readable alias for *universal_newlines*.
 
-   .. versionchanged:: 3.11.2
+   .. versionchanged:: 3.7.17
 
       Changed Windows shell search order for ``shell=True``. The current
       directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1192,7 +1192,23 @@ class Popen(object):
             if shell:
                 startupinfo.dwFlags |= _winapi.STARTF_USESHOWWINDOW
                 startupinfo.wShowWindow = _winapi.SW_HIDE
-                comspec = os.environ.get("COMSPEC", "cmd.exe")
+                if not executable:
+                    # gh-101283: without a fully-qualified path, before Windows
+                    # checks the system directories, it first looks in the
+                    # application directory, and also the current directory if
+                    # NeedCurrentDirectoryForExePathW(ExeName) is true, so try
+                    # to avoid executing unqualified "cmd.exe".
+                    comspec = os.environ.get('ComSpec')
+                    if not comspec:
+                        system_root = os.environ.get('SystemRoot', '')
+                        comspec = os.path.join(system_root, 'System32', 'cmd.exe')
+                        if not os.path.isabs(comspec):
+                            raise FileNotFoundError('shell not found: neither %ComSpec% nor %SystemRoot% is set')
+                    if os.path.isabs(comspec):
+                        executable = comspec
+                else:
+                    comspec = executable
+
                 args = '{} /c "{}"'.format (comspec, args)
 
             # Start the process

--- a/Misc/NEWS.d/next/Security/2023-01-24-16-12-00.gh-issue-101283.9tqu39.rst
+++ b/Misc/NEWS.d/next/Security/2023-01-24-16-12-00.gh-issue-101283.9tqu39.rst
@@ -1,0 +1,3 @@
+:class:`subprocess.Popen` now uses a safer approach to find
+``cmd.exe`` when launching with ``shell=True``. Patch by Eryk Sun,
+based on a patch by Oleg Iarygin.


### PR DESCRIPTION


<!-- gh-issue-number: gh-101283 -->
* Issue: gh-101283
<!-- /gh-issue-number -->
