### PR TITLE
GH-102670: Use sumprod() to simplify, speed up, and improve accuracy of statistics functions

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1137,8 +1137,8 @@ def linear_regression(x, y, /, *, proportional=False):
     if not proportional:
         xbar = fsum(x) / n
         ybar = fsum(y) / n
-        x = [xi - xbar for xi in x]
-        y = [yi - ybar for yi in y]
+        x = [xi - xbar for xi in x]  # List because used three times below
+        y = (yi - ybar for yi in y)  # Generator because only used once below
     sxy = sumprod(x, y)
     sxx = sumprod(x, x)
     try:

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1076,8 +1076,8 @@ def correlation(x, y, /, *, method='linear'):
         y = _rank(y, start=start)
     xbar = fsum(x) / n
     ybar = fsum(y) / n
-    centered_x = [xi - xbar for xi in x]
-    centered_y = [yi - ybar for yi in y]
+    centered_x = [xi - xbar for xi in x] if xbar else x
+    centered_y = [yi - ybar for yi in y] if ybar else y
     sxy = sumprod(centered_x, centered_y)
     sxx = sumprod(centered_x, centered_x)
     syy = sumprod(centered_y, centered_y)

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1074,13 +1074,14 @@ def correlation(x, y, /, *, method='linear'):
         start = (n - 1) / -2            # Center rankings around zero
         x = _rank(x, start=start)
         y = _rank(y, start=start)
-    xbar = fsum(x) / n
-    ybar = fsum(y) / n
-    centered_x = [xi - xbar for xi in x] if xbar else x
-    centered_y = [yi - ybar for yi in y] if ybar else y
-    sxy = sumprod(centered_x, centered_y)
-    sxx = sumprod(centered_x, centered_x)
-    syy = sumprod(centered_y, centered_y)
+    else:
+        xbar = fsum(x) / n
+        ybar = fsum(y) / n
+        x = [xi - xbar for xi in x]
+        y = [yi - ybar for yi in y]
+    sxy = sumprod(x, y)
+    sxx = sumprod(x, x)
+    syy = sumprod(y, y)
     try:
         return sxy / sqrt(sxx * syy)
     except ZeroDivisionError:

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1134,16 +1134,13 @@ def linear_regression(x, y, /, *, proportional=False):
         raise StatisticsError('linear regression requires that both inputs have same number of data points')
     if n < 2:
         raise StatisticsError('linear regression requires at least two data points')
-    if proportional:
-        sxy = sumprod(x, y)
-        sxx = sumprod(x, x)
-    else:
+    if not proportional:
         xbar = fsum(x) / n
         ybar = fsum(y) / n
-        centered_x = [xi - xbar for xi in x]
-        centered_y = (yi - ybar for yi in y)
-        sxy = sumprod(centered_x, centered_y)
-        sxx = sumprod(centered_x, centered_x)
+        x = [xi - xbar for xi in x]
+        y = [yi - ybar for yi in y]
+    sxy = sumprod(x, y)
+    sxx = sumprod(x, x)
     try:
         slope = sxy / sxx   # equivalent to:  covariance(x, y) / variance(x)
     except ZeroDivisionError:

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1139,7 +1139,7 @@ def linear_regression(x, y, /, *, proportional=False):
         ybar = fsum(y) / n
         x = [xi - xbar for xi in x]  # List because used three times below
         y = (yi - ybar for yi in y)  # Generator because only used once below
-    sxy = sumprod(x, y)
+    sxy = sumprod(x, y) + 0.0        # Add zero to coerce result to a float
     sxx = sumprod(x, x)
     try:
         slope = sxy / sxx   # equivalent to:  covariance(x, y) / variance(x)

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1134,13 +1134,15 @@ def linear_regression(x, y, /, *, proportional=False):
     if n < 2:
         raise StatisticsError('linear regression requires at least two data points')
     if proportional:
-        sxy = fsum(xi * yi for xi, yi in zip(x, y))
-        sxx = fsum(xi * xi for xi in x)
+        sxy = sumprod(x, y)
+        sxx = sumprod(x, x)
     else:
         xbar = fsum(x) / n
         ybar = fsum(y) / n
-        sxy = fsum((xi - xbar) * (yi - ybar) for xi, yi in zip(x, y))
-        sxx = fsum((d := xi - xbar) * d for xi in x)
+        centered_x = [xi - xbar for xi in x]
+        centered_y = (yi - ybar for yi in y)
+        sxy = sumprod(centered_x, centered_y)
+        sxx = sumprod(centered_x, centered_x)
     try:
         slope = sxy / sxx   # equivalent to:  covariance(x, y) / variance(x)
     except ZeroDivisionError:

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -134,7 +134,7 @@ import sys
 
 from fractions import Fraction
 from decimal import Decimal
-from itertools import count, groupby, repeat, tee
+from itertools import count, groupby, repeat
 from bisect import bisect_left, bisect_right
 from math import hypot, sqrt, fabs, exp, erf, tau, log, fsum, sumprod
 from functools import reduce
