### PR TITLE
[3.10] gh-90744: Fix erroneous doc links in the sys module (GH-101319)

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -522,55 +522,55 @@ always available.
 
    .. tabularcolumns:: |l|l|L|
 
-   +---------------------+----------------+--------------------------------------------------+
-   | attribute           | float.h macro  | explanation                                      |
-   +=====================+================+==================================================+
-   | :const:`epsilon`    | DBL_EPSILON    | difference between 1.0 and the least value       |
-   |                     |                | greater than 1.0 that is representable as a float|
-   |                     |                |                                                  |
-   |                     |                | See also :func:`math.ulp`.                       |
-   +---------------------+----------------+--------------------------------------------------+
-   | :const:`dig`        | DBL_DIG        | maximum number of decimal digits that can be     |
-   |                     |                | faithfully represented in a float;  see below    |
-   +---------------------+----------------+--------------------------------------------------+
-   | :const:`mant_dig`   | DBL_MANT_DIG   | float precision: the number of base-``radix``    |
-   |                     |                | digits in the significand of a float             |
-   +---------------------+----------------+--------------------------------------------------+
-   | :const:`max`        | DBL_MAX        | maximum representable positive finite float      |
-   +---------------------+----------------+--------------------------------------------------+
-   | :const:`max_exp`    | DBL_MAX_EXP    | maximum integer *e* such that ``radix**(e-1)`` is|
-   |                     |                | a representable finite float                     |
-   +---------------------+----------------+--------------------------------------------------+
-   | :const:`max_10_exp` | DBL_MAX_10_EXP | maximum integer *e* such that ``10**e`` is in the|
-   |                     |                | range of representable finite floats             |
-   +---------------------+----------------+--------------------------------------------------+
-   | :const:`min`        | DBL_MIN        | minimum representable positive *normalized* float|
-   |                     |                |                                                  |
-   |                     |                | Use :func:`math.ulp(0.0) <math.ulp>` to get the  |
-   |                     |                | smallest positive *denormalized* representable   |
-   |                     |                | float.                                           |
-   +---------------------+----------------+--------------------------------------------------+
-   | :const:`min_exp`    | DBL_MIN_EXP    | minimum integer *e* such that ``radix**(e-1)`` is|
-   |                     |                | a normalized float                               |
-   +---------------------+----------------+--------------------------------------------------+
-   | :const:`min_10_exp` | DBL_MIN_10_EXP | minimum integer *e* such that ``10**e`` is a     |
-   |                     |                | normalized float                                 |
-   +---------------------+----------------+--------------------------------------------------+
-   | :const:`radix`      | FLT_RADIX      | radix of exponent representation                 |
-   +---------------------+----------------+--------------------------------------------------+
-   | :const:`rounds`     | FLT_ROUNDS     | integer representing the rounding mode for       |
-   |                     |                | floating-point arithmetic. This reflects the     |
-   |                     |                | value of the system FLT_ROUNDS macro at          |
-   |                     |                | interpreter startup time:                        |
-   |                     |                | ``-1`` indeterminable,                           |
-   |                     |                | ``0`` toward zero,                               |
-   |                     |                | ``1`` to nearest,                                |
-   |                     |                | ``2`` toward positive infinity,                  |
-   |                     |                | ``3`` toward negative infinity                   |
-   |                     |                |                                                  |
-   |                     |                | All other values for FLT_ROUNDS characterize     |
-   |                     |                | implementation-defined rounding behavior.        |
-   +---------------------+----------------+--------------------------------------------------+
+   +---------------------+---------------------+--------------------------------------------------+
+   | attribute           | float.h macro       | explanation                                      |
+   +=====================+=====================+==================================================+
+   | ``epsilon``         | ``DBL_EPSILON``     | difference between 1.0 and the least value       |
+   |                     |                     | greater than 1.0 that is representable as a float|
+   |                     |                     |                                                  |
+   |                     |                     | See also :func:`math.ulp`.                       |
+   +---------------------+---------------------+--------------------------------------------------+
+   | ``dig``             | ``DBL_DIG``         | maximum number of decimal digits that can be     |
+   |                     |                     | faithfully represented in a float;  see below    |
+   +---------------------+---------------------+--------------------------------------------------+
+   | ``mant_dig``        | ``DBL_MANT_DIG``    | float precision: the number of base-``radix``    |
+   |                     |                     | digits in the significand of a float             |
+   +---------------------+---------------------+--------------------------------------------------+
+   | ``max``             | ``DBL_MAX``         | maximum representable positive finite float      |
+   +---------------------+---------------------+--------------------------------------------------+
+   | ``max_exp``         | ``DBL_MAX_EXP``     | maximum integer *e* such that ``radix**(e-1)`` is|
+   |                     |                     | a representable finite float                     |
+   +---------------------+---------------------+--------------------------------------------------+
+   | ``max_10_exp``      | ``DBL_MAX_10_EXP``  | maximum integer *e* such that ``10**e`` is in the|
+   |                     |                     | range of representable finite floats             |
+   +---------------------+---------------------+--------------------------------------------------+
+   | ``min``             | ``DBL_MIN``         | minimum representable positive *normalized* float|
+   |                     |                     |                                                  |
+   |                     |                     | Use :func:`math.ulp(0.0) <math.ulp>` to get the  |
+   |                     |                     | smallest positive *denormalized* representable   |
+   |                     |                     | float.                                           |
+   +---------------------+---------------------+--------------------------------------------------+
+   | ``min_exp``         | ``DBL_MIN_EXP``     | minimum integer *e* such that ``radix**(e-1)`` is|
+   |                     |                     | a normalized float                               |
+   +---------------------+---------------------+--------------------------------------------------+
+   | ``min_10_exp``      | ``DBL_MIN_10_EXP``  | minimum integer *e* such that ``10**e`` is a     |
+   |                     |                     | normalized float                                 |
+   +---------------------+---------------------+--------------------------------------------------+
+   | ``radix``           | ``FLT_RADIX``       | radix of exponent representation                 |
+   +---------------------+---------------------+--------------------------------------------------+
+   | ``rounds``          | ``FLT_ROUNDS``      | integer representing the rounding mode for       |
+   |                     |                     | floating-point arithmetic. This reflects the     |
+   |                     |                     | value of the system ``FLT_ROUNDS`` macro at      |
+   |                     |                     | interpreter startup time:                        |
+   |                     |                     | ``-1`` indeterminable,                           |
+   |                     |                     | ``0`` toward zero,                               |
+   |                     |                     | ``1`` to nearest,                                |
+   |                     |                     | ``2`` toward positive infinity,                  |
+   |                     |                     | ``3`` toward negative infinity                   |
+   |                     |                     |                                                  |
+   |                     |                     | All other values for ``FLT_ROUNDS`` characterize |
+   |                     |                     | implementation-defined rounding behavior.        |
+   +---------------------+---------------------+--------------------------------------------------+
 
    The attribute :attr:`sys.float_info.dig` needs further explanation.  If
    ``s`` is any string representing a decimal number with at most

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -558,12 +558,18 @@ always available.
    +---------------------+----------------+--------------------------------------------------+
    | :const:`radix`      | FLT_RADIX      | radix of exponent representation                 |
    +---------------------+----------------+--------------------------------------------------+
