### PR TITLE
GH-75586: Fix case where PATHEXT isn't applied to items in PATH (Windows)

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -433,12 +433,11 @@ Directory and files operations
    When no *path* is specified, the results of :func:`os.environ` are used,
    returning either the "PATH" value or a fallback of :attr:`os.defpath`.
 
-   On Windows, the current directory is prepended to the *path* if
-   the *mode* does not include ``os.X_OK``. When the *mode* does include
-   ``os.X_OK``, the Windows API ``NeedCurrentDirectoryForExePathW`` will be
-   consulted to determine if the current directory should be prepended to
-   *path*. To avoid consulting the current working directory for executables,
-   and thereby, match the behavior of non-Windows shells: set the environment
+   On Windows, the current directory is prepended to the *path* if *mode* does
+   not include ``os.X_OK``. When the *mode* does include ``os.X_OK``, the
+   Windows API ``NeedCurrentDirectoryForExePathW`` will be consulted to
+   determine if the current directory should be prepended to *path*. To avoid
+   consulting the current working directory for executables: set the environment
    variable ``NoDefaultCurrentDirectoryInExePath``.
 
    Also on Windows, the ``PATHEXT`` variable is used to resolve commands
@@ -450,8 +449,8 @@ Directory and files operations
       >>> shutil.which("python")
       'C:\\Python33\\python.EXE'
 
-   Similar ``PATHEXT`` logic is also applied when a full path to a *cmd* is
-   given, containing a directory component::
+   This is also applied when *cmd* is a path that contains a directory
+   component::
 
       >> shutil.which("C:\\Python33\\python")
       'C:\\Python33\\python.EXE'

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -465,7 +465,7 @@ Directory and files operations
       consult ``NeedCurrentDirectoryForExePathW`` to determine if the
       current working directory should be searched first. Additionally,
       the ``PATHEXT`` environment variable is now consulted even when
-      *cmd* includes an extension. Finally, a *cmd* found with a
+      *cmd* includes a directory component. Finally, a *cmd* found with a
       ``PATHEXT`` extension in an earlier directory from *path* will
       now be returned ahead of any match found later in *path*.
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -462,7 +462,6 @@ Directory and files operations
       :class:`bytes`, the result type is also :class:`bytes`.
 
    .. versionchanged:: 3.12
-   .. versionchanged:: 3.12
       On Windows, the current directory is no longer prepended to the search
       path if *mode* includes ``os.X_OK`` and WinAPI
       ``NeedCurrentDirectoryForExePathW(cmd)`` is false; ``PATHEXT`` is used

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -462,13 +462,13 @@ Directory and files operations
       :class:`bytes`, the result type is also :class:`bytes`.
 
    .. versionchanged:: 3.12
-      On Windows, queries allowing executables (``os.X_OK``) will now
-      consult ``NeedCurrentDirectoryForExePathW`` to determine if the
-      current working directory should be searched first. Additionally,
-      the ``PATHEXT`` environment variable is now consulted even when
-      *cmd* includes a directory component. Finally, a *cmd* found with a
-      ``PATHEXT`` extension in an earlier directory from *path* will
-      now be returned ahead of any match found later in *path*.
+   .. versionchanged:: 3.12
+      On Windows, the current directory is no longer prepended to the search
+      path if *mode* includes ``os.X_OK`` and WinAPI
+      ``NeedCurrentDirectoryForExePathW(cmd)`` is false; ``PATHEXT`` is used
+      now even when *cmd* includes a directory component or ends with an
+      extension that is in ``PATHEXT``; and filenames that have no extension
+      can be found now.
 
 .. exception:: Error
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -433,15 +433,25 @@ Directory and files operations
    When no *path* is specified, the results of :func:`os.environ` are used,
    returning either the "PATH" value or a fallback of :attr:`os.defpath`.
 
