### PR TITLE
gh-104324: Reinstate GIL cleanup during interpreter deletion.

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -22,7 +22,7 @@ struct _ceval_runtime_state;
 
 extern void _Py_FinishPendingCalls(PyThreadState *tstate);
 extern void _PyEval_InitState(PyInterpreterState *, PyThread_type_lock);
-extern void _PyEval_FiniState(struct _ceval_state *ceval);
+extern void _PyEval_FiniState(PyInterpreterState *interp);
 PyAPI_FUNC(void) _PyEval_SignalReceived(PyInterpreterState *interp);
 PyAPI_FUNC(int) _PyEval_AddPendingCall(
     PyInterpreterState *interp,

--- a/Misc/NEWS.d/next/Core and Builtins/2023-05-09-14-27-43.gh-issue-104324.anqapB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-05-09-14-27-43.gh-issue-104324.anqapB.rst
@@ -1,0 +1,1 @@
+Ensure that the GIL is correctly finalized during calls to ``Py_Finalize()``.

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -964,13 +964,15 @@ _PyEval_InitState(PyInterpreterState *interp, PyThread_type_lock pending_lock)
 }
 
 void
-_PyEval_FiniState(struct _ceval_state *ceval)
+_PyEval_FiniState(PyInterpreterState *interp)
 {
-    struct _pending_calls *pending = &ceval->pending;
+    struct _pending_calls *pending = &interp->ceval.pending;
     if (pending->lock != NULL) {
         PyThread_free_lock(pending->lock);
         pending->lock = NULL;
     }
+
+    _PyEval_FiniGIL(interp);
 }
 
 /* Handle signals, pending calls, GIL drop request

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -589,11 +589,6 @@ init_interp_create_gil(PyThreadState *tstate, int own_gil)
 {
     PyStatus status;
 
-    /* finalize_interp_delete() comment explains why _PyEval_FiniGIL() is
-       only called here. */
-    // XXX This is broken with a per-interpreter GIL.
-    _PyEval_FiniGIL(tstate->interp);
-
     /* Auto-thread-state API */
     status = _PyGILState_SetTstate(tstate);
     if (_PyStatus_EXCEPTION(status)) {
@@ -1736,12 +1731,6 @@ finalize_interp_delete(PyInterpreterState *interp)
 {
     /* Cleanup auto-thread-state */
     _PyGILState_Fini(interp);
-
-    /* We can't call _PyEval_FiniGIL() here because destroying the GIL lock can
-       fail when it is being awaited by another running daemon thread (see
-       bpo-9901). Instead pycore_create_interpreter() destroys the previously
-       created GIL, which ensures that Py_Initialize / Py_FinalizeEx can be
-       called multiple times. */
 
     PyInterpreterState_Delete(interp);
 }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -948,7 +948,7 @@ PyInterpreterState_Delete(PyInterpreterState *interp)
 
     zapthreads(interp);
 
-    _PyEval_FiniState(&interp->ceval);
+    _PyEval_FiniState(interp);
 
     // XXX These two calls should be done at the end of clear_interpreter(),
     // but currently some objects get decref'ed after that.


### PR DESCRIPTION
Reinstate GIL cleanup during interpreter deletion, after all threads (including daemons, as per bpo-9901) have been destroyed.

This ensures the GIL is correctly destroyed before being re-initialised.

<!-- gh-issue-number: gh-104324 -->
* Issue: gh-104324
<!-- /gh-issue-number -->
