### PR TITLE
gh-102500: Remove mention of bytes shorthand

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2133,7 +2133,7 @@ Corresponding to collections in :mod:`collections.abc`
    This type represents the types :class:`bytes`, :class:`bytearray`,
    and :class:`memoryview` of byte sequences.
 
-   .. deprecated:: 3.9
+   .. deprecated-removed:: 3.9 3.14
       Prefer :class:`collections.abc.Buffer`, or a union like ``bytes | bytearray | memoryview``.
 
 .. class:: Collection(Sized, Iterable[T_co], Container[T_co])
@@ -2971,6 +2971,8 @@ convenience. This is subject to change, and not all deprecations are listed.
 +----------------------------------+---------------+-------------------+----------------+
 |  ``typing`` versions of standard | 3.9           | Undecided         | :pep:`585`     |
 |  collections                     |               |                   |                |
++----------------------------------+---------------+-------------------+----------------+
+|  ``typing.ByteString``           | 3.9           | 3.14              | :gh:`91896`    |
 +----------------------------------+---------------+-------------------+----------------+
 |  ``typing.Text``                 | 3.11          | Undecided         | :gh:`92332`    |
 +----------------------------------+---------------+-------------------+----------------+

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2130,13 +2130,8 @@ Corresponding to collections in :mod:`collections.abc`
 
 .. class:: ByteString(Sequence[int])
 
-   A generic version of :class:`collections.abc.ByteString`.
-
    This type represents the types :class:`bytes`, :class:`bytearray`,
    and :class:`memoryview` of byte sequences.
-
-   As a shorthand for this type, :class:`bytes` can be used to
-   annotate arguments of any of the types mentioned above.
 
    .. deprecated:: 3.9
       Prefer :class:`collections.abc.Buffer`, or a union like ``bytes | bytearray | memoryview``.


### PR DESCRIPTION
The bytes shorthand was removed in PEP 688:
https://peps.python.org/pep-0688/#no-special-meaning-for-bytes

I also remove the reference to `collections.abc.ByteString`, since that object is also deprecated (#91896) and has different semantics from those documented for `typing.ByteString` (#102092).

I've documented the removal timeline as matching that of `collections.abc.ByteString`, but I'm open to discussion on that point.

I think it would be good to backport this since the changes in the type system are immediate and apply to all versions of Python.

<!-- gh-issue-number: gh-102500 -->
* Issue: gh-102500
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104281.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->