### PR TITLE
gh-101659: Use the Raw Allocator in the _xxinterpchannels Module

### DIFF
--- a/Modules/_xxinterpchannelsmodule.c
+++ b/Modules/_xxinterpchannelsmodule.c
@@ -76,9 +76,9 @@ API..  The module does not create any objects that are shared globally.
 
 
 #define GLOBAL_MALLOC(TYPE) \
-    PyMem_NEW(TYPE, 1)
+    PyMem_RawMalloc(sizeof(TYPE))
 #define GLOBAL_FREE(VAR) \
-    PyMem_Free(VAR)
+    PyMem_RawFree(VAR)
 
 
 static PyInterpreterState *


### PR DESCRIPTION
Using the raw allocator for any of the global state makes sense, especially as we move to a per-interpreter obmalloc state (gh-101660).

<!-- gh-issue-number: gh-101659 -->
* Issue: gh-101659
<!-- /gh-issue-number -->
