### PR TITLE
gh-102988: Detect email address parsing errors and return empty tuple to indicate the parsing error (old API)

### DIFF
--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -122,6 +122,7 @@ def _post_parse_validation(parsedvalues):
     for v in parsedvalues:
         if '[' in v[1]:
             parsedvalues.remove(v)
+            parsedvalues.append(('', ''))
 
     return parsedvalues
 

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -106,12 +106,41 @@ def formataddr(pair, charset='utf-8'):
     return address
 
 
+def _pre_parse_validation(fieldvalues):
+    """Validate the field values are syntactically correct"""
+    for v in fieldvalues:
+        s = str(v).replace('\\(', '').replace('\\)', '')
+        if s.count('(') != s.count(')'):
+            fieldvalues.remove(v)
+            fieldvalues.append('')
+
+    return fieldvalues
+
+
+def _post_parse_validation(parsedvalues):
+    """Validate the parsed values are syntactically correct"""
+    for v in parsedvalues:
+        if '[' in v[1]:
+            parsedvalues.remove(v)
+
+    return parsedvalues
+
 
 def getaddresses(fieldvalues):
     """Return a list of (REALNAME, EMAIL) for each fieldvalue."""
+    fieldvalues = _pre_parse_validation(fieldvalues)
     all = COMMASPACE.join(str(v) for v in fieldvalues)
     a = _AddressList(all)
-    return a.addresslist
+    result = _post_parse_validation(a.addresslist)
+
+    n = 0
+    for v in fieldvalues:
+        n += str(v).count(',') + 1
+
+    if len(result) != n:
+        return [('', '')]
+
+    return result
 
 
 def _format_timetuple_and_zone(timetuple, zone):
