### PR TITLE
gh-48241: Adding note about url needing to be encoded when provided to the urlopen and Request

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -28,7 +28,7 @@ The :mod:`urllib.request` module defines the following functions:
 
 .. function:: urlopen(url, data=None[, timeout], *, cafile=None, capath=None, cadefault=False, context=None)
 
-   Open the URL *url*, which can be either a string or a
+   Open the URL *url*, which can be either a string containing a valid, properly encoded, URL or a
    :class:`Request` object.
 
    *data* must be an object specifying additional data to be sent to the
@@ -192,7 +192,7 @@ The following classes are provided:
 
    This class is an abstraction of a URL request.
 
-   *url* should be a string containing a valid URL.
+   *url* should be a string containing a valid, properly encoded, URL.
 
    *data* must be an object specifying additional data to send to the
    server, or ``None`` if no such data is needed.  Currently HTTP


### PR DESCRIPTION
Adding note about url needing to be encoded when provided to the urlopen function as well as the Request class.

This is a documentation change

- Issue: gh-48241