### PR TITLE
gh-86509: docs for thread-local data - add link to _threading_local.py

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -272,7 +272,7 @@ The instance's values will be different for separate threads.
    A class that represents thread-local data.
 
    For more details and extensive examples, see the documentation string of the
-   :mod:`_threading_local` module.
+   :mod:`_threading_local` module: :source:`Lib/_threading_local.py`.
 
 
 .. _thread-objects:


### PR DESCRIPTION
Tries to fix #86509.

I think that a link is sufficient, though I'd be happy to expand the docstring onto the docs if desired!

<img width="827" alt="fix2" src="https://user-images.githubusercontent.com/116417456/218254337-d652de6b-fe36-4bc5-82d4-09a8cfd6dbdb.png">



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-86509 -->
* Issue: gh-86509
<!-- /gh-issue-number -->
