### PR TITLE
int(x.partition('.')[0]) instead of int(float(x)) in getlineno

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1053,7 +1053,8 @@ class EditorWindow:
 
     def getlineno(self, mark="insert"):
         text = self.text
-        return int(float(text.index(mark)))
+        text_widget_index = text.index(mark)
+        return int(text_widget_index.partition('.')[0])
 
     def get_geometry(self):
         "Return (width, height, x, y)"


### PR DESCRIPTION
Fixes #102220
text.index is a call to tkinter.Text.index, which does return a string. Tkinter text widget indices were assumed to be of the form 'line.column'. int(x.partition('.')[0]) also handles the case 'line.**end**' Both will fail in the other 10 cases, but in those cases it's less clear what getlineno should return.

https://tkdocs.com/shipman/text-index.html

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
