### PR TITLE
gh-102615: Use `list` instead of `tuple` in `repr` of paramspec

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3816,18 +3816,15 @@ class GenericTests(BaseTestCase):
         class MyCallable(Generic[P, T]):
             pass
 
-        self.assertEqual(
-            repr(MyCallable[[], bool]).split('.')[-1],
-            'MyCallable[[], bool]',
-        )
-        self.assertEqual(
-            repr(MyCallable[[int], bool]).split('.')[-1],
-            'MyCallable[[int], bool]',
-        )
-        self.assertEqual(
-            repr(MyCallable[[int, str], bool]).split('.')[-1],
-            "MyCallable[[int, str], bool]",
-        )
+        object_to_expected_repr = {
+            MyCallable[[], bool]:         "MyCallable[[], bool]",
+            MyCallable[[int], bool]:      "MyCallable[[int], bool]",
+            MyCallable[[int, str], bool]: "MyCallable[[int, str], bool]"
+        }
+
+        for obj, expected_repr in object_to_expected_repr.items():
+            with self.subTest(obj=obj, expected_repr=expected_repr):
+                self.assertEqual(repr(obj), MyCallable.__module__ + expected_repr)
 
     def test_eq_1(self):
         self.assertEqual(Generic, Generic)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3824,7 +3824,10 @@ class GenericTests(BaseTestCase):
 
         for obj, expected_repr in object_to_expected_repr.items():
             with self.subTest(obj=obj, expected_repr=expected_repr):
-                self.assertEqual(repr(obj), f"{MyCallable.__module__}.{expected_repr}")
+                self.assertRegex(
+                    repr(obj),
+                    fr"^{re.escape(MyCallable.__module__)}.*\.{re.escape(expected_repr)}$"
+                )
 
     def test_eq_1(self):
         self.assertEqual(Generic, Generic)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3824,7 +3824,7 @@ class GenericTests(BaseTestCase):
 
         for obj, expected_repr in object_to_expected_repr.items():
             with self.subTest(obj=obj, expected_repr=expected_repr):
-                self.assertEqual(repr(obj), MyCallable.__module__ + expected_repr)
+                self.assertEqual(repr(obj), f"{MyCallable.__module__}.{expected_repr}")
 
     def test_eq_1(self):
         self.assertEqual(Generic, Generic)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3809,6 +3809,26 @@ class GenericTests(BaseTestCase):
         self.assertEqual(Y.__qualname__,
                          'GenericTests.test_repr_2.<locals>.Y')
 
+    def test_repr_3(self):
+        T = TypeVar('T')
+        P = ParamSpec('P')
+
+        class MyCallable(Generic[P, T]):
+            pass
+
+        self.assertEqual(
+            repr(MyCallable[[], bool]).split('.')[-1],
+            'MyCallable[[], bool]',
+        )
+        self.assertEqual(
+            repr(MyCallable[[int], bool]).split('.')[-1],
+            'MyCallable[[int], bool]',
+        )
+        self.assertEqual(
+            repr(MyCallable[[int, str], bool]).split('.')[-1],
+            "MyCallable[[int, str], bool]",
+        )
+
     def test_eq_1(self):
         self.assertEqual(Generic, Generic)
         self.assertEqual(Generic[T], Generic[T])

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3811,22 +3811,47 @@ class GenericTests(BaseTestCase):
 
     def test_repr_3(self):
         T = TypeVar('T')
+        T1 = TypeVar('T1')
         P = ParamSpec('P')
+        P2 = ParamSpec('P2')
+        Ts = TypeVarTuple('Ts')
 
         class MyCallable(Generic[P, T]):
             pass
 
