### PR TITLE
GH-102305: Expand some macros in generated_cases.c.h

### DIFF
--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -73,8 +73,7 @@
                 Py_INCREF(value);
                 _tmp_2 = value;
             }
-            NEXTOPARG();
-            JUMPBY(1);
+            oparg = (next_instr++)->op.arg;
             {
                 PyObject *value;
                 value = GETLOCAL(oparg);
@@ -98,8 +97,7 @@
                 Py_INCREF(value);
                 _tmp_2 = value;
             }
-            NEXTOPARG();
-            JUMPBY(1);
+            oparg = (next_instr++)->op.arg;
             {
                 PyObject *value;
                 value = GETITEM(consts, oparg);
@@ -118,8 +116,7 @@
                 PyObject *value = _tmp_1;
                 SETLOCAL(oparg, value);
             }
-            NEXTOPARG();
-            JUMPBY(1);
+            oparg = (next_instr++)->op.arg;
             {
                 PyObject *value;
                 value = GETLOCAL(oparg);
@@ -138,8 +135,7 @@
                 PyObject *value = _tmp_1;
                 SETLOCAL(oparg, value);
             }
-            NEXTOPARG();
-            JUMPBY(1);
+            oparg = (next_instr++)->op.arg;
             {
                 PyObject *value = _tmp_2;
                 SETLOCAL(oparg, value);
@@ -157,8 +153,7 @@
                 Py_INCREF(value);
                 _tmp_2 = value;
             }
-            NEXTOPARG();
-            JUMPBY(1);
+            oparg = (next_instr++)->op.arg;
             {
                 PyObject *value;
                 value = GETLOCAL(oparg);
@@ -253,7 +248,7 @@
             if (prod == NULL) goto pop_2_error;
             STACK_SHRINK(1);
             stack_pointer[-1] = prod;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -273,7 +268,7 @@
             if (prod == NULL) goto pop_2_error;
             STACK_SHRINK(1);
             stack_pointer[-1] = prod;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -291,7 +286,7 @@
             if (sub == NULL) goto pop_2_error;
             STACK_SHRINK(1);
             stack_pointer[-1] = sub;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -310,7 +305,7 @@
             if (sub == NULL) goto pop_2_error;
             STACK_SHRINK(1);
             stack_pointer[-1] = sub;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -328,7 +323,7 @@
             if (res == NULL) goto pop_2_error;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -382,7 +377,7 @@
             if (sum == NULL) goto pop_2_error;
             STACK_SHRINK(1);
             stack_pointer[-1] = sum;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -400,7 +395,7 @@
             if (sum == NULL) goto pop_2_error;
             STACK_SHRINK(1);
             stack_pointer[-1] = sum;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -427,7 +422,7 @@
             if (res == NULL) goto pop_2_error;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -495,7 +490,7 @@
             Py_DECREF(list);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -520,7 +515,7 @@
             Py_DECREF(tuple);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -545,7 +540,7 @@
             Py_DECREF(sub);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -621,7 +616,7 @@
             Py_DECREF(sub);
             if (err) goto pop_3_error;
             STACK_SHRINK(3);
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -647,7 +642,7 @@
             _Py_DECREF_SPECIALIZED(sub, (destructor)PyObject_Free);
             Py_DECREF(list);
             STACK_SHRINK(3);
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -662,7 +657,7 @@
             Py_DECREF(dict);
             if (err) goto pop_3_error;
             STACK_SHRINK(3);
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -936,7 +931,7 @@
             }
             Py_DECREF(v);
             stack_pointer[-1] = retval;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -1156,7 +1151,7 @@
             if (res == 0) goto pop_1_error;
             STACK_SHRINK(1);
             STACK_GROW(oparg);
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -1172,7 +1167,7 @@
             Py_DECREF(seq);
             STACK_SHRINK(1);
             STACK_GROW(oparg);
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -1189,7 +1184,7 @@
             Py_DECREF(seq);
             STACK_SHRINK(1);
             STACK_GROW(oparg);
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -1206,7 +1201,7 @@
             Py_DECREF(seq);
             STACK_SHRINK(1);
             STACK_GROW(oparg);
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -1247,7 +1242,7 @@
             Py_DECREF(owner);
             if (err) goto pop_2_error;
             STACK_SHRINK(2);
-            JUMPBY(4);
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -1412,7 +1407,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = v;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = null; }
-            JUMPBY(5);
+            next_instr += 5;
             DISPATCH();
         }
 
@@ -1436,7 +1431,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = null; }
-            JUMPBY(5);
+            next_instr += 5;
             DISPATCH();
         }
 
@@ -1464,7 +1459,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = null; }
-            JUMPBY(5);
+            next_instr += 5;
             DISPATCH();
         }
 
@@ -1855,7 +1850,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
-            JUMPBY(9);
+            next_instr += 9;
             DISPATCH();
         }
 
@@ -1882,7 +1877,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
-            JUMPBY(9);
+            next_instr += 9;
             DISPATCH();
         }
 
@@ -1909,7 +1904,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
-            JUMPBY(9);
+            next_instr += 9;
             DISPATCH();
         }
 
@@ -1950,7 +1945,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
-            JUMPBY(9);
+            next_instr += 9;
             DISPATCH();
         }
 
@@ -1974,7 +1969,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
-            JUMPBY(9);
+            next_instr += 9;
             DISPATCH();
         }
 
@@ -2000,7 +1995,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
-            JUMPBY(9);
+            next_instr += 9;
             DISPATCH();
         }
 
@@ -2090,7 +2085,7 @@
             }
             Py_DECREF(owner);
             STACK_SHRINK(2);
-            JUMPBY(4);
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -2139,7 +2134,7 @@
             dict->ma_version_tag = new_version;
             Py_DECREF(owner);
             STACK_SHRINK(2);
-            JUMPBY(4);
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -2159,7 +2154,7 @@
             Py_XDECREF(old_value);
             Py_DECREF(owner);
             STACK_SHRINK(2);
-            JUMPBY(4);
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -2175,7 +2170,7 @@
             if (res == NULL) goto pop_2_error;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -2210,7 +2205,7 @@
                 JUMPBY(offset);
             }
             STACK_SHRINK(2);
-            JUMPBY(2);
+            next_instr += 2;
             DISPATCH();
         }
 
@@ -2232,7 +2227,7 @@
                 JUMPBY(offset);
             }
             STACK_SHRINK(2);
-            JUMPBY(2);
+            next_instr += 2;
             DISPATCH();
         }
 
@@ -2257,7 +2252,7 @@
                 JUMPBY(offset);
             }
             STACK_SHRINK(2);
-            JUMPBY(2);
+            next_instr += 2;
             DISPATCH();
         }
 
@@ -2280,7 +2275,7 @@
                 JUMPBY(offset);
             }
             STACK_SHRINK(2);
-            JUMPBY(2);
+            next_instr += 2;
             DISPATCH();
         }
 
@@ -2690,7 +2685,7 @@
             // Common case: no jump, leave it to the code generator
             STACK_GROW(1);
             stack_pointer[-1] = next;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -2719,7 +2714,7 @@
             // Common case: no jump, leave it to the code generator
             STACK_GROW(1);
             stack_pointer[-1] = next;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -2748,7 +2743,7 @@
             // Common case: no jump, leave it to the code generator
             STACK_GROW(1);
             stack_pointer[-1] = next;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -2775,7 +2770,7 @@
             }
             STACK_GROW(1);
             stack_pointer[-1] = next;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -2954,7 +2949,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
-            JUMPBY(9);
+            next_instr += 9;
             DISPATCH();
         }
 
@@ -2977,7 +2972,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
-            JUMPBY(9);
+            next_instr += 9;
             DISPATCH();
         }
 
@@ -3004,7 +2999,7 @@
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
-            JUMPBY(9);
+            next_instr += 9;
             DISPATCH();
         }
 
@@ -3096,7 +3091,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
@@ -3202,7 +3197,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -3225,7 +3220,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
@@ -3248,7 +3243,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
@@ -3282,7 +3277,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
@@ -3323,7 +3318,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
@@ -3368,7 +3363,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
@@ -3413,7 +3408,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
@@ -3451,7 +3446,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -3490,7 +3485,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -3555,7 +3550,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
@@ -3595,7 +3590,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
@@ -3635,7 +3630,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
@@ -3674,7 +3669,7 @@
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(4);
+            next_instr += 4;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
@@ -3885,7 +3880,7 @@
             if (res == NULL) goto pop_2_error;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
-            JUMPBY(1);
+            next_instr += 1;
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -22,7 +22,7 @@
             if (value == NULL) goto unbound_local_error;
             Py_INCREF(value);
             STACK_GROW(1);
-            POKE(1, value);
+            stack_pointer[-1] = value;
             DISPATCH();
         }
 
@@ -32,7 +32,7 @@
             if (value == NULL) goto unbound_local_error;
             Py_INCREF(value);
             STACK_GROW(1);
-            POKE(1, value);
+            stack_pointer[-1] = value;
             DISPATCH();
         }
 
@@ -42,7 +42,7 @@
             assert(value != NULL);
             Py_INCREF(value);
             STACK_GROW(1);
-            POKE(1, value);
+            stack_pointer[-1] = value;
             DISPATCH();
         }
 
@@ -52,12 +52,12 @@
             value = GETITEM(consts, oparg);
             Py_INCREF(value);
             STACK_GROW(1);
-            POKE(1, value);
+            stack_pointer[-1] = value;
             DISPATCH();
         }
 
         TARGET(STORE_FAST) {
-            PyObject *value = PEEK(1);
+            PyObject *value = stack_pointer[-1];
             SETLOCAL(oparg, value);
             STACK_SHRINK(1);
             DISPATCH();
@@ -83,8 +83,8 @@
                 _tmp_1 = value;
             }
             STACK_GROW(2);
