### PR TITLE
gh-103563: Improve performance of `set_update_internal()`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-04-15-12-57-31.gh-issue-103563.w7qBZg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-04-15-12-57-31.gh-issue-103563.w7qBZg.rst
@@ -1,0 +1,1 @@
+Optimize set creation and set updating by using a length (hint) in the general case. Patch by Jeremiah Pascual.

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -908,7 +908,7 @@ set_update_internal(PySetObject *so, PyObject *other)
 
     /* If there's a length or length hint, do one big resize at the start,
      * rather than incrementally resizing as we insert new keys.
-     * Expect that there will be no (or few) overlapping keys.
+     * Expect that there will be no (or few) duplicated keys.
      * Use 0 as a default value to avoid changing the current mask.
      */
     length = PyObject_LengthHint(other, 0);
@@ -919,7 +919,7 @@ set_update_internal(PySetObject *so, PyObject *other)
     if (it == NULL)
         return -1;
 
-    if (length > so->mask) {
+    if ((so->fill + length)*5 >= so->mask*3) {
         if (set_table_resize(so, (so->used + length)*2) != 0)
             return -1;
     }


### PR DESCRIPTION
Use `PyObject_LengthHint()` in `set_update_internal()` to obtain a length to possibly resize the set before updating rather than incrementally resizing as new elements are added.

<!-- gh-issue-number: gh-103563 -->
* Issue: gh-103563
<!-- /gh-issue-number -->
