### PR TITLE
gh-97696: Improve and fix documentation for asyncio eager tasks

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -561,7 +561,7 @@ Eager Task Factory
     of the default :class:`Task`.
 
     *custom_task_constructor* must be a *callable* with the signature matching
-    ``(coro, *, loop=None, name=None, context=None, eager_start=False)``.
+    the signature of :class:`Task.__init__ <Task>`.
     The callable must return a :class:`asyncio.Task`-compatible object.
 
     This function returns a *callable* intended to be used as a task factory of an

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -560,6 +560,13 @@ Eager Task Factory
     using the provided *custom_task_constructor* when creating a new task instead
     of the default :class:`Task`.
 
+    *custom_task_constructor* must be a *callable* with the signature matching
+    ``(coro, *, loop=None, name=None, context=None, eager_start=False)``.
+    The callable must return a :class:`asyncio.Task`-compatible object.
+
+    This function returns a *callable* intended to be used as a task factory of an
+    event loop via :meth:`loop.set_task_factory(factory) <loop.set_task_factory>`).
+
     .. versionadded:: 3.12
 
 
@@ -1014,7 +1021,7 @@ Introspection
 Task Object
 ===========
 
-.. class:: Task(coro, *, loop=None, name=None, context=None)
+.. class:: Task(coro, *, loop=None, name=None, context=None, eager_start=False)
 
    A :class:`Future-like <Future>` object that runs a Python
    :ref:`coroutine <coroutine>`.  Not thread-safe.
@@ -1054,6 +1061,13 @@ Task Object
    If no *context* is provided, the Task copies the current context
    and later runs its coroutine in the copied context.
 
+   An optional keyword-only *eager_start* argument allows eagerly starting
+   the execution of the :class:`asyncio.Task` at task creation time.
+   If set to ``True`` and the event loop is running, the task will start
+   executing the coroutine immediately, until the first time the coroutine
+   blocks. If the coroutine returns or raises without blocking, the task
+   will be finished eagerly and will skip scheduling to the event loop.
+
    .. versionchanged:: 3.7
       Added support for the :mod:`contextvars` module.
 
@@ -1066,6 +1080,9 @@ Task Object
 
    .. versionchanged:: 3.11
       Added the *context* parameter.
+
+   .. versionchanged:: 3.12
+      Added the *eager_start* parameter.
 
    .. method:: done()
 

--- a/Misc/NEWS.d/next/Library/2023-05-03-16-51-53.gh-issue-104144.653Q0P.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-03-16-51-53.gh-issue-104144.653Q0P.rst
@@ -1,1 +1,2 @@
-Optimize :class:`asyncio.TaskGroup` when using :func:`asyncio.eager_task_factory`. Skip scheduling done callbacks when all tasks finish without blocking.
+Optimize :class:`asyncio.TaskGroup` when using :func:`asyncio.eager_task_factory`.
+Skip scheduling a done callback if a TaskGroup task completes eagerly.


### PR DESCRIPTION
- Document `eager_start` argument to Task constructor
- Document usage of `create_eager_task_factory`
- Fix docs nit from https://github.com/python/cpython/pull/104140/files#r1186714354

<!-- gh-issue-number: gh-97696 -->
* Issue: gh-97696
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104256.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->