-            POKE(1, _tmp_1);
-            POKE(2, _tmp_2);
+            stack_pointer[-1] = _tmp_1;
+            stack_pointer[-2] = _tmp_2;
             DISPATCH();
         }
 
@@ -107,13 +107,13 @@
                 _tmp_1 = value;
             }
             STACK_GROW(2);
-            POKE(1, _tmp_1);
-            POKE(2, _tmp_2);
+            stack_pointer[-1] = _tmp_1;
+            stack_pointer[-2] = _tmp_2;
             DISPATCH();
         }
 
         TARGET(STORE_FAST__LOAD_FAST) {
-            PyObject *_tmp_1 = PEEK(1);
+            PyObject *_tmp_1 = stack_pointer[-1];
             {
                 PyObject *value = _tmp_1;
                 SETLOCAL(oparg, value);
@@ -127,13 +127,13 @@
                 Py_INCREF(value);
                 _tmp_1 = value;
             }
-            POKE(1, _tmp_1);
+            stack_pointer[-1] = _tmp_1;
             DISPATCH();
         }
 
         TARGET(STORE_FAST__STORE_FAST) {
-            PyObject *_tmp_1 = PEEK(1);
-            PyObject *_tmp_2 = PEEK(2);
+            PyObject *_tmp_1 = stack_pointer[-1];
+            PyObject *_tmp_2 = stack_pointer[-2];
             {
                 PyObject *value = _tmp_1;
                 SETLOCAL(oparg, value);
@@ -167,13 +167,13 @@
                 _tmp_1 = value;
             }
             STACK_GROW(2);
-            POKE(1, _tmp_1);
-            POKE(2, _tmp_2);
+            stack_pointer[-1] = _tmp_1;
+            stack_pointer[-2] = _tmp_2;
             DISPATCH();
         }
 
         TARGET(POP_TOP) {
-            PyObject *value = PEEK(1);
+            PyObject *value = stack_pointer[-1];
             Py_DECREF(value);
             STACK_SHRINK(1);
             DISPATCH();
@@ -183,13 +183,13 @@
             PyObject *res;
             res = NULL;
             STACK_GROW(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(END_FOR) {
-            PyObject *_tmp_1 = PEEK(1);
-            PyObject *_tmp_2 = PEEK(2);
+            PyObject *_tmp_1 = stack_pointer[-1];
+            PyObject *_tmp_2 = stack_pointer[-2];
             {
                 PyObject *value = _tmp_1;
                 Py_DECREF(value);
@@ -203,17 +203,17 @@
         }
 
         TARGET(UNARY_NEGATIVE) {
-            PyObject *value = PEEK(1);
+            PyObject *value = stack_pointer[-1];
             PyObject *res;
             res = PyNumber_Negative(value);
             Py_DECREF(value);
             if (res == NULL) goto pop_1_error;
-            POKE(1, res);
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(UNARY_NOT) {
-            PyObject *value = PEEK(1);
+            PyObject *value = stack_pointer[-1];
             PyObject *res;
             int err = PyObject_IsTrue(value);
             Py_DECREF(value);
@@ -225,23 +225,23 @@
                 res = Py_False;
             }
             Py_INCREF(res);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(UNARY_INVERT) {
-            PyObject *value = PEEK(1);
+            PyObject *value = stack_pointer[-1];
             PyObject *res;
             res = PyNumber_Invert(value);
             Py_DECREF(value);
             if (res == NULL) goto pop_1_error;
-            POKE(1, res);
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(BINARY_OP_MULTIPLY_INT) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             PyObject *prod;
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyLong_CheckExact(left), BINARY_OP);
@@ -252,14 +252,14 @@
             _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
             if (prod == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, prod);
+            stack_pointer[-1] = prod;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(BINARY_OP_MULTIPLY_FLOAT) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             PyObject *prod;
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyFloat_CheckExact(left), BINARY_OP);
@@ -272,14 +272,14 @@
             _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
             if (prod == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, prod);
+            stack_pointer[-1] = prod;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(BINARY_OP_SUBTRACT_INT) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             PyObject *sub;
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyLong_CheckExact(left), BINARY_OP);
@@ -290,14 +290,14 @@
             _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
             if (sub == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, sub);
+            stack_pointer[-1] = sub;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(BINARY_OP_SUBTRACT_FLOAT) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             PyObject *sub;
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyFloat_CheckExact(left), BINARY_OP);
@@ -309,14 +309,14 @@
             _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
             if (sub == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, sub);
+            stack_pointer[-1] = sub;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(BINARY_OP_ADD_UNICODE) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             PyObject *res;
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
@@ -327,14 +327,14 @@
             _Py_DECREF_SPECIALIZED(right, _PyUnicode_ExactDealloc);
             if (res == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(BINARY_OP_INPLACE_ADD_UNICODE) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
             DEOPT_IF(Py_TYPE(right) != Py_TYPE(left), BINARY_OP);
@@ -367,8 +367,8 @@
         }
 
         TARGET(BINARY_OP_ADD_FLOAT) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             PyObject *sum;
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyFloat_CheckExact(left), BINARY_OP);
@@ -381,14 +381,14 @@
             _Py_DECREF_SPECIALIZED(left, _PyFloat_ExactDealloc);
             if (sum == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, sum);
+            stack_pointer[-1] = sum;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(BINARY_OP_ADD_INT) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             PyObject *sum;
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyLong_CheckExact(left), BINARY_OP);
@@ -399,7 +399,7 @@
             _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
             if (sum == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, sum);
+            stack_pointer[-1] = sum;
             JUMPBY(1);
             DISPATCH();
         }
