### PR TITLE
gh-104619: never leak comprehension locals to outer locals()

### DIFF
--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -516,6 +516,19 @@ class ListComprehensionTest(unittest.TestCase):
         """
         self._check_in_scopes(code, {"a": [1]}, scopes=["function"])
 
+    def test_no_leakage_to_locals(self):
+        code = """
+            def b():
+                [a for b in [1] for _ in []]
+                return b, locals()
+            r, s = b()
+            x = r is b
+            y = list(s.keys())
+        """
+        self._check_in_scopes(code, {"x": True, "y": []}, scopes=["module"])
+        self._check_in_scopes(code, {"x": True, "y": ["b"]}, scopes=["function"])
+        self._check_in_scopes(code, raises=NameError, scopes=["class"])
+
 
 __test__ = {'doctests' : doctests}
 

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5490,30 +5490,28 @@ push_inlined_comprehension_state(struct compiler *c, location loc,
                 }
                 Py_DECREF(outv);
             }
-            if (outsc == LOCAL || outsc == CELL || outsc == FREE) {
-                // local names bound in comprehension must be isolated from
-                // outer scope; push existing value (which may be NULL if
-                // not defined) on stack
+            // local names bound in comprehension must be isolated from
+            // outer scope; push existing value (which may be NULL if
+            // not defined) on stack
+            if (state->pushed_locals == NULL) {
+                state->pushed_locals = PyList_New(0);
                 if (state->pushed_locals == NULL) {
-                    state->pushed_locals = PyList_New(0);
-                    if (state->pushed_locals == NULL) {
-                        return ERROR;
-                    }
-                }
-                // in the case of a cell, this will actually push the cell
-                // itself to the stack, then we'll create a new one for the
-                // comprehension and restore the original one after
-                ADDOP_NAME(c, loc, LOAD_FAST_AND_CLEAR, k, varnames);
-                if (scope == CELL) {
-                    if (outsc == FREE) {
-                        ADDOP_NAME(c, loc, MAKE_CELL, k, freevars);
-                    } else {
-                        ADDOP_NAME(c, loc, MAKE_CELL, k, cellvars);
-                    }
-                }
-                if (PyList_Append(state->pushed_locals, k) < 0) {
                     return ERROR;
                 }
+            }
+            // in the case of a cell, this will actually push the cell
+            // itself to the stack, then we'll create a new one for the
+            // comprehension and restore the original one after
+            ADDOP_NAME(c, loc, LOAD_FAST_AND_CLEAR, k, varnames);
+            if (scope == CELL) {
+                if (outsc == FREE) {
+                    ADDOP_NAME(c, loc, MAKE_CELL, k, freevars);
+                } else {
+                    ADDOP_NAME(c, loc, MAKE_CELL, k, cellvars);
+                }
+            }
+            if (PyList_Append(state->pushed_locals, k) < 0) {
+                return ERROR;
             }
         }
     }


### PR DESCRIPTION
The initial implementation of PEP 709 didn't bother to clear comprehension locals after an inlined comprehension, if the name was a global outside the comprehension. This was purely an optimization to save a couple extra instructions in this case; it didn't seem necessary to clear the comprehension value, since outer references to the name would use `LOAD_GLOBAL` anyway and not see the value in fastlocals.

But it is necessary to clear the comprehension local even in this case, because otherwise it will still show up in `locals()`, or in debugger usage, outside of the comprehension.

<!-- gh-issue-number: gh-104619 -->
* Issue: gh-104619
<!-- /gh-issue-number -->
