### PR TITLE
gh-103978: avoid using 'class' as an identifier

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -226,7 +226,7 @@ extern int _PyLineTable_PreviousAddressRange(PyCodeAddressRange *range);
 
 /* Specialization functions */
 
-extern void _Py_Specialize_LoadSuperAttr(PyObject *global_super, PyObject *klass, PyObject *self,
+extern void _Py_Specialize_LoadSuperAttr(PyObject *global_super, PyObject *cls, PyObject *self,
                                          _Py_CODEUNIT *instr, PyObject *name, int load_method);
 extern void _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr,
                                     PyObject *name);

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -226,7 +226,7 @@ extern int _PyLineTable_PreviousAddressRange(PyCodeAddressRange *range);
 
 /* Specialization functions */
 
-extern void _Py_Specialize_LoadSuperAttr(PyObject *global_super, PyObject *class, PyObject *self,
+extern void _Py_Specialize_LoadSuperAttr(PyObject *global_super, PyObject *klass, PyObject *self,
                                          _Py_CODEUNIT *instr, PyObject *name, int load_method);
 extern void _Py_Specialize_LoadAttr(PyObject *owner, _Py_CODEUNIT *instr,
                                     PyObject *name);

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -515,7 +515,7 @@ specialize_module_load_attr(
 /* Attribute specialization */
 
 void
-_Py_Specialize_LoadSuperAttr(PyObject *global_super, PyObject *klass, PyObject *self,
+_Py_Specialize_LoadSuperAttr(PyObject *global_super, PyObject *cls, PyObject *self,
                              _Py_CODEUNIT *instr, PyObject *name, int load_method) {
     assert(ENABLE_SPECIALIZATION);
     assert(_PyOpcode_Caches[LOAD_SUPER_ATTR] == INLINE_CACHE_ENTRIES_LOAD_SUPER_ATTR);
@@ -528,11 +528,11 @@ _Py_Specialize_LoadSuperAttr(PyObject *global_super, PyObject *klass, PyObject *
         SPECIALIZATION_FAIL(LOAD_SUPER_ATTR, SPEC_FAIL_SUPER_SHADOWED);
         goto fail;
     }
-    if (!PyType_Check(klass)) {
+    if (!PyType_Check(cls)) {
         SPECIALIZATION_FAIL(LOAD_SUPER_ATTR, SPEC_FAIL_SUPER_BAD_CLASS);
         goto fail;
     }
-    PyTypeObject *tp = (PyTypeObject *)klass;
+    PyTypeObject *tp = (PyTypeObject *)cls;
     PyObject *res = _PySuper_LookupDescr(tp, self, name);
     if (res == NULL) {
         SPECIALIZATION_FAIL(LOAD_SUPER_ATTR, SPEC_FAIL_SUPER_ERROR_OR_NOT_FOUND);

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -515,7 +515,7 @@ specialize_module_load_attr(
 /* Attribute specialization */
 
 void
-_Py_Specialize_LoadSuperAttr(PyObject *global_super, PyObject *class, PyObject *self,
+_Py_Specialize_LoadSuperAttr(PyObject *global_super, PyObject *klass, PyObject *self,
                              _Py_CODEUNIT *instr, PyObject *name, int load_method) {
     assert(ENABLE_SPECIALIZATION);
     assert(_PyOpcode_Caches[LOAD_SUPER_ATTR] == INLINE_CACHE_ENTRIES_LOAD_SUPER_ATTR);
@@ -528,11 +528,11 @@ _Py_Specialize_LoadSuperAttr(PyObject *global_super, PyObject *class, PyObject *
         SPECIALIZATION_FAIL(LOAD_SUPER_ATTR, SPEC_FAIL_SUPER_SHADOWED);
         goto fail;
     }
-    if (!PyType_Check(class)) {
+    if (!PyType_Check(klass)) {
         SPECIALIZATION_FAIL(LOAD_SUPER_ATTR, SPEC_FAIL_SUPER_BAD_CLASS);
         goto fail;
     }
-    PyTypeObject *tp = (PyTypeObject *)class;
+    PyTypeObject *tp = (PyTypeObject *)klass;
     PyObject *res = _PySuper_LookupDescr(tp, self, name);
     if (res == NULL) {
         SPECIALIZATION_FAIL(LOAD_SUPER_ATTR, SPEC_FAIL_SUPER_ERROR_OR_NOT_FOUND);


### PR DESCRIPTION
fixes #103978

<!-- gh-issue-number: gh-103978 -->
* Issue: gh-103978
<!-- /gh-issue-number -->
