### PR TITLE
gh-101903: Remove unnecessary undefs for non-existent/old macros Py_EnterRecursiveCall and Py_LeaveRecursiveCall

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3072,14 +3072,10 @@ maybe_dtrace_line(_PyInterpreterFrame *frame,
 /* Implement Py_EnterRecursiveCall() and Py_LeaveRecursiveCall() as functions
    for the limited API. */
 
-#undef Py_EnterRecursiveCall
-
 int Py_EnterRecursiveCall(const char *where)
 {
     return _Py_EnterRecursiveCall(where);
 }
-
-#undef Py_LeaveRecursiveCall
 
 void Py_LeaveRecursiveCall(void)
 {


### PR DESCRIPTION
While taking a look at #101903, I noticed a couple of `undefs` lingering before the function definitions of `Py_EnterRecursiveCall`/`Py_LeaveRecursiveCall`.

The macro definitions for `Py_EnterRecursiveCall`/`Py_LeaveRecursiveCall` were removed in #91988. These `undefs` should therefore be redundant.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101903 -->
* Issue: gh-101903
<!-- /gh-issue-number -->
