### PR TITLE
gh-94673: Fix _PyTypes_InitTypes() and get_type_attr_as_size()

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2102,10 +2102,6 @@ static PyTypeObject* static_types[] = {
 PyStatus
 _PyTypes_InitTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return _PyStatus_OK();
-    }
-
     // All other static types (unless initialized elsewhere)
     for (size_t i=0; i < Py_ARRAY_LENGTH(static_types); i++) {
         PyTypeObject *type = static_types[i];

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -31,6 +31,7 @@ get_type_attr_as_size(PyTypeObject *tp, PyObject *name)
         PyErr_Format(PyExc_TypeError,
                      "Missed attribute '%U' of type %s",
                      name, tp->tp_name);
+        return -1;
     }
     return PyLong_AsSsize_t(v);
 }


### PR DESCRIPTION
This change has two small parts:

1. a follow-up to gh-103940 with one case I missed
2. adding a missing return that I noticed while working on related code

<!-- gh-issue-number: gh-94673 -->
* Issue: gh-94673
<!-- /gh-issue-number -->
