### PR TITLE
gh-101702: Do not write bytecode when running as root

### DIFF
--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -22,6 +22,9 @@
 #    include <fcntl.h>            // O_BINARY
 #  endif
 #endif
+#if defined(HAVE_GETEUID) && defined(HAVE_UNISTD_H)
+#  include <unistd.h>             // geteuid()
+#endif
 
 /* --- Command line options --------------------------------------- */
 
@@ -816,6 +819,11 @@ config_init_defaults(PyConfig *config)
     config->optimization_level = 0;
     config->parser_debug= 0;
     config->write_bytecode = 1;
+#if defined(HAVE_GETEUID) && defined(HAVE_UNISTD_H)
+    if (geteuid() == 0) {
+        config->write_bytecode = 0;
+    }
+#endif
     config->verbose = 0;
     config->quiet = 0;
     config->user_site_directory = 1;


### PR DESCRIPTION
Only applies on systems with a `geteuid()` in `<unistd.h>`. Using `geteuid()` over `getuid()` due to setuid or other similar scenarios. Backports to 3.10 and earlier would only have the `HAVE_UNISTD_H` guard.

Hacked this one up; there is probably a cleaner way to do this. Also needs documenting if concept is sound.

<!-- gh-issue-number: gh-101702 -->
* Issue: gh-101702
<!-- /gh-issue-number -->
