### PR TITLE
gh-103167: Fix `-Wstrict-prototypes` warnings by using `(void)` for functions with no args

### DIFF
--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -121,7 +121,7 @@ Copyright (C) 1994 Steen Lumholt.
 #define WAIT_FOR_STDIN
 
 static PyObject *
-_get_tcl_lib_path()
+_get_tcl_lib_path(void)
 {
     static PyObject *tcl_library_path = NULL;
     static int already_checked = 0;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8546,7 +8546,7 @@ os_setpgrp_impl(PyObject *module)
 #include <processsnapshot.h>
 
 static PyObject*
-win32_getppid()
+win32_getppid(void)
 {
     DWORD error;
     PyObject* result = NULL;
@@ -13330,7 +13330,7 @@ static int has_ShellExecute = -1;
 static HINSTANCE (CALLBACK *Py_ShellExecuteW)(HWND, LPCWSTR, LPCWSTR, LPCWSTR,
                                               LPCWSTR, INT);
 static int
-check_ShellExecute()
+check_ShellExecute(void)
 {
     HINSTANCE hShell32;
 

--- a/PC/launcher.c
+++ b/PC/launcher.c
@@ -449,7 +449,7 @@ locate_pythons_for_key(HKEY root, REGSAM flags)
 }
 
 static void
-locate_store_pythons()
+locate_store_pythons(void)
 {
 #if defined(_M_X64)
     /* 64bit process, so look in native registry */
@@ -466,7 +466,7 @@ locate_store_pythons()
 }
 
 static void
-locate_venv_python()
+locate_venv_python(void)
 {
     static wchar_t venv_python[MAX_PATH];
     INSTALLED_PYTHON * ip;
@@ -495,7 +495,7 @@ locate_venv_python()
 }
 
 static void
-locate_all_pythons()
+locate_all_pythons(void)
 {
     /* venv Python is highest priority */
     locate_venv_python();
@@ -694,7 +694,7 @@ static wchar_t wrapped_script_path[MAX_PATH];
  * valid wrapped script file.
  */
 static void
-locate_wrapped_script()
+locate_wrapped_script(void)
 {
     wchar_t * p;
     size_t plen;
@@ -1034,7 +1034,7 @@ read_config_file(wchar_t * config_path)
     }
 }
 
-static void read_commands()
+static void read_commands(void)
 {
     if (launcher_ini_path[0])
         read_config_file(launcher_ini_path);
@@ -1684,7 +1684,7 @@ wcsdup_pad(const wchar_t *s, int padding, int *newlen)
 }
 
 static wchar_t *
-get_process_name()
+get_process_name(void)
 {
     DWORD bufferLen = MAX_PATH;
     DWORD len = bufferLen;

--- a/PC/launcher2.c
+++ b/PC/launcher2.c
@@ -132,7 +132,7 @@ typedef BOOL (*PIsWow64Process2)(HANDLE, USHORT*, USHORT*);
 
 
 USHORT
-_getNativeMachine()
+_getNativeMachine(void)
 {
     static USHORT _nativeMachine = IMAGE_FILE_MACHINE_UNKNOWN;
     if (_nativeMachine == IMAGE_FILE_MACHINE_UNKNOWN) {
@@ -163,14 +163,14 @@ _getNativeMachine()
 
 
 bool
-isAMD64Host()
+isAMD64Host(void)
 {
     return _getNativeMachine() == IMAGE_FILE_MACHINE_AMD64;
 }
 
 
 bool
-isARM64Host()
+isARM64Host(void)
 {
     return _getNativeMachine() == IMAGE_FILE_MACHINE_ARM64;
 }

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -467,7 +467,7 @@ void _PyEval_SetSwitchInterval(unsigned long microseconds)
     gil->interval = microseconds;
 }
 
-unsigned long _PyEval_GetSwitchInterval()
+unsigned long _PyEval_GetSwitchInterval(void)
 {
     struct _gil_runtime_state *gil = &_PyRuntime.ceval.gil;
     return gil->interval;

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2355,13 +2355,13 @@ config_usage(int error, const wchar_t* program)
 }
 
 static void
-config_envvars_usage()
+config_envvars_usage(void)
 {
     printf(usage_envvars, (wint_t)DELIM, (wint_t)DELIM, PYTHONHOMEHELP);
 }
 
 static void
-config_xoptions_usage()
+config_xoptions_usage(void)
 {
     puts(usage_xoptions);
 }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1488,7 +1488,7 @@ static PyStructSequence_Desc windows_version_desc = {
 };
 
 static PyObject *
-_sys_getwindowsversion_from_kernel32()
+_sys_getwindowsversion_from_kernel32(void)
 {
 #ifndef MS_WINDOWS_DESKTOP
     return NULL;


### PR DESCRIPTION
Are there any others that I've missed?

<!-- gh-issue-number: gh-103167 -->
* Issue: gh-103167
<!-- /gh-issue-number -->
