### PR TITLE
gh-95672: Fix versionadded indentation of get_pagesize in test.rst

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -540,7 +540,7 @@ The :mod:`test.support` module defines the following functions:
 
    Get size of a page in bytes.
 
-    .. versionadded:: 3.12
+   .. versionadded:: 3.12
 
 
 .. function:: setswitchinterval(interval)


### PR DESCRIPTION
Fix versionadded typo of get_pagesize in test.rst

CC. https://docs.python.org/3.12/library/test.html
<img width="298" alt="image" src="https://user-images.githubusercontent.com/27265773/222999360-71dae193-5928-42d8-9e81-29d859c4396b.png">


<!-- gh-issue-number: gh-95672 -->
* Issue: gh-95672
<!-- /gh-issue-number -->
