### PR TITLE
gh-102939: Fix "conversion from Py_ssize_t to long" warning in builtins

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2503,7 +2503,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
                 Py_DECREF(iter);
                 if (PyErr_Occurred())
                     return NULL;
-                return PyLong_FromLong(i_result);
+                return PyLong_FromSsize_t(i_result);
             }
             if (PyLong_CheckExact(item) || PyBool_Check(item)) {
                 Py_ssize_t b;
@@ -2525,7 +2525,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
                 }
             }
             /* Either overflowed or is not an int. Restore real objects and process normally */
-            result = PyLong_FromLong(i_result);
+            result = PyLong_FromSsize_t(i_result);
             if (result == NULL) {
                 Py_DECREF(item);
                 Py_DECREF(iter);


### PR DESCRIPTION
Since we now work with `Py_size_t` instead of `long` (see https://github.com/python/cpython/commit/7559f5fda94ab568a1a910b17683ed81dc3426fb#diff-e4fd8b8ee6a147f86c0719ff122aca6dfca36edbd4812c87892698b3b72e40a1) I've change the `PyLong_` constructor.

<!-- gh-issue-number: gh-102939 -->
* Issue: gh-102939
<!-- /gh-issue-number -->
