### PR TITLE
gh-48241: Clarify URL needs to be encoded when provided to urlopen and Request

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -29,7 +29,7 @@ The :mod:`urllib.request` module defines the following functions:
 .. function:: urlopen(url, data=None[, timeout], *, cafile=None, capath=None, cadefault=False, context=None)
 
    Open *url*, which can be either a string containing a valid, properly
-   encoded, URL or a :class:`Request` object.
+   encoded URL, or a :class:`Request` object.
 
    *data* must be an object specifying additional data to be sent to the
    server, or ``None`` if no such data is needed.  See :class:`Request`

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -192,7 +192,7 @@ The following classes are provided:
 
    This class is an abstraction of a URL request.
 
-   *url* should be a string containing a valid, properly encoded, URL.
+   *url* should be a string containing a valid, properly encoded URL.
 
    *data* must be an object specifying additional data to send to the
    server, or ``None`` if no such data is needed.  Currently HTTP

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -28,8 +28,8 @@ The :mod:`urllib.request` module defines the following functions:
 
 .. function:: urlopen(url, data=None[, timeout], *, cafile=None, capath=None, cadefault=False, context=None)
 
-   Open the URL *url*, which can be either a string or a
-   :class:`Request` object.
+   Open *url*, which can be either a string containing a valid, properly
+   encoded, URL or a :class:`Request` object.
 
    *data* must be an object specifying additional data to be sent to the
    server, or ``None`` if no such data is needed.  See :class:`Request`
@@ -192,7 +192,7 @@ The following classes are provided:
 
    This class is an abstraction of a URL request.
 
-   *url* should be a string containing a valid URL.
+   *url* should be a string containing a valid, properly encoded, URL.
 
    *data* must be an object specifying additional data to send to the
    server, or ``None`` if no such data is needed.  Currently HTTP

--- a/Misc/NEWS.d/next/Documentation/2023-04-25-22-58-08.gh-issue-48241.l1Gxxh.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-04-25-22-58-08.gh-issue-48241.l1Gxxh.rst
@@ -1,0 +1,1 @@
+Clarifying documentation about the url parameter to urllib.request.urlopen and urllib.request.Requst needing to be encoded properly.


### PR DESCRIPTION
Adding note about url needing to be encoded when provided to the urlopen function as well as the Request class.

This is a documentation change

<!-- gh-issue-number: gh-48241 -->
* Issue: gh-48241
<!-- /gh-issue-number -->
