### PR TITLE
gh-103225: Fixed zero lineno issue for pdb

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1352,6 +1352,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         breaklist = self.get_file_breaks(filename)
         try:
             lines, lineno = inspect.getsourcelines(self.curframe)
+            # inspect.getsourcelines() returns lineno = 0 for
+            # module-level frame which breaks our code print line number
+            lineno = max(1, lineno)
         except OSError as err:
             self.error(err)
             return
@@ -1368,6 +1371,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             return
         try:
             lines, lineno = inspect.getsourcelines(obj)
+            # inspect.getsourcelines() returns lineno = 0 for
+            # module-level frame which breaks our code print line number
+            lineno = max(1, lineno)
         except (OSError, TypeError) as err:
             self.error(err)
             return

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1351,10 +1351,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         filename = self.curframe.f_code.co_filename
         breaklist = self.get_file_breaks(filename)
         try:
-            lines, lineno = inspect.getsourcelines(self.curframe)
-            # inspect.getsourcelines() returns lineno = 0 for
-            # module-level frame which breaks our code print line number
-            lineno = max(1, lineno)
+            lines, lineno = self._getsourcelines(self.curframe)
         except OSError as err:
             self.error(err)
             return
@@ -1370,10 +1367,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         except:
             return
         try:
-            lines, lineno = inspect.getsourcelines(obj)
-            # inspect.getsourcelines() returns lineno = 0 for
-            # module-level frame which breaks our code print line number
-            lineno = max(1, lineno)
+            lines, lineno = self._getsourcelines(obj)
         except (OSError, TypeError) as err:
             self.error(err)
             return
@@ -1667,6 +1661,16 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         except SyntaxError as exc:
             return _rstr(self._format_exc(exc))
         return ""
+
+    def _getsourcelines(self, obj):
+        # GH-103319
+        # inspect.getsourcelines() returns lineno = 0 for
+        # module-level frame which breaks our code print line number
+        # This method should be replaced by inspect.getsourcelines(obj)
+        # once this bug is fixed in inspect
+        lines, lineno = inspect.getsourcelines(obj)
+        lineno = max(1, lineno)
+        return lines, lineno
 
 # Collect all command help into docstring, if not run with -OO
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1675,6 +1675,31 @@ def test_pdb_issue_gh_101673():
     (Pdb) continue
     """
 
+def test_pdb_issue_gh_103225():
+    """See GH-103225
+
+    Make sure longlist uses 1-based line numbers in frames that correspond to a module
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'longlist',
+    ...     'continue'
+    ... ]):
+    ...     a = 1
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     b = 2
+    > <doctest test.test_pdb.test_pdb_issue_gh_103225[0]>(7)<module>()
+    -> b = 2
+    (Pdb) longlist
+      1     with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+      2         'longlist',
+      3         'continue'
+      4     ]):
+      5         a = 1
+      6         import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+      7  ->     b = 2
+    (Pdb) continue
+    """
+
 
 @support.requires_subprocess()
 class PdbTestCase(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2023-04-05-01-28-53.gh-issue-103225.QD3JVU.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-05-01-28-53.gh-issue-103225.QD3JVU.rst
@@ -1,1 +1,1 @@
-Fixed the line number display bug on modules for :mod:`pdb`
+Fix a bug in :mod:`pdb` when displaying line numbers of module-level source code.

--- a/Misc/NEWS.d/next/Library/2023-04-05-01-28-53.gh-issue-103225.QD3JVU.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-05-01-28-53.gh-issue-103225.QD3JVU.rst
@@ -1,0 +1,1 @@
+Fixed the line number display bug on modules for :mod:`pdb`


### PR DESCRIPTION
According to #103225, `inspect.getsourcelines()` returns wrong line number. Fixing it it `inspect` will take extra discussion so we fixed it in `pdb` for now. If in the future this got fixed in `inspect` we can take the fix away.

Co-authored-by: Artem Mukhin <ortem00@gmail.com>

<!-- gh-issue-number: gh-103225 -->
* Issue: gh-103225
<!-- /gh-issue-number -->
