### PR TITLE
gh-87092: avoid gcc warning on uninitialized struct field in assemble.c

### DIFF
--- a/Python/assemble.c
+++ b/Python/assemble.c
@@ -128,7 +128,7 @@ assemble_emit_exception_table_entry(struct assembler *a, int start, int end,
     assert(end > start);
     int target = handler->h_offset;
     int depth = handler->h_startdepth - 1;
-    if (handler->h_preserve_lasti) {
+    if (handler->h_preserve_lasti > 0) {
         depth -= 1;
     }
     assert(depth >= 0);
@@ -146,6 +146,7 @@ assemble_exception_table(struct assembler *a, instr_sequence *instrs)
     int ioffset = 0;
     _PyCompile_ExceptHandlerInfo handler;
     handler.h_offset = -1;
+    handler.h_preserve_lasti = -1;
     int start = -1;
     for (int i = 0; i < instrs->s_used; i++) {
         instruction *instr = &instrs->s_instrs[i];


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

I noticed the warn while I built CPython with GCC8 + PGO + LTO.
 
````

gcc -pthread -c -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall    -fno-semantic-interposition -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -g -std=c11 -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Werror=implicit-function-declaration -fvisibility=hidden -fprofile-use -fprofile-correction -I./Include/internal  -I. -I./Include    -DPy_BUILD_CORE -o Python/bltinmodule.o Python/bltinmodule.c
Python/assemble.c: In function ‘_PyAssemble_MakeCodeObject’:
Python/assemble.c:131:8: warning: ‘handler.h_preserve_lasti’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     if (handler->h_preserve_lasti) {
        ^
Python/assemble.c:147:34: note: ‘handler.h_preserve_lasti’ was declared here
     _PyCompile_ExceptHandlerInfo handler;
                                  ^~~~~~~
Python/assemble.c:132:15: warning: ‘handler.h_startdepth’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         depth -= 1;
         ~~~~~~^~~~
Python/assemble.c:147:34: note: ‘handler.h_startdepth’ was declared here
     _PyCompile_ExceptHandlerInfo handler;
                                  ^~~~~~~
````

<!-- gh-issue-number: gh-87092 -->
* Issue: gh-87092
<!-- /gh-issue-number -->
