### PR TITLE
add a mention of PYTHONBREAKPOINT to breakpoint() docs

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -168,10 +168,12 @@ are always available.  They are listed here in alphabetical order.
    If :func:`sys.breakpointhook` is not accessible, this function will
    raise :exc:`RuntimeError`.
 
-   By default (if :func:`sys.breakpointhook` has not been replaced), the
-   behavior of :func:`breakpoint` can be changed with the
-   :envvar:`PYTHONBREAKPOINT` environment variable.  See
-   :func:`sys.breakpointhook` for details.
+   By default, the behavior of :func:`breakpoint` can be changed with
+   the :envvar:`PYTHONBREAKPOINT` environment variable.
+   See :func:`sys.breakpointhook` for usage details.
+
+   Note that this is not guaranteed if :func:`sys.breakpointhook`
+   has been replaced.
 
    .. audit-event:: builtins.breakpoint breakpointhook breakpoint
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -168,6 +168,11 @@ are always available.  They are listed here in alphabetical order.
    If :func:`sys.breakpointhook` is not accessible, this function will
    raise :exc:`RuntimeError`.
 
+   By default (if :func:`sys.breakpointhook` has not been replaced), the
+   behavior of :func:`breakpoint` can be changed with the
+   :envvar:`PYTHONBREAKPOINT` environment variable.  See
+   :func:`sys.breakpointhook` for details.
+
    .. audit-event:: builtins.breakpoint breakpointhook breakpoint
 
    .. versionadded:: 3.7


### PR DESCRIPTION
I wanted to use `breakpoint()`, but have it launch a different debugger.  It was hard to find out about the PYTHONBREAKPOINT environment variable.  This should make it easier.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104430.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->