### PR TITLE
gh-48330: assert warning is emitted on unittest.TestResult with no addDuration

### DIFF
--- a/Lib/test/test_unittest/test_case.py
+++ b/Lib/test/test_unittest/test_case.py
@@ -304,7 +304,8 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
             def test(self):
                 pass
 
-        Foo('test').run()
+        with self.assertWarns(RuntimeWarning):
+            Foo('test').run()
 
     def test_deprecation_of_return_val_from_test(self):
         # Issue 41322 - deprecate return of value that is not None from a test


### PR DESCRIPTION
Fixes the warning below, which started with https://github.com/python/cpython/pull/12271.

```
======================================================================
ERROR: test_run_call_order_default_result (test.test_unittest.test_case.Test_TestCase.test_run_call_order_default_result)
----------------------------------------------------------------------
AttributeError: 'ResultWithNoStartTestRunStopTestRun' object has no attribute 'addDuration'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/iritkatriel/src/cpython/Lib/test/test_unittest/test_case.py", line 307, in test_run_call_order_default_result
    Foo('test').run()
  File "/Users/iritkatriel/src/cpython/Lib/unittest/case.py", line 639, in run
    self._addDuration(result, (time.perf_counter() - start_time))
  File "/Users/iritkatriel/src/cpython/Lib/unittest/case.py", line 580, in _addDuration
    warnings.warn("TestResult has no addDuration method",
RuntimeWarning: TestResult has no addDuration method
```

<!-- gh-issue-number: gh-48330 -->
* Issue: gh-48330
<!-- /gh-issue-number -->
