### PR TITLE
GH-104102: Optimize `pathlib.Path.glob()` handling of `../` pattern segments

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -117,8 +117,8 @@ class _TerminatingSelector:
 
 
 class _ParentSelector(_Selector):
-    def __init__(self, name, child_parts, case_sensitive):
-        _Selector.__init__(self, child_parts, case_sensitive)
+    def __init__(self, name, child_parts, flavour):
+        _Selector.__init__(self, child_parts, flavour)
 
     def _select_from(self,  parent_path, is_dir, exists, scandir):
         path = parent_path._make_child_relpath('..')

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -71,6 +71,8 @@ def _make_selector(pattern_parts, flavour):
         return _TerminatingSelector()
     if pat == '**':
         cls = _RecursiveWildcardSelector
+    elif pat == '..':
+        cls = _ParentSelector
     elif '**' in pat:
         raise ValueError("Invalid pattern: '**' can only be an entire path component")
     elif _is_wildcard_pattern(pat):
@@ -110,6 +112,16 @@ class _TerminatingSelector:
 
     def _select_from(self, parent_path, is_dir, exists, scandir, normcase):
         yield parent_path
+
+
+class _ParentSelector(_Selector):
+    def __init__(self, name, child_parts, case_sensitive):
+        _Selector.__init__(self, child_parts, case_sensitive)
+
+    def _select_from(self,  parent_path, is_dir, exists, scandir, normcase):
+        path = parent_path._make_child_relpath('..')
+        for p in self.successor._select_from(path, is_dir, exists, scandir, normcase):
+            yield p
 
 
 class _PreciseSelector(_Selector):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1892,8 +1892,13 @@ class _BasePathTest(object):
         P = self.cls
         p = P(BASE)
         self.assertEqual(set(p.glob("..")), { P(BASE, "..") })
+        self.assertEqual(set(p.glob("../..")), { P(BASE, "..", "..") })
+        self.assertEqual(set(p.glob("dirA/..")), { P(BASE, "dirA", "..") })
         self.assertEqual(set(p.glob("dirA/../file*")), { P(BASE, "dirA/../fileA") })
+        self.assertEqual(set(p.glob("dirA/../file*/..")), set())
         self.assertEqual(set(p.glob("../xyzzy")), set())
+        self.assertEqual(set(p.glob("xyzzy/..")), set())
+        self.assertEqual(set(p.glob("/".join([".."] * 50))), { P(BASE, *[".."] * 50)})
 
     @os_helper.skip_unless_symlink
     def test_glob_permissions(self):

--- a/Misc/NEWS.d/next/Library/2023-05-02-20-43-03.gh-issue-104102.vgSdEJ.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-02-20-43-03.gh-issue-104102.vgSdEJ.rst
@@ -1,0 +1,2 @@
+Improve performance of :meth:`pathlib.Path.glob` when evaluating patterns
+that contain ``'../'`` segments.


### PR DESCRIPTION
These segments do not require a `stat()` call, as the selector's `_select_from()` method is called after we've established that the parent is a directory.

This PR adds a new `_ParentSelector` class, which is used to evaluate `../` segments rather than `_PreciseSelector`.

<!-- gh-issue-number: gh-104102 -->
* Issue: gh-104102
<!-- /gh-issue-number -->
