### PR TITLE
gh-95672: Update memory_watchdog to use test.support.get_pagesize

### DIFF
--- a/Lib/test/memory_watchdog.py
+++ b/Lib/test/memory_watchdog.py
@@ -5,20 +5,13 @@ and print it out, until terminated."""
 # If the process crashes, reading from the /proc entry will fail with ESRCH.
 
 
-import os
 import sys
 import time
+from test.support import get_pagesize
 
-
-try:
-    page_size = os.sysconf('SC_PAGESIZE')
-except (ValueError, AttributeError):
-    try:
-        page_size = os.sysconf('SC_PAGE_SIZE')
-    except (ValueError, AttributeError):
-        page_size = 4096
 
 while True:
+    page_size = get_pagesize()
     sys.stdin.seek(0)
     statm = sys.stdin.read()
     data = int(statm.split()[5])


### PR DESCRIPTION
The parts of the test(memory_watchdog) that require pagesize are integrated to use the function in support.

https://github.com/python/cpython/pull/102163#discussion_r1121488976

<!-- gh-issue-number: gh-95672 -->
* Issue: gh-95672
<!-- /gh-issue-number -->
