### PR TITLE
gh-104341: Fix threading Module Shutdown

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -345,7 +345,7 @@ class ThreadTests(BaseTestCase):
 
     def test_limbo_cleanup(self):
         # Issue 7481: Failure to start thread should cleanup the limbo map.
-        def fail_new_thread(*args):
+        def fail_new_thread(*args, **kwargs):
             raise threading.ThreadError()
         _start_new_thread = threading._start_new_thread
         threading._start_new_thread = fail_new_thread

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -50,7 +50,10 @@ except AttributeError:
     _CRLock = None
 TIMEOUT_MAX = _thread.TIMEOUT_MAX
 _wait_for_threads_fini = _thread._wait_for_threads_fini
-_internal_after_fork = _thread._after_fork
+try:
+    _internal_after_fork = _thread._after_fork
+except AttributeError:
+    _internal_after_fork = None
 del _thread
 
 
@@ -1683,5 +1686,6 @@ def _after_fork():
 
 
 if hasattr(_os, "register_at_fork"):
-    _os.register_at_fork(after_in_child=_internal_after_fork)
+    if _internal_after_fork is not None:
+        _os.register_at_fork(after_in_child=_internal_after_fork)
     _os.register_at_fork(after_in_child=_after_fork)

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -969,7 +969,7 @@ class Thread:
         with _active_limbo_lock:
             _limbo[self] = self
         try:
-            _start_new_thread(self._bootstrap, ())
+            _start_new_thread(self._bootstrap, (), daemonic=self._daemonic)
         except Exception:
             with _active_limbo_lock:
                 del _limbo[self]

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -49,6 +49,7 @@ try:
 except AttributeError:
     _CRLock = None
 TIMEOUT_MAX = _thread.TIMEOUT_MAX
+_wait_for_threads_fini = _thread._wait_for_threads_fini
 _internal_after_fork = _thread._after_fork
 del _thread
 
@@ -1590,6 +1591,7 @@ def _shutdown():
         pass
 
     # Join all non-deamon threads
+    # XXX We should be able to drop this in favor of _wait_for_threads_fini().
     while True:
         with _shutdown_locks_lock:
             locks = list(_shutdown_locks)
@@ -1605,6 +1607,9 @@ def _shutdown():
 
         # new threads can be spawned while we were waiting for the other
         # threads to complete
+
+    # Wait for all non-daemon threads to be finalized.
+    _wait_for_threads_fini()
 
 
 def main_thread():

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -49,6 +49,7 @@ try:
 except AttributeError:
     _CRLock = None
 TIMEOUT_MAX = _thread.TIMEOUT_MAX
+_internal_after_fork = _thread._after_fork
 del _thread
 
 
@@ -1677,4 +1678,5 @@ def _after_fork():
 
 
 if hasattr(_os, "register_at_fork"):
+    _os.register_at_fork(after_in_child=_internal_after_fork)
     _os.register_at_fork(after_in_child=_after_fork)

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1887,10 +1887,10 @@ static PyMethodDef thread_methods[] = {
      METH_NOARGS, _set_sentinel_doc},
     {"_excepthook",             thread_excepthook,
      METH_O, excepthook_doc},
