### PR TITLE
gh-103193: cache calls to `inspect._shadowed_dict` in `inspect.getattr_static`

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -342,8 +342,9 @@ inspect
   (Contributed by Thomas Krennwallner in :issue:`35759`.)
 
 * The performance of :func:`inspect.getattr_static` has been considerably
-  improved. Most calls to the function should be around 2x faster than they
-  were in Python 3.11. (Contributed by Alex Waygood in :gh:`103193`.)
+  improved. Most calls to the function should be at least 2x faster than they
+  were in Python 3.11, and some may be 6x faster or more. (Contributed by Alex
+  Waygood in :gh:`103193`.)
 
 pathlib
 -------
@@ -597,7 +598,7 @@ typing
   :func:`runtime-checkable protocols <typing.runtime_checkable>` has changed
   significantly. Most ``isinstance()`` checks against protocols with only a few
   members should be at least 2x faster than in 3.11, and some may be 20x
-  faster or more. However, ``isinstance()`` checks against protocols with seven
+  faster or more. However, ``isinstance()`` checks against protocols with fourteen
   or more members may be slower than in Python 3.11. (Contributed by Alex
   Waygood in :gh:`74690` and :gh:`103193`.)
 

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1794,6 +1794,7 @@ def _check_class(klass, attr):
             return entry.__dict__[attr]
     return _sentinel
 
+@functools.lru_cache()
 def _shadowed_dict(klass):
     for entry in _static_getmro(klass):
         dunder_dict = _get_dunder_dict_of_class(entry)

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1795,8 +1795,8 @@ def _check_class(klass, attr):
     return _sentinel
 
 @functools.lru_cache()
-def _shadowed_dict(klass):
-    for entry in _static_getmro(klass):
+def _shadowed_dict_from_mro_tuple(mro):
+    for entry in mro:
         dunder_dict = _get_dunder_dict_of_class(entry)
         if '__dict__' in dunder_dict:
             class_dict = dunder_dict['__dict__']
@@ -1805,6 +1805,9 @@ def _shadowed_dict(klass):
                     class_dict.__objclass__ is entry):
                 return class_dict
     return _sentinel
+
+def _shadowed_dict(klass):
+    return _shadowed_dict_from_mro_tuple(_static_getmro(klass))
 
 def getattr_static(obj, attr, default=_sentinel):
     """Retrieve attributes without triggering dynamic lookup via the

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -2111,6 +2111,28 @@ class TestGetattrStatic(unittest.TestCase):
         self.assertEqual(inspect.getattr_static(foo, 'a'), 3)
         self.assertFalse(test.called)
 
+    def test_mutated_mro(self):
+        test = self
+        test.called = False
+
+        class Foo(dict):
+            a = 3
+            @property
+            def __dict__(self):
+                test.called = True
+                return {}
+
+        class Bar(dict):
+            a = 4
+
+        class Baz(Bar): pass
+
+        baz = Baz()
+        self.assertEqual(inspect.getattr_static(baz, 'a'), 4)
+        Baz.__bases__ = (Foo,)
+        self.assertEqual(inspect.getattr_static(baz, 'a'), 3)
+        self.assertFalse(test.called)
+
     def test_custom_object_dict(self):
         test = self
         test.called = False


### PR DESCRIPTION
EDIT: These performance numbers are out of date with the current PR; read further down the thread for the up-to-date numbers.

This dramatically speeds up calls to `inspect.getattr_static`.

Here are benchmark results on `main`, using @sobolevn's benchmark script from https://github.com/python/cpython/issues/103193#issuecomment-1497396338:

<details>

```
type[Foo]                :   88 ±  0 ns
Foo                      :  158 ±  0 ns
type[Bar]                :   89 ±  0 ns
Bar                      :  158 ±  0 ns
WithParentClassX         :  224 ±  0 ns
Baz                      :  205 ±  0 ns
WithParentX              :  271 ±  1 ns
type[Missing]            :  252 ±  0 ns
Missing                  :  207 ±  0 ns
Slotted                  :  200 ±  1 ns
Method                   :  160 ±  1 ns
StMethod                 :  158 ±  0 ns
ClsMethod                :  158 ±  0 ns
```

</details>

And here are results with this PR:

<details>

```
type[Foo]                :   54 ±  0 ns
Foo                      :   85 ±  0 ns
type[Bar]                :   53 ±  0 ns
Bar                      :   85 ±  0 ns
WithParentClassX         :  102 ±  0 ns
Baz                      :   96 ±  0 ns
WithParentX              :  113 ±  0 ns
type[Missing]            :  110 ±  0 ns
Missing                  :   98 ±  0 ns
Slotted                  :  137 ±  0 ns
Method                   :   85 ±  0 ns
StMethod                 :   85 ±  0 ns
ClsMethod                :   85 ±  0 ns
```

</details>

With this PR, `inspect.getattr_static` is fast enough that even `isinstance()` calls like this, with "pathological" runtime-checkable protocols, are faster than they were on Python 3.11:

<details>
<summary>Pathological protocol</summary>

```py
from typing import Protocol, runtime_checkable

@runtime_checkable
class Foo(Protocol):
    a: int
    b: int
    c: int
    d: int
    e: int
    f: int
    g: int
    h: int
    i: int
    j: int
    k: int
    l: int
    m: int
    n: int
    o: int
    p: int
    q: int
    r: int
    s: int
    t: int
    u: int
    v: int
    w: int
    x: int
    y: int
    z: int

class Bar:
    def __init__(self):
        for attrname in 'abcdefghijklmnopqrstuvwxyz':
            setattr(self, attrname, 42)

isinstance(Bar(), Foo)
```

</details>

This approach makes me a little nervous. There are two plausible reasons I thought of why adding a cache here might not be a good idea:

1. It could cause references to the `klass` argument to be held by the cache even after they've been deleted elsewhere, which could be unexpected behaviour for a low-level function like `getattr_static`
2. Perhaps it's possible that whether or not a `__dict__` attribute is shadowed could change at some point during the lifetime of a class.

However, I _think_ we're okay on both points.

For objection (1): `_shadowed_dict` is only ever called on type objects. The vast majority of classes are defined once in the global namespace and never deleted, so it shouldn't be an issue that the cache is holding strong references to the type objects. (If we _do_ think this is an issue, I also experimented with a version of this PR that uses a `weakref.WeakKeyDictionary` as a cache. It also sped things up, but not by nearly as much.)

For objection (2): It doesn't seem to be possible, once a class has been created, to change the class's `__dict__` attribute, at least from Python code. So for any given class `klass`, `_shadowed_dict(klass)` should _always_ return the same result.

@carljm, what do you think?

<!-- gh-issue-number: gh-103193 -->
* Issue: gh-103193
<!-- /gh-issue-number -->
