### PR TITLE
gh-104487: PYTHON_FOR_REGEN must be minimum Python 3.10

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1204,6 +1204,8 @@ Build Changes
 
   (Contributed by Zhang Na in :gh:`90656`.)
 
+* ``PYTHON_FOR_REGEN`` now require Python 3.10 or newer.
+
 
 C API Changes
 =============

--- a/Misc/NEWS.d/next/Build/2023-05-15-09-34-08.gh-issue-99017.nToOQu.rst
+++ b/Misc/NEWS.d/next/Build/2023-05-15-09-34-08.gh-issue-99017.nToOQu.rst
@@ -1,0 +1,1 @@
+``PYTHON_FOR_REGEN`` now require Python 3.10 or newer.

--- a/configure
+++ b/configure
@@ -3359,7 +3359,7 @@ fi
 
 
 
-for ac_prog in python$PACKAGE_VERSION python3.11 python3.10 python3.9 python3.8 python3.7 python3.6 python3 python
+for ac_prog in python$PACKAGE_VERSION python3.12 python3.11 python3.10 python3 python
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -202,7 +202,7 @@ AC_SUBST([FREEZE_MODULE_DEPS])
 AC_SUBST([PYTHON_FOR_BUILD_DEPS])
 
 AC_CHECK_PROGS([PYTHON_FOR_REGEN],
-  [python$PACKAGE_VERSION python3.11 python3.10 python3.9 python3.8 python3 python],
+  [python$PACKAGE_VERSION python3.12 python3.11 python3.10 python3 python],
   [python3])
 AC_SUBST(PYTHON_FOR_REGEN)
 

--- a/configure.ac
+++ b/configure.ac
@@ -202,7 +202,7 @@ AC_SUBST([FREEZE_MODULE_DEPS])
 AC_SUBST([PYTHON_FOR_BUILD_DEPS])
 
 AC_CHECK_PROGS([PYTHON_FOR_REGEN],
-  [python$PACKAGE_VERSION python3.11 python3.10 python3.9 python3.8 python3.7 python3.6 python3 python],
+  [python$PACKAGE_VERSION python3.11 python3.10 python3.9 python3.8 python3 python],
   [python3])
 AC_SUBST(PYTHON_FOR_REGEN)
 


### PR DESCRIPTION
Also include Python 3.12.

<!-- gh-issue-number: gh-104487 -->
* Issue: gh-104487
<!-- /gh-issue-number -->
