### PR TITLE
gh-103266: Fix a typo in example code for bisect() function

### DIFF
--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -229,7 +229,7 @@ records in a table::
     [Movie(name='The Birds', released=1963, director='Hitchcock'),
      Movie(name='Love Story', released=1970, director='Hiller'),
      Movie(name='Jaws', released=1975, director='Spielberg'),
-     Movie(name='Aliens', released=1986, director='Scott'),
+     Movie(name='Aliens', released=1986, director='Cameron'),
      Movie(name='Titanic', released=1997, director='Cameron')]
 
 If the key function is expensive, it is possible to avoid repeated function

--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -210,7 +210,7 @@ records in a table::
     >>> Movie = namedtuple('Movie', ('name', 'released', 'director'))
 
     >>> movies = [
-    ...     Movie('Jaws', 1975, 'Speilberg'),
+    ...     Movie('Jaws', 1975, 'Spielberg'),
     ...     Movie('Titanic', 1997, 'Cameron'),
     ...     Movie('The Birds', 1963, 'Hitchcock'),
     ...     Movie('Aliens', 1986, 'Scott')
@@ -228,7 +228,7 @@ records in a table::
     >>> pprint(movies)
     [Movie(name='The Birds', released=1963, director='Hitchcock'),
      Movie(name='Love Story', released=1970, director='Hiller'),
-     Movie(name='Jaws', released=1975, director='Speilberg'),
+     Movie(name='Jaws', released=1975, director='Spielberg'),
      Movie(name='Aliens', released=1986, director='Scott'),
      Movie(name='Titanic', released=1997, director='Cameron')]
 

--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -213,7 +213,7 @@ records in a table::
     ...     Movie('Jaws', 1975, 'Spielberg'),
     ...     Movie('Titanic', 1997, 'Cameron'),
     ...     Movie('The Birds', 1963, 'Hitchcock'),
-    ...     Movie('Aliens', 1986, 'Scott')
+    ...     Movie('Aliens', 1986, 'Cameron')
     ... ]
 
     >>> # Find the first movie released after 1960


### PR DESCRIPTION
https://github.com/search?q=repo%3Apython%2Fcpython%20Speilberg&type=code shows that the reported two occurrences are the only ones.

<!-- gh-issue-number: gh-103266 -->
* Issue: gh-103266
<!-- /gh-issue-number -->
