### PR TITLE
gh-104018: disallow "z" format specifier in %-format of byte strings

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -619,6 +619,8 @@ class FormatTest(unittest.TestCase):
         error_msg = re.escape("unsupported format character 'z'")
         with self.assertRaisesRegex(ValueError, error_msg):
             "%z.1f" % 0  # not allowed in old style string interpolation
+        with self.assertRaisesRegex(ValueError, error_msg):
+            b"%z.1f" % 0
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Core and Builtins/2023-05-01-12-03-52.gh-issue-104018.PFxGS4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-05-01-12-03-52.gh-issue-104018.PFxGS4.rst
@@ -1,0 +1,1 @@
+Disallow the "z" format specifier in %-format of bytes objects.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -705,7 +705,6 @@ _PyBytes_FormatEx(const char *format, Py_ssize_t format_len,
                 case ' ': flags |= F_BLANK; continue;
                 case '#': flags |= F_ALT; continue;
                 case '0': flags |= F_ZERO; continue;
-                case 'z': flags |= F_NO_NEG_0; continue;
                 }
                 break;
             }


### PR DESCRIPTION
PEP-0682 specified that %-formatting would not support the "z" specifier, but it was unintentionally allowed for a byte strings.

<!-- gh-issue-number: gh-104018 -->
* Issue: gh-104018
<!-- /gh-issue-number -->
