### PR TITLE
gh-102500: Add PEP 688 and 698 to the 3.12 release highlights

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -72,6 +72,8 @@ New typing features:
 
 * :ref:`whatsnew312-pep692`
 
+* :pep:`698`: Override Decorator for Static Typing
+
 Important deprecations, removals or restrictions:
 
 * :pep:`623`: Remove wstr from Unicode

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -68,13 +68,15 @@ Summary -- Release highlights
 
 New typing features:
 
+* :pep:`688`: Making the buffer protocol accessible in Python
+
 * :ref:`whatsnew312-pep692`
 
 Important deprecations, removals or restrictions:
 
-* :pep:`623`, Remove wstr from Unicode
+* :pep:`623`: Remove wstr from Unicode
 
-* :pep:`632`, Remove the ``distutils`` package.
+* :pep:`632`: Remove the ``distutils`` package
 
 Improved Error Messages
 =======================


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

List on What’s New In Python 3.12.

Follow format of [What’s New In Python 3.11](https://docs.python.org/3.12/whatsnew/3.11.html).

<!-- gh-issue-number: gh-102500 -->
* Issue: gh-102500
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104174.org.readthedocs.build/en/104174/whatsnew/3.12.html

<!-- readthedocs-preview cpython-previews end -->