### PR TITLE
gh-104078: Improve performance of PyObject_HasAttrString

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-05-01-21-05-47.gh-issue-104078.vRaBsU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-05-01-21-05-47.gh-issue-104078.vRaBsU.rst
@@ -1,0 +1,1 @@
+Improve the performance of :c:func:`PyObject_HasAttrString`


### PR DESCRIPTION
fixes gh-104078

## microbenchmark on main

```
python -m pyperf timeit -s '
import _testcapi
hasattr_string = _testcapi.hasattr_string

class A:
  def __init__(self):
    self.attr = 1

a = A()' 'hasattr_string(a, "noattr")'
.....................
Mean +- std dev: 487 ns +- 7 ns
```

## microbenchmark with PR

```
python -m pyperf timeit -s '
import _testcapi
hasattr_string = _testcapi.hasattr_string

class A:
  def __init__(self):
    self.attr = 1

a = A()' 'hasattr_string(a, "noattr")'
.....................
Mean +- std dev: 149 ns +- 4 ns
```

about 3.3X faster