### PR TITLE
gh-97696 Add documentation for get_coro() behavior with eager tasks

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -1175,7 +1175,7 @@ Task Object
       Return the coroutine object wrapped by the :class:`Task`.
 
       .. note::
-        
+
         This will return ``None`` for Tasks which have already
         completed eagerly.
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -1178,12 +1178,13 @@ Task Object
 
       .. note::
 
-        This will return ``None`` for Tasks which have already
-        completed eagerly. See the :ref:`Eager Task Factory <eager-task-factory>`.
+         This will return ``None`` for Tasks which have already
+         completed eagerly. See the :ref:`Eager Task Factory <eager-task-factory>`.
 
       .. versionadded:: 3.8
 
       .. versionchanged:: 3.12
+
          Added note on specific eager task execution behavior.
 
    .. method:: get_context()

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -527,6 +527,8 @@ Running Tasks Concurrently
       and there is no running event loop.
 
 
+.. _eager-task-factory:
+
 Eager Task Factory
 ==================
 
@@ -1177,9 +1179,12 @@ Task Object
       .. note::
 
         This will return ``None`` for Tasks which have already
-        completed eagerly.
+        completed eagerly. See the :ref:`Eager Task Factory <eager-task-factory>`.
 
       .. versionadded:: 3.8
+
+      .. versionchanged:: 3.12
+         Added note on specific eager task execution behavior.
 
    .. method:: get_context()
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -1185,7 +1185,7 @@ Task Object
 
       .. versionchanged:: 3.12
 
-         Added note on specific eager task execution behavior.
+        Newly added eager task execution means result may be ``None``.
 
    .. method:: get_context()
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -1174,6 +1174,11 @@ Task Object
 
       Return the coroutine object wrapped by the :class:`Task`.
 
+      .. note::
+        
+        This will return ``None`` for Tasks which have already
+        completed eagerly.
+
       .. versionadded:: 3.8
 
    .. method:: get_context()

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -1185,7 +1185,7 @@ Task Object
 
       .. versionchanged:: 3.12
 
-        Newly added eager task execution means result may be ``None``.
+         Newly added eager task execution means result may be ``None``.
 
    .. method:: get_context()
 


### PR DESCRIPTION
In response to comments on this issue.

(Note this is a redo of https://github.com/python/cpython/pull/104189)

<!-- gh-issue-number: gh-97696 -->
* Issue: gh-97696
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104304.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->