### PR TITLE
GH-103484: Fix broken links reported by linkcheck

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -271,9 +271,9 @@ linkcheck_anchors_ignore = [
 
 linkcheck_ignore = [
     # The crawler gets "Anchor not found"
-    r'https://github.com.+?#.*',
-    r'https://devguide.python.org.+?/#.*',
     r'https://developer.apple.com/documentation/.+?#.*',
+    r'https://devguide.python.org.+?/#.*',
+    r'https://github.com.+?#.*',
     # Robot crawlers not allowed: "403 Client Error: Forbidden"
     r'https://support.enthought.com/hc/.*',
     # SSLError CertificateError, even though it is valid

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -270,8 +270,6 @@ linkcheck_anchors_ignore = [
 ]
 
 linkcheck_ignore = [
-    # A code sample in Misc/NEWS.d/3.9.0a1.rst
-    'https:\/\/$',
     # The crawler gets "Anchor not found"
     r'https://github.com.+?#.*',
     r'https://devguide.python.org.+?/#.*',

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -263,6 +263,26 @@ linkcheck_allowed_redirects = {
     r'https://github.com/python/cpython/tree/.*': 'https://github.com/python/cpython/blob/.*'
 }
 
+linkcheck_anchors_ignore = [
+    # ignore anchors that starts with a '/', e.g. Wikipedia media:
+    # https://en.wikipedia.org/wiki/Walrus#/media/File:Pacific_Walrus_-_Bull_(8247646168).jpg
+    r'\/.*',
+]
+
+linkcheck_ignore = [
+    # A code sample in Misc/NEWS.d/3.9.0a1.rst
+    'https:\/\/$',
+    # The crawler gets "Anchor not found"
+    r'https://github.com.+?#.*',
+    r'https://devguide.python.org.+?/#.*',
+    r'https://developer.apple.com/documentation/.+?#.*',
+    # Robot crawlers not allowed: "403 Client Error: Forbidden"
+    r'https://support.enthought.com/hc/.*',
+    # SSLError CertificateError, even though it is valid
+    r'https://unix.org/version2/whatsnew/lp64_wp.html',
+]
+
+
 # Options for extensions
 # ----------------------
 

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -264,7 +264,7 @@ linkcheck_allowed_redirects = {
 }
 
 linkcheck_anchors_ignore = [
-    # ignore anchors that starts with a '/', e.g. Wikipedia media:
+    # ignore anchors that start with a '/', e.g. Wikipedia media files:
     # https://en.wikipedia.org/wiki/Walrus#/media/File:Pacific_Walrus_-_Bull_(8247646168).jpg
     r'\/.*',
 ]

--- a/Doc/distributing/index.rst
+++ b/Doc/distributing/index.rst
@@ -129,14 +129,10 @@ involved in creating and publishing a project:
 * `Uploading the project to the Python Package Index`_
 * `The .pypirc file`_
 
-.. _Project structure: \
-    https://packaging.python.org/tutorials/packaging-projects/#packaging-python-projects
-.. _Building and packaging the project: \
-   https://packaging.python.org/tutorials/packaging-projects/#creating-the-package-files
-.. _Uploading the project to the Python Package Index: \
-   https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives
-.. _The .pypirc file: \
-   https://packaging.python.org/specifications/pypirc/
+.. _Project structure: https://packaging.python.org/tutorials/packaging-projects/#packaging-python-projects
+.. _Building and packaging the project: https://packaging.python.org/tutorials/packaging-projects/#creating-the-package-files
+.. _Uploading the project to the Python Package Index: https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives
+.. _The .pypirc file: https://packaging.python.org/specifications/pypirc/
 
 
 How do I...?

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -780,8 +780,8 @@ socket to :meth:`select.select` to check if it's writable.
    The :mod:`asyncio` module provides a general purpose single-threaded and
    concurrent asynchronous library, which can be used for writing non-blocking
    network code.
-   The third-party `Twisted <https://twisted.org/>`_ library is a popular and
-   feature-rich alternative.
+   The third-party `Twisted <https://twisted.org/>`_ library is
+   a popular and feature-rich alternative.
 
 
 Databases

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -780,8 +780,8 @@ socket to :meth:`select.select` to check if it's writable.
    The :mod:`asyncio` module provides a general purpose single-threaded and
    concurrent asynchronous library, which can be used for writing non-blocking
    network code.
-   The third-party `Twisted <https://twistedmatrix.com/trac/>`_ library is
-   a popular and feature-rich alternative.
+   The third-party `Twisted <https://twisted.org/>`_ library is a popular and
+   feature-rich alternative.
 
 
 Databases

--- a/Doc/howto/functional.rst
+++ b/Doc/howto/functional.rst
@@ -1208,8 +1208,8 @@ General
 -------
 
 **Structure and Interpretation of Computer Programs**, by Harold Abelson and
-Gerald Jay Sussman with Julie Sussman.  Full text at
-https://mitpress.mit.edu/sicp/.  In this classic textbook of computer science,
+Gerald Jay Sussman with Julie Sussman.  The book can be found at
+https://mitpress.mit.edu/sicp.  In this classic textbook of computer science,
 chapters 2 and 3 discuss the use of sequences and streams to organize the data
 flow inside a program.  The book uses Scheme for its examples, but many of the
 design approaches described in these chapters are applicable to functional-style

--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -86,7 +86,7 @@ response::
 
     import urllib.request
 
-    req = urllib.request.Request('http://www.voidspace.org.uk')
+    req = urllib.request.Request('http://python.org/')
     with urllib.request.urlopen(req) as response:
        the_page = response.read()
 
@@ -458,7 +458,7 @@ To illustrate creating and installing a handler we will use the
 ``HTTPBasicAuthHandler``. For a more detailed discussion of this subject --
 including an explanation of how Basic Authentication works - see the `Basic
 Authentication Tutorial
-<http://www.voidspace.org.uk/python/articles/authentication.shtml>`_.
+<https://web.archive.org/web/20201215133350/http://www.voidspace.org.uk/python/articles/authentication.shtml>`__.
 
 When authentication is required, the server sends a header (as well as the 401
 error code) requesting authentication.  This specifies the authentication scheme

--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -19,7 +19,7 @@ function.
 
 Readline keybindings may be configured via an initialization file, typically
 ``.inputrc`` in your home directory.  See `Readline Init File
-<https://tiswww.cwru.edu/php/chet/readline/rluserman.html#SEC9>`_
+<https://tiswww.cwru.edu/php/chet/readline/rluserman.html#Readline-Init-File>`_
 in the GNU Readline manual for information about the format and
 allowable constructs of that file, and the capabilities of the
 Readline library in general.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1605,8 +1605,8 @@ expression support in the :mod:`re` module).
    converts it to ``"ss"``.
 
    The casefolding algorithm is
-   `described in section 3.13 of the Unicode Standard
-   <http://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G53253>`__.
+   `described in section 3.13 'Default Case Folding' of the Unicode Standard
+   <http://www.unicode.org/versions/Unicode15.0.0/ch03.pdf>`__.
 
    .. versionadded:: 3.3
 
@@ -1768,8 +1768,9 @@ expression support in the :mod:`re` module).
    one character, ``False`` otherwise.  Alphabetic characters are those characters defined
    in the Unicode character database as "Letter", i.e., those with general category
    property being one of "Lm", "Lt", "Lu", "Ll", or "Lo".  Note that this is different
-   from the `Alphabetic property defined in the Unicode Standard
-   <https://www.unicode.org/versions/Unicode15.0.0/ch04.pdf#G91002>`_.
+   from the `Alphabetic property defined in the section 4.10 'Letters, Alphabetic, and
+   Ideographic' of the Unicode Standard
+   <https://www.unicode.org/versions/Unicode15.0.0/ch04.pdf>`_.
 
 
 .. method:: str.isascii()
@@ -1904,8 +1905,8 @@ expression support in the :mod:`re` module).
    lowercase.
 
    The lowercasing algorithm used is
