### PR TITLE
[3.11] gh-101517: fix line number propagation in code generated for except* (#103550)

### DIFF
--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -574,6 +574,8 @@ class Bdb:
             line = linecache.getline(filename, lineno, frame.f_globals)
             if line:
                 s += lprefix + line.strip()
+        else:
+            s += f'{lprefix}Warning: lineno is None'
         return s
 
     # The following methods can be called by clients to use

--- a/Lib/test/test_bdb.py
+++ b/Lib/test/test_bdb.py
@@ -1206,7 +1206,8 @@ class IssuesTestCase(BaseTestCase):
 class TestRegressions(unittest.TestCase):
     def test_format_stack_entry_no_lineno(self):
         # See gh-101517
-        Bdb().format_stack_entry((sys._getframe(), None))
+        self.assertIn('Warning: lineno is None',
+                      Bdb().format_stack_entry((sys._getframe(), None)))
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1653,6 +1653,25 @@ def test_pdb_issue_gh_101673():
     (Pdb) continue
     """
 
+def test_pdb_issue_gh_101517():
+    """See GH-101517
+
+    Make sure pdb doesn't crash when the exception is caught in a try/except* block
+
+    >>> def test_function():
+    ...     try:
+    ...         raise KeyError
+    ...     except* Exception as e:
+    ...         import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'continue'
+    ... ]):
+    ...    test_function()
+    > <doctest test.test_pdb.test_pdb_issue_gh_101517[0]>(5)test_function()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) continue
+    """
 
 @support.requires_subprocess()
 class PdbTestCase(unittest.TestCase):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1668,8 +1668,8 @@ def test_pdb_issue_gh_101517():
     ...     'continue'
     ... ]):
     ...    test_function()
-    > <doctest test.test_pdb.test_pdb_issue_gh_101517[0]>(5)test_function()
-    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    > <doctest test.test_pdb.test_pdb_issue_gh_101517[0]>(4)test_function()
+    -> except* Exception as e:
     (Pdb) continue
     """
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-04-14-22-35-23.gh-issue-101517.5EqM-S.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-04-14-22-35-23.gh-issue-101517.5EqM-S.rst
@@ -1,0 +1,1 @@
+Fix bug in line numbers of instructions emitted for :keyword:`except* <except_star>`.


### PR DESCRIPTION
Manual backport of https://github.com/python/cpython/pull/103550.



<!-- gh-issue-number: gh-101517 -->
* Issue: gh-101517
<!-- /gh-issue-number -->
