### PR TITLE
gh-103300: Fix `Popen.wait()` deadlock in patchcheck.py

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2023-04-06-06-19-39.gh-issue-103300.nnE7Be.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-04-06-06-19-39.gh-issue-103300.nnE7Be.rst
@@ -1,3 +1,0 @@
-:source:`Tools/patchcheck/patchcheck.py` no longer deadlocks trying to
-process a branch with a large diff relative to ``main``. Patch by Oleg
-Iarygin.

--- a/Misc/NEWS.d/next/Tools-Demos/2023-04-06-06-19-39.gh-issue-103300.nnE7Be.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-04-06-06-19-39.gh-issue-103300.nnE7Be.rst
@@ -1,0 +1,3 @@
+:source:`Tools/patchcheck/patchcheck.py` no longer deadlocks trying to
+process a branch with a large diff relative to ``main``. Patch by Oleg
+Iarygin.

--- a/Tools/patchcheck/patchcheck.py
+++ b/Tools/patchcheck/patchcheck.py
@@ -130,9 +130,10 @@ def changed_files(base_branch=None):
         with subprocess.Popen(cmd.split(),
                               stdout=subprocess.PIPE,
                               cwd=SRCDIR) as st:
-            if st.wait() != 0:
+            git_file_status, _ = st.communicate()
+            if st.returncode != 0:
                 sys.exit(f'error running {cmd}')
-            for line in st.stdout:
+            for line in git_file_status.splitlines():
                 line = line.decode().rstrip()
                 status_text, filename = line.split(maxsplit=1)
                 status = set(status_text)


### PR DESCRIPTION
Use `Popen.communicate()` as recommended by https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait.

<!-- gh-issue-number: gh-103300 -->
* Issue: gh-103300
<!-- /gh-issue-number -->
