### PR TITLE
GH-65238: Fix stripping of trailing slash in pathlib

### DIFF
--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -748,7 +748,10 @@ class PathDistribution(Distribution):
             NotADirectoryError,
             PermissionError,
         ):
-            return self._path.joinpath(filename).read_text(encoding='utf-8')
+            path = self._path
+            if filename:
+                path /= filename
+            return path.read_text(encoding='utf-8')
 
     read_text.__doc__ = Distribution.read_text.__doc__
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -750,10 +750,11 @@ class Path(PurePath):
     def _make_child_relpath(self, name):
         path_str = str(self)
         tail = self._tail
-        if tail:
+        if tail and tail[-1]:
             path_str = f'{path_str}{self._flavour.sep}{name}'
         elif path_str != '.':
             path_str = f'{path_str}{name}'
+            tail = tail[:-1]
         else:
             path_str = name
         path = type(self)(path_str)

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1774,13 +1774,13 @@ class _BasePathTest(object):
 
     def test_iterdir(self):
         P = self.cls
-        p = P(BASE)
-        it = p.iterdir()
-        paths = set(it)
-        expected = ['dirA', 'dirB', 'dirC', 'dirE', 'fileA']
-        if os_helper.can_symlink():
-            expected += ['linkA', 'linkB', 'brokenLink', 'brokenLinkLoop']
-        self.assertEqual(paths, { P(BASE, q) for q in expected })
+        for p in [P(BASE), P(BASE, '')]:
+            it = p.iterdir()
+            paths = set(it)
+            expected = ['dirA', 'dirB', 'dirC', 'dirE', 'fileA']
+            if os_helper.can_symlink():
+                expected += ['linkA', 'linkB', 'brokenLink', 'brokenLinkLoop']
+            self.assertEqual(paths, { P(BASE, q) for q in expected })
 
     @os_helper.skip_unless_symlink
     def test_iterdir_symlink(self):

--- a/Lib/zipfile/_path.py
+++ b/Lib/zipfile/_path.py
@@ -298,23 +298,26 @@ class Path:
 
     @property
     def name(self):
-        return pathlib.Path(self.at).name or self.filename.name
+        return pathlib.Path(self.at.rstrip("/")).name or self.filename.name
 
     @property
     def suffix(self):
-        return pathlib.Path(self.at).suffix or self.filename.suffix
+        return pathlib.Path(self.at.rstrip("/")).suffix or self.filename.suffix
 
     @property
     def suffixes(self):
-        return pathlib.Path(self.at).suffixes or self.filename.suffixes
+        return pathlib.Path(self.at.rstrip("/")).suffixes or self.filename.suffixes
 
     @property
     def stem(self):
-        return pathlib.Path(self.at).stem or self.filename.stem
+        return pathlib.Path(self.at.rstrip("/")).stem or self.filename.stem
 
     @property
     def filename(self):
-        return pathlib.Path(self.root.filename).joinpath(self.at)
+        path = pathlib.Path(self.root.filename)
+        if self.at:
+            path = path.joinpath(self.at.rstrip("/"))
+        return path
 
     def read_text(self, *args, **kwargs):
         encoding, args, kwargs = _extract_text_encoding(*args, **kwargs)

--- a/Misc/NEWS.d/next/Library/2023-04-17-21-25-08.gh-issue-65238.gNfhyT.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-17-21-25-08.gh-issue-65238.gNfhyT.rst
@@ -1,0 +1,1 @@
+Fix issue where :mod:`pathlib` did not preserve trailing slashes.


### PR DESCRIPTION
This brings pathlib in line with [*IEEE Std 1003.1-2017*](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13), where trailing slashes are meaningful to path resolution and should not be discarded.

This is the last known bug in pathlib's path normalization. Fixing such bugs is necessary if we're to return an unnormalized path from `Path.__fspath__()` as an optimization - see #102783. It is also helpful for solving #79634 and #102613.

Although most bugfixes involve changing behaviour, in this case the change is reasonably significant. As such I'd like this to land early in the 3.13 alpha cycle and to skip backporting. 

<!-- gh-issue-number: gh-65238 -->
* Issue: gh-65238
<!-- /gh-issue-number -->
