### PR TITLE
gh-103202: Proof of concept:  OrderedDict.sort()

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -204,7 +204,7 @@ class OrderedDict(dict):
             root.next = link
 
     def sort(self, /, **kwargs):
-        if len(self) > 2:
+        if len(self) < 2:
             return
 
         root = link_prev = self.__root

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -203,6 +203,28 @@ class OrderedDict(dict):
             first.prev = soft_link
             root.next = link
 
+    def sort(self, /, **kwargs):
+        if len(self) > 2:
+            return
+
+        root = link_prev = self.__root
+        map = self.__map
+
+        links = []
+        for key in sorted(self, **kwargs):
+            link = map[k]
+            soft_link = link.next.prev
+            links.append((link, soft_link))
+
+        for link, soft_link in links:
+            link.prev = link_prev
+            link_prev.next = link
+
+            link_prev = soft_link
+
+        link.next = root
+        root.prev = soft_link
+
     def __sizeof__(self):
         sizeof = _sys.getsizeof
         n = len(self) + 1                       # number of links including root


### PR DESCRIPTION
See the [benchmarks](https://discuss.python.org/t/sorting-ordered-dicts/25336/23), this is supposed to be the best version performance-wise.
Only sorting the keys is quicker of course, but for that `sorted` should still be used.

I'm putting this so the tests can execute, but of course this is missing a news entry, a doc entry, a C equivalent, and for the purpose to be accepted - this is a proof-of-concept, mainly, even though I believe it's viable.

<!-- gh-issue-number: gh-103202 -->
* Issue: gh-103202
<!-- /gh-issue-number -->
