### PR TITLE
Migrate to new PSF mailgun account

### DIFF
--- a/.github/workflows/new-bugs-announce-notifier.yml
+++ b/.github/workflows/new-bugs-announce-notifier.yml
@@ -19,13 +19,13 @@ jobs:
       - name: Send notification
         uses: actions/github-script@v6
         env:
-          MAILGUN_API_KEY: ${{ secrets.PSF_MAILGUN_KEY }}
+          MAILGUN_API_KEY: ${{ secrets.MAILGUN_PYTHON_ORG_MAILGUN_KEY }}
         with:
           script: |
             const Mailgun = require("mailgun.js");
             const formData = require('form-data');
             const mailgun = new Mailgun(formData);
-            const DOMAIN = "mg.python.org";
+            const DOMAIN = "mailgun.python.org";
             const mg = mailgun.client({username: 'api', key: process.env.MAILGUN_API_KEY});
             github.rest.issues.get({
               issue_number: context.issue.number,
@@ -44,7 +44,7 @@ jobs:
               };
 
               const data = {
-                from: "CPython Issues <github@mg.python.org>",
+                from: "CPython Issues <github@mailgun.python.org>",
                 to: "new-bugs-announce@python.org",
                 subject: `[Issue ${issue.data.number}] ${issue.data.title}`,
                 template: "new-github-issue",


### PR DESCRIPTION
Our legacy mailgun account is associated with a parent rackspace account that I am trying to decomission.

The necessary secret has been added to the GitHub Actions Secrets already, so this is ready to go on approval.
