### PR TITLE
gh-102703: Fix typo in modules tutorial documentation

### DIFF
--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -438,7 +438,7 @@ When importing the package, Python searches through the directories on
 
 The :file:`__init__.py` files are required to make Python treat directories
 containing the file as packages.  This prevents directories with a common name,
-such as ``string``, unintentionally hiding valid modules that occur later
+such as ``string``, from unintentionally hiding valid modules that occur later
 on the module search path. In the simplest case, :file:`__init__.py` can just be
 an empty file, but it can also execute initialization code for the package or
 set the ``__all__`` variable, described later.


### PR DESCRIPTION
### Fix Modules Doc Typo
**Before**
This prevents directories with a common name, such as ``string``, unintentionally hiding ...
**After**
This prevents directories with a common name, such as ``string``, from unintentionally hiding ...



<!-- gh-issue-number: gh-102703 -->
* Issue: gh-102703
<!-- /gh-issue-number -->