-   `described in section 3.13 of the Unicode Standard
-   <https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G34078>`__.
+   `described in section 3.13 'Default Case Folding' of the Unicode Standard
+   <https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf>`__.
 
 
 .. method:: str.lstrip([chars])
@@ -2250,8 +2251,8 @@ expression support in the :mod:`re` module).
    titlecase).
 
    The uppercasing algorithm used is
-   `described in section 3.13 of the Unicode Standard
-   <https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G34078>`__.
+   `described in section 3.13 'Default Case Folding' of the Unicode Standard
+   <https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf>`__.
 
 
 .. method:: str.zfill(width)

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1606,7 +1606,7 @@ expression support in the :mod:`re` module).
 
    The casefolding algorithm is
    `described in section 3.13 'Default Case Folding' of the Unicode Standard
-   <http://www.unicode.org/versions/Unicode15.0.0/ch03.pdf>`__.
+   <https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf>`__.
 
    .. versionadded:: 3.3
 

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -7,7 +7,7 @@
 .. moduleauthor:: James C. Ahlstrom <jim@interet.com>
 .. sectionauthor:: James C. Ahlstrom <jim@interet.com>
 
-**Source code:** :source:`Lib/zipfile.py`
+**Source code:** :source:`Lib/zipfile/`
 
 --------------
 

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -172,7 +172,7 @@ this edition of "What's New in Python" links to the bug/patch
 item for each change.
 
 Hosting of the Python bug tracker is kindly provided by
-`Upfront Systems <http://www.upfrontsoftware.co.za>`__
+`Upfront Systems <https://upfrontsoftware.co.za>`__
 of Stellenbosch, South Africa.  Martin von Löwis put a
 lot of effort into importing existing bugs and patches from
 SourceForge; his scripts for this import operation are at

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -2104,7 +2104,7 @@ Changes to Python's build process and to the C API include:
 
 * The latest release of the GNU Debugger, GDB 7, can be `scripted
   using Python
-  <https://sourceware.org/gdb/current/onlinedocs/gdb/Python.html>`__.
+  <https://web.archive.org/web/20110715084810/http://sourceware.org/gdb/current/onlinedocs/gdb/Python.html>`__.
   When you begin debugging an executable program P, GDB will look for
   a file named ``P-gdb.py`` and automatically read it.  Dave Malcolm
   contributed a :file:`python-gdb.py` that adds a number of

