### PR TITLE
gh-101739: update docs - default boundary for enum.Flag is CONFORM not STRICT

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -696,10 +696,9 @@ Data Types
 
    .. attribute:: STRICT
 
-      Out-of-range values cause a :exc:`ValueError` to be raised.  This is the
-      default for :class:`Flag`::
+      Out-of-range values cause a :exc:`ValueError` to be raised::
 
-         >>> from enum import Flag, STRICT
+         >>> from enum import Flag, STRICT, auto
          >>> class StrictFlag(Flag, boundary=STRICT):
          ...     RED = auto()
          ...     GREEN = auto()
@@ -715,9 +714,9 @@ Data Types
    .. attribute:: CONFORM
 
       Out-of-range values have invalid values removed, leaving a valid *Flag*
-      value::
+      value. This is the default for :class:`Flag`::
 
-         >>> from enum import Flag, CONFORM
+         >>> from enum import Flag, CONFORM, auto
          >>> class ConformFlag(Flag, boundary=CONFORM):
          ...     RED = auto()
          ...     GREEN = auto()
@@ -731,7 +730,7 @@ Data Types
       Out-of-range values lose their *Flag* membership and revert to :class:`int`.
       This is the default for :class:`IntFlag`::
 
-         >>> from enum import Flag, EJECT
+         >>> from enum import Flag, EJECT, auto
          >>> class EjectFlag(Flag, boundary=EJECT):
          ...     RED = auto()
          ...     GREEN = auto()
@@ -742,10 +741,10 @@ Data Types
 
    .. attribute:: KEEP
 
-      Out-of-range values are kept, and the *Flag* membership is kept.  This is
-      used for some stdlib flags:
+      Out-of-range values are kept, and the *Flag* membership is kept. This is
+      used for some stdlib flags::
 
-         >>> from enum import Flag, KEEP
+         >>> from enum import Flag, KEEP, auto
          >>> class KeepFlag(Flag, boundary=KEEP):
          ...     RED = auto()
          ...     GREEN = auto()


### PR DESCRIPTION
If accepted, I think this would need a backport to 3.11.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101739 -->
* Issue: gh-101739
<!-- /gh-issue-number -->
