### PR TITLE
gh-102781: fix cwd dependence in cases generator

### DIFF
--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -122,8 +122,9 @@ class Formatter:
         self.prefix = " " * indent
         self.emit_line_directives = emit_line_directives
         self.lineno = 1
+        filename = os.path.relpath(self.stream.name, ROOT)
         # Make filename more user-friendly and less platform-specific
-        filename = self.stream.name.replace("\\", "/")
+        filename = filename.replace("\\", "/")
         if filename.startswith("./"):
             filename = filename[2:]
         if filename.endswith(".new"):
@@ -567,6 +568,7 @@ class Analyzer:
         with open(filename) as file:
             src = file.read()
 
+        filename = os.path.relpath(filename, ROOT)
         # Make filename more user-friendly and less platform-specific
         filename = filename.replace("\\", "/")
         if filename.startswith("./"):


### PR DESCRIPTION
Fixes #102781.

With this change, running `make regen-cases` from an out-of-tree build (without any other source changes) results in an unchanged `generated_cases.c.h` (instead of resulting in changes to the filename of every `#line` directive).

<!-- gh-issue-number: gh-102781 -->
* Issue: gh-102781
<!-- /gh-issue-number -->
