### PR TITLE
Rename redundant enum tests so that they run

### DIFF
--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -4580,22 +4580,6 @@ class MiscTestCase(unittest.TestCase):
         self.assertEqual(Double.__doc__, None)
 
 
-    def test_doc_1(self):
-        class Triple(Enum):
-            ONE = 1
-            TWO = 2
-            THREE = 3
-        self.assertEqual(Triple.__doc__, None)
-
-    def test_doc_1(self):
-        class Quadruple(Enum):
-            ONE = 1
-            TWO = 2
-            THREE = 3
-            FOUR = 4
-        self.assertEqual(Quadruple.__doc__, None)
-
-
 # These are unordered here on purpose to ensure that declaration order
 # makes no difference.
 CONVERT_TEST_NAME_D = 5

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -4579,6 +4579,21 @@ class MiscTestCase(unittest.TestCase):
             TWO = 2
         self.assertEqual(Double.__doc__, None)
 
+    def test_doc_3(self):
+        class Triple(Enum):
+            ONE = 1
+            TWO = 2
+            THREE = 3
+        self.assertEqual(Triple.__doc__, None)
+
+    def test_doc_4(self):
+        class Quadruple(Enum):
+            ONE = 1
+            TWO = 2
+            THREE = 3
+            FOUR = 4
+        self.assertEqual(Quadruple.__doc__, None)
+
 
 # These are unordered here on purpose to ensure that declaration order
 # makes no difference.


### PR DESCRIPTION
No issue for this, as I believe that it's trivial.

There are three methods named `test_doc_1` in this class and since only one will ever be executed we should delete two. 
I don't have a particular preference for which but it seems natural to leave the `Single` `Double` enum examples.