### PR TITLE
gh-104265 Disallow instantiation of `_csv.Reader` and `_csv.Writer`

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -7,6 +7,7 @@ import unittest
 from io import StringIO
 from tempfile import TemporaryFile
 import csv
+import _csv
 import gc
 import pickle
 from test import support
@@ -1429,6 +1430,16 @@ class MiscTestCase(unittest.TestCase):
     def test_subclassable(self):
         # issue 44089
         class Foo(csv.Error): ...
+
+    def test_issue104265(self):
+        with self.assertRaisesRegex(TypeError, "cannot create '_csv.reader' instances"):
+            _csv.Reader()
+        with self.assertRaisesRegex(TypeError, "cannot create '_csv.writer' instances"):
+            _csv.Writer()
+        with self.assertRaisesRegex(TypeError, "type '_csv.reader' is not an acceptable base type"):
+            class Foo(_csv.Reader): pass
+        with self.assertRaisesRegex(TypeError, "type '_csv.writer' is not an acceptable base type"):
+            class Foo(_csv.Writer): pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -7,11 +7,10 @@ import unittest
 from io import StringIO
 from tempfile import TemporaryFile
 import csv
-import _csv
 import gc
 import pickle
 from test import support
-from test.support import warnings_helper, check_disallow_instantiation
+from test.support import warnings_helper, import_helper, check_disallow_instantiation
 from itertools import permutations
 from textwrap import dedent
 from collections import OrderedDict
@@ -1431,11 +1430,12 @@ class MiscTestCase(unittest.TestCase):
         # issue 44089
         class Foo(csv.Error): ...
 
-    def test_reader_disallow_instantiation(self):
-        check_disallow_instantiation(self, _csv.Reader)
-
-    def test_writer_disallow_instantiation(self):
-        check_disallow_instantiation(self, _csv.Writer)
+    @support.cpython_only
+    def test_disallow_instantiation(self):
+        _csv = import_helper.import_module("_csv")
+        for tp in _csv.Reader, _csv.Writer:
+            with self.subTest(tp=tp):
+                check_disallow_instantiation(self, tp)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -11,7 +11,7 @@ import _csv
 import gc
 import pickle
 from test import support
-from test.support import warnings_helper
+from test.support import warnings_helper, check_disallow_instantiation
 from itertools import permutations
 from textwrap import dedent
 from collections import OrderedDict
@@ -1431,13 +1431,17 @@ class MiscTestCase(unittest.TestCase):
         # issue 44089
         class Foo(csv.Error): ...
 
-    def test_issue104265(self):
-        with self.assertRaisesRegex(TypeError, "cannot create '_csv.reader' instances"):
-            _csv.Reader()
-        with self.assertRaisesRegex(TypeError, "cannot create '_csv.writer' instances"):
-            _csv.Writer()
+    def test_reader_disallow_instantiation(self):
+        check_disallow_instantiation(self, _csv.Reader)
+
+    def test_writer_disallow_instantiation(self):
+        check_disallow_instantiation(self, _csv.Writer)
+
+    def test_reader_not_basetype(self):
         with self.assertRaisesRegex(TypeError, "type '_csv.reader' is not an acceptable base type"):
             class Foo(_csv.Reader): pass
+
+    def test_writer_not_basetype(self):
         with self.assertRaisesRegex(TypeError, "type '_csv.writer' is not an acceptable base type"):
             class Foo(_csv.Writer): pass
 

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1437,13 +1437,5 @@ class MiscTestCase(unittest.TestCase):
     def test_writer_disallow_instantiation(self):
         check_disallow_instantiation(self, _csv.Writer)
 
-    def test_reader_not_basetype(self):
-        with self.assertRaisesRegex(TypeError, "type '_csv.reader' is not an acceptable base type"):
-            class Foo(_csv.Reader): pass
-
-    def test_writer_not_basetype(self):
-        with self.assertRaisesRegex(TypeError, "type '_csv.writer' is not an acceptable base type"):
-            class Foo(_csv.Writer): pass
-
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2023-05-07-16-13-07.gh-issue-104265.fU60bZ.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-07-16-13-07.gh-issue-104265.fU60bZ.rst
@@ -1,1 +1,0 @@
-Fix a :mod:`!_csv` module regression where :class:`!_csv.Reader` and :class:`!_csv.Writer` types became directly instantiable which led to their improper initialization and subsequent crashes. The regression was introduced in 3.10.0a4 with PR 23224 (:issue:`14935`).

--- a/Misc/NEWS.d/next/Library/2023-05-07-16-13-07.gh-issue-104265.fU60bZ.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-07-16-13-07.gh-issue-104265.fU60bZ.rst
@@ -1,1 +1,1 @@
-Fix a :mod:`_csv` module regression where :class:`~_csv.Reader` and :class:`~_csv.Writer` types became directly instantiable which led to their improper initialization and subsequent crashes. The regression was introduced in 3.10.0a4 with PR 23224 (:bpo:`14935`).
+Fix a :mod:`_csv` module regression where :class:`~_csv.Reader` and :class:`~_csv.Writer` types became directly instantiable which led to their improper initialization and subsequent crashes. The regression was introduced in 3.10.0a4 with PR 23224 (:issue:`14935`).

