### PR TITLE
GH-103085: Fix python locale.getencoding not to emit deprecation warning

### DIFF
--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -545,7 +545,9 @@ def getdefaultlocale(envvars=('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE')):
         "Use setlocale(), getencoding() and getlocale() instead",
         DeprecationWarning, stacklevel=2
     )
+    return _getdefaultlocale(envvars)
 
+def _getdefaultlocale(envvars=('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE')):
     try:
         # check if it's supported by the _locale module
         import _locale
@@ -639,7 +641,7 @@ except ImportError:
             # On Android langinfo.h and CODESET are missing, and UTF-8 is
             # always used in mbstowcs() and wcstombs().
             return 'utf-8'
-        encoding = getdefaultlocale()[1]
+        encoding = _getdefaultlocale()[1]
         if encoding is None:
             # LANG not set, default to UTF-8
             encoding = 'utf-8'

--- a/Misc/NEWS.d/next/Library/2023-03-28-15-12-53.gh-issue-103085.DqNehf.rst
+++ b/Misc/NEWS.d/next/Library/2023-03-28-15-12-53.gh-issue-103085.DqNehf.rst
@@ -1,0 +1,1 @@
+Pure python :func:`locale.getencoding()` will not warn deprecation.


### PR DESCRIPTION


<!-- gh-issue-number: gh-103085 -->
* Issue: gh-103085
<!-- /gh-issue-number -->
