### PR TITLE
gh-103826: fix unused variable warning introduced in gh-102343

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6706,7 +6706,6 @@ type_ready_mro(PyTypeObject *type)
        and static builtin types must have static builtin bases. */
     if (!(type->tp_flags & Py_TPFLAGS_HEAPTYPE)) {
         assert(type->tp_flags & Py_TPFLAGS_IMMUTABLETYPE);
-        int isbuiltin = type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN;
         PyObject *mro = type->tp_mro;
         Py_ssize_t n = PyTuple_GET_SIZE(mro);
         for (Py_ssize_t i = 0; i < n; i++) {
@@ -6718,7 +6717,8 @@ type_ready_mro(PyTypeObject *type)
                              type->tp_name, base->tp_name);
                 return -1;
             }
-            assert(!isbuiltin || (base->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN));
+            assert(!(type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) ||
+                   (base->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN));
         }
     }
     return 0;


### PR DESCRIPTION
gh-102343 introduced a variable used only in the `assert` macro, causing unused variable warnings in release mode.

<!-- gh-issue-number: gh-103826 -->
* Issue: gh-103826
<!-- /gh-issue-number -->
