### PR TITLE
gh-102213: Optimizing the Performance of __getattr__ #102213

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -353,6 +353,7 @@ extern void _PyObject_FreeInstanceAttributes(PyObject *obj);
 extern int _PyObject_IsInstanceDictEmpty(PyObject *);
 extern int _PyType_HasSubclasses(PyTypeObject *);
 extern PyObject* _PyType_GetSubclasses(PyTypeObject *);
+extern PyObject* _PyObject_GenericTryGetAttr(PyObject *, PyObject *);
 
 // Access macro to the members which are floating "behind" the object
 static inline PyMemberDef* _PyHeapType_GET_MEMBERS(PyHeapTypeObject *etype) {

--- a/Include/object.h
+++ b/Include/object.h
@@ -304,6 +304,7 @@ PyAPI_FUNC(int) PyObject_SetAttr(PyObject *, PyObject *, PyObject *);
 PyAPI_FUNC(int) PyObject_HasAttr(PyObject *, PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_SelfIter(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_GenericGetAttr(PyObject *, PyObject *);
+PyAPI_FUNC(PyObject *) PyObject_GenericTryGetAttr(PyObject *, PyObject *);
 PyAPI_FUNC(int) PyObject_GenericSetAttr(PyObject *, PyObject *, PyObject *);
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(int) PyObject_GenericSetDict(PyObject *, PyObject *, void *);

--- a/Include/object.h
+++ b/Include/object.h
@@ -304,7 +304,6 @@ PyAPI_FUNC(int) PyObject_SetAttr(PyObject *, PyObject *, PyObject *);
 PyAPI_FUNC(int) PyObject_HasAttr(PyObject *, PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_SelfIter(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_GenericGetAttr(PyObject *, PyObject *);
-PyAPI_FUNC(PyObject *) PyObject_GenericTryGetAttr(PyObject *, PyObject *);
 PyAPI_FUNC(int) PyObject_GenericSetAttr(PyObject *, PyObject *, PyObject *);
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(int) PyObject_GenericSetDict(PyObject *, PyObject *, void *);

--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-26-13-12-55.gh-issue-102213.fTH8X7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-26-13-12-55.gh-issue-102213.fTH8X7.rst
@@ -1,0 +1,1 @@
+Fix performance loss when accessing an object's attributes with `__getattr__`  defined.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-26-13-12-55.gh-issue-102213.fTH8X7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-26-13-12-55.gh-issue-102213.fTH8X7.rst
@@ -1,1 +1,1 @@
-Fix performance loss when accessing an object's attributes with `__getattr__`  defined.
+Fix performance loss when accessing an object's attributes with ``__getattr__``  defined.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1364,6 +1364,12 @@ PyObject_GenericGetAttr(PyObject *obj, PyObject *name)
     return _PyObject_GenericGetAttrWithDict(obj, name, NULL, 0);
 }
 
+PyObject *
+PyObject_GenericTryGetAttr(PyObject *obj, PyObject *name)
+{
+    return _PyObject_GenericGetAttrWithDict(obj, name, NULL, 1);
+}
+
 int
 _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
                                  PyObject *value, PyObject *dict)

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1365,7 +1365,7 @@ PyObject_GenericGetAttr(PyObject *obj, PyObject *name)
 }
 
 PyObject *
-PyObject_GenericTryGetAttr(PyObject *obj, PyObject *name)
+_PyObject_GenericTryGetAttr(PyObject *obj, PyObject *name)
 {
     return _PyObject_GenericGetAttrWithDict(obj, name, NULL, 1);
 }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8249,15 +8249,16 @@ _Py_slot_tp_getattr_hook(PyObject *self, PyObject *name)
          ((PyWrapperDescrObject *)getattribute)->d_wrapped ==
          (void *)PyObject_GenericGetAttr))
         /* finding nothing is reasonable when __getattr__ is defined */
-        res = PyObject_GenericTryGetAttr(self, name);
+        res = _PyObject_GenericTryGetAttr(self, name);
     else {
         Py_INCREF(getattribute);
         res = call_attribute(self, getattribute, name);
         Py_DECREF(getattribute);
     }
     if (res == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError))
+        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
             PyErr_Clear();
+        }
         res = call_attribute(self, getattr, name);
     }
     Py_DECREF(getattr);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8248,14 +8248,16 @@ _Py_slot_tp_getattr_hook(PyObject *self, PyObject *name)
         (Py_IS_TYPE(getattribute, &PyWrapperDescr_Type) &&
          ((PyWrapperDescrObject *)getattribute)->d_wrapped ==
          (void *)PyObject_GenericGetAttr))
-        res = PyObject_GenericGetAttr(self, name);
+        /* finding nothing is reasonable when __getattr__ is defined */
+        res = PyObject_GenericTryGetAttr(self, name);
     else {
         Py_INCREF(getattribute);
         res = call_attribute(self, getattribute, name);
         Py_DECREF(getattribute);
     }
-    if (res == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
-        PyErr_Clear();
+    if (res == NULL) {
+        if (PyErr_ExceptionMatches(PyExc_AttributeError))
+            PyErr_Clear();
         res = call_attribute(self, getattr, name);
     }
     Py_DECREF(getattr);


### PR DESCRIPTION
when `__getattr__` is defined, python with try to find an attribute using `_PyObject_GenericGetAttrWithDict`. Find nothing is reasonable so we don't need an exception, it will hurt performance.

 Using this test code:
```
import time
import sys

NUM = 1000000

class AttrObj(object):
    def __init__(self) -> None:
        super(AttrObj, self).__init__()
        self.pps = 2

    def __getattr__(self, name):
        return 4

def main():
    start = time.time()
    for i in range(1, NUM):
        pass
    end = time.time()
    peer = end - start
    o = AttrObj()
    print(f"Python version of {sys.version}")
    start = time.time()
    for i in range(1, NUM):
        s = o.ppp
    end = time.time()
    print(f"Call __getattr__ spend time: {end - start - peer}")

if __name__ == "__main__":
    main()
```

Now the result is: `Call __getattr__ spend time: 0.4704132080078125`
After this modification, the result is: `Call __getattr__ spend time: 0.07422256469726562`


<!-- gh-issue-number: gh-102213 -->
* Issue: gh-102213
<!-- /gh-issue-number -->
