### PR TITLE
gh-102899: Fix doc link for getting filesystem error handler

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -697,7 +697,7 @@ always available.
    the encoding used with the :term:`filesystem error handler <filesystem
    encoding and error handler>` to convert between Unicode filenames and bytes
    filenames. The filesystem error handler is returned from
-   :func:`getfilesystemencoding`.
+   :func:`getfilesystemencodeerrors`.
 
    For best compatibility, str should be used for filenames in all cases,
    although representing filenames as bytes is also supported. Functions


### PR DESCRIPTION
The documentation of `sys.getfilesystemencoding` has a link to the function that returns the filesystem error handler. However, the link was wrong and pointed to `sys.getfilesystemencoding` instead of `sys.getfilesystemencodeerrors`.

<!-- gh-issue-number: gh-102899 -->
* Issue: gh-102899
<!-- /gh-issue-number -->
