### PR TITLE
gh-101282: Revert some M4 style for BOLT configuration

### DIFF
--- a/configure
+++ b/configure
@@ -8398,7 +8398,8 @@ $as_echo "$BOLT_INSTRUMENT_FLAGS" >&6; }
 $as_echo_n "checking BOLT_APPLY_FLAGS... " >&6; }
 if test -z "${BOLT_APPLY_FLAGS}"
 then
-  BOLT_APPLY_FLAGS="-update-debug-sections\
+  BOLT_APPLY_FLAGS="\
+ -update-debug-sections\
  -reorder-blocks=ext-tsp\
  -reorder-functions=hfsort+\
  -split-functions\
@@ -8412,7 +8413,8 @@ then
  -indirect-call-promotion=all\
  -dyno-stats\
  -use-gnu-stack\
- -frame-opt=hot"
+ -frame-opt=hot\
+"
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $BOLT_APPLY_FLAGS" >&5
 $as_echo "$BOLT_APPLY_FLAGS" >&6; }

--- a/configure
+++ b/configure
@@ -8398,9 +8398,7 @@ $as_echo "$BOLT_INSTRUMENT_FLAGS" >&6; }
 $as_echo_n "checking BOLT_APPLY_FLAGS... " >&6; }
 if test -z "${BOLT_APPLY_FLAGS}"
 then
-  BOLT_APPLY_FLAGS=-update-debug-sections -reorder-blocks=ext-tsp -reorder-functions=hfsort+ -split-functions -icf=1 -inline-all -split-eh -reorder-functions-use-hot-size -peepholes=none -jump-tables=aggressive -inline-ap -indirect-call-promotion=all -dyno-stats -use-gnu-stack -frame-opt=hot
-
-
+  BOLT_APPLY_FLAGS="-update-debug-sections -reorder-blocks=ext-tsp -reorder-functions=hfsort+ -split-functions -icf=1 -inline-all -split-eh -reorder-functions-use-hot-size -peepholes=none -jump-tables=aggressive -inline-ap -indirect-call-promotion=all -dyno-stats -use-gnu-stack -frame-opt=hot"
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $BOLT_APPLY_FLAGS" >&5
 $as_echo "$BOLT_APPLY_FLAGS" >&6; }

--- a/configure
+++ b/configure
@@ -8398,7 +8398,21 @@ $as_echo "$BOLT_INSTRUMENT_FLAGS" >&6; }
 $as_echo_n "checking BOLT_APPLY_FLAGS... " >&6; }
 if test -z "${BOLT_APPLY_FLAGS}"
 then
