### PR TITLE
gh-87864: Use correct function definition syntax in the docs

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -214,7 +214,7 @@ Glossary
       A callable is an object that can be called, possibly with a set
       of arguments (see :term:`argument`), with the following syntax::
 
-         callable(argument1, argument2, ...)
+         callable(argument1, argument2, argumentN)
 
       A :term:`function`, and by extension a :term:`method`, is a callable.
       An instance of a class that implements the :meth:`~object.__call__`

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1681,7 +1681,7 @@ are always available.  They are listed here in alphabetical order.
 
       class C:
           @staticmethod
-          def f(arg1, arg2, ...): ...
+          def f(arg1, arg2, argN): ...
 
    The ``@staticmethod`` form is a function :term:`decorator` -- see
    :ref:`function` for details.

--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -18,7 +18,7 @@ def abstractmethod(funcobj):
 
         class C(metaclass=ABCMeta):
             @abstractmethod
-            def my_abstract_method(self, ...):
+            def my_abstract_method(self, arg1, arg2, argN):
                 ...
     """
     funcobj.__isabstractmethod__ = True

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -942,7 +942,7 @@ functools_wraps(PyObject *wrapper, PyObject *wrapped)
 
      class C:
          @classmethod
-         def f(cls, arg1, arg2, ...):
+         def f(cls, arg1, arg2, argN):
              ...
 
    It can be called either on the class (e.g. C.f()) or on an instance
@@ -1066,7 +1066,7 @@ To declare a class method, use this idiom:\n\
 \n\
   class C:\n\
       @classmethod\n\
-      def f(cls, arg1, arg2, ...):\n\
+      def f(cls, arg1, arg2, argN):\n\
           ...\n\
 \n\
 It can be called either on the class (e.g. C.f()) or on an instance\n\
@@ -1138,7 +1138,7 @@ PyClassMethod_New(PyObject *callable)
 
      class C:
          @staticmethod
-         def f(arg1, arg2, ...):
+         def f(arg1, arg2, argN):
              ...
 
    It can be called either on the class (e.g. C.f()) or on an instance
@@ -1260,7 +1260,7 @@ To declare a static method, use this idiom:\n\
 \n\
      class C:\n\
          @staticmethod\n\
-         def f(arg1, arg2, ...):\n\
+         def f(arg1, arg2, argN):\n\
              ...\n\
 \n\
 It can be called either on the class (e.g. C.f()) or on an instance\n\


### PR DESCRIPTION
I've changed `...` in the parameter list of function definitions to be `argN` or similar.
It looks to me as it is a better thing to do: while we keep the same (or even clearer semantics), we also use the correct python syntax to do it.

<!-- gh-issue-number: gh-87864 -->
* Issue: gh-87864
<!-- /gh-issue-number -->
