### PR TITLE
Fix a compiler warning in _xxsubinterpretermodule.c

### DIFF
--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -481,7 +481,7 @@ _run_script_in_interpreter(PyObject *mod, PyInterpreterState *interp,
     }
 
     // Run the script.
-    _sharedexception exc;
+    _sharedexception exc = {NULL, NULL};
     int result = _run_script(interp, codestr, shared, &exc);
 
     // Switch back.


### PR DESCRIPTION
Fix a (correct) warning about potential uses of uninitialized memory in _xxsubinterpreter. Unlike newly allocated PyObject structs or global structs, stack-allocated structs are not initialised, and a few places in the code expect the _sharedexception struct data to be NULL when not set.