### PR TITLE
Clickable Email in the "About" Window

### DIFF
--- a/Lib/idlelib/help_about.py
+++ b/Lib/idlelib/help_about.py
@@ -91,6 +91,7 @@ class AboutDialog(Toplevel):
         email = Label(frame_background, text='email:  idle-dev@python.org',
                       justify=LEFT, fg=self.fg, bg=self.bg)
         email.grid(row=6, column=0, columnspan=2, sticky=W, padx=10, pady=0)
+        email.bind("<Button-1>", lambda event: webbrowser.open("mailto:idle-dev@python.org"))
         docs_url = ("https://docs.python.org/%d.%d/library/idle.html" %
                     sys.version_info[:2])
         docs = Label(frame_background, text=docs_url,

--- a/Lib/idlelib/help_about.py
+++ b/Lib/idlelib/help_about.py
@@ -91,7 +91,7 @@ class AboutDialog(Toplevel):
         email = Label(frame_background, text='email:  idle-dev@python.org',
                       justify=LEFT, fg=self.fg, bg=self.bg)
         email.grid(row=6, column=0, columnspan=2, sticky=W, padx=10, pady=0)
-        email.bind("<Button-1>", lambda event: webbrowser.open("mailto:idle-dev@python.org"))
+        email.bind("<Button-1>", lambda event: webbrowser.open("https://discuss.python.org/"))
         docs_url = ("https://docs.python.org/%d.%d/library/idle.html" %
                     sys.version_info[:2])
         docs = Label(frame_background, text=docs_url,


### PR DESCRIPTION
Make email address clickable in the "About" window (using "mailto").
If you click it, it will automatically use your default email client and set the recipient to "idle-dev@python.org".