### PR TITLE
Docs: fix typos in PyFunction_WatchCallback docs and in 3.12 NEWS

### DIFF
--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -169,7 +169,7 @@ There are a few functions specific to Python functions.
    before the modification to *func* takes place, so the prior state of *func*
    can be inspected. The runtime is permitted to optimize away the creation of
    function objects when possible. In such cases no event will be emitted.
-   Although this creates the possitibility of an observable difference of
+   Although this creates the possibility of an observable difference of
    runtime behavior depending on optimization decisions, it does not change
    the semantics of the Python code being executed.
 

--- a/Misc/NEWS.d/3.12.0a2.rst
+++ b/Misc/NEWS.d/3.12.0a2.rst
@@ -1060,7 +1060,7 @@ Add ``getbufferproc`` and ``releasebufferproc`` to the stable API.
 
 Some configurable capabilities of sub-interpreters have changed. They always
 allow subprocesses (:mod:`subprocess`) now, whereas before subprocesses
-could be optionally disaallowed for a sub-interpreter. Instead
+could be optionally disallowed for a sub-interpreter. Instead
 :func:`os.exec` can now be disallowed. Disallowing daemon threads is now
 supported.  Disallowing all threads is still allowed, but is never done by
 default. Note that the optional restrictions are only available through

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -113,7 +113,7 @@ fold_unaryop(expr_ty node, PyArena *arena, _PyASTOptimizeState *state)
     return make_const(node, newval, arena);
 }
 
-/* Check whether a collection doesn't contain too many items (including
+/* Check whether a collection doesn't containing too much items (including
    subcollections).  This protects from creating a constant that needs
    too much time for calculating a hash.
    "limit" is the maximal number of items.

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -113,7 +113,7 @@ fold_unaryop(expr_ty node, PyArena *arena, _PyASTOptimizeState *state)
     return make_const(node, newval, arena);
 }
 
-/* Check whether a collection doesn't containing too much items (including
+/* Check whether a collection doesn't contain too many items (including
    subcollections).  This protects from creating a constant that needs
    too much time for calculating a hash.
    "limit" is the maximal number of items.


### PR DESCRIPTION
- possitibility => possibility
- disaallowed => disallowed