-   On Windows, the current directory is always prepended to the *path* whether
-   or not you use the default or provide your own, which is the behavior the
-   command shell uses when finding executables.  Additionally, when finding the
-   *cmd* in the *path*, the ``PATHEXT`` environment variable is checked.  For
-   example, if you call ``shutil.which("python")``, :func:`which` will search
-   ``PATHEXT`` to know that it should look for ``python.exe`` within the *path*
-   directories.  For example, on Windows::
+   On Windows, the current directory is prepended to the *path* if
+   the *mode* does not include ``os.X_OK``. When the *mode* does include
+   ``os.X_OK``, the Windows API ``NeedCurrentDirectoryForExePathW`` will be
+   consulted to determine if the current directory should be prepended to
+   *path*.
+
+   Additionally, when finding the *cmd* in the *path*, the ``PATHEXT``
+   environment variable is checked.  For example, if you call
+   ``shutil.which("python")``, :func:`which` will search ``PATHEXT``
+   to know that it should look for ``python.exe`` within the *path*
+   directories. For example, on Windows::
 
       >>> shutil.which("python")
+      'C:\\Python33\\python.EXE'
+
+   Similar ``PATHEXT`` logic is also applied when a full path to a *cmd* is
+   given, though without an extension::
+
+      >> shutil.which("C:\\Python33\\python")
       'C:\\Python33\\python.EXE'
 
    .. versionadded:: 3.3
@@ -449,6 +459,15 @@ Directory and files operations
    .. versionchanged:: 3.8
       The :class:`bytes` type is now accepted.  If *cmd* type is
       :class:`bytes`, the result type is also :class:`bytes`.
+
+   .. versionchanged:: 3.12
+      On Windows: ``NeedCurrentDirectoryForExePathW`` will be consulted
+      for non- ``os.X_OK`` modes to determine if the current working directory
+      should be prepended to *path*. Additionally, the ``PATHEXT`` environment
+      variable is now consulted when a full path to a cmd, minus the extension,
+      is given. Also, now a *cmd* with a matching ``PATHEXT`` extension will
+      be returned prior to one fully matching, if the fully matching one is
+      found later in *path*.
 
 .. exception:: Error
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -464,11 +464,11 @@ Directory and files operations
    .. versionchanged:: 3.12
       On Windows, the current directory is no longer prepended to the search
       path if *mode* includes ``os.X_OK`` and WinAPI
-      ``NeedCurrentDirectoryForExePathW(cmd)`` is false. When the current
-      directory is a prepended, it is prepended before the *path*.  ``PATHEXT``
-      is used now even when *cmd* includes a directory component or ends with
-      an extension that is in ``PATHEXT``; and filenames that have no extension
-      can be found now.
+      ``NeedCurrentDirectoryForExePathW(cmd)`` is false, else the current
+      directory is prepended even if it is already in the search path;
+      ``PATHEXT`` is used now even when *cmd* includes a directory component
+      or ends with an extension that is in ``PATHEXT``; and filenames that
+      have no extension can now be found.
 
 .. exception:: Error
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -437,7 +437,9 @@ Directory and files operations
    the *mode* does not include ``os.X_OK``. When the *mode* does include
    ``os.X_OK``, the Windows API ``NeedCurrentDirectoryForExePathW`` will be
    consulted to determine if the current directory should be prepended to
-   *path*.
+   *path*. To avoid consulting the current working directory for executables,
+   and thereby, match the behavior of non-Windows shells: set the environment
+   variable ``NoDefaultCurrentDirectoryInExePath``.
 
    Also on Windows, the ``PATHEXT`` variable is used to resolve commands
    that may not already include an extension. For example, if you call

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -461,13 +461,13 @@ Directory and files operations
       :class:`bytes`, the result type is also :class:`bytes`.
 
    .. versionchanged:: 3.12
-      On Windows: ``NeedCurrentDirectoryForExePathW`` will be consulted
-      for non- ``os.X_OK`` modes to determine if the current working directory
-      should be prepended to *path*. Additionally, the ``PATHEXT`` environment
-      variable is now consulted when a full path to a cmd, minus the extension,
-      is given. Also, now a *cmd* with a matching ``PATHEXT`` extension will
-      be returned prior to one fully matching, if the fully matching one is
-      found later in *path*.
+      On Windows, queries allowing executables (``os.X_OK``) will now
+      consult ``NeedCurrentDirectoryForExePathW`` to determine if the
+      current working directory should be searched first. Additionally,
+      the ``PATHEXT`` environment variable is now consulted even when
+      *cmd* includes an extension. Finally, a *cmd* found with a
+      ``PATHEXT`` extension in an earlier directory from *path* will
+      now be returned ahead of any match found later in *path*.
 
 .. exception:: Error
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -449,7 +449,7 @@ Directory and files operations
       'C:\\Python33\\python.EXE'
 
    Similar ``PATHEXT`` logic is also applied when a full path to a *cmd* is
