### PR TITLE
gh-48511: Make pwd and grp expose inner errors

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -250,7 +250,7 @@ def expanduser(path):
                 return path
             try:
                 userhome = pwd.getpwuid(os.getuid()).pw_dir
-            except KeyError:
+            except (KeyError, OSError):
                 # bpo-10496: if the current user identifier doesn't exist in the
                 # password database, return the path unchanged
                 return path
@@ -267,7 +267,7 @@ def expanduser(path):
             name = os.fsdecode(name)
         try:
             pwent = pwd.getpwnam(name)
-        except KeyError:
+        except (KeyError, OSError):
             # bpo-10496: if the user name from the path doesn't exist in the
             # password database, return the path unchanged
             return path

--- a/Misc/NEWS.d/next/Library/2023-02-24-18-17-01.gh-issue-48511.a7Tra5.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-24-18-17-01.gh-issue-48511.a7Tra5.rst
@@ -1,0 +1,6 @@
+The Unix user (:func:`pwd.getpwuid`, :func:`pwd.getpwnam`) and group
+(:func:`grp.getgrgid`, :func:`grp.getgrnam`) database functions now
+differentiate between a lack of record (:exc:`KeyError` is risen, the current behaviour)
+and a database access error (:exc:`OSError` is risen).
+
+Based on a patch by Oleg Iarygin.

--- a/Misc/NEWS.d/next/Library/2023-02-24-18-17-01.gh-issue-48511.a7Tra5.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-24-18-17-01.gh-issue-48511.a7Tra5.rst
@@ -1,0 +1,6 @@
+The Unix user (:func:`pwd.getpwuid`, :func:`pwd.getpwnam`) and group (
+:func:`grp.getgrgid`, :func:`grp.getgrnam`) database functions now 
+differentiate between a lack of record (:exc:`KeyError` is risen, the current behaviour)
+and a database access error (:exc:`OSError` is risen).
+
+Based on a patch by Oleg Iarygin.

--- a/Misc/NEWS.d/next/Library/2023-02-24-18-17-01.gh-issue-48511.a7Tra5.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-24-18-17-01.gh-issue-48511.a7Tra5.rst
@@ -1,5 +1,5 @@
-The Unix user (:func:`pwd.getpwuid`, :func:`pwd.getpwnam`) and group (
-:func:`grp.getgrgid`, :func:`grp.getgrnam`) database functions now 
+The Unix user (:func:`pwd.getpwuid`, :func:`pwd.getpwnam`) and group
+(:func:`grp.getgrgid`, :func:`grp.getgrnam`) database functions now
 differentiate between a lack of record (:exc:`KeyError` is risen, the current behaviour)
 and a database access error (:exc:`OSError` is risen).
 

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -179,24 +179,29 @@ grp_getgrgid_impl(PyObject *module, PyObject *id)
     p = getgrgid(gid);
 #endif
     if (p == NULL) {
-#ifndef HAVE_GETGRGID_R
-        PyMutex_Unlock(&group_db_mutex);
-#endif
-        PyMem_RawFree(buf);
         if (nomem == 1) {
-            return PyErr_NoMemory();
+            retval = PyErr_NoMemory();
         }
-        PyObject *gid_obj = _PyLong_FromGid(gid);
-        if (gid_obj == NULL)
-            return NULL;
-        PyErr_Format(PyExc_KeyError, "getgrgid(): gid not found: %S", gid_obj);
-        Py_DECREF(gid_obj);
-        return NULL;
+        else if (errno == 0) {
+            PyObject *gid_obj = _PyLong_FromGid(gid);
+            if (gid_obj == NULL) {
+                retval = NULL;
+            }
+            else {
+                retval = PyErr_Format(PyExc_KeyError,
+                                      "getgrgid(): gid not found: %S", gid_obj);
+                Py_DECREF(gid_obj);
+            }
+        }
+        else {
+            retval = PyErr_SetFromErrno(PyExc_OSError);
+        }
     }
-    retval = mkgrent(module, p);
-#ifdef HAVE_GETGRGID_R
+    else {
+        retval = mkgrent(module, p);
+    }
     PyMem_RawFree(buf);
