### PR TITLE
CI: Cache config.cache across runs to speed up build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: config.cache
-          key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
+          key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac', '.github/workflows/build.yml') }}
       - uses: actions/setup-python@v3
       - name: Install Dependencies
         run: sudo ./.github/workflows/posix-deps-apt.sh
@@ -187,7 +187,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: config.cache
-        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac', '.github/workflows/build.yml') }}
     - name: Install Homebrew dependencies
       run: brew install pkg-config openssl@1.1 xz gdbm tcl-tk
     - name: Configure CPython
@@ -253,7 +253,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ env.CPYTHON_BUILDDIR }}/config.cache
-        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac', '.github/workflows/build.yml') }}
     - name: Configure CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: |
@@ -295,7 +295,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: config.cache
-        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac', '.github/workflows/build.yml') }}
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
     - name: Install Dependencies
@@ -374,7 +374,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ env.CPYTHON_BUILDDIR }}/config.cache
-        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac', '.github/workflows/build.yml') }}
     - name: Configure CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: |
@@ -453,7 +453,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: config.cache
-        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac', '.github/workflows/build.yml') }}
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
     - name: Install Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: config.cache
-          key: ${{ github.job }}-${{ hashFiles('configure', 'configure.ac') }}
+          key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
       - uses: actions/setup-python@v3
       - name: Install Dependencies
         run: sudo ./.github/workflows/posix-deps-apt.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: config.cache
-          key: ${{ github.job }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
+          key: ${{ github.job }}-${{ hashFiles('configure', 'configure.ac') }}
       - uses: actions/setup-python@v3
       - name: Install Dependencies
         run: sudo ./.github/workflows/posix-deps-apt.sh
@@ -187,7 +187,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: config.cache
-        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
     - name: Install Homebrew dependencies
       run: brew install pkg-config openssl@1.1 xz gdbm tcl-tk
     - name: Configure CPython
@@ -253,7 +253,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ env.CPYTHON_BUILDDIR }}/config.cache
-        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
     - name: Configure CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: |
@@ -295,7 +295,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: config.cache
-        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
     - name: Install Dependencies
@@ -374,7 +374,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ env.CPYTHON_BUILDDIR }}/config.cache
-        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
     - name: Configure CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: |
@@ -453,7 +453,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: config.cache
-        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure', 'configure.ac') }}
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
     - name: Install Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,11 @@ jobs:
     if: needs.check_source.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
+      - name: Restore config.cache
+        uses: actions/cache@v3
+        with:
+          path: config.cache
+          key: ${{ github.job }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
       - uses: actions/setup-python@v3
       - name: Install Dependencies
         run: sudo ./.github/workflows/posix-deps-apt.sh
@@ -97,7 +102,7 @@ jobs:
       - name: Configure CPython
         run: |
           # Build Python with the libpython dynamic library
-          ./configure --with-pydebug --enable-shared
+          ./configure --config-cache --with-pydebug --enable-shared
       - name: Regenerate autoconf files with container image
         run: make regen-configure
       - name: Build CPython
@@ -178,6 +183,11 @@ jobs:
       PYTHONSTRICTEXTENSIONBUILD: 1
     steps:
     - uses: actions/checkout@v3
+    - name: Restore config.cache
+      uses: actions/cache@v3
+      with:
+        path: config.cache
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
     - name: Install Homebrew dependencies
       run: brew install pkg-config openssl@1.1 xz gdbm tcl-tk
     - name: Configure CPython
@@ -186,6 +196,7 @@ jobs:
         LDFLAGS="-L$(brew --prefix gdbm)/lib -I$(brew --prefix xz)/lib" \
         PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" \
         ./configure \
+          --config-cache \
           --with-pydebug \
           --prefix=/opt/python-dev \
           --with-openssl="$(brew --prefix openssl@1.1)"
@@ -238,9 +249,18 @@ jobs:
       run: mkdir -p $CPYTHON_RO_SRCDIR $CPYTHON_BUILDDIR
     - name: Bind mount sources read-only
       run: sudo mount --bind -o ro $GITHUB_WORKSPACE $CPYTHON_RO_SRCDIR
+    - name: Restore config.cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.CPYTHON_BUILDDIR }}/config.cache
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
     - name: Configure CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
