### PR TITLE
gh-103884: Docs CI: Only attempt nit-picky PR annotations for PRs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -56,11 +56,13 @@ jobs:
 
     # Add pull request annotations for Sphinx nitpicks (missing references)
     - name: 'Get list of changed files'
+      if: github.event_name == 'pull_request'
       id: changed_files
       uses: Ana06/get-changed-files@v2.2.0
       with:
         filter: "Doc/**"
     - name: 'Build changed files in nit-picky mode'
+      if: github.event_name == 'pull_request'
       continue-on-error: true
       run: |
         # Mark files the pull request modified


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

# Demo

## workflow_dispatch

Here's a run triggered via workflow_dispatch that skips the PR-only steps:

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/1324225/234688690-80f5f9f6-b31d-41e4-9049-f51aa8accbc3.png">

https://github.com/hugovk/cpython/actions/runs/4812500548/jobs/8567820152

## PR

Still runs the PR-only steps:

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/1324225/234690365-93da2fb4-7513-4a59-a9be-5608fd6605b8.png">

https://github.com/python/cpython/actions/runs/4812826762/jobs/8568570462?pr=103889


<!-- gh-issue-number: gh-103884 -->
* Issue: gh-103884
<!-- /gh-issue-number -->
