### PR TITLE
Change 'dependant' to 'dependent'

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -470,7 +470,7 @@ user's system, including environment variables, system registry settings, and
 installed packages. The standard library is included as pre-compiled and
 optimized ``.pyc`` files in a ZIP, and ``python3.dll``, ``python37.dll``,
 ``python.exe`` and ``pythonw.exe`` are all provided. Tcl/tk (including all
-dependants, such as Idle), pip and the Python documentation are not included.
+dependents, such as Idle), pip and the Python documentation are not included.
 
 .. note::
 

--- a/Lib/idlelib/idle_test/test_sidebar.py
+++ b/Lib/idlelib/idle_test/test_sidebar.py
@@ -328,7 +328,7 @@ class LineNumbersTest(unittest.TestCase):
         self.assertEqual(self.linenumber.sidebar_text.index('@0,0'), '11.0')
 
         # Generate a mouse-wheel event and make sure it scrolled up or down.
-        # The meaning of the "delta" is OS-dependant, so this just checks for
+        # The meaning of the "delta" is OS-dependent, so this just checks for
         # any change.
         self.linenumber.sidebar_text.event_generate('<MouseWheel>',
                                                     x=0, y=0,
@@ -691,7 +691,7 @@ class ShellSidebarTest(unittest.TestCase):
         self.assertIsNotNone(text.dlineinfo(text.index(f'{last_lineno}.0')))
 
         # Scroll up using the <MouseWheel> event.
-        # The meaning delta is platform-dependant.
+        # The meaning delta is platform-dependent.
         delta = -1 if sys.platform == 'darwin' else 120
         sidebar.canvas.event_generate('<MouseWheel>', x=0, y=0, delta=delta)
         yield

--- a/Lib/idlelib/idle_test/test_sidebar.py
+++ b/Lib/idlelib/idle_test/test_sidebar.py
@@ -691,7 +691,7 @@ class ShellSidebarTest(unittest.TestCase):
         self.assertIsNotNone(text.dlineinfo(text.index(f'{last_lineno}.0')))
 
         # Scroll up using the <MouseWheel> event.
-        # The meaning delta is platform-dependent.
+        # The meaning of delta is platform-dependent.
         delta = -1 if sys.platform == 'darwin' else 120
         sidebar.canvas.event_generate('<MouseWheel>', x=0, y=0, delta=delta)
         yield


### PR DESCRIPTION
The word 'dependent' is both an adjective and a noun.  A 'dependant' is a British alternative spelling for the noun form.  In idlelib.sidebar,  'OS-dependant' is an adjective and clearly wrong.  In 'Using', 'dependant' as a noun would be acceptable in Britain, but we use American spellings in Python docs.
https://www.merriam-webster.com/words-at-play/spelling-variants-dependent-vs-dependant