### PR TITLE
Tweak polynomial itertool recipes

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -876,8 +876,8 @@ which incur interpreter overhead.
        n = len(coefficients)
        if n == 0:
            return x * 0  # coerce zero to the type of x
-       powers = map(pow, repeat(x), range(n))
-       return math.sumprod(reversed(coefficients), powers)
+       powers = map(pow, repeat(x), reversed(range(n)))
+       return math.sumprod(coefficients, powers)
 
    def polynomial_from_roots(roots):
        """Compute a polynomial's coefficients from its roots.

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -866,6 +866,17 @@ which incur interpreter overhead.
            window.append(x)
            yield math.sumprod(kernel, window)
 
+   def polynomial_from_roots(roots):
+       """Compute a polynomial's coefficients from its roots.
+
+          (x - 5) (x + 4) (x - 3)  expands to:   x³ -4x² -17x + 60
+       """
+       # polynomial_from_roots([5, -4, 3]) --> [1, -4, -17, 60]
+       expansion = [1]
+       for r in roots:
+           expansion = convolve(expansion, (1, -r))
+       return list(expansion)
+
    def polynomial_eval(coefficients, x):
        """Evaluate a polynomial at a specific value.
 
@@ -878,18 +889,6 @@ which incur interpreter overhead.
            return x * 0  # coerce zero to the type of x
        powers = map(pow, repeat(x), reversed(range(n)))
        return math.sumprod(coefficients, powers)
-
-   def polynomial_from_roots(roots):
-       """Compute a polynomial's coefficients from its roots.
-
-          (x - 5) (x + 4) (x - 3)  expands to:   x³ -4x² -17x + 60
-       """
-       # polynomial_from_roots([5, -4, 3]) --> [1, -4, -17, 60]
-       roots = list(map(operator.neg, roots))
-       return [
-           sum(map(math.prod, combinations(roots, k)))
-           for k in range(len(roots) + 1)
-       ]
 
    def iter_index(iterable, value, start=0):
        "Return indices where a value occurs in a sequence or iterable."


### PR DESCRIPTION
* Applying `reversed` to the range object instead of coefficients reduces the requirements for the coefficients.  Now, only `__iter__` and `__len__` are needed.  Formerly, either `__getitem__` or `__reversed__` were needed as well.

* Express the `polynomial_from_roots` recipe in terms of `convolve()` this better matches the way it would be done by hand.  Also, it nicely demonstrates iterator nesting.   The previous version was meant to show-off an application of `combinations` but that was already demonstrated in the `powerset()` recipe.