### PR TITLE
[3.10] gh-102947: Improve traceback when calling `fields()` on a non-dataclass (#102948)

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1195,7 +1195,7 @@ def fields(class_or_instance):
     try:
         fields = getattr(class_or_instance, _FIELDS)
     except AttributeError:
-        raise TypeError('must be called with a dataclass type or instance')
+        raise TypeError('must be called with a dataclass type or instance') from None
 
     # Exclude pseudo-fields.  Note that fields is sorted by insertion
     # order, so the order of the tuple is as the fields were defined.

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -5,10 +5,12 @@
 from dataclasses import *
 
 import abc
+import io
 import pickle
 import inspect
 import builtins
 import types
+import traceback
 import unittest
 from unittest.mock import Mock
 from typing import ClassVar, Any, List, Union, Tuple, Dict, Generic, TypeVar, Optional, Protocol
@@ -1413,6 +1415,16 @@ class TestCase(unittest.TestCase):
             fields(C)
         with self.assertRaisesRegex(TypeError, 'dataclass type or instance'):
             fields(C())
+
+    def test_clean_traceback_from_fields_exception(self):
+        stdout = io.StringIO()
+        try:
+            fields(object)
+        except TypeError as exc:
+            traceback.print_exception(exc, file=stdout)
+        printed_traceback = stdout.getvalue()
+        self.assertNotIn("AttributeError", printed_traceback)
+        self.assertNotIn("__dataclass_fields__", printed_traceback)
 
     def test_helper_asdict(self):
         # Basic tests for asdict(), it should return a new dictionary.

--- a/Misc/NEWS.d/next/Library/2023-03-23-13-34-33.gh-issue-102947.cTwcpU.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-23-13-34-33.gh-issue-102947.cTwcpU.rst
@@ -1,0 +1,2 @@
+Improve traceback when :func:`dataclasses.fields` is called on a
+non-dataclass. Patch by Alex Waygood


### PR DESCRIPTION
(cherry picked from commit https://github.com/python/cpython/commit/baf4eb083c09b323cc12b8636c28c14089b87de8)

<!-- gh-issue-number: gh-102947 -->
* Issue: gh-102947
<!-- /gh-issue-number -->
