### PR TITLE
gh-84436: Improve Immortalization for Builtin Types

### DIFF
--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -20,6 +20,24 @@ extern "C" {
 #define _PY_NSMALLNEGINTS           5
 
 
+struct _Py_immortalized_object {
+    PyObject *obj;
+    int final_refcnt;
+    struct _Py_immortalized_object *next;
+};
+
+struct _Py_immortalized_objects {
+    Py_ssize_t count;
+    struct _Py_immortalized_object *head;
+    struct _Py_immortalized_object *last;
+#define _Py_IMMORTALIZED_ARRAY_SIZE 100
+    struct _Py_immortalized_object _objects[_Py_IMMORTALIZED_ARRAY_SIZE];
+};
+
+extern void _Py_EnsureImmortal(PyObject *);
+extern void _Py_ImmortalObjectsFini(void);
+
+
 // Only immutable objects should be considered runtime-global.
 // All others must be per-interpreter.
 

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -74,16 +74,6 @@ static inline void _Py_SetImmortal(PyObject *op)
 #define _Py_SetImmortal(op) _Py_SetImmortal(_PyObject_CAST(op))
 
 static inline void
-_Py_EnsureImmortal(PyObject *op)
-{
-    if (_Py_IsImmortal(op)) {
-        return;
-    }
-    assert(op->ob_type != &PyTuple_Type || PyTuple_GET_SIZE(op) > 0);
-    _Py_SetImmortal(op);
-}
-
-static inline void
 _Py_DECREF_SPECIALIZED(PyObject *op, const destructor destruct)
 {
     if (_Py_IsImmortal(op)) {

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -74,6 +74,16 @@ static inline void _Py_SetImmortal(PyObject *op)
 #define _Py_SetImmortal(op) _Py_SetImmortal(_PyObject_CAST(op))
 
 static inline void
+_Py_EnsureImmortal(PyObject *op)
+{
+    if (_Py_IsImmortal(op)) {
+        return;
+    }
+    assert(op->ob_type != &PyTuple_Type || PyTuple_GET_SIZE(op) > 0);
+    _Py_SetImmortal(op);
+}
+
+static inline void
 _Py_DECREF_SPECIALIZED(PyObject *op, const destructor destruct)
 {
     if (_Py_IsImmortal(op)) {

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -152,6 +152,8 @@ typedef struct pyruntimestate {
     struct _Py_unicode_runtime_state unicode_state;
     struct _types_runtime_state types;
 
+    /* All non-static immortal objects (need to be cleaned up during fini). */
+    struct _Py_immortalized_objects immortalized_objects;
     /* All the objects that are shared by the runtime's interpreters. */
     struct _Py_static_objects static_objects;
 

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -512,6 +512,8 @@ _PyStructSequence_InitBuiltinWithFlags(PyTypeObject *type,
     PyMemberDef *members;
     Py_ssize_t n_members, n_unnamed_members;
 
+    assert(type->tp_name == NULL);
+    assert(type->tp_members == NULL);
     members = initialize_members(desc, &n_members, &n_unnamed_members);
     if (members == NULL) {
         return -1;
@@ -603,8 +605,12 @@ _PyStructSequence_FiniType(PyTypeObject *type)
 
     // Undo _PyStructSequence_InitBuiltinWithFlags()
     PyMem_Free(type->tp_members);
+    type->tp_members = NULL;
 
     _PyStaticType_Dealloc(type);
+
+    // Mark the type as un-initialized.
+    type->tp_name = NULL;
 }
 
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7030,6 +7030,7 @@ PyType_Ready(PyTypeObject *type)
 int
 _PyStaticType_InitBuiltin(PyTypeObject *self)
 {
+    assert(_Py_IsImmortal((PyObject *)self));
     self->tp_flags |= _Py_TPFLAGS_STATIC_BUILTIN;
 
     assert(NEXT_GLOBAL_VERSION_TAG <= _Py_MAX_GLOBAL_TYPE_VERSION_TAG);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7055,15 +7055,9 @@ _PyStaticType_InitBuiltin(PyTypeObject *self)
         static_builtin_state_clear(self);
     }
 
-    _Py_SetImmortal(self->tp_dict);
-    if (!_Py_IsImmortal(self->tp_bases)) {
-        assert(PyTuple_GET_SIZE(self->tp_bases) > 0);
-        _Py_SetImmortal(self->tp_bases);
-    }
-    if (!_Py_IsImmortal(self->tp_mro)) {
-        assert(PyTuple_GET_SIZE(self->tp_mro) > 0);
-        _Py_SetImmortal(self->tp_mro);
-    }
+    _Py_EnsureImmortal(self->tp_dict);
+    _Py_EnsureImmortal(self->tp_bases);
+    _Py_EnsureImmortal(self->tp_mro);
 
     return res;
 }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2357,6 +2357,9 @@ mro_internal(PyTypeObject *type, PyObject **p_old_mro)
     }
 
     type->tp_mro = new_mro;
+    if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
+        _Py_EnsureImmortal(new_mro);
+    }
 
     type_mro_modified(type, type->tp_mro);
     /* corner case: the super class might have been hidden
@@ -4498,6 +4501,17 @@ _PyStaticType_Dealloc(PyTypeObject *type)
 
     type_dealloc_common(type);
 
+    if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
+        if (type->tp_dict != NULL) {
+            type->tp_dict->ob_refcnt = 1;
+        }
+        if (type->tp_bases != NULL && PyTuple_GET_SIZE(type->tp_bases) > 0) {
+            type->tp_bases->ob_refcnt = 1;
+        }
+        if (type->tp_mro != NULL && PyTuple_GET_SIZE(type->tp_mro) > 0) {
+            type->tp_mro->ob_refcnt = 1;
+        }
+    }
     Py_CLEAR(type->tp_dict);
     Py_CLEAR(type->tp_bases);
     Py_CLEAR(type->tp_mro);
@@ -6585,6 +6599,9 @@ type_ready_set_bases(PyTypeObject *type)
             return -1;
         }
         type->tp_bases = bases;
+        if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
+            _Py_EnsureImmortal(bases);
+        }
     }
     return 0;
 }
@@ -6602,6 +6619,9 @@ type_ready_set_dict(PyTypeObject *type)
         return -1;
     }
     type->tp_dict = dict;
+    if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
+        _Py_SetImmortal(dict);
+    }
     return 0;
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2357,9 +2357,6 @@ mro_internal(PyTypeObject *type, PyObject **p_old_mro)
     }
 
     type->tp_mro = new_mro;
-    if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
-        _Py_EnsureImmortal(new_mro);
-    }
 
     type_mro_modified(type, type->tp_mro);
     /* corner case: the super class might have been hidden
@@ -6599,9 +6596,6 @@ type_ready_set_bases(PyTypeObject *type)
             return -1;
         }
         type->tp_bases = bases;
-        if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
-            _Py_EnsureImmortal(bases);
-        }
     }
     return 0;
 }
@@ -6619,9 +6613,6 @@ type_ready_set_dict(PyTypeObject *type)
         return -1;
     }
     type->tp_dict = dict;
-    if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
-        _Py_SetImmortal(dict);
-    }
     return 0;
 }
 
@@ -7063,6 +7054,17 @@ _PyStaticType_InitBuiltin(PyTypeObject *self)
     if (res < 0) {
         static_builtin_state_clear(self);
     }
+
+    _Py_SetImmortal(self->tp_dict);
+    if (!_Py_IsImmortal(self->tp_bases)) {
+        assert(PyTuple_GET_SIZE(self->tp_bases) > 0);
+        _Py_SetImmortal(self->tp_bases);
+    }
+    if (!_Py_IsImmortal(self->tp_mro)) {
+        assert(PyTuple_GET_SIZE(self->tp_mro) > 0);
+        _Py_SetImmortal(self->tp_mro);
+    }
+
     return res;
 }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1733,6 +1733,7 @@ finalize_interp_clear(PyThreadState *tstate)
         _Py_ClearFileSystemEncoding();
         _Py_Deepfreeze_Fini();
         _PyPerfTrampoline_Fini();
+        _Py_ImmortalObjectsFini();
     }
 
     finalize_interp_types(tstate->interp);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2758,6 +2758,82 @@ _register_builtins_for_crossinterpreter_data(struct _xidregistry *xidregistry)
 }
 
 
+/******************/
+/* global objects */
+/******************/
+
+static void
+immortalized_add(struct _Py_immortalized_objects *state, PyObject *obj)
+{
+    struct _Py_immortalized_object *entry;
+    if (state->count < _Py_IMMORTALIZED_ARRAY_SIZE) {
+        entry = &state->_objects[state->count];
+    }
+    else {
+        entry = PyMem_RawMalloc(sizeof(*entry));
+        if (entry == NULL) {
+            Py_FatalError("could not allocate immortalized list entry");
+        }
+    }
+
+    entry->obj = obj;
+    entry->final_refcnt = Py_REFCNT(obj);
+    entry->next = NULL;
+
+    if (state->head == NULL) {
+        assert(state->count == 0);
+        assert(state->last == NULL);
+        state->head = entry;
+    }
+    else {
+        state->last->next = entry;
+    }
+    state->count += 1;
+    state->last = entry;
+}
+
+static void
+immortalized_fini(struct _Py_immortalized_objects *state)
+{
+    struct _Py_immortalized_object *next = state->head;
+    state->head = NULL;
+    state->last = NULL;
+    for (int i = 0; i < _Py_IMMORTALIZED_ARRAY_SIZE && next != NULL; i++) {
+        struct _Py_immortalized_object *entry = next;
+        next = entry->next;
+        entry->obj->ob_refcnt = entry->final_refcnt;
+    }
+    while (next != NULL) {
+        struct _Py_immortalized_object *entry = next;
+        next = next->next;
+        entry->obj->ob_refcnt = entry->final_refcnt;
+        PyMem_RawFree(entry);
+    }
+}
+
+void
+_Py_EnsureImmortal(PyObject *obj)
+{
+    assert(_Py_IsMainInterpreter(_PyInterpreterState_GET()));
+    if (_Py_IsImmortal(obj)) {
+        return;
+    }
+
+    _Py_SetImmortal(obj);
+    immortalized_add(&_PyRuntime.immortalized_objects, obj);
+}
+
+void
+_Py_ImmortalObjectsFini(void)
+{
+    immortalized_fini(&_PyRuntime.immortalized_objects);
+}
+
+
+/*************/
+/* other API */
+/*************/
+
 _PyFrameEvalFunction
 _PyInterpreterState_GetEvalFrameFunc(PyInterpreterState *interp)
 {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2821,6 +2821,23 @@ _Py_EnsureImmortal(PyObject *obj)
 
     _Py_SetImmortal(obj);
     immortalized_add(&_PyRuntime.immortalized_objects, obj);
+
+    if (Py_TYPE(obj) == &PyDict_Type) {
+        Py_ssize_t i = 0;
+        PyObject *key, *value;  // borrowed ref
+        while (PyDict_Next(obj, &i, &key, &value)) {
+            _Py_EnsureImmortal(key);
+            _Py_EnsureImmortal(value);
+        }
+    }
+    else if (Py_TYPE(obj) == &PyTuple_Type) {
+        assert(PyTuple_GET_SIZE(obj) > 0);
+        Py_ssize_t size = PyTuple_GET_SIZE(obj);
+        assert(size > 0);
+        for (Py_ssize_t i = 0; i < size; i++) {
+            _Py_EnsureImmortal(PyTuple_GET_ITEM(obj, i));
+        }
+    }
 }
 
 void


### PR DESCRIPTION
We do two things here:  immortalize the builtin structseq types, and immortalize `tp_dict`, `tp_bases`, and `tp_mro` for builtin types.  This is necessary for a per-interpreter GIL.

Note that we could also take the approach to immortalization that no immortal object should ever be freed, even if allocated dynamically.  That's something we'll sort out as soon as we can.  In the meantime, the change here takes care of isolation concerns.

<!-- gh-issue-number: gh-84436 -->
* Issue: gh-84436
<!-- /gh-issue-number -->
