### PR TITLE
GH-99944: Make dis display the value of oparg of KW_NAMES

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -368,9 +368,8 @@ def _get_const_value(op, arg, co_consts):
     assert op in hasconst
 
     argval = UNKNOWN
-    if op == LOAD_CONST or op == RETURN_CONST:
-        if co_consts is not None:
-            argval = co_consts[arg]
+    if co_consts is not None:
+        argval = co_consts[arg]
     return argval
 
 def _get_const_info(op, arg, co_consts):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -932,7 +932,7 @@ class DisTests(DisTestBase):
         self.do_disassembly_test(bug46724, dis_bug46724)
 
     def test_kw_names(self):
-        # Test that information is populated for KW_NAMES
+        # Test that value is displayed for KW_NAMES
         self.do_disassembly_test(wrap_func_w_kwargs, dis_kw_names)
 
     def test_big_linenos(self):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -234,16 +234,18 @@ def wrap_func_w_kwargs():
     func_w_kwargs(1, 2, c=5)
 
 dis_kw_names = """\
-%3d           0 RESUME                   0
-              2 LOAD_GLOBAL              1 (NULL + f)
-             12 LOAD_CONST               1 (1)
-             14 LOAD_CONST               2 (2)
-             16 LOAD_CONST               3 (5)
-             18 KW_NAMES                 4 (('c',))
-             20 CALL                     3
-             28 POP_TOP
-             30 RETURN_CONST             0 (None)
-""" % (wrap_func_w_kwargs.__code__.co_firstlineno)
+%3d        RESUME                   0
+
+%3d        LOAD_GLOBAL              1 (NULL + func_w_kwargs)
+           LOAD_CONST               1 (1)
+           LOAD_CONST               2 (2)
+           LOAD_CONST               3 (5)
+           KW_NAMES                 4 (('c',))
+           CALL                     3
+           POP_TOP
+           RETURN_CONST             0 (None)
+""" % (wrap_func_w_kwargs.__code__.co_firstlineno,
+       wrap_func_w_kwargs.__code__.co_firstlineno + 1)
 
 _BIG_LINENO_FORMAT = """\
   1        RESUME                   0

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -227,6 +227,24 @@ dis_bug46724 = """\
        JUMP_FORWARD            -4 (to 0)
 """
 
+def func_w_kwargs(a, b, **c):
+    pass
+
+def wrap_func_w_kwargs():
+    func_w_kwargs(1, 2, c=5)
+
+dis_kw_names = """\
+%3d           0 RESUME                   0
+              2 LOAD_GLOBAL              1 (NULL + f)
+             12 LOAD_CONST               1 (1)
+             14 LOAD_CONST               2 (2)
+             16 LOAD_CONST               3 (5)
+             18 KW_NAMES                 4 (('c',))
+             20 CALL                     3
+             28 POP_TOP
+             30 RETURN_CONST             0 (None)
+""" % (wrap_func_w_kwargs.__code__.co_firstlineno)
+
 _BIG_LINENO_FORMAT = """\
   1        RESUME                   0
 
@@ -910,6 +928,10 @@ class DisTests(DisTestBase):
     def test_bug_46724(self):
         # Test that negative operargs are handled properly
         self.do_disassembly_test(bug46724, dis_bug46724)
+
+    def test_kw_names(self):
+        # Test that information is populated for KW_NAMES
+        self.do_disassembly_test(wrap_func_w_kwargs, dis_kw_names)
 
     def test_big_linenos(self):
         def func(count):

--- a/Misc/NEWS.d/next/Library/2023-04-25-22-59-06.gh-issue-99944.pst8iT.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-25-22-59-06.gh-issue-99944.pst8iT.rst
@@ -1,0 +1,1 @@
+Make :mod:`dis` display the value of oparg of :opcode:`KW_NAMES`.


### PR DESCRIPTION
Make the dis module display the value of the oparg of KW_NAMES.

Co-authored-by: chilaxan <chilaxan@gmail.com>

Fixes #99944 

<!-- gh-issue-number: gh-99944 -->
* Issue: gh-99944
<!-- /gh-issue-number -->
