### PR TITLE
Remove non-existing tools from Sundry skiplist

### DIFF
--- a/Lib/test/test_tools/test_sundry.py
+++ b/Lib/test/test_tools/test_sundry.py
@@ -1,4 +1,4 @@
-"""Tests for scripts in the Tools directory.
+"""Tests for scripts in the Tools/scripts directory.
 
 This file contains extremely basic regression tests for the scripts found in
 the Tools directory of a Python checkout or tarball which don't have separate
@@ -17,14 +17,7 @@ class TestSundryScripts(unittest.TestCase):
     # At least make sure the rest don't have syntax errors.  When tests are
     # added for a script it should be added to the allowlist below.
 
-    # scripts that have independent tests.
-    allowlist = ['reindent']
-    # scripts that can't be imported without running
-    denylist = ['make_ctype']
-    # denylisted for other reasons
-    other = ['2to3']
-
-    skiplist = denylist + allowlist + other
+    skiplist = ['2to3']
 
     # import logging registers "atfork" functions which keep indirectly the
     # logging module dictionary alive. Mock the function to be able to unload


### PR DESCRIPTION
This test removes `make_ctype` and `reindent` from a skiplist of `Lib/test/test_tools/test_sundry.py`:

1. `Tools/scripts/make_ctype.py` was removed in gh-97675
1. `Tools/scripts/reindent.py` was moved into `Tools/patchcheck/` (not touched by the test) in gh-98186

No backport is needed.

cc @vstinner 
