### PR TITLE
gh-102184: Test os.sync() only if "largefile" resource is enabled

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -66,8 +66,12 @@ class PosixTester(unittest.TestCase):
         NO_ARG_FUNCTIONS = [ "ctermid", "getcwd", "getcwdb", "uname",
                              "times", "getloadavg",
                              "getegid", "geteuid", "getgid", "getgroups",
-                             "getpid", "getpgrp", "getppid", "getuid", "sync",
+                             "getpid", "getpgrp", "getppid", "getuid",
                            ]
+        # gh-102184: Don't test sync() by default since it might cause heavy
+        # I/O and block for a long time.
+        if support.is_resource_enabled('largefile'):
+            NO_ARG_FUNCTIONS.append("sync")
 
         for name in NO_ARG_FUNCTIONS:
             posix_func = getattr(posix, name, None)

--- a/Misc/NEWS.d/next/Tests/2023-02-23-17-38-36.gh-issue-102184.W71J5G.rst
+++ b/Misc/NEWS.d/next/Tests/2023-02-23-17-38-36.gh-issue-102184.W71J5G.rst
@@ -1,0 +1,1 @@
+Test ``os.sync()`` only if "largefile" resource is enabled.


### PR DESCRIPTION
Calling `os.sync()` when the Linux page cache is large and full of dirty pages and the storage device is slow can block the process in "uninterruptible sleep" state for minutes, making the test run unkillable even with SIGKILL. Avoid this by testing `os.sync()` only if "largefile" resource is enabled.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102184 -->
* Issue: gh-102184
<!-- /gh-issue-number -->
