### PR TITLE
gh-104146: Remove unused vars from Argument Clinic

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4230,10 +4230,8 @@ class DSLParser:
 
     def directive_class(self, name, typedef, type_object):
         fields = name.split('.')
-        in_classes = False
         parent = self
         name = fields.pop()
-        so_far = []
         module, cls = self.clinic._module_and_class(fields)
 
         parent = cls or module


### PR DESCRIPTION
Remove 'in_classes' and 'so_far' from DSLParser.directive_module()


<!-- gh-issue-number: gh-104146 -->
* Issue: gh-104146
<!-- /gh-issue-number -->
