### PR TITLE
gh-104235: Fix doctest loading issues in `test_enum`

### DIFF
--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2,6 +2,7 @@ import copy
 import enum
 import doctest
 import inspect
+import os
 import pydoc
 import sys
 import unittest
@@ -25,11 +26,11 @@ python_version = sys.version_info[:2]
 
 def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(enum))
-    tests.addTests(doctest.DocFileSuite(
-        '../../Doc/library/enum.rst',
-        optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
-        module_relative=True
-        ))
+    if os.path.exists('../../Doc/library/enum.rst'):
+        tests.addTests(doctest.DocFileSuite(
+                '../../Doc/library/enum.rst',
+                optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
+                ))
     return tests
 
 MODULE = __name__

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2,7 +2,6 @@ import copy
 import enum
 import doctest
 import inspect
-import os
 import pydoc
 import sys
 import unittest
@@ -26,11 +25,11 @@ python_version = sys.version_info[:2]
 
 def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(enum))
-    if os.path.exists('Doc/library/enum.rst'):
-        tests.addTests(doctest.DocFileSuite(
-                '../../Doc/library/enum.rst',
-                optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
-                ))
+    tests.addTests(doctest.DocFileSuite(
+        '../../Doc/library/enum.rst',
+        optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
+        module_relative=True
+        ))
     return tests
 
 MODULE = __name__

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -26,10 +26,11 @@ python_version = sys.version_info[:2]
 
 def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(enum))
-    if os.path.exists('../../Doc/library/enum.rst'):
+    if os.path.exists(f"{os.path.dirname(__file__)}/../../Doc/library/enum.rst"):
         tests.addTests(doctest.DocFileSuite(
                 '../../Doc/library/enum.rst',
                 optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
+                module_relative=True
                 ))
     return tests
 


### PR DESCRIPTION
Fixes problems with `test_enum` mentioned in #104235.
* remove invalid doc file existence check
* mark path to doc as module-relative by using `module_relative` flag

<!-- gh-issue-number: gh-104235 -->
* Issue: gh-104235
<!-- /gh-issue-number -->
