### PR TITLE
gh-102921: Clarify `exc` argument name in `BaseExceptionGroup` is plural

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -948,8 +948,8 @@ their subgroups based on the types of the contained exceptions.
       these fields do not need to be updated by :meth:`derive`. ::
 
          >>> class MyGroup(ExceptionGroup):
-         ...     def derive(self, exc):
-         ...         return MyGroup(self.message, exc)
+         ...     def derive(self, excs):
+         ...         return MyGroup(self.message, excs)
          ...
          >>> e = MyGroup("eg", [ValueError(1), TypeError(2)])
          >>> e.add_note("a note")


### PR DESCRIPTION
Fix #102921

This merge request updates the `BaseExceptionGroup` derive documentation example to use `excs` to reduce confusion about the type of the received argument to the exception group.

<!-- gh-issue-number: gh-102921 -->
* Issue: gh-102921
<!-- /gh-issue-number -->
