### PR TITLE
gh-103000: Optimise `dataclasses.asdict` for the common case

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-05-10-19-33-36.gh-issue-103000.j0KSfD.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-10-19-33-36.gh-issue-103000.j0KSfD.rst
@@ -1,0 +1,2 @@
+Improve performance of :func:`dataclasses.asdict` for the common case where
+`dict_factory` is `dict`.

--- a/Misc/NEWS.d/next/Library/2023-05-10-19-33-36.gh-issue-103000.j0KSfD.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-10-19-33-36.gh-issue-103000.j0KSfD.rst
@@ -1,2 +1,2 @@
 Improve performance of :func:`dataclasses.asdict` for the common case where
-`dict_factory` is `dict`. Patch by David C Ellis.
+*dict_factory* is ``dict``. Patch by David C Ellis.

--- a/Misc/NEWS.d/next/Library/2023-05-10-19-33-36.gh-issue-103000.j0KSfD.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-10-19-33-36.gh-issue-103000.j0KSfD.rst
@@ -1,2 +1,2 @@
 Improve performance of :func:`dataclasses.asdict` for the common case where
-`dict_factory` is `dict`.
+`dict_factory` is `dict`. Patch by David C Ellis.


### PR DESCRIPTION
Now that PEP 709 has been implemented, this change speeds up the following benchmark by 15% on my machine (Windows, PGO-optimised non-debug build):

<details>
<summary>Benchmark:</summary>

```py
from dataclasses import dataclass, asdict
import timeit

@dataclass
class Foo:
    x: int

@dataclass
class Bar:
    x: Foo
    y: Foo
    z: Foo

@dataclass
class Baz:
    x: Bar
    y: Bar
    z: Bar

foo = Foo(42)
bar = Bar(foo, foo, foo)
baz = Baz(bar, bar, bar)

print(timeit.timeit(lambda: asdict(baz), number=250_000))
```

</details>

This idea was originally @DavidCEllis's, but prior to PEP 709, comprehensions had too much overhead to make it worthwhile. Now that PEP 709 has been implemented, the impact of the patch seems pretty different.

Co-authored-by: David Ellis <ducksual@gmail.com>

<!-- gh-issue-number: gh-103000 -->
* Issue: gh-103000
<!-- /gh-issue-number -->
