### PR TITLE
gh-102027: Fix macro name

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-21-23-42-39.gh-issue-102027.fQARG0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-21-23-42-39.gh-issue-102027.fQARG0.rst
@@ -1,0 +1,2 @@
+Fix SSE2 and SSE3 detection in ``_blake2`` internal module. Patch by Max
+Bachmann.

--- a/Modules/_blake2/impl/blake2-config.h
+++ b/Modules/_blake2/impl/blake2-config.h
@@ -53,7 +53,7 @@
 #endif
 #endif
 
-#ifdef HAVE_SSE41
+#ifdef HAVE_SSE4_1
 #ifndef HAVE_SSSE3
 #define HAVE_SSSE3
 #endif


### PR DESCRIPTION
This fixes the ssse3 / sse2 detection

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102027 -->
* Issue: gh-102027
<!-- /gh-issue-number -->
