### PR TITLE
Improve readability of `typing._ProtocolMeta.__instancecheck__`

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1801,9 +1801,11 @@ class _ProtocolMeta(ABCMeta):
     def __instancecheck__(cls, instance):
         # We need this method for situations where attributes are
         # assigned in __init__.
-        is_protocol_cls = getattr(cls, "_is_protocol", False)
+        if not getattr(cls, "_is_protocol", False):
+            # i.e., it's a concrete subclass of a protocol
+            return super().__instancecheck__(instance)
+
         if (
-            is_protocol_cls and
             not getattr(cls, '_is_runtime_protocol', False) and
             not _allow_reckless_class_checks(depth=2)
         ):
@@ -1813,17 +1815,16 @@ class _ProtocolMeta(ABCMeta):
         if super().__instancecheck__(instance):
             return True
 
-        if is_protocol_cls:
-            getattr_static = _lazy_load_getattr_static()
-            for attr in cls.__protocol_attrs__:
-                try:
-                    val = getattr_static(instance, attr)
-                except AttributeError:
-                    break
-                if val is None and callable(getattr(cls, attr, None)):
-                    break
-            else:
-                return True
+        getattr_static = _lazy_load_getattr_static()
+        for attr in cls.__protocol_attrs__:
+            try:
+                val = getattr_static(instance, attr)
+            except AttributeError:
+                break
+            if val is None and callable(getattr(cls, attr, None)):
+                break
+        else:
+            return True
 
         return False
 


### PR DESCRIPTION
This doesn't change behaviour at all. It _might_ improve performance slightly for `isinstance()` checks against concrete subclasses of protocols, but the difference wasn't that significant. This is mainly just a cleanup to improve readability, and make the code more maintainable.