### PR TITLE
gh-102799: remove unnecessary calls to sys.exc_info() in tests

### DIFF
--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -1889,8 +1889,8 @@ class TestFork(unittest.IsolatedAsyncioTestCase):
                 os.write(w, b'LOOP:' + str(id(loop)).encode())
             except RuntimeError:
                 os.write(w, b'NO LOOP')
-            except:
-                os.write(w, b'ERROR:' + ascii(sys.exc_info()).encode())
+            except BaseException as e:
+                os.write(w, b'ERROR:' + ascii(e).encode())
             finally:
                 os._exit(0)
         else:

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -599,8 +599,8 @@ class ExceptionTests(unittest.TestCase):
     def testWithTraceback(self):
         try:
             raise IndexError(4)
-        except:
-            tb = sys.exc_info()[2]
+        except Exception as e:
+            tb = e.__traceback__
 
         e = BaseException().with_traceback(tb)
         self.assertIsInstance(e, BaseException)
@@ -653,8 +653,8 @@ class ExceptionTests(unittest.TestCase):
     def testNoneClearsTracebackAttr(self):
         try:
             raise IndexError(4)
-        except:
-            tb = sys.exc_info()[2]
+        except Exception as e:
+            tb = e.__traceback__
 
         e = Exception()
         e.__traceback__ = tb
@@ -1337,11 +1337,11 @@ class ExceptionTests(unittest.TestCase):
         def g():
             try:
                 return g()
-            except RecursionError:
-                return sys.exc_info()
-        e, v, tb = g()
-        self.assertIsInstance(v, RecursionError, type(v))
-        self.assertIn("maximum recursion depth exceeded", str(v))
+            except RecursionError as e:
+                return e
+        exc = g()
+        self.assertIsInstance(exc, RecursionError, type(exc))
+        self.assertIn("maximum recursion depth exceeded", str(exc))
 
 
     @cpython_only

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5492,10 +5492,10 @@ class TCPTimeoutTest(SocketTCPTest):
                 self.fail("caught timeout instead of Alarm")
             except Alarm:
                 pass
-            except:
+            except BaseException as e:
                 self.fail("caught other exception instead of Alarm:"
                           " %s(%s):\n%s" %
-                          (sys.exc_info()[:2] + (traceback.format_exc(),)))
+                          (type(e), e, traceback.format_exc()))
             else:
                 self.fail("nothing caught")
             finally:

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1649,8 +1649,8 @@ class SizeofTest(unittest.TestCase):
         check(_ast.AST(), size('P'))
         try:
             raise TypeError
-        except TypeError:
-            tb = sys.exc_info()[2]
+        except TypeError as e:
+            tb = e.__traceback__
             # traceback
             if tb is not None:
                 check(tb, size('2P2i'))

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -296,15 +296,15 @@ class TracebackCases(unittest.TestCase):
                 def __init__(self):
                     try:
                         x = 1 / 0
-                    except Exception:
-                        self.exc_info = sys.exc_info()
-                        # self.exc_info[1] (traceback) contains frames:
+                    except Exception as e:
+                        self.exc = e
+                        # self.exc.__traceback__ contains frames:
                         # explicitly clear the reference to self in the current
                         # frame to break a reference cycle
                         self = None
 
                 def __del__(self):
-                    traceback.print_exception(*self.exc_info)
+                    traceback.print_exception(self.exc)
 
             # Keep a reference in the module namespace to call the destructor
             # when the module is unloaded
@@ -923,8 +923,8 @@ class TracebackFormatTests(unittest.TestCase):
         from _testcapi import traceback_print
         try:
             self.some_exception()
-        except KeyError:
-            type_, value, tb = sys.exc_info()
+        except KeyError as e:
+            tb = e.__traceback__
             if cleanup_func is not None:
                 # Clear the inner frames, not this one
                 cleanup_func(tb.tb_next)
@@ -1228,8 +1228,8 @@ class TracebackFormatTests(unittest.TestCase):
         except UnhashableException:
             try:
                 raise ex1
-            except UnhashableException:
-                exc_type, exc_val, exc_tb = sys.exc_info()
+            except UnhashableException as e:
+                exc_val = e
 
         with captured_output("stderr") as stderr_f:
             exception_print(exc_val)
@@ -2133,8 +2133,8 @@ class LimitTests(unittest.TestCase):
     def test_extract_tb(self):
         try:
             self.last_raises5()
