### PR TITLE
gh-104469: Convert _testcapi/watchers.c to use AC

### DIFF
--- a/Modules/_testcapi/clinic/watchers.c.h
+++ b/Modules/_testcapi/clinic/watchers.c.h
@@ -11,8 +11,7 @@ preserve
 PyDoc_STRVAR(_testcapi_watch_dict__doc__,
 "watch_dict($module, watcher_id, dict, /)\n"
 "--\n"
-"\n"
-"Watch dict.");
+"\n");
 
 #define _TESTCAPI_WATCH_DICT_METHODDEF    \
     {"watch_dict", _PyCFunction_CAST(_testcapi_watch_dict), METH_FASTCALL, _testcapi_watch_dict__doc__},
@@ -44,8 +43,7 @@ exit:
 PyDoc_STRVAR(_testcapi_unwatch_dict__doc__,
 "unwatch_dict($module, watcher_id, dict, /)\n"
 "--\n"
-"\n"
-"Unwatch dict.");
+"\n");
 
 #define _TESTCAPI_UNWATCH_DICT_METHODDEF    \
     {"unwatch_dict", _PyCFunction_CAST(_testcapi_unwatch_dict), METH_FASTCALL, _testcapi_unwatch_dict__doc__},
@@ -77,8 +75,7 @@ exit:
 PyDoc_STRVAR(_testcapi_watch_type__doc__,
 "watch_type($module, watcher_id, type, /)\n"
 "--\n"
-"\n"
-"Watch type.");
+"\n");
 
 #define _TESTCAPI_WATCH_TYPE_METHODDEF    \
     {"watch_type", _PyCFunction_CAST(_testcapi_watch_type), METH_FASTCALL, _testcapi_watch_type__doc__},
@@ -110,8 +107,7 @@ exit:
 PyDoc_STRVAR(_testcapi_unwatch_type__doc__,
 "unwatch_type($module, watcher_id, type, /)\n"
 "--\n"
-"\n"
-"Unwatch type.");
+"\n");
 
 #define _TESTCAPI_UNWATCH_TYPE_METHODDEF    \
     {"unwatch_type", _PyCFunction_CAST(_testcapi_unwatch_type), METH_FASTCALL, _testcapi_unwatch_type__doc__},
@@ -201,4 +197,4 @@ _testcapi_set_func_kwdefaults_via_capi(PyObject *module, PyObject *const *args, 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6fe009b91cf50293 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8b0f3e8f8e0a49cf input=a9049054013a1b77]*/

--- a/Modules/_testcapi/clinic/watchers.c.h
+++ b/Modules/_testcapi/clinic/watchers.c.h
@@ -139,8 +139,7 @@ exit:
 PyDoc_STRVAR(_testcapi_set_func_defaults_via_capi__doc__,
 "set_func_defaults_via_capi($module, func, defaults, /)\n"
 "--\n"
-"\n"
-"Set default values to a given function.");
+"\n");
 
 #define _TESTCAPI_SET_FUNC_DEFAULTS_VIA_CAPI_METHODDEF    \
     {"set_func_defaults_via_capi", _PyCFunction_CAST(_testcapi_set_func_defaults_via_capi), METH_FASTCALL, _testcapi_set_func_defaults_via_capi__doc__},
@@ -168,33 +167,32 @@ exit:
 }
 
 PyDoc_STRVAR(_testcapi_set_func_kwdefaults_via_capi__doc__,
-"set_func_kwdefaults_via_capi($module, func, kwdefaults, /)\n"
+"set_func_kwdefaults_via_capi($module, func, defaults, /)\n"
 "--\n"
-"\n"
-"Set keyword deafult values to a given function.");
+"\n");
 
 #define _TESTCAPI_SET_FUNC_KWDEFAULTS_VIA_CAPI_METHODDEF    \
     {"set_func_kwdefaults_via_capi", _PyCFunction_CAST(_testcapi_set_func_kwdefaults_via_capi), METH_FASTCALL, _testcapi_set_func_kwdefaults_via_capi__doc__},
 
 static PyObject *
 _testcapi_set_func_kwdefaults_via_capi_impl(PyObject *module, PyObject *func,
-                                            PyObject *kwdefaults);
+                                            PyObject *defaults);
 
 static PyObject *
 _testcapi_set_func_kwdefaults_via_capi(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *func;
-    PyObject *kwdefaults;
+    PyObject *defaults;
 
     if (!_PyArg_CheckPositional("set_func_kwdefaults_via_capi", nargs, 2, 2)) {
         goto exit;
     }
     func = args[0];
-    kwdefaults = args[1];
-    return_value = _testcapi_set_func_kwdefaults_via_capi_impl(module, func, kwdefaults);
+    defaults = args[1];
+    return_value = _testcapi_set_func_kwdefaults_via_capi_impl(module, func, defaults);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8b0f3e8f8e0a49cf input=a9049054013a1b77]*/
+/*[clinic end generated code: output=12c375089125d165 input=a9049054013a1b77]*/

