### PR TITLE
Remove misformatted exclamation marks in docs

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -61,7 +61,7 @@ running from a virtual environment.
 A virtual environment may be "activated" using a script in its binary directory
 (``bin`` on POSIX; ``Scripts`` on Windows).
 This will prepend that directory to your :envvar:`!PATH`, so that running
-:program:`!python` will invoke the environment's Python interpreter
+:program:`python` will invoke the environment's Python interpreter
 and you can run installed scripts without having to use their full path.
 The invocation of the activation script is platform-specific
 (:samp:`{<venv>}` must be replaced by the path to the directory
@@ -84,7 +84,7 @@ containing the virtual environment):
 +-------------+------------+--------------------------------------------------+
 
 .. versionadded:: 3.4
-   :program:`!fish` and :program:`!csh` activation scripts.
+   :program:`fish` and :program:`csh` activation scripts.
 
 .. versionadded:: 3.8
    PowerShell activation scripts installed under POSIX for PowerShell Core

--- a/Misc/NEWS.d/3.12.0a2.rst
+++ b/Misc/NEWS.d/3.12.0a2.rst
@@ -959,7 +959,7 @@ Fix ``make regen-test-levenshtein`` for out-of-tree builds.
 
 Don't use vendored ``libmpdec`` headers if :option:`--with-system-libmpdec`
 is passed to :program:`configure`. Don't use vendored ``libexpat`` headers
-if :option:`--with-system-expat` is passed to :program:`!configure`.
+if :option:`--with-system-expat` is passed to :program:`configure`.
 
 ..
 


### PR DESCRIPTION
Remove the exclamation mark from :program:\`!foo\` in .rst files because it inadvertently shows up in the rendered HTML.

(Sphinx's cross-referencing roles use a '!' prefix to suppress hyperlinking\[1\], but :program: is not a cross-referencing role so the '!' is displayed verbatim.)

The exclamation marks in venv.rst were introduced in #98350. See https://github.com/python/cpython/pull/98350#issuecomment-1285965759 and https://github.com/python/cpython/pull/98350#issuecomment-1286394047 for additional discussion.

[1]\: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-syntax
