### PR TITLE
expand the warning about untrusted archives in the `tarfile` docs

### DIFF
--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -407,9 +407,10 @@ be finalized; only the internally used file object will be closed. See the
    .. warning::
 
       Never extract archives from untrusted sources without prior inspection.
-      It is possible that files are created outside of *path*, e.g. members
-      that have absolute filenames starting with ``"/"`` or filenames with two
-      dots ``".."``.
+      It is possible for files to be created or written to outside of *path*.
+      Some examples include members that have absolute or relative filenames
+      that are not in the current path, and symbolic or hard links pointing
+      outside of *path*.
 
    .. versionchanged:: 3.5
       Added the *numeric_owner* parameter.


### PR DESCRIPTION
The current warning mentions one class of attacks, but there's at least one other major class that relies on links. Are there other classes? If so we should probably add something like "This list is not exhaustive; do not try to solve this problem yourself."