### PR TITLE
gh-103323: Get the "Current" Thread State from a Thread-Local Variable

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -69,17 +69,6 @@ extern _Py_thread_local PyThreadState *_Py_tss_tstate;
 #endif
 PyAPI_DATA(PyThreadState *) _PyThreadState_GetCurrent(void);
 
-static inline PyThreadState*
-_PyRuntimeState_GetThreadState(_PyRuntimeState *runtime)
-{
-#if defined(HAVE_THREAD_LOCAL) && !defined(Py_BUILD_CORE_MODULE)
-    return _Py_tss_tstate;
-#else
-    return _PyThreadState_GetCurrent();
-#endif
-}
-
-
 /* Get the current Python thread state.
 
    This function is unsafe: it does not check for error and it can return NULL.
@@ -90,8 +79,19 @@ _PyRuntimeState_GetThreadState(_PyRuntimeState *runtime)
 static inline PyThreadState*
 _PyThreadState_GET(void)
 {
-    return _PyRuntimeState_GetThreadState(&_PyRuntime);
+#if defined(HAVE_THREAD_LOCAL) && !defined(Py_BUILD_CORE_MODULE)
+    return _Py_tss_tstate;
+#else
+    return _PyThreadState_GetCurrent();
+#endif
 }
+
+static inline PyThreadState*
+_PyRuntimeState_GetThreadState(_PyRuntimeState *Py_UNUSED(runtime))
+{
+    return _PyThreadState_GET();
+}
+
 
 static inline void
 _Py_EnsureFuncTstateNotNULL(const char *func, PyThreadState *tstate)

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -64,13 +64,21 @@ _Py_ThreadCanHandlePendingCalls(void)
 /* Variable and macro for in-line access to current thread
    and interpreter state */
 
+#if defined(HAVE_THREAD_LOCAL) && !defined(Py_BUILD_CORE_MODULE)
+extern thread_local PyThreadState *_Py_tss_tstate;
+#endif
 PyAPI_DATA(PyThreadState *) _PyThreadState_GetCurrent(void);
 
 static inline PyThreadState*
 _PyRuntimeState_GetThreadState(_PyRuntimeState *runtime)
 {
+#if defined(HAVE_THREAD_LOCAL) && !defined(Py_BUILD_CORE_MODULE)
+    return _Py_tss_tstate;
+#else
     return _PyThreadState_GetCurrent();
+#endif
 }
+
 
 /* Get the current Python thread state.
 
@@ -82,7 +90,7 @@ _PyRuntimeState_GetThreadState(_PyRuntimeState *runtime)
 static inline PyThreadState*
 _PyThreadState_GET(void)
 {
-    return _PyThreadState_GetCurrent();
+    return _PyRuntimeState_GetThreadState(&_PyRuntime);
 }
 
 static inline void

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -64,12 +64,12 @@ _Py_ThreadCanHandlePendingCalls(void)
 /* Variable and macro for in-line access to current thread
    and interpreter state */
 
-PyAPI_DATA(thread_local PyThreadState *) _Py_tss_tstate;
+PyAPI_DATA(PyThreadState *) _PyThreadState_GetCurrent(void);
 
 static inline PyThreadState*
 _PyRuntimeState_GetThreadState(_PyRuntimeState *runtime)
 {
-    return _Py_tss_tstate;
+    return _PyThreadState_GetCurrent();
 }
 
 /* Get the current Python thread state.
@@ -82,7 +82,7 @@ _PyRuntimeState_GetThreadState(_PyRuntimeState *runtime)
 static inline PyThreadState*
 _PyThreadState_GET(void)
 {
-    return _PyRuntimeState_GetThreadState(&_PyRuntime);
+    return _PyThreadState_GetCurrent();
 }
 
 static inline void

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -65,7 +65,7 @@ _Py_ThreadCanHandlePendingCalls(void)
    and interpreter state */
 
 #if defined(HAVE_THREAD_LOCAL) && !defined(Py_BUILD_CORE_MODULE)
-extern thread_local PyThreadState *_Py_tss_tstate;
+extern _Py_thread_local PyThreadState *_Py_tss_tstate;
 #endif
 PyAPI_DATA(PyThreadState *) _PyThreadState_GetCurrent(void);
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -64,17 +64,17 @@ _Py_ThreadCanHandlePendingCalls(void)
 /* Variable and macro for in-line access to current thread
    and interpreter state */
 
