### PR TITLE
gh-101765: Fix SystemError / segmentation fault in iter `__reduce__` when internal access of `builtins.__dict__` exhausts the iterator

### DIFF
--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -266,9 +266,8 @@ class TestCase(unittest.TestCase):
                     list(it)
                     return other == "iter"
 
-            _iter = builtins["iter"]
             del builtins["iter"]
-            builtins[CustomStr()] = _iter
+            builtins[CustomStr()] = orig_iter
 
             return it.__reduce__()
 
@@ -277,11 +276,12 @@ class TestCase(unittest.TestCase):
             ([bytes], 8),
             ([bytearray], 8),
             ([tuple], range(8)),
-            ([lambda: (lambda: 0), 0],)
+            ([lambda: (lambda: 0), 0],),
+            ([tuple[int]],)  # GenericAlias
         ]
 
         try:
-            self.assertEqual(run(([str], "xyz")), (orig_iter, ("xyz",), 0))
+            self.assertEqual(run(([str], "xyz")), (orig_iter, ("",)))
             self.assertEqual(run(([list], range(8))), (orig_iter, ([],)))
             for case in types:
                 self.assertEqual(run(case), (orig_iter, ((),)))

--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -9,6 +9,7 @@ import pickle
 import collections.abc
 import functools
 import contextlib
