### PR TITLE
gh-104328: Fix typo in ``typing.Generic`` multiple inheritance error message

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1896,7 +1896,7 @@ class Generic:
                         base.__origin__ is Generic):
                     if gvars is not None:
                         raise TypeError(
-                            "Cannot inherit from Generic[...] multiple types.")
+                            "Cannot inherit from Generic[...] multiple times.")
                     gvars = base.__parameters__
             if gvars is not None:
                 tvarset = set(tvars)


### PR DESCRIPTION


<!-- gh-issue-number: gh-104328 -->
* Issue: gh-104328
<!-- /gh-issue-number -->
