### PR TITLE
gh-98608: Stop Treating All Errors from _Py_NewInterpreterFromConfig() as Fatal

### DIFF
--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -25,6 +25,7 @@ PyAPI_FUNC(PyStatus) PyStatus_Exit(int exitcode);
 PyAPI_FUNC(int) PyStatus_IsError(PyStatus err);
 PyAPI_FUNC(int) PyStatus_IsExit(PyStatus err);
 PyAPI_FUNC(int) PyStatus_Exception(PyStatus err);
+PyAPI_FUNC(PyObject *) _PyErr_SetFromPyStatus(PyStatus status);
 
 /* --- PyWideStringList ------------------------------------------------ */
 

--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -62,5 +62,6 @@ PyAPI_FUNC(int) _Py_CoerceLegacyLocale(int warn);
 PyAPI_FUNC(int) _Py_LegacyLocaleDetected(int warn);
 PyAPI_FUNC(char *) _Py_SetLocaleFromEnv(int category);
 
-PyAPI_FUNC(PyThreadState *) _Py_NewInterpreterFromConfig(
-    const _PyInterpreterConfig *);
+PyAPI_FUNC(PyStatus) _Py_NewInterpreterFromConfig(
+    PyThreadState **tstate_p,
+    const _PyInterpreterConfig *config);

--- a/Include/internal/pycore_initconfig.h
+++ b/Include/internal/pycore_initconfig.h
@@ -44,8 +44,6 @@ struct pyruntimestate;
 #define _PyStatus_UPDATE_FUNC(err) \
     do { (err).func = _PyStatus_GET_FUNC(); } while (0)
 
-PyObject* _PyErr_SetFromPyStatus(PyStatus status);
-
 /* --- PyWideStringList ------------------------------------------------ */
 
 #define _PyWideStringList_INIT (PyWideStringList){.length = 0, .items = NULL}

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1545,7 +1545,9 @@ run_in_subinterp_with_config(PyObject *self, PyObject *args, PyObject *kwargs)
            state. */
         PyThreadState_Swap(mainstate);
         _PyErr_SetFromPyStatus(status);
+        PyObject *exc = PyErr_GetRaisedException();
         PyErr_SetString(PyExc_RuntimeError, "sub-interpreter creation failed");
+        _PyErr_ChainExceptions1(exc);
         return NULL;
     }
     assert(substate != NULL);

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1538,15 +1538,17 @@ run_in_subinterp_with_config(PyObject *self, PyObject *args, PyObject *kwargs)
         .allow_daemon_threads = allow_daemon_threads,
         .check_multi_interp_extensions = check_multi_interp_extensions,
     };
-    substate = _Py_NewInterpreterFromConfig(&config);
-    if (substate == NULL) {
+    PyStatus status = _Py_NewInterpreterFromConfig(&substate, &config);
+    if (PyStatus_Exception(status)) {
         /* Since no new thread state was created, there is no exception to
            propagate; raise a fresh one after swapping in the old thread
            state. */
         PyThreadState_Swap(mainstate);
+        _PyErr_SetFromPyStatus(status);
         PyErr_SetString(PyExc_RuntimeError, "sub-interpreter creation failed");
         return NULL;
     }
+    assert(substate != NULL);
     r = PyRun_SimpleStringFlags(code, &cflags);
     Py_EndInterpreter(substate);
 

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -559,7 +559,9 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
            propagate; raise a fresh one after swapping in the old thread
            state. */
         _PyErr_SetFromPyStatus(status);
+        PyObject *exc = PyErr_GetRaisedException();
         PyErr_SetString(PyExc_RuntimeError, "interpreter creation failed");
+        _PyErr_ChainExceptions1(exc);
         return NULL;
     }
     assert(tstate != NULL);

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -551,15 +551,18 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
         ? (_PyInterpreterConfig)_PyInterpreterConfig_INIT
         : (_PyInterpreterConfig)_PyInterpreterConfig_LEGACY_INIT;
     // XXX Possible GILState issues?
-    PyThreadState *tstate = _Py_NewInterpreterFromConfig(&config);
+    PyThreadState *tstate = NULL;
+    PyStatus status = _Py_NewInterpreterFromConfig(&tstate, &config);
     PyThreadState_Swap(save_tstate);
-    if (tstate == NULL) {
+    if (PyStatus_Exception(status)) {
         /* Since no new thread state was created, there is no exception to
            propagate; raise a fresh one after swapping in the old thread
            state. */
+        _PyErr_SetFromPyStatus(status);
         PyErr_SetString(PyExc_RuntimeError, "interpreter creation failed");
         return NULL;
     }
+    assert(tstate != NULL);
     PyInterpreterState *interp = PyThreadState_GetInterpreter(tstate);
     PyObject *idobj = _PyInterpreterState_GetIDObject(interp);
     if (idobj == NULL) {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2064,22 +2064,23 @@ error:
     return status;
 }
 
-PyThreadState *
-_Py_NewInterpreterFromConfig(const _PyInterpreterConfig *config)
+PyStatus
+_Py_NewInterpreterFromConfig(PyThreadState **tstate_p,
+                             const _PyInterpreterConfig *config)
 {
-    PyThreadState *tstate = NULL;
-    PyStatus status = new_interpreter(&tstate, config);
-    if (_PyStatus_EXCEPTION(status)) {
-        Py_ExitStatusException(status);
-    }
-    return tstate;
+    return new_interpreter(tstate_p, config);
 }
 
 PyThreadState *
 Py_NewInterpreter(void)
 {
+    PyThreadState *tstate = NULL;
     const _PyInterpreterConfig config = _PyInterpreterConfig_LEGACY_INIT;
-    return _Py_NewInterpreterFromConfig(&config);
+    PyStatus status = _Py_NewInterpreterFromConfig(&tstate, &config);
+    if (_PyStatus_EXCEPTION(status)) {
+        Py_ExitStatusException(status);
+    }
+    return tstate;
 }
 
 /* Delete an interpreter and its last thread.  This requires that the


### PR DESCRIPTION
Prior to this change, errors in `_Py_NewInterpreterFromConfig()` were always fatal.  Instead, callers should be able to handle such errors and keep going.  That's what this change supports.  Note that the existing [fatal] behavior of the public `Py_NewInterpreter()` is preserved.

<!-- gh-issue-number: gh-98608 -->
* Issue: gh-98608
<!-- /gh-issue-number -->