-   given, though without an extension::
+   given, containing a directory component::
 
       >> shutil.which("C:\\Python33\\python")
       'C:\\Python33\\python.EXE'

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -439,8 +439,8 @@ Directory and files operations
    consulted to determine if the current directory should be prepended to
    *path*.
 
-   Additionally, when finding the *cmd* in the *path*, the ``PATHEXT``
-   environment variable is checked.  For example, if you call
+   Also on Windows, the ``PATHEXT`` variable is used to resolve commands
+   that may not already include an extension. For example, if you call
    ``shutil.which("python")``, :func:`which` will search ``PATHEXT``
    to know that it should look for ``python.exe`` within the *path*
    directories. For example, on Windows::

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -464,9 +464,10 @@ Directory and files operations
    .. versionchanged:: 3.12
       On Windows, the current directory is no longer prepended to the search
       path if *mode* includes ``os.X_OK`` and WinAPI
-      ``NeedCurrentDirectoryForExePathW(cmd)`` is false; ``PATHEXT`` is used
-      now even when *cmd* includes a directory component or ends with an
-      extension that is in ``PATHEXT``; and filenames that have no extension
+      ``NeedCurrentDirectoryForExePathW(cmd)`` is false. When the current
+      directory is a prepended, it is prepended before the *path*.  ``PATHEXT``
+      is used now even when *cmd* includes a directory component or ends with
+      an extension that is in ``PATHEXT``; and filenames that have no extension
       can be found now.
 
 .. exception:: Error

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -343,6 +343,10 @@ shutil
   will be removed in Python 3.14.
   (Contributed by Irit Katriel in :gh:`102828`.)
 
+* :func:`shutil.which` now consults the *PATHEXT* environment variable to
+  find matches within *PATH* on Windows.
+  (Contributed by Charles Machalow in :gh:`103179`.)
+
 
 sqlite3
 -------

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -344,9 +344,19 @@ shutil
   (Contributed by Irit Katriel in :gh:`102828`.)
 
 * :func:`shutil.which` now consults the *PATHEXT* environment variable to
-  find matches within *PATH* on Windows.
+  find matches within *PATH* on Windows even when the given *cmd* includes
+  a directory component.
   (Contributed by Charles Machalow in :gh:`103179`.)
 
+  :func:`shutil.which` will call ``NeedCurrentDirectoryForExePathW`` when
+  querying for executables on Windows to determine if the current working
+  directory should be prepended to the search path.
+  (Contributed by Charles Machalow in :gh:`103179`.)
+
+  :func:`shutil.which` will return a path matching the *cmd* with a component
+  from ``PATHEXT`` prior to a direct match elsewhere in the search path on
+  Windows.
+  (Contributed by Charles Machalow in :gh:`103179`.)
 
 sqlite3
 -------

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1458,7 +1458,7 @@ def _win_path_needs_curdir(cmd, mode):
     if we should add the cwd to PATH when searching for executables if
     the mode is executable.
     """
-    return (not (mode & os.X_OK) or
+    return (not (mode & os.X_OK)) or \
             _winapi.NeedCurrentDirectoryForExePath(
                 cmd if isinstance(cmd, str) else os.fsdecode(cmd))
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1458,7 +1458,9 @@ def _win_path_needs_curdir(cmd, mode):
     if we should add the cwd to PATH when searching for executables if
     the mode is executable.
     """
