### PR TITLE
gh-103716: Add test support requires fork in simple_subprocess 

### DIFF
--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -56,7 +56,7 @@ if HAVE_UNIX_SOCKETS and HAVE_FORKING:
                                     socketserver.UnixDatagramServer):
         pass
 
-
+@test.support.requires_fork()
 @contextlib.contextmanager
 def simple_subprocess(testcase):
     """Tests that a custom child process is not waited on (Issue 1540386)"""


### PR DESCRIPTION
Adds `requires_fork`  decorator in `simple_subprocess` in Lib/test/test_socketserver.py


<!-- gh-issue-number: gh-103716 -->
* Issue: gh-103716
<!-- /gh-issue-number -->
