### PR TITLE
gh-104341: Minor Fixes in the _thread Module

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -57,8 +57,6 @@ struct _is {
         uint64_t next_unique_id;
         /* The linked list of threads, newest first. */
         PyThreadState *head;
-        /* Used in Modules/_threadmodule.c. */
-        long count;
         /* Support for runtime thread stack size tuning.
            A value of 0 means using the platform's default stack size
            or the size specified by the THREAD_STACK_SIZE macro. */

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -345,7 +345,7 @@ class ThreadTests(BaseTestCase):
 
     def test_limbo_cleanup(self):
         # Issue 7481: Failure to start thread should cleanup the limbo map.
-        def fail_new_thread(*args):
+        def fail_new_thread(*args, **kwargs):
             raise threading.ThreadError()
         _start_new_thread = threading._start_new_thread
         threading._start_new_thread = fail_new_thread

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -49,6 +49,10 @@ try:
 except AttributeError:
     _CRLock = None
 TIMEOUT_MAX = _thread.TIMEOUT_MAX
+try:
+    _internal_after_fork = _thread._after_fork
+except AttributeError:
+    _internal_after_fork = None
 del _thread
 
 
@@ -1677,4 +1681,6 @@ def _after_fork():
 
 
 if hasattr(_os, "register_at_fork"):
+    if _internal_after_fork is not None:
+        _os.register_at_fork(after_in_child=_internal_after_fork)
     _os.register_at_fork(after_in_child=_after_fork)

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -968,7 +968,7 @@ class Thread:
         with _active_limbo_lock:
             _limbo[self] = self
         try:
-            _start_new_thread(self._bootstrap, ())
+            _start_new_thread(self._bootstrap, (), daemonic=self._daemonic)
         except Exception:
             with _active_limbo_lock:
                 del _limbo[self]

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -87,7 +87,6 @@ struct module_threads {
     struct {
         long all;
         long running;
-        long non_daemon_running;
         long pyfuncs_running;
     } counts;
 };

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -115,13 +115,15 @@ module_threads_reinit(struct module_threads *threads)
 #endif
     assert(tstate->thread_id == PyThread_get_thread_ident());
 
-    if (_PyThread_at_fork_reinit(threads->mutex) < 0) {
+    PyThread_type_lock lock = threads->mutex;
+    assert(lock != NULL);
+    if (_PyThread_at_fork_reinit(&lock) < 0) {
         PyErr_SetString(ThreadError, "failed to reinitialize lock at fork");
         return -1;
     }
 
     *threads = (struct module_threads){
-        .mutex = threads->mutex,
+        .mutex = lock,
         // The counts are all reset to 0.
     };
     return 0;

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -110,7 +110,9 @@ module_threads_init(struct module_threads *threads)
 static int
 module_threads_reinit(struct module_threads *threads)
 {
+#ifndef NDEBUG
     PyThreadState *tstate = _PyThreadState_GET();
+#endif
     assert(tstate->thread_id == PyThread_get_thread_ident());
 
     if (_PyThread_at_fork_reinit(threads->mutex) < 0) {
@@ -1802,9 +1804,9 @@ thread__after_fork(PyObject *module, PyObject *Py_UNUSED(ignored))
 #endif
 
 static PyMethodDef thread_methods[] = {
-    {"start_new_thread",        (PyCFunction)thread_PyThread_start_new_thread,
+    {"start_new_thread",        _PyCFunction_CAST(thread_PyThread_start_new_thread),
      METH_VARARGS | METH_KEYWORDS, start_new_doc},
-    {"start_new",               (PyCFunction)thread_PyThread_start_new_thread,
+    {"start_new",               _PyCFunction_CAST(thread_PyThread_start_new_thread),
      METH_VARARGS | METH_KEYWORDS, start_new_doc},
     {"daemon_threads_allowed",  (PyCFunction)thread_daemon_threads_allowed,
      METH_NOARGS, daemon_threads_allowed_doc},

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -190,6 +190,9 @@ set_module_thread_finished(struct module_threads *threads,
     threads->counts.pyfuncs_running--;
 
     PyThread_release_lock(threads->mutex);
+
+    // Notify other threads that this one is done.
+    // XXX Do it explicitly here rather than via tstate.on_delete().
 }
 
 static void

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -26,10 +26,11 @@ static struct PyModuleDef thread_module;
 
 struct module_thread {
     PyThreadState *tstate;
+    int daemonic;
 };
 
 static struct module_thread *
-new_module_thread(PyInterpreterState *interp)
+new_module_thread(PyInterpreterState *interp, int daemonic)
 {
     PyThreadState *tstate = _PyThreadState_New(interp);
     if (tstate == NULL) {
@@ -51,6 +52,7 @@ new_module_thread(PyInterpreterState *interp)
 
     *mt = (struct module_thread){
         .tstate = tstate,
+        .daemonic = daemonic,
     };
     return mt;
 }
@@ -1167,13 +1169,18 @@ Return True if daemon threads are allowed in the current interpreter,\n\
 and False otherwise.\n");
 
 static PyObject *
-thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
+thread_PyThread_start_new_thread(PyObject *self,
+                                 PyObject *fargs, PyObject *fkwargs)
 {
+    char *kwlist[] = {"", "", "", "daemonic", NULL};
     PyObject *func, *args, *kwargs = NULL;
-
-    if (!PyArg_UnpackTuple(fargs, "start_new_thread", 2, 3,
-                           &func, &args, &kwargs))
+    int daemonic = 0;
+    if (!PyArg_ParseTupleAndKeywords(fargs, fkwargs,
+                                     "OO|Op:start_new_thread", kwlist,
+                                     &func, &args, &kwargs, &daemonic))
+    {
         return NULL;
+    }
     if (!PyCallable_Check(func)) {
         PyErr_SetString(PyExc_TypeError,
                         "first arg must be callable");
@@ -1202,7 +1209,7 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
         return NULL;
     }
 
-    struct module_thread *mt = new_module_thread(interp);
+    struct module_thread *mt = new_module_thread(interp, daemonic);
     if (mt == NULL) {
         return NULL;
     }
@@ -1227,7 +1234,7 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
 }
 
 PyDoc_STRVAR(start_new_doc,
-"start_new_thread(function, args[, kwargs])\n\
+"start_new_thread(function, args[, kwargs], daemonic=0)\n\
 (start_new() is an obsolete synonym)\n\
 \n\
 Start a new thread and return its identifier.  The thread will call the\n\
@@ -1607,9 +1614,9 @@ Handle uncaught Thread.run() exception.");
 
 static PyMethodDef thread_methods[] = {
     {"start_new_thread",        (PyCFunction)thread_PyThread_start_new_thread,
-     METH_VARARGS, start_new_doc},
+     METH_VARARGS | METH_KEYWORDS, start_new_doc},
     {"start_new",               (PyCFunction)thread_PyThread_start_new_thread,
-     METH_VARARGS, start_new_doc},
+     METH_VARARGS | METH_KEYWORDS, start_new_doc},
     {"daemon_threads_allowed",  (PyCFunction)thread_daemon_threads_allowed,
      METH_NOARGS, daemon_threads_allowed_doc},
     {"allocate_lock",           thread_PyThread_allocate_lock,


### PR DESCRIPTION
This is primarily cleanup in preparation for the fix for gh-104341.  However, in the process I found and fixed the following:

* `PyThreadState_Delete() wasn't called at the bottom of `thread_PyThread_start_new_thread()`
* the thread count (`PyInterpreterState.threads.count`) wasn't getting reset after fork
* the `PyInterpreterState.threads.count` field was effectively leaking the state of the threading module out into the broader runtime
* in `thread_run()`, the bootstate variable wasn't freed if its a daemon thread that exits early (due to interp finalizing)

other observations:
* unlike with bootstate, there isn't much we can do about leaking the func/args/kwargs objects in the similar case
* in threading._after_fork(), we update `thread._ident` but don't update `thread._native_id`