### PR TITLE
howto/urllib2: remove link to an outdated French translation

### DIFF
--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -6,13 +6,6 @@
 
 :Author: `Michael Foord <https://agileabstractions.com/>`_
 
-.. note::
-
-    There is a French translation of an earlier revision of this
-    HOWTO, available at `urllib2 - Le Manuel manquant
-    <https://web.archive.org/web/20200910051922/http://www.voidspace.org.uk/python/articles/urllib2_francais.shtml>`_.
-
-
 
 Introduction
 ============


### PR DESCRIPTION
We now have our own translation and it's not outdated.

Ping @JulienPalard 