### PR TITLE
[3.10] CI: Do not allow merge if labelled DO-NOT-MERGE (GH-103337)

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -1,0 +1,18 @@
+name: Check labels
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    name: DO-NOT-MERGE
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: mheap/github-action-required-labels@v4
+        with:
+          mode: exactly
+          count: 0
+          labels: "DO-NOT-MERGE"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

For https://github.com/python/core-workflow/issues/498.

Backport of GH-103337 (the workflow) and GH-103437 (adds timeout) to 3.10.

It's already in `main` and `3.11` and needs backporting back to 3.7.