### PR TITLE
gh-104015: Fix direct invocation of `test_dataclasses`

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3671,7 +3671,7 @@ class TestStringAnnotations(unittest.TestCase):
 ByMakeDataClass = make_dataclass('ByMakeDataClass', [('x', int)])
 ManualModuleMakeDataClass = make_dataclass('ManualModuleMakeDataClass',
                                            [('x', int)],
-                                           module='test.test_dataclasses')
+                                           module=__name__)
 WrongNameMakeDataclass = make_dataclass('Wrong', [('x', int)])
 WrongModuleMakeDataclass = make_dataclass('WrongModuleMakeDataclass',
                                           [('x', int)],


### PR DESCRIPTION
Local tests do pass now:

```
» ./python.exe Lib/test/test_dataclasses.py 
........................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 232 tests in 1.113s

OK
```

Closes #104015

<!-- gh-issue-number: gh-104015 -->
* Issue: gh-104015
<!-- /gh-issue-number -->
