### PR TITLE
gh-103291: Re-activate virtual environments in child processes

### DIFF
--- a/Lib/venv/scripts/posix/activate.fish
+++ b/Lib/venv/scripts/posix/activate.fish
@@ -30,6 +30,13 @@ function deactivate  -d "Exit virtual environment and return to normal shell env
     end
 end
 
+# deactivate isn't exported to child processes, so we re-activate
+function reactivate --on-event fish_prompt
+    if set -q VIRTUAL_ENV; and not type -q deactivate
+      source $VIRTUAL_ENV/bin/activate.fish
+    end
+end
+
 # Unset irrelevant variables.
 deactivate nondestructive
 

--- a/Misc/NEWS.d/next/Library/2023-04-11-22-58-14.gh-issue-103291.iwNTOw.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-11-22-58-14.gh-issue-103291.iwNTOw.rst
@@ -1,0 +1,1 @@
+Virtual environments can now always be deactivated in fish shell.


### PR DESCRIPTION
In child processes, virtual environments are 'activated' by exported variables, but can't be deactivated correctly. This change re-activates environments if necessary.

<!-- gh-issue-number: gh-103291 -->
* Issue: gh-103291
<!-- /gh-issue-number -->