### PR TITLE
GH-99293: Document that `Py_TPFLAGS_VALID_VERSION_TAG` shouldn't be used.

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1313,6 +1313,16 @@ and :c:type:`PyType_Type` effectively act as defaults.)
       .. versionadded:: 3.10
 
 
+   .. data:: Py_TPFLAGS_VALID_VERSION_TAG
+
+      Internal. Do not set or unset this flag.
+      To indicate that a class has changed call :cfunc:`PyType_Modified()`
+
+      .. warning::
+         This flag is present in header files, but is an internal feature and should
+         not be used. It will be removed in a future version of CPython
+
+
 .. c:member:: const char* PyTypeObject.tp_doc
 
    An optional pointer to a NUL-terminated C string giving the docstring for this

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1316,7 +1316,7 @@ and :c:type:`PyType_Type` effectively act as defaults.)
    .. data:: Py_TPFLAGS_VALID_VERSION_TAG
 
       Internal. Do not set or unset this flag.
-      To indicate that a class has changed call :cfunc:`PyType_Modified()`
+      To indicate that a class has changed call :c:func:`PyType_Modified`
 
       .. warning::
          This flag is present in header files, but is an internal feature and should

--- a/Misc/NEWS.d/next/C API/2023-02-09-10-38-20.gh-issue-99293.mFqfpp.rst
+++ b/Misc/NEWS.d/next/C API/2023-02-09-10-38-20.gh-issue-99293.mFqfpp.rst
@@ -1,0 +1,2 @@
+Document that the Py_TPFLAGS_VALID_VERSION_TAG is an internal feature,
+should not be used, and will be removed.


### PR DESCRIPTION


<!-- gh-issue-number: gh-99293 -->
* Issue: gh-99293
<!-- /gh-issue-number -->
