### PR TITLE
GH-103484: Fix redirected permanently URLs

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -263,13 +263,15 @@ coverage_ignore_c_items = {
 
 linkcheck_allowed_redirects = {
     # bpo-NNNN -> BPO -> GH Issues
-    r'https://bugs.python.org/issue\?@action=redirect&bpo=\d+': 'https://github.com/python/cpython/issues/\d+',
+    r'https://bugs.python.org/issue\?@action=redirect&bpo=\d+': r'https://github.com/python/cpython/issues/\d+',
     # GH-NNNN used to refer to pull requests
     r'https://github.com/python/cpython/issues/\d+': r'https://github.com/python/cpython/pull/\d+',
     # :source:`something` linking files in the repository
     r'https://github.com/python/cpython/tree/.*': 'https://github.com/python/cpython/blob/.*',
     # Intentional HTTP use at Misc/NEWS.d/3.5.0a1.rst
     r'http://www.python.org/$': 'https://www.python.org/$',
+    # Used in license page, keep as is
+    r'https://www.zope.org/': r'https://www.zope.dev/',
     # Microsoft's redirects to learn.microsoft.com
     r'https://msdn.microsoft.com/.*': 'https://learn.microsoft.com/.*',
     r'https://docs.microsoft.com/.*': 'https://learn.microsoft.com/.*',

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -267,7 +267,23 @@ linkcheck_allowed_redirects = {
     # GH-NNNN used to refer to pull requests
     r'https://github.com/python/cpython/issues/\d+': 'https://github.com/python/cpython/pull/\d+',
     # :source:`something` linking files in the repository
-    r'https://github.com/python/cpython/tree/.*': 'https://github.com/python/cpython/blob/.*'
+    r'https://github.com/python/cpython/tree/.*': 'https://github.com/python/cpython/blob/.*',
+    # Intentional HTTP use at Misc/NEWS.d/3.5.0a1.rst
+    r'http://www.python.org/$': 'https://www.python.org/$',
+    # Microsoft's redirects to learn.microsoft.com
+    r'https://msdn.microsoft.com/.*': 'https://learn.microsoft.com/.*',
+    r'https://docs.microsoft.com/.*': 'https://learn.microsoft.com/.*',
+    r'https://go.microsoft.com/fwlink/\?LinkID=\d+': 'https://learn.microsoft.com/.*',
+    # Language redirects
+    r'https://toml.io': 'https://toml.io/en/',
+    r'https://www.redhat.com': 'https://www.redhat.com/en',
+    # Other redirects
+    r'https://www.boost.org/libs/.+': 'https://www.boost.org/doc/libs/\d_\d+_\d/.+',
+    r'https://support.microsoft.com/en-us/help/\d+': 'https://support.microsoft.com/en-us/topic/.+',
+    r'https://perf.wiki.kernel.org$': 'https://perf.wiki.kernel.org/index.php/Main_Page',
+    r'https://www.sqlite.org': 'https://www.sqlite.org/index.html',
+    r'https://mitpress.mit.edu/sicp$': 'https://mitpress.mit.edu/9780262510875/structure-and-interpretation-of-computer-programs/',
+    r'https://www.python.org/psf/': 'https://www.python.org/psf-landing/',
 }
 
 linkcheck_anchors_ignore = [

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -265,7 +265,7 @@ linkcheck_allowed_redirects = {
     # bpo-NNNN -> BPO -> GH Issues
     r'https://bugs.python.org/issue\?@action=redirect&bpo=\d+': 'https://github.com/python/cpython/issues/\d+',
     # GH-NNNN used to refer to pull requests
-    r'https://github.com/python/cpython/issues/\d+': 'https://github.com/python/cpython/pull/\d+',
+    r'https://github.com/python/cpython/issues/\d+': r'https://github.com/python/cpython/pull/\d+',
     # :source:`something` linking files in the repository
     r'https://github.com/python/cpython/tree/.*': 'https://github.com/python/cpython/blob/.*',
     # Intentional HTTP use at Misc/NEWS.d/3.5.0a1.rst
@@ -278,7 +278,7 @@ linkcheck_allowed_redirects = {
     r'https://toml.io': 'https://toml.io/en/',
     r'https://www.redhat.com': 'https://www.redhat.com/en',
     # Other redirects
-    r'https://www.boost.org/libs/.+': 'https://www.boost.org/doc/libs/\d_\d+_\d/.+',
+    r'https://www.boost.org/libs/.+': r'https://www.boost.org/doc/libs/\d_\d+_\d/.+',
     r'https://support.microsoft.com/en-us/help/\d+': 'https://support.microsoft.com/en-us/topic/.+',
     r'https://perf.wiki.kernel.org$': 'https://perf.wiki.kernel.org/index.php/Main_Page',
     r'https://www.sqlite.org': 'https://www.sqlite.org/index.html',

--- a/Doc/faq/extending.rst
+++ b/Doc/faq/extending.rst
@@ -42,7 +42,7 @@ on what you're trying to do.
 .. XXX make sure these all work
 
 `Cython <https://cython.org>`_ and its relative `Pyrex
-<https://www.cosc.canterbury.ac.nz/greg.ewing/python/Pyrex/>`_ are compilers
+<https://www.csse.canterbury.ac.nz/greg.ewing/python/Pyrex/>`_ are compilers
 that accept a slightly modified form of Python and generate the corresponding
 C code.  Cython and Pyrex make it possible to write an extension without having
 to learn Python's C API.

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -54,8 +54,8 @@ commercial use, to sell copies of Python in source or binary form (modified or
 unmodified), or to sell products that incorporate Python in some form.  We would
 still like to know about all commercial use of Python, of course.
 
-See `the PSF license page <https://www.python.org/psf/license/>`_ to find further
-explanations and a link to the full text of the license.
+See `the license page <https://docs.python.org/3/license.html>`_ to find further
+explanations and the full text of the PSF License.
 
 The Python logo is trademarked, and in certain cases permission is required to
 use it.  Consult `the Trademark Usage Policy
@@ -215,7 +215,7 @@ every day, and Usenet readers are often more able to cope with this volume.
 Announcements of new software releases and events can be found in
 comp.lang.python.announce, a low-traffic moderated list that receives about five
 postings per day.  It's available as `the python-announce mailing list
-<https://mail.python.org/mailman/listinfo/python-announce-list>`_.
+<https://mail.python.org/mailman3/lists/python-announce-list.python.org/>`_.
 
 More info about other mailing lists and newsgroups
 can be found at https://www.python.org/community/lists/.
@@ -352,7 +352,7 @@ titled "Python X.Y Release Schedule", where X.Y is a version that hasn't been
 publicly released yet.
 
 New development is discussed on `the python-dev mailing list
-<https://mail.python.org/mailman/listinfo/python-dev/>`_.
+<https://mail.python.org/mailman3/lists/python-dev.python.org/>`_.
 
 
 Is it reasonable to propose incompatible changes to Python?

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -61,7 +61,7 @@ Yes.
 `Pyflakes <https://github.com/PyCQA/pyflakes>`_ do basic checking that will
 help you catch bugs sooner.
 
-Static type checkers such as `Mypy <http://mypy-lang.org/>`_,
+Static type checkers such as `Mypy <https://mypy-lang.org/>`_,
 `Pyre <https://pyre-check.org/>`_, and
 `Pytype <https://github.com/google/pytype>`_ can check type hints in Python
 source code.

--- a/Doc/howto/pyporting.rst
+++ b/Doc/howto/pyporting.rst
@@ -438,7 +438,7 @@ to make sure everything functions as expected in both versions of Python.
 .. _Futurize: https://python-future.org/automatic_conversion.html
 .. _importlib2: https://pypi.org/project/importlib2
 .. _Modernize: https://python-modernize.readthedocs.io/
-.. _mypy: http://mypy-lang.org/
+.. _mypy: https://mypy-lang.org/
 .. _Porting to Python 3: http://python3porting.com/
 .. _Pylint: https://pypi.org/project/pylint
 

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -529,7 +529,7 @@ Opening network connections
       specifies requirements for algorithms that reduce this user-visible
       delay and provides an algorithm.
 
-      For more information: https://tools.ietf.org/html/rfc6555
+      For more information: https://datatracker.ietf.org/doc/html/rfc6555
 
    .. versionchanged:: 3.11
 

--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -432,7 +432,7 @@ Constructor functions also accept the following tree hashing parameters:
    :alt: Explanation of tree mode parameters.
 
 See section 2.10 in `BLAKE2 specification
-<https://blake2.net/blake2_20130129.pdf>`_ for comprehensive review of tree
+<https://www.blake2.net/blake2_20130129.pdf>`_ for comprehensive review of tree
 hashing.
 
 
@@ -619,7 +619,7 @@ on the hash function used in digital signatures.
     by the signer.
 
     (`NIST SP-800-106 "Randomized Hashing for Digital Signatures"
-    <https://csrc.nist.gov/publications/detail/sp/800-106/final>`_)
+    <https://csrc.nist.gov/publications/detail/sp/800-106/archive/2009-02-25>`_)
 
 In BLAKE2 the salt is processed as a one-time input to the hash function during
 initialization, rather than as an input to each compression function.
@@ -628,7 +628,7 @@ initialization, rather than as an input to each compression function.
 
     *Salted hashing* (or just hashing) with BLAKE2 or any other general-purpose
     cryptographic hash function, such as SHA-256, is not suitable for hashing
-    passwords.  See `BLAKE2 FAQ <https://blake2.net/#qa>`_ for more
+    passwords.  See `BLAKE2 FAQ <https://www.blake2.net/#qa>`_ for more
     information.
 ..
 
@@ -764,9 +764,9 @@ Domain Dedication 1.0 Universal:
 
 * *Alexandr Sokolovskiy*
 
-.. _BLAKE2: https://blake2.net
+.. _BLAKE2: https://www.blake2.net
 .. _HMAC: https://en.wikipedia.org/wiki/Hash-based_message_authentication_code
-.. _BLAKE: https://131002.net/blake/
+.. _BLAKE: https://web.archive.org/web/20200918190133/https://131002.net/blake/
 .. _SHA-3: https://en.wikipedia.org/wiki/NIST_hash_function_competition
 .. _ChaCha: https://cr.yp.to/chacha.html
 .. _pyblake2: https://pythonhosted.org/pyblake2/
@@ -782,7 +782,7 @@ Domain Dedication 1.0 Universal:
    Module :mod:`base64`
       Another way to encode binary hashes for non-binary environments.
 
-   https://blake2.net
+   https://www.blake2.net
       Official BLAKE2 website.
 
    https://csrc.nist.gov/csrc/media/publications/fips/180/2/archive/2002-08-01/documents/fips180-2.pdf

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -354,7 +354,7 @@ HTTPConnection Objects
    the CONNECT request.
 
    As HTTP/1.1 is used for HTTP CONNECT tunnelling request, `as per the RFC
-   <https://tools.ietf.org/html/rfc7231#section-4.3.6>`_, a HTTP ``Host:``
+   <https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.6>`_, a HTTP ``Host:``
    header must be provided, matching the authority-form of the request target
    provided as the destination for the CONNECT request. If a HTTP ``Host:``
    header is not provided via the headers argument, one is generated and

--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -178,7 +178,7 @@ The "selectable" entry points were introduced in ``importlib_metadata``
 no parameters and always returned a dictionary of entry points, keyed
 by group. With ``importlib_metadata`` 5.0 and Python 3.12,
 ``entry_points`` always returns an ``EntryPoints`` object. See
-`backports.entry_points_selectable <https://pypi.org/project/backports.entry_points_selectable>`_
+`backports.entry-points-selectable <https://pypi.org/project/backports.entry-points-selectable>`_
 for compatibility options.
 
 

--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -178,7 +178,7 @@ The "selectable" entry points were introduced in ``importlib_metadata``
 no parameters and always returned a dictionary of entry points, keyed
 by group. With ``importlib_metadata`` 5.0 and Python 3.12,
 ``entry_points`` always returns an ``EntryPoints`` object. See
-`backports.entry-points-selectable <https://pypi.org/project/backports.entry-points-selectable>`_
+`backports.entry_points_selectable <https://pypi.org/project/backports.entry-points-selectable>`_
 for compatibility options.
 
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4593,7 +4593,7 @@ written in Python, such as a mail server's external command delivery program.
    :attr:`!children_system`, and :attr:`!elapsed` in that order.
 
    See the Unix manual page
-   :manpage:`times(2)` and `times(3) <https://www.freebsd.org/cgi/man.cgi?time(3)>`_ manual page on Unix or `the GetProcessTimes MSDN
+   :manpage:`times(2)` and `times(3) <https://man.freebsd.org/cgi/man.cgi?time(3)>`_ manual page on Unix or `the GetProcessTimes MSDN
    <https://docs.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocesstimes>`_
    on Windows. On Windows, only :attr:`!user` and :attr:`!system` are known; the other attributes are zero.
 

--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -46,7 +46,7 @@ or :class:`datetime.datetime` objects.
 
 .. seealso::
 
-   `PList manual page <https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/PropertyLists/>`_
+   `PList manual page <https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/PropertyLists/>`_
       Apple's documentation of the file format.
 
 

--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -244,7 +244,7 @@ platform.
    used by all of this user id's processes.
    This limit is enforced only if bit 1 of the vm.overcommit sysctl is set.
    Please see
-   `tuning(7) <https://www.freebsd.org/cgi/man.cgi?query=tuning&sektion=7>`__
+   `tuning(7) <https://man.freebsd.org/cgi/man.cgi?query=tuning&sektion=7>`__
    for a complete description of this sysctl.
 
    .. availability:: FreeBSD.

--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -505,7 +505,7 @@ Kqueue Objects
 Kevent Objects
 --------------
 
-https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
+https://man.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
 
 .. attribute:: kevent.ident
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1719,7 +1719,7 @@ to speed up repeated connections from the same clients.
    .. versionadded:: 3.3
 
    .. seealso::
-      `SSL/TLS & Perfect Forward Secrecy <https://vincent.bernat.im/en/blog/2011-ssl-perfect-forward-secrecy>`_
+      `SSL/TLS & Perfect Forward Secrecy <https://vincent.bernat.ch/en/blog/2011-ssl-perfect-forward-secrecy>`_
          Vincent Bernat.
 
 .. method:: SSLContext.wrap_socket(sock, server_side=False, \

--- a/Doc/library/statistics.rst
+++ b/Doc/library/statistics.rst
@@ -22,7 +22,7 @@ This module provides functions for calculating mathematical statistics of
 numeric (:class:`~numbers.Real`-valued) data.
 
 The module is not intended to be a competitor to third-party libraries such
-as `NumPy <https://numpy.org>`_, `SciPy <https://www.scipy.org/>`_, or
+as `NumPy <https://numpy.org>`_, `SciPy <https://scipy.org/>`_, or
 proprietary full-featured statistics packages aimed at professional
 statisticians such as Minitab, SAS and Matlab. It is aimed at the level of
 graphing and scientific calculators.

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -602,4 +602,4 @@ The :mod:`struct` module also defines the following type:
 
 .. _ieee 754 standard: https://en.wikipedia.org/wiki/IEEE_754-2008_revision
 
-.. _IETF RFC 1700: https://tools.ietf.org/html/rfc1700
+.. _IETF RFC 1700: https://datatracker.ietf.org/doc/html/rfc1700

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -792,7 +792,7 @@ always available.
    additional garbage collector overhead if the object is managed by the garbage
    collector.
 
-   See `recursive sizeof recipe <https://code.activestate.com/recipes/577504>`_
+   See `recursive sizeof recipe <https://code.activestate.com/recipes/577504/>`_
    for an example of using :func:`getsizeof` recursively to find the size of
    containers and all their contents.
 

--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -1074,7 +1074,7 @@ subclass.
 Sometimes this is inconvenient. For example, `one user
 <https://code.google.com/archive/p/mock/issues/105>`_ is subclassing mock to
 created a `Twisted adaptor
-<https://twistedmatrix.com/documents/11.0.0/api/twisted.python.components.html>`_.
+<https://twisted.org/documents/11.0.0/api/twisted.python.components.html>`_.
 Having this applied to attributes too actually causes errors.
 
 ``Mock`` (in all its flavours) uses a method called ``_get_child_mock`` to create

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -72,7 +72,7 @@ test runner
    a GUI tool for test discovery and execution.  This is intended largely for ease of use
    for those new to unit testing.  For production environments it is
    recommended that tests be driven by a continuous integration system such as
-   `Buildbot <https://buildbot.net/>`_, `Jenkins <https://jenkins.io/>`_,
+   `Buildbot <https://buildbot.net/>`_, `Jenkins <https://www.jenkins.io/>`_,
    `GitHub Actions <https://github.com/features/actions>`_, or
    `AppVeyor <https://www.appveyor.com/>`_.
 

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -161,7 +161,7 @@ between conformable Python objects and XML on the wire.
 
 .. seealso::
 
-   `XML-RPC HOWTO <https://www.tldp.org/HOWTO/XML-RPC-HOWTO/index.html>`_
+   `XML-RPC HOWTO <https://tldp.org/HOWTO/XML-RPC-HOWTO/index.html>`_
       A good description of XML-RPC operation and client software in several languages.
       Contains pretty much everything an XML-RPC client developer needs to know.
 

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -128,7 +128,7 @@ The module defines the following items:
       Documentation on the ZIP file format by Phil Katz, the creator of the format and
       algorithms used.
 
-   `Info-ZIP Home Page <http://www.info-zip.org/>`_
+   `Info-ZIP Home Page <https://infozip.sourceforge.net/>`_
       Information about the Info-ZIP project's ZIP archive programs and development
       libraries.
 

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -22,7 +22,7 @@ Virginia where he released several versions of the software.
 In May 2000, Guido and the Python core development team moved to BeOpen.com to
 form the BeOpen PythonLabs team.  In October of the same year, the PythonLabs
 team moved to Digital Creations (now Zope Corporation; see
-https://www.zope.dev/).  In 2001, the Python Software Foundation (PSF, see
+https://www.zope.org/).  In 2001, the Python Software Foundation (PSF, see
 https://www.python.org/psf/) was formed, a non-profit organization created
 specifically to own Python-related Intellectual Property.  Zope Corporation is a
 sponsoring member of the PSF.

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -22,7 +22,7 @@ Virginia where he released several versions of the software.
 In May 2000, Guido and the Python core development team moved to BeOpen.com to
 form the BeOpen PythonLabs team.  In October of the same year, the PythonLabs
 team moved to Digital Creations (now Zope Corporation; see
-https://www.zope.org/).  In 2001, the Python Software Foundation (PSF, see
+https://www.zope.dev/).  In 2001, the Python Software Foundation (PSF, see
 https://www.python.org/psf/) was formed, a non-profit organization created
 specifically to own Python-related Intellectual Property.  Zope Corporation is a
 sponsoring member of the PSF.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1564,7 +1564,7 @@ Basic customization
       This is intended to provide protection against a denial-of-service caused
       by carefully chosen inputs that exploit the worst case performance of a
       dict insertion, O(n\ :sup:`2`) complexity.  See
-      http://www.ocert.org/advisories/ocert-2011-003.html for details.
+      http://ocert.org/advisories/ocert-2011-003.html for details.
 
       Changing hash values affects the iteration order of sets.
       Python has never made guarantees about this ordering

--- a/Doc/reference/introduction.rst
+++ b/Doc/reference/introduction.rst
@@ -74,7 +74,7 @@ PyPy
    and a Just in Time compiler. One of the goals of the project is to encourage
    experimentation with the language itself by making it easier to modify the
    interpreter (since it is written in Python).  Additional information is
-   available on `the PyPy project's home page <https://pypy.org/>`_.
+   available on `the PyPy project's home page <https://www.pypy.org/>`_.
 
 Each of these implementations varies in some way from the language as documented
 in this manual, or introduces specific information beyond what's covered in the

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -370,7 +370,7 @@ Miscellaneous options
    Hash randomization is intended to provide protection against a
    denial-of-service caused by carefully chosen inputs that exploit the worst
    case performance of a dict construction, O(n\ :sup:`2`) complexity.  See
-   http://www.ocert.org/advisories/ocert-2011-003.html for details.
+   http://ocert.org/advisories/ocert-2011-003.html for details.
 
    :envvar:`PYTHONHASHSEED` allows you to set a fixed value for the hash
    seed secret.

--- a/Doc/using/mac.rst
+++ b/Doc/using/mac.rst
@@ -66,7 +66,7 @@ number of standard Unix command line editors, :program:`vim` and
 :program:`BBEdit` or :program:`TextWrangler` from Bare Bones Software (see
 http://www.barebones.com/products/bbedit/index.html) are good choices, as is
 :program:`TextMate` (see https://macromates.com/). Other editors include
-:program:`Gvim` (https://macvim-dev.github.io/macvim/) and :program:`Aquamacs`
+:program:`Gvim` (https://macvim.org/macvim/) and :program:`Aquamacs`
 (http://aquamacs.org/).
 
 To run your script from the Terminal window you must make sure that

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -541,7 +541,7 @@ Besides the standard CPython distribution, there are modified packages including
 additional functionality.  The following is a list of popular versions and their
 key features:
 
-`ActivePython <https://www.activestate.com/activepython/>`_
+`ActivePython <https://www.activestate.com/products/python/>`_
     Installer with multi-platform compatibility, documentation, PyWin32
 
 `Anaconda <https://www.anaconda.com/download/>`_

--- a/Doc/whatsnew/2.0.rst
+++ b/Doc/whatsnew/2.0.rst
@@ -933,7 +933,7 @@ using it::
    parser.parse( 'hamlet.xml' )
 
 For more information, consult the Python documentation, or the XML HOWTO at
-http://pyxml.sourceforge.net/topics/howto/xml-howto.html.
+https://pyxml.sourceforge.net/topics/howto/xml-howto.html.
 
 
 DOM Support

--- a/Doc/whatsnew/2.1.rst
+++ b/Doc/whatsnew/2.1.rst
@@ -613,7 +613,7 @@ New and Improved Modules
   framework based on running embedded examples in docstrings and comparing the
   results against the expected output.  PyUnit, contributed by Steve Purcell, is a
   unit testing framework inspired by JUnit, which was in turn an adaptation of
-  Kent Beck's Smalltalk testing framework.  See http://pyunit.sourceforge.net/ for
+  Kent Beck's Smalltalk testing framework.  See https://pyunit.sourceforge.net/ for
   more information about PyUnit.
 
 * The :mod:`difflib` module contains a class, :class:`SequenceMatcher`, which

--- a/Doc/whatsnew/2.2.rst
+++ b/Doc/whatsnew/2.2.rst
@@ -632,10 +632,10 @@ queen threatens another) and the Knight's Tour (a route that takes a knight to
 every square of an $NxN$ chessboard without visiting any square twice).
 
 The idea of generators comes from other programming languages, especially Icon
-(https://www.cs.arizona.edu/icon/), where the idea of generators is central.  In
+(https://www2.cs.arizona.edu/icon/), where the idea of generators is central.  In
 Icon, every expression and function call behaves like a generator.  One example
 from "An Overview of the Icon Programming Language" at
-https://www.cs.arizona.edu/icon/docs/ipd266.htm gives an idea of what this looks
+https://www2.cs.arizona.edu/icon/docs/ipd266.htm gives an idea of what this looks
 like::
 
    sentence := "Store it in the neighboring harbor"

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -218,10 +218,10 @@ queen threatens another) and the Knight's Tour (a route that takes a knight to
 every square of an $NxN$ chessboard without visiting any square twice).
 
 The idea of generators comes from other programming languages, especially Icon
-(https://www.cs.arizona.edu/icon/), where the idea of generators is central.  In
+(https://www2.cs.arizona.edu/icon/), where the idea of generators is central.  In
 Icon, every expression and function call behaves like a generator.  One example
 from "An Overview of the Icon Programming Language" at
-https://www.cs.arizona.edu/icon/docs/ipd266.htm gives an idea of what this looks
+https://www2.cs.arizona.edu/icon/docs/ipd266.htm gives an idea of what this looks
 like::
 
    sentence := "Store it in the neighboring harbor"
@@ -1332,7 +1332,7 @@ complete list of changes, or look through the CVS logs for all the details.
   (Contributed by Kevin O'Connor.)
 
 * The IDLE integrated development environment has been updated using the code
-  from the IDLEfork project (http://idlefork.sourceforge.net).  The most notable feature is
+  from the IDLEfork project (https://idlefork.sourceforge.net).  The most notable feature is
   that the code being developed is now executed in a subprocess, meaning that
   there's no longer any need for manual ``reload()`` operations. IDLE's core code
   has been incorporated into the standard library as the :mod:`idlelib` package.

--- a/Doc/whatsnew/2.4.rst
+++ b/Doc/whatsnew/2.4.rst
@@ -756,7 +756,7 @@ API that perform ASCII-only conversions, ignoring the locale setting:
   :c:expr:`double` to an ASCII string.
 
 The code for these functions came from the GLib library
-(https://developer.gnome.org/glib/stable/), whose developers kindly
+(https://developer-old.gnome.org/glib/2.26/), whose developers kindly
 relicensed the relevant functions and donated them to the Python Software
 Foundation.  The :mod:`locale` module  can now change the numeric locale,
 letting extensions such as GTK+  produce the correct results.

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -1433,7 +1433,7 @@ one, :func:`math.trunc`, that's been backported to Python 2.6.
 
    `Scheme's numerical tower <https://www.gnu.org/software/guile/manual/html_node/Numerical-Tower.html#Numerical-Tower>`__, from the Guile manual.
 
-   `Scheme's number datatypes <https://schemers.org/Documents/Standards/R5RS/HTML/r5rs-Z-H-9.html#%_sec_6.2>`__ from the R5RS Scheme specification.
+   `Scheme's number datatypes <https://conservatory.scheme.org/schemers/Documents/Standards/R5RS/HTML/r5rs-Z-H-9.html#%_sec_6.2>`__ from the R5RS Scheme specification.
 
 
 The :mod:`fractions` Module
@@ -2363,7 +2363,7 @@ changes, or look through the Subversion logs for all the details.
   negotiation itself.  (Patch contributed by Bill Fenner;
   :issue:`829951`.)
 
-* The :mod:`socket` module now supports TIPC (http://tipc.sourceforge.net/),
+* The :mod:`socket` module now supports TIPC (https://tipc.sourceforge.net/),
   a high-performance non-IP-based protocol designed for use in clustered
   environments.  TIPC addresses are 4- or 5-tuples.
   (Contributed by Alberto Bertogli; :issue:`1646`.)

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -74,7 +74,7 @@ New built-in features:
 New standard library modules:
 
 * :pep:`680`: :mod:`tomllib` —
-  Support for parsing `TOML <https://toml.io/>`_ in the Standard Library
+  Support for parsing `TOML <https://toml.io>`_ in the Standard Library
 
 Interpreter improvements:
 
@@ -220,7 +220,7 @@ The copy of the :ref:`launcher` included with Python 3.11 has been significantly
 updated. It now supports company/tag syntax as defined in :pep:`514` using the
 ``-V:<company>/<tag>`` argument instead of the limited ``-<major>.<minor>``.
 This allows launching distributions other than ``PythonCore``,
-the one hosted on `python.org <https://python.org>`_.
+the one hosted on `python.org <https://www.python.org>`_.
 
 When using ``-V:`` selectors, either company or tag can be omitted, but all
 installs will be searched. For example, ``-V:OtherPython/`` will select the
@@ -2489,7 +2489,7 @@ Porting to Python 3.11
       #endif
 
   Or use the `pythoncapi_compat project
-  <https://github.com/python/pythoncapi_compat>`__ to get these two
+  <https://github.com/python/pythoncapi-compat>`__ to get these two
   functions on older Python versions.
 
 * Changes of the :c:type:`PyThreadState` structure members:
@@ -2541,8 +2541,8 @@ Porting to Python 3.11
       }
       #endif
 
-  Or use `the pythoncapi_compat project
-  <https://github.com/python/pythoncapi_compat>`__ to get these functions
+  Or use `the pythoncapi-compat project
+  <https://github.com/python/pythoncapi-compat>`__ to get these functions
   on old Python functions.
 
 * Distributors are encouraged to build Python with the optimized Blake2

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -74,7 +74,7 @@ New built-in features:
 New standard library modules:
 
 * :pep:`680`: :mod:`tomllib` —
-  Support for parsing `TOML <https://toml.io>`_ in the Standard Library
+  Support for parsing `TOML <https://toml.io/>`_ in the Standard Library
 
 Interpreter improvements:
 

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -785,8 +785,8 @@ functools
 
   (Contributed by Raymond Hettinger and incorporating design ideas from Jim
   Baker, Miki Tebeka, and Nick Coghlan; see `recipe 498245
-  <https://code.activestate.com/recipes/498245>`_\, `recipe 577479
-  <https://code.activestate.com/recipes/577479>`_\, :issue:`10586`, and
+  <https://code.activestate.com/recipes/498245/>`_\, `recipe 577479
+  <https://code.activestate.com/recipes/577479/>`_\, :issue:`10586`, and
   :issue:`10593`.)
 
 * The :func:`functools.wraps` decorator now adds a :attr:`__wrapped__` attribute
@@ -2603,7 +2603,7 @@ Also, there were a number of updates to the Mac OS X build, see
 for details.  For users running a 32/64-bit
 build, there is a known problem with the default Tcl/Tk on Mac OS X 10.6.
 Accordingly, we recommend installing an updated alternative such as
-`ActiveState Tcl/Tk 8.5.9 <https://www.activestate.com/activetcl/downloads>`_\.
+`ActiveState Tcl/Tk 8.5.9 <https://web.archive.org/web/20101208191259/https://www.activestate.com/activetcl/downloads>`_\.
 See https://www.python.org/download/mac/tcltk/ for additional details.
 
 Porting to Python 3.2

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -1893,7 +1893,7 @@ socket
 
 * The :class:`~socket.socket` class now supports the PF_RDS protocol family
   (https://en.wikipedia.org/wiki/Reliable_Datagram_Sockets and
-  https://oss.oracle.com/projects/rds/).
+  `https://oss.oracle.com/projects/rds <https://web.archive.org/web/20130115155505/https://oss.oracle.com/projects/rds/>`__).
 
 * The :class:`~socket.socket` class now supports the ``PF_SYSTEM`` protocol
   family on OS X.  (Contributed by Michael Goderbauer in :issue:`13777`.)

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -2212,7 +2212,7 @@ for details.)
 The :c:member:`PyTypeObject.tp_finalize` slot is now part of the stable ABI.
 
 Windows builds now require Microsoft Visual C++ 14.0, which
-is available as part of `Visual Studio 2015 <https://web.archive.org/web/20150924233002/https://www.visualstudio.com//>`_.
+is available as part of `Visual Studio 2015 <https://visualstudio.microsoft.com/en/vs/older-downloads/#visual-studio-2015-and-other-products>`_.
 
 Extension modules now include a platform information tag in their filename on
 some platforms (the tag is optional, and CPython will import extensions without

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -425,7 +425,7 @@ are declared in the annotations::
 While these annotations are available at runtime through the usual
 :attr:`__annotations__` attribute, *no automatic type checking happens at
 runtime*.  Instead, it is assumed that a separate off-line type checker
-(e.g. `mypy <http://mypy-lang.org>`_) will be used for on-demand
+(e.g. `mypy <https://mypy-lang.org>`_) will be used for on-demand
 source code analysis.
 
 The type system supports unions, generic types, and a special type
@@ -2212,7 +2212,7 @@ for details.)
 The :c:member:`PyTypeObject.tp_finalize` slot is now part of the stable ABI.
 
 Windows builds now require Microsoft Visual C++ 14.0, which
-is available as part of `Visual Studio 2015 <https://www.visualstudio.com/>`_.
+is available as part of `Visual Studio 2015 <https://web.archive.org/web/20150924233002/https://www.visualstudio.com//>`_.
 
 Extension modules now include a platform information tag in their filename on
 some platforms (the tag is optional, and CPython will import extensions without

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -238,7 +238,7 @@ and the ``__annotations__`` attribute.
       and Guido van Rossum. Implemented by Ivan Levkivskyi.
 
    Tools that use or will use the new syntax:
-   `mypy <http://www.mypy-lang.org/>`_,
+   `mypy <https://www.mypy-lang.org/>`_,
    `pytype <https://github.com/google/pytype>`_, PyCharm, etc.
 
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -2229,7 +2229,7 @@ The benchmarks were measured on an
 `Intel® Core™ i7-4960HQ processor
 <https://ark.intel.com/content/www/us/en/ark/products/76088/intel-core-i7-4960hq-processor-6m-cache-up-to-3-80-ghz.html>`_
 running the macOS 64-bit builds found at
-`python.org <https://www.python.org/downloads/mac-osx/>`_.
+`python.org <https://www.python.org/downloads/macos/>`_.
 The benchmark script displays timings in nanoseconds.
 
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -849,7 +849,7 @@ in nanoseconds.  The benchmarks were measured on an
 `Intel® Core™ i7-4960HQ processor
 <https://ark.intel.com/content/www/us/en/ark/products/76088/intel-core-i7-4960hq-processor-6m-cache-up-to-3-80-ghz.html>`_
 running the macOS 64-bit builds found at
-`python.org <https://www.python.org/downloads/mac-osx/>`_.
+`python.org <https://www.python.org/downloads/macos/>`_.
 
 
 Deprecated

--- a/Misc/NEWS.d/3.7.0a1.rst
+++ b/Misc/NEWS.d/3.7.0a1.rst
@@ -6255,7 +6255,7 @@ Fix python-gdb.py didn't support new dict implementation.
 .. section: Tools/Demos
 
 The pybench and pystone microbenchmark have been removed from Tools. Please
-use the new Python benchmark suite https://github.com/python/performance
+use the new Python benchmark suite https://github.com/python/pyperformance
 which is more reliable and includes a portable version of pybench working on
 Python 2 and Python 3.
 


### PR DESCRIPTION
This is another patch required to fix the current state of `make linkcheck` in Python Docs.

This pull request fixes occurrences of "redirected permanently" as reported by make linkcheck. The last one is "redirected with Found", which I plan to present after this one.

See [the full output containing redirected permanently](https://github.com/python/cpython/files/11360440/main-log-redir-permanently.txt).

Note on backporting to 3.11:
 - The changes in 'main' to Doc/library/importlib.metadata.rst will fail because there is no change to apply to '3.11'
 - Need to apply changes (http->https and domain) to apiref.rst, examples.rst and setupscript.rst at Doc/distutils/

I collapsed the contents of this message to reduce the size of the original message and make easier to reach the comments.

<details>
<summary><h3>Content no longer available</h3></summary>
<pre>
library/hashlib.rst:737: [redirected permanently] https://131002.net/blake/ to https://www.aumasson.jp/
whatsnew/3.5.rst:2214: [redirected permanently] https://www.visualstudio.com/ to https://visualstudio.microsoft.com/
whatsnew/2.4.rst:758: [redirected permanently] https://developer.gnome.org/glib/stable/ to https://docs.gtk.org/glib/
whatsnew/3.3.rst:1894: [redirected permanently] https://oss.oracle.com/projects/rds/ to https://oss.oracle.com:443/
</pre>

I used wayback machine because the current website is not available anymore, or its current content does not reflect the contents from that time (e.g. visual studio was meant to be version 2015, which surely is different from today's).
</details>

<details>
<summary><h3>Redirecting to new domain</h3></summary>
<pre>
faq/extending.rst:44: [redirected permanently] https://www.cosc.canterbury.ac.nz/greg.ewing/python/Pyrex/ to https://www.csse.canterbury.ac.nz/greg.ewing/python/Pyrex/
license.rst:22: [redirected permanently] https://www.zope.org/ to https://www.zope.dev/
library/zipfile.rst:132: [redirected permanently] http://www.info-zip.org/ to https://infozip.sourceforge.net/
using/mac.rst:62: [redirected permanently] https://macvim-dev.github.io/macvim/ to https://macvim.org/macvim/
library/unittest.mock-examples.rst:1074: [redirected permanently] https://twistedmatrix.com/documents/11.0.0/api/twisted.python.components.html to https://twisted.org/documents/11.0.0/api/twisted.python.components.html
whatsnew/2.6.rst:1436: [redirected permanently] https://schemers.org/Documents/Standards/R5RS/HTML/r5rs-Z-H-9.html#%_sec_6.2 to https://conservatory.scheme.org/schemers/Documents/Standards/R5RS/HTML/r5rs-Z-H-9.html#%_sec_6.2
library/ssl.rst:1722: [redirected permanently] https://vincent.bernat.im/en/blog/2011-ssl-perfect-forward-secrecy to https://vincent.bernat.ch/en/blog/2011-ssl-perfect-forward-secrecy
</pre>

Simply updated the domain.
</details>

<details>
<summary><h3>http to https</h3></summary>
<pre>
faq/programming.rst:64: [redirected permanently] http://mypy-lang.org/ to https://mypy-lang.org/
whatsnew/2.1.rst:611: [redirected permanently] http://pyunit.sourceforge.net/ to https://pyunit.sourceforge.net/
whatsnew/changelog.rst:38796: [redirected permanently] http://www.python.org/ to https://www.python.org/
whatsnew/2.6.rst:2366: [redirected permanently] http://tipc.sourceforge.net/ to https://tipc.sourceforge.net/
whatsnew/3.5.rst:425: [redirected permanently] http://mypy-lang.org to https://mypy-lang.org/
whatsnew/2.3.rst:1334: [redirected permanently] http://idlefork.sourceforge.net to https://idlefork.sourceforge.net/
whatsnew/2.0.rst:935: [redirected permanently] http://pyxml.sourceforge.net/topics/howto/xml-howto.html to https://pyxml.sourceforge.net/topics/howto/xml-howto.html
</pre>

"http://www.python.org": kept as is and added to allowed redirects because its use was intentional in the doc (Misc/NEWS.d/3.5.0a1.rst)

The rest of them I simply replaced with the redirect.
</details>

<details>
<summary><h3>Subdomain changed (www, ww2, man)</h3></summary>
<pre>
library/hashlib.rst:340: [redirected permanently] https://blake2.net to https://www.blake2.net/
library/unittest.rst:71: [redirected permanently] https://jenkins.io/ to https://www.jenkins.io/
library/statistics.rst:24: [redirected permanently] https://www.scipy.org/ to https://scipy.org/
reference/introduction.rst:72: [redirected permanently] https://pypy.org/ to https://www.pypy.org/
whatsnew/3.11.rst:219: [redirected permanently] https://python.org to https://www.python.org/
library/xmlrpc.client.rst:166: [redirected permanently] https://www.tldp.org/HOWTO/XML-RPC-HOWTO/index.html to https://tldp.org/HOWTO/XML-RPC-HOWTO/index.html
reference/datamodel.rst:1564: [redirected permanently] http://www.ocert.org/advisories/ocert-2011-003.html to http://ocert.org/advisories/ocert-2011-003.html
whatsnew/2.2.rst:634: [redirected permanently] https://www.cs.arizona.edu/icon/ to https://www2.cs.arizona.edu/icon/
library/os.rst:4594: [redirected permanently] https://www.freebsd.org/cgi/man.cgi?time(3) to https://man.freebsd.org/cgi/man.cgi?time(3)
library/resource.rst:243: [redirected permanently] https://www.freebsd.org/cgi/man.cgi?query=tuning&sektion=7 to https://man.freebsd.org/cgi/man.cgi?query=tuning&sektion=7
library/select.rst:508: [redirected permanently] https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2 to https://man.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
</pre>

Simply replaced with the redirect.
</details>

<details>
<summary><h3>App name changed</h3></summary>
<pre>
whatsnew/changelog.rst:27868: [redirected permanently] https://github.com/python/performance to https://github.com/python/pyperformance
library/importlib.metadata.rst:176: [redirected permanently] https://pypi.org/project/backports.entry_points_selectable to https://pypi.org/project/backports.entry-points-selectable/
whatsnew/3.11.rst:2491: [redirected permanently] https://github.com/python/pythoncapi_compat to https://github.com/python/pythoncapi-compat
</pre>

Simply replaced with the redirect.
</details>

<details>
<summary><h3>Microsoft redirecting to learn.microsoft.com</h3></summary>
<pre>
library/asyncio-eventloop.rst:1716: [redirected permanently] https://docs.microsoft.com/en-ca/windows/desktop/FileIO/i-o-completion-ports to https://learn.microsoft.com/en-ca/windows/win32/fileio/i-o-completion-ports
library/msilib.rst:131: [redirected permanently] https://msdn.microsoft.com/en-us/library/bb432265.aspx to https://learn.microsoft.com/en-us/windows/win32/api/fci/nf-fci-fcicreate?redirectedfrom=MSDN
library/venv.rst:93: [redirected permanently] https://go.microsoft.com/fwlink/?LinkID=135170 to https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.3
</pre>

The above lines are just examples. The output file shows several occurrences of these three redirects. I felt it would be better to use allowed redirect instead of replacing it for both reducing the commit lines and to keep history.
</details>

<details>
<summary><h3>Redirecting to English version</h3></summary>
<pre>
faq/general.rst:337: [redirected permanently] https://www.redhat.com to https://www.redhat.com/en
whatsnew/3.11.rst:76: [redirected permanently] https://toml.io/ to https://toml.io/en/
</pre>
These websites' well-known URLs redirect to their English versions. I added allowed redirect because felt using the URL without language looks cleaner.
</details>

<details>
<summary><h3>Redirecting to proper landing page</h3></summary>
<pre>
faq/general.rst:36: [redirected permanently] https://www.python.org/psf/ to https://www.python.org/psf-landing/
faq/general.rst:57: [redirected permanently] https://www.python.org/psf/license/ to https://docs.python.org/3/license.html
howto/perf_profiling.rst:11: [redirected permanently] https://perf.wiki.kernel.org to https://perf.wiki.kernel.org/index.php/Main_Page
library/asyncio-eventloop.rst:532: [redirected permanently] https://tools.ietf.org/html/rfc6555 to https://datatracker.ietf.org/doc/html/rfc6555
library/http.client.rst:356: [redirected permanently] https://tools.ietf.org/html/rfc7231#section-4.3.6 to https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.6
library/struct.rst:173: [redirected permanently] https://tools.ietf.org/html/rfc1700 to https://datatracker.ietf.org/doc/html/rfc1700
library/sqlite3.rst:47: [redirected permanently] https://www.sqlite.org to https://www.sqlite.org/index.html
</pre>
IETF URLs: I changed to the new one, as Tools website was decommissioned (as per authors.ietf.org, redirected from tools.ietf.org)

PSF License: I replaced with the redirected link and updated the text, there is no PSF license page linking to the full text of the license — it all goes to license page in Python's documentation

The rest of them I included to the allowed redirects because I felt they seemed better as they are now.
</details>

<details>
<summary><h3>Redirecting to new structure in the website</h3></summary>
<pre>
faq/extending.rst:50: [redirected permanently] https://www.boost.org/libs/python/doc/index.html to https://www.boost.org/doc/libs/1_82_0/libs/python/doc/html/index.html
faq/general.rst:215: [redirected permanently] https://mail.python.org/mailman/listinfo/python-announce-list to https://mail.python.org/mailman3/lists/python-announce-list.python.org/
faq/general.rst:354: [redirected permanently] https://mail.python.org/mailman/listinfo/python-dev/ to https://mail.python.org/mailman3/lists/python-dev.python.org/
faq/windows.rst:283: [redirected permanently] https://support.microsoft.com/en-us/help/3118401/ to https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-322bf30f-4735-bb94-3949-49f5c49f4732
howto/functional.rst:1210: [redirected permanently] https://mitpress.mit.edu/sicp to https://mitpress.mit.edu/9780262510875/structure-and-interpretation-of-computer-programs/
library/hashlib.rst:621: [redirected permanently] https://csrc.nist.gov/publications/detail/sp/800-106/final to https://csrc.nist.gov/publications/detail/sp/800-106/archive/2009-02-25
whatsnew/3.8.rst:2228: [redirected permanently] https://www.python.org/downloads/mac-osx/ to https://www.python.org/downloads/macos/
whatsnew/3.2.rst:786: [redirected permanently] https://code.activestate.com/recipes/498245 to https://code.activestate.com:443/recipes/498245/
library/sys.rst:788: [redirected permanently] https://code.activestate.com/recipes/577504 to https://code.activestate.com:443/recipes/577504/
whatsnew/3.2.rst:786: [redirected permanently] https://code.activestate.com/recipes/577479 to https://code.activestate.com:443/recipes/577479/
using/windows.rst:545: [redirected permanently] https://www.activestate.com/activepython/ to https://www.activestate.com/products/python/
whatsnew/3.2.rst:2601: [redirected permanently] https://www.activestate.com/activetcl/downloads to https://www.activestate.com/products/tcl/
library/plistlib.rst:49: [redirected permanently] https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/PropertyLists/ to https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/PropertyLists/
using/windows.rst:549: [redirected permanently] https://www.anaconda.com/download/ to https://www.anaconda.com/products/distribution
</pre>

boost: added to allowed redirect because the URL is used without mentioning specific version, so linking to boost 1.82 could not be as expected by the author. There is no "latest" URL -- I mean, it exists but redirects to the latest released version, 1.82 as of this PR.

support.microsoft.com: added to allowed redirect because it seems cleaner and more future proof than the redirected URL.

SICP: added to allowed redirect because the URL is not a hyperlink with other text, so replacing the redirected URL would look weird and huge.

activestate recipes: adding '/' to the end of the URL solved the redirect reported.

activetcl: The text refers to a specific old version, so I used wayback machine.

The rest of them I replaced with the redirect.
</details>

<!-- gh-issue-number: gh-103484 -->
* Issue: gh-103484
<!-- /gh-issue-number -->