-#else
+#ifndef HAVE_GETGRGID_R
     PyMutex_Unlock(&group_db_mutex);
 #endif
     return retval;
@@ -268,18 +273,20 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
     p = getgrnam(name_chars);
 #endif
     if (p == NULL) {
-#ifndef HAVE_GETGRNAM_R
-        PyMutex_Unlock(&group_db_mutex);
-#endif
         if (nomem == 1) {
-            PyErr_NoMemory();
+            retval = PyErr_NoMemory();
+        }
+        else if (errno == 0) {
+            retval = PyErr_Format(PyExc_KeyError,
+                                  "getgrnam(): name not found: %R", name);
         }
         else {
-            PyErr_Format(PyExc_KeyError, "getgrnam(): name not found: %R", name);
+            retval = PyErr_SetFromErrno(PyExc_OSError);
         }
-        goto out;
     }
-    retval = mkgrent(module, p);
+    else {
+        retval = mkgrent(module, p);
+    }
 #ifndef HAVE_GETGRNAM_R
     PyMutex_Unlock(&group_db_mutex);
 #endif

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -187,27 +187,31 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
     p = getpwuid(uid);
 #endif
     if (p == NULL) {
-#ifndef HAVE_GETPWUID_R
-        PyMutex_Unlock(&pwd_db_mutex);
-#endif
-        PyMem_RawFree(buf);
         if (nomem == 1) {
-            return PyErr_NoMemory();
+            retval = PyErr_NoMemory();
         }
-        PyObject *uid_obj = _PyLong_FromUid(uid);
-        if (uid_obj == NULL)
-            return NULL;
-        PyErr_Format(PyExc_KeyError,
-                     "getpwuid(): uid not found: %S", uid_obj);
-        Py_DECREF(uid_obj);
-        return NULL;
+        else if (errno == 0) {
+            PyObject *uid_obj = _PyLong_FromUid(uid);
+            if (uid_obj == NULL) {
+                retval = NULL;
+            }
+            else {
+                retval = PyErr_Format(PyExc_KeyError,
+                                      "getpwuid(): uid not found: %S", uid_obj);
+                Py_DECREF(uid_obj);
+            }
+        }
+        else {
+            retval = PyErr_SetFromErrno(PyExc_OSError);
+        }
     }
-    retval = mkpwent(module, p);
-#ifdef HAVE_GETPWUID_R
-    PyMem_RawFree(buf);
-#else
+    else {
+        retval = mkpwent(module, p);
+    }
+#ifndef HAVE_GETPWUID_R
     PyMutex_Unlock(&pwd_db_mutex);
 #endif
+    PyMem_RawFree(buf);
     return retval;
 }
 
@@ -278,19 +282,20 @@ pwd_getpwnam_impl(PyObject *module, PyObject *name)
     p = getpwnam(name_chars);
 #endif
     if (p == NULL) {
-#ifndef HAVE_GETPWNAM_R
-        PyMutex_Unlock(&pwd_db_mutex);
-#endif
         if (nomem == 1) {
-            PyErr_NoMemory();
+            retval = PyErr_NoMemory();
+        }
+        else if (errno == 0) {
+            retval = PyErr_Format(PyExc_KeyError,
+                                  "getpwnam(): name not found: %R", name);
         }
         else {
-            PyErr_Format(PyExc_KeyError,
-                         "getpwnam(): name not found: %R", name);
+            retval = PyErr_SetFromErrno(PyExc_OSError);
         }
-        goto out;
     }
-    retval = mkpwent(module, p);
+    else {
+        retval = mkpwent(module, p);
+    }
 #ifndef HAVE_GETPWNAM_R
     PyMutex_Unlock(&pwd_db_mutex);
 #endif


### PR DESCRIPTION
Distinguish between the case when the user/group does not exist and error conditions.
If the user does not exit, raise KeyError as  now, for errors raise OSError.

Based on https://github.com/arhadthedev/cpython/commit/46c34b6785a831f1646948555c9b6ab0d69b9945

<!-- gh-issue-number: gh-48511 -->
* Issue: gh-48511
<!-- /gh-issue-number -->
