### PR TITLE
gh-104497: Make tkinter test pass with tk 8.7

### DIFF
--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -1402,10 +1402,8 @@ class MenuTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_configure_type(self):
         widget = self.create()
-        r = tkinter.Tk()
-        tkver = r.getvar('tk_version')
-        r.destroy()
-        opts = ('normal, tearoff, or menubar' if tkver < '8.7' else
+        opts = ('normal, tearoff, or menubar'
+                if widget.info_patchlevel() < (8, 7) else
                 'menubar, normal, or tearoff')
         self.checkEnumParam(
             widget, 'type',

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -1402,10 +1402,15 @@ class MenuTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_configure_type(self):
         widget = self.create()
+        r = tkinter.Tk()
+        tkver = r.getvar('tk_version')
+        r.destroy()
+        opts = ('normal, tearoff, or menubar' if tkver < '8.7' else
+                'menubar, normal, or tearoff')
         self.checkEnumParam(
             widget, 'type',
             'normal', 'tearoff', 'menubar',
-            errmsg='bad type "{}": must be normal, tearoff, or menubar',
+            errmsg='bad type "{}": must be ' + opts,
             )
 
     def test_entryconfigure(self):


### PR DESCRIPTION
For test_widgets.MenuTest.test_configure_type, the options in the error message change to alphabetical order.


<!-- gh-issue-number: gh-104497 -->
* Issue: gh-104497
<!-- /gh-issue-number -->
