### PR TITLE
gh-98539: Make _SSLTransportProtocol.abort() safe to call when closed

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -244,7 +244,8 @@ class _SSLProtocolTransport(transports._FlowControlMixin,
         called with None as its argument.
         """
         self._closed = True
-        self._ssl_protocol._abort()
+        if self._ssl_protocol is not None:
+            self._ssl_protocol._abort()
 
     def _force_close(self, exc):
         self._closed = True


### PR DESCRIPTION
Changes in #98540 made it unsafe to call `.abort()` (and other methods) after closing. This atleast makes it possible to call `.abort()` without worrying about this.

I'm not sure if any of the others methods should be updated (e.g. with a `raise RuntimeError("Transport is closed")`). It might also be an idea to do the same change to `_force_close()`, but I wasn't sure if there was a risk or not of this method being called internally after close.

<!-- gh-issue-number: gh-98539 -->
* Issue: gh-98539
<!-- /gh-issue-number -->
