### PR TITLE
GH-102300: Reuse objects with refcount == 1 in float specialized binary ops.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-02-27-15-48-31.gh-issue-102300.8o-_Mt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-02-27-15-48-31.gh-issue-102300.8o-_Mt.rst
@@ -1,0 +1,1 @@
+Reuse operands with refcount of 1 in float specializations of BINARY_OP.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -195,10 +195,22 @@ dummy_func(
             STAT_INC(BINARY_OP, hit);
             double dprod = ((PyFloatObject *)left)->ob_fval *
                 ((PyFloatObject *)right)->ob_fval;
-            prod = PyFloat_FromDouble(dprod);
-            _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-            _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
-            ERROR_IF(prod == NULL, error);
+            if (Py_REFCNT(left) == 1) {
+                ((PyFloatObject *)left)->ob_fval = dprod;
+                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
+                prod = left;
+            }
+            else if (Py_REFCNT(right) == 1) {
+                ((PyFloatObject *)right)->ob_fval = dprod;
+                _Py_DECREF_NO_DEALLOC(left);
+                prod = right;
+            }
+            else {
+                prod = PyFloat_FromDouble(dprod);
+                _Py_DECREF_NO_DEALLOC(left);
+                _Py_DECREF_NO_DEALLOC(right);
+                ERROR_IF(prod == NULL, error);
+            }
         }
 
         inst(BINARY_OP_SUBTRACT_INT, (unused/1, left, right -- sub)) {
@@ -218,10 +230,22 @@ dummy_func(
             DEOPT_IF(!PyFloat_CheckExact(right), BINARY_OP);
             STAT_INC(BINARY_OP, hit);
             double dsub = ((PyFloatObject *)left)->ob_fval - ((PyFloatObject *)right)->ob_fval;
-            sub = PyFloat_FromDouble(dsub);
-            _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-            _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
-            ERROR_IF(sub == NULL, error);
+            if (Py_REFCNT(left) == 1) {
+                ((PyFloatObject *)left)->ob_fval = dsub;
+                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
+                sub = left;
+            }
+            else if (Py_REFCNT(right) == 1) {
+                ((PyFloatObject *)right)->ob_fval = dsub;
+                _Py_DECREF_NO_DEALLOC(left);
+                sub = right;
+            }
+            else {
+                sub = PyFloat_FromDouble(dsub);
+                _Py_DECREF_NO_DEALLOC(left);
+                _Py_DECREF_NO_DEALLOC(right);
+                ERROR_IF(sub == NULL, error);
+            }
         }
 
         inst(BINARY_OP_ADD_UNICODE, (unused/1, left, right -- res)) {
@@ -278,10 +302,22 @@ dummy_func(
             STAT_INC(BINARY_OP, hit);
             double dsum = ((PyFloatObject *)left)->ob_fval +
                 ((PyFloatObject *)right)->ob_fval;
-            sum = PyFloat_FromDouble(dsum);
-            _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-            _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
-            ERROR_IF(sum == NULL, error);
+            if (Py_REFCNT(left) == 1) {
+                ((PyFloatObject *)left)->ob_fval = dsum;
+                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
+                sum = left;
+            }
+            else if (Py_REFCNT(right) == 1) {
+                ((PyFloatObject *)right)->ob_fval = dsum;
+                _Py_DECREF_NO_DEALLOC(left);
+                sum = right;
+            }
+            else {
+                sum = PyFloat_FromDouble(dsum);
+                _Py_DECREF_NO_DEALLOC(left);
+                _Py_DECREF_NO_DEALLOC(right);
+                ERROR_IF(sum == NULL, error);
+            }
         }
 
         inst(BINARY_OP_ADD_INT, (unused/1, left, right -- sum)) {

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -195,22 +195,7 @@ dummy_func(
             STAT_INC(BINARY_OP, hit);
             double dprod = ((PyFloatObject *)left)->ob_fval *
                 ((PyFloatObject *)right)->ob_fval;
-            if (Py_REFCNT(left) == 1) {
-                ((PyFloatObject *)left)->ob_fval = dprod;
-                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-                prod = left;
-            }
-            else if (Py_REFCNT(right) == 1) {
-                ((PyFloatObject *)right)->ob_fval = dprod;
-                _Py_DECREF_NO_DEALLOC(left);
-                prod = right;
-            }
-            else {
-                prod = PyFloat_FromDouble(dprod);
-                _Py_DECREF_NO_DEALLOC(left);
-                _Py_DECREF_NO_DEALLOC(right);
-                ERROR_IF(prod == NULL, error);
-            }
+            DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dprod, prod);
         }
 
         inst(BINARY_OP_SUBTRACT_INT, (unused/1, left, right -- sub)) {
@@ -230,22 +215,7 @@ dummy_func(
             DEOPT_IF(!PyFloat_CheckExact(right), BINARY_OP);
             STAT_INC(BINARY_OP, hit);
             double dsub = ((PyFloatObject *)left)->ob_fval - ((PyFloatObject *)right)->ob_fval;
-            if (Py_REFCNT(left) == 1) {
-                ((PyFloatObject *)left)->ob_fval = dsub;
-                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-                sub = left;
-            }
-            else if (Py_REFCNT(right) == 1) {
-                ((PyFloatObject *)right)->ob_fval = dsub;
-                _Py_DECREF_NO_DEALLOC(left);
-                sub = right;
-            }
-            else {
-                sub = PyFloat_FromDouble(dsub);
-                _Py_DECREF_NO_DEALLOC(left);
-                _Py_DECREF_NO_DEALLOC(right);
-                ERROR_IF(sub == NULL, error);
-            }
+            DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dsub, sub);
         }
 
         inst(BINARY_OP_ADD_UNICODE, (unused/1, left, right -- res)) {
@@ -302,22 +272,7 @@ dummy_func(
             STAT_INC(BINARY_OP, hit);
             double dsum = ((PyFloatObject *)left)->ob_fval +
                 ((PyFloatObject *)right)->ob_fval;
-            if (Py_REFCNT(left) == 1) {
-                ((PyFloatObject *)left)->ob_fval = dsum;
-                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-                sum = left;
-            }
-            else if (Py_REFCNT(right) == 1) {
-                ((PyFloatObject *)right)->ob_fval = dsum;
-                _Py_DECREF_NO_DEALLOC(left);
-                sum = right;
-            }
-            else {
-                sum = PyFloat_FromDouble(dsum);
-                _Py_DECREF_NO_DEALLOC(left);
-                _Py_DECREF_NO_DEALLOC(right);
-                ERROR_IF(sum == NULL, error);
-            }
+            DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dsum, sum);
         }
 
         inst(BINARY_OP_ADD_INT, (unused/1, left, right -- sum)) {

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -365,8 +365,8 @@ do { \
     }\
     else { \
         result = PyFloat_FromDouble(dval); \
+        if ((result) == NULL) goto error; \
         _Py_DECREF_NO_DEALLOC(left); \
         _Py_DECREF_NO_DEALLOC(right); \
-        ERROR_IF((result) == NULL, error); \
     } \
 } while (0)

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -350,3 +350,23 @@ GETITEM(PyObject *v, Py_ssize_t i) {
 
 #define KWNAMES_LEN() \
     (kwnames == NULL ? 0 : ((int)PyTuple_GET_SIZE(kwnames)))
+
+#define DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dval, result) \
+do { \
+    if (Py_REFCNT(left) == 1) { \
+        ((PyFloatObject *)left)->ob_fval = (dval); \
+        _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);\
+        result = (left); \
+    } \
+    else if (Py_REFCNT(right) == 1)  {\
+        ((PyFloatObject *)right)->ob_fval = (dval); \
+        _Py_DECREF_NO_DEALLOC(left); \
+        result = (right); \
+    }\
+    else { \
+        result = PyFloat_FromDouble(dval); \
+        _Py_DECREF_NO_DEALLOC(left); \
+        _Py_DECREF_NO_DEALLOC(right); \
+        ERROR_IF((result) == NULL, error); \
+    } \
+} while (0)

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -267,10 +267,22 @@
             STAT_INC(BINARY_OP, hit);
             double dprod = ((PyFloatObject *)left)->ob_fval *
                 ((PyFloatObject *)right)->ob_fval;
-            prod = PyFloat_FromDouble(dprod);
-            _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-            _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
-            if (prod == NULL) goto pop_2_error;
+            if (Py_REFCNT(left) == 1) {
+                ((PyFloatObject *)left)->ob_fval = dprod;
+                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
+                prod = left;
+            }
+            else if (Py_REFCNT(right) == 1) {
+                ((PyFloatObject *)right)->ob_fval = dprod;
+                _Py_DECREF_NO_DEALLOC(left);
+                prod = right;
+            }
+            else {
+                prod = PyFloat_FromDouble(dprod);
+                _Py_DECREF_NO_DEALLOC(left);
+                _Py_DECREF_NO_DEALLOC(right);
+                if (prod == NULL) goto pop_2_error;
+            }
             STACK_SHRINK(1);
             POKE(1, prod);
             JUMPBY(1);
@@ -304,10 +316,22 @@
             DEOPT_IF(!PyFloat_CheckExact(right), BINARY_OP);
             STAT_INC(BINARY_OP, hit);
             double dsub = ((PyFloatObject *)left)->ob_fval - ((PyFloatObject *)right)->ob_fval;
-            sub = PyFloat_FromDouble(dsub);
-            _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-            _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
-            if (sub == NULL) goto pop_2_error;
+            if (Py_REFCNT(left) == 1) {
+                ((PyFloatObject *)left)->ob_fval = dsub;
+                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
+                sub = left;
+            }
+            else if (Py_REFCNT(right) == 1) {
+                ((PyFloatObject *)right)->ob_fval = dsub;
+                _Py_DECREF_NO_DEALLOC(left);
+                sub = right;
+            }
+            else {
+                sub = PyFloat_FromDouble(dsub);
+                _Py_DECREF_NO_DEALLOC(left);
+                _Py_DECREF_NO_DEALLOC(right);
+                if (sub == NULL) goto pop_2_error;
+            }
             STACK_SHRINK(1);
             POKE(1, sub);
             JUMPBY(1);
@@ -376,10 +400,22 @@
             STAT_INC(BINARY_OP, hit);
             double dsum = ((PyFloatObject *)left)->ob_fval +
                 ((PyFloatObject *)right)->ob_fval;
-            sum = PyFloat_FromDouble(dsum);
-            _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-            _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
-            if (sum == NULL) goto pop_2_error;
+            if (Py_REFCNT(left) == 1) {
+                ((PyFloatObject *)left)->ob_fval = dsum;
+                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
+                sum = left;
+            }
+            else if (Py_REFCNT(right) == 1) {
+                ((PyFloatObject *)right)->ob_fval = dsum;
+                _Py_DECREF_NO_DEALLOC(left);
+                sum = right;
+            }
+            else {
+                sum = PyFloat_FromDouble(dsum);
+                _Py_DECREF_NO_DEALLOC(left);
+                _Py_DECREF_NO_DEALLOC(right);
+                if (sum == NULL) goto pop_2_error;
+            }
             STACK_SHRINK(1);
             POKE(1, sum);
             JUMPBY(1);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -267,22 +267,7 @@
             STAT_INC(BINARY_OP, hit);
             double dprod = ((PyFloatObject *)left)->ob_fval *
                 ((PyFloatObject *)right)->ob_fval;
-            if (Py_REFCNT(left) == 1) {
-                ((PyFloatObject *)left)->ob_fval = dprod;
-                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-                prod = left;
-            }
-            else if (Py_REFCNT(right) == 1) {
-                ((PyFloatObject *)right)->ob_fval = dprod;
-                _Py_DECREF_NO_DEALLOC(left);
-                prod = right;
-            }
-            else {
-                prod = PyFloat_FromDouble(dprod);
-                _Py_DECREF_NO_DEALLOC(left);
-                _Py_DECREF_NO_DEALLOC(right);
-                if (prod == NULL) goto pop_2_error;
-            }
+            DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dprod, prod);
             STACK_SHRINK(1);
             POKE(1, prod);
             JUMPBY(1);
@@ -316,22 +301,7 @@
             DEOPT_IF(!PyFloat_CheckExact(right), BINARY_OP);
             STAT_INC(BINARY_OP, hit);
             double dsub = ((PyFloatObject *)left)->ob_fval - ((PyFloatObject *)right)->ob_fval;
-            if (Py_REFCNT(left) == 1) {
-                ((PyFloatObject *)left)->ob_fval = dsub;
-                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-                sub = left;
-            }
-            else if (Py_REFCNT(right) == 1) {
-                ((PyFloatObject *)right)->ob_fval = dsub;
-                _Py_DECREF_NO_DEALLOC(left);
-                sub = right;
-            }
-            else {
-                sub = PyFloat_FromDouble(dsub);
-                _Py_DECREF_NO_DEALLOC(left);
-                _Py_DECREF_NO_DEALLOC(right);
-                if (sub == NULL) goto pop_2_error;
-            }
+            DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dsub, sub);
             STACK_SHRINK(1);
             POKE(1, sub);
             JUMPBY(1);
