### PR TITLE
gh-104340: Suppress warning about unawaited exception for closed pipe stdin

### DIFF
--- a/Lib/asyncio/subprocess.py
+++ b/Lib/asyncio/subprocess.py
@@ -81,6 +81,9 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
                 self._stdin_closed.set_result(None)
             else:
                 self._stdin_closed.set_exception(exc)
+                # Since calling `wait_closed()` is not mandatory,
+                # we shouldn't log the traceback if this is not awaited.
+                self._stdin_closed._log_traceback = False
             return
         if fd == 1:
             reader = self.stdout

--- a/Misc/NEWS.d/next/Library/2023-05-17-20-03-01.gh-issue-104340.kp_XmX.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-17-20-03-01.gh-issue-104340.kp_XmX.rst
@@ -1,0 +1,1 @@
+When an ``asyncio`` pipe protocol loses its connection due to an error, and the caller doesn't await ``wait_closed()`` on the corresponding ``StreamWriter``, don't log a warning about an exception that was never retrieved. After all, according to the ``StreamWriter.close()`` docs, the ``wait_closed()`` call is optional ("not mandatory").


### PR DESCRIPTION
According to my analysis in the issue, the warning is more annoying/distracting than useful, and since the docs for `StreamWriter.close()` say that calling `wait_closed()` is optional, we shouldn't penalize users for not waiting if there was an error (e.g. `BrokenPipeError` in `drain()`).

<!-- gh-issue-number: gh-104340 -->
* Issue: gh-104340
<!-- /gh-issue-number -->
