### PR TITLE
[3.8] GH-102306 Avoid GHA CI macOS test_posix failure by using the appropriate macOS SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Configure CPython
-      run: ./configure --with-pydebug --with-openssl=/usr/local/opt/openssl --prefix=/opt/python-dev
+      run: SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk ./configure --with-pydebug --with-openssl=/usr/local/opt/openssl --prefix=/opt/python-dev
     - name: Build CPython
       run: make -j4
     - name: Display build info

--- a/Misc/NEWS.d/next/Build/2023-02-27-18-55-32.gh-issue-102306.bkokFL.rst
+++ b/Misc/NEWS.d/next/Build/2023-02-27-18-55-32.gh-issue-102306.bkokFL.rst
@@ -1,0 +1,2 @@
+[3.8] Avoid GHA CI macOS test_posix failure by using the appropriate macOS
+SDK.


### PR DESCRIPTION


<!-- gh-issue-number: gh-102306 -->
* Issue: gh-102306
<!-- /gh-issue-number -->
