### PR TITLE
GH-94841: Fix usage of `Py_ALWAYS_INLINE`

### DIFF
--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -882,7 +882,7 @@ _Py_GetGlobalAllocatedBlocks(void)
 
 /* Return a pointer to a bottom tree node, return NULL if it doesn't exist or
  * it cannot be created */
-static Py_ALWAYS_INLINE arena_map_bot_t *
+static inline Py_ALWAYS_INLINE arena_map_bot_t *
 arena_map_get(OMState *state, pymem_block *p, int create)
 {
 #ifdef USE_INTERIOR_NODES


### PR DESCRIPTION
This silences a compiler warning on non-debug builds:

```
Objects/obmalloc.c:886:1: warning: always_inline function might not be inlinable [-Wattributes]
  886 | arena_map_get(OMState *state, pymem_block *p, int create)
      | ^~~~~~~~~~~~~
```

The issue is that `Py_ALWAYS_INLINE` only works for `static inline` functions.

I'm also going to run the benchmarks on this out of an abundance of caution, since (at least in theory) this could force the compiler to make poor inlining decisions it currently avoids.

<!-- gh-issue-number: gh-94841 -->
* Issue: gh-94841
<!-- /gh-issue-number -->
