### PR TITLE
gh-84436: Make Interned Strings Immortal

### DIFF
--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -28,6 +28,10 @@ extern "C" {
 
 struct _Py_cached_objects {
     PyObject *interned_strings;
+    /* A thread state tied to the main interpreter,
+       used exclusively for when a global object (e.g. interned strings)
+       is resized (i.e. deallocated + allocated) from an arbitrary thread. */
+    PyThreadState main_tstate;
 };
 
 #define _Py_GLOBAL_OBJECT(NAME) \

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -130,9 +130,6 @@ PyAPI_FUNC(void) _PyThreadState_DeleteExcept(PyThreadState *tstate);
 extern void _PyThreadState_InitDetached(PyThreadState *, PyInterpreterState *);
 extern void _PyThreadState_ClearDetached(PyThreadState *);
 
-extern PyThreadState * _Py_AcquireGlobalObjectsState(PyInterpreterState *);
-extern void _Py_ReleaseGlobalObjectsState(PyThreadState *);
-
 extern PyObject * _Py_AddToGlobalDict(PyObject *, PyObject *, PyObject *);
 
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -126,7 +126,9 @@ PyAPI_FUNC(void) _PyThreadState_Bind(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_Init(
     PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_DeleteExcept(PyThreadState *tstate);
+
 extern void _PyThreadState_InitDetached(PyThreadState *, PyInterpreterState *);
+extern void _PyThreadState_ClearDetached(PyThreadState *);
 
 
 static inline void

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -121,9 +121,7 @@ static inline PyInterpreterState* _PyInterpreterState_GET(void) {
 // PyThreadState functions
 
 PyAPI_FUNC(PyThreadState *) _PyThreadState_New(PyInterpreterState *interp);
-PyAPI_FUNC(int) _PyThreadState_IsBound(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_Bind(PyThreadState *tstate);
-PyAPI_FUNC(void) _PyThreadState_Unbind(PyThreadState *tstate);
 // We keep this around exclusively for stable ABI compatibility.
 PyAPI_FUNC(void) _PyThreadState_Init(
     PyThreadState *tstate);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -133,6 +133,8 @@ extern void _PyThreadState_ClearDetached(PyThreadState *);
 extern PyThreadState * _Py_AcquireGlobalObjectsState(PyInterpreterState *);
 extern void _Py_ReleaseGlobalObjectsState(PyThreadState *);
 
+extern PyObject * _Py_AddToGlobalDict(PyObject *, PyObject *, PyObject *);
+
 
 static inline void
 _PyThreadState_UpdateTracingState(PyThreadState *tstate)

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -121,7 +121,9 @@ static inline PyInterpreterState* _PyInterpreterState_GET(void) {
 // PyThreadState functions
 
 PyAPI_FUNC(PyThreadState *) _PyThreadState_New(PyInterpreterState *interp);
+PyAPI_FUNC(int) _PyThreadState_IsBound(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_Bind(PyThreadState *tstate);
+PyAPI_FUNC(void) _PyThreadState_Unbind(PyThreadState *tstate);
 // We keep this around exclusively for stable ABI compatibility.
 PyAPI_FUNC(void) _PyThreadState_Init(
     PyThreadState *tstate);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -126,6 +126,7 @@ PyAPI_FUNC(void) _PyThreadState_Bind(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_Init(
     PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_DeleteExcept(PyThreadState *tstate);
+extern void _PyThreadState_InitDetached(PyThreadState *, PyInterpreterState *);
 
 
 static inline void

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -130,6 +130,9 @@ PyAPI_FUNC(void) _PyThreadState_DeleteExcept(PyThreadState *tstate);
 extern void _PyThreadState_InitDetached(PyThreadState *, PyInterpreterState *);
 extern void _PyThreadState_ClearDetached(PyThreadState *);
 
+extern PyThreadState * _Py_AcquireGlobalObjectsState(PyInterpreterState *);
+extern void _Py_ReleaseGlobalObjectsState(PyThreadState *);
+
 
 static inline void
 _PyThreadState_UpdateTracingState(PyThreadState *tstate)

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -58,6 +58,9 @@ extern PyTypeObject _PyExc_MemoryError;
         .types = { \
             .next_version_tag = 1, \
         }, \
+        .cached_objects = { \
+            .main_tstate = _PyThreadState_INIT, \
+        }, \
         .static_objects = { \
             .singletons = { \
                 .small_ints = _Py_small_ints_INIT, \

--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -33,6 +33,11 @@ struct _Py_unicode_runtime_ids {
 };
 
 struct _Py_unicode_runtime_state {
+    struct {
+        PyThreadState *tstate;
+        /* The actual interned dict is at
+           _PyRuntime.cached_objects.interned_strings. */
+    } interned;
     struct _Py_unicode_runtime_ids ids;
 };
 

--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -33,12 +33,8 @@ struct _Py_unicode_runtime_ids {
 };
 
 struct _Py_unicode_runtime_state {
-    struct {
-        PyThreadState *tstate;
-        /* The actual interned dict is at
-           _PyRuntime.cached_objects.interned_strings. */
-    } interned;
     struct _Py_unicode_runtime_ids ids;
+    /* The interned dict is at _PyRuntime.cached_objects.interned_strings. */
 };
 
 /* fs_codec.encoding is initialized to NULL.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14588,29 +14588,7 @@ error:
 static PyThreadState *
 get_interned_tstate(void)
 {
-    PyThreadState *tstate = _PyRuntime.unicode_state.interned.tstate;
-    if (tstate == NULL) {
-        PyInterpreterState *main_interp = _PyInterpreterState_Main();
-        /* We do not "bind" the thread state here. */
-        tstate = _PyThreadState_New(main_interp);
-        if (tstate == NULL) {
-            PyErr_Clear();
-            return NULL;
-        }
-        _PyRuntime.unicode_state.interned.tstate = tstate;
-    }
-    return tstate;
-}
-
-static void
-clear_interned_tstate(void)
-{
-    PyThreadState *tstate = _PyRuntime.unicode_state.interned.tstate;
-    if (tstate != NULL) {
-        _PyRuntime.unicode_state.interned.tstate = NULL;
-        PyThreadState_Clear(tstate);
-        PyThreadState_Delete(tstate);
-    }
+    return &_PyRuntime.cached_objects.main_tstate;
 }
 
 static inline PyObject *
@@ -14623,9 +14601,6 @@ store_interned(PyObject *obj)
     PyThreadState *oldts = NULL;
     if (!_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
         PyThreadState *main_tstate = get_interned_tstate();
-        if (main_tstate == NULL) {
-            return NULL;
-        }
         oldts = PyThreadState_Swap(main_tstate);
         assert(oldts != NULL);
     }
@@ -14750,8 +14725,6 @@ _PyUnicode_ClearInterned(PyInterpreterState *interp)
     PyDict_Clear(interned);
     Py_DECREF(interned);
     set_interned_dict(NULL);
-
-    clear_interned_tstate();
 }
 
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14611,16 +14611,22 @@ PyUnicode_InternInPlace(PyObject **p)
     PyObject *interned = get_interned_dict();
     assert(interned != NULL);
 
+    // XXX Swap to the main interpreter.
+
     PyObject *t = PyDict_SetDefault(interned, s, s);
     if (t == NULL) {
         PyErr_Clear();
         return;
     }
 
+    // XXX Swap back.
+
     if (t != s) {
         Py_SETREF(*p, Py_NewRef(t));
         return;
     }
+
+    // XXX Immortalize the object.
 
     /* The two references in interned dict (key and value) are not counted by
        refcnt. unicode_dealloc() and _PyUnicode_ClearInterned() take care of

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14585,6 +14585,24 @@ error:
 }
 
 
+static inline PyObject *
+store_interned(PyObject *obj)
+{
+    PyObject *interned = get_interned_dict();
+    assert(interned != NULL);
+
+    // XXX Swap to the main interpreter.
+
+    PyObject *t = PyDict_SetDefault(interned, obj, obj);
+    if (t == NULL) {
+        PyErr_Clear();
+    }
+
+    // XXX Swap back.
+
+    return t;
+}
+
 void
 PyUnicode_InternInPlace(PyObject **p)
 {
@@ -14608,21 +14626,11 @@ PyUnicode_InternInPlace(PyObject **p)
         return;
     }
 
-    PyObject *interned = get_interned_dict();
-    assert(interned != NULL);
-
-    // XXX Swap to the main interpreter.
-
-    PyObject *t = PyDict_SetDefault(interned, s, s);
-    if (t == NULL) {
-        PyErr_Clear();
-        return;
-    }
-
-    // XXX Swap back.
-
+    PyObject *t = store_interned(s);
     if (t != s) {
-        Py_SETREF(*p, Py_NewRef(t));
+        if (t != NULL) {
+            Py_SETREF(*p, Py_NewRef(t));
+        }
         return;
     }
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14619,14 +14619,26 @@ store_interned(PyObject *obj)
     PyObject *interned = get_interned_dict();
     assert(interned != NULL);
 
-    // XXX Swap to the main interpreter.
+    /* Swap to the main interpreter, if necessary. */
+    PyThreadState *oldts = NULL;
+    if (!_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
+        PyThreadState *main_tstate = get_interned_tstate();
+        if (main_tstate == NULL) {
+            return NULL;
+        }
+        oldts = PyThreadState_Swap(main_tstate);
+        assert(oldts != NULL);
+    }
 
     PyObject *t = PyDict_SetDefault(interned, obj, obj);
     if (t == NULL) {
         PyErr_Clear();
     }
 
-    // XXX Swap back.
+    /* Swap back. */
+    if (oldts != NULL) {
+        PyThreadState_Swap(oldts);
+    }
 
     return t;
 }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14601,8 +14601,15 @@ store_interned(PyObject *obj)
     PyThreadState *oldts = NULL;
     if (!_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
         PyThreadState *main_tstate = get_interned_tstate();
+        int bound = _PyThreadState_IsBound(main_tstate);
+        if (!bound) {
+            _PyThreadState_Bind(main_tstate);
+        }
         oldts = PyThreadState_Swap(main_tstate);
         assert(oldts != NULL);
+        if (!bound) {
+            _PyThreadState_Unbind(main_tstate);
+        }
     }
 
     PyObject *t = PyDict_SetDefault(interned, obj, obj);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14585,6 +14585,34 @@ error:
 }
 
 
+static PyThreadState *
+get_interned_tstate(void)
+{
+    PyThreadState *tstate = _PyRuntime.unicode_state.interned.tstate;
+    if (tstate == NULL) {
+        PyInterpreterState *main_interp = _PyInterpreterState_Main();
+        /* We do not "bind" the thread state here. */
+        tstate = _PyThreadState_New(main_interp);
+        if (tstate == NULL) {
+            PyErr_Clear();
+            return NULL;
+        }
+        _PyRuntime.unicode_state.interned.tstate = tstate;
+    }
+    return tstate;
+}
+
+static void
+clear_interned_tstate(void)
+{
+    PyThreadState *tstate = _PyRuntime.unicode_state.interned.tstate;
+    if (tstate != NULL) {
+        _PyRuntime.unicode_state.interned.tstate = NULL;
+        PyThreadState_Clear(tstate);
+        PyThreadState_Delete(tstate);
+    }
+}
+
 static inline PyObject *
 store_interned(PyObject *obj)
 {
@@ -14710,6 +14738,8 @@ _PyUnicode_ClearInterned(PyInterpreterState *interp)
     PyDict_Clear(interned);
     Py_DECREF(interned);
     set_interned_dict(NULL);
+
+    clear_interned_tstate();
 }
 
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -239,6 +239,7 @@ static inline PyObject *get_interned_dict(void)
 static inline void set_interned_dict(PyObject *dict)
 {
     _Py_CACHED_OBJECT(interned_strings) = dict;
+    _Py_SetImmortal(dict);
 }
 
 #define _Py_RETURN_UNICODE_EMPTY()   \

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -635,6 +635,8 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
         return status;
     }
 
+    _PyThreadState_InitDetached(&runtime->cached_objects.main_tstate, interp);
+
     *tstate_p = tstate;
     return _PyStatus_OK();
 }
@@ -1927,6 +1929,8 @@ Py_FinalizeEx(void)
      */
     // XXX Do this sooner during finalization.
     // XXX Ensure finalizer errors are handled properly.
+
+    _PyThreadState_ClearDetached(&runtime->cached_objects.main_tstate);
 
     finalize_interp_clear(tstate);
     finalize_interp_delete(tstate->interp);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -606,6 +606,22 @@ unbind_global_objects_state(_PyRuntimeState *runtime)
 #endif
 }
 
+static inline void
+acquire_global_objects_lock(_PyRuntimeState *runtime)
+{
+    /* For now we can rely on the GIL, so we don't actually
+       acquire a global lock here. */
+    assert(current_fast_get(runtime) != NULL);
+}
+
+static inline void
+release_global_objects_lock(_PyRuntimeState *runtime)
+{
+    /* For now we can rely on the GIL, so we don't actually
+       release a global lock here. */
+    assert(current_fast_get(runtime) != NULL);
+}
+
 PyObject *
 _Py_AddToGlobalDict(PyObject *dict, PyObject *key, PyObject *value)
 {
@@ -623,7 +639,7 @@ _Py_AddToGlobalDict(PyObject *dict, PyObject *key, PyObject *value)
        starting at this point and ending before we return.
        Note that the operations in this function are very fucused
        and we should not expect any reentrancy. */
-    // For now we rely on the GIL.
+    acquire_global_objects_lock(runtime);
 
     /* Swap to the main interpreter, if necessary. */
     PyThreadState *oldts = NULL;
@@ -659,8 +675,7 @@ _Py_AddToGlobalDict(PyObject *dict, PyObject *key, PyObject *value)
         unbind_global_objects_state(runtime);
     }
 
-    // This is where we would release the global lock,
-    // if we weren't relying on the GIL.
+    release_global_objects_lock(runtime);
 
     // XXX Immortalize the key and value.
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1923,6 +1923,12 @@ PyThreadState_Swap(PyThreadState *newts)
 }
 
 
+int
+_PyThreadState_IsBound(PyThreadState *tstate)
+{
+    return tstate_is_bound(tstate);
+}
+
 void
 _PyThreadState_Bind(PyThreadState *tstate)
 {
@@ -1932,6 +1938,14 @@ _PyThreadState_Bind(PyThreadState *tstate)
     if (gilstate_tss_get(tstate->interp->runtime) == NULL) {
         bind_gilstate_tstate(tstate);
     }
+}
+
+void
+_PyThreadState_Unbind(PyThreadState *tstate)
+{
+    /* For now, we do not allow the initial tstate to be unbound. */
+    assert(gilstate_tss_get(tstate->interp->runtime) != tstate);
+    unbind_tstate(tstate);
 }
 
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -677,7 +677,14 @@ _Py_AddToGlobalDict(PyObject *dict, PyObject *key, PyObject *value)
 
     release_global_objects_lock(runtime);
 
-    // XXX Immortalize the key and value.
+    /* Immortalize the key and value. */
+    if (actual == value) {
+        /* It was added. */
+        _Py_SetImmortal(key);
+        if (value != key) {
+            _Py_SetImmortal(value);
+        }
+    }
 
     return actual;
 }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1358,6 +1358,20 @@ _PyThreadState_Init(PyThreadState *tstate)
 }
 
 void