--- a/Misc/NEWS.d/next/Library/2023-05-07-16-13-07.gh-issue-104265.fU60bZ.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-07-16-13-07.gh-issue-104265.fU60bZ.rst
@@ -1,1 +1,1 @@
-Fix a :mod:`_csv` module regression where :class:`~_csv.Reader` and :class:`~_csv.Writer` types became directly instantiable which led to their improper initialization and subsequent crashes. The regression was introduced in 3.10.0a4 with :gh:`23224`.
+Fix a :mod:`_csv` module regression where :class:`~_csv.Reader` and :class:`~_csv.Writer` types became directly instantiable which led to their improper initialization and subsequent crashes. The regression was introduced in 3.10.0a4 with PR 23224 (:bpo:`14935`).

--- a/Misc/NEWS.d/next/Library/2023-05-07-16-13-07.gh-issue-104265.fU60bZ.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-07-16-13-07.gh-issue-104265.fU60bZ.rst
@@ -1,0 +1,1 @@
+Fix a :mod:`_csv` module regression where :class:`~_csv.Reader` and :class:`~_csv.Writer` types became directly instantiable which led to their improper initialization and subsequent crashes. The regression was introduced in 3.10.0a4 with :gh:`23224`.

--- a/Misc/NEWS.d/next/Library/2023-05-07-16-13-07.gh-issue-104265.fU60bZ.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-07-16-13-07.gh-issue-104265.fU60bZ.rst
@@ -1,1 +1,1 @@
-Fix a :mod:`_csv` module regression where :class:`~_csv.Reader` and :class:`~_csv.Writer` types became directly instantiable which led to their improper initialization and subsequent crashes. The regression was introduced in 3.10.0a4 with PR 23224 (:issue:`14935`).
+Fix a :mod:`!_csv` module regression where :class:`!_csv.Reader` and :class:`!_csv.Writer` types became directly instantiable which led to their improper initialization and subsequent crashes. The regression was introduced in 3.10.0a4 with PR 23224 (:issue:`14935`).

--- a/Misc/NEWS.d/next/Library/2023-05-07-19-56-45.gh-issue-104265.fVblry.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-07-19-56-45.gh-issue-104265.fVblry.rst
@@ -1,0 +1,1 @@
+Prevent possible crash by disallow instantiation of the :class:`!_csv.Reader` and :class:`!_csv.Writer` types. The regression was introduced in 3.10.0a4 with PR 23224 (:issue:`14935`). Patch by Radislav Chugunov.

--- a/Misc/NEWS.d/next/Library/2023-05-07-19-56-45.gh-issue-104265.fVblry.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-07-19-56-45.gh-issue-104265.fVblry.rst
@@ -1,1 +1,4 @@
-Prevent possible crash by disallow instantiation of the :class:`!_csv.Reader` and :class:`!_csv.Writer` types. The regression was introduced in 3.10.0a4 with PR 23224 (:issue:`14935`). Patch by Radislav Chugunov.
+Prevent possible crash by disallowing instantiation of the
+:class:`!_csv.Reader` and :class:`!_csv.Writer` types.
+The regression was introduced in 3.10.0a4 with PR 23224 (:issue:`14935`).
+Patch by Radislav Chugunov.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -999,7 +999,7 @@ static PyType_Slot Reader_Type_slots[] = {
 PyType_Spec Reader_Type_spec = {
     .name = "_csv.reader",
     .basicsize = sizeof(ReaderObj),
-    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC |
               Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION),
     .slots = Reader_Type_slots
 };
@@ -1430,7 +1430,7 @@ static PyType_Slot Writer_Type_slots[] = {
 PyType_Spec Writer_Type_spec = {
     .name = "_csv.writer",
     .basicsize = sizeof(WriterObj),
-    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC |
               Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION),
     .slots = Writer_Type_slots,
 };

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -999,8 +999,8 @@ static PyType_Slot Reader_Type_slots[] = {
 PyType_Spec Reader_Type_spec = {
     .name = "_csv.reader",
     .basicsize = sizeof(ReaderObj),
-    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC |
-              Py_TPFLAGS_IMMUTABLETYPE),
+    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+              Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION),
     .slots = Reader_Type_slots
 };
 
@@ -1430,8 +1430,8 @@ static PyType_Slot Writer_Type_slots[] = {
 PyType_Spec Writer_Type_spec = {
     .name = "_csv.writer",
     .basicsize = sizeof(WriterObj),
-    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC |
-              Py_TPFLAGS_IMMUTABLETYPE),
+    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+              Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION),
     .slots = Writer_Type_slots,
 };
 


### PR DESCRIPTION
Fixes #104265 

Set `Py_TPFLAGS_DISALLOW_INSTANTIATION` and unset `Py_TPFLAGS_BASETYPE` flags on `Reader` and `Writer` types to prevent their instantiation and subtyping


<!-- gh-issue-number: gh-104265 -->
* Issue: gh-104265
<!-- /gh-issue-number -->
