### PR TITLE
gh-102190: Add additional zipfile pwd docstrings

### DIFF
--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1518,7 +1518,9 @@ class ZipFile:
         self._didModify = True
 
     def read(self, name, pwd=None):
-        """Return file bytes for name."""
+        """Return file bytes for name. 'pwd' is the password to decrypt
+        encrypted files.
+        """
         with self.open(name, "r", pwd) as fp:
             return fp.read()
 
@@ -1665,7 +1667,8 @@ class ZipFile:
         """Extract a member from the archive to the current working directory,
            using its full name. Its file information is extracted as accurately
            as possible. `member' may be a filename or a ZipInfo object. You can
-           specify a different directory using `path'.
+           specify a different directory using `path'. You can specify the
+           password to decrypt the file using 'pwd'.
         """
         if path is None:
             path = os.getcwd()
@@ -1678,7 +1681,8 @@ class ZipFile:
         """Extract all members from the archive to the current working
            directory. `path' specifies a different directory to extract to.
            `members' is optional and must be a subset of the list returned
-           by namelist().
+           by namelist(). You can specify the password to decrypt all files
+           using 'pwd'.
         """
         if members is None:
             members = self.namelist()

--- a/Misc/NEWS.d/next/Documentation/2023-02-23-23-42-43.gh-issue-102194.bTlEeI.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-02-23-23-42-43.gh-issue-102194.bTlEeI.rst
@@ -1,0 +1,1 @@
+Add additional pwd docstrings to ``Lib/zipfile/__init__.py``.


### PR DESCRIPTION
Per original issue, add additional pwd docstrings into zipfile. All added docstrings are adapted from existing pwd documentation for clarity. 

- Issue: https://github.com/python/cpython/issues/102190


<!-- gh-issue-number: gh-102190 -->
* Issue: gh-102190
<!-- /gh-issue-number -->
