### PR TITLE
Remove `expert-*` from `project-updater` GH workflow

### DIFF
--- a/.github/workflows/project-updater.yml
+++ b/.github/workflows/project-updater.yml
@@ -20,8 +20,6 @@ jobs:
           # if an issue has any of these labels, it will be added
           # to the corresponding project
           - { project:  2, label: "release-blocker, deferred-blocker" }
-          - { project:  3, label: expert-subinterpreters }
-          - { project: 29, label: expert-asyncio }
           - { project: 32, label: sprint }
 
     steps:


### PR DESCRIPTION
The `expert-*` labels are being renamed to `topic-*`, breaking the `project-updater` workflow.  In the meanwhile GitHub also added a project workflow to automatically add issues (and PRs) to a project, that might be used to replace the workflow entirely.

I now updated both the Subinterpreters and Asyncio projects and enable to auto-add workflow, so we can safely remove them from here.  Eventually we might get rid of the workflow altogether.

See:
* https://github.com/python/core-workflow/issues/450#issuecomment-1509743345
* https://discuss.python.org/t/lets-rename-expert-labels-to-something-more-welcoming/24826
* https://github.blog/changelog/2023-03-09-github-issues-projects-march-9th-update/#robot-automatically-add-and-archive-project-items