### PR TITLE
[3.11] gh-103880: Fix `assertRaises` usage in `test_genericalias` (GH-103916)

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -305,8 +305,11 @@ class BaseTest(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             list[int][int]
+        with self.assertRaises(TypeError):
             dict[T, int][str, int]
+        with self.assertRaises(TypeError):
             dict[str, T][str, int]
+        with self.assertRaises(TypeError):
             dict[T, T][str, int]
 
     def test_equality(self):


### PR DESCRIPTION
(cherry picked from commit dff8e5dc8d0758d1f9c55fdef308e44aefebe1a2)


<!-- gh-issue-number: gh-103880 -->
* Issue: gh-103880
<!-- /gh-issue-number -->
