### PR TITLE
gh-104235: Fix documentation for `enum.Enum.__dir__`

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -278,8 +278,8 @@ Data Types
 
    .. method:: Enum.__dir__(self)
 
-      Returns ``['__class__', '__doc__', '__module__', 'name', 'value']`` and
-      any public methods defined on *self.__class__*::
+      Returns ``['__class__', '__doc__', '__eq__', '__hash__', '__module__', 'name', 'value']``
+      along with any public members and methods defined on *self.__class__*::
 
          >>> from datetime import date
          >>> class Weekday(Enum):
@@ -295,7 +295,7 @@ Data Types
          ...         print('today is %s' % cls(date.today().isoweekday()).name)
          ...
          >>> dir(Weekday.SATURDAY)
-         ['__class__', '__doc__', '__eq__', '__hash__', '__module__', 'name', 'today', 'value']
+         ['FRIDAY', 'MONDAY', 'SATURDAY', 'SUNDAY', 'THURSDAY', 'TUESDAY', 'WEDNESDAY', '__class__', '__doc__', '__eq__', '__hash__', '__module__', 'name', 'today', 'value']
 
    .. method:: Enum._generate_next_value_(name, start, count, last_values)
 


### PR DESCRIPTION
Fixes #104235

* mention in doc text that method also returns public members defined on enum class
* add `__eq__` and `__hash__` to return value in doc text
* add enum members to return value in example

<!-- gh-issue-number: gh-104235 -->
* Issue: gh-104235
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104237.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->