### PR TITLE
gh-100227: Make the Global PyModuleDef Cache Safe for Isolated Interpreters

### DIFF
--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -14,13 +14,15 @@ struct _import_runtime_state {
        which is just about every time an extension module is imported.
        See PyInterpreterState.modules_by_index for more info. */
     Py_ssize_t last_module_index;
-    /* A dict mapping (filename, name) to PyModuleDef for modules.
-       Only legacy (single-phase init) extension modules are added
-       and only if they support multiple initialization (m_size >- 0)
-       or are imported in the main interpreter.
-       This is initialized lazily in _PyImport_FixupExtensionObject().
-       Modules are added there and looked up in _imp.find_extension(). */
-    PyObject *extensions;
+    struct {
+        /* A dict mapping (filename, name) to PyModuleDef for modules.
+           Only legacy (single-phase init) extension modules are added
+           and only if they support multiple initialization (m_size >- 0)
+           or are imported in the main interpreter.
+           This is initialized lazily in _PyImport_FixupExtensionObject().
+           Modules are added there and looked up in _imp.find_extension(). */
+        PyObject *dict;
+    } extensions;
     /* Package context -- the full module name for package imports */
     const char * pkgcontext;
 };

--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -15,6 +15,10 @@ struct _import_runtime_state {
        See PyInterpreterState.modules_by_index for more info. */
     Py_ssize_t last_module_index;
     struct {
+        /* A thread state tied to the main interpreter,
+           used exclusively for when the extensions dict is access/modified
+           from an arbitrary thread. */
+        PyThreadState main_tstate;
         /* A dict mapping (filename, name) to PyModuleDef for modules.
            Only legacy (single-phase init) extension modules are added
            and only if they support multiple initialization (m_size >- 0)

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -126,7 +126,9 @@ PyAPI_FUNC(void) _PyThreadState_Bind(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_Init(
     PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_DeleteExcept(PyThreadState *tstate);
+
 extern void _PyThreadState_InitDetached(PyThreadState *, PyInterpreterState *);
+extern void _PyThreadState_ClearDetached(PyThreadState *);
 
 
 static inline void

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -129,6 +129,8 @@ PyAPI_FUNC(void) _PyThreadState_DeleteExcept(PyThreadState *tstate);
 
 extern void _PyThreadState_InitDetached(PyThreadState *, PyInterpreterState *);
 extern void _PyThreadState_ClearDetached(PyThreadState *);
+extern void _PyThreadState_BindDetached(PyThreadState *);
+extern void _PyThreadState_UnbindDetached(PyThreadState *);
 
 
 static inline void

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -126,6 +126,7 @@ PyAPI_FUNC(void) _PyThreadState_Bind(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_Init(
     PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_DeleteExcept(PyThreadState *tstate);
+extern void _PyThreadState_InitDetached(PyThreadState *, PyInterpreterState *);
 
 
 static inline void

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -41,6 +41,11 @@ extern PyTypeObject _PyExc_MemoryError;
            in accordance with the specification. */ \
         .autoTSSkey = Py_tss_NEEDS_INIT, \
         .parser = _parser_runtime_state_INIT, \
+        .imports = { \
+            .extensions = { \
+                .main_tstate = _PyThreadState_INIT, \
+            }, \
+        }, \
         .ceval = { \
             .perf = _PyEval_RUNTIME_PERF_INIT, \
         }, \

--- a/Python/import.c
+++ b/Python/import.c
@@ -1004,8 +1004,6 @@ _extensions_cache_delete(PyObject *filename, PyObject *name)
         goto finally;
     }
 
-    _PyThreadState_BindDetached(&EXTENSIONS.main_tstate);
-
     PyObject *extensions = EXTENSIONS.dict;
     if (extensions == NULL) {
         res = 0;

--- a/Python/import.c
+++ b/Python/import.c
@@ -984,6 +984,7 @@ _extensions_cache_set(PyObject *filename, PyObject *name, PyModuleDef *def)
 
 finally:
     if (oldts != NULL) {
+        _PyThreadState_Swap(interp->runtime, oldts);
         _PyThreadState_UnbindDetached(main_tstate);
     }
     Py_XDECREF(key);
@@ -1037,6 +1038,7 @@ _extensions_cache_delete(PyObject *filename, PyObject *name)
 
 finally:
     if (oldts != NULL) {
+        _PyThreadState_Swap(interp->runtime, oldts);
         _PyThreadState_UnbindDetached(main_tstate);
     }
     Py_XDECREF(key);

--- a/Python/import.c
+++ b/Python/import.c
@@ -986,6 +986,8 @@ finally:
     if (oldts != NULL) {
         _PyThreadState_Swap(interp->runtime, oldts);
         _PyThreadState_UnbindDetached(main_tstate);
+        Py_DECREF(name);
+        Py_DECREF(filename);
     }
     Py_XDECREF(key);
     extensions_lock_release();

--- a/Python/import.c
+++ b/Python/import.c
@@ -1051,7 +1051,7 @@ _extensions_cache_clear_all(void)
 {
     /* The runtime (i.e. main interpreter) must be finalizing,
        so we don't need to worry about the lock. */
-    assert(_Py_IsMainInterpreter(_PyInterpreterState_GET()));
+    // XXX assert(_Py_IsMainInterpreter(_PyInterpreterState_GET()));
     Py_CLEAR(EXTENSIONS.dict);
     _PyThreadState_ClearDetached(&EXTENSIONS.main_tstate);
 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -939,6 +939,13 @@ _extensions_cache_set(PyObject *filename, PyObject *name, PyModuleDef *def)
         _PyThreadState_BindDetached(main_tstate);
         oldts = _PyThreadState_Swap(interp->runtime, main_tstate);
         assert(!_Py_IsMainInterpreter(oldts->interp));
+
+        /* Make sure the name and filename objects are owned
+           by the main interpreter. */
+        name = PyUnicode_InternFromString(PyUnicode_AsUTF8(name));
+        assert(name != NULL);
+        filename = PyUnicode_InternFromString(PyUnicode_AsUTF8(filename));
+        assert(filename != NULL);
     }
 
     PyObject *key = PyTuple_Pack(2, filename, name);

--- a/Python/import.c
+++ b/Python/import.c
@@ -881,7 +881,7 @@ gets even messier.
 static PyModuleDef *
 _extensions_cache_get(PyObject *filename, PyObject *name)
 {
-    PyObject *extensions = EXTENSIONS;
+    PyObject *extensions = EXTENSIONS.dict;
     if (extensions == NULL) {
         return NULL;
     }
@@ -897,13 +897,13 @@ _extensions_cache_get(PyObject *filename, PyObject *name)
 static int
 _extensions_cache_set(PyObject *filename, PyObject *name, PyModuleDef *def)
 {
-    PyObject *extensions = EXTENSIONS;
+    PyObject *extensions = EXTENSIONS.dict;
     if (extensions == NULL) {
         extensions = PyDict_New();
         if (extensions == NULL) {
             return -1;
         }
-        EXTENSIONS = extensions;
+        EXTENSIONS.dict = extensions;
     }
     PyObject *key = PyTuple_Pack(2, filename, name);
     if (key == NULL) {
@@ -920,7 +920,7 @@ _extensions_cache_set(PyObject *filename, PyObject *name, PyModuleDef *def)
 static int
 _extensions_cache_delete(PyObject *filename, PyObject *name)
 {
-    PyObject *extensions = EXTENSIONS;
+    PyObject *extensions = EXTENSIONS.dict;
     if (extensions == NULL) {
         return 0;
     }
@@ -942,7 +942,7 @@ _extensions_cache_delete(PyObject *filename, PyObject *name)
 static void
 _extensions_cache_clear_all(void)
 {
-    Py_CLEAR(EXTENSIONS);
+    Py_CLEAR(EXTENSIONS.dict);
 }
 
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1603,8 +1603,9 @@ _PyThreadState_ClearDetached(PyThreadState *tstate)
 void
 _PyThreadState_BindDetached(PyThreadState *tstate)
 {
+    assert(!_Py_IsMainInterpreter(
+        current_fast_get(tstate->interp->runtime)->interp));
     assert(_Py_IsMainInterpreter(tstate->interp));
-    assert(_Py_IsMainInterpreter(_PyInterpreterState_GET()));
     bind_tstate(tstate);
     /* Unlike _PyThreadState_Bind(), we do not modify gilstate TSS. */
 }
@@ -1612,8 +1613,9 @@ _PyThreadState_BindDetached(PyThreadState *tstate)
 void
 _PyThreadState_UnbindDetached(PyThreadState *tstate)
 {
+    assert(!_Py_IsMainInterpreter(
+        current_fast_get(tstate->interp->runtime)->interp));
     assert(_Py_IsMainInterpreter(tstate->interp));
-    assert(_Py_IsMainInterpreter(_PyInterpreterState_GET()));
     assert(tstate_is_alive(tstate));
     assert(!tstate->_status.active);
     assert(gilstate_tss_get(tstate->interp->runtime) != tstate);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1358,6 +1358,20 @@ _PyThreadState_Init(PyThreadState *tstate)
 }
 
 void
+_PyThreadState_InitDetached(PyThreadState *tstate, PyInterpreterState *interp)
+{
+    _PyRuntimeState *runtime = interp->runtime;
+
+    HEAD_LOCK(runtime);
+    interp->threads.next_unique_id += 1;
+    uint64_t id = interp->threads.next_unique_id;
+    HEAD_UNLOCK(runtime);
+
+    init_threadstate(tstate, interp, id);
+    // We do not call add_threadstate().
+}
+
+void
 PyThreadState_Clear(PyThreadState *tstate)
 {
     assert(tstate->_status.initialized && !tstate->_status.cleared);


### PR DESCRIPTION
Sharing mutable (or non-immortal) objects between interpreters is generally not safe.  We can work around that but not easily. 
 There are two restrictions that are critical for objects that break interpreter isolation.

The first is that the object's state be guarded by a global lock.  For now the GIL meets this requirement, but a granular global lock is needed once we have a per-interpreter GIL.

The second restriction is that the object (and, for a container, its items) be deallocated/resized only when the interpreter in which it was allocated is the current one.  This is because every interpreter has (or will have, see gh-101660) its own object allocator.  Deallocating an object with a different allocator can cause crashes.

The dict for the cache of module defs is completely internal, which simplifies what we have to do to meet those requirements.  To do so, we do the following:

* add a mechanism for re-using a temporary thread state tied to the main interpreter in an arbitrary thread
   * add `_PyRuntime.imports.extensions.main_tstate` 
   * add `_PyThreadState_InitDetached()` and `_PyThreadState_ClearDetached()` (pystate.c)
   * add `_PyThreadState_BindDetached()` and `_PyThreadState_UnbindDetached()` (pystate.c)
* make sure the cache dict (`_PyRuntime.imports.extensions.dict`) and its items are all owned by the main interpreter)
* add a placeholder using for a granular global lock

Note that the cache is only used for legacy extension modules and not for multi-phase init modules.

(This PR was derived from gh-102925, which I recently reverted.  Also, there was a similar, more complex PR that I've closed: gh-102938.)

<!-- gh-issue-number: gh-100227 -->
* Issue: gh-100227
<!-- /gh-issue-number -->
