### PR TITLE
gh-103571: Add runtime-global strings to the initial per-interpreter interned_dict

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -244,13 +244,6 @@ init_interned_dict(PyInterpreterState *interp)
     if (interned == NULL) {
         return -1;
     }
-    for (int ch = 0; ch < 256; ch++) {
-        PyObject *singleton_str = LATIN1(ch);
-        if (PyDict_SetItem(interned, singleton_str, singleton_str) == -1) {
-            Py_DECREF(interned);
-            return -1;
-        }
-    }
     _Py_INTERP_CACHED_OBJECT(interp, interned_strings) = interned;
     return 0;
 }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -244,6 +244,13 @@ init_interned_dict(PyInterpreterState *interp)
     if (interned == NULL) {
         return -1;
     }
+    for (int ch = 0; ch < 256; ch++) {
+        PyObject *singleton_str = LATIN1(ch);
+        if (PyDict_SetItem(interned, singleton_str, singleton_str) == -1) {
+            Py_DECREF(interned);
+            return -1;
+        }
+    }
     _Py_INTERP_CACHED_OBJECT(interp, interned_strings) = interned;
     return 0;
 }


### PR DESCRIPTION
bpo-46430 caused an interesting side effect; the code `x = 'a'; x[0] is x` no longer returned True. This in turn is because there are two different cached versions of 'a':

- One that was cached when code in frozen modules was compiled (and is stored in the interned_dict)
- One that is stored as a runtime-global object that is used during function calls (and is stored in _Py_SINGLETON(strings))

However, some characters do not have this behaviour (for example, 'g', 'u', and 'z'). I suspect it because these characters are not used in co_consts of frozen modules.

The interned_dict is per interpreter, and is initialized by `init_interned_dict(PyInterpreterState *)`. The prior implementation initialize it to an empty dict, which allows code in frozen modules to use their (different and per interpreter) singleton strings instead of the runtime-global one.

The new implementation add all runtime-global singleton strings to the interned_dict when it initialized, causing the frozen modules to use the same immortal singleton string and for `x = 'a'; x[0] is x` to return True.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-103571 -->
* Issue: gh-103571
<!-- /gh-issue-number -->
