### PR TITLE
Docs: don't render files in includes/, they're for embedding only

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -68,8 +68,10 @@ highlight_language = 'python3'
 # Minimum version of sphinx required
 needs_sphinx = '3.2'
 
+# Ignore any .rst files in the includes/ directory;
+# they're embedded in pages but not rendered individually.
 # Ignore any .rst files in the venv/ directory.
-exclude_patterns = ['venv/*', 'README.rst']
+exclude_patterns = ['includes/*.rst', 'venv/*', 'README.rst']
 venvdir = os.getenv('VENVDIR')
 if venvdir is not None:
     exclude_patterns.append(venvdir + '/*')


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

# Before

1. Go to https://docs.python.org/3.12/ and search for `wasi`
2. https://docs.python.org/3.12/search.html?q=wasi shows a `<no title>` page first:

![image](https://user-images.githubusercontent.com/1324225/230399780-5c76b827-1439-4ceb-bc70-92acc9d50dd0.png)

3. Click `<no title>`, it shows https://docs.python.org/3/includes/wasm-notavail.html?highlight=wasi:

![image](https://user-images.githubusercontent.com/1324225/230399827-2f61ead3-4a9c-4745-a002-59a5967366ad.png)

That's https://github.com/python/cpython/blob/main/Doc/includes/wasm-notavail.rst which is not meant to be rendered as a standalone page.

Instead it is meant to be embedded into pages via:

```rst
.. include:: ../includes/wasm-notavail.rst
```

For example:

* https://docs.python.org/3/library/venv.html?highlight=wasi
* https://raw.githubusercontent.com/python/cpython/3.11/Doc/library/venv.rst

![image](https://user-images.githubusercontent.com/1324225/230399945-353dc4bb-7eee-4c25-8d5e-b78cf515fa3a.png)

So let's exclude files in `includes/` from being rendered individually by adding it to `exclude_patterns`.

* https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-exclude_patterns

# After

1. Go to https://deploy-preview-103313--python-cpython-preview.netlify.app/ and search for `wasi`
2. https://deploy-preview-103313--python-cpython-preview.netlify.app/search.html?q=wasi&check_keywords=yes&area=default shows a `<no title>` page first:

![image](https://user-images.githubusercontent.com/1324225/230400053-e687e9c7-3d46-40eb-b930-0a33248898a1.png)

3. There is no `<no title>` result and there is no standalone https://deploy-preview-103313--python-cpython-preview.netlify.app/includes/wasm-notavail.html?highlight=wasi

4. The include is still embedded on pages such as https://deploy-preview-103313--python-cpython-preview.netlify.app/library/venv.html?highlight=wasi
