### PR TITLE
gh-101765: unicodeobject: use Py_XDECREF correctly

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14795,7 +14795,7 @@ unicodeiter_reduce(unicodeiterobject *it, PyObject *Py_UNUSED(ignored))
     } else {
         PyObject *u = unicode_new_empty();
         if (u == NULL) {
-            Py_DECREF(iter);
+            Py_XDECREF(iter);
             return NULL;
         }
         return Py_BuildValue("N(N)", iter, u);


### PR DESCRIPTION
See https://github.com/python/cpython/pull/102265#discussion_r1118008479. Thanks @kumaraditya303 for finding all my mistakes, and sorry for the thrash here!

<!-- gh-issue-number: gh-101765 -->
* Issue: gh-101765
<!-- /gh-issue-number -->