--- a/Misc/NEWS.d/3.7.0b2.rst
+++ b/Misc/NEWS.d/3.7.0b2.rst
@@ -357,7 +357,7 @@ Wirtel
 
 Add TLSVersion constants and SSLContext.maximum_version / minimum_version
 attributes. The new API wraps OpenSSL 1.1
-https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_set_min_proto_version.html
+https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_min_proto_version.html
 feature.
 
 ..

--- a/Misc/NEWS.d/3.7.0b2.rst
+++ b/Misc/NEWS.d/3.7.0b2.rst
@@ -357,7 +357,7 @@ Wirtel
 
 Add TLSVersion constants and SSLContext.maximum_version / minimum_version
 attributes. The new API wraps OpenSSL 1.1
-https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_min_proto_version.html
+https://web.archive.org/web/20180309043602/https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_set_min_proto_version.html
 feature.
 
 ..

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -5951,7 +5951,7 @@ Wirtel
 
 Add TLSVersion constants and SSLContext.maximum_version / minimum_version
 attributes. The new API wraps OpenSSL 1.1
-https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_set_min_proto_version.html
+https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_min_proto_version.html
 feature.
 
 ..

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -5951,7 +5951,7 @@ Wirtel
 
 Add TLSVersion constants and SSLContext.maximum_version / minimum_version
 attributes. The new API wraps OpenSSL 1.1
-https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_min_proto_version.html
+https://web.archive.org/web/20180309043602/https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_set_min_proto_version.html
 feature.
 
 ..

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -4887,7 +4887,7 @@ Fix use of registry values to launch Python from Microsoft Store app.
 .. section: Windows
 
 Fix memory leak on Windows in creating an SSLContext object or running
-urllib.request.urlopen('https://...').
+``urllib.request.urlopen('https://...')``.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a2.rst
+++ b/Misc/NEWS.d/3.9.0a2.rst
@@ -686,7 +686,7 @@ added.
 
 Update documentation to state that to activate virtual environments under
 fish one should use `source`, not `.` as documented at
-https://fishshell.com/docs/current/commands.html#source.
+https://fishshell.com/docs/current/cmds/source.html.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a4.rst
+++ b/Misc/NEWS.d/3.9.0a4.rst
@@ -392,7 +392,7 @@ The distutils ``bdist_msi`` command is deprecated in Python 3.9, use
 Improved performance of zipfile.Path for files with a large number of
 entries. Also improved performance and fixed minor issue as published with
 `importlib_metadata 1.5
-<https://importlib-metadata.readthedocs.io/en/latest/changelog%20(links).html#v1-5-0>`_.
+<https://importlib-metadata.readthedocs.io/en/latest/history.html#v1-5-0>`_.
 
 ..
 


