### PR TITLE
gh-97696: Remove redundant #include

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -8,7 +8,6 @@
 #include "pycore_runtime_init.h"  // _Py_ID()
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "structmember.h"         // PyMemberDef
-#include "cpython/context.h"
 #include <stddef.h>               // offsetof()
 
 


### PR DESCRIPTION
As per discussion on https://github.com/python/cpython/pull/102853.


<!-- gh-issue-number: gh-97696 -->
* Issue: gh-97696
<!-- /gh-issue-number -->
