### PR TITLE
Fix typo in Py_GetPythonHome signature

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -818,7 +818,7 @@ Process-wide parameters
    .. deprecated:: 3.11
 
 
-.. c:function:: w_char* Py_GetPythonHome()
+.. c:function:: wchar_t* Py_GetPythonHome()
 
    Return the default "home", that is, the value set by a previous call to
    :c:func:`Py_SetPythonHome`, or the value of the :envvar:`PYTHONHOME`


### PR DESCRIPTION
Fix .rst return value of Py_GetPythonHome