### PR TITLE
gh-103025: fix ctypes doc issues 

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -375,8 +375,8 @@ that they can be converted to the required C data type::
 
 .. _ctypes-calling-variadic-functions:
 
-Calling varadic functions
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Calling variadic functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On a lot of platforms calling variadic functions through ctypes is exactly the same
 as calling functions with a fixed number of parameters. On some platforms, and in
@@ -508,7 +508,7 @@ a string pointer and a char, and returns a pointer to a string::
 
 If you want to avoid the ``ord("x")`` calls above, you can set the
 :attr:`argtypes` attribute, and the second argument will be converted from a
-single character Python bytes object into a C char::
+single character Python bytes object into a C char:
 
 .. doctest::
 


### PR DESCRIPTION
1/ Rectify typo 'varadic' functions to 'variadic'. 

2/ Fix doctest directive mistake.



<!-- gh-issue-number: gh-103025 -->
* Issue: gh-103025
<!-- /gh-issue-number -->
