### PR TITLE
gh-104057: Fix direct invocation of test_super

### DIFF
--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -359,7 +359,7 @@ class TestSuper(unittest.TestCase):
             def method(self):
                 return super().msg
 
-        with patch("test.test_super.super", MySuper) as m:
+        with patch(f"{__name__}.super", MySuper) as m:
             self.assertEqual(C().method(), "super super")
 
     def test_shadowed_dynamic_two_arg(self):
@@ -373,7 +373,7 @@ class TestSuper(unittest.TestCase):
             def method(self):
                 return super(1, 2).msg
 
-        with patch("test.test_super.super", MySuper) as m:
+        with patch(f"{__name__}.super", MySuper) as m:
             self.assertEqual(C().method(), "super super")
             self.assertEqual(call_args, [(1, 2)])
 


### PR DESCRIPTION
```python3
PS C:\Users\KIRILL-1\CLionProjects\cpython> ./python Lib/test/test_super.py            
Running Debug|x64 interpreter...
.................EE............
======================================================================
ERROR: test_shadowed_dynamic (__main__.TestSuper.test_shadowed_dynamic)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\KIRILL-1\CLionProjects\cpython\Lib\test\test_super.py", line 363, in test_shadowed_dynamic
    self.assertEqual(C().method(), "super super")
                     ^^^^^^^^^^^^
  File "C:\Users\KIRILL-1\CLionProjects\cpython\Lib\test\test_super.py", line 360, in method
    return super().msg
           ^^^^^^^^^^^
AttributeError: 'super' object has no attribute 'msg'

======================================================================
ERROR: test_shadowed_dynamic_two_arg (__main__.TestSuper.test_shadowed_dynamic_two_arg)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\KIRILL-1\CLionProjects\cpython\Lib\test\test_super.py", line 377, in test_shadowed_dynamic_two_arg
    self.assertEqual(C().method(), "super super")
                     ^^^^^^^^^^^^
  File "C:\Users\KIRILL-1\CLionProjects\cpython\Lib\test\test_super.py", line 374, in method
    return super(1, 2).msg
           ^^^^^^^^^^^^^^^
TypeError: super() argument 1 must be a type, not int

----------------------------------------------------------------------
Ran 31 tests in 0.040s

FAILED (errors=2)
```
After fix, error will disappear.

<!-- gh-issue-number: gh-104057 -->
* Issue: gh-104057
<!-- /gh-issue-number -->
