### PR TITLE
gh-102304: Move _Py_RefTotal to _PyRuntimeState

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -11,7 +11,9 @@ PyAPI_FUNC(void) _Py_ForgetReference(PyObject *);
 #endif
 
 #ifdef Py_REF_DEBUG
-PyAPI_FUNC(Py_ssize_t) _Py_GetRefTotal(void);
+/* These are useful as debugging aids when chasing down refleaks. */
+PyAPI_FUNC(Py_ssize_t) _Py_GetGlobalRefTotal(void);
+#  define _Py_GetRefTotal() _Py_GetGlobalRefTotal()
 #endif
 
 

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -14,6 +14,7 @@ PyAPI_FUNC(void) _Py_ForgetReference(PyObject *);
 /* These are useful as debugging aids when chasing down refleaks. */
 PyAPI_FUNC(Py_ssize_t) _Py_GetGlobalRefTotal(void);
 #  define _Py_GetRefTotal() _Py_GetGlobalRefTotal()
+PyAPI_FUNC(Py_ssize_t) _Py_GetLegacyRefTotal(void);
 #endif
 
 

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -46,6 +46,7 @@ PyAPI_DATA(Py_ssize_t) _Py_RefTotal;
 extern void _Py_AddRefTotal(Py_ssize_t);
 extern void _Py_IncRefTotal(void);
 extern void _Py_DecRefTotal(void);
+
 #  define _Py_DEC_REFTOTAL() _Py_RefTotal--
 #endif
 

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -47,7 +47,7 @@ extern void _Py_AddRefTotal(Py_ssize_t);
 extern void _Py_IncRefTotal(void);
 extern void _Py_DecRefTotal(void);
 
