### PR TITLE
gh-101100: Fix sphinx warnings in `zipapp` and `zipfile` modules

### DIFF
--- a/Doc/library/zipapp.rst
+++ b/Doc/library/zipapp.rst
@@ -215,7 +215,7 @@ using the :func:`create_archive` function::
    >>> import zipapp
    >>> zipapp.create_archive('old_archive.pyz', 'new_archive.pyz', '/usr/bin/python3')
 
-To update the file in place, do the replacement in memory using a :class:`BytesIO`
+To update the file in place, do the replacement in memory using a :class:`~io.BytesIO`
 object, and then overwrite the source afterwards.  Note that there is a risk
 when overwriting a file in place that an error will result in the loss of
 the original file.  This code does not protect against such errors, but

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -288,7 +288,7 @@ ZipFile Objects
    (``ZipExtFile``) is read-only and provides the following methods:
    :meth:`~io.BufferedIOBase.read`, :meth:`~io.IOBase.readline`,
    :meth:`~io.IOBase.readlines`, :meth:`~io.IOBase.seek`,
-   :meth:`~io.IOBase.tell`, :meth:`__iter__`, :meth:`~iterator.__next__`.
+   :meth:`~io.IOBase.tell`, :meth:`~container.__iter__`, :meth:`~iterator.__next__`.
    These objects can operate independently of the ZipFile.
 
    With ``mode='w'``, a writable file handle is returned, which supports the


### PR DESCRIPTION
I've decided to unite these simple fixes into a single PR.

Warnings:

```
./cpython/Doc/library/zipapp.rst:218: WARNING: py:class reference target not found: BytesIO
./cpython/Doc/library/zipfile.rst:287: WARNING: py:meth reference target not found: __iter__
```

Some details:
1. Fixed missing link to https://docs.python.org/3/library/io.html#io.BytesIO
2. Fixed missing link to https://docs.python.org/3/library/stdtypes.html#container.__iter__ 

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
