### PR TITLE
[3.11] gh-101786: Clarify docs that asyncio.Server.sockets is a socket-like TransportSocket (GH-103877)

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1538,7 +1538,7 @@ Server objects are created by :meth:`loop.create_server`,
 :meth:`loop.create_unix_server`, :func:`start_server`,
 and :func:`start_unix_server` functions.
 
-Do not instantiate the class directly.
+Do not instantiate the :class:`Server` class directly.
 
 .. class:: Server
 
@@ -1629,7 +1629,8 @@ Do not instantiate the class directly.
 
    .. attribute:: sockets
 
-      List of :class:`socket.socket` objects the server is listening on.
+      List of socket-like objects, ``asyncio.trsock.TransportSocket``, which
+      the server is listening on.
 
       .. versionchanged:: 3.7
          Prior to Python 3.7 ``Server.sockets`` used to return an


### PR DESCRIPTION
Clarify that asyncio.Server.sockets is a socket-like TransportSocket (cherry picked from commit 1c0a9c5a1c84bc334f2bde9d45676f19d9632823)

<!-- gh-issue-number: gh-101786 -->
* Issue: gh-101786
<!-- /gh-issue-number -->
