### PR TITLE
gh-103656: [RFC] do not use `tok_mode` at call_invalid_rules mode

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1532,5 +1532,18 @@ x = (
                                     "f-string: expecting a valid expression after '{'"):
             compile("f'{**a}'", "?", "exec")
 
+    def test_semicolon(self):
+        self.assertAllRaise(SyntaxError,
+                            "f-string: expecting a valid expression after '{'",
+                            ["f'{_=}{;",
+                             "f'{1=}{+;'",
+                             "f'{1=}{2}{;'",
+                             ])
+        self.assertAllRaise(SyntaxError,
+                            "f-string: expecting '=', or '!', or ':', or '}'",
+                            ["f'{1=}{1;'",
+                             "f'{1=}{1;}'",
+                             ])
+
 if __name__ == '__main__':
     unittest.main()

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -1415,7 +1415,7 @@ expr_ty _PyPegen_formatted_value(Parser *p, expr_ty expression, Token *debug, ex
         end_col_offset, arena
     );
 
-    if (debug) {
+    if (debug && !p->call_invalid_rules) {
         /* Find the non whitespace token after the "=" */
         int debug_end_line, debug_end_offset;
 


### PR DESCRIPTION
This is one of the options that solve #103656.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-103656 -->
* Issue: gh-103656
<!-- /gh-issue-number -->
