### PR TITLE
gh-103590: mention that the change is included in 3.11.4 and clarify except* documentation

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -363,7 +363,7 @@ one :keyword:`!except*` clause, the first that matches it. ::
 
 Any remaining exceptions that were not handled by any :keyword:`!except*`
 clause are re-raised at the end, along with all exceptions that were
-raised from the within :keyword:`!except*` clauses. If this list contains
+raised from within the :keyword:`!except*` clauses. If this list contains
 more than one exception to reraise, they are combined into an exception
 group.
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -362,8 +362,10 @@ one :keyword:`!except*` clause, the first that matches it. ::
 
 
 Any remaining exceptions that were not handled by any :keyword:`!except*`
-clause are re-raised at the end, combined into an exception group along with
-all exceptions that were raised from within :keyword:`!except*` clauses.
+clause are re-raised at the end, along with all exceptions that were
+raised from the within :keyword:`!except*` clauses. If this list contains
+more than one exception to reraise, they are combined into an exception
+group.
 
 If the raised exception is not an exception group and its type matches
 one of the :keyword:`!except*` clauses, it is caught and wrapped by an

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -239,7 +239,8 @@ Other Language Changes
 
 * When a ``try-except*`` construct handles the entire :exc:`ExceptionGroup`
   and raises one other exception, that exception is no longer wrapped in an
-  :exc:`ExceptionGroup`. (Contributed by Irit Katriel in :gh:`103590`.)
+  :exc:`ExceptionGroup`. Also changed in version 3.11.4. (Contributed by Irit
+  Katriel in :gh:`103590`.)
 
 
 New Modules


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104095.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-103590 -->
* Issue: gh-103590
<!-- /gh-issue-number -->
