### PR TITLE
gh-89792: Limit test_tools freeze test build parallelism based on the number of cores

### DIFF
--- a/Misc/NEWS.d/next/Tests/2023-02-11-20-28-08.gh-issue-89792.S-Y5BZ.rst
+++ b/Misc/NEWS.d/next/Tests/2023-02-11-20-28-08.gh-issue-89792.S-Y5BZ.rst
@@ -1,3 +1,4 @@
-``test_tools`` now copies up to 10x less source data to a temporary
-directory during the ``freeze`` test by ignoring git metadata and other
-artifacts.
+``test_tools`` now copies up to 10x less source data to a temporary directory
+during the ``freeze`` test by ignoring git metadata and other artifacts.  It
+also limits its python build parallelism based on os.cpu_count instead of hard
+coding it as 8 cores.


### PR DESCRIPTION


<!-- gh-issue-number: gh-89792 -->
* Issue: gh-89792
<!-- /gh-issue-number -->
