### PR TITLE
gh-100227: Fix Cleanup of the Extensions Cache

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -983,13 +983,13 @@ _extensions_cache_set(PyObject *filename, PyObject *name, PyModuleDef *def)
     res = 0;
 
 finally:
+    Py_XDECREF(key);
     if (oldts != NULL) {
         _PyThreadState_Swap(interp->runtime, oldts);
         _PyThreadState_UnbindDetached(main_tstate);
         Py_DECREF(name);
         Py_DECREF(filename);
     }
-    Py_XDECREF(key);
     extensions_lock_release();
     return res;
 }


### PR DESCRIPTION
Decref the key in the right interpreter in _extensions_cache_set().

This is a follow-up to gh-103084.  I found the bug while working on gh-101660.

<!-- gh-issue-number: gh-100227 -->
* Issue: gh-100227
<!-- /gh-issue-number -->
