### PR TITLE
gh-103068: Check condition expression of breakpoints for pdb

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -377,8 +377,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         # stop when the debuggee is returning from such generators.
         prefix = 'Internal ' if (not exc_traceback
                                     and exc_type is StopIteration) else ''
-        self.message('%s%s' % (prefix,
-            traceback.format_exception_only(exc_type, exc_value)[-1].strip()))
+        self.message('%s%s' % (prefix, self._format_exc(exc_value)))
         self.interaction(frame, exc_traceback)
 
     # General interaction function
@@ -851,7 +850,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         try:
             compile(expr, "<stdin>", "eval")
         except SyntaxError as exc:
-            return _rstr(traceback.format_exception_only(exc)[-1].strip())
+            return _rstr(self._format_exc(exc))
         return None
 
     def do_enable(self, arg):
@@ -1267,12 +1266,11 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             else:
                 return eval(arg, frame.f_globals, frame.f_locals)
         except BaseException as exc:
-            err = traceback.format_exception_only(exc)[-1].strip()
-            return _rstr('** raised %s **' % err)
+            return _rstr('** raised %s **' % self._format_exc(exc))
 
     def _error_exc(self):
-        exc_info = sys.exc_info()[:2]
-        self.error(traceback.format_exception_only(*exc_info)[-1].strip())
+        exc = sys.exc_info()[1]
+        self.error(self._format_exc(exc))
 
     def _msg_val_func(self, arg, func):
         try:
@@ -1663,6 +1661,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         __main__.__dict__.update(target.namespace)
 
         self.run(target.code)
+
+    def _format_exc(self, exc: BaseException):
+        return traceback.format_exception_only(exc)[-1].strip()
 
 
 # Collect all command help into docstring, if not run with -OO

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -266,6 +266,8 @@ def test_pdb_breakpoint_commands():
     ...     'commands 10',  # out of range
     ...     'commands a',   # display help
     ...     'commands 4',   # already deleted
+    ...     'break 6, undefined', # condition causing `NameError` during evaluation
+    ...     'continue', # will stop, ignoring runtime error
     ...     'continue',
     ... ]):
     ...    test_function()
@@ -337,8 +339,13 @@ def test_pdb_breakpoint_commands():
             end
     (Pdb) commands 4
     *** cannot set commands: Breakpoint 4 already deleted
+    (Pdb) break 6, undefined
+    Breakpoint 5 at <doctest test.test_pdb.test_pdb_breakpoint_commands[0]>:6
     (Pdb) continue
     3
+    > <doctest test.test_pdb.test_pdb_breakpoint_commands[0]>(6)test_function()
+    -> print(4)
+    (Pdb) continue
     4
     """
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -603,6 +603,7 @@ def test_pdb_display_command():
     ...     'undisplay',
     ...     'display a < 1',
     ...     'n',
+    ...     'display undefined',
     ...     'continue',
     ... ]):
     ...    test_function()
@@ -633,6 +634,8 @@ def test_pdb_display_command():
     (Pdb) n
     > <doctest test.test_pdb.test_pdb_display_command[0]>(7)test_function()
     -> a = 4
+    (Pdb) display undefined
+    display undefined: ** raised NameError: name 'undefined' is not defined **
     (Pdb) continue
     """
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -240,9 +240,11 @@ def test_pdb_breakpoint_commands():
 
     >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
     ...     'break 3',
+    ...     'break 4, +',
     ...     'disable 1',
     ...     'ignore 1 10',
     ...     'condition 1 1 < 2',
+    ...     'condition 1 1 <',
     ...     'break 4',
     ...     'break 4',
     ...     'break',
@@ -271,12 +273,16 @@ def test_pdb_breakpoint_commands():
     -> print(1)
     (Pdb) break 3
     Breakpoint 1 at <doctest test.test_pdb.test_pdb_breakpoint_commands[0]>:3
+    (Pdb) break 4, +
+    *** Invalid condition +: SyntaxError: invalid syntax
     (Pdb) disable 1
     Disabled breakpoint 1 at <doctest test.test_pdb.test_pdb_breakpoint_commands[0]>:3
     (Pdb) ignore 1 10
     Will ignore next 10 crossings of breakpoint 1.
     (Pdb) condition 1 1 < 2
     New condition set for breakpoint 1.
+    (Pdb) condition 1 1 <
+    *** Invalid condition 1 <: SyntaxError: invalid syntax
     (Pdb) break 4
     Breakpoint 2 at <doctest test.test_pdb.test_pdb_breakpoint_commands[0]>:4
     (Pdb) break 4
@@ -603,7 +609,7 @@ def test_pdb_display_command():
     > <doctest test.test_pdb.test_pdb_display_command[0]>(4)test_function()
     -> a = 1
     (Pdb) display +
-    Unable to display +: ** raised SyntaxError: invalid syntax **
+    *** Unable to display +: SyntaxError: invalid syntax
     (Pdb) display
     No expression is being displayed
     (Pdb) display a

--- a/Misc/NEWS.d/next/Library/2023-03-28-05-14-59.gh-issue-103068.YQTmrA.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-28-05-14-59.gh-issue-103068.YQTmrA.rst
@@ -1,0 +1,1 @@
+Breakpoint's condition expression is checked for SyntaxError on :mod:`pdb`.

--- a/Misc/NEWS.d/next/Library/2023-03-28-05-14-59.gh-issue-103068.YQTmrA.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-28-05-14-59.gh-issue-103068.YQTmrA.rst
@@ -1,1 +1,2 @@
-Breakpoint's condition expression is checked for SyntaxError on :mod:`pdb`.
+It's no longer possible to register conditional breakpoints in
+:class:`~pdb.Pdb` that raise :exc:`SyntaxError`. Patch by Tian Gao.


### PR DESCRIPTION
If the condition expression is not even valid, we should ignore the command and warn the users.

As this is a similar check as `display`, I made some modifications for `display` command so they are using the same logic. This also freed `_getval_except` to do what it used to do - provide the string regardless of the exception. Also, `self.error` is used for `display` command when it failed because that's what other(most of?) commands do and it will make the most of sense to users.

walrus operator is used but this will merge back to 3.10 at most, so all the versions affected should support it.

<!-- gh-issue-number: gh-103068 -->
* Issue: gh-103068
<!-- /gh-issue-number -->
