### PR TITLE
gh-96663: Add a better error message for __dict__-less classes setattr

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -2,7 +2,6 @@
 
 import unittest
 
-
 testmeths = [
 
 # Binary operations
@@ -641,6 +640,14 @@ class ClassTests(unittest.TestCase):
         class B:
             y = 0
             __slots__ = ('z',)
+        class C:
+            __slots__ = ("y",)
+
+            def __setattr__(self, name, value) -> None:
+                if name == "z":
+                    super().__setattr__("y", 1)
+                else:
+                    super().__setattr__(name, value)
 
         error_msg = "'A' object has no attribute 'x'"
         with self.assertRaisesRegex(AttributeError, error_msg):
@@ -656,6 +663,11 @@ class ClassTests(unittest.TestCase):
         with self.assertRaisesRegex(
             AttributeError,
             "'B' object has no attribute 'x' and no __dict__ for setting new attributes"
+        ):
+            B().x = 0
+        with self.assertRaisesRegex(
+            AttributeError,
+            "'C' object has no attribute 'x'"
         ):
             B().x = 0
 

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -640,7 +640,7 @@ class ClassTests(unittest.TestCase):
             pass
         class B:
             y = 0
-            __slots__ = ('z',)
+            __slots__ = ('z', "foo")
 
         error_msg = "'A' object has no attribute 'x'"
         with self.assertRaisesRegex(AttributeError, error_msg):
@@ -648,13 +648,22 @@ class ClassTests(unittest.TestCase):
         with self.assertRaisesRegex(AttributeError, error_msg):
             del A().x
 
-        error_msg = "'B' object has no attribute 'x'"
+        error_msg = ("'B' object has no attribute 'x' and no "
+                     "__dict__ for setting new attributes")
         with self.assertRaisesRegex(AttributeError, error_msg):
             B().x
         with self.assertRaisesRegex(AttributeError, error_msg):
             del B().x
         with self.assertRaisesRegex(AttributeError, error_msg):
             B().x = 0
+
+        with self.assertRaisesRegex(
+            AttributeError,
+            "'B' object has no attribute 'x' and no "
+            "__dict__ for setting new attributes. Did you mean: 'foo'"
+            ""
+        ):
+            B().fod = 1
 
         error_msg = "'B' object attribute 'y' is read-only"
         with self.assertRaisesRegex(AttributeError, error_msg):

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -648,13 +648,15 @@ class ClassTests(unittest.TestCase):
         with self.assertRaisesRegex(AttributeError, error_msg):
             del A().x
 
-        error_msg = ("'B' object has no attribute 'x' and no "
-                     "__dict__ for setting new attributes")
+        error_msg = ("'B' object has no attribute 'x'")
         with self.assertRaisesRegex(AttributeError, error_msg):
             B().x
         with self.assertRaisesRegex(AttributeError, error_msg):
             del B().x
-        with self.assertRaisesRegex(AttributeError, error_msg):
+        with self.assertRaisesRegex(
+            AttributeError,
+            "'B' object has no attribute 'x' and no __dict__ for setting new attributes"
+        ):
             B().x = 0
 
         with self.assertRaisesRegex(

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -661,8 +661,8 @@ class ClassTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             AttributeError,
-            "'B' object has no attribute 'x' and no "
-            "__dict__ for setting new attributes. Did you mean: 'foo'"
+            "'B' object has no attribute 'fod' and no "
+            r"__dict__ for setting new attributes. Did you mean: 'foo'\?"
             ""
         ):
             B().fod = 1

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -640,7 +640,7 @@ class ClassTests(unittest.TestCase):
             pass
         class B:
             y = 0
-            __slots__ = ('z', 'foo')
+            __slots__ = ('z',)
 
         error_msg = "'A' object has no attribute 'x'"
         with self.assertRaisesRegex(AttributeError, error_msg):
@@ -658,14 +658,6 @@ class ClassTests(unittest.TestCase):
             "'B' object has no attribute 'x' and no __dict__ for setting new attributes"
         ):
             B().x = 0
-
-        with self.assertRaisesRegex(
-            AttributeError,
-            "'B' object has no attribute 'fod' and no "
-            r"__dict__ for setting new attributes. Did you mean: 'foo'\?"
-            ""
-        ):
-            B().fod = 1
 
         error_msg = "'B' object attribute 'y' is read-only"
         with self.assertRaisesRegex(AttributeError, error_msg):

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+
 testmeths = [
 
 # Binary operations
@@ -669,7 +670,7 @@ class ClassTests(unittest.TestCase):
             AttributeError,
             "'C' object has no attribute 'x'"
         ):
