### PR TITLE
gh-103960: Dark mode: invert image brightness

### DIFF
--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -418,6 +418,7 @@ The flow of log event information in loggers and handlers is illustrated in the
 following diagram.
 
 .. image:: logging_flow.png
+   :class: invert-in-dark-mode
 
 Loggers
 ^^^^^^^

--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -430,6 +430,7 @@ Constructor functions also accept the following tree hashing parameters:
 
 .. figure:: hashlib-blake2-tree.png
    :alt: Explanation of tree mode parameters.
+   :class: invert-in-dark-mode
 
 See section 2.10 in `BLAKE2 specification
 <https://blake2.net/blake2_20130129.pdf>`_ for comprehensive review of tree

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -21,6 +21,7 @@ inherit from pure paths but also provide I/O operations.
 
 .. image:: pathlib-inheritance.png
    :align: center
+   :class: invert-in-dark-mode
 
 If you've never used this module before or just aren't sure which class is
 right for your task, :class:`Path` is most likely what you need. It instantiates


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

For gh-103960.

Use the CSS class added in https://github.com/python/python-docs-theme/pull/128 to invert images when in dark mode.

To test:

1. checkout this PR
2. checkout https://github.com/python/python-docs-theme/pull/128 in a parallel directory
3. `cd python-docs-theme && make html`
4. `open ../cpython/Doc/build/html/howto/logging.html`
5. `open ../cpython/Doc/build/html/library/hashlib.html`
6. `open ../cpython/Doc/build/html/library/pathlib.html`
7. Check images are good in light and dark modes

This can be merged before https://github.com/python/python-docs-theme/pull/128 is merged/released and the images will be ready for when the theme is deployed.

Dark mode previews:

<details>
<summary>Details</summary>

<img width="829" alt="image" src="https://user-images.githubusercontent.com/1324225/235236997-1a609237-68ab-4c7b-8339-7d2a3973525b.png">

</details>

<details>
<summary>Details</summary>

<img width="767" alt="image" src="https://user-images.githubusercontent.com/1324225/235237083-ca067639-1452-46dc-ba17-97f137453885.png">

</details>

<details>
<summary>Details</summary>

<img width="807" alt="image" src="https://user-images.githubusercontent.com/1324225/235237240-9af10c42-5a8a-42bc-8d3c-1e6ceac23eb9.png">

</details>

I didn't invert the installer or tkinter.messagebox screenshots shown in https://github.com/python/cpython/issues/103960#issuecomment-1526948099 because they're screenshots of real dialogs and inverting would be misleading and potentially confusing. It's okay to have some lighter screenshots in dark mode.
