### PR TITLE
[3.11] Fix duplicated words in the docs

### DIFF
--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -58,7 +58,7 @@ The modern interface provides:
    This allows an application to e.g. generate URL or filesystem safe Base64
    strings.  The default is ``None``, for which the standard Base64 alphabet is used.
 
-   May assert or raise a a :exc:`ValueError` if the length of *altchars* is not 2.  Raises a
+   May assert or raise a :exc:`ValueError` if the length of *altchars* is not 2.  Raises a
    :exc:`TypeError` if *altchars* is not a :term:`bytes-like object`.
 
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -816,7 +816,7 @@ keyword against a subject.  Syntax:
 
 If the OR pattern fails, the AS pattern fails.  Otherwise, the AS pattern binds
 the subject to the name on the right of the as keyword and succeeds.
-``capture_pattern`` cannot be a a ``_``.
+``capture_pattern`` cannot be a ``_``.
 
 In simple terms ``P as NAME`` will match with ``P``, and on success it will
 set ``NAME = <subject>``.

--- a/Misc/NEWS.d/3.11.0a6.rst
+++ b/Misc/NEWS.d/3.11.0a6.rst
@@ -1055,7 +1055,7 @@ Patch by Victor Stinner.
 .. section: Build
 
 Building Python now requires support for floating point Not-a-Number (NaN):
-remove the ``Py_NO_NAN`` macro. Patch by by Victor Stinner.
+remove the ``Py_NO_NAN`` macro. Patch by Victor Stinner.
 
 ..
 


### PR DESCRIPTION
(cherry-picked from commit f6ca71a422)

With grep utility found some duplicated words