### PR TITLE
gh-102433: Add tests for how classes with properties interact with `isinstance()` checks on `typing.runtime_checkable` protocols

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2555,8 +2555,9 @@ class ProtocolTests(BaseTestCase):
         class F(C): ...
         class G(D): ...
 
-        self.assertEqual(C().attr, 42)
-        self.assertEqual(D().attr, 42)
+        for klass in C, D, F, G:
+            with self.subTest(klass=klass.__name__):
+                self.assertEqual(klass().attr, 42)
 
         T = TypeVar('T')
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2553,13 +2553,7 @@ class ProtocolTests(BaseTestCase):
         class E(C): ...
         class F(D): ...
 
-        for klass in C, D, E, F:
-            with self.subTest(klass=klass.__name__):
-                self.assertEqual(klass().attr, 42)
-
-        class G: ...
-
-        self.assertFalse(hasattr(G(), "attr"))
+        class Empty: ...
 
         T = TypeVar('T')
 
@@ -2590,7 +2584,7 @@ class ProtocolTests(BaseTestCase):
                     self.assertIsInstance(klass(), protocol_class)
 
             with self.subTest(protocol_class=protocol_class.__name__):
-                self.assertNotIsInstance(G(), protocol_class)
+                self.assertNotIsInstance(Empty(), protocol_class)
 
         class BadP(Protocol):
             @property
@@ -2607,7 +2601,7 @@ class ProtocolTests(BaseTestCase):
             attr: T
 
         for obj in PG[T], PG[C], PG1[T], PG1[C], BadP, BadP1, BadPG, BadPG1:
-            for klass in C, D, E, F, G:
+            for klass in C, D, E, F, Empty:
                 with self.subTest(klass=klass.__name__, obj=obj):
                     with self.assertRaises(TypeError):
                         isinstance(klass(), obj)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2583,7 +2583,7 @@ class ProtocolTests(BaseTestCase):
                 ):
                     self.assertIsInstance(klass(), protocol_class)
 
-            with self.subTest(protocol_class=protocol_class.__name__):
+            with self.subTest(klass="Empty", protocol_class=protocol_class.__name__):
                 self.assertNotIsInstance(Empty(), protocol_class)
 
         class BadP(Protocol):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2548,16 +2548,18 @@ class ProtocolTests(BaseTestCase):
         class D:
             attr = CustomDescriptor()
 
-        class E: ...
-
         # Check that properties set on superclasses
         # are still found by the isinstance() logic
-        class F(C): ...
-        class G(D): ...
+        class E(C): ...
+        class F(D): ...
 
-        for klass in C, D, F, G:
+        for klass in C, D, E, F:
             with self.subTest(klass=klass.__name__):
                 self.assertEqual(klass().attr, 42)
+
+        class G: ...
+
+        self.assertFalse(hasattr(G(), "attr"))
 
         T = TypeVar('T')
 
@@ -2580,7 +2582,7 @@ class ProtocolTests(BaseTestCase):
             attr: T
 
         for protocol_class in P, P1, PG, PG1:
-            for klass in C, D, F, G:
+            for klass in C, D, E, F:
                 with self.subTest(
                     klass=klass.__name__,
                     protocol_class=protocol_class.__name__
@@ -2588,7 +2590,7 @@ class ProtocolTests(BaseTestCase):
                     self.assertIsInstance(klass(), protocol_class)
 
             with self.subTest(protocol_class=protocol_class.__name__):
-                self.assertNotIsInstance(E(), protocol_class)
+                self.assertNotIsInstance(G(), protocol_class)
 
         class BadP(Protocol):
             @property


### PR DESCRIPTION
It appears we currently have no tests for how classes with properties interact with `isinstance` checks for protocols decorated with `@runtime_checkable`.

I'm trying to only add tests here for uncontroversial behaviour that we won't want changed, whether or not any of the patches discussed in https://github.com/python/typing/issues/1363 is implemented.

<!-- gh-issue-number: gh-102433 -->
* Issue: gh-102433
<!-- /gh-issue-number -->
