### PR TITLE
[NO ISSUE] Adds __eq__ support for non-normalized fractions

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -910,7 +910,7 @@ class Fraction(numbers.Rational):
     def __eq__(a, b):
         """a == b"""
         if type(b) is int:
-            return a._numerator == b and a._denominator == 1
+            return a._numerator / a._denominator == b
         if isinstance(b, numbers.Rational):
             return (a._numerator == b.numerator and
                     a._denominator == b.denominator)


### PR DESCRIPTION
If a fraction is created with the `_normalize` parameter set to false, it fill fail equality checks it should not. 

For example before this fix: `Fraction(4,2,_normalize=False) != 2`.

This PR changes the equality check from just checking that the comparison int equals the numerator to checking that numerator/denominator is equal to the int.