### PR TITLE
GH-97850: Suppress cross-references to the removed ``module_repr`` method

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -706,7 +706,7 @@ Here are the exact rules used:
  * Otherwise, just use the module's ``__name__`` in the repr.
 
 .. versionchanged:: 3.12
-   Use of :meth:`module_repr`, having been deprecated since Python 3.4, was
+   Use of :meth:`!module_repr`, having been deprecated since Python 3.4, was
    removed in Python 3.12 and is no longer called during the resolution of a
    module's repr.
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1612,7 +1612,7 @@ Deprecated
   (superseded by :meth:`~importlib.abc.Finder.find_spec`),
   :meth:`~importlib.abc.Loader.load_module`
   (superseded by :meth:`~importlib.abc.Loader.exec_module`),
-  :meth:`~importlib.abc.Loader.module_repr` (which the import system
+  :meth:`!module_repr` (which the import system
   takes care of for you), the ``__package__`` attribute
   (superseded by ``__spec__.parent``), the ``__loader__`` attribute
   (superseded by ``__spec__.loader``), and the ``__cached__`` attribute
@@ -1693,14 +1693,14 @@ Deprecated
   (Contributed by Brett Cannon in :issue:`43720`.)
 
 * The import system now uses the ``__spec__`` attribute on modules before
-  falling back on :meth:`~importlib.abc.Loader.module_repr` for a module's
+  falling back on :meth:`!module_repr` for a module's
   ``__repr__()`` method. Removal of the use of ``module_repr()`` is scheduled
   for Python 3.12.
   (Contributed by Brett Cannon in :issue:`42137`.)
 
-* :meth:`importlib.abc.Loader.module_repr`,
-  :meth:`importlib.machinery.FrozenLoader.module_repr`, and
-  :meth:`importlib.machinery.BuiltinLoader.module_repr` are deprecated and
+* :meth:`!importlib.abc.Loader.module_repr`,
+  :meth:`!importlib.machinery.FrozenLoader.module_repr`, and
+  :meth:`!importlib.machinery.BuiltinLoader.module_repr` are deprecated and
   slated for removal in Python 3.12.
   (Contributed by Brett Cannon in :issue:`42136`.)
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1877,7 +1877,7 @@ C APIs pending removal are
 * The :class:`typing.re <typing.Pattern>` namespace
 * :func:`!cgi.log`
 * :func:`!importlib.find_loader`
-* :meth:`importlib.abc.Loader.module_repr`
+* :meth:`!importlib.abc.Loader.module_repr`
 * :meth:`!importlib.abc.MetaPathFinder.find_module`
 * :meth:`!importlib.abc.PathEntryFinder.find_loader`
 * :meth:`!importlib.abc.PathEntryFinder.find_module`

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -983,7 +983,7 @@ Removed
 * Many previously deprecated cleanups in :mod:`importlib` have now been
   completed:
 
-  * References to, and support for ``module_repr()`` has been removed.
+  * References to, and support for :meth:`!module_repr()` has been removed.
     (Contributed by Barry Warsaw in :gh:`97850`.)
 
   * ``importlib.util.set_package`` has been removed. (Contributed by Brett

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -2096,7 +2096,7 @@ Deprecations in the Python API
   :meth:`importlib.abc.InspectLoader.exec_module`
   :meth:`importlib.abc.SourceLoader.exec_module`) and let the import system
   take care of the rest; and
-  :meth:`importlib.abc.Loader.module_repr`,
+  :meth:`!importlib.abc.Loader.module_repr`,
   :meth:`importlib.util.module_for_loader`, :meth:`importlib.util.set_loader`,
   and :meth:`importlib.util.set_package` are no longer needed because their
   functions are now handled automatically by the import system.


### PR DESCRIPTION


<!-- gh-issue-number: gh-97850 -->
* Issue: gh-97850
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104133.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->