### PR TITLE
gh-99352: Export `HTTPSHandler` from `urllib.request`

### DIFF
--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -123,7 +123,7 @@ __all__ = [
     'HTTPBasicAuthHandler', 'ProxyBasicAuthHandler', 'AbstractDigestAuthHandler',
     'HTTPDigestAuthHandler', 'ProxyDigestAuthHandler', 'HTTPHandler',
     'FileHandler', 'FTPHandler', 'CacheFTPHandler', 'DataHandler',
-    'UnknownHandler', 'HTTPErrorProcessor',
+    'HTTPSHandler', 'UnknownHandler', 'HTTPErrorProcessor',
     # Functions
     'urlopen', 'install_opener', 'build_opener',
     'pathname2url', 'url2pathname', 'getproxies',


### PR DESCRIPTION
Fixes a builbot failure due to gh-99353 importing previously unexported `urllib.request.HTTPSHandler` into a test:

```plain
test test_urllib2 crashed -- Traceback (most recent call last):
  File "/home/buildbot/buildarea/pull_request.cstratak-RHEL7-x86_64/build/Lib/test/libregrtest/runtest.py", line 360, in _runtest_inner
    refleak = _runtest_inner2(ns, test_name)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/buildbot/buildarea/pull_request.cstratak-RHEL7-x86_64/build/Lib/test/libregrtest/runtest.py", line 300, in _runtest_inner2
    the_module = importlib.import_module(abstest)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/buildbot/buildarea/pull_request.cstratak-RHEL7-x86_64/build/Lib/importlib/__init__.py", line 124, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1332, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1305, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1276, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 841, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1025, in exec_module
  File "<frozen importlib._bootstrap>", line 400, in _call_with_frames_removed
  File "/home/buildbot/buildarea/pull_request.cstratak-RHEL7-x86_64/build/Lib/test/test_urllib2.py", line 527, in <module>
    class MockHTTPSHandler(urllib.request.HTTPSHandler):
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'urllib.request' has no attribute 'HTTPSHandler'. Did you mean: 'HTTPHandler'?
```

I've met this error in https://github.com/python/cpython/pull/19474#issuecomment-1518692480.

<!-- gh-issue-number: gh-99352 -->
* Issue: gh-99352
<!-- /gh-issue-number -->
