### PR TITLE
gh-101754: document that on Windows, keys in `os.environ` are converted to uppercase

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -212,6 +212,13 @@ process and user.
       cause memory leaks.  Refer to the system documentation for
       :c:func:`putenv`.
 
+   .. note::
+
+      On Windows, the keys are converted to uppercase. This also applies when
+      getting, setting, or deleting an item. For example,
+      ``environ['monty'] = 'python'`` maps the key ``'MONTY'`` to the value
+      ``'python'``.
+
    You can delete items in this mapping to unset environment variables.
    :func:`unsetenv` will be called automatically when an item is deleted from
    :data:`os.environ`, and when one of the :meth:`pop` or :meth:`clear` methods is

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -201,6 +201,11 @@ process and user.
    ``'surrogateescape'`` error handler. Use :data:`environb` if you would like
    to use a different encoding.
 
+   On Windows, the keys are converted to uppercase. This also applies when
+   getting, setting, or deleting an item. For example,
+   ``environ['monty'] = 'python'`` maps the key ``'MONTY'`` to the value
+   ``'python'``.
+
    .. note::
 
       Calling :func:`putenv` directly does not change :data:`os.environ`, so it's better
@@ -211,13 +216,6 @@ process and user.
       On some platforms, including FreeBSD and macOS, setting ``environ`` may
       cause memory leaks.  Refer to the system documentation for
       :c:func:`putenv`.
-
-   .. note::
-
-      On Windows, the keys are converted to uppercase. This also applies when
-      getting, setting, or deleting an item. For example,
-      ``environ['monty'] = 'python'`` maps the key ``'MONTY'`` to the value
-      ``'python'``.
 
    You can delete items in this mapping to unset environment variables.
    :func:`unsetenv` will be called automatically when an item is deleted from


### PR DESCRIPTION
Tries to fix #101754. 

Relevant:

- https://stackoverflow.com/questions/7797269/python-environment-case-senstivity-os-environ
- https://stackoverflow.com/questions/19023238/why-python-uppercases-all-environment-variables-in-windows

This PR adds the third note:

<img width="829" alt="prfix" src="https://user-images.githubusercontent.com/116417456/218293993-0126c3c1-204f-46cf-8c17-61059f1e72bd.png">


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101754 -->
* Issue: gh-101754
<!-- /gh-issue-number -->
