### PR TITLE
gh-49174: document that the effect of calling gc.collect() during a collection is undefined

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -50,6 +50,9 @@ The :mod:`gc` module provides the following functions:
    is run.  Not all items in some free lists may be freed due to the
    particular implementation, in particular :class:`float`.
 
+   The effect of calling ``collect`` while the interpreter is already
+   performing a collection is undefined.
+
 
 .. function:: set_debug(flags)
 

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -50,7 +50,7 @@ The :mod:`gc` module provides the following functions:
    is run.  Not all items in some free lists may be freed due to the
    particular implementation, in particular :class:`float`.
 
-   The effect of calling ``collect`` while the interpreter is already
+   The effect of calling ``gc.collect()`` while the interpreter is already
    performing a collection is undefined.
 
 


### PR DESCRIPTION
Fixes #49174.

As discussed in the issue, currently gc.collect() during a collection is ignored (even if its specifies more generations than the ongoing collection). But I don't think we should enshrine this in the docs, so I propose to say it's undefined.




<!-- gh-issue-number: gh-49174 -->
* Issue: gh-49174
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104699.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->