-            B().x = 0
+            C().x = 0
 
         error_msg = "'B' object attribute 'y' is read-only"
         with self.assertRaisesRegex(AttributeError, error_msg):

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -640,7 +640,7 @@ class ClassTests(unittest.TestCase):
             pass
         class B:
             y = 0
-            __slots__ = ('z', "foo")
+            __slots__ = ('z', 'foo')
 
         error_msg = "'A' object has no attribute 'x'"
         with self.assertRaisesRegex(AttributeError, error_msg):
@@ -648,7 +648,7 @@ class ClassTests(unittest.TestCase):
         with self.assertRaisesRegex(AttributeError, error_msg):
             del A().x
 
-        error_msg = ("'B' object has no attribute 'x'")
+        error_msg = "'B' object has no attribute 'x'"
         with self.assertRaisesRegex(AttributeError, error_msg):
             B().x
         with self.assertRaisesRegex(AttributeError, error_msg):

--- a/Lib/test/test_descrtut.py
+++ b/Lib/test/test_descrtut.py
@@ -8,9 +8,9 @@
 # of much interest anymore), and a few were fiddled to make the output
 # deterministic.
 
-from test.support import sortdict
 import doctest
 import unittest
+from test.support import sortdict
 
 
 class defaultdict(dict):
@@ -139,7 +139,7 @@ instance variables cannot be assigned to:
     >>> a.x1 = 1
     Traceback (most recent call last):
       File "<stdin>", line 1, in ?
-    AttributeError: 'defaultdict2' object has no attribute 'x1'
+    AttributeError: 'defaultdict2' object has no attribute 'x1' and no __dict__ for setting new attributes
     >>>
 
 """

--- a/Lib/test/test_descrtut.py
+++ b/Lib/test/test_descrtut.py
@@ -8,9 +8,9 @@
 # of much interest anymore), and a few were fiddled to make the output
 # deterministic.
 
+from test.support import sortdict
 import doctest
 import unittest
-from test.support import sortdict
 
 
 class defaultdict(dict):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-04-04-00-40-04.gh-issue-96663.PdR9hK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-04-04-00-40-04.gh-issue-96663.PdR9hK.rst
@@ -1,0 +1,1 @@
+Add a better, more introspect-able error message when setting attributes on classes without a ``__dict__`` and no slot member for the attribute.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1545,10 +1545,17 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
         }
         if (dictptr == NULL) {
             if (descr == NULL) {
-                PyErr_Format(PyExc_AttributeError,
-                            "'%.100s' object has no attribute '%U' and no "
-                            "__dict__ for setting new attributes",
-                            tp->tp_name, name);
+                if (tp->tp_setattro == PyObject_GenericSetAttr) {
+                    PyErr_Format(PyExc_AttributeError,
+                                "'%.100s' object has no attribute '%U' and no "
+                                "__dict__ for setting new attributes",
+                                tp->tp_name, name);
+                }
+                else {
+                    PyErr_Format(PyExc_AttributeError,
+                                "'%.100s' object has no attribute '%U'",
+                                tp->tp_name, name);
+                }
                 set_attribute_error_context(obj, name);
             }
             else {

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1546,8 +1546,10 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
         if (dictptr == NULL) {
             if (descr == NULL) {
                 PyErr_Format(PyExc_AttributeError,
-                            "'%.100s' object has no attribute '%U'",
+                            "'%.100s' object has no attribute '%U' and no "
+                            "__dict__ for setting new attributes",
                             tp->tp_name, name);
+                set_attribute_error_context(obj, name);
             }
             else {
                 PyErr_Format(PyExc_AttributeError,
@@ -1577,9 +1579,11 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
         }
         else {
             PyErr_Format(PyExc_AttributeError,
-                         "'%.100s' object has no attribute '%U'",
+                         "'%.100s' object has no attribute '%U' and no "
+                         "__dict__ for setting new attributes",
                          tp->tp_name, name);
         }
+        set_attribute_error_context(obj, name);
     }
   done:
     Py_XDECREF(descr);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1579,8 +1579,7 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
         }
         else {
             PyErr_Format(PyExc_AttributeError,
-                         "'%.100s' object has no attribute '%U' and no "
-                         "__dict__ for setting new attributes",
+                         "'%.100s' object has no attribute '%U'",
                          tp->tp_name, name);
         }
         set_attribute_error_context(obj, name);


### PR DESCRIPTION
I think this addresses all the issues I have with the current message. Thanks to Eryk for the pointer as to where I should be editing.

<!-- gh-issue-number: gh-96663 -->
* Issue: gh-96663
<!-- /gh-issue-number -->
