### PR TITLE
gh-103180: Add CI timeouts to all GitHub Actions jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
   check_source:
     name: 'Check for source changes'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       run_tests: ${{ steps.check.outputs.run_tests }}
     steps:
@@ -63,6 +64,7 @@ jobs:
   check_generated_files:
     name: 'Check if generated files are up to date'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     steps:
@@ -118,6 +120,7 @@ jobs:
   build_win32:
     name: 'Windows (x86)'
     runs-on: windows-latest
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
@@ -126,7 +129,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build CPython
       run: .\PCbuild\build.bat -e -d -p Win32
-      timeout-minutes: 30
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests
@@ -135,6 +137,7 @@ jobs:
   build_win_amd64:
     name: 'Windows (x64)'
     runs-on: windows-latest
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
@@ -145,7 +148,6 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
       run: .\PCbuild\build.bat -e -d -p x64
-      timeout-minutes: 30
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests
@@ -154,6 +156,7 @@ jobs:
   build_macos:
     name: 'macOS'
     runs-on: macos-latest
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
@@ -184,6 +187,7 @@ jobs:
   build_ubuntu:
     name: 'Ubuntu'
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
@@ -241,6 +245,7 @@ jobs:
   build_ubuntu_ssltests:
     name: 'Ubuntu SSL tests with OpenSSL'
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     strategy:
@@ -290,6 +295,7 @@ jobs:
   build_asan:
     name: 'Address sanitizer'
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:

--- a/.github/workflows/build_msi.yml
+++ b/.github/workflows/build_msi.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     name: Windows Installer
     runs-on: windows-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         type: [x86, x64, arm64]

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -36,6 +36,7 @@ jobs:
   build_doc:
     name: 'Docs'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
     - name: Register Sphinx problem matcher
@@ -80,6 +81,7 @@ jobs:
   doctest:
     name: 'Doctest'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
     - name: Register Sphinx problem matcher

--- a/.github/workflows/new-bugs-announce-notifier.yml
+++ b/.github/workflows/new-bugs-announce-notifier.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   notify-new-bugs-announce:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/project-updater.yml
+++ b/.github/workflows/project-updater.yml
@@ -13,6 +13,7 @@ jobs:
   add-to-project:
     name: Add issues to projects
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         include:
@@ -22,7 +23,7 @@ jobs:
           - { project:  3, label: expert-subinterpreters }
           - { project: 29, label: expert-asyncio }
           - { project: 32, label: sprint }
-    
+
     steps:
       - uses: actions/add-to-project@v0.1.0
         with:

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -8,6 +8,7 @@ jobs:
   label:
     name: DO-NOT-MERGE
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: mheap/github-action-required-labels@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
     if: github.repository_owner == 'python'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
     - name: "Check PRs"

--- a/.github/workflows/verify-ensurepip-wheels.yml
+++ b/.github/workflows/verify-ensurepip-wheels.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
See https://github.com/python/cpython/issues/103180#issuecomment-1502977283 on why I used the numbers I used.

Docs: https://docs.github.com/ru/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

<!-- gh-issue-number: gh-103180 -->
* Issue: gh-103180
<!-- /gh-issue-number -->
