### PR TITLE
gh-101100: Test only Doc/ files in nit-picky mode

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -57,6 +57,8 @@ jobs:
     - name: 'Get list of changed files'
       id: changed_files
       uses: Ana06/get-changed-files@v2.2.0
+      with:
+        filter: "Doc/**"
     - name: 'Build changed files in nit-picky mode'
       continue-on-error: true
       run: |


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Follow on from https://github.com/python/cpython/pull/102513.

To fix https://github.com/python/cpython/pull/102513#issuecomment-1483414024.

The problem is that the https://github.com/Ana06/get-changed-files action gives an error if there's a filename with a space, for example, a news file such as `Misc/NEWS.d/next/Core and Builtins/2023-03-17-12-09-45.gh-issue-100982.Pf_BI6.rst`.

The error suggests using another format:

> Error: One of your files includes a space. Consider using a different output format or removing spaces from your filenames. Please submit an issue on this action's GitHub repo.

We can get in CSV or JSON format instead:

* https://github.com/Ana06/get-changed-files#get-all-added-and-modified-files-as-csv

But that would require some refactoring, as we need to `touch` the list of files.

The quick fix is to filter for files in the `Doc/` directory, to only consider those:

* https://github.com/Ana06/get-changed-files#filtering

It would of course be good to check the NEWS files, but it's less urgent than fixing the CI and unblocking other PRs!

# Demo

https://github.com/hugovk/cpython/pull/45 is a PR that modifies a `Doc/` file plus a `Misc/NEWS.d/next/Core and Builtins/` file, and the "Docs / Docs" CI check fails, as expected.

https://github.com/hugovk/cpython/pull/44 is the same but also has this change, and "Docs / Docs" passes.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
