### PR TITLE
gh-102615: Fix type vars substitution of `collections.abc.Callable` and custom generics with `ParamSpec`

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -498,6 +498,17 @@ class _CallableGenericAlias(GenericAlias):
             t_result = new_args[-1]
             t_args = new_args[:-1]
             new_args = (t_args, t_result)
+
+        # This happens in cases like `Callable[P, T][[P, str], bool][int]`,
+        # we need to flatten the result.
+        if len(new_args) > 2:
+            res = []
+            for new_arg in new_args:
+                if isinstance(new_arg, tuple):
+                    res.extend(new_arg)
+                else:
+                    res.append(new_arg)
+            new_args = (res[:-1], res[-1])
         return _CallableGenericAlias(Callable, tuple(new_args))
 
 def _is_param_expr(obj):

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -501,7 +501,9 @@ class _CallableGenericAlias(GenericAlias):
 
         # This happens in cases like `Callable[P, T][[P, str], bool][int]`,
         # we need to flatten the result.
-        if len(new_args) > 2:
+        if (len(new_args) > 2
+                and self.__parameters__
+                and _is_param_expr(self.__parameters__[0])):
             res = []
             for new_arg in new_args:
                 if isinstance(new_arg, tuple):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -254,6 +254,8 @@ def _collect_parameters(args):
         # We don't want __parameters__ descriptor of a bare Python class.
         if isinstance(t, type):
             continue
+        if isinstance(t, tuple):
+            parameters.extend(_collect_parameters(t))
         if hasattr(t, '__typing_subst__'):
             if t not in parameters:
                 parameters.append(t)
@@ -1440,54 +1442,85 @@ class _GenericAlias(_BaseGenericAlias, _root=True):
 
         new_args = []
         for old_arg in self.__args__:
-
-            if isinstance(old_arg, type):
-                new_args.append(old_arg)
-                continue
-
-            substfunc = getattr(old_arg, '__typing_subst__', None)
-            if substfunc:
-                new_arg = substfunc(new_arg_by_param[old_arg])
+            if isinstance(old_arg, tuple):
+                self._substitute_tuple_args(old_arg, new_args, new_arg_by_param)
             else:
-                subparams = getattr(old_arg, '__parameters__', ())
-                if not subparams:
-                    new_arg = old_arg
-                else:
-                    subargs = []
-                    for x in subparams:
-                        if isinstance(x, TypeVarTuple):
-                            subargs.extend(new_arg_by_param[x])
-                        else:
-                            subargs.append(new_arg_by_param[x])
-                    new_arg = old_arg[tuple(subargs)]
-
-            if self.__origin__ == collections.abc.Callable and isinstance(new_arg, tuple):
-                # Consider the following `Callable`.
-                #   C = Callable[[int], str]
-                # Here, `C.__args__` should be (int, str) - NOT ([int], str).
-                # That means that if we had something like...
-                #   P = ParamSpec('P')
-                #   T = TypeVar('T')
-                #   C = Callable[P, T]
-                #   D = C[[int, str], float]
-                # ...we need to be careful; `new_args` should end up as
-                # `(int, str, float)` rather than `([int, str], float)`.
-                new_args.extend(new_arg)
-            elif _is_unpacked_typevartuple(old_arg):
-                # Consider the following `_GenericAlias`, `B`:
-                #   class A(Generic[*Ts]): ...
-                #   B = A[T, *Ts]
-                # If we then do:
-                #   B[float, int, str]
-                # The `new_arg` corresponding to `T` will be `float`, and the
-                # `new_arg` corresponding to `*Ts` will be `(int, str)`. We
-                # should join all these types together in a flat list
-                # `(float, int, str)` - so again, we should `extend`.
-                new_args.extend(new_arg)
-            else:
-                new_args.append(new_arg)
-
+                self._substitute_arg(old_arg, new_args, new_arg_by_param)
         return tuple(new_args)
+
+    def _substitute_tuple_args(self, old_arg, new_args, new_arg_by_param):
+        # This method required to make this case correct:
+        #
+        # P = ParamSpec("P")
+        # T = TypeVar("T")
+        # class MyCallable(Generic[P, T]): ...
+        #
+        # MyCallable[P, T][[P, str], bool][int]
+        #
+        # Which must be equal to:
+        # MyCallable[[int, str], bool]
+        sub_args = []
+        for sub_old_arg in old_arg:
+            if _is_param_expr(sub_old_arg):
+                self._substitute_arg(sub_old_arg, sub_args, new_arg_by_param)
+            else:
+                sub_args.append(sub_old_arg)
+
+        # Now, unflatten the result:
+        res = []
+        for sub_arg in sub_args:
+            if isinstance(sub_arg, tuple):
+                res.extend(sub_arg)
+                continue
+            res.append(sub_arg)
+        new_args.append(tuple(res))
+
+    def _substitute_arg(self, old_arg, new_args, new_arg_by_param):
+        if isinstance(old_arg, type):
+            new_args.append(old_arg)
+            return
+
+        substfunc = getattr(old_arg, '__typing_subst__', None)
+        if substfunc:
+            new_arg = substfunc(new_arg_by_param[old_arg])
+        else:
+            subparams = getattr(old_arg, '__parameters__', ())
+            if not subparams:
+                new_arg = old_arg
+            else:
+                subargs = []
+                for x in subparams:
+                    if isinstance(x, TypeVarTuple):
+                        subargs.extend(new_arg_by_param[x])
+                    else:
+                        subargs.append(new_arg_by_param[x])
+                new_arg = old_arg[tuple(subargs)]
+
+        if self.__origin__ == collections.abc.Callable and isinstance(new_arg, tuple):
+            # Consider the following `Callable`.
+            #   C = Callable[[int], str]
+            # Here, `C.__args__` should be (int, str) - NOT ([int], str).
+            # That means that if we had something like...
+            #   P = ParamSpec('P')
+            #   T = TypeVar('T')
+            #   C = Callable[P, T]
+            #   D = C[[int, str], float]
+            # ...we need to be careful; `new_args` should end up as
+            # `(int, str, float)` rather than `([int, str], float)`.
+            new_args.extend(new_arg)
+        elif _is_unpacked_typevartuple(old_arg):
+            # Consider the following `_GenericAlias`, `B`:
+            #   class A(Generic[*Ts]): ...
+            #   B = A[T, *Ts]
+            # If we then do:
+            #   B[float, int, str]
+            # The `new_arg` corresponding to `T` will be `float`, and the
+            # `new_arg` corresponding to `*Ts` will be `(int, str)`. We
+            # should join all these types together in a flat list
+            # `(float, int, str)` - so again, we should `extend`.
+            new_args.extend(new_arg)
+        else:
+            new_args.append(new_arg)
 
     def copy_with(self, args):
         return self.__class__(self.__origin__, args, name=self._name, inst=self._inst,

--- a/Misc/NEWS.d/next/Library/2023-03-14-10-11-46.gh-issue-102615.hgTYdd.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-14-10-11-46.gh-issue-102615.hgTYdd.rst
@@ -1,0 +1,2 @@
+Fix type variables substitution of :class:`collections.abc.Callable` and
+custom generics with ``ParamSpec``.


### PR DESCRIPTION
I would prefer to create two PRs to fix https://github.com/python/cpython/issues/102615
1. This one that fixes a bug with `Callable` and custom generics with `ParamSpec`
2. https://github.com/python/cpython/pull/102637 to change the `repr`

<!-- gh-issue-number: gh-102615 -->
* Issue: gh-102615
<!-- /gh-issue-number -->
