### PR TITLE
gh-101819: Fix inverted debug preprocessor check in winconsoleio.c

### DIFF
--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -267,7 +267,7 @@ _io__WindowsConsoleIO___init___impl(winconsoleio *self, PyObject *nameobj,
     int fd_is_own = 0;
     HANDLE handle = NULL;
 
-#ifdef NDEBUG
+#ifndef NDEBUG
     _PyIO_State *state = find_io_state_by_def(Py_TYPE(self));
     assert(PyObject_TypeCheck(self, state->PyWindowsConsoleIO_Type));
 #endif


### PR DESCRIPTION


<!-- gh-issue-number: gh-101819 -->
* Issue: gh-101819
<!-- /gh-issue-number -->
