### PR TITLE
[3.11] gh-31802: Correct docstrings for in-place builtin operators

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-03-10-21-48-05.bpo-46978.f5QFfw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-03-10-21-48-05.bpo-46978.f5QFfw.rst
@@ -1,0 +1,1 @@
+Fixed docstrings for in-place operators of built-in types.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8022,7 +8022,7 @@ typedef struct wrapperbase slotdef;
            NAME "($self, /)\n--\n\n" DOC)
 #define IBSLOT(NAME, SLOT, FUNCTION, WRAPPER, DOC) \
     ETSLOT(NAME, as_number.SLOT, FUNCTION, WRAPPER, \
-           NAME "($self, value, /)\n--\n\nReturn self" DOC "value.")
+           NAME "($self, value, /)\n--\n\nCompute self " DOC " value.")
 #define BINSLOT(NAME, SLOT, FUNCTION, DOC) \
     ETSLOT(NAME, as_number.SLOT, FUNCTION, wrap_binaryfunc_l, \
            NAME "($self, value, /)\n--\n\nReturn self" DOC "value.")


### PR DESCRIPTION
(cherry picked from commit 128379b8cdb88a6d3d7fed24df082c9a654b3fb8)