### PR TITLE
No need for two spaces between words in an import error message

### DIFF
--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -1260,7 +1260,7 @@ def _find_and_load_unlocked(name, import_):
         try:
             path = parent_module.__path__
         except AttributeError:
-            msg = f'{_ERR_MSG_PREFIX} {name!r}; {parent!r} is not a package'
+            msg = f'{_ERR_MSG_PREFIX}{name!r}; {parent!r} is not a package'
             raise ModuleNotFoundError(msg, name=name) from None
         parent_spec = parent_module.__spec__
         child = name.rpartition('.')[2]


### PR DESCRIPTION
Fixes the double-space in this error:
```
ModuleNotFoundError: No module named  'sys.monitoring'; 'sys' is not a package
```