### PR TITLE
gh-103532: Remove TKINTER_PROTECT_LOADTK code

### DIFF
--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -324,10 +324,6 @@ static int quitMainLoop = 0;
 static int errorInCmd = 0;
 static PyObject *excInCmd;
 
-#ifdef TKINTER_PROTECT_LOADTK
-static int tk_load_failed = 0;
-#endif
-
 
 static PyObject *Tkapp_UnicodeResult(TkappObject *);
 
@@ -532,17 +528,7 @@ Tcl_AppInit(Tcl_Interp *interp)
         return TCL_OK;
     }
 
-#ifdef TKINTER_PROTECT_LOADTK
-    if (tk_load_failed) {
-        PySys_WriteStderr("Tk_Init error: %s\n", TKINTER_LOADTK_ERRMSG);
-        return TCL_ERROR;
-    }
-#endif
-
     if (Tk_Init(interp) == TCL_ERROR) {
-#ifdef TKINTER_PROTECT_LOADTK
-        tk_load_failed = 1;
-#endif
         PySys_WriteStderr("Tk_Init error: %s\n", Tcl_GetStringResult(interp));
         return TCL_ERROR;
     }
@@ -635,12 +621,6 @@ Tkapp_New(const char *screenName, const char *className,
         Tcl_SetVar(v->interp,
                         "_tkinter_skip_tk_init", "1", TCL_GLOBAL_ONLY);
     }
-#ifdef TKINTER_PROTECT_LOADTK
-    else if (tk_load_failed) {
-        Tcl_SetVar(v->interp,
-                        "_tkinter_tk_failed", "1", TCL_GLOBAL_ONLY);
-    }
-#endif
 
     /* some initial arguments need to be in argv */
     if (sync || use) {
@@ -702,18 +682,6 @@ Tkapp_New(const char *screenName, const char *className,
 
     if (Tcl_AppInit(v->interp) != TCL_OK) {
         PyObject *result = Tkinter_Error(v);
-#ifdef TKINTER_PROTECT_LOADTK
-        if (wantTk) {
-            const char *_tkinter_tk_failed;
-            _tkinter_tk_failed = Tcl_GetVar(v->interp,
-                            "_tkinter_tk_failed", TCL_GLOBAL_ONLY);
-
-            if ( _tkinter_tk_failed != NULL &&
-                            strcmp(_tkinter_tk_failed, "1") == 0) {
-                tk_load_failed = 1;
-            }
-        }
-#endif
         Py_DECREF((PyObject *)v);
         return (TkappObject *)result;
     }
@@ -2780,18 +2748,6 @@ _tkinter_tkapp_loadtk_impl(TkappObject *self)
     const char * _tk_exists = NULL;
     int err;
 
-#ifdef TKINTER_PROTECT_LOADTK
-    /* Up to Tk 8.4.13, Tk_Init deadlocks on the second call when the
-     * first call failed.
-     * To avoid the deadlock, we just refuse the second call through
-     * a static variable.
-     */
-    if (tk_load_failed) {
-        PyErr_SetString(Tkinter_TclError, TKINTER_LOADTK_ERRMSG);
-        return NULL;
-    }
-#endif
-
     /* We want to guard against calling Tk_Init() multiple times */
     CHECK_TCL_APPARTMENT;
     ENTER_TCL
@@ -2811,9 +2767,6 @@ _tkinter_tkapp_loadtk_impl(TkappObject *self)
     if (_tk_exists == NULL || strcmp(_tk_exists, "1") != 0)     {
         if (Tk_Init(interp)             == TCL_ERROR) {
             Tkinter_Error(self);
-#ifdef TKINTER_PROTECT_LOADTK
-            tk_load_failed = 1;
-#endif
             return NULL;
         }
     }

--- a/Modules/tkappinit.c
+++ b/Modules/tkappinit.c
@@ -18,18 +18,10 @@
 
 #include "tkinter.h"
 
-#ifdef TKINTER_PROTECT_LOADTK
-/* See Tkapp_TkInit in _tkinter.c for the usage of tk_load_faile */
-static int tk_load_failed;
-#endif
-
 int
 Tcl_AppInit(Tcl_Interp *interp)
 {
     const char *_tkinter_skip_tk_init;
-#ifdef TKINTER_PROTECT_LOADTK
-    const char *_tkinter_tk_failed;
-#endif
 
 #ifdef TK_AQUA
 #ifndef MAX_PATH_LEN
@@ -90,23 +82,7 @@ Tcl_AppInit(Tcl_Interp *interp)
         return TCL_OK;
     }
 
-#ifdef TKINTER_PROTECT_LOADTK
-    _tkinter_tk_failed = Tcl_GetVar(interp,
-                    "_tkinter_tk_failed", TCL_GLOBAL_ONLY);
-
-    if (tk_load_failed || (
-                            _tkinter_tk_failed != NULL &&
-                            strcmp(_tkinter_tk_failed, "1") == 0)) {
-        Tcl_SetResult(interp, TKINTER_LOADTK_ERRMSG, TCL_STATIC);
-        return TCL_ERROR;
-    }
-#endif
-
     if (Tk_Init(interp) == TCL_ERROR) {
-#ifdef TKINTER_PROTECT_LOADTK
-        tk_load_failed = 1;
-        Tcl_SetVar(interp, "_tkinter_tk_failed", "1", TCL_GLOBAL_ONLY);
-#endif
         return TCL_ERROR;
     }
 

--- a/Modules/tkinter.h
+++ b/Modules/tkinter.h
@@ -16,12 +16,4 @@
                         (TK_RELEASE_LEVEL << 8) | \
                         (TK_RELEASE_SERIAL << 0))
 
-/* Protect Tk 8.4.13 and older from a deadlock that happens when trying
- * to load tk after a failed attempt. */
-#if TK_HEX_VERSION < 0x0804020e
-#define TKINTER_PROTECT_LOADTK
-#define TKINTER_LOADTK_ERRMSG \
-        "Calling Tk_Init again after a previous call failed might deadlock"
-#endif
-
 #endif /* !TKINTER_H */


### PR DESCRIPTION
This was only needed for Tk 8.4.13 and older, but Tkinter already requires at least 8.5.12.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-103532 -->
* Issue: gh-103532
<!-- /gh-issue-number -->
