### PR TITLE
gh-103186: assert in tests that UnsafeMailcapInput warnings are provided

### DIFF
--- a/Lib/test/test_mailcap.py
+++ b/Lib/test/test_mailcap.py
@@ -243,7 +243,6 @@ class FindmatchTest(unittest.TestCase):
 
     def test_unsafe_mailcap_input(self):
         plist = ["total=*"]
-
         with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,
                                    'Refusing to substitute parameter.*into a shell command'):
             self.assertEqual(mailcap.subst("echo %{total}", "audio/wav", "foo.txt", plist), None)

--- a/Lib/test/test_mailcap.py
+++ b/Lib/test/test_mailcap.py
@@ -242,17 +242,20 @@ class FindmatchTest(unittest.TestCase):
         self._run_cases(cases)
 
     def test_unsafe_mailcap_input(self):
-        c     = MAILCAPDICT
         plist = ["total=*"]
 
-        with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,'Refusing to substitute parameter.*into a shell command'):
+        with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,
+                                   'Refusing to substitute parameter.*into a shell command'):
             self.assertEqual(mailcap.subst("echo %{total}", "audio/wav", "foo.txt", plist), None)
-        
-        with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,'Refusing to substitute MIME type.*into a shell'):
+
+        with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,
+                                   'Refusing to substitute MIME type.*into a shell'):
             self.assertEqual(mailcap.subst("echo %t", "audio/*", "foo.txt"), None)
-        
-        with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,'Refusing to use mailcap with filename.*Use a safe temporary filename.'):
-            self.assertEqual(mailcap.findmatch(c, "audio/wav", filename="foo*.txt"), (None, None))
+
+        with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,
+                                   'Refusing to use mailcap with filename.*Use a safe temporary filename.'):
+            self.assertEqual(mailcap.findmatch(MAILCAPDICT,
+                                               "audio/wav", filename="foo*.txt"), (None, None))
 
     def _run_cases(self, cases):
         for c in cases:

--- a/Lib/test/test_mailcap.py
+++ b/Lib/test/test_mailcap.py
@@ -127,14 +127,18 @@ class HelperFunctionTest(unittest.TestCase):
             (["", "audio/*", "foo.txt"], ""),
             (["echo foo", "audio/*", "foo.txt"], "echo foo"),
             (["echo %s", "audio/*", "foo.txt"], "echo foo.txt"),
-            (["echo %t", "audio/*", "foo.txt"], None),
+            (["echo %t", "audio/*", "foo.txt"], None, {"warn_type": mailcap.UnsafeMailcapInput}),
             (["echo %t", "audio/wav", "foo.txt"], "echo audio/wav"),
             (["echo \\%t", "audio/*", "foo.txt"], "echo %t"),
             (["echo foo", "audio/*", "foo.txt", plist], "echo foo"),
             (["echo %{total}", "audio/*", "foo.txt", plist], "echo 3")
         ]
         for tc in test_cases:
-            self.assertEqual(mailcap.subst(*tc[0]), tc[1])
+            if len(tc) == 3:
+                with warnings_helper.check_warnings(('', tc[2]["warn_type"]), quiet=True):
+                    self.assertEqual(mailcap.subst(*tc[0]), tc[1])
+            else:
+                self.assertEqual(mailcap.subst(*tc[0]), tc[1])
 
 
 class GetcapsTest(unittest.TestCase):
@@ -212,7 +216,8 @@ class FindmatchTest(unittest.TestCase):
              ('"An audio fragment"', audio_basic_entry)),
             ([c, "audio/*"],
              {"filename": fname},
-             (None, None)),
+             (None, None),
+             {"warn_type": mailcap.UnsafeMailcapInput}),
             ([c, "audio/wav"],
              {"filename": fname},
              ("/usr/local/bin/showaudio audio/wav", audio_entry)),
@@ -247,7 +252,11 @@ class FindmatchTest(unittest.TestCase):
 
     def _run_cases(self, cases):
         for c in cases:
