### PR TITLE
gh-102281: fix potential nullptr dereference + use of uninitialized memory

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-03-02-13-49-21.gh-issue-102281.QCuu2N.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-03-02-13-49-21.gh-issue-102281.QCuu2N.rst
@@ -1,0 +1,1 @@
+Fix potential nullptr dereference and use of uninitialized memory in fileutils. Patch by Max Bachmann.

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -447,7 +447,10 @@ getpath_realpath(PyObject *Py_UNUSED(self) , PyObject *args)
             if (s) {
                 *s = L'\0';
             }
-            path2 = _Py_normpath(_Py_join_relfile(path, resolved), -1);
+            path2 = _Py_join_relfile(path, resolved);
+            if (path2) {
+                path2 = _Py_normpath(path2, -1);
+            }
             PyMem_RawFree((void *)path);
             path = path2;
         }

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2199,7 +2199,8 @@ _Py_find_basename(const wchar_t *filename)
 wchar_t *
 _Py_normpath(wchar_t *path, Py_ssize_t size)
 {
-    if (path == NULL || !path[0] || size == 0) {
+    assert(path != NULL);
+    if (!path[0] || size == 0) {
         return path;
     }
     wchar_t *pEnd = size >= 0 ? &path[size] : NULL;

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2158,7 +2158,10 @@ _Py_join_relfile(const wchar_t *dirname, const wchar_t *relfile)
     }
     assert(wcslen(dirname) < MAXPATHLEN);
     assert(wcslen(relfile) < MAXPATHLEN - wcslen(dirname));
-    join_relfile(filename, bufsize, dirname, relfile);
+    if (join_relfile(filename, bufsize, dirname, relfile) < 0) {
+        PyMem_RawFree(filename);
+        return NULL;
+    }
     return filename;
 }
 
@@ -2196,7 +2199,7 @@ _Py_find_basename(const wchar_t *filename)
 wchar_t *
 _Py_normpath(wchar_t *path, Py_ssize_t size)
 {
-    if (!path[0] || size == 0) {
+    if (path == NULL || !path[0] || size == 0) {
         return path;
     }
     wchar_t *pEnd = size >= 0 ? &path[size] : NULL;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102281 -->
* Issue: gh-102281
<!-- /gh-issue-number -->
