### PR TITLE
gh-84436: Add static flag in PyLongObject's lv_tag

### DIFF
--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -237,14 +237,17 @@ _PyLong_SetSignAndDigitCount(PyLongObject *op, int sign, Py_ssize_t size)
     assert(size >= 0);
     assert(-1 <= sign && sign <= 1);
     assert(sign != 0 || size == 0);
-    op->long_value.lv_tag = TAG_FROM_SIGN_AND_SIZE(sign, (size_t)size);
+    op->long_value.lv_tag = TAG_FROM_SIGN_AND_SIZE(sign, (size_t)size) |
+        (op->long_value.lv_tag & SIGN_STATIC);
 }
 
 static inline void
 _PyLong_SetDigitCount(PyLongObject *op, Py_ssize_t size)
 {
     assert(size >= 0);
-    op->long_value.lv_tag = (((size_t)size) << NON_SIZE_BITS) | (op->long_value.lv_tag & SIGN_MASK);
+    op->long_value.lv_tag = (((size_t)size) << NON_SIZE_BITS) |
+        (op->long_value.lv_tag & SIGN_MASK) |
+        (op->long_value.lv_tag & SIGN_STATIC);
 }
 
 #define NON_SIZE_MASK ~((1 << NON_SIZE_BITS) - 1)

--- a/Misc/NEWS.d/next/Core and Builtins/2023-04-09-23-02-10.gh-issue-84436.IIBB5W.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-04-09-23-02-10.gh-issue-84436.IIBB5W.rst
@@ -1,0 +1,3 @@
+Add a static flag in PyLongObject's lv_tag and rework the respective
+functions to correctly account for it. This also initializes small ints,
+False, and True with the static flag set.


### PR DESCRIPTION
This adds a new `SIGN_STATIC` flag to PyLongObject's `lv_tag` which is used to determine if a given long object was statically allocated. It also reworks all the functions that use `NON_SIZE_BITS` to correctly account for this new flag.

<!-- gh-issue-number: gh-84436 -->
* Issue: gh-84436
<!-- /gh-issue-number -->
