### PR TITLE
gh-102255: use `GetVersionEx` instead of `GetVersionExW`

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -353,7 +353,7 @@ remove_unusable_flags(PyObject *m)
     }
 #ifndef MS_WINDOWS_DESKTOP
     info.dwOSVersionInfoSize = sizeof(info);
-    if (!GetVersionExW((OSVERSIONINFOW*) &info)) {
+    if (!GetVersionEx((OSVERSIONINFO*) &info)) {
         PyErr_SetFromWindowsErr(0);
         return -1;
     }


### PR DESCRIPTION
as an alternative we can change the rest of the function to use the wide APIs. It does not really matter here though.

<!-- gh-issue-number: gh-102255 -->
* Issue: gh-102255
<!-- /gh-issue-number -->