-   | :const:`rounds`     | FLT_ROUNDS     | integer constant representing the rounding mode  |
-   |                     |                | used for arithmetic operations.  This reflects   |
-   |                     |                | the value of the system FLT_ROUNDS macro at      |
-   |                     |                | interpreter startup time.  See section 5.2.4.2.2 |
-   |                     |                | of the C99 standard for an explanation of the    |
-   |                     |                | possible values and their meanings.              |
+   | :const:`rounds`     | FLT_ROUNDS     | integer representing the rounding mode for       |
+   |                     |                | floating-point arithmetic. This reflects the     |
+   |                     |                | value of the system FLT_ROUNDS macro at          |
+   |                     |                | interpreter startup time:                        |
+   |                     |                | ``-1`` indeterminable,                           |
+   |                     |                | ``0`` toward zero,                               |
+   |                     |                | ``1`` to nearest,                                |
+   |                     |                | ``2`` toward positive infinity,                  |
+   |                     |                | ``3`` toward negative infinity                   |
+   |                     |                |                                                  |
+   |                     |                | All other values for FLT_ROUNDS characterize     |
+   |                     |                | implementation-defined rounding behavior.        |
    +---------------------+----------------+--------------------------------------------------+
 
    The attribute :attr:`sys.float_info.dig` needs further explanation.  If


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Backport of GH-101319.

Also include GH-99675 to avoid conflict, and which wasn't originally backported.


<!-- gh-issue-number: gh-90744 -->
* Issue: gh-90744
<!-- /gh-issue-number -->
