### PR TITLE
gh-104341: Wait Completely at threading._shutdown()

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -211,7 +211,7 @@ struct _ts {
      * weakref-to-lock (on_delete_data) argument, and release_sentinel releases
      * the indirectly held lock.
      */
-    void (*on_delete)(void *);
+    int (*on_delete)(void *);
     void *on_delete_data;
 
     int coroutine_origin_tracking_depth;

--- a/Include/internal/pycore_ceval_state.h
+++ b/Include/internal/pycore_ceval_state.h
@@ -71,7 +71,7 @@ struct _pending_calls {
        thread state.
        Guarded by the GIL. */
     int async_exc;
-#define NPENDINGCALLS 32
+#define NPENDINGCALLS 100
     struct {
         int (*func)(void *);
         void *arg;

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1307,7 +1307,7 @@ yet finished.\n\
 This function is meant for internal and specialized purposes only.\n\
 In most applications `threading.enumerate()` should be used instead.");
 
-static void
+static int
 release_sentinel(void *wr_raw)
 {
     PyObject *wr = _PyObject_CAST(wr_raw);
@@ -1326,6 +1326,7 @@ release_sentinel(void *wr_raw)
     /* Deallocating a weakref with a NULL callback only calls
        PyObject_GC_Del(), which can't call any Python code. */
     Py_DECREF(wr);
+    return 0;
 }
 
 static PyObject *

--- a/Tools/c-analyzer/c_analyzer/analyze.py
+++ b/Tools/c-analyzer/c_analyzer/analyze.py
@@ -174,7 +174,14 @@ def find_typedecl(decl, typespec, typespecs):
             # If the decl is in a source file then we expect the
             # type to be in the same file or in a header file.
             continue
-        candidates.append(typedecl)
+        for c in candidates:
+            if c.name == typedecl.name and c.data == typedecl.data:
+                # The type was duplicated in another file.
+                assert c.parent == typedecl.parent
+                break
+        else:
+            candidates.append(typedecl)
+
     if not candidates:
         return None
     elif len(candidates) == 1:


### PR DESCRIPTION
(This should solve the semi-frequent buildbot failures we've been seeing.)

In `Py_EndInterpreter()` we almost immediately wait for all non-daemon Python threads to finish, by calling `theading._shutdown()`.  However, with a per-interpreter GIL there's a race because `threading._shutdown()` doesn't wait long enough.  This change fixes that by making sure `_PyThreadState_DeleteCurrent()` *completely* finishes before releasing the lock on which `threading._shutdown()` depends.

The gist of it is that we release that lock (and clean it up) later than we would normally be able to, by doing the cleanup in another thread via a "pending" call.

This isn't an ideal solution, but other approaches I tried involved more invasive changes, which I'd like to avoid this close to the beta 1 release.

<!-- gh-issue-number: gh-104341 -->
* Issue: gh-104341
<!-- /gh-issue-number -->
