### PR TITLE
gh-104057: Fix direct invocation of test_support

### DIFF
--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -30,7 +30,7 @@ class TestSupport(unittest.TestCase):
             "test.support.warnings_helper", like=".*used in test_support.*"
         )
         cls._test_support_token = support.ignore_deprecations_from(
-            "test.test_support", like=".*You should NOT be seeing this.*"
+            __name__, like=".*You should NOT be seeing this.*"
         )
         assert len(warnings.filters) == orig_filter_len + 2
 


### PR DESCRIPTION
```python3
./python Lib/test/test_support.py
Running Debug|x64 interpreter...
.....................s.F......s.........s...
======================================================================
FAIL: test_ignored_deprecations_are_silent (__main__.TestSupport.test_ignored_deprecations_are_silent)
Test support.ignore_deprecations_from() silences warnings
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\KIRILL-1\CLionProjects\cpython\Lib\test\test_support.py", line 52, in test_ignored_deprecations_are_silent       
    self.assertEqual(len(messages), 0, messages)
AssertionError: 1 != 0 : ['You should NOT be seeing this.']

----------------------------------------------------------------------
Ran 44 tests in 8.697s

FAILED (failures=1, skipped=3)
```
However, there's an another bug with `test_make_bad_fd` (only on Windows) but it's not related.

<!-- gh-issue-number: gh-104057 -->
* Issue: gh-104057
<!-- /gh-issue-number -->
