### PR TITLE
gh-102069: Fix `__weakref__` descriptor generation for custom dataclasses

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1192,7 +1192,7 @@ def _add_slots(cls, is_frozen, weakref_slot):
     # Remove __dict__ itself.
     cls_dict.pop('__dict__', None)
 
-    # Clear exiting `__weakref__` descriptor, it belongs to a previous type:
+    # Clear existing `__weakref__` descriptor, it belongs to a previous type:
     cls_dict.pop('__weakref__', None)  # gh-102069
 
     # And finally create the class.

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1192,6 +1192,9 @@ def _add_slots(cls, is_frozen, weakref_slot):
     # Remove __dict__ itself.
     cls_dict.pop('__dict__', None)
 
+    # Clear exiting `__weakref__` descriptor, it belongs to a previous type:
+    cls_dict.pop('__weakref__', None)  # gh-102069
+
     # And finally create the class.
     qualname = getattr(cls, '__qualname__', None)
     cls = type(cls)(cls.__name__, cls.__bases__, cls_dict)

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3119,6 +3119,8 @@ class TestSlots(unittest.TestCase):
         with self.assertRaisesRegex(TypeError,
                                     "cannot create weak reference"):
             weakref.ref(a)
+        with self.assertRaises(AttributeError):
+            a.__weakref__
 
     def test_slots_weakref(self):
         @dataclass(slots=True, weakref_slot=True)
@@ -3127,7 +3129,9 @@ class TestSlots(unittest.TestCase):
 
         self.assertIn("__weakref__", A.__slots__)
         a = A(1)
-        weakref.ref(a)
+        a_ref = weakref.ref(a)
+
+        self.assertIs(a.__weakref__, a_ref)
 
     def test_slots_weakref_base_str(self):
         class Base:
@@ -3193,7 +3197,8 @@ class TestSlots(unittest.TestCase):
         self.assertIn("__weakref__", Base.__slots__)
         self.assertNotIn("__weakref__", A.__slots__)
         a = A(1)
-        weakref.ref(a)
+        a_ref = weakref.ref(a)
+        self.assertIs(a.__weakref__, a_ref)
 
     def test_weakref_slot_subclass_no_weakref_slot(self):
         @dataclass(slots=True, weakref_slot=True)
@@ -3209,7 +3214,8 @@ class TestSlots(unittest.TestCase):
         self.assertIn("__weakref__", Base.__slots__)
         self.assertNotIn("__weakref__", A.__slots__)
         a = A(1)
-        weakref.ref(a)
+        a_ref = weakref.ref(a)
+        self.assertIs(a.__weakref__, a_ref)
 
     def test_weakref_slot_normal_base_weakref_slot(self):
         class Base:
@@ -3224,7 +3230,8 @@ class TestSlots(unittest.TestCase):
         self.assertIn("__weakref__", Base.__slots__)
         self.assertNotIn("__weakref__", A.__slots__)
         a = A(1)
-        weakref.ref(a)
+        a_ref = weakref.ref(a)
+        self.assertIs(a.__weakref__, a_ref)
 
 
 class TestDescriptors(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2023-02-20-16-47-56.gh-issue-102069.FS7f1j.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-20-16-47-56.gh-issue-102069.FS7f1j.rst
@@ -1,0 +1,1 @@
+Fix ``__weakref__`` descriptor generation for custom dataclasses.


### PR DESCRIPTION
Since we recreate a class, we have a descriptor from a previous type. This is why `check_descr` fails.

<!-- gh-issue-number: gh-102069 -->
* Issue: gh-102069
<!-- /gh-issue-number -->
