### PR TITLE
gh-90953: Don't use deprecated AST nodes in clinic.py

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4701,10 +4701,8 @@ class DSLParser:
                     c_default = "NULL"
                 elif (isinstance(expr, ast.BinOp) or
                     (isinstance(expr, ast.UnaryOp) and
-                     not (isinstance(expr.operand, ast.Num) or
-                          (hasattr(ast, 'Constant') and
-                           isinstance(expr.operand, ast.Constant) and
-                           type(expr.operand.value) in (int, float, complex)))
+                     not (isinstance(expr.operand, ast.Constant) and
+                          type(expr.operand.value) in {int, float, complex})
                     )):
                     c_default = kwargs.get("c_default")
                     if not (isinstance(c_default, str) and c_default):
@@ -4806,13 +4804,9 @@ class DSLParser:
         self.function.parameters[key] = p
 
     def parse_converter(self, annotation):
-        if (hasattr(ast, 'Constant') and
-            isinstance(annotation, ast.Constant) and
+        if (isinstance(annotation, ast.Constant) and
             type(annotation.value) is str):
             return annotation.value, True, {}
-
-        if isinstance(annotation, ast.Str):
-            return annotation.s, True, {}
 
         if isinstance(annotation, ast.Name):
             return annotation.id, False, {}


### PR DESCRIPTION
Following https://github.com/python/cpython/commit/376137f6ec73e0800e49cec6100e401f6154b693, usage of `ast.Num` and `ast.Str` causes `DeprecationWarning`s to be emitted. This PR updates `clinic.py` to use the newer AST nodes, avoiding deprecation warnings when running `test_clinic.py`.

It looks like this script currently takes pains so that it can maintain compatibility with older Python versions. This change means that it won't be possible to run it on Python 3.7 anymore, but Python 3.7 is nearly end-of-life now anyway.

<!-- gh-issue-number: gh-90953 -->
* Issue: gh-90953
<!-- /gh-issue-number -->
