### PR TITLE
gh-102250: Fix double-decref in COMPARE_AND_BRANCH error case

### DIFF
--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -319,6 +319,26 @@ class BoolTest(unittest.TestCase):
                 return -1
         self.assertRaises(ValueError, bool, Eggs())
 
+    def test_interpreter_convert_to_bool_raises(self):
+        class SymbolicBool:
+            def __bool__(self):
+                raise TypeError
+
+        class Symbol:
+            def __gt__(self, other):
+                return SymbolicBool()
+
+        x = Symbol()
+
+        with self.assertRaises(TypeError):
+            if x > 0:
+                msg = "x > 0 was true"
+            else:
+                msg = "x > 0 was false"
+
+        # This used to create negative refcounts, see gh-102250
+        del x
+
     def test_from_bytes(self):
         self.assertIs(bool.from_bytes(b'\x00'*8, 'big'), False)
         self.assertIs(bool.from_bytes(b'abcd', 'little'), True)

--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-26-23-10-32.gh-issue-102250.7MUKoC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-26-23-10-32.gh-issue-102250.7MUKoC.rst
@@ -1,0 +1,1 @@
+Fixed a segfault occurring when the interpreter calls a ``__bool__`` method that raises.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1754,9 +1754,7 @@ dummy_func(
             int offset = next_instr[1].op.arg;
             int err = PyObject_IsTrue(cond);
             Py_DECREF(cond);
-            if (err < 0) {
-                goto error;
-            }
+            ERROR_IF(err < 0, error);
             if (jump_on_true == (err != 0)) {
                 JUMPBY(offset);
             }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2205,9 +2205,7 @@
             int offset = next_instr[1].op.arg;
             int err = PyObject_IsTrue(cond);
             Py_DECREF(cond);
-            if (err < 0) {
-                goto error;
-            }
+            if (err < 0) goto pop_2_error;
             if (jump_on_true == (err != 0)) {
                 JUMPBY(offset);
             }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102250 -->
* Issue: gh-102250
<!-- /gh-issue-number -->
