### PR TITLE
gh-87092: refactor assemble() to a number of separate functions, which do not need the compiler struct

### DIFF
--- a/Lib/test/support/bytecode_helper.py
+++ b/Lib/test/support/bytecode_helper.py
@@ -103,7 +103,7 @@ class CompilationStepTestCase(unittest.TestCase):
             if isinstance(oparg, self.Label):
                 arg = oparg.value
             else:
-                arg = oparg if opcode in self.HAS_ARG else None
+                arg = oparg if opcode in self.HAS_ARG else 0
             opcode = dis.opname[opcode]
             res.append((opcode, arg, *loc))
         return res

--- a/Lib/test/support/bytecode_helper.py
+++ b/Lib/test/support/bytecode_helper.py
@@ -103,7 +103,7 @@ class CompilationStepTestCase(unittest.TestCase):
             if isinstance(oparg, self.Label):
                 arg = oparg.value
             else:
-                arg = oparg if opcode in self.HAS_ARG else 0
+                arg = oparg if opcode in self.HAS_ARG else None
             opcode = dis.opname[opcode]
             res.append((opcode, arg, *loc))
         return res
@@ -125,7 +125,7 @@ class CfgOptimizationTestCase(CompilationStepTestCase):
             assert isinstance(item, tuple)
             inst = list(reversed(item))
             opcode = dis.opmap[inst.pop()]
-            oparg = inst.pop() if opcode in self.HAS_ARG_OR_TARGET else 0
+            oparg = inst.pop()
             loc = inst + [-1] * (4 - len(inst))
             res.append((opcode, oparg, *loc))
         return res

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -995,15 +995,20 @@ class DirectiCfgOptimizerTests(CfgOptimizationTestCase):
             ('LOAD_CONST', 2, 13),
             lbl,
             ('LOAD_CONST', 3, 14),
+            ('RETURN_VALUE', 14),
         ]
-        expected = [
+        expected_insts = [
             ('LOAD_NAME', 1, 11),
             ('POP_JUMP_IF_TRUE', lbl := self.Label(), 12),
-            ('LOAD_CONST', 2, 13),
+            ('LOAD_CONST', 1, 13),
             lbl,
-            ('LOAD_CONST', 3, 14)
+            ('NOP', 0, 14),
+            ('RETURN_CONST', 2, 0),
         ]
-        self.cfg_optimization_test(insts, expected, consts=list(range(5)))
+        self.cfg_optimization_test(insts,
+                                   expected_insts,
+                                   consts=[0, 1, 2, 3, 4],
+                                   expected_consts=[0, 2, 3])
 
     def test_conditional_jump_forward_const_condition(self):
         # The unreachable branch of the jump is removed, the jump
@@ -1015,26 +1020,33 @@ class DirectiCfgOptimizerTests(CfgOptimizationTestCase):
             ('LOAD_CONST', 2, 13),
             lbl,
             ('LOAD_CONST', 3, 14),
+            ('RETURN_VALUE', 14),
         ]
