### PR TITLE
gh-101117: Improve accuracy of sqlite3.Cursor.rowcount docs

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1694,7 +1694,10 @@ Cursor objects
       ``INSERT``, ``UPDATE``, ``DELETE``, and ``REPLACE`` statements;
       is ``-1`` for other statements,
       including :abbr:`CTE (Common Table Expression)` queries.
-      It is only updated by the :meth:`execute` and :meth:`executemany` methods.
+      It is only updated by the :meth:`execute` and :meth:`executemany` methods,
+      after the statement has run to completion.
+      This means that any resulting rows must be fetched in order for
+      :attr:`!rowcount` to be updated.
 
    .. attribute:: row_factory
 


### PR DESCRIPTION
The SQLite C API sqlite3_changes() can only be relied upon when the
statment has been run to completion.


<!-- gh-issue-number: gh-101117 -->
* Issue: gh-101117
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104287.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->