### PR TITLE
Fix the stable ABI correctness check post 3.13 version bump

### DIFF
--- a/Misc/stable_abi.toml
+++ b/Misc/stable_abi.toml
@@ -2406,3 +2406,8 @@
     added = '3.12'
 [const.Py_TPFLAGS_ITEMS_AT_END]
     added = '3.12'
+
+[function._Py_IncRefTotal_DO_NOT_USE_THIS]
+    added = '3.13'
+[function._Py_DecRefTotal_DO_NOT_USE_THIS]
+    added = '3.13'


### PR DESCRIPTION
Add _Py_IncRefTotal_DO_NOT_USE_THIS and _Py_DecRefTotal_DO_NOT_USE_THIS, two symbols defined conditionally on Py_LIMITED_API > 0x030C0000 (3.12), to Misc/stable_abi.toml.

