### PR TITLE
gh-103857: Update deprecation stacktrace to point to calling line

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-05-12-19-29-28.gh-issue-103857.0IzSxr.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-12-19-29-28.gh-issue-103857.0IzSxr.rst
@@ -1,0 +1,1 @@
+Update datetime deprecations' stracktrace to point to the calling line

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5147,7 +5147,7 @@ datetime_utcnow(PyObject *cls, PyObject *dummy)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.utcnow() is deprecated and scheduled for removal in a "
         "future version. Use timezone-aware objects to represent datetimes "
-        "in UTC: datetime.now(datetime.UTC).", 2))
+        "in UTC: datetime.now(datetime.UTC).", 1))
     {
         return NULL;
     }
@@ -5190,7 +5190,7 @@ datetime_utcfromtimestamp(PyObject *cls, PyObject *args)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.utcfromtimestamp() is deprecated and scheduled for removal "
         "in a future version. Use timezone-aware objects to represent "
-        "datetimes in UTC: datetime.now(datetime.UTC).", 2))
+        "datetimes in UTC: datetime.now(datetime.UTC).", 1))
     {
         return NULL;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

# Set up

```sh
# From CPython repo:
git clone https://github.com/hugovk/pepotron ../pepotron
./python.exe -m pip install "../pepotron[tests]"
```

# Before

Warnings don't point to the actual lines of code that calls the deprecated `utcfromtimestamp` and `utcnow`:

```console
$ ./python.exe -m pytest ../pepotron
...
==================================================================== warnings summary =====================================================================
../../.local/lib/python3.12/site-packages/dateutil/tz/__init__.py:2
  /Users/hugo/.local/lib/python3.12/site-packages/dateutil/tz/__init__.py:2: DeprecationWarning: datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.now(datetime.UTC).
    from .tz import *

tests/test_pepotron.py::test_url[dead batteries-https://peps.python.org/pep-0594/]
tests/test_pepotron.py::test_url_base_url[dead batteries-https://hugovk.github.io/peps-https://hugovk.github.io/peps/pep-0594/]
  /Users/hugo/.local/lib/python3.12/site-packages/pepotron/__init__.py:54: DeprecationWarning: datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.now(datetime.UTC).
    cache_file = _cache.filename(json_url)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
...
```

# After

Now points to the actual lines of code directly calling `utcfromtimestamp` and `utcnow`:


```console
$ $ ./python.exe -m pytest ../pepotron
...
==================================================================== warnings summary =====================================================================
../../.local/lib/python3.12/site-packages/dateutil/tz/tz.py:37
  /Users/hugo/.local/lib/python3.12/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.now(datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

tests/test_pepotron.py::test_url[dead batteries-https://peps.python.org/pep-0594/]
tests/test_pepotron.py::test_url_base_url[dead batteries-https://hugovk.github.io/peps-https://hugovk.github.io/peps/pep-0594/]
  /Users/hugo/.local/lib/python3.12/site-packages/pepotron/_cache.py:30: DeprecationWarning: datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.now(datetime.UTC).
    today = dt.datetime.utcnow().strftime("%Y-%m-%d")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
...
```

<!-- gh-issue-number: gh-103857 -->
* Issue: gh-103857
<!-- /gh-issue-number -->
