### PR TITLE
gh-104341: Ensure tstate Holding GIL is Always Current

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -101,6 +101,7 @@ extern void _PyEval_FiniGIL(PyInterpreterState *interp);
 
 extern void _PyEval_AcquireLock(PyThreadState *tstate);
 extern void _PyEval_ReleaseLock(PyThreadState *tstate);
+extern int _PyEval_HoldsLock(PyThreadState *tstate);
 extern PyThreadState * _PyThreadState_SwapNoGIL(PyThreadState *);
 
 extern void _PyEval_DeactivateOpCache(void);

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -3,6 +3,7 @@
 /* Interface to Sjoerd's portable C thread library */
 
 #include "Python.h"
+#include "pycore_ceval.h"         // _PyEval_HoldsLock()
 #include "pycore_interp.h"        // _PyInterpreterState.threads.count
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "pycore_pylifecycle.h"

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -629,6 +629,13 @@ _PyEval_ReleaseLock(PyThreadState *tstate)
     drop_gil(ceval, tstate);
 }
 
+int
+_PyEval_HoldsLock(PyThreadState *tstate)
+{
+    _Py_EnsureTstateNotNULL(tstate);
+    return current_thread_holds_gil(tstate->interp->ceval.gil, tstate);
+}
+
 void
 PyEval_AcquireThread(PyThreadState *tstate)
 {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2027,8 +2027,16 @@ new_interpreter(PyThreadState **tstate_p, const PyInterpreterConfig *config)
     }
     _PyThreadState_Bind(tstate);
 
+    // We must release the GIL before swapping.
+    PyThreadState *current_tstate = _PyThreadState_GET();
+    if (current_tstate != NULL) {
+        // XXX Might new_interpreter() have been called without the GIL held?
+        _PyEval_ReleaseLock(current_tstate);
+    }
+
     // XXX For now we do this before the GIL is created.
     PyThreadState *save_tstate = _PyThreadState_SwapNoGIL(tstate);
+    assert(save_tstate == current_tstate);
     int has_gil = 0;
 
     /* From this point until the init_interp_create_gil() call,
@@ -2039,8 +2047,6 @@ new_interpreter(PyThreadState **tstate_p, const PyInterpreterConfig *config)
     /* Copy the current interpreter config into the new interpreter */
     const PyConfig *src_config;
     if (save_tstate != NULL) {
-        // XXX Might new_interpreter() have been called without the GIL held?
-        _PyEval_ReleaseLock(save_tstate);
         src_config = _PyInterpreterState_GetConfig(save_tstate->interp);
     }
     else

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1564,8 +1564,10 @@ _PyThreadState_DeleteCurrent(PyThreadState *tstate)
 {
     _Py_EnsureTstateNotNULL(tstate);
     tstate_delete_common(tstate);
-    current_fast_clear(tstate->interp->runtime);
+    assert(_Py_tss_tstate == tstate);
+    assert(_PyEval_HoldsLock(tstate));
     _PyEval_ReleaseLock(tstate);
+    current_fast_clear(tstate->interp->runtime);
     free_threadstate(tstate);
 }
 


### PR DESCRIPTION
This change fixes places where we weren't enforcing this constraint.  This is worth doing regardless of the impact on gh-104341, though it should have a small impact since it slightly reduces the chance of some remote races.