### PR TITLE
gh-103171: Document and test behaviour change in 3.11 for runtime-checkable protocols decorated with `@final`

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1619,6 +1619,13 @@ These are not used in annotations. They are building blocks for creating generic
 
    .. versionadded:: 3.8
 
+   .. versionchanged:: 3.11
+      Where a runtime-checkable protocol class ``X`` is decorated with
+      :func:`@typing.final <typing.final>`, an object ``y`` will now only be
+      considered an instance of ``X`` if the class of ``y`` is also decorated
+      with ``@final``. Runtime-checkable protocols decorated with ``@final``
+      can also no longer be used in :func:`issubclass` calls.
+
 Other special directives
 """"""""""""""""""""""""
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2597,6 +2597,22 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             isinstance(C(), BadPG)
 
+    def test_protocols_isinstance_final(self):
+        @final
+        @runtime_checkable
+        class FinalHasX(Protocol):
+            x: int
+
+        class Eggs:
+            x = 42
+
+        @final
+        class Spam:
+            x = 42
+
+        self.assertNotIsInstance(Eggs(), FinalHasX)
+        self.assertIsInstance(Spam(), FinalHasX)
+
     def test_protocols_isinstance_properties_and_descriptors(self):
         class C:
             @property


### PR DESCRIPTION


<!-- gh-issue-number: gh-103171 -->
* Issue: gh-103171
<!-- /gh-issue-number -->
