### PR TITLE
Trivial - Clarify logging severity "above"

### DIFF
--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -87,8 +87,8 @@ described below (in increasing order of severity):
 +--------------+---------------------------------------------+
 
 The default level is ``WARNING``, which means that only events of this level
-and above will be tracked, unless the logging package is configured to do
-otherwise.
+of severity and above (``ERROR`` and ``CRITICAL``) will be tracked, unless the
+logging package is configured to do otherwise.
 
 Events that are tracked can be handled in different ways. The simplest way of
 handling tracked events is to print them to the console. Another common way


### PR DESCRIPTION
A minor phrasing change to make it clearer that the word "above" in regards the default logging, refers to higher severity, rather than higher ("above it") on the preceding table of severities, which is (slightly confusingly) in **_increasing_** order of severity.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104185.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->