### PR TITLE
gh-103963: fix 'make regen-opcode' in out-of-tree builds

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1376,7 +1376,7 @@ regen-opcode:
 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/build/generate_opcode_h.py \
 		$(srcdir)/Lib/opcode.py \
 		$(srcdir)/Include/opcode.h.new \
-		$(srcdir)/Include/internal/pycore_opcode.h.new
+		$(srcdir)/Include/internal/pycore_opcode.h.new \
 		$(srcdir)/Include/internal/pycore_intrinsics.h.new
 	$(UPDATE_FILE) $(srcdir)/Include/opcode.h $(srcdir)/Include/opcode.h.new
 	$(UPDATE_FILE) $(srcdir)/Include/internal/pycore_opcode.h $(srcdir)/Include/internal/pycore_opcode.h.new

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1377,8 +1377,10 @@ regen-opcode:
 		$(srcdir)/Lib/opcode.py \
 		$(srcdir)/Include/opcode.h.new \
 		$(srcdir)/Include/internal/pycore_opcode.h.new
+		$(srcdir)/Include/internal/pycore_intrinsics.h.new
 	$(UPDATE_FILE) $(srcdir)/Include/opcode.h $(srcdir)/Include/opcode.h.new
 	$(UPDATE_FILE) $(srcdir)/Include/internal/pycore_opcode.h $(srcdir)/Include/internal/pycore_opcode.h.new
+	$(UPDATE_FILE) $(srcdir)/Include/internal/pycore_intrinsics.h $(srcdir)/Include/internal/pycore_intrinsics.h.new
 
 .PHONY: regen-token
 regen-token:

--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -59,7 +59,7 @@
           Inputs="@(_OpcodeSources)" Outputs="@(_OpcodeOutputs)"
           DependsOnTargets="FindPythonForBuild">
     <Message Text="Regenerate @(_OpcodeOutputs->'%(Filename)%(Extension)',' ')" Importance="high" />
-    <Exec Command="$(PythonForBuild) Tools\build\generate_opcode_h.py Lib\opcode.py Include\opcode.h Include\internal\pycore_opcode.h"
+    <Exec Command="$(PythonForBuild) Tools\build\generate_opcode_h.py Lib\opcode.py Include\opcode.h Include\internal\pycore_opcode.h Include\internal\pycore_intrinsics.h"
           WorkingDirectory="$(PySourcePath)" />
     <Exec Command="$(PythonForBuild) Python\makeopcodetargets.py Python\opcode_targets.h"
           WorkingDirectory="$(PySourcePath)" />

--- a/Tools/build/generate_opcode_h.py
+++ b/Tools/build/generate_opcode_h.py
@@ -233,4 +233,4 @@ def main(opcode_py, outfile='Include/opcode.h',
 
 
 if __name__ == '__main__':
-    main(sys.argv[1], sys.argv[2], sys.argv[3])
+    main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])


### PR DESCRIPTION
#104029 added a new file generated by `make regen-opcode`, but unlike the existing path arguments to `generate_opcode_h.py`, the new `intrinsicoutfile` argument was not wired in as an explicitly-provided argument from the Makefile. The result is that the default relative path is always used, which only works for in-tree builds. (The Makefile always uses a path relative to `$srcdir` which is set correctly in out-of-tree builds to find the source tree.)

This PR handles `intrinsicoutfile` in the same way that `outfile` and `internaloutfile` were already handled, which allows `make regen-opcode` to work again in out-of-tree builds.

This also makes the update of the file use `Tools/build/update_file.py`, which avoids replacing the file if the contents haven't changed. This can avoid needless rebuilds.

<!-- gh-issue-number: gh-103963 -->
* Issue: gh-103963
<!-- /gh-issue-number -->
