### PR TITLE
GH-102711: Fix warnings found by clang

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-03-15-02-03-39.gh-issue-102711.zTkjts.rst
+++ b/Misc/NEWS.d/next/Build/2023-03-15-02-03-39.gh-issue-102711.zTkjts.rst
@@ -1,0 +1,1 @@
+Fix ``-Wstrict-prototypes`` compiler warnings.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -250,7 +250,7 @@ _PyPegen_fill_token(Parser *p)
 #define memo_statistics _PyRuntime.parser.memo_statistics
 
 void
-_PyPegen_clear_memo_statistics()
+_PyPegen_clear_memo_statistics(void)
 {
     for (int i = 0; i < NSTATISTICS; i++) {
         memo_statistics[i] = 0;
@@ -258,7 +258,7 @@ _PyPegen_clear_memo_statistics()
 }
 
 PyObject *
-_PyPegen_get_memo_statistics()
+_PyPegen_get_memo_statistics(void)
 {
     PyObject *ret = PyList_New(NSTATISTICS);
     if (ret == NULL) {


### PR DESCRIPTION
There are some warnings if build python via clang:

```
/home/lge/rpmbuild/BUILD/Python-3.10.9/Parser/pegen.c:812:31: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
_PyPegen_clear_memo_statistics()
                              ^
                               void
/home/lge/rpmbuild/BUILD/Python-3.10.9/Parser/pegen.c:820:29: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
_PyPegen_get_memo_statistics()
                            ^
                             void

```

Fix it to make clang happy.

<!-- gh-issue-number: gh-102711 -->
* Issue: gh-102711
<!-- /gh-issue-number -->
