### PR TITLE
gh-67056: document that registering/unregistering an atexit func from within an atexit func is undefined

### DIFF
--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -20,6 +20,9 @@ at interpreter termination time they will be run in the order ``C``, ``B``,
 program is killed by a signal not handled by Python, when a Python fatal
 internal error is detected, or when :func:`os._exit` is called.
 
+**Note:** The effect of registering or unregistering functions from within
+a cleanup function is underfined.
+
 .. versionchanged:: 3.7
     When used with C-API subinterpreters, registered functions
     are local to the interpreter they were registered in.

--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -21,7 +21,7 @@ program is killed by a signal not handled by Python, when a Python fatal
 internal error is detected, or when :func:`os._exit` is called.
 
 **Note:** The effect of registering or unregistering functions from within
-a cleanup function is underfined.
+a cleanup function is undefined.
 
 .. versionchanged:: 3.7
     When used with C-API subinterpreters, registered functions

--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -45,6 +45,9 @@ internal error is detected, or when :func:`os._exit` is called.
    This function returns *func*, which makes it possible to use it as a
    decorator.
 
+   The effect of calling :func:`register` from another registered cleanup
+   function is undefined.
+
 
 .. function:: unregister(func)
 
@@ -55,6 +58,8 @@ internal error is detected, or when :func:`os._exit` is called.
    comparisons (``==``) are used internally during unregistration, so function
    references do not need to have matching identities.
 
+   The effect of calling :func:`unregister` from a registered cleanup function
+   is undefined.
 
 .. seealso::
 

--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -45,9 +45,6 @@ internal error is detected, or when :func:`os._exit` is called.
    This function returns *func*, which makes it possible to use it as a
    decorator.
 
-   The effect of calling :func:`register` from another registered cleanup
-   function is undefined.
-
 
 .. function:: unregister(func)
 
@@ -58,8 +55,6 @@ internal error is detected, or when :func:`os._exit` is called.
    comparisons (``==``) are used internally during unregistration, so function
    references do not need to have matching identities.
 
-   The effect of calling :func:`unregister` from a registered cleanup function
-   is undefined.
 
 .. seealso::
 

--- a/Misc/NEWS.d/next/Documentation/2023-05-14-12-11-28.gh-issue-67056.nVC2Rf.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-05-14-12-11-28.gh-issue-67056.nVC2Rf.rst
@@ -1,2 +1,2 @@
-Document that the efect of registering or unregistering an :mod:`atexit`
+Document that the effect of registering or unregistering an :mod:`atexit`
 cleanup function from within a registered cleanup function is undefined.

--- a/Misc/NEWS.d/next/Documentation/2023-05-14-12-11-28.gh-issue-67056.nVC2Rf.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-05-14-12-11-28.gh-issue-67056.nVC2Rf.rst
@@ -1,0 +1,2 @@
+Document that the efect of registering or unregistering an :mod:`atexit`
+cleanup function from within a registered cleanup function is undefined.


### PR DESCRIPTION
Fixes #67056.

<!-- gh-issue-number: gh-67056 -->
* Issue: gh-67056
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104473.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->