### PR TITLE
gh-82054: Implements test.regrtest unittest sharding to pull in long tails for asyncio

### DIFF
--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -143,6 +143,15 @@ STDTESTS = [
 # set of tests that we don't want to be executed when using regrtest
 NOTTESTS = set()
 
+#If these test directories are encountered recurse into them and treat each
+# test_ .py or dir as a separate test module. This can increase parallelism.
+# Beware this can't generally be done for any directory with sub-tests as the
+# __init__.py may do things which alter what tests are to be run.
+
+SPLITTESTDIRS = {
+     "test_asyncio",
+     "test_compiler",
+}
 
 # Storage of uncollectable objects
 FOUND_GARBAGE = []
@@ -158,7 +167,7 @@ def findtestdir(path=None):
     return path or os.path.dirname(os.path.dirname(__file__)) or os.curdir
 
 
-def findtests(testdir=None, stdtests=STDTESTS, nottests=NOTTESTS):
+def findtests(testdir=None, stdtests=STDTESTS, nottests=NOTTESTS, splittestdirs=SPLITTESTDIRS, base_mod=""):
     """Return a list of all applicable test modules."""
     testdir = findtestdir(testdir)
     names = os.listdir(testdir)
@@ -166,8 +175,16 @@ def findtests(testdir=None, stdtests=STDTESTS, nottests=NOTTESTS):
     others = set(stdtests) | nottests
     for name in names:
         mod, ext = os.path.splitext(name)
-        if mod[:5] == "test_" and ext in (".py", "") and mod not in others:
-            tests.append(mod)
+        if mod[:5] == "test_" and mod not in others:
+            if mod in splittestdirs:
+                subdir = os.path.join(testdir, mod)
+                if len(base_mod):
+                    mod = f"{base_mod}.{mod}"
+                else:
+                    mod = f"test.{mod}"
+                tests.extend(findtests(subdir, [], nottests, splittestdirs, mod))
+            elif ext in (".py", ""):
+                tests.append(f"{base_mod}.{mod}" if len(base_mod) else mod)
     return stdtests + sorted(tests)
 
 


### PR DESCRIPTION
# gh-82054: Implements test.regrtest unittest sharding to pull in long tails for asyncio and compiler

TLDR: This runs test_asyncio and test_compiler sub-tests in parallel

Below is a summary about this change which is the same information from the issue in cinder that addressed this. It can be found at  https://github.com/facebookincubator/cinder/commit/3c6be0192d3c3fb7813cd2a27533aedbbed397f4
## Summary:

These two tests are typically the long-poles in runs because they are modules with a lot of further sub-tests run serially. By breaking out the sub-tests as independent modules we can run a lot more in parallel.

The real win comes in the next diff but with this change alone on my devserver:
* With a debug build:
  * `time make testcinder` goes from ~25m -> ~19m.
  * `time make testcinder_jit` goes from ~26m -> ~18m.
* With a release build:
  * `time make testcinder` goes from ~6m15s -> ~4m45s.
  * `time make testcinder_jit` goes from ~6m -> ~5m30s.

While this is a bit hacky and annoyingly involves changing CPython test infra, I think the maintenance overhead is worth it. It's not a complicated change and I think the win in productivity with the diff above is significant.