### PR TITLE
gh-104112: link from cached_property docs to method-caching FAQ

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -110,18 +110,10 @@ The :mod:`functools` module defines the following functions:
    ``__slots__`` without including ``__dict__`` as one of the defined slots
    (as such classes don't provide a ``__dict__`` attribute at all).
 
-   If a mutable mapping is not available or if space-efficient key sharing
-   is desired, an effect similar to :func:`cached_property` can be achieved
-   by a stacking :func:`property` on top of :func:`cache`::
-
-       class DataSet:
-           def __init__(self, sequence_of_numbers):
-               self._data = sequence_of_numbers
-
-           @property
-           @cache
-           def stdev(self):
-               return statistics.stdev(self._data)
+   If a mutable mapping is not available or if space-efficient key sharing is
+   desired, an effect similar to :func:`cached_property` can also be achieved by
+   stacking :func:`property` on top of :func:`lru_cache`. See
+   :ref:`faq-cache-method-calls`
 
    .. versionadded:: 3.8
 

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -113,7 +113,7 @@ The :mod:`functools` module defines the following functions:
    If a mutable mapping is not available or if space-efficient key sharing is
    desired, an effect similar to :func:`cached_property` can also be achieved by
    stacking :func:`property` on top of :func:`lru_cache`. See
-   :ref:`faq-cache-method-calls`
+   :ref:`faq-cache-method-calls` for more details on how this differs from :func:`cached_property`.
 
    .. versionadded:: 3.8
 


### PR DESCRIPTION
fixes #104112 

<!-- gh-issue-number: gh-104112 -->
* Issue: gh-104112
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104113.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->