### PR TITLE
gh-102839: remove AC for math.log

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-03-20-12-21-19.gh-issue-102839.RjRi12.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-20-12-21-19.gh-issue-102839.RjRi12.rst
@@ -1,1 +1,1 @@
-Improve performance of :func:`math.log` arguments handling.
+Improve performance of :func:`math.log` arguments handling by removing the argument clinic.

--- a/Misc/NEWS.d/next/Library/2023-03-20-12-21-19.gh-issue-102839.RjRi12.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-20-12-21-19.gh-issue-102839.RjRi12.rst
@@ -1,0 +1,1 @@
+Improve performance of :func:`math.log` arguments handling.

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -186,49 +186,6 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(math_log__doc__,
-"log(x, [base=math.e])\n"
-"Return the logarithm of x to the given base.\n"
-"\n"
-"If the base not specified, returns the natural logarithm (base e) of x.");
-
-#define MATH_LOG_METHODDEF    \
-    {"log", (PyCFunction)math_log, METH_VARARGS, math_log__doc__},
-
-static PyObject *
-math_log_impl(PyObject *module, PyObject *x, int group_right_1,
-              PyObject *base);
-
-static PyObject *
-math_log(PyObject *module, PyObject *args)
-{
-    PyObject *return_value = NULL;
-    PyObject *x;
-    int group_right_1 = 0;
-    PyObject *base = NULL;
-
-    switch (PyTuple_GET_SIZE(args)) {
-        case 1:
-            if (!PyArg_ParseTuple(args, "O:log", &x)) {
-                goto exit;
-            }
-            break;
-        case 2:
-            if (!PyArg_ParseTuple(args, "OO:log", &x, &base)) {
-                goto exit;
-            }
-            group_right_1 = 1;
-            break;
-        default:
-            PyErr_SetString(PyExc_TypeError, "math.log requires 1 to 2 arguments");
-            goto exit;
-    }
-    return_value = math_log_impl(module, x, group_right_1, base);
-
-exit:
-    return return_value;
-}
-
 PyDoc_STRVAR(math_log2__doc__,
 "log2($module, x, /)\n"
 "--\n"
@@ -954,4 +911,4 @@ math_ulp(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=899211ec70e4506c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a6437a3ba18c486a input=a9049054013a1b77]*/

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2284,6 +2284,8 @@ loghelper(PyObject* arg, double (*func)(double))
 }
 
 
+/* AC: cannot convert yet, see gh-102839 and gh-89381, waiting
+   for support of multiple signatures */
 static PyObject *
 math_log(PyObject *module, PyObject * const *args, Py_ssize_t nargs)
 {

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2284,33 +2284,20 @@ loghelper(PyObject* arg, double (*func)(double))
 }
 
 
-/*[clinic input]
-math.log
-
-    x:    object
-    [
-    base: object(c_default="NULL") = math.e
-    ]
-    /
-
-Return the logarithm of x to the given base.
-
-If the base not specified, returns the natural logarithm (base e) of x.
-[clinic start generated code]*/
-
 static PyObject *
-math_log_impl(PyObject *module, PyObject *x, int group_right_1,
-              PyObject *base)
-/*[clinic end generated code: output=7b5a39e526b73fc9 input=0f62d5726cbfebbd]*/
+math_log(PyObject *module, PyObject * const *args, Py_ssize_t nargs)
 {
     PyObject *num, *den;
     PyObject *ans;
 
-    num = loghelper(x, m_log);
-    if (num == NULL || base == NULL)
+    if (!_PyArg_CheckPositional("log", nargs, 1, 2))
+        return NULL;
+
+    num = loghelper(args[0], m_log);
+    if (num == NULL || nargs == 1)
         return num;
 
-    den = loghelper(base, m_log);
+    den = loghelper(args[1], m_log);
     if (den == NULL) {
         Py_DECREF(num);
         return NULL;
@@ -2322,6 +2309,10 @@ math_log_impl(PyObject *module, PyObject *x, int group_right_1,
     return ans;
 }
 
+PyDoc_STRVAR(math_log_doc,
+"log(x, [base=math.e])\n\
+Return the logarithm of x to the given base.\n\n\
+If the base not specified, returns the natural logarithm (base e) of x.");
 
 /*[clinic input]
 math.log2
@@ -4045,7 +4036,7 @@ static PyMethodDef math_methods[] = {
     {"lcm",             _PyCFunction_CAST(math_lcm),       METH_FASTCALL,  math_lcm_doc},
     MATH_LDEXP_METHODDEF
     {"lgamma",          math_lgamma,    METH_O,         math_lgamma_doc},
-    MATH_LOG_METHODDEF
+    {"log",             _PyCFunction_CAST(math_log),       METH_FASTCALL,  math_log_doc},
     {"log1p",           math_log1p,     METH_O,         math_log1p_doc},
     MATH_LOG10_METHODDEF
     MATH_LOG2_METHODDEF


### PR DESCRIPTION
Before:
```
$ ./python -m timeit -s 'from math import log' 'log(1.1)' 1000000 loops, best of 5: 344 nsec per loop
$ ./python -m timeit -s 'from math import log' 'log(1.1, 3.2)' 500000 loops, best of 5: 601 nsec per loop
```
After:
```
$ ./python -m timeit -s 'from math import log' 'log(1.1)' 2000000 loops, best of 5: 171 nsec per loop
$ ./python -m timeit -s 'from math import log' 'log(1.1, 3.2)' 1000000 loops, best of 5: 348 nsec per loop
```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102839 -->
* Issue: gh-102839
<!-- /gh-issue-number -->
