### PR TITLE
GH-98040: Suppress cross-references to the removed ``imp`` module

### DIFF
--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -186,10 +186,10 @@ Importing Modules
 
    .. versionadded:: 3.2
    .. versionchanged:: 3.3
-      Uses :func:`imp.source_from_cache()` in calculating the source path if
+      Uses :func:`!imp.source_from_cache()` in calculating the source path if
       only the bytecode path is provided.
    .. versionchanged:: 3.12
-      No longer uses the removed ``imp`` module.
+      No longer uses the removed :mod:`!imp` module.
 
 
 .. c:function:: long PyImport_GetMagicNumber()

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1987,6 +1987,7 @@ are always available.  They are listed here in alphabetical order.
 
    .. index::
       statement: import
+      module: builtins
 
    .. note::
 

--- a/Doc/whatsnew/3.0.rst
+++ b/Doc/whatsnew/3.0.rst
@@ -840,7 +840,7 @@ Builtins
   need it; however, 99 percent of the time an explicit :keyword:`for`
   loop is more readable.
 
-* Removed :func:`reload`.  Use :func:`imp.reload`.
+* Removed :func:`reload`.  Use :func:`!imp.reload`.
 
 * Removed. :meth:`dict.has_key` -- use the :keyword:`in` operator
   instead.

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1682,7 +1682,7 @@ Deprecated
   classes as appropriate instead.
   (Contributed by Brett Cannon in :issue:`42135`.)
 
-* The deprecations of :mod:`imp`, :func:`!importlib.find_loader`,
+* The deprecations of :mod:`!imp`, :func:`!importlib.find_loader`,
   :func:`importlib.util.set_package_wrapper`,
   :func:`importlib.util.set_loader_wrapper`,
   :func:`importlib.util.module_for_loader`,

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1872,7 +1872,7 @@ C APIs pending removal are
 * The :mod:`asynchat` module
 * The :mod:`asyncore` module
 * The :ref:`entire distutils package <distutils-deprecated>`
-* The :mod:`imp` module
+* The :mod:`!imp` module
 * The :class:`typing.io <typing.IO>` namespace
 * The :class:`typing.re <typing.Pattern>` namespace
 * :func:`!cgi.log`

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -995,7 +995,7 @@ Removed
   * ``importlib.abc.Finder``, ``pkg.ImpImporter``, and ``pkg.ImpLoader`` have
     been removed.  (Contributed by Barry Warsaw in :gh:`98040`.)
 
