### PR TITLE
gh-102936: typing: document performance pitfalls of protocols decorated with `@runtime_checkable`

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1585,10 +1585,11 @@ These are not used in annotations. They are building blocks for creating generic
       assert isinstance(open('/some/file'), Closable)
 
       @runtime_checkable
-      class HasErrNo(Protocol):
-          errno: int
+      class Named(Protocol):
+          name: str
 
-      assert isinstance(OSError(42, 'foo'), HasErrNo)
+      import threading
+      assert isinstance(threading.Thread(name='Bob'), Named)
 
    .. note::
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1584,15 +1584,30 @@ These are not used in annotations. They are building blocks for creating generic
 
       assert isinstance(open('/some/file'), Closable)
 
+      @runtime_checkable
+      class HasErrNo(Protocol):
+          errno: int
+
+      assert isinstance(OSError(42, 'foo'), HasErrNo)
+
    .. note::
 
-        :func:`runtime_checkable` will check only the presence of the required
-        methods, not their type signatures. For example, :class:`ssl.SSLObject`
+        :func:`!runtime_checkable` will check only the presence of the required
+        methods or attributes, not their type signatures or types.
+        For example, :class:`ssl.SSLObject`
         is a class, therefore it passes an :func:`issubclass`
         check against :data:`Callable`.  However, the
         ``ssl.SSLObject.__init__`` method exists only to raise a
         :exc:`TypeError` with a more informative message, therefore making
         it impossible to call (instantiate) :class:`ssl.SSLObject`.
+
+   .. note::
+
+        An :func:`isinstance` check against a runtime-checkable protocol can be
+        surprisingly slow compared to an ``isinstance()`` check against
+        a non-protocol class. Consider using alternative idioms such as
+        :func:`hasattr` calls for structural checks in performance-sensitive
+        code.
 
    .. versionadded:: 3.8
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-102936 -->
* Issue: gh-102936
<!-- /gh-issue-number -->
