### PR TITLE
gh-101100: Fix sphinx warnings in `typing` module

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1588,7 +1588,7 @@ These are not used in annotations. They are building blocks for creating generic
         methods, not their type signatures. For example, :class:`ssl.SSLObject`
         is a class, therefore it passes an :func:`issubclass`
         check against :data:`Callable`.  However, the
-        :meth:`ssl.SSLObject.__init__` method exists only to raise a
+        ``ssl.SSLObject.__init__`` method exists only to raise a
         :exc:`TypeError` with a more informative message, therefore making
         it impossible to call (instantiate) :class:`ssl.SSLObject`.
 


### PR DESCRIPTION
There was a warning during doc build inside `typing.rst` when running with `make html SPHINXERRORHANDLING=-n`:

```
./cpython/Doc/library/typing.rst:1587: WARNING: py:meth reference target not found: ssl.SSLObject.__init__
```

It happened because https://docs.python.org/3/library/ssl.html#ssl.SSLObject does not have `__init__` documented (since it does not do anything useful).

Now the warning is gone:

<img width="752" alt="Снимок экрана 2023-02-25 в 23 59 05" src="https://user-images.githubusercontent.com/4660275/221379337-a20e225b-fa1f-4055-b3e2-4ec9980a032b.png">


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
