### PR TITLE
gh-101525: Fix make test if the --enable-bolt enabled

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -38,6 +38,7 @@ CC=		@CC@
 CXX=		@CXX@
 LINKCC=		@LINKCC@
 AR=		@AR@
+READELF=	@READELF@
 SOABI=		@SOABI@
 LDVERSION=	@LDVERSION@
 LIBPYTHON=	@LIBPYTHON@
@@ -670,13 +671,18 @@ profile-opt: profile-run-stamp
 
 bolt-opt: @PREBOLT_RULE@
 	rm -f *.fdata
-	@LLVM_BOLT@ ./$(BUILDPYTHON) -instrument -instrumentation-file-append-pid -instrumentation-file=$(abspath $(BUILDPYTHON).bolt) -o $(BUILDPYTHON).bolt_inst
-	./$(BUILDPYTHON).bolt_inst $(PROFILE_TASK) || true
-	@MERGE_FDATA@ $(BUILDPYTHON).*.fdata > $(BUILDPYTHON).fdata
-	@LLVM_BOLT@ ./$(BUILDPYTHON) -o $(BUILDPYTHON).bolt -data=$(BUILDPYTHON).fdata -update-debug-sections -reorder-blocks=ext-tsp -reorder-functions=hfsort+ -split-functions -icf=1 -inline-all -split-eh -reorder-functions-use-hot-size -peepholes=none -jump-tables=aggressive -inline-ap -indirect-call-promotion=all -dyno-stats -use-gnu-stack -frame-opt=hot
-	rm -f *.fdata
-	rm -f $(BUILDPYTHON).bolt_inst
-	mv $(BUILDPYTHON).bolt $(BUILDPYTHON)
+	@if $(READELF) -p .note.bolt_info $(BUILDPYTHON) | grep BOLT > /dev/null; then\
+		echo "skip: $(BUILDPYTHON) is already BOLTed."; \
+	else \
+		@LLVM_BOLT@ ./$(BUILDPYTHON) -instrument -instrumentation-file-append-pid -instrumentation-file=$(abspath $(BUILDPYTHON).bolt) -o $(BUILDPYTHON).bolt_inst; \
+		./$(BUILDPYTHON).bolt_inst $(PROFILE_TASK) || true; \
+		@MERGE_FDATA@ $(BUILDPYTHON).*.fdata > $(BUILDPYTHON).fdata; \
+		@LLVM_BOLT@ ./$(BUILDPYTHON) -o $(BUILDPYTHON).bolt -data=$(BUILDPYTHON).fdata -update-debug-sections -reorder-blocks=ext-tsp -reorder-functions=hfsort+ -split-functions -icf=1 -inline-all -split-eh -reorder-functions-use-hot-size -peepholes=none -jump-tables=aggressive -inline-ap -indirect-call-promotion=all -dyno-stats -use-gnu-stack -frame-opt=hot; \
+		rm -f *.fdata; \
+		rm -f $(BUILDPYTHON).bolt_inst; \
+		mv $(BUILDPYTHON).bolt $(BUILDPYTHON); \
+	fi
+
 
 # Compile and run with gcov
 .PHONY=coverage coverage-lcov coverage-report

--- a/configure
+++ b/configure
@@ -892,6 +892,8 @@ PGO_PROF_USE_FLAG
 PGO_PROF_GEN_FLAG
 MERGE_FDATA
 LLVM_BOLT
+ac_ct_READELF
+READELF
 PREBOLT_RULE
 LLVM_AR_FOUND
 LLVM_AR
@@ -7915,6 +7917,112 @@ if test "$Py_BOLT" = 'true' ; then
   PREBOLT_RULE="${DEF_MAKE_ALL_RULE}"
   DEF_MAKE_ALL_RULE="bolt-opt"
   DEF_MAKE_RULE="build_all"
+
+
+  if test -n "$ac_tool_prefix"; then
+  for ac_prog in readelf
+  do
+    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+set dummy $ac_tool_prefix$ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_READELF+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$READELF"; then
+  ac_cv_prog_READELF="$READELF" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_READELF="$ac_tool_prefix$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+READELF=$ac_cv_prog_READELF
+if test -n "$READELF"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $READELF" >&5
+$as_echo "$READELF" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+    test -n "$READELF" && break
+  done
+fi
+if test -z "$READELF"; then
+  ac_ct_READELF=$READELF
+  for ac_prog in readelf
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_READELF+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$ac_ct_READELF"; then
+  ac_cv_prog_ac_ct_READELF="$ac_ct_READELF" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_READELF="$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_READELF=$ac_cv_prog_ac_ct_READELF
+if test -n "$ac_ct_READELF"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_READELF" >&5
+$as_echo "$ac_ct_READELF" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$ac_ct_READELF" && break
+done
+
+  if test "x$ac_ct_READELF" = x; then
+    READELF=""notfound""
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    READELF=$ac_ct_READELF
+  fi
+fi
+
+  if test "$READELF" == "notfound"
+  then
+    as_fn_error $? "readelf is required for a --enable-bolt build but could not be found." "$LINENO" 5
+  fi
 
   # -fno-reorder-blocks-and-partition is required for bolt to work.
   # Possibly GCC only.

--- a/configure.ac
+++ b/configure.ac
@@ -1938,6 +1938,13 @@ if test "$Py_BOLT" = 'true' ; then
   DEF_MAKE_ALL_RULE="bolt-opt"
   DEF_MAKE_RULE="build_all"
 
+  AC_SUBST(READELF)
+  AC_CHECK_TOOLS(READELF, [readelf], "notfound")
+  if test "$READELF" == "notfound"
+  then
+    AC_MSG_ERROR([readelf is required for a --enable-bolt build but could not be found.])
+  fi
+      
   # -fno-reorder-blocks-and-partition is required for bolt to work.
   # Possibly GCC only.
   AX_CHECK_COMPILE_FLAG([-fno-reorder-blocks-and-partition],[


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The `make test` failed without this change due to the already BOLTed binary.
Skip the BOLTrized process if the binary is already BOLTed.

````
$ make test
Rebuilding with profile guided optimizations:
rm -f profile-clean-stamp
make build_all CFLAGS_NODIST=" -fprofile-use -fprofile-correction" LDFLAGS_NODIST=""
make[1]: Entering directory '/home1/corona10/cpython'
./python -E -S -m sysconfig --generate-posix-vars ;\
if test $? -ne 0 ; then \
        echo "generate-posix-vars failed" ; \
        rm -f ./pybuilddir.txt ; \
        exit 1 ; \
fi
./python -E -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
The necessary bits to build these optional modules were not found:
nis
To find the necessary bits, look in configure.ac and config.log.

Checked 111 modules (30 built-in, 79 shared, 1 n/a on linux-x86_64, 0 disabled, 1 missing, 0 failed on import)
make[1]: Leaving directory '/home1/corona10/cpython'
rm -f *.fdata
/usr/local/bin/llvm-bolt ./python -instrument -instrumentation-file-append-pid -instrumentation-file=/home1/corona10/cpython/python.bolt -o python.bolt_inst
BOLT-INFO: Target architecture: x86_64
BOLT-INFO: BOLT version: 712dfec1781db8aa92782b98cac5517db548b7f9
/usr/local/bin/llvm-bolt: './python': BOLT-ERROR: input file was processed by BOLT. Cannot re-optimize.
make: *** [Makefile:827: bolt-opt] Error 1
````

I used the recommended approach to detect the BOLTed binary from the BOLT team.
https://github.com/llvm/llvm-project/issues/60253




<!-- gh-issue-number: gh-101525 -->
* Issue: gh-101525
<!-- /gh-issue-number -->
