### PR TITLE
gh-104109: Expose Py_NewInterpreterFromConfig() in the Public C-API

### DIFF
--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -252,7 +252,7 @@ typedef struct {
     int allow_threads;
     int allow_daemon_threads;
     int check_multi_interp_extensions;
-} _PyInterpreterConfig;
+} PyInterpreterConfig;
 
 #define _PyInterpreterConfig_INIT \
     { \

--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -62,9 +62,9 @@ PyAPI_FUNC(int) _Py_CoerceLegacyLocale(int warn);
 PyAPI_FUNC(int) _Py_LegacyLocaleDetected(int warn);
 PyAPI_FUNC(char *) _Py_SetLocaleFromEnv(int category);
 
-PyAPI_FUNC(PyStatus) _Py_NewInterpreterFromConfig(
+PyAPI_FUNC(PyStatus) Py_NewInterpreterFromConfig(
     PyThreadState **tstate_p,
-    const _PyInterpreterConfig *config);
+    const PyInterpreterConfig *config);
 
 typedef void (*atexit_datacallbackfunc)(void *);
 PyAPI_FUNC(int) _Py_AtExit(

--- a/Misc/NEWS.d/next/C API/2023-05-02-21-05-54.gh-issue-104109.0tnDZV.rst
+++ b/Misc/NEWS.d/next/C API/2023-05-02-21-05-54.gh-issue-104109.0tnDZV.rst
@@ -1,0 +1,5 @@
+We've added ``Py_NewInterpreterFromConfig()`` and ``PyInterpreterConfig`` to
+the public C-API (but not the stable ABI; not yet at least).  The new
+function may be used to create a new interpreter with various features
+configured.  The function was added to support PEP 684 (per-interpreter
+GIL).

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1538,7 +1538,7 @@ run_in_subinterp_with_config(PyObject *self, PyObject *args, PyObject *kwargs)
 
     PyThreadState_Swap(NULL);
 
-    const _PyInterpreterConfig config = {
+    const PyInterpreterConfig config = {
         .use_main_obmalloc = use_main_obmalloc,
         .allow_fork = allow_fork,
         .allow_exec = allow_exec,
@@ -1546,7 +1546,7 @@ run_in_subinterp_with_config(PyObject *self, PyObject *args, PyObject *kwargs)
         .allow_daemon_threads = allow_daemon_threads,
         .check_multi_interp_extensions = check_multi_interp_extensions,
     };
-    PyStatus status = _Py_NewInterpreterFromConfig(&substate, &config);
+    PyStatus status = Py_NewInterpreterFromConfig(&substate, &config);
     if (PyStatus_Exception(status)) {
         /* Since no new thread state was created, there is no exception to
            propagate; raise a fresh one after swapping in the old thread

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -513,12 +513,12 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
 
     // Create and initialize the new interpreter.
     PyThreadState *save_tstate = _PyThreadState_GET();
-    const _PyInterpreterConfig config = isolated
-        ? (_PyInterpreterConfig)_PyInterpreterConfig_INIT
-        : (_PyInterpreterConfig)_PyInterpreterConfig_LEGACY_INIT;
+    const PyInterpreterConfig config = isolated
+        ? (PyInterpreterConfig)_PyInterpreterConfig_INIT
+        : (PyInterpreterConfig)_PyInterpreterConfig_LEGACY_INIT;
     // XXX Possible GILState issues?
     PyThreadState *tstate = NULL;
-    PyStatus status = _Py_NewInterpreterFromConfig(&tstate, &config);
+    PyStatus status = Py_NewInterpreterFromConfig(&tstate, &config);
     PyThreadState_Swap(save_tstate);
     if (PyStatus_Exception(status)) {
         /* Since no new thread state was created, there is no exception to

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -546,7 +546,8 @@ pycore_init_runtime(_PyRuntimeState *runtime,
 
 
 static PyStatus
-init_interp_settings(PyInterpreterState *interp, const _PyInterpreterConfig *config)
+init_interp_settings(PyInterpreterState *interp,
+                     const PyInterpreterConfig *config)
 {
     assert(interp->feature_flags == 0);
 
@@ -631,7 +632,7 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
         return status;
     }
 
-    const _PyInterpreterConfig config = _PyInterpreterConfig_LEGACY_INIT;
+    const PyInterpreterConfig config = _PyInterpreterConfig_LEGACY_INIT;
     status = init_interp_settings(interp, &config);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
@@ -1991,7 +1992,7 @@ Py_Finalize(void)
 */
 
 static PyStatus
-new_interpreter(PyThreadState **tstate_p, const _PyInterpreterConfig *config)
+new_interpreter(PyThreadState **tstate_p, const PyInterpreterConfig *config)
 {
     PyStatus status;
 
@@ -2079,8 +2080,8 @@ error:
 }
 
 PyStatus
-_Py_NewInterpreterFromConfig(PyThreadState **tstate_p,
-                             const _PyInterpreterConfig *config)
+Py_NewInterpreterFromConfig(PyThreadState **tstate_p,
+                            const PyInterpreterConfig *config)
 {
     return new_interpreter(tstate_p, config);
 }
@@ -2089,8 +2090,8 @@ PyThreadState *
 Py_NewInterpreter(void)
 {
     PyThreadState *tstate = NULL;
-    const _PyInterpreterConfig config = _PyInterpreterConfig_LEGACY_INIT;
-    PyStatus status = _Py_NewInterpreterFromConfig(&tstate, &config);
+    const PyInterpreterConfig config = _PyInterpreterConfig_LEGACY_INIT;
+    PyStatus status = new_interpreter(&tstate, &config);
     if (_PyStatus_EXCEPTION(status)) {
         Py_ExitStatusException(status);
     }


### PR DESCRIPTION
We also expose `PyInterpreterConfig`.  This is part of the PEP 684 (per-interpreter GIL) implementation.  We will add docs as soon as we can.

FYI, I'm adding the new config field for per-interpreter GIL in gh-99114.

<!-- gh-issue-number: gh-104109 -->
* Issue: gh-104109
<!-- /gh-issue-number -->
