### PR TITLE
gh-98608: Fix Failure-handling in new_interpreter()

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2056,10 +2056,10 @@ error:
 
     /* Oops, it didn't work.  Undo it all. */
     PyErr_PrintEx(0);
+    PyThreadState_Swap(save_tstate);
     PyThreadState_Clear(tstate);
     PyThreadState_Delete(tstate);
     PyInterpreterState_Delete(interp);
-    PyThreadState_Swap(save_tstate);
 
     return status;
 }


### PR DESCRIPTION
The error-handling code in `new_interpreter()` has been broken for a while.  We hadn't noticed because those code mostly doesn't fail.  (I noticed while working on gh-101660.)  The problem is that we try to clear/delete the newly-created thread/interpreter using itself, which just failed.  The solution is to switch back to the calling thread state first.

<!-- gh-issue-number: gh-98608 -->
* Issue: gh-98608
<!-- /gh-issue-number -->
