### PR TITLE
gh-94673: More Per-Interpreter Fields for Builtin Static Types

### DIFF
--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -44,6 +44,8 @@ struct type_cache {
 
 typedef struct {
     PyTypeObject *type;
+    // XXX tp_dict, tp_bases, and tp_mro can probably be statically
+    // allocated, instead of dynamically and stored on the interpreter.
     PyObject *tp_dict;
     PyObject *tp_bases;
     PyObject *tp_mro;

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -44,6 +44,9 @@ struct type_cache {
 
 typedef struct {
     PyTypeObject *type;
+    PyObject *tp_dict;
+    PyObject *tp_bases;
+    PyObject *tp_mro;
     PyObject *tp_subclasses;
     /* We never clean up weakrefs for static builtin types since
        they will effectively never get triggered.  However, there

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -44,6 +44,8 @@ struct type_cache {
 
 typedef struct {
     PyTypeObject *type;
+    int readying;
+    int ready;
     // XXX tp_dict, tp_bases, and tp_mro can probably be statically
     // allocated, instead of dynamically and stored on the interpreter.
     PyObject *tp_dict;

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -7,6 +7,7 @@
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "pycore_object.h"        // _PyType_GetSubclasses()
 #include "pycore_runtime.h"       // _Py_ID()
+#include "pycore_typeobject.h"    // _PyType_GetMRO()
 #include "clinic/_abc.c.h"
 
 /*[clinic input]

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -511,7 +511,6 @@ _PyStructSequence_InitBuiltinWithFlags(PyInterpreterState *interp,
     Py_ssize_t n_members = count_members(desc, &n_unnamed_members);
     PyMemberDef *members = NULL;
 
-    int initialized = 1;
     if ((type->tp_flags & Py_TPFLAGS_READY) == 0) {
         assert(type->tp_name == NULL);
         assert(type->tp_members == NULL);
@@ -524,7 +523,6 @@ _PyStructSequence_InitBuiltinWithFlags(PyInterpreterState *interp,
         initialize_static_fields(type, desc, members, tp_flags);
 
         _Py_SetImmortal(type);
-        initialized = 0;
     }
 #ifndef NDEBUG
     else {
@@ -543,13 +541,10 @@ _PyStructSequence_InitBuiltinWithFlags(PyInterpreterState *interp,
                      desc->name);
         goto error;
     }
-    // This should be dropped if tp_dict is made per-interpreter.
-    if (initialized) {
-        return 0;
-    }
 
     if (initialize_structseq_dict(
-            desc, _PyType_GetDict(type), n_members, n_unnamed_members) < 0) {
+            desc, _PyType_GetDict(type), n_members, n_unnamed_members) < 0)
+    {
         goto error;
     }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7274,15 +7274,12 @@ _PyStaticType_InitBuiltin(PyInterpreterState *interp, PyTypeObject *self)
 
         static_builtin_state_init(interp, self);
 
-        /* Per-interpreter tp_subclasses is done lazily.
-           Otherwise we would initialize it here. */
-
-        assert(_PyType_CheckConsistency(self));
         /* We must explicitly set these for subinterpreters.
            tp_subclasses is set lazily. */
         type_ready_set_dict(self);
         type_ready_set_bases(self);
         type_ready_mro(self);
+        assert(_PyType_CheckConsistency(self));
         return 0;
     }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6758,6 +6758,10 @@ type_ready_pre_checks(PyTypeObject *type)
 static int
 type_ready_set_bases(PyTypeObject *type)
 {
+    if (lookup_tp_bases(type) != NULL) {
+        return 0;
+    }
+
     /* Initialize tp_base (defaults to BaseObject unless that's us) */
     PyTypeObject *base = type->tp_base;
     if (base == NULL && type != &PyBaseObject_Type) {
@@ -7274,6 +7278,11 @@ _PyStaticType_InitBuiltin(PyInterpreterState *interp, PyTypeObject *self)
            Otherwise we would initialize it here. */
 
         assert(_PyType_CheckConsistency(self));
+        /* We must explicitly set these for subinterpreters.
+           tp_subclasses is set lazily. */
+        type_ready_set_dict(self);
+        type_ready_set_bases(self);
+        type_ready_mro(self);
         return 0;
     }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1082,13 +1082,21 @@ type_set_abstractmethods(PyTypeObject *type, PyObject *value, void *context)
 static PyObject *
 type_get_bases(PyTypeObject *type, void *context)
 {
-    return Py_NewRef(lookup_tp_bases(type));
+    PyObject *bases = lookup_tp_bases(type);
+    if (bases == NULL) {
+        Py_RETURN_NONE;
+    }
+    return Py_NewRef(bases);
 }
 
 static PyObject *
 type_get_mro(PyTypeObject *type, void *context)
 {
-    return Py_NewRef(lookup_tp_mro(type));
+    PyObject *mro = lookup_tp_mro(type);
+    if (mro == NULL) {
+        Py_RETURN_NONE;
+    }
+    return Py_NewRef(mro);
 }
 
 static PyTypeObject *best_base(PyObject *);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -184,6 +184,7 @@ lookup_tp_dict(PyTypeObject *self)
 PyObject *
 _PyType_GetDict(PyTypeObject *self)
 {
+    /* It returns a borrowed reference. */
     return lookup_tp_dict(self);
 }
 
@@ -229,6 +230,7 @@ lookup_tp_bases(PyTypeObject *self)
 PyObject *
 _PyType_GetBases(PyTypeObject *self)
 {
+    /* It returns a borrowed reference. */
     return lookup_tp_bases(self);
 }
 
@@ -274,6 +276,7 @@ lookup_tp_mro(PyTypeObject *self)
 PyObject *
 _PyType_GetMRO(PyTypeObject *self)
 {
+    /* It returns a borrowed reference. */
     return lookup_tp_mro(self);
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -809,7 +809,6 @@ static PyMemberDef type_members[] = {
     {"__base__", T_OBJECT, offsetof(PyTypeObject, tp_base), READONLY},
     {"__dictoffset__", T_PYSSIZET,
      offsetof(PyTypeObject, tp_dictoffset), READONLY},
-    {"__mro__", T_OBJECT, offsetof(PyTypeObject, tp_mro), READONLY},
     {0}
 };
 
@@ -1024,6 +1023,12 @@ static PyObject *
 type_get_bases(PyTypeObject *type, void *context)
 {
     return Py_NewRef(lookup_tp_bases(type));
+}
+
+static PyObject *
+type_get_mro(PyTypeObject *type, void *context)
+{
+    return Py_NewRef(lookup_tp_mro(type));
 }
 
 static PyTypeObject *best_base(PyObject *);
@@ -1402,6 +1407,7 @@ static PyGetSetDef type_getsets[] = {
     {"__name__", (getter)type_name, (setter)type_set_name, NULL},
     {"__qualname__", (getter)type_qualname, (setter)type_set_qualname, NULL},
     {"__bases__", (getter)type_get_bases, (setter)type_set_bases, NULL},
+    {"__mro__", (getter)type_get_mro, NULL, NULL},
     {"__module__", (getter)type_module, (setter)type_set_module, NULL},
     {"__abstractmethods__", (getter)type_abstractmethods,
      (setter)type_set_abstractmethods, NULL},


### PR DESCRIPTION
This involves moving `tp_dict`, `tp_bases`, and `tp_mro` to `PyInterpreterState`, in the same way we did for `tp_subclasses`.  Those three fields are effectively const for builtin static types (unlike `tp_subclasses`).  In theory we only need to make their values immortal, along with their contents.  However, that isn't such a simple proposition.  (See gh-103823.)  In the meantime the simplest solution is to move the fields into the interpreter.

One alternative is to statically allocate the values, but that's its own can of worms.

<!-- gh-issue-number: gh-94673 -->
* Issue: gh-94673
<!-- /gh-issue-number -->
