### PR TITLE
gh-104050: Argument clinic: Add annotations to the `LandMine` class

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2560,6 +2560,9 @@ class LandMine:
     def __repr__(self) -> str:
         return '<LandMine ' + repr(self.__message__) + ">"
 
+    # Type checkers wouldn't check attribute access on instances of this class properly
+    # if they saw it had a __getattribute__ method,
+    # so pretend to type checkers that the __getattribute__ method doesn't exist
     if not TYPE_CHECKING:
         def __getattribute__(self, name):
             if name in ('__repr__', '__message__'):

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -29,7 +29,7 @@ import traceback
 
 from collections.abc import Callable
 from types import FunctionType, NoneType
-from typing import Any, Final, NamedTuple, NoReturn, Literal, overload
+from typing import TYPE_CHECKING, Any, Final, NamedTuple, NoReturn, Literal, overload
 
 # TODO:
 #
@@ -2554,17 +2554,21 @@ class Parameter:
 
 class LandMine:
     # try to access any
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         self.__message__ = message
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<LandMine ' + repr(self.__message__) + ">"
 
-    def __getattribute__(self, name):
-        if name in ('__repr__', '__message__'):
-            return super().__getattribute__(name)
-        # raise RuntimeError(repr(name))
-        fail("Stepped on a land mine, trying to access attribute " + repr(name) + ":\n" + self.__message__)
+    if not TYPE_CHECKING:
+        def __getattribute__(self, name):
+            if name in ('__repr__', '__message__'):
+                return super().__getattribute__(name)
+            # raise RuntimeError(repr(name))
+            fail(
+                f"Stepped on a land mine, trying to access attribute "
+                f"{name!r}:\n{self.__message__}"
+            )
 
 
 def add_c_converter(f, name=None):


### PR DESCRIPTION
When type checkers see that a class has a `__getattr__` or `__getattribute__` method, they'll assume that there are things going on with that class that are too magical for them to understand. As such, they will refrain from emitting any errors relating to setting or retrieving attributes from instances of that class. That's basically the opposite of what we want here (there'll be a runtime exception from _any_ attribute access on an instance of `LandMine`). As such, it's much better to pretend to the type checkers that the `__getattribute__` method doesn't exist.

<!-- gh-issue-number: gh-104050 -->
* Issue: gh-104050
<!-- /gh-issue-number -->
