### PR TITLE
Finding a `test_importlib` refleak on `aarch64 RHEL8` #101394

### DIFF
--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1601,44 +1601,5 @@ class LongTest(unittest.TestCase):
                 self.assertEqual(n**2,
                     (1 << (2 * bitlen)) - (1 << (bitlen + 1)) + 1)
 
-    def test___sizeof__(self):
-        self.assertEqual(int.__itemsize__, sys.int_info.sizeof_digit)
-
-        # Pairs (test_value, number of allocated digits)
-        test_values = [
-            # We always allocate space for at least one digit, even for
-            # a value of zero; sys.getsizeof should reflect that.
-            (0, 1),
-            (1, 1),
-            (-1, 1),
-            (BASE-1, 1),
-            (1-BASE, 1),
-            (BASE, 2),
-            (-BASE, 2),
-            (BASE*BASE - 1, 2),
-            (BASE*BASE, 3),
-        ]
-
-        for value, ndigits in test_values:
-            with self.subTest(value):
-                self.assertEqual(
-                    value.__sizeof__(),
-                    int.__basicsize__ + int.__itemsize__ * ndigits
-                )
-
-        # Same test for a subclass of int.
-        class MyInt(int):
-            pass
-
-        self.assertEqual(MyInt.__itemsize__, sys.int_info.sizeof_digit)
-
-        for value, ndigits in test_values:
-            with self.subTest(value):
-                self.assertEqual(
-                    MyInt(value).__sizeof__(),
-                    MyInt.__basicsize__ + MyInt.__itemsize__ * ndigits
-                )
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -4,8 +4,6 @@
 #include "pycore_object.h"      // _Py_FatalRefcountError()
 #include "pycore_runtime.h"       // _Py_ID()
 
-#include <stddef.h>
-
 /* We define bool_repr to return "False" or "True" */
 
 static PyObject *
@@ -155,8 +153,8 @@ bool_dealloc(PyObject* Py_UNUSED(ignore))
 PyTypeObject PyBool_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "bool",
-    offsetof(struct _longobject, long_value.ob_digit),  /* tp_basicsize */
-    sizeof(digit),                              /* tp_itemsize */
+    sizeof(struct _longobject),
+    0,
     bool_dealloc,                               /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5882,10 +5882,13 @@ static Py_ssize_t
 int___sizeof___impl(PyObject *self)
 /*[clinic end generated code: output=3303f008eaa6a0a5 input=9b51620c76fc4507]*/
 {
-    /* using Py_MAX(..., 1) because we always allocate space for at least
-       one digit, even though the integer zero has a Py_SIZE of 0 */
-    Py_ssize_t ndigits = Py_MAX(Py_ABS(Py_SIZE(self)), 1);
-    return Py_TYPE(self)->tp_basicsize + Py_TYPE(self)->tp_itemsize * ndigits;
+    Py_ssize_t res;
+
+    res = offsetof(PyLongObject, long_value.ob_digit)
+        /* using Py_MAX(..., 1) because we always allocate space for at least
+           one digit, even though the integer zero has a Py_SIZE of 0 */
+        + Py_MAX(Py_ABS(Py_SIZE(self)), 1)*sizeof(digit);
+    return res;
 }
 
 /*[clinic input]


### PR DESCRIPTION
This reverts commit 39017e04b55d4c110787551dc9a0cb753f27d700.

I am experimenting to detect the source of the leak here: https://github.com/python/cpython/issues/101766

This PR was the first one that has a recorded history of this failure. However, it does not look directly related.

Refs https://github.com/python/cpython/pull/101394
Refs https://github.com/python/cpython/issues/101766

<!-- gh-issue-number: gh-101266 -->
* Issue: gh-101266
<!-- /gh-issue-number -->
