### PR TITLE
gh-104372: Use non-Raw malloc for c_fds_to_keep in _posixsubprocess

### DIFF
--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -1074,7 +1074,7 @@ subprocess_fork_exec_impl(PyObject *module, PyObject *process_args,
 #endif /* HAVE_SETREUID */
     }
 
-    c_fds_to_keep = PyMem_RawMalloc(fds_to_keep_len * sizeof(int));
+    c_fds_to_keep = PyMem_Malloc(fds_to_keep_len * sizeof(int));
     if (c_fds_to_keep == NULL) {
         PyErr_SetString(PyExc_MemoryError, "failed to malloc c_fds_to_keep");
         goto cleanup;
@@ -1157,7 +1157,7 @@ subprocess_fork_exec_impl(PyObject *module, PyObject *process_args,
 
 cleanup:
     if (c_fds_to_keep != NULL) {
-        PyMem_RawFree(c_fds_to_keep);
+        PyMem_Free(c_fds_to_keep);
     }
 
     if (saved_errno != 0) {


### PR DESCRIPTION
As the code could ask for 0 length.

This is a tiny fix to a theoretical issue with PR #104518.

<!-- gh-issue-number: gh-104372 -->
* Issue: gh-104372
<!-- /gh-issue-number -->
