### PR TITLE
GH-103319: Fix `inspect.getsourcelines()` to return 1-based line numbers

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1260,7 +1260,7 @@ def getsourcelines(object):
     # for module or frame that corresponds to module, return all source lines
     if (ismodule(object) or
         (isframe(object) and object.f_code.co_name == "<module>")):
-        return lines, 0
+        return lines, 1
     else:
         return getblock(lines[lnum:]), lnum + 1
 

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -654,6 +654,17 @@ class TestRetrievingSourceCode(GetSourceBase):
         finally:
             del linecache.cache[co.co_filename]
 
+    def test_getsourcelines(self):
+        # Check source lines and starting line number for a module
+        mod_lines, mod_lineno = inspect.getsourcelines(mod)
+        self.assertEqual(len(mod_lines), 115)
+        self.assertEqual(mod_lineno, 1)
+
+        # Check source lines and starting line number for a function
+        spam_lines, spam_lineno = inspect.getsourcelines(mod.spam)
+        self.assertEqual(len(spam_lines), 2)
+        self.assertEqual(spam_lineno, 8)
+
     def test_getfile(self):
         self.assertEqual(inspect.getfile(mod.StupidGit), mod.__file__)
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1675,6 +1675,31 @@ def test_pdb_issue_gh_101673():
     (Pdb) continue
     """
 
+def test_pdb_issue_gh_103225():
+    """See GH-103225
+
+    Make sure longlist uses 1-based line numbers in frames that correspond to a module
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'longlist',
+    ...     'continue'
+    ... ]):
+    ...     a = 1
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     b = 2
+    > <doctest test.test_pdb.test_pdb_issue_gh_103225[0]>(7)<module>()
+    -> b = 2
+    (Pdb) longlist
+      1     with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+      2         'longlist',
+      3         'continue'
+      4     ]):
+      5         a = 1
+      6         import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+      7  ->     b = 2
+    (Pdb) continue
+    """
+
 
 @support.requires_subprocess()
 class PdbTestCase(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2023-04-03-22-11-58.gh-issue-103225.nwprfk.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-03-22-11-58.gh-issue-103225.nwprfk.rst
@@ -1,0 +1,1 @@
+Fix :func:`inspect.getsourcelines` function to return 1-based line numbers for modules and frames that correspond to modules.


### PR DESCRIPTION
The problem is described in GH-103225.

I did not find any other usages of a line number returned by `inspect.getsourcelines()` except for `pdb`. However, I am not sure how many external usages of `inspect.getsourcelines()` already rely on 0-based line numbers for modules.

<!-- gh-issue-number: gh-103319 -->
* Issue: gh-103319
<!-- /gh-issue-number -->
