### PR TITLE
gh-94673: Properly Initialize and Finalize Static Builtin Types for Each Interpreter

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -272,8 +272,9 @@ _PyObject_GET_WEAKREFS_LISTPTR(PyObject *op)
 {
     if (PyType_Check(op) &&
             ((PyTypeObject *)op)->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
+        PyInterpreterState *interp = _PyInterpreterState_GET();
         static_builtin_state *state = _PyStaticType_GetState(
-                                                        (PyTypeObject *)op);
+                                                interp, (PyTypeObject *)op);
         return _PyStaticType_GET_WEAKREFS_LISTPTR(state);
     }
     // Essentially _PyObject_GET_WEAKREFS_LISTPTR_FROM_OFFSET():

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -39,7 +39,7 @@ extern PyStatus _PySys_Create(
 extern PyStatus _PySys_ReadPreinitWarnOptions(PyWideStringList *options);
 extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
 extern int _PySys_UpdateConfig(PyThreadState *tstate);
-extern void _PySys_Fini(PyInterpreterState *interp);
+extern void _PySys_FiniTypes(PyInterpreterState *interp);
 extern int _PyBuiltins_AddExceptions(PyObject * bltinmod);
 extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 

--- a/Include/internal/pycore_structseq.h
+++ b/Include/internal/pycore_structseq.h
@@ -16,18 +16,22 @@ PyAPI_FUNC(PyTypeObject *) _PyStructSequence_NewType(
     unsigned long tp_flags);
 
 extern int _PyStructSequence_InitBuiltinWithFlags(
+    PyInterpreterState *interp,
     PyTypeObject *type,
     PyStructSequence_Desc *desc,
     unsigned long tp_flags);
 
 static inline int
-_PyStructSequence_InitBuiltin(PyTypeObject *type,
+_PyStructSequence_InitBuiltin(PyInterpreterState *interp,
+                              PyTypeObject *type,
                               PyStructSequence_Desc *desc)
 {
-    return _PyStructSequence_InitBuiltinWithFlags(type, desc, 0);
+    return _PyStructSequence_InitBuiltinWithFlags(interp, type, desc, 0);
 }
 
-extern void _PyStructSequence_FiniBuiltin(PyTypeObject *type);
+extern void _PyStructSequence_FiniBuiltin(
+    PyInterpreterState *interp,
+    PyTypeObject *type);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -104,10 +104,10 @@ _PyType_GetModuleState(PyTypeObject *type)
 }
 
 
-extern int _PyStaticType_InitBuiltin(PyTypeObject *type);
-extern static_builtin_state * _PyStaticType_GetState(PyTypeObject *);
-extern void _PyStaticType_ClearWeakRefs(PyTypeObject *type);
-extern void _PyStaticType_Dealloc(PyTypeObject *type);
+extern int _PyStaticType_InitBuiltin(PyInterpreterState *, PyTypeObject *type);
+extern static_builtin_state * _PyStaticType_GetState(PyInterpreterState *, PyTypeObject *);
+extern void _PyStaticType_ClearWeakRefs(PyInterpreterState *, PyTypeObject *type);
+extern void _PyStaticType_Dealloc(PyInterpreterState *, PyTypeObject *);
 
 PyObject *
 _Py_type_getattro_impl(PyTypeObject *type, PyObject *name, int *suppress_missing_attribute);

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -680,7 +680,7 @@ _PyIO_InitTypes(PyInterpreterState *interp)
 
     for (size_t i=0; i < Py_ARRAY_LENGTH(static_types); i++) {
         PyTypeObject *type = static_types[i];
-        if (_PyStaticType_InitBuiltin(type) < 0) {
+        if (_PyStaticType_InitBuiltin(interp, type) < 0) {
             return _PyStatus_ERR("Can't initialize builtin type");
         }
     }
@@ -699,7 +699,7 @@ _PyIO_FiniTypes(PyInterpreterState *interp)
     // their base classes.
     for (Py_ssize_t i=Py_ARRAY_LENGTH(static_types) - 1; i >= 0; i--) {
         PyTypeObject *type = static_types[i];
-        _PyStaticType_Dealloc(type);
+        _PyStaticType_Dealloc(interp, type);
     }
 }
 

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -691,10 +691,6 @@ _PyIO_InitTypes(PyInterpreterState *interp)
 void
 _PyIO_FiniTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return;
-    }
-
     // Deallocate types in the reverse order to deallocate subclasses before
     // their base classes.
     for (Py_ssize_t i=Py_ARRAY_LENGTH(static_types) - 1; i >= 0; i--) {

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3609,10 +3609,6 @@ _PyExc_InitTypes(PyInterpreterState *interp)
 static void
 _PyExc_FiniTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return;
-    }
-
     for (Py_ssize_t i=Py_ARRAY_LENGTH(static_exceptions) - 1; i >= 0; i--) {
         PyTypeObject *exc = static_exceptions[i].exc;
         _PyStaticType_Dealloc(interp, exc);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3598,7 +3598,7 @@ _PyExc_InitTypes(PyInterpreterState *interp)
 {
     for (size_t i=0; i < Py_ARRAY_LENGTH(static_exceptions); i++) {
         PyTypeObject *exc = static_exceptions[i].exc;
-        if (_PyStaticType_InitBuiltin(exc) < 0) {
+        if (_PyStaticType_InitBuiltin(interp, exc) < 0) {
             return -1;
         }
     }
@@ -3615,7 +3615,7 @@ _PyExc_FiniTypes(PyInterpreterState *interp)
 
     for (Py_ssize_t i=Py_ARRAY_LENGTH(static_exceptions) - 1; i >= 0; i--) {
         PyTypeObject *exc = static_exceptions[i].exc;
-        _PyStaticType_Dealloc(exc);
+        _PyStaticType_Dealloc(interp, exc);
     }
 }
 

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -2029,9 +2029,6 @@ _PyFloat_Fini(PyInterpreterState *interp)
 void
 _PyFloat_FiniType(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return;
-    }
     _PyStructSequence_FiniBuiltin(interp, &FloatInfoType);
 }
 

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1991,8 +1991,9 @@ PyStatus
 _PyFloat_InitTypes(PyInterpreterState *interp)
 {
     /* Init float info */
-    if (_PyStructSequence_InitBuiltin(&FloatInfoType,
-                                      &floatinfo_desc) < 0) {
+    if (_PyStructSequence_InitBuiltin(interp, &FloatInfoType,
+                                      &floatinfo_desc) < 0)
+    {
         return _PyStatus_ERR("can't init float info type");
     }
 
@@ -2028,9 +2029,10 @@ _PyFloat_Fini(PyInterpreterState *interp)
 void
 _PyFloat_FiniType(PyInterpreterState *interp)
 {
-    if (_Py_IsMainInterpreter(interp)) {
-        _PyStructSequence_FiniBuiltin(&FloatInfoType);
+    if (!_Py_IsMainInterpreter(interp)) {
+        return;
     }
+    _PyStructSequence_FiniBuiltin(interp, &FloatInfoType);
 }
 
 /* Print summary info about the state of the optimized allocator */

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6352,7 +6352,9 @@ PyStatus
 _PyLong_InitTypes(PyInterpreterState *interp)
 {
     /* initialize int_info */
-    if (_PyStructSequence_InitBuiltin(&Int_InfoType, &int_info_desc) < 0) {
+    if (_PyStructSequence_InitBuiltin(interp, &Int_InfoType,
+                                      &int_info_desc) < 0)
+    {
         return _PyStatus_ERR("can't init int info type");
     }
 
@@ -6367,5 +6369,5 @@ _PyLong_FiniTypes(PyInterpreterState *interp)
         return;
     }
 
-    _PyStructSequence_FiniBuiltin(&Int_InfoType);
+    _PyStructSequence_FiniBuiltin(interp, &Int_InfoType);
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -7,7 +7,6 @@
 #include "pycore_initconfig.h"    // _PyStatus_OK()
 #include "pycore_long.h"          // _Py_SmallInts
 #include "pycore_object.h"        // _PyObject_Init()
-#include "pycore_pystate.h"       // _Py_IsMainInterpreter()
 #include "pycore_runtime.h"       // _PY_NSMALLPOSINTS
 #include "pycore_structseq.h"     // _PyStructSequence_FiniBuiltin()
 
@@ -6365,9 +6364,5 @@ _PyLong_InitTypes(PyInterpreterState *interp)
 void
 _PyLong_FiniTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return;
-    }
-
     _PyStructSequence_FiniBuiltin(interp, &Int_InfoType);
 }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2105,7 +2105,7 @@ _PyTypes_InitTypes(PyInterpreterState *interp)
     // All other static types (unless initialized elsewhere)
     for (size_t i=0; i < Py_ARRAY_LENGTH(static_types); i++) {
         PyTypeObject *type = static_types[i];
-        if (_PyStaticType_InitBuiltin(type) < 0) {
+        if (_PyStaticType_InitBuiltin(interp, type) < 0) {
             return _PyStatus_ERR("Can't initialize builtin type");
         }
         if (type == &PyType_Type) {
@@ -2136,7 +2136,7 @@ _PyTypes_FiniTypes(PyInterpreterState *interp)
     // their base classes.
     for (Py_ssize_t i=Py_ARRAY_LENGTH(static_types)-1; i>=0; i--) {
         PyTypeObject *type = static_types[i];
-        _PyStaticType_Dealloc(type);
+        _PyStaticType_Dealloc(interp, type);
     }
 }
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2128,10 +2128,6 @@ _PyTypes_InitTypes(PyInterpreterState *interp)
 void
 _PyTypes_FiniTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return;
-    }
-
     // Deallocate types in the reverse order to deallocate subclasses before
     // their base classes.
     for (Py_ssize_t i=Py_ARRAY_LENGTH(static_types)-1; i>=0; i--) {

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -537,7 +537,7 @@ _PyStructSequence_InitBuiltinWithFlags(PyInterpreterState *interp,
     }
 #endif
 
-    if (_PyStaticType_InitBuiltin(type) < 0) {
+    if (_PyStaticType_InitBuiltin(interp, type) < 0) {
         PyErr_Format(PyExc_RuntimeError,
                      "Can't initialize builtin type %s",
                      desc->name);
@@ -621,13 +621,15 @@ _PyStructSequence_FiniBuiltin(PyInterpreterState *interp, PyTypeObject *type)
         return;
     }
 
-    _PyStaticType_Dealloc(type);
+    _PyStaticType_Dealloc(interp, type);
 
-    // Undo _PyStructSequence_InitBuiltinWithFlags().
-    type->tp_name = NULL;
-    PyMem_Free(type->tp_members);
-    type->tp_members = NULL;
-    type->tp_base = NULL;
+    if (_Py_IsMainInterpreter(interp)) {
+        // Undo _PyStructSequence_InitBuiltinWithFlags().
+        type->tp_name = NULL;
+        PyMem_Free(type->tp_members);
+        type->tp_members = NULL;
+        type->tp_base = NULL;
+    }
 }
 
 

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -502,7 +502,8 @@ initialize_static_type(PyTypeObject *type, PyStructSequence_Desc *desc,
 }
 
 int
-_PyStructSequence_InitBuiltinWithFlags(PyTypeObject *type,
+_PyStructSequence_InitBuiltinWithFlags(PyInterpreterState *interp,
+                                       PyTypeObject *type,
                                        PyStructSequence_Desc *desc,
                                        unsigned long tp_flags)
 {
@@ -606,7 +607,7 @@ PyStructSequence_InitType(PyTypeObject *type, PyStructSequence_Desc *desc)
    initialized via _PyStructSequence_InitBuiltinWithFlags(). */
 
 void
-_PyStructSequence_FiniBuiltin(PyTypeObject *type)
+_PyStructSequence_FiniBuiltin(PyInterpreterState *interp, PyTypeObject *type)
 {
     // Ensure that the type is initialized
     assert(type->tp_name != NULL);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4501,7 +4501,7 @@ clear_static_type_objects(PyInterpreterState *interp, PyTypeObject *type)
 void
 _PyStaticType_Dealloc(PyInterpreterState *interp, PyTypeObject *type)
 {
-    assert(!(type->tp_flags & Py_TPFLAGS_HEAPTYPE));
+    assert(type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN);
     assert(_Py_IsImmortal((PyObject *)type));
 
     type_dealloc_common(type);
@@ -4512,11 +4512,9 @@ _PyStaticType_Dealloc(PyInterpreterState *interp, PyTypeObject *type)
     type->tp_flags &= ~Py_TPFLAGS_VALID_VERSION_TAG;
     type->tp_version_tag = 0;
 
-    if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
-        _PyStaticType_ClearWeakRefs(interp, type);
-        static_builtin_state_clear(interp, type);
-        /* We leave _Py_TPFLAGS_STATIC_BUILTIN set on tp_flags. */
-    }
+    _PyStaticType_ClearWeakRefs(interp, type);
+    static_builtin_state_clear(interp, type);
+    /* We leave _Py_TPFLAGS_STATIC_BUILTIN set on tp_flags. */
 }
 
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4502,15 +4502,11 @@ void
 _PyStaticType_Dealloc(PyInterpreterState *interp, PyTypeObject *type)
 {
     assert(!(type->tp_flags & Py_TPFLAGS_HEAPTYPE));
+    assert(_Py_IsImmortal((PyObject *)type));
 
     type_dealloc_common(type);
 
     clear_static_type_objects(interp, type);
-
-    // PyObject_ClearWeakRefs() raises an exception if Py_REFCNT() != 0
-    if (Py_REFCNT(type) == 0) {
-        PyObject_ClearWeakRefs((PyObject *)type);
-    }
 
     type->tp_flags &= ~Py_TPFLAGS_READY;
     type->tp_flags &= ~Py_TPFLAGS_VALID_VERSION_TAG;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7041,16 +7041,23 @@ _PyStaticType_InitBuiltin(PyInterpreterState *interp, PyTypeObject *self)
 {
     assert(_Py_IsImmortal((PyObject *)self));
     assert(!(self->tp_flags & Py_TPFLAGS_HEAPTYPE));
+    assert(!(self->tp_flags & Py_TPFLAGS_MANAGED_DICT));
+    assert(!(self->tp_flags & Py_TPFLAGS_MANAGED_WEAKREF));
 
+    int ismain = _Py_IsMainInterpreter(interp);
     if (self->tp_flags & Py_TPFLAGS_READY) {
+        assert(!ismain);
         assert(self->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN);
-        assert(_PyType_CheckConsistency(self));
+        assert(self->tp_flags & Py_TPFLAGS_VALID_VERSION_TAG);
+
         /* Per-interpreter tp_subclasses is done lazily.
            Otherwise we would initialize it here. */
+
+        assert(_PyType_CheckConsistency(self));
         return 0;
     }
 
-    assert(_Py_IsMainInterpreter(interp));
+    assert(ismain);
 
     self->tp_flags |= _Py_TPFLAGS_STATIC_BUILTIN;
     self->tp_flags |= Py_TPFLAGS_IMMUTABLETYPE;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4486,6 +4486,18 @@ clear_static_tp_subclasses(PyTypeObject *type)
     clear_subclasses(type);
 }
 
+static void
+clear_static_type_objects(PyInterpreterState *interp, PyTypeObject *type)
+{
+    if (_Py_IsMainInterpreter(interp)) {
+        Py_CLEAR(type->tp_dict);
+        Py_CLEAR(type->tp_bases);
+        Py_CLEAR(type->tp_mro);
+        Py_CLEAR(type->tp_cache);
+    }
+    clear_static_tp_subclasses(type);
+}
+
 void
 _PyStaticType_Dealloc(PyInterpreterState *interp, PyTypeObject *type)
 {
@@ -4493,11 +4505,7 @@ _PyStaticType_Dealloc(PyInterpreterState *interp, PyTypeObject *type)
 
     type_dealloc_common(type);
 
-    Py_CLEAR(type->tp_dict);
-    Py_CLEAR(type->tp_bases);
-    Py_CLEAR(type->tp_mro);
-    Py_CLEAR(type->tp_cache);
-    clear_static_tp_subclasses(type);
+    clear_static_type_objects(interp, type);
 
     // PyObject_ClearWeakRefs() raises an exception if Py_REFCNT() != 0
     if (Py_REFCNT(type) == 0) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -144,7 +144,9 @@ static_builtin_state_clear(PyInterpreterState *interp, PyTypeObject *self)
     state->type = NULL;
     assert(state->tp_weaklist == NULL);  // It was already cleared out.
 
-    static_builtin_index_clear(self);
+    if (_Py_IsMainInterpreter(interp)) {
+        static_builtin_index_clear(self);
+    }
 
     assert(interp->types.num_builtins_initialized > 0);
     interp->types.num_builtins_initialized--;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7050,6 +7050,8 @@ _PyStaticType_InitBuiltin(PyInterpreterState *interp, PyTypeObject *self)
         assert(self->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN);
         assert(self->tp_flags & Py_TPFLAGS_VALID_VERSION_TAG);
 
+        static_builtin_state_init(interp, self);
+
         /* Per-interpreter tp_subclasses is done lazily.
            Otherwise we would initialize it here. */
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6938,7 +6938,8 @@ type_ready_post_checks(PyTypeObject *type)
     else if (type->tp_dictoffset < (Py_ssize_t)sizeof(PyObject)) {
         if (type->tp_dictoffset + type->tp_basicsize <= 0) {
             PyErr_Format(PyExc_SystemError,
-                         "type %s has a tp_dictoffset that is too small");
+                         "type %s has a tp_dictoffset that is too small",
+                         type->tp_name);
         }
     }
     return 0;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -69,13 +69,11 @@ static inline PyTypeObject * subclass_from_ref(PyObject *ref);
 
 /* helpers for for static builtin types */
 
-#ifndef NDEBUG
 static inline int
 static_builtin_index_is_set(PyTypeObject *self)
 {
     return self->tp_subclasses != NULL;
 }
-#endif
 
 static inline size_t
 static_builtin_index_get(PyTypeObject *self)
@@ -7046,7 +7044,9 @@ _PyStaticType_InitBuiltin(PyInterpreterState *interp, PyTypeObject *self)
     assert(!(self->tp_flags & Py_TPFLAGS_MANAGED_DICT));
     assert(!(self->tp_flags & Py_TPFLAGS_MANAGED_WEAKREF));
 
+#ifndef NDEBUG
     int ismain = _Py_IsMainInterpreter(interp);
+#endif
     if (self->tp_flags & Py_TPFLAGS_READY) {
         assert(!ismain);
         assert(self->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15158,10 +15158,6 @@ unicode_is_finalizing(void)
 void
 _PyUnicode_FiniTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return;
-    }
-
     _PyStaticType_Dealloc(interp, &EncodingMapType);
     _PyStaticType_Dealloc(interp, &PyFieldNameIter_Type);
     _PyStaticType_Dealloc(interp, &PyFormatterIter_Type);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14573,13 +14573,13 @@ _PyUnicode_InitGlobalObjects(PyInterpreterState *interp)
 PyStatus
 _PyUnicode_InitTypes(PyInterpreterState *interp)
 {
-    if (_PyStaticType_InitBuiltin(&EncodingMapType) < 0) {
+    if (_PyStaticType_InitBuiltin(interp, &EncodingMapType) < 0) {
         goto error;
     }
-    if (_PyStaticType_InitBuiltin(&PyFieldNameIter_Type) < 0) {
+    if (_PyStaticType_InitBuiltin(interp, &PyFieldNameIter_Type) < 0) {
         goto error;
     }
-    if (_PyStaticType_InitBuiltin(&PyFormatterIter_Type) < 0) {
+    if (_PyStaticType_InitBuiltin(interp, &PyFormatterIter_Type) < 0) {
         goto error;
     }
     return _PyStatus_OK();
@@ -15162,9 +15162,9 @@ _PyUnicode_FiniTypes(PyInterpreterState *interp)
         return;
     }
 
-    _PyStaticType_Dealloc(&EncodingMapType);
-    _PyStaticType_Dealloc(&PyFieldNameIter_Type);
-    _PyStaticType_Dealloc(&PyFormatterIter_Type);
+    _PyStaticType_Dealloc(interp, &EncodingMapType);
+    _PyStaticType_Dealloc(interp, &PyFieldNameIter_Type);
+    _PyStaticType_Dealloc(interp, &PyFormatterIter_Type);
 }
 
 

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -1017,9 +1017,9 @@ PyObject_ClearWeakRefs(PyObject *object)
  * or anything else.
  */
 void
-_PyStaticType_ClearWeakRefs(PyTypeObject *type)
+_PyStaticType_ClearWeakRefs(PyInterpreterState *interp, PyTypeObject *type)
 {
-    static_builtin_state *state = _PyStaticType_GetState(type);
+    static_builtin_state *state = _PyStaticType_GetState(interp, type);
     PyObject **list = _PyStaticType_GET_WEAKREFS_LISTPTR(state);
     while (*list != NULL) {
         /* Note that clear_weakref() pops the first ref off the type's

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -1354,10 +1354,6 @@ _PyErr_InitTypes(PyInterpreterState *interp)
 void
 _PyErr_FiniTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return;
-    }
-
     _PyStructSequence_FiniBuiltin(interp, &UnraisableHookArgsType);
 }
 

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -1342,8 +1342,9 @@ static PyStructSequence_Desc UnraisableHookArgs_desc = {
 PyStatus
 _PyErr_InitTypes(PyInterpreterState *interp)
 {
-    if (_PyStructSequence_InitBuiltin(&UnraisableHookArgsType,
-                                      &UnraisableHookArgs_desc) < 0) {
+    if (_PyStructSequence_InitBuiltin(interp, &UnraisableHookArgsType,
+                                      &UnraisableHookArgs_desc) < 0)
+    {
         return _PyStatus_ERR("failed to initialize UnraisableHookArgs type");
     }
     return _PyStatus_OK();
@@ -1357,7 +1358,7 @@ _PyErr_FiniTypes(PyInterpreterState *interp)
         return;
     }
 
-    _PyStructSequence_FiniBuiltin(&UnraisableHookArgsType);
+    _PyStructSequence_FiniBuiltin(interp, &UnraisableHookArgsType);
 }
 
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1663,6 +1663,8 @@ flush_std_files(void)
 static void
 finalize_interp_types(PyInterpreterState *interp)
 {
+    _PyIO_FiniTypes(interp);
+
     _PyUnicode_FiniTypes(interp);
     _PySys_Fini(interp);
     _PyExc_Fini(interp);
@@ -1705,8 +1707,6 @@ finalize_interp_clear(PyThreadState *tstate)
 
     /* Clear interpreter state and all thread states */
     _PyInterpreterState_Clear(tstate);
-
-    _PyIO_FiniTypes(tstate->interp);
 
     /* Clear all loghooks */
     /* Both _PySys_Audit function and users still need PyObject, such as tuple.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1666,7 +1666,7 @@ finalize_interp_types(PyInterpreterState *interp)
     _PyIO_FiniTypes(interp);
 
     _PyUnicode_FiniTypes(interp);
-    _PySys_Fini(interp);
+    _PySys_FiniTypes(interp);
     _PyExc_Fini(interp);
     _PyAsyncGen_Fini(interp);
     _PyContext_Fini(interp);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3493,12 +3493,8 @@ error:
 
 
 void
-_PySys_Fini(PyInterpreterState *interp)
+_PySys_FiniTypes(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return;
-    }
-
     _PyStructSequence_FiniBuiltin(interp, &VersionInfoType);
     _PyStructSequence_FiniBuiltin(interp, &FlagsType);
 #if defined(MS_WINDOWS)
@@ -3507,7 +3503,9 @@ _PySys_Fini(PyInterpreterState *interp)
     _PyStructSequence_FiniBuiltin(interp, &Hash_InfoType);
     _PyStructSequence_FiniBuiltin(interp, &AsyncGenHooksType);
 #ifdef __EMSCRIPTEN__
-    Py_CLEAR(EmscriptenInfoType);
+    if (_Py_IsMainInterpreter(interp)) {
+        Py_CLEAR(EmscriptenInfoType);
+    }
 #endif
 }
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3141,6 +3141,7 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
 {
     PyObject *version_info;
     int res;
+    PyInterpreterState *interp = tstate->interp;
 
     /* stdin/stdout/stderr are set in pylifecycle.c */
 
@@ -3166,7 +3167,9 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
     SET_SYS("float_info", PyFloat_GetInfo());
     SET_SYS("int_info", PyLong_GetInfo());
     /* initialize hash_info */
-    if (_PyStructSequence_InitBuiltin(&Hash_InfoType, &hash_info_desc) < 0) {
+    if (_PyStructSequence_InitBuiltin(interp, &Hash_InfoType,
+                                      &hash_info_desc) < 0)
+    {
         goto type_init_failed;
     }
     SET_SYS("hash_info", get_hash_info(tstate));
@@ -3190,7 +3193,7 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
 #define ENSURE_INFO_TYPE(TYPE, DESC) \
     do { \
         if (_PyStructSequence_InitBuiltinWithFlags( \
-                &TYPE, &DESC, Py_TPFLAGS_DISALLOW_INSTANTIATION) < 0) { \
+                interp, &TYPE, &DESC, Py_TPFLAGS_DISALLOW_INSTANTIATION) < 0) { \
             goto type_init_failed; \
         } \
     } while (0)
@@ -3226,8 +3229,9 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
     SET_SYS("thread_info", PyThread_GetInfo());
 
     /* initialize asyncgen_hooks */
-    if (_PyStructSequence_InitBuiltin(
-            &AsyncGenHooksType, &asyncgen_hooks_desc) < 0) {
+    if (_PyStructSequence_InitBuiltin(interp, &AsyncGenHooksType,
+                                      &asyncgen_hooks_desc) < 0)
+    {
         goto type_init_failed;
     }
 
@@ -3491,18 +3495,20 @@ error:
 void
 _PySys_Fini(PyInterpreterState *interp)
 {
-    if (_Py_IsMainInterpreter(interp)) {
-        _PyStructSequence_FiniBuiltin(&VersionInfoType);
-        _PyStructSequence_FiniBuiltin(&FlagsType);
-#if defined(MS_WINDOWS)
-        _PyStructSequence_FiniBuiltin(&WindowsVersionType);
-#endif
-        _PyStructSequence_FiniBuiltin(&Hash_InfoType);
-        _PyStructSequence_FiniBuiltin(&AsyncGenHooksType);
-#ifdef __EMSCRIPTEN__
-        Py_CLEAR(EmscriptenInfoType);
-#endif
+    if (!_Py_IsMainInterpreter(interp)) {
+        return;
     }
+
+    _PyStructSequence_FiniBuiltin(interp, &VersionInfoType);
+    _PyStructSequence_FiniBuiltin(interp, &FlagsType);
+#if defined(MS_WINDOWS)
+    _PyStructSequence_FiniBuiltin(interp, &WindowsVersionType);
+#endif
+    _PyStructSequence_FiniBuiltin(interp, &Hash_InfoType);
+    _PyStructSequence_FiniBuiltin(interp, &AsyncGenHooksType);
+#ifdef __EMSCRIPTEN__
+    Py_CLEAR(EmscriptenInfoType);
+#endif
 }
 
 

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -137,7 +137,8 @@ PyThread_GetInfo(void)
     int len;
 #endif
 
-    if (_PyStructSequence_InitBuiltin(&ThreadInfoType, &threadinfo_desc) < 0) {
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    if (_PyStructSequence_InitBuiltin(interp, &ThreadInfoType, &threadinfo_desc) < 0) {
         return NULL;
     }
 
@@ -195,5 +196,5 @@ _PyThread_FiniType(PyInterpreterState *interp)
         return;
     }
 
-    _PyStructSequence_FiniBuiltin(&ThreadInfoType);
+    _PyStructSequence_FiniBuiltin(interp, &ThreadInfoType);
 }

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -192,9 +192,5 @@ PyThread_GetInfo(void)
 void
 _PyThread_FiniType(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return;
-    }
-
     _PyStructSequence_FiniBuiltin(interp, &ThreadInfoType);
 }


### PR DESCRIPTION
Until now, we haven't been initializing nor finalizing the per-interpreter state properly.

<!-- gh-issue-number: gh-94673 -->
* Issue: gh-94673
<!-- /gh-issue-number -->
