### PR TITLE
Revert "Avoid error lexing multiprocessing docs code block on Pygments 2.15.0"

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -452,9 +452,7 @@ process which created it.
    importable by the children. This is covered in :ref:`multiprocessing-programming`
    however it is worth pointing out here. This means that some examples, such
    as the :class:`multiprocessing.pool.Pool` examples will not work in the
-   interactive interpreter. For example:
-
-   .. code-block:: text
+   interactive interpreter. For example::
 
       >>> from multiprocessing import Pool
       >>> p = Pool(5)


### PR DESCRIPTION
Pygments 2.15.1 has been released fixing the error that required GH-103421.

* https://github.com/pygments/pygments/releases/tag/2.15.1
* https://github.com/pygments/pygments/issues/2407#issuecomment-1513650300

This therefore reverts GH-103421.

Only needs backporting to 3.11 because the backports of the original only went that far.

We can therefore closes the other original, unmerged backports:

* Closes https://github.com/python/cpython/pull/103428 (3.10)
* Closes https://github.com/python/cpython/pull/103429 (3.9)
* Closes https://github.com/python/cpython/pull/103430 (3.8)
* Closes https://github.com/python/cpython/pull/103431 (3.7)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
