### PR TITLE
Docs: improve accuracy of pdb alias example

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -513,7 +513,7 @@ can be overridden by the local file.
    :file:`.pdbrc` file)::
 
       # Print instance variables (usage "pi classInst")
-      alias pi for k in %1.__dict__.keys(): print("%1.",k,"=",%1.__dict__[k])
+      alias pi for k in %1.__dict__.keys(): print(f"%1.{k} = {%1.__dict__[k]}")
       # Print instance variables in self
       alias ps pi self
 


### PR DESCRIPTION
This is a minor change on pdb docs. The doc use to give an alias example below:

```python
# Print instance variables (usage "pi classInst")
alias pi for k in %1.__dict__.keys(): print("%1.",k,"=",%1.__dict__[k])
```

However, using this alias, there will be a space between the object name and the attribute like ``self. attr = 1``, which is not how we are used to. By using f-strings(which is supported on all live python versions), we can make the alias do ``self.attr = 1``