### PR TITLE
[3.10] GH-101673: Fix pdb bug where local variable changes are lost after longlist (#101674)

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -104,15 +104,6 @@ def find_function(funcname, filename):
                 return funcname, filename, lineno
     return None
 
-def getsourcelines(obj):
-    lines, lineno = inspect.findsource(obj)
-    if inspect.isframe(obj) and obj.f_globals is obj.f_locals:
-        # must be a module frame: do not try to cut a block out of it
-        return lines, 1
-    elif inspect.ismodule(obj):
-        return lines, 1
-    return inspect.getblock(lines[lineno:]), lineno+1
-
 def lasti2lineno(code, lasti):
     linestarts = list(dis.findlinestarts(code))
     linestarts.reverse()
@@ -1273,7 +1264,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         filename = self.curframe.f_code.co_filename
         breaklist = self.get_file_breaks(filename)
         try:
-            lines, lineno = getsourcelines(self.curframe)
+            lines, lineno = inspect.getsourcelines(self.curframe)
         except OSError as err:
             self.error(err)
             return
@@ -1289,7 +1280,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         except:
             return
         try:
-            lines, lineno = getsourcelines(obj)
+            lines, lineno = inspect.getsourcelines(obj)
         except (OSError, TypeError) as err:
             self.error(err)
             return

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1351,6 +1351,35 @@ def test_pdb_issue_43318():
     4
     """
 
+def test_pdb_issue_gh_101673():
+    """See GH-101673
+
+    Make sure ll won't revert local variable assignment
+
+    >>> def test_function():
+    ...    a = 1
+    ...    import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     '!a = 2',
+    ...     'll',
+    ...     'p a',
+    ...     'continue'
+    ... ]):
+    ...     test_function()
+    --Return--
+    > <doctest test.test_pdb.test_pdb_issue_gh_101673[0]>(3)test_function()->None
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) !a = 2
+    (Pdb) ll
+      1         def test_function():
+      2            a = 1
+      3  ->        import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) p a
+    2
+    (Pdb) continue
+    """
+
 
 class PdbTestCase(unittest.TestCase):
     def tearDown(self):

--- a/Misc/NEWS.d/next/Library/2023-02-09-19-40-41.gh-issue-101673.mX-Ppq.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-09-19-40-41.gh-issue-101673.mX-Ppq.rst
@@ -1,0 +1,1 @@
+Fix a :mod:`pdb` bug where ``ll`` clears the changes to local variables.


### PR DESCRIPTION
Manual backport. 

(cherry picked from commit 5d677c556f03a34d1c2d86e4cc96025870c20c12)



<!-- gh-issue-number: gh-101673 -->
* Issue: gh-101673
<!-- /gh-issue-number -->
