### PR TITLE
gh-81762: Clarify and simplify description of print's flush param

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1444,8 +1444,9 @@ are always available.  They are listed here in alphabetical order.
    arguments are converted to text strings, :func:`print` cannot be used with
    binary mode file objects.  For these, use ``file.write(...)`` instead.
 
-   Whether the output is buffered is usually determined by *file*, but if the
-   *flush* keyword argument is true, the stream is forcibly flushed.
+   Output buffering is usually determined by *file*.
+   However, if *flush* is true, the stream is forcibly flushed.
+
 
    .. versionchanged:: 3.3
       Added the *flush* keyword argument.


### PR DESCRIPTION
As discussed in #81762 , this implements @aeros 's Option 4 to clarify and simplify the docs language referring to the [print function flush parameter](https://docs.python.org/3/library/functions.html#print).

<!-- gh-issue-number: gh-81762 -->
* Issue: gh-81762
<!-- /gh-issue-number -->
