### PR TITLE
gh-89240: Limit multiprocessing.Pool to 61 workers on Windows

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2209,6 +2209,10 @@ with the :class:`Pool` class.
 
    *processes* is the number of worker processes to use.  If *processes* is
    ``None`` then the number returned by :func:`os.cpu_count` is used.
+   On Windows, *processes* must be equal or lower than ``61``. If it is not
+   then :exc:`ValueError` will be raised. If *processes* is ``None``, then
+   the default chosen will be at most ``61``, even if more processors are
+   available.
 
    If *initializer* is not ``None`` then each worker process will call
    ``initializer(*initargs)`` when it starts.

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2772,6 +2772,18 @@ class _TestPool(BaseTestCase):
             pool = None
             support.gc_collect()
 
+class TestPoolMaxWorkers(unittest.TestCase):
+    @unittest.skipUnless(sys.platform=='win32', 'Windows-only process limit')
+    def test_max_workers_too_large(self):
+        with self.assertRaisesRegex(ValueError, "max_workers must be <= 61"):
+            multiprocessing.pool.Pool(62)
+
+        # ThreadPool have no limit.
+        p = multiprocessing.pool.ThreadPool(62)
+        p.close()
+        p.join()
+
+
 def raising():
     raise KeyError("key")
 

--- a/Misc/NEWS.d/next/Library/2023-03-22-22-45-13.gh-issue-89240.rtEHSo.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-22-22-45-13.gh-issue-89240.rtEHSo.rst
@@ -1,0 +1,2 @@
+Limit ``processes`` in :class:`multiprocessing.Pool` to 61 to work around a
+WaitForMultipleObjects limitation.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-89240 -->
* Issue: gh-89240
<!-- /gh-issue-number -->
