### PR TITLE
Use a better variable name in `opcode._specialized_instructions`

### DIFF
--- a/Lib/opcode.py
+++ b/Lib/opcode.py
@@ -404,7 +404,7 @@ _specializations = {
     ],
 }
 _specialized_instructions = [
-    opcode for family in _specializations.values() for opcode in family
+    opname for family in _specializations.values() for opname in family
 ]
 
 _cache_format = {


### PR DESCRIPTION
`_specializations` contains opnames, so the variable name should reflect that.

This is a trivial change, so I think no issue is needed.