-      run: ../cpython-ro-srcdir/configure --with-pydebug --with-openssl=$OPENSSL_DIR
+      run: |
+        ../cpython-ro-srcdir/configure \
+          --config-cache \
+          --with-pydebug \
+          --with-openssl=$OPENSSL_DIR
     - name: Build CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: make -j4
@@ -271,6 +291,11 @@ jobs:
       LD_LIBRARY_PATH: ${{ github.workspace }}/multissl/openssl/${{ matrix.openssl_ver }}/lib
     steps:
     - uses: actions/checkout@v3
+    - name: Restore config.cache
+      uses: actions/cache@v3
+      with:
+        path: config.cache
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
     - name: Install Dependencies
@@ -295,7 +320,7 @@ jobs:
     - name: Configure ccache action
       uses: hendrikmuhs/ccache-action@v1.2
     - name: Configure CPython
-      run: ./configure --with-pydebug --with-openssl=$OPENSSL_DIR
+      run: ./configure --config-cache --with-pydebug --with-openssl=$OPENSSL_DIR
     - name: Build CPython
       run: make -j4
     - name: Display build info
@@ -304,7 +329,7 @@ jobs:
       run: ./python Lib/test/ssltests.py
 
   test_hypothesis:
-    name: "Hypothesis Tests on Ubuntu"
+    name: "Hypothesis tests on Ubuntu"
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     needs: check_source
@@ -345,9 +370,18 @@ jobs:
       run: mkdir -p $CPYTHON_RO_SRCDIR $CPYTHON_BUILDDIR
     - name: Bind mount sources read-only
       run: sudo mount --bind -o ro $GITHUB_WORKSPACE $CPYTHON_RO_SRCDIR
+    - name: Restore config.cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.CPYTHON_BUILDDIR }}/config.cache
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
     - name: Configure CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
-      run: ../cpython-ro-srcdir/configure --with-pydebug --with-openssl=$OPENSSL_DIR
+      run: |
+        ../cpython-ro-srcdir/configure \
+          --config-cache \
+          --with-pydebug \
+          --with-openssl=$OPENSSL_DIR
     - name: Build CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: make -j4
@@ -415,6 +449,11 @@ jobs:
       ASAN_OPTIONS: detect_leaks=0:allocator_may_return_null=1:handle_segv=0
     steps:
     - uses: actions/checkout@v3
+    - name: Restore config.cache
+      uses: actions/cache@v3
+      with:
+        path: config.cache
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
     - name: Install Dependencies
@@ -443,7 +482,7 @@ jobs:
     - name: Configure ccache action
       uses: hendrikmuhs/ccache-action@v1.2
     - name: Configure CPython
-      run: ./configure --with-address-sanitizer --without-pymalloc
+      run: ./configure --config-cache --with-address-sanitizer --without-pymalloc
     - name: Build CPython
       run: make -j4
     - name: Display build info


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Run `./configure` with the `--config-cache` to create a cache file on Ubuntu and macOS jobs, and use https://github.com/actions/cache to re-use it between runs:

```yml
uses: actions/cache@v3
with:
  path: config.cache
  key: ${{ github.job }}-${{ hashFiles('configure') }}-${{ hashFiles('configure.ac') }}
```

When the key changes, the action will upload a fresh cache file.

So we have a unique cache file per job ID ([`github.job`](https://docs.github.com/en/actions/learn-github-actions/contexts), for example: `build_macos`, `build_ubuntu_ssltests`), and we'll also get a fresh cache file whenever the `configure` or `configure.ac` files change.

Seconds to download cache + configure:

Job | Without cache | With cache | Times faster | Seconds saved
-- | -- | -- | -- | --
check_generated_files | 22 | 4 | 5.5 | 18
build_macos | 96 | 17 | 5.6 | 79
build_ubuntu | 23 | 4 | 5.8 | 19
build_ubuntu_ssltests (1.1.1t) | 24 | 4 | 6.0 | 20
build_ubuntu_ssltests (3.0.8) | 25 | 8 | 3.1 | 17
build_ubuntu_ssltests (3.0.8) | 25 | 7 | 3.6 | 18
test_hypothesis | 24 | 4 | 6.0 | 20
build_asan | 29 | 5 | 5.8 | 24
  |   |   |   |  
Total: | 268 | 53 | 5.1 | 215
  | [link](https://github.com/python/cpython/actions/runs/5058962194/attempts/1) | [link](https://github.com/python/cpython/actions/runs/5058962194)


