### PR TITLE
GH-103857: Deprecate utcnow and utcfromtimestamp

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -896,6 +896,10 @@ Other constructors, all class methods:
       in UTC. As such, the recommended way to create an object representing the
       current time in UTC is by calling ``datetime.now(timezone.utc)``.
 
+   .. deprecated:: 3.12
+
+      Use :meth:`datetime.now` with :attr:`UTC` instead.
+
 
 .. classmethod:: datetime.fromtimestamp(timestamp, tz=None)
 
@@ -963,6 +967,10 @@ Other constructors, all class methods:
       is out of the range of values supported by the platform C
       :c:func:`gmtime` function. Raise :exc:`OSError` instead of
       :exc:`ValueError` on :c:func:`gmtime` failure.
+
+   .. deprecated:: 3.12
+
+      Use :meth:`datetime.fromtimestamp` with :attr:`UTC` instead.
 
 
 .. classmethod:: datetime.fromordinal(ordinal)

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1803,10 +1803,9 @@ class datetime(date):
         """Construct a naive UTC datetime from a POSIX timestamp."""
         import warnings
         warnings.warn("datetime.utcfromtimestamp() is deprecated and scheduled "
-                      "for removal in a future version. It is instead "
-                      "recommended that users use timezone-aware objects to "
-                      "represent datetimes in UTC. To get such an object from "
-                      "a timestamp, use datetime.fromtimestamp(t, datetime.UTC).",
+                      "for removal in a future version. Use timezone-aware "
+                      "objects to represent datetimes in UTC: "
+                      "datetime.fromtimestamp(t, datetime.UTC).",
                       DeprecationWarning,
                       stacklevel=2)
         return cls._fromtimestamp(t, True, None)
@@ -1822,10 +1821,9 @@ class datetime(date):
         "Construct a UTC datetime from time.time()."
         import warnings
         warnings.warn("datetime.utcnow() is deprecated and scheduled for "
-                      "removal in a future version. It is instead recommended "
-                      "that users use timezone-aware objects to represent "
-                      "datetimes in UTC. To get such an object representing "
-                      "the current time, use datetime.now(datetime.UTC).",
+                      "removal in a future version. Instead, Use timezone-aware "
+                      "objects to represent datetimes in UTC: "
+                      "datetime.now(datetime.UTC).",
                       DeprecationWarning,
                       stacklevel=2)
         t = _time.time()

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1801,6 +1801,14 @@ class datetime(date):
     @classmethod
     def utcfromtimestamp(cls, t):
         """Construct a naive UTC datetime from a POSIX timestamp."""
+        import warnings
+        warnings.warn("datetime.utcfromtimestamp() is deprecated and scheduled "
+                      "for removal in a future version. It is instead "
+                      "recommended that users use timezone-aware objects to "
+                      "represent datetimes in UTC. To get such an object from "
+                      "a timestamp, use datetime.fromtimestamp(t, datetime.UTC).",
+                      DeprecationWarning,
+                      stacklevel=2)
         return cls._fromtimestamp(t, True, None)
 
     @classmethod
@@ -1812,8 +1820,16 @@ class datetime(date):
     @classmethod
     def utcnow(cls):
         "Construct a UTC datetime from time.time()."
+        import warnings
+        warnings.warn("datetime.utcnow() is deprecated and scheduled for "
+                      "removal in a future version. It is instead recommended "
+                      "that users use timezone-aware objects to represent "
+                      "datetimes in UTC. To get such an object representing "
+                      "the current time, use datetime.now(datetime.UTC).",
+                      DeprecationWarning,
+                      stacklevel=2)
         t = _time.time()
-        return cls.utcfromtimestamp(t)
+        return cls._fromtimestamp(t, True, None)
 
     @classmethod
     def combine(cls, date, time, tzinfo=True):

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -143,13 +143,13 @@ def formatdate(timeval=None, localtime=False, usegmt=False):
     # 2822 requires that day and month names be the English abbreviations.
     if timeval is None:
         timeval = time.time()
-    if localtime or usegmt:
-        dt = datetime.datetime.fromtimestamp(timeval, datetime.timezone.utc)
-    else:
-        dt = datetime.datetime.utcfromtimestamp(timeval)
+    dt = datetime.datetime.fromtimestamp(timeval, datetime.timezone.utc)
+
     if localtime:
         dt = dt.astimezone()
         usegmt = False
+    elif not usegmt:
+        dt = dt.replace(tzinfo=None)
     return format_datetime(dt, usegmt)
 
 def format_datetime(dt, usegmt=False):

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -104,9 +104,9 @@ def time2isoz(t=None):
 
     """
     if t is None:
-        dt = datetime.datetime.utcnow()
+        dt = datetime.datetime.now(tz=datetime.UTC)
     else:
-        dt = datetime.datetime.utcfromtimestamp(t)
+        dt = datetime.datetime.fromtimestamp(t, tz=datetime.UTC)
     return "%04d-%02d-%02d %02d:%02d:%02dZ" % (
         dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
 
@@ -122,9 +122,9 @@ def time2netscape(t=None):
 
     """
     if t is None:
-        dt = datetime.datetime.utcnow()
+        dt = datetime.datetime.now(tz=datetime.UTC)
     else:
