### PR TITLE
gh-103329: Add regression test for PropertyMock with side effect

### DIFF
--- a/Lib/test/test_unittest/testmock/testhelpers.py
+++ b/Lib/test/test_unittest/testmock/testhelpers.py
@@ -1077,7 +1077,7 @@ class TestCallList(unittest.TestCase):
             p.stop()
 
 
-    def test_propertymock_returnvalue(self):
+    def test_propertymock_bare(self):
         m = MagicMock()
         p = PropertyMock()
         type(m).foo = p
@@ -1086,6 +1086,27 @@ class TestCallList(unittest.TestCase):
         p.assert_called_once_with()
         self.assertIsInstance(returned, MagicMock)
         self.assertNotIsInstance(returned, PropertyMock)
+
+
+    def test_propertymock_returnvalue(self):
+        m = MagicMock()
+        p = PropertyMock(return_value=42)
+        type(m).foo = p
+
+        returned = m.foo
+        p.assert_called_once_with()
+        self.assertEqual(returned, 42)
+        self.assertNotIsInstance(returned, PropertyMock)
+
+
+    def test_propertymock_sideffect(self):
+        m = MagicMock()
+        p = PropertyMock(side_effect=ValueError)
+        type(m).foo = p
+
+        with self.assertRaises(ValueError):
+            m.foo
+        p.assert_called_once_with()
 
 
 class TestCallablePredicate(unittest.TestCase):

--- a/Lib/test/test_unittest/testmock/testhelpers.py
+++ b/Lib/test/test_unittest/testmock/testhelpers.py
@@ -1099,7 +1099,7 @@ class TestCallList(unittest.TestCase):
         self.assertNotIsInstance(returned, PropertyMock)
 
 
-    def test_propertymock_sideffect(self):
+    def test_propertymock_side_effect(self):
         m = MagicMock()
         p = PropertyMock(side_effect=ValueError)
         type(m).foo = p

--- a/Misc/NEWS.d/next/Tests/2023-04-08-00-50-23.gh-issue-103329.M38tqF.rst
+++ b/Misc/NEWS.d/next/Tests/2023-04-08-00-50-23.gh-issue-103329.M38tqF.rst
@@ -1,0 +1,1 @@
+Regression tests for the behaviour of ``unittest.mock.PropertyMock`` were added.


### PR DESCRIPTION
#102213 introduced an optimisation to `__getattr__` that had some unexpected side effects, one of which was a change in behavior of PropertyMock when the property has a side effect.

This change was reverted in #103332; This PR adds a regression test to ensure that PropertyMock behavior is preserved. It also enhances the test of the return value for PropertyMock.

Fixes #103329.

<!-- gh-issue-number: gh-103329 -->
* Issue: gh-103329
<!-- /gh-issue-number -->
