### PR TITLE
Docs: Fix build preview banner

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,7 @@ build:
     python: "3"
 
   commands:
+    - printenv
     - make -C Doc venv html
     - mkdir _readthedocs
     - mv Doc/build/html _readthedocs/html


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

There should be a banner at the top of PR build previews for docs. Here's it working on this branch as a PR on my fork:

<img width="1582" alt="image" src="https://user-images.githubusercontent.com/1324225/235580360-e1109673-61a3-446d-b74b-a0e05f0bc692.png">

But for some reason it's missing for this upstream:

TODO

The code to control this:

https://github.com/python/cpython/blob/f0ad4567319ee4ae878d570ab7709ab63df9123e/Doc/conf.py#L117-L124

Let's start with a draft PR to debug the env vars.