### PR TITLE
gh-101979: fix a bug that parentheses in metavar argument of add_argument() were dropped

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -403,7 +403,8 @@ class HelpFormatter(object):
             except ValueError:
                 continue
             else:
-                end = start + len(group._group_actions)
+                group_action_count = len(group._group_actions)
+                end = start + group_action_count
                 if actions[start:end] == group._group_actions:
 
                     suppressed_actions_count = 0
@@ -412,7 +413,7 @@ class HelpFormatter(object):
                         if action.help is SUPPRESS:
                             suppressed_actions_count += 1
 
-                    exposed_actions_count = len(group._group_actions) - suppressed_actions_count
+                    exposed_actions_count = group_action_count - suppressed_actions_count
 
                     if not group.required:
                         if start in inserts:

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -405,8 +405,15 @@ class HelpFormatter(object):
             else:
                 end = start + len(group._group_actions)
                 if actions[start:end] == group._group_actions:
+
+                    suppressed_actions_count = 0
                     for action in group._group_actions:
                         group_actions.add(action)
+                        if action.help is SUPPRESS:
+                            suppressed_actions_count += 1
+
+                    exposed_actions_count = len(group._group_actions) - suppressed_actions_count
+
                     if not group.required:
                         if start in inserts:
                             inserts[start] += ' ['
@@ -416,7 +423,7 @@ class HelpFormatter(object):
                             inserts[end] += ']'
                         else:
                             inserts[end] = ']'
-                    elif len(group._group_actions) > 1:
+                    elif exposed_actions_count > 1:
                         if start in inserts:
                             inserts[start] += ' ('
                         else:

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -416,7 +416,7 @@ class HelpFormatter(object):
                             inserts[end] += ']'
                         else:
                             inserts[end] = ']'
-                    else:
+                    elif len(group._group_actions) > 1:
                         if start in inserts:
                             inserts[start] += ' ('
                         else:

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -490,7 +490,6 @@ class HelpFormatter(object):
         text = _re.sub(r'(%s) ' % open, r'\1', text)
         text = _re.sub(r' (%s)' % close, r'\1', text)
         text = _re.sub(r'%s *%s' % (open, close), r'', text)
-        text = _re.sub(r'\(([^|]*)\)', r'\1', text)
         text = text.strip()
 
         # return the text

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -3764,6 +3764,28 @@ class TestHelpUsage(HelpTestCase):
     version = ''
 
 
+class TestHelpUsageWithParenthesis(HelpTestCase):
+    parser_signature = Sig(prog='PROG')
+    argument_signatures = [
+        Sig('positional', metavar='(example) positional'),
+        Sig('-p', '--optional', metavar='{1 (option A), 2 (option B)}'),
+    ]
+
+    usage = '''\
+        usage: PROG [-h] [-p {1 (option A), 2 (option B)}] (example) positional
+        '''
+    help = usage + '''\
+
+        positional arguments:
+          (example) positional
+
+        options:
+          -h, --help            show this help message and exit
+          -p {1 (option A), 2 (option B)}, --optional {1 (option A), 2 (option B)}
+        '''
+    version = ''
+
+
 class TestHelpOnlyUserGroups(HelpTestCase):
     """Test basic usage messages"""
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -3764,7 +3764,7 @@ class TestHelpUsage(HelpTestCase):
     version = ''
 
 
-class TestHelpUsageWithParenthesis(HelpTestCase):
+class TestHelpUsageWithParentheses(HelpTestCase):
     parser_signature = Sig(prog='PROG')
     argument_signatures = [
         Sig('positional', metavar='(example) positional'),

--- a/Misc/NEWS.d/next/Library/2023-02-28-09-52-25.gh-issue-101979.or3hXV.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-28-09-52-25.gh-issue-101979.or3hXV.rst
@@ -1,2 +1,2 @@
-Fix a bug that parentheses in metavar param of :func:`add_argument()` were
+Fix a bug that parentheses in metavar argument of :func:`add_argument()` were
 dropped. Patch by Yeojin Kim.

--- a/Misc/NEWS.d/next/Library/2023-02-28-09-52-25.gh-issue-101979.or3hXV.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-28-09-52-25.gh-issue-101979.or3hXV.rst
@@ -1,0 +1,2 @@
+Fix a bug that parentheses in metavar param of :func:`add_argument()` were
+dropped. Patch by Yeojin Kim.

--- a/Misc/NEWS.d/next/Library/2023-02-28-09-52-25.gh-issue-101979.or3hXV.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-28-09-52-25.gh-issue-101979.or3hXV.rst
@@ -1,2 +1,2 @@
-Fix a bug that parentheses in metavar argument of :func:`add_argument()` were
+Fix a bug where parentheses in the ``metavar`` argument to :meth:`argparse.ArgumentParser.add_argument` were
 dropped. Patch by Yeojin Kim.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Remove a regular expression that removes parentheses. Instead, add parentheses only if you use two or more non required and non suppressed actions.

<!-- gh-issue-number: gh-101979 -->
* Issue: gh-101979
<!-- /gh-issue-number -->
