### PR TITLE
gh-101346: compare and hash code objects by identity

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -330,7 +330,8 @@ class CodeTest(unittest.TestCase):
             return lambda: arg
         code = func.__code__
         newcode = code.replace(co_name="func")  # Should not raise SystemError
-        self.assertEqual(code, newcode)
+        for attr in ("co_names", "co_varnames", "co_cellvars", "co_freevars"):
+            self.assertEqual(getattr(code, attr), getattr(newcode, attr))
 
     def test_empty_linetable(self):
         def func():
@@ -451,52 +452,12 @@ class CodeTest(unittest.TestCase):
             self.assertIsNone(line)
             self.assertEqual(end_line, new_code.co_firstlineno + 1)
 
-    def test_code_equality(self):
-        def f():
-            try:
-                a()
-            except:
-                b()
-            else:
-                c()
-            finally:
-                d()
-        code_a = f.__code__
-        code_b = code_a.replace(co_linetable=b"")
-        code_c = code_a.replace(co_exceptiontable=b"")
-        code_d = code_b.replace(co_exceptiontable=b"")
-        self.assertNotEqual(code_a, code_b)
-        self.assertNotEqual(code_a, code_c)
-        self.assertNotEqual(code_a, code_d)
-        self.assertNotEqual(code_b, code_c)
-        self.assertNotEqual(code_b, code_d)
-        self.assertNotEqual(code_c, code_d)
-
-    def test_code_hash_uses_firstlineno(self):
-        c1 = (lambda: 1).__code__
-        c2 = (lambda: 1).__code__
+    def test_code_equality_is_identity(self):
+        def func():
+            pass
+        c1 = func.__code__
+        c2 = c1.replace()
         self.assertNotEqual(c1, c2)
-        self.assertNotEqual(hash(c1), hash(c2))
-        c3 = c1.replace(co_firstlineno=17)
-        self.assertNotEqual(c1, c3)
-        self.assertNotEqual(hash(c1), hash(c3))
-
-    def test_code_hash_uses_order(self):
-        # Swapping posonlyargcount and kwonlyargcount should change the hash.
-        c = (lambda x, y, *, z=1, w=1: 1).__code__
-        self.assertEqual(c.co_argcount, 2)
-        self.assertEqual(c.co_posonlyargcount, 0)
-        self.assertEqual(c.co_kwonlyargcount, 2)
-        swapped = c.replace(co_posonlyargcount=2, co_kwonlyargcount=0)
-        self.assertNotEqual(c, swapped)
-        self.assertNotEqual(hash(c), hash(swapped))
-
-    def test_code_hash_uses_bytecode(self):
-        c = (lambda x, y: x + y).__code__
-        d = (lambda x, y: x * y).__code__
-        c1 = c.replace(co_code=d.co_code)
-        self.assertNotEqual(c, c1)
-        self.assertNotEqual(hash(c), hash(c1))
 
 
 def isinterned(s):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-04-05-23-55-56.gh-issue-101346.Xi7BZx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-04-05-23-55-56.gh-issue-101346.Xi7BZx.rst
@@ -1,0 +1,1 @@
+Code objects are now compared by identity rather than by value.


### PR DESCRIPTION
This removes the complex, finicky, and unnecessary hash and comparison methods of code objects. As code objects change, these methods regularly become out of date and have to be updated to account for new fields. And as code objects have become more mutable with the specializing interpreter, it makes less sense to treat them as value types.

After this PR, code objects are hashed/equal solely by identity (the default behavior of Python objects), which is faster and simpler.

Given that "naturally occurring" code objects are in practice never equal to each other by the old rules anyway, this only impacts such artificial cases as `code == code.replace()` (which was previously true and is no longer true with this PR.)

Closes #101346.


<!-- gh-issue-number: gh-101346 -->
* Issue: gh-101346
<!-- /gh-issue-number -->
