### PR TITLE
Document the behaviour of iterating over a set

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4232,6 +4232,10 @@ The constructors for both classes work the same:
 
       Test *x* for non-membership in *s*.
 
+   .. describe:: iter(s)
+
+      Return an iterator over the elements in *s* (in arbitrary order).
+
    .. method:: isdisjoint(other)
 
       Return ``True`` if the set has no elements in common with *other*.  Sets are


### PR DESCRIPTION
While the documentation already vaguely mentioned that sets support `for` loops, the more general case of `iter(s)` (and, by extension, `list(s)` etc.) was missing.

There is no issue, but this is a trivial clarification in the documentation, so I don't think one should be necessary.