### PR TITLE
gh-102660: Fix is_core_module()

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -1110,7 +1110,17 @@ get_core_module_dict(PyInterpreterState *interp,
 static inline int
 is_core_module(PyInterpreterState *interp, PyObject *name, PyObject *filename)
 {
-    return get_core_module_dict(interp, name, filename) != NULL;
+    /* This might be called before the core dict copies are in place,
+       so we can't rely on get_core_module_dict() here. */
+    if (filename == name) {
+        if (PyUnicode_CompareWithASCIIString(name, "sys") == 0) {
+            return 1;
+        }
+        if (PyUnicode_CompareWithASCIIString(name, "builtins") == 0) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 static int
@@ -1136,6 +1146,8 @@ fix_up_extension(PyObject *mod, PyObject *name, PyObject *filename)
     // when the extension module doesn't support sub-interpreters.
     if (def->m_size == -1) {
         if (!is_core_module(tstate->interp, name, filename)) {
+            assert(PyUnicode_CompareWithASCIIString(name, "sys") != 0);
+            assert(PyUnicode_CompareWithASCIIString(name, "builtins") != 0);
             if (def->m_base.m_copy) {
                 /* Somebody already imported the module,
                    likely under a different name.


### PR DESCRIPTION
In gh-102744 we added `is_core_module()` (in Python/import.c), which relies on 'get_core_module_dict()` (also added in that PR).  The problem is that `_PyImport_FixupBuiltin()`, which ultimately calls `is_core_module()`, is called on the builtins module before `interp->builtins_copy` is set.  Consequently, the builtins module isn't considered a "core" module while it is getting "fixed up" and its module def `m_copy` get set.  Under isolated interpreters this causes problems since sys and builtins are allowed even though they are still single-phase init modules.  (This was discovered while working on gh-101660.)

The solution is to stop relying on `get_core_module_dict()` in `is_core_module()`.

<!-- gh-issue-number: gh-102660 -->
* Issue: gh-102660
<!-- /gh-issue-number -->
