### PR TITLE
gh-101975: Fixed a potential SegFault on garbage collection

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-03-18-02-36-39.gh-issue-101975.HwMR1d.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-03-18-02-36-39.gh-issue-101975.HwMR1d.rst
@@ -1,0 +1,1 @@
+Fixed ``stacktop`` value on tracing entries to avoid corruption on garbage collection.

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -310,6 +310,7 @@ GETITEM(PyObject *v, Py_ssize_t i) {
         _PyFrame_SetStackPointer(frame, stack_pointer); \
         int err = trace_function_entry(tstate, frame); \
         stack_pointer = _PyFrame_GetStackPointer(frame); \
+        frame->stacktop = -1; \
         if (err) { \
             goto error; \
         } \


### PR DESCRIPTION
`frame->stacktop = 1` is missing on trace entry which could cause the `gc` on another thread to access freed memory.

<!-- gh-issue-number: gh-101975 -->
* Issue: gh-101975
<!-- /gh-issue-number -->
