### PR TITLE
gh-101849: Add upgrade codes for old versions of launcher that ended up with later version numbers

### DIFF
--- a/Misc/NEWS.d/next/Windows/2023-02-13-16-32-50.gh-issue-101849.7lm_53.rst
+++ b/Misc/NEWS.d/next/Windows/2023-02-13-16-32-50.gh-issue-101849.7lm_53.rst
@@ -1,1 +1,1 @@
-Fixes installer correctly upgrading existing ``py.exe`` launcher installs.
+Ensures installer will correctly upgrade existing ``py.exe`` launcher installs.

--- a/Misc/NEWS.d/next/Windows/2023-02-13-16-32-50.gh-issue-101849.7lm_53.rst
+++ b/Misc/NEWS.d/next/Windows/2023-02-13-16-32-50.gh-issue-101849.7lm_53.rst
@@ -1,0 +1,1 @@
+Fixes installer correctly upgrading existing ``py.exe`` launcher installs.

--- a/Tools/msi/common.wxs
+++ b/Tools/msi/common.wxs
@@ -25,7 +25,6 @@
             <UpgradeVersion Property="DOWNGRADE" Minimum="$(var.Version)" IncludeMinimum="no" OnlyDetect="yes" />
             <UpgradeVersion Property="UPGRADE" Minimum="$(var.UpgradeMinimumVersion)" IncludeMinimum="yes" Maximum="$(var.Version)" IncludeMaximum="no" />
         </Upgrade>
-        <?endif ?>
         
         <?ifdef CoreUpgradeCode ?>
         <?if $(var.UpgradeCode)!=$(var.CoreUpgradeCode) ?>
@@ -42,6 +41,7 @@
         <InstallExecuteSequence>
             <RemoveExistingProducts After="InstallInitialize" Overridable="yes">UPGRADE</RemoveExistingProducts>
         </InstallExecuteSequence>
+        <?endif ?>
     </Fragment>
     
     <Fragment>

--- a/Tools/msi/launcher/launcher.wxs
+++ b/Tools/msi/launcher/launcher.wxs
@@ -34,7 +34,11 @@
             <Custom Before="SetLauncherInstallDirectoryLM" Action="SetLauncherInstallDirectoryCU">NOT Installed AND NOT ALLUSERS=1</Custom>
             <Custom Before="CostFinalize" Action="SetLauncherInstallDirectoryLM">NOT Installed AND ALLUSERS=1</Custom>
 
+            <?if $(var.UpgradeMinimumVersion)="3.11.0.0" ?>
             <RemoveExistingProducts After="InstallValidate">UPGRADE or REMOVE_350_LAUNCHER or REMOVE_360A1_LAUNCHER or UPGRADE_3_11_0 or UPGRADE_3_11_1</RemoveExistingProducts>
+            <?else ?>
+            <RemoveExistingProducts After="InstallValidate">UPGRADE or REMOVE_350_LAUNCHER or REMOVE_360A1_LAUNCHER</RemoveExistingProducts>
+            <?endif ?>
         </InstallExecuteSequence>
 
         <?if $(var.UpgradeMinimumVersion)="3.11.0.0" ?>

--- a/Tools/msi/launcher/launcher.wxs
+++ b/Tools/msi/launcher/launcher.wxs
@@ -34,13 +34,30 @@
             <Custom Before="SetLauncherInstallDirectoryLM" Action="SetLauncherInstallDirectoryCU">NOT Installed AND NOT ALLUSERS=1</Custom>
             <Custom Before="CostFinalize" Action="SetLauncherInstallDirectoryLM">NOT Installed AND ALLUSERS=1</Custom>
 
-            <RemoveExistingProducts After="InstallValidate">UPGRADE or REMOVE_350_LAUNCHER or REMOVE_360A1_LAUNCHER</RemoveExistingProducts>
+            <RemoveExistingProducts After="InstallValidate">UPGRADE or REMOVE_350_LAUNCHER or REMOVE_360A1_LAUNCHER or UPGRADE_3_11_0 or UPGRADE_3_11_1</RemoveExistingProducts>
         </InstallExecuteSequence>
+
+        <?if $(var.UpgradeMinimumVersion)="3.11.0.0" ?>
+        <Condition Message="!(loc.NoDowngrade)">Installed OR NOT DOWNGRADE OR UPGRADE_3_11_0 OR UPGRADE_3_11_1</Condition>
+        <?else ?>
+        <Condition Message="!(loc.NoDowngrade)">Installed OR NOT DOWNGRADE</Condition>
+        <?endif ?>
 
         <!-- Upgrade all versions of the launcher -->
         <Upgrade Id="$(var.UpgradeCode)">
             <UpgradeVersion Property="DOWNGRADE" Minimum="$(var.Version)" IncludeMinimum="no" OnlyDetect="yes" />
             <UpgradeVersion Property="UPGRADE" Minimum="0.0.0.0" IncludeMinimum="yes" Maximum="$(var.Version)" IncludeMaximum="no" />
+            <!--
+            Prior to 3.11.2150, version numbers incorrectly used date-based
+            revision numbers in the third field. Because these are higher than
+            the real version, it prevents upgrades.
+            Releases of 3.10 have a similar issue, however, no significant
+            changes have shipped in the launcher, so we don't worry about it.
+            -->
+            <?if $(var.UpgradeMinimumVersion)="3.11.0.0" ?>
+            <UpgradeVersion Property="UPGRADE_3_11_0" Minimum="3.11.7966.0" IncludeMinimum="yes" Maximum="3.11.7966.0" IncludeMaximum="yes" />
+            <UpgradeVersion Property="UPGRADE_3_11_1" Minimum="3.11.8009.0" IncludeMinimum="yes" Maximum="3.11.8009.0" IncludeMaximum="yes" />
+            <?endif ?>
         </Upgrade>
         <!-- Python 3.5.0 shipped with a different UpgradeCode -->
         <Upgrade Id="A71530B9-E89D-53DB-9C2D-C6D7551876D8">


### PR DESCRIPTION
An accidental fix in the release build process corrected the version numbers used for the launcher installer. However, since the incorrect versions are higher and have already been released, we now need to detect them specifically to ensure that upgrades work correctly.

This also applies to 3.10, however, there are no significant fixes to the launcher for 3.10, so the lack of upgrades won't cause any issue there. Any install of 3.11 will upgrade from a 3.10 launcher.

<!-- gh-issue-number: gh-101849 -->
* Issue: gh-101849
<!-- /gh-issue-number -->
