### PR TITLE
gh-99113: Add Py_MOD_PER_INTERPRETER_GIL_SUPPORTED

### DIFF
--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -87,6 +87,7 @@ struct PyModuleDef_Slot {
 /* for Py_mod_multiple_interpreters: */
 #define Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED ((void *)0)
 #define Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED ((void *)1)
+#define Py_MOD_PER_INTERPRETER_GIL_SUPPORTED ((void *)2)
 
 #endif /* New in 3.5 */
 

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -944,6 +944,7 @@ _abcmodule_free(void *module)
 
 static PyModuleDef_Slot _abcmodule_slots[] = {
     {Py_mod_exec, _abcmodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -3803,6 +3803,7 @@ module_exec(PyObject *mod)
 
 static struct PyModuleDef_Slot module_slots[] = {
     {Py_mod_exec, module_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/Modules/_bisectmodule.c
+++ b/Modules/_bisectmodule.c
@@ -457,6 +457,7 @@ bisect_modexec(PyObject *m)
 
 static PyModuleDef_Slot bisect_slots[] = {
     {Py_mod_exec, bisect_modexec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_blake2/blake2module.c
+++ b/Modules/_blake2/blake2module.c
@@ -127,6 +127,7 @@ blake2_exec(PyObject *m)
 
 static PyModuleDef_Slot _blake2_slots[] = {
     {Py_mod_exec, blake2_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -799,6 +799,7 @@ _bz2_free(void *module)
 
 static struct PyModuleDef_Slot _bz2_slots[] = {
     {Py_mod_exec, _bz2_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_codecsmodule.c
+++ b/Modules/_codecsmodule.c
@@ -1049,6 +1049,7 @@ static PyMethodDef _codecs_functions[] = {
 };
 
 static PyModuleDef_Slot _codecs_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2571,6 +2571,7 @@ collections_exec(PyObject *module) {
 
 static struct PyModuleDef_Slot collections_slots[] = {
     {Py_mod_exec, collections_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_contextvarsmodule.c
+++ b/Modules/_contextvarsmodule.c
@@ -44,6 +44,7 @@ _contextvars_exec(PyObject *m)
 
 static struct PyModuleDef_Slot _contextvars_slots[] = {
     {Py_mod_exec, _contextvars_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_cryptmodule.c
+++ b/Modules/_cryptmodule.c
@@ -58,6 +58,7 @@ static PyMethodDef crypt_methods[] = {
 };
 
 static PyModuleDef_Slot _crypt_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1798,6 +1798,7 @@ csv_exec(PyObject *module) {
 
 static PyModuleDef_Slot csv_slots[] = {
     {Py_mod_exec, csv_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -1054,6 +1054,7 @@ _testfunc_pylist_append(PyObject *list, PyObject *item)
 }
 
 static struct PyModuleDef_Slot _ctypes_test_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_curses_panel.c
+++ b/Modules/_curses_panel.c
@@ -691,6 +691,7 @@ _curses_panel_exec(PyObject *mod)
 static PyModuleDef_Slot _curses_slots[] = {
     {Py_mod_exec, _curses_panel_exec},
     // XXX gh-103092: fix isolation.
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
     //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };

--- a/Modules/_curses_panel.c
+++ b/Modules/_curses_panel.c
@@ -690,6 +690,8 @@ _curses_panel_exec(PyObject *mod)
 
 static PyModuleDef_Slot _curses_slots[] = {
     {Py_mod_exec, _curses_panel_exec},
+    // XXX gh-103092: fix isolation.
+    //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -583,6 +583,7 @@ _dbm_module_free(void *module)
 
 static PyModuleDef_Slot _dbmmodule_slots[] = {
     {Py_mod_exec, _dbm_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -4419,6 +4419,8 @@ error:
 
 static struct PyModuleDef_Slot elementtree_slots[] = {
     {Py_mod_exec, module_exec},
+    // XXX gh-103092: fix isolation.
+    //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -4420,6 +4420,7 @@ error:
 static struct PyModuleDef_Slot elementtree_slots[] = {
     {Py_mod_exec, module_exec},
     // XXX gh-103092: fix isolation.
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
     //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1520,6 +1520,7 @@ _functools_free(void *module)
 
 static struct PyModuleDef_Slot _functools_slots[] = {
     {Py_mod_exec, _functools_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -793,6 +793,7 @@ _gdbm_module_free(void *module)
 
 static PyModuleDef_Slot _gdbm_module_slots[] = {
     {Py_mod_exec, _gdbm_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -2260,6 +2260,7 @@ static PyModuleDef_Slot hashlib_slots[] = {
     {Py_mod_exec, hashlib_md_meth_names},
     {Py_mod_exec, hashlib_init_constructors},
     {Py_mod_exec, hashlib_exception},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -682,6 +682,7 @@ heapq_exec(PyObject *m)
 
 static struct PyModuleDef_Slot heapq_slots[] = {
     {Py_mod_exec, heapq_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1801,6 +1801,7 @@ _json_exec(PyObject *module)
 
 static PyModuleDef_Slot _json_slots[] = {
     {Py_mod_exec, _json_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -874,6 +874,7 @@ _locale_exec(PyObject *module)
 
 static struct PyModuleDef_Slot _locale_slots[] = {
     {Py_mod_exec, _locale_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -1002,6 +1002,7 @@ _lsprof_exec(PyObject *module)
 static PyModuleDef_Slot _lsprofslots[] = {
     {Py_mod_exec, _lsprof_exec},
     // XXX gh-103092: fix isolation.
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
     //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -1001,6 +1001,8 @@ _lsprof_exec(PyObject *module)
 
 static PyModuleDef_Slot _lsprofslots[] = {
     {Py_mod_exec, _lsprof_exec},
+    // XXX gh-103092: fix isolation.
+    //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -1611,6 +1611,7 @@ static PyMethodDef lzma_methods[] = {
 
 static PyModuleDef_Slot lzma_slots[] = {
     {Py_mod_exec, lzma_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_multiprocessing/multiprocessing.c
+++ b/Modules/_multiprocessing/multiprocessing.c
@@ -276,6 +276,7 @@ multiprocessing_exec(PyObject *module)
 
 static PyModuleDef_Slot multiprocessing_slots[] = {
     {Py_mod_exec, multiprocessing_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_multiprocessing/posixshmem.c
+++ b/Modules/_multiprocessing/posixshmem.c
@@ -110,12 +110,19 @@ static PyMethodDef module_methods[ ] = {
 };
 
 
+static PyModuleDef_Slot module_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {0, NULL}
+};
+
+
 static struct PyModuleDef _posixshmemmodule = {
     PyModuleDef_HEAD_INIT,
     .m_name = "_posixshmem",
     .m_doc = "POSIX shared memory module",
     .m_size = 0,
     .m_methods = module_methods,
+    .m_slots = module_slots,
 };
 
 /* Module init function */

--- a/Modules/_opcode.c
+++ b/Modules/_opcode.c
@@ -94,12 +94,18 @@ opcode_functions[] =  {
     {NULL, NULL, 0, NULL}
 };
 
+static PyModuleDef_Slot module_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {0, NULL}
+};
+
 static struct PyModuleDef opcodemodule = {
     PyModuleDef_HEAD_INIT,
     .m_name = "_opcode",
     .m_doc = "Opcode support module.",
     .m_size = 0,
-    .m_methods = opcode_functions
+    .m_methods = opcode_functions,
+    .m_slots = module_slots,
 };
 
 PyMODINIT_FUNC

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -1828,6 +1828,7 @@ operator_exec(PyObject *module)
 
 static struct PyModuleDef_Slot operator_slots[] = {
     {Py_mod_exec, operator_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -7912,6 +7912,7 @@ _pickle_exec(PyObject *m)
 
 static PyModuleDef_Slot pickle_slots[] = {
     {Py_mod_exec, _pickle_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -1140,6 +1140,7 @@ static PyMethodDef module_methods[] = {
 };
 
 static PyModuleDef_Slot _posixsubprocess_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -431,6 +431,7 @@ queuemodule_exec(PyObject *module)
 
 static PyModuleDef_Slot queuemodule_slots[] = {
     {Py_mod_exec, queuemodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -624,6 +624,7 @@ _random_exec(PyObject *module)
 
 static PyModuleDef_Slot _random_slots[] = {
     {Py_mod_exec, _random_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_scproxy.c
+++ b/Modules/_scproxy.c
@@ -232,6 +232,7 @@ static PyMethodDef mod_methods[] = {
 };
 
 static PyModuleDef_Slot _scproxy_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_sha3/sha3module.c
+++ b/Modules/_sha3/sha3module.c
@@ -641,6 +641,7 @@ _sha3_exec(PyObject *m)
 
 static PyModuleDef_Slot _sha3_slots[] = {
     {Py_mod_exec, _sha3_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -785,6 +785,7 @@ error:
 
 static struct PyModuleDef_Slot module_slots[] = {
     {Py_mod_exec, module_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -3221,6 +3221,7 @@ error:
 
 static PyModuleDef_Slot sre_slots[] = {
     {Py_mod_exec, sre_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -6161,6 +6161,8 @@ static PyModuleDef_Slot sslmodule_slots[] = {
     {Py_mod_exec, sslmodule_init_constants},
     {Py_mod_exec, sslmodule_init_versioninfo},
     {Py_mod_exec, sslmodule_init_strings},
+    // XXX gh-103092: fix isolation.
+    //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -6162,6 +6162,7 @@ static PyModuleDef_Slot sslmodule_slots[] = {
     {Py_mod_exec, sslmodule_init_versioninfo},
     {Py_mod_exec, sslmodule_init_strings},
     // XXX gh-103092: fix isolation.
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
     //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };

--- a/Modules/_stat.c
+++ b/Modules/_stat.c
@@ -612,6 +612,7 @@ stat_exec(PyObject *module)
 
 static PyModuleDef_Slot stat_slots[] = {
     {Py_mod_exec, stat_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_statisticsmodule.c
+++ b/Modules/_statisticsmodule.c
@@ -129,6 +129,7 @@ PyDoc_STRVAR(statistics_doc,
 "Accelerators for the statistics module.\n");
 
 static struct PyModuleDef_Slot _statisticsmodule_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2572,6 +2572,7 @@ _structmodule_exec(PyObject *m)
 
 static PyModuleDef_Slot _structmodule_slots[] = {
     {Py_mod_exec, _structmodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -789,6 +789,7 @@ module_exec(PyObject *module)
 
 static struct PyModuleDef_Slot module_slots[] = {
     {Py_mod_exec, module_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -441,6 +441,7 @@ static int execfunc(PyObject *m)
 
 static PyModuleDef_Slot main_slots[] = {
     {Py_mod_exec, execfunc},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 
@@ -745,6 +746,7 @@ PyInit__testmultiphase_create_unreported_exception(void)
 static PyModuleDef_Slot slots_nonmodule_with_exec_slots[] = {
     {Py_mod_create, createfunc_nonmodule},
     {Py_mod_exec, execfunc},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 
@@ -765,6 +767,7 @@ execfunc_err(PyObject *mod)
 
 static PyModuleDef_Slot slots_exec_err[] = {
     {Py_mod_exec, execfunc_err},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 
@@ -786,6 +789,7 @@ execfunc_raise(PyObject *spec)
 
 static PyModuleDef_Slot slots_exec_raise[] = {
     {Py_mod_exec, execfunc_raise},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 
@@ -807,6 +811,7 @@ execfunc_unreported_exception(PyObject *mod)
 
 static PyModuleDef_Slot slots_exec_unreported_exception[] = {
     {Py_mod_exec, execfunc_unreported_exception},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 
@@ -845,6 +850,7 @@ meth_state_access_exec(PyObject *m)
 
 static PyModuleDef_Slot meth_state_access_slots[] = {
     {Py_mod_exec, meth_state_access_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1710,6 +1710,7 @@ The 'threading' module provides a more convenient interface.");
 
 static PyModuleDef_Slot thread_module_slots[] = {
     {Py_mod_exec, thread_module_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_typingmodule.c
+++ b/Modules/_typingmodule.c
@@ -36,6 +36,7 @@ PyDoc_STRVAR(typing_doc,
 "Accelerators for the typing module.\n");
 
 static struct PyModuleDef_Slot _typingmodule_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_uuidmodule.c
+++ b/Modules/_uuidmodule.c
@@ -106,6 +106,7 @@ static PyMethodDef uuid_methods[] = {
 
 static PyModuleDef_Slot uuid_slots[] = {
     {Py_mod_exec, uuid_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_weakref.c
+++ b/Modules/_weakref.c
@@ -174,6 +174,7 @@ weakref_exec(PyObject *module)
 
 static struct PyModuleDef_Slot weakref_slots[] = {
     {Py_mod_exec, weakref_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -2259,6 +2259,7 @@ static int winapi_exec(PyObject *m)
 
 static PyModuleDef_Slot winapi_slots[] = {
     {Py_mod_exec, winapi_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/_xxinterpchannelsmodule.c
+++ b/Modules/_xxinterpchannelsmodule.c
@@ -2418,6 +2418,7 @@ error:
 
 static struct PyModuleDef_Slot module_slots[] = {
     {Py_mod_exec, module_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -822,6 +822,7 @@ error:
 
 static struct PyModuleDef_Slot module_slots[] = {
     {Py_mod_exec, module_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -2822,7 +2822,10 @@ error:
 }
 
 static PyModuleDef_Slot zoneinfomodule_slots[] = {
-    {Py_mod_exec, zoneinfomodule_exec}, {0, NULL}};
+    {Py_mod_exec, zoneinfomodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {0, NULL},
+};
 
 static struct PyModuleDef zoneinfomodule = {
     .m_base = PyModuleDef_HEAD_INIT,

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3111,6 +3111,7 @@ array_modexec(PyObject *m)
 
 static PyModuleDef_Slot arrayslots[] = {
     {Py_mod_exec, array_modexec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -314,12 +314,18 @@ upon normal program termination.\n\
 Two public functions, register and unregister, are defined.\n\
 ");
 
+static PyModuleDef_Slot atexitmodule_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {0, NULL}
+};
+
 static struct PyModuleDef atexitmodule = {
     PyModuleDef_HEAD_INIT,
     .m_name = "atexit",
     .m_doc = atexit__doc__,
     .m_size = 0,
     .m_methods = atexit_methods,
+    .m_slots = atexitmodule_slots,
 };
 
 PyMODINIT_FUNC

--- a/Modules/audioop.c
+++ b/Modules/audioop.c
@@ -1975,6 +1975,7 @@ audioop_exec(PyObject* module)
 
 static PyModuleDef_Slot audioop_slots[] = {
     {Py_mod_exec, audioop_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -1291,6 +1291,7 @@ binascii_exec(PyObject *module) {
 
 static PyModuleDef_Slot binascii_slots[] = {
     {Py_mod_exec, binascii_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/cjkcodecs/cjkcodecs.h
+++ b/Modules/cjkcodecs/cjkcodecs.h
@@ -502,6 +502,7 @@ static struct PyMethodDef _cjk_methods[] = {
 
 static PyModuleDef_Slot _cjk_slots[] = {
     {Py_mod_exec, _cjk_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -2062,6 +2062,7 @@ static struct PyMethodDef _multibytecodec_methods[] = {
 
 static PyModuleDef_Slot _multibytecodec_slots[] = {
     {Py_mod_exec, _multibytecodec_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/cmathmodule.c
+++ b/Modules/cmathmodule.c
@@ -1411,6 +1411,7 @@ cmath_exec(PyObject *mod)
 
 static PyModuleDef_Slot cmath_slots[] = {
     {Py_mod_exec, cmath_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/errnomodule.c
+++ b/Modules/errnomodule.c
@@ -940,6 +940,7 @@ errno_exec(PyObject *module)
 
 static PyModuleDef_Slot errno_slots[] = {
     {Py_mod_exec, errno_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1274,6 +1274,8 @@ PyExec_faulthandler(PyObject *module) {
 
 static PyModuleDef_Slot faulthandler_slots[] = {
     {Py_mod_exec, PyExec_faulthandler},
+    // XXX gh-103092: fix isolation.
+    //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -686,6 +686,7 @@ fcntl_exec(PyObject *module)
 
 static PyModuleDef_Slot fcntl_slots[] = {
     {Py_mod_exec, fcntl_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -2044,6 +2044,7 @@ gcmodule_exec(PyObject *module)
 
 static PyModuleDef_Slot gcmodule_slots[] = {
     {Py_mod_exec, gcmodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -327,6 +327,7 @@ grpmodule_exec(PyObject *module)
 
 static PyModuleDef_Slot grpmodule_slots[] = {
     {Py_mod_exec, grpmodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -4693,6 +4693,7 @@ itertoolsmodule_exec(PyObject *mod)
 
 static struct PyModuleDef_Slot itertoolsmodule_slots[] = {
     {Py_mod_exec, itertoolsmodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -4064,6 +4064,7 @@ static PyMethodDef math_methods[] = {
 
 static PyModuleDef_Slot math_slots[] = {
     {Py_mod_exec, math_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/md5module.c
+++ b/Modules/md5module.c
@@ -340,6 +340,7 @@ md5_exec(PyObject *m)
 
 static PyModuleDef_Slot _md5_slots[] = {
     {Py_mod_exec, md5_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1713,6 +1713,7 @@ mmap_exec(PyObject *module)
 
 static PyModuleDef_Slot mmap_slots[] = {
     {Py_mod_exec, mmap_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/nismodule.c
+++ b/Modules/nismodule.c
@@ -503,6 +503,7 @@ nis_exec(PyObject *module)
 static PyModuleDef_Slot nis_slots[] = {
     {Py_mod_exec, nis_exec},
     // XXX gh-103092: fix isolation.
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
     //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };

--- a/Modules/nismodule.c
+++ b/Modules/nismodule.c
@@ -502,6 +502,8 @@ nis_exec(PyObject *module)
 
 static PyModuleDef_Slot nis_slots[] = {
     {Py_mod_exec, nis_exec},
+    // XXX gh-103092: fix isolation.
+    //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -2050,6 +2050,7 @@ overlapped_exec(PyObject *module)
 
 static PyModuleDef_Slot overlapped_slots[] = {
     {Py_mod_exec, overlapped_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -16793,6 +16793,7 @@ posixmodule_exec(PyObject *m)
 
 static PyModuleDef_Slot posixmodile_slots[] = {
     {Py_mod_exec, posixmodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -336,6 +336,7 @@ pwdmodule_exec(PyObject *module)
 
 static PyModuleDef_Slot pwdmodule_slots[] = {
     {Py_mod_exec, pwdmodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -2056,6 +2056,8 @@ pyexpat_free(void *module)
 
 static PyModuleDef_Slot pyexpat_slots[] = {
     {Py_mod_exec, pyexpat_exec},
+    // XXX gh-103092: fix isolation.
+    //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -2057,6 +2057,7 @@ pyexpat_free(void *module)
 static PyModuleDef_Slot pyexpat_slots[] = {
     {Py_mod_exec, pyexpat_exec},
     // XXX gh-103092: fix isolation.
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
     //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };

--- a/Modules/resource.c
+++ b/Modules/resource.c
@@ -514,6 +514,7 @@ resource_exec(PyObject *module)
 
 static struct PyModuleDef_Slot resource_slots[] = {
     {Py_mod_exec, resource_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -2651,6 +2651,7 @@ _select_exec(PyObject *m)
 
 static PyModuleDef_Slot _select_slots[] = {
     {Py_mod_exec, _select_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/sha1module.c
+++ b/Modules/sha1module.c
@@ -344,6 +344,7 @@ _sha1_exec(PyObject *module)
 
 static PyModuleDef_Slot _sha1_slots[] = {
     {Py_mod_exec, _sha1_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/sha2module.c
+++ b/Modules/sha2module.c
@@ -785,6 +785,7 @@ static int sha2_exec(PyObject *module)
 
 static PyModuleDef_Slot _sha2_slots[] = {
     {Py_mod_exec, sha2_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -1695,6 +1695,7 @@ _signal_module_free(void *module)
 
 static PyModuleDef_Slot signal_slots[] = {
     {Py_mod_exec, signal_module_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -8870,6 +8870,7 @@ error:
 
 static struct PyModuleDef_Slot socket_slots[] = {
     {Py_mod_exec, socket_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/Modules/spwdmodule.c
+++ b/Modules/spwdmodule.c
@@ -224,6 +224,7 @@ spwdmodule_exec(PyObject *module)
 
 static PyModuleDef_Slot spwdmodule_slots[] = {
     {Py_mod_exec, spwdmodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/symtablemodule.c
+++ b/Modules/symtablemodule.c
@@ -100,6 +100,7 @@ symtable_init_constants(PyObject *m)
 
 static PyModuleDef_Slot symtable_slots[] = {
     {Py_mod_exec, symtable_init_constants},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -406,6 +406,7 @@ syslog_exec(PyObject *module)
 
 static PyModuleDef_Slot syslog_slots[] = {
     {Py_mod_exec, syslog_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -1253,6 +1253,7 @@ termios_exec(PyObject *mod)
 
 static PyModuleDef_Slot termios_slots[] = {
     {Py_mod_exec, termios_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -2107,6 +2107,7 @@ time_module_free(void *module)
 
 static struct PyModuleDef_Slot time_slots[] = {
     {Py_mod_exec, time_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -1516,6 +1516,7 @@ unicodedata_exec(PyObject *module)
 
 static PyModuleDef_Slot unicodedata_slots[] = {
     {Py_mod_exec, unicodedata_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -390,6 +390,7 @@ xx_modexec(PyObject *m)
 
 static PyModuleDef_Slot xx_slots[] = {
     {Py_mod_exec, xx_modexec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/xxlimited_35.c
+++ b/Modules/xxlimited_35.c
@@ -293,6 +293,7 @@ xx_modexec(PyObject *m)
 
 static PyModuleDef_Slot xx_slots[] = {
     {Py_mod_exec, xx_modexec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/xxmodule.c
+++ b/Modules/xxmodule.c
@@ -383,6 +383,7 @@ xx_exec(PyObject *m)
 
 static struct PyModuleDef_Slot xx_slots[] = {
     {Py_mod_exec, xx_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/Modules/xxsubtype.c
+++ b/Modules/xxsubtype.c
@@ -286,6 +286,7 @@ xxsubtype_exec(PyObject* m)
 
 static struct PyModuleDef_Slot xxsubtype_slots[] = {
     {Py_mod_exec, xxsubtype_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -2109,6 +2109,7 @@ zlib_exec(PyObject *mod)
 
 static PyModuleDef_Slot zlib_slots[] = {
     {Py_mod_exec, zlib_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -250,6 +250,7 @@ PyModule_FromDefAndSpec2(PyModuleDef* def, PyObject *spec, int module_api_versio
     int has_execution_slots = 0;
     const char *name;
     int ret;
+    PyInterpreterState *interp = _PyInterpreterState_GET();
 
     PyModuleDef_Init(def);
 
@@ -316,13 +317,13 @@ PyModule_FromDefAndSpec2(PyModuleDef* def, PyObject *spec, int module_api_versio
         multiple_interpreters = Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED;
     }
     if (multiple_interpreters == Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED) {
-        PyInterpreterState *interp = _PyInterpreterState_GET();
         if (!_Py_IsMainInterpreter(interp)
             && _PyImport_CheckSubinterpIncompatibleExtensionAllowed(name) < 0)
         {
             goto error;
         }
     }
+    // XXX Do a similar check once we have PyInterpreterState.ceval.own_gil.
 
     if (create) {
         m = create(spec, def);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15192,12 +15192,18 @@ static PyMethodDef _string_methods[] = {
     {NULL, NULL}
 };
 
+static PyModuleDef_Slot module_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {0, NULL}
+};
+
 static struct PyModuleDef _string_module = {
     PyModuleDef_HEAD_INIT,
     .m_name = "_string",
     .m_doc = PyDoc_STR("string helper module"),
     .m_size = 0,
     .m_methods = _string_methods,
+    .m_slots = module_slots,
 };
 
 PyMODINIT_FUNC

--- a/PC/_testconsole.c
+++ b/PC/_testconsole.c
@@ -31,6 +31,7 @@ static int execfunc(PyObject *m)
 
 PyModuleDef_Slot testconsole_slots[] = {
     {Py_mod_exec, execfunc},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 

--- a/PC/msvcrtmodule.c
+++ b/PC/msvcrtmodule.c
@@ -661,6 +661,7 @@ exec_module(PyObject* m)
 
 static PyModuleDef_Slot msvcrt_slots[] = {
     {Py_mod_exec, exec_module},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -2184,6 +2184,7 @@ exec_module(PyObject *m)
 
 static PyModuleDef_Slot winreg_slots[] = {
     {Py_mod_exec, exec_module},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/PC/winsound.c
+++ b/PC/winsound.c
@@ -235,6 +235,7 @@ exec_module(PyObject *module)
 
 static PyModuleDef_Slot sound_slots[] = {
     {Py_mod_exec, exec_module},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1206,6 +1206,7 @@ class ASTModuleVisitor(PickleVisitor):
         self.emit("""
 static PyModuleDef_Slot astmodule_slots[] = {
     {Py_mod_exec, astmodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -12193,6 +12193,7 @@ astmodule_exec(PyObject *m)
 
 static PyModuleDef_Slot astmodule_slots[] = {
     {Py_mod_exec, astmodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Python/Python-tokenize.c
+++ b/Python/Python-tokenize.c
@@ -151,6 +151,7 @@ static PyMethodDef tokenize_methods[] = {
 
 static PyModuleDef_Slot tokenizemodule_slots[] = {
     {Py_mod_exec, tokenizemodule_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1449,6 +1449,7 @@ warnings_module_exec(PyObject *module)
 
 static PyModuleDef_Slot warnings_slots[] = {
     {Py_mod_exec, warnings_module_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -3840,6 +3840,7 @@ imp_module_exec(PyObject *module)
 
 static PyModuleDef_Slot imp_slots[] = {
     {Py_mod_exec, imp_module_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1870,6 +1870,7 @@ marshal_module_exec(PyObject *mod)
 
 static PyModuleDef_Slot marshalmodule_slots[] = {
     {Py_mod_exec, marshal_module_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 


### PR DESCRIPTION
Here we are doing no more than adding the value for `Py_mod_multiple_interpreters`.  We will start checking for it in gh-104206 (once `PyInterpreterState.ceval.own_gil` is added in gh-104204).

<!-- gh-issue-number: gh-99113 -->
* Issue: gh-99113
<!-- /gh-issue-number -->
