### PR TITLE
gh-104231: make `str(x)` a str, `bytes(x)` a bytes

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1050,7 +1050,7 @@ class BytesTest(BaseBytesTest, unittest.TestCase):
             def __bytes__(self):
                 return OtherBytesSubclass(b'abc')
         self.assertEqual(bytes(A()), b'abc')
-        self.assertIs(type(bytes(A())), OtherBytesSubclass)
+        self.assertIs(type(bytes(A())), bytes)
         self.assertEqual(BytesSubclass(A()), b'abc')
         self.assertIs(type(BytesSubclass(A())), BytesSubclass)
 

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -2396,7 +2396,7 @@ class UnicodeTest(string_tests.CommonTest,
         self.assertEqual(str(StrSubclassToStr("bar")), "foo")
         s = str(StrSubclassToStrSubclass("foo"))
         self.assertEqual(s, "foofoo")
-        self.assertIs(type(s), StrSubclassToStrSubclass)
+        self.assertIs(type(s), str)
         s = StrSubclass(StrSubclassToStrSubclass("foo"))
         self.assertEqual(s, "foofoo")
         self.assertIs(type(s), StrSubclass)

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2645,7 +2645,7 @@ bytes_new_impl(PyTypeObject *type, PyObject *x, const char *encoding,
         bytes = PyBytes_FromObject(x);
     }
 
-    if (bytes != NULL && type != &PyBytes_Type) {
+    if (bytes != NULL && (type != &PyBytes_Type || bytes->ob_type != type)) {
         Py_SETREF(bytes, bytes_subtype_new(type, bytes));
     }
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14354,7 +14354,8 @@ unicode_new_impl(PyTypeObject *type, PyObject *x, const char *encoding,
         unicode = PyUnicode_FromEncodedObject(x, encoding, errors);
     }
 
-    if (unicode != NULL && type != &PyUnicode_Type) {
+    if (unicode != NULL &&
+        (type != &PyUnicode_Type || unicode->ob_type != type)) {
         Py_SETREF(unicode, unicode_subtype_new(type, unicode));
     }
     return unicode;


### PR DESCRIPTION
Implicitly converting subclass of `__str__` and `__bytes__`.

<!-- gh-issue-number: gh-104231 -->
* Issue: gh-104231
<!-- /gh-issue-number -->
