### PR TITLE
GH-86275: Run hypothesis tests in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -377,6 +377,8 @@ jobs:
         # failing when executed from inside a virtual environment.
         ${{ env.VENV_PYTHON }} -m test \
           -W \
+          -o \
+          -j4 \
           -x test_asyncio \
           -x test_multiprocessing_fork \
           -x test_multiprocessing_forkserver \


### PR DESCRIPTION
The existing tests are very slow because we left out `-j4` to run the tests in parallel.

This also adds `-o`, to give us some idea of which tests are going slowest in case we want to filter out more of them.

<!-- gh-issue-number: gh-86275 -->
* Issue: gh-86275
<!-- /gh-issue-number -->