--- a/Modules/_testcapi/clinic/watchers.c.h
+++ b/Modules/_testcapi/clinic/watchers.c.h
@@ -1,0 +1,204 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+#if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+#  include "pycore_gc.h"            // PyGC_Head
+#  include "pycore_runtime.h"       // _Py_ID()
+#endif
+
+
+PyDoc_STRVAR(_testcapi_watch_dict__doc__,
+"watch_dict($module, watcher_id, dict, /)\n"
+"--\n"
+"\n"
+"Watch dict.");
+
+#define _TESTCAPI_WATCH_DICT_METHODDEF    \
+    {"watch_dict", _PyCFunction_CAST(_testcapi_watch_dict), METH_FASTCALL, _testcapi_watch_dict__doc__},
+
+static PyObject *
+_testcapi_watch_dict_impl(PyObject *module, int watcher_id, PyObject *dict);
+
+static PyObject *
+_testcapi_watch_dict(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    int watcher_id;
+    PyObject *dict;
+
+    if (!_PyArg_CheckPositional("watch_dict", nargs, 2, 2)) {
+        goto exit;
+    }
+    watcher_id = _PyLong_AsInt(args[0]);
+    if (watcher_id == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    dict = args[1];
+    return_value = _testcapi_watch_dict_impl(module, watcher_id, dict);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(_testcapi_unwatch_dict__doc__,
+"unwatch_dict($module, watcher_id, dict, /)\n"
+"--\n"
+"\n"
+"Unwatch dict.");
+
+#define _TESTCAPI_UNWATCH_DICT_METHODDEF    \
+    {"unwatch_dict", _PyCFunction_CAST(_testcapi_unwatch_dict), METH_FASTCALL, _testcapi_unwatch_dict__doc__},
+
+static PyObject *
+_testcapi_unwatch_dict_impl(PyObject *module, int watcher_id, PyObject *dict);
+
+static PyObject *
+_testcapi_unwatch_dict(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    int watcher_id;
+    PyObject *dict;
+
+    if (!_PyArg_CheckPositional("unwatch_dict", nargs, 2, 2)) {
+        goto exit;
+    }
+    watcher_id = _PyLong_AsInt(args[0]);
+    if (watcher_id == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    dict = args[1];
+    return_value = _testcapi_unwatch_dict_impl(module, watcher_id, dict);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(_testcapi_watch_type__doc__,
+"watch_type($module, watcher_id, type, /)\n"
+"--\n"
+"\n"
+"Watch type.");
+
+#define _TESTCAPI_WATCH_TYPE_METHODDEF    \
+    {"watch_type", _PyCFunction_CAST(_testcapi_watch_type), METH_FASTCALL, _testcapi_watch_type__doc__},
+
+static PyObject *
+_testcapi_watch_type_impl(PyObject *module, int watcher_id, PyObject *type);
+
+static PyObject *
+_testcapi_watch_type(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    int watcher_id;
+    PyObject *type;
+
+    if (!_PyArg_CheckPositional("watch_type", nargs, 2, 2)) {
+        goto exit;
+    }
+    watcher_id = _PyLong_AsInt(args[0]);
+    if (watcher_id == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    type = args[1];
+    return_value = _testcapi_watch_type_impl(module, watcher_id, type);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(_testcapi_unwatch_type__doc__,
+"unwatch_type($module, watcher_id, type, /)\n"
+"--\n"
+"\n"
+"Unwatch type.");
+
+#define _TESTCAPI_UNWATCH_TYPE_METHODDEF    \
+    {"unwatch_type", _PyCFunction_CAST(_testcapi_unwatch_type), METH_FASTCALL, _testcapi_unwatch_type__doc__},
+
+static PyObject *
+_testcapi_unwatch_type_impl(PyObject *module, int watcher_id, PyObject *type);
+
+static PyObject *
+_testcapi_unwatch_type(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    int watcher_id;
+    PyObject *type;
+
+    if (!_PyArg_CheckPositional("unwatch_type", nargs, 2, 2)) {
+        goto exit;
+    }
+    watcher_id = _PyLong_AsInt(args[0]);
+    if (watcher_id == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    type = args[1];
+    return_value = _testcapi_unwatch_type_impl(module, watcher_id, type);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(_testcapi_set_func_defaults_via_capi__doc__,
+"set_func_defaults_via_capi($module, func, defaults, /)\n"
+"--\n"
+"\n"
+"Set default values to a given function.");
+
+#define _TESTCAPI_SET_FUNC_DEFAULTS_VIA_CAPI_METHODDEF    \
+    {"set_func_defaults_via_capi", _PyCFunction_CAST(_testcapi_set_func_defaults_via_capi), METH_FASTCALL, _testcapi_set_func_defaults_via_capi__doc__},
+
+static PyObject *
+_testcapi_set_func_defaults_via_capi_impl(PyObject *module, PyObject *func,
+                                          PyObject *defaults);
+
+static PyObject *
+_testcapi_set_func_defaults_via_capi(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *func;
+    PyObject *defaults;
+
+    if (!_PyArg_CheckPositional("set_func_defaults_via_capi", nargs, 2, 2)) {
+        goto exit;
+    }
+    func = args[0];
+    defaults = args[1];
+    return_value = _testcapi_set_func_defaults_via_capi_impl(module, func, defaults);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(_testcapi_set_func_kwdefaults_via_capi__doc__,
+"set_func_kwdefaults_via_capi($module, func, kwdefaults, /)\n"
+"--\n"
+"\n"
+"Set keyword deafult values to a given function.");
+
+#define _TESTCAPI_SET_FUNC_KWDEFAULTS_VIA_CAPI_METHODDEF    \
+    {"set_func_kwdefaults_via_capi", _PyCFunction_CAST(_testcapi_set_func_kwdefaults_via_capi), METH_FASTCALL, _testcapi_set_func_kwdefaults_via_capi__doc__},
+
+static PyObject *
+_testcapi_set_func_kwdefaults_via_capi_impl(PyObject *module, PyObject *func,
+                                            PyObject *kwdefaults);
+
+static PyObject *
+_testcapi_set_func_kwdefaults_via_capi(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *func;
+    PyObject *kwdefaults;
+
+    if (!_PyArg_CheckPositional("set_func_kwdefaults_via_capi", nargs, 2, 2)) {
+        goto exit;
+    }
+    func = args[0];
+    kwdefaults = args[1];
+    return_value = _testcapi_set_func_kwdefaults_via_capi_impl(module, func, kwdefaults);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=6fe009b91cf50293 input=a9049054013a1b77]*/

--- a/Modules/_testcapi/watchers.c
+++ b/Modules/_testcapi/watchers.c
@@ -1,8 +1,15 @@
 #include "parts.h"
 
+#include "clinic/watchers.c.h"
+
 #define Py_BUILD_CORE
 #include "pycore_function.h"  // FUNC_MAX_WATCHERS
 #include "pycore_code.h"  // CODE_MAX_WATCHERS
+
+/*[clinic input]
+module _testcapi
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=6361033e795369fc]*/
 
 // Test dict watching
 static PyObject *g_dict_watch_events;
@@ -119,28 +126,36 @@ clear_dict_watcher(PyObject *self, PyObject *watcher_id)
     Py_RETURN_NONE;
 }
 
+/*[clinic input]
+_testcapi.watch_dict
+    watcher_id: int
+    dict: object
+    /
+Watch dict.
+[clinic start generated code]*/
+
 static PyObject *
-watch_dict(PyObject *self, PyObject *args)
+_testcapi_watch_dict_impl(PyObject *module, int watcher_id, PyObject *dict)
+/*[clinic end generated code: output=1426e0273cebe2d8 input=ffbe7762b6c79c52]*/
 {
-    PyObject *dict;
-    int watcher_id;
-    if (!PyArg_ParseTuple(args, "iO", &watcher_id, &dict)) {
-        return NULL;
-    }
     if (PyDict_Watch(watcher_id, dict)) {
         return NULL;
     }
     Py_RETURN_NONE;
 }
 
+/*[clinic input]
+_testcapi.unwatch_dict
+    watcher_id: int
+    dict: object
+    /
+Unwatch dict.
+[clinic start generated code]*/
+
 static PyObject *
-unwatch_dict(PyObject *self, PyObject *args)
+_testcapi_unwatch_dict_impl(PyObject *module, int watcher_id, PyObject *dict)
+/*[clinic end generated code: output=512b1a71ae33c351 input=5621f8bbc4ef8e6a]*/
 {
-    PyObject *dict;
-    int watcher_id;
-    if (!PyArg_ParseTuple(args, "iO", &watcher_id, &dict)) {
-        return NULL;
-    }
     if (PyDict_Unwatch(watcher_id, dict)) {
         return NULL;
     }
@@ -250,28 +265,36 @@ get_type_modified_events(PyObject *self, PyObject *Py_UNUSED(args))
     return Py_NewRef(g_type_modified_events);
 }
 
+/*[clinic input]
+_testcapi.watch_type
+    watcher_id: int
+    type: object
+    /
+Watch type.
+[clinic start generated code]*/
+
 static PyObject *
-watch_type(PyObject *self, PyObject *args)
+_testcapi_watch_type_impl(PyObject *module, int watcher_id, PyObject *type)
+/*[clinic end generated code: output=fdf4777126724fc4 input=70ac8124d5b8296d]*/
 {
-    PyObject *type;
-    int watcher_id;
-    if (!PyArg_ParseTuple(args, "iO", &watcher_id, &type)) {
-        return NULL;
-    }
     if (PyType_Watch(watcher_id, type)) {
         return NULL;
     }
     Py_RETURN_NONE;
 }
 
+/*[clinic input]
+_testcapi.unwatch_type
+    watcher_id: int
+    type: object
+    /
+Unwatch type.
+[clinic start generated code]*/
+
 static PyObject *
-unwatch_type(PyObject *self, PyObject *args)
+_testcapi_unwatch_type_impl(PyObject *module, int watcher_id, PyObject *type)
+/*[clinic end generated code: output=0389672d4ad5f68b input=33cdc13902253394]*/
 {
-    PyObject *type;
-    int watcher_id;
-    if (!PyArg_ParseTuple(args, "iO", &watcher_id, &type)) {
-        return NULL;
-    }
     if (PyType_Unwatch(watcher_id, type)) {
         return NULL;
     }
@@ -605,28 +628,38 @@ allocate_too_many_func_watchers(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
+/*[clinic input]
+_testcapi.set_func_defaults_via_capi
+    func: object
+    defaults: object
+    /
+Set default values to a given function.
+[clinic start generated code]*/
+
 static PyObject *
-set_func_defaults(PyObject *self, PyObject *args)
+_testcapi_set_func_defaults_via_capi_impl(PyObject *module, PyObject *func,
+                                          PyObject *defaults)
+/*[clinic end generated code: output=caf0cb39db31ac24 input=9a7d91215cd0f05b]*/
 {
-    PyObject *func = NULL;
-    PyObject *defaults = NULL;
-    if (!PyArg_ParseTuple(args, "OO", &func, &defaults)) {
-        return NULL;
-    }
     if (PyFunction_SetDefaults(func, defaults) < 0) {
         return NULL;
     }
     Py_RETURN_NONE;
 }
 
+/*[clinic input]
+_testcapi.set_func_kwdefaults_via_capi
+    func: object
+    kwdefaults: object
+    /
+Set keyword deafult values to a given function.
+[clinic start generated code]*/
+
 static PyObject *
-set_func_kwdefaults(PyObject *self, PyObject *args)
+_testcapi_set_func_kwdefaults_via_capi_impl(PyObject *module, PyObject *func,
+                                            PyObject *kwdefaults)
+/*[clinic end generated code: output=5ea36d7f9db6a01d input=ee84c08d30ae135e]*/
 {
-    PyObject *func = NULL;
-    PyObject *kwdefaults = NULL;
-    if (!PyArg_ParseTuple(args, "OO", &func, &kwdefaults)) {
-        return NULL;
-    }
     if (PyFunction_SetKwDefaults(func, kwdefaults) < 0) {
         return NULL;
     }
@@ -637,16 +670,16 @@ static PyMethodDef test_methods[] = {
     // Dict watchers.
     {"add_dict_watcher",         add_dict_watcher,        METH_O,       NULL},
     {"clear_dict_watcher",       clear_dict_watcher,      METH_O,       NULL},
-    {"watch_dict",               watch_dict,              METH_VARARGS, NULL},
-    {"unwatch_dict",             unwatch_dict,            METH_VARARGS, NULL},
+    _TESTCAPI_WATCH_DICT_METHODDEF
+    _TESTCAPI_UNWATCH_DICT_METHODDEF
     {"get_dict_watcher_events",
      (PyCFunction) get_dict_watcher_events,               METH_NOARGS,  NULL},
 
     // Type watchers.
     {"add_type_watcher",         add_type_watcher,        METH_O,       NULL},
     {"clear_type_watcher",       clear_type_watcher,      METH_O,       NULL},
-    {"watch_type",               watch_type,              METH_VARARGS, NULL},
-    {"unwatch_type",             unwatch_type,            METH_VARARGS, NULL},
+    _TESTCAPI_WATCH_TYPE_METHODDEF
+    _TESTCAPI_UNWATCH_TYPE_METHODDEF
     {"get_type_modified_events",
      (PyCFunction) get_type_modified_events,              METH_NOARGS, NULL},
 
@@ -663,8 +696,8 @@ static PyMethodDef test_methods[] = {
     // Function watchers.
     {"add_func_watcher",         add_func_watcher,        METH_O,       NULL},
     {"clear_func_watcher",       clear_func_watcher,      METH_O,       NULL},
-    {"set_func_defaults_via_capi", set_func_defaults,     METH_VARARGS, NULL},
-    {"set_func_kwdefaults_via_capi", set_func_kwdefaults, METH_VARARGS, NULL},
+    _TESTCAPI_SET_FUNC_DEFAULTS_VIA_CAPI_METHODDEF
+    _TESTCAPI_SET_FUNC_KWDEFAULTS_VIA_CAPI_METHODDEF
     {"allocate_too_many_func_watchers", allocate_too_many_func_watchers,
      METH_NOARGS, NULL},
     {NULL},

--- a/Modules/_testcapi/watchers.c
+++ b/Modules/_testcapi/watchers.c
@@ -131,12 +131,11 @@ _testcapi.watch_dict
     watcher_id: int
     dict: object
     /
-Watch dict.
 [clinic start generated code]*/
 
 static PyObject *
 _testcapi_watch_dict_impl(PyObject *module, int watcher_id, PyObject *dict)
-/*[clinic end generated code: output=1426e0273cebe2d8 input=ffbe7762b6c79c52]*/
+/*[clinic end generated code: output=1426e0273cebe2d8 input=5d11ddf8ccb22a05]*/
 {
     if (PyDict_Watch(watcher_id, dict)) {
         return NULL;
@@ -145,16 +144,12 @@ _testcapi_watch_dict_impl(PyObject *module, int watcher_id, PyObject *dict)
 }
 
 /*[clinic input]
-_testcapi.unwatch_dict
-    watcher_id: int
-    dict: object
-    /
-Unwatch dict.
+_testcapi.unwatch_dict = _testcapi.watch_dict
 [clinic start generated code]*/
 
 static PyObject *
 _testcapi_unwatch_dict_impl(PyObject *module, int watcher_id, PyObject *dict)
-/*[clinic end generated code: output=512b1a71ae33c351 input=5621f8bbc4ef8e6a]*/
+/*[clinic end generated code: output=512b1a71ae33c351 input=cae7dc1b6f7713b8]*/
 {
     if (PyDict_Unwatch(watcher_id, dict)) {
         return NULL;
@@ -270,12 +265,11 @@ _testcapi.watch_type
     watcher_id: int
     type: object
     /
-Watch type.
 [clinic start generated code]*/
 
 static PyObject *
 _testcapi_watch_type_impl(PyObject *module, int watcher_id, PyObject *type)
-/*[clinic end generated code: output=fdf4777126724fc4 input=70ac8124d5b8296d]*/
+/*[clinic end generated code: output=fdf4777126724fc4 input=b0a72ed7db885ee8]*/
 {
     if (PyType_Watch(watcher_id, type)) {
         return NULL;
@@ -284,16 +278,12 @@ _testcapi_watch_type_impl(PyObject *module, int watcher_id, PyObject *type)
 }
 
 /*[clinic input]
-_testcapi.unwatch_type
-    watcher_id: int
-    type: object
-    /
-Unwatch type.
+_testcapi.unwatch_type = _testcapi.watch_type
 [clinic start generated code]*/
 
 static PyObject *
 _testcapi_unwatch_type_impl(PyObject *module, int watcher_id, PyObject *type)
-/*[clinic end generated code: output=0389672d4ad5f68b input=33cdc13902253394]*/
+/*[clinic end generated code: output=0389672d4ad5f68b input=6701911fb45edc9e]*/
 {
     if (PyType_Unwatch(watcher_id, type)) {
         return NULL;

--- a/Modules/_testcapi/watchers.c
+++ b/Modules/_testcapi/watchers.c
@@ -135,7 +135,7 @@ _testcapi.watch_dict
 
 static PyObject *
 _testcapi_watch_dict_impl(PyObject *module, int watcher_id, PyObject *dict)
-/*[clinic end generated code: output=1426e0273cebe2d8 input=5d11ddf8ccb22a05]*/
+/*[clinic end generated code: output=1426e0273cebe2d8 input=269b006d60c358bd]*/
 {
     if (PyDict_Watch(watcher_id, dict)) {
         return NULL;
@@ -269,7 +269,7 @@ _testcapi.watch_type
 
 static PyObject *
 _testcapi_watch_type_impl(PyObject *module, int watcher_id, PyObject *type)
-/*[clinic end generated code: output=fdf4777126724fc4 input=b0a72ed7db885ee8]*/
+/*[clinic end generated code: output=fdf4777126724fc4 input=5a808bf12be7e3ed]*/
 {
     if (PyType_Watch(watcher_id, type)) {
         return NULL;
@@ -623,13 +623,12 @@ _testcapi.set_func_defaults_via_capi
     func: object
     defaults: object
     /
-Set default values to a given function.
 [clinic start generated code]*/
 
 static PyObject *
 _testcapi_set_func_defaults_via_capi_impl(PyObject *module, PyObject *func,
                                           PyObject *defaults)
-/*[clinic end generated code: output=caf0cb39db31ac24 input=9a7d91215cd0f05b]*/
+/*[clinic end generated code: output=caf0cb39db31ac24 input=e04a8508ca9d42fc]*/
 {
     if (PyFunction_SetDefaults(func, defaults) < 0) {
         return NULL;
@@ -638,19 +637,15 @@ _testcapi_set_func_defaults_via_capi_impl(PyObject *module, PyObject *func,
 }
 
 /*[clinic input]
-_testcapi.set_func_kwdefaults_via_capi
-    func: object
-    kwdefaults: object
-    /
-Set keyword deafult values to a given function.
+_testcapi.set_func_kwdefaults_via_capi = _testcapi.set_func_defaults_via_capi
 [clinic start generated code]*/
 
 static PyObject *
 _testcapi_set_func_kwdefaults_via_capi_impl(PyObject *module, PyObject *func,
-                                            PyObject *kwdefaults)
-/*[clinic end generated code: output=5ea36d7f9db6a01d input=ee84c08d30ae135e]*/
+                                            PyObject *defaults)
+/*[clinic end generated code: output=9ed3b08177025070 input=f3cd1ca3c18de8ce]*/
 {
-    if (PyFunction_SetKwDefaults(func, kwdefaults) < 0) {
+    if (PyFunction_SetKwDefaults(func, defaults) < 0) {
         return NULL;
     }
     Py_RETURN_NONE;


### PR DESCRIPTION
Skipping news, because there are not use-facing changes. 
CC @corona10 @erlend-aasland 

<!-- gh-issue-number: gh-104469 -->
* Issue: gh-104469
<!-- /gh-issue-number -->
