### PR TITLE
gh-102507 Remove invisible pagebreak characters

### DIFF
--- a/Lib/email/__init__.py
+++ b/Lib/email/__init__.py
@@ -25,7 +25,6 @@ __all__ = [
     ]
 
 
-
 # Some convenience routines.  Don't import Parser and Message as side-effects
 # of importing email since those cascadingly import most of the rest of the
 # email package.

--- a/Lib/email/base64mime.py
+++ b/Lib/email/base64mime.py
@@ -45,7 +45,6 @@ EMPTYSTRING = ''
 MISC_LEN = 7
 
 
-
 # Helpers
 def header_length(bytearray):
     """Return the length of s when it is encoded with base64."""
@@ -57,7 +56,6 @@ def header_length(bytearray):
     return n
 
 
-
 def header_encode(header_bytes, charset='iso-8859-1'):
     """Encode a single header line with Base64 encoding in a given charset.
 
@@ -72,7 +70,6 @@ def header_encode(header_bytes, charset='iso-8859-1'):
     return '=?%s?b?%s?=' % (charset, encoded)
 
 
-
 def body_encode(s, maxlinelen=76, eol=NL):
     r"""Encode a string with base64.
 
@@ -98,7 +95,6 @@ def body_encode(s, maxlinelen=76, eol=NL):
     return EMPTYSTRING.join(encvec)
 
 
-
 def decode(string):
     """Decode a raw base64 string, returning a bytes object.
 

--- a/Lib/email/charset.py
+++ b/Lib/email/charset.py
@@ -18,7 +18,6 @@ from email import errors
 from email.encoders import encode_7or8bit
 
 
-
 # Flags for types of header encodings
 QP          = 1 # Quoted-Printable
 BASE64      = 2 # Base64
@@ -32,7 +31,6 @@ UNKNOWN8BIT = 'unknown-8bit'
 EMPTYSTRING = ''
 
 
-
 # Defaults
 CHARSETS = {
     # input        header enc  body enc output conv
@@ -104,7 +102,6 @@ CODEC_MAP = {
     }
 
 
-
 # Convenience functions for extending the above mappings
 def add_charset(charset, header_enc=None, body_enc=None, output_charset=None):
     """Add character set properties to the global registry.
@@ -153,7 +150,6 @@ def add_codec(charset, codecname):
     CODEC_MAP[charset] = codecname
 
 
-
 # Convenience function for encoding strings, taking into account
 # that they might be unknown-8bit (ie: have surrogate-escaped bytes)
 def _encode(string, codec):
@@ -163,7 +159,6 @@ def _encode(string, codec):
         return string.encode(codec)
 
 
-
 class Charset:
     """Map character sets to their email properties.
 

--- a/Lib/email/encoders.py
+++ b/Lib/email/encoders.py
@@ -16,7 +16,6 @@ from base64 import encodebytes as _bencode
 from quopri import encodestring as _encodestring
 
 
-
 def _qencode(s):
     enc = _encodestring(s, quotetabs=True)
     # Must encode spaces, which quopri.encodestring() doesn't do
@@ -34,7 +33,6 @@ def encode_base64(msg):
     msg['Content-Transfer-Encoding'] = 'base64'
 
 
-
 def encode_quopri(msg):
     """Encode the message's payload in quoted-printable.
 
@@ -46,7 +44,6 @@ def encode_quopri(msg):
     msg['Content-Transfer-Encoding'] = 'quoted-printable'
 
 
-
 def encode_7or8bit(msg):
     """Set the Content-Transfer-Encoding header to 7bit or 8bit."""
     orig = msg.get_payload(decode=True)
@@ -64,6 +61,5 @@ def encode_7or8bit(msg):
         msg['Content-Transfer-Encoding'] = '7bit'
 
 
-
 def encode_noop(msg):
     """Do nothing."""

--- a/Lib/email/feedparser.py
+++ b/Lib/email/feedparser.py
@@ -41,7 +41,6 @@ NL = '\n'
 NeedMoreData = object()
 
 
-
 class BufferedSubFile(object):
     """A file-ish object that can have new data loaded into it.
 
@@ -132,7 +131,6 @@ class BufferedSubFile(object):
         return line
 
 
-
 class FeedParser:
     """A feed-style parser of email."""
 

--- a/Lib/email/generator.py
+++ b/Lib/email/generator.py
@@ -391,6 +391,7 @@ class Generator:
     def _compile_re(cls, s, flags):
         return re.compile(s, flags)
 
+
 class BytesGenerator(Generator):
     """Generates a bytes version of a Message object tree.
 

--- a/Lib/email/generator.py
+++ b/Lib/email/generator.py
@@ -22,7 +22,6 @@ NLCRE = re.compile(r'\r\n|\r|\n')
 fcre = re.compile(r'^From ', re.MULTILINE)
 
 
-
 class Generator:
     """Generates output from a Message object tree.
 
@@ -392,7 +391,6 @@ class Generator:
     def _compile_re(cls, s, flags):
         return re.compile(s, flags)
 
-
 class BytesGenerator(Generator):
     """Generates a bytes version of a Message object tree.
 
