### PR TITLE
gh-64595: Fix write file logic in Argument Clinic

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1975,11 +1975,7 @@ def file_changed(filename: str, new_contents: str) -> bool:
         return True
 
 
-def write_file(filename: str, new_contents: str, force=False):
-    if not force and not file_changed(filename, new_contents):
-        # no change: avoid modifying the file modification time
-        return
-
+def write_file(filename: str, new_contents: str):
     # Atomic write using a temporary file and os.replace()
     filename_new = f"{filename}.new"
     with open(filename_new, "w", encoding="utf-8") as fp:
@@ -2241,11 +2237,12 @@ def parse_file(filename, *, verify=True, output=None):
     clinic = Clinic(language, verify=verify, filename=filename)
     src_out, clinic_out = clinic.parse(raw)
 
-    # If clinic output changed, force updating the source file as well.
-    force = any(file_changed(fn, data) for fn, data in clinic_out)
-    write_file(output, src_out, force=force)
-    for fn, data in clinic_out:
-        write_file(fn, data)
+    changes = [(fn, data) for fn, data in clinic_out if file_changed(fn, data)]
+    if changes:
+        # Always (re)write the source file.
+        write_file(output, src_out)
+        for fn, data in clinic_out:
+            write_file(fn, data)
 
 
 def compute_checksum(input, length=None):


### PR DESCRIPTION
Check if any clinic output actually changes any of the output files
before deciding if we should touch the source file. This needs to be
done before we eventually update the source file.


<!-- gh-issue-number: gh-64595 -->
* Issue: gh-64595
<!-- /gh-issue-number -->
