### PR TITLE
gh-100227: Make the Global Interned Dict Safe for Isolated Interpreters

### DIFF
--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -33,6 +33,11 @@ struct _Py_unicode_runtime_ids {
 };
 
 struct _Py_unicode_runtime_state {
+    struct {
+        PyThreadState *tstate;
+        /* The actual interned dict is at
+           _PyRuntime.cached_objects.interned_strings. */
+    } interned;
     struct _Py_unicode_runtime_ids ids;
 };
 

--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -34,6 +34,7 @@ struct _Py_unicode_runtime_ids {
 
 struct _Py_unicode_runtime_state {
     struct {
+        PyThread_type_lock lock;
         PyThreadState *tstate;
         /* The actual interned dict is at
            _PyRuntime.cached_objects.interned_strings. */

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14664,7 +14664,9 @@ PyUnicode_InternInPlace(PyObject **p)
         return;
     }
 
+    PyThread_acquire_lock(_PyRuntime.unicode_state.interned.lock, WAIT_LOCK);
     PyObject *t = store_interned(s);
+    PyThread_release_lock(_PyRuntime.unicode_state.interned.lock);
     if (t != s) {
         if (t != NULL) {
             Py_SETREF(*p, Py_NewRef(t));

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14672,7 +14672,8 @@ PyUnicode_InternInPlace(PyObject **p)
         return;
     }
 
-    // XXX Immortalize the object.
+    /* Immortalize the object. */
+    _Py_SetImmortal(s);
 
     /* The two references in interned dict (key and value) are not counted by
        refcnt. unicode_dealloc() and _PyUnicode_ClearInterned() take care of

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14610,16 +14610,22 @@ PyUnicode_InternInPlace(PyObject **p)
     PyObject *interned = get_interned_dict();
     assert(interned != NULL);
 
+    // XXX Swap to the main interpreter.
+
     PyObject *t = PyDict_SetDefault(interned, s, s);
     if (t == NULL) {
         PyErr_Clear();
         return;
     }
 
+    // XXX Swap back.
+
     if (t != s) {
         Py_SETREF(*p, Py_NewRef(t));
         return;
     }
+
+    // XXX Immortalize the object.
 
     /* The two references in interned dict (key and value) are not counted by
        refcnt. unicode_dealloc() and _PyUnicode_ClearInterned() take care of

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14533,13 +14533,12 @@ _PyUnicode_InitGlobalObjects(PyInterpreterState *interp)
         return _PyStatus_OK();
     }
 
-    // Initialize the global interned dict
+    /* Initialize the global interned dict. */
     PyObject *interned = PyDict_New();
     if (interned == NULL) {
         PyErr_Clear();
         return _PyStatus_ERR("failed to create interned dict");
     }
-
     set_interned_dict(interned);
 
     /* Intern statically allocated string identifiers and deepfreeze strings.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14673,7 +14673,8 @@ PyUnicode_InternInPlace(PyObject **p)
     }
 
     /* Immortalize the object. */
-    _Py_SetImmortal(s);
+    // XXX Uncomment this once the PEP 683 implementation has landed.
+    //_Py_SetImmortal(s);
 
     /* The two references in interned dict (key and value) are not counted by
        refcnt. unicode_dealloc() and _PyUnicode_ClearInterned() take care of


### PR DESCRIPTION
This is an alternative to gh-102339, where we keep the interned dict global instead of making it per-interpreter.

<!-- gh-issue-number: gh-100227 -->
* Issue: gh-100227
<!-- /gh-issue-number -->
