### PR TITLE
Fix outdated note about 'int' rounding or truncating

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -335,11 +335,10 @@ Notes:
       single: ceil() (in module math)
       single: trunc() (in module math)
       pair: numeric; conversions
-      pair: C; language
 
-   Conversion from floating point to integer may round or truncate
-   as in C; see functions :func:`math.floor` and :func:`math.ceil` for
-   well-defined conversions.
+   Conversion from :class:`float` to :class:`int` truncates, discarding the
+   fractional part. See functions :func:`math.floor` and :func:`math.ceil` for
+   alternative conversions.
 
 (4)
    float also accepts the strings "nan" and "inf" with an optional prefix "+"


### PR DESCRIPTION
This PR fixes an out-of-date note attached to `int` conversions in `stdtypes.rst`.

The "may round or truncate as in C" language dates from [almost 30 years ago](https://github.com/python/cpython/blob/5fdeeeae2a12b9956cc84d62eae82f72cabc8664/Doc/lib/libtypes.tex#L186-L193), when [conversion](https://github.com/python/cpython/blob/5fdeeeae2a12b9956cc84d62eae82f72cabc8664/Objects/floatobject.c#L347-L355) from a Python `float` to a Python `int` involved at C level a `(long)` cast applied to a C `double` value. Prior to standard C, presumably the precise behaviour of that cast couldn't be relied upon. But since C89 standardised this behaviour and we can reasonably rely on all current C compilers adhering to that or later standards, the note is out of date. (Moreover, the current code for converting a Python 3 `int` to a C double is very different.)

Related discuss.python.org thread: https://discuss.python.org/t/built-in-types-int-round-or-truncate-please-elaborate/24840
