### PR TITLE
GH-103484: Docs: add linkcheck allowed redirects entries for most cases

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -254,6 +254,15 @@ coverage_ignore_c_items = {
 # Options for the link checker
 # ----------------------------
 
+linkcheck_allow_redirect = {
+    # bpo-NNNN -> BPO -> GH Issues
+    r'https://bugs.python.org/issue\?@action=redirect&bpo=\d+': 'https://github.com/python/cpython/issues/\d+',
+    # GH-NNNN used to refer to pull requests
+    r'https://github.com/python/cpython/issues/\d+': 'https://github.com/python/cpython/pull/\d+',
+    # :source:`something` linking files in the repository
+    r'https://github.com/python/cpython/tree/.*': 'https://github.com/python/cpython/blob/.*'
+}
+
 # Ignore certain URLs.
 linkcheck_ignore = [r'https://bugs.python.org/(issue)?\d+']
 

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -263,10 +263,6 @@ linkcheck_allowed_redirects = {
     r'https://github.com/python/cpython/tree/.*': 'https://github.com/python/cpython/blob/.*'
 }
 
-# Ignore certain URLs.
-linkcheck_ignore = [r'https://bugs.python.org/(issue)?\d+']
-
-
 # Options for extensions
 # ----------------------
 

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -254,7 +254,7 @@ coverage_ignore_c_items = {
 # Options for the link checker
 # ----------------------------
 
-linkcheck_allow_redirect = {
+linkcheck_allowed_redirects = {
     # bpo-NNNN -> BPO -> GH Issues
     r'https://bugs.python.org/issue\?@action=redirect&bpo=\d+': 'https://github.com/python/cpython/issues/\d+',
     # GH-NNNN used to refer to pull requests


### PR DESCRIPTION
This is one of the patches required to fix the current state of `make linkcheck` in Python Docs, see #103484.

This pull request solves the cases that result in the most output (8000+ of 8327 output lines) when running `make linkcheck`. Find below examples of each case.

```
c-api/intro.rst:178: [redirected permanently] https://bugs.python.org/issue?@action=redirect&bpo=33720 to https://github.com/python/cpython/issues/77901
```

This redirect is caused by using the bpo-NNNNN custom role, which links https://bugs.python.org/issueNNNNN. Accessing that will redirect to CPython's GitHub issues. Instead of changing all occurrences to GH-NNNNN, this marks that redirect as allowed.

```
whatsnew/3.12.rst:185: [redirected with Found] https://github.com/python/cpython/issues/100581 to https://github.com/python/cpython/pull/100581
```

This is caused by using GH-NNNNN (which links to GitHub issues) to link pull requests. Instead of adding a new syntax for GitHub pull requests, this marks that redirect as allowed.

```
library/collections.abc.rst:13: [redirected permanently] https://github.com/python/cpython/tree/main/Lib/_collections_abc.py to https://github.com/python/cpython/blob/main/Lib/_collections_abc.py
```

This is caused by using ```:source:`something` ``` to link a file. source results in 'https://github.com/python/cpython/tree/main/' + something, but the url for files in GitHub repos is /blob/ instead of /tree/. Changing `:source:`'s URL from /tree/ to /blob/ wouldn't solve it because if a directory was linked, it would pop-up a redirect from /blob/ to /tree/. Hence it is better to allow this redirect.



<!-- gh-issue-number: gh-103484 -->
* Issue: gh-103484
<!-- /gh-issue-number -->
