### PR TITLE
gh-103438: Don't define CTYPES_PASS_BY_REF_HACK on aarch64 or riscv64

### DIFF
--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1139,8 +1139,7 @@ GetComError(HRESULT errcode, GUID *riid, IUnknown *pIunk)
 }
 #endif
 
-#if (defined(__x86_64__) && (defined(__MINGW64__) || defined(__CYGWIN__))) || \
-    defined(__aarch64__) || defined(__riscv)
+#if (defined(__x86_64__) && (defined(__MINGW64__) || defined(__CYGWIN__)))
 #define CTYPES_PASS_BY_REF_HACK
 #define POW2(x) (((x & ~(x - 1)) == x) ? x : 0)
 #define IS_PASS_BY_REF(x) (x > 8 || !POW2(x))


### PR DESCRIPTION
This was a workaround for a bug in libffi that has been fixed.


<!-- gh-issue-number: gh-103438 -->
* Issue: gh-103438
<!-- /gh-issue-number -->
