### PR TITLE
gh-103112: Add http.client.HTTPResponse.read docstring and fix pydoc output

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -448,7 +448,7 @@ class HTTPResponse(io.BufferedIOBase):
         return self.fp is None
 
     def read(self, amt=None):
-        """    Read and return the response body, or up to the next amt bytes."""
+        """Read and return the response body, or up to the next amt bytes."""
         if self.fp is None:
             return b""
 

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -448,22 +448,7 @@ class HTTPResponse(io.BufferedIOBase):
         return self.fp is None
 
     def read(self, amt=None):
-        '''Read and return up to amt bytes.
-        
-        If the argument is omitted, None, or negative, reads and
-        returns all data until EOF.
-        
-        If the argument is positive, and the underlying raw stream is
-        not 'interactive', multiple raw reads may be issued to satisfy
-        the byte count (unless EOF is reached first).  But for
-        interactive raw streams (as well as sockets and pipes), at most
-        one raw read will be issued, and a short result does not imply
-        that EOF is imminent.
-        
-        Returns an empty bytes object on EOF.
-        
-        Returns None if the underlying raw stream was open in non-blocking
-        mode and no data is available at the moment.'''
+        """    Read and return the response body, or up to the next amt bytes."""
         if self.fp is None:
             return b""
 

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -448,6 +448,22 @@ class HTTPResponse(io.BufferedIOBase):
         return self.fp is None
 
     def read(self, amt=None):
+        '''Read and return up to amt bytes.
+        
+        If the argument is omitted, None, or negative, reads and
+        returns all data until EOF.
+        
+        If the argument is positive, and the underlying raw stream is
+        not 'interactive', multiple raw reads may be issued to satisfy
+        the byte count (unless EOF is reached first).  But for
+        interactive raw streams (as well as sockets and pipes), at most
+        one raw read will be issued, and a short result does not imply
+        that EOF is imminent.
+        
+        Returns an empty bytes object on EOF.
+        
+        Returns None if the underlying raw stream was open in non-blocking
+        mode and no data is available at the moment.'''
         if self.fp is None:
             return b""
 

--- a/Misc/NEWS.d/next/Documentation/2023-03-29-14-51-39.gh-issue-103112.XgGSEO.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-03-29-14-51-39.gh-issue-103112.XgGSEO.rst
@@ -1,1 +1,1 @@
-documentation of http.client.HTTPResponse.read, Parameter amt fixed.
+Add http.client.HTTPResponse.read docstring and fix help output.

--- a/Misc/NEWS.d/next/Documentation/2023-03-29-14-51-39.gh-issue-103112.XgGSEO.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-03-29-14-51-39.gh-issue-103112.XgGSEO.rst
@@ -1,1 +1,1 @@
-Add docstring to :meth:`http.client.HTTPResponse.read` to fix :cmd:`pydoc` output.
+Add docstring to :meth:`http.client.HTTPResponse.read` to fix ``pydoc`` output.

--- a/Misc/NEWS.d/next/Documentation/2023-03-29-14-51-39.gh-issue-103112.XgGSEO.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-03-29-14-51-39.gh-issue-103112.XgGSEO.rst
@@ -1,1 +1,1 @@
-Add http.client.HTTPResponse.read docstring and fix help output.
+Add http.client.HTTPResponse.read docstring and fix pydoc output.

--- a/Misc/NEWS.d/next/Documentation/2023-03-29-14-51-39.gh-issue-103112.XgGSEO.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-03-29-14-51-39.gh-issue-103112.XgGSEO.rst
@@ -1,1 +1,1 @@
-Add http.client.HTTPResponse.read docstring and fix pydoc output.
+Add docstring to :meth:`http.client.HTTPResponse.read` to fix :cmd:`pydoc` output.

--- a/Misc/NEWS.d/next/Documentation/2023-03-29-14-51-39.gh-issue-103112.XgGSEO.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-03-29-14-51-39.gh-issue-103112.XgGSEO.rst
@@ -1,0 +1,1 @@
+documentation of http.client.HTTPResponse.read, Parameter amt fixed.


### PR DESCRIPTION
`pydoc http.client.HTTPResponse.read`

results in help text:

```
http.client.HTTPResponse.read = read(self, amt=None)
    Read and return up to n bytes.
```
The parameter is called “amt” but the help text refers to “n”.

[Issue 103112](https://github.com/python/cpython/issues/103112)
[Discussion](https://discuss.python.org/t/wrong-parameter-name-in-http-client-read-documentation-amt-vs-n/25284)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-103112 -->
* Issue: gh-103112
<!-- /gh-issue-number -->