@@ -407,8 +407,8 @@
         TARGET(BINARY_SUBSCR) {
             PREDICTED(BINARY_SUBSCR);
             static_assert(INLINE_CACHE_ENTRIES_BINARY_SUBSCR == 4, "incorrect cache size");
-            PyObject *sub = PEEK(1);
-            PyObject *container = PEEK(2);
+            PyObject *sub = stack_pointer[-1];
+            PyObject *container = stack_pointer[-2];
             PyObject *res;
             #if ENABLE_SPECIALIZATION
             _PyBinarySubscrCache *cache = (_PyBinarySubscrCache *)next_instr;
@@ -426,15 +426,15 @@
             Py_DECREF(sub);
             if (res == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             DISPATCH();
         }
 
         TARGET(BINARY_SLICE) {
-            PyObject *stop = PEEK(1);
-            PyObject *start = PEEK(2);
-            PyObject *container = PEEK(3);
+            PyObject *stop = stack_pointer[-1];
+            PyObject *start = stack_pointer[-2];
+            PyObject *container = stack_pointer[-3];
             PyObject *res;
             PyObject *slice = _PyBuildSlice_ConsumeRefs(start, stop);
             // Can't use ERROR_IF() here, because we haven't
@@ -449,15 +449,15 @@
             Py_DECREF(container);
             if (res == NULL) goto pop_3_error;
             STACK_SHRINK(2);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(STORE_SLICE) {
-            PyObject *stop = PEEK(1);
-            PyObject *start = PEEK(2);
-            PyObject *container = PEEK(3);
-            PyObject *v = PEEK(4);
+            PyObject *stop = stack_pointer[-1];
+            PyObject *start = stack_pointer[-2];
+            PyObject *container = stack_pointer[-3];
+            PyObject *v = stack_pointer[-4];
             PyObject *slice = _PyBuildSlice_ConsumeRefs(start, stop);
             int err;
             if (slice == NULL) {
@@ -475,8 +475,8 @@
         }
 
         TARGET(BINARY_SUBSCR_LIST_INT) {
-            PyObject *sub = PEEK(1);
-            PyObject *list = PEEK(2);
+            PyObject *sub = stack_pointer[-1];
+            PyObject *list = stack_pointer[-2];
             PyObject *res;
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyLong_CheckExact(sub), BINARY_SUBSCR);
@@ -494,14 +494,14 @@
             _Py_DECREF_SPECIALIZED(sub, (destructor)PyObject_Free);
             Py_DECREF(list);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             DISPATCH();
         }
 
         TARGET(BINARY_SUBSCR_TUPLE_INT) {
-            PyObject *sub = PEEK(1);
-            PyObject *tuple = PEEK(2);
+            PyObject *sub = stack_pointer[-1];
+            PyObject *tuple = stack_pointer[-2];
             PyObject *res;
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyLong_CheckExact(sub), BINARY_SUBSCR);
@@ -519,14 +519,14 @@
             _Py_DECREF_SPECIALIZED(sub, (destructor)PyObject_Free);
             Py_DECREF(tuple);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             DISPATCH();
         }
 
         TARGET(BINARY_SUBSCR_DICT) {
-            PyObject *sub = PEEK(1);
-            PyObject *dict = PEEK(2);
+            PyObject *sub = stack_pointer[-1];
+            PyObject *dict = stack_pointer[-2];
             PyObject *res;
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyDict_CheckExact(dict), BINARY_SUBSCR);
@@ -544,14 +544,14 @@
             Py_DECREF(dict);
             Py_DECREF(sub);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             DISPATCH();
         }
 
         TARGET(BINARY_SUBSCR_GETITEM) {
-            PyObject *sub = PEEK(1);
-            PyObject *container = PEEK(2);
+            PyObject *sub = stack_pointer[-1];
+            PyObject *container = stack_pointer[-2];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint16_t func_version = read_u16(&next_instr[3].cache);
             PyTypeObject *tp = Py_TYPE(container);
@@ -575,8 +575,8 @@
         }
 
         TARGET(LIST_APPEND) {
-            PyObject *v = PEEK(1);
-            PyObject *list = PEEK(2 + (oparg-1));
+            PyObject *v = stack_pointer[-1];
+            PyObject *list = stack_pointer[-(2 + (oparg-1))];
             if (_PyList_AppendTakeRef((PyListObject *)list, v) < 0) goto pop_1_error;
             STACK_SHRINK(1);
             PREDICT(JUMP_BACKWARD);
@@ -584,8 +584,8 @@
         }
 
         TARGET(SET_ADD) {
-            PyObject *v = PEEK(1);
-            PyObject *set = PEEK(2 + (oparg-1));
+            PyObject *v = stack_pointer[-1];
+            PyObject *set = stack_pointer[-(2 + (oparg-1))];
             int err = PySet_Add(set, v);
             Py_DECREF(v);
             if (err) goto pop_1_error;
@@ -597,9 +597,9 @@
         TARGET(STORE_SUBSCR) {
             PREDICTED(STORE_SUBSCR);
             static_assert(INLINE_CACHE_ENTRIES_STORE_SUBSCR == 1, "incorrect cache size");
-            PyObject *sub = PEEK(1);
-            PyObject *container = PEEK(2);
-            PyObject *v = PEEK(3);
+            PyObject *sub = stack_pointer[-1];
+            PyObject *container = stack_pointer[-2];
+            PyObject *v = stack_pointer[-3];
             uint16_t counter = read_u16(&next_instr[0].cache);
             #if ENABLE_SPECIALIZATION
             if (ADAPTIVE_COUNTER_IS_ZERO(counter)) {
@@ -626,9 +626,9 @@
         }
 
         TARGET(STORE_SUBSCR_LIST_INT) {
-            PyObject *sub = PEEK(1);
-            PyObject *list = PEEK(2);
-            PyObject *value = PEEK(3);
+            PyObject *sub = stack_pointer[-1];
+            PyObject *list = stack_pointer[-2];
+            PyObject *value = stack_pointer[-3];
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyLong_CheckExact(sub), STORE_SUBSCR);
             DEOPT_IF(!PyList_CheckExact(list), STORE_SUBSCR);
@@ -652,9 +652,9 @@
         }
 
         TARGET(STORE_SUBSCR_DICT) {
-            PyObject *sub = PEEK(1);
-            PyObject *dict = PEEK(2);
-            PyObject *value = PEEK(3);
+            PyObject *sub = stack_pointer[-1];
+            PyObject *dict = stack_pointer[-2];
+            PyObject *value = stack_pointer[-3];
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyDict_CheckExact(dict), STORE_SUBSCR);
             STAT_INC(STORE_SUBSCR, hit);
@@ -667,8 +667,8 @@
         }
 
         TARGET(DELETE_SUBSCR) {
-            PyObject *sub = PEEK(1);
-            PyObject *container = PEEK(2);
+            PyObject *sub = stack_pointer[-1];
+            PyObject *container = stack_pointer[-2];
             /* del container[sub] */
             int err = PyObject_DelItem(container, sub);
             Py_DECREF(container);
@@ -679,19 +679,19 @@
         }
 
         TARGET(CALL_INTRINSIC_1) {
-            PyObject *value = PEEK(1);
+            PyObject *value = stack_pointer[-1];
             PyObject *res;
             assert(oparg <= MAX_INTRINSIC_1);
             res = _PyIntrinsics_UnaryFunctions[oparg](tstate, value);
             Py_DECREF(value);
             if (res == NULL) goto pop_1_error;
-            POKE(1, res);
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(CALL_INTRINSIC_2) {
-            PyObject *value1 = PEEK(1);
-            PyObject *value2 = PEEK(2);
+            PyObject *value1 = stack_pointer[-1];
+            PyObject *value2 = stack_pointer[-2];
             PyObject *res;
             assert(oparg <= MAX_INTRINSIC_2);
             res = _PyIntrinsics_BinaryFunctions[oparg](tstate, value2, value1);
@@ -699,12 +699,12 @@
             Py_DECREF(value1);
             if (res == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(RAISE_VARARGS) {
-            PyObject **args = &PEEK(oparg);
+            PyObject **args = (stack_pointer - oparg);
             PyObject *cause = NULL, *exc = NULL;
             switch (oparg) {
             case 2:
@@ -725,7 +725,7 @@
         }
 
         TARGET(INTERPRETER_EXIT) {
-            PyObject *retval = PEEK(1);
+            PyObject *retval = stack_pointer[-1];
             assert(frame == &entry_frame);
             assert(_PyFrame_IsIncomplete(frame));
             STACK_SHRINK(1);  // Since we're not going to DISPATCH()
@@ -740,7 +740,7 @@
         }
 
         TARGET(RETURN_VALUE) {
-            PyObject *retval = PEEK(1);
+            PyObject *retval = stack_pointer[-1];
             STACK_SHRINK(1);
             assert(EMPTY());
             _PyFrame_SetStackPointer(frame, stack_pointer);
@@ -774,7 +774,7 @@
         }
 
         TARGET(GET_AITER) {
-            PyObject *obj = PEEK(1);
+            PyObject *obj = stack_pointer[-1];
             PyObject *iter;
             unaryfunc getter = NULL;
             PyTypeObject *type = Py_TYPE(obj);
@@ -806,12 +806,12 @@
                 Py_DECREF(iter);
                 if (true) goto pop_1_error;
             }
-            POKE(1, iter);
+            stack_pointer[-1] = iter;
             DISPATCH();
         }
 
         TARGET(GET_ANEXT) {
-            PyObject *aiter = PEEK(1);
+            PyObject *aiter = stack_pointer[-1];
             PyObject *awaitable;
             unaryfunc getter = NULL;
             PyObject *next_iter = NULL;
@@ -857,14 +857,14 @@
             }
 
             STACK_GROW(1);
-            POKE(1, awaitable);
+            stack_pointer[-1] = awaitable;
             PREDICT(LOAD_CONST);
             DISPATCH();
         }
 
         TARGET(GET_AWAITABLE) {
             PREDICTED(GET_AWAITABLE);
-            PyObject *iterable = PEEK(1);
+            PyObject *iterable = stack_pointer[-1];
             PyObject *iter;
             iter = _PyCoro_GetAwaitableIter(iterable);
 
@@ -890,15 +890,15 @@
 
             if (iter == NULL) goto pop_1_error;
 
-            POKE(1, iter);
+            stack_pointer[-1] = iter;
             PREDICT(LOAD_CONST);
             DISPATCH();
         }
 
         TARGET(SEND) {
             PREDICTED(SEND);
-            PyObject *v = PEEK(1);
-            PyObject *receiver = PEEK(2);
+            PyObject *v = stack_pointer[-1];
+            PyObject *receiver = stack_pointer[-2];
             PyObject *retval;
             #if ENABLE_SPECIALIZATION
             _PySendCache *cache = (_PySendCache *)next_instr;
@@ -935,14 +935,14 @@
                 assert(retval != NULL);
             }
             Py_DECREF(v);
-            POKE(1, retval);
+            stack_pointer[-1] = retval;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(SEND_GEN) {
-            PyObject *v = PEEK(1);
-            PyObject *receiver = PEEK(2);
+            PyObject *v = stack_pointer[-1];
+            PyObject *receiver = stack_pointer[-2];
             assert(cframe.use_tracing == 0);
             PyGenObject *gen = (PyGenObject *)receiver;
             DEOPT_IF(Py_TYPE(gen) != &PyGen_Type &&
@@ -961,7 +961,7 @@
         }
 
         TARGET(YIELD_VALUE) {
-            PyObject *retval = PEEK(1);
+            PyObject *retval = stack_pointer[-1];
             // NOTE: It's important that YIELD_VALUE never raises an exception!
             // The compiler treats any exception raised here as a failed close()
             // or throw() call.
@@ -983,7 +983,7 @@
         }
 
         TARGET(POP_EXCEPT) {
-            PyObject *exc_value = PEEK(1);
+            PyObject *exc_value = stack_pointer[-1];
             _PyErr_StackItem *exc_info = tstate->exc_info;
             Py_XSETREF(exc_info->exc_value, exc_value);
             STACK_SHRINK(1);
@@ -991,8 +991,8 @@
         }
 
         TARGET(RERAISE) {
-            PyObject *exc = PEEK(1);
-            PyObject **values = &PEEK(1 + oparg);
+            PyObject *exc = stack_pointer[-1];
+            PyObject **values = (stack_pointer - (1 + oparg));
             assert(oparg >= 0 && oparg <= 2);
             if (oparg) {
                 PyObject *lasti = values[0];
@@ -1015,8 +1015,8 @@
         }
 
         TARGET(END_ASYNC_FOR) {
-            PyObject *exc = PEEK(1);
-            PyObject *awaitable = PEEK(2);
+            PyObject *exc = stack_pointer[-1];
+            PyObject *awaitable = stack_pointer[-2];
             assert(exc && PyExceptionInstance_Check(exc));
             if (PyErr_GivenExceptionMatches(exc, PyExc_StopAsyncIteration)) {
                 Py_DECREF(awaitable);
@@ -1034,9 +1034,9 @@
         }
 
         TARGET(CLEANUP_THROW) {
-            PyObject *exc_value = PEEK(1);
-            PyObject *last_sent_val = PEEK(2);
-            PyObject *sub_iter = PEEK(3);
+            PyObject *exc_value = stack_pointer[-1];
+            PyObject *last_sent_val = stack_pointer[-2];
+            PyObject *sub_iter = stack_pointer[-3];
             PyObject *none;
             PyObject *value;
             assert(throwflag);
@@ -1053,8 +1053,8 @@
                 goto exception_unwind;
             }
             STACK_SHRINK(1);
-            POKE(1, value);
-            POKE(2, none);
+            stack_pointer[-1] = value;
+            stack_pointer[-2] = none;
             DISPATCH();
         }
 
@@ -1062,7 +1062,7 @@
             PyObject *value;
             value = Py_NewRef(PyExc_AssertionError);
             STACK_GROW(1);
-            POKE(1, value);
+            stack_pointer[-1] = value;
             DISPATCH();
         }
 
@@ -1090,12 +1090,12 @@
                 }
             }
             STACK_GROW(1);
-            POKE(1, bc);
+            stack_pointer[-1] = bc;
             DISPATCH();
         }
 
         TARGET(STORE_NAME) {
-            PyObject *v = PEEK(1);
+            PyObject *v = stack_pointer[-1];
             PyObject *name = GETITEM(names, oparg);
             PyObject *ns = LOCALS();
             int err;
@@ -1138,7 +1138,7 @@
         TARGET(UNPACK_SEQUENCE) {
             PREDICTED(UNPACK_SEQUENCE);
             static_assert(INLINE_CACHE_ENTRIES_UNPACK_SEQUENCE == 1, "incorrect cache size");
-            PyObject *seq = PEEK(1);
+            PyObject *seq = stack_pointer[-1];
             #if ENABLE_SPECIALIZATION
             _PyUnpackSequenceCache *cache = (_PyUnpackSequenceCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -1161,7 +1161,7 @@
         }
 
         TARGET(UNPACK_SEQUENCE_TWO_TUPLE) {
-            PyObject *seq = PEEK(1);
+            PyObject *seq = stack_pointer[-1];
             PyObject **values = stack_pointer - (1);
             DEOPT_IF(!PyTuple_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyTuple_GET_SIZE(seq) != 2, UNPACK_SEQUENCE);
@@ -1177,7 +1177,7 @@
         }
 
         TARGET(UNPACK_SEQUENCE_TUPLE) {
-            PyObject *seq = PEEK(1);
+            PyObject *seq = stack_pointer[-1];
             PyObject **values = stack_pointer - (1);
             DEOPT_IF(!PyTuple_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyTuple_GET_SIZE(seq) != oparg, UNPACK_SEQUENCE);
@@ -1194,7 +1194,7 @@
         }
 
         TARGET(UNPACK_SEQUENCE_LIST) {
-            PyObject *seq = PEEK(1);
+            PyObject *seq = stack_pointer[-1];
             PyObject **values = stack_pointer - (1);
             DEOPT_IF(!PyList_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyList_GET_SIZE(seq) != oparg, UNPACK_SEQUENCE);
@@ -1211,7 +1211,7 @@
         }
 
         TARGET(UNPACK_EX) {
-            PyObject *seq = PEEK(1);
+            PyObject *seq = stack_pointer[-1];
             int totalargs = 1 + (oparg & 0xFF) + (oparg >> 8);
             PyObject **top = stack_pointer + totalargs - 1;
             int res = unpack_iterable(tstate, seq, oparg & 0xFF, oparg >> 8, top);
@@ -1224,8 +1224,8 @@
         TARGET(STORE_ATTR) {
             PREDICTED(STORE_ATTR);
             static_assert(INLINE_CACHE_ENTRIES_STORE_ATTR == 4, "incorrect cache size");
-            PyObject *owner = PEEK(1);
-            PyObject *v = PEEK(2);
+            PyObject *owner = stack_pointer[-1];
+            PyObject *v = stack_pointer[-2];
             uint16_t counter = read_u16(&next_instr[0].cache);
             #if ENABLE_SPECIALIZATION
             if (ADAPTIVE_COUNTER_IS_ZERO(counter)) {
@@ -1252,7 +1252,7 @@
         }
 
         TARGET(DELETE_ATTR) {
-            PyObject *owner = PEEK(1);
+            PyObject *owner = stack_pointer[-1];
             PyObject *name = GETITEM(names, oparg);
             int err = PyObject_SetAttr(owner, name, (PyObject *)NULL);
             Py_DECREF(owner);
@@ -1262,7 +1262,7 @@
         }
 
         TARGET(STORE_GLOBAL) {
-            PyObject *v = PEEK(1);
+            PyObject *v = stack_pointer[-1];
             PyObject *name = GETITEM(names, oparg);
             int err = PyDict_SetItem(GLOBALS(), name, v);
             Py_DECREF(v);
@@ -1347,7 +1347,7 @@
                 }
             }
             STACK_GROW(1);
-            POKE(1, v);
+            stack_pointer[-1] = v;
             DISPATCH();
         }
 
@@ -1410,8 +1410,8 @@
             null = NULL;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, v);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), null); }
