### PR TITLE
docs: fix wrong indentation causing rendering error in dis page

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -622,8 +622,8 @@ not have to be) the original ``STACK[-2]``.
 
    .. versionadded:: 3.8
 
-    .. versionchanged:: 3.11
-       Exception representation on the stack now consist of one, not three, items.
+   .. versionchanged:: 3.11
+      Exception representation on the stack now consist of one, not three, items.
 
 
 .. opcode:: CLEANUP_THROW


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Before:（`:`）

<img width="845" alt="image" src="https://github.com/python/cpython/assets/38436475/159ac932-6f87-4761-8824-42532043d8b7">

https://docs.python.org/3.12/library/dis.html#opcode-END_ASYNC_FOR

After:（`.`）

<img width="833" alt="image" src="https://github.com/python/cpython/assets/38436475/2970451d-05ae-4dae-bcff-62701080864b">

<https://cpython-previews--104661.org.readthedocs.build/en/104661/library/dis.html#opcode-END_ASYNC_FOR>


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104661.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->