-        expected = [
+        expected_insts = [
             ('NOP', None, 11),
             ('NOP', None, 12),
-            ('LOAD_CONST', 3, 14)
+            ('NOP', 0, 14),
+            ('RETURN_CONST', 1, 0),
         ]
-        self.cfg_optimization_test(insts, expected, consts=list(range(5)))
+        self.cfg_optimization_test(insts,
+                                   expected_insts,
+                                   consts=[0, 1, 2, 3, 4],
+                                   expected_consts=[0, 3])
 
     def test_conditional_jump_backward_non_const_condition(self):
         insts = [
             lbl1 := self.Label(),
             ('LOAD_NAME', 1, 11),
             ('POP_JUMP_IF_TRUE', lbl1, 12),
-            ('LOAD_CONST', 2, 13),
+            ('LOAD_NAME', 2, 13),
+            ('RETURN_VALUE', 13),
         ]
         expected = [
             lbl := self.Label(),
             ('LOAD_NAME', 1, 11),
             ('POP_JUMP_IF_TRUE', lbl, 12),
-            ('LOAD_CONST', 2, 13)
+            ('LOAD_NAME', 2, 13),
+            ('RETURN_VALUE', 13),
         ]
         self.cfg_optimization_test(insts, expected, consts=list(range(5)))
 
@@ -1042,16 +1054,17 @@ class DirectiCfgOptimizerTests(CfgOptimizationTestCase):
         # The unreachable branch of the jump is removed
         insts = [
             lbl1 := self.Label(),
-            ('LOAD_CONST', 1, 11),
+            ('LOAD_CONST', 3, 11),
             ('POP_JUMP_IF_TRUE', lbl1, 12),
             ('LOAD_CONST', 2, 13),
+            ('RETURN_VALUE', 13),
         ]
-        expected = [
+        expected_insts = [
             lbl := self.Label(),
             ('NOP', None, 11),
-            ('JUMP', lbl, 12)
+            ('JUMP', lbl, 12),
         ]
-        self.cfg_optimization_test(insts, expected, consts=list(range(5)))
+        self.cfg_optimization_test(insts, expected_insts, consts=list(range(5)))
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1002,8 +1002,7 @@ class DirectiCfgOptimizerTests(CfgOptimizationTestCase):
             ('POP_JUMP_IF_TRUE', lbl := self.Label(), 12),
             ('LOAD_CONST', 1, 13),
             lbl,
-            ('NOP', 0, 14),
-            ('RETURN_CONST', 2, 0),
+            ('RETURN_CONST', 2, 14),
         ]
         self.cfg_optimization_test(insts,
                                    expected_insts,
@@ -1023,10 +1022,9 @@ class DirectiCfgOptimizerTests(CfgOptimizationTestCase):
             ('RETURN_VALUE', 14),
         ]
         expected_insts = [
-            ('NOP', None, 11),
-            ('NOP', None, 12),
-            ('NOP', 0, 14),
-            ('RETURN_CONST', 1, 0),
+            ('NOP', 11),
+            ('NOP', 12),
+            ('RETURN_CONST', 1, 14),
         ]
         self.cfg_optimization_test(insts,
                                    expected_insts,
@@ -1061,7 +1059,7 @@ class DirectiCfgOptimizerTests(CfgOptimizationTestCase):
         ]
         expected_insts = [
             lbl := self.Label(),
-            ('NOP', None, 11),
+            ('NOP', 11),
             ('JUMP', lbl, 12),
         ]
         self.cfg_optimization_test(insts, expected_insts, consts=list(range(5)))

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -9844,9 +9844,15 @@ instructions_to_cfg(PyObject *instructions, cfg_builder *g)
         if (PyErr_Occurred()) {
             goto error;
         }
-        int oparg = PyLong_AsLong(PyTuple_GET_ITEM(item, 1));
-        if (PyErr_Occurred()) {
-            goto error;
+        int oparg;
+        if (HAS_ARG(opcode)) {
+            oparg = PyLong_AsLong(PyTuple_GET_ITEM(item, 1));
+            if (PyErr_Occurred()) {
+                goto error;
+            }
+        }
+        else {
+            oparg = 0;
         }
         location loc;
         loc.lineno = PyLong_AsLong(PyTuple_GET_ITEM(item, 2));

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -8790,7 +8790,7 @@ assemble_code_unit(struct compiler_unit *u, PyObject *const_cache,
 
     /* Can't modify the bytecode after computing jump offsets. */
     assemble_jump_offsets(g.g_entryblock);
-    /* Create assembler */
+
     struct assembler a;
     int res = assemble_emit(&a, g.g_entryblock, u->u_firstlineno, const_cache);
     if (res == SUCCESS) {
@@ -8803,7 +8803,6 @@ assemble_code_unit(struct compiler_unit *u, PyObject *const_cache,
     Py_XDECREF(consts);
     cfg_builder_fini(&g);
     return co;
-
 }
 
 static PyCodeObject *


### PR DESCRIPTION
This PR:

1. further breaks up the assemble() function, and extracts out of it the optimize_code_unit(), assemble_code_unit(), assemble_emit() and resolve_line_numbers() steps into separate functions.
2. passes less stuff around (namely, not passing the whole compiler struct but only what is needed). 
3. unit tests (_PyCompile_OptimizeCfg ) run all of optimize_code_unit(), not just optimize_cfg(), so we can test dead code removal, unused const removal, hot/cold code arrangements, etc.
4. _PyCompile_CodeGen no longer constructs a cfg.

<!-- gh-issue-number: gh-87092 -->
* Issue: gh-87092
<!-- /gh-issue-number -->
