### PR TITLE
gh-68654: Clarify subdirectories used by pkgutil.extend_path

### DIFF
--- a/Doc/library/pkgutil.rst
+++ b/Doc/library/pkgutil.rst
@@ -25,9 +25,9 @@ support.
       from pkgutil import extend_path
       __path__ = extend_path(__path__, __name__)
 
-   This will add to the package's ``__path__`` all subdirectories of directories
-   on :data:`sys.path` named after the package.  This is useful if one wants to
-   distribute different parts of a single logical package as multiple
+   For each directory on :data:`sys.path` that has a subdirectory that matches the
+   package name, add the subdirectory to the package's :attr:`__path__`.  This is useful
+   if one wants to distribute different parts of a single logical package as multiple
    directories.
 
    It also looks for :file:`\*.pkg` files beginning where ``*`` matches the

--- a/Lib/pkgutil.py
+++ b/Lib/pkgutil.py
@@ -511,10 +511,10 @@ def extend_path(path, name):
         from pkgutil import extend_path
         __path__ = extend_path(__path__, __name__)
 
-    This will add to the package's __path__ all subdirectories of
-    directories on sys.path named after the package.  This is useful
-    if one wants to distribute different parts of a single logical
-    package as multiple directories.
+    For each directory on sys.path that has a subdirectory that
+    matches the package name, add the subdirectory to the package's
+    __path__.  This is useful if one wants to distribute different
+    parts of a single logical package as multiple directories.
 
     It also looks for *.pkg files beginning where * matches the name
     argument.  This feature is similar to *.pth files (see site.py),


### PR DESCRIPTION
Clarified sub directories used by pkgutil extend_path in docs and doc string

<!-- gh-issue-number: gh-68654 -->
* Issue: gh-68654
<!-- /gh-issue-number -->
