### PR TITLE
gh-104555: Fix isinstance() and issubclass() for runtime-checkable protocols that use PEP 695

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3136,18 +3136,18 @@ class ProtocolTests(BaseTestCase):
 
     def test_pep695_generic_protocol_callable_members(self):
         @runtime_checkable
-        class Foo[T_co](Protocol):
-            def meth(self, x: T_co) -> None: ...
+        class Foo[T](Protocol):
+            def meth(self, x: T) -> None: ...
 
-        class Bar[T_co]:
-            def meth(self, x: T_co) -> None: ...
+        class Bar[T]:
+            def meth(self, x: T) -> None: ...
 
         self.assertIsInstance(Bar(), Foo)
         self.assertIsSubclass(Bar, Foo)
 
         @runtime_checkable
-        class SupportsTrunc[T_co](Protocol):
-            def __trunc__(self) -> T_co: ...
+        class SupportsTrunc[T](Protocol):
+            def __trunc__(self) -> T: ...
 
         self.assertIsInstance(0.0, SupportsTrunc)
         self.assertIsSubclass(float, SupportsTrunc)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3134,6 +3134,24 @@ class ProtocolTests(BaseTestCase):
 
         self.assertIsInstance(Test(), PSub)
 
+    def test_pep695_generic_protocol_callable_members(self):
+        @runtime_checkable
+        class Foo[T_co](Protocol):
+            def meth(self, x: T_co) -> None: ...
+
+        class Bar[T_co]:
+            def meth(self, x: T_co) -> None: ...
+
+        self.assertIsInstance(Bar(), Foo)
+        self.assertIsSubclass(Bar, Foo)
+
+        @runtime_checkable
+        class SupportsTrunc[T_co](Protocol):
+            def __trunc__(self) -> T_co: ...
+
+        self.assertIsInstance(0.0, SupportsTrunc)
+        self.assertIsSubclass(float, SupportsTrunc)
+
     def test_init_called(self):
         T = TypeVar('T')
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1663,7 +1663,7 @@ class _TypingEllipsis:
 _TYPING_INTERNALS = frozenset({
     '__parameters__', '__orig_bases__',  '__orig_class__',
     '_is_protocol', '_is_runtime_protocol', '__protocol_attrs__',
-    '__callable_proto_members_only__',
+    '__callable_proto_members_only__', '__type_params__',
 })
 
 _SPECIAL_NAMES = frozenset({


### PR DESCRIPTION
Fixes #104555

<!-- gh-issue-number: gh-104555 -->
* Issue: gh-104555
<!-- /gh-issue-number -->
