### PR TITLE
gh-74690: Document changes made to runtime-checkable protocols in 3.12

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1598,15 +1598,6 @@ These are not used in annotations. They are building blocks for creating generic
       import threading
       assert isinstance(threading.Thread(name='Bob'), Named)
 
-   .. versionchanged:: 3.12
-      The internal implementation of :func:`isinstance` checks against
-      runtime-checkable protocols now uses :func:`inspect.getattr_static`
-      to look up attributes (previously, :func:`hasattr` was used).
-      As a result, some objects which used to be considered instances
-      of a runtime-checkable protocol may no longer be considered instances
-      of that protocol on Python 3.12+, and vice versa.
-      Most users are unlikely to be affected by this change.
-
    .. note::
 
         :func:`!runtime_checkable` will check only the presence of the required
@@ -1627,6 +1618,40 @@ These are not used in annotations. They are building blocks for creating generic
         code.
 
    .. versionadded:: 3.8
+
+   .. versionchanged:: 3.12
+      The internal implementation of :func:`isinstance` checks against
+      runtime-checkable protocols now uses :func:`inspect.getattr_static`
+      to look up attributes (previously, :func:`hasattr` was used).
+      As a result, some objects which used to be considered instances
+      of a runtime-checkable protocol may no longer be considered instances
+      of that protocol on Python 3.12+, and vice versa.
+      Most users are unlikely to be affected by this change.
+
+   .. versionchanged:: 3.12
+      The members of a runtime-checkable protocol are now considered "frozen"
+      at runtime as soon as the class has been created. Monkey-patching
+      attributes onto a runtime-checkable protocol will still work, but will
+      have no impact on :func:`isinstance` checks comparing objects to the
+      protocol. For example::
+
+          >>> from typing import Protocol, runtime_checkable
+          >>> @runtime_checkable
+          ... class HasX(Protocol):
+          ...     x = 1
+          ...
+          >>> class Foo: ...
+          ...
+          >>> f = Foo()
+          >>> isinstance(f, HasX)
+          False
+          >>> f.x = 1
+          >>> isinstance(f, HasX)
+          True
+          >>> HasX.y = 2
+          >>> isinstance(f, HasX)  # unchanged, even though HasX now also has a `y` attribute
+          True
+
 
 Other special directives
 """"""""""""""""""""""""

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1649,7 +1649,7 @@ These are not used in annotations. They are building blocks for creating generic
           >>> isinstance(f, HasX)
           True
           >>> HasX.y = 2
-          >>> isinstance(f, HasX)  # unchanged, even though HasX now also has a `y` attribute
+          >>> isinstance(f, HasX)  # unchanged, even though HasX now also has a "y" attribute
           True
 
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1633,24 +1633,8 @@ These are not used in annotations. They are building blocks for creating generic
       at runtime as soon as the class has been created. Monkey-patching
       attributes onto a runtime-checkable protocol will still work, but will
       have no impact on :func:`isinstance` checks comparing objects to the
-      protocol. For example:
-
-          >>> from typing import Protocol, runtime_checkable
-          >>> @runtime_checkable
-          ... class HasX(Protocol):
-          ...     x = 1
-          ...
-          >>> class Foo: ...
-          ...
-          >>> f = Foo()
-          >>> isinstance(f, HasX)
-          False
-          >>> f.x = 1
-          >>> isinstance(f, HasX)
-          True
-          >>> HasX.y = 2
-          >>> isinstance(f, HasX)  # unchanged, even though HasX now also has a "y" attribute
-          True
+      protocol. See :ref:`"What's new in Python 3.12" <whatsnew-typing-py312>`
+      for more details.
 
 
 Other special directives

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1633,7 +1633,7 @@ These are not used in annotations. They are building blocks for creating generic
       at runtime as soon as the class has been created. Monkey-patching
       attributes onto a runtime-checkable protocol will still work, but will
       have no impact on :func:`isinstance` checks comparing objects to the
-      protocol. For example::
+      protocol. For example:
 
           >>> from typing import Protocol, runtime_checkable
           >>> @runtime_checkable

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -418,6 +418,8 @@ tempfile
 The :class:`tempfile.NamedTemporaryFile` function has a new optional parameter
 *delete_on_close* (Contributed by Evgeny Zorin in :gh:`58451`.)
 
+.. _whatsnew-typing-py312
+
 typing
 ------
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -437,6 +437,39 @@ typing
   vice versa. Most users are unlikely to be affected by this change.
   (Contributed by Alex Waygood in :gh:`102433`.)
 
