### PR TITLE
gh-101947: Remove size check from sqlite3 serialize test

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -606,7 +606,6 @@ class SerializeTests(unittest.TestCase):
             with cx:
                 cx.execute("create table t(t)")
             data = cx.serialize()
-            self.assertEqual(len(data), 8192)
 
             # Remove test table, verify that it was removed.
             with cx:


### PR DESCRIPTION
The size of the returned data is too implementation specific.


<!-- gh-issue-number: gh-101947 -->
* Issue: gh-101947
<!-- /gh-issue-number -->
