### PR TITLE
gh-99113: A Per-Interpreter GIL!

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -103,7 +103,7 @@ _PyEval_Vector(PyThreadState *tstate,
             PyObject* const* args, size_t argcount,
             PyObject *kwnames);
 
-extern int _PyEval_ThreadsInitialized(struct pyruntimestate *runtime);
+extern int _PyEval_ThreadsInitialized(PyInterpreterState *interp);
 extern PyStatus _PyEval_InitGIL(PyThreadState *tstate);
 extern void _PyEval_FiniGIL(PyInterpreterState *interp);
 

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -30,7 +30,7 @@ struct _ceval_runtime_state;
 extern void _Py_FinishPendingCalls(PyThreadState *tstate);
 extern void _PyEval_InitRuntimeState(_PyRuntimeState *);
 extern void _PyEval_InitState(PyInterpreterState *, PyThread_type_lock);
-extern void _PyEval_FiniState(struct _ceval_state *ceval);
+extern void _PyEval_FiniState(PyInterpreterState *);
 PyAPI_FUNC(void) _PyEval_SignalReceived(PyInterpreterState *interp);
 PyAPI_FUNC(int) _PyEval_AddPendingCall(
     PyInterpreterState *interp,

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -28,7 +28,6 @@ struct _ceval_runtime_state;
 
 
 extern void _Py_FinishPendingCalls(PyThreadState *tstate);
-extern void _PyEval_InitRuntimeState(_PyRuntimeState *);
 extern void _PyEval_InitState(PyInterpreterState *, PyThread_type_lock);
 extern void _PyEval_FiniState(PyInterpreterState *);
 PyAPI_FUNC(void) _PyEval_SignalReceived(PyInterpreterState *interp);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -29,7 +29,7 @@ struct _ceval_runtime_state;
 
 extern void _Py_FinishPendingCalls(PyThreadState *tstate);
 extern void _PyEval_InitRuntimeState(struct _ceval_runtime_state *);
-extern void _PyEval_InitState(struct _ceval_state *, PyThread_type_lock);
+extern void _PyEval_InitState(PyInterpreterState *, PyThread_type_lock);
 extern void _PyEval_FiniState(struct _ceval_state *ceval);
 PyAPI_FUNC(void) _PyEval_SignalReceived(PyInterpreterState *interp);
 PyAPI_FUNC(int) _PyEval_AddPendingCall(

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -28,7 +28,7 @@ struct _ceval_runtime_state;
 
 
 extern void _Py_FinishPendingCalls(PyThreadState *tstate);
-extern void _PyEval_InitRuntimeState(struct _ceval_runtime_state *);
+extern void _PyEval_InitRuntimeState(_PyRuntimeState *);
 extern void _PyEval_InitState(PyInterpreterState *, PyThread_type_lock);
 extern void _PyEval_FiniState(struct _ceval_state *ceval);
 PyAPI_FUNC(void) _PyEval_SignalReceived(PyInterpreterState *interp);

--- a/Include/internal/pycore_gil.h
+++ b/Include/internal/pycore_gil.h
@@ -21,7 +21,7 @@ extern "C" {
 #define FORCE_SWITCHING
 
 /* ** The GIL ** */
-struct _gil_runtime_state {
+struct _gil_state {
     /* microseconds (the Python API uses seconds, though) */
     unsigned long interval;
     /* Last PyThreadState holding / having held the GIL. This helps us

--- a/Include/internal/pycore_gil.h
+++ b/Include/internal/pycore_gil.h
@@ -20,6 +20,7 @@ extern "C" {
 #undef FORCE_SWITCHING
 #define FORCE_SWITCHING
 
+/* ** The GIL ** */
 struct _gil_runtime_state {
     /* microseconds (the Python API uses seconds, though) */
     unsigned long interval;

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -50,6 +50,8 @@ struct _ceval_state {
     _Py_atomic_int eval_breaker;
     /* Request for dropping the GIL */
     _Py_atomic_int gil_drop_request;
+    /* The GIL */
+    struct _gil_state gil;
     /* Pending calls */
     struct _pending_calls pending;
 };

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -18,6 +18,7 @@ extern "C" {
 #include "pycore_exceptions.h"    // struct _Py_exc_state
 #include "pycore_floatobject.h"   // struct _Py_float_state
 #include "pycore_genobject.h"     // struct _Py_async_gen_state
+#include "pycore_gil.h"           // struct _gil_state
 #include "pycore_gc.h"            // struct _gc_runtime_state
 #include "pycore_list.h"          // struct _Py_list_state
 #include "pycore_tuple.h"         // struct _Py_tuple_state

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -50,6 +50,7 @@ struct _ceval_state {
     _Py_atomic_int eval_breaker;
     /* Request for dropping the GIL */
     _Py_atomic_int gil_drop_request;
+    /* Pending calls */
     struct _pending_calls pending;
 };
 

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -9,7 +9,6 @@ extern "C" {
 #endif
 
 #include "pycore_atomic.h"          /* _Py_atomic_address */
-#include "pycore_gil.h"             // struct _gil_state
 #include "pycore_global_objects.h"  // struct _Py_global_objects
 #include "pycore_interp.h"          // PyInterpreterState
 #include "pycore_unicodeobject.h"   // struct _Py_unicode_runtime_ids
@@ -26,8 +25,6 @@ struct _ceval_runtime_state {
        the main thread of the main interpreter can handle signals: see
        _Py_ThreadCanHandleSignals(). */
     _Py_atomic_int signals_pending;
-    /* The GIL */
-    struct _gil_state gil;
 };
 
 /* GIL state */

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -26,6 +26,7 @@ struct _ceval_runtime_state {
        the main thread of the main interpreter can handle signals: see
        _Py_ThreadCanHandleSignals(). */
     _Py_atomic_int signals_pending;
+    /* The GIL */
     struct _gil_state gil;
 };
 

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 #include "pycore_atomic.h"          /* _Py_atomic_address */
-#include "pycore_gil.h"             // struct _gil_runtime_state
+#include "pycore_gil.h"             // struct _gil_state
 #include "pycore_global_objects.h"  // struct _Py_global_objects
 #include "pycore_interp.h"          // PyInterpreterState
 #include "pycore_unicodeobject.h"   // struct _Py_unicode_runtime_ids
@@ -26,7 +26,7 @@ struct _ceval_runtime_state {
        the main thread of the main interpreter can handle signals: see
        _Py_ThreadCanHandleSignals(). */
     _Py_atomic_int signals_pending;
-    struct _gil_runtime_state gil;
+    struct _gil_state gil;
 };
 
 /* GIL state */

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -220,13 +220,18 @@ is_tstate_valid(PyThreadState *tstate)
    and only the main interpreter is responsible to create
    and destroy it. */
 #define _GET_OWN_GIL(interp) \
-    (_Py_IsMainInterpreter(interp) ? (&_PyRuntime.ceval.gil) : NULL)
+    (_Py_IsMainInterpreter(interp) \
+        ?  (&_PyRuntime.interpreters.main->ceval.gil) \
+        : NULL)
 
 static inline struct _gil_state *
 _get_gil(PyInterpreterState *interp)
 {
+    //if (interp->config->_isolated_interpreter) {
+    //    return &interp->ceval.gil;
+    //}
     assert(interp->runtime == &_PyRuntime);
-    return &_PyRuntime.ceval.gil;
+    return &_PyRuntime.interpreters.main->ceval.gil;
 }
 
 

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -914,12 +914,6 @@ Py_MakePendingCalls(void)
 /* The interpreter's recursion limit */
 
 void
-_PyEval_InitRuntimeState(_PyRuntimeState *runtime)
-{
-    //_gil_initialize(&runtime->ceval.gil);
-}
-
-void
 _PyEval_InitState(PyInterpreterState *interp, PyThread_type_lock pending_lock)
 {
     /* Each interpreter is responsible to create and destroy

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -220,9 +220,7 @@ is_tstate_valid(PyThreadState *tstate)
    and only the main interpreter is responsible to create
    and destroy it. */
 #define _GET_OWN_GIL(interp) \
-    (_Py_IsMainInterpreter(interp) \
-        ?  (&_PyRuntime.interpreters.main->ceval.gil) \
-        : NULL)
+    (&interp->ceval.gil)
 
 static inline struct _gil_state *
 _get_gil(PyInterpreterState *interp)

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -225,7 +225,9 @@ is_tstate_valid(PyThreadState *tstate)
 static inline struct _gil_state *
 _get_gil(PyInterpreterState *interp)
 {
-    assert(interp->runtime == &_PyRuntime);
+    if (interp->config._isolated_interpreter) {
+        return _GET_OWN_GIL(interp);
+    }
     return &_PyRuntime.interpreters.main->ceval.gil;
 }
 

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -908,11 +908,12 @@ _PyEval_InitRuntimeState(struct _ceval_runtime_state *ceval)
 }
 
 void
-_PyEval_InitState(struct _ceval_state *ceval, PyThread_type_lock pending_lock)
+_PyEval_InitState(PyInterpreterState *interp, PyThread_type_lock pending_lock)
 {
+    struct _ceval_state *ceval = &interp->ceval;
+
     struct _pending_calls *pending = &ceval->pending;
     assert(pending->lock == NULL);
-
     pending->lock = pending_lock;
 }
 

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -920,6 +920,8 @@ _PyEval_InitRuntimeState(_PyRuntimeState *runtime)
 void
 _PyEval_InitState(PyInterpreterState *interp, PyThread_type_lock pending_lock)
 {
+    /* Everthing GIL-related is initialized in _PyEval_InitGIL(). */
+
     struct _pending_calls *pending = &interp->ceval.pending;
     assert(pending->lock == NULL);
     pending->lock = pending_lock;
@@ -933,6 +935,8 @@ _PyEval_FiniState(struct _ceval_state *ceval)
         PyThread_free_lock(pending->lock);
         pending->lock = NULL;
     }
+
+    /* Everthing GIL-related is finalized in _PyEval_FiniGIL(). */
 }
 
 /* Handle signals, pending calls, GIL drop request

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -930,9 +930,9 @@ _PyEval_InitState(PyInterpreterState *interp, PyThread_type_lock pending_lock)
 }
 
 void
-_PyEval_FiniState(struct _ceval_state *ceval)
+_PyEval_FiniState(PyInterpreterState *interp)
 {
-    struct _pending_calls *pending = &ceval->pending;
+    struct _pending_calls *pending = &interp->ceval.pending;
     if (pending->lock != NULL) {
         PyThread_free_lock(pending->lock);
         pending->lock = NULL;

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -912,9 +912,9 @@ Py_MakePendingCalls(void)
 /* The interpreter's recursion limit */
 
 void
-_PyEval_InitRuntimeState(struct _ceval_runtime_state *ceval)
+_PyEval_InitRuntimeState(_PyRuntimeState *runtime)
 {
-    _gil_initialize(&ceval->gil);
+    _gil_initialize(&runtime->ceval.gil);
 }
 
 void

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -227,9 +227,6 @@ is_tstate_valid(PyThreadState *tstate)
 static inline struct _gil_state *
 _get_gil(PyInterpreterState *interp)
 {
-    //if (interp->config->_isolated_interpreter) {
-    //    return &interp->ceval.gil;
-    //}
     assert(interp->runtime == &_PyRuntime);
     return &_PyRuntime.interpreters.main->ceval.gil;
 }

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -462,16 +462,22 @@ unsigned long _PyEval_GetSwitchInterval()
 
 
 int
-_PyEval_ThreadsInitialized(_PyRuntimeState *runtime)
+_PyEval_ThreadsInitialized(PyInterpreterState *interp)
 {
-    return gil_created(&runtime->ceval.gil);
+    if (interp == NULL) {
+        interp = &_PyRuntime.main;
+        if (interp == NULL) {
+            return 0;
+        }
+    }
+    return gil_created(&interp->runtime->ceval.gil);
 }
 
 int
 PyEval_ThreadsInitialized(void)
 {
-    _PyRuntimeState *runtime = &_PyRuntime;
-    return _PyEval_ThreadsInitialized(runtime);
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    return _PyEval_ThreadsInitialized(interp);
 }
 
 PyStatus

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -465,7 +465,7 @@ int
 _PyEval_ThreadsInitialized(PyInterpreterState *interp)
 {
     if (interp == NULL) {
-        interp = &_PyRuntime.main;
+        interp = _PyRuntime.interpreters.main;
         if (interp == NULL) {
             return 0;
         }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1679,7 +1679,8 @@ PyGILState_Ensure(void)
 
     /* Ensure that _PyEval_InitThreads() has been called by Py_Initialize() */
     // XXX Use the appropriate interpreter.
-    assert(runtime->main && _PyEval_ThreadsInitialized(runtime->main));
+    assert(runtime->interpreters.main &&
+           _PyEval_ThreadsInitialized(runtime->interpreters.main));
     /* Ensure that _PyGILState_Init() has been called by Py_Initialize() */
     assert(gilstate->autoInterpreterState);
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1677,9 +1677,10 @@ PyGILState_Ensure(void)
        spells out other issues.  Embedders are expected to have
        called Py_Initialize(). */
 
-    /* Ensure that _PyEval_InitThreads() and _PyGILState_Init() have been
-       called by Py_Initialize() */
-    assert(_PyEval_ThreadsInitialized(runtime));
+    /* Ensure that _PyEval_InitThreads() has been called by Py_Initialize() */
+    // XXX Use the appropriate interpreter.
+    assert(runtime->main && _PyEval_ThreadsInitialized(runtime->main));
+    /* Ensure that _PyGILState_Init() has been called by Py_Initialize() */
     assert(gilstate->autoInterpreterState);
 
     PyThreadState *tcur = (PyThreadState *)PyThread_tss_get(&gilstate->autoTSSkey);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -121,8 +121,6 @@ init_runtime(_PyRuntimeState *runtime,
     runtime->open_code_userdata = open_code_userdata;
     runtime->audit_hook_head = audit_hook_head;
 
-    _PyEval_InitRuntimeState(runtime);
-
     PyPreConfig_InitPythonConfig(&runtime->preconfig);
 
     runtime->interpreters.mutex = interpreters_mutex;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -121,7 +121,7 @@ init_runtime(_PyRuntimeState *runtime,
     runtime->open_code_userdata = open_code_userdata;
     runtime->audit_hook_head = audit_hook_head;
 
-    _PyEval_InitRuntimeState(&runtime->ceval);
+    _PyEval_InitRuntimeState(runtime);
 
     PyPreConfig_InitPythonConfig(&runtime->preconfig);
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -495,7 +495,7 @@ PyInterpreterState_Delete(PyInterpreterState *interp)
     struct pyinterpreters *interpreters = &runtime->interpreters;
     zapthreads(interp, 0);
 
-    _PyEval_FiniState(&interp->ceval);
+    _PyEval_FiniState(interp);
 
     /* Delete current thread. After this, many C API calls become crashy. */
     _PyThreadState_Swap(&runtime->gilstate, NULL);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -305,7 +305,7 @@ init_interpreter(PyInterpreterState *interp,
     assert(next != NULL || (interp == runtime->interpreters.main));
     interp->next = next;
 
-    _PyEval_InitState(&interp->ceval, pending_lock);
+    _PyEval_InitState(interp, pending_lock);
     _PyGC_InitState(&interp->gc);
     PyConfig_InitPythonConfig(&interp->config);
     _PyType_InitCache(interp);


### PR DESCRIPTION
This is the culmination of PEP 684 (and of my 8-year long multi-core Python project)!

Each subinterpreter may now be created with its own GIL (via `Py_NewInterpreterFromConfig()`).  If not so configured then the interpreter will share with the main interpreter--the status quo since the subinterpreters were added decades ago.  The main interpreter always has its own GIL and subinterpreters from `Py_NewInterpreter()` will always share with the main interpreter.

(FYI, I've split up the original gh-99114 into multiple PRs, with this one being the final one in the chain.)

<!-- gh-issue-number: gh-99113 -->
* Issue: gh-99113
<!-- /gh-issue-number -->
