### PR TITLE
[3.11] gh-100809: Fix handling of drive-relative paths in pathlib.Path.absolute() (GH-100812)

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -976,7 +976,12 @@ class Path(PurePath):
         """
         if self.is_absolute():
             return self
-        return self._from_parts([self.cwd()] + self._parts)
+        elif self._drv:
+            # There is a CWD on each drive-letter drive.
+            cwd = self._flavour.pathmod.abspath(self._drv)
+        else:
+            cwd = self.cwd()
+        return self._from_parts([cwd] + self._parts)
 
     def resolve(self, strict=False):
         """

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -4,6 +4,7 @@ import errno
 import os
 import re
 import stat
+import string
 import sys
 import time
 import unittest
@@ -715,3 +716,37 @@ class EnvironmentVarGuard(collections.abc.MutableMapping):
             else:
                 self._environ[k] = v
         os.environ = self._environ
+
+
+try:
+    import ctypes
+    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+
+    ERROR_FILE_NOT_FOUND = 2
+    DDD_REMOVE_DEFINITION = 2
+    DDD_EXACT_MATCH_ON_REMOVE = 4
+    DDD_NO_BROADCAST_SYSTEM = 8
+except (ImportError, AttributeError):
+    def subst_drive(path):
+        raise unittest.SkipTest('ctypes or kernel32 is not available')
+else:
+    @contextlib.contextmanager
+    def subst_drive(path):
+        """Temporarily yield a substitute drive for a given path."""
+        for c in reversed(string.ascii_uppercase):
+            drive = f'{c}:'
+            if (not kernel32.QueryDosDeviceW(drive, None, 0) and
+                    ctypes.get_last_error() == ERROR_FILE_NOT_FOUND):
+                break
+        else:
+            raise unittest.SkipTest('no available logical drive')
+        if not kernel32.DefineDosDeviceW(
+                DDD_NO_BROADCAST_SYSTEM, drive, path):
+            raise ctypes.WinError(ctypes.get_last_error())
+        try:
+            yield drive
+        finally:
+            if not kernel32.DefineDosDeviceW(
+                    DDD_REMOVE_DEFINITION | DDD_EXACT_MATCH_ON_REMOVE,
+                    drive, path):
+                raise ctypes.WinError(ctypes.get_last_error())

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2733,6 +2733,26 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
             self.assertEqual(str(P('a', 'b', 'c').absolute()),
                              os.path.join(share, 'a', 'b', 'c'))
 
+        drive = os.path.splitdrive(BASE)[0]
+        with os_helper.change_cwd(BASE):
+            # Relative path with root
+            self.assertEqual(str(P('\\').absolute()), drive + '\\')
+            self.assertEqual(str(P('\\foo').absolute()), drive + '\\foo')
+
+            # Relative path on current drive
+            self.assertEqual(str(P(drive).absolute()), BASE)
+            self.assertEqual(str(P(drive + 'foo').absolute()), os.path.join(BASE, 'foo'))
+
+        with os_helper.subst_drive(BASE) as other_drive:
+            # Set the working directory on the substitute drive
+            saved_cwd = os.getcwd()
+            other_cwd = f'{other_drive}\\dirA'
+            os.chdir(other_cwd)
+            os.chdir(saved_cwd)
+
+            # Relative path on another drive
+            self.assertEqual(str(P(other_drive).absolute()), other_cwd)
+            self.assertEqual(str(P(other_drive + 'foo').absolute()), other_cwd + '\\foo')
 
     def test_glob(self):
         P = self.cls

--- a/Misc/NEWS.d/next/Library/2023-01-06-21-14-41.gh-issue-100809.I697UT.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-06-21-14-41.gh-issue-100809.I697UT.rst
@@ -1,0 +1,3 @@
+Fix handling of drive-relative paths (like 'C:' and 'C:foo') in
+:meth:`pathlib.Path.absolute`. This method now uses the OS API
+to retrieve the correct current working directory for the drive.


### PR DESCRIPTION
Resolving the drive independently uses the OS API, which ensures it starts from the current directory on that drive. (cherry picked from commit 072011b3c38f871cdc3ab62630ea2234d09456d1)

<!-- gh-issue-number: gh-100809 -->
* Issue: gh-100809
<!-- /gh-issue-number -->
