### PR TITLE
gh-103606: raise RuntimeError if config file is invalid or empty

### DIFF
--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -88,7 +88,7 @@ in :mod:`logging` itself) and defining handlers which are declared either in
    configuration).
 
    It will raise :exc:`FileNotFoundError` if the file
-   doesn't exist and :exc:`ValueError` if the file is invalid or
+   doesn't exist and :exc:`RuntimeError` if the file is invalid or
    empty.
 
    :param fname: A filename, or a file-like object, or an instance derived
@@ -130,7 +130,7 @@ in :mod:`logging` itself) and defining handlers which are declared either in
     .. versionadded:: 3.10
        The *encoding* parameter is added.
 
-    .. versionadded:: 3.12
+    .. versionchanged:: 3.12
        An exception will be thrown if the provided file
        doesn't exist or is invalid or empty.
 

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -65,7 +65,7 @@ def fileConfig(fname, defaults=None, disable_existing_loggers=True, encoding=Non
         if not os.path.exists(fname):
             raise FileNotFoundError(f"{fname} doesn't exist")
         elif not os.path.getsize(fname):
-            raise ValueError(f'{fname} is an empty file')
+            raise RuntimeError(f'{fname} is an empty file')
 
     if isinstance(fname, configparser.RawConfigParser):
         cp = fname
@@ -78,7 +78,7 @@ def fileConfig(fname, defaults=None, disable_existing_loggers=True, encoding=Non
                 encoding = io.text_encoding(encoding)
                 cp.read(fname, encoding=encoding)
         except configparser.ParsingError as e:
-            raise ValueError(f'{fname} is invalid: {e}')
+            raise RuntimeError(f'{fname} is invalid: {e}')
 
     formatters = _create_formatters(cp)
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1781,12 +1781,12 @@ class ConfigFileTest(BaseTest):
             """
 
         file = io.StringIO(textwrap.dedent(test_config))
-        self.assertRaises(ValueError, logging.config.fileConfig, file)
+        self.assertRaises(RuntimeError, logging.config.fileConfig, file)
 
     def test_exception_if_confg_file_is_empty(self):
         fd, fn = tempfile.mkstemp(prefix='test_empty_', suffix='.ini')
         os.close(fd)
-        self.assertRaises(ValueError, logging.config.fileConfig, fn)
+        self.assertRaises(RuntimeError, logging.config.fileConfig, fn)
         os.remove(fn)
 
     def test_exception_if_config_file_does_not_exist(self):


### PR DESCRIPTION


<!-- gh-issue-number: gh-103606 -->
* Issue: gh-103606
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104701.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->