### PR TITLE
gh-97696: Move around and update the whatsnew entry for asyncio eager task factory

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -282,6 +282,11 @@ asyncio
   writing to sockets and uses :meth:`~socket.socket.sendmsg` if the platform
   supports it. (Contributed by Kumar Aditya in :gh:`91166`.)
 
+* Added :func:`asyncio.eager_task_factory` and :func:`asyncio.create_eager_task_factory`
+  functions to allow opting an event loop in to eager task execution,
+  making some use-cases 2x to 5x faster.
+  (Contributed by Jacob Bower & Itamar O in :gh:`102853`, :gh:`104140`, and :gh:`104138`)
+
 * On Linux, :mod:`asyncio` uses :class:`~asyncio.PidfdChildWatcher` by default
   if :func:`os.pidfd_open` is available and functional instead of
   :class:`~asyncio.ThreadedChildWatcher`.
@@ -643,11 +648,6 @@ Optimizations
 
 * Speed up :class:`asyncio.Task` creation by deferring expensive string formatting.
   (Contributed by Itamar O in :gh:`103793`.)
-
-* Added :func:`asyncio.eager_task_factory` and :func:`asyncio.create_eager_task_factory`
-  functions to allow opting an event loop in to eager task execution,
-  speeding up some use-cases by up to 50%.
-  (Contributed by Jacob Bower & Itamar O in :gh:`102853`)
 
 
 CPython bytecode changes


### PR DESCRIPTION
Looking at the what's new section, I thought the eager task factory, as a new feature, fits better under the asyncio section as opposed to the "optimizations" section.

Also wanted to update the quoted speedup to include the extra wins from eager gather & TaskGroup PRs.

not sure about the "deferred name formatting" entry - does it belong under the optimizations section, or asyncio section? (for now I left it under "optimizations" since it's not a user-visible change or feature, it's purely perf)

<!-- gh-issue-number: gh-97696 -->
* Issue: gh-97696
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104298.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->