### PR TITLE
gh-79940: skip `TestGetAsyncGenState` on wasm as it requires working sockets

### DIFF
--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -67,7 +67,8 @@ git = mod.StupidGit()
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    if support.has_socket_support:
+        asyncio.set_event_loop_policy(None)
 
 
 def signatures_with_lexicographic_keyword_only_parameters():
@@ -2326,6 +2327,7 @@ class TestGetCoroutineState(unittest.TestCase):
                          {'a': None, 'gencoro': gencoro, 'b': 'spam'})
 
 
+@support.requires_working_socket()
 class TestGetAsyncGenState(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):

--- a/Misc/NEWS.d/next/Tests/2023-03-11-11-14-01.gh-issue-79940.UH4d3k.rst
+++ b/Misc/NEWS.d/next/Tests/2023-03-11-11-14-01.gh-issue-79940.UH4d3k.rst
@@ -1,2 +1,0 @@
-Fix failed :mod:`test_inspect` tests on wasm32-emscripten and wasm32-wasi.
-Patch by Thomas Krennwallner.

--- a/Misc/NEWS.d/next/Tests/2023-03-11-11-14-01.gh-issue-79940.UH4d3k.rst
+++ b/Misc/NEWS.d/next/Tests/2023-03-11-11-14-01.gh-issue-79940.UH4d3k.rst
@@ -1,0 +1,2 @@
+Fix failed :mod:`test_inspect` tests on wasm32-emscripten and wasm32-wasi.
+Patch by Thomas Krennwallner.


### PR DESCRIPTION
Skip `TestGetAsyncGenState` and restoring of the default event loop policy in `test_inspect` if platform lacks working socket support.

Fixes #11590

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-79940 -->
* Issue: gh-79940
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:kumaraditya303