### PR TITLE
gh-101907: Removes use of non-standard C++ extension from Include/cpython/code.h

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -21,16 +21,16 @@ typedef union {
     struct {
         uint8_t opcode;
         uint8_t oparg;
-    };
+    } _op;
 } _Py_CODEUNIT;
 
-#define _Py_OPCODE(word) ((word).opcode)
-#define _Py_OPARG(word) ((word).oparg)
+#define _Py_OPCODE(word) ((word)._op.opcode)
+#define _Py_OPARG(word) ((word)._op.oparg)
 
 static inline void
 _py_set_opcode(_Py_CODEUNIT *word, uint8_t opcode)
 {
-    word->opcode = opcode;
+    word->_op.opcode = opcode;
 }
 
 #define _Py_SET_OPCODE(word, opcode) _py_set_opocde(&(word), opcode)

--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -33,7 +33,15 @@ _py_set_opcode(_Py_CODEUNIT *word, uint8_t opcode)
     word->_op.opcode = opcode;
 }
 
-#define _Py_SET_OPCODE(word, opcode) _py_set_opocde(&(word), opcode)
+#define _Py_SET_OPCODE(word, opcode) _py_set_opcode(&(word), opcode)
+
+static inline void
+_py_set_oparg(_Py_CODEUNIT *word, uint8_t oparg)
+{
+    word->_op.oparg = oparg;
+}
+
+#define _Py_SET_OPARG(word, opcode) _py_set_oparg(&(word), opcode)
 
 typedef struct {
     PyObject *_co_code;

--- a/Misc/NEWS.d/next/C API/2023-02-14-15-53-01.gh-issue-101907.HgF1N2.rst
+++ b/Misc/NEWS.d/next/C API/2023-02-14-15-53-01.gh-issue-101907.HgF1N2.rst
@@ -1,0 +1,1 @@
+Removes use of non-standard C++ extension in public header files.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1507,10 +1507,10 @@ deopt_code(_Py_CODEUNIT *instructions, Py_ssize_t len)
         _Py_CODEUNIT instruction = instructions[i];
         int opcode = _PyOpcode_Deopt[_Py_OPCODE(instruction)];
         int caches = _PyOpcode_Caches[opcode];
-        instructions[i].opcode = opcode;
+        _Py_OPCODE(instructions[i]) = opcode;
         while (caches--) {
-            instructions[++i].opcode = CACHE;
-            instructions[i].oparg = 0;
+            _Py_OPCODE(instructions[++i]) = CACHE;
+            _Py_OPARG(instructions[i]) = 0;
         }
     }
 }
@@ -1763,8 +1763,8 @@ code_richcompare(PyObject *self, PyObject *other, int op)
     for (int i = 0; i < Py_SIZE(co); i++) {
         _Py_CODEUNIT co_instr = _PyCode_CODE(co)[i];
         _Py_CODEUNIT cp_instr = _PyCode_CODE(cp)[i];
-        co_instr.opcode = _PyOpcode_Deopt[_Py_OPCODE(co_instr)];
-        cp_instr.opcode =_PyOpcode_Deopt[_Py_OPCODE(cp_instr)];
+        _Py_OPCODE(co_instr) = _PyOpcode_Deopt[_Py_OPCODE(co_instr)];
+        _Py_OPCODE(cp_instr) =_PyOpcode_Deopt[_Py_OPCODE(cp_instr)];
         eq = co_instr.cache == cp_instr.cache;
         if (!eq) {
             goto unequal;

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1507,10 +1507,10 @@ deopt_code(_Py_CODEUNIT *instructions, Py_ssize_t len)
         _Py_CODEUNIT instruction = instructions[i];
         int opcode = _PyOpcode_Deopt[_Py_OPCODE(instruction)];
         int caches = _PyOpcode_Caches[opcode];
-        _Py_OPCODE(instructions[i]) = opcode;
+        _Py_SET_OPCODE(instructions[i], opcode);
         while (caches--) {
-            _Py_OPCODE(instructions[++i]) = CACHE;
-            _Py_OPARG(instructions[i]) = 0;
+            _Py_SET_OPCODE(instructions[++i], CACHE);
+            _Py_SET_OPARG(instructions[i], 0);
         }
     }
 }