-  * The ``imp`` module has been removed.  (Contributed by Barry Warsaw in
+  * The :mod:`!imp` module has been removed.  (Contributed by Barry Warsaw in
     :gh:`98040`.)
 
 * Removed the ``suspicious`` rule from the documentation Makefile, and

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -319,7 +319,7 @@ aspects that are visible to the programmer:
    >>> collections.__cached__ # doctest: +SKIP
    'c:/py32/lib/__pycache__/collections.cpython-32.pyc'
 
-* The tag that is unique to each interpreter is accessible from the :mod:`imp`
+* The tag that is unique to each interpreter is accessible from the :mod:`!imp`
   module:
 
    >>> import imp # doctest: +SKIP
@@ -328,7 +328,7 @@ aspects that are visible to the programmer:
 
 * Scripts that try to deduce source filename from the imported file now need to
   be smarter.  It is no longer sufficient to simply strip the "c" from a ".pyc"
-  filename.  Instead, use the new functions in the :mod:`imp` module:
+  filename.  Instead, use the new functions in the :mod:`!imp` module:
 
   >>> imp.source_from_cache('c:/py32/lib/__pycache__/collections.cpython-32.pyc') # doctest: +SKIP
   'c:/py32/lib/collections.py'

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -685,7 +685,7 @@ through normal attribute access.
 Using importlib as the Implementation of Import
 ===============================================
 :issue:`2377` - Replace __import__ w/ importlib.__import__
-:issue:`13959` - Re-implement parts of :mod:`imp` in pure Python
+:issue:`13959` - Re-implement parts of :mod:`!imp` in pure Python
 :issue:`14605` - Make import machinery explicit
 :issue:`14646` - Require loaders set __loader__ and __package__
 
@@ -762,7 +762,7 @@ Loaders are also now expected to set the ``__package__`` attribute from
 from :mod:`importlib` and import itself is setting the attribute post-load.
 
 ``None`` is now inserted into :attr:`sys.path_importer_cache` when no finder
-can be found on :attr:`sys.path_hooks`. Since :class:`imp.NullImporter` is not
+can be found on :attr:`sys.path_hooks`. Since :class:`!imp.NullImporter` is not
 directly exposed on :attr:`sys.path_hooks` it could no longer be relied upon to
 always be available to use as a value representing no finder found.
 
@@ -2385,7 +2385,7 @@ Porting Python code
 * Because ``None`` is now inserted into :attr:`sys.path_importer_cache`, if you
   are clearing out entries in the dictionary of paths that do not have a
   finder, you will need to remove keys paired with values of ``None`` **and**
-  :class:`imp.NullImporter` to be backwards-compatible. This will lead to extra
+  :class:`!imp.NullImporter` to be backwards-compatible. This will lead to extra
   overhead on older versions of Python that re-insert ``None`` into
   :attr:`sys.path_importer_cache` where it represents the use of implicit
   finders, but semantically it should not change anything.

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -991,18 +991,18 @@ for the :meth:`~importlib.abc.InspectLoader.get_code` method.  However,
 it will normally be desirable to override the default implementation
 for performance reasons.  (Contributed by Brett Cannon in :issue:`18072`.)
 
-The :func:`~importlib.reload` function has been moved from :mod:`imp` to
-:mod:`importlib` as part of the :mod:`imp` module deprecation.  (Contributed by
+The :func:`~importlib.reload` function has been moved from :mod:`!imp` to
+:mod:`importlib` as part of the :mod:`!imp` module deprecation.  (Contributed by
 Berker Peksag in :issue:`18193`.)
 
 :mod:`importlib.util` now has a :data:`~importlib.util.MAGIC_NUMBER` attribute
 providing access to the bytecode version number.  This replaces the
-:func:`~imp.get_magic` function in the deprecated :mod:`imp` module.
+:func:`!get_magic` function in the deprecated :mod:`!imp` module.
 (Contributed by Brett Cannon in :issue:`18192`.)
 
 New :mod:`importlib.util` functions :func:`~importlib.util.cache_from_source`
 and :func:`~importlib.util.source_from_cache` replace the same-named functions
-in the deprecated :mod:`imp` module.  (Contributed by Brett Cannon in
+in the deprecated :mod:`!imp` module.  (Contributed by Brett Cannon in
 :issue:`18194`.)
 
 The :mod:`importlib` bootstrap :class:`.NamespaceLoader` now conforms to
@@ -2101,7 +2101,7 @@ Deprecations in the Python API
   and :meth:`importlib.util.set_package` are no longer needed because their
   functions are now handled automatically by the import system.
 
-* The :mod:`imp` module is pending deprecation. To keep compatibility with
+* The :mod:`!imp` module is pending deprecation. To keep compatibility with
   Python 2/3 code bases, the module's removal is currently not scheduled.
 
 * The :mod:`formatter` module is pending deprecation and is slated for removal
@@ -2300,7 +2300,7 @@ Changes in the Python API
   then you can see if the module's ``__spec__.location`` is set to ``'frozen'``,
   check if the loader is a subclass of
   :class:`importlib.machinery.FrozenImporter`,
-  or if Python 2 compatibility is necessary you can use :func:`imp.is_frozen`.
+  or if Python 2 compatibility is necessary you can use :func:`!imp.is_frozen`.
 
 * :func:`py_compile.compile` now raises :exc:`FileExistsError` if the file path
   it would write to is a symlink or a non-regular file. This is to act as a

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -2180,7 +2180,7 @@ Changes in the Python API
   now raises :exc:`ValueError` for out-of-range values, rather than
   returning :const:`None`.  See :issue:`20059`.
 
-* The :mod:`imp` module now raises a :exc:`DeprecationWarning` instead of
+* The :mod:`!imp` module now raises a :exc:`DeprecationWarning` instead of
   :exc:`PendingDeprecationWarning`.
 
 * The following modules have had missing APIs added to their :attr:`__all__`

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -3818,7 +3818,7 @@ user.
 .. section: Library
 
 The :2to3fixer:`reload` fixer now uses :func:`importlib.reload` instead of
-deprecated :func:`imp.reload`.
+deprecated :func:`!imp.reload`.
 
 ..
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-98040 -->
* Issue: gh-98040
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104131.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->