### PR TITLE
gh-97786: Fix compiler warnings in pytime.c

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-02-11-13-23-29.gh-issue-97786.QjvQ1B.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-11-13-23-29.gh-issue-97786.QjvQ1B.rst
@@ -1,0 +1,2 @@
+Fix potential undefined behaviour in corner cases of floating-point-to-time
+conversions.

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -311,8 +311,10 @@ pytime_double_to_denominator(double d, time_t *sec, long *numerator,
        assumption that time_t is a two's complement integer type with no trap
        representation, and that `PY_TIME_T_MIN` is within the representable
        range of a C double.
+
+       Note: we want the `if` condition below to be true for NaNs; therefore,
+       resist any temptation to simplify by applying De Morgan's laws.
     */
-    assert(fmod(intpart, 1.0) == 0.0);
     if (!((double)PY_TIME_T_MIN <= intpart && intpart < -(double)PY_TIME_T_MIN)) {
         pytime_time_t_overflow();
         return -1;
@@ -369,7 +371,6 @@ _PyTime_ObjectToTime_t(PyObject *obj, time_t *sec, _PyTime_round_t round)
         (void)modf(d, &intpart);
 
         /* See comments in pytime_double_to_denominator */
-        assert(fmod(intpart, 1.0) == 0.0);
         if (!((double)PY_TIME_T_MIN <= intpart && intpart < -(double)PY_TIME_T_MIN)) {
             pytime_time_t_overflow();
             return -1;
@@ -537,7 +538,6 @@ pytime_from_double(_PyTime_t *tp, double value, _PyTime_round_t round,
     d = pytime_round(d, round);
 
     /* See comments in pytime_double_to_denominator */
-    assert(fmod(d, 1.0) == 0.0);
     if (!((double)_PyTime_MIN <= d && d < -(double)_PyTime_MIN)) {
         pytime_time_t_overflow();
         return -1;

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1,5 +1,4 @@
 #include "Python.h"
-#include "pycore_pymath.h"        // _Py_InIntegralTypeRange()
 #ifdef MS_WINDOWS
 #  include <winsock2.h>           // struct timeval
 #endif
@@ -39,6 +38,14 @@
 #  define PY_TIME_T_MIN LONG_MIN
 #else
 #  error "unsupported time_t size"
+#endif
+
+#if PY_TIME_T_MAX + PY_TIME_T_MIN != -1
+#  error "time_t is not a two's complement integer type"
+#endif
+
+#if _PyTime_MIN + _PyTime_MAX != -1
+#  error "_PyTime_t is not a two's complement integer type"
 #endif
 
 
@@ -294,7 +301,19 @@ pytime_double_to_denominator(double d, time_t *sec, long *numerator,
     }
     assert(0.0 <= floatpart && floatpart < denominator);
 
-    if (!_Py_InIntegralTypeRange(time_t, intpart)) {
+    /*
+       Conversion of an out-of-range value to time_t gives undefined behaviour
+       (C99 §6.3.1.4p1), so we must guard against it. However, checking that
+       `intpart` is in range is delicate: the obvious expression `intpart <=
+       PY_TIME_T_MAX` will first convert the value `PY_TIME_T_MAX` to a double,
+       potentially changing its value and leading to us failing to catch some
+       UB-inducing values. The code below works correctly under the mild
+       assumption that time_t is a two's complement integer type with no trap
+       representation, and that `PY_TIME_T_MIN` is within the representable
+       range of a C double.
+    */
+    assert(fmod(intpart, 1.0) == 0.0);
+    if (!((double)PY_TIME_T_MIN <= intpart && intpart < -(double)PY_TIME_T_MIN)) {
         pytime_time_t_overflow();
         return -1;
     }
@@ -349,7 +368,9 @@ _PyTime_ObjectToTime_t(PyObject *obj, time_t *sec, _PyTime_round_t round)
         d = pytime_round(d, round);
         (void)modf(d, &intpart);
 
-        if (!_Py_InIntegralTypeRange(time_t, intpart)) {
+        /* See comments in pytime_double_to_denominator */
+        assert(fmod(intpart, 1.0) == 0.0);
+        if (!((double)PY_TIME_T_MIN <= intpart && intpart < -(double)PY_TIME_T_MIN)) {
             pytime_time_t_overflow();
             return -1;
         }
@@ -515,8 +536,10 @@ pytime_from_double(_PyTime_t *tp, double value, _PyTime_round_t round,
     d *= (double)unit_to_ns;
     d = pytime_round(d, round);
 
-    if (!_Py_InIntegralTypeRange(_PyTime_t, d)) {
-        pytime_overflow();
+    /* See comments in pytime_double_to_denominator */
+    assert(fmod(d, 1.0) == 0.0);
+    if (!((double)_PyTime_MIN <= d && d < -(double)_PyTime_MIN)) {
+        pytime_time_t_overflow();
         return -1;
     }
     _PyTime_t ns = (_PyTime_t)d;
@@ -910,7 +933,7 @@ py_get_system_clock(_PyTime_t *tp, _Py_clock_info_t *info, int raise_exc)
         info->monotonic = 0;
         info->adjustable = 1;
         if (clock_getres(CLOCK_REALTIME, &res) == 0) {
-            info->resolution = res.tv_sec + res.tv_nsec * 1e-9;
+            info->resolution = (double)res.tv_sec + (double)res.tv_nsec * 1e-9;
         }
         else {
             info->resolution = 1e-9;


### PR DESCRIPTION
This PR fixes some compiler warnings in `pytime.c`, and at the same time fixes our out-of-range double-to-integer checks to properly avoid undefined behaviour.

It's hard to write *strictly* portable code for this kind of thing, but the new check should work under a set of (very) mild assumptions, that are highly unlikely to be violated on any actual platform that we care about:

- That `time_t` is a two's complement signed integer type with no trap representation. (The weakest part of this is the assumption that `time_t` is a signed integer type _at all_, but we're already making that assumption.)
- That `_PyTime_t` is also a two's complement signed integer type with no trap representation. (This is already true with the current `typedef int64_t _PyTime_t;` declaration.)
- That `PY_TIME_T_MIN` and `_PyTime_MIN` are within the range of a C double. These days we're assuming IEEE 754 binary64 doubles, so we're safe so long as the integer types `_PyTime_t` and `time_t` don't have a width of _more_ than 1024.

Here's the underlying logic for the changes, for the record:

- We want to check that a C double value `x` is within the range of a (potentially unknown) signed integer type `I` with min and max values `IMIN` and `IMAX`. More specifically, we want to be sure that a conversion from `x` to type `I` will not invoke undefined behaviour; this means that the _integer part_ of `x` (discarding the fractional part, if any) must be in `[IMIN, IMAX]`.
- Assuming that `I` uses two's complement with no trap representation, `IMIN` must be the negation of a power of two, and `IMAX == -1 - IMIN`.
- So `IMIN` is exactly representable as a `double` (assuming that it's not larger than `2**1023`), and `(double)IMIN` does not change the value.
- So the bottom-end check, `(double)IMIN <= x`, does exactly what we want it to.
- For the top-end check, `x <= IMAX` is problematic since the implicit conversion of `IMAX` to type `double` may change the value. But assuming that `x` is an integer (which it is for all cases in this PR), `x <= IMAX` is mathematically equivalent to `x < (IMAX + 1)`, which with our two's complement assumption is equivalent to `x < -IMIN`, and we can express this as `x < -(double)IMIN`.


<!-- gh-issue-number: gh-97786 -->
* Issue: gh-97786
<!-- /gh-issue-number -->
