### PR TITLE
gh-102486: use concise APIs of the traceback module

### DIFF
--- a/Lib/asyncio/base_tasks.py
+++ b/Lib/asyncio/base_tasks.py
@@ -88,5 +88,5 @@ def _task_print_stack(task, limit, file):
 
     traceback.print_list(extracted_list, file=file)
     if exc is not None:
-        for line in traceback.format_exception_only(exc.__class__, exc):
+        for line in traceback.format_exception_only(exc):
             print(line, file=file, end='')

--- a/Lib/cgi.py
+++ b/Lib/cgi.py
@@ -896,7 +896,7 @@ def print_exception(type=None, value=None, tb=None, limit=None):
     print()
     print("<H3>Traceback (most recent call last):</H3>")
     list = traceback.format_tb(tb, limit) + \
-           traceback.format_exception_only(type, value)
+           traceback.format_exception_only(value)
     print("<PRE>%s<B>%s</B></PRE>" % (
         html.escape("".join(list[:-1])),
         html.escape(list[-1]),

--- a/Lib/code.py
+++ b/Lib/code.py
@@ -121,7 +121,7 @@ class InteractiveInterpreter:
                 value = SyntaxError(msg, (filename, lineno, offset, line))
                 sys.last_value = value
         if sys.excepthook is sys.__excepthook__:
-            lines = traceback.format_exception_only(type, value)
+            lines = traceback.format_exception_only(value)
             self.write(''.join(lines))
         else:
             # If someone has set sys.excepthook, we let that take precedence

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1376,7 +1376,7 @@ class DocTestRunner:
 
             # The example raised an exception:  check if it was expected.
             else:
-                exc_msg = traceback.format_exception_only(*exception[:2])[-1]
+                exc_msg = traceback.format_exception_only(exception[1])[-1]
                 if not quiet:
                     got += _exception_traceback(exception)
 

--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -229,7 +229,7 @@ def get_message_lines(typ, exc, tb):
             sys.__excepthook__(typ, exc, tb)
         return [err.getvalue().split("\n")[-2] + "\n"]
     else:
-        return traceback.format_exception_only(typ, exc)
+        return traceback.format_exception_only(exc)
 
 
 def print_exception():

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1079,7 +1079,7 @@ class Handler(Filterer):
             t, v, tb = sys.exc_info()
             try:
                 sys.stderr.write('--- Logging error ---\n')
-                traceback.print_exception(t, v, tb, None, sys.stderr)
+                traceback.print_exc(limit=None, file=sys.stderr)
                 sys.stderr.write('Call stack:\n')
                 # Walk the stack frame up until we're out of logging,
                 # so as to print the calling context.

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -387,7 +387,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         prefix = 'Internal ' if (not exc_traceback
                                     and exc_type is StopIteration) else ''
         self.message('%s%s' % (prefix,
-            traceback.format_exception_only(exc_type, exc_value)[-1].strip()))
+            traceback.format_exception_only(exc_value)[-1].strip()))
         self.interaction(frame, exc_traceback)
 
     # General interaction function
@@ -1258,14 +1258,13 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 return eval(arg, self.curframe.f_globals, self.curframe_locals)
             else:
                 return eval(arg, frame.f_globals, frame.f_locals)
-        except:
-            exc_info = sys.exc_info()[:2]
-            err = traceback.format_exception_only(*exc_info)[-1].strip()
+        except Exception as exc:
+            err = traceback.format_exception_only(exc)[-1].strip()
             return _rstr('** raised %s **' % err)
 
     def _error_exc(self):
-        exc_info = sys.exc_info()[:2]
-        self.error(traceback.format_exception_only(*exc_info)[-1].strip())
+        exc = sys.exc_info()[1]
+        self.error(traceback.format_exception_only(exc)[-1].strip())
 
     def _msg_val_func(self, arg, func):
         try:

--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -47,7 +47,7 @@ class PyCompileError(Exception):
         exc_type_name = exc_type.__name__
         if exc_type is SyntaxError:
             tbtext = ''.join(traceback.format_exception_only(
-                exc_type, exc_value))
+                exc_value))
             errmsg = tbtext.replace('File "<string>"', 'File "%s"' % file)
         else:
             errmsg = "Sorry: %s: %s" % (exc_type_name,exc_value)

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -194,7 +194,7 @@ def addpackage(sitedir, name, known_paths):
                 print("Error processing line {:d} of {}:\n".format(n+1, fullname),
                       file=sys.stderr)
                 import traceback
-                for record in traceback.format_exception(*sys.exc_info()):
+                for record in traceback.format_exc():
                     for line in record.splitlines():
                         print('  '+line, file=sys.stderr)
                 print("\nRemainder of file ignored", file=sys.stderr)

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -254,7 +254,7 @@ def requires_tls_version(version):
 
 
 def handle_error(prefix):
-    exc_format = ' '.join(traceback.format_exception(*sys.exc_info()))
+    exc_format = ' '.join(traceback.format_exc())
     if support.verbose:
         sys.stdout.write(prefix + exc_format)
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -179,7 +179,7 @@ def _safe_string(value, what, func=str):
 # --
 
 def print_exc(limit=None, file=None, chain=True):
-    """Shorthand for 'print_exception(*sys.exc_info(), limit, file)'."""
+    """Shorthand for 'print_exception(*sys.exc_info(), limit, file, chain)'."""
     print_exception(*sys.exc_info(), limit=limit, file=file, chain=chain)
 
 def format_exc(limit=None, chain=True):
@@ -188,7 +188,7 @@ def format_exc(limit=None, chain=True):
 
 def print_last(limit=None, file=None, chain=True):
     """This is a shorthand for 'print_exception(sys.last_type,
-    sys.last_value, sys.last_traceback, limit, file)'."""
+    sys.last_value, sys.last_traceback, limit, file, chain)'."""
     if not hasattr(sys, "last_type"):
         raise ValueError("no last exception")
     print_exception(sys.last_type, sys.last_value, sys.last_traceback,


### PR DESCRIPTION
1. traceback.format_exc() is an alias of traceback.format_exception(*sys.exc_info())

2.  format_exception_only(exc)  is an alias for format_exception_only(typ, exc) 

3. traceback.print_exc() is an alias for traceback.print_exception(sys.exc_info())
 
<!-- gh-issue-number: gh-102486 -->
* Issue: gh-102486
<!-- /gh-issue-number -->
