### PR TITLE
gh-100226: Clarify StreamReader.read behavior

### DIFF
--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -209,15 +209,16 @@ StreamReader
       Read up to *n* bytes from the stream.
 
       If *n* is not provided, or set to ``-1``,
-      read until EOF. After EOF is received, return all read bytes.
+      read until EOF, then return all read :class:`bytes`.
       If EOF was received and the internal buffer is empty,
       return an empty ``bytes`` object.
 
       If *n* is ``0``, return an empty ``bytes`` object immediately.
 
-      If *n* is positive, this function tries to read *n* bytes, and may return
-      less or equal bytes than requested, but at least one byte. If EOF was
-      received before any byte is read, this function returns an empty
+      If *n* is positive, wait for at least 1 byte to become available
+      (or EOF), then return the available ``bytes`` which might be less
+      than *n*.
+      If EOF is received before any byte is read, return an empty
       ``bytes`` object.
 
    .. coroutinemethod:: readline()

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -206,14 +206,14 @@ StreamReader
 
    .. coroutinemethod:: read(n=-1)
 
-      Read up to *n* bytes.
+      Read up to *n* bytes from the stream.
 
       If *n* is not provided, or set to ``-1``,
       read until EOF. After EOF is received, return all read bytes.
       If EOF was received and the internal buffer is empty,
       return an empty ``bytes`` object.
 
-      If *n* is zero, return empty ``bytes`` object immediately.
+      If *n* is ``0``, return an empty ``bytes`` object immediately.
 
       If *n* is positive, this function tries to read *n* bytes, and may return
       less or equal bytes than requested, but at least one byte. If EOF was

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -208,16 +208,15 @@ StreamReader
 
       Read up to *n* bytes from the stream.
 
-      If *n* is not provided, or set to ``-1``,
+      If *n* is not provided or set to ``-1``,
       read until EOF, then return all read :class:`bytes`.
       If EOF was received and the internal buffer is empty,
       return an empty ``bytes`` object.
 
       If *n* is ``0``, return an empty ``bytes`` object immediately.
 
-      If *n* is positive, wait for at least 1 byte to become available
-      (or EOF), then return the available ``bytes`` which might be less
-      than *n*.
+      If *n* is positive, return at most *n* available ``bytes``
+      as soon as at least 1 byte is available in the internal buffer.
       If EOF is received before any byte is read, return an empty
       ``bytes`` object.
 

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -206,11 +206,19 @@ StreamReader
 
    .. coroutinemethod:: read(n=-1)
 
-      Read up to *n* bytes.  If *n* is not provided, or set to ``-1``,
-      read until EOF and return all read bytes.
+      Read up to *n* bytes.
 
+      If *n* is not provided, or set to ``-1``,
+      read until EOF. After EOF is received, return all read bytes.
       If EOF was received and the internal buffer is empty,
       return an empty ``bytes`` object.
+
+      If *n* is zero, return empty ``bytes`` object immediately.
+
+      If *n* is positive, this function tries to read *n* bytes, and may return
+      less or equal bytes than requested, but at least one byte. If EOF was
+      received before any byte is read, this function returns an empty
+      ``bytes`` object.
 
    .. coroutinemethod:: readline()
 

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -655,9 +655,9 @@ class StreamReader:
 
         If n is zero, return empty bytes object immediately.
 
-        If n is positive, this function try to read `n` bytes, and may return
+        If n is positive, this function tries to read `n` bytes, and may return
         less or equal bytes than requested, but at least one byte. If EOF was
-        received before any byte is read, this function returns empty byte
+        received before any byte is read, this function returns an empty bytes
         object.
 
         Returned value is not limited with limit, configured at stream

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -649,16 +649,17 @@ class StreamReader:
     async def read(self, n=-1):
         """Read up to `n` bytes from the stream.
 
-        If n is not provided, or set to -1, read until EOF and return all read
-        bytes. If the EOF was received and the internal buffer is empty, return
-        an empty bytes object.
+        If `n` is not provided or set to -1,
+        read until EOF, then return all read bytes.
+        If EOF was received and the internal buffer is empty,
+        return an empty bytes object.
 
-        If n is zero, return empty bytes object immediately.
+        If `n` is 0, return an empty bytes object immediately.
 
-        If n is positive, this function tries to read `n` bytes, and may return
-        less or equal bytes than requested, but at least one byte. If EOF was
-        received before any byte is read, this function returns an empty bytes
-        object.
+        If `n` is positive, return at most `n` available bytes
+        as soon as at least 1 byte is available in the internal buffer.
+        If EOF is received before any byte is read, return an empty
+        bytes object.
 
         Returned value is not limited with limit, configured at stream
         creation.


### PR DESCRIPTION
This clarifies the `StreamReader.read` behavior in the public documentation; mostly copying from the more precise docstring of the function.

While we're at it, also fix some minor grammar in the docstring itself.

Addresses #100226.

Should this be backported so that the documentation for older releases is also updated?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-100226 -->
* Issue: gh-100226
<!-- /gh-issue-number -->
