### PR TITLE
GH-103929: handle long input lines with PyOS_InputHook

### DIFF
--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -151,6 +151,8 @@ the same library that the Python runtime is using.
    event loops, as done in :file:`Modules/_tkinter.c` in the
    Python source code.
 
+   This function should block until stdin is readable.
+
    .. versionchanged:: 3.12
       This function is only called from the
       :ref:`main interpreter <sub-interpreter-support>`.

--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -151,7 +151,8 @@ the same library that the Python runtime is using.
    event loops, as done in :file:`Modules/_tkinter.c` in the
    Python source code.
 
-   This function should block until stdin is readable.
+   This function should block until stdin is readable but may return
+   early.
 
    .. versionchanged:: 3.12
       This function is only called from the

--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -151,8 +151,7 @@ the same library that the Python runtime is using.
    event loops, as done in :file:`Modules/_tkinter.c` in the
    Python source code.
 
-   This function should block until stdin is readable but may return
-   early.
+   This function should block until stdin is readable.
 
    .. versionchanged:: 3.12
       This function is only called from the

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-29-00-00-00.gh-issue-103929.InputHook.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-29-00-00-00.gh-issue-103929.InputHook.rst
@@ -1,0 +1,1 @@
+Fix repeated calls to :c:var:`PyOS_InputHook` for long input lines.

--- a/Parser/myreadline.c
+++ b/Parser/myreadline.c
@@ -38,7 +38,7 @@ int (*PyOS_InputHook)(void) = NULL;
    except if _PyOS_InterruptOccurred() returns true. */
 
 static int
-my_fgets(PyThreadState* tstate, char *buf, int len, FILE *fp)
+my_fgets(PyThreadState* tstate, char *buf, int len, FILE *fp, int n)
 {
 #ifdef MS_WINDOWS
     HANDLE handle;
@@ -53,7 +53,7 @@ my_fgets(PyThreadState* tstate, char *buf, int len, FILE *fp)
 #endif
 
     while (1) {
-        if (PyOS_InputHook != NULL &&
+        if (PyOS_InputHook != NULL && n == 0 &&
             // GH-104668: See PyOS_ReadlineFunctionPointer's comment below...
             _Py_IsMainInterpreter(tstate->interp))
         {
@@ -333,7 +333,7 @@ PyOS_StdioReadline(FILE *sys_stdin, FILE *sys_stdout, const char *prompt)
             return NULL;
         }
         p = pr;
-        int err = my_fgets(tstate, p + n, (int)incr, sys_stdin);
+        int err = my_fgets(tstate, p + n, (int)incr, sys_stdin, n);
         if (err == 1) {
             // Interrupt
             PyMem_RawFree(p);

--- a/Parser/myreadline.c
+++ b/Parser/myreadline.c
@@ -306,12 +306,12 @@ PyOS_StdioReadline(FILE *sys_stdin, FILE *sys_stdout, const char *prompt)
         fprintf(stderr, "%s", prompt);
     }
     fflush(stderr);
-
+    // Keep this outside my_fgets(): long lines call my_fgets() repeatedly.
     if (PyOS_InputHook != NULL &&
         // GH-104668: See PyOS_ReadlineFunctionPointer's comment below...
         _Py_IsMainInterpreter(tstate->interp))
     {
-      (void)(PyOS_InputHook)();
+        (void)(PyOS_InputHook)();
     }
 
     n = 0;


### PR DESCRIPTION
If:
 - stdin is in line buffer mode
 - the readline module is not loaded
 - not on windows
 - a GUI toolkit has installd PyOS_InputHook

Then, if the user enters lines longer than 98 characters into `input`:

 - user calls `input(...)`
 - user types/pastes a line longer than 98 characters + 1 newline
 - PyOS_InputHook returns
 - the first 99 characters are returned
 - the last character is not a new line so we go back to my_fgets
 - the PyOS_InputHook blocks because despite there being value in the buffer, stdin does not flag itself as ready to be read again
 - user hits enter again and to finish reading the input
 - the extra new line comes out the next time the user calls input

This fixes this bug by passing the currently read number of characters to `my_fgets` to skip the input hook when reading out a long buffer.

closes #103929


------

Qustions:

 - I do not know how to test this other than manually
 - It seems to work when stdin is unbuffered, but I do not fully understand why
 - Is the edit to the docs of PyOS_InputHook correct?


<!-- gh-issue-number: gh-103929 -->
* Issue: gh-103929
<!-- /gh-issue-number -->
