### PR TITLE
gh-87092: fix refleak in peepholer test harness

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7148,10 +7148,6 @@ _PyCompile_OptimizeCfg(PyObject *instructions, PyObject *consts)
     }
 
     cfg_builder g;
-    memset(&g, 0, sizeof(cfg_builder));
-    if (_PyCfgBuilder_Init(&g) < 0) {
-        goto error;
-    }
     if (instructions_to_cfg(instructions, &g) < 0) {
         goto error;
     }


### PR DESCRIPTION
Double initialisation.

<!-- gh-issue-number: gh-87092 -->
* Issue: gh-87092
<!-- /gh-issue-number -->
