### PR TITLE
gh-103334: Ignore `Tools/c-analyzer/cpython/_parser.py` from `patchcheck`

### DIFF
--- a/Tools/c-analyzer/cpython/_parser.py
+++ b/Tools/c-analyzer/cpython/_parser.py
@@ -47,6 +47,7 @@ def clean_lines(text):
 '''
 
 # XXX Handle these.
+# Tab separated:
 EXCLUDED = clean_lines('''
 # @begin=conf@
 

--- a/Tools/patchcheck/patchcheck.py
+++ b/Tools/patchcheck/patchcheck.py
@@ -169,12 +169,24 @@ def report_modified_files(file_paths):
         return "\n".join(lines)
 
 
+#: Python files that have tabs by design:
+_PYTHON_FILES_WITH_TABS = frozenset({
+    'Tools/c-analyzer/cpython/_parser.py',
+})
+
+
 @status("Fixing Python file whitespace", info=report_modified_files)
 def normalize_whitespace(file_paths):
     """Make sure that the whitespace for .py files have been normalized."""
     reindent.makebackup = False  # No need to create backups.
-    fixed = [path for path in file_paths if path.endswith('.py') and
-             reindent.check(os.path.join(SRCDIR, path))]
+    fixed = [
+        path for path in file_paths
+        if (
+            path.endswith('.py')
+            and path not in _PYTHON_FILES_WITH_TABS
+            and reindent.check(os.path.join(SRCDIR, path))
+        )
+    ]
     return fixed
 
 


### PR DESCRIPTION
I've also added a small comment to `Tools/c-analyzer/cpython/_parser.py` to trigger the `patchcheck` CI. It must pass now.

<!-- gh-issue-number: gh-103334 -->
* Issue: gh-103334
<!-- /gh-issue-number -->

Automerge-Triggered-By: GH:ericsnowcurrently