### PR TITLE
gh-102799: replace sys.exc_info by sys.exception in inspect and traceback modules

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1766,7 +1766,9 @@ def stack(context=1):
 
 def trace(context=1):
     """Return a list of records for the stack below the current exception."""
-    return getinnerframes(sys.exc_info()[2], context)
+    exc = sys.exception()
+    tb = None if exc is None else exc.__traceback__
+    return getinnerframes(tb, context)
 
 
 # ------------------------------------------------ static version of getattr

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -179,12 +179,12 @@ def _safe_string(value, what, func=str):
 # --
 
 def print_exc(limit=None, file=None, chain=True):
-    """Shorthand for 'print_exception(*sys.exc_info(), limit, file, chain)'."""
-    print_exception(*sys.exc_info(), limit=limit, file=file, chain=chain)
+    """Shorthand for 'print_exception(sys.exception(), limit, file, chain)'."""
+    print_exception(sys.exception(), limit=limit, file=file, chain=chain)
 
 def format_exc(limit=None, chain=True):
     """Like print_exc() but return a string."""
-    return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
+    return "".join(format_exception(sys.exception(), limit=limit, chain=chain))
 
 def print_last(limit=None, file=None, chain=True):
     """This is a shorthand for 'print_exception(sys.last_exc, limit, file, chain)'."""


### PR DESCRIPTION


<!-- gh-issue-number: gh-102799 -->
* Issue: gh-102799
<!-- /gh-issue-number -->
