### PR TITLE
gh-104555: Runtime-checkable protocols: Don't let previous calls to `isinstance()` influence whether `issubclass()` raises an exception

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2665,7 +2665,7 @@ class ProtocolTests(BaseTestCase):
 
         # gh-104555: ABCMeta might cache the result of this isinstance check
         # if we called super().__instancecheck__ in the wrong place
-        # in _ProtocolMeta.__instancheck__...
+        # in _ProtocolMeta.__instancecheck__...
         self.assertIsInstance(Eggs(), Spam)
 
         # ...and if it did, then TypeError wouldn't be raised here!
@@ -2683,7 +2683,7 @@ class ProtocolTests(BaseTestCase):
 
         # gh-104555: ABCMeta might cache the result of this isinstance check
         # if we called super().__instancecheck__ in the wrong place
-        # in _ProtocolMeta.__instancheck__...
+        # in _ProtocolMeta.__instancecheck__...
         self.assertIsInstance(Eggs(42), Spam)
 
         # ...and if it did, then TypeError wouldn't be raised here!

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2656,17 +2656,17 @@ class ProtocolTests(BaseTestCase):
 
     def test_no_weird_caching_with_issubclass_after_isinstance(self):
         @runtime_checkable
-        class Spam(Protocol[T]):
-            x: T
+        class Spam(Protocol):
+            x: int
 
-        class Eggs(Generic[T]):
-            def __init__(self, x: T) -> None:
-                self.x = x
+        class Eggs:
+            def __init__(self) -> None:
+                self.x = 42
 
         # gh-104555: ABCMeta might cache the result of this isinstance check
         # if we called super().__instancecheck__ in the wrong place
         # in _ProtocolMeta.__instancheck__...
-        self.assertIsInstance(Eggs(42), Spam)
+        self.assertIsInstance(Eggs(), Spam)
 
         # ...and if it did, then TypeError wouldn't be raised here!
         with self.assertRaises(TypeError):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2673,7 +2673,7 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(Eggs, Spam)
 
-    def test_no_weird_caching_with_issubclass_after_isinstance2(self):
+    def test_no_weird_caching_with_issubclass_after_isinstance_2(self):
         @runtime_checkable
         class Spam(Protocol):
             x: int
@@ -2690,7 +2690,7 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(Eggs, Spam)
 
-    def test_no_weird_caching_with_issubclass_after_isinstance3(self):
+    def test_no_weird_caching_with_issubclass_after_isinstance_3(self):
         @runtime_checkable
         class Spam(Protocol):
             x: int

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2663,12 +2663,13 @@ class ProtocolTests(BaseTestCase):
             def __init__(self) -> None:
                 self.x = 42
 
-        # gh-104555: ABCMeta might cache the result of this isinstance check
-        # if we called super().__instancecheck__ in the wrong place
-        # in _ProtocolMeta.__instancecheck__...
         self.assertIsInstance(Eggs(), Spam)
 
-        # ...and if it did, then TypeError wouldn't be raised here!
+        # gh-104555: If we didn't override ABCMeta.__subclasscheck__ in _ProtocolMeta,
+        # TypeError wouldn't be raised here,
+        # as the cached result of the isinstance() check immediately above
+        # would mean the issubclass() call would short-circuit
+        # before we got to the "raise TypeError" line
         with self.assertRaises(TypeError):
             issubclass(Eggs, Spam)
 
@@ -2679,12 +2680,13 @@ class ProtocolTests(BaseTestCase):
 
         class Eggs: ...
 
-        # gh-104555: ABCMeta might cache the result of this isinstance check
-        # if we called super().__instancecheck__ in the wrong place
-        # in _ProtocolMeta.__instancecheck__...
         self.assertNotIsInstance(Eggs(), Spam)
 
-        # ...and if it did, then TypeError wouldn't be raised here!
+        # gh-104555: If we didn't override ABCMeta.__subclasscheck__ in _ProtocolMeta,
+        # TypeError wouldn't be raised here,
+        # as the cached result of the isinstance() check immediately above
+        # would mean the issubclass() call would short-circuit
+        # before we got to the "raise TypeError" line
         with self.assertRaises(TypeError):
             issubclass(Eggs, Spam)
 
@@ -2699,12 +2701,13 @@ class ProtocolTests(BaseTestCase):
                     return 42
                 raise AttributeError(attr)
 
