### PR TITLE
[3.11] gh-103883: Doc: Move PyUnicode_FromObject doc (GH-103913)

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -572,6 +572,15 @@ APIs:
    arguments.
 
 
+.. c:function:: PyObject* PyUnicode_FromObject(PyObject *obj)
+
+   Copy an instance of a Unicode subtype to a new true Unicode object if
+   necessary. If *obj* is already a true Unicode object (not a subtype),
+   return the reference with incremented refcount.
+
+   Objects other than Unicode or its subtypes will cause a :exc:`TypeError`.
+
+
 .. c:function:: PyObject* PyUnicode_FromEncodedObject(PyObject *obj, \
                                const char *encoding, const char *errors)
 
@@ -750,15 +759,6 @@ Extension modules can continue using them, as they will not be removed in Python
    .. deprecated-removed:: 3.3 3.12
       Part of the old-style Unicode API, please migrate to using
       :c:func:`PyUnicode_GET_LENGTH`.
-
-
-.. c:function:: PyObject* PyUnicode_FromObject(PyObject *obj)
-
-   Copy an instance of a Unicode subtype to a new true Unicode object if
-   necessary. If *obj* is already a true Unicode object (not a subtype),
-   return the reference with incremented refcount.
-
-   Objects other than Unicode or its subtypes will cause a :exc:`TypeError`.
 
 
 Locale Encoding


### PR DESCRIPTION
This API is one of Unicode creator APIs.
This APIs should not be placed in PEP 393 deprecated APIs.

(cherry picked from commit ce2383ec6665850a1bdffad388876481b6f3205f)

<!-- gh-issue-number: gh-103883 -->
* Issue: gh-103883
<!-- /gh-issue-number -->
