### PR TITLE
[3.11] gh-103479: [Enum] require __new__ to be considered a data type (GH-103495)

### DIFF
--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -837,17 +837,19 @@ Some rules:
 4. When another data type is mixed in, the :attr:`value` attribute is *not the
    same* as the enum member itself, although it is equivalent and will compare
    equal.
-5. %-style formatting:  ``%s`` and ``%r`` call the :class:`Enum` class's
+5. A ``data type`` is a mixin that defines :meth:`__new__`, or a
+   :class:`~dataclasses.dataclass`
+6. %-style formatting:  ``%s`` and ``%r`` call the :class:`Enum` class's
    :meth:`__str__` and :meth:`__repr__` respectively; other codes (such as
    ``%i`` or ``%h`` for IntEnum) treat the enum member as its mixed-in type.
-6. :ref:`Formatted string literals <f-strings>`, :meth:`str.format`,
+7. :ref:`Formatted string literals <f-strings>`, :meth:`str.format`,
    and :func:`format` will use the enum's :meth:`__str__` method.
 
 .. note::
 
    Because :class:`IntEnum`, :class:`IntFlag`, and :class:`StrEnum` are
    designed to be drop-in replacements for existing constants, their
-   :meth:`__str__` method has been reset to their data types
+   :meth:`__str__` method has been reset to their data types'
    :meth:`__str__` method.
 
 When to use :meth:`__new__` vs. :meth:`__init__`

--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -837,8 +837,7 @@ Some rules:
 4. When another data type is mixed in, the :attr:`value` attribute is *not the
    same* as the enum member itself, although it is equivalent and will compare
    equal.
-5. A ``data type`` is a mixin that defines :meth:`__new__`, or a
-   :class:`~dataclasses.dataclass`
+5. A ``data type`` is a mixin that defines :meth:`__new__`.
 6. %-style formatting:  ``%s`` and ``%r`` call the :class:`Enum` class's
    :meth:`__str__` and :meth:`__repr__` respectively; other codes (such as
    ``%i`` or ``%h`` for IntEnum) treat the enum member as its mixed-in type.

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -981,7 +981,7 @@ class EnumType(type):
 
     @classmethod
     def _find_data_type_(mcls, class_name, bases):
-        # a datatype has a __new__ method, or a __dataclass_fields__ attribute
+        # a datatype has a __new__ method
         data_types = set()
         base_chain = set()
         for chain in bases:
@@ -994,7 +994,7 @@ class EnumType(type):
                     if base._member_type_ is not object:
                         data_types.add(base._member_type_)
                         break
-                elif '__new__' in base.__dict__:
+                elif '__new__' in base.__dict__ or '__dataclass_fields__' in base.__dict__:
                     if isinstance(base, EnumType):
                         continue
                     data_types.add(candidate or base)

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -981,6 +981,7 @@ class EnumType(type):
 
     @classmethod
     def _find_data_type_(mcls, class_name, bases):
+        # a datatype has a __new__ method, or a __dataclass_fields__ attribute
         data_types = set()
         base_chain = set()
         for chain in bases:
@@ -993,7 +994,7 @@ class EnumType(type):
                     if base._member_type_ is not object:
                         data_types.add(base._member_type_)
                         break
-                elif '__new__' in base.__dict__ or '__init__' in base.__dict__:
+                elif '__new__' in base.__dict__:
                     if isinstance(base, EnumType):
                         continue
                     data_types.add(candidate or base)

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2667,13 +2667,14 @@ class TestSpecial(unittest.TestCase):
             a: int
         class Entries(Foo, Enum):
             ENTRY1 = 1
+        self.assertEqual(repr(Entries.ENTRY1), '<Entries.ENTRY1: ha hah!>')
+        self.assertTrue(Entries.ENTRY1.value == Foo(1), Entries.ENTRY1.value)
         self.assertTrue(isinstance(Entries.ENTRY1, Foo))
         self.assertTrue(Entries._member_type_ is Foo, Entries._member_type_)
         self.assertTrue(Entries.ENTRY1.value == Foo(1), Entries.ENTRY1.value)
         self.assertEqual(repr(Entries.ENTRY1), '<Entries.ENTRY1: Foo(a=1)>')
 
-    def test_repr_with_init_data_type_mixin(self):
-        # non-data_type is a mixin that doesn't define __new__
+    def test_repr_with_init_mixin(self):
         class Foo:
             def __init__(self, a):
                 self.a = a
@@ -2682,9 +2683,9 @@ class TestSpecial(unittest.TestCase):
         class Entries(Foo, Enum):
             ENTRY1 = 1
         #
-        self.assertEqual(repr(Entries.ENTRY1), '<Entries.ENTRY1: Foo(a=1)>')
+        self.assertEqual(repr(Entries.ENTRY1), 'Foo(a=1)')
 
-    def test_repr_and_str_with_non_data_type_mixin(self):
+    def test_repr_and_str_with_no_init_mixin(self):
         # non-data_type is a mixin that doesn't define __new__
         class Foo:
             def __repr__(self):
@@ -2790,6 +2791,8 @@ class TestSpecial(unittest.TestCase):
 
     def test_init_exception(self):
         class Base:
+            def __new__(cls, *args):
+                return object.__new__(cls)
             def __init__(self, x):
                 raise ValueError("I don't like", x)
         with self.assertRaises(TypeError):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2667,8 +2667,6 @@ class TestSpecial(unittest.TestCase):
             a: int
         class Entries(Foo, Enum):
             ENTRY1 = 1
-        self.assertEqual(repr(Entries.ENTRY1), '<Entries.ENTRY1: ha hah!>')
-        self.assertTrue(Entries.ENTRY1.value == Foo(1), Entries.ENTRY1.value)
         self.assertTrue(isinstance(Entries.ENTRY1, Foo))
         self.assertTrue(Entries._member_type_ is Foo, Entries._member_type_)
         self.assertTrue(Entries.ENTRY1.value == Foo(1), Entries.ENTRY1.value)
@@ -2679,7 +2677,7 @@ class TestSpecial(unittest.TestCase):
             def __init__(self, a):
                 self.a = a
             def __repr__(self):
-                return f'Foo(a={self.a!r})'
+                return 'Foo(a=%r)' % self._value_
         class Entries(Foo, Enum):
             ENTRY1 = 1
         #


### PR DESCRIPTION
a mixin must have a __new__ method to be interpreted as a data-type, an __init__ method is not enough (restores pre-3.11 behavior)

(cherry picked from commit a6f95941a3d686707fb38e0f37758e666f25e180)

Co-authored-by: Ethan Furman <ethan@stoneleaf.us>

<!-- gh-issue-number: gh-103479 -->
* Issue: gh-103479
<!-- /gh-issue-number -->
