### PR TITLE
GH-102653: Make recipe docstring show the correct distribution

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -610,7 +610,8 @@ from the combinatoric iterators in the :mod:`itertools` module:
        return tuple(pool[i] for i in indices)
 
    def random_combination_with_replacement(iterable, r):
-       "Random selection from itertools.combinations_with_replacement(iterable, r)"
+       "Choose r elements with replacement.  Order the result to match the iterable."
+       # Result will be in set(itertools.combinations_with_replacement(iterable, r)).
        pool = tuple(iterable)
        n = len(pool)
        indices = sorted(random.choices(range(n), k=r))


### PR DESCRIPTION
The old docstring conflated the support with the probability distribution.

<!-- gh-issue-number: gh-102653 -->
* Issue: gh-102653
<!-- /gh-issue-number -->