+PyAPI_DATA(thread_local PyThreadState *) _Py_tss_tstate;
+
 static inline PyThreadState*
 _PyRuntimeState_GetThreadState(_PyRuntimeState *runtime)
 {
-    return (PyThreadState*)_Py_atomic_load_relaxed(&runtime->tstate_current);
+    return _Py_tss_tstate;
 }
 
 /* Get the current Python thread state.
 
-   Efficient macro reading directly the 'tstate_current' atomic
-   variable. The macro is unsafe: it does not check for error and it can
-   return NULL.
+   This function is unsafe: it does not check for error and it can return NULL.
 
    The caller must hold the GIL.
 

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -119,9 +119,6 @@ typedef struct pyruntimestate {
 
     unsigned long main_thread;
 
-    /* Assuming the current thread holds the GIL, this is the
-       PyThreadState for the current thread. */
-    _Py_atomic_address tstate_current;
     /* Used for the thread state bound to the current thread. */
     Py_tss_t autoTSSkey;
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -664,18 +664,21 @@ extern char * _getpty(int *, int, mode_t, int);
 #endif
 
 #ifdef WITH_THREAD
-#  ifndef thread_local
-#    if __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
-#      define thread_local _Thread_local
-#      define HAVE_THREAD_LOCAL 1
-#    elif defined(_MSC_VER)  /* AKA NT_THREADS */
-#      define thread_local __declspec(thread)
-#      define HAVE_THREAD_LOCAL 1
-#    elif defined(__GNUC__)  /* includes clang */
-#      define thread_local __thread
-#      define HAVE_THREAD_LOCAL 1
-     // else: fall back to the PyThread_tss_*() API, or ignore.
-#    endif
+#  ifdef HAVE_THREAD_LOCAL
+#    error "unexpectedly, HAVE_THREAD_LOCAL is already defined"
+#  endif
+#  define HAVE_THREAD_LOCAL 1
+#  ifdef thread_local
+#    define _Py_thread_local thread_local
+#  elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
+#    define _Py_thread_local _Thread_local
+#  elif defined(_MSC_VER)  /* AKA NT_THREADS */
+#    define _Py_thread_local __declspec(thread)
+#  elif defined(__GNUC__)  /* includes clang */
+#    define _Py_thread_local __thread
+#  else
+     // fall back to the PyThread_tss_*() API, or ignore.
+#    undef HAVE_THREAD_LOCAL
 #  endif
 #endif
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -664,21 +664,23 @@ extern char * _getpty(int *, int, mode_t, int);
 #endif
 
 #ifdef WITH_THREAD
-#  ifdef HAVE_THREAD_LOCAL
-#    error "unexpectedly, HAVE_THREAD_LOCAL is already defined"
-#  endif
-#  define HAVE_THREAD_LOCAL 1
-#  ifdef thread_local
-#    define _Py_thread_local thread_local
-#  elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
-#    define _Py_thread_local _Thread_local
-#  elif defined(_MSC_VER)  /* AKA NT_THREADS */
-#    define _Py_thread_local __declspec(thread)
-#  elif defined(__GNUC__)  /* includes clang */
-#    define _Py_thread_local __thread
-#  else
-     // fall back to the PyThread_tss_*() API, or ignore.
-#    undef HAVE_THREAD_LOCAL
+#  ifdef Py_BUILD_CORE
+#    ifdef HAVE_THREAD_LOCAL
+#      error "unexpectedly, HAVE_THREAD_LOCAL is already defined"
+#    endif
+#    define HAVE_THREAD_LOCAL 1
+#    ifdef thread_local
+#      define _Py_thread_local thread_local
+#    elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
+#      define _Py_thread_local _Thread_local
+#    elif defined(_MSC_VER)  /* AKA NT_THREADS */
+#      define _Py_thread_local __declspec(thread)
+#    elif defined(__GNUC__)  /* includes clang */
+#      define _Py_thread_local __thread
+#    else
+       // fall back to the PyThread_tss_*() API, or ignore.
+#      undef HAVE_THREAD_LOCAL
+#    endif
 #  endif
 #endif
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -667,11 +667,15 @@ extern char * _getpty(int *, int, mode_t, int);
 #  ifndef thread_local
 #    if __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
 #      define thread_local _Thread_local
+#      define HAVE_THREAD_LOCAL 1
 #    elif defined(_MSC_VER)  /* AKA NT_THREADS */
 #      define thread_local __declspec(thread)
+#      define HAVE_THREAD_LOCAL 1
 #    elif defined(__GNUC__)  /* includes clang */
 #      define thread_local __thread
+#      define HAVE_THREAD_LOCAL 1
 #    else
+       // XXX Fall back to the PyThread_tss_*() API.
 #      error "no supported thread-local variable storage classifier"
 #    endif
 #  endif

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -663,6 +663,20 @@ extern char * _getpty(int *, int, mode_t, int);
 #  define WITH_THREAD
 #endif
 
