### PR TITLE
GH-83863: Drop support for using `pathlib.Path` objects as context managers

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -115,6 +115,9 @@ Removed
   are now removed. The items in those namespaces can be imported directly
   from :mod:`typing`. (Contributed by Sebastian Rittau in :gh:`92871`.)
 
+* Remove support for using :class:`pathlib.Path` objects as context managers.
+  This functionality was deprecated and made a no-op in Python 3.9.
+
 Porting to Python 3.13
 ======================
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1080,25 +1080,6 @@ class Path(PurePath):
             cls = WindowsPath if os.name == 'nt' else PosixPath
         return object.__new__(cls)
 
-    def __enter__(self):
-        # In previous versions of pathlib, __exit__() marked this path as
-        # closed; subsequent attempts to perform I/O would raise an IOError.
-        # This functionality was never documented, and had the effect of
-        # making Path objects mutable, contrary to PEP 428.
-        # In Python 3.9 __exit__() was made a no-op.
-        # In Python 3.11 __enter__() began emitting DeprecationWarning.
-        # In Python 3.13 __enter__() and __exit__() should be removed.
-        warnings.warn("pathlib.Path.__enter__() is deprecated and scheduled "
-                      "for removal in Python 3.13; Path objects as a context "
-                      "manager is a no-op",
-                      DeprecationWarning, stacklevel=2)
-        return self
-
-    def __exit__(self, t, v, tb):
-        pass
-
-    # Public API
-
     @classmethod
     def cwd(cls):
         """Return a new path pointing to the current working directory."""

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2080,26 +2080,6 @@ class _BasePathTest(object):
         finally:
             os.chdir(old_cwd)
 
-    def test_with(self):
-        p = self.cls(BASE)
-        it = p.iterdir()
-        it2 = p.iterdir()
-        next(it2)
-        # bpo-46556: path context managers are deprecated in Python 3.11.
-        with self.assertWarns(DeprecationWarning):
-            with p:
-                pass
-        # Using a path as a context manager is a no-op, thus the following
-        # operations should still succeed after the context manage exits.
-        next(it)
-        next(it2)
-        p.exists()
-        p.resolve()
-        p.absolute()
-        with self.assertWarns(DeprecationWarning):
-            with p:
-                pass
-
     @os_helper.skip_unless_working_chmod
     def test_chmod(self):
         p = self.cls(BASE) / 'fileA'

--- a/Misc/NEWS.d/next/Library/2023-05-23-19-53-18.gh-issue-83863.eRI5JG.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-23-19-53-18.gh-issue-83863.eRI5JG.rst
@@ -1,0 +1,4 @@
+Support for using :class:`pathlib.Path` objects as context managers has been
+removed. Before Python 3.9, exiting the context manager marked a path as
+"closed", which caused some (but not all!) methods to raise when called.
+Since Python 3.9, using a path as a context manager does nothing.


### PR DESCRIPTION
In Python 3.8 and prior, `pathlib.Path.__exit__()` marked a path as closed; some subsequent attempts to perform I/O would raise an IOError. This functionality was never documented, and had the effect of making `Path` objects mutable, contrary to PEP 428. In Python 3.9 we made `__exit__()` a no-op, and in 3.11 `__enter__()` began raising deprecation warnings. Here we remove both methods.

<!-- gh-issue-number: gh-83863 -->
* Issue: gh-83863
<!-- /gh-issue-number -->
