### PR TITLE
gh-102628: Fix sqlite3 CLI promt text on Windows

### DIFF
--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -94,12 +94,13 @@ def main():
         db_name = repr(args.filename)
 
     # Prepare REPL banner and prompts.
+    eofkey = "CTRL-Z" if sys.platform == "win32" else "CTRL-D"
     banner = dedent(f"""
         sqlite3 shell, running on SQLite version {sqlite3.sqlite_version}
         Connected to {db_name}
 
         Each command will be run using execute() on the cursor.
-        Type ".help" for more information; type ".quit" or CTRL-D to quit.
+        Type ".help" for more information; type ".quit" or {eofkey} to quit.
     """).strip()
     sys.ps1 = "sqlite> "
     sys.ps2 = "    ... "

--- a/Misc/NEWS.d/next/Library/2023-04-27-00-05-32.gh-issue-102628.X230E-.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-27-00-05-32.gh-issue-102628.X230E-.rst
@@ -1,0 +1,2 @@
+Substitute CTRL-D with CTRL-Z in :mod:`sqlite3` CLI banner when running on
+Windows.


### PR DESCRIPTION
CTRL-Z is the Windows equivalent of CTRL-D.


<!-- gh-issue-number: gh-102628 -->
* Issue: gh-102628
<!-- /gh-issue-number -->
