### PR TITLE
[3.11] gh-65022: Fix description of tuple return value in copyreg (GH-103892)

### DIFF
--- a/Doc/library/copyreg.rst
+++ b/Doc/library/copyreg.rst
@@ -28,8 +28,8 @@ Such constructors may be factory functions or class instances.
 .. function:: pickle(type, function, constructor_ob=None)
 
    Declares that *function* should be used as a "reduction" function for objects
-   of type *type*.  *function* should return either a string or a tuple
-   containing two or three elements. See the :attr:`~pickle.Pickler.dispatch_table`
+   of type *type*.  *function* must return either a string or a tuple
+   containing between two and six elements. See the :attr:`~pickle.Pickler.dispatch_table`
    for more details on the interface of *function*.
 
    The *constructor_ob* parameter is a legacy feature and is now ignored, but if


### PR DESCRIPTION
The previous buggy change https://github.com/python/cpython/pull/102656 wasn't backported.

(cherry picked from commit 587f2f018051049cf5d9de3e12ed5aa7644404dc)

<!-- gh-issue-number: gh-65022 -->
* Issue: gh-65022
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104098.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->