### PR TITLE
doc: Remove a duplicate 'versionchanged' in library/asyncio-task

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -814,9 +814,6 @@ Waiting Primitives
    Raises :exc:`TimeoutError` if the timeout occurs before
    all Futures are done.
 
-   .. versionchanged:: 3.10
-      Removed the *loop* parameter.
-
    Example::
 
        for coro in as_completed(aws):


### PR DESCRIPTION
This is simple duplication removal in `Doc/library/asyncio-task.rst`.
