### PR TITLE
gh-101810: Remove duplicated st_ino calculation

### DIFF
--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1162,8 +1162,6 @@ _Py_fstat_noraise(int fd, struct _Py_stat_struct *status)
     }
 
     _Py_attribute_data_to_stat(&info, 0, status);
-    /* specific to fstat() */
-    status->st_ino = (((uint64_t)info.nFileIndexHigh) << 32) + info.nFileIndexLow;
     return 0;
 #else
     return fstat(fd, status);


### PR DESCRIPTION
The deleted `status->st_ino = (((uint64_t)info.nFileIndexHigh) << 32) + info.nFileIndexLow;` is already calculated and assigned in the function `_Py_attribute_data_to_stat()`. So removing the duplicated code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-101810: Duplicated st_ino calculation
```

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
