### PR TITLE
gh-76327: freeze_support for non-Windows platforms

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -216,13 +216,6 @@ A library which wants to use a particular start method should probably
 use :func:`get_context` to avoid interfering with the choice of the
 library user.
 
-.. warning::
-
-   The ``'spawn'`` and ``'forkserver'`` start methods generally cannot
-   be used with "frozen" executables (i.e., binaries produced by
-   packages like **PyInstaller** and **cx_Freeze**) on POSIX systems.
-   The ``'fork'`` start method may work if code does not use threads.
-
 
 Exchanging objects between processes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1008,7 +1008,7 @@ Miscellaneous
 .. function:: freeze_support()
 
    Add support for when a program which uses :mod:`multiprocessing` has been
-   frozen to produce a Windows executable.  (Has been tested with **py2exe**,
+   frozen to produce an executable.  (Has been tested with **py2exe**,
    **PyInstaller** and **cx_Freeze**.)
 
    One needs to call this function straight after the ``if __name__ ==
@@ -1026,10 +1026,8 @@ Miscellaneous
    If the ``freeze_support()`` line is omitted then trying to run the frozen
    executable will raise :exc:`RuntimeError`.
 
-   Calling ``freeze_support()`` has no effect when invoked on any operating
-   system other than Windows.  In addition, if the module is being run
-   normally by the Python interpreter on Windows (the program has not been
-   frozen), then ``freeze_support()`` has no effect.
+   If the module is being run normally by the Python interpreter (the program
+   has not been frozen), then ``freeze_support()`` has no effect.
 
 .. function:: get_all_start_methods()
 

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -145,7 +145,7 @@ class BaseContext(object):
         '''Check whether this is a fake forked process in a frozen executable.
         If so then run code specified by commandline and exit.
         '''
-        if sys.platform == 'win32' and getattr(sys, 'frozen', False):
+        if getattr(sys, 'frozen', False):
             from .spawn import freeze_support
             freeze_support()
 

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -66,6 +66,16 @@ def freeze_support():
     '''
     Run code for process object if this in not the main process
     '''
+    if (
+        len(sys.argv) >= 2 and sys.argv[-2] == '-c' and sys.argv[-1].startswith((
+            'from multiprocessing.semaphore_tracker import main',  # Py<3.8
+            'from multiprocessing.resource_tracker import main',  # Py>=3.8
+            'from multiprocessing.forkserver import main'
+        )) and set(sys.argv[1:-2]) == set(util._args_from_interpreter_flags())
+    ):
+        exec(sys.argv[-1])
+        sys.exit()
+
     if is_forking(sys.argv):
         kwds = {}
         for arg in sys.argv[2:]:

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -68,8 +68,7 @@ def freeze_support():
     '''
     if (
         len(sys.argv) >= 2 and sys.argv[-2] == '-c' and sys.argv[-1].startswith((
-            'from multiprocessing.semaphore_tracker import main',  # Py<3.8
-            'from multiprocessing.resource_tracker import main',  # Py>=3.8
+            'from multiprocessing.resource_tracker import main',
             'from multiprocessing.forkserver import main'
         )) and set(sys.argv[1:-2]) == set(util._args_from_interpreter_flags())
     ):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-05-18-09-43-02.gh-issue-76327.tHxKwf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-05-18-09-43-02.gh-issue-76327.tHxKwf.rst
@@ -1,0 +1,2 @@
+Fix multiprocessing support for frozen executable on non-Windows platforms.
+Remove outdated warning in document.


### PR DESCRIPTION
# gh-76327: freeze_support for non-Windows platforms

This is a brief fix for the multiprocessing frozen executable infinite loop issue on non-Windows platform. #76327
And the `freeze_support` patch was exactly the same patch from [PyInstaller](https://github.com/pyinstaller/pyinstaller/blob/develop/PyInstaller/hooks/rthooks/pyi_rth_multiprocessing.py#L26), which already worked for them.

This patch does not influence `PyInstaller`.
However, this patch will enable `cx_freeze` or other similar tools to build multiprocessing apps for Linux and Mac.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104607.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->