### PR TITLE
gh-102810 Improve the sphinx docs for `asyncio.Timeout`

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -629,13 +629,12 @@ Timeouts
        An :ref:`asynchronous context manager <async-context-managers>`
        for cancelling overdue coroutines.
 
-       The ``when`` parameter specifies at what time the context should
-       time out. It's value should be either a float relative to the
-       current :meth:`loop.time` or ``None``.
+       ``when`` should be either a float relative to the current
+       :meth:`loop.time` or ``None``:
 
-       If ``when`` is ``None``, the timeout will never trigger.
-       If ``when < loop.time()``, the timeout will trigger on the next
-       iteration of the event loop.
+       - If ``when`` is ``None``, the timeout will never trigger.
+       - If ``when < loop.time()``, the timeout will trigger on the next
+         iteration of the event loop.
 
        .. versionadded:: 3.11
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -630,7 +630,7 @@ Timeouts
        for cancelling overdue coroutines.
 
        ``when`` should be an absolute time at which the context should time out,
-       as measured by the event loop's clock.
+       as measured by the event loop's clock:
 
        - If ``when`` is ``None``, the timeout will never trigger.
        - If ``when < loop.time()``, the timeout will trigger on the next

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -636,8 +636,6 @@ Timeouts
        - If ``when < loop.time()``, the timeout will trigger on the next
          iteration of the event loop.
 
-       .. versionadded:: 3.11
-
         .. method:: when() -> float | None
 
            Return the current deadline, or ``None`` if the current

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -624,10 +624,24 @@ Timeouts
     The context manager produced by :func:`asyncio.timeout` can be
     rescheduled to a different deadline and inspected.
 
-    .. class:: Timeout()
+    .. class:: Timeout(when)
 
        An :ref:`asynchronous context manager <async-context-managers>`
-       that limits time spent inside of it.
+       context manager for cancelling overdue coroutines.
+
+       .. note::
+
+            Please use :meth:`timeout()` or :meth:`timeout_at()`
+            rather than instantiating this class directly.
+
+       The ``when`` parameter specifies at what time the context should
+       time out. It's value should be either a float relative to the
+       current :meth:`loop.time` or ``None``, if the context should never
+       expire.
+
+       If ``when`` is ``None``, the timeout will never trigger.
+       If ``when < loop.time()``, the timeout will trigger on the next
+       iteration of the event loop.
 
         .. versionadded:: 3.11
 
@@ -636,20 +650,9 @@ Timeouts
            Return the current deadline, or ``None`` if the current
            deadline is not set.
 
-           The deadline is a float, consistent with the time returned by
-           :meth:`loop.time`.
-
         .. method:: reschedule(when: float | None)
 
             Change the time the timeout will trigger.
-
-            If *when* is ``None``, any current deadline will be removed, and the
-            context manager will wait indefinitely.
-
-            If *when* is a float, it is set as the new deadline.
-
-            if *when* is in the past, the timeout will trigger on the next
-            iteration of the event loop.
 
         .. method:: expired() -> bool
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -629,8 +629,8 @@ Timeouts
        An :ref:`asynchronous context manager <async-context-managers>`
        for cancelling overdue coroutines.
 
-       ``when`` should be either a float relative to the current
-       :meth:`loop.time` or ``None``:
+       ``when`` should be an absolute time at which the context should time out,
+       as measured by the event loop's clock.
 
        - If ``when`` is ``None``, the timeout will never trigger.
        - If ``when < loop.time()``, the timeout will trigger on the next

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -627,7 +627,7 @@ Timeouts
     .. class:: Timeout(when)
 
        An :ref:`asynchronous context manager <async-context-managers>`
-       context manager for cancelling overdue coroutines.
+       for cancelling overdue coroutines.
 
        .. note::
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -636,8 +636,7 @@ Timeouts
 
        The ``when`` parameter specifies at what time the context should
        time out. It's value should be either a float relative to the
-       current :meth:`loop.time` or ``None``, if the context should never
-       expire.
+       current :meth:`loop.time` or ``None``.
 
        If ``when`` is ``None``, the timeout will never trigger.
        If ``when < loop.time()``, the timeout will trigger on the next

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -629,11 +629,6 @@ Timeouts
        An :ref:`asynchronous context manager <async-context-managers>`
        for cancelling overdue coroutines.
 
-       .. note::
-
-            Please use :meth:`timeout()` or :meth:`timeout_at()`
-            rather than instantiating this class directly.
-
        The ``when`` parameter specifies at what time the context should
        time out. It's value should be either a float relative to the
        current :meth:`loop.time` or ``None``.
@@ -642,7 +637,7 @@ Timeouts
        If ``when < loop.time()``, the timeout will trigger on the next
        iteration of the event loop.
 
-        .. versionadded:: 3.11
+       .. versionadded:: 3.11
 
         .. method:: when() -> float | None
 
@@ -651,7 +646,7 @@ Timeouts
 
         .. method:: reschedule(when: float | None)
 
-            Change the time the timeout will trigger.
+            Reschedule the timeout.
 
         .. method:: expired() -> bool
 


### PR DESCRIPTION
I've drafted a PR of some updates to the sphinx docs, as requested on a prev. PR for this issue by @AlexWaygood[0].

- Add a note recommending the use of the async context factories `timeout()` and `timeout_at()`
- Add the missing argument to the class definition
- Add a description of what the `when` param does, and it's possible values.

[0]. https://github.com/python/cpython/pull/102811#issuecomment-1475361441

<!-- gh-issue-number: gh-102810 -->
* Issue: gh-102810
<!-- /gh-issue-number -->
