### PR TITLE
gh-100227: Only Use deepfreeze for the Main Interpreter

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1194,7 +1194,7 @@ Tools/build/freeze_modules.py: $(FREEZE_MODULE)
 
 .PHONY: regen-frozen
 regen-frozen: Tools/build/freeze_modules.py $(FROZEN_FILES_IN)
-	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/build/freeze_modules.py
+	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/build/freeze_modules.py --frozen-modules
 	@echo "The Makefile was updated, you may need to re-run make."
 
 ############################################################################

--- a/Python/frozen.c
+++ b/Python/frozen.c
@@ -41,6 +41,29 @@
 #include <stdbool.h>
 
 /* Includes for frozen modules: */
+#include "frozen_modules/importlib._bootstrap.h"
+#include "frozen_modules/importlib._bootstrap_external.h"
+#include "frozen_modules/zipimport.h"
+#include "frozen_modules/abc.h"
+#include "frozen_modules/codecs.h"
+#include "frozen_modules/io.h"
+#include "frozen_modules/_collections_abc.h"
+#include "frozen_modules/_sitebuiltins.h"
+#include "frozen_modules/genericpath.h"
+#include "frozen_modules/ntpath.h"
+#include "frozen_modules/posixpath.h"
+#include "frozen_modules/os.h"
+#include "frozen_modules/site.h"
+#include "frozen_modules/stat.h"
+#include "frozen_modules/importlib.util.h"
+#include "frozen_modules/importlib.machinery.h"
+#include "frozen_modules/runpy.h"
+#include "frozen_modules/__hello__.h"
+#include "frozen_modules/__phello__.h"
+#include "frozen_modules/__phello__.ham.h"
+#include "frozen_modules/__phello__.ham.eggs.h"
+#include "frozen_modules/__phello__.spam.h"
+#include "frozen_modules/frozen_only.h"
 /* End includes */
 
 #define GET_CODE(name) _Py_get_##name##_toplevel
