### PR TITLE
gh-102864: Remove access to f_locals in pdb

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1562,6 +1562,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         or '<lambda>', the input arguments, the return value, and the
         line of code (if it exists).
 
+        This function is overwritten because accessing frame.f_locals will
+        refresh the dictionary. We need to provide cached f_locals to avoid
+        reverting local variable changes to it
         """
         import linecache, reprlib
         filename = self.canonic(frame.f_code.co_filename)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1475,9 +1475,9 @@ def test_pdb_issue_gh_94215():
     """
 
 def test_pdb_issue_gh_101673():
-    """See GH-101673
+    """See GH-101673 and GH-102864
 
-    Make sure ll won't revert local variable assignment
+    Make sure ll and switching frames won't revert local variable assignment
 
     >>> def test_function():
     ...    a = 1
@@ -1486,6 +1486,9 @@ def test_pdb_issue_gh_101673():
     >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
     ...     '!a = 2',
     ...     'll',
+    ...     'p a',
+    ...     'u',
+    ...     'd',
     ...     'p a',
     ...     'continue'
     ... ]):
@@ -1498,6 +1501,14 @@ def test_pdb_issue_gh_101673():
       1         def test_function():
       2            a = 1
       3  ->        import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) p a
+    2
+    (Pdb) u
+    > <doctest test.test_pdb.test_pdb_issue_gh_101673[1]>(10)<module>()
+    -> test_function()
+    (Pdb) d
+    > <doctest test.test_pdb.test_pdb_issue_gh_101673[0]>(3)test_function()->None
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) p a
     2
     (Pdb) continue

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1475,9 +1475,9 @@ def test_pdb_issue_gh_94215():
     """
 
 def test_pdb_issue_gh_101673():
-    """See GH-101673 and GH-102864
+    """See GH-101673
 
-    Make sure ll and switching frames won't revert local variable assignment
+    Make sure ll won't revert local variable assignment
 
     >>> def test_function():
     ...    a = 1
@@ -1486,9 +1486,6 @@ def test_pdb_issue_gh_101673():
     >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
     ...     '!a = 2',
     ...     'll',
-    ...     'p a',
-    ...     'u',
-    ...     'd',
     ...     'p a',
     ...     'continue'
     ... ]):
@@ -1501,14 +1498,6 @@ def test_pdb_issue_gh_101673():
       1         def test_function():
       2            a = 1
       3  ->        import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
-    (Pdb) p a
-    2
-    (Pdb) u
-    > <doctest test.test_pdb.test_pdb_issue_gh_101673[1]>(10)<module>()
-    -> test_function()
-    (Pdb) d
-    > <doctest test.test_pdb.test_pdb_issue_gh_101673[0]>(3)test_function()->None
-    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) p a
     2
     (Pdb) continue

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1475,9 +1475,9 @@ def test_pdb_issue_gh_94215():
     """
 
 def test_pdb_issue_gh_101673():
-    """See GH-101673
+    """See GH-101673 and GH-102864
 
-    Make sure ll won't revert local variable assignment
+    Make sure ll and switching frames won't revert local variable assignment
 
     >>> def test_function():
     ...    a = 1

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1487,6 +1487,9 @@ def test_pdb_issue_gh_101673():
     ...     '!a = 2',
     ...     'll',
     ...     'p a',
+    ...     'u',
+    ...     'd',
+    ...     'p a',
     ...     'continue'
     ... ]):
     ...     test_function()
@@ -1498,6 +1501,14 @@ def test_pdb_issue_gh_101673():
       1         def test_function():
       2            a = 1
       3  ->        import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) p a
+    2
+    (Pdb) u
+    > <doctest test.test_pdb.test_pdb_issue_gh_101673[1]>(10)<module>()
+    -> test_function()
+    (Pdb) d
+    > <doctest test.test_pdb.test_pdb_issue_gh_101673[0]>(3)test_function()->None
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) p a
     2
     (Pdb) continue

--- a/Misc/NEWS.d/next/Library/2023-03-21-04-38-42.gh-issue-102864.FskZue.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-21-04-38-42.gh-issue-102864.FskZue.rst
@@ -1,0 +1,1 @@
+Fixed the bug where switching frames would revert local variable changes


### PR DESCRIPTION
Avoid accessing f_locals in pdb which will clear local variable changes.

<!-- gh-issue-number: gh-102864 -->
* Issue: gh-102864
<!-- /gh-issue-number -->