### PR DESCRIPTION
This is another patch required to fix the current state of `make linkcheck` in Python Docs, see #103484.

This pull request fixes some broken links reported by `make linkcheck`. The backport to 3.11 has a few differences and I have already a patch ready for it, just waiting for any change in this one.

Find below the reported error and what solution I applied in this PR:

```
distributing/index.rst:128: [broken]  https://packaging.python.org/tutorials/packaging-projects/#creating-the-package-files: 
distributing/index.rst:127: [broken]  https://packaging.python.org/tutorials/packaging-projects/#packaging-python-projects:
distributing/index.rst:129: [broken]  https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives:
distributing/index.rst:130: [broken]  https://packaging.python.org/specifications/pypirc/:
```

The link is fine, but for some reason a newline in the doc resulted in being considered as broken for linkcheck, even though it is not broken in the documentation. I removed that newline and this made linkcheck happy.

```
library/stdtypes.rst:1607: [broken] http://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G53253: 'utf-8' codec can't decode byte 0xe2 in position 10: invalid continuation byte
library/stdtypes.rst:1767: [broken] https://www.unicode.org/versions/Unicode15.0.0/ch04.pdf#G91002: 'utf-8' codec can't decode byte 0xe2 in position 10: invalid continuation byte
library/stdtypes.rst:1906: [broken] https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G34078: 'utf-8' codec can't decode byte 0xe2 in position 10: invalid continuation byte
```

That's sphinx-doc/sphinx#11041. I removed the anchor and added the section name next to it's [section] number so the reader has no doubt of what section the text is talking about.

```
whatsnew/changelog.rst:18176: [broken] https://: Invalid URL 'https://': No host supplied
```

This is the code sample `urllib.request.urlopen('https://...').` at Misc/NEWS.d/3.9.0a1.rst. Added it to ignored list as `'https:\/\/$'` (`$` to not match any other link).

```
howto/urllib2.rst:457: [broken] http://www.voidspace.org.uk/python/articles/authentication.shtml: HTTPConnectionPool(host='www.voidspace.org.uk', port=80): Max retries exceeded with url: /python/articles/authentication.shtml (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f1bb795e250>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution'))
```

www.voidspace.org.uk is down, so I replaced it with a Wayback Machine link. There was a code sample that also used this broken link and I replaced with a valid link: http://www.python.org following the previous example in the same file

```
whatsnew/2.6.rst:174: [broken] http://www.upfrontsoftware.co.za: HTTPSConnectionPool(host='www.upfrontsoftware.co.za', port=443): Max retries exceeded with url: / (Caused by SSLError(CertificateError("hostname 'www.upfrontsoftware.co.za' doesn't match either of 'agibase.com', 'gazette.co.za', 'icinga.siyavula.com', 'icinga.upfronthosting.co.za', 'lists.agibase.com', 'test.agibase.com', 'upfrontsoftware.co.za', 'www.agibase.com', 'www.gazette.co.za'")))
```

Fix removing 'www', replacing with https://upfrontsoftware.co.za

```
using/mac.rst:20: [broken] https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes#Python: Anchor 'Python' not found
bugs.rst:39: [broken] https://devguide.python.org/docquality/#helping-with-documentation: Anchor 'helping-with-documentation' not found
whatsnew/3.4.rst:1962: [broken] https://devguide.python.org/coverage/#measuring-coverage-of-c-code-with-gcov-and-lcov: Anchor 'measuring-coverage-of-c-code-with-gcov-and-lcov' not found
bugs.rst:41: [broken] https://devguide.python.org/documenting/#translating: Anchor 'translating' not found
library/gc.rst:101: [broken] https://devguide.python.org/garbage_collector/#collecting-the-oldest-generation: Anchor 'collecting-the-oldest-generation' not found
using/unix.rst:69: [broken] https://devguide.python.org/setup/#get-the-source-code: Anchor 'get-the-source-code' not found
```

These links lead to the expected anchors without issue, so I added ignore entries to these links.

