### PR TITLE
Doc: Avoid error lexing multiprocessing docs code block on Pygments 2.15.0

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -452,7 +452,9 @@ process which created it.
    importable by the children. This is covered in :ref:`multiprocessing-programming`
    however it is worth pointing out here. This means that some examples, such
    as the :class:`multiprocessing.pool.Pool` examples will not work in the
-   interactive interpreter. For example::
+   interactive interpreter. For example:
+
+   .. code-block:: text
 
       >>> from multiprocessing import Pool
       >>> p = Pool(5)


### PR DESCRIPTION
Due to the changes in how tracebacks are lexed in Pygments 2.15.0 (pygments/pygments#2226 and pygments/pygments#2329 ), the following code block in the multiprocessing docs:

https://github.com/python/cpython/blob/c3cd3d10788769558a4668e9e5cfff42fe377852/Doc/library/multiprocessing.rst?plain=1#L455-L472

results in a docs build error when attempting to lex the code for syntax highlighting and other features:

```
WARNING: Could not lex literal_block as "pycon". Highlighting skipped.
```

due to pygments apparently attempting to parse the traceback, which fails. This was reported in pygments/pygments#2407 , but unless and until that is fixed, we need to unbreak the docs build.

Note that the fix will need to be backported as far as 3.7 to fix the docs CIs/builds there (given that I confirmed Pygments 2.15 should be picked up even that far back), otherwise any future PRs/commits on those branches will also run into the error.

Ideally it would be nice to avoid breaking syntax highlighting, the `>>>` button, selection of only the user-entered text and other custom `pycon` features on the whole block, which could be done by splitting it into two code blocks, one with the code and one with the output. However, this would be more complex and complicate backporting, since the error is apparently different in different versions and there were other changes in between.

We could also pin to Pygments 2.14, but at the moment its unclear if they will fix it upstream (since its an extremely narrow corner case and unclear how they would distinguish it from valid cases), so it might block adoption of current and future Sphinx and pygments versions all for one single code block. This also would probably need a separate fix on the docs build server which is onerous to touch.

Therefore, I've just changed that block to use plain `text` as the lexer, which is slightly less ideal but is the simplest all-around solution for now, and can easily be changed/reverted later if it does get fixed upstream. Conveniently for the purpose, it also discourages the user from actually trying the example, which will hang their Python interpreter.