+import builtins
 
 # Test result of triple loop (too big to inline)
 TRIPLETS = [(0, 0, 0), (0, 0, 1), (0, 0, 2),
@@ -252,7 +253,7 @@ class TestCase(unittest.TestCase):
         # depending on the order of C argument evaluation, which is undefined
 
         # Backup builtins
-        builtins = __builtins__
+        builtins_dict = builtins.__dict__
         orig = {"iter": iter, "reversed": reversed}
 
         def run(builtin_name, item, init=None, sentinel=None):
@@ -277,8 +278,8 @@ class TestCase(unittest.TestCase):
 
             # del is required here
             # to avoid calling the last test case's custom __eq__
-            del builtins[builtin_name]
-            builtins[CustomStr(builtin_name, it)] = orig[builtin_name]
+            del builtins_dict[builtin_name]
+            builtins_dict[CustomStr(builtin_name, it)] = orig[builtin_name]
 
             return it.__reduce__()
 
@@ -314,12 +315,12 @@ class TestCase(unittest.TestCase):
             # we also need to supress KeyErrors in case
             # a failed test deletes the key without setting anything
             with contextlib.suppress(KeyError):
-                del builtins["iter"]
+                del builtins_dict["iter"]
             with contextlib.suppress(KeyError):
-                del builtins["reversed"]
+                del builtins_dict["reversed"]
             # Restore original builtins
             for key, func in orig.items():
-                builtins[key] = func
+                builtins_dict[key] = func
 
     # Test a new_style class with __iter__ but no next() method
     def test_new_style_iter_class(self):

--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -274,8 +274,8 @@ class TestCase(unittest.TestCase):
                     return other == self.name
 
             # del is required here
-            # since only setting will result in
-            # both keys existing with a hash collision
+            # to not prematurely call __eq__ from
+            # the hash collision with the old key
             del builtins_dict[builtin_name]
             builtins_dict[CustomStr(builtin_name, it)] = orig[builtin_name]
 
@@ -309,10 +309,13 @@ class TestCase(unittest.TestCase):
                 self.assertEqual(run_iter(*case), (orig["iter"], ((),)))
         finally:
             # Restore original builtins
-            # need to suppress KeyErrors in case
-            # a failed test deletes the key without setting anything
             for key, func in orig.items():
+                # need to suppress KeyErrors in case
+                # a failed test deletes the key without setting anything
                 with contextlib.suppress(KeyError):
+                    # del is required here
+                    # to not invoke our custom __eq__ from
+                    # the hash collision with the old key
                     del builtins_dict[key]
                 builtins_dict[key] = func
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-10-07-21-47.gh-issue-101765.MO5LlC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-10-07-21-47.gh-issue-101765.MO5LlC.rst
@@ -1,0 +1,1 @@
+Fix SystemError / segmentation fault in iter `__reduce__` when calling `__builtins__.__dict__["iter"]` mutates the iter object.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-10-07-21-47.gh-issue-101765.MO5LlC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-10-07-21-47.gh-issue-101765.MO5LlC.rst
@@ -1,1 +1,1 @@
-Fix SystemError / segmentation fault in iter ``__reduce__`` when calling ``__builtins__.__dict__["iter"]`` mutates the iter object.
+Fix SystemError / segmentation fault in iter ``__reduce__`` when internal access of ``builtins.__dict__`` keys mutates the iter object.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-10-07-21-47.gh-issue-101765.MO5LlC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-10-07-21-47.gh-issue-101765.MO5LlC.rst
@@ -1,1 +1,1 @@
-Fix SystemError / segmentation fault in iter `__reduce__` when calling `__builtins__.__dict__["iter"]` mutates the iter object.
+Fix SystemError / segmentation fault in iter ``__reduce__`` when calling ``__builtins__.__dict__["iter"]`` mutates the iter object.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2391,11 +2391,17 @@ PyDoc_STRVAR(length_hint_doc,
 static PyObject *
 bytearrayiter_reduce(bytesiterobject *it, PyObject *Py_UNUSED(ignored))
 {
+    PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
+
+    /* _PyEval_GetBuiltin can invoke arbitrary code.
+     * calls must be *before* access of `it` pointers,
+     * since C/C++ parameter eval order is undefined.
+     * see issue #101765 */
+
     if (it->it_seq != NULL) {
-        return Py_BuildValue("N(O)n", _PyEval_GetBuiltin(&_Py_ID(iter)),
-                             it->it_seq, it->it_index);
+        return Py_BuildValue("N(O)n", iter, it->it_seq, it->it_index);
     } else {
-        return Py_BuildValue("N(())", _PyEval_GetBuiltin(&_Py_ID(iter)));
+        return Py_BuildValue("N(())", iter);
     }
 }
 

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2393,9 +2393,8 @@ bytearrayiter_reduce(bytesiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
 
-    /* _PyEval_GetBuiltin can invoke arbitrary code.
-     * calls must be *before* access of `it` pointers,
-     * since C parameter eval order is undefined.
+    /* _PyEval_GetBuiltin can invoke arbitrary code,
+     * call must be before access of iterator pointers.
      * see issue #101765 */
 
     if (it->it_seq != NULL) {

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2395,7 +2395,7 @@ bytearrayiter_reduce(bytesiterobject *it, PyObject *Py_UNUSED(ignored))
 
     /* _PyEval_GetBuiltin can invoke arbitrary code.
      * calls must be *before* access of `it` pointers,
-     * since C/C++ parameter eval order is undefined.
+     * since C parameter eval order is undefined.
      * see issue #101765 */
 
     if (it->it_seq != NULL) {

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3173,7 +3173,7 @@ striter_reduce(striterobject *it, PyObject *Py_UNUSED(ignored))
 
     /* _PyEval_GetBuiltin can invoke arbitrary code.
      * calls must be *before* access of `it` pointers,
-     * since C/C++ parameter eval order is undefined.
+     * since C parameter eval order is undefined.
      * see issue #101765 */
 
     if (it->it_seq != NULL) {

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3171,9 +3171,8 @@ striter_reduce(striterobject *it, PyObject *Py_UNUSED(ignored))
 {
     PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
 
-    /* _PyEval_GetBuiltin can invoke arbitrary code.
-     * calls must be *before* access of `it` pointers,
-     * since C parameter eval order is undefined.
+    /* _PyEval_GetBuiltin can invoke arbitrary code,
+     * call must be before access of iterator pointers.
      * see issue #101765 */
 
     if (it->it_seq != NULL) {

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3169,11 +3169,17 @@ PyDoc_STRVAR(length_hint_doc,
 static PyObject *
 striter_reduce(striterobject *it, PyObject *Py_UNUSED(ignored))
 {
+    PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
+
+    /* _PyEval_GetBuiltin can invoke arbitrary code.
+     * calls must be *before* access of `it` pointers,
+     * since C/C++ parameter eval order is undefined.
+     * see issue #101765 */
+
     if (it->it_seq != NULL) {
-        return Py_BuildValue("N(O)n", _PyEval_GetBuiltin(&_Py_ID(iter)),
-                             it->it_seq, it->it_index);
+        return Py_BuildValue("N(O)n", iter, it->it_seq, it->it_index);
     } else {
-        return Py_BuildValue("N(())", _PyEval_GetBuiltin(&_Py_ID(iter)));
+        return Py_BuildValue("N(())", iter);
     }
 }
 

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -880,9 +880,8 @@ ga_iter_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
     PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
     gaiterobject *gi = (gaiterobject *)self;
 
-    /* _PyEval_GetBuiltin can invoke arbitrary code.
-     * call must be *before* access of `gi` pointers,
-     * since C parameter eval order is undefined.
+    /* _PyEval_GetBuiltin can invoke arbitrary code,
+     * call must be before access of iterator pointers.
      * see issue #101765 */
 
     if (gi->obj)

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -877,8 +877,18 @@ ga_iter_clear(PyObject *self) {
 static PyObject *
 ga_iter_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
+    PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
     gaiterobject *gi = (gaiterobject *)self;
-    return Py_BuildValue("N(O)", _PyEval_GetBuiltin(&_Py_ID(iter)), gi->obj);
+
+    /* _PyEval_GetBuiltin can invoke arbitrary code.
+     * call must be *before* access of `gi` pointers,
+     * since C parameter eval order is undefined.
+     * see issue #101765 */
+
+    if (gi->obj)
+        return Py_BuildValue("N(O)", iter, gi->obj);
+    else
+        return Py_BuildValue("N(())", iter);
 }
 
 static PyMethodDef ga_iter_methods[] = {

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -102,11 +102,17 @@ PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(
 static PyObject *
 iter_reduce(seqiterobject *it, PyObject *Py_UNUSED(ignored))
 {
+    PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
+
+    /* _PyEval_GetBuiltin can invoke arbitrary code.
+     * calls must be *before* access of `it` pointers,
+     * since C/C++ parameter eval order is undefined.
+     * see issue #101765 */
+
     if (it->it_seq != NULL)
-        return Py_BuildValue("N(O)n", _PyEval_GetBuiltin(&_Py_ID(iter)),
-                             it->it_seq, it->it_index);
+        return Py_BuildValue("N(O)n", iter, it->it_seq, it->it_index);
     else
-        return Py_BuildValue("N(())", _PyEval_GetBuiltin(&_Py_ID(iter)));
+        return Py_BuildValue("N(())", iter);
 }
 
 PyDoc_STRVAR(reduce_doc, "Return state information for pickling.");
@@ -239,11 +245,17 @@ calliter_iternext(calliterobject *it)
 static PyObject *
 calliter_reduce(calliterobject *it, PyObject *Py_UNUSED(ignored))
 {
+    PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
+
+    /* _PyEval_GetBuiltin can invoke arbitrary code.
+     * calls must be *before* access of `it` pointers,
+     * since C/C++ parameter eval order is undefined.
+     * see issue #101765 */
+
     if (it->it_callable != NULL && it->it_sentinel != NULL)
-        return Py_BuildValue("N(OO)", _PyEval_GetBuiltin(&_Py_ID(iter)),
-                             it->it_callable, it->it_sentinel);
+        return Py_BuildValue("N(OO)", iter, it->it_callable, it->it_sentinel);
     else
-        return Py_BuildValue("N(())", _PyEval_GetBuiltin(&_Py_ID(iter)));
+        return Py_BuildValue("N(())", iter);
 }
 
 static PyMethodDef calliter_methods[] = {

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -106,7 +106,7 @@ iter_reduce(seqiterobject *it, PyObject *Py_UNUSED(ignored))
 
     /* _PyEval_GetBuiltin can invoke arbitrary code.
      * calls must be *before* access of `it` pointers,
-     * since C/C++ parameter eval order is undefined.
+     * since C parameter eval order is undefined.
      * see issue #101765 */
 
     if (it->it_seq != NULL)

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -249,7 +249,7 @@ calliter_reduce(calliterobject *it, PyObject *Py_UNUSED(ignored))
 
     /* _PyEval_GetBuiltin can invoke arbitrary code.
      * calls must be *before* access of `it` pointers,
-     * since C/C++ parameter eval order is undefined.
+     * since C parameter eval order is undefined.
      * see issue #101765 */
 
     if (it->it_callable != NULL && it->it_sentinel != NULL)

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -104,9 +104,8 @@ iter_reduce(seqiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
 
-    /* _PyEval_GetBuiltin can invoke arbitrary code.
-     * calls must be *before* access of `it` pointers,
-     * since C parameter eval order is undefined.
+    /* _PyEval_GetBuiltin can invoke arbitrary code,
+     * call must be before access of iterator pointers.
      * see issue #101765 */
 
     if (it->it_seq != NULL)
@@ -247,9 +246,8 @@ calliter_reduce(calliterobject *it, PyObject *Py_UNUSED(ignored))
 {
     PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
 
-    /* _PyEval_GetBuiltin can invoke arbitrary code.
-     * calls must be *before* access of `it` pointers,
-     * since C parameter eval order is undefined.
+    /* _PyEval_GetBuiltin can invoke arbitrary code,
+     * call must be before access of iterator pointers.
      * see issue #101765 */
 
     if (it->it_callable != NULL && it->it_sentinel != NULL)

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3443,19 +3443,26 @@ static PyObject *
 listiter_reduce_general(void *_it, int forward)
 {
     PyObject *list;
+    PyObject *iter;
+    PyObject *reversed;
+
+    /* _PyEval_GetBuiltin can invoke arbitrary `__eq__` code.
+     * calls must be *before* access of _it pointers,
+     * since C/C++ parameter eval order is undefined.
+     * see issue #101765 */
 
     /* the objects are not the same, index is of different types! */
     if (forward) {
+        iter = _PyEval_GetBuiltin(&_Py_ID(iter));
         _PyListIterObject *it = (_PyListIterObject *)_it;
         if (it->it_seq) {
-            return Py_BuildValue("N(O)n", _PyEval_GetBuiltin(&_Py_ID(iter)),
-                                 it->it_seq, it->it_index);
+            return Py_BuildValue("N(O)n", iter, it->it_seq, it->it_index);
         }
     } else {
+        reversed = _PyEval_GetBuiltin(&_Py_ID(reversed));
         listreviterobject *it = (listreviterobject *)_it;
         if (it->it_seq) {
-            return Py_BuildValue("N(O)n", _PyEval_GetBuiltin(&_Py_ID(reversed)),
-                                 it->it_seq, it->it_index);
+            return Py_BuildValue("N(O)n", reversed, it->it_seq, it->it_index);
         }
     }
     /* empty iterator, create an empty list */

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3444,9 +3444,8 @@ listiter_reduce_general(void *_it, int forward)
 {
     PyObject *list;
 
-    /* _PyEval_GetBuiltin can invoke arbitrary code.
-     * calls must be *before* access of `_it` pointers,
-     * since C parameter eval order is undefined.
+    /* _PyEval_GetBuiltin can invoke arbitrary code,
+     * call must be before access of iterator pointers.
      * see issue #101765 */
 
     /* the objects are not the same, index is of different types! */

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3448,7 +3448,7 @@ listiter_reduce_general(void *_it, int forward)
 
     /* _PyEval_GetBuiltin can invoke arbitrary code.
      * calls must be *before* access of `_it` pointers,
-     * since C/C++ parameter eval order is undefined.
+     * since C parameter eval order is undefined.
      * see issue #101765 */
 
     /* the objects are not the same, index is of different types! */

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3447,7 +3447,7 @@ listiter_reduce_general(void *_it, int forward)
     PyObject *reversed;
 
     /* _PyEval_GetBuiltin can invoke arbitrary code.
-     * calls must be *before* access of _it pointers,
+     * calls must be *before* access of `_it` pointers,
      * since C/C++ parameter eval order is undefined.
      * see issue #101765 */
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3446,7 +3446,7 @@ listiter_reduce_general(void *_it, int forward)
     PyObject *iter;
     PyObject *reversed;
 
-    /* _PyEval_GetBuiltin can invoke arbitrary `__eq__` code.
+    /* _PyEval_GetBuiltin can invoke arbitrary code.
      * calls must be *before* access of _it pointers,
      * since C/C++ parameter eval order is undefined.
      * see issue #101765 */

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3443,8 +3443,6 @@ static PyObject *
 listiter_reduce_general(void *_it, int forward)
 {
     PyObject *list;
-    PyObject *iter;
-    PyObject *reversed;
 
     /* _PyEval_GetBuiltin can invoke arbitrary code.
      * calls must be *before* access of `_it` pointers,
@@ -3453,13 +3451,13 @@ listiter_reduce_general(void *_it, int forward)
 
     /* the objects are not the same, index is of different types! */
     if (forward) {
-        iter = _PyEval_GetBuiltin(&_Py_ID(iter));
+        PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
         _PyListIterObject *it = (_PyListIterObject *)_it;
         if (it->it_seq) {
             return Py_BuildValue("N(O)n", iter, it->it_seq, it->it_index);
         }
     } else {
-        reversed = _PyEval_GetBuiltin(&_Py_ID(reversed));
+        PyObject *reversed = _PyEval_GetBuiltin(&_Py_ID(reversed));
         listreviterobject *it = (listreviterobject *)_it;
         if (it->it_seq) {
             return Py_BuildValue("N(O)n", reversed, it->it_seq, it->it_index);

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -1050,9 +1050,8 @@ tupleiter_reduce(_PyTupleIterObject *it, PyObject *Py_UNUSED(ignored))
 {
     PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
 
-    /* _PyEval_GetBuiltin can invoke arbitrary code.
-     * calls must be *before* access of `it` pointers,
-     * since C parameter eval order is undefined.
+    /* _PyEval_GetBuiltin can invoke arbitrary code,
+     * call must be before access of iterator pointers.
      * see issue #101765 */
 
     if (it->it_seq)

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -1052,7 +1052,7 @@ tupleiter_reduce(_PyTupleIterObject *it, PyObject *Py_UNUSED(ignored))
 
     /* _PyEval_GetBuiltin can invoke arbitrary code.
      * calls must be *before* access of `it` pointers,
-     * since C/C++ parameter eval order is undefined.
+     * since C parameter eval order is undefined.
      * see issue #101765 */
 
     if (it->it_seq)

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -1048,11 +1048,17 @@ PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(
 static PyObject *
 tupleiter_reduce(_PyTupleIterObject *it, PyObject *Py_UNUSED(ignored))
 {
+    PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
+
+    /* _PyEval_GetBuiltin can invoke arbitrary code.
+     * calls must be *before* access of `it` pointers,
+     * since C/C++ parameter eval order is undefined.
+     * see issue #101765 */
+
     if (it->it_seq)
-        return Py_BuildValue("N(O)n", _PyEval_GetBuiltin(&_Py_ID(iter)),
-                             it->it_seq, it->it_index);
+        return Py_BuildValue("N(O)n", iter, it->it_seq, it->it_index);
     else
-        return Py_BuildValue("N(())", _PyEval_GetBuiltin(&_Py_ID(iter)));
+        return Py_BuildValue("N(())", iter);
 }
 
 static PyObject *

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14785,10 +14785,9 @@ static PyObject *
 unicodeiter_reduce(unicodeiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
-    
-    /* _PyEval_GetBuiltin can invoke arbitrary code.
-     * calls must be *before* access of `it` pointers,
-     * since C parameter eval order is undefined.
+
+    /* _PyEval_GetBuiltin can invoke arbitrary code,
+     * call must be before access of iterator pointers.
      * see issue #101765 */
 
     if (it->it_seq != NULL) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14785,6 +14785,11 @@ static PyObject *
 unicodeiter_reduce(unicodeiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
+    
+    /* _PyEval_GetBuiltin can invoke arbitrary code.
+     * calls must be *before* access of `it` pointers,
+     * since C parameter eval order is undefined.
+     * see issue #101765 */
 
     if (it->it_seq != NULL) {
         return Py_BuildValue("N(O)n", iter, it->it_seq, it->it_index);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14784,14 +14784,15 @@ PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(
 static PyObject *
 unicodeiter_reduce(unicodeiterobject *it, PyObject *Py_UNUSED(ignored))
 {
+    PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
+
     if (it->it_seq != NULL) {
-        return Py_BuildValue("N(O)n", _PyEval_GetBuiltin(&_Py_ID(iter)),
-                             it->it_seq, it->it_index);
+        return Py_BuildValue("N(O)n", iter, it->it_seq, it->it_index);
     } else {
         PyObject *u = unicode_new_empty();
         if (u == NULL)
             return NULL;
-        return Py_BuildValue("N(N)", _PyEval_GetBuiltin(&_Py_ID(iter)), u);
+        return Py_BuildValue("N(N)", iter, u);
     }
 }
 


### PR DESCRIPTION
# Summary
- Fixes potential segmentation fault or SystemError when `__reduce__` is called on `iter` objects when the key of the hash of `"iter"` within `__builtins__.__dict__` is a custom object that executes arbitrary code within `__eq__`, mutating the `iter` object and causing illegal memory access or SystemError (based on C argument evaluation order, which is undefined behavior).

## Affected methods
* `iterobject.c`
  - [x] `iter_reduce`
  - [x] `calliter_reduce`
* `listobject.c`
  - [x] `listiter_reduce_general`
* `bytearrayobject.c`
  - [x] `bytearrayiter_reduce`
* `bytesobject.c`
  - [x] `striter_reduce`
* `tupleobject.c`
  - [x] `tupleiter_reduce`
* `genericaliasobject.c`
  - [x] `ga_iter_reduce`

This PR also fixes a compounded issue where currently `genericaliasobject.ga_iter_reduce` does not handle empty iterators at all and has no NULL check
```python
Python 3.11.0 (main, Oct 26 2022, 10:14:06) [GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> x = tuple[int]
>>>
>>> it = iter(x)
>>> _ = list(it)
>>>
>>> it.__reduce__()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SystemError: NULL object passed to Py_BuildValue
```
Along with moving the evaluation of `_PyEval_GetBuiltin` for potential side effects, this also adds handling of the NULL case (like the other `iter_reduce` functions have:
```python
Python 3.12.0a5+ (heads/fix-reduce-dirty:93854e172e, Feb 10 2023, 13:41:45) [GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> x = tuple[int]
>>>
>>> it = iter(x)
>>> _ = list(it)
>>>
>>> it.__reduce__()
(<built-in function iter>, ((),))
```

## Linked Issue
<!-- gh-issue-number: gh-101765 -->
* Issue: gh-101765
<!-- /gh-issue-number -->
