### PR TITLE
gh-91896: Fixup some docs issues following ByteString deprecation

### DIFF
--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -15,6 +15,7 @@
 .. testsetup:: *
 
    import warnings
+   # Ignore warning when ByteString is imported
    with warnings.catch_warnings(action='ignore', category=DeprecationWarning):
        from collections.abc import *
    import itertools

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -14,7 +14,9 @@
 
 .. testsetup:: *
 
-   from collections.abc import *
+   import warnings
+   with warnings.catch_warnings(action='ignore', category=DeprecationWarning):
+       from collections.abc import *
    import itertools
    __name__ = '<doctest>'
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -831,6 +831,9 @@ Pending Removal in Python 3.14
   For use in typing, prefer a union, like ``bytes | bytearray``, or :class:`collections.abc.Buffer`.
   (Contributed by Shantanu Jain in :gh:`91896`.)
 
+* :class:`typing.ByteString`, deprecated since Python 3.9, now causes an
+  :exc:`DeprecationWarning` to be emitted when it is used or accessed.
+
 * Creating immutable types (:data:`Py_TPFLAGS_IMMUTABLETYPE`) with mutable
   bases using the C API.
 


### PR DESCRIPTION
- Get the doctests for `collections.abc` working again (see https://github.com/python/cpython/actions/runs/4957850824/jobs/8870015699 as an example failure). It was broken by #104294
- Explicitly note in whatsnew that `typing.ByteString` now causes `DeprecationWarning`s, as well as `collections.abc.ByteString`.


<!-- gh-issue-number: gh-91896 -->
* Issue: gh-91896
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104422.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->
