### PR TITLE
gh-101758: Add a Test For Single-Phase Init Modules in Multiple Interpreters

### DIFF
--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -153,6 +153,9 @@ PyAPI_DATA(const struct _frozen *) _PyImport_FrozenStdlib;
 PyAPI_DATA(const struct _frozen *) _PyImport_FrozenTest;
 extern const struct _module_alias * _PyImport_FrozenAliases;
 
+// for testing
+PyAPI_FUNC(int) _PyImport_ClearExtension(PyObject *name, PyObject *filename);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -317,6 +317,11 @@ class ImportTests(unittest.TestCase):
         fileobj, pathname, _ = imp.find_module(basename)
         fileobj.close()
 
+        def clean_up():
+            import _testsinglephase
+            _testsinglephase._clear_globals()
+        self.addCleanup(clean_up)
+
         modules = {}
         def load(name):
             assert name not in modules

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -285,13 +285,19 @@ class ImportTests(unittest.TestCase):
         script = textwrap.dedent(f'''
             import _testsinglephase
 
+            expected = %d
             init_count =  _testsinglephase.initialized_count()
-            if init_count != %d:
+            if init_count != expected:
                 raise Exception(init_count)
 
             lookedup = _testsinglephase.look_up_self()
             if lookedup is not _testsinglephase:
                 raise Exception((_testsinglephase, lookedup))
+
+            # Attrs set after loading are not in m_copy.
+            if hasattr(_testsinglephase, 'spam'):
+                raise Exception(_testsinglephase.spam)
+            _testsinglephase.spam = expected
             ''')
 
         # Use an interpreter that gets destroyed right away.

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -294,6 +294,12 @@ class ImportTests(unittest.TestCase):
             if lookedup is not _testsinglephase:
                 raise Exception((_testsinglephase, lookedup))
 
+            # Attrs set in the module init func are in m_copy.
+            _initialized = _testsinglephase._initialized
+            initialized = _testsinglephase.initialized()
+            if _initialized != initialized:
+                raise Exception((_initialized, initialized))
+
             # Attrs set after loading are not in m_copy.
             if hasattr(_testsinglephase, 'spam'):
                 raise Exception(_testsinglephase.spam)

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -671,6 +671,20 @@ get_interp_settings(PyObject *self, PyObject *args)
 }
 
 
+static PyObject *
+clear_extension(PyObject *self, PyObject *args)
+{
+    PyObject *name = NULL, *filename = NULL;
+    if (!PyArg_ParseTuple(args, "OO:clear_extension", &name, &filename)) {
+        return NULL;
+    }
+    if (_PyImport_ClearExtension(name, filename) < 0) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+
 static PyMethodDef module_functions[] = {
     {"get_configs", get_configs, METH_NOARGS},
     {"get_recursion_depth", get_recursion_depth, METH_NOARGS},
@@ -692,6 +706,7 @@ static PyMethodDef module_functions[] = {
     _TESTINTERNALCAPI_COMPILER_CODEGEN_METHODDEF
     _TESTINTERNALCAPI_OPTIMIZE_CFG_METHODDEF
     {"get_interp_settings", get_interp_settings, METH_VARARGS, NULL},
+    {"clear_extension", clear_extension, METH_VARARGS, NULL},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Modules/_testsinglephase.c
+++ b/Modules/_testsinglephase.c
@@ -134,6 +134,16 @@ init_module(PyObject *module, module_state *state)
     if (PyModule_AddObjectRef(module, "str_const", state->str_const) != 0) {
         return -1;
     }
+
+    double d = _PyTime_AsSecondsDouble(state->initialized);
+    PyObject *initialized = PyFloat_FromDouble(d);
+    if (initialized == NULL) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(module, "_initialized", initialized) != 0) {
+        return -1;
+    }
+
     return 0;
 }
 

--- a/Modules/_testsinglephase.c
+++ b/Modules/_testsinglephase.c
@@ -17,12 +17,27 @@ typedef struct {
     PyObject *str_const;
 } module_state;
 
+
 /* Process-global state is only used by _testsinglephase
    since it's the only one that does not support re-init. */
 static struct {
     int initialized_count;
     module_state module;
-} global_state = { .initialized_count = -1 };
+} global_state = {
+
+#define NOT_INITIALIZED -1
+    .initialized_count = NOT_INITIALIZED,
+};
+
+static void clear_state(module_state *state);
+
+static void
+clear_global_state(void)
+{
+    clear_state(&global_state.module);
+    global_state.initialized_count = NOT_INITIALIZED;
+}
+
 
 static inline module_state *
 get_module_state(PyObject *module)
@@ -105,6 +120,7 @@ error:
     clear_state(state);
     return -1;
 }
+
 
 static int
 init_module(PyObject *module, module_state *state)
@@ -198,8 +214,26 @@ basic_initialized_count(PyObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 #define INITIALIZED_COUNT_METHODDEF \
-    {"initialized_count", basic_initialized_count, METH_VARARGS, \
+    {"initialized_count", basic_initialized_count, METH_NOARGS, \
      basic_initialized_count_doc}
+
+
+PyDoc_STRVAR(basic__clear_globals_doc,
+"_clear_globals()\n\
+\n\
+Free all global state and set it to uninitialized.");
+
+static PyObject *
+basic__clear_globals(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    assert(PyModule_GetDef(self)->m_size == -1);
+    clear_global_state();
+    Py_RETURN_NONE;
+}
+
+#define _CLEAR_GLOBALS_METHODDEF \
+    {"_clear_globals", basic__clear_globals, METH_NOARGS, \
+     basic__clear_globals_doc}
 
 
 /*********************************************/
@@ -223,6 +257,7 @@ static PyMethodDef TestMethods_Basic[] = {
     SUM_METHODDEF,
     INITIALIZED_METHODDEF,
     INITIALIZED_COUNT_METHODDEF,
+    _CLEAR_GLOBALS_METHODDEF,
     {NULL, NULL}           /* sentinel */
 };
 


### PR DESCRIPTION
The test verifies the behavior of single-phase init modules when loaded in multiple interpreters.

This test would have identified the failure I hit [the other day](https://github.com/python/cpython/pull/101660#issuecomment-1424507393).

<!-- gh-issue-number: gh-101758 -->
* Issue: gh-101758
<!-- /gh-issue-number -->
