### PR TITLE
gh-74690: `typing._ProtocolMeta.__instancecheck__`: Exit early for protocols that only have callable members

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2577,6 +2577,18 @@ class ProtocolTests(BaseTestCase):
         class PG(Protocol[T]):
             def meth(x): ...
 
+        @runtime_checkable
+        class WeirdProto(Protocol):
+            meth = str.maketrans
+
+        class CustomCallable:
+            def __call__(self, *args, **kwargs):
+                pass
+
+        @runtime_checkable
+        class WeirderProto(Protocol):
+            meth = CustomCallable()
+
         class BadP(Protocol):
             def meth(x): ...
 
@@ -2588,6 +2600,8 @@ class ProtocolTests(BaseTestCase):
 
         self.assertIsInstance(C(), P)
         self.assertIsInstance(C(), PG)
+        self.assertIsInstance(C(), WeirdProto)
+        self.assertIsInstance(C(), WeirderProto)
         with self.assertRaises(TypeError):
             isinstance(C(), PG[T])
         with self.assertRaises(TypeError):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2032,7 +2032,11 @@ class _ProtocolMeta(ABCMeta):
         if super().__instancecheck__(instance):
             return True
 
-        if is_protocol_cls:
+        # Skip the below loop for protocols where `cls.__callable_proto_members_only__ == True`.
+        # For these protocols, this just duplicates checks that have already been done
+        # in the `_proto_hook` function,
+        # which is called as part of the super().__instancecheck__ method above.
+        if is_protocol_cls and not cls.__callable_proto_members_only__:
             getattr_static = _lazy_load_getattr_static()
             for attr in cls.__protocol_attrs__:
                 try:


### PR DESCRIPTION
This speeds up this `isinstance()` call 12x, while maintaining all invariants:

```py
from typing import SupportsInt
isinstance(object(), SupportsInt)
```

The performance of other kinds of `isinstance()` calls is not impacted.

<details>
<summary>Benchmark script</summary>

```py
import time
from typing import Protocol, runtime_checkable, SupportsInt

@runtime_checkable
class HasX(Protocol):
    x: int

@runtime_checkable
class SupportsIntAndX(Protocol):
    x: int
    def __int__(self) -> int: ...

class Empty:
    description = "Empty class with no attributes"

class Registered:
    description = "Subclass registered using ABCMeta.register"

HasX.register(Registered)
SupportsInt.register(Registered)
SupportsIntAndX.register(Registered)

class PropertyX:
    description = "Class with a property x"
    @property
    def x(self) -> int:
        return 42

class HasIntMethod:
    description = "Class with an __int__ method"
    def __int__(self):
        return 42

class PropertyXWithInt:
    description = "Class with a property x and an __int__ method"
    @property
    def x(self) -> int:
        return 42
    def __int__(self):
        return 42

class ClassVarX:
    description = "Class with a ClassVar x"
    x = 42

class ClassVarXWithInt:
    description = "Class with a ClassVar x and an __int__ method"
    x = 42
    def __int__(self):
        return 42

class InstanceVarX:
    description = "Class with an instance var x"
    def __init__(self):
        self.x = 42

class InstanceVarXWithInt:
    description = "Class with an instance var x and an __int__ method"
    def __init__(self):
        self.x = 42
    def __int__(self):
        return 42
    
class NominalX(HasX):
    description = "Class that explicitly subclasses HasX"
    def __init__(self):
        self.x = 42

class NominalSupportsInt(SupportsInt):
    description = "Class that explicitly subclasses SupportsInt"
    def __int__(self):
        return 42

class NominalXWithInt(SupportsIntAndX):
    description = "Class that explicitly subclasses NominalXWithInt"
    def __init__(self):
        self.x = 42


num_instances = 500_000

classes = {}
for cls in (
    Empty, Registered, PropertyX, PropertyXWithInt, ClassVarX, ClassVarXWithInt,
    InstanceVarX, InstanceVarXWithInt, NominalX, NominalXWithInt, HasIntMethod,
    NominalSupportsInt
):
    classes[cls] = [cls() for _ in range(num_instances)]


def bench(objs, title, protocol):
    start_time = time.perf_counter()
    for obj in objs:
        isinstance(obj, protocol)
    elapsed = time.perf_counter() - start_time
    print(f"{title}: {elapsed:.2f}")


print("Protocols with no callable members\n")
for cls in Empty, Registered, PropertyX, ClassVarX, InstanceVarX, NominalX:
    bench(classes[cls], cls.description, HasX)

print("\nProtocols with only callable members\n")
for cls in Empty, Registered, HasIntMethod, NominalSupportsInt:
    bench(classes[cls], cls.description, SupportsInt)

print("\nProtocols with callable and non-callable members\n")
for cls in (
    Empty, Registered, PropertyXWithInt, ClassVarXWithInt, InstanceVarXWithInt,
    NominalXWithInt
):
    bench(classes[cls], cls.description, SupportsIntAndX)
```

</details>

<details>
<summary>Full benchmark results on `main`</summary>

```
Protocols with no callable members

Empty class with no attributes: 2.46
Subclass registered using ABCMeta.register: 0.45
Class with a property x: 1.40
Class with a ClassVar x: 1.44
Class with an instance var x: 6.41
Class that explicitly subclasses HasX: 0.63

Protocols with only callable members

Empty class with no attributes: 8.41
Subclass registered using ABCMeta.register: 3.32
Class with an __int__ method: 0.61
Class that explicitly subclasses SupportsInt: 0.61

Protocols with callable and non-callable members

Empty class with no attributes: 8.43
Subclass registered using ABCMeta.register: 1.61
Class with a property x and an __int__ method: 9.19
Class with a ClassVar x and an __int__ method: 9.22
Class with an instance var x and an __int__ method: 11.27
Class that explicitly subclasses NominalXWithInt: 0.62
```

</details>

<details>
<summary>Full benchmark results with this PR</summary>

```
Protocols with no callable members

Empty class with no attributes: 2.46
Subclass registered using ABCMeta.register: 0.45
Class with a property x: 1.41
Class with a ClassVar x: 1.41
Class with an instance var x: 6.40
Class that explicitly subclasses HasX: 0.61

Protocols with only callable members

Empty class with no attributes: 0.68
Subclass registered using ABCMeta.register: 3.36
Class with an __int__ method: 0.63
Class that explicitly subclasses SupportsInt: 0.61

Protocols with callable and non-callable members

Empty class with no attributes: 8.33
Subclass registered using ABCMeta.register: 1.60
Class with a property x and an __int__ method: 9.14
Class with a ClassVar x and an __int__ method: 9.17
Class with an instance var x and an __int__ method: 11.59
Class that explicitly subclasses NominalXWithInt: 0.62
```

</details>

<!-- gh-issue-number: gh-74690 -->
* Issue: gh-74690
<!-- /gh-issue-number -->
