### PR TITLE
gh-101726: Update the OpenSSL version to 1.1.1t

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -57,7 +57,7 @@ jobs:
   variables:
     testRunTitle: '$(build.sourceBranchName)-linux'
     testRunPlatform: linux
-    openssl_version: 1.1.1q
+    openssl_version: 1.1.1t
 
   steps:
   - template: ./posix-steps.yml
@@ -83,7 +83,7 @@ jobs:
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
     testRunPlatform: linux-coverage
-    openssl_version: 1.1.1q
+    openssl_version: 1.1.1t
 
   steps:
   - template: ./posix-steps.yml

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -57,7 +57,7 @@ jobs:
   variables:
     testRunTitle: '$(system.pullRequest.TargetBranch)-linux'
     testRunPlatform: linux
-    openssl_version: 1.1.1q
+    openssl_version: 1.1.1t
 
   steps:
   - template: ./posix-steps.yml
@@ -83,7 +83,7 @@ jobs:
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
     testRunPlatform: linux-coverage
-    openssl_version: 1.1.1q
+    openssl_version: 1.1.1t
 
   steps:
   - template: ./posix-steps.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,7 +176,7 @@ jobs:
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
-      OPENSSL_VER: 1.1.1s
+      OPENSSL_VER: 1.1.1t
       PYTHONSTRICTEXTENSIONBUILD: 1
     steps:
     - uses: actions/checkout@v3
@@ -235,7 +235,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        openssl_ver: [1.1.1s, 3.0.7, 3.1.0-beta1]
+        openssl_ver: [1.1.1t, 3.0.8, 3.1.0-beta1]
     env:
       OPENSSL_VER: ${{ matrix.openssl_ver }}
       MULTISSL_DIR: ${{ github.workspace }}/multissl
@@ -282,7 +282,7 @@ jobs:
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
-      OPENSSL_VER: 1.1.1s
+      OPENSSL_VER: 1.1.1t
       PYTHONSTRICTEXTENSIONBUILD: 1
       ASAN_OPTIONS: detect_leaks=0:allocator_may_return_null=1:handle_segv=0
     steps:

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -246,9 +246,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.1.1s",
-              url="https://www.openssl.org/source/openssl-1.1.1s.tar.gz",
-              checksum='c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa',
+              name="OpenSSL 1.1.1t",
+              url="https://www.openssl.org/source/openssl-1.1.1t.tar.gz",
+              checksum='8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/Security/2023-02-08-22-03-04.gh-issue-101727.9P5eZz.rst
+++ b/Misc/NEWS.d/next/Security/2023-02-08-22-03-04.gh-issue-101727.9P5eZz.rst
@@ -1,0 +1,4 @@
+Updated the OpenSSL version used in Windows and macOS binary release builds
+to 1.1.1t to address CVE-2023-0286, CVE-2022-4303, and CVE-2022-4303 per
+`the OpenSSL 2023-02-07 security advisory
+<https://www.openssl.org/news/secadv/20230207.txt>`_.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -53,7 +53,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.8
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.4.3
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1s
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1t
 set libraries=%libraries%                                       sqlite-3.39.4.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.13.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.13.0
@@ -77,7 +77,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.4.3
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1s
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1t
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.13.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -74,8 +74,8 @@
     <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.3\</libffiDir>
     <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
     <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1s\</opensslDir>
-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1s\$(ArchName)\</opensslOutDir>
+    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1t\</opensslDir>
+    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1t\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.13\</zlibDir>

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -169,7 +169,7 @@ _lzma
     Homepage:
         https://tukaani.org/xz/
 _ssl
-    Python wrapper for version 1.1.1q of the OpenSSL secure sockets
+    Python wrapper for version 1.1.1t of the OpenSSL secure sockets
     library, which is downloaded from our binaries repository at
     https://github.com/python/cpython-bin-deps.
 

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -46,7 +46,7 @@ OPENSSL_OLD_VERSIONS = [
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "1.1.1s",
+    "1.1.1t",
     "3.0.7"
 ]
 

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -47,7 +47,7 @@ OPENSSL_OLD_VERSIONS = [
 
 OPENSSL_RECENT_VERSIONS = [
     "1.1.1t",
-    "3.0.7"
+    "3.0.8"
 ]
 
 LIBRESSL_OLD_VERSIONS = [


### PR DESCRIPTION
Fixes CVE-2023-0286 (High) and a couple of Medium security issues.

https://www.openssl.org/news/secadv/20230207.txt

* [ ] Someone on windows-team needs to update [the openssl-bin branch of cpython-bin-deps](https://github.com/python/cpython-bin-deps/tree/openssl-bin) for this PR to work.

<!-- gh-issue-number: gh-101726 -->
* Issue: gh-101726
<!-- /gh-issue-number -->
