### PR TITLE
Corrected identifier

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -244,7 +244,7 @@ Operations which work with sequences (some of them with mappings too) include:
 
 .. function:: length_hint(obj, default=0)
 
-   Return an estimated length for the object *o*. First try to return its
+   Return an estimated length for the object *obj*. First try to return its
    actual length, then an estimate using :meth:`object.__length_hint__`, and
    finally return the default value.
 


### PR DESCRIPTION
The `operator.length_hint` method takes an argument `obj`.

The description of this method referred to the argument as simply `o`. This PR edits the description to use `obj`.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104713.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->