### PR TITLE
Optimize fmean() weighted average 

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -496,26 +496,23 @@ def fmean(data, weights=None):
     >>> fmean([3.5, 4.0, 5.25])
     4.25
     """
-    try:
-        n = len(data)
-    except TypeError:
-        # Handle iterators that do not define __len__().
-        n = 0
-        def count(iterable):
-            nonlocal n
-            for n, x in enumerate(iterable, start=1):
-                yield x
-        data = count(data)
     if weights is None:
+        try:
+            n = len(data)
+        except TypeError:
+            # Handle iterators that do not define __len__().
+            n = 0
+            def count(iterable):
+                nonlocal n
+                for n, x in enumerate(iterable, start=1):
+                    yield x
+            data = count(data)
         total = fsum(data)
         if not n:
             raise StatisticsError('fmean requires at least one data point')
         return total / n
-    try:
-        num_weights = len(weights)
-    except TypeError:
+    if not isinstance(weights, (list, tuple)):
         weights = list(weights)
-        num_weights = len(weights)
     try:
         num = sumprod(data, weights)
     except ValueError:

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -136,9 +136,9 @@ from fractions import Fraction
 from decimal import Decimal
 from itertools import count, groupby, repeat
 from bisect import bisect_left, bisect_right
-from math import hypot, sqrt, fabs, exp, erf, tau, log, fsum
+from math import hypot, sqrt, fabs, exp, erf, tau, log, fsum, sumprod
 from functools import reduce
-from operator import mul, itemgetter
+from operator import itemgetter
 from collections import Counter, namedtuple, defaultdict
 
 _SQRT2 = sqrt(2.0)
@@ -516,8 +516,9 @@ def fmean(data, weights=None):
     except TypeError:
         weights = list(weights)
         num_weights = len(weights)
-    num = fsum(map(mul, data, weights))
-    if n != num_weights:
+    try:
+        num = sumprod(data, weights)
+    except ValueError:
         raise StatisticsError('data and weights must be the same length')
     den = fsum(weights)
     if not den:


### PR DESCRIPTION
Use the new `math.sumprod()` function to compute the weighted average.

As compared to `fsum(map(mul, data, weights))` the `sumprod(data, weights)` code is simpler, faster, and more accurate.  It is faster because we don't need a succession of calls to `mul`.  It is more accurate because all of the intermediate products are computed losslessly rather than rounded immedately by `mul`.  Also, we no longer need the `count()` wrapper for this path because `sumprod()` already incorporates a test to make sure the inputs are the same length.

**Baseline timing**

% ./python.exe -m timeit -r11 -s 'from random import expovariate as r' -s 'from statistics import fmean' -s 'n=100' -s 'data = [r() for i in range(n)]' -s 'weights = [r() for i in range(n)]' 'fmean(data, weights)'
50000 loops, best of 11: 4.96 usec per loop

**Improved timing**

% ./python.exe -m timeit -r11 -s 'from random import expovariate as r' -s 'from statistics import fmea
n' -s 'n=100' -s 'data = [r() for i in range(n)]' -s 'weights = [r() for i in range(n)]' 'fmean(data, weights)'
100000 loops, best of 11: 2.06 usec per loop