### PR TITLE
GH-103220: Fix `ntpath.join()` of partial UNC drive with trailing slash

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -142,7 +142,7 @@ def join(path, *paths):
             result_path = result_path + p_path
         ## add separator between UNC and non-absolute path
         if (result_path and not result_root and
-            result_drive and result_drive[-1:] != colon):
+            result_drive and result_drive[-1:] not in colon + seps):
             return result_drive + sep + result_path
         return result_drive + result_root + result_path
     except (TypeError, AttributeError, BytesWarning):

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -299,6 +299,11 @@ class TestNtpath(NtpathTestCase):
         tester("ntpath.join('//computer/share', 'a', 'b')", '//computer/share\\a\\b')
         tester("ntpath.join('//computer/share', 'a/b')", '//computer/share\\a/b')
 
+        tester("ntpath.join('\\\\', 'computer')", '\\\\computer')
+        tester("ntpath.join('\\\\computer\\', 'share')", '\\\\computer\\share')
+        tester("ntpath.join('\\\\computer\\share\\', 'a')", '\\\\computer\\share\\a')
+        tester("ntpath.join('\\\\computer\\share\\a\\', 'b')", '\\\\computer\\share\\a\\b')
+
     def test_normpath(self):
         tester("ntpath.normpath('A//////././//.//B')", r'A\B')
         tester("ntpath.normpath('A/./B')", r'A\B')

--- a/Misc/NEWS.d/next/Library/2023-04-03-21-08-53.gh-issue-103220.OW_Bj5.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-03-21-08-53.gh-issue-103220.OW_Bj5.rst
@@ -1,0 +1,2 @@
+Fix issue where :func:`os.path.join` added a slash when joining onto an
+incomplete UNC drive with a trailing slash on Windows.


### PR DESCRIPTION
Before:

```python
>>> ntpath.join('\\\\server\\', 'share')
'\\\\server\\\\share'
>>> ntpath.join('\\\\', 'server')
'\\\\\\server'
```

After:

```python
>>> ntpath.join('\\\\server\\', 'share')
'\\\\server\\share'
>>> ntpath.join('\\\\', 'server')
'\\\\server'
```

<!-- gh-issue-number: gh-103220 -->
* Issue: gh-103220
<!-- /gh-issue-number -->
