### PR TITLE
gh-103971: Add unreachable line test for match-case block

### DIFF
--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -3165,6 +3165,19 @@ class TestTracing(unittest.TestCase):
         self.assertListEqual(self._trace(f, "go x"), [1, 2, 3])
         self.assertListEqual(self._trace(f, "spam"), [1, 2, 3])
 
+    def test_unreachable_code(self):
+        def f(command):               # 0
+            match command:            # 1
+                case 1:               # 2
+                    if False:         # 3
+                        return 1      # 4
+                case _:               # 5
+                    if False:         # 6
+                        return 0      # 7
+
+        self.assertListEqual(self._trace(f, 1), [1, 2, 3])
+        self.assertListEqual(self._trace(f, 0), [1, 2, 5, 6])
+
     def test_parser_deeply_nested_patterns(self):
         # Deeply nested patterns can cause exponential backtracking when parsing.
         # See gh-93671 for more information.


### PR DESCRIPTION
This is the same test from #103980, just add it in main as well to avoid regression in the future.

<!-- gh-issue-number: gh-103971 -->
* Issue: gh-103971
<!-- /gh-issue-number -->
