### PR TITLE
gh-74690: typing: Simplify and optimise `_ProtocolMeta.__instancecheck__`

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2013,6 +2013,9 @@ class _ProtocolMeta(ABCMeta):
             raise TypeError("Instance and class checks can only be used with"
                             " @runtime_checkable protocols")
 
+        if super().__instancecheck__(instance):
+            return True
+
         if not is_protocol_cls and issubclass(instance.__class__, cls):
             return True
 
@@ -2031,7 +2034,8 @@ class _ProtocolMeta(ABCMeta):
                      getattr(instance, attr) is not None)
                     for attr in protocol_attrs):
                 return True
-        return super().__instancecheck__(instance)
+
+        return False
 
 
 class Protocol(Generic, metaclass=_ProtocolMeta):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2027,20 +2027,9 @@ class _ProtocolMeta(ABCMeta):
         if super().__instancecheck__(instance):
             return True
 
-        if not is_protocol_cls and issubclass(instance.__class__, cls):
-            return True
-
-        protocol_attrs = _get_protocol_attrs(cls)
-
-        if (
-            _is_callable_members_only(cls, protocol_attrs)
-            and issubclass(instance.__class__, cls)
-        ):
-            return True
-
         if is_protocol_cls:
             getattr_static = _lazy_load_getattr_static()
-            for attr in protocol_attrs:
+            for attr in _get_protocol_attrs(cls):
                 try:
                     val = getattr_static(instance, attr)
                 except AttributeError:


### PR DESCRIPTION
This implements the optimisation suggested by @ilevkivskyi in https://github.com/python/cpython/issues/74690#issuecomment-1239525629. However, I'm not sure if it's the right thing to do. I'm posting it here for discussion, and so that people can have a play around with it.

This dramatically speeds up `isinstance()` checks for nominal subclasses of runtime-checkable protocols and subclasses registered via `ABCMeta.register`, i.e. situations like the following:

```py
from typing import Protocol, runtime_checkable

@runtime_checkable
class HasX(Protocol)
    x: int

class Bar(HasX):
    def __init__(self):
        self.x = 42

class Baz: ...
HasX.register(Baz)

isinstance(Bar(), HasX)  # this is ~12x faster
isinstance(Baz(), HasX)  # this is ~2x faster
```

However, speeding these two up comes at the cost of the performance of `isinstance()` checks with "structural subclasses". These are all _slightly_ slower:

```py
class Eggs:
    def __init__(self):
        self.x = 42

class Spam:
    x = 42

class Ham:
    @property
    def x(self):
        return 42

isinstance(Eggs(), HasX)
isinstance(Spam(), HasX)
isinstance(Ham(), HasX)
```

So the question is: is it worth making `isinstance()` calls against nominal and registered subclasses much, much faster, at the cost of making those^ `isinstance()` calls a bit slower? I'm not sure it is, as kind of the "whole point" of runtime-checkable protocols is that an object `x` _doesn't_ have to directly inherit from a protocol `X` in order it to be considered an instance of `X`. So I don't know how common it is for people to directly inherit from protocols in their own code.

_But_, I'm very curious about what other people think.

Here's a benchmarking script for people to play around with. The results of the benchmark script for the structural-subclass cases are a bit noisy on my machine, but consistently a _little_ bit slower than on `main`:

<details>
<summary>Benchmark script</summary>

```py
import time
from typing import Protocol, runtime_checkable

@runtime_checkable
class HasX(Protocol):
    x: int

class Foo:
    @property
    def x(self) -> int:
        return 42

class Bar:
    x = 42

class Baz:
    def __init__(self):
        self.x = 42

class Egg: ...

class Nominal(HasX):
    def __init__(self):
        self.x = 42

class Registered: ...

HasX.register(Registered)

num_instances = 500_000
foos = [Foo() for _ in range(num_instances)]
bars = [Bar() for _ in range(num_instances)]
bazzes = [Baz() for _ in range(num_instances)]
basket = [Egg() for _ in range(num_instances)]
nominals = [Nominal() for _ in range(num_instances)]
registereds = [Registered() for _ in range(num_instances)]


def bench(objs, title):
    start_time = time.perf_counter()
    for obj in objs:
        isinstance(obj, HasX)
    elapsed = time.perf_counter() - start_time
    print(f"{title}: {elapsed:.2f}")


bench(foos, "Time taken for objects with a property")
bench(bars, "Time taken for objects with a classvar")
bench(bazzes, "Time taken for objects with an instance var")
bench(basket, "Time taken for objects with no var")
bench(nominals, "Time taken for nominal subclass instances")
bench(registereds, "Time taken for registered subclass instances")
```

</details>

<!-- gh-issue-number: gh-74690 -->
* Issue: gh-74690
<!-- /gh-issue-number -->
