### PR TITLE
gh-104683: Argument clinic: use `dict` over `OrderedDict`

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2060,8 +2060,8 @@ impl_definition block
         self.printer = printer or BlockPrinter(language)
         self.verify = verify
         self.filename = filename
-        self.modules = collections.OrderedDict()
-        self.classes = collections.OrderedDict()
+        self.modules = {}
+        self.classes = {}
         self.functions = []
 
         self.line_prefix = self.line_suffix = ''
@@ -2074,18 +2074,18 @@ impl_definition block
             self.add_destination("file", "file", "{dirname}/clinic/{basename}.h")
 
         d = self.get_destination_buffer
-        self.destination_buffers = collections.OrderedDict((
-            ('cpp_if', d('file')),
-            ('docstring_prototype', d('suppress')),
-            ('docstring_definition', d('file')),
-            ('methoddef_define', d('file')),
-            ('impl_prototype', d('file')),
-            ('parser_prototype', d('suppress')),
-            ('parser_definition', d('file')),
-            ('cpp_endif', d('file')),
-            ('methoddef_ifndef', d('file', 1)),
-            ('impl_definition', d('block')),
-        ))
+        self.destination_buffers = {
+            'cpp_if': d('file'),
+            'docstring_prototype': d('suppress'),
+            'docstring_definition': d('file'),
+            'methoddef_define': d('file'),
+            'impl_prototype': d('file'),
+            'parser_prototype': d('suppress'),
+            'parser_definition': d('file'),
+            'cpp_endif': d('file'),
+            'methoddef_ifndef': d('file', 1),
+            'impl_definition': d('block'),
+        }
 
         self.destination_buffers_stack = []
         self.ifndef_symbols = set()
@@ -2098,7 +2098,7 @@ impl_definition block
                 continue
             name, value, *options = line.split()
             if name == 'preset':
-                self.presets[value] = preset = collections.OrderedDict()
+                self.presets[value] = preset = {}
                 continue
 
             if len(options):
@@ -2301,8 +2301,8 @@ class Module:
         self.name = name
         self.module = self.parent = module
 
-        self.modules: ModuleDict = collections.OrderedDict()
-        self.classes: ClassDict = collections.OrderedDict()
+        self.modules: ModuleDict = {}
+        self.classes: ClassDict = {}
         self.functions: list[Function] = []
 
     def __repr__(self) -> str:
@@ -2327,7 +2327,7 @@ class Class:
         self.type_object = type_object
         self.parent = cls or module
 
-        self.classes: ClassDict = collections.OrderedDict()
+        self.classes: ClassDict = {}
         self.functions: list[Function] = []
 
     def __repr__(self) -> str:
@@ -2428,7 +2428,7 @@ class Function:
                  return_converter, return_annotation=inspect.Signature.empty,
                  docstring=None, kind=CALLABLE, coexist=False,
                  docstring_only=False):
-        self.parameters = parameters or collections.OrderedDict()
+        self.parameters = parameters or {}
         self.return_annotation = return_annotation
         self.name = name
         self.full_name = full_name
@@ -2489,12 +2489,10 @@ class Function:
             }
         kwargs.update(overrides)
         f = Function(**kwargs)
-
-        parameters = collections.OrderedDict()
-        for name, value in f.parameters.items():
-            value = value.copy(function=f)
-            parameters[name] = value
-        f.parameters = parameters
+        f.parameters = {
+            name: value.copy(function=f)
+            for name, value in f.parameters.items()
+        }
         return f
 
 


### PR DESCRIPTION
Instances of `builtins.dict` have been ordered since 3.6, and have been guaranteed by the language to be ordered since Python 3.7. Since Argument Clinic requires Python 3.10+, we can replace usages of `OrderedDict` with `dict`. This is less verbose, more readable, and might be slightly more performant. (`OrderedDict`s have a few features that `dict`s don't have, but we don't use any of those features in Argument Clinic.)

<!-- gh-issue-number: gh-104683 -->
* Issue: gh-104683
<!-- /gh-issue-number -->