-  BOLT_APPLY_FLAGS="-update-debug-sections -reorder-blocks=ext-tsp -reorder-functions=hfsort+ -split-functions -icf=1 -inline-all -split-eh -reorder-functions-use-hot-size -peepholes=none -jump-tables=aggressive -inline-ap -indirect-call-promotion=all -dyno-stats -use-gnu-stack -frame-opt=hot"
+  BOLT_APPLY_FLAGS="-update-debug-sections\
+ -reorder-blocks=ext-tsp\
+ -reorder-functions=hfsort+\
+ -split-functions\
+ -icf=1\
+ -inline-all\
+ -split-eh\
+ -reorder-functions-use-hot-size\
+ -peepholes=none\
+ -jump-tables=aggressive\
+ -inline-ap\
+ -indirect-call-promotion=all\
+ -dyno-stats\
+ -use-gnu-stack\
+ -frame-opt=hot"
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $BOLT_APPLY_FLAGS" >&5
 $as_echo "$BOLT_APPLY_FLAGS" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -2085,26 +2085,7 @@ AC_ARG_VAR(
 AC_MSG_CHECKING([BOLT_APPLY_FLAGS])
 if test -z "${BOLT_APPLY_FLAGS}"
 then
-  AS_VAR_SET(
-    [BOLT_APPLY_FLAGS],
-    [m4_join([ ],
-      [-update-debug-sections],
-      [-reorder-blocks=ext-tsp],
-      [-reorder-functions=hfsort+],
-      [-split-functions],
-      [-icf=1],
-      [-inline-all],
-      [-split-eh],
-      [-reorder-functions-use-hot-size],
-      [-peepholes=none],
-      [-jump-tables=aggressive],
-      [-inline-ap],
-      [-indirect-call-promotion=all],
-      [-dyno-stats],
-      [-use-gnu-stack],
-      [-frame-opt=hot]
-    )]
-  )
+  BOLT_APPLY_FLAGS="-update-debug-sections -reorder-blocks=ext-tsp -reorder-functions=hfsort+ -split-functions -icf=1 -inline-all -split-eh -reorder-functions-use-hot-size -peepholes=none -jump-tables=aggressive -inline-ap -indirect-call-promotion=all -dyno-stats -use-gnu-stack -frame-opt=hot"
 fi
 AC_MSG_RESULT([$BOLT_APPLY_FLAGS])
 

--- a/configure.ac
+++ b/configure.ac
@@ -2085,7 +2085,21 @@ AC_ARG_VAR(
 AC_MSG_CHECKING([BOLT_APPLY_FLAGS])
 if test -z "${BOLT_APPLY_FLAGS}"
 then
-  BOLT_APPLY_FLAGS="-update-debug-sections -reorder-blocks=ext-tsp -reorder-functions=hfsort+ -split-functions -icf=1 -inline-all -split-eh -reorder-functions-use-hot-size -peepholes=none -jump-tables=aggressive -inline-ap -indirect-call-promotion=all -dyno-stats -use-gnu-stack -frame-opt=hot"
+  BOLT_APPLY_FLAGS="-update-debug-sections\
+ -reorder-blocks=ext-tsp\
+ -reorder-functions=hfsort+\
+ -split-functions\
+ -icf=1\
+ -inline-all\
+ -split-eh\
+ -reorder-functions-use-hot-size\
+ -peepholes=none\
+ -jump-tables=aggressive\
+ -inline-ap\
+ -indirect-call-promotion=all\
+ -dyno-stats\
+ -use-gnu-stack\
+ -frame-opt=hot"
 fi
 AC_MSG_RESULT([$BOLT_APPLY_FLAGS])
 

--- a/configure.ac
+++ b/configure.ac
@@ -2085,7 +2085,8 @@ AC_ARG_VAR(
 AC_MSG_CHECKING([BOLT_APPLY_FLAGS])
 if test -z "${BOLT_APPLY_FLAGS}"
 then
-  BOLT_APPLY_FLAGS="-update-debug-sections\
+  BOLT_APPLY_FLAGS="\
+ -update-debug-sections\
  -reorder-blocks=ext-tsp\
  -reorder-functions=hfsort+\
  -split-functions\
@@ -2099,7 +2100,8 @@ then
  -indirect-call-promotion=all\
  -dyno-stats\
  -use-gnu-stack\
- -frame-opt=hot"
+ -frame-opt=hot\
+"
 fi
 AC_MSG_RESULT([$BOLT_APPLY_FLAGS])
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101282 -->
* Issue: gh-101282
<!-- /gh-issue-number -->

Without this revert on macOS:
````
checking for --enable-bolt... no
checking BOLT_INSTRUMENT_FLAGS...
checking BOLT_APPLY_FLAGS... ./configure: line 8401: -reorder-blocks=ext-tsp: command not found

````

With this revert on macOS:
````
checking BOLT_INSTRUMENT_FLAGS...
checking BOLT_APPLY_FLAGS... -update-debug-sections -reorder-blocks=ext-tsp -reorder-functions=hfsort+ -split-functions -icf=1 -inline-all -split-eh -reorder-functions-use-hot-size -peepholes=none -jump-tables=aggressive -inline-ap -indirect-call-promotion=all -dyno-stats -use-gnu-stack -frame-opt=hot

````