### PR TITLE
gh-74690: Make a typing test more resilient

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3154,10 +3154,10 @@ class ProtocolTests(BaseTestCase):
 
         class NonPR(PR): pass
 
-        class C:
+        class C(metaclass=abc.ABCMeta):
             x = 1
 
-        class D:
+        class D(metaclass=abc.ABCMeta):
             def meth(self): pass
 
         self.assertNotIsInstance(C(), NonP)
@@ -3174,8 +3174,7 @@ class ProtocolTests(BaseTestCase):
 
         acceptable_extra_attrs = {
             '_is_protocol', '_is_runtime_protocol', '__parameters__',
-            '__subclasshook__', '__abstractmethods__', '_abc_impl',
-            '__init__', '__annotations__',
+            '__init__', '__annotations__', '__subclasshook__',
         }
         self.assertLessEqual(vars(NonP).keys(), vars(C).keys() | acceptable_extra_attrs)
         self.assertLessEqual(


### PR DESCRIPTION
While backporting https://github.com/python/cpython/pull/104622 to `typing_extensions` (https://github.com/python/typing_extensions/pull/161), I discovered that one of the tests I added in https://github.com/python/cpython/pull/104622 fails on PyPy due to small differences in PyPy's implementation of `abc.ABCMeta`. Tests in CPython's test suite should generally be implementation-agnostic unless a test is explicitly marked with `@test.support.cpython_only` (or similar), so let's adapt the test so that it works equally well on alternative implementations.

<!-- gh-issue-number: gh-74690 -->
* Issue: gh-74690
<!-- /gh-issue-number -->