-        except Exception:
-            exc_type, exc_value, tb = sys.exc_info()
+        except Exception as e:
+            tb = e.__traceback__
         def extract(**kwargs):
             return traceback.extract_tb(tb, **kwargs)
 
@@ -2160,12 +2160,12 @@ class LimitTests(unittest.TestCase):
     def test_format_exception(self):
         try:
             self.last_raises5()
-        except Exception:
-            exc_type, exc_value, tb = sys.exc_info()
+        except Exception as e:
+            exc = e
         # [1:-1] to exclude "Traceback (...)" header and
         # exception type and value
         def extract(**kwargs):
-            return traceback.format_exception(exc_type, exc_value, tb, **kwargs)[1:-1]
+            return traceback.format_exception(exc, **kwargs)[1:-1]
 
         with support.swap_attr(sys, 'tracebacklimit', 1000):
             nolim = extract()
@@ -2203,8 +2203,8 @@ class MiscTracebackCases(unittest.TestCase):
 
         try:
             outer()
-        except:
-            type_, value, tb = sys.exc_info()
+        except BaseException as e:
+            tb = e.__traceback__
 
         # Initial assertion: there's one local in the inner frame.
         inner_frame = tb.tb_next.tb_next.tb_next.tb_frame
@@ -2282,8 +2282,8 @@ class TestStack(unittest.TestCase):
     def test_walk_tb(self):
         try:
             1/0
-        except Exception:
-            _, _, tb = sys.exc_info()
+        except Exception as e:
+            tb = e.__traceback__
         s = list(traceback.walk_tb(tb))
         self.assertEqual(len(s), 1)
 
@@ -2386,10 +2386,10 @@ class TestStack(unittest.TestCase):
         def g():
             try:
                 f()
-            except:
-                return sys.exc_info()
+            except Exception as e:
+                return e.__traceback__
 
-        exc_info = g()
+        tb = g()
 
         class Skip_G(traceback.StackSummary):
             def format_frame_summary(self, frame_summary):
@@ -2398,7 +2398,7 @@ class TestStack(unittest.TestCase):
                 return super().format_frame_summary(frame_summary)
 
         stack = Skip_G.extract(
-            traceback.walk_tb(exc_info[2])).format()
+            traceback.walk_tb(tb)).format()
 
         self.assertEqual(len(stack), 1)
         lno = f.__code__.co_firstlineno + 1
@@ -2416,17 +2416,17 @@ class TestTracebackException(unittest.TestCase):
     def test_smoke(self):
         try:
             1/0
