### PR TITLE
gh-102336: Ensure CancelIoEx result is not ignored

### DIFF
--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -288,7 +288,7 @@ _winapi_Overlapped_cancel_impl(OverlappedObject *self)
 
     if (self->pending) {
         Py_BEGIN_ALLOW_THREADS
-        CancelIoEx(self->handle, &self->overlapped);
+        res = CancelIoEx(self->handle, &self->overlapped);
         Py_END_ALLOW_THREADS
     }
 


### PR DESCRIPTION
@zooba This fixes a bug I introduced in https://github.com/python/cpython/pull/102337, where I ignore  the return value of `CancelIoEx`

<!-- gh-issue-number: gh-102336 -->
* Issue: gh-102336
<!-- /gh-issue-number -->
