### PR TITLE
gh-103395: Improve `typing._GenericAlias.__dir__` coverage

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -859,7 +859,6 @@ class UnpackTests(BaseTestCase):
         dir_items = set(dir(Unpack[Tuple[int]]))
         for required_item in [
             '__args__', '__parameters__', '__origin__',
-            'copy_with',
         ]:
             with self.subTest(required_item=required_item):
                 self.assertIn(required_item, dir_items)
@@ -1712,7 +1711,6 @@ class UnionTests(BaseTestCase):
         dir_items = set(dir(Union[str, int]))
         for required_item in [
             '__args__', '__parameters__', '__origin__',
-            'copy_with',
         ]:
             with self.subTest(required_item=required_item):
                 self.assertIn(required_item, dir_items)
@@ -1862,8 +1860,6 @@ class BaseCallableTests:
         dir_items = set(dir(Callable[..., int]))
         for required_item in [
             '__args__', '__parameters__', '__origin__',
-            # TODO: add to `collections.abc.Callable`:
-            # 'copy_with',
         ]:
             with self.subTest(required_item=required_item):
                 self.assertIn(required_item, dir_items)
@@ -2184,7 +2180,6 @@ class LiteralTests(BaseTestCase):
         dir_items = set(dir(Literal[1, 2, 3]))
         for required_item in [
             '__args__', '__parameters__', '__origin__',
-            'copy_with',
         ]:
             with self.subTest(required_item=required_item):
                 self.assertIn(required_item, dir_items)
@@ -7358,7 +7353,6 @@ class AnnotatedTests(BaseTestCase):
         for required_item in [
             '__args__', '__parameters__', '__origin__',
             '__metadata__',
-            'copy_with',
         ]:
             with self.subTest(required_item=required_item):
                 self.assertIn(required_item, dir_items)
@@ -8086,7 +8080,6 @@ class ConcatenateTests(BaseTestCase):
         dir_items = set(dir(Concatenate[int, P]))
         for required_item in [
             '__args__', '__parameters__', '__origin__',
-            'copy_with',
         ]:
             with self.subTest(required_item=required_item):
                 self.assertIn(required_item, dir_items)
@@ -8376,7 +8369,6 @@ class SpecialAttrsTests(BaseTestCase):
         for required_item in [
             'bar', 'baz',
             '__args__', '__parameters__', '__origin__',
-            'copy_with',
         ]:
             with self.subTest(required_item=required_item):
                 self.assertIn(required_item, dir_items)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -855,6 +855,15 @@ class UnpackTests(BaseTestCase):
         (*tuple[int],)
         Unpack[Tuple[int]]
 
+    def test_dir(self):
+        dir_items = set(dir(Unpack[Tuple[int]]))
+        for required_item in [
+            '__args__', '__parameters__', '__origin__',
+            'copy_with',
+        ]:
+            with self.subTest(required_item=required_item):
+                self.assertIn(required_item, dir_items)
+
     def test_rejects_multiple_types(self):
         with self.assertRaises(TypeError):
             Unpack[Tuple[int], Tuple[str]]
@@ -1699,6 +1708,15 @@ class UnionTests(BaseTestCase):
         u = Optional[str]
         self.assertEqual(repr(u), 'typing.Optional[str]')
 
+    def test_dir(self):
+        dir_items = set(dir(Union[str, int]))
+        for required_item in [
+            '__args__', '__parameters__', '__origin__',
+            'copy_with',
+        ]:
+            with self.subTest(required_item=required_item):
+                self.assertIn(required_item, dir_items)
+
     def test_cannot_subclass(self):
         with self.assertRaisesRegex(TypeError,
                 r'Cannot subclass typing\.Union'):
@@ -1838,6 +1856,17 @@ class BaseCallableTests:
         self.assertNotEqual(C, Callable[[], int])
         self.assertNotEqual(C, Callable[..., int])
         self.assertNotEqual(C, Callable)
+
+    def test_dir(self):
+        Callable = self.Callable
+        dir_items = set(dir(Callable[..., int]))
+        for required_item in [
+            '__args__', '__parameters__', '__origin__',
+            # TODO: add to `collections.abc.Callable`:
+            # 'copy_with',
+        ]:
+            with self.subTest(required_item=required_item):
+                self.assertIn(required_item, dir_items)
 
     def test_cannot_instantiate(self):
         Callable = self.Callable
@@ -2150,6 +2179,15 @@ class LiteralTests(BaseTestCase):
         self.assertEqual(repr(Literal), "typing.Literal")
         self.assertEqual(repr(Literal[None]), "typing.Literal[None]")
         self.assertEqual(repr(Literal[1, 2, 3, 3]), "typing.Literal[1, 2, 3]")
+
+    def test_dir(self):
+        dir_items = set(dir(Literal[1, 2, 3]))
+        for required_item in [
+            '__args__', '__parameters__', '__origin__',
+            'copy_with',
+        ]:
+            with self.subTest(required_item=required_item):
+                self.assertIn(required_item, dir_items)
 
     def test_cannot_init(self):
         with self.assertRaises(TypeError):
@@ -7315,6 +7353,16 @@ class AnnotatedTests(BaseTestCase):
             "typing.Annotated[typing.List[int], 4, 5]"
         )
 
+    def test_dir(self):
+        dir_items = set(dir(Annotated[int, 4]))
+        for required_item in [
+            '__args__', '__parameters__', '__origin__',
+            '__metadata__',
+            'copy_with',
+        ]:
+            with self.subTest(required_item=required_item):
+                self.assertIn(required_item, dir_items)
+
     def test_flatten(self):
         A = Annotated[Annotated[int, 4], 5]
         self.assertEqual(A, Annotated[int, 4, 5])
@@ -8033,6 +8081,16 @@ class ConcatenateTests(BaseTestCase):
         c = Concatenate[MyClass, P]
         self.assertNotEqual(c, Concatenate)
 
+    def test_dir(self):
+        P = ParamSpec('P')
+        dir_items = set(dir(Concatenate[int, P]))
+        for required_item in [
+            '__args__', '__parameters__', '__origin__',
+            'copy_with',
+        ]:
+            with self.subTest(required_item=required_item):
+                self.assertIn(required_item, dir_items)
+
     def test_valid_uses(self):
         P = ParamSpec('P')
         T = TypeVar('T')
@@ -8310,10 +8368,19 @@ class SpecialAttrsTests(BaseTestCase):
             def bar(self):
                 pass
             baz = 3
+            __magic__ = 4
+
         # The class attributes of the original class should be visible even
         # in dir() of the GenericAlias. See bpo-45755.
-        self.assertIn('bar', dir(Foo[int]))
-        self.assertIn('baz', dir(Foo[int]))
+        dir_items = set(dir(Foo[int]))
+        for required_item in [
+            'bar', 'baz',
+            '__args__', '__parameters__', '__origin__',
+            'copy_with',
+        ]:
+            with self.subTest(required_item=required_item):
+                self.assertIn(required_item, dir_items)
+        self.assertNotIn('__magic__', dir_items)
 
 
 class RevealTypeTests(BaseTestCase):


### PR DESCRIPTION
One interesting thing about `Callable`: https://github.com/python/cpython/issues/103395#issuecomment-1501075970

Did I cover all magic props / methods that we promise to have?
Do I need to add anything else to the test?

<!-- gh-issue-number: gh-103395 -->
* Issue: gh-103395
<!-- /gh-issue-number -->