+            stack_pointer[-1] = v;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = null; }
             JUMPBY(5);
             DISPATCH();
         }
@@ -1434,8 +1434,8 @@
             null = NULL;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), null); }
+            stack_pointer[-1] = res;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = null; }
             JUMPBY(5);
             DISPATCH();
         }
@@ -1462,8 +1462,8 @@
             null = NULL;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), null); }
+            stack_pointer[-1] = res;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = null; }
             JUMPBY(5);
             DISPATCH();
         }
@@ -1535,7 +1535,7 @@
                 Py_INCREF(value);
             }
             STACK_GROW(1);
-            POKE(1, value);
+            stack_pointer[-1] = value;
             DISPATCH();
         }
 
@@ -1549,12 +1549,12 @@
             }
             Py_INCREF(value);
             STACK_GROW(1);
-            POKE(1, value);
+            stack_pointer[-1] = value;
             DISPATCH();
         }
 
         TARGET(STORE_DEREF) {
-            PyObject *v = PEEK(1);
+            PyObject *v = stack_pointer[-1];
             PyObject *cell = GETLOCAL(oparg);
             PyObject *oldobj = PyCell_GET(cell);
             PyCell_SET(cell, v);
@@ -1578,7 +1578,7 @@
         }
 
         TARGET(BUILD_STRING) {
-            PyObject **pieces = &PEEK(oparg);
+            PyObject **pieces = (stack_pointer - oparg);
             PyObject *str;
             str = _PyUnicode_JoinArray(&_Py_STR(empty), pieces, oparg);
             for (int i = 0; i < oparg; i++) {
@@ -1587,35 +1587,35 @@
             if (str == NULL) { STACK_SHRINK(oparg); goto error; }
             STACK_SHRINK(oparg);
             STACK_GROW(1);
-            POKE(1, str);
+            stack_pointer[-1] = str;
             DISPATCH();
         }
 
         TARGET(BUILD_TUPLE) {
-            PyObject **values = &PEEK(oparg);
+            PyObject **values = (stack_pointer - oparg);
             PyObject *tup;
             tup = _PyTuple_FromArraySteal(values, oparg);
             if (tup == NULL) { STACK_SHRINK(oparg); goto error; }
             STACK_SHRINK(oparg);
             STACK_GROW(1);
-            POKE(1, tup);
+            stack_pointer[-1] = tup;
             DISPATCH();
         }
 
         TARGET(BUILD_LIST) {
-            PyObject **values = &PEEK(oparg);
+            PyObject **values = (stack_pointer - oparg);
             PyObject *list;
             list = _PyList_FromArraySteal(values, oparg);
             if (list == NULL) { STACK_SHRINK(oparg); goto error; }
             STACK_SHRINK(oparg);
             STACK_GROW(1);
-            POKE(1, list);
+            stack_pointer[-1] = list;
             DISPATCH();
         }
 
         TARGET(LIST_EXTEND) {
-            PyObject *iterable = PEEK(1);
-            PyObject *list = PEEK(2 + (oparg-1));
+            PyObject *iterable = stack_pointer[-1];
+            PyObject *list = stack_pointer[-(2 + (oparg-1))];
             PyObject *none_val = _PyList_Extend((PyListObject *)list, iterable);
             if (none_val == NULL) {
                 if (_PyErr_ExceptionMatches(tstate, PyExc_TypeError) &&
@@ -1636,8 +1636,8 @@
         }
 
         TARGET(SET_UPDATE) {
-            PyObject *iterable = PEEK(1);
-            PyObject *set = PEEK(2 + (oparg-1));
+            PyObject *iterable = stack_pointer[-1];
+            PyObject *set = stack_pointer[-(2 + (oparg-1))];
             int err = _PySet_Update(set, iterable);
             Py_DECREF(iterable);
             if (err < 0) goto pop_1_error;
@@ -1646,7 +1646,7 @@
         }
 
         TARGET(BUILD_SET) {
-            PyObject **values = &PEEK(oparg);
+            PyObject **values = (stack_pointer - oparg);
             PyObject *set;
             set = PySet_New(NULL);
             if (set == NULL)
@@ -1664,12 +1664,12 @@
             }
             STACK_SHRINK(oparg);
             STACK_GROW(1);
-            POKE(1, set);
+            stack_pointer[-1] = set;
             DISPATCH();
         }
 
         TARGET(BUILD_MAP) {
-            PyObject **values = &PEEK(oparg*2);
+            PyObject **values = (stack_pointer - oparg*2);
             PyObject *map;
             map = _PyDict_FromItems(
                     values, 2,
@@ -1685,7 +1685,7 @@
             if (map == NULL) { STACK_SHRINK(oparg*2); goto error; }
             STACK_SHRINK(oparg*2);
             STACK_GROW(1);
-            POKE(1, map);
+            stack_pointer[-1] = map;
             DISPATCH();
         }
 
@@ -1733,8 +1733,8 @@
         }
 
         TARGET(BUILD_CONST_KEY_MAP) {
-            PyObject *keys = PEEK(1);
-            PyObject **values = &PEEK(1 + oparg);
+            PyObject *keys = stack_pointer[-1];
+            PyObject **values = (stack_pointer - (1 + oparg));
             PyObject *map;
             if (!PyTuple_CheckExact(keys) ||
                 PyTuple_GET_SIZE(keys) != (Py_ssize_t)oparg) {
@@ -1751,12 +1751,12 @@
             }
             if (map == NULL) { STACK_SHRINK(oparg); goto pop_1_error; }
             STACK_SHRINK(oparg);
-            POKE(1, map);
+            stack_pointer[-1] = map;
             DISPATCH();
         }
 
         TARGET(DICT_UPDATE) {
-            PyObject *update = PEEK(1);
+            PyObject *update = stack_pointer[-1];
             PyObject *dict = PEEK(oparg + 1);  // update is still on the stack
             if (PyDict_Update(dict, update) < 0) {
                 if (_PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
@@ -1773,7 +1773,7 @@
         }
 
         TARGET(DICT_MERGE) {
-            PyObject *update = PEEK(1);
+            PyObject *update = stack_pointer[-1];
             PyObject *dict = PEEK(oparg + 1);  // update is still on the stack
 
             if (_PyDict_MergeEx(dict, update, 2) < 0) {
@@ -1788,8 +1788,8 @@
         }
 
         TARGET(MAP_ADD) {
-            PyObject *value = PEEK(1);
-            PyObject *key = PEEK(2);
+            PyObject *value = stack_pointer[-1];
+            PyObject *key = stack_pointer[-2];
             PyObject *dict = PEEK(oparg + 2);  // key, value are still on the stack
             assert(PyDict_CheckExact(dict));
             /* dict[key] = value */
@@ -1803,7 +1803,7 @@
         TARGET(LOAD_ATTR) {
             PREDICTED(LOAD_ATTR);
             static_assert(INLINE_CACHE_ENTRIES_LOAD_ATTR == 9, "incorrect cache size");
-            PyObject *owner = PEEK(1);
+            PyObject *owner = stack_pointer[-1];
             PyObject *res2 = NULL;
             PyObject *res;
             #if ENABLE_SPECIALIZATION
@@ -1853,14 +1853,14 @@
                 if (res == NULL) goto pop_1_error;
             }
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), res2); }
+            stack_pointer[-1] = res;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
             JUMPBY(9);
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_INSTANCE_VALUE) {
-            PyObject *owner = PEEK(1);
+            PyObject *owner = stack_pointer[-1];
             PyObject *res2 = NULL;
             PyObject *res;
             uint32_t type_version = read_u32(&next_instr[1].cache);
@@ -1880,14 +1880,14 @@
             res2 = NULL;
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), res2); }
+            stack_pointer[-1] = res;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
             JUMPBY(9);
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_MODULE) {
-            PyObject *owner = PEEK(1);
+            PyObject *owner = stack_pointer[-1];
             PyObject *res2 = NULL;
             PyObject *res;
             uint32_t type_version = read_u32(&next_instr[1].cache);
@@ -1907,14 +1907,14 @@
             res2 = NULL;
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), res2); }
+            stack_pointer[-1] = res;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
             JUMPBY(9);
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_WITH_HINT) {
-            PyObject *owner = PEEK(1);
+            PyObject *owner = stack_pointer[-1];
             PyObject *res2 = NULL;
             PyObject *res;
             uint32_t type_version = read_u32(&next_instr[1].cache);
@@ -1948,14 +1948,14 @@
             res2 = NULL;
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), res2); }
+            stack_pointer[-1] = res;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
             JUMPBY(9);
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_SLOT) {
-            PyObject *owner = PEEK(1);
+            PyObject *owner = stack_pointer[-1];
             PyObject *res2 = NULL;
             PyObject *res;
             uint32_t type_version = read_u32(&next_instr[1].cache);
@@ -1972,14 +1972,14 @@
             res2 = NULL;
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), res2); }
+            stack_pointer[-1] = res;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
             JUMPBY(9);
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_CLASS) {
-            PyObject *cls = PEEK(1);
+            PyObject *cls = stack_pointer[-1];
             PyObject *res2 = NULL;
             PyObject *res;
             uint32_t type_version = read_u32(&next_instr[1].cache);
@@ -1998,14 +1998,14 @@
             Py_INCREF(res);
             Py_DECREF(cls);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), res2); }