-            self.assertEqual(mailcap.findmatch(*c[0], **c[1]), c[2])
+            if len(c) == 4:
+                with warnings_helper.check_warnings(('', c[3]["warn_type"]), quiet=True):
+                    self.assertEqual(mailcap.findmatch(*c[0], **c[1]), c[2])
+            else: 
+                self.assertEqual(mailcap.findmatch(*c[0], **c[1]), c[2])
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_mailcap.py
+++ b/Lib/test/test_mailcap.py
@@ -255,7 +255,7 @@ class FindmatchTest(unittest.TestCase):
             if len(c) == 4:
                 with warnings_helper.check_warnings(('', c[3]["warn_type"]), quiet=True):
                     self.assertEqual(mailcap.findmatch(*c[0], **c[1]), c[2])
-            else: 
+            else:
                 self.assertEqual(mailcap.findmatch(*c[0], **c[1]), c[2])
 
 

--- a/Lib/test/test_mailcap.py
+++ b/Lib/test/test_mailcap.py
@@ -243,17 +243,26 @@ class FindmatchTest(unittest.TestCase):
 
     def test_unsafe_mailcap_input(self):
         with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,
-                                   'Refusing to substitute parameter.*into a shell command'):
-            unsafe_param = mailcap.subst("echo %{total}", "audio/wav", "foo.txt", ["total=*"])
+                                   'Refusing to substitute parameter.*'
+                                   'into a shell command'):
+            unsafe_param = mailcap.subst("echo %{total}",
+                                         "audio/wav",
+                                         "foo.txt",
+                                         ["total=*"])
             self.assertEqual(unsafe_param, None)
 
         with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,
-                                   'Refusing to substitute MIME type.*into a shell'):
-            self.assertEqual(mailcap.subst("echo %t", "audio/*", "foo.txt"), None)
+                                   'Refusing to substitute MIME type'
+                                   '.*into a shell'):
+            unsafe_mimetype = mailcap.subst("echo %t", "audio/*", "foo.txt")
+            self.assertEqual(unsafe_mimetype, None)
 
         with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,
-                                   'Refusing to use mailcap with filename.*Use a safe temporary filename.'):
-            unsafe_filename = mailcap.findmatch(MAILCAPDICT,"audio/wav", filename="foo*.txt")
+                                   'Refusing to use mailcap with filename.*'
+                                   'Use a safe temporary filename.'):
+            unsafe_filename = mailcap.findmatch(MAILCAPDICT,
+                                                "audio/wav",
+                                                filename="foo*.txt")
             self.assertEqual(unsafe_filename, (None, None))
 
     def _run_cases(self, cases):

--- a/Lib/test/test_mailcap.py
+++ b/Lib/test/test_mailcap.py
@@ -242,10 +242,10 @@ class FindmatchTest(unittest.TestCase):
         self._run_cases(cases)
 
     def test_unsafe_mailcap_input(self):
-        plist = ["total=*"]
         with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,
                                    'Refusing to substitute parameter.*into a shell command'):
-            self.assertEqual(mailcap.subst("echo %{total}", "audio/wav", "foo.txt", plist), None)
+            unsafe_param = mailcap.subst("echo %{total}", "audio/wav", "foo.txt", ["total=*"])
+            self.assertEqual(unsafe_param, None)
 
         with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,
                                    'Refusing to substitute MIME type.*into a shell'):

--- a/Lib/test/test_mailcap.py
+++ b/Lib/test/test_mailcap.py
@@ -253,8 +253,8 @@ class FindmatchTest(unittest.TestCase):
 
         with self.assertWarnsRegex(mailcap.UnsafeMailcapInput,
                                    'Refusing to use mailcap with filename.*Use a safe temporary filename.'):
-            self.assertEqual(mailcap.findmatch(MAILCAPDICT,
-                                               "audio/wav", filename="foo*.txt"), (None, None))
+            unsafe_filename = mailcap.findmatch(MAILCAPDICT,"audio/wav", filename="foo*.txt")
+            self.assertEqual(unsafe_filename, (None, None))
 
     def _run_cases(self, cases):
         for c in cases:


### PR DESCRIPTION
These warnings are expected as the function result being asserted is None

<!-- gh-issue-number: gh-103186 -->
* Issue: gh-103186
<!-- /gh-issue-number -->
