### PR TITLE
gh-103857: Document utcnow and utcfromtimestamp deprecations in What's New

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -771,6 +771,16 @@ Deprecated
   ``int``, convert to int explicitly with ``~int(x)``. (Contributed by Tim Hoffmann
   in :gh:`103487`.)
 
+* :class:`datetime.datetime`'s
+  :meth:`~datetime.datetime.utcnow` and
+  :meth:`~datetime.datetime.utcfromtimestamp` are deprecated and will be
+  removed in a future version. Instead, use timezone-aware objects to represent
+  datetimes in UTC: respectively, call
+  :meth:`~datetime.datetime.now` and
+  :meth:`~datetime.datetime.fromtimestamp`  with the *tz* parameter set to
+  :attr:`datetime.UTC`.
+  (Contributed by Paul Ganssle in :gh:`103857`.)
+
 Pending Removal in Python 3.13
 ------------------------------
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5190,7 +5190,7 @@ datetime_utcfromtimestamp(PyObject *cls, PyObject *args)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.utcfromtimestamp() is deprecated and scheduled for removal "
         "in a future version. Use timezone-aware objects to represent "
-        "datetimes in UTC: datetime.now(datetime.UTC).", 1))
+        "datetimes in UTC: datetime.fromtimestamp(datetime.UTC).", 1))
     {
         return NULL;
     }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5147,7 +5147,7 @@ datetime_utcnow(PyObject *cls, PyObject *dummy)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.utcnow() is deprecated and scheduled for removal in a "
         "future version. Use timezone-aware objects to represent datetimes "
-        "in UTC: datetime.now(timestamp, datetime.UTC).", 1))
+        "in UTC: datetime.now(datetime.UTC).", 1))
     {
         return NULL;
     }
@@ -5190,7 +5190,7 @@ datetime_utcfromtimestamp(PyObject *cls, PyObject *args)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.utcfromtimestamp() is deprecated and scheduled for removal "
         "in a future version. Use timezone-aware objects to represent "
-        "datetimes in UTC: datetime.fromtimestamp(datetime.UTC).", 1))
+        "datetimes in UTC: datetime.fromtimestamp(timestamp, datetime.UTC).", 1))
     {
         return NULL;
     }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5147,7 +5147,7 @@ datetime_utcnow(PyObject *cls, PyObject *dummy)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.utcnow() is deprecated and scheduled for removal in a "
         "future version. Use timezone-aware objects to represent datetimes "
-        "in UTC: datetime.now(datetime.UTC).", 1))
+        "in UTC: datetime.now(timestamp, datetime.UTC).", 1))
     {
         return NULL;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Re: https://github.com/python/cpython/issues/103857#issuecomment-1526076657, add the deprecations to "What's New in 3.12".

Also fix a typo in a deprecation warning.

---

And should we clarify these warnings?

```c
    if (PyErr_WarnEx(PyExc_DeprecationWarning,
        "datetime.utcnow() is deprecated and scheduled for removal in a "
        "future version. Use timezone-aware objects to represent datetimes "
        "in UTC: datetime.now(datetime.UTC).", 1))
```
```c
    if (PyErr_WarnEx(PyExc_DeprecationWarning,
        "datetime.utcfromtimestamp() is deprecated and scheduled for removal "
        "in a future version. Use timezone-aware objects to represent "
        "datetimes in UTC: datetime.fromtimestamp(timestamp, datetime.UTC).", 1))
```

It's really `datetime.datetime.utcnow()` and `datetime.datetime.utcfromtimestamp()`, and not `datetime.utcnow()` and `datetime.utcfromtimestamp()`.

Reason: to avoid confusion with `datetime.UTC` (which is _not_ really `datetime.datetime.UTC`).


<!-- gh-issue-number: gh-103857 -->
* Issue: gh-103857
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104542.org.readthedocs.build/en/104542/whatsnew/3.12.html#deprecated

<!-- readthedocs-preview cpython-previews end -->