### PR TITLE
GH-102537: Handle check for PYTHONTZPATH failing in zoneinfo test

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1543,13 +1543,20 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
     @contextlib.contextmanager
     def python_tzpath_context(value):
         path_var = "PYTHONTZPATH"
+        unset_env_sentinel = object()
+        old_env = unset_env_sentinel
         try:
             with OS_ENV_LOCK:
                 old_env = os.environ.get(path_var, None)
                 os.environ[path_var] = value
                 yield
         finally:
-            if old_env is None:
+            if old_env is unset_env_sentinel:
+                # In this case, `old_env` was never retrieved from the
+                # environment for whatever reason, so there's no need to
+                # reset the environment TZPATH.
+                pass
+            elif old_env is None:
                 del os.environ[path_var]
             else:
                 os.environ[path_var] = old_env  # pragma: nocover

--- a/Misc/NEWS.d/next/Tests/2023-03-08-13-54-20.gh-issue-102537.Vfplpb.rst
+++ b/Misc/NEWS.d/next/Tests/2023-03-08-13-54-20.gh-issue-102537.Vfplpb.rst
@@ -1,0 +1,2 @@
+Adjust the error handling strategy in
+``test_zoneinfo.TzPathTest.python_tzpath_context``. Patch by Paul Ganssle.


### PR DESCRIPTION
It is possible but unlikely for the `python_tzpath_context` function to fail between the start of the `try` block and the point where `os.environ.get` succeeds, in which case `old_env` will be undefined. In this case, we want to take no action.

Practically speaking this will really only happen in an error condition anyway, so it doesn't really matter, but we should probably do it right anyway.

<!-- gh-issue-number: gh-102537 -->
* Issue: gh-102537
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:pganssle