@@ -400,22 +370,7 @@
             STAT_INC(BINARY_OP, hit);
             double dsum = ((PyFloatObject *)left)->ob_fval +
                 ((PyFloatObject *)right)->ob_fval;
-            if (Py_REFCNT(left) == 1) {
-                ((PyFloatObject *)left)->ob_fval = dsum;
-                _Py_DECREF_SPECIALIZED(right, _PyFloat_ExactDealloc);
-                sum = left;
-            }
-            else if (Py_REFCNT(right) == 1) {
-                ((PyFloatObject *)right)->ob_fval = dsum;
-                _Py_DECREF_NO_DEALLOC(left);
-                sum = right;
-            }
-            else {
-                sum = PyFloat_FromDouble(dsum);
-                _Py_DECREF_NO_DEALLOC(left);
-                _Py_DECREF_NO_DEALLOC(right);
-                if (sum == NULL) goto pop_2_error;
-            }
+            DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dsum, sum);
             STACK_SHRINK(1);
             POKE(1, sum);
             JUMPBY(1);


### PR DESCRIPTION
About 0.5% faster:

https://github.com/faster-cpython/benchmarking/tree/main/results/bm-20230227-3.12.0a5%2B-c29d369

The results are quite noisy.
But the results seem good, as the most float heavy benchmark, nbody, does show a 7% speedup.

<!-- gh-issue-number: gh-102300 -->
* Issue: gh-102300
<!-- /gh-issue-number -->