+#ifdef WITH_THREAD
+#  ifndef thread_local
+#    if __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
+#      define thread_local _Thread_local
+#    elif defined(_MSC_VER)  /* AKA NT_THREADS */
+#      define thread_local __declspec(thread)
+#    elif defined(__GNUC__)  /* includes clang */
+#      define thread_local __thread
+#    else
+#      error "no supported thread-local variable storage classifier"
+#    endif
+#  endif
+#endif
+
 /* Check that ALT_SOABI is consistent with Py_TRACE_REFS:
    ./configure --with-trace-refs should must be used to define Py_TRACE_REFS */
 #if defined(ALT_SOABI) && defined(Py_TRACE_REFS)

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -666,7 +666,7 @@ extern char * _getpty(int *, int, mode_t, int);
 #ifdef WITH_THREAD
 #  ifdef Py_BUILD_CORE
 #    ifdef HAVE_THREAD_LOCAL
-#      error "unexpectedly, HAVE_THREAD_LOCAL is already defined"
+#      error "HAVE_THREAD_LOCAL is already defined"
 #    endif
 #    define HAVE_THREAD_LOCAL 1
 #    ifdef thread_local

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -674,9 +674,7 @@ extern char * _getpty(int *, int, mode_t, int);
 #    elif defined(__GNUC__)  /* includes clang */
 #      define thread_local __thread
 #      define HAVE_THREAD_LOCAL 1
-#    else
-       // XXX Fall back to the PyThread_tss_*() API.
-#      error "no supported thread-local variable storage classifier"
+     // else: fall back to the PyThread_tss_*() API, or ignore.
 #    endif
 #  endif
 #endif

--- a/Misc/NEWS.d/next/Core and Builtins/2023-04-07-12-18-41.gh-issue-103323.9802br.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-04-07-12-18-41.gh-issue-103323.9802br.rst
@@ -1,0 +1,3 @@
+We've replaced our use of ``_PyRuntime.tstate_current`` with a thread-local
+variable.  This is a fairly low-level implementation detail, and there
+should be no change in behavior.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -60,23 +60,26 @@ extern "C" {
    For each of these functions, the GIL must be held by the current thread.
  */
 
+
+thread_local PyThreadState *_Py_tss_tstate;
+
 static inline PyThreadState *
-current_fast_get(_PyRuntimeState *runtime)
+current_fast_get(_PyRuntimeState *Py_UNUSED(runtime))
 {
-    return (PyThreadState*)_Py_atomic_load_relaxed(&runtime->tstate_current);
+    return _Py_tss_tstate;
 }
 
 static inline void
-current_fast_set(_PyRuntimeState *runtime, PyThreadState *tstate)
+current_fast_set(_PyRuntimeState *Py_UNUSED(runtime), PyThreadState *tstate)
 {
     assert(tstate != NULL);
-    _Py_atomic_store_relaxed(&runtime->tstate_current, (uintptr_t)tstate);
+    _Py_tss_tstate = tstate;
 }
 
 static inline void
-current_fast_clear(_PyRuntimeState *runtime)
+current_fast_clear(_PyRuntimeState *Py_UNUSED(runtime))
 {
-    _Py_atomic_store_relaxed(&runtime->tstate_current, (uintptr_t)NULL);
+    _Py_tss_tstate = NULL;
 }
 
 #define tstate_verify_not_active(tstate) \

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -61,7 +61,13 @@ extern "C" {
  */
 
 
-thread_local PyThreadState *_Py_tss_tstate;
+thread_local PyThreadState *_Py_tss_tstate = NULL;
+
+PyThreadState *
+_PyThreadState_GetCurrent(void)
+{
+    return _Py_tss_tstate;
+}
 
 static inline PyThreadState *
 current_fast_get(_PyRuntimeState *Py_UNUSED(runtime))


### PR DESCRIPTION
We replace `_PyRuntime.tstate_current` with a thread-local variable.  As part of this change, we add a `_Py_thread_local` macro in pyport.h (only for the core runtime) to smooth out the compiler differences.  The main motivation here is in support of a per-interpreter GIL, but this change also provides some performance improvement opportunities.

Note that we do not provide a fallback to the thread-local, either falling back to the old `tstate_current` or to thread-specific storage (`PyThread_tss_*()`).  If that proves problematic then we can circle back.  I consider it unlikely, but will run the buildbots to double-check.

Also note that this does not change any of the code related to the GILState API, where it uses a thread state stored in thread-specific storage.  I suspect we can combine that with `_Py_tss_tstate` (from here).  However, that can be addressed separately and is not urgent (nor critical).

My only remaining uncertainty is with the existing "GIL is held" constraint.  With `_PyRuntime.tstate_current`, it was only guaranteed valid in the thread currently holding the GIL, if any.  With this change, it is valid even when the GIL isn't held.  I don't see how that would be a problem, but I'm going to double-check anyway.

(While this change was mostly done independently, I did take some inspiration from earlier (~2020) work by @markshannon (https://github.com/python/cpython/compare/main...markshannon:threadstate_in_tls) and @vstinner (https://github.com/python/cpython/pull/23976).)

<!-- gh-issue-number: gh-103323 -->
* Issue: gh-103323
<!-- /gh-issue-number -->
