### PR TITLE
gh-102733: Stop the `getsitepackages` function from returning non site package directories on windows

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -372,7 +372,6 @@ def getsitepackages(prefixes=None):
                                     "site-packages")
                 sitepackages.append(path)
         else:
-            sitepackages.append(prefix)
             sitepackages.append(os.path.join(prefix, "Lib", "site-packages"))
     return sitepackages
 

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -298,10 +298,9 @@ class HelperFunctionsTests(unittest.TestCase):
             self.assertEqual(dirs[-1], wanted)
         else:
             # other platforms
-            self.assertEqual(len(dirs), 2)
-            self.assertEqual(dirs[0], 'xoxo')
+            self.assertEqual(len(dirs), 1)
             wanted = os.path.join('xoxo', 'lib', 'site-packages')
-            self.assertEqual(os.path.normcase(dirs[1]),
+            self.assertEqual(os.path.normcase(dirs[0]),
                              os.path.normcase(wanted))
 
     @unittest.skipUnless(HAS_USER_SITE, 'need user site')

--- a/Misc/NEWS.d/next/Windows/2023-03-24-22-06-39.gh-issue-102733.ULXi9K.rst
+++ b/Misc/NEWS.d/next/Windows/2023-03-24-22-06-39.gh-issue-102733.ULXi9K.rst
@@ -1,0 +1,1 @@
+Stop the :func:`site.getsitepackages` function from returning non-site package directories on windows. Patch by Robert Prater


### PR DESCRIPTION
### Description
Stop the `site.getsitepackages` method from returning nonsite package directories on Windows.

### Before 
```python 
Python 3.10.10 (tags/v3.10.10:aad5f6a, Feb  7 2023, 17:20:36) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import site
>>> site.getsitepackages()
['C:\\Users\\Administrator\\AppData\\Local\\Programs\\Python\\Python310', 'C:\\Users\\Administrator\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages']
```
### After
```python
Python 3.12.0a6+ (heads/issue-102733:e63679c328, Mar 24 2023, 22:54:23) [MSC v.1935 64 bit (AMD64)] on win32 on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import site
>>> site.getsitepackages()
['C:\\Users\\Administrator\\Documents\\rprater\\cpython\\Lib\\site-packages']
```

<!-- gh-issue-number: gh-102733 -->
* Issue: gh-102733
<!-- /gh-issue-number -->