+            stack_pointer[-1] = res;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
             JUMPBY(9);
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_PROPERTY) {
-            PyObject *owner = PEEK(1);
+            PyObject *owner = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint32_t func_version = read_u32(&next_instr[3].cache);
             PyObject *fget = read_obj(&next_instr[5].cache);
@@ -2035,7 +2035,7 @@
         }
 
         TARGET(LOAD_ATTR_GETATTRIBUTE_OVERRIDDEN) {
-            PyObject *owner = PEEK(1);
+            PyObject *owner = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint32_t func_version = read_u32(&next_instr[3].cache);
             PyObject *getattribute = read_obj(&next_instr[5].cache);
@@ -2067,8 +2067,8 @@
         }
 
         TARGET(STORE_ATTR_INSTANCE_VALUE) {
-            PyObject *owner = PEEK(1);
-            PyObject *value = PEEK(2);
+            PyObject *owner = stack_pointer[-1];
+            PyObject *value = stack_pointer[-2];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint16_t index = read_u16(&next_instr[3].cache);
             assert(cframe.use_tracing == 0);
@@ -2095,8 +2095,8 @@
         }
 
         TARGET(STORE_ATTR_WITH_HINT) {
-            PyObject *owner = PEEK(1);
-            PyObject *value = PEEK(2);
+            PyObject *owner = stack_pointer[-1];
+            PyObject *value = stack_pointer[-2];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint16_t hint = read_u16(&next_instr[3].cache);
             assert(cframe.use_tracing == 0);
@@ -2144,8 +2144,8 @@
         }
 
         TARGET(STORE_ATTR_SLOT) {
-            PyObject *owner = PEEK(1);
-            PyObject *value = PEEK(2);
+            PyObject *owner = stack_pointer[-1];
+            PyObject *value = stack_pointer[-2];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint16_t index = read_u16(&next_instr[3].cache);
             assert(cframe.use_tracing == 0);
@@ -2164,8 +2164,8 @@
         }
 
         TARGET(COMPARE_OP) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             PyObject *res;
             STAT_INC(COMPARE_OP, deferred);
             assert((oparg >> 4) <= Py_GE);
@@ -2174,15 +2174,15 @@
             Py_DECREF(right);
             if (res == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(COMPARE_AND_BRANCH) {
             PREDICTED(COMPARE_AND_BRANCH);
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             #if ENABLE_SPECIALIZATION
             _PyCompareOpCache *cache = (_PyCompareOpCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -2215,8 +2215,8 @@
         }
 
         TARGET(COMPARE_AND_BRANCH_FLOAT) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyFloat_CheckExact(left), COMPARE_AND_BRANCH);
             DEOPT_IF(!PyFloat_CheckExact(right), COMPARE_AND_BRANCH);
@@ -2237,8 +2237,8 @@
         }
 
         TARGET(COMPARE_AND_BRANCH_INT) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyLong_CheckExact(left), COMPARE_AND_BRANCH);
             DEOPT_IF(!PyLong_CheckExact(right), COMPARE_AND_BRANCH);
@@ -2262,8 +2262,8 @@
         }
 
         TARGET(COMPARE_AND_BRANCH_STR) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             assert(cframe.use_tracing == 0);
             DEOPT_IF(!PyUnicode_CheckExact(left), COMPARE_AND_BRANCH);
             DEOPT_IF(!PyUnicode_CheckExact(right), COMPARE_AND_BRANCH);
@@ -2285,21 +2285,21 @@
         }
 
         TARGET(IS_OP) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             PyObject *b;
             int res = Py_Is(left, right) ^ oparg;
             Py_DECREF(left);
             Py_DECREF(right);
             b = Py_NewRef(res ? Py_True : Py_False);
             STACK_SHRINK(1);
-            POKE(1, b);
+            stack_pointer[-1] = b;
             DISPATCH();
         }
 
         TARGET(CONTAINS_OP) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             PyObject *b;
             int res = PySequence_Contains(right, left);
             Py_DECREF(left);
@@ -2307,13 +2307,13 @@
             if (res < 0) goto pop_2_error;
             b = Py_NewRef((res^oparg) ? Py_True : Py_False);
             STACK_SHRINK(1);
