### PR TITLE
[3.10] gh-103262: Fixes Windows installer build to work with latest compilers

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-04-05-15-59-46.gh-issue-103262.nV83ub.rst
+++ b/Misc/NEWS.d/next/Build/2023-04-05-15-59-46.gh-issue-103262.nV83ub.rst
@@ -1,0 +1,1 @@
+Fixes Windows installer build to work with latest compilers.

--- a/Tools/msi/bundle/bootstrap/pythonba.vcxproj
+++ b/Tools/msi/bundle/bootstrap/pythonba.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <!-- v143 is not supported by the version of WiX Toolset obtained by get_externals.bat -->
     <PlatformToolset Condition="'$(PlatformToolset)' == '' and '$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
     <PlatformToolset Condition="'$(PlatformToolset)' == '' and '$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <PlatformToolset Condition="'$(PlatformToolset)' == '' and ('$(MSBuildToolsVersion)' == '15.0' or '$(VisualStudioVersion)' == '15.0')">v141</PlatformToolset>
@@ -49,8 +50,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;gdiplus.lib;msimg32.lib;shlwapi.lib;wininet.lib;dutil.lib;balutil.lib;version.lib;uxtheme.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories Condition="'$(PlatformToolset)' == 'v142'">$(WixInstallPath)sdk\vs2017\lib\x86</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(PlatformToolset)' == 'v141'">$(WixInstallPath)sdk\vs2017\lib\x86</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="$(PlatformToolset.StartsWith(`v14`))">$(WixInstallPath)sdk\vs2017\lib\x86</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(PlatformToolset)' == 'v140'">$(WixInstallPath)sdk\vs2015\lib\x86</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(PlatformToolset)' == 'v120'">$(WixInstallPath)sdk\vs2013\lib\x86</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>pythonba.def</ModuleDefinitionFile>


### PR DESCRIPTION
This was fixed in GH-30885 for later versions, but was not backported all the way to 3.10.

<!-- gh-issue-number: gh-103262 -->
* Issue: gh-103262
<!-- /gh-issue-number -->
