### PR TITLE
gh-91896: Improve visibility of `ByteString` deprecation warnings

### DIFF
--- a/Lib/collections/abc.py
+++ b/Lib/collections/abc.py
@@ -1,3 +1,12 @@
 from _collections_abc import *
 from _collections_abc import __all__
 from _collections_abc import _CallableGenericAlias
+
+_deprecated_ByteString = globals().pop("ByteString")
+
+def __getattr__(attr):
+    if attr == "ByteString":
+        import warnings
+        warnings._deprecated("collections.abc.ByteString", remove=(3, 14))
+        return _deprecated_ByteString
+    raise AttributeError(f"module 'collections.abc' has no attribute {attr!r}")

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -11,6 +11,7 @@ from itertools import product, chain, combinations
 import string
 import sys
 from test import support
+from test.support.import_helper import import_fresh_module
 import types
 import unittest
 
@@ -25,7 +26,7 @@ from collections.abc import Sized, Container, Callable, Collection
 from collections.abc import Set, MutableSet
 from collections.abc import Mapping, MutableMapping, KeysView, ItemsView, ValuesView
 from collections.abc import Sequence, MutableSequence
-from collections.abc import ByteString, Buffer
+from collections.abc import Buffer
 
 
 class TestUserObjects(unittest.TestCase):
@@ -1939,6 +1940,8 @@ class TestCollectionABCs(ABCTestCase):
                             nativeseq, seqseq, (letter, start, stop))
 
     def test_ByteString(self):
+        with self.assertWarns(DeprecationWarning):
+            from collections.abc import ByteString
         for sample in [bytes, bytearray]:
             with self.assertWarns(DeprecationWarning):
                 self.assertIsInstance(sample(), ByteString)
@@ -1959,6 +1962,11 @@ class TestCollectionABCs(ABCTestCase):
         with self.assertWarns(DeprecationWarning):
             # No metaclass conflict
             class Z(ByteString, Awaitable): pass
+
+    def test_ByteString_attribute_access(self):
+        collections_abc = import_fresh_module("collections.abc")
+        with self.assertWarns(DeprecationWarning):
+            collections_abc.ByteString
 
     def test_Buffer(self):
         for sample in [bytes, bytearray, memoryview]:

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8,6 +8,7 @@ import pickle
 import re
 import sys
 import warnings
+from test.support.import_helper import import_fresh_module
 from unittest import TestCase, main, skipUnless, skip
 from unittest.mock import patch
 from copy import copy, deepcopy
@@ -3908,7 +3909,14 @@ class GenericTests(BaseTestCase):
         self.assertEqual(MyChain[int]().__orig_class__, MyChain[int])
 
     def test_all_repr_eq_any(self):
-        objs = (getattr(typing, el) for el in typing.__all__)
+        typing = import_fresh_module("typing")
+        with warnings.catch_warnings(record=True) as wlog:
+            warnings.filterwarnings('always', '', DeprecationWarning)
+            objs = [getattr(typing, el) for el in typing.__all__]
+        self.assertEqual(
+            [str(w.message) for w in wlog],
+            ["'typing.ByteString' is deprecated and slated for removal in Python 3.14"]
+        )
         for obj in objs:
             self.assertNotEqual(repr(obj), '')
             self.assertEqual(obj, obj)
@@ -5996,8 +6004,16 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertNotIsInstance((), typing.MutableSequence)
 
     def test_bytestring(self):
-        self.assertIsInstance(b'', typing.ByteString)
-        self.assertIsInstance(bytearray(b''), typing.ByteString)
+        with self.assertWarns(DeprecationWarning):
+            from typing import ByteString
+        with self.assertWarns(DeprecationWarning):
+            self.assertIsInstance(b'', ByteString)
+        with self.assertWarns(DeprecationWarning):
+            self.assertIsInstance(bytearray(b''), ByteString)
+        with self.assertWarns(DeprecationWarning):
+            class Foo(ByteString):
+                def __len__(self): return 42
+                def __getitem__(self, n): return 42
 
     def test_list(self):
         self.assertIsSubclass(list, typing.List)
@@ -8293,6 +8309,10 @@ SpecialAttrsT = typing.TypeVar('SpecialAttrsT', int, float, complex)
 class SpecialAttrsTests(BaseTestCase):
 
     def test_special_attrs(self):
+        with warnings.catch_warnings(
+            action='ignore', category=DeprecationWarning
+        ):
+            typing_ByteString = typing.ByteString
         cls_to_check = {
             # ABC classes
             typing.AbstractSet: 'AbstractSet',
@@ -8301,7 +8321,7 @@ class SpecialAttrsTests(BaseTestCase):
             typing.AsyncIterable: 'AsyncIterable',
             typing.AsyncIterator: 'AsyncIterator',
             typing.Awaitable: 'Awaitable',
-            typing.ByteString: 'ByteString',
+            typing_ByteString: 'ByteString',
             typing.Callable: 'Callable',
             typing.ChainMap: 'ChainMap',
             typing.Collection: 'Collection',
@@ -8626,6 +8646,8 @@ class AllTests(BaseTestCase):
                 getattr(v, '__module__', None) == typing.__name__
             )
         }
+        # Deprecated; added dynamically via module __getattr__
+        computed_all.add("ByteString")
         self.assertSetEqual(computed_all, actual_all)
 
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6011,9 +6011,9 @@ class CollectionsAbcTests(BaseTestCase):
         with self.assertWarns(DeprecationWarning):
             self.assertIsInstance(bytearray(b''), ByteString)
         with self.assertWarns(DeprecationWarning):
-            class Foo(ByteString):
-                def __len__(self): return 42
-                def __getitem__(self, n): return 42
+            class Foo(ByteString): ...
+        with self.assertWarns(DeprecationWarning):
+            class Bar(ByteString, typing.Awaitable): ...
 
     def test_list(self):
         self.assertIsSubclass(list, typing.List)


### PR DESCRIPTION
#102096 added deprecation warnings for `collections.abc.ByteString`, but these warnings are currently only emitted on subclassing `ByteString` or calling `isinstance()` against it. Importing `ByteString` or accessing it via `import collections.abc; collections.abc.ByteString` does not currently trigger any warnings, meaning somebody who's just using the class for type annotations might not get any warning that the class will be removed in 3.14. Moreover, the `isinstance()` deprecation warnings are only emitted on `isinstance()` checks against `collections.abc.ByteString`, not on `isinstance()` checks against `typing.ByteString`. The docs update that we just made in https://github.com/python/cpython/commit/1f5679540ca4aa5c0eae06d3a2d5eda34b47e041 says that `typing.ByteString` will also be removed in Python 3.14, so we should emit the same deprecation warnings for `typing.ByteString`.

This PR adds deprecation warnings for:
- `from collections.abc import ByteString`
- `import collections.abc; collections.abc.ByteString`
- `from typing import ByteString`
- `import typing; typing.ByteString`
- `isinstance(b"", typing.ByteString)`

<!-- gh-issue-number: gh-91896 -->
* Issue: gh-91896
<!-- /gh-issue-number -->
