### PR TITLE
asyncio docs: Fix dangling hyphen

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -524,8 +524,8 @@ Opening network connections
       When a server's IPv4 path and protocol are working, but the server's
       IPv6 path and protocol are not working, a dual-stack client
       application experiences significant connection delay compared to an
-      IPv4-only client.  This is undesirable because it causes the dual-
-      stack client to have a worse user experience.  This document
+      IPv4-only client.  This is undesirable because it causes the
+      dual-stack client to have a worse user experience.  This document
       specifies requirements for algorithms that reduce this user-visible
       delay and provides an algorithm.
 


### PR DESCRIPTION
Currently this gets rendered with a dangling hyphen.

I'm not sure this paragraph belongs here at all: it's the abstract of the RFC but isn't clearly labeled as such. Perhaps we should replace it with a shorter explanation that more clearly explains what it is about?
![Screen Shot 2023-02-24 at 5 05 59 PM](https://user-images.githubusercontent.com/906600/221327462-8b03003c-b66a-4b0c-9710-c43b20357656.png)
