### PR TITLE
gh-99108: Add missing md5/sha1 defines to Modules/Setup

### DIFF
--- a/Modules/Setup
+++ b/Modules/Setup
@@ -163,8 +163,8 @@ PYTHONPATH=$(COREPYTHONPATH)
 
 # hashing builtins
 #_blake2 _blake2/blake2module.c _blake2/blake2b_impl.c _blake2/blake2s_impl.c
-#_md5 md5module.c -I$(srcdir)/Modules/_hacl/include _hacl/Hacl_Hash_MD5.c
-#_sha1 sha1module.c -I$(srcdir)/Modules/_hacl/include _hacl/Hacl_Hash_SHA1.c
+#_md5 md5module.c -I$(srcdir)/Modules/_hacl/include _hacl/Hacl_Hash_MD5.c -D_BSD_SOURCE -D_DEFAULT_SOURCE
+#_sha1 sha1module.c -I$(srcdir)/Modules/_hacl/include _hacl/Hacl_Hash_SHA1.c -D_BSD_SOURCE -D_DEFAULT_SOURCE
 #_sha2 sha2module.c -I$(srcdir)/Modules/_hacl/include Modules/_hacl/libHacl_Streaming_SHA2.a
 #_sha3 _sha3/sha3module.c
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-99108 -->
* Issue: gh-99108
<!-- /gh-issue-number -->
