### PR TITLE
gh-104035: Do not ignore user-defined `__{get,set}state__` in slotted frozen dataclasses

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1227,8 +1227,10 @@ def _add_slots(cls, is_frozen, weakref_slot):
 
     if is_frozen:
         # Need this for pickling frozen classes with slots.
-        cls.__getstate__ = _dataclass_getstate
-        cls.__setstate__ = _dataclass_setstate
+        if '__getstate__' not in cls_dict:
+            cls.__getstate__ = _dataclass_getstate
+        if '__setstate__' not in cls_dict:
+            cls.__setstate__ = _dataclass_setstate
 
     return cls
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3184,6 +3184,74 @@ class TestSlots(unittest.TestCase):
                 self.assertIsNot(obj, p)
                 self.assertEqual(obj, p)
 
+    @dataclass(frozen=True, slots=True)
+    class FrozenSlotsGetStateClass:
+        foo: str
+        bar: int
+
+        getstate_called: bool = field(default=False, compare=False)
+
+        def __getstate__(self):
+            object.__setattr__(self, 'getstate_called', True)
+            return [self.foo, self.bar]
+
+    @dataclass(frozen=True, slots=True)
+    class FrozenSlotsSetStateClass:
+        foo: str
+        bar: int
+
+        setstate_called: bool = field(default=False, compare=False)
+
+        def __setstate__(self, state):
+            object.__setattr__(self, 'setstate_called', True)
+            object.__setattr__(self, 'foo', state[0])
+            object.__setattr__(self, 'bar', state[1])
+
+    @dataclass(frozen=True, slots=True)
+    class FrozenSlotsAllStateClass:
+        foo: str
+        bar: int
+
+        getstate_called: bool = field(default=False, compare=False)
+        setstate_called: bool = field(default=False, compare=False)
+
+        def __getstate__(self):
+            object.__setattr__(self, 'getstate_called', True)
+            return [self.foo, self.bar]
+
+        def __setstate__(self, state):
+            object.__setattr__(self, 'setstate_called', True)
+            object.__setattr__(self, 'foo', state[0])
+            object.__setattr__(self, 'bar', state[1])
+
+    def test_frozen_slots_pickle_custom_state(self):
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(proto=proto):
+                obj = self.FrozenSlotsGetStateClass('a', 1)
+                dumped = pickle.dumps(obj, protocol=proto)
+
+                self.assertTrue(obj.getstate_called)
+                self.assertEqual(obj, pickle.loads(dumped))
+
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(proto=proto):
+                obj = self.FrozenSlotsSetStateClass('a', 1)
+                obj2 = pickle.loads(pickle.dumps(obj, protocol=proto))
+
+                self.assertTrue(obj2.setstate_called)
+                self.assertEqual(obj, obj2)
+
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(proto=proto):
+                obj = self.FrozenSlotsAllStateClass('a', 1)
+                dumped = pickle.dumps(obj, protocol=proto)
+
+                self.assertTrue(obj.getstate_called)
+
+                obj2 = pickle.loads(dumped)
+                self.assertTrue(obj2.setstate_called)
+                self.assertEqual(obj, obj2)
+
     def test_slots_with_default_no_init(self):
         # Originally reported in bpo-44649.
         @dataclass(slots=True)

--- a/Misc/NEWS.d/next/Library/2023-05-01-16-43-28.gh-issue-104035.MrJBw8.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-01-16-43-28.gh-issue-104035.MrJBw8.rst
@@ -1,2 +1,2 @@
-Do not ignore user-defined ``__getstate__`` and ``__setstate__`` method for
+Do not ignore user-defined ``__getstate__`` and ``__setstate__`` methods for
 slotted frozen dataclasses.

--- a/Misc/NEWS.d/next/Library/2023-05-01-16-43-28.gh-issue-104035.MrJBw8.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-01-16-43-28.gh-issue-104035.MrJBw8.rst
@@ -1,0 +1,2 @@
+Do not ignore user-defined ``__getstate__`` and ``__setstate__`` method for
+slotted frozen dataclasses.


### PR DESCRIPTION
I had some time to look at this problem. Here's what I found:
1. Our docs do not say anything about `__getstate__` or `__setstate__` methods and their generation: https://docs.python.org/3/library/dataclasses.html
2. I think that this new implementation is in-line with other methods / attributes generation
3. It should not break any existing code, except cases where some invalid `__getstate__` / `__setstate__` method was overridden with the correct one (but, there's nothing we can do if user already has invalid code)
4. This seems like a bug-fix, so probably it should be back-ported to 3.11 as well

<!-- gh-issue-number: gh-104035 -->
* Issue: gh-104035
<!-- /gh-issue-number -->
