### PR TITLE
Quote literal tokens in standard format specifier grammar

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -310,7 +310,7 @@ non-empty format specification typically modifies the result.
 The general form of a *standard format specifier* is:
 
 .. productionlist:: format-spec
-   format_spec: [[`fill`]`align`][`sign`][z][#][0][`width`][`grouping_option`][.`precision`][`type`]
+   format_spec: [[`fill`]`align`][`sign`]["z"]["#"]["0"][`width`][`grouping_option`]["." `precision`][`type`]
    fill: <any character>
    align: "<" | ">" | "=" | "^"
    sign: "+" | "-" | " "


### PR DESCRIPTION
Reported by Damian Duckeck: https://mail.python.org/archives/list/docs@python.org/thread/UZTWBJIXC3MBKTHXVTIBPGDPKBNWZ5LN/
