### PR TITLE
Improve assert_type phrasing

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2484,14 +2484,15 @@ Functions and decorators
 
    Ask a static type checker to confirm that *val* has an inferred type of *typ*.
 
-   When the type checker encounters a call to ``assert_type()``, it
+   At runtime this does nothing: it returns the first argument unchanged with no
+   checks or side effects, no matter the actual type of the argument.
+
+   When a static type checker encounters a call to ``assert_type()``, it
    emits an error if the value is not of the specified type::
 
        def greet(name: str) -> None:
            assert_type(name, str)  # OK, inferred type of `name` is `str`
            assert_type(name, int)  # type checker error
-
-   At runtime this returns the first argument unchanged with no side effects.
 
    This function is useful for ensuring the type checker's understanding of a
    script is in line with the developer's intentions::

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2308,15 +2308,16 @@ def cast(typ, val):
 def assert_type(val, typ, /):
     """Ask a static type checker to confirm that the value is of the given type.
 
-    When the type checker encounters a call to assert_type(), it
+    At runtime this does nothing: it returns the first argument unchanged with no
+   checks or side effects, no matter the actual type of the argument.
+
+    When a static type checker encounters a call to assert_type(), it
     emits an error if the value is not of the specified type::
 
         def greet(name: str) -> None:
             assert_type(name, str)  # ok
             assert_type(name, int)  # type checker error
 
-    At runtime this returns the first argument unchanged and otherwise
-    does nothing.
     """
     return val
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2309,7 +2309,7 @@ def assert_type(val, typ, /):
     """Ask a static type checker to confirm that the value is of the given type.
 
     At runtime this does nothing: it returns the first argument unchanged with no
-   checks or side effects, no matter the actual type of the argument.
+    checks or side effects, no matter the actual type of the argument.
 
     When a static type checker encounters a call to assert_type(), it
     emits an error if the value is not of the specified type::


### PR DESCRIPTION
I'd like to make the fact that this does nothing at runtime really obvious, since I suspect this is unintuitive for users who are unfamiliar with static type checking.

I thought of this because of
https://discuss.python.org/t/add-arg-check-type-to-types/26384 wherein I'm a little skeptical that the user really did want `assert_type`.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104081.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->