### PR TITLE
[3.11] gh-103180: Add CI timeouts to all GitHub Actions jobs (GH-103437).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
   check_source:
     name: 'Check for source changes'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       run_tests: ${{ steps.check.outputs.run_tests }}
       run_ssl_tests: ${{ steps.check.outputs.run_ssl_tests }}
@@ -96,6 +97,7 @@ jobs:
   check_generated_files:
     name: 'Check if generated files are up to date'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     steps:
@@ -148,6 +150,7 @@ jobs:
   build_win32:
     name: 'Windows (x86)'
     runs-on: windows-latest
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
@@ -156,7 +159,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build CPython
       run: .\PCbuild\build.bat -e -d -p Win32
-      timeout-minutes: 30
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests
@@ -165,6 +167,7 @@ jobs:
   build_win_amd64:
     name: 'Windows (x64)'
     runs-on: windows-latest
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
@@ -175,7 +178,6 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
       run: .\PCbuild\build.bat -e -d -p x64
-      timeout-minutes: 30
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests
@@ -184,6 +186,7 @@ jobs:
   build_macos:
     name: 'macOS'
     runs-on: macos-latest
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
@@ -214,6 +217,7 @@ jobs:
   build_ubuntu:
     name: 'Ubuntu'
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
@@ -271,6 +275,7 @@ jobs:
   build_ubuntu_ssltests:
     name: 'Ubuntu SSL tests with OpenSSL'
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true' && needs.check_source.outputs.run_ssl_tests == 'true'
     strategy:
@@ -320,6 +325,7 @@ jobs:
   build_asan:
     name: 'Address sanitizer'
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:

--- a/.github/workflows/build_msi.yml
+++ b/.github/workflows/build_msi.yml
@@ -34,6 +34,7 @@ jobs:
   build_win32:
     name: 'Windows (x86) Installer'
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
     - name: Build CPython installer
@@ -42,6 +43,7 @@ jobs:
   build_win_amd64:
     name: 'Windows (x64) Installer'
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
     - name: Build CPython installer
@@ -50,6 +52,7 @@ jobs:
   build_win_arm64:
     name: 'Windows (ARM64) Installer'
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
     - name: Build CPython installer

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -36,6 +36,7 @@ jobs:
   build_doc:
     name: 'Docs'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
     - name: Register Sphinx problem matcher
@@ -62,6 +63,7 @@ jobs:
   doctest:
     name: 'Doctest'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
     - name: Register Sphinx problem matcher

--- a/.github/workflows/new-bugs-announce-notifier.yml
+++ b/.github/workflows/new-bugs-announce-notifier.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   notify-new-bugs-announce:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -8,6 +8,7 @@ jobs:
   label:
     name: DO-NOT-MERGE
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: mheap/github-action-required-labels@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
     if: github.repository_owner == 'python'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
     - name: "Check PRs"

--- a/.github/workflows/verify-ensurepip-wheels.yml
+++ b/.github/workflows/verify-ensurepip-wheels.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
(cherry picked from commit be8903eb9d66ef1229f93a3a6036aeafc3bb0bda)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-103180 -->
* Issue: gh-103180
<!-- /gh-issue-number -->
