### PR TITLE
Fix unused functions warnings in instrumentation.c.

### DIFF
--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -125,6 +125,7 @@ is_instrumented(int opcode) {
     return opcode >= MIN_INSTRUMENTED_OPCODE;
 }
 
+#ifndef NDEBUG
 static inline bool
 monitors_equals(_Py_Monitors a, _Py_Monitors b)
 {
@@ -135,6 +136,7 @@ monitors_equals(_Py_Monitors a, _Py_Monitors b)
     }
     return true;
 }
+#endif
 
 static inline _Py_Monitors
 monitors_sub(_Py_Monitors a, _Py_Monitors b)
@@ -146,6 +148,7 @@ monitors_sub(_Py_Monitors a, _Py_Monitors b)
     return res;
 }
 
+#ifndef NDEBUG
 static inline _Py_Monitors
 monitors_and(_Py_Monitors a, _Py_Monitors b)
 {
@@ -155,6 +158,7 @@ monitors_and(_Py_Monitors a, _Py_Monitors b)
     }
     return res;
 }
+#endif
 
 static inline _Py_Monitors
 monitors_or(_Py_Monitors a, _Py_Monitors b)


### PR DESCRIPTION
```
clang -c -fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -g -O3 -Wall    -std=c11 -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Werror=implicit-function-declaration -fvisibility=hidden  -I../cpython/Include/internal -IObjects -IInclude -IPython -I. -I../cpython/Include    -DPy_BUILD_CORE -o Python/instrumentation.o ../cpython/Python/instrumentation.c
../cpython/Python/instrumentation.c:129:1: warning: unused function 'monitors_equals' [-Wunused-function]
monitors_equals(_Py_Monitors a, _Py_Monitors b)
^
../cpython/Python/instrumentation.c:150:1: warning: unused function 'monitors_and' [-Wunused-function]
monitors_and(_Py_Monitors a, _Py_Monitors b)
^
2 warnings generated.
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
