### PR TITLE
gh-97797: Mention `__metadata__` in docstrings of `typing.{_AnnotatedAlias, Annotated}`

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2154,6 +2154,8 @@ class _AnnotatedAlias(_NotIterable, _GenericAlias, _root=True):
     with extra annotations. The alias behaves like a normal typing alias,
     instantiating is the same as instantiating the underlying type, binding
     it to types is also the same.
+
+    The metadata itself is storred in '__metadata__' attribute as a tuple.
     """
     def __init__(self, origin, metadata):
         if isinstance(origin, _AnnotatedAlias):
@@ -2209,6 +2211,10 @@ class Annotated:
     Details:
 
     - It's an error to call `Annotated` with less than two arguments.
+    - Metadata can be accessed in runtime with::
+
+        Annotated[int, '$'].__metadata__ == ('$',)
+
     - Nested Annotated are flattened::
 
         Annotated[Annotated[T, Ann1, Ann2], Ann3] == Annotated[T, Ann1, Ann2, Ann3]

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2155,7 +2155,7 @@ class _AnnotatedAlias(_NotIterable, _GenericAlias, _root=True):
     instantiating is the same as instantiating the underlying type, binding
     it to types is also the same.
 
-    The metadata itself is storred in '__metadata__' attribute as a tuple.
+    The metadata itself is stored in '__metadata__' attribute as a tuple.
     """
     def __init__(self, origin, metadata):
         if isinstance(origin, _AnnotatedAlias):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2155,7 +2155,7 @@ class _AnnotatedAlias(_NotIterable, _GenericAlias, _root=True):
     instantiating is the same as instantiating the underlying type, binding
     it to types is also the same.
 
-    The metadata itself is stored in '__metadata__' attribute as a tuple.
+    The metadata itself is stored in a '__metadata__' attribute as a tuple.
     """
     def __init__(self, origin, metadata):
         if isinstance(origin, _AnnotatedAlias):
@@ -2211,7 +2211,7 @@ class Annotated:
     Details:
 
     - It's an error to call `Annotated` with less than two arguments.
-    - Metadata can be accessed in runtime with::
+    - Access the metadata via the ``__metadata__`` attribute::
 
         Annotated[int, '$'].__metadata__ == ('$',)
 


### PR DESCRIPTION
New `help` output:

```python
>>> help(typing._AnnotatedAlias)
Help on class _AnnotatedAlias in module typing:

class _AnnotatedAlias(_NotIterable, _GenericAlias)
 |  _AnnotatedAlias(origin, metadata)
 |
 |  Runtime representation of an annotated type.
 |
 |  At its core 'Annotated[t, dec1, dec2, ...]' is an alias for the type 't'
 |  with extra annotations. The alias behaves like a normal typing alias,
 |  instantiating is the same as instantiating the underlying type, binding
 |  it to types is also the same.
 |
 |  The metadata itself is storred in '__metadata__' attribute as a tuple.
 |
 |  Method resolution order:
 |      _AnnotatedAlias
 |      _NotIterable
 |      _GenericAlias
 |      _BaseGenericAlias
 |      _Final
 |      builtins.object
 |
 |  Methods defined here:
 |
 |  __eq__(self, other)
 |      Return self==value.
 |
 |  __getattr__(self, attr)
 |
 |  __hash__(self)
 |      Return hash(self).
 |
 |  __init__(self, origin, metadata)
 |      Initialize self.  See help(type(self)) for accurate signature.
 |
 |  __mro_entries__(self, bases)
 |
 |  __reduce__(self)
 |      Helper for pickle.
 |
 |  __repr__(self)
 |      Return repr(self).
 |
 |  copy_with(self, params)
 |
 |  ----------------------------------------------------------------------
 |  Data descriptors defined here:
 |
 |  __dict__
 |      dictionary for instance variables (if defined)
 |
 |  __weakref__
 |      list of weak references to the object (if defined)
 |
 |  ----------------------------------------------------------------------
 |  Data and other attributes inherited from _NotIterable:
 |
 |  __iter__ = None
 |
 |  ----------------------------------------------------------------------
 |  Methods inherited from _GenericAlias:
 |
 |  __getitem__(self, args)
 |
 |  __or__(self, right)
 |      Return self|value.
 |
 |  __ror__(self, left)
 |      Return value|self.
 |
 |  ----------------------------------------------------------------------
 |  Methods inherited from _BaseGenericAlias:
 |
 |  __call__(self, *args, **kwargs)
 |      Call self as a function.
 |
 |  __dir__(self)
 |      Default dir() implementation.
 |
 |  __instancecheck__(self, obj)
 |      Check if an object is an instance.
 |
 |  __setattr__(self, attr, val)
 |      Implement setattr(self, name, value).
 |
 |  __subclasscheck__(self, cls)
 |      Check if a class is a subclass.
 |
 |  ----------------------------------------------------------------------
 |  Class methods inherited from _Final:
 |
 |  __init_subclass__(*args, **kwds) from builtins.type
 |      This method is called when a class is subclassed.
 |
 |      The default implementation does nothing. It may be
 |      overridden to extend subclasses.

```

and:

```python
>>> help(typing.Annotated)
Help on class Annotated in module typing:

class Annotated(builtins.object)
 |  Annotated(*args, **kwargs)
 |
 |  Add context specific metadata to a type.
 |
 |  Example: Annotated[int, runtime_check.Unsigned] indicates to the
 |  hypothetical runtime_check module that this type is an unsigned int.
 |  Every other consumer of this type can ignore this metadata and treat
 |  this type as int.
 |
 |  The first argument to Annotated must be a valid type.
 |
 |  Details:
 |
 |  - It's an error to call `Annotated` with less than two arguments.
 |  - Metadata can be accessed in runtime with::
 |
 |      Annotated[int, '$'].__metadata__ == ('$',)
 |
 |  - Nested Annotated are flattened::
 |
 |      Annotated[Annotated[T, Ann1, Ann2], Ann3] == Annotated[T, Ann1, Ann2, Ann3]
 |
 |  - Instantiating an annotated type is equivalent to instantiating the
 |  underlying type::
 |
 |      Annotated[C, Ann1](5) == C(5)
 |
 |  - Annotated can be used as a generic type alias::
 |
 |      Optimized = Annotated[T, runtime.Optimize()]
 |      Optimized[int] == Annotated[int, runtime.Optimize()]
 |
 |      OptimizedList = Annotated[List[T], runtime.Optimize()]
 |      OptimizedList[int] == Annotated[List[int], runtime.Optimize()]
 |
 |  - Annotated cannot be used with an unpacked TypeVarTuple::
 |
 |      Annotated[*Ts, Ann1]  # NOT valid
 |
 |    This would be equivalent to
 |
 |      Annotated[T1, T2, T3, ..., Ann1]
 |
 |    where T1, T2 etc. are TypeVars, which would be invalid, because
 |    only one type should be passed to Annotated.
 |
 |  Class methods defined here:
 |
 |  __class_getitem__(params) from builtins.type
 |
 |  __init_subclass__(*args, **kwargs) from builtins.type
 |      This method is called when a class is subclassed.
 |
 |      The default implementation does nothing. It may be
 |      overridden to extend subclasses.
 |
 |  ----------------------------------------------------------------------
 |  Static methods defined here:
 |
 |  __new__(cls, *args, **kwargs)
 |      Create and return a new object.  See help(type) for accurate signature.

```

<!-- gh-issue-number: gh-97797 -->
* Issue: gh-97797
<!-- /gh-issue-number -->
