### PR TITLE
gh-102721: Improve coverage of `_collections_abc._CallableGenericAlias`

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -481,14 +481,7 @@ class _CallableGenericAlias(GenericAlias):
         # rather than the default types.GenericAlias object.  Most of the
         # code is copied from typing's _GenericAlias and the builtin
         # types.GenericAlias.
-
         if not isinstance(item, tuple):
-            item = (item,)
-        # A special case in PEP 612 where if X = Callable[P, int],
-        # then X[int, str] == X[[int, str]].
-        if (len(self.__parameters__) == 1
-                and _is_param_expr(self.__parameters__[0])
-                and item and not _is_param_expr(item[0])):
             item = (item,)
 
         new_args = super().__getitem__(item).__args__

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1936,11 +1936,12 @@ class BaseCallableTests:
         ]
         for alias in samples:
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                s = pickle.dumps(alias, proto)
-                loaded = pickle.loads(s)
-                self.assertEqual(alias.__origin__, loaded.__origin__)
-                self.assertEqual(alias.__args__, loaded.__args__)
-                self.assertEqual(alias.__parameters__, loaded.__parameters__)
+                with self.subTest(alias=alias, proto=proto):
+                    s = pickle.dumps(alias, proto)
+                    loaded = pickle.loads(s)
+                    self.assertEqual(alias.__origin__, loaded.__origin__)
+                    self.assertEqual(alias.__args__, loaded.__args__)
+                    self.assertEqual(alias.__parameters__, loaded.__parameters__)
 
         del T_pickle, P_pickle, TS_pickle  # cleaning up global state
 
@@ -1973,7 +1974,9 @@ class BaseCallableTests:
         P = ParamSpec('P')
         T = TypeVar('T')
 
-        with self.assertRaises(TypeError):
+        pat = "Expected a list of types, an ellipsis, ParamSpec, or Concatenate."
+
+        with self.assertRaisesRegex(TypeError, pat):
             Callable[P, T][0, int]
 
     def test_type_erasure(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1921,14 +1921,28 @@ class BaseCallableTests:
         self.assertEqual(weakref.ref(alias)(), alias)
 
     def test_pickle(self):
+        global T_pickle, P_pickle, TS_pickle  # needed for pickling
         Callable = self.Callable
-        alias = Callable[[int, str], float]
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            s = pickle.dumps(alias, proto)
-            loaded = pickle.loads(s)
-            self.assertEqual(alias.__origin__, loaded.__origin__)
-            self.assertEqual(alias.__args__, loaded.__args__)
-            self.assertEqual(alias.__parameters__, loaded.__parameters__)
+        T_pickle = TypeVar('T_pickle')
+        P_pickle = ParamSpec('P_pickle')
+        TS_pickle = TypeVarTuple('TS_pickle')
+
+        samples = [
+            Callable[[int, str], float],
+            Callable[P_pickle, int],
+            Callable[P_pickle, T_pickle],
+            Callable[Concatenate[int, P_pickle], int],
+            Callable[Concatenate[*TS_pickle, P_pickle], int],
+        ]
+        for alias in samples:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                s = pickle.dumps(alias, proto)
+                loaded = pickle.loads(s)
+                self.assertEqual(alias.__origin__, loaded.__origin__)
+                self.assertEqual(alias.__args__, loaded.__args__)
+                self.assertEqual(alias.__parameters__, loaded.__parameters__)
+
+        del T_pickle, P_pickle, TS_pickle  # cleaning up global state
 
     def test_var_substitution(self):
         Callable = self.Callable
@@ -1953,6 +1967,14 @@ class BaseCallableTests:
         C5 = Callable[[typing.List[T], tuple[KT, T], VT], int]
         self.assertEqual(C5[int, str, float],
                          Callable[[typing.List[int], tuple[str, int], float], int])
+
+    def test_type_subst_error(self):
+        Callable = self.Callable
+        P = ParamSpec('P')
+        T = TypeVar('T')
+
+        with self.assertRaises(TypeError):
+            Callable[P, T][0, int]
 
     def test_type_erasure(self):
         Callable = self.Callable


### PR DESCRIPTION
Two main changes:
1. More `pickle` tests with different callables
2. Passing things like `0` is not allowed, so I think testing this behaviour won't hurt. The test is quite simple

All tests work for both `typing.Callable` and `_collections_abc.Callable`.

I also went ahead and remove this suspicious `if` from https://github.com/python/cpython/pull/102681#issuecomment-1468136367

Moreover, all tests pass without it.
I cannot find any examples where it is needed. Please, prove me wrong.

CC @AlexWaygood 

<!-- gh-issue-number: gh-102721 -->
* Issue: gh-102721
<!-- /gh-issue-number -->
