### PR TITLE
gh-104698: Fix reference leak in mmapmodule.c

### DIFF
--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -249,8 +249,8 @@ do {                                                                    \
 do {                                                                    \
     if (self->data == NULL) {                                           \
     PyErr_SetString(PyExc_ValueError, "mmap closed or invalid");        \
-    PyBuffer_Release(&buffer);                                          \
-    return err;                                                         \
+    PyBuffer_Release(&(buffer));                                        \
+    return (err);                                                       \
     }                                                                   \
 } while (0)
 #endif /* UNIX */

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -231,8 +231,8 @@ do {                                                                    \
 do {                                                                    \
     if (self->map_handle == NULL) {                                     \
     PyErr_SetString(PyExc_ValueError, "mmap closed or invalid");        \
-    PyBuffer_Release(&buffer);                                          \
-    return err;                                                         \
+    PyBuffer_Release(&(buffer));                                        \
+    return (err);                                                       \
     }                                                                   \
 } while (0)
 #endif /* MS_WINDOWS */

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -227,7 +227,7 @@ do {                                                                    \
     return err;                                                         \
     }                                                                   \
 } while (0)
-#define CHECK_VALID_OR_RELEASE(err, buffer)                            \
+#define CHECK_VALID_OR_RELEASE(err, buffer)                             \
 do {                                                                    \
     if (self->map_handle == NULL) {                                     \
     PyErr_SetString(PyExc_ValueError, "mmap closed or invalid");        \
@@ -245,7 +245,7 @@ do {                                                                    \
     return err;                                                         \
     }                                                                   \
 } while (0)
-#define CHECK_VALID_OR_RELEASE(err, buffer)                            \
+#define CHECK_VALID_OR_RELEASE(err, buffer)                             \
 do {                                                                    \
     if (self->data == NULL) {                                           \
     PyErr_SetString(PyExc_ValueError, "mmap closed or invalid");        \

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -227,6 +227,14 @@ do {                                                                    \
     return err;                                                         \
     }                                                                   \
 } while (0)
+#define CHECK_VALID_AND_RELEASE(err, buffer)                            \
+do {                                                                    \
+    if (self->map_handle == NULL) {                                     \
+    PyErr_SetString(PyExc_ValueError, "mmap closed or invalid");        \
+    PyBuffer_Release(&buffer);                                          \
+    return err;                                                         \
+    }                                                                   \
+} while (0)
 #endif /* MS_WINDOWS */
 
 #ifdef UNIX
@@ -234,6 +242,14 @@ do {                                                                    \
 do {                                                                    \
     if (self->data == NULL) {                                           \
     PyErr_SetString(PyExc_ValueError, "mmap closed or invalid");        \
+    return err;                                                         \
+    }                                                                   \
+} while (0)
+#define CHECK_VALID_AND_RELEASE(err, buffer)                            \
+do {                                                                    \
+    if (self->data == NULL) {                                           \
+    PyErr_SetString(PyExc_ValueError, "mmap closed or invalid");        \
+    PyBuffer_Release(&buffer);                                          \
     return err;                                                         \
     }                                                                   \
 } while (0)
@@ -326,7 +342,7 @@ mmap_gfind(mmap_object *self,
             end = self->size;
 
         Py_ssize_t res;
-        CHECK_VALID(NULL);
+        CHECK_VALID_AND_RELEASE(NULL, view);
         if (reverse) {
             res = _PyBytes_ReverseFind(
                 self->data + start, end - start,
@@ -403,7 +419,7 @@ mmap_write_method(mmap_object *self,
         return NULL;
     }
 
-    CHECK_VALID(NULL);
+    CHECK_VALID_AND_RELEASE(NULL, data);
     memcpy(&self->data[self->pos], data.buf, data.len);
     self->pos += data.len;
     PyBuffer_Release(&data);
@@ -1087,7 +1103,7 @@ mmap_ass_subscript(mmap_object *self, PyObject *item, PyObject *value)
             return -1;
         }
 
-        CHECK_VALID(-1);
+        CHECK_VALID_AND_RELEASE(-1, vbuf);
         if (slicelen == 0) {
         }
         else if (step == 1) {

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -227,7 +227,7 @@ do {                                                                    \
     return err;                                                         \
     }                                                                   \
 } while (0)
-#define CHECK_VALID_AND_RELEASE(err, buffer)                            \
+#define CHECK_VALID_OR_RELEASE(err, buffer)                            \
 do {                                                                    \
     if (self->map_handle == NULL) {                                     \
     PyErr_SetString(PyExc_ValueError, "mmap closed or invalid");        \
@@ -245,7 +245,7 @@ do {                                                                    \
     return err;                                                         \
     }                                                                   \
 } while (0)
-#define CHECK_VALID_AND_RELEASE(err, buffer)                            \
+#define CHECK_VALID_OR_RELEASE(err, buffer)                            \
 do {                                                                    \
     if (self->data == NULL) {                                           \
     PyErr_SetString(PyExc_ValueError, "mmap closed or invalid");        \
@@ -342,7 +342,7 @@ mmap_gfind(mmap_object *self,
             end = self->size;
 
         Py_ssize_t res;
-        CHECK_VALID_AND_RELEASE(NULL, view);
+        CHECK_VALID_OR_RELEASE(NULL, view);
         if (reverse) {
             res = _PyBytes_ReverseFind(
                 self->data + start, end - start,
@@ -419,7 +419,7 @@ mmap_write_method(mmap_object *self,
         return NULL;
     }
 
-    CHECK_VALID_AND_RELEASE(NULL, data);
+    CHECK_VALID_OR_RELEASE(NULL, data);
     memcpy(&self->data[self->pos], data.buf, data.len);
     self->pos += data.len;
     PyBuffer_Release(&data);
@@ -1103,7 +1103,7 @@ mmap_ass_subscript(mmap_object *self, PyObject *item, PyObject *value)
             return -1;
         }
 
-        CHECK_VALID_AND_RELEASE(-1, vbuf);
+        CHECK_VALID_OR_RELEASE(-1, vbuf);
         if (slicelen == 0) {
         }
         else if (step == 1) {


### PR DESCRIPTION
Since macro `CHECK_VALID` need to redesigned to solve this error, I decided to write new macro `CHECK_VALID_AND_RELEASE`, which behave the same as `CHECK_VALID`, but also release a buffer. 

<!-- gh-issue-number: gh-104698 -->
* Issue: gh-104698
<!-- /gh-issue-number -->
