### PR TITLE
gh-82054: allow test runner to split test_asyncio to execute in parallel by sharding.

### DIFF
--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -150,7 +150,7 @@ NOTTESTS = set()
 
 SPLITTESTDIRS = {
     "test_asyncio",
-    "test_compiler",
+    "test_multiprocessing",
 }
 
 # Storage of uncollectable objects

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -177,13 +177,10 @@ def findtests(testdir=None, stdtests=STDTESTS, nottests=NOTTESTS, *, split_test_
         if mod[:5] == "test_" and mod not in others:
             if mod in split_test_dirs:
                 subdir = os.path.join(testdir, mod)
-                if len(base_mod):
-                    mod = f"{base_mod}.{mod}"
-                else:
-                    mod = f"test.{mod}"
+                mod = f"{base_mod or 'test'}.{mod}"
                 tests.extend(findtests(subdir, [], nottests, split_test_dirs=split_test_dirs, base_mod=mod))
             elif ext in (".py", ""):
-                tests.append(f"{base_mod}.{mod}" if len(base_mod) else mod)
+                tests.append(f"{base_mod}.{mod}" if base_mod else mod)
     return stdtests + sorted(tests)
 
 

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -19,10 +19,10 @@ from test.libregrtest.utils import clear_caches, format_duration, print_warning
 
 class TestResult:
     def __init__(
-            self,
-            name: str,
-            duration_sec: float = 0.0,
-            xml_data: list[str] | None = None,
+        self,
+        name: str,
+        duration_sec: float = 0.0,
+        xml_data: list[str] | None = None,
     ) -> None:
         self.name = name
         self.duration_sec = duration_sec
@@ -39,12 +39,12 @@ class Passed(TestResult):
 
 class Failed(TestResult):
     def __init__(
-            self,
-            name: str,
-            duration_sec: float = 0.0,
-            xml_data: list[str] | None = None,
-            errors: list[tuple[str, str]] | None = None,
-            failures: list[tuple[str, str]] | None = None,
+        self,
+        name: str,
+        duration_sec: float = 0.0,
+        xml_data: list[str] | None = None,
+        errors: list[tuple[str, str]] | None = None,
+        failures: list[tuple[str, str]] | None = None,
     ) -> None:
         super().__init__(name, duration_sec=duration_sec, xml_data=xml_data)
         self.errors = errors
@@ -128,16 +128,16 @@ PROGRESS_MIN_TIME = 30.0   # seconds
 # small set of tests to determine if we have a basically functioning interpreter
 # (i.e. if any of these fail, then anything else is likely to follow)
 STDTESTS = [
-        'test_grammar',
-        'test_opcodes',
-        'test_dict',
-        'test_builtin',
-        'test_exceptions',
-        'test_types',
-        'test_unittest',
-        'test_doctest',
-        'test_doctest2',
-        'test_support'
+    'test_grammar',
+    'test_opcodes',
+    'test_dict',
+    'test_builtin',
+    'test_exceptions',
+    'test_types',
+    'test_unittest',
+    'test_doctest',
+    'test_doctest2',
+    'test_support'
 ]
 
 # set of tests that we don't want to be executed when using regrtest
@@ -149,8 +149,8 @@ NOTTESTS = set()
 # __init__.py may do things which alter what tests are to be run.
 
 SPLITTESTDIRS = {
-        "test_asyncio",
-        "test_compiler",
+    "test_asyncio",
+    "test_compiler",
 }
 
 # Storage of uncollectable objects
@@ -203,7 +203,7 @@ def _runtest(ns: Namespace, test_name: str) -> TestResult:
     output_on_failure = ns.verbose3
 
     use_timeout = (
-            ns.timeout is not None and threading_helper.can_start_thread
+        ns.timeout is not None and threading_helper.can_start_thread
     )
     if use_timeout:
         faulthandler.dump_traceback_later(ns.timeout, exit=True)
@@ -234,7 +234,7 @@ def _runtest(ns: Namespace, test_name: str) -> TestResult:
                 print_warning.orig_stderr = stream
 
                 result = _runtest_inner(ns, test_name,
-                                                                display_failure=False)
+                                        display_failure=False)
                 if not isinstance(result, Passed):
                     output = stream.getvalue()
             finally:
@@ -250,13 +250,13 @@ def _runtest(ns: Namespace, test_name: str) -> TestResult:
             support.verbose = ns.verbose
 
             result = _runtest_inner(ns, test_name,
-                                                            display_failure=not ns.verbose)
+                                    display_failure=not ns.verbose)
 
         if xml_list:
             import xml.etree.ElementTree as ET
             result.xml_data = [
-                    ET.tostring(x).decode('us-ascii')
-                    for x in xml_list
+                ET.tostring(x).decode('us-ascii')
+                for x in xml_list
             ]
 
         result.duration_sec = time.perf_counter() - start_time
