### PR TITLE
Revert "gh-102213: Optimize the performance of `__getattr__`  (GH-102248)"

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -375,7 +375,6 @@ extern void _PyObject_FreeInstanceAttributes(PyObject *obj);
 extern int _PyObject_IsInstanceDictEmpty(PyObject *);
 extern int _PyType_HasSubclasses(PyTypeObject *);
 extern PyObject* _PyType_GetSubclasses(PyTypeObject *);
-extern PyObject* _PyObject_GenericTryGetAttr(PyObject *, PyObject *);
 
 // Access macro to the members which are floating "behind" the object
 static inline PyMemberDef* _PyHeapType_GET_MEMBERS(PyHeapTypeObject *etype) {

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1491,12 +1491,6 @@ PyObject_GenericGetAttr(PyObject *obj, PyObject *name)
     return _PyObject_GenericGetAttrWithDict(obj, name, NULL, 0);
 }
 
-PyObject *
-_PyObject_GenericTryGetAttr(PyObject *obj, PyObject *name)
-{
-    return _PyObject_GenericGetAttrWithDict(obj, name, NULL, 1);
-}
-
 int
 _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
                                  PyObject *value, PyObject *dict)

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8274,17 +8274,14 @@ _Py_slot_tp_getattr_hook(PyObject *self, PyObject *name)
         (Py_IS_TYPE(getattribute, &PyWrapperDescr_Type) &&
          ((PyWrapperDescrObject *)getattribute)->d_wrapped ==
          (void *)PyObject_GenericGetAttr))
-        /* finding nothing is reasonable when __getattr__ is defined */
-        res = _PyObject_GenericTryGetAttr(self, name);
+        res = PyObject_GenericGetAttr(self, name);
     else {
         Py_INCREF(getattribute);
         res = call_attribute(self, getattribute, name);
         Py_DECREF(getattribute);
     }
-    if (res == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
-        }
+    if (res == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        PyErr_Clear();
         res = call_attribute(self, getattr, name);
     }
     Py_DECREF(getattr);


### PR DESCRIPTION
This commit caused at least two regressions:
1. https://github.com/python/cpython/issues/103272
2. https://github.com/python/cpython/issues/103329

CC @wangxiang-hz @Fidget-Spinner @sunmy2019

@sunmy2019 can you please send your test case as the next PR?
I want to keep this one a pure revert, with no extra changes :)

<!-- gh-issue-number: gh-102213 -->
* Issue: gh-102213
<!-- /gh-issue-number -->
