### PR TITLE
gh-104050: Improve some typing around `default`s and sentinel values

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -29,7 +29,7 @@ import traceback
 
 from collections.abc import Callable
 from types import FunctionType, NoneType
-from typing import Any, NamedTuple, NoReturn, Literal, overload
+from typing import Any, Final, NamedTuple, NoReturn, Literal, overload
 
 # TODO:
 #
@@ -74,6 +74,7 @@ NULL: Final = Sentinels.NULL
 unknown: Final = Sentinels.unknown
 
 NullType = type(Sentinels.NULL)
+
 
 sig_end_marker = '--'
 
@@ -2597,7 +2598,7 @@ class CConverter(metaclass=CConverterAutoRegister):
     # Or the magic value "unknown" if this value is a cannot be evaluated
     # at Argument-Clinic-preprocessing time (but is presumed to be valid
     # at runtime).
-    default: bool | Unspecified = unspecified
+    default: bool | Literal[Sentinels.unspecified] = unspecified
 
     # If not None, default must be isinstance() of this type.
     # (You can also specify a tuple of types.)
@@ -2697,10 +2698,8 @@ class CConverter(metaclass=CConverterAutoRegister):
 
         if default is not unspecified:
             if (self.default_type
-                and not (
-                    isinstance(default, self.default_type)
-                    or default is unknown
-                )
+                and default is not unknown
+                and not isinstance(default, self.default_type)
             ):
                 if isinstance(self.default_type, type):
                     types_str = self.default_type.__name__

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -29,15 +29,7 @@ import traceback
 
 from collections.abc import Callable
 from types import FunctionType, NoneType
-from typing import (
-    Any,
-    Final,
-    Literal,
-    NamedTuple,
-    NoReturn,
-    Type,
-    overload,
-)
+from typing import Any, NamedTuple, NoReturn, Literal, overload
 
 # TODO:
 #

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -12,6 +12,7 @@ import collections
 import contextlib
 import copy
 import cpp
+import enum
 import functools
 import hashlib
 import inspect
@@ -28,7 +29,7 @@ import traceback
 
 from collections.abc import Callable
 from types import FunctionType, NoneType
-from typing import Any, NamedTuple, NoReturn, Literal, overload
+from typing import Any, Final, NamedTuple, NoReturn, Literal, overload
 
 # TODO:
 #
@@ -58,25 +59,19 @@ CLINIC_PREFIXED_ARGS = {
     "return_value",
 }
 
-class Unspecified:
+
+class Sentinels(enum.Enum):
+    unspecified = "unspecified"
+    NULL = "null"
+    unknown = "unknown"
+
     def __repr__(self) -> str:
-        return '<Unspecified>'
-
-unspecified = Unspecified()
+        return f"<{self.value.capitalize()}>"
 
 
-class Null:
-    def __repr__(self) -> str:
-        return '<Null>'
-
-NULL = Null()
-
-
-class Unknown:
-    def __repr__(self) -> str:
-        return '<Unknown>'
-
-unknown = Unknown()
+unspecified: Final = Sentinels.unspecified
+NULL: Final = Sentinels.NULL
+unknown: Final = Sentinels.unknown
 
 sig_end_marker = '--'
 
@@ -2690,7 +2685,7 @@ class CConverter(metaclass=CConverterAutoRegister):
              *,  # Keyword only args:
              c_default: str | None = None,
              py_default: str | None = None,
-             annotation: str | Unspecified = unspecified,
+             annotation: str | Literal[Sentinels.unspecified] = unspecified,
              unused: bool = False,
              **kwargs
     ):


### PR DESCRIPTION
- Convert `unspecified` and `unknown` to be members of a `Sentinels` enum, rather than instances of bespoke classes.
  - An enum feels more idiomatic here, and works better with type checkers.
  - Convert some `==` and `!=` checks for these values to identity checks, which are more idiomatic with sentinels.
  - _Don't_ do the same for `Null`, as this needs to be a distinct type due to its usage in `clinic.py`.
- Use `object` as the annotation for `default` across `clinic.py`. `default` can be literally any object, so `object` is the correct annotation here.

<!-- gh-issue-number: gh-104050 -->
* Issue: gh-104050
<!-- /gh-issue-number -->