-    {"_wait_for_threads_fini",  thread__wait_for_threads_fini,
+    {"_wait_for_threads_fini",  (PyCFunction)thread__wait_for_threads_fini,
      METH_NOARGS, NULL},
 #ifdef HAVE_FORK
-    {"_after_fork",             thread__after_fork,
+    {"_after_fork",             (PyCFunction)thread__after_fork,
      METH_NOARGS, NULL},
 #endif
     {NULL,                      NULL}           /* sentinel */

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1819,7 +1819,6 @@ PyDoc_STRVAR(excepthook_doc,
 \n\
 Handle uncaught Thread.run() exception.");
 
-#ifdef HAVE_FORK
 static PyObject *
 thread__wait_for_threads_fini(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
@@ -1828,6 +1827,7 @@ thread__wait_for_threads_fini(PyObject *module, PyObject *Py_UNUSED(ignored))
     Py_RETURN_NONE;
 }
 
+#ifdef HAVE_FORK
 static PyObject *
 thread__after_fork(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
@@ -1870,10 +1870,10 @@ static PyMethodDef thread_methods[] = {
      METH_NOARGS, _set_sentinel_doc},
     {"_excepthook",             thread_excepthook,
      METH_O, excepthook_doc},
-    {"_wait_for_threads_fini",  (PyCFunction)thread__wait_for_threads_fini,
+    {"_wait_for_threads_fini",  thread__wait_for_threads_fini,
      METH_NOARGS, NULL},
 #ifdef HAVE_FORK
-    {"_after_fork",             (PyCFunction)thread__after_fork,
+    {"_after_fork",             thread__after_fork,
      METH_NOARGS, NULL},
 #endif
     {NULL,                      NULL}           /* sentinel */

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1870,10 +1870,10 @@ static PyMethodDef thread_methods[] = {
      METH_NOARGS, _set_sentinel_doc},
     {"_excepthook",             thread_excepthook,
      METH_O, excepthook_doc},
-    {"_wait_for_threads_fini",  thread__wait_for_threads_fini,
+    {"_wait_for_threads_fini",  (PyCFunction)thread__wait_for_threads_fini,
      METH_NOARGS, NULL},
 #ifdef HAVE_FORK
-    {"_after_fork",             thread__after_fork,
+    {"_after_fork",             (PyCFunction)thread__after_fork,
      METH_NOARGS, NULL},
 #endif
     {NULL,                      NULL}           /* sentinel */

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -22,7 +22,7 @@
 static struct PyModuleDef thread_module;
 
 
-/* threads owned by the modulo */
+/* threads owned by the module */
 
 struct module_thread {
     PyThreadState *tstate;

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -82,6 +82,15 @@ module_threads_reinit(struct module_threads *threads)
 static void
 module_threads_fini(struct module_threads *threads)
 {
+    // Wait for all the threads to finalize.
+    PyThread_acquire_lock(threads->mutex, WAIT_LOCK);
+    while (threads->head != NULL) {
+        PyThread_release_lock(threads->mutex);
+        // XXX Sleep?
+        PyThread_acquire_lock(threads->mutex, WAIT_LOCK);
+    }
+    PyThread_release_lock(threads->mutex);
+
     PyThread_free_lock(threads->mutex);
 }
 

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -22,7 +22,132 @@
 static struct PyModuleDef thread_module;
 
 
+/* threads owned by the modulo */
+
+struct module_thread {
+    PyThreadState *tstate;
+    struct module_thread *prev;
+    struct module_thread *next;
+};
+
+struct module_threads {
+    PyThread_type_lock mutex;
+    struct module_thread *head;
+    struct module_thread *tail;
+};
+
+static int
+module_threads_init(struct module_threads *threads)
+{
+    threads->head = NULL;
+    threads->tail = NULL;
+    threads->mutex = PyThread_allocate_lock();
+    if (threads->mutex == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    return 0;
+}
+
+static void
+module_threads_fini(struct module_threads *threads)
+{
+    PyThread_free_lock(threads->mutex);
+}
+
+static void
+module_threads_add(struct module_threads *threads, struct module_thread *mt)
+{
+    PyThread_acquire_lock(threads->mutex, WAIT_LOCK);
+
+    // Add it to the end of the list.
+    if (threads->head == NULL) {
+        threads->head = mt;
+    }
+    else {
+        mt->prev = threads->tail;
+        threads->tail->next = mt;
+    }
+    threads->tail = mt;
+
+    PyThread_release_lock(threads->mutex);
+}
+
+static void
+module_threads_remove(struct module_threads *threads, struct module_thread *mt)
+{
+    PyThread_acquire_lock(threads->mutex, WAIT_LOCK);
+
+    if (mt->prev == NULL) {
+        threads->head = mt->next;
+    }
+    else {
+        mt->prev->next = mt->next;
+    }
+    if (mt->next == NULL) {
+        threads->tail = mt->prev;
+    }
+    else {
+        mt->next->prev = mt->prev;
+    }
+
+    PyThread_release_lock(threads->mutex);
+}
+
+static struct module_thread *
+add_module_thread(struct module_threads *threads, PyThreadState *tstate)
+{
+    // Create the new list entry.
+    struct module_thread *mt = PyMem_RawMalloc(sizeof(struct module_thread));
+    if (mt == NULL) {
+        if (!PyErr_Occurred()) {
+            PyErr_NoMemory();
+        }
+        return NULL;
+    }
+    mt->tstate = tstate;
+    mt->prev = NULL;
+    mt->next = NULL;
+
+    // Add the entry to the end of the list.
+    module_threads_add(threads, mt);
+
+    return mt;
+}
+
+static void
+module_thread_starting(struct module_thread *mt)
+{
+    assert(mt->tstate == PyThreadState_Get());
+
+    mt->tstate->interp->threads.count++;
+}
+
+static void
+module_thread_finished(struct module_thread *mt)
+{
+    mt->tstate->interp->threads.count--;
+
+    // Notify other threads that this one is done.
+    // XXX Do it explicitly here rather than via tstate.on_delete().
+}
+
+static void
+remove_module_thread(struct module_threads *threads, struct module_thread *mt)
+{
+    // Remove it from the list.
+    module_threads_remove(threads, mt);
+
+    // Deallocate everything.
+    PyMem_RawFree(mt);
+}
+
+
+/* module state */
+
 typedef struct {
+    struct module_threads threads;
+
     PyTypeObject *excepthook_type;
     PyTypeObject *lock_type;
     PyTypeObject *local_type;
@@ -1054,6 +1179,8 @@ struct bootstate {
     PyObject *kwargs;
     PyThreadState *tstate;
     _PyRuntimeState *runtime;
+    thread_module_state *module_state;
+    struct module_thread *module_thread;
 };
 
 
@@ -1071,12 +1198,14 @@ static void
 thread_run(void *boot_raw)
 {
     struct bootstate *boot = (struct bootstate *) boot_raw;
-    PyThreadState *tstate;
+    PyThreadState *tstate = boot->tstate;
+    thread_module_state *state = boot->module_state;
+    struct module_thread *mt = boot->module_thread;
 
-    tstate = boot->tstate;
     _PyThreadState_Bind(tstate);
     PyEval_AcquireThread(tstate);
-    tstate->interp->threads.count++;
+
+    module_thread_starting(mt);
 
     PyObject *res = PyObject_Call(boot->func, boot->args, boot->kwargs);
     if (res == NULL) {
@@ -1091,10 +1220,12 @@ thread_run(void *boot_raw)
         Py_DECREF(res);
     }
 
+    module_thread_finished(mt);
+
     thread_bootstate_free(boot);
-    tstate->interp->threads.count--;
     PyThreadState_Clear(tstate);
     _PyThreadState_DeleteCurrent(tstate);
+    remove_module_thread(&state->threads, mt);
 
     // bpo-44434: Don't call explicitly PyThread_exit_thread(). On Linux with
     // the glibc, pthread_exit() can abort the whole process if dlopen() fails
@@ -1167,6 +1298,14 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
         if (!PyErr_Occurred()) {
             return PyErr_NoMemory();
         }
+        return NULL;
+    }
+    thread_module_state *state = get_thread_state(self);
+    boot->module_state = state;
+    boot->module_thread = add_module_thread(&state->threads, boot->tstate);
+    if (boot->module_thread == NULL) {
+        PyThreadState_Clear(boot->tstate);
+        PyMem_Free(boot);
         return NULL;
     }
     boot->runtime = runtime;
@@ -1609,6 +1748,11 @@ thread_module_exec(PyObject *module)
     // Initialize the C thread library
     PyThread_init_thread();
 
+    // Initialize the list of threads owned by this module.
+    if (module_threads_init(&state->threads) < 0) {
+        return -1;
+    }
+
     // Lock
     state->lock_type = (PyTypeObject *)PyType_FromSpec(&lock_type_spec);
     if (state->lock_type == NULL) {
@@ -1699,6 +1843,8 @@ thread_module_clear(PyObject *module)
 static void
 thread_module_free(void *module)
 {
+    thread_module_state *state = get_thread_state(module);
+    module_threads_fini(&state->threads);
     thread_module_clear((PyObject *)module);
 }
 


### PR DESCRIPTION
This should fix the frequent crashes in test_threading and test__xxsubinterpreters.

There is some duplication with the threading module which could be removed after this lands.  We can also eliminate `PyThreadState.on_delete` and `PyInterpreterState.threads.count`, both of which are cases where the state of the threading module leaked out into the runtime.

(Also see gh-63008 and gh-18296.)

<!-- gh-issue-number: gh-104341 -->
* Issue: gh-104341
<!-- /gh-issue-number -->
