### PR TITLE
[3.10] gh-101566: Sync with zipp 3.14. (GH-102018).

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -3209,6 +3209,17 @@ with zipfile.ZipFile(io.BytesIO(), "w") as zf:
             file = cls(alpharep).joinpath('some dir').parent
             assert isinstance(file, cls)
 
+    @pass_alpharep
+    def test_extract_orig_with_implied_dirs(self, alpharep):
+        """
+        A zip file wrapped in a Path should extract even with implied dirs.
+        """
+        source_path = self.zipfile_ondisk(alpharep)
+        zf = zipfile.ZipFile(source_path)
+        # wrap the zipfile for its side effect
+        zipfile.Path(zf)
+        zf.extractall(source_path.parent)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -2197,6 +2197,17 @@ class CompleteDirs(ZipFile):
         dir_match = name not in names and dirname in names
         return dirname if dir_match else name
 
+    def getinfo(self, name):
+        """
+        Supplement getinfo for implied dirs.
+        """
+        try:
+            return super().getinfo(name)
+        except KeyError:
+            if not name.endswith('/') or name not in self._name_set():
+                raise
+            return ZipInfo(filename=name)
+
     @classmethod
     def make(cls, source):
         """

--- a/Misc/NEWS.d/next/Library/2023-02-17-20-24-15.gh-issue-101566.FjgWBt.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-17-20-24-15.gh-issue-101566.FjgWBt.rst
@@ -1,0 +1,3 @@
+In zipfile, apply
+fix for extractall on the underlying zipfile after being wrapped in
+``Path``.


### PR DESCRIPTION
(cherry picked from commit 36854bbb240e417c0df6f0014924fcc899388186)

Includes the bugfix only.


<!-- gh-issue-number: gh-101566 -->
* Issue: gh-101566
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:jaraco