### PR TITLE
add hacl2 files to sha256module in Modules/Setup

### DIFF
--- a/Modules/Setup
+++ b/Modules/Setup
@@ -165,7 +165,7 @@ PYTHONPATH=$(COREPYTHONPATH)
 #_blake2 _blake2/blake2module.c _blake2/blake2b_impl.c _blake2/blake2s_impl.c
 #_md5 md5module.c
 #_sha1 sha1module.c
-#_sha256 sha256module.c
+#_sha256 sha256module.c _hacl/Hacl_Streaming_SHA2.c
 #_sha512 sha512module.c
 #_sha3 _sha3/sha3module.c
 


### PR DESCRIPTION
to be honest, I don't know if this is correct but it fixes the nightly builds for deadsnakes -- it looks like this was missed in #99109 cc @msprotz 