### PR TITLE
gh-101967: add a missing error check

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-16-23-19-01.gh-issue-101967.Kqr1dz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-16-23-19-01.gh-issue-101967.Kqr1dz.rst
@@ -1,0 +1,1 @@
+Fix possible segfault in ``positional_only_passed_as_keyword`` function, when new list created.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1256,7 +1256,7 @@ positional_only_passed_as_keyword(PyThreadState *tstate, PyCodeObject *co,
     int posonly_conflicts = 0;
     PyObject* posonly_names = PyList_New(0);
     if (posonly_names == NULL)
-        return 1;
+        goto fail; 
     for(int k=0; k < co->co_posonlyargcount; k++){
         PyObject* posonly_name = PyTuple_GET_ITEM(co->co_localsplusnames, k);
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1255,7 +1255,8 @@ positional_only_passed_as_keyword(PyThreadState *tstate, PyCodeObject *co,
 {
     int posonly_conflicts = 0;
     PyObject* posonly_names = PyList_New(0);
-
+    if (posonly_names == NULL)
+        return 1;
     for(int k=0; k < co->co_posonlyargcount; k++){
         PyObject* posonly_name = PyTuple_GET_ITEM(co->co_localsplusnames, k);
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1255,8 +1255,9 @@ positional_only_passed_as_keyword(PyThreadState *tstate, PyCodeObject *co,
 {
     int posonly_conflicts = 0;
     PyObject* posonly_names = PyList_New(0);
-    if (posonly_names == NULL)
-        goto fail; 
+    if (posonly_names == NULL) {
+        goto fail;
+    }
     for(int k=0; k < co->co_posonlyargcount; k++){
         PyObject* posonly_name = PyTuple_GET_ITEM(co->co_localsplusnames, k);
 


### PR DESCRIPTION
Resolves #101967 
According to the semantics of function, I prefered to return `1` instead of `NULL`. Does it correct?

<!-- gh-issue-number: gh-101967 -->
* Issue: gh-101967
<!-- /gh-issue-number -->
