### PR TITLE
gh-104472: Skip `test_subprocess.ProcessTestCase.test_empty_env` if ASAN is enabled

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import mock
 from test import support
+from test.support import check_sanitizer
 from test.support import import_helper
 from test.support import os_helper
 from test.support import warnings_helper
@@ -790,6 +791,8 @@ class ProcessTestCase(BaseTestCase):
     @unittest.skipIf(sysconfig.get_config_var('Py_ENABLE_SHARED') == 1,
                      'The Python shared library cannot be loaded '
                      'with an empty environment.')
+    @unittest.skipIf(check_sanitizer(address=True),
+                     'AddressSanitizer cannot be runned with empty env')
     def test_empty_env(self):
         """Verify that env={} is as empty as possible."""
 

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -792,7 +792,7 @@ class ProcessTestCase(BaseTestCase):
                      'The Python shared library cannot be loaded '
                      'with an empty environment.')
     @unittest.skipIf(check_sanitizer(address=True),
-                     'AddressSanitizer cannot be runned with empty env')
+                     'AddressSanitizer adds to the environment.')
     def test_empty_env(self):
         """Verify that env={} is as empty as possible."""
 


### PR DESCRIPTION
Fixes #104472

<!-- gh-issue-number: gh-104472 -->
* Issue: gh-104472
<!-- /gh-issue-number -->
