### PR TITLE
Backport 'Fix ctypes structs' (97702) to 3.11

### DIFF
--- a/Lib/ctypes/test/test_bitfields.py
+++ b/Lib/ctypes/test/test_bitfields.py
@@ -3,6 +3,7 @@ from ctypes.test import need_symbol
 from test import support
 import unittest
 import os
+import sys
 
 import _ctypes_test
 
@@ -28,6 +29,30 @@ class BITS(Structure):
 func = CDLL(_ctypes_test.__file__).unpack_bitfields
 func.argtypes = POINTER(BITS), c_char
 
+
+class BITS_msvc(Structure):
+    _ms_struct_ = 1
+    _fields_ = [("A", c_int, 1),
+                ("B", c_int, 2),
+                ("C", c_int, 3),
+                ("D", c_int, 4),
+                ("E", c_int, 5),
+                ("F", c_int, 6),
+                ("G", c_int, 7),
+                ("H", c_int, 8),
+                ("I", c_int, 9),
+
+                ("M", c_short, 1),
+                ("N", c_short, 2),
+                ("O", c_short, 3),
+                ("P", c_short, 4),
+                ("Q", c_short, 5),
+                ("R", c_short, 6),
+                ("S", c_short, 7)]
+
+func_msvc = CDLL(_ctypes_test.__file__).unpack_bitfields_msvc
+func_msvc.argtypes = POINTER(BITS_msvc), c_char
+
 ##for n in "ABCDEFGHIMNOPQRS":
 ##    print n, hex(getattr(BITS, n).size), getattr(BITS, n).offset
 
@@ -40,18 +65,43 @@ class C_Test(unittest.TestCase):
                 setattr(b, name, i)
                 self.assertEqual(getattr(b, name), func(byref(b), name.encode('ascii')))
 
-    # bpo-46913: _ctypes/cfield.c h_get() has an undefined behavior
-    @support.skip_if_sanitizer(ub=True)
     def test_shorts(self):
         b = BITS()
         name = "M"
+        # See Modules/_ctypes/_ctypes_test.c for where the magic 999 comes from.
         if func(byref(b), name.encode('ascii')) == 999:
+            # unpack_bitfields and unpack_bitfields_msvc in
+            # Modules/_ctypes/_ctypes_test.c return 999 to indicate
+            # an invalid name. 'M' is only valid, if signed short bitfields
+            # are supported by the C compiler.
             self.skipTest("Compiler does not support signed short bitfields")
         for i in range(256):
             for name in "MNOPQRS":
                 b = BITS()
                 setattr(b, name, i)
-                self.assertEqual(getattr(b, name), func(byref(b), name.encode('ascii')))
+                self.assertEqual(
+                    getattr(b, name),
+                    func(byref(b), (name.encode('ascii'))),
+                    (name, i))
+
+    def test_shorts_msvc_mode(self):
+        b = BITS_msvc()
+        name = "M"
+        # See Modules/_ctypes/_ctypes_test.c for where the magic 999 comes from.
+        if func_msvc(byref(b), name.encode('ascii')) == 999:
+            # unpack_bitfields and unpack_bitfields_msvc in
+            # Modules/_ctypes/_ctypes_test.c return 999 to indicate
+            # an invalid name. 'M' is only valid, if signed short bitfields
+            # are supported by the C compiler.
+            self.skipTest("Compiler does not support signed short bitfields")
+        for i in range(256):
+            for name in "MNOPQRS":
+                b = BITS_msvc()
+                setattr(b, name, i)
+                self.assertEqual(
+                    getattr(b, name),
+                    func_msvc(byref(b), name.encode('ascii')),
+                    (name, i))
 
 signed_int_types = (c_byte, c_short, c_int, c_long, c_longlong)
 unsigned_int_types = (c_ubyte, c_ushort, c_uint, c_ulong, c_ulonglong)
@@ -235,6 +285,157 @@ class BitFieldTest(unittest.TestCase):
             self.assertEqual(sizeof(X), sizeof(c_int) * 4)
         else:
             self.assertEqual(sizeof(X), sizeof(c_int) * 2)
