### PR TITLE
GH-97950: Allow translation of index directive content

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -91,6 +91,11 @@ smartquotes_excludes = {
 # Avoid a warning with Sphinx >= 2.0
 master_doc = 'contents'
 
+# Allow translation of index directives
+gettext_additional_targets = [
+    'index',
+]
+
 # Options for HTML output
 # -----------------------
 

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -684,6 +684,11 @@ def patch_pairindextypes(app) -> None:
     except ImportError:
         pass
     else:
+        # Sphinx checks if a 'pair' type entry on an index directive is one of
+        # the Sphinx-translated pairindextypes values. As we intend to move
+        # away from this, we need Sphinx to believe that these values don't
+        # exist, by deleting them when using the gettext builder.
+
         # pairindextypes.pop('module', None)
         # pairindextypes.pop('keyword', None)
         # pairindextypes.pop('operator', None)

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -674,6 +674,27 @@ def process_audit_events(app, doctree, fromdocname):
         node.replace_self(table)
 
 
+def patch_pairindextypes(app) -> None:
+    if app.builder.name != 'gettext':
+        return
+
+    # allow translating deprecated index entries
+    try:
+        from sphinx.domains.python import pairindextypes
+    except ImportError:
+        pass
+    else:
+        pairindextypes.pop('module', None)
+        pairindextypes.pop('keyword', None)
+        pairindextypes.pop('operator', None)
+        pairindextypes.pop('object', None)
+        pairindextypes.pop('exception', None)
+        pairindextypes.pop('statement', None)
+        pairindextypes.pop('builtin', None)
+
+        del pairindextypes
+
+
 def setup(app):
     app.add_role('issue', issue_role)
     app.add_role('gh', gh_issue_role)
@@ -695,6 +716,7 @@ def setup(app):
     app.add_directive_to_domain('py', 'awaitablemethod', PyAwaitableMethod)
     app.add_directive_to_domain('py', 'abstractmethod', PyAbstractMethod)
     app.add_directive('miscnews', MiscNews)
+    app.connect('builder-inited', patch_pairindextypes)
     app.connect('doctree-resolved', process_audit_events)
     app.connect('env-merge-info', audit_events_merge)
     app.connect('env-purge-doc', audit_events_purge)

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -692,8 +692,6 @@ def patch_pairindextypes(app) -> None:
         # pairindextypes.pop('statement', None)
         # pairindextypes.pop('builtin', None)
 
-        del pairindextypes
-
 
 def setup(app):
     app.add_role('issue', issue_role)

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -692,6 +692,10 @@ def patch_pairindextypes(app) -> None:
         # pairindextypes.pop('statement', None)
         # pairindextypes.pop('builtin', None)
 
+        # there needs to be at least one statement in this block, will be
+        # removed when the first of the below is uncommented.
+        pass
+
 
 def setup(app):
     app.add_role('issue', issue_role)

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -684,13 +684,13 @@ def patch_pairindextypes(app) -> None:
     except ImportError:
         pass
     else:
-        pairindextypes.pop('module', None)
-        pairindextypes.pop('keyword', None)
-        pairindextypes.pop('operator', None)
-        pairindextypes.pop('object', None)
-        pairindextypes.pop('exception', None)
-        pairindextypes.pop('statement', None)
-        pairindextypes.pop('builtin', None)
+        # pairindextypes.pop('module', None)
+        # pairindextypes.pop('keyword', None)
+        # pairindextypes.pop('operator', None)
+        # pairindextypes.pop('object', None)
+        # pairindextypes.pop('exception', None)
+        # pairindextypes.pop('statement', None)
+        # pairindextypes.pop('builtin', None)
 
         del pairindextypes
 


### PR DESCRIPTION
[This comment](https://github.com/python/cpython/issues/97950#issuecomment-1405405765), which eventually links to [this comment](https://github.com/sphinx-doc/sphinx/pull/6970#issuecomment-605458628) point out that Sphinx's support for translating ``index`` directives isn't as straightfowards as it could be.

This PR is my best attempt at a workaround -- the reason for the commenting out is that there is [a test](https://github.com/sphinx-doc/sphinx/blob/ba7408209e84ee413f240afc20f3c6b484a81f8f/sphinx/builders/gettext.py#L162-L165) to check if an entry of a ``pair`` directive is one of the already-translated ``pairindextypes`` values. As we intend to move away from this, we need Sphinx to believe that these values don't exist, by deleting them when using the ``gettext`` builder.

https://github.com/sphinx-doc/sphinx/blob/ba7408209e84ee413f240afc20f3c6b484a81f8f/sphinx/builders/gettext.py#L162-L165

A

<!-- gh-issue-number: gh-97950 -->
* Issue: gh-97950
<!-- /gh-issue-number -->
