### PR TITLE
gh-104252: Immortalize Py_EMPTY_KEYS

### DIFF
--- a/Include/internal/pycore_dict_state.h
+++ b/Include/internal/pycore_dict_state.h
@@ -27,8 +27,6 @@ struct _Py_dict_state {
     uint64_t global_version;
     uint32_t next_keys_version;
 
-//    PyDictKeysObject empty_keys_struct;
-
 #if PyDict_MAXFREELIST > 0
     /* Dictionary reuse scheme to save calls to malloc and free */
     PyDictObject *free_list[PyDict_MAXFREELIST];

--- a/Include/internal/pycore_dict_state.h
+++ b/Include/internal/pycore_dict_state.h
@@ -27,6 +27,8 @@ struct _Py_dict_state {
     uint64_t global_version;
     uint32_t next_keys_version;
 
+//    PyDictKeysObject empty_keys_struct;
+
 #if PyDict_MAXFREELIST > 0
     /* Dictionary reuse scheme to save calls to malloc and free */
     PyDictObject *free_list[PyDict_MAXFREELIST];
@@ -37,6 +39,11 @@ struct _Py_dict_state {
 
     PyDict_WatchCallback watchers[DICT_MAX_WATCHERS];
 };
+
+#define _dict_state_INIT \
+    { \
+        .next_keys_version = 2, \
+    }
 
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -107,9 +107,7 @@ extern PyTypeObject _PyExc_MemoryError;
             }, \
         }, \
         .dtoa = _dtoa_state_INIT(&(INTERP)), \
-        .dict_state = { \
-            .next_keys_version = 2, \
-        }, \
+        .dict_state = _dict_state_INIT, \
         .func_state = { \
             .next_version = 1, \
         }, \

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3574,7 +3574,7 @@ _PyDict_SizeOf(PyDictObject *mp)
     }
     /* If the dictionary is split, the keys portion is accounted-for
        in the type object. */
