### PR TITLE
Remove unused internal macros

### DIFF
--- a/Include/internal/pycore_pymath.h
+++ b/Include/internal/pycore_pymath.h
@@ -56,21 +56,6 @@ static inline void _Py_ADJUST_ERANGE2(double x, double y)
     }
 }
 
-// Return the maximum value of integral type *type*.
-#define _Py_IntegralTypeMax(type) \
-    (_Py_IS_TYPE_SIGNED(type) ? (((((type)1 << (sizeof(type)*CHAR_BIT - 2)) - 1) << 1) + 1) : ~(type)0)
-
-// Return the minimum value of integral type *type*.
-#define _Py_IntegralTypeMin(type) \
-    (_Py_IS_TYPE_SIGNED(type) ? -_Py_IntegralTypeMax(type) - 1 : 0)
-
-// Check whether *v* is in the range of integral type *type*. This is most
-// useful if *v* is floating-point, since demoting a floating-point *v* to an
-// integral type that cannot represent *v*'s integral part is undefined
-// behavior.
-#define _Py_InIntegralTypeRange(type, v) \
-    (_Py_IntegralTypeMin(type) <= v && v <= _Py_IntegralTypeMax(type))
-
 
 //--- HAVE_PY_SET_53BIT_PRECISION macro ------------------------------------
 //


### PR DESCRIPTION
Since #101826, the internal macro `_Py_InIntegralTypeRange` is unused, as are its supporting macros `_Py_IntegralTypeMax` and `_Py_IntegralTypeMin`. This PR removes them.

Note that `_Py_InIntegralTypeRange` doesn't actually work as advertised - it's not a safe way to avoid undefined behaviour in an integer to double conversion.