### PR TITLE
gh-87646: Added `.path` to tempfile

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -90,9 +90,9 @@ The module defines the following user-callable items:
    attribute is the underlying true file object. This :term:`file-like object`
    can be used in a :keyword:`with` statement, just like a normal file.  The
    name of the temporary file can be retrieved from the :attr:`name` attribute
-   of the returned file-like object. On Unix, unlike with the
-   :func:`TemporaryFile`, the directory entry does not get unlinked immediately
-   after the file creation.
+   and :class:`pathlib.Path` path using :attr:`path` of the returned file-like
+   object. On Unix, unlike with the :func:`TemporaryFile`, the directory entry
+   does not get unlinked immediately after the file creation.
 
    If *delete* is true (the default) and *delete_on_close* is true (the
    default), the file is deleted as soon as it is closed. If *delete* is true
@@ -141,6 +141,9 @@ The module defines the following user-callable items:
 
    .. versionchanged:: 3.12
       Added *delete_on_close* parameter.
+
+   .. versionchanged:: 3.13
+      Added *path* property.
 
 
 .. class:: SpooledTemporaryFile(max_size=0, mode='w+b', buffering=-1, encoding=None, newline=None, suffix=None, prefix=None, dir=None, *, errors=None)
@@ -210,6 +213,9 @@ The module defines the following user-callable items:
 
    .. versionchanged:: 3.12
       Added the *delete* parameter.
+
+   .. versionchanged:: 3.13
+      Added *path* property.
 
 
 .. function:: mkstemp(suffix=None, prefix=None, dir=None, text=False)
@@ -420,6 +426,15 @@ Here are some examples of typical usage of the :mod:`tempfile` module::
     ...     print('created temporary directory', tmpdirname)
     >>>
     # directory and contents have been removed
+
+    # create a named temporary file, similar to TemporaryFile
+    # but location and name is accessible
+    >>> with tempfile.NamedTemporaryFile as fp:
+    ...    print('file name: ', fp.name)
+    ...    print('file path: ', fp.path)
+    file name: '/tmp/tmpfiehg5my'
+    file path: PosixPath('/tmp/tmpfiehg5my')
+
 
 .. _tempfile-mktemp-deprecated:
 

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -40,6 +40,7 @@ import functools as _functools
 import warnings as _warnings
 import io as _io
 import os as _os
+from pathlib import Path as _Path
 import shutil as _shutil
 import errno as _errno
 from random import Random as _Random
@@ -518,6 +519,10 @@ class _TemporaryFileWrapper:
         for line in self.file:
             yield line
 
+    @_functools.cached_property
+    def path(self):
+        return _Path(self.name)
+
 def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
                        newline=None, suffix=None, prefix=None,
                        dir=None, delete=True, *, errors=None,
@@ -917,6 +922,10 @@ class TemporaryDirectory:
     def __exit__(self, exc, value, tb):
         if self._delete:
             self.cleanup()
+
+    @_functools.cached_property
+    def path(self):
+        return _Path(self.name)
 
     def cleanup(self):
         if self._finalizer.detach() or _os.path.exists(self.name):

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1147,6 +1147,12 @@ class TestNamedTemporaryFile(BaseTestCase):
         mock_open().close.assert_called()
         self.assertEqual(os.listdir(dir), [])
 
+    def test_path_method(self):
+        d = self.do_create()
+        path = d.path
+        self.assertTrue(issubclass(type(path), pathlib.Path), "unexpected return type")
+        self.assertEqual(str(path), d.name, ".path .name mismatch")
+
     # How to test the mode and bufsize parameters?
 
 class TestSpooledTemporaryFile(BaseTestCase):
@@ -1852,6 +1858,13 @@ class TestTemporaryDirectory(BaseTestCase):
             pass
         self.assertTrue(os.path.exists(working_dir))
         shutil.rmtree(working_dir)
+
+    def test_path_method(self):
+        d = self.do_create()
+        path = d.path
+        self.assertTrue(issubclass(type(path), pathlib.Path), "unexpected return type")
+        self.assertEqual(str(path), d.name, ".path .name mismatch")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2023-05-14-11-46-21.gh-issue-87646.DNJjDX.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-14-11-46-21.gh-issue-87646.DNJjDX.rst
@@ -1,0 +1,3 @@
+:class:`tempfile.NamedTemporaryFile` and  :class:`tempfile.TemporaryDirectory`
+includes a new ``.path`` property. This provides the temporary file name as a
+:class:`pathlib.Path` object


### PR DESCRIPTION
Added `.path` to generate pathlib's `Path` objects for NamedTemporaryFile and TemporaryDirectory

Note: Original suggestion was to make it a method so the `Path` creation will be lazy. I'm ok with both and wanted the opinion of a maintainer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-87646 -->
* Issue: gh-87646
<!-- /gh-issue-number -->
