### PR TITLE
gh-102551 Fixed inspect.signature.bind behavior on kwargs

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2837,10 +2837,13 @@ class BoundArguments:
 
     __slots__ = ('arguments', '_signature', '_kwarg_names', '__weakref__')
 
-    def __init__(self, signature, arguments, kwarg_names={}):
+    def __init__(self, signature, arguments, kwarg_names=None):
         self.arguments = arguments
         self._signature = signature
-        self._kwarg_names = kwarg_names
+        if kwarg_names is None:
+            self._kwarg_names = {}
+        else:
+            self._kwarg_names = kwarg_names
 
     @property
     def signature(self):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -4084,7 +4084,7 @@ class TestSignatureBind(unittest.TestCase):
         ba = sig.bind(1, 2, 3)
         self.assertEqual(ba.args, (1, 2, 3))
         ba = sig.bind(1, self=2, b=3)
-        self.assertEqual(ba.args, (1, 2, 3))
+        self.assertEqual(ba.args, (1,))
 
     def test_signature_bind_vararg_name(self):
         def test(a, *args):

--- a/Misc/NEWS.d/next/Library/2023-03-18-21-53-08.gh-issue-102551.HjjSLL.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-18-21-53-08.gh-issue-102551.HjjSLL.rst
@@ -1,0 +1,1 @@
+Fixed inspect.signature.bind behavior on keyword arguments


### PR DESCRIPTION
`inspect.signature.bind` is not working properly with keyword arguments on keyword/positional parameters.

```python
import inspect

def add(a, b, c=100):
    return a + b + c

bound = inspect.signature(add).bind(1, 2, c=100)
print(bound.args)
```

The result should be `(1, 2)`, not `(1, 2, 100)`

However, we simply do not have enough information in `BoundArguments` to figure out if an argument is provided as keyword argument, if that parameter itself could be keyword and positional, and it's right after positional arguments(no such parameter is skipped).

In this PR, a new member `kwarg_names` is introduced to `BoundArguments` to track which arguments are provided as keyword arguments. In the official documentation, we only listed `BoundArguments` as a result of `Signature.bind()` or `Signature.bind_partial()`, so it should be fine if we added an extra parameter. Also the parameter is optional so it won't break the code that has attempted to use it.

A wrong test in `test_inspect` is also fixed to the correct behavior.

However, there are a couple of tests in `test_unittest` relies on the potentially incorrect fact that `(1, 2)` and `(a=1, b=2)` are the same arguments. We need to discuss that part - whether to change the test to "correct" behavior(which is how it's used in the official docs), or change the unittest library to accommodate the new changes to keep the old behavior.

<!-- gh-issue-number: gh-102551 -->
* Issue: gh-102551
<!-- /gh-issue-number -->
