### PR TITLE
gh-68141: Guard `test_mmap.LargeMmapTests.*` with a timeout

### DIFF
--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from test.support import (
     requires, _2G, _4G, gc_collect, cpython_only, is_emscripten
 )
@@ -896,21 +897,29 @@ class LargeMmapTests(unittest.TestCase):
         unlink(TESTFN)
 
     def _make_test_file(self, num_zeroes, tail):
-        if sys.platform[:3] == 'win' or sys.platform == 'darwin':
-            requires('largefile',
-                'test requires %s bytes and a long time to run' % str(0x180000000))
-        f = open(TESTFN, 'w+b')
-        try:
-            f.seek(num_zeroes)
-            f.write(tail)
-            f.flush()
-        except (OSError, OverflowError, ValueError):
+        # gh-68141: some systems cannot create sparse files leading to
+		# an extremely long attempt to initialize 5GB of disc space.
+		# In this case, abort the test after a short timeout.
+        def potentially_superlong_seek():
+            f = open(TESTFN, 'w+b')
             try:
-                f.close()
-            except (OSError, OverflowError):
-                pass
-            raise unittest.SkipTest("filesystem does not have largefile support")
-        return f
+                f.seek(num_zeroes)
+                f.write(tail)
+                f.flush()
+            except (OSError, OverflowError, ValueError):
+                try:
+                    f.close()
+                except (OSError, OverflowError):
+                    pass
+                raise unittest.SkipTest("filesystem does not have largefile support")
+                
+            with ThreadPoolExecutor(max_workers=1) as pool:
+	            worker = pool.submit(potentially_superlong_seek)
+	            try:
+		            worker.result(timeout=min(SHORT_TIMEOUT, 5.0))
+	            except TimeoutError:
+		            raise unittest.SkipTest('skip honest creation of a huge file')
+            return f
 
     def test_large_offset(self):
         with self._make_test_file(0x14FFFFFFF, b" ") as f:

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -906,6 +906,7 @@ class LargeMmapTests(unittest.TestCase):
                 f.seek(num_zeroes)
                 f.write(tail)
                 f.flush()
+                return f
             except (OSError, OverflowError, ValueError):
                 try:
                     f.close()
@@ -916,10 +917,9 @@ class LargeMmapTests(unittest.TestCase):
             with ThreadPoolExecutor(max_workers=1) as pool:
 	            worker = pool.submit(potentially_superlong_seek)
 	            try:
-		            worker.result(timeout=min(SHORT_TIMEOUT, 5.0))
+		            return worker.result(timeout=min(SHORT_TIMEOUT, 5.0))
 	            except TimeoutError:
 		            raise unittest.SkipTest('skip honest creation of a huge file')
-            return f
 
     def test_large_offset(self):
         with self._make_test_file(0x14FFFFFFF, b" ") as f:

--- a/Misc/NEWS.d/next/Tests/2023-02-10-07-25-34.gh-issue-68141.XjTTqb.rst
+++ b/Misc/NEWS.d/next/Tests/2023-02-10-07-25-34.gh-issue-68141.XjTTqb.rst
@@ -1,0 +1,2 @@
+Guard ``test_mmap.LargeMmapTests`` with a timeout. Patch by Oleg
+Iarygin.


### PR DESCRIPTION
Some file systems don't support sparse files required by `test_mmap` to work with huge sizes in theory only, without extremely long and likely unsuccessful initialization of disc space.

Currently `test_mmap.LargeMmapTests._make_test_file()` [assumes](https://github.com/python/cpython/blob/448c7d154e72506158d0a7a766e9f1cb8adf3dec/Lib/test/test_mmap.py#L898-L901) that sparse files are unsupported on Windows and macOS but always supported on Linux. However, filesystems like ZFS available on Linux break this assumption. As a result, we should rely on difference in duration of initialization between a single sector for sparse files and many gigabytes for non-sparse files.

Since `SHORT_TIMEOUT` can be changed with `--timeout`, we should put a really short bar enough for 4KB page to be written even in the worst case of process management and antivirus scan (like `min(SHORT_TIMEOUT, 5.0)`).

<!-- gh-issue-number: gh-68141 -->
* Issue: gh-68141
<!-- /gh-issue-number -->