-#  define _Py_DEC_REFTOTAL() _Py_RefTotal--
+#  define _Py_DEC_REFTOTAL() _PyRuntime.object_state.reftotal--
 #endif
 
 // Increment reference count by n

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -226,7 +226,7 @@ static inline void _PyObject_GC_UNTRACK(
 #endif
 
 #ifdef Py_REF_DEBUG
-extern void _Py_ClearRefTotal(_PyRuntimeState *);
+extern void _Py_FinalizeRefTotal(_PyRuntimeState *);
 extern void _PyDebug_PrintTotalRefs(void);
 #endif
 

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -226,7 +226,7 @@ static inline void _PyObject_GC_UNTRACK(
 #endif
 
 #ifdef Py_REF_DEBUG
-extern void _Py_SetFinalRefTotal(_PyRuntimeState *);
+extern void _Py_ClearRefTotal(_PyRuntimeState *);
 extern void _PyDebug_PrintTotalRefs(void);
 #endif
 

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -226,6 +226,7 @@ static inline void _PyObject_GC_UNTRACK(
 #endif
 
 #ifdef Py_REF_DEBUG
+extern void _Py_SetFinalRefTotal(_PyRuntimeState *);
 extern void _PyDebug_PrintTotalRefs(void);
 #endif
 

--- a/Include/internal/pycore_object_state.h
+++ b/Include/internal/pycore_object_state.h
@@ -1,0 +1,23 @@
+#ifndef Py_INTERNAL_OBJECT_STATE_H
+#define Py_INTERNAL_OBJECT_STATE_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+struct _py_object_runtime_state {
+#ifdef Py_REF_DEBUG
+    Py_ssize_t reftotal;
+#else
+    int _not_used;
+#endif
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_OBJECT_STATE_H */

--- a/Include/internal/pycore_object_state.h
+++ b/Include/internal/pycore_object_state.h
@@ -10,6 +10,7 @@ extern "C" {
 
 struct _py_object_runtime_state {
 #ifdef Py_REF_DEBUG
+    Py_ssize_t last_legacy_reftotal;
     Py_ssize_t reftotal;
 #else
     int _not_used;

--- a/Include/internal/pycore_object_state.h
+++ b/Include/internal/pycore_object_state.h
@@ -10,7 +10,6 @@ extern "C" {
 
 struct _py_object_runtime_state {
 #ifdef Py_REF_DEBUG
-    Py_ssize_t last_legacy_reftotal;
     Py_ssize_t reftotal;
 #else
     int _not_used;

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -16,6 +16,7 @@ extern "C" {
 #include "pycore_global_objects.h"  // struct _Py_global_objects
 #include "pycore_import.h"          // struct _import_runtime_state
 #include "pycore_interp.h"          // PyInterpreterState
+#include "pycore_object_state.h"    // struct _py_object_runtime_state
 #include "pycore_parser.h"          // struct _parser_runtime_state
 #include "pycore_pymem.h"           // struct _pymem_allocators
 #include "pycore_pyhash.h"          // struct pyhash_runtime_state
@@ -151,6 +152,7 @@ typedef struct pyruntimestate {
     void *open_code_userdata;
     _Py_AuditHookEntry *audit_hook_head;
 
+    struct _py_object_runtime_state object_state;
     struct _Py_float_runtime_state float_state;
     struct _Py_unicode_runtime_state unicode_state;
     struct _Py_dict_runtime_state dict_state;

--- a/Include/object.h
+++ b/Include/object.h
@@ -494,11 +494,6 @@ you can count such references to the type object.)
 extern Py_ssize_t _Py_RefTotal;
 #    define _Py_INC_REFTOTAL() _Py_RefTotal++
 #    define _Py_DEC_REFTOTAL() _Py_RefTotal--
-#  elif defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
-extern void _Py_IncRefTotal(void);
-extern void _Py_DecRefTotal(void);
-#    define _Py_INC_REFTOTAL() _Py_IncRefTotal()
-#    define _Py_DEC_REFTOTAL() _Py_DecRefTotal()
 #  elif !defined(Py_LIMITED_API) || Py_LIMITED_API+0 > 0x030C0000
 extern void _Py_IncRefTotal_DO_NOT_USE_THIS(void);
 extern void _Py_DecRefTotal_DO_NOT_USE_THIS(void);

--- a/Include/object.h
+++ b/Include/object.h
@@ -495,8 +495,8 @@ extern Py_ssize_t _Py_RefTotal;
 #    define _Py_INC_REFTOTAL() _Py_RefTotal++
 #    define _Py_DEC_REFTOTAL() _Py_RefTotal--
 #  elif !defined(Py_LIMITED_API) || Py_LIMITED_API+0 > 0x030C0000
-extern void _Py_IncRefTotal_DO_NOT_USE_THIS(void);
-extern void _Py_DecRefTotal_DO_NOT_USE_THIS(void);
+PyAPI_FUNC(void) _Py_IncRefTotal_DO_NOT_USE_THIS(void);
+PyAPI_FUNC(void) _Py_DecRefTotal_DO_NOT_USE_THIS(void);
 #    define _Py_INC_REFTOTAL() _Py_IncRefTotal_DO_NOT_USE_THIS()
 #    define _Py_DEC_REFTOTAL() _Py_DecRefTotal_DO_NOT_USE_THIS()
 #  endif

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1698,6 +1698,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_moduleobject.h \
 		$(srcdir)/Include/internal/pycore_namespace.h \
 		$(srcdir)/Include/internal/pycore_object.h \
+		$(srcdir)/Include/internal/pycore_object_state.h \
 		$(srcdir)/Include/internal/pycore_obmalloc.h \
 		$(srcdir)/Include/internal/pycore_obmalloc_init.h \
 		$(srcdir)/Include/internal/pycore_pathconfig.h \

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -54,31 +54,39 @@ _PyObject_CheckConsistency(PyObject *op, int check_content)
 
 
 #ifdef Py_REF_DEBUG
+// XXX Move this to _PyRuntimeState.
 Py_ssize_t _Py_RefTotal;
+#endif
+
+#ifdef Py_REF_DEBUG
+
+#  define REFTOTAL _Py_RefTotal
 
 static inline void
 reftotal_increment(void)
 {
-    _Py_RefTotal++;
+    REFTOTAL++;
 }
 
 static inline void
 reftotal_decrement(void)
 {
-    _Py_RefTotal--;
+    REFTOTAL--;
 }
 
 void
 _Py_AddRefTotal(Py_ssize_t n)
 {
-    _Py_RefTotal += n;
+    REFTOTAL += n;
 }
 
 Py_ssize_t
 _Py_GetRefTotal(void)
 {
-    return _Py_RefTotal;
+    return REFTOTAL;
 }
+
+#undef REFTOTAL
 
 void
 _PyDebug_PrintTotalRefs(void) {
@@ -196,6 +204,9 @@ _Py_DecRef(PyObject *o)
 #endif
     Py_DECREF(o);
 }
+
+
+/**************************************/
 
 PyObject *
 PyObject_Init(PyObject *op, PyTypeObject *tp)

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -74,14 +74,14 @@ reftotal_decrement(void)
     REFTOTAL--;
 }
 
-void
-_Py_AddRefTotal(Py_ssize_t n)
+static inline void
+reftotal_add(Py_ssize_t n)
 {
     REFTOTAL += n;
 }
 
-Py_ssize_t
-_Py_GetRefTotal(void)
+static inline Py_ssize_t
+get_global_reftotal(void)
 {
     return REFTOTAL;
 }
@@ -92,7 +92,7 @@ void
 _PyDebug_PrintTotalRefs(void) {
     fprintf(stderr,
             "[%zd refs, %zd blocks]\n",
-            _Py_GetRefTotal(), _Py_GetAllocatedBlocks());
+            get_global_reftotal(), _Py_GetAllocatedBlocks());
 }
 #endif /* Py_REF_DEBUG */
 
@@ -171,6 +171,18 @@ void
 _Py_DecRefTotal(void)
 {
     reftotal_decrement();
+}
+
+void
+_Py_AddRefTotal(Py_ssize_t n)
+{
+    reftotal_add(n);
+}
+
+Py_ssize_t
+_Py_GetRefTotal(void)
+{
+    return get_global_reftotal();
 }
 
 #endif /* Py_REF_DEBUG */

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -54,13 +54,13 @@ _PyObject_CheckConsistency(PyObject *op, int check_content)
 
 
 #ifdef Py_REF_DEBUG
-// XXX Move this to _PyRuntimeState.
+/* We keep the legacy symbol around for backward compatibility. */
 Py_ssize_t _Py_RefTotal;
 #endif
 
 #ifdef Py_REF_DEBUG
 
-#  define REFTOTAL _Py_RefTotal
+#  define REFTOTAL (_PyRuntime.object_state.reftotal)
 
 static inline void
 reftotal_increment(void)

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -180,7 +180,7 @@ _Py_AddRefTotal(Py_ssize_t n)
 }
 
 Py_ssize_t
-_Py_GetRefTotal(void)
+_Py_GetGlobalRefTotal(void)
 {
     return get_global_reftotal();
 }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -60,18 +60,9 @@ _PyObject_CheckConsistency(PyObject *op, int check_content)
 /* We keep the legacy symbol around for backward compatibility. */
 Py_ssize_t _Py_RefTotal;
 
-static inline void
-sync_legacy_reftotal(_PyRuntimeState *runtime)
-{
-    Py_ssize_t last = OBJSTATE(runtime).last_legacy_reftotal;
-    OBJSTATE(runtime).last_legacy_reftotal = _Py_RefTotal;
-    OBJSTATE(runtime).reftotal += _Py_RefTotal - last;
-}
-
 static inline Py_ssize_t
-get_legacy_reftotal(_PyRuntimeState *runtime)
+get_legacy_reftotal(void)
 {
-    sync_legacy_reftotal(runtime);
     return _Py_RefTotal;
 }
 #endif
@@ -111,15 +102,14 @@ _Py_ClearRefTotal(_PyRuntimeState *runtime)
 {
     last_final_reftotal += get_global_reftotal(runtime);
     REFTOTAL = 0;
-    _Py_RefTotal = 0;
 }
 
 static inline Py_ssize_t
 get_global_reftotal(_PyRuntimeState *runtime)
 {
     /* For an update from _Py_RefTotal first. */
-    sync_legacy_reftotal(runtime);
-    return REFTOTAL + last_final_reftotal;
+    Py_ssize_t legacy = get_legacy_reftotal();
+    return REFTOTAL + legacy + last_final_reftotal;
 }
 
 #undef REFTOTAL
@@ -228,7 +218,7 @@ _Py_GetGlobalRefTotal(void)
 Py_ssize_t
 _Py_GetLegacyRefTotal(void)
 {
-    return get_legacy_reftotal(&_PyRuntime);
+    return get_legacy_reftotal();
 }
 
 #endif /* Py_REF_DEBUG */

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -92,7 +92,8 @@ get_global_reftotal(void)
     Py_ssize_t last = _PyRuntime.object_state.last_legacy_reftotal;
     Py_ssize_t legacy = get_legacy_reftotal();
     _PyRuntime.object_state.last_legacy_reftotal = legacy;
-    return REFTOTAL + legacy - last;
+    REFTOTAL += legacy - last;
+    return REFTOTAL;
 }
 
 #undef REFTOTAL

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -93,9 +93,10 @@ reftotal_add(_PyRuntimeState *runtime, Py_ssize_t n)
 static Py_ssize_t last_final_reftotal = 0;
 
 void
-_Py_SetFinalRefTotal(_PyRuntimeState *runtime)
+_Py_ClearRefTotal(_PyRuntimeState *runtime)
 {
     last_final_reftotal += REFTOTAL;
+    REFTOTAL = 0;
 }
 
 static inline Py_ssize_t

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -158,15 +158,15 @@ _Py_NegativeRefcount(const char *filename, int lineno, PyObject *op)
                            filename, lineno, __func__);
 }
 
-/* This is exposed strictly for use in Py_INCREF(). */
-PyAPI_FUNC(void)
+/* This is used strictly by Py_INCREF(). */
+void
 _Py_IncRefTotal_DO_NOT_USE_THIS(void)
 {
     reftotal_increment();
 }
 
-/* This is exposed strictly for use in Py_DECREF(). */
-PyAPI_FUNC(void)
+/* This is used strictly by Py_DECREF(). */
+void
 _Py_DecRefTotal_DO_NOT_USE_THIS(void)
 {
     reftotal_decrement();

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -220,18 +220,12 @@ Py_DecRef(PyObject *o)
 void
 _Py_IncRef(PyObject *o)
 {
-#ifdef Py_REF_DEBUG
-    reftotal_increment();
-#endif
     Py_INCREF(o);
 }
 
 void
 _Py_DecRef(PyObject *o)
 {
-#ifdef Py_REF_DEBUG
-    reftotal_decrement();
-#endif
     Py_DECREF(o);
 }
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -96,7 +96,7 @@ static inline Py_ssize_t get_global_reftotal(_PyRuntimeState *);
 static Py_ssize_t last_final_reftotal = 0;
 
 void
-_Py_ClearRefTotal(_PyRuntimeState *runtime)
+_Py_FinalizeRefTotal(_PyRuntimeState *runtime)
 {
     last_final_reftotal += get_global_reftotal(runtime);
     REFTOTAL(runtime) = 0;

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -26,9 +26,6 @@
 extern "C" {
 #endif
 
-#define OBJSTATE(runtime) \
-    (runtime)->object_state
-
 /* Defined in tracemalloc.c */
 extern void _PyMem_DumpTraceback(int fd, const void *ptr);
 
@@ -69,24 +66,25 @@ get_legacy_reftotal(void)
 
 #ifdef Py_REF_DEBUG
 
-#  define REFTOTAL (OBJSTATE(runtime).reftotal)
+#  define REFTOTAL(runtime) \
+    (runtime)->object_state.reftotal
 
 static inline void
 reftotal_increment(_PyRuntimeState *runtime)
 {
-    REFTOTAL++;
+    REFTOTAL(runtime)++;
 }
 
 static inline void
 reftotal_decrement(_PyRuntimeState *runtime)
 {
-    REFTOTAL--;
+    REFTOTAL(runtime)--;
 }
 
 static inline void
 reftotal_add(_PyRuntimeState *runtime, Py_ssize_t n)
 {
-    REFTOTAL += n;
+    REFTOTAL(runtime) += n;
 }
 
 static inline Py_ssize_t get_global_reftotal(_PyRuntimeState *);
@@ -101,7 +99,7 @@ void
 _Py_ClearRefTotal(_PyRuntimeState *runtime)
 {
     last_final_reftotal += get_global_reftotal(runtime);
-    REFTOTAL = 0;
+    REFTOTAL(runtime) = 0;
 }
 
 static inline Py_ssize_t
@@ -109,7 +107,7 @@ get_global_reftotal(_PyRuntimeState *runtime)
 {
     /* For an update from _Py_RefTotal first. */
     Py_ssize_t legacy = get_legacy_reftotal();
-    return REFTOTAL + legacy + last_final_reftotal;
+    return REFTOTAL(runtime) + legacy + last_final_reftotal;
 }
 
 #undef REFTOTAL

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -98,7 +98,7 @@ static Py_ssize_t last_final_reftotal = 0;
 void
 _Py_FinalizeRefTotal(_PyRuntimeState *runtime)
 {
-    last_final_reftotal += get_global_reftotal(runtime);
+    last_final_reftotal = get_global_reftotal(runtime);
     REFTOTAL(runtime) = 0;
 }
 

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -238,6 +238,7 @@
     <ClInclude Include="..\Include\internal\pycore_moduleobject.h" />
     <ClInclude Include="..\Include\internal\pycore_namespace.h" />
     <ClInclude Include="..\Include\internal\pycore_object.h" />
+    <ClInclude Include="..\Include\internal\pycore_object_state.h" />
     <ClInclude Include="..\Include\internal\pycore_obmalloc.h" />
     <ClInclude Include="..\Include\internal\pycore_obmalloc_init.h" />
     <ClInclude Include="..\Include\internal\pycore_pathconfig.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -618,6 +618,9 @@
     <ClInclude Include="..\Include\internal\pycore_object.h">
       <Filter>Include\internal</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_object_state.h">
+      <Filter>Include\internal</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_obmalloc.h">
       <Filter>Include\internal</Filter>
     </ClInclude>

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1930,6 +1930,7 @@ Py_FinalizeEx(void)
     if (show_ref_count) {
         _PyDebug_PrintTotalRefs();
     }
+    _Py_SetFinalRefTotal(runtime);
 #endif
 
 #ifdef Py_TRACE_REFS

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1930,7 +1930,7 @@ Py_FinalizeEx(void)
     if (show_ref_count) {
         _PyDebug_PrintTotalRefs();
     }
-    _Py_ClearRefTotal(runtime);
+    _Py_FinalizeRefTotal(runtime);
 #endif
 
 #ifdef Py_TRACE_REFS

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1930,7 +1930,7 @@ Py_FinalizeEx(void)
     if (show_ref_count) {
         _PyDebug_PrintTotalRefs();
     }
-    _Py_SetFinalRefTotal(runtime);
+    _Py_ClearRefTotal(runtime);
 #endif
 
 #ifdef Py_TRACE_REFS

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -482,6 +482,9 @@ _PyRuntimeState_Init(_PyRuntimeState *runtime)
 void
 _PyRuntimeState_Fini(_PyRuntimeState *runtime)
 {
+    /* The reftotal is cleared by _Py_FinalizeRefTotal(). */
+    assert(runtime->object_state.reftotal == 0);
+
     if (gilstate_tss_initialized(runtime)) {
         gilstate_tss_fini(runtime);
     }
@@ -506,9 +509,6 @@ _PyRuntimeState_Fini(_PyRuntimeState *runtime)
 
 #undef FREE_LOCK
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
-
-    /* The reftotal is cleared by _Py_ClearRefTotal(). */
-    assert(runtime->object_state.reftotal == 0);
 }
 
 #ifdef HAVE_FORK

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -506,6 +506,9 @@ _PyRuntimeState_Fini(_PyRuntimeState *runtime)
 
 #undef FREE_LOCK
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+
+    /* The reftotal is cleared by _Py_ClearRefTotal(). */
+    assert(runtime->object_state.reftotal == 0);
 }
 
 #ifdef HAVE_FORK

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1850,7 +1850,7 @@ static Py_ssize_t
 sys_gettotalrefcount_impl(PyObject *module)
 /*[clinic end generated code: output=4103886cf17c25bc input=53b744faa5d2e4f6]*/
 {
-    return _Py_GetRefTotal();
+    return _Py_GetGlobalRefTotal();
 }
 
 #endif /* Py_REF_DEBUG */

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -141,7 +141,6 @@ Modules/syslogmodule.c	-	S_log_open	-
 ##-----------------------
 ## kept for stable ABI compatibility
 
-# XXX should be per-interpreter, without impacting stable ABI extensions
 Objects/object.c	-	_Py_RefTotal	-
 
 ##-----------------------

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -299,6 +299,7 @@ Objects/genobject.c	-	NON_INIT_CORO_MSG	-
 Objects/longobject.c	-	_PyLong_DigitValue	-
 Objects/object.c	-	_Py_SwappedOp	-
 Objects/object.c	-	_Py_abstract_hack	-
+Objects/object.c	-	last_final_reftotal	-
 Objects/object.c	-	static_types	-
 Objects/obmalloc.c	-	_PyMem	-
 Objects/obmalloc.c	-	_PyMem_Debug	-


### PR DESCRIPTION
The essentially eliminates the global variable, with the associated benefits.  This is also a precursor to isolating this bit of state to `PyInterpreterState`.

Folks that currently read `_Py_RefTotal` directly would have to start using `_Py_GetGlobalRefTotal()` instead.

<!-- gh-issue-number: gh-102304 -->
* Issue: gh-102304
<!-- /gh-issue-number -->
