### PR TITLE
gh-95299: Remove lingering setuptools reference in installer scripts

### DIFF
--- a/PC/layout/support/pip.py
+++ b/PC/layout/support/pip.py
@@ -67,7 +67,6 @@ def extract_pip_files(ns):
             "--no-color",
             "install",
             "pip",
-            "setuptools",
             "--upgrade",
             "--target",
             str(dest),


### PR DESCRIPTION


<!-- gh-issue-number: gh-95299 -->
* Issue: gh-95299
<!-- /gh-issue-number -->
