### PR TITLE
require-pr-label.yml: Add missing "permissions:"

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, synchronize]
 
+permissions:
+  issues: read
+  pull-requests: read
+
 jobs:
   label:
     name: DO-NOT-MERGE / unresolved review


### PR DESCRIPTION
I assume this does not need an issue/ticket but I can create one if needed.

This is in reaction to https://github.com/python/cpython/pull/103635#pullrequestreview-1417378035 where @ezio-melotti and I both liked the idea of making the permissions of workflow `require-pr-label.yml` explicit both for (1) clarity and (2) consistency with all the other workflows that already have their minimally needed permissions set: this is the only worflow where it's missing. For "proof":
```console
# ls -1 .github/workflows/*.yml | grep -F -v -f <(git grep -l permissions -- .github/workflows/)
.github/workflows/require-pr-label.yml
```

The action's author recommends granting _write_ permissions for full functionality since commit https://github.com/mheap/github-action-required-labels/commit/e33092117bdd8c435e9b654d53726c6936f19518 but:
- that is not my mission and out of scope.
- the action seems to do its base job — effectively marking things as red through failing CI — without write permissions already today.

What do you think?

Looking forward to review, happy to adjust as needed :beers: