### PR TITLE
[3.11] GH-94841: Fix usage of `Py_ALWAYS_INLINE`

### DIFF
--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1445,7 +1445,7 @@ static arena_map_bot_t arena_map_root;
 
 /* Return a pointer to a bottom tree node, return NULL if it doesn't exist or
  * it cannot be created */
-static Py_ALWAYS_INLINE arena_map_bot_t *
+static inline Py_ALWAYS_INLINE arena_map_bot_t *
 arena_map_get(block *p, int create)
 {
 #ifdef USE_INTERIOR_NODES


### PR DESCRIPTION


<!-- gh-issue-number: gh-94841 -->
* Issue: gh-94841
<!-- /gh-issue-number -->
