### PR TITLE
gh-104692: Include commoninstall as a prerequisite for bininstall

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1980,7 +1980,7 @@ altbininstall: $(BUILDPYTHON) @FRAMEWORKPYTHONW@
 	fi
 
 .PHONY: bininstall
-bininstall: altbininstall
+bininstall: commoninstall altbininstall
 	if test ! -d $(DESTDIR)$(LIBPC); then \
 		echo "Creating directory $(LIBPC)"; \
 		$(INSTALL) -d -m $(DIRMODE) $(DESTDIR)$(LIBPC); \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1980,6 +1980,10 @@ altbininstall: $(BUILDPYTHON) @FRAMEWORKPYTHONW@
 	fi
 
 .PHONY: bininstall
+# We depend on commoninstall here to make sure the installation is already usable
+# before we possibly overwrite the global 'python3' symlink to avoid causing
+# problems for anything else trying to run 'python3' while we install, particularly
+# if we're installing in parallel with -j.
 bininstall: commoninstall altbininstall
 	if test ! -d $(DESTDIR)$(LIBPC); then \
 		echo "Creating directory $(LIBPC)"; \

--- a/Misc/NEWS.d/next/Build/2023-05-20-23-49-30.gh-issue-104692.s5UIu5.rst
+++ b/Misc/NEWS.d/next/Build/2023-05-20-23-49-30.gh-issue-104692.s5UIu5.rst
@@ -1,0 +1,6 @@
+Include ``commoninstall`` as a prerequisite for ``bininstall``
+
+This ensures that ``commoninstall`` is completed before ``bininstall``
+is started when parallel builds are used (``make -j install``), and so
+the ``python3`` symlink is only installed after all standard library
+modules are installed.


### PR DESCRIPTION
This ensures that `commoninstall` is completed before `bininstall` is started when parallel builds are used (`make -j install`), and so the `python3` symlink is only installed after all standard library modules are installed.

<!-- gh-issue-number: gh-104692 -->
* Issue: gh-104692
<!-- /gh-issue-number -->
