### PR TITLE
gh-102994: Profile docs has typo in example

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -82,7 +82,7 @@ the following::
 
 The first line indicates that 214 calls were monitored.  Of those calls, 207
 were :dfn:`primitive`, meaning that the call was not induced via recursion. The
-next line: ``Ordered by: cumulative name``, indicates that the text string in the
+next line: ``Ordered by: cumulative time``, indicates that the text string in the
 far right column was used to sort the output. The column headings include:
 
 ncalls


### PR DESCRIPTION
[fixes](https://github.com/python/cpython/pull/103074/commits/b5c67c67a803afa918aa213395e3a3c66dadf286) https://github.com/python/cpython/issues/102994

<!-- gh-issue-number: gh-102994 -->
* Issue: gh-102994
<!-- /gh-issue-number -->
