### PR TITLE
gh-48572:  Function with modified __name__ uses original name when there's an arg error

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -194,7 +194,6 @@ def total_ordering(cls):
     root = max(roots)       # prefer __lt__ to __le__ to __gt__ to __ge__
     for opname, opfunc in _convert[root]:
         if opname not in roots:
-            opfunc.__name__ = opname
             setattr(cls, opname, opfunc)
     return cls
 

--- a/Lib/test/test_extcall.py
+++ b/Lib/test/test_extcall.py
@@ -498,6 +498,12 @@ Too many arguments:
     Traceback (most recent call last):
       ...
     TypeError: f() takes from 1 to 2 positional arguments but 3 positional arguments (and 1 keyword-only argument) were given
+    >>> def f(): pass
+    >>> f.__name__ = 'changed_f'
+    >>> f(1)
+    Traceback (most recent call last):
+      ...
+    TypeError: changed_f() takes 0 positional arguments but 1 was given
 
 Too few and missing arguments:
 

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -138,7 +138,7 @@ class GeneratorTest(unittest.TestCase):
         func.__name__ = "func_name"
         gen = func()
         self.assertEqual(gen.__name__, "func_name")
-        self.assertEqual(gen.__qualname__, "func_qualname")
+        self.assertEqual(gen.__qualname__, "func_name")
 
         # unnamed generator
         gen = (x for x in range(10))

--- a/Lib/test/test_keywordonlyarg.py
+++ b/Lib/test/test_keywordonlyarg.py
@@ -67,6 +67,20 @@ class KeywordOnlyArgTestCase(unittest.TestCase):
                     "positional arguments but 3 were given")
         self.assertEqual(str(exc.exception), expected)
 
+        with self.assertRaises(TypeError) as exc:
+            f.__name__ = 'changed_f'
+            f(1, 2, 3)
+        expected = (f"{f.__qualname__}() takes from 1 to 2 "
+                        "positional arguments but 3 were given")
+        self.assertEqual(str(exc.exception), expected)
+
+        with self.assertRaises(TypeError) as exc:
+            f.__qualname__ = 'changed_f2'
+            f(1, 2, 3)
+        expected = (f"{f.__qualname__}() takes from 1 to 2 "
+                    "positional arguments but 3 were given")
+        self.assertEqual(str(exc.exception), expected)
+
     def testSyntaxErrorForFunctionCall(self):
         self.assertRaisesSyntaxError("f(p, k=1, p2)")
         self.assertRaisesSyntaxError("f(p, k1=50, *(1,2), k1=100)")

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -517,7 +517,16 @@ func_set_name(PyFunctionObject *op, PyObject *value, void *Py_UNUSED(ignored))
                         "__name__ must be set to a string object");
         return -1;
     }
+
+    _Py_DECLARE_STR(dot, ".");
+    PyObject *dotted_path = PyUnicode_Split(op->func_qualname, &_Py_STR(dot), -1);
+    Py_ssize_t n = PyList_GET_SIZE(dotted_path);
+    PyList_SetItem(dotted_path, n - 1, value);
+    Py_INCREF(value);
+    dotted_path = PyUnicode_Join(&_Py_STR(dot), dotted_path);
+
     Py_XSETREF(op->func_name, Py_NewRef(value));
+    Py_XSETREF(op->func_qualname, Py_NewRef(dotted_path));
     return 0;
 }
 

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -518,15 +518,24 @@ func_set_name(PyFunctionObject *op, PyObject *value, void *Py_UNUSED(ignored))
         return -1;
     }
 
-    _Py_DECLARE_STR(dot, ".");
-    PyObject *dotted_path = PyUnicode_Split(op->func_qualname, &_Py_STR(dot), -1);
+    PyObject *separator, *qual_name, *dotted_path, *new_dotted_path;
+
+    separator = PyUnicode_FromString(".");
+    qual_name = PyObject_GetAttrString((PyObject *)op, "__qualname__");
+    dotted_path = PyUnicode_Split(qual_name, separator, -1);
+
     Py_ssize_t n = PyList_GET_SIZE(dotted_path);
     PyList_SetItem(dotted_path, n - 1, value);
     Py_INCREF(value);
-    dotted_path = PyUnicode_Join(&_Py_STR(dot), dotted_path);
+    new_dotted_path = PyUnicode_Join(separator, dotted_path);
 
     Py_XSETREF(op->func_name, Py_NewRef(value));
-    Py_XSETREF(op->func_qualname, Py_NewRef(dotted_path));
+    Py_XSETREF(op->func_qualname, Py_NewRef(new_dotted_path));
+
+    Py_DECREF(qual_name);
+    Py_DECREF(dotted_path);
+    Py_DECREF(new_dotted_path);
+    Py_DECREF(separator);
     return 0;
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-48572 -->
* Issue: gh-48572
<!-- /gh-issue-number -->


When too many arguments are passed to a function, a `TypeError` is generated using `__qualname__`. The issue is seems to be solved  by updating the `__qualname__`  when the function `__name__`  attribute is changed. I know it is not a very good solution, so I am waiting for your ideas and suggestions.

```C
_PyErr_Format(tstate, PyExc_TypeError,
              "%U() takes %U positional argument%s but %zd%U %s given",
              qualname,
              sig,
              plural ? "s" : "",
              given,
              kwonly_sig,
              given == 1 && !kwonly_given ? "was" : "were");
```