### PR TITLE
gh-101952: Fix possible segfault in `BUILD_SET` opcode

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-16-16-57-23.gh-issue-101952.Zo1dlq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-16-16-57-23.gh-issue-101952.Zo1dlq.rst
@@ -1,0 +1,1 @@
+Fix possible segfault in ``BUILD_SET`` opcode, when new set created.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1302,6 +1302,8 @@ dummy_func(
 
         inst(BUILD_SET, (values[oparg] -- set)) {
             set = PySet_New(NULL);
+            if (set == NULL)
+                goto error;
             int err = 0;
             for (int i = 0; i < oparg; i++) {
                 PyObject *item = values[i];

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1649,6 +1649,8 @@
             PyObject **values = &PEEK(oparg);
             PyObject *set;
             set = PySet_New(NULL);
+            if (set == NULL)
+                goto error;
             int err = 0;
             for (int i = 0; i < oparg; i++) {
                 PyObject *item = values[i];


### PR DESCRIPTION
Resolves #101952 

<!-- gh-issue-number: gh-101952 -->
* Issue: gh-101952
<!-- /gh-issue-number -->
