### PR TITLE
Also fail DO-NOT-MERGE when "awaiting changes" or "awaiting change review" present on PR

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   label:
-    name: DO-NOT-MERGE
+    name: DO-NOT-MERGE / unresolved review
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -15,4 +15,4 @@ jobs:
         with:
           mode: exactly
           count: 0
-          labels: "DO-NOT-MERGE"
+          labels: "DO-NOT-MERGE, awaiting changes, awaiting change review"


### PR DESCRIPTION
"awaiting changes" means somebody put a review that requested changes.

"awaiting change review" means that the PR author published changes after a red review and then requested a re-review.