### PR TITLE
gh-101659: Clean Up the General Import Tests for Subinterpreters

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -1437,10 +1437,10 @@ class SubinterpImportTests(unittest.TestCase):
             os.write({fd}, text.encode('utf-8'))
             ''')
 
-    def run_shared(self, name, *,
-                   check_singlephase_setting=False,
-                   check_singlephase_override=None,
-                   ):
+    def run_here(self, name, *,
+                 check_singlephase_setting=False,
+                 check_singlephase_override=None,
+                 ):
         """
         Try importing the named module in a subinterpreter.
 
@@ -1470,27 +1470,35 @@ class SubinterpImportTests(unittest.TestCase):
         self.assertEqual(ret, 0)
         return os.read(r, 100)
 
-    def check_compatible_shared(self, name, *, strict=False):
+    def check_compatible_here(self, name, *, strict=False):
         # Verify that the named module may be imported in a subinterpreter.
-        # (See run_shared() for more info.)
-        out = self.run_shared(name, check_singlephase_setting=strict)
+        # (See run_here() for more info.)
+        out = self.run_here(name,
+                            check_singlephase_setting=strict,
+                            )
         self.assertEqual(out, b'okay')
 
-    def check_incompatible_shared(self, name):
-        # Differences from check_compatible_shared():
+    def check_incompatible_here(self, name):
+        # Differences from check_compatible_here():
         #  * verify that import fails
         #  * "strict" is always True
-        out = self.run_shared(name, check_singlephase_setting=True)
+        out = self.run_here(name,
+                            check_singlephase_setting=True,
+                            )
         self.assertEqual(
             out.decode('utf-8'),
             f'ImportError: module {name} does not support loading in subinterpreters',
         )
 
-    def check_compatible_isolated(self, name, *, strict=False):
-        # Differences from check_compatible_shared():
+    def check_compatible_fresh(self, name, *, strict=False):
+        # Differences from check_compatible_here():
         #  * subinterpreter in a new process
         #  * module has never been imported before in that process
         #  * this tests importing the module for the first time
+        kwargs = dict(
+            **self.RUN_KWARGS,
+            check_multi_interp_extensions=strict,
+        )
         _, out, err = script_helper.assert_python_ok('-c', textwrap.dedent(f'''
             import _testcapi, sys
             assert (
@@ -1499,25 +1507,27 @@ class SubinterpImportTests(unittest.TestCase):
             ), repr({name!r})
             ret = _testcapi.run_in_subinterp_with_config(
                 {self.import_script(name, "sys.stdout.fileno()")!r},
-                **{self.RUN_KWARGS},
-                check_multi_interp_extensions={strict},
+                **{kwargs},
             )
             assert ret == 0, ret
             '''))
         self.assertEqual(err, b'')
         self.assertEqual(out, b'okay')
 
-    def check_incompatible_isolated(self, name):
-        # Differences from check_compatible_isolated():
+    def check_incompatible_fresh(self, name):
+        # Differences from check_compatible_fresh():
         #  * verify that import fails
         #  * "strict" is always True
+        kwargs = dict(
+            **self.RUN_KWARGS,
+            check_multi_interp_extensions=True,
+        )
         _, out, err = script_helper.assert_python_ok('-c', textwrap.dedent(f'''
             import _testcapi, sys
             assert {name!r} not in sys.modules, {name!r}
             ret = _testcapi.run_in_subinterp_with_config(
                 {self.import_script(name, "sys.stdout.fileno()")!r},
-                **{self.RUN_KWARGS},
-                check_multi_interp_extensions=True,
+                **{kwargs},
             )
             assert ret == 0, ret
             '''))
@@ -1532,9 +1542,9 @@ class SubinterpImportTests(unittest.TestCase):
         # since they still don't implement multi-phase init.
         module = '_imp'
         with self.subTest(f'{module}: not strict'):
-            self.check_compatible_shared(module, strict=False)
-        with self.subTest(f'{module}: strict, shared'):
-            self.check_compatible_shared(module, strict=True)
+            self.check_compatible_here(module, strict=False)
+        with self.subTest(f'{module}: strict, not fresh'):
+            self.check_compatible_here(module, strict=True)
 
     @cpython_only
     def test_frozen_compat(self):
@@ -1542,47 +1552,47 @@ class SubinterpImportTests(unittest.TestCase):
         if __import__(module).__spec__.origin != 'frozen':
             raise unittest.SkipTest(f'{module} is unexpectedly not frozen')
         with self.subTest(f'{module}: not strict'):
-            self.check_compatible_shared(module, strict=False)
-        with self.subTest(f'{module}: strict, shared'):
-            self.check_compatible_shared(module, strict=True)
+            self.check_compatible_here(module, strict=False)
+        with self.subTest(f'{module}: strict, not fresh'):
+            self.check_compatible_here(module, strict=True)
 
     @unittest.skipIf(_testsinglephase is None, "test requires _testsinglephase module")
     def test_single_init_extension_compat(self):
         module = '_testsinglephase'
         with self.subTest(f'{module}: not strict'):
-            self.check_compatible_shared(module, strict=False)
-        with self.subTest(f'{module}: strict, shared'):
-            self.check_incompatible_shared(module)
-        with self.subTest(f'{module}: strict, isolated'):
-            self.check_incompatible_isolated(module)
+            self.check_compatible_here(module, strict=False)
+        with self.subTest(f'{module}: strict, not fresh'):
+            self.check_incompatible_here(module)
+        with self.subTest(f'{module}: strict, fresh'):
+            self.check_incompatible_fresh(module)
 
     @unittest.skipIf(_testmultiphase is None, "test requires _testmultiphase module")
     def test_multi_init_extension_compat(self):
         module = '_testmultiphase'
         with self.subTest(f'{module}: not strict'):
-            self.check_compatible_shared(module, strict=False)
-        with self.subTest(f'{module}: strict, shared'):
-            self.check_compatible_shared(module, strict=True)
-        with self.subTest(f'{module}: strict, isolated'):
-            self.check_compatible_isolated(module, strict=True)
+            self.check_compatible_here(module, strict=False)
+        with self.subTest(f'{module}: strict, not fresh'):
+            self.check_compatible_here(module, strict=True)
+        with self.subTest(f'{module}: strict, fresh'):
+            self.check_compatible_fresh(module, strict=True)
 
     def test_python_compat(self):
         module = 'threading'
         if __import__(module).__spec__.origin == 'frozen':
             raise unittest.SkipTest(f'{module} is unexpectedly frozen')
         with self.subTest(f'{module}: not strict'):
-            self.check_compatible_shared(module, strict=False)
-        with self.subTest(f'{module}: strict, shared'):
-            self.check_compatible_shared(module, strict=True)
-        with self.subTest(f'{module}: strict, isolated'):
-            self.check_compatible_isolated(module, strict=True)
+            self.check_compatible_here(module, strict=False)
+        with self.subTest(f'{module}: strict, not fresh'):
+            self.check_compatible_here(module, strict=True)
+        with self.subTest(f'{module}: strict, fresh'):
+            self.check_compatible_fresh(module, strict=True)
 
     @unittest.skipIf(_testsinglephase is None, "test requires _testsinglephase module")
     def test_singlephase_check_with_setting_and_override(self):
         module = '_testsinglephase'
 
         def check_compatible(setting, override):
-            out = self.run_shared(
+            out = self.run_here(
                 module,
                 check_singlephase_setting=setting,
                 check_singlephase_override=override,
@@ -1590,7 +1600,7 @@ class SubinterpImportTests(unittest.TestCase):
             self.assertEqual(out, b'okay')
 
         def check_incompatible(setting, override):
-            out = self.run_shared(
+            out = self.run_here(
                 module,
                 check_singlephase_setting=setting,
                 check_singlephase_override=override,

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -1528,7 +1528,9 @@ class SubinterpImportTests(unittest.TestCase):
         )
 
     def test_builtin_compat(self):
-        module = 'sys'
+        # For now we avoid using sys or builtins
+        # since they still don't implement multi-phase init.
+        module = '_imp'
         with self.subTest(f'{module}: not strict'):
             self.check_compatible_shared(module, strict=False)
         with self.subTest(f'{module}: strict, shared'):


### PR DESCRIPTION
This involves 3 changes: some general cleanup, checks to match the kind of module, and switch from testing against sys to _imp.

This is a precursor to gh-103150, though the changes are meant to stand on their own.

<!-- gh-issue-number: gh-101659 -->
* Issue: gh-101659
<!-- /gh-issue-number -->
