### PR TITLE
GH-104308: socket.getnameinfo should release the GIL

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-05-08-20-57-17.gh-issue-104307.DSB93G.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-08-20-57-17.gh-issue-104307.DSB93G.rst
@@ -1,0 +1,1 @@
+:func:`socket.getnameinfo` now releases the GIL while contacting the DNS server

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -6883,8 +6883,10 @@ socket_getnameinfo(PyObject *self, PyObject *args)
         }
 #endif
     }
+    Py_BEGIN_ALLOW_THREADS
     error = getnameinfo(res->ai_addr, (socklen_t) res->ai_addrlen,
                     hbuf, sizeof(hbuf), pbuf, sizeof(pbuf), flags);
+    Py_END_ALLOW_THREADS
     if (error) {
         socket_state *state = get_module_state(self);
         set_gaierror(state, error);


### PR DESCRIPTION
I have no idea how we all missed this :-) Thanks to @brandyn for the report at https://github.com/python-trio/trio/issues/1249#issuecomment-1537547879

Fixes #104308