### PR TITLE
gh-102192: use PyErr_SetHandledException instead of the legacy PyErr_SetExcInfo

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1842,7 +1842,7 @@ dummy_func(
             ERROR_IF(match == NULL, error);
 
             if (!Py_IsNone(match)) {
-                PyErr_SetExcInfo(NULL, Py_NewRef(match), NULL);
+                PyErr_SetHandledException(match);
             }
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2591,7 +2591,7 @@
             if (match == NULL) goto pop_2_error;
 
             if (!Py_IsNone(match)) {
-                PyErr_SetExcInfo(NULL, Py_NewRef(match), NULL);
+                PyErr_SetHandledException(match);
             }
             #line 2597 "Python/generated_cases.c.h"
             stack_pointer[-1] = match;


### PR DESCRIPTION


<!-- gh-issue-number: gh-102192 -->
* Issue: gh-102192
<!-- /gh-issue-number -->
