### PR TITLE
[3.10] gh-101892: Fix `SystemError` when a callable iterator call exhausts the iterator (GH-101896)

### DIFF
--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -266,6 +266,31 @@ class TestCase(unittest.TestCase):
             return i
         self.check_iterator(iter(spam, 20), list(range(10)), pickle=False)
 
+    def test_iter_function_concealing_reentrant_exhaustion(self):
+        # gh-101892: Test two-argument iter() with a function that
+        # exhausts its associated iterator but forgets to either return
+        # a sentinel value or raise StopIteration.
+        HAS_MORE = 1
+        NO_MORE = 2
+
+        def exhaust(iterator):
+            """Exhaust an iterator without raising StopIteration."""
+            list(iterator)
+
+        def spam():
+            # Touching the iterator with exhaust() below will call
+            # spam() once again so protect against recursion.
+            if spam.is_recursive_call:
+                return NO_MORE
+            spam.is_recursive_call = True
+            exhaust(spam.iterator)
+            return HAS_MORE
+
+        spam.is_recursive_call = False
+        spam.iterator = iter(spam, NO_MORE)
+        with self.assertRaises(StopIteration):
+            next(spam.iterator)
+
     # Test exception propagation through function iterator
     def test_exception_function(self):
         def spam(state=[0]):

--- a/Misc/NEWS.d/next/Library/2023-02-14-09-08-48.gh-issue-101892.FMos8l.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-14-09-08-48.gh-issue-101892.FMos8l.rst
@@ -1,0 +1,3 @@
+Callable iterators no longer raise :class:`SystemError` when the
+callable object exhausts the iterator but forgets to either return a
+sentinel value or raise :class:`StopIteration`.

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -218,7 +218,7 @@ calliter_iternext(calliterobject *it)
     }
 
     result = _PyObject_CallNoArg(it->it_callable);
-    if (result != NULL) {
+    if (result != NULL && it->it_sentinel != NULL){
         int ok;
 
         ok = PyObject_RichCompareBool(it->it_sentinel, result, Py_EQ);
@@ -226,7 +226,6 @@ calliter_iternext(calliterobject *it)
             return result; /* Common case, fast path */
         }
 
-        Py_DECREF(result);
         if (ok > 0) {
             Py_CLEAR(it->it_callable);
             Py_CLEAR(it->it_sentinel);
@@ -237,6 +236,7 @@ calliter_iternext(calliterobject *it)
         Py_CLEAR(it->it_callable);
         Py_CLEAR(it->it_sentinel);
     }
+    Py_XDECREF(result);
     return NULL;
 }
 


### PR DESCRIPTION
(cherry picked from commit https://github.com/python/cpython/commit/705487c6557c3d8866622b4d32528bf7fc2e4204)

Co-authored-by: Raj <51259329+workingpayload@users.noreply.github.com>
Co-authored-by: Oleg Iarygin <oleg@arhadthedev.net>

<!-- gh-issue-number: gh-101892 -->
* Issue: gh-101892
<!-- /gh-issue-number -->