@@ -1763,8 +1763,8 @@ code_richcompare(PyObject *self, PyObject *other, int op)
     for (int i = 0; i < Py_SIZE(co); i++) {
         _Py_CODEUNIT co_instr = _PyCode_CODE(co)[i];
         _Py_CODEUNIT cp_instr = _PyCode_CODE(cp)[i];
-        _Py_OPCODE(co_instr) = _PyOpcode_Deopt[_Py_OPCODE(co_instr)];
-        _Py_OPCODE(cp_instr) =_PyOpcode_Deopt[_Py_OPCODE(cp_instr)];
+        _Py_SET_OPCODE(co_instr, _PyOpcode_Deopt[_Py_OPCODE(co_instr)]);
+        _Py_SET_OPCODE(cp_instr, _PyOpcode_Deopt[_Py_OPCODE(cp_instr)]);
         eq = co_instr.cache == cp_instr.cache;
         if (!eq) {
             goto unequal;

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -371,9 +371,9 @@ gen_close(PyGenObject *gen, PyObject *args)
     _PyInterpreterFrame *frame = (_PyInterpreterFrame *)gen->gi_iframe;
     /* It is possible for the previous instruction to not be a
      * YIELD_VALUE if the debugger has changed the lineno. */
-    if (err == 0 && frame->prev_instr->opcode == YIELD_VALUE) {
-        assert(frame->prev_instr[1].opcode == RESUME);
-        int exception_handler_depth = frame->prev_instr->oparg;
+    if (err == 0 && _Py_OPCODE(frame->prev_instr[0]) == YIELD_VALUE) {
+        assert(_Py_OPCODE(frame->prev_instr[1]) == RESUME);
+        int exception_handler_depth = _Py_OPCODE(frame->prev_instr[0]);
         assert(exception_handler_depth > 0);
         /* We can safely ignore the outermost try block
          * as it automatically generated to handle

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -274,31 +274,31 @@ write_instr(_Py_CODEUNIT *codestr, struct instr *instruction, int ilen)
     int caches = _PyOpcode_Caches[opcode];
     switch (ilen - caches) {
         case 4:
-            _Py_OPCODE(*codestr) = EXTENDED_ARG;
-            _Py_OPARG(*codestr) = (oparg >> 24) & 0xFF;
+            _Py_SET_OPCODE(*codestr, EXTENDED_ARG);
+            _Py_SET_OPARG(*codestr, (oparg >> 24) & 0xFF);
             codestr++;
             /* fall through */
         case 3:
-            _Py_OPCODE(*codestr) = EXTENDED_ARG;
-            _Py_OPARG(*codestr) = (oparg >> 16) & 0xFF;
+            _Py_SET_OPCODE(*codestr, EXTENDED_ARG);
+            _Py_SET_OPARG(*codestr, (oparg >> 16) & 0xFF);
             codestr++;
             /* fall through */
         case 2:
-            _Py_OPCODE(*codestr) = EXTENDED_ARG;
-            _Py_OPARG(*codestr) = (oparg >> 8) & 0xFF;
+            _Py_SET_OPCODE(*codestr, EXTENDED_ARG);
+            _Py_SET_OPARG(*codestr, (oparg >> 8) & 0xFF);
             codestr++;
             /* fall through */
         case 1:
-            _Py_OPCODE(*codestr) = opcode;
-            _Py_OPARG(*codestr) = oparg & 0xFF;
+            _Py_SET_OPCODE(*codestr, opcode);
+            _Py_SET_OPARG(*codestr, oparg & 0xFF);
             codestr++;
             break;
         default:
             Py_UNREACHABLE();
     }
     while (caches--) {
-        _Py_OPCODE(*codestr) = CACHE;
-        _Py_OPARG(*codestr) = 0;
+        _Py_SET_OPCODE(*codestr, CACHE);
+        _Py_SET_OPARG(*codestr, 0);
         codestr++;
     }
 }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -274,31 +274,31 @@ write_instr(_Py_CODEUNIT *codestr, struct instr *instruction, int ilen)
     int caches = _PyOpcode_Caches[opcode];
     switch (ilen - caches) {
         case 4:
-            codestr->opcode = EXTENDED_ARG;
-            codestr->oparg = (oparg >> 24) & 0xFF;
+            _Py_OPCODE(*codestr) = EXTENDED_ARG;
+            _Py_OPARG(*codestr) = (oparg >> 24) & 0xFF;
             codestr++;
             /* fall through */
         case 3:
-            codestr->opcode = EXTENDED_ARG;
-            codestr->oparg = (oparg >> 16) & 0xFF;
+            _Py_OPCODE(*codestr) = EXTENDED_ARG;
+            _Py_OPARG(*codestr) = (oparg >> 16) & 0xFF;
             codestr++;
             /* fall through */
         case 2:
-            codestr->opcode = EXTENDED_ARG;
-            codestr->oparg = (oparg >> 8) & 0xFF;
+            _Py_OPCODE(*codestr) = EXTENDED_ARG;
+            _Py_OPARG(*codestr) = (oparg >> 8) & 0xFF;
             codestr++;
             /* fall through */
         case 1:
-            codestr->opcode = opcode;
-            codestr->oparg = oparg & 0xFF;
+            _Py_OPCODE(*codestr) = opcode;
+            _Py_OPARG(*codestr) = oparg & 0xFF;
             codestr++;
             break;
         default:
             Py_UNREACHABLE();
     }
     while (caches--) {
-        codestr->opcode = CACHE;
-        codestr->oparg = 0;
+        _Py_OPCODE(*codestr) = CACHE;
+        _Py_OPARG(*codestr) = 0;
         codestr++;
     }
 }

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -291,19 +291,19 @@ _PyCode_Quicken(PyCodeObject *code)
         }
         switch (previous_opcode << 8 | opcode) {
             case LOAD_CONST << 8 | LOAD_FAST:
-                _Py_OPCODE(instructions[i - 1]) = LOAD_CONST__LOAD_FAST;
+                _Py_SET_OPCODE(instructions[i - 1], LOAD_CONST__LOAD_FAST);
                 break;
             case LOAD_FAST << 8 | LOAD_CONST:
-                _Py_OPCODE(instructions[i - 1]) = LOAD_FAST__LOAD_CONST;
+                _Py_SET_OPCODE(instructions[i - 1], LOAD_FAST__LOAD_CONST);
                 break;
             case LOAD_FAST << 8 | LOAD_FAST:
-                _Py_OPCODE(instructions[i - 1]) = LOAD_FAST__LOAD_FAST;
+                _Py_SET_OPCODE(instructions[i - 1], LOAD_FAST__LOAD_FAST);
                 break;
             case STORE_FAST << 8 | LOAD_FAST:
-                _Py_OPCODE(instructions[i - 1]) = STORE_FAST__LOAD_FAST;
+                _Py_SET_OPCODE(instructions[i - 1], STORE_FAST__LOAD_FAST);
                 break;
             case STORE_FAST << 8 | STORE_FAST:
-                _Py_OPCODE(instructions[i - 1]) = STORE_FAST__STORE_FAST;
+                _Py_SET_OPCODE(instructions[i - 1], STORE_FAST__STORE_FAST);
                 break;
             case COMPARE_OP << 8 | POP_JUMP_IF_TRUE:
             case COMPARE_OP << 8 | POP_JUMP_IF_FALSE:
@@ -314,8 +314,8 @@ _PyCode_Quicken(PyCodeObject *code)
                 if (opcode == POP_JUMP_IF_FALSE) {
                     mask = mask ^ 0xf;
                 }
-                _Py_OPCODE(instructions[i - 1 - INLINE_CACHE_ENTRIES_COMPARE_OP]) = COMPARE_AND_BRANCH;
-                _Py_OPARG(instructions[i - 1 - INLINE_CACHE_ENTRIES_COMPARE_OP]) = (oparg & 0xf0) | mask;
+                _Py_SET_OPCODE(instructions[i - 1 - INLINE_CACHE_ENTRIES_COMPARE_OP], COMPARE_AND_BRANCH);
+                _Py_SET_OPARG(instructions[i - 1 - INLINE_CACHE_ENTRIES_COMPARE_OP], (oparg & 0xf0) | mask);
                 break;
             }
         }

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -291,31 +291,31 @@ _PyCode_Quicken(PyCodeObject *code)
         }
         switch (previous_opcode << 8 | opcode) {
             case LOAD_CONST << 8 | LOAD_FAST:
-                instructions[i - 1].opcode = LOAD_CONST__LOAD_FAST;
+                _Py_OPCODE(instructions[i - 1]) = LOAD_CONST__LOAD_FAST;
                 break;
             case LOAD_FAST << 8 | LOAD_CONST:
-                instructions[i - 1].opcode = LOAD_FAST__LOAD_CONST;
+                _Py_OPCODE(instructions[i - 1]) = LOAD_FAST__LOAD_CONST;
                 break;
             case LOAD_FAST << 8 | LOAD_FAST:
-                instructions[i - 1].opcode = LOAD_FAST__LOAD_FAST;
+                _Py_OPCODE(instructions[i - 1]) = LOAD_FAST__LOAD_FAST;
                 break;
             case STORE_FAST << 8 | LOAD_FAST:
-                instructions[i - 1].opcode = STORE_FAST__LOAD_FAST;
+                _Py_OPCODE(instructions[i - 1]) = STORE_FAST__LOAD_FAST;
                 break;
             case STORE_FAST << 8 | STORE_FAST:
-                instructions[i - 1].opcode = STORE_FAST__STORE_FAST;
+                _Py_OPCODE(instructions[i - 1]) = STORE_FAST__STORE_FAST;
                 break;
             case COMPARE_OP << 8 | POP_JUMP_IF_TRUE:
             case COMPARE_OP << 8 | POP_JUMP_IF_FALSE:
             {
-                int oparg = instructions[i - 1 - INLINE_CACHE_ENTRIES_COMPARE_OP].oparg;
+                int oparg = _Py_OPARG(instructions[i - 1 - INLINE_CACHE_ENTRIES_COMPARE_OP]);
                 assert((oparg >> 4) <= Py_GE);
                 int mask = compare_masks[oparg >> 4];
                 if (opcode == POP_JUMP_IF_FALSE) {
                     mask = mask ^ 0xf;
                 }
-                instructions[i - 1 - INLINE_CACHE_ENTRIES_COMPARE_OP].opcode = COMPARE_AND_BRANCH;
-                instructions[i - 1 - INLINE_CACHE_ENTRIES_COMPARE_OP].oparg = (oparg & 0xf0) | mask;
+                _Py_OPCODE(instructions[i - 1 - INLINE_CACHE_ENTRIES_COMPARE_OP]) = COMPARE_AND_BRANCH;
+                _Py_OPARG(instructions[i - 1 - INLINE_CACHE_ENTRIES_COMPARE_OP]) = (oparg & 0xf0) | mask;
                 break;
             }
         }


### PR DESCRIPTION
Updates all references to use the macros, so that changes are localised to the header file.

<!-- gh-issue-number: gh-101907 -->
* Issue: gh-101907
<!-- /gh-issue-number -->
