### PR TITLE
gh-103082: Fix shifted field initialization in `instrumentation.c`

### DIFF
--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -16,14 +16,14 @@
 
 static PyObject DISABLE =
 {
-    _PyObject_IMMORTAL_REFCNT,
-    &PyBaseObject_Type
+    .ob_refcnt = _PyObject_IMMORTAL_REFCNT,
+    .ob_type = &PyBaseObject_Type
 };
 
 PyObject _PyInstrumentation_MISSING =
 {
-    _PyObject_IMMORTAL_REFCNT,
-    &PyBaseObject_Type
+    .ob_refcnt = _PyObject_IMMORTAL_REFCNT,
+    .ob_type = &PyBaseObject_Type
 };
 
 static const int8_t EVENT_FOR_OPCODE[256] = {


### PR DESCRIPTION
If `Py_TRACE_REFS` is defined, `PyObject` initializers without field names like: https://github.com/python/cpython/blob/2b6f5c3483597abcb8422508aeffab04f500f568/Python/instrumentation.c#L17-L21 are compiled in a totally unusable way:

```plain
_ob_next = _PyObject_IMMORTAL_REFCNT (999999999)
_ob_prev = &PyBaseObject_Type
ob_refcnt = 0
ob_type = NULL
```

The reason is implicit insertion of two extra fields under `#ifdef Py_TRACE_REFS`: https://github.com/python/cpython/blob/2b6f5c3483597abcb8422508aeffab04f500f568/Include/object.h#L102-L106 https://github.com/python/cpython/blob/2b6f5c3483597abcb8422508aeffab04f500f568/Include/object.h#L65-L76

~This commit fixes declarations that fail the `AMD64 Arch Linux TraceRefs PR` buildbot. Other declarations will be fixed in another, pending PR.~ (edit: all other places use `_PyObject_HEAD_EXTRA`)

I desided to not use `_PyObject_HEAD_EXTRA` because it can be forgotten easily (unlike explicit field names) so we should phase it out from CPython codebase if possible.

<!-- gh-issue-number: gh-103082 -->
* Issue: gh-103082
<!-- /gh-issue-number -->
