### PR TITLE
gh-74895: adjust tests to work on Solaris

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1622,7 +1622,7 @@ class GeneralModuleTests(unittest.TestCase):
 
         from _testcapi import ULONG_MAX, LONG_MAX, LONG_MIN
         try:
-            socket.getaddrinfo(None, ULONG_MAX + 1)
+            socket.getaddrinfo(None, ULONG_MAX + 1, type=socket.SOCK_STREAM)
         except OverflowError:
             # Platforms differ as to what values consitute a getaddrinfo() error
             # return. Some fail for LONG_MAX+1, others ULONG_MAX+1, and Windows
@@ -1632,28 +1632,28 @@ class GeneralModuleTests(unittest.TestCase):
             pass
 
         try:
-            socket.getaddrinfo(None, LONG_MAX + 1)
+            socket.getaddrinfo(None, LONG_MAX + 1, type=socket.SOCK_STREAM)
         except OverflowError:
             self.fail("Either no error or socket.gaierror expected.")
         except socket.gaierror:
             pass
 
         try:
-            socket.getaddrinfo(None, LONG_MAX - 0xffff + 1)
+            socket.getaddrinfo(None, LONG_MAX - 0xffff + 1, type=socket.SOCK_STREAM)
         except OverflowError:
             self.fail("Either no error or socket.gaierror expected.")
         except socket.gaierror:
             pass
 
         try:
-            socket.getaddrinfo(None, LONG_MIN - 1)
+            socket.getaddrinfo(None, LONG_MIN - 1, type=socket.SOCK_STREAM)
         except OverflowError:
             self.fail("Either no error or socket.gaierror expected.")
         except socket.gaierror:
             pass
 
-        socket.getaddrinfo(None, 0)  # No error expected.
-        socket.getaddrinfo(None, 0xffff)  # No error expected.
+        socket.getaddrinfo(None, 0, type=socket.SOCK_STREAM)  # No error expected.
+        socket.getaddrinfo(None, 0xffff, type=socket.SOCK_STREAM)  # No error expected.
 
     def test_getnameinfo(self):
         # only IP addresses are allowed


### PR DESCRIPTION
This change adjusts tests introduced in #2435 such that they work on platforms where `socket.getaddrinfo(None, port)` doesn't end with success; however, it does so when `socket.SOCK_STREAM` is present.

I am aware only of Solaris that works this way, but it's still well within the standard (if not _"more correct"_).

All other tests calling `getaddrinfo(None, ....)` include `socket.SOCK_STREAM` as well, and the addition doesn't change at all the thing the test is testing, so hopefully, this is acceptable.

(can I reuse the original issue for an additional commit?)

<!-- gh-issue-number: gh-74895 -->
* Issue: gh-74895
<!-- /gh-issue-number -->
