### PR TITLE
Remove the unused import 'warnings' from unittest's loader module

### DIFF
--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -6,7 +6,6 @@ import sys
 import traceback
 import types
 import functools
-import warnings
 
 from fnmatch import fnmatch, fnmatchcase
 


### PR DESCRIPTION
Not the most glamorous PR, but the import isn't being used and is imported every time `$python -m unittest` is run.