### PR TITLE
gh-101517: bdb should not lookup linecache with lineno=None

### DIFF
--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -570,9 +570,10 @@ class Bdb:
             rv = frame.f_locals['__return__']
             s += '->'
             s += reprlib.repr(rv)
-        line = linecache.getline(filename, lineno, frame.f_globals)
-        if line:
-            s += lprefix + line.strip()
+        if lineno is not None:
+            line = linecache.getline(filename, lineno, frame.f_globals)
+            if line:
+                s += lprefix + line.strip()
         return s
 
     # The following methods can be called by clients to use

--- a/Lib/test/test_bdb.py
+++ b/Lib/test/test_bdb.py
@@ -1203,5 +1203,11 @@ class IssuesTestCase(BaseTestCase):
                 tracer.runcall(tfunc_import)
 
 
+class TestRegressions(unittest.TestCase):
+    def test_format_stack_entry_no_lineno(self):
+        # See gh-101517
+        Bdb().format_stack_entry((sys._getframe(), None))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2023-02-10-16-02-29.gh-issue-101517.r7S2u8.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-10-16-02-29.gh-issue-101517.r7S2u8.rst
@@ -1,0 +1,1 @@
+Fixed bug where :mod:`bdb` looks up the source line with :mod:`linecache` with a ``lineno=None``, which causes it to fail with an unhandled exception.


### PR DESCRIPTION
The root cause of gh-101517 is that the line number was missing in the bytecode, but pdb should not have failed the way it did. 

This PR makes bdb check that the lineno is not None before looking it up in the linecache.