@@ -443,7 +441,6 @@ class BytesGenerator(Generator):
         return re.compile(s.encode('ascii'), flags)
 
 
-
 _FMT = '[Non-text (%(type)s) part of message omitted, filename %(filename)s]'
 
 class DecodedGenerator(Generator):
@@ -503,7 +500,6 @@ class DecodedGenerator(Generator):
                     }, file=self)
 
 
-
 # Helper used by Generator._make_boundary
 _width = len(repr(sys.maxsize-1))
 _fmt = '%%0%dd' % _width

--- a/Lib/email/header.py
+++ b/Lib/email/header.py
@@ -52,12 +52,10 @@ fcre = re.compile(r'[\041-\176]+:$')
 _embedded_header = re.compile(r'\n[^ \t]+:')
 
 
-
 # Helpers
 _max_append = email.quoprimime._max_append
 
 
-
 def decode_header(header):
     """Decode a message header value without converting charset.
 
@@ -152,7 +150,6 @@ def decode_header(header):
     return collapsed
 
 
-
 def make_header(decoded_seq, maxlinelen=None, header_name=None,
                 continuation_ws=' '):
     """Create a Header from a sequence of pairs as returned by decode_header()
@@ -175,7 +172,6 @@ def make_header(decoded_seq, maxlinelen=None, header_name=None,
     return h
 
 
-
 class Header:
     def __init__(self, s=None, charset=None,
                  maxlinelen=None, header_name=None,
@@ -409,7 +405,6 @@ class Header:
         self._chunks = chunks
 
 
-
 class _ValueFormatter:
     def __init__(self, headerlen, maxlen, continuation_ws, splitchars):
         self._maxlen = maxlen

--- a/Lib/email/iterators.py
+++ b/Lib/email/iterators.py
@@ -15,7 +15,6 @@ import sys
 from io import StringIO
 
 
-
 # This function will become a method of the Message class
 def walk(self):
     """Walk over the message tree, yielding each subpart.
@@ -29,7 +28,6 @@ def walk(self):
             yield from subpart.walk()
 
 
-
 # These two functions are imported into the Iterators.py interface module.
 def body_line_iterator(msg, decode=False):
     """Iterate over the parts, returning string payloads line-by-line.
@@ -55,7 +53,6 @@ def typed_subpart_iterator(msg, maintype='text', subtype=None):
                 yield subpart
 
 
-
 def _structure(msg, fp=None, level=0, include_default=False):
     """A handy debugging aid"""
     if fp is None:

--- a/Lib/email/mime/base.py
+++ b/Lib/email/mime/base.py
@@ -11,7 +11,6 @@ import email.policy
 from email import message
 
 
-
 class MIMEBase(message.Message):
     """Base class for MIME specializations."""
 

--- a/Lib/email/mime/message.py
+++ b/Lib/email/mime/message.py
@@ -10,7 +10,6 @@ from email import message
 from email.mime.nonmultipart import MIMENonMultipart
 
 
-
 class MIMEMessage(MIMENonMultipart):
     """Class representing message/* MIME documents."""
 

--- a/Lib/email/mime/multipart.py
+++ b/Lib/email/mime/multipart.py
@@ -9,7 +9,6 @@ __all__ = ['MIMEMultipart']
 from email.mime.base import MIMEBase
 
 
-
 class MIMEMultipart(MIMEBase):
     """Base class for MIME multipart/* type messages."""
 

--- a/Lib/email/mime/nonmultipart.py
+++ b/Lib/email/mime/nonmultipart.py
@@ -10,7 +10,6 @@ from email import errors
 from email.mime.base import MIMEBase
 
 
-
 class MIMENonMultipart(MIMEBase):
     """Base class for MIME non-multipart type messages."""
 

--- a/Lib/email/mime/text.py
+++ b/Lib/email/mime/text.py
@@ -10,7 +10,6 @@ from email.charset import Charset
 from email.mime.nonmultipart import MIMENonMultipart
 
 
-
 class MIMEText(MIMENonMultipart):
     """Class for generating text/* type MIME documents."""
 

--- a/Lib/email/parser.py
+++ b/Lib/email/parser.py
@@ -64,7 +64,6 @@ class Parser:
         return self.parse(StringIO(text), headersonly=headersonly)
 
 
-
 class HeaderParser(Parser):
     def parse(self, fp, headersonly=True):
         return Parser.parse(self, fp, True)
@@ -72,7 +71,7 @@ class HeaderParser(Parser):
     def parsestr(self, text, headersonly=True):
         return Parser.parsestr(self, text, True)
 
-
+
 class BytesParser:
 
     def __init__(self, *args, **kw):

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1742,7 +1742,6 @@ _bufferedreader_peek_unlocked(buffered *self)
     self->pos = 0;
     return PyBytes_FromStringAndSize(self->buffer, r);
 }
-
 
 
 /*
@@ -2052,7 +2051,6 @@ error:
     LEAVE_BUFFERED(self)
     return res;
 }
-
 
 
 /*
@@ -2266,7 +2264,6 @@ bufferedrwpair_closed_get(rwpair *self, void *context)
     }
     return PyObject_GetAttr((PyObject *) self->writer, &_Py_ID(closed));
 }
-
 
 
 /*

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -5,7 +5,7 @@
 # Minimally patched to make it even more xgettext compatible
 # by Peter Funk <pf@artcom-gmbh.de>
 #
-# 2002-11-22 Jürgen Hermann <jh@web.de>
+# 2002-11-22 Jï¿½rgen Hermann <jh@web.de>
 # Added checks that _() only contains string literals, and
 # command line args are resolved to module lists, i.e. you
 # can now pass a filename, a module or package name, or a
@@ -174,7 +174,6 @@ DEFAULTKEYWORDS = ', '.join(default_keywords)
 EMPTYSTRING = ''
 
 
-
 # The normal pot-file header. msgmerge and Emacs's po-mode work better if it's
 # there.
 pot_header = _('''\
@@ -196,7 +195,6 @@ msgstr ""
 
 ''')
 
-
 def usage(code, msg=''):
     print(__doc__ % globals(), file=sys.stderr)
     if msg:
@@ -204,12 +202,11 @@ def usage(code, msg=''):
     sys.exit(code)
 
 
-
 def make_escapes(pass_nonascii):
     global escapes, escape
     if pass_nonascii:
         # Allow non-ascii characters to pass through so that e.g. 'msgid
-        # "Höhe"' would result not result in 'msgid "H\366he"'.  Otherwise we
+        # "Hï¿½he"' would result not result in 'msgid "H\366he"'.  Otherwise we
         # escape any character outside the 32..126 range.
         mod = 128
         escape = escape_ascii
@@ -258,7 +255,7 @@ def normalize(s, encoding):
         s = '""\n"' + lineterm.join(lines) + '"'
     return s
 
-
+
 def containsAny(str, set):
     """Check whether 'str' contains ANY of the chars in 'set'"""
     return 1 in [c in str for c in set]
@@ -307,7 +304,6 @@ def getFilesForName(name):
 
     return []
 
-
 class TokenEater:
     def __init__(self, options):
         self.__options = options
@@ -515,7 +511,6 @@ class TokenEater:
                 print('msgstr ""\n', file=fp)
 
 
-
 def main():
     global default_keywords
     try:
@@ -675,7 +670,6 @@ def main():
         if closep:
             fp.close()
 
-
 if __name__ == '__main__':
     main()
     # some more test strings

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -195,6 +195,7 @@ msgstr ""
 
 ''')
 
+
 def usage(code, msg=''):
     print(__doc__ % globals(), file=sys.stderr)
     if msg:
@@ -303,6 +304,7 @@ def getFilesForName(name):
         return [name]
 
     return []
+
 
 class TokenEater:
     def __init__(self, options):
@@ -669,6 +671,7 @@ def main():
     finally:
         if closep:
             fp.close()
+
 
 if __name__ == '__main__':
     main()

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -5,7 +5,7 @@
 # Minimally patched to make it even more xgettext compatible
 # by Peter Funk <pf@artcom-gmbh.de>
 #
-# 2002-11-22 JÃ¼rgen Hermann <jh@web.de>
+# 2002-11-22 Jürgen Hermann <jh@web.de>
 # Added checks that _() only contains string literals, and
 # command line args are resolved to module lists, i.e. you
 # can now pass a filename, a module or package name, or a
@@ -207,7 +207,7 @@ def make_escapes(pass_nonascii):
     global escapes, escape
     if pass_nonascii:
         # Allow non-ascii characters to pass through so that e.g. 'msgid
-        # "HÃ¶he"' would result not result in 'msgid "H\366he"'.  Otherwise we
+        # "Höhe"' would result not result in 'msgid "H\366he"'.  Otherwise we
         # escape any character outside the 32..126 range.
         mod = 128
         escape = escape_ascii

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -5,7 +5,7 @@
 # Minimally patched to make it even more xgettext compatible
 # by Peter Funk <pf@artcom-gmbh.de>
 #
-# 2002-11-22 J�rgen Hermann <jh@web.de>
+# 2002-11-22 Jürgen Hermann <jh@web.de>
 # Added checks that _() only contains string literals, and
 # command line args are resolved to module lists, i.e. you
 # can now pass a filename, a module or package name, or a
@@ -207,7 +207,7 @@ def make_escapes(pass_nonascii):
     global escapes, escape
     if pass_nonascii:
         # Allow non-ascii characters to pass through so that e.g. 'msgid
-        # "H�he"' would result not result in 'msgid "H\366he"'.  Otherwise we
+        # "Höhe"' would result not result in 'msgid "H\366he"'.  Otherwise we
         # escape any character outside the 32..126 range.
         mod = 128
         escape = escape_ascii


### PR DESCRIPTION
Removes invisible pagebreak chars from the repository.

These chars are not visible in the gh-diff, but code editors should display them. For instance VSCode displays it as this strange red box:

![image](https://user-images.githubusercontent.com/48555120/223698858-52d9b540-7573-4a90-989c-08b7254a42c7.png)




<!-- gh-issue-number: gh-102507 -->
* Issue: gh-102507
<!-- /gh-issue-number -->
