### PR TITLE
gh-88071: Update docstrings of dataclass' astuple and asdict

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1284,7 +1284,7 @@ def asdict(obj, *, dict_factory=dict):
     If given, 'dict_factory' will be used instead of built-in dict.
     The function applies recursively to field values that are
     dataclass instances. This will also look into built-in containers:
-    tuples, lists, and dicts.
+    tuples, lists, and dicts. Other objects are copied with 'copy.deepcopy()'.
     """
     if not _is_dataclass_instance(obj):
         raise TypeError("asdict() should be called on dataclass instances")
@@ -1356,7 +1356,7 @@ def astuple(obj, *, tuple_factory=tuple):
     If given, 'tuple_factory' will be used instead of built-in tuple.
     The function applies recursively to field values that are
     dataclass instances. This will also look into built-in containers:
-    tuples, lists, and dicts.
+    tuples, lists, and dicts. Other objects are copied with 'copy.deepcopy()'.
     """
 
     if not _is_dataclass_instance(obj):


### PR DESCRIPTION
Updated docstrings of `astuple` and `asdict` to reflect that they deep copy objects in the field values, according to the changes in the docs (see https://github.com/python/cpython/pull/26154 and https://github.com/python/cpython/issues/88071).

I believe that this behaviour of `astuple` and `asdict` is rather counter-intuitive and it is important to inform the developer about it in the docstring. (I personally spent half an hour trying to fix a bug that appeared because I wasn't aware of it.)



<!-- gh-issue-number: gh-88071 -->
* Issue: gh-88071
<!-- /gh-issue-number -->
