### PR TITLE
gh-86275: improve Hypothesis configuration for CI and local runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -368,6 +368,14 @@ jobs:
         echo "HYPOVENV=${VENV_LOC}" >> $GITHUB_ENV
         echo "VENV_PYTHON=${VENV_PYTHON}" >> $GITHUB_ENV
         ./python -m venv $VENV_LOC && $VENV_PYTHON -m pip install -U hypothesis
+    - name: 'Restore Hypothesis database'
+      id: cache-hypothesis-database
+      uses: actions/cache@v3
+      with:
+        path: ./hypothesis
+        key: hypothesis-database-${{ github.head_ref || github.run_id }}
+        restore-keys:
+          - hypothesis-database-
     - name: "Run tests"
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,6 +396,11 @@ jobs:
           -x test_subprocess \
           -x test_signal \
           -x test_sysconfig
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: hypothesis-example-db
+        path: .hypothesis/examples/
 
 
   build_asan:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -374,7 +374,7 @@ jobs:
       with:
         path: ./hypothesis
         key: hypothesis-database-${{ github.head_ref || github.run_id }}
-        restore-keys:
+        restore-keys: |
           - hypothesis-database-
     - name: "Run tests"
       working-directory: ${{ env.CPYTHON_BUILDDIR }}

--- a/Lib/test/support/hypothesis_helper.py
+++ b/Lib/test/support/hypothesis_helper.py
@@ -1,3 +1,5 @@
+import os
+
 try:
     import hypothesis
 except ImportError:
@@ -11,3 +13,23 @@ else:
         suppress_health_check=[hypothesis.HealthCheck.too_slow],
     )
     hypothesis.settings.load_profile("slow-is-ok")
+
+    # For local development, we'll write to the default on-local-disk database
+    # of failing examples, and also use a pull-through cache to automatically
+    # replay any failing examples discovered in CI.  For details on how this
+    # works, see https://hypothesis.readthedocs.io/en/latest/database.html
+    if "CI" not in os.environ:
+        from hypothesis.database import (
+            GitHubArtifactDatabase,
+            MultiplexedDatabase,
+            ReadOnlyDatabase,
+        )
+
+        hypothesis.settings.register_profile(
+            "cpython-local-dev",
+            database=MultiplexedDatabase(
+                hypothesis.settings.default.database,
+                ReadOnlyDatabase(GitHubArtifactDatabase("python", "cpython")),
+            ),
+        )
+        hypothesis.settings.load_profile("cpython-local-dev")

--- a/Lib/test/support/hypothesis_helper.py
+++ b/Lib/test/support/hypothesis_helper.py
@@ -2,3 +2,12 @@ try:
     import hypothesis
 except ImportError:
     from . import _hypothesis_stubs as hypothesis
+else:
+    # When using the real Hypothesis, we'll configure it to ignore occasional
+    # slow tests (avoiding flakiness from random VM slowness in CI).
+    hypothesis.settings.register_profile(
+        "slow-is-ok",
+        deadline=None,
+        suppress_health_check=[hypothesis.HealthCheck.too_slow],
+    )
+    hypothesis.settings.load_profile("slow-is-ok")


### PR DESCRIPTION
Per https://github.com/python/cpython/pull/22863#issuecomment-1545958244, this PR configures Hypothesis to ignore unexpectedly slow tests.  Relative to the default of failing, this reduces flakiness due to variable performance of CI machines.

The second commit adds caching to the CI test run, so that if a CI run finds a rare but real failure that input will be replayed in future CI runs (at least until the cache expires, or the test passes and Hypothesis discards the now-passing input).  This doesn't come up often, but if it does will convert flaky tests into reliable failures.

Third, we can upload the database as an "artifact" from CI and configure local runs to use that as a pull-through cache - meaning that "reproducing a failure from CI" is just "run the tests locally".  No impact on flakiness but it's a rather nice workflow! [^#]

[^#]: Unfortunately [the 'dump a patch with explicit examples' workflow relies on `libcst` and our pytest plugin](https://hypothesis.readthedocs.io/en/latest/changes.html#v6-75-0) - if this would be particularly interesting we can talk about making it work with `unittest` and perhaps even `ast`. 

cc @pganssle for review / checking that it works on your machine

<!-- gh-issue-number: gh-86275 -->
* Issue: gh-86275
<!-- /gh-issue-number -->
