### PR TITLE
gh-103046: Display current line correctly for `dis.disco()` with CACHE entries

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -581,7 +581,12 @@ def _disassemble_bytes(code, lasti=-1, varname_from_oparg=None,
                            instr.offset > 0)
         if new_source_line:
             print(file=file)
-        is_current_instr = instr.offset == lasti
+        if show_caches:
+            is_current_instr = instr.offset == lasti
+        else:
+            # Each CACHE takes 2 bytes
+            is_current_instr = instr.offset <= lasti \
+                <= instr.offset + 2 * _inline_cache_entries[_deoptop(instr.opcode)]
         print(instr._disassemble(lineno_width, is_current_instr, offset_width),
               file=file)
     if exception_entries:

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1218,8 +1218,13 @@ class DisTests(DisTestBase):
         else:
             self.fail("Can't find a CACHE entry in the function provided to do the test")
 
-        self.assertEqual(self.get_disassembly(f.__code__, lasti=op_offset, wrapper=False),
-                         self.get_disassembly(f.__code__, lasti=cache_offset, wrapper=False))
+        assem_op = self.get_disassembly(f.__code__, lasti=op_offset, wrapper=False)
+        assem_cache = self.get_disassembly(f.__code__, lasti=cache_offset, wrapper=False)
+
+        # Make sure --> exists and points to the correct offset
+        self.assertRegex(assem_op, fr"-->\s+{op_offset}")
+        # Make sure when lasti points to cache, it shows the same disassembly
+        self.assertEqual(assem_op, assem_cache)
 
 
 class DisWithFileTests(DisTests):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1198,6 +1198,17 @@ class DisTests(DisTestBase):
                     self.assertEqual(caches.count(""), empty_caches)
                     self.assertEqual(len(caches), total_caches)
 
+    @cpython_only
+    def test_show_currinstr_with_cache(self):
+        def f():
+            print(a)
+        # The code above should generate a LOAD_GLOBAL which has CACHE instr after
+        # Make sure that with lasti pointing to CACHE, it still shows the current
+        # line correctly
+        self.assertEqual(self.get_disassembly(f.__code__, lasti=2, wrapper=False),
+                         self.get_disassembly(f.__code__, lasti=4, wrapper=False))
+
+
 class DisWithFileTests(DisTests):
 
     # Run the tests again, using the file arg instead of print

--- a/Misc/NEWS.d/next/Library/2023-03-26-20-54-57.gh-issue-103046.xBlA2l.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-26-20-54-57.gh-issue-103046.xBlA2l.rst
@@ -1,1 +1,1 @@
-Display current line label correctly for :mod:`dis` when CACHE entries exist
+Display current line label correctly in :mod:`dis` when ``show_caches`` is False and ``lasti`` points to a CACHE entry.

--- a/Misc/NEWS.d/next/Library/2023-03-26-20-54-57.gh-issue-103046.xBlA2l.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-26-20-54-57.gh-issue-103046.xBlA2l.rst
@@ -1,0 +1,1 @@
+Display current line label correctly for :mod:`dis` when CACHE entries exist


### PR DESCRIPTION


<!-- gh-issue-number: gh-103046 -->
* Issue: gh-103046
<!-- /gh-issue-number -->
