### PR TITLE
gh-101517: Add regression test for entering pdb in try/except* block

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1700,6 +1700,26 @@ def test_pdb_issue_gh_103225():
     (Pdb) continue
     """
 
+def test_pdb_issue_gh_101517():
+    """See GH-101517
+
+    Make sure pdb doesn't crash when the exception is caught in a try/except* block
+
+    >>> def test_function():
+    ...     try:
+    ...         raise KeyError
+    ...     except* Exception as e:
+    ...         import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'continue'
+    ... ]):
+    ...    test_function()
+    --Return--
+    > <doctest test.test_pdb.test_pdb_issue_gh_101517[0]>(None)test_function()->None
+    (Pdb) continue
+    """
+
 
 @support.requires_subprocess()
 class PdbTestCase(unittest.TestCase):


### PR DESCRIPTION
@iritkatriel I guess this does not require a news entry.

<!-- gh-issue-number: gh-101517 -->
* Issue: gh-101517
<!-- /gh-issue-number -->
