### PR TITLE
gh-103776: Remove explicit uses of $(SHELL) from Makefile

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -982,7 +982,7 @@ Makefile Modules/config.c: Makefile.pre \
 				Modules/Setup.local \
 				Modules/Setup.bootstrap \
 				Modules/Setup.stdlib
-	$(SHELL) $(MAKESETUP) -c $(srcdir)/Modules/config.c.in \
+	$(MAKESETUP) -c $(srcdir)/Modules/config.c.in \
 				-s Modules \
 				Modules/Setup.local \
 				Modules/Setup.stdlib \
@@ -2423,12 +2423,12 @@ frameworkinstallextras:
 
 # Build the toplevel Makefile
 Makefile.pre: $(srcdir)/Makefile.pre.in config.status
-	CONFIG_FILES=Makefile.pre CONFIG_HEADERS= $(SHELL) config.status
+	CONFIG_FILES=Makefile.pre CONFIG_HEADERS= ./config.status
 	$(MAKE) -f Makefile.pre Makefile
 
 # Run the configure script.
 config.status:	$(srcdir)/configure
-	$(SHELL) $(srcdir)/configure $(CONFIG_ARGS)
+	$(srcdir)/configure $(CONFIG_ARGS)
 
 .PRECIOUS: config.status $(BUILDPYTHON) Makefile Makefile.pre
 
@@ -2453,8 +2453,8 @@ reindent:
 # Rerun configure with the same options as it was run last time,
 # provided the config.status script exists
 recheck:
-	$(SHELL) config.status --recheck
-	$(SHELL) config.status
+	./config.status --recheck
+	./config.status
 
 # Regenerate configure and pyconfig.h.in
 .PHONY: autoconf


### PR DESCRIPTION
This avoids conflicting with the shebang of the called scripts as well
as avoiding hard errors on platforms where the called script runs a
failing unchecked command in the usual course of checking since
`SHELL=/bin/sh -e` as of a90863c.

Fixes gh-103776.
