### PR TITLE
gh-102594: test_fetch_exception_with_broken_init @ 3.12.0a3

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -360,10 +360,20 @@ class ExceptionTests(unittest.TestCase):
             self.assertRaises(SystemError, _testcapi.raise_exception,
                               InvalidException, 1)
 
+        def test_capi4():
+            import _testcapi
+            class FlakyException(Exception):
+                def __init__(self):
+                    raise ValueError("Broken __init__")
+
+            fetched_type_name = _testcapi.exc_set_object_fetch(FlakyException, ())
+            self.assertEqual(fetched_type_name, 'FlakyException')
+
         if not sys.platform.startswith('java'):
             test_capi1()
             test_capi2()
             test_capi3()
+            test_capi4()
 
     def test_WindowsError(self):
         try:


### PR DESCRIPTION
Reproducer for #102594 based on 3.12.0a3 (b6bd7ffcbc1ffaa68e3423e7415ef8ba0f8a188d): **Works as expected.**

<!-- gh-issue-number: gh-102594 -->
* Issue: gh-102594
<!-- /gh-issue-number -->
