### PR TITLE
gh-103053: Skip the whole `test_freeze` module in tests on `s390x` with `PGO`

### DIFF
--- a/Lib/test/test_tools/test_freeze.py
+++ b/Lib/test/test_tools/test_freeze.py
@@ -12,6 +12,13 @@ skip_if_missing('freeze')
 with imports_under_tool('freeze', 'test'):
     import freeze as helper
 
+# See gh-103053:
+skip_on_s390x_pgo = unittest.skipIf(
+    support.PGO and hasattr(os, 'uname') and os.uname().machine == 's390x',
+    's390x with PGO takes too long',
+)
+
+@skip_on_s390x_pgo
 @support.requires_zlib()
 @unittest.skipIf(sys.platform.startswith('win'), 'not supported on Windows')
 @support.skip_if_buildbot('not all buildbots have enough space')


### PR DESCRIPTION
Now, let's try the buildbot test with these changes.

<!-- gh-issue-number: gh-103053 -->
* Issue: gh-103053
<!-- /gh-issue-number -->
