### PR TITLE
gh-94673: Ensure Builtin Static Types are Readied Properly

### DIFF
--- a/Include/internal/pycore_bytesobject.h
+++ b/Include/internal/pycore_bytesobject.h
@@ -9,11 +9,6 @@ extern "C" {
 #endif
 
 
-/* runtime lifecycle */
-
-extern PyStatus _PyBytes_InitTypes(PyInterpreterState *);
-
-
 /* Substring Search.
 
    Returns the index of the first occurrence of

--- a/Include/internal/pycore_tuple.h
+++ b/Include/internal/pycore_tuple.h
@@ -14,7 +14,6 @@ extern "C" {
 /* runtime lifecycle */
 
 extern PyStatus _PyTuple_InitGlobalObjects(PyInterpreterState *);
-extern PyStatus _PyTuple_InitTypes(PyInterpreterState *);
 extern void _PyTuple_Fini(PyInterpreterState *);
 
 

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -671,13 +671,11 @@ static PyTypeObject* static_types[] = {
 PyStatus
 _PyIO_InitTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return _PyStatus_OK();
-    }
-
-    // Set type base classes
 #ifdef HAVE_WINDOWS_CONSOLE_IO
-    PyWindowsConsoleIO_Type.tp_base = &PyRawIOBase_Type;
+    if (_Py_IsMainInterpreter(interp)) {
+        // Set type base classes
+        PyWindowsConsoleIO_Type.tp_base = &PyRawIOBase_Type;
+    }
 #endif
 
     for (size_t i=0; i < Py_ARRAY_LENGTH(static_types); i++) {

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2096,7 +2096,7 @@ math_trunc(PyObject *module, PyObject *x)
         return PyFloat_Type.tp_as_number->nb_int(x);
     }
 
-    if (Py_TYPE(x)->tp_dict == NULL) {
+    if (_PyType_IsReady(Py_TYPE(x))) {
         if (PyType_Ready(Py_TYPE(x)) < 0)
             return NULL;
     }

--- a/Modules/symtablemodule.c
+++ b/Modules/symtablemodule.c
@@ -67,12 +67,6 @@ static PyMethodDef symtable_methods[] = {
 };
 
 static int
-symtable_init_stentry_type(PyObject *m)
-{
-    return PyType_Ready(&PySTEntry_Type);
-}
-
-static int
 symtable_init_constants(PyObject *m)
 {
     if (PyModule_AddIntMacro(m, USE) < 0) return -1;
@@ -105,7 +99,6 @@ symtable_init_constants(PyObject *m)
 }
 
 static PyModuleDef_Slot symtable_slots[] = {
-    {Py_mod_exec, symtable_init_stentry_type},
     {Py_mod_exec, symtable_init_constants},
     {0, NULL}
 };

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3090,25 +3090,6 @@ error:
 }
 
 
-PyStatus
-_PyBytes_InitTypes(PyInterpreterState *interp)
-{
-    if (!_Py_IsMainInterpreter(interp)) {
-        return _PyStatus_OK();
-    }
-
-    if (PyType_Ready(&PyBytes_Type) < 0) {
-        return _PyStatus_ERR("Can't initialize bytes type");
-    }
-
-    if (PyType_Ready(&PyBytesIter_Type) < 0) {
-        return _PyStatus_ERR("Can't initialize bytes iterator type");
-    }
-
-    return _PyStatus_OK();
-}
-
-
 /*********************** Bytes Iterator ****************************/
 
 typedef struct {

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -181,7 +181,7 @@ method_getattro(PyObject *obj, PyObject *name)
     PyObject *descr = NULL;
 
     {
-        if (tp->tp_dict == NULL) {
+        if (!_PyType_IsReady(tp)) {
             if (PyType_Ready(tp) < 0)
                 return NULL;
         }
@@ -395,7 +395,7 @@ instancemethod_getattro(PyObject *self, PyObject *name)
     PyTypeObject *tp = Py_TYPE(self);
     PyObject *descr = NULL;
 
-    if (tp->tp_dict == NULL) {
+    if (!_PyType_IsReady(tp)) {
         if (PyType_Ready(tp) < 0)
             return NULL;
     }

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3591,10 +3591,6 @@ static struct static_exception static_exceptions[] = {
 int
 _PyExc_InitTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return 0;
-    }
-
     for (size_t i=0; i < Py_ARRAY_LENGTH(static_exceptions); i++) {
         PyTypeObject *exc = static_exceptions[i].exc;
         if (_PyStaticType_InitBuiltin(exc) < 0) {

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1990,10 +1990,6 @@ _PyFloat_InitState(PyInterpreterState *interp)
 PyStatus
 _PyFloat_InitTypes(PyInterpreterState *interp)
 {
-    if (PyType_Ready(&PyFloat_Type) < 0) {
-        return _PyStatus_ERR("Can't initialize float type");
-    }
-
     /* Init float info */
     if (_PyStructSequence_InitBuiltin(&FloatInfoType,
                                       &floatinfo_desc) < 0) {

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1990,20 +1990,14 @@ _PyFloat_InitState(PyInterpreterState *interp)
 PyStatus
 _PyFloat_InitTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return _PyStatus_OK();
-    }
-
     if (PyType_Ready(&PyFloat_Type) < 0) {
         return _PyStatus_ERR("Can't initialize float type");
     }
 
     /* Init float info */
-    if (FloatInfoType.tp_name == NULL) {
-        if (_PyStructSequence_InitBuiltin(&FloatInfoType,
-                                          &floatinfo_desc) < 0) {
-            return _PyStatus_ERR("can't init float info type");
-        }
+    if (_PyStructSequence_InitBuiltin(&FloatInfoType,
+                                      &floatinfo_desc) < 0) {
+        return _PyStatus_ERR("can't init float info type");
     }
 
     return _PyStatus_OK();

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6351,19 +6351,13 @@ PyLong_GetInfo(void)
 PyStatus
 _PyLong_InitTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return _PyStatus_OK();
-    }
-
     if (PyType_Ready(&PyLong_Type) < 0) {
         return _PyStatus_ERR("Can't initialize int type");
     }
 
     /* initialize int_info */
-    if (Int_InfoType.tp_name == NULL) {
-        if (_PyStructSequence_InitBuiltin(&Int_InfoType, &int_info_desc) < 0) {
-            return _PyStatus_ERR("can't init int info type");
-        }
+    if (_PyStructSequence_InitBuiltin(&Int_InfoType, &int_info_desc) < 0) {
+        return _PyStatus_ERR("can't init int info type");
     }
 
     return _PyStatus_OK();

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6351,10 +6351,6 @@ PyLong_GetInfo(void)
 PyStatus
 _PyLong_InitTypes(PyInterpreterState *interp)
 {
-    if (PyType_Ready(&PyLong_Type) < 0) {
-        return _PyStatus_ERR("Can't initialize int type");
-    }
-
     /* initialize int_info */
     if (_PyStructSequence_InitBuiltin(&Int_InfoType, &int_info_desc) < 0) {
         return _PyStatus_ERR("can't init int info type");

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -890,7 +890,7 @@ PyObject_Hash(PyObject *v)
      * an explicit call to PyType_Ready, we implicitly call
      * PyType_Ready here and then check the tp_hash slot again
      */
-    if (tp->tp_dict == NULL) {
+    if (!_PyType_IsReady(tp)) {
         if (PyType_Ready(tp) < 0)
             return -1;
         if (tp->tp_hash != NULL)
@@ -1385,7 +1385,7 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
     }
     Py_INCREF(name);
 
-    if (tp->tp_dict == NULL) {
+    if (!_PyType_IsReady(tp)) {
         if (PyType_Ready(tp) < 0)
             goto done;
     }
@@ -1507,8 +1507,9 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
         return -1;
     }
 
-    if (tp->tp_dict == NULL && PyType_Ready(tp) < 0)
+    if (!_PyType_IsReady(tp) && PyType_Ready(tp) < 0) {
         return -1;
+    }
 
     Py_INCREF(name);
     Py_INCREF(tp);

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -524,11 +524,15 @@ _PyStructSequence_InitBuiltinWithFlags(PyTypeObject *type,
         return -1;
     }
     initialize_static_fields(type, desc, members, tp_flags);
+
+    Py_INCREF(type);  // XXX It should be immortal.
     if (_PyStaticType_InitBuiltin(type) < 0) {
         PyMem_Free(members);
         goto failed_init_builtin;
     }
-    if (initialize_static_type(type, desc, n_members, n_unnamed_members) < 0) {
+
+    if (initialize_structseq_dict(
+            desc, type->tp_dict, n_members, n_unnamed_members) < 0) {
         PyMem_Free(members);
         return -1;
     }

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -960,24 +960,6 @@ _PyTuple_Resize(PyObject **pv, Py_ssize_t newsize)
 }
 
 
-PyStatus
-_PyTuple_InitTypes(PyInterpreterState *interp)
-{
-    if (!_Py_IsMainInterpreter(interp)) {
-        return _PyStatus_OK();
-    }
-
-    if (PyType_Ready(&PyTuple_Type) < 0) {
-        return _PyStatus_ERR("Can't initialize tuple type");
-    }
-
-    if (PyType_Ready(&PyTupleIter_Type) < 0) {
-        return _PyStatus_ERR("Can't initialize tuple iterator type");
-    }
-
-    return _PyStatus_OK();
-}
-
 static void maybe_freelist_clear(PyInterpreterState *, int);
 
 void

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6948,8 +6948,12 @@ type_ready_post_checks(PyTypeObject *type)
 static int
 type_ready(PyTypeObject *type)
 {
+    _PyObject_ASSERT((PyObject *)type,
+                     (type->tp_flags & Py_TPFLAGS_READYING) == 0);
+    type->tp_flags |= Py_TPFLAGS_READYING;
+
     if (type_ready_pre_checks(type) < 0) {
-        return -1;
+        goto error;
     }
 
 #ifdef Py_TRACE_REFS
@@ -6963,74 +6967,81 @@ type_ready(PyTypeObject *type)
 
     /* Initialize tp_dict: _PyType_IsReady() tests if tp_dict != NULL */
     if (type_ready_set_dict(type) < 0) {
-        return -1;
+        goto error;
     }
     if (type_ready_set_bases(type) < 0) {
-        return -1;
+        goto error;
     }
     if (type_ready_mro(type) < 0) {
-        return -1;
+        goto error;
     }
     if (type_ready_set_new(type) < 0) {
-        return -1;
+        goto error;
     }
     if (type_ready_fill_dict(type) < 0) {
-        return -1;
+        goto error;
     }
     if (type_ready_inherit(type) < 0) {
-        return -1;
+        goto error;
     }
     if (type_ready_preheader(type) < 0) {
-        return -1;
+        goto error;
     }
     if (type_ready_set_hash(type) < 0) {
-        return -1;
+        goto error;
     }
     if (type_ready_add_subclasses(type) < 0) {
-        return -1;
+        goto error;
     }
     if (type_ready_managed_dict(type) < 0) {
-        return -1;
+        goto error;
     }
     if (type_ready_post_checks(type) < 0) {
-        return -1;
+        goto error;
     }
-    return 0;
-}
 
+    /* All done -- set the ready flag */
+    type->tp_flags = (type->tp_flags & ~Py_TPFLAGS_READYING) | Py_TPFLAGS_READY;
+
+    assert(_PyType_CheckConsistency(type));
+    return 0;
+
+error:
+    type->tp_flags &= ~Py_TPFLAGS_READYING;
+    return -1;
+}
 
 int
 PyType_Ready(PyTypeObject *type)
 {
+    assert(!(type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN));
+
     if (type->tp_flags & Py_TPFLAGS_READY) {
         assert(_PyType_CheckConsistency(type));
         return 0;
     }
-    _PyObject_ASSERT((PyObject *)type,
-                     (type->tp_flags & Py_TPFLAGS_READYING) == 0);
-
-    type->tp_flags |= Py_TPFLAGS_READYING;
 
     /* Historically, all static types were immutable. See bpo-43908 */
     if (!(type->tp_flags & Py_TPFLAGS_HEAPTYPE)) {
         type->tp_flags |= Py_TPFLAGS_IMMUTABLETYPE;
     }
 
-    if (type_ready(type) < 0) {
-        type->tp_flags &= ~Py_TPFLAGS_READYING;
-        return -1;
-    }
-
-    /* All done -- set the ready flag */
-    type->tp_flags = (type->tp_flags & ~Py_TPFLAGS_READYING) | Py_TPFLAGS_READY;
-    assert(_PyType_CheckConsistency(type));
-    return 0;
+    return type_ready(type);
 }
 
 int
 _PyStaticType_InitBuiltin(PyTypeObject *self)
 {
+    assert(!(self->tp_flags & Py_TPFLAGS_HEAPTYPE));
+
+    if (self->tp_flags & Py_TPFLAGS_READY) {
+        assert(self->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN);
+        assert(_PyType_CheckConsistency(self));
+        return 0;
+    }
+
     self->tp_flags |= _Py_TPFLAGS_STATIC_BUILTIN;
+    self->tp_flags |= Py_TPFLAGS_IMMUTABLETYPE;
 
     assert(NEXT_GLOBAL_VERSION_TAG <= _Py_MAX_GLOBAL_TYPE_VERSION_TAG);
     self->tp_version_tag = NEXT_GLOBAL_VERSION_TAG++;
@@ -7038,7 +7049,7 @@ _PyStaticType_InitBuiltin(PyTypeObject *self)
 
     static_builtin_state_init(self);
 
-    int res = PyType_Ready(self);
+    int res = type_ready(self);
     if (res < 0) {
         static_builtin_state_clear(self);
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7014,12 +7014,11 @@ error:
 int
 PyType_Ready(PyTypeObject *type)
 {
-    assert(!(type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN));
-
     if (type->tp_flags & Py_TPFLAGS_READY) {
         assert(_PyType_CheckConsistency(type));
         return 0;
     }
+    assert(!(type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN));
 
     /* Historically, all static types were immutable. See bpo-43908 */
     if (!(type->tp_flags & Py_TPFLAGS_HEAPTYPE)) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14573,10 +14573,6 @@ _PyUnicode_InitGlobalObjects(PyInterpreterState *interp)
 PyStatus
 _PyUnicode_InitTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return _PyStatus_OK();
-    }
-
     if (_PyStaticType_InitBuiltin(&EncodingMapType) < 0) {
         goto error;
     }

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2316,7 +2316,7 @@ builtin_round_impl(PyObject *module, PyObject *number, PyObject *ndigits)
 {
     PyObject *round, *result;
 
-    if (Py_TYPE(number)->tp_dict == NULL) {
+    if (!_PyType_IsReady(Py_TYPE(number))) {
         if (PyType_Ready(Py_TYPE(number)) < 0)
             return NULL;
     }

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -1342,15 +1342,9 @@ static PyStructSequence_Desc UnraisableHookArgs_desc = {
 PyStatus
 _PyErr_InitTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return _PyStatus_OK();
-    }
-
-    if (UnraisableHookArgsType.tp_name == NULL) {
-        if (_PyStructSequence_InitBuiltin(&UnraisableHookArgsType,
-                                          &UnraisableHookArgs_desc) < 0) {
-            return _PyStatus_ERR("failed to initialize UnraisableHookArgs type");
-        }
+    if (_PyStructSequence_InitBuiltin(&UnraisableHookArgsType,
+                                      &UnraisableHookArgs_desc) < 0) {
+        return _PyStatus_ERR("failed to initialize UnraisableHookArgs type");
     }
     return _PyStatus_OK();
 }

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -3,6 +3,7 @@
 
 #include "Python.h"
 #include "pycore_abstract.h"   // _PyIndex_Check()
+#include "pycore_object.h"     // _PyType_IsReady()
 
 #define FLAG_SIZE_T 1
 typedef double va_double;
@@ -693,7 +694,7 @@ PyModule_AddStringConstant(PyObject *m, const char *name, const char *value)
 int
 PyModule_AddType(PyObject *module, PyTypeObject *type)
 {
-    if (PyType_Ready(type) < 0) {
+    if (!_PyType_IsReady(type) && PyType_Ready(type) < 0) {
         return -1;
     }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2,7 +2,6 @@
 
 #include "Python.h"
 
-#include "pycore_bytesobject.h"   // _PyBytes_InitTypes()
 #include "pycore_ceval.h"         // _PyEval_FiniGIL()
 #include "pycore_context.h"       // _PyContext_Init()
 #include "pycore_exceptions.h"    // _PyExc_InitTypes()
@@ -26,7 +25,6 @@
 #include "pycore_sliceobject.h"   // _PySlice_Fini()
 #include "pycore_sysmodule.h"     // _PySys_ClearAuditHooks()
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads()
-#include "pycore_tuple.h"         // _PyTuple_InitTypes()
 #include "pycore_typeobject.h"    // _PyTypes_InitTypes()
 #include "pycore_unicodeobject.h" // _PyUnicode_InitTypes()
 #include "opcode.h"
@@ -684,11 +682,6 @@ pycore_init_types(PyInterpreterState *interp)
         return status;
     }
 
-    status = _PyBytes_InitTypes(interp);
-    if (_PyStatus_EXCEPTION(status)) {
-        return status;
-    }
-
     status = _PyLong_InitTypes(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
@@ -700,11 +693,6 @@ pycore_init_types(PyInterpreterState *interp)
     }
 
     status = _PyFloat_InitTypes(interp);
-    if (_PyStatus_EXCEPTION(status)) {
-        return status;
-    }
-
-    status = _PyTuple_InitTypes(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3166,10 +3166,8 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
     SET_SYS("float_info", PyFloat_GetInfo());
     SET_SYS("int_info", PyLong_GetInfo());
     /* initialize hash_info */
-    if (Hash_InfoType.tp_name == NULL) {
-        if (_PyStructSequence_InitBuiltin(&Hash_InfoType, &hash_info_desc) < 0) {
-            goto type_init_failed;
-        }
+    if (_PyStructSequence_InitBuiltin(&Hash_InfoType, &hash_info_desc) < 0) {
+        goto type_init_failed;
     }
     SET_SYS("hash_info", get_hash_info(tstate));
     SET_SYS("maxunicode", PyLong_FromLong(0x10FFFF));
@@ -3191,11 +3189,9 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
 
 #define ENSURE_INFO_TYPE(TYPE, DESC) \
     do { \
-        if (TYPE.tp_name == NULL) { \
-            if (_PyStructSequence_InitBuiltinWithFlags( \
-                    &TYPE, &DESC, Py_TPFLAGS_DISALLOW_INSTANTIATION) < 0) { \
-                goto type_init_failed; \
-            } \
+        if (_PyStructSequence_InitBuiltinWithFlags( \
+                &TYPE, &DESC, Py_TPFLAGS_DISALLOW_INSTANTIATION) < 0) { \
+            goto type_init_failed; \
         } \
     } while (0)
 
@@ -3230,11 +3226,9 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
     SET_SYS("thread_info", PyThread_GetInfo());
 
     /* initialize asyncgen_hooks */
-    if (AsyncGenHooksType.tp_name == NULL) {
-        if (_PyStructSequence_InitBuiltin(
-                &AsyncGenHooksType, &asyncgen_hooks_desc) < 0) {
-            goto type_init_failed;
-        }
+    if (_PyStructSequence_InitBuiltin(
+            &AsyncGenHooksType, &asyncgen_hooks_desc) < 0) {
+        goto type_init_failed;
     }
 
 #ifdef __EMSCRIPTEN__

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -137,10 +137,8 @@ PyThread_GetInfo(void)
     int len;
 #endif
 
-    if (ThreadInfoType.tp_name == 0) {
-        if (_PyStructSequence_InitBuiltin(&ThreadInfoType,
-                                          &threadinfo_desc) < 0)
-            return NULL;
+    if (_PyStructSequence_InitBuiltin(&ThreadInfoType, &threadinfo_desc) < 0) {
+        return NULL;
     }
 
     threadinfo = PyStructSequence_New(&ThreadInfoType);


### PR DESCRIPTION
There were cases where we do unnecessary work for builtin static types.  This also simplifies some work necessary for a per-interpreter GIL.

<!-- gh-issue-number: gh-94673 -->
* Issue: gh-94673
<!-- /gh-issue-number -->