+        class DoubleSpec(Generic[P, P2, T]):
+            pass
+
+        class TsP(Generic[*Ts, P]):
+            pass
+
         object_to_expected_repr = {
-            MyCallable[[], bool]:         "MyCallable[[], bool]",
-            MyCallable[[int], bool]:      "MyCallable[[int], bool]",
-            MyCallable[[int, str], bool]: "MyCallable[[int, str], bool]"
+            MyCallable[P, T]:                         "MyCallable[~P, ~T]",
+            MyCallable[Concatenate[T1, P], T]:        "MyCallable[typing.Concatenate[~T1, ~P], ~T]",
+            MyCallable[[], bool]:                     "MyCallable[[], bool]",
+            MyCallable[[int], bool]:                  "MyCallable[[int], bool]",
+            MyCallable[[int, str], bool]:             "MyCallable[[int, str], bool]",
+            MyCallable[[int, list[int]], bool]:       "MyCallable[[int, list[int]], bool]",
+            MyCallable[Concatenate[*Ts, P], T]:       "MyCallable[typing.Concatenate[*Ts, ~P], ~T]",
+
+            DoubleSpec[P2, P, T]:                     "DoubleSpec[~P2, ~P, ~T]",
+            DoubleSpec[[int], [str], bool]:           "DoubleSpec[[int], [str], bool]",
+            DoubleSpec[[int, int], [str, str], bool]: "DoubleSpec[[int, int], [str, str], bool]",
+
+            TsP[*Ts, P]:                              "TsP[*Ts, ~P]",
+            TsP[int, str, list[int], []]:             "TsP[int, str, list[int], []]",
+            TsP[int, [str, list[int]]]:               "TsP[int, [str, list[int]]]",
+
+            # These lines are just too long to fit:
+            MyCallable[Concatenate[*Ts, P], int][int, str, [bool, float]]:
+                                                      "MyCallable[[int, str, bool, float], int]",
         }
 
         for obj, expected_repr in object_to_expected_repr.items():
             with self.subTest(obj=obj, expected_repr=expected_repr):
                 self.assertRegex(
                     repr(obj),
-                    fr"^{re.escape(MyCallable.__module__)}.*\.{re.escape(expected_repr)}$"
+                    fr"^{re.escape(MyCallable.__module__)}.*\.{re.escape(expected_repr)}$",
                 )
 
     def test_eq_1(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -237,9 +237,12 @@ def _type_repr(obj):
             return obj.__qualname__
         return f'{obj.__module__}.{obj.__qualname__}'
     if obj is ...:
-        return('...')
+        return '...'
     if isinstance(obj, types.FunctionType):
         return obj.__name__
+    if isinstance(obj, tuple):
+        # Special case for `repr` of types with `ParamSpec`:
+        return '[' + ', '.join(_type_repr(t) for t in obj) + ']'
     return repr(obj)
 
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -230,8 +230,6 @@ def _type_repr(obj):
     typically enough to uniquely identify a type.  For everything
     else, we fall back on repr(obj).
     """
-    if isinstance(obj, types.GenericAlias):
-        return repr(obj)
     if isinstance(obj, type):
         if obj.__module__ == 'builtins':
             return obj.__qualname__

--- a/Misc/NEWS.d/next/Library/2023-03-13-12-05-55.gh-issue-102615.NcA_ZL.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-13-12-05-55.gh-issue-102615.NcA_ZL.rst
@@ -1,1 +1,3 @@
-Use list instead of tuple in ``repr`` of generic aliases with ``ParamSpec``.
+Typing: Improve the ``repr`` of generic aliases for classes generic over a
+:class:`~typing.ParamSpec`. (Use square brackets to represent a parameter
+list.)

--- a/Misc/NEWS.d/next/Library/2023-03-13-12-05-55.gh-issue-102615.NcA_ZL.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-13-12-05-55.gh-issue-102615.NcA_ZL.rst
@@ -1,0 +1,1 @@
+Use list instead of tuple in ``repr`` of generic aliases with ``ParamSpec``.


### PR DESCRIPTION


<!-- gh-issue-number: gh-102615 -->
* Issue: gh-102615
<!-- /gh-issue-number -->