-        dt = datetime.datetime.utcfromtimestamp(t)
+        dt = datetime.datetime.fromtimestamp(t, tz=datetime.UTC)
     return "%s, %02d-%s-%04d %02d:%02d:%02d GMT" % (
         DAYS[dt.weekday()], dt.day, MONTHS[dt.month-1],
         dt.year, dt.hour, dt.minute, dt.second)

--- a/Lib/test/support/testresult.py
+++ b/Lib/test/support/testresult.py
@@ -18,10 +18,13 @@ class RegressionTestResult(unittest.TextTestResult):
         self.buffer = True
         if self.USE_XML:
             from xml.etree import ElementTree as ET
-            from datetime import datetime
+            from datetime import datetime, UTC
             self.__ET = ET
             self.__suite = ET.Element('testsuite')
-            self.__suite.set('start', datetime.utcnow().isoformat(' '))
+            self.__suite.set('start',
+                             datetime.now(UTC)
+                                     .replace(tzinfo=None)
+                                     .isoformat(' '))
             self.__e = None
         self.__start_time = None
 

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -925,7 +925,7 @@ class TestBinaryPlistlib(unittest.TestCase):
         # Issue #26709: 32-bit timestamp out of range
         for ts in -2**31-1, 2**31:
             with self.subTest(ts=ts):
-                d = (datetime.datetime.utcfromtimestamp(0) +
+                d = (datetime.datetime(1970, 1, 1, 0, 0) +
                      datetime.timedelta(seconds=ts))
                 data = plistlib.dumps(d, fmt=plistlib.FMT_BINARY)
                 self.assertEqual(plistlib.loads(data), d)

--- a/Lib/test/test_sqlite3/test_types.py
+++ b/Lib/test/test_sqlite3/test_types.py
@@ -517,7 +517,7 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(ts, ts2)
 
     def test_sql_timestamp(self):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(tz=datetime.UTC)
         self.cur.execute("insert into test(ts) values (current_timestamp)")
         self.cur.execute("select ts from test")
         with self.assertWarnsRegex(DeprecationWarning, "converter"):

--- a/Misc/NEWS.d/next/Library/2023-04-25-17-03-18.gh-issue-103857.Mr2Cak.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-25-17-03-18.gh-issue-103857.Mr2Cak.rst
@@ -1,0 +1,2 @@
+Deprecated :meth:`datetime.datetime.utcnow` and
+:meth:`datetime.datetime.utcfromtimestamp`. (Patch by Paul Ganssle)

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5147,9 +5147,8 @@ datetime_utcnow(PyObject *cls, PyObject *dummy)
     PyErr_WarnEx(
         PyExc_DeprecationWarning,
         "datetime.utcnow() is deprecated and scheduled for removal in a future "
-        "version. It is instead recommended that users use timezone-aware "
-        "objects to represent datetimes in UTC. To get such an object "
-        "representing the current time, use datetime.now(datetime.UTC).",
+        "version. Use timezone-aware objects to represent datetimes in UTC: "
+        "datetime.now(datetime.UTC).",
         2
     );
     return datetime_best_possible(cls, _PyTime_gmtime, Py_None);
@@ -5191,9 +5190,8 @@ datetime_utcfromtimestamp(PyObject *cls, PyObject *args)
     PyErr_WarnEx(
         PyExc_DeprecationWarning,
         "datetime.utcfromtimestamp() is deprecated and scheduled for removal "
-        "in a future version. It is instead recommended that users use "
-        "timezone-aware objects to represent datetimes in UTC. To get such an "
-        "object from a timestamp, use datetime.fromtimestamp(t, datetime.UTC).",
+        "in a future version. Use timezone-aware objects to represent "
+        "datetimes in UTC: datetime.now(datetime.UTC).",
         2
     );
     PyObject *timestamp;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5144,6 +5144,14 @@ datetime_datetime_now_impl(PyTypeObject *type, PyObject *tz)
 static PyObject *
 datetime_utcnow(PyObject *cls, PyObject *dummy)
 {
+    PyErr_WarnEx(
+        PyExc_DeprecationWarning,
+        "datetime.utcnow() is deprecated and scheduled for removal in a future "
+        "version. It is instead recommended that users use timezone-aware "
+        "objects to represent datetimes in UTC. To get such an object "
+        "representing the current time, use datetime.now(datetime.UTC).",
+        2
+    );
     return datetime_best_possible(cls, _PyTime_gmtime, Py_None);
 }
 
@@ -5180,6 +5188,14 @@ datetime_fromtimestamp(PyObject *cls, PyObject *args, PyObject *kw)
 static PyObject *
 datetime_utcfromtimestamp(PyObject *cls, PyObject *args)
 {
+    PyErr_WarnEx(
+        PyExc_DeprecationWarning,
+        "datetime.utcfromtimestamp() is deprecated and scheduled for removal "
+        "in a future version. It is instead recommended that users use "
+        "timezone-aware objects to represent datetimes in UTC. To get such an "
+        "object from a timestamp, use datetime.fromtimestamp(t, datetime.UTC).",
+        2
+    );
     PyObject *timestamp;
     PyObject *result = NULL;
 


### PR DESCRIPTION
Per the reasoning in #103857.

To do:

- [x] Add tests
- [x] Clean up internal uses of `utcnow` and `utcfromtimestamp`

<!-- gh-issue-number: gh-103857 -->
* Issue: gh-103857
<!-- /gh-issue-number -->
