### PR TITLE
gh-97930: Also include subdirectory in makefile.

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2075,6 +2075,8 @@ TESTSUBDIRS=	idlelib/idle_test \
 		test/test_importlib/resources/data01/subdirectory \
 		test/test_importlib/resources/data02 \
 		test/test_importlib/resources/data02/one \
+		test/test_importlib/resources/data02/subdirectory \
+		test/test_importlib/resources/data02/subdirectory/subsubdir \
 		test/test_importlib/resources/data02/two \
 		test/test_importlib/resources/data03 \
 		test/test_importlib/resources/data03/namespace \


### PR DESCRIPTION
Fixes buildbot failures introduced in #102010.


<!-- gh-issue-number: gh-97930 -->
* Issue: gh-97930
<!-- /gh-issue-number -->
