### PR TITLE
gh-101863: Fix wrong comments in EUC-KR codec

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -322,6 +322,7 @@ Adal Chiriliuc
 Matt Chisholm
 Lita Cho
 Kit Yan Choi
+Byeongmin Choi
 Sayan Chowdhury
 Yuan-Chao Chou
 Anders Chrigström

--- a/Modules/cjkcodecs/_codecs_kr.c
+++ b/Modules/cjkcodecs/_codecs_kr.c
@@ -60,7 +60,7 @@ ENCODER(euc_kr)
         }
         else {
             /* Mapping is found in CP949 extension,
-               but we encode it in KS X 1001:1998 Annex 3,
+               but we encode it in KS X 1001:1998,
                make-up sequence for EUC-KR. */
 
             REQUIRE_OUTBUF(8);
@@ -120,7 +120,7 @@ DECODER(euc_kr)
 
         if (c == EUCKR_JAMO_FIRSTBYTE &&
             INBYTE2 == EUCKR_JAMO_FILLER) {
-            /* KS X 1001:1998 Annex 3 make-up sequence */
+            /* KS X 1001:1998 make-up sequence */
             DBCHAR cho, jung, jong;
 
             REQUIRE_INBUF(8);


### PR DESCRIPTION
This PR fix the wrong comments in the code related to #101863.

The encoding method using "Hangul Filler" is defined in subclause 4.3 of KS X 1001, whereas Annex 3 defines an alternative 2-byte Johab code.

<!-- gh-issue-number: gh-101863 -->
* Issue: gh-101863
<!-- /gh-issue-number -->
