### PR TITLE
gh-101100: Fix sphinx warnings in `types` module

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -486,7 +486,7 @@ Coroutine Utility Functions
    The generator-based coroutine is still a :term:`generator iterator`,
    but is also considered to be a :term:`coroutine` object and is
    :term:`awaitable`.  However, it may not necessarily implement
-   the :meth:`__await__` method.
+   the __await__ method.
 
    If *gen_func* is a generator function, it will be modified in-place.
 

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -486,7 +486,7 @@ Coroutine Utility Functions
    The generator-based coroutine is still a :term:`generator iterator`,
    but is also considered to be a :term:`coroutine` object and is
    :term:`awaitable`.  However, it may not necessarily implement
-   the __await__ method.
+   the :meth:`~object.__await__` method.
 
    If *gen_func* is a generator function, it will be modified in-place.
 


### PR DESCRIPTION

We had a Sphinx warning in `types.rst` module:

```
./cpython/Doc/library/types.rst:484: WARNING: py:meth reference target not found: __await__
```

This is the only warning we had for this module.

I've done a small research: whether it is `__await__` or 

```
``__await__``
```

It looks like the first case is slightly more popular. Example: https://github.com/python/cpython/blame/main/Doc/library/types.rst#L466


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
