### PR TITLE
GH-103517: Improve tests for `pathlib.Path.walk()`

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2678,20 +2678,20 @@ class WalkTests(unittest.TestCase):
             del self.sub2_tree[1][:1]
 
     def test_walk_topdown(self):
-        all = list(self.walk_path.walk())
-
-        self.assertEqual(len(all), 4)
-        # We can't know which order SUB1 and SUB2 will appear in.
-        # Not flipped:  TESTFN, SUB1, SUB11, SUB2
-        #     flipped:  TESTFN, SUB2, SUB1, SUB11
-        flipped = all[0][1][0] != "SUB1"
-        all[0][1].sort()
-        all[3 - 2 * flipped][-1].sort()
-        all[3 - 2 * flipped][1].sort()
-        self.assertEqual(all[0], (self.walk_path, ["SUB1", "SUB2"], ["tmp1"]))
-        self.assertEqual(all[1 + flipped], (self.sub1_path, ["SUB11"], ["tmp2"]))
-        self.assertEqual(all[2 + flipped], (self.sub11_path, [], []))
-        self.assertEqual(all[3 - 2 * flipped], self.sub2_tree)
+        walker = self.walk_path.walk()
+        entry = next(walker)
+        entry[1].sort()  # Ensure we visit SUB1 before SUB2
+        self.assertEqual(entry, (self.walk_path, ["SUB1", "SUB2"], ["tmp1"]))
+        entry = next(walker)
+        self.assertEqual(entry, (self.sub1_path, ["SUB11"], ["tmp2"]))
+        entry = next(walker)
+        self.assertEqual(entry, (self.sub11_path, [], []))
+        entry = next(walker)
+        entry[1].sort()
+        entry[2].sort()
+        self.assertEqual(entry, self.sub2_tree)
+        with self.assertRaises(StopIteration):
+            next(walker)
 
     def test_walk_prune(self, walk_path=None):
         if walk_path is None:
@@ -2715,24 +2715,37 @@ class WalkTests(unittest.TestCase):
         self.test_walk_prune(FakePath(self.walk_path).__fspath__())
 
     def test_walk_bottom_up(self):
-        all = list(self.walk_path.walk( top_down=False))
-
-        self.assertEqual(len(all), 4, all)
-        # We can't know which order SUB1 and SUB2 will appear in.
-        # Not flipped:  SUB11, SUB1, SUB2, TESTFN
-        #     flipped:  SUB2, SUB11, SUB1, TESTFN
-        flipped = all[3][1][0] != "SUB1"
-        all[3][1].sort()
-        all[2 - 2 * flipped][-1].sort()
-        all[2 - 2 * flipped][1].sort()
-        self.assertEqual(all[3],
-                         (self.walk_path, ["SUB1", "SUB2"], ["tmp1"]))
-        self.assertEqual(all[flipped],
-                         (self.sub11_path, [], []))
-        self.assertEqual(all[flipped + 1],
-                         (self.sub1_path, ["SUB11"], ["tmp2"]))
-        self.assertEqual(all[2 - 2 * flipped],
-                         self.sub2_tree)
+        seen_testfn = seen_sub1 = seen_sub11 = seen_sub2 = False
+        for path, dirnames, filenames in self.walk_path.walk(top_down=False):
+            if path == self.walk_path:
+                self.assertFalse(seen_testfn)
+                self.assertTrue(seen_sub1)
+                self.assertTrue(seen_sub2)
+                self.assertEqual(sorted(dirnames), ["SUB1", "SUB2"])
+                self.assertEqual(filenames, ["tmp1"])
+                seen_testfn = True
+            elif path == self.sub1_path:
+                self.assertFalse(seen_testfn)
+                self.assertFalse(seen_sub1)
+                self.assertTrue(seen_sub11)
+                self.assertEqual(dirnames, ["SUB11"])
+                self.assertEqual(filenames, ["tmp2"])
+                seen_sub1 = True
+            elif path == self.sub11_path:
+                self.assertFalse(seen_sub1)
+                self.assertFalse(seen_sub11)
+                self.assertEqual(dirnames, [])
+                self.assertEqual(filenames, [])
+                seen_sub11 = True
+            elif path == self.sub2_path:
+                self.assertFalse(seen_testfn)
+                self.assertFalse(seen_sub2)
+                self.assertEqual(sorted(dirnames), sorted(self.sub2_tree[1]))
+                self.assertEqual(sorted(filenames), sorted(self.sub2_tree[2]))
+                seen_sub2 = True
+            else:
+                raise AssertionError(f"Unexpected path: {path}")
+        self.assertTrue(seen_testfn)
 
     @os_helper.skip_unless_symlink
     def test_walk_follow_symlinks(self):


### PR DESCRIPTION
Remove list index juggling from tests for `pathlib.Path.walk(top_down=True)` and `walk(top_down=False)`, which makes them more readable.

We no longer check the order that sibling directories are visited in bottom-up mode. This order is arbitrary and cannot be controlled by the user.

<!-- gh-issue-number: gh-103517 -->
* Issue: gh-103517
<!-- /gh-issue-number -->
