### PR TITLE
gh-102215: importlib documentation cleanups

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -1,11 +1,11 @@
 .. _using:
 
-=================================
- Using :mod:`!importlib.metadata`
-=================================
+========================================================
+:mod:`!importlib.metadata` -- Accessing package metadata
+========================================================
 
 .. module:: importlib.metadata
-   :synopsis: The implementation of the importlib metadata.
+   :synopsis: Accessing package metadata
 
 .. versionadded:: 3.8
 .. versionchanged:: 3.10

--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -173,10 +173,10 @@ for more information on entry points, their definition, and usage.
 
 *Compatibility Note*
 
-The "selectable" entry points were introduced in ``importlib.metadata``
+The "selectable" entry points were introduced in ``importlib_metadata``
 3.6 and Python 3.10. Prior to those changes, ``entry_points`` accepted
 no parameters and always returned a dictionary of entry points, keyed
-by group. With ``importlib.metadata`` 5.0 and Python 3.12,
+by group. With ``importlib_metadata`` 5.0 and Python 3.12,
 ``entry_points`` always returns an ``EntryPoints`` object. See
 `backports.entry_points_selectable <https://pypi.org/project/backports.entry_points_selectable>`_
 for compatibility options.

--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -13,7 +13,7 @@
 
 **Source code:** :source:`Lib/importlib/metadata/__init__.py`
 
-``importlib_metadata`` is a library that provides access to
+``importlib.metadata`` is a library that provides access to
 the metadata of an installed `Distribution Package <https://packaging.python.org/en/latest/glossary/#term-Distribution-Package>`_,
 such as its entry points
 or its top-level names (`Import Package <https://packaging.python.org/en/latest/glossary/#term-Import-Package>`_\s, modules, if any).
@@ -24,7 +24,7 @@ API`_ and `metadata API`_ of ``pkg_resources``.  Along with
 this package can eliminate the need to use the older and less efficient
 ``pkg_resources`` package.
 
-``importlib_metadata`` operates on third-party *distribution packages*
+``importlib.metadata`` operates on third-party *distribution packages*
 installed into Python's ``site-packages`` directory via tools such as
 `pip <https://pypi.org/project/pip/>`_.
 Specifically, it works with distributions with discoverable
@@ -173,10 +173,10 @@ for more information on entry points, their definition, and usage.
 
 *Compatibility Note*
 
-The "selectable" entry points were introduced in ``importlib_metadata``
+The "selectable" entry points were introduced in ``importlib.metadata``
 3.6 and Python 3.10. Prior to those changes, ``entry_points`` accepted
 no parameters and always returned a dictionary of entry points, keyed
-by group. With ``importlib_metadata`` 5.0 and Python 3.12,
+by group. With ``importlib.metadata`` 5.0 and Python 3.12,
 ``entry_points`` always returns an ``EntryPoints`` object. See
 `backports.entry_points_selectable <https://pypi.org/project/backports.entry_points_selectable>`_
 for compatibility options.
@@ -364,7 +364,7 @@ system :ref:`finders <finders-and-loaders>`.  To find a distribution package's m
 ``importlib.metadata`` queries the list of :term:`meta path finders <meta path finder>` on
 :data:`sys.meta_path`.
 
-By default ``importlib_metadata`` installs a finder for distribution packages
+By default ``importlib.metadata`` installs a finder for distribution packages
 found on the file system.
 This finder doesn't actually find any *distributions*,
 but it can find their metadata.

--- a/Doc/library/importlib.resources.rst
+++ b/Doc/library/importlib.resources.rst
@@ -97,7 +97,7 @@ for example, a package and its resources can be imported from a zip file using
 
 
 Deprecated functions
---------------------
+^^^^^^^^^^^^^^^^^^^^
 
 An older, deprecated set of functions is still available, but is
 scheduled for removal in a future version of Python.

--- a/Doc/library/importlib.resources.rst
+++ b/Doc/library/importlib.resources.rst
@@ -1,5 +1,5 @@
-:mod:`importlib.resources` -- Resources
----------------------------------------
+:mod:`importlib.resources` -- Package resource reading, opening and access
+--------------------------------------------------------------------------
 
 .. module:: importlib.resources
     :synopsis: Package resource reading, opening, and access


### PR DESCRIPTION
Fixes a heading at the wrong level, headings in the wrong format, and undescriptive module synopses.

<!-- gh-issue-number: gh-102215 -->
* Issue: gh-102215
<!-- /gh-issue-number -->
