### PR TITLE
[3.11] gh-51574: Document behaviour of `mkdtemp` on 3.11 and lower

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -226,7 +226,10 @@ The module defines the following user-callable items:
    The *prefix*, *suffix*, and *dir* arguments are the same as for
    :func:`mkstemp`.
 
-   :func:`mkdtemp` returns the absolute pathname of the new directory.
+   :func:`mkdtemp` returns the absolute pathname of the new directory if *dir*
+   is ``None`` or is an absolute path. If *dir* is a relative path,
+   :func:`mkdtemp` returns a relative path on Python 3.11 and lower. However,
+   on 3.12 it will return an absolute path in all situations.
 
    .. audit-event:: tempfile.mkdtemp fullpath tempfile.mkdtemp
 


### PR DESCRIPTION
A bug has been fixed in 3.12 where `mkdtemp` does not return an absolute path if a relative path is supplied to the *dir* argument (https://github.com/python/cpython/pull/94612). However, the bugfix is not suitable to be backported, meaning the bug will not be fixed in the 3.11 branch and lower.

We should note the existing behaviour in the docs for the 3.11 branch, so that users are not misinformed about what will happen when the function is called.

Closes #51574

- Issue: gh-51574