### PR TITLE
gh-103648: Make `datetime.timestamp()` raise `OverflowError` when overflow on Windows

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -2481,6 +2481,11 @@ class TestDateTime(TestDate):
         self.assertEqual(t.timestamp(),
                          18000 + 3600 + 2*60 + 3 + 4*1e-6)
 
+    @unittest.skipUnless(sys.platform == "win32", "This only overflows on Windows")
+    def test_timestamp_overflow_windows(self):
+        t = self.theclass(9000, 1, 1, 1, 2, 3, 4)
+        self.assertRaises(OverflowError, t.timestamp)
+
     @support.run_with_tz('MSK-03')  # Something east of Greenwich
     def test_microsecond_rounding(self):
         for fts in [self.theclass.fromtimestamp,

--- a/Misc/NEWS.d/next/Library/2023-04-20-18-51-57.gh-issue-103648.rXB8z5.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-20-18-51-57.gh-issue-103648.rXB8z5.rst
@@ -1,0 +1,1 @@
+Make :func:`datetime.datetime.timestamp()` raise ``OverflowError`` when overflow on Windows

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1307,8 +1307,17 @@ _PyTime_localtime(time_t t, struct tm *tm)
 
     error = localtime_s(tm, &t);
     if (error != 0) {
+        // There are only 3 cases where an error could occur:
+        //   * tm is NULL
+        //   * &t is NULL (impossible in this usage)
+        //   * it overflows (t < 0 or t > _MAX__TIME64_T)
         errno = error;
-        PyErr_SetFromErrno(PyExc_OSError);
+        if (tm == NULL) {
+            PyErr_SetFromErrno(PyExc_OSError);
+        } else {
+            PyErr_SetString(PyExc_OverflowError,
+                            "localtime argument out of range");
+        }
         return -1;
     }
     return 0;

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1310,7 +1310,7 @@ _PyTime_localtime(time_t t, struct tm *tm)
     error = localtime_s(tm, &t);
     if (error != 0) {
         // There are only 3 cases where an error could occur:
-        //   * tm is NULL
+        //   * tm is NULL (impossible in this usage)
         //   * &t is NULL (impossible in this usage)
         //   * it overflows (t < 0 or t > _MAX__TIME64_T)
         errno = error;

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1302,6 +1302,8 @@ _PyTime_GetPerfCounter(void)
 int
 _PyTime_localtime(time_t t, struct tm *tm)
 {
+    assert(tm != NULL);
+
 #ifdef MS_WINDOWS
     int error;
 
@@ -1312,12 +1314,8 @@ _PyTime_localtime(time_t t, struct tm *tm)
         //   * &t is NULL (impossible in this usage)
         //   * it overflows (t < 0 or t > _MAX__TIME64_T)
         errno = error;
-        if (tm == NULL) {
-            PyErr_SetFromErrno(PyExc_OSError);
-        } else {
-            PyErr_SetString(PyExc_OverflowError,
-                            "localtime argument out of range");
-        }
+        PyErr_SetString(PyExc_OverflowError,
+                        "localtime argument out of range");
         return -1;
     }
     return 0;


### PR DESCRIPTION
Currently on Windows, if `localtime_s()` returns an error in `_PyTime_localtime`, we just set an OS error. However, the [docs](https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp) says it should raise an `OverflowError`. According to [Microsoft docs](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s?view=msvc-170), `localtime_s` only fails if either pointer is `NULL`, or it overflows. So we can confidently set the error to overflow if none of the pointer is NULL.

<!-- gh-issue-number: gh-103648 -->
* Issue: gh-103648
<!-- /gh-issue-number -->
