### PR TITLE
gh-101578: mention in what's new in 3.12 that exceptions are now normalized before stored

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -984,7 +984,7 @@ Porting to Python 3.12
 
 * The interpreter's error indicator is now always normalized. This means
   that :c:func:`PyErr_SetObject`, :c:func:`PyErr_SetString` and the other
-  functions that set the error indicator now need to normalize the exception
+  functions that set the error indicator now normalize the exception
   before storing it. (Contributed by Mark Shannon in :gh:`101578`.)
 
 Deprecated

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -982,6 +982,11 @@ Porting to Python 3.12
   effects, these side effects are no longer duplicated.
   (Contributed by Victor Stinner in :gh:`98724`.)
 
+* The interpreter's error indicator is now always normalized. This means
+  that :c:func:`PyErr_SetObject`, :c:func:`PyErr_SetString` and the other
+  functions that set the error indicator now need to normalize the exception
+  before storing it. (Contributed by Mark Shannon in :gh:`101578`.)
+
 Deprecated
 ----------
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-101578 -->
* Issue: gh-101578
<!-- /gh-issue-number -->
