### PR TITLE
gh-104061: Add socket.SO_BINDTOIFINDEX constant

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -445,6 +445,11 @@ Constants
       Added ``IP_PKTINFO``, ``IP_UNBLOCK_SOURCE``, ``IP_BLOCK_SOURCE``,
       ``IP_ADD_SOURCE_MEMBERSHIP``, ``IP_DROP_SOURCE_MEMBERSHIP``.
 
+   .. versionchanged:: 3.13
+      Added ``SO_BINDTOIFINDEX``. On Linux this constant can be used in the
+      same way that ``SO_BINDTODEVICE`` is used, but with the index of a
+      network interface instead of its name.
+
 .. data:: AF_CAN
           PF_CAN
           SOL_CAN_*

--- a/Misc/NEWS.d/next/Library/2023-05-01-22-28-57.gh-issue-104061.vxfBXf.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-01-22-28-57.gh-issue-104061.vxfBXf.rst
@@ -1,0 +1,1 @@
+Add :data:`socket.SO_BINDTOIFINDEX` constant.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7926,6 +7926,9 @@ socket_exec(PyObject *m)
 #ifdef  SO_BINDTODEVICE
     ADD_INT_MACRO(m, SO_BINDTODEVICE);
 #endif
+#ifdef  SO_BINDTOIFINDEX
+    ADD_INT_MACRO(m, SO_BINDTOIFINDEX);
+#endif
 #ifdef  SO_PRIORITY
     ADD_INT_MACRO(m, SO_PRIORITY);
 #endif


### PR DESCRIPTION
This socket option avoids a race condition between SO_BINDTODEVICE and network interface renaming.




<!-- gh-issue-number: gh-104061 -->
* Issue: gh-104061
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104062.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->