### PR TITLE
gh-68968: Correcting message display issue with assertEqual

### DIFF
--- a/Lib/test/test_unittest/test_assertions.py
+++ b/Lib/test/test_unittest/test_assertions.py
@@ -273,9 +273,9 @@ class TestLongMessage(unittest.TestCase):
 
     def testAssertMultiLineEqual(self):
         self.assertMessages('assertMultiLineEqual', ("", "foo"),
-                            [r"\+ foo$", "^oops$",
-                             r"\+ foo$",
-                             r"\+ foo : oops$"])
+                            [r"\+ foo\n$", "^oops$",
+                             r"\+ foo\n$",
+                             r"\+ foo\n : oops$"])
 
     def testAssertLess(self):
         self.assertMessages('assertLess', (2, 1),

--- a/Lib/test/test_unittest/test_case.py
+++ b/Lib/test/test_unittest/test_case.py
@@ -1149,6 +1149,66 @@ test case
             error = str(e).split('\n', 1)[1]
             self.assertEqual(sample_text_error, error)
 
+    def testAssertEqualwithEmptyString(self):
+        '''Verify when there is an empty string involved, the diff output
+         does not treat the empty string as a single empty line. It should
+         instead be handled as a non-line.
+        '''
+        sample_text = ''
+        revised_sample_text = 'unladen swallows fly quickly'
+        sample_text_error = '''\
++ unladen swallows fly quickly
+'''
+        try:
+            self.assertEqual(sample_text, revised_sample_text)
+        except self.failureException as e:
+            # need to remove the first line of the error message
+            error = str(e).split('\n', 1)[1]
+            self.assertEqual(sample_text_error, error)
+
+    def testAssertEqualMultipleLinesMissingNewlineTerminator(self):
+        '''Verifying format of diff output from assertEqual involving strings
+         with multiple lines, but missing the terminating newline on both.
+        '''
+        sample_text = 'laden swallows\nfly sloely'
+        revised_sample_text = 'laden swallows\nfly slowly'
+        sample_text_error = '''\
+  laden swallows
+- fly sloely
+?        ^
++ fly slowly
+?        ^
+'''
+        try:
+            self.assertEqual(sample_text, revised_sample_text)
+        except self.failureException as e:
+            # need to remove the first line of the error message
+            error = str(e).split('\n', 1)[1]
+            self.assertEqual(sample_text_error, error)
+
+    def testAssertEqualMultipleLinesMismatchedNewlinesTerminators(self):
+        '''Verifying format of diff output from assertEqual involving strings
+         with multiple lines and mismatched newlines. The output should
+         include a - on it's own line to indicate the newline difference
+         between the two strings
+        '''
+        sample_text = 'laden swallows\nfly sloely\n'
+        revised_sample_text = 'laden swallows\nfly slowly'
+        sample_text_error = '''\
+  laden swallows
+- fly sloely
+?        ^
++ fly slowly
+?        ^
+-\x20
+'''
+        try:
+            self.assertEqual(sample_text, revised_sample_text)
+        except self.failureException as e:
+            # need to remove the first line of the error message
+            error = str(e).split('\n', 1)[1]
+            self.assertEqual(sample_text_error, error)
+
     def testEqualityBytesWarning(self):
         if sys.flags.bytes_warning:
             def bytes_warning():

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1236,13 +1236,13 @@ class TestCase(object):
             # \n should be added
             first_presplit = first
             second_presplit = second
-            if first != '' and second != '':
+            if first and second:
                 if first[-1] != '\n' or second[-1] != '\n':
                     first_presplit += '\n'
                     second_presplit += '\n'
-            elif first == '' and second != '' and second[-1] != '\n':
+            elif second and second[-1] != '\n':
                 second_presplit += '\n'
-            elif second == '' and first != '' and first[-1] != '\n':
+            elif first and first[-1] != '\n':
                 first_presplit += '\n'
 
             firstlines = first_presplit.splitlines(keepends=True)

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1216,20 +1216,38 @@ class TestCase(object):
             self.fail(msg)
 
     def assertMultiLineEqual(self, first, second, msg=None):
-        """Assert that two multi-line strings are equal."""
-        self.assertIsInstance(first, str, 'First argument is not a string')
-        self.assertIsInstance(second, str, 'Second argument is not a string')
+        """Assert that two multi-line strings are equal.
+         If the assertion fails, then provide an error message with a detailed
+         diff output
+        """
+        self.assertIsInstance(first, str, "First argument is not a string")
+        self.assertIsInstance(second, str, "Second argument is not a string")
 
         if first != second:
-            # don't use difflib if the strings are too long
+            # Don't use difflib if the strings are too long
             if (len(first) > self._diffThreshold or
                 len(second) > self._diffThreshold):
                 self._baseAssertEqual(first, second, msg)
-            firstlines = first.splitlines(keepends=True)
-            secondlines = second.splitlines(keepends=True)
-            if len(firstlines) == 1 and first.strip('\r\n') == first:
-                firstlines = [first + '\n']
-                secondlines = [second + '\n']
+
+            # Append \n to both strings if either is missing the \n.
+            # This allows the final ndiff to show the \n difference. The
+            # exception here is if the string is empty, in which case no
+            # \n should be added
+            first_presplit = first
+            second_presplit = second
+            if first != '' and second != '':
+                if first[-1] != '\n' or second[-1] != '\n':
+                    first_presplit += '\n'
+                    second_presplit += '\n'
+            elif first == '' and second != '' and second[-1] != '\n':
+                second_presplit += '\n'
+            elif second == '' and first != '' and first[-1] != '\n':
+                first_presplit += '\n'
+
+            firstlines = first_presplit.splitlines(keepends=True)
+            secondlines = second_presplit.splitlines(keepends=True)
+
+            # Generate the message and diff, then raise the exception
             standardMsg = '%s != %s' % _common_shorten_repr(first, second)
             diff = '\n' + ''.join(difflib.ndiff(firstlines, secondlines))
             standardMsg = self._truncateMessage(standardMsg, diff)

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1217,8 +1217,9 @@ class TestCase(object):
 
     def assertMultiLineEqual(self, first, second, msg=None):
         """Assert that two multi-line strings are equal.
-         If the assertion fails, then provide an error message with a detailed
-         diff output
+
+         If the assertion fails, provide an error message with a detailed
+         diff output.
         """
         self.assertIsInstance(first, str, "First argument is not a string")
         self.assertIsInstance(second, str, "Second argument is not a string")

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1216,11 +1216,7 @@ class TestCase(object):
             self.fail(msg)
 
     def assertMultiLineEqual(self, first, second, msg=None):
-        """Assert that two multi-line strings are equal.
-
-         If the assertion fails, provide an error message with a detailed
-         diff output.
-        """
+        """Assert that two multi-line strings are equal."""
         self.assertIsInstance(first, str, "First argument is not a string")
         self.assertIsInstance(second, str, "Second argument is not a string")
 

--- a/Misc/NEWS.d/next/Library/2023-04-27-18-46-31.gh-issue-68968.E3tnhy.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-27-18-46-31.gh-issue-68968.E3tnhy.rst
@@ -1,1 +1,1 @@
-Correcting message display issue causing output of assertEqual to be garbled when provided string inputs.
+Fixed garbled output of :meth:`~unittest.TestCase.assertEqual` when an input lacks final newline.

--- a/Misc/NEWS.d/next/Library/2023-04-27-18-46-31.gh-issue-68968.E3tnhy.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-27-18-46-31.gh-issue-68968.E3tnhy.rst
@@ -1,0 +1,1 @@
+Correcting message display issue causing output of assertEqual to be garbled when provided string inputs.


### PR DESCRIPTION
Correcting message display issue causing output of assertEqual  to be garbled when provided string inputs.


<!-- gh-issue-number: gh-68968 -->
* Issue: gh-68968
<!-- /gh-issue-number -->
