### PR TITLE
gh-104451: improve accuracy of mimetypes guess_extension

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -193,9 +193,15 @@ class MimeTypes:
         Optional `strict' argument when false adds a bunch of commonly found,
         but non-standard types.
         """
+        parts = type.split("/")
+        possible_extension = "." + parts[1].lower() if len(parts) == 2 else None
         extensions = self.guess_all_extensions(type, strict)
-        if not extensions:
+
+        if possible_extension and possible_extension in extensions:
+            return possible_extension
+        elif not extensions:
             return None
+
         return extensions[0]
 
     def read(self, filename, strict=True):

--- a/Misc/NEWS.d/next/Library/2023-05-13-16-40-45.gh-issue-104451.il5J_e.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-13-16-40-45.gh-issue-104451.il5J_e.rst
@@ -1,0 +1,1 @@
+improving accuracy of mimetypes guess_extension


### PR DESCRIPTION
Implementation of #104451 

Most mimetypes are in the format `type/subtype`. where subtype is often the extension of the file.

In this PR, instead of `guess_extension` returning `extensions[0]` directly, I check for the value of the subtype  extension in the list of extensions (`guess_all_extensions()`) and return it if present in the list. 

If not, it returns None or extensions[0] as usual.

<!-- gh-issue-number: gh-104451 -->
* Issue: gh-104451
<!-- /gh-issue-number -->