-        except Exception:
-            exc_info = sys.exc_info()
-            exc = traceback.TracebackException(*exc_info)
+        except Exception as e:
+            exc_obj = e
+            exc = traceback.TracebackException.from_exception(e)
             expected_stack = traceback.StackSummary.extract(
-                traceback.walk_tb(exc_info[2]))
+                traceback.walk_tb(e.__traceback__))
         self.assertEqual(None, exc.__cause__)
         self.assertEqual(None, exc.__context__)
         self.assertEqual(False, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(exc_info[0], exc.exc_type)
-        self.assertEqual(str(exc_info[1]), str(exc))
+        self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(str(exc_obj), str(exc))
 
     def test_from_exception(self):
         # Check all the parameters are accepted.
@@ -2435,9 +2435,10 @@ class TestTracebackException(unittest.TestCase):
         try:
             foo()
         except Exception as e:
-            exc_info = sys.exc_info()
+            exc_obj = e
+            tb = e.__traceback__
             self.expected_stack = traceback.StackSummary.extract(
-                traceback.walk_tb(exc_info[2]), limit=1, lookup_lines=False,
+                traceback.walk_tb(tb), limit=1, lookup_lines=False,
                 capture_locals=True)
             self.exc = traceback.TracebackException.from_exception(
                 e, limit=1, lookup_lines=False, capture_locals=True)
@@ -2447,8 +2448,8 @@ class TestTracebackException(unittest.TestCase):
         self.assertEqual(None, exc.__context__)
         self.assertEqual(False, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(exc_info[0], exc.exc_type)
-        self.assertEqual(str(exc_info[1]), str(exc))
+        self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(str(exc_obj), str(exc))
 
     def test_cause(self):
         try:
@@ -2459,18 +2460,18 @@ class TestTracebackException(unittest.TestCase):
                 exc_context = traceback.TracebackException(*exc_info_context)
                 cause = Exception("cause")
                 raise Exception("uh oh") from cause
-        except Exception:
-            exc_info = sys.exc_info()
-            exc = traceback.TracebackException(*exc_info)
+        except Exception as e:
+            exc_obj = e
+            exc = traceback.TracebackException.from_exception(e)
             expected_stack = traceback.StackSummary.extract(
-                traceback.walk_tb(exc_info[2]))
+                traceback.walk_tb(e.__traceback__))
         exc_cause = traceback.TracebackException(Exception, cause, None)
         self.assertEqual(exc_cause, exc.__cause__)
         self.assertEqual(exc_context, exc.__context__)
         self.assertEqual(True, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(exc_info[0], exc.exc_type)
-        self.assertEqual(str(exc_info[1]), str(exc))
+        self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(str(exc_obj), str(exc))
 
     def test_context(self):
         try:
@@ -2480,17 +2481,17 @@ class TestTracebackException(unittest.TestCase):
                 exc_info_context = sys.exc_info()
                 exc_context = traceback.TracebackException(*exc_info_context)
                 raise Exception("uh oh")
-        except Exception:
-            exc_info = sys.exc_info()
-            exc = traceback.TracebackException(*exc_info)
+        except Exception as e:
+            exc_obj = e
+            exc = traceback.TracebackException.from_exception(e)
             expected_stack = traceback.StackSummary.extract(
-                traceback.walk_tb(exc_info[2]))
+                traceback.walk_tb(e.__traceback__))
         self.assertEqual(None, exc.__cause__)
         self.assertEqual(exc_context, exc.__context__)
         self.assertEqual(False, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(exc_info[0], exc.exc_type)
-        self.assertEqual(str(exc_info[1]), str(exc))
+        self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(str(exc_obj), str(exc))
 
     def test_long_context_chain(self):
         def f():
@@ -2501,12 +2502,12 @@ class TestTracebackException(unittest.TestCase):
 
         try:
             f()
-        except RecursionError:
-            exc_info = sys.exc_info()
+        except RecursionError as e:
+            exc_obj = e
         else:
             self.fail("Exception not raised")
 
-        te = traceback.TracebackException(*exc_info)
+        te = traceback.TracebackException.from_exception(exc_obj)
         res = list(te.format())
 
         # many ZeroDiv errors followed by the RecursionError
@@ -2524,18 +2525,18 @@ class TestTracebackException(unittest.TestCase):
             finally:
                 cause = Exception("cause")
                 raise Exception("uh oh") from cause
-        except Exception:
-            exc_info = sys.exc_info()
-            exc = traceback.TracebackException(*exc_info, compact=True)
+        except Exception as e:
+            exc_obj = e
+            exc = traceback.TracebackException.from_exception(exc_obj, compact=True)
             expected_stack = traceback.StackSummary.extract(
-                traceback.walk_tb(exc_info[2]))
+                traceback.walk_tb(exc_obj.__traceback__))
         exc_cause = traceback.TracebackException(Exception, cause, None)
         self.assertEqual(exc_cause, exc.__cause__)
         self.assertEqual(None, exc.__context__)
         self.assertEqual(True, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(exc_info[0], exc.exc_type)
-        self.assertEqual(str(exc_info[1]), str(exc))
+        self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(str(exc_obj), str(exc))
 
     def test_compact_no_cause(self):
         try:
@@ -2545,37 +2546,37 @@ class TestTracebackException(unittest.TestCase):
                 exc_info_context = sys.exc_info()
                 exc_context = traceback.TracebackException(*exc_info_context)
                 raise Exception("uh oh")
-        except Exception:
-            exc_info = sys.exc_info()
-            exc = traceback.TracebackException(*exc_info, compact=True)
+        except Exception as e:
+            exc_obj = e
+            exc = traceback.TracebackException.from_exception(e, compact=True)
             expected_stack = traceback.StackSummary.extract(
-                traceback.walk_tb(exc_info[2]))
+                traceback.walk_tb(exc_obj.__traceback__))
         self.assertEqual(None, exc.__cause__)
         self.assertEqual(exc_context, exc.__context__)
         self.assertEqual(False, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(exc_info[0], exc.exc_type)
-        self.assertEqual(str(exc_info[1]), str(exc))
+        self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(str(exc_obj), str(exc))
 
     def test_no_refs_to_exception_and_traceback_objects(self):
         try:
             1/0
-        except Exception:
-            exc_info = sys.exc_info()
+        except Exception as e:
+            exc_obj = e
 
-        refcnt1 = sys.getrefcount(exc_info[1])
-        refcnt2 = sys.getrefcount(exc_info[2])
-        exc = traceback.TracebackException(*exc_info)
-        self.assertEqual(sys.getrefcount(exc_info[1]), refcnt1)
-        self.assertEqual(sys.getrefcount(exc_info[2]), refcnt2)
+        refcnt1 = sys.getrefcount(exc_obj)
+        refcnt2 = sys.getrefcount(exc_obj.__traceback__)
+        exc = traceback.TracebackException.from_exception(exc_obj)
+        self.assertEqual(sys.getrefcount(exc_obj), refcnt1)
+        self.assertEqual(sys.getrefcount(exc_obj.__traceback__), refcnt2)
 
     def test_comparison_basic(self):
         try:
             1/0
-        except Exception:
-            exc_info = sys.exc_info()
-            exc = traceback.TracebackException(*exc_info)
-            exc2 = traceback.TracebackException(*exc_info)
+        except Exception as e:
+            exc_obj = e
+            exc = traceback.TracebackException.from_exception(exc_obj)
+            exc2 = traceback.TracebackException.from_exception(exc_obj)
         self.assertIsNot(exc, exc2)
         self.assertEqual(exc, exc2)
         self.assertNotEqual(exc, object())
@@ -2594,28 +2595,28 @@ class TestTracebackException(unittest.TestCase):
 
         try:
             raise_with_locals()
-        except Exception:
-            exc_info = sys.exc_info()
+        except Exception as e:
+            exc_obj = e
 
-        exc = traceback.TracebackException(*exc_info)
-        exc1 = traceback.TracebackException(*exc_info, limit=10)
-        exc2 = traceback.TracebackException(*exc_info, limit=2)
+        exc = traceback.TracebackException.from_exception(exc_obj)
+        exc1 = traceback.TracebackException.from_exception(exc_obj, limit=10)
+        exc2 = traceback.TracebackException.from_exception(exc_obj, limit=2)
 
         self.assertEqual(exc, exc1)      # limit=10 gets all frames
         self.assertNotEqual(exc, exc2)   # limit=2 truncates the output
 
         # locals change the output
-        exc3 = traceback.TracebackException(*exc_info, capture_locals=True)
+        exc3 = traceback.TracebackException.from_exception(exc_obj, capture_locals=True)
         self.assertNotEqual(exc, exc3)
 
         # there are no locals in the innermost frame
-        exc4 = traceback.TracebackException(*exc_info, limit=-1)
-        exc5 = traceback.TracebackException(*exc_info, limit=-1, capture_locals=True)
+        exc4 = traceback.TracebackException.from_exception(exc_obj, limit=-1)
+        exc5 = traceback.TracebackException.from_exception(exc_obj, limit=-1, capture_locals=True)
         self.assertEqual(exc4, exc5)
 
         # there are locals in the next-to-innermost frame
-        exc6 = traceback.TracebackException(*exc_info, limit=-2)
-        exc7 = traceback.TracebackException(*exc_info, limit=-2, capture_locals=True)
+        exc6 = traceback.TracebackException.from_exception(exc_obj, limit=-2)
+        exc7 = traceback.TracebackException.from_exception(exc_obj, limit=-2, capture_locals=True)
         self.assertNotEqual(exc6, exc7)
 
     def test_comparison_equivalent_exceptions_are_equal(self):
@@ -2623,8 +2624,8 @@ class TestTracebackException(unittest.TestCase):
         for _ in range(2):
             try:
                 1/0
-            except:
-                excs.append(traceback.TracebackException(*sys.exc_info()))
+            except Exception as e:
+                excs.append(traceback.TracebackException.from_exception(e))
         self.assertEqual(excs[0], excs[1])
         self.assertEqual(list(excs[0].format()), list(excs[1].format()))
 
@@ -2640,9 +2641,9 @@ class TestTracebackException(unittest.TestCase):
         except UnhashableException:
             try:
                 raise ex1
-            except UnhashableException:
-                exc_info = sys.exc_info()
-        exc = traceback.TracebackException(*exc_info)
+            except UnhashableException as e:
+                exc_obj = e
+        exc = traceback.TracebackException.from_exception(exc_obj)
         formatted = list(exc.format())
         self.assertIn('UnhashableException: ex2\n', formatted[2])
         self.assertIn('UnhashableException: ex1\n', formatted[6])
@@ -2655,11 +2656,10 @@ class TestTracebackException(unittest.TestCase):
                 1/0
         try:
             recurse(10)
-        except Exception:
-            exc_info = sys.exc_info()
-            exc = traceback.TracebackException(*exc_info, limit=5)
+        except Exception as e:
+            exc = traceback.TracebackException.from_exception(e, limit=5)
             expected_stack = traceback.StackSummary.extract(
-                traceback.walk_tb(exc_info[2]), limit=5)
+                traceback.walk_tb(e.__traceback__), limit=5)
         self.assertEqual(expected_stack, exc.stack)
 
     def test_lookup_lines(self):
@@ -2706,9 +2706,9 @@ class TestTracebackException(unittest.TestCase):
             x = 12
             try:
                 x/0
-            except Exception:
-                return sys.exc_info()
-        exc = traceback.TracebackException(*f(), capture_locals=True)
+            except Exception as e:
+                return e
+        exc = traceback.TracebackException.from_exception(f(), capture_locals=True)
         output = StringIO()
         exc.print(file=output)
         self.assertEqual(
@@ -2723,7 +2723,7 @@ class TestTracebackException(unittest.TestCase):
 class TestTracebackException_ExceptionGroups(unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.eg_info = self._get_exception_group()
+        self.eg = self._get_exception_group()
 
     def _get_exception_group(self):
         def f():
@@ -2753,26 +2753,26 @@ class TestTracebackException_ExceptionGroups(unittest.TestCase):
             except Exception as e:
                 exc4 = e
             raise ExceptionGroup("eg2", [exc3, exc4])
-        except ExceptionGroup:
-            return sys.exc_info()
+        except ExceptionGroup as eg:
+            return eg
         self.fail('Exception Not Raised')
 
     def test_exception_group_construction(self):
-        eg_info = self.eg_info
-        teg1 = traceback.TracebackException(*eg_info)
-        teg2 = traceback.TracebackException.from_exception(eg_info[1])
+        eg = self.eg
+        teg1 = traceback.TracebackException(type(eg), eg, eg.__traceback__)
+        teg2 = traceback.TracebackException.from_exception(eg)
         self.assertIsNot(teg1, teg2)
         self.assertEqual(teg1, teg2)
 
     def test_exception_group_format_exception_only(self):
-        teg = traceback.TracebackException(*self.eg_info)
+        teg = traceback.TracebackException.from_exception(self.eg)
         formatted = ''.join(teg.format_exception_only()).split('\n')
         expected = "ExceptionGroup: eg2 (2 sub-exceptions)\n".split('\n')
 
         self.assertEqual(formatted, expected)
 
     def test_exception_group_format(self):
-        teg = traceback.TracebackException(*self.eg_info)
+        teg = traceback.TracebackException.from_exception(self.eg)
 
         formatted = ''.join(teg.format()).split('\n')
         lno_f = self.lno_f
@@ -2884,18 +2884,18 @@ class TestTracebackException_ExceptionGroups(unittest.TestCase):
 
     def test_comparison(self):
         try:
-            raise self.eg_info[1]
-        except ExceptionGroup:
-            exc_info = sys.exc_info()
+            raise self.eg
+        except ExceptionGroup as e:
+            exc = e
         for _ in range(5):
             try:
-                raise exc_info[1]
-            except:
-                exc_info = sys.exc_info()
-        exc = traceback.TracebackException(*exc_info)
-        exc2 = traceback.TracebackException(*exc_info)
-        exc3 = traceback.TracebackException(*exc_info, limit=300)
-        ne = traceback.TracebackException(*exc_info, limit=3)
+                raise exc
+            except Exception as e:
+                exc_obj = e
+        exc = traceback.TracebackException.from_exception(exc_obj)
+        exc2 = traceback.TracebackException.from_exception(exc_obj)
+        exc3 = traceback.TracebackException.from_exception(exc_obj, limit=300)
+        ne = traceback.TracebackException.from_exception(exc_obj, limit=3)
         self.assertIsNot(exc, exc2)
         self.assertEqual(exc, exc2)
         self.assertEqual(exc, exc3)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102799 -->
* Issue: gh-102799
<!-- /gh-issue-number -->
