### PR TITLE
GH-97850: Suppress cross-references to removed ``importlib.util`` functions

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1683,9 +1683,9 @@ Deprecated
   (Contributed by Brett Cannon in :issue:`42135`.)
 
 * The deprecations of :mod:`!imp`, :func:`!importlib.find_loader`,
-  :func:`importlib.util.set_package_wrapper`,
-  :func:`importlib.util.set_loader_wrapper`,
-  :func:`importlib.util.module_for_loader`,
+  :func:`!importlib.util.set_package_wrapper`,
+  :func:`!importlib.util.set_loader_wrapper`,
+  :func:`!importlib.util.module_for_loader`,
   :class:`!pkgutil.ImpImporter`, and
   :class:`!pkgutil.ImpLoader` have all been updated to list Python 3.12 as the
   slated version of removal (they began raising :exc:`DeprecationWarning` in

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1889,7 +1889,7 @@ C APIs pending removal are
 * :meth:`!importlib.machinery.FrozenLoader.module_repr`
 * :meth:`!importlib.machinery.PathFinder.find_module`
 * :meth:`!importlib.machinery.WindowsRegistryFinder.find_module`
-* :func:`importlib.util.module_for_loader`
+* :func:`!importlib.util.module_for_loader`
 * :func:`!importlib.util.set_loader_wrapper`
 * :func:`!importlib.util.set_package_wrapper`
 * :class:`!pkgutil.ImpImporter`

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -2097,8 +2097,8 @@ Deprecations in the Python API
   :meth:`importlib.abc.SourceLoader.exec_module`) and let the import system
   take care of the rest; and
   :meth:`importlib.abc.Loader.module_repr`,
-  :meth:`importlib.util.module_for_loader`, :meth:`importlib.util.set_loader`,
-  and :meth:`importlib.util.set_package` are no longer needed because their
+  :meth:`!importlib.util.module_for_loader`, :meth:`!importlib.util.set_loader`,
+  and :meth:`!importlib.util.set_package` are no longer needed because their
   functions are now handled automatically by the import system.
 
 * The :mod:`!imp` module is pending deprecation. To keep compatibility with
@@ -2277,7 +2277,7 @@ Changes in the Python API
   in a backwards-compatible fashion, use e.g.
   ``getattr(module, '__loader__', None) is not None``.  (:issue:`17115`.)
 
-* :meth:`importlib.util.module_for_loader` now sets ``__loader__`` and
+* :meth:`!importlib.util.module_for_loader` now sets ``__loader__`` and
   ``__package__`` unconditionally to properly support reloading. If this is not
   desired then you will need to set these attributes manually. You can use
   :func:`importlib.util.module_to_load` for module management.

--- a/Misc/NEWS.d/3.10.0a5.rst
+++ b/Misc/NEWS.d/3.10.0a5.rst
@@ -499,7 +499,7 @@ Araujo.
 .. nonce: HY2beA
 .. section: Documentation
 
-Updated importlib.utils.resolve_name() doc to use __spec__.parent instead of
+Updated importlib.util.resolve_name() doc to use __spec__.parent instead of
 __package__. (Thanks Yair Frid.)
 
 ..

--- a/Misc/NEWS.d/3.12.0a1.rst
+++ b/Misc/NEWS.d/3.12.0a1.rst
@@ -2028,8 +2028,8 @@ resources.
 .. nonce: NzdREm
 .. section: Library
 
-Remove deprecated :func:`importlib.utils.set_loader` and
-:func:`importlib.utils.module_for_loader` from :mod:`importlib.utils`.
+Remove deprecated :func:`!importlib.utils.set_loader` and
+:func:`!importlib.utils.module_for_loader` from :mod:`importlib.utils`.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0a1.rst
+++ b/Misc/NEWS.d/3.12.0a1.rst
@@ -2028,8 +2028,8 @@ resources.
 .. nonce: NzdREm
 .. section: Library
 
-Remove deprecated :func:`!importlib.utils.set_loader` and
-:func:`!importlib.utils.module_for_loader` from :mod:`importlib.utils`.
+Remove deprecated :func:`!importlib.util.set_loader` and
+:func:`!importlib.util.module_for_loader` from :mod:`importlib.util`.
 
 ..
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-97850 -->
* Issue: gh-97850
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104134.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->