+* The members of a runtime-checkable protocol are now considered "frozen" at
+  runtime as soon as the class has been created. Monkey-patching attributes
+  onto a runtime-checkable protocol will still work, but will have no impact on
+  :func:`isinstance` checks comparing objects to the protocol. For example::
+
+      >>> from typing import Protocol, runtime_checkable
+      >>> @runtime_checkable
+      ... class HasX(Protocol):
+      ...     x = 1
+      ...
+      >>> class Foo: ...
+      ...
+      >>> f = Foo()
+      >>> isinstance(f, HasX)
+      False
+      >>> f.x = 1
+      >>> isinstance(f, HasX)
+      True
+      >>> HasX.y = 2
+      >>> isinstance(f, HasX)  # unchanged, even though HasX now also has a `y` attribute
+      True
+
+  This change was made in order to speed up ``isinstance()` checks against
+  runtime-checkable protocols.
+
+* The performance profile of :func:`isinstance` checks against
+  :func:`runtime-checkable protocols <typing.runtime_checkable>` has changed
+  significantly. Most ``isinstance()`` checks against protocols with only a few
+  members should be at least 2x faster than in 3.11, and some may be 20x
+  faster or more. However, ``isinstance()`` checks against protocols with seven
+  or more members may be slower than in Python 3.11. (Contributed by Alex
+  Waygood in :gh:`74690` and :gh:`103193`.)
+
 sys
 ---
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -418,7 +418,7 @@ tempfile
 The :class:`tempfile.NamedTemporaryFile` function has a new optional parameter
 *delete_on_close* (Contributed by Evgeny Zorin in :gh:`58451`.)
 
-.. _whatsnew-typing-py312
+.. _whatsnew-typing-py312:
 
 typing
 ------

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -459,7 +459,7 @@ typing
       >>> isinstance(f, HasX)  # unchanged, even though HasX now also has a `y` attribute
       True
 
-  This change was made in order to speed up ``isinstance()` checks against
+  This change was made in order to speed up ``isinstance()`` checks against
   runtime-checkable protocols.
 
 * The performance profile of :func:`isinstance` checks against

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -456,7 +456,7 @@ typing
       >>> isinstance(f, HasX)
       True
       >>> HasX.y = 2
-      >>> isinstance(f, HasX)  # unchanged, even though HasX now also has a `y` attribute
+      >>> isinstance(f, HasX)  # unchanged, even though HasX now also has a "y" attribute
       True
 
   This change was made in order to speed up ``isinstance()`` checks against

--- a/Misc/NEWS.d/next/Library/2023-04-07-15-09-26.gh-issue-74690.0f886b.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-07-15-09-26.gh-issue-74690.0f886b.rst
@@ -1,0 +1,3 @@
+The members of a runtime-checkable protocol are now considered "frozen" at
+runtime as soon as the class has been created. See the documentation for
+:func:`typing.runtime_checkable` for more details. Patch by Alex Waygood.

--- a/Misc/NEWS.d/next/Library/2023-04-07-15-09-26.gh-issue-74690.0f886b.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-07-15-09-26.gh-issue-74690.0f886b.rst
@@ -1,3 +1,3 @@
 The members of a runtime-checkable protocol are now considered "frozen" at
 runtime as soon as the class has been created. See
-:ref:`"What's new in Python 3.12" <whatsnew-typing-py312>`for more details.
+:ref:`"What's new in Python 3.12" <whatsnew-typing-py312>` for more details.

--- a/Misc/NEWS.d/next/Library/2023-04-07-15-09-26.gh-issue-74690.0f886b.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-07-15-09-26.gh-issue-74690.0f886b.rst
@@ -1,3 +1,3 @@
 The members of a runtime-checkable protocol are now considered "frozen" at
-runtime as soon as the class has been created. See the documentation for
-:func:`typing.runtime_checkable` for more details. Patch by Alex Waygood.
+runtime as soon as the class has been created. See
+:ref:`"What's new in Python 3.12" <whatsnew-typing-py312>`for more details.

--- a/Misc/NEWS.d/next/Library/2023-04-07-15-15-40.gh-issue-74690.un84hh.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-07-15-15-40.gh-issue-74690.un84hh.rst
@@ -1,0 +1,8 @@
+The performance of :func:`isinstance` checks against
+:func:`runtime-checkable protocols <typing.runtime_checkable>` has been
+considerably improved for protocols that only have a few members. To achieve
+this improvement, several internal implementation details of the
+:mod:`typing` module have been refactored, including
+``typing._ProtocolMeta.__instancecheck__``,
+``typing._is_callable_members_only``, and ``typing._get_protocol_attrs``.
+Patches by Alex Waygood.


### PR DESCRIPTION
Adds docs, NEWS and WhatsNew entries for changes made in these PRs:

- #103141
- #103152
- #103159
- #103160
- #103280
- #103195
- #103318
- #103321

<!-- gh-issue-number: gh-74690 -->
* Issue: gh-74690
<!-- /gh-issue-number -->
