### PR TITLE
GH-103545: Add macOS specific constants for ``os.setpriority`` to ``os``

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -493,6 +493,17 @@ process and user.
    .. versionadded:: 3.3
 
 
+.. data:: PRIO_DARWIN_THREAD
+          PRIO_DARWIN_PROCESS
+          PRIO_DARWIN_BG
+          PRIO_DARWIN_NONUI
+
+   Parameters for the :func:`getpriority` and :func:`setpriority` functions.
+
+   .. availability:: macOS
+
+   .. versionadded:: 3.12
+
 .. function:: getresuid()
 
    Return a tuple (ruid, euid, suid) denoting the current process's

--- a/Misc/NEWS.d/next/macOS/2023-05-18-08-52-04.gh-issue-103545.pi5k2N.rst
+++ b/Misc/NEWS.d/next/macOS/2023-05-18-08-52-04.gh-issue-103545.pi5k2N.rst
@@ -1,0 +1,1 @@
+Add ``os.PRIO_DARWIN_THREAD``, ``os.PRIO_DARWIN_PROCESS``, ``os.PRIO_DARWIN_BG`` and ``os.PRIO_DARWIN_NONUI``. These can be used with ``os.setpriority`` to run the process at a lower priority and make use of the efficiency cores on Apple Silicon systems.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -15917,6 +15917,18 @@ all_ins(PyObject *m)
 #ifdef PRIO_USER
     if (PyModule_AddIntMacro(m, PRIO_USER)) return -1;
 #endif
+#ifdef PRIO_DARWIN_THREAD
+    if (PyModule_AddIntMacro(m, PRIO_DARWIN_THREAD)) return -1;
+#endif
+#ifdef PRIO_DARWIN_PROCESS
+    if (PyModule_AddIntMacro(m, PRIO_DARWIN_PROCESS)) return -1;
+#endif
+#ifdef PRIO_DARWIN_BG
+    if (PyModule_AddIntMacro(m, PRIO_DARWIN_BG)) return -1;
+#endif
+#ifdef PRIO_DARWIN_NONUI
+    if (PyModule_AddIntMacro(m, PRIO_DARWIN_NONUI)) return -1;
+#endif
 #ifdef O_CLOEXEC
     if (PyModule_AddIntMacro(m, O_CLOEXEC)) return -1;
 #endif


### PR DESCRIPTION
This adds a number of ``PRIO_DARWIN_*`` constants to the ``os`` module for use with ``os.setpriority``.


<!-- gh-issue-number: gh-103545 -->
* Issue: gh-103545
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104606.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->