### PR TITLE
gh-102737: Un-ignore ceval.c in the CI globals check

### DIFF
--- a/Tools/c-analyzer/c_parser/preprocessor/gcc.py
+++ b/Tools/c-analyzer/c_parser/preprocessor/gcc.py
@@ -153,9 +153,13 @@ def _iter_top_include_lines(lines, topfile, cwd,
                 # XXX How can a file return to line 1?
                 #assert lno > 1, (line, lno)
             else:
-                # It's the next line from the file.
-                assert included == files[-1], (line, files)
-                assert lno > 1, (line, lno)
+                if included == files[-1]:
+                    # It's the next line from the file.
+                    assert lno > 1, (line, lno)
+                else:
+                    # We ran into a user-added #LINE directive,
+                    # which we promptly ignore.
+                    pass
         elif not files:
             raise NotImplementedError((line,))
         elif filter_reqfile(files[-1]):

--- a/Tools/c-analyzer/cpython/_parser.py
+++ b/Tools/c-analyzer/cpython/_parser.py
@@ -96,10 +96,6 @@ EXCLUDED += clean_lines('''
 # has gone wrong where # we handle "maybe inline actual"
 # in Tools/c-analyzer/c_parser/parser/_global.py.
 Modules/expat/xmlparse.c
-
-# The parser doesn't like the #line directives
-# that originate from generated_cases.c.h
-Python/ceval.c
 ''')
 
 INCL_DIRS = clean_lines('''


### PR DESCRIPTION
The tool now allows user-added `#LINE` preprocessor directives.

<!-- gh-issue-number: gh-102737 -->
* Issue: gh-102737
<!-- /gh-issue-number -->
