### PR TITLE
GH-102456 Fix docstring and getopt options for base64

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -558,12 +558,12 @@ def decodebytes(s):
 def main():
     """Small main program"""
     import sys, getopt
-    usage = f"""usage: {sys.argv[0]} [-h|-d|-e|-u|-t] [file|-]
+    usage = f"""usage: {sys.argv[0]} [-h|-d|-e|-u] [file|-]
         -h: print this help message and exit
         -d, -u: decode
         -e: encode (default)"""
     try:
-        opts, args = getopt.getopt(sys.argv[1:], 'hdeut')
+        opts, args = getopt.getopt(sys.argv[1:], 'hdeu')
     except getopt.error as msg:
         sys.stdout = sys.stderr
         print(msg)


### PR DESCRIPTION
The `-t` option for base64 `python -m base64 -t` is removed in the PR https://github.com/python/cpython/pull/94230

But some references still exist in the docstring and getopt short options. Because of this we can still run the following command
without getting any error
```bash
python -m base64 -t /dev/null
```


<!-- gh-issue-number: gh-102456 -->
* Issue: gh-102456
<!-- /gh-issue-number -->
