### PR TITLE
[3.10] Add missing 'is' to `cmath.log()` docstring (GH-102049)

### DIFF
--- a/Modules/clinic/cmathmodule.c.h
+++ b/Modules/clinic/cmathmodule.c.h
@@ -638,7 +638,7 @@ PyDoc_STRVAR(cmath_log__doc__,
 "\n"
 "log(z[, base]) -> the logarithm of z to the given base.\n"
 "\n"
-"If the base not specified, returns the natural logarithm (base e) of z.");
+"If the base is not specified, returns the natural logarithm (base e) of z.");
 
 #define CMATH_LOG_METHODDEF    \
     {"log", (PyCFunction)(void(*)(void))cmath_log, METH_FASTCALL, cmath_log__doc__},
@@ -953,4 +953,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=353347db2e808e0d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=717d3d9f0640e893 input=a9049054013a1b77]*/

--- a/Modules/cmathmodule.c
+++ b/Modules/cmathmodule.c
@@ -950,12 +950,12 @@ cmath.log
 
 log(z[, base]) -> the logarithm of z to the given base.
 
-If the base not specified, returns the natural logarithm (base e) of z.
+If the base is not specified, returns the natural logarithm (base e) of z.
 [clinic start generated code]*/
 
 static PyObject *
 cmath_log_impl(PyObject *module, Py_complex x, PyObject *y_obj)
-/*[clinic end generated code: output=4effdb7d258e0d94 input=230ed3a71ecd000a]*/
+/*[clinic end generated code: output=4effdb7d258e0d94 input=e1f81d4fcfd26497]*/
 {
     Py_complex y;
 


### PR DESCRIPTION
Fix missing 'is' in cmath.log() docstring.
(cherry picked from commit 71f614ef2a3d66213b9cae807cbbc1ed03741221)

Automerge-Triggered-By: GH:mdickinson