```
whatsnew/3.8.rst:77: [broken] https://en.wikipedia.org/wiki/Walrus#/media/File:Pacific_Walrus_-_Bull_(8247646168).jpg: Anchor '/media/File:Pacific_Walrus_-_Bull_(8247646168).jpg' not found
```

The link is works, but the #/... is considered by linkcheck as invalid anchor. Added it to ignored anchors.

```
whatsnew/changelog.rst:16408: [broken] https://fishshell.com/docs/current/commands.html#source: Anchor 'source' not found
```

The `source` command is now on another page, so I updated the URL.

```
whatsnew/3.11.rst:1320: [broken] https://github.com/faster-cpython/ideas#published-results: Anchor 'published-results' not found
```

Anchors from Markdown files in GitHub repositories are not recognized, even though they work just fine. Hence I added this case to ignored links.

```
whatsnew/changelog.rst:15577: [broken] https://importlib-metadata.readthedocs.io/en/latest/changelog%20(links).html#v1-5-0: 404 Client Error: Not Found for url: https://importlib-metadata.readthedocs.io/en/latest/changelog%20(links).html
```

Updated the URL with the new page containing the versions history.

```
howto/functional.rst:1210: [broken] https://mitpress.mit.edu/sicp/: 404 Client Error: Not Found for url: https://mitpress.mit.edu/sicp/
```

Removing the trailing '/' solves the 404 Client Error.

However, there is another issue: The book is no longer freely available <s>(wayback machine disagrees)</s>, so I updated the text to say "The book can be found at" instead of "Full text at".

```
whatsnew/2.7.rst:2105: [broken] https://sourceware.org/gdb/current/onlinedocs/gdb/Python.html: 404 Client Error: Not Found for url: https://sourceware.org/gdb/current/onlinedocs/gdb/Python.html
```

Used Wayback Machine because the paragraph mentions GDB 7, so I linked to the latest GDB online docs available, from 2011.

```
using/windows.rst:554: [broken] https://support.enthought.com/hc/en-us/articles/360038600051-Canopy-GUI-end-of-life-transition-to-the-Enthought-Deployment-Manager-EDM-and-Visual-Studio-Code: 403 Client Error: Forbidden for url: https://support.enthought.com/hc/en-us/articles/360038600051-Canopy-GUI-end-of-life-transition-to-the-Enthought-Deployment-Manager-EDM-and-Visual-Studio-Code
```

Looks like crawling in this website is not allowed: link is ok in the browser, but fails with `curl` or sphinx's linkcheck. Added to ignored links.

```
library/readline.rst:20: [broken] https://tiswww.cwru.edu/php/chet/readline/rluserman.html#SEC9: Anchor 'SEC9' not found
```

The SEC9 anchor was about "Readline Init File" ([wayback machine link](https://web.archive.org/web/20210319041218/https://tiswww.cwru.edu/php/chet/readline/rluserman.html#SEC9)). I updated the anchor to match the same subject in the updated documentation.

```
faq/library.rst:780: [broken] https://twistedmatrix.com/trac/: 404 Client Error: Not Found for url: https://twisted.org/trac/
```

Updated URL to https://twisted.org/

```
whatsnew/2.5.rst:879: [broken] https://unix.org/version2/whatsnew/lp64_wp.html: HTTPSConnectionPool(host='unix.org', port=443): Max retries exceeded with url: /version2/whatsnew/lp64_wp.html (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1129)')))
```

GoDaddy-hosted website, and GoDaddy's certificate chain is not installed causing curl and linkcheck to fail. Using a web browser works, though. So I added this to the ignored links list.

```
whatsnew/changelog.rst:22339: [broken] https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_set_min_proto_version.html: 404 Client Error: Not Found for url: https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_set_min_proto_version.html
```

Updated the URL, using the version 1.1.1 published as the closest possible to 1.1.0 mentioned in the paragraph.

```
library/zipfile.rst:10: [broken] https://github.com/python/cpython/tree/main/Lib/zipfile.py: 404 Client Error: Not Found for url: https://github.com/python/cpython/tree/main/Lib/zipfile.py
```

zipfile is a package since #98103. This change is post-3.11, hence a backport must not include this or will cause another 'broken' entry by linkcheck.

<!-- gh-issue-number: gh-103484 -->
* Issue: gh-103484
<!-- /gh-issue-number -->
