### PR TITLE
gh-103724: ensure error is raised when no arg is supplied

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -231,6 +231,9 @@ class PosixTester(unittest.TestCase):
         with self.assertRaises(TypeError, msg="Invalid arg was allowed"):
             # Ensure a combination of valid and invalid is an error.
             os.register_at_fork(before=None, after_in_parent=lambda: 3)
+        with self.assertRaises(TypeError, msg="At least one argument is required."):
+            # when no arg is passed
+            os.register_at_fork()
         with self.assertRaises(TypeError, msg="Invalid arg was allowed"):
             # Ensure a combination of valid and invalid is an error.
             os.register_at_fork(before=lambda: None, after_in_child='')

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -231,7 +231,7 @@ class PosixTester(unittest.TestCase):
         with self.assertRaises(TypeError, msg="Invalid arg was allowed"):
             # Ensure a combination of valid and invalid is an error.
             os.register_at_fork(before=None, after_in_parent=lambda: 3)
-        with self.assertRaises(TypeError, msg="At least one argument is required."):
+        with self.assertRaises(TypeError, msg="At least one argument is required"):
             # when no arg is passed
             os.register_at_fork()
         with self.assertRaises(TypeError, msg="Invalid arg was allowed"):

--- a/Misc/NEWS.d/next/Tests/2023-04-23-18-38-13.gh-issue-103724.XE53jS.rst
+++ b/Misc/NEWS.d/next/Tests/2023-04-23-18-38-13.gh-issue-103724.XE53jS.rst
@@ -1,0 +1,1 @@
+Add test case for missing arg in os.register_at_fork

--- a/Misc/NEWS.d/next/Tests/2023-04-23-18-38-13.gh-issue-103724.XE53jS.rst
+++ b/Misc/NEWS.d/next/Tests/2023-04-23-18-38-13.gh-issue-103724.XE53jS.rst
@@ -1,1 +1,0 @@
-Add test case for missing arg in os.register_at_fork


### PR DESCRIPTION
Added a test case to assert type error when no arg is supplied

<!-- gh-issue-number: gh-103724 -->
* Issue: gh-103724
<!-- /gh-issue-number -->
