### PR TITLE
gh-102383: [docs] Arguments of `PyObject_CopyData` are `PyObject *`

### DIFF
--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -499,7 +499,7 @@ Buffer-related functions
    This function fails if *len* != *src->len*.
 
 
-.. c:function:: int PyObject_CopyData(Py_buffer *dest, Py_buffer *src)
+.. c:function:: int PyObject_CopyData(PyObject *dest, PyObject *src)
 
    Copy data from *src* to *dest* buffer. Can convert between C-style and
    or Fortran-style buffers.


### PR DESCRIPTION


<!-- gh-issue-number: gh-102383 -->
* Issue: gh-102383
<!-- /gh-issue-number -->
