### PR TITLE
gh-103193: Improve `getattr_static` test coverage

### DIFF
--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -2187,6 +2187,35 @@ class TestGetattrStatic(unittest.TestCase):
             inspect.getattr_static(Thing, "spam")
         self.assertFalse(Thing.executed)
 
+    def test_custom___getattr__(self):
+        test = self
+        test.called = False
+
+        class Foo:
+            def __getattr__(self, attr):
+                test.called = True
+                return {}
+
+        with self.assertRaises(AttributeError):
+            inspect.getattr_static(Foo(), 'whatever')
+
+        self.assertFalse(test.called)
+
+    def test_custom___getattribute__(self):
+        test = self
+        test.called = False
+
+        class Foo:
+            def __getattribute__(self, attr):
+                test.called = True
+                return {}
+
+        with self.assertRaises(AttributeError):
+            inspect.getattr_static(Foo(), 'really_could_be_anything')
+
+        self.assertFalse(test.called)
+
+
 class TestGetGeneratorState(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Currently, no tests would fail if we were to apply this optimisation to `getattr_static`, which makes things a fair bit faster:

```diff
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1780,13 +1780,9 @@ def trace(context=1):


 def _check_instance(obj, attr):
-    instance_dict = {}
-    try:
-        instance_dict = object.__getattribute__(obj, "__dict__")
-    except AttributeError:
-        pass
-    return dict.get(instance_dict, attr, _sentinel)
-
+    if hasattr(obj, "__dict__"):
+        return dict.get(obj.__dict__, attr, _sentinel)
+    return _sentinel
```

However, the optimisation would lead to incorrect behaviour. `test_custom___getattribute__`, added in this PR, would correctly fail if the incorrect optimisation were applied.

<!-- gh-issue-number: gh-103193 -->
* Issue: gh-103193
<!-- /gh-issue-number -->
