### PR TITLE
gh-101857: Allow xattr detection on musl libc

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-12-22-40-22.gh-issue-101857._bribG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-12-22-40-22.gh-issue-101857._bribG.rst
@@ -1,0 +1,1 @@
+Fix xattr support detection on Linux systems by widening the check to linux, not just glibc. This fixes support for musl.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -276,7 +276,7 @@ corresponding Unix manual entries for more information on calls.");
 
 #if defined(HAVE_SYS_XATTR_H) && defined(__linux__) && !defined(__FreeBSD_kernel__) && !defined(__GNU__)
 #  define USE_XATTRS
-#  include <linux/limits.h>
+#  include <linux/limits.h>  // Needed for XATTR_SIZE_MAX on musl libc.
 #endif
 
 #ifdef USE_XATTRS

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -274,8 +274,9 @@ corresponding Unix manual entries for more information on calls.");
 #  undef HAVE_SCHED_SETAFFINITY
 #endif
 
-#if defined(HAVE_SYS_XATTR_H) && defined(__GLIBC__) && !defined(__FreeBSD_kernel__) && !defined(__GNU__)
+#if defined(HAVE_SYS_XATTR_H) && defined(__linux__) && !defined(__FreeBSD_kernel__) && !defined(__GNU__)
 #  define USE_XATTRS
+#  include <linux/limits.h>
 #endif
 
 #ifdef USE_XATTRS


### PR DESCRIPTION
Previously, we checked exclusively for __GLIBC__ (AND'd with some other conditions). Checking for __linux__ instead should be fine.

This fixes using e.g. os.listxattr() on systems using musl libc.

Bug: https://bugs.gentoo.org/894130

<!-- gh-issue-number: gh-101857 -->
* Issue: gh-101857
<!-- /gh-issue-number -->
