### PR TITLE
[3.8] gh-103935: Use `io.open_code()` when executing code in trace and profile modules (GH-103947)

### DIFF
--- a/Lib/cProfile.py
+++ b/Lib/cProfile.py
@@ -7,6 +7,7 @@
 __all__ = ["run", "runctx", "Profile"]
 
 import _lsprof
+import io
 import profile as _pyprofile
 
 # ____________________________________________________________
@@ -183,7 +184,7 @@ def main():
         else:
             progname = args[0]
             sys.path.insert(0, os.path.dirname(progname))
-            with open(progname, 'rb') as fp:
+            with io.open_code(progname) as fp:
                 code = compile(fp.read(), progname, 'exec')
             globs = {
                 '__file__': progname,

--- a/Lib/profile.py
+++ b/Lib/profile.py
@@ -24,6 +24,7 @@
 # governing permissions and limitations under the License.
 
 
+import io
 import sys
 import time
 import marshal
@@ -603,7 +604,7 @@ def main():
         else:
             progname = args[0]
             sys.path.insert(0, os.path.dirname(progname))
-            with open(progname, 'rb') as fp:
+            with io.open_code(progname) as fp:
                 code = compile(fp.read(), progname, 'exec')
             globs = {
                 '__file__': progname,

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -49,6 +49,7 @@ Sample use, programmatically
 """
 __all__ = ['Trace', 'CoverageResults']
 
+import io
 import linecache
 import os
 import sys
@@ -732,7 +733,7 @@ def main():
             sys.argv = [opts.progname, *opts.arguments]
             sys.path[0] = os.path.dirname(opts.progname)
 
-            with open(opts.progname, 'rb') as fp:
+            with io.open_code(opts.progname) as fp:
                 code = compile(fp.read(), opts.progname, 'exec')
             # try to emulate __main__ namespace as much as possible
             globs = {

--- a/Misc/NEWS.d/next/Library/2023-04-27-20-03-08.gh-issue-103935.Uaf2M0.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-27-20-03-08.gh-issue-103935.Uaf2M0.rst
@@ -1,0 +1,1 @@
+Use :func:`io.open_code` for files to be executed instead of raw :func:`open`


### PR DESCRIPTION


<!-- gh-issue-number: gh-103935 -->
* Issue: gh-103935
<!-- /gh-issue-number -->
