### PR TITLE
filedialog.py: Move comment closer to relevant code

### DIFF
--- a/Lib/tkinter/filedialog.py
+++ b/Lib/tkinter/filedialog.py
@@ -312,13 +312,13 @@ class _Dialog(commondialog.Dialog):
 
     def _fixresult(self, widget, result):
         if result:
-            # keep directory and filename until next time
             # convert Tcl path objects to strings
             try:
                 result = result.string
             except AttributeError:
                 # it already is a string
                 pass
+            # keep directory and filename until next time
             path, file = os.path.split(result)
             self.options["initialdir"] = path
             self.options["initialfile"] = file


### PR DESCRIPTION
The "convert Tcl path objects to strings" step in `filedialog._Dialog._fixresult()` was originally added in 25c7b50e8f5c, but left the "keep directory and filename until next time" comment separated from the more relevant code statements. This PR moves the comment down back next to the more relevant statements, as done in `filedialog.Directory._fixresult()` by 85f48e3b9b07.