### PR TITLE
gh-89188: replace bitfield with struct fields in PyASCIIObject

### DIFF
--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -155,11 +155,9 @@ extern PyTypeObject _PyExc_MemoryError;
         .ob_base = _PyObject_IMMORTAL_INIT(&PyUnicode_Type), \
         .length = sizeof(LITERAL) - 1, \
         .hash = -1, \
-        .state = { \
-            .kind = 1, \
-            .compact = 1, \
-            .ascii = (ASCII), \
-        }, \
+        .kind = 1, \
+        .compact = 1, \
+        .ascii = (ASCII), \
     }
 #define _PyASCIIObject_INIT(LITERAL) \
     { \

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1555,5 +1555,11 @@ class Test_Pep523API(unittest.TestCase):
         self.do_test(func2)
 
 
+class Test_UnicodeObjectAlignment(unittest.TestCase):
+
+    def test_unicodeobject_data_alignment(self):
+        _testinternalcapi.check_compactunicodeobject_data_alignment()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -684,6 +684,21 @@ clear_extension(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
+static PyObject *
+check_compactunicodeobject_data_alignment()
+{
+    size_t data_offset = sizeof(PyCompactUnicodeObject);
+    if (data_offset % 4 != 0) {
+        // This is required so that the data (which immediately follows a
+        // compact unicode offset) is correctly aligned in the largest case (UCS_4)
+        PyErr_Format(PyExc_AssertionError,
+                     "PyCompactUnicodeObject size offset is %i, needs to be multiple of 4 bytes",
+                     data_offset);
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
 
 static PyMethodDef module_functions[] = {
     {"get_configs", get_configs, METH_NOARGS},
@@ -707,6 +722,7 @@ static PyMethodDef module_functions[] = {
     _TESTINTERNALCAPI_OPTIMIZE_CFG_METHODDEF
     {"get_interp_settings", get_interp_settings, METH_VARARGS, NULL},
     {"clear_extension", clear_extension, METH_VARARGS, NULL},
+    {"check_compactunicodeobject_data_alignment", check_compactunicodeobject_data_alignment, METH_NOARGS, NULL},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -1092,9 +1092,9 @@ _Py_DumpASCII(int fd, PyObject *text)
         return;
 
     size = ascii->length;
-    kind = ascii->state.kind;
-    if (ascii->state.compact) {
-        if (ascii->state.ascii)
+    kind = ascii->kind;
+    if (ascii->compact) {
+        if (ascii->ascii)
             data = ascii + 1;
         else
             data = _PyCompactUnicodeObject_CAST(text) + 1;
@@ -1114,7 +1114,7 @@ _Py_DumpASCII(int fd, PyObject *text)
     }
 
     // Is an ASCII string?
-    if (ascii->state.ascii) {
+    if (ascii->ascii) {
         assert(kind == PyUnicode_1BYTE_KIND);
         char *str = data;
 
@@ -1341,4 +1341,3 @@ _Py_DumpTracebackThreads(int fd, PyInterpreterState *interp,
 
     return NULL;
 }
-

--- a/Tools/build/deepfreeze.py
+++ b/Tools/build/deepfreeze.py
@@ -198,10 +198,9 @@ class Printer:
                     self.object_head("PyUnicode_Type")
                     self.write(f".length = {len(s)},")
                     self.write(".hash = -1,")
-                    with self.block(".state =", ","):
-                        self.write(".kind = 1,")
-                        self.write(".compact = 1,")
-                        self.write(".ascii = 1,")
+                    self.write(".kind = 1,")
+                    self.write(".compact = 1,")
+                    self.write(".ascii = 1,")
                 self.write(f"._data = {make_string_literal(s.encode('ascii'))},")
                 return f"& {name}._ascii.ob_base"
             else:
@@ -210,10 +209,9 @@ class Printer:
                         self.object_head("PyUnicode_Type")
                         self.write(f".length = {len(s)},")
                         self.write(".hash = -1,")
-                        with self.block(".state =", ","):
-                            self.write(f".kind = {kind},")
-                            self.write(".compact = 1,")
-                            self.write(".ascii = 0,")
+                        self.write(f".kind = {kind},")
+                        self.write(".compact = 1,")
+                        self.write(".ascii = 0,")
                     utf8 = s.encode('utf-8')
                     self.write(f'.utf8 = {make_string_literal(utf8)},')
                     self.write(f'.utf8_length = {len(utf8)},')

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1389,16 +1389,15 @@ class PyUnicodeObjectPtr(PyObjectPtr):
     def proxyval(self, visited):
         compact = self.field('_base')
         ascii = compact['_base']
-        state = ascii['state']
-        is_compact_ascii = (int(state['ascii']) and int(state['compact']))
+        is_compact_ascii = (int(compact['ascii']) and int(compact['compact']))
         field_length = int(ascii['length'])
         if is_compact_ascii:
             field_str = ascii.address + 1
-        elif int(state['compact']):
+        elif int(compact['compact']):
             field_str = compact.address + 1
         else:
             field_str = self.field('data')['any']
-        repr_kind = int(state['kind'])
+        repr_kind = int(compact['kind'])
         if repr_kind == 1:
             field_str = field_str.cast(_type_unsigned_char_ptr())
         elif repr_kind == 2:


### PR DESCRIPTION
Closes #89188

I noticed that `PyASCIIObject.state` is a 32-bit bitfield with 4 members, so I replaced it with 4 separate `uint8_t` fields. The advantage of doing this is that C bitfield layout is implementation-defined, which makes it hard to interact with them from non-C languages (e.g. Rust).

cc @encukou @vstinner as you participated in the discussion on the original issue, I'd be interested to hear if you think this looks like a suitable solution.

<!-- gh-issue-number: gh-89188 -->
* Issue: gh-89188
<!-- /gh-issue-number -->