@@ -78,46 +101,46 @@ extern PyObject *_Py_get_frozen_only_toplevel(void);
 /* End extern declarations */
 
 static const struct _frozen bootstrap_modules[] = {
-    {"_frozen_importlib", NULL, 0, false, GET_CODE(importlib__bootstrap)},
-    {"_frozen_importlib_external", NULL, 0, false, GET_CODE(importlib__bootstrap_external)},
-    {"zipimport", NULL, 0, false, GET_CODE(zipimport)},
+    {"_frozen_importlib", _Py_M__importlib__bootstrap, (int)sizeof(_Py_M__importlib__bootstrap), false, GET_CODE(importlib__bootstrap)},
+    {"_frozen_importlib_external", _Py_M__importlib__bootstrap_external, (int)sizeof(_Py_M__importlib__bootstrap_external), false, GET_CODE(importlib__bootstrap_external)},
+    {"zipimport", _Py_M__zipimport, (int)sizeof(_Py_M__zipimport), false, GET_CODE(zipimport)},
     {0, 0, 0} /* bootstrap sentinel */
 };
 static const struct _frozen stdlib_modules[] = {
     /* stdlib - startup, without site (python -S) */
-    {"abc", NULL, 0, false, GET_CODE(abc)},
-    {"codecs", NULL, 0, false, GET_CODE(codecs)},
-    {"io", NULL, 0, false, GET_CODE(io)},
+    {"abc", _Py_M__abc, (int)sizeof(_Py_M__abc), false, GET_CODE(abc)},
+    {"codecs", _Py_M__codecs, (int)sizeof(_Py_M__codecs), false, GET_CODE(codecs)},
+    {"io", _Py_M__io, (int)sizeof(_Py_M__io), false, GET_CODE(io)},
 
     /* stdlib - startup, with site */
-    {"_collections_abc", NULL, 0, false, GET_CODE(_collections_abc)},
-    {"_sitebuiltins", NULL, 0, false, GET_CODE(_sitebuiltins)},
-    {"genericpath", NULL, 0, false, GET_CODE(genericpath)},
-    {"ntpath", NULL, 0, false, GET_CODE(ntpath)},
-    {"posixpath", NULL, 0, false, GET_CODE(posixpath)},
-    {"os.path", NULL, 0, false, GET_CODE(posixpath)},
-    {"os", NULL, 0, false, GET_CODE(os)},
-    {"site", NULL, 0, false, GET_CODE(site)},
-    {"stat", NULL, 0, false, GET_CODE(stat)},
+    {"_collections_abc", _Py_M___collections_abc, (int)sizeof(_Py_M___collections_abc), false, GET_CODE(_collections_abc)},
+    {"_sitebuiltins", _Py_M___sitebuiltins, (int)sizeof(_Py_M___sitebuiltins), false, GET_CODE(_sitebuiltins)},
+    {"genericpath", _Py_M__genericpath, (int)sizeof(_Py_M__genericpath), false, GET_CODE(genericpath)},
+    {"ntpath", _Py_M__ntpath, (int)sizeof(_Py_M__ntpath), false, GET_CODE(ntpath)},
+    {"posixpath", _Py_M__posixpath, (int)sizeof(_Py_M__posixpath), false, GET_CODE(posixpath)},
+    {"os.path", _Py_M__posixpath, (int)sizeof(_Py_M__posixpath), false, GET_CODE(posixpath)},
+    {"os", _Py_M__os, (int)sizeof(_Py_M__os), false, GET_CODE(os)},
+    {"site", _Py_M__site, (int)sizeof(_Py_M__site), false, GET_CODE(site)},
+    {"stat", _Py_M__stat, (int)sizeof(_Py_M__stat), false, GET_CODE(stat)},
 
     /* runpy - run module with -m */
-    {"importlib.util", NULL, 0, false, GET_CODE(importlib_util)},
-    {"importlib.machinery", NULL, 0, false, GET_CODE(importlib_machinery)},
-    {"runpy", NULL, 0, false, GET_CODE(runpy)},
+    {"importlib.util", _Py_M__importlib_util, (int)sizeof(_Py_M__importlib_util), false, GET_CODE(importlib_util)},
+    {"importlib.machinery", _Py_M__importlib_machinery, (int)sizeof(_Py_M__importlib_machinery), false, GET_CODE(importlib_machinery)},
+    {"runpy", _Py_M__runpy, (int)sizeof(_Py_M__runpy), false, GET_CODE(runpy)},
     {0, 0, 0} /* stdlib sentinel */
 };
 static const struct _frozen test_modules[] = {
-    {"__hello__", NULL, 0, false, GET_CODE(__hello__)},
-    {"__hello_alias__", NULL, 0, false, GET_CODE(__hello__)},
-    {"__phello_alias__", NULL, 0, true, GET_CODE(__hello__)},
-    {"__phello_alias__.spam", NULL, 0, false, GET_CODE(__hello__)},
-    {"__phello__", NULL, 0, true, GET_CODE(__phello__)},
-    {"__phello__.__init__", NULL, 0, false, GET_CODE(__phello__)},
-    {"__phello__.ham", NULL, 0, true, GET_CODE(__phello___ham)},
-    {"__phello__.ham.__init__", NULL, 0, false, GET_CODE(__phello___ham)},
-    {"__phello__.ham.eggs", NULL, 0, false, GET_CODE(__phello___ham_eggs)},
-    {"__phello__.spam", NULL, 0, false, GET_CODE(__phello___spam)},
-    {"__hello_only__", NULL, 0, false, GET_CODE(frozen_only)},
+    {"__hello__", _Py_M____hello__, (int)sizeof(_Py_M____hello__), false, GET_CODE(__hello__)},
+    {"__hello_alias__", _Py_M____hello__, (int)sizeof(_Py_M____hello__), false, GET_CODE(__hello__)},
+    {"__phello_alias__", _Py_M____hello__, (int)sizeof(_Py_M____hello__), true, GET_CODE(__hello__)},
+    {"__phello_alias__.spam", _Py_M____hello__, (int)sizeof(_Py_M____hello__), false, GET_CODE(__hello__)},
+    {"__phello__", _Py_M____phello__, (int)sizeof(_Py_M____phello__), true, GET_CODE(__phello__)},
+    {"__phello__.__init__", _Py_M____phello__, (int)sizeof(_Py_M____phello__), false, GET_CODE(__phello__)},
+    {"__phello__.ham", _Py_M____phello___ham, (int)sizeof(_Py_M____phello___ham), true, GET_CODE(__phello___ham)},
+    {"__phello__.ham.__init__", _Py_M____phello___ham, (int)sizeof(_Py_M____phello___ham), false, GET_CODE(__phello___ham)},
+    {"__phello__.ham.eggs", _Py_M____phello___ham_eggs, (int)sizeof(_Py_M____phello___ham_eggs), false, GET_CODE(__phello___ham_eggs)},
+    {"__phello__.spam", _Py_M____phello___spam, (int)sizeof(_Py_M____phello___spam), false, GET_CODE(__phello___spam)},
+    {"__hello_only__", _Py_M__frozen_only, (int)sizeof(_Py_M__frozen_only), false, GET_CODE(frozen_only)},
     {0, 0, 0} /* test sentinel */
 };
 const struct _frozen *_PyImport_FrozenBootstrap = bootstrap_modules;

--- a/Python/import.c
+++ b/Python/import.c
@@ -2021,9 +2021,9 @@ find_frozen(PyObject *nameobj, struct frozen_info *info)
 }
 
 static PyObject *
-unmarshal_frozen_code(struct frozen_info *info)
+unmarshal_frozen_code(PyInterpreterState *interp, struct frozen_info *info)
 {
-    if (info->get_code) {
+    if (info->get_code && _Py_IsMainInterpreter(interp)) {
         PyObject *code = info->get_code();
         assert(code != NULL);
         return code;
@@ -2070,7 +2070,7 @@ PyImport_ImportFrozenModuleObject(PyObject *name)
         set_frozen_error(status, name);
         return -1;
     }
-    co = unmarshal_frozen_code(&info);
+    co = unmarshal_frozen_code(tstate->interp, &info);
     if (co == NULL) {
         return -1;
     }
@@ -3528,7 +3528,8 @@ _imp_get_frozen_object_impl(PyObject *module, PyObject *name,
         return NULL;
     }
 
-    PyObject *codeobj = unmarshal_frozen_code(&info);
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    PyObject *codeobj = unmarshal_frozen_code(interp, &info);
     if (dataobj != Py_None) {
         PyBuffer_Release(&buf);
     }


### PR DESCRIPTION
Deep-frozen code objects are cannot be shared (currently) by interpreters, due to how adaptive specialization can modify the bytecodes.  We work around this by only using the deep-frozen objects in the main interpreter.  This does incur a performance penalty for subinterpreters, which we may be able to resolve later.

<!-- gh-issue-number: gh-100227 -->
* Issue: gh-100227
<!-- /gh-issue-number -->
