### PR TITLE
gh-103193: Speedup and inline `inspect._is_type`

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1791,13 +1791,6 @@ def _check_class(klass, attr):
             return entry.__dict__[attr]
     return _sentinel
 
-def _is_type(obj):
-    try:
-        _static_getmro(obj)
-    except TypeError:
-        return False
-    return True
-
 def _shadowed_dict(klass):
     for entry in _static_getmro(klass):
         dunder_dict = _get_dunder_dict_of_class(entry)
@@ -1821,8 +1814,10 @@ def getattr_static(obj, attr, default=_sentinel):
        documentation for details.
     """
     instance_result = _sentinel
-    if not _is_type(obj):
-        klass = type(obj)
+
+    objtype = type(obj)
+    if type not in _static_getmro(objtype):
+        klass = objtype
         dict_attr = _shadowed_dict(klass)
         if (dict_attr is _sentinel or
             type(dict_attr) is types.MemberDescriptorType):


### PR DESCRIPTION
(Using @sobolevn's benchmark script from https://github.com/python/cpython/issues/103193#issuecomment-1497396338.)

Benchmarks on `main`:

```
type[Foo]                :   74 ±  0 ns
Foo                      :  177 ±  1 ns
type[Bar]                :   74 ±  0 ns
Bar                      :  177 ±  0 ns
WithParentClassX         :  229 ±  0 ns
Baz                      :  216 ±  0 ns
WithParentX              :  266 ±  1 ns
type[Missing]            :  210 ±  0 ns
Missing                  :  219 ±  1 ns
Slotted                  :  214 ±  0 ns
Method                   :  178 ±  0 ns
StMethod                 :  178 ±  0 ns
ClsMethod                :  178 ±  1 ns
```

Benchmarks with this PR:

```
type[Foo]                :   74 ±  0 ns
Foo                      :  134 ±  0 ns
type[Bar]                :   74 ±  0 ns
Bar                      :  133 ±  0 ns
WithParentClassX         :  187 ±  0 ns
Baz                      :  171 ±  0 ns
WithParentX              :  220 ±  0 ns
type[Missing]            :  210 ±  1 ns
Missing                  :  174 ±  0 ns
Slotted                  :  169 ±  0 ns
Method                   :  133 ±  0 ns
StMethod                 :  133 ±  0 ns
ClsMethod                :  133 ±  0 ns
```

This speeds up this `isinstance()` call 1.25x relative to `main`:

```py
from typing import *

@runtime_checkable
class Foo(Protocol):
    a: int
    b: int
    c: int
    d: int
    e: int
    f: int
    g: int
    h: int
    i: int
    j: int

class Bar:
    def __init__(self):
        for attrname in 'abcdefghij':
            setattr(self, attrname, 42)

isinstance(Bar(), Foo)
```

<!-- gh-issue-number: gh-103193 -->
* Issue: gh-103193
<!-- /gh-issue-number -->
