### PR TITLE
gh-104018: remove unused format "z" handling in string formatfloat()

### DIFF
--- a/Include/internal/pycore_format.h
+++ b/Include/internal/pycore_format.h
@@ -14,14 +14,12 @@ extern "C" {
  * F_BLANK      ' '
  * F_ALT        '#'
  * F_ZERO       '0'
- * F_NO_NEG_0   'z'
  */
 #define F_LJUST (1<<0)
 #define F_SIGN  (1<<1)
 #define F_BLANK (1<<2)
 #define F_ALT   (1<<3)
 #define F_ZERO  (1<<4)
-#define F_NO_NEG_0 (1<<5)
 
 #ifdef __cplusplus
 }

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -423,9 +423,6 @@ formatfloat(PyObject *v, int flags, int prec, int type,
     if (flags & F_ALT) {
         dtoa_flags |= Py_DTSF_ALT;
     }
-    if (flags & F_NO_NEG_0) {
-        dtoa_flags |= Py_DTSF_NO_NEG_0;
-    }
     p = PyOS_double_to_string(x, type, prec, dtoa_flags, NULL);
 
     if (p == NULL)

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -13452,8 +13452,6 @@ formatfloat(PyObject *v, struct unicode_format_arg_t *arg,
 
     if (arg->flags & F_ALT)
         dtoa_flags |= Py_DTSF_ALT;
-    if (arg->flags & F_NO_NEG_0)
-        dtoa_flags |= Py_DTSF_NO_NEG_0;
     p = PyOS_double_to_string(x, arg->ch, prec, dtoa_flags, NULL);
     if (p == NULL)
         return -1;

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -317,7 +317,6 @@ simple_format_arg_parse(PyObject *fmt, Py_ssize_t *ppos,
             case ' ': *flags |= F_BLANK; continue;
             case '#': *flags |= F_ALT; continue;
             case '0': *flags |= F_ZERO; continue;
-            case 'z': *flags |= F_NO_NEG_0; continue;
         }
         break;
     }


### PR DESCRIPTION
This is a cleanup overlooked in PR #104033.

Please skip NEWS.

<!-- gh-issue-number: gh-104018 -->
* Issue: gh-104018
<!-- /gh-issue-number -->
