### PR TITLE
gh-101819: Explicitly disallow pickle protocols 0 and 1 in _io

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4258,9 +4258,9 @@ class MiscIOTest(unittest.TestCase):
                 kwargs["encoding"] = "utf-8"
             for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
                 with self.subTest(protocol=protocol, kwargs=kwargs):
-                     with self.open(os_helper.TESTFN, **kwargs) as f:
-                         with self.assertRaisesRegex(TypeError, msg):
-                             pickle.dumps(f, protocol)
+                    with self.open(os_helper.TESTFN, **kwargs) as f:
+                        with self.assertRaisesRegex(TypeError, msg):
+                            pickle.dumps(f, protocol)
 
     @unittest.skipIf(
         support.is_emscripten, "fstat() of a pipe fd is not supported"

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4242,6 +4242,7 @@ class MiscIOTest(unittest.TestCase):
 
     def test_pickling(self):
         # Pickling file objects is forbidden
+        msg = "cannot pickle"
         for kwargs in [
                 {"mode": "w"},
                 {"mode": "wb"},
@@ -4256,8 +4257,10 @@ class MiscIOTest(unittest.TestCase):
             if "b" not in kwargs["mode"]:
                 kwargs["encoding"] = "utf-8"
             for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
-                with self.open(os_helper.TESTFN, **kwargs) as f:
-                    self.assertRaises(TypeError, pickle.dumps, f, protocol)
+                with self.subTest(protocol=protocol, kwargs=kwargs):
+                     with self.open(os_helper.TESTFN, **kwargs) as f:
+                         with self.assertRaisesRegex(TypeError, msg):
+                             pickle.dumps(f, protocol)
 
     @unittest.skipIf(
         support.is_emscripten, "fstat() of a pipe fd is not supported"

--- a/Modules/_io/_iomodule.h
+++ b/Modules/_io/_iomodule.h
@@ -195,6 +195,7 @@ find_io_state_by_def(PyTypeObject *type)
 }
 
 extern _PyIO_State *_PyIO_get_module_state(void);
+extern PyObject *_PyIOBase_cannot_pickle(PyObject *self, PyObject *args);
 
 #ifdef HAVE_WINDOWS_CONSOLE_IO
 extern char _PyIO_get_console_type(PyObject *);

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -2446,6 +2446,9 @@ static PyMethodDef bufferedreader_methods[] = {
     {"tell", (PyCFunction)buffered_tell, METH_NOARGS},
     _IO__BUFFERED_TRUNCATE_METHODDEF
     {"__sizeof__", (PyCFunction)buffered_sizeof, METH_NOARGS},
+
+    {"__reduce__", _PyIOBase_cannot_pickle, METH_VARARGS},
+    {"__reduce_ex__", _PyIOBase_cannot_pickle, METH_VARARGS},
     {NULL, NULL}
 };
 
@@ -2503,6 +2506,9 @@ static PyMethodDef bufferedwriter_methods[] = {
     _IO__BUFFERED_SEEK_METHODDEF
     {"tell", (PyCFunction)buffered_tell, METH_NOARGS},
     {"__sizeof__", (PyCFunction)buffered_sizeof, METH_NOARGS},
+
+    {"__reduce__", _PyIOBase_cannot_pickle, METH_VARARGS},
+    {"__reduce_ex__", _PyIOBase_cannot_pickle, METH_VARARGS},
     {NULL, NULL}
 };
 
@@ -2618,6 +2624,9 @@ static PyMethodDef bufferedrandom_methods[] = {
     _IO__BUFFERED_PEEK_METHODDEF
     _IO_BUFFEREDWRITER_WRITE_METHODDEF
     {"__sizeof__", (PyCFunction)buffered_sizeof, METH_NOARGS},
+
+    {"__reduce__", _PyIOBase_cannot_pickle, METH_VARARGS},
+    {"__reduce_ex__", _PyIOBase_cannot_pickle, METH_VARARGS},
     {NULL, NULL}
 };
 

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -1157,6 +1157,9 @@ static PyMethodDef fileio_methods[] = {
     _IO_FILEIO_FILENO_METHODDEF
     _IO_FILEIO_ISATTY_METHODDEF
     {"_dealloc_warn", (PyCFunction)fileio_dealloc_warn, METH_O, NULL},
+
+    {"__reduce__", _PyIOBase_cannot_pickle, METH_VARARGS},
+    {"__reduce_ex__", _PyIOBase_cannot_pickle, METH_VARARGS},
     {NULL,           NULL}             /* sentinel */
 };
 

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -225,6 +225,13 @@ iobase_check_writable(PyObject *self, PyObject *args)
     return _PyIOBase_check_writable(state, self, args);
 }
 
+PyObject *
+_PyIOBase_cannot_pickle(PyObject *self, PyObject *args)
+{
+    return PyErr_Format(PyExc_TypeError, "cannot pickle '%.100s' instances",
+                        _PyType_Name(Py_TYPE(self)));
+}
+
 /* XXX: IOBase thinks it has to maintain its own internal state in
    `__IOBase_closed` and call flush() by itself, but it is redundant with
    whatever behaviour a non-trivial derived class will implement. */

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -226,7 +226,7 @@ iobase_check_writable(PyObject *self, PyObject *args)
 }
 
 PyObject *
-_PyIOBase_cannot_pickle(PyObject *self, PyObject *args)
+_PyIOBase_cannot_pickle(PyObject *self, PyObject *Py_UNUSED(args))
 {
     return PyErr_Format(PyExc_TypeError, "cannot pickle '%.100s' instances",
                         _PyType_Name(Py_TYPE(self)));


### PR DESCRIPTION
This is part of the preparations for isolating the _io module.


<!-- gh-issue-number: gh-101819 -->
* Issue: gh-101819
<!-- /gh-issue-number -->
