### PR TITLE
gh-103373: `__mro_entries__` docs: improve cross references

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -75,7 +75,7 @@ Dynamic Type Creation
 
    This function looks for items in *bases* that are not instances of
    :class:`type`, and returns a tuple where each such object that has
-   an ``__mro_entries__`` method is replaced with an unpacked result of
+   an :meth:`~object.__mro_entries__` method is replaced with an unpacked result of
    calling this method.  If a *bases* item is an instance of :class:`type`,
    or it doesn't have an ``__mro_entries__`` method, then it is included in
    the return tuple unchanged.

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -77,7 +77,7 @@ Dynamic Type Creation
    :class:`type`, and returns a tuple where each such object that has
    an :meth:`~object.__mro_entries__` method is replaced with an unpacked result of
    calling this method.  If a *bases* item is an instance of :class:`type`,
-   or it doesn't have an ``__mro_entries__`` method, then it is included in
+   or it doesn't have an :meth:`!__mro_entries__` method, then it is included in
    the return tuple unchanged.
 
    .. versionadded:: 3.7

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2092,13 +2092,18 @@ Resolving MRO entries
    :class:`type`, then an ``__mro_entries__`` method is searched on the base.
    If an ``__mro_entries__`` method is found, the base is substituted with the
    result of a call to ``__mro_entries__`` when creating the class.
-   The method is called with the original bases tuple, and must return a tuple
+   The method is called with the original bases tuple
+   passed to the *bases* parameter, and must return a tuple
    of classes that will be used instead of the base. The returned tuple may be
    empty: in these cases, the original base is ignored.
 
 .. seealso::
 
-   :pep:`560` - Core support for typing module and generic types
+   :func:`types.resolve_bases`
+      Dynamically resolve bases that are not instances of :class:`type`.
+
+   :pep:`560`
+      Core support for typing module and generic types
 
 
 Determining the appropriate metaclass

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2089,9 +2089,9 @@ Resolving MRO entries
 .. method:: object.__mro_entries__(self, bases)
 
    If a base that appears in a class definition is not an instance of
-   :class:`type`, then an ``__mro_entries__`` method is searched on the base.
-   If an ``__mro_entries__`` method is found, the base is substituted with the
-   result of a call to ``__mro_entries__`` when creating the class.
+   :class:`type`, then an :meth:`!__mro_entries__` method is searched on the base.
+   If an :meth:`!__mro_entries__` method is found, the base is substituted with the
+   result of a call to :meth:`!__mro_entries__` when creating the class.
    The method is called with the original bases tuple
    passed to the *bases* parameter, and must return a tuple
    of classes that will be used instead of the base. The returned tuple may be
@@ -2103,7 +2103,7 @@ Resolving MRO entries
       Dynamically resolve bases that are not instances of :class:`type`.
 
    :pep:`560`
-      Core support for typing module and generic types
+      Core support for typing module and generic types.
 
 
 Determining the appropriate metaclass


### PR DESCRIPTION
- Improve cross references between the "data model" page, and `types.rst`
- Address post-merge review of https://github.com/python/cpython/pull/103374 by @CAM-Gerlach

---

<!-- gh-issue-number: gh-103373 -->
* Issue: gh-103373
<!-- /gh-issue-number -->
