### PR TITLE
gh-102310: Change error range for invalid bytes literals

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1853,6 +1853,30 @@ x: *b
     Traceback (most recent call last):
         ...
     SyntaxError: invalid syntax
+
+Invalid bytes literals:
+
+   >>> b"Ā"
+   Traceback (most recent call last):
+      ...
+       b"Ā"
+        ^^^
+   SyntaxError: bytes can only contain ASCII literal characters
+
+   >>> b"абвгде"
+   Traceback (most recent call last):
+      ...
+       b"абвгде"
+        ^^^^^^^^
+   SyntaxError: bytes can only contain ASCII literal characters
+
+   >>> b"abc ъющый"  # first 3 letters are ascii
+   Traceback (most recent call last):
+      ...
+       b"abc ъющый"
+        ^^^^^^^^^^^
+   SyntaxError: bytes can only contain ASCII literal characters
+
 """
 
 import re

--- a/Misc/NEWS.d/next/Core and Builtins/2023-04-21-17-03-14.gh-issue-102310.anLjDx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-04-21-17-03-14.gh-issue-102310.anLjDx.rst
@@ -1,0 +1,1 @@
+Change the error range for invalid bytes literals.

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -248,7 +248,8 @@ _PyPegen_parse_string(Parser *p, Token *t)
         const char *ch;
         for (ch = s; *ch; ch++) {
             if (Py_CHARMASK(*ch) >= 0x80) {
-                RAISE_SYNTAX_ERROR(
+                RAISE_SYNTAX_ERROR_KNOWN_LOCATION(
+                                   t,
                                    "bytes can only contain ASCII "
                                    "literal characters");
                 return NULL;


### PR DESCRIPTION
Before:

```
>>> b"Ā"
  File "<stdin>", line 1
    b"Ā"
        ^
SyntaxError: bytes can only contain ASCII literal characters
```

After:

```
» ./python.exe
Python 3.12.0a7+ (heads/main-dirty:a4967d9d59, Apr 21 2023, 16:58:05) [Clang 11.0.0 (clang-1100.0.33.16)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> b"Ā"
  File "<stdin>", line 1
    b"Ā"
    ^^^^
SyntaxError: bytes can only contain ASCII literal characters
```

Please, let me know if this needs a unit test.

<!-- gh-issue-number: gh-102310 -->
* Issue: gh-102310
<!-- /gh-issue-number -->
