### PR TITLE
gh-100530: Change the error message for `MatchClass`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-04-16-14-38-39.gh-issue-100530.OR6-sn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-04-16-14-38-39.gh-issue-100530.OR6-sn.rst
@@ -1,1 +1,1 @@
-Change the error message for ``MatchClass``.
+Clarify the error message raised when the called part of a class pattern isn't actually a class.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-04-16-14-38-39.gh-issue-100530.OR6-sn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-04-16-14-38-39.gh-issue-100530.OR6-sn.rst
@@ -1,0 +1,1 @@
+Change the error message for ``MatchClass``.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -416,7 +416,7 @@ match_class(PyThreadState *tstate, PyObject *subject, PyObject *type,
             Py_ssize_t nargs, PyObject *kwargs)
 {
     if (!PyType_Check(type)) {
-        const char *e = "called match pattern must be a type";
+        const char *e = "called match pattern must be a class";
         _PyErr_Format(tstate, PyExc_TypeError, e);
         return NULL;
     }


### PR DESCRIPTION
@brandtbucher do you agree with this wording? :)

<!-- gh-issue-number: gh-100530 -->
* Issue: gh-100530
<!-- /gh-issue-number -->
