### PR TITLE
GH-103805: Lib test f541 linting issue fix

### DIFF
--- a/Lib/test/test__xxinterpchannels.py
+++ b/Lib/test/test__xxinterpchannels.py
@@ -1469,19 +1469,19 @@ class ExhaustiveChannelTests(TestBase):
             with self.assertRaises(channels.ChannelClosedError):
                 channels.close(fix.cid, force=True)
         else:
-            run_interp(interp.id, f"""
+            run_interp(interp.id, """
                 with helpers.expect_channel_closed():
                     channels.recv(cid)
                 """)
-            run_interp(interp.id, f"""
+            run_interp(interp.id, """
                 with helpers.expect_channel_closed():
                     channels.send(cid, b'spam')
                 """)
-            run_interp(interp.id, f"""
+            run_interp(interp.id, """
                 with helpers.expect_channel_closed():
                     channels.close(cid)
                 """)
-            run_interp(interp.id, f"""
+            run_interp(interp.id, """
                 with helpers.expect_channel_closed():
                     channels.close(cid, force=True)
                 """)

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -798,7 +798,7 @@ class RunStringTests(TestBase):
             """))
 
         shared = {'spam': b'ham'}
-        script = dedent(f"""
+        script = dedent("""
             ns2 = dict(vars())
             del ns2['__builtins__']
         """)
@@ -902,7 +902,7 @@ class RunStringTests(TestBase):
     # XXX Fix this test!
     @unittest.skip('blocking forever')
     def test_still_running_at_exit(self):
-        script = dedent(f"""
+        script = dedent("""
         from textwrap import dedent
         import threading
         import _xxsubinterpreters as _interpreters

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1400,7 +1400,7 @@ class TestThreadState(unittest.TestCase):
     @threading_helper.requires_working_threading()
     def test_gilstate_ensure_no_deadlock(self):
         # See https://github.com/python/cpython/issues/96071
-        code = textwrap.dedent(f"""
+        code = textwrap.dedent("""
             import _testcapi
 
             def callback():

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -356,7 +356,7 @@ class CodeTest(unittest.TestCase):
         foo.__code__ = foo.__code__.replace(
             co_code=b'\xe5' + foo.__code__.co_code[1:])
 
-        msg = f"unknown opcode 229"
+        msg = "unknown opcode 229"
         with self.assertRaisesRegex(SystemError, msg):
             foo()
 

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1626,7 +1626,7 @@ class TestCollectionABCs(ABCTestCase):
         class SetUsingInstanceFromIterable(MutableSet):
             def __init__(self, values, created_by):
                 if not created_by:
-                    raise ValueErro('created_by must be specified')
+                    raise ValueError('created_by must be specified')
                 self.created_by = created_by
                 self._values = set(values)
 

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1626,7 +1626,7 @@ class TestCollectionABCs(ABCTestCase):
         class SetUsingInstanceFromIterable(MutableSet):
             def __init__(self, values, created_by):
                 if not created_by:
-                    raise ValueError(f'created_by must be specified')
+                    raise ValueErro('created_by must be specified')
                 self.created_by = created_by
                 self._values = set(values)
 

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2365,15 +2365,15 @@ class OriginTrackingTest(unittest.TestCase):
                 f"coroutine '{corofn.__qualname__}' was never awaited\n",
                 "Coroutine created at (most recent call last)\n",
                 f'  File "{a1_filename}", line {a1_lineno}, in a1\n',
-                f'    return corofn()  # comment in a1',
+                "    return corofn()  # comment in a1",
             ]))
             check(2, "".join([
                 f"coroutine '{corofn.__qualname__}' was never awaited\n",
                 "Coroutine created at (most recent call last)\n",
                 f'  File "{a2_filename}", line {a2_lineno}, in a2\n',
-                f'    return a1()  # comment in a2\n',
+                "    return a1()  # comment in a2\n",
                 f'  File "{a1_filename}", line {a1_lineno}, in a1\n',
-                f'    return corofn()  # comment in a1',
+                "    return corofn()  # comment in a1",
             ]))
 
         finally:

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -757,8 +757,8 @@ class TestCase(unittest.TestCase):
                 class Subclass(typ): pass
 
                 with self.assertRaisesRegex(ValueError,
-                                            f"mutable default .*Subclass'>"
-                                            ' for field z is not allowed'
+                                            "mutable default .*Subclass'>"
+                                            " for field z is not allowed"
                                             ):
                     @dataclass
                     class Point:

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -110,7 +110,7 @@ class EmbeddingTestsMixin:
             print(f"--- {cmd} failed ---")
             print(f"stdout:\n{out}")
             print(f"stderr:\n{err}")
-            print(f"------")
+            print("------")
 
         self.assertEqual(p.returncode, returncode,
                          "bad returncode %d, stderr is %r" %

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -1868,7 +1868,7 @@ class TestSinglePhaseSnapshot(ModuleSnapshot):
             self.init_count = mod.initialized_count()
         return self
 
-    SCRIPT_BODY = ModuleSnapshot.SCRIPT_BODY + textwrap.dedent(f'''
+    SCRIPT_BODY = ModuleSnapshot.SCRIPT_BODY + textwrap.dedent('''
         snapshot['module'].update(dict(
             int_const=mod.int_const,
             str_const=mod.str_const,

--- a/Lib/test/test_launcher.py
+++ b/Lib/test/test_launcher.py
@@ -394,17 +394,17 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
 
     def test_filter_to_tag(self):
         company = "PythonTestSuite"
-        data = self.run_py([f"-V:3.100"])
+        data = self.run_py(["-V:3.100"])
         self.assertEqual("X.Y.exe", data["LaunchCommand"])
         self.assertEqual(company, data["env.company"])
         self.assertEqual("3.100", data["env.tag"])
 
-        data = self.run_py([f"-V:3.100-32"])
+        data = self.run_py(["-V:3.100-32"])
         self.assertEqual("X.Y-32.exe", data["LaunchCommand"])
         self.assertEqual(company, data["env.company"])
         self.assertEqual("3.100-32", data["env.tag"])
 
-        data = self.run_py([f"-V:3.100-arm64"])
+        data = self.run_py(["-V:3.100-arm64"])
         self.assertEqual("X.Y-arm64.exe -X fake_arg_for_test", data["LaunchCommand"])
         self.assertEqual(company, data["env.company"])
         self.assertEqual("3.100-arm64", data["env.tag"])
@@ -421,7 +421,7 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
     def test_filter_with_single_install(self):
         company = "PythonTestSuite1"
         data = self.run_py(
-            [f"-V:Nonexistent"],
+            ["-V:Nonexistent"],
             env={"PYLAUNCHER_LIMIT_TO_COMPANY": company},
             expect_returncode=103,
         )
@@ -500,7 +500,7 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
                     data = self.run_py(["--version"], argv=f'{argv0} --version')
                     self.assertEqual("PythonTestSuite", data["SearchInfo.company"])
                     self.assertEqual("3.100", data["SearchInfo.tag"])
-                    self.assertEqual(f'X.Y.exe --version', data["stdout"].strip())
+                    self.assertEqual("X.Y.exe --version", data["stdout"].strip())
 
     def test_py_default_in_list(self):
         data = self.run_py(["-0"], env=TEST_PY_ENV)
@@ -662,7 +662,7 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
         self.assertIn("9PJPW5LDXLZ5", cmd)
 
     def test_literal_shebang_absolute(self):
-        with self.script(f"#! C:/some_random_app -witharg") as script:
+        with self.script("#! C:/some_random_app -witharg") as script:
             data = self.run_py([script])
         self.assertEqual(
             f"C:\\some_random_app -witharg {script}",
@@ -670,7 +670,7 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
         )
 
     def test_literal_shebang_relative(self):
-        with self.script(f"#! ..\\some_random_app -witharg") as script:
+        with self.script("#! ..\\some_random_app -witharg") as script:
             data = self.run_py([script])
         self.assertEqual(
             f"{script.parent.parent}\\some_random_app -witharg {script}",
@@ -678,14 +678,14 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
         )
 
     def test_literal_shebang_quoted(self):
-        with self.script(f'#! "some random app" -witharg') as script:
+        with self.script('#! "some random app" -witharg') as script:
             data = self.run_py([script])
         self.assertEqual(
             f'"{script.parent}\\some random app" -witharg {script}',
             data["stdout"].strip(),
         )
 
-        with self.script(f'#! some" random "app -witharg') as script:
+        with self.script('#! some" random "app -witharg') as script:
             data = self.run_py([script])
         self.assertEqual(
             f'"{script.parent}\\some random app" -witharg {script}',
@@ -693,7 +693,7 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
         )
 
     def test_literal_shebang_quoted_escape(self):
-        with self.script(f'#! some\\" random "app -witharg') as script:
+        with self.script('#! some\\" random "app -witharg') as script:
             data = self.run_py([script])
         self.assertEqual(
             f'"{script.parent}\\some\\ random app" -witharg {script}',

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -810,7 +810,7 @@ class TestMarkingVariablesAsUnKnown(BytecodeTestCase):
         self.assertInBytecode(f, 'LOAD_FAST', "a73")
 
     def test_setting_lineno_no_undefined(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent("""\
             def f():
                 x = y = 2
                 if not x:
@@ -842,7 +842,7 @@ class TestMarkingVariablesAsUnKnown(BytecodeTestCase):
         self.assertEqual(f.__code__.co_code, co_code)
 
     def test_setting_lineno_one_undefined(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent("""\
             def f():
                 x = y = 2
                 if not x:
@@ -876,7 +876,7 @@ class TestMarkingVariablesAsUnKnown(BytecodeTestCase):
         self.assertEqual(f.__code__.co_code, co_code)
 
     def test_setting_lineno_two_undefined(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent("""\
             def f():
                 x = y = 2
                 if not x:

--- a/Lib/test/test_sqlite3/test_regression.py
+++ b/Lib/test/test_sqlite3/test_regression.py
@@ -491,21 +491,21 @@ class RecursiveUseOfCursors(unittest.TestCase):
     def test_recursive_cursor_init(self):
         conv = lambda x: self.cur.__init__(self.con)
         with patch.dict(sqlite.converters, {"INIT": conv}):
-            self.cur.execute(f'select x as "x [INIT]", x from test')
+            self.cur.execute('select x as "x [INIT]", x from test')
             self.assertRaisesRegex(sqlite.ProgrammingError, self.msg,
                                    self.cur.fetchall)
 
     def test_recursive_cursor_close(self):
         conv = lambda x: self.cur.close()
         with patch.dict(sqlite.converters, {"CLOSE": conv}):
-            self.cur.execute(f'select x as "x [CLOSE]", x from test')
+            self.cur.execute('select x as "x [CLOSE]", x from test')
             self.assertRaisesRegex(sqlite.ProgrammingError, self.msg,
                                    self.cur.fetchall)
 
     def test_recursive_cursor_iter(self):
         conv = lambda x, l=[]: self.cur.fetchone() if l else l.append(None)
         with patch.dict(sqlite.converters, {"ITER": conv}):
-            self.cur.execute(f'select x as "x [ITER]", x from test')
+            self.cur.execute('select x as "x [ITER]", x from test')
             self.assertRaisesRegex(sqlite.ProgrammingError, self.msg,
                                    self.cur.fetchall)
 

--- a/Lib/test/test_sqlite3/test_userfunctions.py
+++ b/Lib/test/test_sqlite3/test_userfunctions.py
@@ -562,7 +562,7 @@ class WindowFunctionTests(unittest.TestCase):
         # callback errors to sqlite3_step(); this implies that OperationalError
         # is _not_ raised.
         with patch.object(WindowSumInt, "finalize", side_effect=BadWindow):
-            name = f"exception_in_finalize"
+            name = "exception_in_finalize"
             self.con.create_window_function(name, 1, WindowSumInt)
             self.cur.execute(self.query % name)
             self.cur.fetchall()

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -802,12 +802,12 @@ class TracebackErrorLocationCaretTestBase:
             )()
         actual = self.get_exception(f)
         expected = [
-            f"Traceback (most recent call last):",
+            "Traceback (most recent call last):",
             f"  File \"{__file__}\", line {self.callable_line}, in get_exception",
-            f"    callable()",
+            "    callable()",
             f"  File \"{__file__}\", line {f.__code__.co_firstlineno + 2}, in f",
-            f"    .method",
-            f"     ^^^^^^",
+            "    .method",
+            "     ^^^^^^",
         ]
         self.assertEqual(actual, expected)
 
@@ -818,11 +818,11 @@ class TracebackErrorLocationCaretTestBase:
             )()
         actual = self.get_exception(f)
         expected = [
-            f"Traceback (most recent call last):",
+            "Traceback (most recent call last):",
             f"  File \"{__file__}\", line {self.callable_line}, in get_exception",
-            f"    callable()",
+            "    callable()",
             f"  File \"{__file__}\", line {f.__code__.co_firstlineno + 2}, in f",
-            f"    method",
+            "    method",
         ]
         self.assertEqual(actual, expected)
 
@@ -833,12 +833,12 @@ class TracebackErrorLocationCaretTestBase:
             )()
         actual = self.get_exception(f)
         expected = [
-            f"Traceback (most recent call last):",
+            "Traceback (most recent call last):",
             f"  File \"{__file__}\", line {self.callable_line}, in get_exception",
-            f"    callable()",
+            "    callable()",
             f"  File \"{__file__}\", line {f.__code__.co_firstlineno + 2}, in f",
-            f"    . method",
-            f"      ^^^^^^",
+            "    . method",
+            "      ^^^^^^",
         ]
         self.assertEqual(actual, expected)
 
@@ -848,11 +848,11 @@ class TracebackErrorLocationCaretTestBase:
 
         actual = self.get_exception(f)
         expected = [
-            f"Traceback (most recent call last):",
+            "Traceback (most recent call last):",
             f"  File \"{__file__}\", line {self.callable_line}, in get_exception",
-            f"    callable()",
+            "    callable()",
             f"  File \"{__file__}\", line {f.__code__.co_firstlineno + 1}, in f",
-            f"    ｗｉｄｔｈ",
+            "    ｗｉｄｔｈ",
         ]
         self.assertEqual(actual, expected)
 
@@ -864,11 +864,11 @@ class TracebackErrorLocationCaretTestBase:
 
         actual = self.get_exception(f)
         expected = [
-            f"Traceback (most recent call last):",
+            "Traceback (most recent call last):",
             f"  File \"{__file__}\", line {self.callable_line}, in get_exception",
-            f"    callable()",
+            "    callable()",
             f"  File \"{__file__}\", line {f.__code__.co_firstlineno + 2}, in f",
-            f"    raise ValueError(ｗｉｄｔｈ)",
+            "    raise ValueError(ｗｉｄｔｈ)",
         ]
         self.assertEqual(actual, expected)
 
@@ -882,12 +882,12 @@ class TracebackErrorLocationCaretTestBase:
 
         actual = self.get_exception(f)
         expected = [
-            f"Traceback (most recent call last):",
+            "Traceback (most recent call last):",
             f"  File \"{__file__}\", line {self.callable_line}, in get_exception",
-            f"    callable()",
+            "    callable()",
             f"  File \"{__file__}\", line {f.__code__.co_firstlineno + 4}, in f",
-            f"    print(1, ｗｗｗ(",
-            f"             ^^^^",
+            "    print(1, ｗｗｗ(",
+            "             ^^^^",
         ]
         self.assertEqual(actual, expected)
 
@@ -2844,26 +2844,26 @@ class TestTracebackException_ExceptionGroups(unittest.TestCase):
         formatted = ''.join(teg.format()).split('\n')
 
         expected = [
-                    f'  | ExceptionGroup: eg (2 sub-exceptions)',
-                    f'  +-+---------------- 1 ----------------',
-                    f'    | ExceptionGroup: eg1 (3 sub-exceptions)',
-                    f'    +-+---------------- 1 ----------------',
-                    f'      | ValueError: 0',
-                    f'      +---------------- 2 ----------------',
-                    f'      | ValueError: 1',
-                    f'      +---------------- ... ----------------',
-                    f'      | and 1 more exception',
-                    f'      +------------------------------------',
-                    f'    +---------------- 2 ----------------',
-                    f'    | ExceptionGroup: eg2 (10 sub-exceptions)',
-                    f'    +-+---------------- 1 ----------------',
-                    f'      | TypeError: 0',
-                    f'      +---------------- 2 ----------------',
-                    f'      | TypeError: 1',
-                    f'      +---------------- ... ----------------',
-                    f'      | and 8 more exceptions',
-                    f'      +------------------------------------',
-                    f'']
+                    '  | ExceptionGroup: eg (2 sub-exceptions)',
+                    '  +-+---------------- 1 ----------------',
+                    '    | ExceptionGroup: eg1 (3 sub-exceptions)',
+                    '    +-+---------------- 1 ----------------',
+                    '      | ValueError: 0',
+                    '      +---------------- 2 ----------------',
+                    '      | ValueError: 1',
+                    '      +---------------- ... ----------------',
+                    '      | and 1 more exception',
+                    '      +------------------------------------',
+                    '    +---------------- 2 ----------------',
+                    '    | ExceptionGroup: eg2 (10 sub-exceptions)',
+                    '    +-+---------------- 1 ----------------',
+                    '      | TypeError: 0',
+                    '      +---------------- 2 ----------------',
+                    '      | TypeError: 1',
+                    '      +---------------- ... ----------------',
+                    '      | and 8 more exceptions',
+                    '      +------------------------------------',
+                    '']
 
         self.assertEqual(formatted, expected)
 
@@ -2876,22 +2876,22 @@ class TestTracebackException_ExceptionGroups(unittest.TestCase):
         formatted = ''.join(teg.format()).split('\n')
 
         expected = [
-                    f'  | ExceptionGroup: exc (3 sub-exceptions)',
-                    f'  +-+---------------- 1 ----------------',
-                    f'    | ValueError: -2',
-                    f'    +---------------- 2 ----------------',
-                    f'    | ExceptionGroup: exc (3 sub-exceptions)',
-                    f'    +-+---------------- 1 ----------------',
-                    f'      | ValueError: -1',
-                    f'      +---------------- 2 ----------------',
-                    f'      | ... (max_group_depth is 2)',
-                    f'      +---------------- 3 ----------------',
-                    f'      | ValueError: 1',
-                    f'      +------------------------------------',
-                    f'    +---------------- 3 ----------------',
-                    f'    | ValueError: 2',
-                    f'    +------------------------------------',
-                    f'']
+                    '  | ExceptionGroup: exc (3 sub-exceptions)',
+                    '  +-+---------------- 1 ----------------',
+                    '    | ValueError: -2',
+                    '    +---------------- 2 ----------------',
+                    '    | ExceptionGroup: exc (3 sub-exceptions)',
+                    '    +-+---------------- 1 ----------------',
+                    '      | ValueError: -1',
+                    '      +---------------- 2 ----------------',
+                    '      | ... (max_group_depth is 2)',
+                    '      +---------------- 3 ----------------',
+                    '      | ValueError: 1',
+                    '      +------------------------------------',
+                    '    +---------------- 3 ----------------',
+                    '    | ValueError: 2',
+                    '    +------------------------------------',
+                    '']
 
         self.assertEqual(formatted, expected)
 

--- a/Misc/NEWS.d/next/Tests/2023-04-24-22-51-30.gh-issue-103805.uOUOod.rst
+++ b/Misc/NEWS.d/next/Tests/2023-04-24-22-51-30.gh-issue-103805.uOUOod.rst
@@ -1,1 +1,0 @@
-This PR makes some minor linting adjustments to the Lib/test module caught by ruff. The adjustments are all related to the F541 f-string without any placeholders issue.

--- a/Misc/NEWS.d/next/Tests/2023-04-24-22-51-30.gh-issue-103805.uOUOod.rst
+++ b/Misc/NEWS.d/next/Tests/2023-04-24-22-51-30.gh-issue-103805.uOUOod.rst
@@ -1,0 +1,1 @@
+This PR makes some minor linting adjustments to the Lib/test module caught by ruff. The adjustments are all related to the F541 f-string without any placeholders issue.


### PR DESCRIPTION
This PR makes some minor linting adjustments to the Lib/test module caught by [ruff](https://github.com/charliermarsh/ruff). The adjustments are all related to the `F541 f-string without any placeholders` issue.

Issue: https://github.com/python/cpython/issues/103805

<!-- gh-issue-number: gh-103805 -->
* Issue: gh-103805
<!-- /gh-issue-number -->
