### PR TITLE
gh-103193: Micro-optimise helper functions for `inspect.getattr_static`

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1772,9 +1772,9 @@ def trace(context=1):
 # ------------------------------------------------ static version of getattr
 
 _sentinel = object()
+_static_getmro = type.__dict__['__mro__'].__get__
+_dunder_dict_descriptor = type.__dict__["__dict__"]
 
-def _static_getmro(klass):
-    return type.__dict__['__mro__'].__get__(klass)
 
 def _check_instance(obj, attr):
     instance_dict = {}
@@ -1802,10 +1802,9 @@ def _is_type(obj):
     return True
 
 def _shadowed_dict(klass):
-    dict_attr = type.__dict__["__dict__"]
     for entry in _static_getmro(klass):
         try:
-            class_dict = dict_attr.__get__(entry)["__dict__"]
+            class_dict = _dunder_dict_descriptor.__get__(entry)["__dict__"]
         except KeyError:
             pass
         else:

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1773,7 +1773,7 @@ def trace(context=1):
 
 _sentinel = object()
 _static_getmro = type.__dict__['__mro__'].__get__
-_dunder_dict_descriptor = type.__dict__["__dict__"]
+_get_dunder_dict_of_class = type.__dict__["__dict__"].__get__
 
 
 def _check_instance(obj, attr):
@@ -1804,7 +1804,7 @@ def _is_type(obj):
 def _shadowed_dict(klass):
     for entry in _static_getmro(klass):
         try:
-            class_dict = _dunder_dict_descriptor.__get__(entry)["__dict__"]
+            class_dict = _get_dunder_dict_of_class(entry)["__dict__"]
         except KeyError:
             pass
         else:

--- a/Misc/NEWS.d/next/Library/2023-04-02-17-51-08.gh-issue-103193.xrZbM1.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-02-17-51-08.gh-issue-103193.xrZbM1.rst
@@ -1,0 +1,2 @@
+Improve performance of :func:`inspect.getattr_static`. Patch by Alex
+Waygood.


### PR DESCRIPTION
Micro-optimising `inspect._static_getmro` and `inspect._shadowed_dict` leads to a significant improvement in the time taken to call `isinstance()` on a runtime-checkable protocol. (This is a useful benchmark, as it's a real-world use of `inspect.getattr_static` in a tight loop, that's found in the stdlib.)

Benchmark results on a0305c5fdfdef7a362d0262c54399c4a6013d1ea:

```
Time taken for objects with a property: 3.34
Time taken for objects with a classvar: 3.08
Time taken for objects with an instance var: 12.15
Time taken for objects with no var: 15.38
Time taken for nominal subclass instances: 25.13
Time taken for registered subclass instances: 21.65
```

Benchmark results with this PR:

```
Time taken for objects with a property: 2.82
Time taken for objects with a classvar: 2.85
Time taken for objects with an instance var: 8.62
Time taken for objects with no var: 14.01
Time taken for nominal subclass instances: 21.80
Time taken for registered subclass instances: 20.23
```

<details>
<summary>Benchmark script:</summary>

```py
import time
from typing import Protocol, runtime_checkable

@runtime_checkable
class HasX(Protocol):
    x: int

class Foo:
    @property
    def x(self) -> int:
        return 42

class Bar:
    x = 42

class Baz:
    def __init__(self):
        self.x = 42

class Egg: ...

class Nominal(HasX):
    def __init__(self):
        self.x = 42

class Registered: ...

HasX.register(Registered)

num_instances = 500_000
foos = [Foo() for _ in range(num_instances)]
bars = [Bar() for _ in range(num_instances)]
bazzes = [Baz() for _ in range(num_instances)]
basket = [Egg() for _ in range(num_instances)]
nominals = [Nominal() for _ in range(num_instances)]
registereds = [Registered() for _ in range(num_instances)]


def bench(objs, title):
    start_time = time.perf_counter()
    for obj in objs:
        isinstance(obj, HasX)
    elapsed = time.perf_counter() - start_time
    print(f"{title}: {elapsed:.2f}")


bench(foos, "Time taken for objects with a property")
bench(bars, "Time taken for objects with a classvar")
bench(bazzes, "Time taken for objects with an instance var")
bench(basket, "Time taken for objects with no var")
bench(nominals, "Time taken for nominal subclass instances")
bench(registereds, "Time taken for registered subclass instances")
```
</details>

<!-- gh-issue-number: gh-103193 -->
* Issue: gh-103193
<!-- /gh-issue-number -->
