### PR TITLE
gh-104602: Add additional test for listcomp with lambda

### DIFF
--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -510,6 +510,16 @@ class ListComprehensionTest(unittest.TestCase):
         """
         self._check_in_scopes(code, {"z": 1, "out": [(3, 2, 1)]})
 
+    def test_lambda_in_iter(self):
+        code = """
+            (func, c), = [(a, b) for b in [1] for a in [lambda : a]]
+            d = func()
+            assert d is func
+            # must use "a" in this scope
+            e = a if False else None
+        """
+        self._check_in_scopes(code, {"c": 1, "e": None})
+
     def test_assign_to_comp_iter_var_in_outer_function(self):
         code = """
             a = [1 for a in [0]]


### PR DESCRIPTION
This threw a SystemError before #104603. Adding a separate test
because this was a different failure mode than the other two new
tests from #104603, both of which used to segfault.


<!-- gh-issue-number: gh-104602 -->
* Issue: gh-104602
<!-- /gh-issue-number -->
