### PR TITLE
gh-74623: Avoid untar errors when write-protected files are tarred twice

### DIFF
--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -2976,6 +2976,29 @@ class NumericOwnerTest(unittest.TestCase):
                               tarfl.extract, filename_1, TEMPDIR, False, True)
 
 
+class ReadonlyArchivedFileTest(TarTest):
+
+    def setUp(self):
+        self.file_name = os.path.join(TEMPDIR, 'read_only_file.txt')
+        with open(self.file_name, 'w') as outfile:
+            outfile.write('')
+
+        os.chmod(self.file_name, 0o444)
+
+    def tearDown(self):
+        os.remove(self.file_name)
+
+    def test_extract_doubly_added_file(self):
+        # gh-74623: tarring a readonly file twice, then extracting,
+        # should succeed.
+        with tarfile.open(tmpname, 'w') as tarfl:
+            tarfl.add(self.file_name)
+            tarfl.add(self.file_name)
+
+        with tarfile.open(tmpname) as tarfl:
+            tarfl.extractall()
+
+
 def setUpModule():
     os_helper.unlink(TEMPDIR)
     os.makedirs(TEMPDIR)

--- a/Misc/NEWS.d/next/Library/2023-02-04-23-12-18.gh-issue-74623.c6SxrJ.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-04-23-12-18.gh-issue-74623.c6SxrJ.rst
@@ -1,0 +1,2 @@
+Avoid untar errors when write-protected files are tarred twice. Patch by
+Catherine Devlin.


### PR DESCRIPTION
This is a manual rebase of gh-1808.

The original author commited using a email slightly different from the one the new CLA is signed with. So I squashed everything to add the expected e-mail as `Co-authored-by`.

<!-- gh-issue-number: gh-74623 -->
* Issue: gh-74623
<!-- /gh-issue-number -->