-            POKE(1, b);
+            stack_pointer[-1] = b;
             DISPATCH();
         }
 
         TARGET(CHECK_EG_MATCH) {
-            PyObject *match_type = PEEK(1);
-            PyObject *exc_value = PEEK(2);
+            PyObject *match_type = stack_pointer[-1];
+            PyObject *exc_value = stack_pointer[-2];
             PyObject *rest;
             PyObject *match;
             if (check_except_star_type_valid(tstate, match_type) < 0) {
@@ -2336,14 +2336,14 @@
             if (!Py_IsNone(match)) {
                 PyErr_SetExcInfo(NULL, Py_NewRef(match), NULL);
             }
-            POKE(1, match);
-            POKE(2, rest);
+            stack_pointer[-1] = match;
+            stack_pointer[-2] = rest;
             DISPATCH();
         }
 
         TARGET(CHECK_EXC_MATCH) {
-            PyObject *right = PEEK(1);
-            PyObject *left = PEEK(2);
+            PyObject *right = stack_pointer[-1];
+            PyObject *left = stack_pointer[-2];
             PyObject *b;
             assert(PyExceptionInstance_Check(left));
             if (check_except_type_valid(tstate, right) < 0) {
@@ -2354,13 +2354,13 @@
             int res = PyErr_GivenExceptionMatches(left, right);
             Py_DECREF(right);
             b = Py_NewRef(res ? Py_True : Py_False);
-            POKE(1, b);
+            stack_pointer[-1] = b;
             DISPATCH();
         }
 
         TARGET(IMPORT_NAME) {
-            PyObject *fromlist = PEEK(1);
-            PyObject *level = PEEK(2);
+            PyObject *fromlist = stack_pointer[-1];
+            PyObject *level = stack_pointer[-2];
             PyObject *res;
             PyObject *name = GETITEM(names, oparg);
             res = import_name(tstate, frame, name, fromlist, level);
@@ -2368,18 +2368,18 @@
             Py_DECREF(fromlist);
             if (res == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(IMPORT_FROM) {
-            PyObject *from = PEEK(1);
+            PyObject *from = stack_pointer[-1];
             PyObject *res;
             PyObject *name = GETITEM(names, oparg);
             res = import_from(tstate, from, name);
             if (res == NULL) goto error;
             STACK_GROW(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
@@ -2398,7 +2398,7 @@
 
         TARGET(POP_JUMP_IF_FALSE) {
             PREDICTED(POP_JUMP_IF_FALSE);
-            PyObject *cond = PEEK(1);
+            PyObject *cond = stack_pointer[-1];
             if (Py_IsTrue(cond)) {
                 _Py_DECREF_NO_DEALLOC(cond);
             }
@@ -2421,7 +2421,7 @@
         }
 
         TARGET(POP_JUMP_IF_TRUE) {
-            PyObject *cond = PEEK(1);
+            PyObject *cond = stack_pointer[-1];
             if (Py_IsFalse(cond)) {
                 _Py_DECREF_NO_DEALLOC(cond);
             }
@@ -2444,7 +2444,7 @@
         }
 
         TARGET(POP_JUMP_IF_NOT_NONE) {
-            PyObject *value = PEEK(1);
+            PyObject *value = stack_pointer[-1];
             if (!Py_IsNone(value)) {
                 Py_DECREF(value);
                 JUMPBY(oparg);
@@ -2457,7 +2457,7 @@
         }
 
         TARGET(POP_JUMP_IF_NONE) {
-            PyObject *value = PEEK(1);
+            PyObject *value = stack_pointer[-1];
             if (Py_IsNone(value)) {
                 _Py_DECREF_NO_DEALLOC(value);
                 JUMPBY(oparg);
@@ -2470,7 +2470,7 @@
         }
 
         TARGET(JUMP_IF_FALSE_OR_POP) {
-            PyObject *cond = PEEK(1);
+            PyObject *cond = stack_pointer[-1];
             bool jump = false;
             int err;
             if (Py_IsTrue(cond)) {
@@ -2499,7 +2499,7 @@
         }
 
         TARGET(JUMP_IF_TRUE_OR_POP) {
-            PyObject *cond = PEEK(1);
+            PyObject *cond = stack_pointer[-1];
             bool jump = false;
             int err;
             if (Py_IsFalse(cond)) {
@@ -2538,7 +2538,7 @@
         }
 
         TARGET(GET_LEN) {
-            PyObject *obj = PEEK(1);
+            PyObject *obj = stack_pointer[-1];
             PyObject *len_o;
             // PUSH(len(TOS))
             Py_ssize_t len_i = PyObject_Length(obj);
@@ -2546,14 +2546,14 @@
             len_o = PyLong_FromSsize_t(len_i);
             if (len_o == NULL) goto error;
             STACK_GROW(1);
-            POKE(1, len_o);
+            stack_pointer[-1] = len_o;
             DISPATCH();
         }
 
         TARGET(MATCH_CLASS) {
-            PyObject *names = PEEK(1);
-            PyObject *type = PEEK(2);
-            PyObject *subject = PEEK(3);
+            PyObject *names = stack_pointer[-1];
+            PyObject *type = stack_pointer[-2];
+            PyObject *subject = stack_pointer[-3];
             PyObject *attrs;
             // Pop TOS and TOS1. Set TOS to a tuple of attributes on success, or
             // None on failure.
@@ -2570,57 +2570,57 @@
                 attrs = Py_NewRef(Py_None);  // Failure!
             }
             STACK_SHRINK(2);
-            POKE(1, attrs);
+            stack_pointer[-1] = attrs;
             DISPATCH();
         }
 
         TARGET(MATCH_MAPPING) {
-            PyObject *subject = PEEK(1);
+            PyObject *subject = stack_pointer[-1];
             PyObject *res;
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
             res = Py_NewRef(match ? Py_True : Py_False);
             STACK_GROW(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             PREDICT(POP_JUMP_IF_FALSE);
             DISPATCH();
         }
 
         TARGET(MATCH_SEQUENCE) {
-            PyObject *subject = PEEK(1);
+            PyObject *subject = stack_pointer[-1];
             PyObject *res;
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
             res = Py_NewRef(match ? Py_True : Py_False);
             STACK_GROW(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             PREDICT(POP_JUMP_IF_FALSE);
             DISPATCH();
         }
 
         TARGET(MATCH_KEYS) {
-            PyObject *keys = PEEK(1);
-            PyObject *subject = PEEK(2);
+            PyObject *keys = stack_pointer[-1];
+            PyObject *subject = stack_pointer[-2];
             PyObject *values_or_none;
             // On successful match, PUSH(values). Otherwise, PUSH(None).
             values_or_none = match_keys(tstate, subject, keys);
             if (values_or_none == NULL) goto error;
             STACK_GROW(1);
-            POKE(1, values_or_none);
+            stack_pointer[-1] = values_or_none;
             DISPATCH();
         }
 
         TARGET(GET_ITER) {
-            PyObject *iterable = PEEK(1);
+            PyObject *iterable = stack_pointer[-1];
             PyObject *iter;
             /* before: [obj]; after [getiter(obj)] */
             iter = PyObject_GetIter(iterable);
             Py_DECREF(iterable);
             if (iter == NULL) goto pop_1_error;
-            POKE(1, iter);
+            stack_pointer[-1] = iter;
             DISPATCH();
         }
 
         TARGET(GET_YIELD_FROM_ITER) {
-            PyObject *iterable = PEEK(1);
+            PyObject *iterable = stack_pointer[-1];
             PyObject *iter;
             /* before: [obj]; after [getiter(obj)] */
             if (PyCoro_CheckExact(iterable)) {
@@ -2646,7 +2646,7 @@
                 }
                 Py_DECREF(iterable);
             }
-            POKE(1, iter);
+            stack_pointer[-1] = iter;
             PREDICT(LOAD_CONST);
             DISPATCH();
         }
@@ -2654,7 +2654,7 @@
         TARGET(FOR_ITER) {
             PREDICTED(FOR_ITER);
             static_assert(INLINE_CACHE_ENTRIES_FOR_ITER == 1, "incorrect cache size");
-            PyObject *iter = PEEK(1);
+            PyObject *iter = stack_pointer[-1];
             PyObject *next;
             #if ENABLE_SPECIALIZATION
             _PyForIterCache *cache = (_PyForIterCache *)next_instr;
@@ -2689,13 +2689,13 @@
             }
             // Common case: no jump, leave it to the code generator
             STACK_GROW(1);
-            POKE(1, next);
+            stack_pointer[-1] = next;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(FOR_ITER_LIST) {
-            PyObject *iter = PEEK(1);
+            PyObject *iter = stack_pointer[-1];
             PyObject *next;
             assert(cframe.use_tracing == 0);
             DEOPT_IF(Py_TYPE(iter) != &PyListIter_Type, FOR_ITER);
@@ -2718,13 +2718,13 @@
         end_for_iter_list:
             // Common case: no jump, leave it to the code generator
             STACK_GROW(1);
-            POKE(1, next);
+            stack_pointer[-1] = next;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(FOR_ITER_TUPLE) {
-            PyObject *iter = PEEK(1);
+            PyObject *iter = stack_pointer[-1];
             PyObject *next;
             assert(cframe.use_tracing == 0);
             _PyTupleIterObject *it = (_PyTupleIterObject *)iter;
@@ -2747,13 +2747,13 @@
         end_for_iter_tuple:
             // Common case: no jump, leave it to the code generator
             STACK_GROW(1);
-            POKE(1, next);
+            stack_pointer[-1] = next;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(FOR_ITER_RANGE) {
-            PyObject *iter = PEEK(1);
+            PyObject *iter = stack_pointer[-1];
             PyObject *next;
             assert(cframe.use_tracing == 0);
             _PyRangeIterObject *r = (_PyRangeIterObject *)iter;
@@ -2774,13 +2774,13 @@
                 goto error;
             }
             STACK_GROW(1);
-            POKE(1, next);
+            stack_pointer[-1] = next;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(FOR_ITER_GEN) {
-            PyObject *iter = PEEK(1);
+            PyObject *iter = stack_pointer[-1];
             assert(cframe.use_tracing == 0);
             PyGenObject *gen = (PyGenObject *)iter;
             DEOPT_IF(Py_TYPE(gen) != &PyGen_Type, FOR_ITER);
@@ -2798,7 +2798,7 @@
         }
 
         TARGET(BEFORE_ASYNC_WITH) {
-            PyObject *mgr = PEEK(1);
+            PyObject *mgr = stack_pointer[-1];
             PyObject *exit;
             PyObject *res;
             PyObject *enter = _PyObject_LookupSpecial(mgr, &_Py_ID(__aenter__));
@@ -2831,14 +2831,14 @@
                 if (true) goto pop_1_error;
             }
             STACK_GROW(1);
-            POKE(1, res);
-            POKE(2, exit);
+            stack_pointer[-1] = res;
+            stack_pointer[-2] = exit;
             PREDICT(GET_AWAITABLE);
             DISPATCH();
         }
 
         TARGET(BEFORE_WITH) {
-            PyObject *mgr = PEEK(1);
+            PyObject *mgr = stack_pointer[-1];
             PyObject *exit;
             PyObject *res;
             /* pop the context manager, push its __exit__ and the
@@ -2874,15 +2874,15 @@
                 if (true) goto pop_1_error;
             }
             STACK_GROW(1);
-            POKE(1, res);
-            POKE(2, exit);
+            stack_pointer[-1] = res;
+            stack_pointer[-2] = exit;
             DISPATCH();
         }
 
         TARGET(WITH_EXCEPT_START) {
-            PyObject *val = PEEK(1);
-            PyObject *lasti = PEEK(3);
-            PyObject *exit_func = PEEK(4);
+            PyObject *val = stack_pointer[-1];
+            PyObject *lasti = stack_pointer[-3];
+            PyObject *exit_func = stack_pointer[-4];
             PyObject *res;
             /* At the top of the stack are 4 values:
                - val: TOP = exc_info()
@@ -2905,12 +2905,12 @@
                     3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
             if (res == NULL) goto error;
             STACK_GROW(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(PUSH_EXC_INFO) {
-            PyObject *new_exc = PEEK(1);
+            PyObject *new_exc = stack_pointer[-1];
             PyObject *prev_exc;
             _PyErr_StackItem *exc_info = tstate->exc_info;
             if (exc_info->exc_value != NULL) {
@@ -2922,13 +2922,13 @@
             assert(PyExceptionInstance_Check(new_exc));
             exc_info->exc_value = Py_NewRef(new_exc);
             STACK_GROW(1);
-            POKE(1, new_exc);
-            POKE(2, prev_exc);
+            stack_pointer[-1] = new_exc;
+            stack_pointer[-2] = prev_exc;
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_METHOD_WITH_VALUES) {
-            PyObject *self = PEEK(1);
+            PyObject *self = stack_pointer[-1];
             PyObject *res2 = NULL;
             PyObject *res;
             uint32_t type_version = read_u32(&next_instr[1].cache);
@@ -2952,14 +2952,14 @@
             res = self;
             assert(oparg & 1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), res2); }
+            stack_pointer[-1] = res;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
             JUMPBY(9);
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_METHOD_NO_DICT) {
-            PyObject *self = PEEK(1);
+            PyObject *self = stack_pointer[-1];
             PyObject *res2 = NULL;
             PyObject *res;
             uint32_t type_version = read_u32(&next_instr[1].cache);
@@ -2975,14 +2975,14 @@
             res = self;
             assert(oparg & 1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), res2); }
+            stack_pointer[-1] = res;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
             JUMPBY(9);
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_METHOD_LAZY_DICT) {
-            PyObject *self = PEEK(1);
+            PyObject *self = stack_pointer[-1];
             PyObject *res2 = NULL;
             PyObject *res;
             uint32_t type_version = read_u32(&next_instr[1].cache);
@@ -3002,8 +3002,8 @@
             res = self;
             assert(oparg & 1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            POKE(1, res);
-            if (oparg & 1) { POKE(1 + ((oparg & 1) ? 1 : 0), res2); }
+            stack_pointer[-1] = res;
+            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
             JUMPBY(9);
             DISPATCH();
         }
@@ -3018,9 +3018,9 @@
         TARGET(CALL) {
             PREDICTED(CALL);
             static_assert(INLINE_CACHE_ENTRIES_CALL == 4, "incorrect cache size");
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *method = stack_pointer[-(2 + oparg)];
             PyObject *res;
             int is_meth = method != NULL;
             int total_args = oparg;
@@ -3095,15 +3095,15 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
         TARGET(CALL_BOUND_METHOD_EXACT_ARGS) {
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *method = stack_pointer[-(2 + oparg)];
             DEOPT_IF(method != NULL, CALL);
             DEOPT_IF(Py_TYPE(callable) != &PyMethod_Type, CALL);
             STAT_INC(CALL, hit);
@@ -3117,9 +3117,9 @@
 
         TARGET(CALL_PY_EXACT_ARGS) {
             PREDICTED(CALL_PY_EXACT_ARGS);
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *method = stack_pointer[-(2 + oparg)];
             uint32_t func_version = read_u32(&next_instr[1].cache);
             assert(kwnames == NULL);
             DEOPT_IF(tstate->interp->eval_frame, CALL);
@@ -3148,9 +3148,9 @@
         }
 
         TARGET(CALL_PY_WITH_DEFAULTS) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *method = stack_pointer[-(2 + oparg)];
             uint32_t func_version = read_u32(&next_instr[1].cache);
             uint16_t min_args = read_u16(&next_instr[3].cache);
             assert(kwnames == NULL);
@@ -3185,9 +3185,9 @@
         }
 
         TARGET(CALL_NO_KW_TYPE_1) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *null = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *null = stack_pointer[-(2 + oparg)];
             PyObject *res;
             assert(kwnames == NULL);
             assert(cframe.use_tracing == 0);
@@ -3201,15 +3201,15 @@
             Py_DECREF(&PyType_Type);  // I.e., callable
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             DISPATCH();
         }
 
         TARGET(CALL_NO_KW_STR_1) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *null = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *null = stack_pointer[-(2 + oparg)];
             PyObject *res;
             assert(kwnames == NULL);
             assert(cframe.use_tracing == 0);
@@ -3224,16 +3224,16 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
         TARGET(CALL_NO_KW_TUPLE_1) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *null = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *null = stack_pointer[-(2 + oparg)];
             PyObject *res;
             assert(kwnames == NULL);
             assert(oparg == 1);
@@ -3247,16 +3247,16 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
         TARGET(CALL_BUILTIN_CLASS) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *method = stack_pointer[-(2 + oparg)];
             PyObject *res;
             int is_meth = method != NULL;
             int total_args = oparg;
@@ -3281,16 +3281,16 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
         TARGET(CALL_NO_KW_BUILTIN_O) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *method = stack_pointer[-(2 + oparg)];
             PyObject *res;
             assert(cframe.use_tracing == 0);
             /* Builtin METH_O functions */
@@ -3322,16 +3322,16 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
         TARGET(CALL_NO_KW_BUILTIN_FAST) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *method = stack_pointer[-(2 + oparg)];
             PyObject *res;
             assert(cframe.use_tracing == 0);
             /* Builtin METH_FASTCALL functions, without keywords */
@@ -3367,16 +3367,16 @@
                 */
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
         TARGET(CALL_BUILTIN_FAST_WITH_KEYWORDS) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *method = stack_pointer[-(2 + oparg)];
             PyObject *res;
             assert(cframe.use_tracing == 0);
             /* Builtin METH_FASTCALL | METH_KEYWORDS functions */
@@ -3412,16 +3412,16 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
         TARGET(CALL_NO_KW_LEN) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *method = stack_pointer[-(2 + oparg)];
             PyObject *res;
             assert(cframe.use_tracing == 0);
             assert(kwnames == NULL);
@@ -3450,15 +3450,15 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             DISPATCH();
         }
 
         TARGET(CALL_NO_KW_ISINSTANCE) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *callable = PEEK(1 + oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *callable = stack_pointer[-(1 + oparg)];
+            PyObject *method = stack_pointer[-(2 + oparg)];
             PyObject *res;
             assert(cframe.use_tracing == 0);
             assert(kwnames == NULL);
@@ -3489,15 +3489,15 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             DISPATCH();
         }
 
         TARGET(CALL_NO_KW_LIST_APPEND) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *self = PEEK(1 + oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *self = stack_pointer[-(1 + oparg)];
+            PyObject *method = stack_pointer[-(2 + oparg)];
             assert(cframe.use_tracing == 0);
             assert(kwnames == NULL);
             assert(oparg == 1);
@@ -3519,8 +3519,8 @@
         }
 
         TARGET(CALL_NO_KW_METHOD_DESCRIPTOR_O) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *method = stack_pointer[-(2 + oparg)];
             PyObject *res;
             assert(kwnames == NULL);
             int is_meth = method != NULL;
@@ -3554,15 +3554,15 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
         TARGET(CALL_METHOD_DESCRIPTOR_FAST_WITH_KEYWORDS) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *method = stack_pointer[-(2 + oparg)];
             PyObject *res;
             int is_meth = method != NULL;
             int total_args = oparg;
@@ -3594,15 +3594,15 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
         TARGET(CALL_NO_KW_METHOD_DESCRIPTOR_NOARGS) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *method = stack_pointer[-(2 + oparg)];
             PyObject *res;
             assert(kwnames == NULL);
             assert(oparg == 0 || oparg == 1);
@@ -3634,15 +3634,15 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
         TARGET(CALL_NO_KW_METHOD_DESCRIPTOR_FAST) {
-            PyObject **args = &PEEK(oparg);
-            PyObject *method = PEEK(2 + oparg);
+            PyObject **args = (stack_pointer - oparg);
+            PyObject *method = stack_pointer[-(2 + oparg)];
             PyObject *res;
             assert(kwnames == NULL);
             int is_meth = method != NULL;
@@ -3673,7 +3673,7 @@
             if (res == NULL) { STACK_SHRINK(oparg); goto pop_2_error; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(4);
             CHECK_EVAL_BREAKER();
             DISPATCH();
@@ -3681,9 +3681,9 @@
 
         TARGET(CALL_FUNCTION_EX) {
             PREDICTED(CALL_FUNCTION_EX);
-            PyObject *kwargs = (oparg & 1) ? PEEK(((oparg & 1) ? 1 : 0)) : NULL;
-            PyObject *callargs = PEEK(1 + ((oparg & 1) ? 1 : 0));
-            PyObject *func = PEEK(2 + ((oparg & 1) ? 1 : 0));
+            PyObject *kwargs = (oparg & 1) ? stack_pointer[-(((oparg & 1) ? 1 : 0))] : NULL;
+            PyObject *callargs = stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))];
+            PyObject *func = stack_pointer[-(2 + ((oparg & 1) ? 1 : 0))];
             PyObject *result;
             if (oparg & 1) {
                 // DICT_MERGE is called before this opcode if there are kwargs.
@@ -3711,17 +3711,17 @@
             if (result == NULL) { STACK_SHRINK(((oparg & 1) ? 1 : 0)); goto pop_3_error; }
             STACK_SHRINK(((oparg & 1) ? 1 : 0));
             STACK_SHRINK(2);
-            POKE(1, result);
+            stack_pointer[-1] = result;
             CHECK_EVAL_BREAKER();
             DISPATCH();
         }
 
         TARGET(MAKE_FUNCTION) {
-            PyObject *codeobj = PEEK(1);
-            PyObject *closure = (oparg & 0x08) ? PEEK(1 + ((oparg & 0x08) ? 1 : 0)) : NULL;
-            PyObject *annotations = (oparg & 0x04) ? PEEK(1 + ((oparg & 0x08) ? 1 : 0) + ((oparg & 0x04) ? 1 : 0)) : NULL;
-            PyObject *kwdefaults = (oparg & 0x02) ? PEEK(1 + ((oparg & 0x08) ? 1 : 0) + ((oparg & 0x04) ? 1 : 0) + ((oparg & 0x02) ? 1 : 0)) : NULL;
-            PyObject *defaults = (oparg & 0x01) ? PEEK(1 + ((oparg & 0x08) ? 1 : 0) + ((oparg & 0x04) ? 1 : 0) + ((oparg & 0x02) ? 1 : 0) + ((oparg & 0x01) ? 1 : 0)) : NULL;
+            PyObject *codeobj = stack_pointer[-1];
+            PyObject *closure = (oparg & 0x08) ? stack_pointer[-(1 + ((oparg & 0x08) ? 1 : 0))] : NULL;
+            PyObject *annotations = (oparg & 0x04) ? stack_pointer[-(1 + ((oparg & 0x08) ? 1 : 0) + ((oparg & 0x04) ? 1 : 0))] : NULL;
+            PyObject *kwdefaults = (oparg & 0x02) ? stack_pointer[-(1 + ((oparg & 0x08) ? 1 : 0) + ((oparg & 0x04) ? 1 : 0) + ((oparg & 0x02) ? 1 : 0))] : NULL;
+            PyObject *defaults = (oparg & 0x01) ? stack_pointer[-(1 + ((oparg & 0x08) ? 1 : 0) + ((oparg & 0x04) ? 1 : 0) + ((oparg & 0x02) ? 1 : 0) + ((oparg & 0x01) ? 1 : 0))] : NULL;
             PyObject *func;
 
             PyFunctionObject *func_obj = (PyFunctionObject *)
@@ -3752,7 +3752,7 @@
             func_obj->func_version = ((PyCodeObject *)codeobj)->co_version;
             func = (PyObject *)func_obj;
             STACK_SHRINK(((oparg & 0x01) ? 1 : 0) + ((oparg & 0x02) ? 1 : 0) + ((oparg & 0x04) ? 1 : 0) + ((oparg & 0x08) ? 1 : 0));
-            POKE(1, func);
+            stack_pointer[-1] = func;
             DISPATCH();
         }
 
@@ -3780,9 +3780,9 @@
         }
 
         TARGET(BUILD_SLICE) {
-            PyObject *step = (oparg == 3) ? PEEK(((oparg == 3) ? 1 : 0)) : NULL;
-            PyObject *stop = PEEK(1 + ((oparg == 3) ? 1 : 0));
-            PyObject *start = PEEK(2 + ((oparg == 3) ? 1 : 0));
+            PyObject *step = (oparg == 3) ? stack_pointer[-(((oparg == 3) ? 1 : 0))] : NULL;
+            PyObject *stop = stack_pointer[-(1 + ((oparg == 3) ? 1 : 0))];
+            PyObject *start = stack_pointer[-(2 + ((oparg == 3) ? 1 : 0))];
             PyObject *slice;
             slice = PySlice_New(start, stop, step);
             Py_DECREF(start);
@@ -3791,13 +3791,13 @@
             if (slice == NULL) { STACK_SHRINK(((oparg == 3) ? 1 : 0)); goto pop_2_error; }
             STACK_SHRINK(((oparg == 3) ? 1 : 0));
             STACK_SHRINK(1);
-            POKE(1, slice);
+            stack_pointer[-1] = slice;
             DISPATCH();
         }
 
         TARGET(FORMAT_VALUE) {
-            PyObject *fmt_spec = ((oparg & FVS_MASK) == FVS_HAVE_SPEC) ? PEEK((((oparg & FVS_MASK) == FVS_HAVE_SPEC) ? 1 : 0)) : NULL;
-            PyObject *value = PEEK(1 + (((oparg & FVS_MASK) == FVS_HAVE_SPEC) ? 1 : 0));
+            PyObject *fmt_spec = ((oparg & FVS_MASK) == FVS_HAVE_SPEC) ? stack_pointer[-((((oparg & FVS_MASK) == FVS_HAVE_SPEC) ? 1 : 0))] : NULL;
+            PyObject *value = stack_pointer[-(1 + (((oparg & FVS_MASK) == FVS_HAVE_SPEC) ? 1 : 0))];
             PyObject *result;
             /* Handles f-string value formatting. */
             PyObject *(*conv_fn)(PyObject *);
@@ -3845,25 +3845,25 @@
                 if (result == NULL) { STACK_SHRINK((((oparg & FVS_MASK) == FVS_HAVE_SPEC) ? 1 : 0)); goto pop_1_error; }
             }
             STACK_SHRINK((((oparg & FVS_MASK) == FVS_HAVE_SPEC) ? 1 : 0));
-            POKE(1, result);
+            stack_pointer[-1] = result;
             DISPATCH();
         }
 
         TARGET(COPY) {
-            PyObject *bottom = PEEK(1 + (oparg-1));
+            PyObject *bottom = stack_pointer[-(1 + (oparg-1))];
             PyObject *top;
             assert(oparg > 0);
             top = Py_NewRef(bottom);
             STACK_GROW(1);
-            POKE(1, top);
+            stack_pointer[-1] = top;
             DISPATCH();
         }
 
         TARGET(BINARY_OP) {
             PREDICTED(BINARY_OP);
             static_assert(INLINE_CACHE_ENTRIES_BINARY_OP == 1, "incorrect cache size");
-            PyObject *rhs = PEEK(1);
-            PyObject *lhs = PEEK(2);
+            PyObject *rhs = stack_pointer[-1];
+            PyObject *lhs = stack_pointer[-2];
             PyObject *res;
             #if ENABLE_SPECIALIZATION
             _PyBinaryOpCache *cache = (_PyBinaryOpCache *)next_instr;
@@ -3884,17 +3884,17 @@
             Py_DECREF(rhs);
             if (res == NULL) goto pop_2_error;
             STACK_SHRINK(1);
-            POKE(1, res);
+            stack_pointer[-1] = res;
             JUMPBY(1);
             DISPATCH();
         }
 
         TARGET(SWAP) {
-            PyObject *top = PEEK(1);
-            PyObject *bottom = PEEK(2 + (oparg-2));
+            PyObject *top = stack_pointer[-1];
+            PyObject *bottom = stack_pointer[-(2 + (oparg-2))];
             assert(oparg >= 2);
-            POKE(1, bottom);
-            POKE(2 + (oparg-2), top);
+            stack_pointer[-1] = bottom;
+            stack_pointer[-(2 + (oparg-2))] = top;
             DISPATCH();
         }
 

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -322,7 +322,7 @@ class Instruction:
                 else:
                     out.declare(oeffect, None)
 
-        # out.emit(f"JUMPBY(OPSIZE({self.inst.name}) - 1);")
+        # out.emit(f"next_instr += OPSIZE({self.inst.name}) - 1;")
 
         self.write_body(out, 0)
 
@@ -359,7 +359,7 @@ class Instruction:
 
         # Write cache effect
         if self.cache_offset:
-            out.emit(f"JUMPBY({self.cache_offset});")
+            out.emit(f"next_instr += {self.cache_offset};")
 
     def write_body(self, out: Formatter, dedent: int, cache_adjust: int = 0) -> None:
         """Write the instruction body."""
@@ -1058,17 +1058,13 @@ class Analyzer:
         with self.wrap_super_or_macro(sup):
             first = True
             for comp in sup.parts:
-                if first:
-                    pass
-                    # self.out.emit("JUMPBY(OPSIZE(opcode) - 1);")
-                else:
-                    self.out.emit("NEXTOPARG();")
-                    self.out.emit("JUMPBY(1);")
-                    # self.out.emit("JUMPBY(OPSIZE(opcode));")
+                if not first:
+                    self.out.emit("oparg = (next_instr++)->op.arg;")
+                # self.out.emit("next_instr += OPSIZE(opcode) - 1;")
                 first = False
                 comp.write_body(self.out, 0)
                 if comp.instr.cache_offset:
-                    self.out.emit(f"JUMPBY({comp.instr.cache_offset});")
+                    self.out.emit(f"next_instr += {comp.instr.cache_offset};")
 
     def write_macro(self, mac: MacroInstruction) -> None:
         """Write code for a macro instruction."""
@@ -1085,7 +1081,7 @@ class Analyzer:
                         cache_adjust += comp.instr.cache_offset
 
             if cache_adjust:
-                self.out.emit(f"JUMPBY({cache_adjust});")
+                self.out.emit(f"next_instr += {cache_adjust};")
 
             if (
                 last_instr


### PR DESCRIPTION
The code generator used `PEEK(i)` to read the `i`-th stack item (1-based). Since this just obscures the meaning, we're just emitting `stack_pointer[-i]` now. Similar for `POKE(i, x)`, which becomes `stack_pointer[-i] = x`.

Similar for `JUMPBY(i)`, becomes `next_instr += i`.

Also expand `NEXTOPARG()` -- in the expansion I found that it is redundantly extracting the opcode (in the case of a super-instruction) so removed that,leaving only `oparg = (next_instr++)->op.arg`.

<!-- gh-issue-number: gh-102305 -->
* Issue: gh-102305
<!-- /gh-issue-number -->
