### PR TITLE
gh-104341: Clean Up threading Module

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -188,32 +188,6 @@ struct _ts {
 
     struct _py_trashcan trash;
 
-    /* Called when a thread state is deleted normally, but not when it
-     * is destroyed after fork().
-     * Pain:  to prevent rare but fatal shutdown errors (issue 18808),
-     * Thread.join() must wait for the join'ed thread's tstate to be unlinked
-     * from the tstate chain.  That happens at the end of a thread's life,
-     * in pystate.c.
-     * The obvious way doesn't quite work:  create a lock which the tstate
-     * unlinking code releases, and have Thread.join() wait to acquire that
-     * lock.  The problem is that we _are_ at the end of the thread's life:
-     * if the thread holds the last reference to the lock, decref'ing the
-     * lock will delete the lock, and that may trigger arbitrary Python code
-     * if there's a weakref, with a callback, to the lock.  But by this time
-     * _PyRuntime.gilstate.tstate_current is already NULL, so only the simplest
-     * of C code can be allowed to run (in particular it must not be possible to
-     * release the GIL).
-     * So instead of holding the lock directly, the tstate holds a weakref to
-     * the lock:  that's the value of on_delete_data below.  Decref'ing a
-     * weakref is harmless.
-     * on_delete points to _threadmodule.c's static release_sentinel() function.
-     * After the tstate is unlinked, release_sentinel is called with the
-     * weakref-to-lock (on_delete_data) argument, and release_sentinel releases
-     * the indirectly held lock.
-     */
-    void (*on_delete)(void *);
-    void *on_delete_data;
-
     int coroutine_origin_tracking_depth;
 
     PyObject *async_gen_firstiter;

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -57,8 +57,6 @@ struct _is {
         uint64_t next_unique_id;
         /* The linked list of threads, newest first. */
         PyThreadState *head;
-        /* Used in Modules/_threadmodule.c. */
-        long count;
         /* Support for runtime thread stack size tuning.
            A value of 0 means using the platform's default stack size
            or the size specified by the THREAD_STACK_SIZE macro. */

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -49,6 +49,7 @@ try:
 except AttributeError:
     _CRLock = None
 TIMEOUT_MAX = _thread.TIMEOUT_MAX
+_internal_after_fork = _thread._after_fork
 del _thread
 
 
@@ -1024,8 +1025,7 @@ class Thread:
         Set a lock object which will be released by the interpreter when
         the underlying thread state (see pystate.h) gets deleted.
         """
-        self._tstate_lock = _allocate_lock()
-        _set_sentinel(self._tstate_lock)
+        self._tstate_lock = _set_sentinel()
         self._tstate_lock.acquire()
 
         if not self.daemon:
@@ -1678,4 +1678,5 @@ def _after_fork():
 
 
 if hasattr(_os, "register_at_fork"):
+    _os.register_at_fork(after_in_child=_internal_after_fork)
     _os.register_at_fork(after_in_child=_after_fork)

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1144,9 +1144,7 @@ class Thread:
             return
 
         try:
-            if lock.acquire(block, timeout):
-                lock.release()
-                self._stop()
+            locked = lock.acquire(block, timeout)
         except:
             if lock.locked():
                 # bpo-45274: lock.acquire() acquired the lock, but the function
@@ -1156,6 +1154,9 @@ class Thread:
                 lock.release()
                 self._stop()
             raise
+        if locked:
+            lock.release()
+            self._stop()
 
     @property
     def name(self):

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1024,7 +1024,8 @@ class Thread:
         Set a lock object which will be released by the interpreter when
         the underlying thread state (see pystate.h) gets deleted.
         """
-        self._tstate_lock = _set_sentinel()
+        self._tstate_lock = _allocate_lock()
+        _set_sentinel(self._tstate_lock)
         self._tstate_lock.acquire()
 
         if not self.daemon:

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1528,15 +1528,15 @@ thread__set_sentinel(PyObject *module, PyObject *Py_UNUSED(ignored))
     struct module_thread *mt = module_threads_lookup(&state->threads, tstate);
     if (mt == NULL) {
         /* It must be the "main" thread. */
-        lock = (PyObject *) newlockobject(state);
-        if (lock == NULL) {
+        mt = add_module_thread(state, &state->threads, tstate);
+        if (mt == NULL) {
             return NULL;
         }
     }
     else {
         assert(mt->running_lock != NULL);
-        lock = Py_NewRef(mt->running_lock);
     }
+    lock = Py_NewRef(mt->running_lock);
 
     if (tstate->on_delete_data != NULL) {
         /* We must support the re-creation of the lock from a
@@ -1551,9 +1551,6 @@ thread__set_sentinel(PyObject *module, PyObject *Py_UNUSED(ignored))
        hangs to the thread state. */
     wr = PyWeakref_NewRef(lock, NULL);
     if (wr == NULL) {
-        if (mt == NULL) {
-            Py_DECREF(lock);
-        }
         return NULL;
     }
     tstate->on_delete_data = (void *) wr;

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1551,7 +1551,9 @@ thread__set_sentinel(PyObject *module, PyObject *Py_UNUSED(ignored))
        hangs to the thread state. */
     wr = PyWeakref_NewRef(lock, NULL);
     if (wr == NULL) {
-        Py_DECREF(lock);
+        if (mt == NULL) {
+            Py_DECREF(lock);
+        }
         return NULL;
     }
     tstate->on_delete_data = (void *) wr;

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -140,6 +140,13 @@ module_thread_finished(struct module_thread *mt)
 static void
 remove_module_thread(struct module_threads *threads, struct module_thread *mt)
 {
+    // Notify other threads that this one is done.
+    // XXX This should happen in module_thread_finished().
+    // XXX These fields could be removed from PyThreadState.
+    if (mt->tstate->on_delete != NULL) {
+        mt->tstate->on_delete(mt->tstate->on_delete_data);
+    }
+
     // Remove it from the list.
     module_threads_remove(threads, mt);
 

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1048,12 +1048,10 @@ _localdummy_destroyed(PyObject *localweakref, PyObject *dummyweakref)
 /* Module functions */
 
 struct bootstate {
-    PyInterpreterState *interp;
     PyObject *func;
     PyObject *args;
     PyObject *kwargs;
     PyThreadState *tstate;
-    _PyRuntimeState *runtime;
 };
 
 
@@ -1122,7 +1120,6 @@ and False otherwise.\n");
 static PyObject *
 thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
 {
-    _PyRuntimeState *runtime = &_PyRuntime;
     PyObject *func, *args, *kwargs = NULL;
 
     if (!PyArg_UnpackTuple(fargs, "start_new_thread", 2, 3,
@@ -1160,8 +1157,7 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
     if (boot == NULL) {
         return PyErr_NoMemory();
     }
-    boot->interp = _PyInterpreterState_GET();
-    boot->tstate = _PyThreadState_New(boot->interp);
+    boot->tstate = _PyThreadState_New(interp);
     if (boot->tstate == NULL) {
         PyMem_Free(boot);
         if (!PyErr_Occurred()) {
@@ -1169,7 +1165,6 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
         }
         return NULL;
     }
-    boot->runtime = runtime;
     boot->func = Py_NewRef(func);
     boot->args = Py_NewRef(args);
     boot->kwargs = Py_XNewRef(kwargs);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1490,10 +1490,6 @@ PyThreadState_Clear(PyThreadState *tstate)
 
     Py_CLEAR(tstate->context);
 
-    if (tstate->on_delete != NULL) {
-        tstate->on_delete(tstate->on_delete_data);
-    }
-
     tstate->_status.cleared = 1;
 
     // XXX Call _PyThreadStateSwap(runtime, NULL) here if "current".


### PR DESCRIPTION
To fix gh-104341, we need to change the threading module to utilize two locks for each thread: one for if it running (for `join()`) and one for its overall lifetime, on which `Py_EndInterpreter()` will wait.  This PR cleans things up to make it easier to make that change.  As part of that, we move all the module's state out of `PyThreadState` and `PyInterpreterState`.