### PR TITLE
GH-103699:  Add `__orig_bases__` to various typing classes

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7125,6 +7125,9 @@ class TypedDictTests(BaseTestCase):
         a = A(a = 1)
         self.assertIs(type(a), dict)
         self.assertEqual(a, {'a': 1})
+    
+    def test_orig_bases(self):
+        self.assertEqual(ChildTotalMovie.__orig_bases__, (ParentNontotalMovie,))
 
 
 class RequiredTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7125,7 +7125,7 @@ class TypedDictTests(BaseTestCase):
         a = A(a = 1)
         self.assertIs(type(a), dict)
         self.assertEqual(a, {'a': 1})
-    
+
     def test_orig_bases(self):
         self.assertEqual(ChildTotalMovie.__orig_bases__, (ParentNontotalMovie,))
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6695,6 +6695,46 @@ class NamedTupleTests(BaseTestCase):
                 self.assertEqual(jane2, jane)
                 self.assertIsInstance(jane2, cls)
 
+    def test_orig_bases(self):
+        T = TypeVar('T')
+
+        class Parent(NamedTuple):
+            pass
+
+        class Child(Parent):
+            pass
+
+        class OtherChild(Parent):
+            pass
+
+        class MixedChild(Child, OtherChild, Parent):
+            pass
+
+        class GenericParent(NamedTuple, Generic[T]):
+            pass
+
+        class GenericChild(GenericParent[int]):
+            pass
+
+        class OtherGenericChild(GenericParent[str]):
+            pass
+
+        class MixedGenericChild(GenericChild, OtherGenericChild, GenericParent[float]):
+            pass
+
+        class MultipleGenericBases(GenericParent[int], GenericParent[float]):
+            pass
+
+        self.assertEqual(Parent.__orig_bases__, (NamedTuple,))
+        self.assertEqual(Child.__orig_bases__, (Parent,))
+        self.assertEqual(OtherChild.__orig_bases__, (Parent,))
+        self.assertEqual(MixedChild.__orig_bases__, (Child, OtherChild, Parent,))
+        self.assertEqual(GenericParent.__orig_bases__, (NamedTuple, Generic[T]))
+        self.assertEqual(GenericChild.__orig_bases__, (GenericParent[int],))
+        self.assertEqual(OtherGenericChild.__orig_bases__, (GenericParent[str],))
+        self.assertEqual(MixedGenericChild.__orig_bases__, (GenericChild, OtherGenericChild, GenericParent[float]))
+        self.assertEqual(MultipleGenericBases.__orig_bases__, (GenericParent[int], GenericParent[float]))
+
 
 class TypedDictTests(BaseTestCase):
     def test_basics_functional_syntax(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7127,7 +7127,40 @@ class TypedDictTests(BaseTestCase):
         self.assertEqual(a, {'a': 1})
 
     def test_orig_bases(self):
-        self.assertEqual(ChildTotalMovie.__orig_bases__, (ParentNontotalMovie,))
+        T = TypeVar('T')
+
+        class Parent(TypedDict):
+            pass
+
+        class Child(Parent):
+            pass
+
+        class OtherChild(Parent):
+            pass
+
+        class MixedChild(Child, OtherChild, Parent):
+            pass
+
+        class GenericParent(TypedDict, Generic[T]):
+            pass
+
+        class GenericChild(GenericParent[int]):
+            pass
+
+        class OtherGenericChild(GenericParent[str]):
+            pass
+
+        class MixedGenericChild(GenericChild, OtherGenericChild, GenericParent[float]):
+            pass
+
+        self.assertEqual(Parent.__orig_bases__, (TypedDict,))
+        self.assertEqual(Child.__orig_bases__, (Parent,))
+        self.assertEqual(OtherChild.__orig_bases__, (Parent,))
+        self.assertEqual(MixedChild.__orig_bases__, (Child, OtherChild, Parent,))
+        self.assertEqual(GenericParent.__orig_bases__, (TypedDict, Generic[T]))
+        self.assertEqual(GenericChild.__orig_bases__, (GenericParent[int],))
+        self.assertEqual(OtherGenericChild.__orig_bases__, (GenericParent[str],))
+        self.assertEqual(MixedGenericChild.__orig_bases__, (GenericChild, OtherGenericChild, GenericParent[float]))
 
 
 class RequiredTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6698,42 +6698,18 @@ class NamedTupleTests(BaseTestCase):
     def test_orig_bases(self):
         T = TypeVar('T')
 
-        class Parent(NamedTuple):
+        class SimpleNamedTuple(NamedTuple):
             pass
 
-        class Child(Parent):
+        class GenericNamedTuple(NamedTuple, Generic[T]):
             pass
 
-        class OtherChild(Parent):
-            pass
+        self.assertEqual(SimpleNamedTuple.__orig_bases__, (NamedTuple,))
+        self.assertEqual(GenericNamedTuple.__orig_bases__, (NamedTuple, Generic[T]))
 
-        class MixedChild(Child, OtherChild, Parent):
-            pass
+        CallNamedTuple = NamedTuple('CallNamedTuple', [])
 
-        class GenericParent(NamedTuple, Generic[T]):
-            pass
-
-        class GenericChild(GenericParent[int]):
-            pass
-
-        class OtherGenericChild(GenericParent[str]):
-            pass
-
-        class MixedGenericChild(GenericChild, OtherGenericChild, GenericParent[float]):
-            pass
-
-        class MultipleGenericBases(GenericParent[int], GenericParent[float]):
-            pass
-
-        self.assertEqual(Parent.__orig_bases__, (NamedTuple,))
-        self.assertEqual(Child.__orig_bases__, (Parent,))
-        self.assertEqual(OtherChild.__orig_bases__, (Parent,))
-        self.assertEqual(MixedChild.__orig_bases__, (Child, OtherChild, Parent,))
-        self.assertEqual(GenericParent.__orig_bases__, (NamedTuple, Generic[T]))
-        self.assertEqual(GenericChild.__orig_bases__, (GenericParent[int],))
-        self.assertEqual(OtherGenericChild.__orig_bases__, (GenericParent[str],))
-        self.assertEqual(MixedGenericChild.__orig_bases__, (GenericChild, OtherGenericChild, GenericParent[float]))
-        self.assertEqual(MultipleGenericBases.__orig_bases__, (GenericParent[int], GenericParent[float]))
+        self.assertEqual(CallNamedTuple.__orig_bases__, (NamedTuple,))
 
 
 class TypedDictTests(BaseTestCase):
@@ -7196,6 +7172,8 @@ class TypedDictTests(BaseTestCase):
         class MultipleGenericBases(GenericParent[int], GenericParent[float]):
             pass
 
+        CallTypedDict = TypedDict('CallTypedDict', {})
+
         self.assertEqual(Parent.__orig_bases__, (TypedDict,))
         self.assertEqual(Child.__orig_bases__, (Parent,))
         self.assertEqual(OtherChild.__orig_bases__, (Parent,))
@@ -7205,6 +7183,7 @@ class TypedDictTests(BaseTestCase):
         self.assertEqual(OtherGenericChild.__orig_bases__, (GenericParent[str],))
         self.assertEqual(MixedGenericChild.__orig_bases__, (GenericChild, OtherGenericChild, GenericParent[float]))
         self.assertEqual(MultipleGenericBases.__orig_bases__, (GenericParent[int], GenericParent[float]))
+        self.assertEqual(CallTypedDict.__orig_bases__, (TypedDict,))
 
 
 class RequiredTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7153,6 +7153,9 @@ class TypedDictTests(BaseTestCase):
         class MixedGenericChild(GenericChild, OtherGenericChild, GenericParent[float]):
             pass
 
+        class MultipleGenericBases(GenericParent[int], GenericParent[float]):
+            pass
+
         self.assertEqual(Parent.__orig_bases__, (TypedDict,))
         self.assertEqual(Child.__orig_bases__, (Parent,))
         self.assertEqual(OtherChild.__orig_bases__, (Parent,))
@@ -7161,6 +7164,7 @@ class TypedDictTests(BaseTestCase):
         self.assertEqual(GenericChild.__orig_bases__, (GenericParent[int],))
         self.assertEqual(OtherGenericChild.__orig_bases__, (GenericParent[str],))
         self.assertEqual(MixedGenericChild.__orig_bases__, (GenericChild, OtherGenericChild, GenericParent[float]))
+        self.assertEqual(MultipleGenericBases.__orig_bases__, (GenericParent[int], GenericParent[float]))
 
 
 class RequiredTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2994,6 +2994,9 @@ class _TypedDictMeta(type):
 
         tp_dict = type.__new__(_TypedDictMeta, name, (*generic_base, dict), ns)
 
+        if not hasattr(tp_dict, '__orig_bases__'):
+            tp_dict.__orig_bases__ = bases
+
         annotations = {}
         own_annotations = ns.get('__annotations__', {})
         msg = "TypedDict('Name', {f0: t0, f1: t1, ...}); each t must be a type"

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2962,7 +2962,9 @@ def NamedTuple(typename, fields=None, /, **kwargs):
     elif kwargs:
         raise TypeError("Either list of fields or keywords"
                         " can be provided to NamedTuple, not both")
-    return _make_nmtuple(typename, fields, module=_caller())
+    nt = _make_nmtuple(typename, fields, module=_caller())
+    nt.__orig_bases__ = (NamedTuple,)
+    return nt
 
 _NamedTuple = type.__new__(NamedTupleMeta, 'NamedTuple', (), {})
 
@@ -3107,7 +3109,9 @@ def TypedDict(typename, fields=None, /, *, total=True, **kwargs):
         # Setting correct module is necessary to make typed dict classes pickleable.
         ns['__module__'] = module
 
-    return _TypedDictMeta(typename, (), ns, total=total)
+    td = _TypedDictMeta(typename, (), ns, total=total)
+    td.__orig_bases__ = (TypedDict,)
+    return td
 
 _TypedDict = type.__new__(_TypedDictMeta, 'TypedDict', (), {})
 TypedDict.__mro_entries__ = lambda bases: (_TypedDict,)

--- a/Misc/NEWS.d/next/Library/2023-04-22-22-37-39.gh-issue-103699.NizCjc.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-22-22-37-39.gh-issue-103699.NizCjc.rst
@@ -1,0 +1,1 @@
+Add `__orig_bases__` to non-generic TypedDicts

--- a/Misc/NEWS.d/next/Library/2023-04-22-22-37-39.gh-issue-103699.NizCjc.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-22-22-37-39.gh-issue-103699.NizCjc.rst
@@ -1,1 +1,2 @@
-Add ``__orig_bases__`` to non-generic TypedDicts
+Add ``__orig_bases__`` to non-generic TypedDicts, call-based TypedDicts, and
+call-based NamedTuples

--- a/Misc/NEWS.d/next/Library/2023-04-22-22-37-39.gh-issue-103699.NizCjc.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-22-22-37-39.gh-issue-103699.NizCjc.rst
@@ -1,1 +1,1 @@
-Add `__orig_bases__` to non-generic TypedDicts
+Add ``__orig_bases__`` to non-generic TypedDicts

--- a/Misc/NEWS.d/next/Library/2023-04-22-22-37-39.gh-issue-103699.NizCjc.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-22-22-37-39.gh-issue-103699.NizCjc.rst
@@ -1,2 +1,2 @@
 Add ``__orig_bases__`` to non-generic TypedDicts, call-based TypedDicts, and
-call-based NamedTuples
+call-based NamedTuples. Other TypedDicts and NamedTuples already had the attribute.


### PR DESCRIPTION
As discussed at the typing summit, non generic TypedDict's completely loose all inheritance information. Funny enough, _generic_ TypedDict's actually preserve it via `__orig_bases__` because Generic does that. So this just brings non-generic TypedDicts to be the same.

<!-- gh-issue-number: gh-103699 -->
* Issue: gh-103699
<!-- /gh-issue-number -->
