### PR TITLE
gh-104233: Fix "unused variable" warning in `ceval_gil.c`

### DIFF
--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -547,9 +547,11 @@ _PyEval_FiniGIL(PyInterpreterState *interp)
         return;
     }
     else if (!interp->ceval.own_gil) {
+#ifdef Py_DEBUG
         PyInterpreterState *main_interp = _PyInterpreterState_Main();
         assert(interp != main_interp);
         assert(interp->ceval.gil == main_interp->ceval.gil);
+#endif
         interp->ceval.gil = NULL;
         return;
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-104233 -->
* Issue: gh-104233
<!-- /gh-issue-number -->
