### PR TITLE
gh-104415: Fix refleak tests for `typing.ByteString` deprecation

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6004,8 +6004,9 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertNotIsInstance((), typing.MutableSequence)
 
     def test_bytestring(self):
+        _typing = import_fresh_module('typing')
         with self.assertWarns(DeprecationWarning):
-            from typing import ByteString
+            ByteString = _typing.ByteString
         with self.assertWarns(DeprecationWarning):
             self.assertIsInstance(b'', ByteString)
         with self.assertWarns(DeprecationWarning):
@@ -6013,7 +6014,7 @@ class CollectionsAbcTests(BaseTestCase):
         with self.assertWarns(DeprecationWarning):
             class Foo(ByteString): ...
         with self.assertWarns(DeprecationWarning):
-            class Bar(ByteString, typing.Awaitable): ...
+            class Bar(ByteString, _typing.Awaitable): ...
 
     def test_list(self):
         self.assertIsSubclass(list, typing.List)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6004,9 +6004,8 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertNotIsInstance((), typing.MutableSequence)
 
     def test_bytestring(self):
-        _typing = import_fresh_module('typing')
         with self.assertWarns(DeprecationWarning):
-            ByteString = _typing.ByteString
+            from typing import ByteString
         with self.assertWarns(DeprecationWarning):
             self.assertIsInstance(b'', ByteString)
         with self.assertWarns(DeprecationWarning):
@@ -6014,7 +6013,7 @@ class CollectionsAbcTests(BaseTestCase):
         with self.assertWarns(DeprecationWarning):
             class Foo(ByteString): ...
         with self.assertWarns(DeprecationWarning):
-            class Bar(ByteString, _typing.Awaitable): ...
+            class Bar(ByteString, typing.Awaitable): ...
 
     def test_list(self):
         self.assertIsSubclass(list, typing.List)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3586,3 +3586,12 @@ def __getattr__(attr):
             )
         return ByteString
     raise AttributeError(f"module 'typing' has no attribute {attr!r}")
+
+
+def _remove_cached_ByteString_from_globals():
+    try:
+        del globals()["ByteString"]
+    except KeyError:
+        pass
+
+_cleanups.append(_remove_cached_ByteString_from_globals)


### PR DESCRIPTION
It passes now! 🎉 

<!-- gh-issue-number: gh-104415 -->
* Issue: gh-104415
<!-- /gh-issue-number -->