@@ -1076,9 +1076,11 @@ def correlation(x, y, /, *, method='linear'):
         y = _rank(y, start=start)
     xbar = fsum(x) / n
     ybar = fsum(y) / n
-    sxy = sumprod((xi - xbar for xi in x), (yi - ybar for yi in y))
-    sxx = sumprod(*tee(xi - xbar for xi in x))
-    syy = sumprod(*tee(yi - ybar for yi in y))
+    centered_x = [xi - xbar for xi in x]
+    centered_y = [yi - ybar for yi in y]
+    sxy = sumprod(centered_x, centered_y)
+    sxx = sumprod(centered_x, centered_x)
+    syy = sumprod(centered_y, centered_y)
     try:
         return sxy / sqrt(sxx * syy)
     except ZeroDivisionError:

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -134,7 +134,7 @@ import sys
 
 from fractions import Fraction
 from decimal import Decimal
-from itertools import count, groupby, repeat
+from itertools import count, groupby, repeat, tee
 from bisect import bisect_left, bisect_right
 from math import hypot, sqrt, fabs, exp, erf, tau, log, fsum, sumprod
 from functools import reduce
@@ -1076,9 +1076,9 @@ def correlation(x, y, /, *, method='linear'):
         y = _rank(y, start=start)
     xbar = fsum(x) / n
     ybar = fsum(y) / n
-    sxy = fsum((xi - xbar) * (yi - ybar) for xi, yi in zip(x, y))
-    sxx = fsum((d := xi - xbar) * d for xi in x)
-    syy = fsum((d := yi - ybar) * d for yi in y)
+    sxy = sumprod((xi - xbar for xi in x), (yi - ybar for yi in y))
+    sxx = sumprod(*tee(xi - xbar for xi in x))
+    syy = sumprod(*tee(yi - ybar for yi in y))
     try:
         return sxy / sqrt(sxx * syy)
     except ZeroDivisionError:

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1036,7 +1036,7 @@ def covariance(x, y, /):
         raise StatisticsError('covariance requires at least two data points')
     xbar = fsum(x) / n
     ybar = fsum(y) / n
-    sxy = fsum((xi - xbar) * (yi - ybar) for xi, yi in zip(x, y))
+    sxy = sumprod((xi - xbar for xi in x), (yi - ybar for yi in y))
     return sxy / (n - 1)
 
 

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -1,4 +1,4 @@
-"""Test suite for statistics module, including helper NumericTestCase and
+x = """Test suite for statistics module, including helper NumericTestCase and
 approx_equal function.
 
 """
@@ -2609,6 +2609,16 @@ class TestLinearRegression(unittest.TestCase):
         slope, intercept = statistics.linear_regression(x, y, proportional=True)
         self.assertAlmostEqual(slope, 20 + 1/150)
         self.assertEqual(intercept, 0.0)
+
+    def test_float_output(self):
+        x = [Fraction(2, 3), Fraction(3, 4)]
+        y = [Fraction(4, 5), Fraction(5, 6)]
+        slope, intercept = statistics.linear_regression(x, y)
+        self.assertTrue(isinstance(slope, float))
+        self.assertTrue(isinstance(intercept, float))
+        slope, intercept = statistics.linear_regression(x, y, proportional=True)
+        self.assertTrue(isinstance(slope, float))
+        self.assertTrue(isinstance(intercept, float))
 
 class TestNormalDist:
 

--- a/Misc/NEWS.d/next/Library/2023-03-13-18-27-00.gh-issue-102670.GyoThv.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-13-18-27-00.gh-issue-102670.GyoThv.rst
@@ -1,0 +1,2 @@
+Optimized fmean(), correlation(), covariance(), and linear_regression()
+using the new math.sumprod() function.


### PR DESCRIPTION
* Use sumprod() which is faster, simpler, and more accurate than rounding each multiplication before summation.
* For an additional speed-up and simplification, compute the `(x_xi - bar)` only once instead of multiple times.
* For Spearman's rank correlation, we can skip the `(x_xi - bar)`  step because the ranks are centered around zero.

**Baseline timing**

```
% ./python.exe -m timeit -r11 -s 'from random import expovariate as r' -s 'from statistics import correlation' -s 'n=100' -s 'data = [r() for i in range(n)]' -s 'weights = [r() for i in range(n)]' 'correlation(data, weights)'
10000 loops, best of 11: 21 usec per loop
```

**Timing with PR**

```
% ./python.exe -m timeit -r11 -s 'from random import expovariate as r' -s 'from statistics import correlation' -s 'n=100' -s 'data = [r() for i in range(n)]' -s 'weights = [r() for i in range(n)]' 'correlation(data, weights)'
50000 loops, best of 11: 8.92 usec per loop
```

<!-- gh-issue-number: gh-102670 -->
* Issue: gh-102670
<!-- /gh-issue-number -->
