### PR TITLE
gh-102941: Fix "‘subobj’ may be used uninitialized in this function" warning in `bytes_methods.c`

### DIFF
--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -774,7 +774,7 @@ _Py_bytes_tailmatch(const char *str, Py_ssize_t len,
 {
     Py_ssize_t start = 0;
     Py_ssize_t end = PY_SSIZE_T_MAX;
-    PyObject *subobj;
+    PyObject *subobj = NULL;
     int result;
 
     if (!stringlib_parse_args_finds(function_name, args, &subobj, &start, &end))


### PR DESCRIPTION
I still think that this warning is a false positive and there's no way to actually abuse it.
So, I hope that `= NULL` will just make it go away.

<!-- gh-issue-number: gh-102941 -->
* Issue: gh-102941
<!-- /gh-issue-number -->
