### PR TITLE
gh-103721: Improve cross-references for generic-alias docs

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -354,10 +354,10 @@ Standard names are defined for the following types:
    .. seealso::
 
       :ref:`Generic Alias Types<types-genericalias>`
-         In-depth documentation on instances of `types.GenericAlias`
+         In-depth documentation on instances of :class:`!types.GenericAlias`
 
       :pep:`585` - Type Hinting Generics In Standard Collections
-         Introducing the `types.GenericAlias` class
+         Introducing the :class:`!types.GenericAlias` class
 
 .. class:: UnionType
 

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -351,6 +351,13 @@ Standard names are defined for the following types:
    .. versionchanged:: 3.9.2
       This type can now be subclassed.
 
+   .. seealso::
+
+      :ref:`Generic Alias Types<types-genericalias>`
+         In-depth documentation on instances of `types.GenericAlias`
+
+      :pep:`585` - Type Hinting Generics In Standard Collections
+         Introducing the `types.GenericAlias` class
 
 .. class:: UnionType
 


### PR DESCRIPTION
Cc. @adriangb

The "stub documentation" in `types.rst` does already link to the in-depth docs in `stdtypes.rst`, but the link isn't obvious for new users. It deserves to be made more prominent.

- Issue: https://github.com/python/cpython/issues/103721