### PR TITLE
gh-103417: use time.monotonic in the example for sched.scheduler

### DIFF
--- a/Doc/library/sched.rst
+++ b/Doc/library/sched.rst
@@ -36,7 +36,7 @@ scheduler:
 Example::
 
    >>> import sched, time
-   >>> s = sched.scheduler(time.time, time.sleep)
+   >>> s = sched.scheduler(time.monotonic, time.sleep)
    >>> def print_time(a='default'):
    ...     print("From print_time", time.time(), a)
    ...


### PR DESCRIPTION
updates the docs for `scheduler.sched` to use a monontonic clock to avoid time bugs
https://github.com/python/cpython/issues/103417


<!-- gh-issue-number: gh-103417 -->
* Issue: gh-103417
<!-- /gh-issue-number -->