-        # gh-104555: ABCMeta might cache the result of this isinstance check
-        # if we called super().__instancecheck__ in the wrong place
-        # in _ProtocolMeta.__instancecheck__...
         self.assertNotIsInstance(Eggs(), Spam)
 
-        # ...and if it did, then TypeError wouldn't be raised here!
+        # gh-104555: If we didn't override ABCMeta.__subclasscheck__ in _ProtocolMeta,
+        # TypeError wouldn't be raised here,
+        # as the cached result of the isinstance() check immediately above
+        # would mean the issubclass() call would short-circuit
+        # before we got to the "raise TypeError" line
         with self.assertRaises(TypeError):
             issubclass(Eggs, Spam)
 
@@ -2717,12 +2720,13 @@ class ProtocolTests(BaseTestCase):
             def __init__(self, x: T) -> None:
                 self.x = x
 
-        # gh-104555: ABCMeta might cache the result of this isinstance check
-        # if we called super().__instancecheck__ in the wrong place
-        # in _ProtocolMeta.__instancecheck__...
         self.assertIsInstance(Eggs(42), Spam)
 
-        # ...and if it did, then TypeError wouldn't be raised here!
+        # gh-104555: If we didn't override ABCMeta.__subclasscheck__ in _ProtocolMeta,
+        # TypeError wouldn't be raised here,
+        # as the cached result of the isinstance() check immediately above
+        # would mean the issubclass() call would short-circuit
+        # before we got to the "raise TypeError" line
         with self.assertRaises(TypeError):
             issubclass(Eggs, Spam)
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1775,8 +1775,8 @@ del _pickle_psargs, _pickle_pskwargs
 
 
 class _ProtocolMeta(ABCMeta):
-    # This metaclass is really unfortunate and exists only because of
-    # the lack of __instancehook__.
+    # This metaclass is somewhat unfortunate,
+    # but is necessary for several reasons...
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
         cls.__protocol_attrs__ = _get_protocol_attrs(cls)
@@ -1785,6 +1785,17 @@ class _ProtocolMeta(ABCMeta):
         cls.__callable_proto_members_only__ = all(
             callable(getattr(cls, attr, None)) for attr in cls.__protocol_attrs__
         )
+
+    def __subclasscheck__(cls, other):
+        if (
+            getattr(cls, '_is_protocol', False)
+            and not cls.__callable_proto_members_only__
+            and not _allow_reckless_class_checks(depth=2)
+        ):
+            raise TypeError(
+                "Protocols with non-method members don't support issubclass()"
+            )
+        return super().__subclasscheck__(other)
 
     def __instancecheck__(cls, instance):
         # We need this method for situations where attributes are
@@ -1798,17 +1809,10 @@ class _ProtocolMeta(ABCMeta):
             raise TypeError("Instance and class checks can only be used with"
                             " @runtime_checkable protocols")
 
-        # gh-104555: Don't call super().__instancecheck__ here,
-        # ABCMeta.__instancecheck__ would erroneously use it to populate the cache,
-        # which would cause incorrect results for *issubclass()* calls
-        if type.__instancecheck__(cls, instance):
+        if super().__instancecheck__(instance):
             return True
 
         if is_protocol_cls:
-            # Fast path for protocols with only callable members
-            if cls.__callable_proto_members_only__ and issubclass(type(instance), cls):
-                return True
-
             getattr_static = _lazy_load_getattr_static()
             for attr in cls.__protocol_attrs__:
                 try:
@@ -1820,7 +1824,7 @@ class _ProtocolMeta(ABCMeta):
             else:
                 return True
 
-        return super().__instancecheck__(instance)
+        return False
 
 
 class Protocol(Generic, metaclass=_ProtocolMeta):
@@ -1876,11 +1880,6 @@ class Protocol(Generic, metaclass=_ProtocolMeta):
                 raise TypeError("Instance and class checks can only be used with"
                                 " @runtime_checkable protocols")
 
-            if not cls.__callable_proto_members_only__ :
-                if _allow_reckless_class_checks():
-                    return NotImplemented
-                raise TypeError("Protocols with non-method members"
-                                " don't support issubclass()")
             if not isinstance(other, type):
                 # Same error message as for issubclass(1, int).
                 raise TypeError('issubclass() arg 1 must be a class')

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1805,6 +1805,7 @@ class _ProtocolMeta(ABCMeta):
             return True
 
         if is_protocol_cls:
+            # Fast path for protocols with only callable members
             if cls.__callable_proto_members_only__ and issubclass(type(instance), cls):
                 return True
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1798,7 +1798,10 @@ class _ProtocolMeta(ABCMeta):
             raise TypeError("Instance and class checks can only be used with"
                             " @runtime_checkable protocols")
 
