### PR TITLE
pydoc.safeimport: Use importlib.import_module instead of __import__

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -448,7 +448,7 @@ def safeimport(path, forceload=0, cache={}):
                     # Prevent garbage collection.
                     cache[key] = sys.modules[key]
                     del sys.modules[key]
-        module = __import__(path)
+        module = importlib.import_module(path)
     except BaseException as err:
         # Did the error occur before or after the module was found?
         if path in sys.modules:
@@ -463,9 +463,6 @@ def safeimport(path, forceload=0, cache={}):
         else:
             # Some other error occurred during the importing process.
             raise ErrorDuringImport(path, err)
-    for part in path.split('.')[1:]:
-        try: module = getattr(module, part)
-        except AttributeError: return None
     return module
 
 # ---------------------------------------------------- formatter base class


### PR DESCRIPTION
Some libraries behave a bit differently:
```
$ import torch.optim.sgd   # success
$ torch.optim.sgd
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Input In [2], in <cell line: 1>()
----> 1 torch.optim.sgd

AttributeError: module 'torch.optim' has no attribute 'sgd'
```
For such modules, `safeimport` fails to import the module because it tries to access the attribute "sgd". On the other hand, `importlib.import_module` can do it correctly.
Using `import_module` also simplifies code.