@@ -212,9 +241,18 @@ def parseaddr(addr):
     Return a tuple of realname and email address, unless the parse fails, in
     which case return a 2-tuple of ('', '').
     """
-    addrs = _AddressList(addr).addresslist
-    if not addrs:
-        return '', ''
+    if type(addr) == list:
+        addr = addr[0]
+
+    if type(addr) != str:
+        return ('', '')
+
+    addr = _pre_parse_validation([addr])[0]
+    addrs = _post_parse_validation(_AddressList(addr).addresslist)
+
+    if not addrs or len(addrs) > 1:
+        return ('', '')
+
     return addrs[0]
 
 

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3319,15 +3319,90 @@ Foo
            [('Al Person', 'aperson@dom.ain'),
             ('Bud Person', 'bperson@dom.ain')])
 
+    def test_getaddresses_parsing_errors(self):
+        """Test for parsing errors from CVE-2023-27043"""
+        eq = self.assertEqual
+        eq(utils.getaddresses(['alice@example.org(<bob@example.com>']),
+           [('' ,'')])
+        eq(utils.getaddresses(['alice@example.org)<bob@example.com>']),
+           [('' ,'')])
+        eq(utils.getaddresses(['alice@example.org<<bob@example.com>']),
+           [('' ,'')])
+        eq(utils.getaddresses(['alice@example.org><bob@example.com>']),
+           [('' ,'')])
+        eq(utils.getaddresses(['alice@example.org@<bob@example.com>']),
+           [('' ,'')])
+        eq(utils.getaddresses(['alice@example.org,<bob@example.com>']),
+           [('', 'alice@example.org'), ('', 'bob@example.com')])
+        eq(utils.getaddresses(['alice@example.org;<bob@example.com>']),
+           [('' ,'')])
+        eq(utils.getaddresses(['alice@example.org:<bob@example.com>']),
+           [('' ,'')])
+        eq(utils.getaddresses(['alice@example.org.<bob@example.com>']),
+           [('' ,'')])
+        eq(utils.getaddresses(['alice@example.org"<bob@example.com>']),
+           [('' ,'')])
+        eq(utils.getaddresses(['alice@example.org[<bob@example.com>']),
+           [('' ,'')])
+        eq(utils.getaddresses(['alice@example.org]<bob@example.com>']),
+           [('' ,'')])
+
+    def test_parseaddr_parsing_errors(self):
+        """Test for parsing errors from CVE-2023-27043"""
+        eq = self.assertEqual
+        eq(utils.parseaddr(['alice@example.org(<bob@example.com>']),
+           ('' ,''))
+        eq(utils.parseaddr(['alice@example.org)<bob@example.com>']),
+           ('' ,''))
+        eq(utils.parseaddr(['alice@example.org<<bob@example.com>']),
+           ('' ,''))
+        eq(utils.parseaddr(['alice@example.org><bob@example.com>']),
+           ('' ,''))
+        eq(utils.parseaddr(['alice@example.org@<bob@example.com>']),
+           ('' ,''))
+        eq(utils.parseaddr(['alice@example.org,<bob@example.com>']),
+           ('' ,''))
+        eq(utils.parseaddr(['alice@example.org;<bob@example.com>']),
+           ('' ,''))
+        eq(utils.parseaddr(['alice@example.org:<bob@example.com>']),
+           ('' ,''))
+        eq(utils.parseaddr(['alice@example.org.<bob@example.com>']),
+           ('' ,''))
+        eq(utils.parseaddr(['alice@example.org"<bob@example.com>']),
+           ('' ,''))
+        eq(utils.parseaddr(['alice@example.org[<bob@example.com>']),
+           ('' ,''))
+        eq(utils.parseaddr(['alice@example.org]<bob@example.com>']),
+           ('' ,''))
+
     def test_getaddresses_nasty(self):
         eq = self.assertEqual
         eq(utils.getaddresses(['foo: ;']), [('', '')])
-        eq(utils.getaddresses(
-           ['[]*-- =~$']),
-           [('', ''), ('', ''), ('', '*--')])
+        eq(utils.getaddresses(['[]*-- =~$']), [('', '')])
         eq(utils.getaddresses(
            ['foo: ;', '"Jason R. Mastaler" <jason@dom.ain>']),
            [('', ''), ('Jason R. Mastaler', 'jason@dom.ain')])
+        eq(utils.getaddresses(
+           ['Pete(A nice \) chap) <pete(his account)@silly.test(his host)>']),
+           [('Pete (A nice ) chap his account his host)', 'pete@silly.test')])
+        eq(utils.getaddresses(
+           ['(Empty list)(start)Undisclosed recipients  :(nobody(I know))']),
+           [('', '')])
+        eq(utils.getaddresses(
+           ['Mary <@machine.tld:mary@example.net>, , jdoe@test   . example']),
+           [('Mary', 'mary@example.net'), ('', ''), ('', 'jdoe@test.example')])
+        eq(utils.getaddresses(
+           ['John Doe <jdoe@machine(comment).  example>']),
+           [('John Doe (comment)', 'jdoe@machine.example')])
+        eq(utils.getaddresses(
+           ['"Mary Smith: Personal Account" <smith@home.example>']),
+           [('Mary Smith: Personal Account', 'smith@home.example')])
+        eq(utils.getaddresses(
+           ['Undisclosed recipients:;']),
+           [('', '')])
+        eq(utils.getaddresses(
+           ['<boss@nil.test>, "Giant; \"Big\" Box" <bob@example.net>']),
+           [('', 'boss@nil.test'), ('Giant;  Big  Box', 'bob@example.net')])
 
     def test_getaddresses_embedded_comment(self):
         """Test proper handling of a nested comment"""


### PR DESCRIPTION
# Pull Request title

gh-102988: This PR is designed to detect parsing errors and return an empty tuple to indicate the parsing error. Additionally, this PR updates the `test_email.py` to check for these bugs, as well as, adds some other wacky Address Headers that are in the examples of RFC 2822 and makes sure they are being parsed correctly.

I realize that this PR dose not actually track down the bug and fix it. It simply detects the error has happened and returns a parsing error. However, `Lib/email/utils.py` is a much simple file than `Lib/email/_parseaddr.py`, so it is much easier to review this change. Additionally, there are actually multiple bugs which are causing erroneous  output. Tracing the code flow for each and fixing them would be prone to error considering all of the wacky stuff that RFC 2822 allows for in Address headers. Finally, this change is actually rather simple.
