### PR TITLE
[3.11] gh-102500: collections.abc.Buffer doesn't exist in 3.11

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2094,7 +2094,7 @@ Corresponding to collections in :mod:`collections.abc`
    and :class:`memoryview` of byte sequences.
 
    .. deprecated-removed:: 3.9 3.14
-      Prefer :class:`collections.abc.Buffer`, or a union like ``bytes | bytearray | memoryview``.
+      Prefer ``typing_extensions.Buffer``, or a union like ``bytes | bytearray | memoryview``.
 
 .. class:: Collection(Sized, Iterable[T_co], Container[T_co])
 


### PR DESCRIPTION
Small correction to this backport PR: https://github.com/python/cpython/pull/104288

<!-- gh-issue-number: gh-102500 -->
* Issue: gh-102500
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104317.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->