+
+    def test_mixed_5(self):
+        class X(Structure):
+            _fields_ = [
+                ('A', c_uint, 1),
+                ('B', c_ushort, 16)]
+        a = X()
+        a.A = 0
+        a.B = 1
+        self.assertEqual(1, a.B)
+
+    def test_mixed_6(self):
+        class X(Structure):
+            _fields_ = [
+                ('A', c_ulonglong, 1),
+                ('B', c_uint, 32)]
+        a = X()
+        a.A = 0
+        a.B = 1
+        self.assertEqual(1, a.B)
+
+    def test_mixed_7(self):
+        class X(Structure):
+            _fields_ = [
+                ("A", c_uint),
+                ('B', c_uint, 20),
+                ('C', c_ulonglong, 24)]
+        self.assertEqual(16, sizeof(X))
+
+    def test_mixed_8(self):
+        class Foo(Structure):
+            _fields_ = [
+                ("A", c_uint),
+                ("B", c_uint, 32),
+                ("C", c_ulonglong, 1),
+                ]
+
+        class Bar(Structure):
+            _fields_ = [
+                ("A", c_uint),
+                ("B", c_uint),
+                ("C", c_ulonglong, 1),
+                ]
+        self.assertEqual(sizeof(Foo), sizeof(Bar))
+
+    def test_mixed_9(self):
+        class X(Structure):
+            _fields_ = [
+                ("A", c_uint8),
+                ("B", c_uint, 1),
+                ]
+        if sys.platform == 'win32':
+            self.assertEqual(8, sizeof(X))
+        else:
+            self.assertEqual(4, sizeof(X))
+
+    def test_mixed_10(self):
+        class X(Structure):
+            _fields_ = [
+                ("A", c_uint32, 1),
+                ("B", c_uint64, 1),
+                ]
+        if sys.platform == 'win32':
+            self.assertEqual(8, alignment(X))
+            self.assertEqual(16, sizeof(X))
+        else:
+            self.assertEqual(8, alignment(X))
+            self.assertEqual(8, sizeof(X))
+
+    def test_gh_95496(self):
+        for field_width in range(1, 33):
+            class TestStruct(Structure):
+                _fields_ = [
+                    ("Field1", c_uint32, field_width),
+                    ("Field2", c_uint8, 8)
+                ]
+
+            cmd = TestStruct()
+            cmd.Field2 = 1
+            self.assertEqual(1, cmd.Field2)
+
+    def test_gh_84039(self):
+        class Bad(Structure):
+            _pack_ = 1
+            _fields_ = [
+                ("a0", c_uint8, 1),
+                ("a1", c_uint8, 1),
+                ("a2", c_uint8, 1),
+                ("a3", c_uint8, 1),
+                ("a4", c_uint8, 1),
+                ("a5", c_uint8, 1),
+                ("a6", c_uint8, 1),
+                ("a7", c_uint8, 1),
+                ("b0", c_uint16, 4),
+                ("b1", c_uint16, 12),
+            ]
+
+
+        class GoodA(Structure):
+            _pack_ = 1
+            _fields_ = [
+                ("a0", c_uint8, 1),
+                ("a1", c_uint8, 1),
+                ("a2", c_uint8, 1),
+                ("a3", c_uint8, 1),
+                ("a4", c_uint8, 1),
+                ("a5", c_uint8, 1),
+                ("a6", c_uint8, 1),
+                ("a7", c_uint8, 1),
+            ]
+
+
+        class Good(Structure):
+            _pack_ = 1
+            _fields_ = [
+                ("a", GoodA),
+                ("b0", c_uint16, 4),
+                ("b1", c_uint16, 12),
+            ]
+
+        self.assertEqual(3, sizeof(Bad))
+        self.assertEqual(3, sizeof(Good))
+
+    def test_gh_73939(self):
+        class MyStructure(Structure):
+            _pack_      = 1
+            _fields_    = [
+                            ("P",       c_uint16),
+                            ("L",       c_uint16, 9),
+                            ("Pro",     c_uint16, 1),
+                            ("G",       c_uint16, 1),
+                            ("IB",      c_uint16, 1),
+                            ("IR",      c_uint16, 1),
+                            ("R",       c_uint16, 3),
+                            ("T",       c_uint32, 10),
+                            ("C",       c_uint32, 20),
+                            ("R2",      c_uint32, 2)
+                        ]
+        self.assertEqual(8, sizeof(MyStructure))
+
+    def test_gh_86098(self):
+        class X(Structure):
+            _fields_ = [
+                ("a", c_uint8, 8),
+                ("b", c_uint8, 8),
+                ("c", c_uint32, 16)
+            ]
+        if sys.platform == 'win32':
+            self.assertEqual(8, sizeof(X))
+        else:
+            self.assertEqual(4, sizeof(X))
 
     def test_anon_bitfields(self):
         # anonymous bit-fields gave a strange error message

--- a/Misc/NEWS.d/next/C API/2022-10-01-09-56-27.gh-issue-97588.Gvg54o.rst
+++ b/Misc/NEWS.d/next/C API/2022-10-01-09-56-27.gh-issue-97588.Gvg54o.rst
@@ -1,0 +1,1 @@
+Fix ctypes construction of structs from description.

--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -592,11 +592,54 @@ struct BITS {
  */
 #ifndef __xlc__
 #define SIGNED_SHORT_BITFIELDS
-     short M: 1, N: 2, O: 3, P: 4, Q: 5, R: 6, S: 7;
+    signed short M: 1, N: 2, O: 3, P: 4, Q: 5, R: 6, S: 7;
 #endif
 };
 
 EXPORT(int) unpack_bitfields(struct BITS *bits, char name)
+{
+    switch (name) {
+    case 'A': return bits->A;
+    case 'B': return bits->B;
+    case 'C': return bits->C;
+    case 'D': return bits->D;
+    case 'E': return bits->E;
+    case 'F': return bits->F;
+    case 'G': return bits->G;
+    case 'H': return bits->H;
+    case 'I': return bits->I;
+
+#ifdef SIGNED_SHORT_BITFIELDS
+    case 'M': return bits->M;
+    case 'N': return bits->N;
+    case 'O': return bits->O;
+    case 'P': return bits->P;
+    case 'Q': return bits->Q;
+    case 'R': return bits->R;
+    case 'S': return bits->S;
+#endif
+    }
+    return 999;
+}
+
+struct
+#ifndef MS_WIN32
+__attribute__ ((ms_struct))
+#endif
+BITS_msvc
+{
+    signed int A: 1, B:2, C:3, D:4, E: 5, F: 6, G: 7, H: 8, I: 9;
+/*
+ * The test case needs/uses "signed short" bitfields, but the
+ * IBM XLC compiler does not support this
+ */
+#ifndef __xlc__
+#define SIGNED_SHORT_BITFIELDS
+    signed short M: 1, N: 2, O: 3, P: 4, Q: 5, R: 6, S: 7;
+#endif
+};
+
+EXPORT(int) unpack_bitfields_msvc(struct BITS_msvc *bits, char name)
 {
     switch (name) {
     case 'A': return bits->A;

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -147,9 +147,10 @@ extern struct fielddesc *_ctypes_get_fielddesc(const char *fmt);
 
 extern PyObject *
 PyCField_FromDesc(PyObject *desc, Py_ssize_t index,
-                Py_ssize_t *pfield_size, int bitsize, int *pbitofs,
-                Py_ssize_t *psize, Py_ssize_t *poffset, Py_ssize_t *palign,
-                int pack, int is_big_endian);
+                Py_ssize_t *pfield_size, Py_ssize_t bitsize,
+                Py_ssize_t *pbitofs, Py_ssize_t *psize, Py_ssize_t *poffset,
+                Py_ssize_t *palign,
+                int pack, int is_big_endian, int ms_struct);
 
 extern PyObject *PyCData_AtAddress(PyObject *type, void *buf);
 extern PyObject *PyCData_FromBytes(PyObject *type, char *data, Py_ssize_t length);


### PR DESCRIPTION
Mostly for testing against libraries like numpy.  I am not sure whether it will make sense to actually release the backport, as it breaks bug-for-bug compatibility.  See https://github.com/python/cpython/pull/97702/ for the discussion.

<!-- gh-issue-number: gh-97588 -->
* Issue: gh-97588
<!-- /gh-issue-number -->

<!-- gh-issue-number: gh-95496 -->
* Issue: gh-95496
<!-- /gh-issue-number -->

<!-- gh-issue-number: gh-84039 -->
* Issue: gh-84039
<!-- /gh-issue-number -->

<!-- gh-issue-number: gh-73939 -->
* Issue: gh-73939
<!-- /gh-issue-number -->

<!-- gh-issue-number: gh-59324 -->
* Issue: gh-59324
<!-- /gh-issue-number -->

<!-- gh-issue-number: gh-86098 -->
* Issue: gh-86098
<!-- /gh-issue-number -->