### PR TITLE
gh-101659: initialize stack variable _sharedexception

### DIFF
--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -481,7 +481,7 @@ _run_script_in_interpreter(PyObject *mod, PyInterpreterState *interp,
     }
 
     // Run the script.
-    _sharedexception exc;
+    _sharedexception exc = no_exception;
     int result = _run_script(interp, codestr, shared, &exc);
 
     // Switch back.


### PR DESCRIPTION
In `./Modules/_xxsubinterpretersmodule.c` a variable `_sharedexception exc` on stack is declared introduced in #102659. The variable is not initialized.

In `_run_script`, it's possible that the function hits an error and goes to `error` label without properly initializing the variable. Then `_sharedexception_bind` can also potentially error out to trigger `_sharedexception_clear(sharedexc)`, which may free the uninitialized pointer. I have not found an exploit on this, but there's a potential path. Also the fix is so easy and cheap so I think we can just initialize the variable with `no_exception` (basically `{0}`).

Oh BTW, gcc complains with the possible unitialized variable.

I would guess @ericsnowcurrently is the right person to review this? Thanks!

<!-- gh-issue-number: gh-101659 -->
* Issue: gh-101659
<!-- /gh-issue-number -->