-    if (mp->ma_keys->dk_refcnt == 1 || mp->ma_keys == Py_EMPTY_KEYS) {
+    if (mp->ma_keys->dk_refcnt == 1) {
         res += _PyDict_KeysSize(mp->ma_keys);
     }
     assert(res <= (size_t)PY_SSIZE_T_MAX);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2089,7 +2089,7 @@ PyDict_Clear(PyObject *op)
         dictkeys_decref(interp, oldkeys);
     }
     else {
-        assert(oldkeys->dk_refcnt == 1 || oldkeys == Py_EMPTY_KEYS);
+        assert(oldkeys->dk_refcnt == 1);
         dictkeys_decref(interp, oldkeys);
     }
     ASSERT_CONSISTENT(mp);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1542,10 +1542,10 @@ dictresize(PyInterpreterState *interp, PyDictObject *mp,
 
         // We can not use free_keys_object here because key's reference
         // are moved already.
-#ifdef Py_REF_DEBUG
-        _Py_DecRefTotal(_PyInterpreterState_GET());
-#endif
         if (oldkeys != Py_EMPTY_KEYS) {
+#ifdef Py_REF_DEBUG
+            _Py_DecRefTotal(_PyInterpreterState_GET());
+#endif
             assert(oldkeys->dk_kind != DICT_KEYS_SPLIT);
             assert(oldkeys->dk_refcnt == 1);
 #if PyDict_MAXFREELIST > 0

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -300,11 +300,12 @@ _PyDict_DebugMallocStats(FILE *out)
 
 static void free_keys_object(PyInterpreterState *interp, PyDictKeysObject *keys);
 
-/* We might consider modifying PyDictKeysObject so we could use
-   Py_INCREF() instead of dictkeys_incref() (and likewise with
-   Py_DECREF() and dictkeys_decref()).  However, there doesn't
-   seem to be enough benefit (performance or otherwise) to justify
-   the change. */
+/* PyDictKeysObject has refcounts like PyObject does, so we have the
+   following two functions to mirror what Py_INCREF() and Py_DECREF() do.
+   (Keep in mind that PyDictKeysObject isn't actually a PyObject.)
+   Likewise a PyDictKeysObject can be immortal (e.g. Py_EMPTY_KEYS),
+   so we apply a naive version of what Py_INCREF() and Py_DECREF() do
+   for immortal objects. */
 
 static inline void
 dictkeys_incref(PyDictKeysObject *dk)

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -300,18 +300,26 @@ _PyDict_DebugMallocStats(FILE *out)
 
 static void free_keys_object(PyInterpreterState *interp, PyDictKeysObject *keys);
 
+// XXX Switch to Py_INCREF()?
 static inline void
 dictkeys_incref(PyDictKeysObject *dk)
 {
+    if (dk->dk_refcnt == _Py_IMMORTAL_REFCNT) {
+        return;
+    }
 #ifdef Py_REF_DEBUG
     _Py_IncRefTotal(_PyInterpreterState_GET());
 #endif
     dk->dk_refcnt++;
 }
 
+// XXX Switch to Py_DECREF()?
 static inline void
 dictkeys_decref(PyInterpreterState *interp, PyDictKeysObject *dk)
 {
+    if (dk->dk_refcnt == _Py_IMMORTAL_REFCNT) {
+        return;
+    }
     assert(dk->dk_refcnt > 0);
 #ifdef Py_REF_DEBUG
     _Py_DecRefTotal(_PyInterpreterState_GET());
@@ -447,7 +455,7 @@ estimate_log2_keysize(Py_ssize_t n)
  * (which cannot fail and thus can do no allocation).
  */
 static PyDictKeysObject empty_keys_struct = {
-        1, /* dk_refcnt */
+        _Py_IMMORTAL_REFCNT, /* dk_refcnt */
         0, /* dk_log2_size */
         0, /* dk_log2_index_bytes */
         DICT_KEYS_UNICODE, /* dk_kind */

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -846,7 +846,7 @@ PyObject *
 PyDict_New(void)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    dictkeys_incref(Py_EMPTY_KEYS);
+    /* We don't incref Py_EMPTY_KEYS here because it is immortal. */
     return new_dict(interp, Py_EMPTY_KEYS, NULL, 0, 0);
 }
 
@@ -1344,7 +1344,7 @@ insert_to_emptydict(PyInterpreterState *interp, PyDictObject *mp,
         Py_DECREF(value);
         return -1;
     }
-    dictkeys_decref(interp, Py_EMPTY_KEYS);
+    /* We don't decref Py_EMPTY_KEYS here because it is immortal. */
     mp->ma_keys = newkeys;
     mp->ma_values = NULL;
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -300,7 +300,12 @@ _PyDict_DebugMallocStats(FILE *out)
 
 static void free_keys_object(PyInterpreterState *interp, PyDictKeysObject *keys);
 
-// XXX Switch to Py_INCREF()?
+/* We might consider modifying PyDictKeysObject so we could use
+   Py_INCREF() instead of dictkeys_incref() (and likewise with
+   Py_DECREF() and dictkeys_decref()).  However, there doesn't
+   seem to be enough benefit (performance or otherwise) to justify
+   the change. */
+
 static inline void
 dictkeys_incref(PyDictKeysObject *dk)
 {
@@ -313,7 +318,6 @@ dictkeys_incref(PyDictKeysObject *dk)
     dk->dk_refcnt++;
 }
 
-// XXX Switch to Py_DECREF()?
 static inline void
 dictkeys_decref(PyInterpreterState *interp, PyDictKeysObject *dk)
 {


### PR DESCRIPTION
This was missed in gh-19474.  It matters for with a per-interpreter GIL since `PyDictKeysObject.dk_refcnt` breaks isolation and leads to races.

cc @eduardo-elizondo

<!-- gh-issue-number: gh-104252 -->
* Issue: gh-104252
<!-- /gh-issue-number -->