@@ -284,7 +284,7 @@ def runtest(ns: Namespace, test_name: str) -> TestResult:
         if not ns.pgo:
             msg = traceback.format_exc()
             print(f"test {test_name} crashed -- {msg}",
-                      file=sys.stderr, flush=True)
+                  file=sys.stderr, flush=True)
         return Failed(test_name)
 
 
@@ -345,7 +345,7 @@ def _runtest_inner2(ns: Namespace, test_name: str) -> bool:
     if gc.garbage:
         support.environment_altered = True
         print_warning(f"{test_name} created {len(gc.garbage)} "
-                                  f"uncollectable object(s).")
+                      f"uncollectable object(s).")
 
         # move the uncollectable objects somewhere,
         # so we don't see them again
@@ -358,7 +358,7 @@ def _runtest_inner2(ns: Namespace, test_name: str) -> bool:
 
 
 def _runtest_inner(
-        ns: Namespace, test_name: str, display_failure: bool = True
+    ns: Namespace, test_name: str, display_failure: bool = True
 ) -> TestResult:
     # Detect environment changes, handle exceptions.
 
@@ -404,7 +404,7 @@ def _runtest_inner(
         if not ns.pgo:
             msg = traceback.format_exc()
             print(f"test {test_name} crashed -- {msg}",
-                      file=sys.stderr, flush=True)
+                  file=sys.stderr, flush=True)
         return UncaughtException(test_name)
 
     if refleak:
@@ -432,7 +432,7 @@ def cleanup_test_droppings(test_name: str, verbose: int) -> None:
             kind, nuker = "file", os.unlink
         else:
             raise RuntimeError(f"os.path says {name!r} exists but is neither "
-                                               f"directory nor file")
+                               f"directory nor file")
 
         if verbose:
             print_warning(f"{test_name} left behind {kind} {name!r}")
@@ -445,4 +445,4 @@ def cleanup_test_droppings(test_name: str, verbose: int) -> None:
             nuker(name)
         except Exception as exc:
             print_warning(f"{test_name} left behind {kind} {name!r} "
-                                      f"and it couldn't be removed: {exc}")
+                          f"and it couldn't be removed: {exc}")

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -150,7 +150,6 @@ NOTTESTS = set()
 
 SPLITTESTDIRS = {
     "test_asyncio",
-    "test_multiprocessing",
 }
 
 # Storage of uncollectable objects
@@ -167,7 +166,7 @@ def findtestdir(path=None):
     return path or os.path.dirname(os.path.dirname(__file__)) or os.curdir
 
 
-def findtests(testdir=None, stdtests=STDTESTS, nottests=NOTTESTS, splittestdirs=SPLITTESTDIRS, base_mod=""):
+def findtests(testdir=None, stdtests=STDTESTS, nottests=NOTTESTS, *, split_test_dirs=SPLITTESTDIRS, base_mod=""):
     """Return a list of all applicable test modules."""
     testdir = findtestdir(testdir)
     names = os.listdir(testdir)
@@ -176,13 +175,13 @@ def findtests(testdir=None, stdtests=STDTESTS, nottests=NOTTESTS, splittestdirs=
     for name in names:
         mod, ext = os.path.splitext(name)
         if mod[:5] == "test_" and mod not in others:
-            if mod in splittestdirs:
+            if mod in split_test_dirs:
                 subdir = os.path.join(testdir, mod)
                 if len(base_mod):
                     mod = f"{base_mod}.{mod}"
                 else:
                     mod = f"test.{mod}"
-                tests.extend(findtests(subdir, [], nottests, splittestdirs, mod))
+                tests.extend(findtests(subdir, [], nottests, split_test_dirs=split_test_dirs, base_mod=mod))
             elif ext in (".py", ""):
                 tests.append(f"{base_mod}.{mod}" if len(base_mod) else mod)
     return stdtests + sorted(tests)


### PR DESCRIPTION
## Summary:

This runs test_asyncio sub-tests in parallel using sharding from Cinder. This suite is typically the longest-pole in runs because it is a test package with a lot of further sub-tests otherwise run serially. By breaking out the sub-tests as independent modules we can run a lot more in parallel.

After porting we can see the direct impact on a multicore system.
* Without this change:
  * Running make test is 5 min 26 seconds
* With this change:
  * Running make test takes 3 min 39 seconds

The drawbacks are that this implementation is hacky and due to the sorting of the tests it obscures when the asyncio tests occur and involves changing CPython test infrastructure but, the wall time saved it is worth it, especially in low-core count CI runs as it pulls a long tail. The win for productivity and reserved CI resource usage is significant.

Future tests that deserve to be refactored into split up suites to benefit from are `test_concurrent_futures` and the way the `_test_multiprocessing` suite gets run for all start methods.  As exposed by passing the `-o` flag to `python -m test` to get a list of the 10 longest running tests.

<!-- gh-issue-number: gh-82054 -->
* Issue: gh-82054
<!-- /gh-issue-number -->
