### PR TITLE
gh-103023: Add SyntaxError check in pdb's `display` command

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1445,7 +1445,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         else:
             val, exc = self._getval_except(arg)
             if isinstance(exc, SyntaxError):
-                self.message(f'Unable to display "{arg}": SyntaxError')
+                self.message('Unable to display %s: %r' % (arg, val))
             else:
                 self.displaying.setdefault(self.curframe, {})[arg] = val
                 self.message('display %s: %r' % (arg, val))

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1249,9 +1249,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 return eval(arg, self.curframe.f_globals, self.curframe_locals), None
             else:
                 return eval(arg, frame.f_globals, frame.f_locals), None
-        except Exception as e:
-            err = traceback.format_exception_only(e)[-1].strip()
-            return _rstr('** raised %s **' % err), e
+        except BaseException as exc:
+            err = traceback.format_exception_only(exc)[-1].strip()
+            return _rstr('** raised %s **' % err), exc
 
     def _error_exc(self):
         exc_info = sys.exc_info()[:2]

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -399,7 +399,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         displaying = self.displaying.get(self.curframe)
         if displaying:
             for expr, oldvalue in displaying.items():
-                newvalue = self._getval_except(expr)
+                newvalue, _ = self._getval_except(expr)
                 # check for identity first; this prevents custom __eq__ to
                 # be called at every loop, and also prevents instances whose
                 # fields are changed to be displayed
@@ -1246,13 +1246,12 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def _getval_except(self, arg, frame=None):
         try:
             if frame is None:
-                return eval(arg, self.curframe.f_globals, self.curframe_locals)
+                return eval(arg, self.curframe.f_globals, self.curframe_locals), None
             else:
-                return eval(arg, frame.f_globals, frame.f_locals)
-        except:
-            exc_info = sys.exc_info()[:2]
-            err = traceback.format_exception_only(*exc_info)[-1].strip()
-            return _rstr('** raised %s **' % err)
+                return eval(arg, frame.f_globals, frame.f_locals), None
+        except Exception as e:
+            err = traceback.format_exception_only(e)[-1].strip()
+            return _rstr('** raised %s **' % err), e
 
     def _error_exc(self):
         exc_info = sys.exc_info()[:2]
@@ -1441,9 +1440,12 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             for item in self.displaying.get(self.curframe, {}).items():
                 self.message('%s: %r' % item)
         else:
-            val = self._getval_except(arg)
-            self.displaying.setdefault(self.curframe, {})[arg] = val
-            self.message('display %s: %r' % (arg, val))
+            val, exc = self._getval_except(arg)
+            if isinstance(exc, SyntaxError):
+                self.message(f'Unable to display "{arg}": SyntaxError')
+            else:
+                self.displaying.setdefault(self.curframe, {})[arg] = val
+                self.message('display %s: %r' % (arg, val))
 
     complete_display = _complete_expression
 

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1436,9 +1436,12 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         Without expression, list all display expressions for the current frame.
         """
         if not arg:
-            self.message('Currently displaying:')
-            for item in self.displaying.get(self.curframe, {}).items():
-                self.message('%s: %r' % item)
+            if self.displaying:
+                self.message('Currently displaying:')
+                for item in self.displaying.get(self.curframe, {}).items():
+                    self.message('%s: %r' % item)
+            else:
+                self.message('No expression is being displayed')
         else:
             val, exc = self._getval_except(arg)
             if isinstance(exc, SyntaxError):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -586,6 +586,7 @@ def test_pdb_display_command():
     ...     a = 4
 
     >>> with PdbTestInput([  # doctest: +ELLIPSIS
+    ...     'display +',
     ...     'display a',
     ...     'n',
     ...     'display',
@@ -600,6 +601,8 @@ def test_pdb_display_command():
     ...    test_function()
     > <doctest test.test_pdb.test_pdb_display_command[0]>(4)test_function()
     -> a = 1
+    (Pdb) display +
+    Unable to display "+": SyntaxError
     (Pdb) display a
     display a: 0
     (Pdb) n

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -587,6 +587,7 @@ def test_pdb_display_command():
 
     >>> with PdbTestInput([  # doctest: +ELLIPSIS
     ...     'display +',
+    ...     'display',
     ...     'display a',
     ...     'n',
     ...     'display',
@@ -603,6 +604,8 @@ def test_pdb_display_command():
     -> a = 1
     (Pdb) display +
     Unable to display "+": SyntaxError
+    (Pdb) display
+    No expression is being displayed
     (Pdb) display a
     display a: 0
     (Pdb) n

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -603,7 +603,7 @@ def test_pdb_display_command():
     > <doctest test.test_pdb.test_pdb_display_command[0]>(4)test_function()
     -> a = 1
     (Pdb) display +
-    Unable to display "+": SyntaxError
+    Unable to display +: ** raised SyntaxError: invalid syntax **
     (Pdb) display
     No expression is being displayed
     (Pdb) display a

--- a/Misc/NEWS.d/next/Library/2023-03-25-02-08-05.gh-issue-103023.Qfn7Hl.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-25-02-08-05.gh-issue-103023.Qfn7Hl.rst
@@ -1,1 +1,2 @@
-Added SyntaxError check on :mod:`pdb`'s display command
+It's no longer possible to register expressions to display in
+:class:`~pdb.Pdb` that raise :exc:`SyntaxError`. Patch by Tian Gao.

--- a/Misc/NEWS.d/next/Library/2023-03-25-02-08-05.gh-issue-103023.Qfn7Hl.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-25-02-08-05.gh-issue-103023.Qfn7Hl.rst
@@ -1,0 +1,1 @@
+Added SyntaxError check on :mod:`pdb`'s display command


### PR DESCRIPTION
In this PR, extra stuff was cleaned up a bit:
1. `sys.exc_info()` is no longer needed now that `format_exception_only` supported exception object directly.
2. A clearer message is sent to the users when no expression is being displayed

<!-- gh-issue-number: gh-103023 -->
* Issue: gh-103023
<!-- /gh-issue-number -->
