### PR TITLE
[3.11] Docs: Fix getstatus() -> getcode() typos (GH-101296)

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -530,7 +530,7 @@ statement.
    .. deprecated:: 3.9
       Deprecated in favor of :attr:`~HTTPResponse.headers`.
 
-.. method:: HTTPResponse.getstatus()
+.. method:: HTTPResponse.getcode()
 
    .. deprecated:: 3.9
       Deprecated in favor of :attr:`~HTTPResponse.status`.

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1630,7 +1630,7 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
       .. deprecated:: 3.9
          Deprecated in favor of :attr:`~addinfourl.status`.
 
-   .. method:: getstatus()
+   .. method:: getcode()
 
       .. deprecated:: 3.9
          Deprecated in favor of :attr:`~addinfourl.status`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
(cherry picked from commit 61f2be08661949e2f6dfc94143436297e60d47de)
