### PR TITLE
gh-104404: fix crasher with nested comprehensions plus lambdas

### DIFF
--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -338,6 +338,14 @@ class ListComprehensionTest(unittest.TestCase):
         outputs = {"y": [1, 3, 5]}
         self._check_in_scopes(code, outputs)
 
+    def test_nested_4(self):
+        code = """
+            items = [([lambda: x for x in range(2)], lambda: x) for x in range(3)]
+            out = [([fn() for fn in fns], fn()) for fns, fn in items]
+        """
+        outputs = {"out": [([1, 1], 2), ([1, 1], 2), ([1, 1], 2)]}
+        self._check_in_scopes(code, outputs)
+
     def test_nameerror(self):
         code = """
             [x for x in [1]]


### PR DESCRIPTION
The fix for gh-104357 (#104368) is the cause of this crash. We can't promote a local to a cell before `analyze_cells` has run, or we'll fail to see that that local resolves a free var from a child scope. Instead we have to record the names that need promoting to cell in the scope due to being a cell in an inlined comprehension, and handle them within `analyze_cells`.

Fixes gh-104404.