+_PyThreadState_InitDetached(PyThreadState *tstate, PyInterpreterState *interp)
+{
+    _PyRuntimeState *runtime = interp->runtime;
+
+    HEAD_LOCK(runtime);
+    interp->threads.next_unique_id += 1;
+    uint64_t id = interp->threads.next_unique_id;
+    HEAD_UNLOCK(runtime);
+
+    init_threadstate(tstate, interp, id);
+    // We do not call add_threadstate().
+}
+
+void
 PyThreadState_Clear(PyThreadState *tstate)
 {
     assert(tstate->_status.initialized && !tstate->_status.cleared);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1923,12 +1923,6 @@ PyThreadState_Swap(PyThreadState *newts)
 }
 
 
-int
-_PyThreadState_IsBound(PyThreadState *tstate)
-{
-    return tstate_is_bound(tstate);
-}
-
 void
 _PyThreadState_Bind(PyThreadState *tstate)
 {
@@ -1938,14 +1932,6 @@ _PyThreadState_Bind(PyThreadState *tstate)
     if (gilstate_tss_get(tstate->interp->runtime) == NULL) {
         bind_gilstate_tstate(tstate);
     }
-}
-
-void
-_PyThreadState_Unbind(PyThreadState *tstate)
-{
-    /* For now, we do not allow the initial tstate to be unbound. */
-    assert(gilstate_tss_get(tstate->interp->runtime) != tstate);
-    unbind_tstate(tstate);
 }
 
 


### PR DESCRIPTION
This is a prerequisite for a per-interpreter GIL if the interned strings dict stays global (e.g. gh-102858).

(This is based on gh-102925.  It also requires gh-19474.)

<!-- gh-issue-number: gh-84436 -->
* Issue: gh-84436
<!-- /gh-issue-number -->
