### PR TITLE
gh-104276: Make `_struct.unpack_iterator` type use type flag instead of custom constructor

### DIFF
--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1832,11 +1832,6 @@ unpackiter_iternext(unpackiterobject *self)
     return result;
 }
 
-PyObject *unpackiter_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
-    PyErr_Format(PyExc_TypeError, "Cannot create '%.200s objects", _PyType_Name(type));
-    return NULL;
-}
-
 static PyType_Slot unpackiter_type_slots[] = {
     {Py_tp_dealloc, unpackiter_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -1844,7 +1839,6 @@ static PyType_Slot unpackiter_type_slots[] = {
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, unpackiter_iternext},
     {Py_tp_methods, unpackiter_methods},
-    {Py_tp_new, unpackiter_new},
     {0, 0},
 };
 
@@ -1853,7 +1847,7 @@ static PyType_Spec unpackiter_type_spec = {
     sizeof(unpackiterobject),
     0,
     (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-     Py_TPFLAGS_IMMUTABLETYPE),
+     Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION),
     unpackiter_type_slots
 };
 


### PR DESCRIPTION
#104276 

* remove `unpackiter_new` function
* remove item from `unpackiter_type_slots`
* add `Py_TPFLAGS_DISALLOW_INSTANTIATION` to type flags