### PR TITLE
Exclude `ceval.c` from the C-analyzer tool

### DIFF
--- a/Tools/c-analyzer/cpython/_parser.py
+++ b/Tools/c-analyzer/cpython/_parser.py
@@ -91,10 +91,15 @@ Python/bytecodes.c
 # XXX Fix the parser.
 EXCLUDED += clean_lines('''
 # The tool should be able to parse these...
+
 # The problem with xmlparse.c is that something
 # has gone wrong where # we handle "maybe inline actual"
 # in Tools/c-analyzer/c_parser/parser/_global.py.
 Modules/expat/xmlparse.c
+
+# The parser doesn't like the #line directives
+# that originate from generated_cases.c.h
+Python/ceval.c
 ''')
 
 INCL_DIRS = clean_lines('''


### PR DESCRIPTION
The "check if generated files are up to date" CI check appears to be currently failing on all PRs (but not on pushes to main) 

See, for example:
- https://github.com/python/cpython/pull/94468
- https://github.com/python/cpython/pull/102734
- https://github.com/python/cpython/pull/102731

This appears to be because the C-analyzer tool doesn't like the `#line` directives introduced in https://github.com/python/cpython/commit/70185de1abfe428049a5c43d58fcb656b46db96c. I'm advised by the message printed to the terminal in https://github.com/python/cpython/actions/runs/4428706945/jobs/7768216988#step:14:84 that this is the appropriate short-term fix!

Cc. @ericsnowcurrently

Automerge-Triggered-By: GH:AlexWaygood