### PR TITLE
gh-74690: Micro-optimise `typing._get_protocol_attrs`

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1928,7 +1928,8 @@ def _get_protocol_attrs(cls):
     for base in cls.__mro__[:-1]:  # without object
         if base.__name__ in {'Protocol', 'Generic'}:
             continue
-        for attr in (*base.__dict__, *base.__annotations__):
+        annotations = getattr(base, '__annotations__', {})
+        for attr in (*base.__dict__, *annotations):
             if not attr.startswith('_abc_') and attr not in EXCLUDED_ATTRIBUTES:
                 attrs.add(attr)
     return attrs

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1903,15 +1903,19 @@ class _TypingEllipsis:
     """Internal placeholder for ... (ellipsis)."""
 
 
-_TYPING_INTERNALS = ['__parameters__', '__orig_bases__',  '__orig_class__',
-                     '_is_protocol', '_is_runtime_protocol']
+_TYPING_INTERNALS = frozenset({
+    '__parameters__', '__orig_bases__',  '__orig_class__',
+    '_is_protocol', '_is_runtime_protocol'
+})
 
-_SPECIAL_NAMES = ['__abstractmethods__', '__annotations__', '__dict__', '__doc__',
-                  '__init__', '__module__', '__new__', '__slots__',
-                  '__subclasshook__', '__weakref__', '__class_getitem__']
+_SPECIAL_NAMES = frozenset({
+    '__abstractmethods__', '__annotations__', '__dict__', '__doc__',
+    '__init__', '__module__', '__new__', '__slots__',
+    '__subclasshook__', '__weakref__', '__class_getitem__'
+})
 
 # These special attributes will be not collected as protocol members.
-EXCLUDED_ATTRIBUTES = _TYPING_INTERNALS + _SPECIAL_NAMES + ['_MutableMapping__marker']
+EXCLUDED_ATTRIBUTES = _TYPING_INTERNALS | _SPECIAL_NAMES | {'_MutableMapping__marker'}
 
 
 def _get_protocol_attrs(cls):
@@ -1922,10 +1926,9 @@ def _get_protocol_attrs(cls):
     """
     attrs = set()
     for base in cls.__mro__[:-1]:  # without object
-        if base.__name__ in ('Protocol', 'Generic'):
+        if base.__name__ in {'Protocol', 'Generic'}:
             continue
-        annotations = getattr(base, '__annotations__', {})
-        for attr in list(base.__dict__.keys()) + list(annotations.keys()):
+        for attr in (*base.__dict__, *base.__annotations__):
             if not attr.startswith('_abc_') and attr not in EXCLUDED_ATTRIBUTES:
                 attrs.add(attr)
     return attrs


### PR DESCRIPTION
This PR is a bunch of micro-optimisations for `typing._get_protocol_attrs` that together have a significant impact on the speed of `isinstance` checks against runtime-checkable protocols.

<details>
<summary>Benchmark:</summary>

```py
import time
from typing import Protocol, runtime_checkable

@runtime_checkable
class HasX(Protocol):
    x: int

class Foo:
    @property
    def x(self) -> int:
        return 42

class Bar:
    x = 42

class Baz:
    def __init__(self):
        self.x = 42

class Egg: ...

class Nominal(HasX):
    def __init__(self):
        self.x = 42

class Registered: ...

HasX.register(Registered)

num_instances = 500_000
foos = [Foo() for _ in range(num_instances)]
bars = [Bar() for _ in range(num_instances)]
bazzes = [Baz() for _ in range(num_instances)]
basket = [Egg() for _ in range(num_instances)]
nominals = [Nominal() for _ in range(num_instances)]
registereds = [Registered() for _ in range(num_instances)]


def bench(objs, title):
    start_time = time.perf_counter()
    for obj in objs:
        isinstance(obj, HasX)
    elapsed = time.perf_counter() - start_time
    print(f"{title}: {elapsed:.2f}")


bench(foos, "Time taken for objects with a property")
bench(bars, "Time taken for objects with a classvar")
bench(bazzes, "Time taken for objects with an instance var")
bench(basket, "Time taken for objects with no var")
bench(nominals, "Time taken for nominal subclass instances")
bench(registereds, "Time taken for registered subclass instances")
```

</details>

Results on dfc4c95762f417e84dcb21dbbe6399ab7b7cef19:

```
Time taken for objects with a property: 2.17
Time taken for objects with a classvar: 2.10
Time taken for objects with an instance var: 2.13
Time taken for objects with no var: 2.47
Time taken for nominal subclass instances: 2.20
Time taken for registered subclass instances: 4.72
```

Results with this PR:

```
Time taken for objects with a property: 1.65
Time taken for objects with a classvar: 1.60
Time taken for objects with an instance var: 1.61
Time taken for objects with no var: 1.89
Time taken for nominal subclass instances: 1.61
Time taken for registered subclass instances: 3.79
```

I'm once again skipping NEWS, since #103034 will counteract the boost to performance here, so the overall impact on performance for runtime-checkable protocols in 3.12 is still TBD.

<!-- gh-issue-number: gh-74690 -->
* Issue: gh-74690
<!-- /gh-issue-number -->
