### PR TITLE
gh-99108: Refresh HACL* from upstream

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -359,6 +359,15 @@ class HashLibTestCase(unittest.TestCase):
         h.update(b"hello world")
         self.assertEqual(h.hexdigest(), "a5364f7a52ebe2e25f1838a4ca715a893b6fd7a23f2a0d9e9762120da8b1bf53")
 
+    @requires_resource('cpu')
+    def test_sha3_256_update_over_4gb(self):
+        zero_1mb = b"\0" * 1024 * 1024
+        h = hashlib.sha3_256()
+        for i in range(0, 4096):
+            h.update(zero_1mb)
+        h.update(b"hello world")
+        self.assertEqual(h.hexdigest(), "e2d4535e3b613135c14f2fe4e026d7ad8d569db44901740beffa30d430acb038")
+
     def check(self, name, data, hexdigest, shake=False, **kwargs):
         length = len(hexdigest)//2
         hexdigest = hexdigest.lower()

--- a/Modules/_hacl/Hacl_Hash_SHA3.c
+++ b/Modules/_hacl/Hacl_Hash_SHA3.c
@@ -244,7 +244,7 @@ Hacl_Streaming_Keccak_update(Hacl_Streaming_Keccak_state *p, uint8_t *data, uint
   Hacl_Streaming_Keccak_hash_buf block_state = s.block_state;
   uint64_t total_len = s.total_len;
   Spec_Hash_Definitions_hash_alg i = block_state.fst;
-  if ((uint64_t)len > (uint64_t)0xffffffffU - total_len)
+  if ((uint64_t)len > (uint64_t)0xffffffffffffffffU - total_len)
   {
     return (uint32_t)1U;
   }

--- a/Modules/_hacl/refresh.sh
+++ b/Modules/_hacl/refresh.sh
@@ -22,7 +22,7 @@ fi
 
 # Update this when updating to a new version after verifying that the changes
 # the update brings in are good.
-expected_hacl_star_rev=363eae2c2eb60e46f182ddd4bd1cd3f1d00b35c9
+expected_hacl_star_rev=b6903a3e6458000730c3d83174d4b08d6d3e2ece
 
 hacl_dir="$(realpath "$1")"
 cd "$(dirname "$0")"


### PR DESCRIPTION
This PR refreshes the vendored HACL* code with an upstream version. It contains a single fix, which increases the maximum length that can be processed by SHA3. This does not affect correctness of the verified code: the previous version would simply return a "maximum length exceeded" error too soon.

This was previously not covered by the Python testsuite, so I added one for this precisely. (Tests are being added upstream, too.)

@gpshead we should definitely get this in before 3.12

<!-- gh-issue-number: gh-99108 -->
* Issue: gh-99108
<!-- /gh-issue-number -->