-        if super().__instancecheck__(instance):
+        # gh-104555: Don't call super().__instancecheck__ here,
+        # ABCMeta.__instancecheck__ would erroneously use it to populate the cache,
+        # which would cause incorrect results for *issubclass()* calls
+        if type.__instancecheck__(cls, instance):
             return True
 
         if is_protocol_cls:
@@ -1813,7 +1816,7 @@ class _ProtocolMeta(ABCMeta):
             else:
                 return True
 
-        return False
+        return super().__instancecheck__(instance)
 
 
 class Protocol(Generic, metaclass=_ProtocolMeta):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1804,10 +1804,10 @@ class _ProtocolMeta(ABCMeta):
         if type.__instancecheck__(cls, instance):
             return True
 
-        if cls.__callable_proto_members_only__ and issubclass(type(instance), cls):
-            return True
-
         if is_protocol_cls:
+            if cls.__callable_proto_members_only__ and issubclass(type(instance), cls):
+                return True
+
             getattr_static = _lazy_load_getattr_static()
             for attr in cls.__protocol_attrs__:
                 try:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1804,6 +1804,9 @@ class _ProtocolMeta(ABCMeta):
         if type.__instancecheck__(cls, instance):
             return True
 
+        if cls.__callable_proto_members_only__ and issubclass(type(instance), cls):
+            return True
+
         if is_protocol_cls:
             getattr_static = _lazy_load_getattr_static()
             for attr in cls.__protocol_attrs__:

--- a/Misc/NEWS.d/next/Library/2023-05-17-16-58-23.gh-issue-104555.5rb5oM.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-17-16-58-23.gh-issue-104555.5rb5oM.rst
@@ -1,0 +1,7 @@
+Fix issue where an :func:`issubclass` check comparing a class ``X`` against a
+:func:`runtime-checkable protocol <typing.runtime_checkable>` ``Y`` with
+non-callable members would not cause :exc:`TypeError` to be raised if an
+:func:`isinstance` call had previously been made comparing an instance of ``X``
+to ``Y``. This issue was present in edge cases on Python 3.11, but became more
+prominent in 3.12 due to some unrelated changes that were made to
+runtime-checkable protocols. Patch by Alex Waygood.


### PR DESCRIPTION
`ABCMeta.__instancecheck__` caches `isinstance()` calls against classes that have `ABCMeta` as their metaclass. It uses these cache entries not only to inform how future `isinstance()` calls behave, but also how *`issubclass()`* calls behave. That means that on `main` we now have some _rather_ unfortunate behaviour when it comes to runtime-checkable protocols, due to the fact that `typing._ProtocolMeta` is a subclass of `ABCMeta`, and `typing._ProtocolMeta.__instancecheck__` calls `super().__instancecheck__()` too soon (following https://github.com/python/cpython/commit/47753ecde21b79b5c5f11d883946fda2a340e427):

```pycon
Python 3.12.0a7+ (heads/main:1163782868, May 16 2023, 18:09:28) [MSC v.1932 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from typing import *
>>> @runtime_checkable
... class Foo(Protocol):
...     x: int
...
>>> class Bar:
...     x = 42
...
>>> issubclass(Bar, Foo)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\alexw\coding\cpython\Lib\abc.py", line 123, in __subclasscheck__
    return _abc_subclasscheck(cls, subclass)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\alexw\coding\cpython\Lib\typing.py", line 1875, in _proto_hook
    raise TypeError("Protocols with non-method members"
TypeError: Protocols with non-method members don't support issubclass()
>>> isinstance(Bar(), Foo)
True
>>> issubclass(Bar, Foo)
False
```

This PR fixes the incorrect behaviour. It means that these `isinstance()` checks will be about twice as slow as they are on `main`:

```py
@runtime_checkable
class Foo:
    def meth(self): ...

@Foo.register
class Bar: ...

isinstance(Bar(), Foo)
```

But they'll still be much faster than they are on 3.11. Use of `ABCMeta.register` with protocols is pretty rare anyway, as far as I know, since `ABCMeta.register` isn't supported by type checkers. Other kinds of `isinstance()` checks do not suffer a significant performance regression.

Fixes #104555.

(Skipping news, as this bug doesn't exist on any released version of Python.)

<!-- gh-issue-number: gh-104555 -->
* Issue: gh-104555
<!-- /gh-issue-number -->
