### PR TITLE
gh-104223: Fix issues with inheriting from buffer classes

### DIFF
--- a/Include/cpython/memoryobject.h
+++ b/Include/cpython/memoryobject.h
@@ -24,6 +24,7 @@ typedef struct {
 #define _Py_MEMORYVIEW_FORTRAN     0x004  /* Fortran contiguous layout */
 #define _Py_MEMORYVIEW_SCALAR      0x008  /* scalar: ndim = 0 */
 #define _Py_MEMORYVIEW_PIL         0x010  /* PIL-style layout */
+#define _Py_MEMORYVIEW_RESTRICTED  0x020  /* Disallow additional references */
 
 typedef struct {
     PyObject_VAR_HEAD

--- a/Include/cpython/memoryobject.h
+++ b/Include/cpython/memoryobject.h
@@ -24,7 +24,7 @@ typedef struct {
 #define _Py_MEMORYVIEW_FORTRAN     0x004  /* Fortran contiguous layout */
 #define _Py_MEMORYVIEW_SCALAR      0x008  /* scalar: ndim = 0 */
 #define _Py_MEMORYVIEW_PIL         0x010  /* PIL-style layout */
-#define _Py_MEMORYVIEW_RESTRICTED  0x020  /* Disallow additional references */
+#define _Py_MEMORYVIEW_RESTRICTED  0x020  /* Disallow new references to the memoryview's buffer */
 
 typedef struct {
     PyObject_VAR_HEAD

--- a/Include/internal/pycore_memoryobject.h
+++ b/Include/internal/pycore_memoryobject.h
@@ -9,7 +9,8 @@ extern "C" {
 #endif
 
 PyObject *
-PyMemoryView_FromObjectAndFlags(PyObject *v, int flags);
+_PyMemoryView_FromBufferProc(PyObject *v, int flags,
+                             getbufferproc bufferproc);
 
 #ifdef __cplusplus
 }

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4579,6 +4579,15 @@ class TestPythonBufferProtocol(unittest.TestCase):
             buf.__release_buffer__(mv)
         self.assertEqual(buf.references, 0)
 
+    def test_inheritance(self):
+        class A(bytearray):
+            def __buffer__(self, flags):
+                return super().__buffer__(flags)
+
+        a = A(b"hello")
+        mv = memoryview(a)
+        self.assertEqual(mv.tobytes(), b"hello")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4588,6 +4588,22 @@ class TestPythonBufferProtocol(unittest.TestCase):
         mv = memoryview(a)
         self.assertEqual(mv.tobytes(), b"hello")
 
+    def test_inheritance_releasebuffer(self):
+        rb_call_count = 0
+        class B(bytearray):
+            def __buffer__(self, flags):
+                return super().__buffer__(flags)
+            def __release_buffer__(self, view):
+                nonlocal rb_call_count
+                rb_call_count += 1
+                super().__release_buffer__(view)
+
+        b = B(b"hello")
+        with memoryview(b) as mv:
+            self.assertEqual(mv.tobytes(), b"hello")
+            self.assertEqual(rb_call_count, 0)
+        self.assertEqual(rb_call_count, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4670,6 +4670,26 @@ class TestPythonBufferProtocol(unittest.TestCase):
         with self.assertRaises(ValueError):
             smuggled_buffer.tobytes()
 
+    def test_release_saves_reference_no_subclassing(self):
+        ba = bytearray(b"hello")
+
+        class C:
+            def __buffer__(self, flags):
+                return memoryview(ba)
+
+            def __release_buffer__(self, buffer):
+                self.buffer = buffer
+
+        c = C()
+        with memoryview(c) as mv:
+            self.assertEqual(mv.tobytes(), b"hello")
+        self.assertEqual(c.buffer.tobytes(), b"hello")
+
+        with self.assertRaises(BufferError):
+            ba.clear()
+        c.buffer.release()
+        ba.clear()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -61,6 +61,7 @@ static void
 bytearray_releasebuffer(PyByteArrayObject *obj, Py_buffer *view)
 {
     obj->ob_exports--;
+    assert(obj->ob_exports >= 0);
 }
 
 static int

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -9119,7 +9119,7 @@ releasebuffer_call_python(PyObject *self, Py_buffer *buffer)
 {
     PyObject *mv;
     bool is_buffer_wrapper = Py_TYPE(buffer->obj) == &_PyBufferWrapper_Type;
-    if (Py_TYPE(buffer->obj) == &_PyBufferWrapper_Type) {
+    if (is_buffer_wrapper) {
         // Make sure we pass the same memoryview to
         // __release_buffer__() that __buffer__() returned.
         PyBufferWrapper *bw = (PyBufferWrapper *)buffer->obj;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -9085,7 +9085,7 @@ releasebuffer_maybe_call_super(PyObject *self, Py_buffer *buffer)
     Py_ssize_t i;
 
     /* No need to check the last one: it's gonna be skipped anyway.  */
-    for (i = 0; i+1 < n; i++) {
+    for (i = 0;  i < n -1; i++) {
         if ((PyObject *)(self_type) == PyTuple_GET_ITEM(mro, i))
             break;
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8993,13 +8993,8 @@ bufferwrapper_releasebuf(PyObject *self, Py_buffer *view)
         return;
     }
 
-    PyObject *mv = Py_NewRef(bw->mv);
-    PyObject *obj = Py_NewRef(bw->obj);
-
-    // Clear these fields first, in case we somehow get called
-    // recursively.
-    Py_CLEAR(bw->mv);
-    Py_CLEAR(bw->obj);
+    PyObject *mv = bw->mv;
+    PyObject *obj = bw->obj;
 
     assert(PyMemoryView_Check(mv));
     Py_TYPE(mv)->tp_as_buffer->bf_releasebuffer(mv, view);
@@ -9011,8 +9006,8 @@ bufferwrapper_releasebuf(PyObject *self, Py_buffer *view)
         releasebuffer_call_python(obj, view);
     }
 
-    Py_DECREF(mv);
-    Py_DECREF(obj);
+    Py_CLEAR(bw->mv);
+    Py_CLEAR(bw->obj);
 }
 
 static PyBufferProcs bufferwrapper_as_buffer = {


### PR DESCRIPTION
This fixes various issues that crop up when inheriting from a class that implements the C buffer protocol.

* In `wrap_buffer`, we need to make sure to call the exact slot that we're wrapping, or we might recursively call ourselves inside a call to `super()`.
* In `bufferwrapper_releasebuf`, we should only call the `bf_releasebuf` slot if it's a Python function. If it's a C slot inherited from a base class, it will just be called when we release the memoryview.
* The C bf_releasebuf slot of classes that inherit from C buffer classes was not called. Fix this.
* The wrapper memoryview created in `releasebuffer_call_python` allowed a use-after-free. To guard against that, create a new restricted-mode memoryview that does not allow the user to hold on to the buffer.

<!-- gh-issue-number: gh-104223 -->
* Issue: gh-104223
<!-- /gh-issue-number -->