-    return mode & os.X_OK and _winapi.NeedCurrentDirectoryForExePath(cmd if isinstance(cmd, str) else os.fsdecode(cmd))
+    return mode & os.X_OK and _winapi.NeedCurrentDirectoryForExePath(
+        cmd if isinstance(cmd, str) else os.fsdecode(cmd)
+    )
 
 
 def which(cmd, mode=os.F_OK | os.X_OK, path=None):

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1459,7 +1459,7 @@ def _win_path_needs_curdir(cmd, mode):
     the mode is executable.
     """
     return (not (mode & os.X_OK)) or _winapi.NeedCurrentDirectoryForExePath(
-                cmd if isinstance(cmd, str) else os.fsdecode(cmd))
+                os.fsdecode(cmd))
 
 
 def which(cmd, mode=os.F_OK | os.X_OK, path=None):

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1458,8 +1458,7 @@ def _win_path_needs_curdir(cmd, mode):
     if we should add the cwd to PATH when searching for executables if
     the mode is executable.
     """
-    return (not (mode & os.X_OK)) or \
-            _winapi.NeedCurrentDirectoryForExePath(
+    return (not (mode & os.X_OK)) or _winapi.NeedCurrentDirectoryForExePath(
                 cmd if isinstance(cmd, str) else os.fsdecode(cmd))
 
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1508,8 +1508,7 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
             curdir = os.curdir
             if use_bytes:
                 curdir = os.fsencode(curdir)
-            if curdir not in path:
-                path.insert(0, curdir)
+            path.insert(0, curdir)
 
     if sys.platform == "win32":
         # PATHEXT is necessary to check on Windows.

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1458,9 +1458,9 @@ def _win_path_needs_curdir(cmd, mode):
     if we should add the cwd to PATH when searching for executables if
     the mode is executable.
     """
-    return mode & os.X_OK and _winapi.NeedCurrentDirectoryForExePath(
-        cmd if isinstance(cmd, str) else os.fsdecode(cmd)
-    )
+    return (not (mode & os.X_OK) or
+            _winapi.NeedCurrentDirectoryForExePath(
+                cmd if isinstance(cmd, str) else os.fsdecode(cmd))
 
 
 def which(cmd, mode=os.F_OK | os.X_OK, path=None):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2206,7 +2206,7 @@ class TestWhich(BaseTest, unittest.TestCase):
     # See GH-75586
     @unittest.skipUnless(sys.platform == "win32", 'test specific to Windows')
     def test_win_path_needs_curdir(self):
-        with unittest.mock.patch('shutil._winapi.NeedCurrentDirectoryForExePath', return_value=True) as need_curdir_mock:
+        with unittest.mock.patch('_winapi.NeedCurrentDirectoryForExePath', return_value=True) as need_curdir_mock:
             self.assertTrue(shutil._win_path_needs_curdir('dontcare', os.X_OK))
             need_curdir_mock.assert_called_once_with('dontcare')
             need_curdir_mock.reset_mock()

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2058,6 +2058,26 @@ class TestWhich(BaseTest, unittest.TestCase):
                 # Current directory not on PATH
                 self.assertIsNone(rv)
 
+    @unittest.skipUnless(sys.platform == "win32",
+                         "test is for win32")
+    def test_pathext_match_before_path_full_match(self):
+        base_dir = pathlib.Path(os.fsdecode(self.dir))
+        dir1 = base_dir / 'dir1'
+        dir2 = base_dir / 'dir2'
+        dir1.mkdir()
+        dir2.mkdir()
+
+        pathext_match = dir1 / 'hello.com.exe'
+        path_match = dir2 / 'hello.com'
+        pathext_match.touch()
+        path_match.touch()
+
+        test_path = os.pathsep.join([str(dir1), str(dir2)])
+        assert os.path.basename(shutil.which(
+            'hello.com', path=test_path, mode = os.F_OK
+        )).lower() == 'hello.com.exe'
+
+
     @os_helper.skip_if_dac_override
     def test_non_matching_mode(self):
         # Set the file read-only and ask for writeable files.

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2210,8 +2210,12 @@ class TestWhich(BaseTest, unittest.TestCase):
             self.assertTrue(shutil._win_path_needs_curdir('dontcare', os.X_OK))
             need_curdir_mock.assert_called_once_with('dontcare')
             need_curdir_mock.reset_mock()
-            self.assertFalse(shutil._win_path_needs_curdir('dontcare', 0))
+            self.assertTrue(shutil._win_path_needs_curdir('dontcare', 0))
             need_curdir_mock.assert_not_called()
+
+        with unittest.mock.patch('shutil._winapi.NeedCurrentDirectoryForExePath', return_value=False) as need_curdir_mock:
+            self.assertFalse(shutil._win_path_needs_curdir('dontcare', os.X_OK))
+            need_curdir_mock.assert_called_once_with('dontcare')
 
 
 class TestWhichBytes(TestWhich):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2191,6 +2191,21 @@ class TestWhich(BaseTest, unittest.TestCase):
 
             self.assertEqual(shutil.which("test_program"), str(test_path))
 
+    # See GH-75586
+    @unittest.skipUnless(sys.platform == "win32", 'test specific to Windows')
+    def test_win32_need_current_directory_for_exe_path_true_without_ctypes(self):
+        with unittest.mock.patch('shutil._CTYPES_SUPPORTED', False):
+            self.assertTrue(shutil._win32_need_current_directory_for_exe_path('anything'))
+
+    # See GH-75586
+    @unittest.skipUnless(sys.platform == "win32", 'test specific to Windows')
+    def test_win32_need_current_directory_for_exe_path_with_ctypes(self):
+        with unittest.mock.patch('shutil._CTYPES_SUPPORTED', True):
+            with unittest.mock.patch('shutil.ctypes') as ctypes_mock:
+                ctypes_mock.windll.kernel32.NeedCurrentDirectoryForExePathW.return_value = 0
+                self.assertFalse(shutil._win32_need_current_directory_for_exe_path('test.exe'))
+                ctypes_mock.windll.kernel32.NeedCurrentDirectoryForExePathW.assert_called_once_with('test.exe')
+
 
 class TestWhichBytes(TestWhich):
     def setUp(self):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2179,6 +2179,18 @@ class TestWhich(BaseTest, unittest.TestCase):
             rv = shutil.which(program, path=self.temp_dir)
             self.assertEqual(rv, temp_filexyz.name)
 
+    # See GH-75586
+    @unittest.skipUnless(sys.platform == "win32", 'test specific to Windows')
+    def test_pathext_applied_on_files_in_path(self):
+        with os_helper.EnvironmentVarGuard() as env:
+            env["PATH"] = self.temp_dir
+            env["PATHEXT"] = ".test"
+
+            test_path = pathlib.Path(self.temp_dir) / "test_program.test"
+            test_path.touch(mode=0o755)
+
+            self.assertEqual(shutil.which("test_program"), str(test_path))
+
 
 class TestWhichBytes(TestWhich):
     def setUp(self):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2213,7 +2213,7 @@ class TestWhich(BaseTest, unittest.TestCase):
             self.assertTrue(shutil._win_path_needs_curdir('dontcare', 0))
             need_curdir_mock.assert_not_called()
 
-        with unittest.mock.patch('shutil._winapi.NeedCurrentDirectoryForExePath', return_value=False) as need_curdir_mock:
+        with unittest.mock.patch('_winapi.NeedCurrentDirectoryForExePath', return_value=False) as need_curdir_mock:
             self.assertFalse(shutil._win_path_needs_curdir('dontcare', os.X_OK))
             need_curdir_mock.assert_called_once_with('dontcare')
 

--- a/Misc/NEWS.d/next/Library/2023-04-02-22-04-26.gh-issue-75586.526iJm.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-02-22-04-26.gh-issue-75586.526iJm.rst
@@ -1,1 +1,1 @@
-Fix an issue with ``shutil.which`` on Windows where PATHEXT was not consulted when checking for a match in PATH.
+Fix various Windows-specific issues with ``shutil.which``.

--- a/Misc/NEWS.d/next/Library/2023-04-02-22-04-26.gh-issue-75586.526iJm.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-02-22-04-26.gh-issue-75586.526iJm.rst
@@ -1,0 +1,1 @@
+Fix an issue with `shutil.which` on Windows where PATHEXT was not consulted when checking for a match in PATH.

--- a/Misc/NEWS.d/next/Library/2023-04-02-22-04-26.gh-issue-75586.526iJm.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-02-22-04-26.gh-issue-75586.526iJm.rst
@@ -1,1 +1,1 @@
-Fix an issue with `shutil.which` on Windows where PATHEXT was not consulted when checking for a match in PATH.
+Fix an issue with ``shutil.which`` on Windows where PATHEXT was not consulted when checking for a match in PATH.

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -2054,6 +2054,26 @@ _winapi__mimetypes_read_windows_registry_impl(PyObject *module,
 #undef CB_TYPE
 }
 
+/*[clinic input]
+_winapi.NeedCurrentDirectoryForExePath -> bool
+
+    exe_name: LPCWSTR
+    /
+[clinic start generated code]*/
+
+static int
+_winapi_NeedCurrentDirectoryForExePath_impl(PyObject *module,
+                                            LPCWSTR exe_name)
+/*[clinic end generated code: output=a65ec879502b58fc input=972aac88a1ec2f00]*/
+{
+    BOOL result;
+
+    Py_BEGIN_ALLOW_THREADS
+    result = NeedCurrentDirectoryForExePathW(exe_name);
+    Py_END_ALLOW_THREADS
+
+    return result;
+}
 
 static PyMethodDef winapi_functions[] = {
     _WINAPI_CLOSEHANDLE_METHODDEF
@@ -2089,6 +2109,7 @@ static PyMethodDef winapi_functions[] = {
     _WINAPI_GETACP_METHODDEF
     _WINAPI_GETFILETYPE_METHODDEF
     _WINAPI__MIMETYPES_READ_WINDOWS_REGISTRY_METHODDEF
+    _WINAPI_NEEDCURRENTDIRECTORYFOREXEPATH_METHODDEF
     {NULL, NULL}
 };
 

--- a/Modules/clinic/_winapi.c.h
+++ b/Modules/clinic/_winapi.c.h
@@ -1371,4 +1371,44 @@ _winapi__mimetypes_read_windows_registry(PyObject *module, PyObject *const *args
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=edb1a9d1bbfd6394 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(_winapi_NeedCurrentDirectoryForExePath__doc__,
+"NeedCurrentDirectoryForExePath($module, exe_name, /)\n"
+"--\n"
+"\n");
+
+#define _WINAPI_NEEDCURRENTDIRECTORYFOREXEPATH_METHODDEF    \
+    {"NeedCurrentDirectoryForExePath", (PyCFunction)_winapi_NeedCurrentDirectoryForExePath, METH_O, _winapi_NeedCurrentDirectoryForExePath__doc__},
+
+static int
+_winapi_NeedCurrentDirectoryForExePath_impl(PyObject *module,
+                                            LPCWSTR exe_name);
+
+static PyObject *
+_winapi_NeedCurrentDirectoryForExePath(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    LPCWSTR exe_name = NULL;
+    int _return_value;
+
+    if (!PyUnicode_Check(arg)) {
+        _PyArg_BadArgument("NeedCurrentDirectoryForExePath", "argument", "str", arg);
+        goto exit;
+    }
+    exe_name = PyUnicode_AsWideCharString(arg, NULL);
+    if (exe_name == NULL) {
+        goto exit;
+    }
+    _return_value = _winapi_NeedCurrentDirectoryForExePath_impl(module, exe_name);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyBool_FromLong((long)_return_value);
+
+exit:
+    /* Cleanup for exe_name */
+    PyMem_Free((void *)exe_name);
+
+    return return_value;
+}
+/*[clinic end generated code: output=96ea65ece7912d0a input=a9049054013a1b77]*/


### PR DESCRIPTION
GH-75586 - Fix case where PATHEXT isn't applied to items in PATH.

The logic change here makes it so that if the command passed into `shutil.which` on windows, it will be verified against how it is passed in and against the various items in PATHEXT. 

For example:
```
shutil.which('C:/windows/system32/cmd') 
```

will now return 
```
'C:/windows/system32/cmd.EXE'
```

Instead of `None`. 

If this looks good, I'd be happy to create a changelog entry, etc. Just feeling the water with this first commit. 