### PR TITLE
gh-101283: Fix the `versionchanged` of gh-101283 (3.12 only)

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -111,7 +111,7 @@ underlying :class:`Popen` interface can be used directly.
       Added the *text* parameter, as a more understandable alias of *universal_newlines*.
       Added the *capture_output* parameter.
 
-   .. versionchanged:: 3.11.3
+   .. versionchanged:: 3.12
 
       Changed Windows shell search order for ``shell=True``. The current
       directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
@@ -495,7 +495,7 @@ functions.
       *executable* parameter accepts a bytes and :term:`path-like object`
       on Windows.
 
-   .. versionchanged:: 3.11.3
+   .. versionchanged:: 3.12
 
       Changed Windows shell search order for ``shell=True``. The current
       directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
@@ -1174,7 +1174,7 @@ calls these functions.
    .. versionchanged:: 3.3
       *timeout* was added.
 
-   .. versionchanged:: 3.11.3
+   .. versionchanged:: 3.12
 
       Changed Windows shell search order for ``shell=True``. The current
       directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
@@ -1214,7 +1214,7 @@ calls these functions.
    .. versionchanged:: 3.3
       *timeout* was added.
 
-   .. versionchanged:: 3.11.3
+   .. versionchanged:: 3.12
 
       Changed Windows shell search order for ``shell=True``. The current
       directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and
@@ -1277,7 +1277,7 @@ calls these functions.
    .. versionadded:: 3.7
       *text* was added as a more readable alias for *universal_newlines*.
 
-   .. versionchanged:: 3.11.3
+   .. versionchanged:: 3.12
 
       Changed Windows shell search order for ``shell=True``. The current
       directory and ``%PATH%`` are replaced with ``%COMSPEC%`` and


### PR DESCRIPTION
Addresses https://github.com/python/cpython/pull/101286#discussion_r1100763049:

> This version number is wrong. 3.11.2 was released before this change was merged. As this PR is in the main branch, listing it as 3.12 in these docs is more appropriate. Documentation readers should not be expected to know which patch release versions came before a major release.

cc @gpshead @zooba @eryksun

<!-- gh-issue-number: gh-101283 -->
* Issue: gh-101283
<!-- /gh-issue-number -->
