### PR TITLE
gh-103295: fix stack overwrite on 32-bit in perf map test harness

### DIFF
--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -762,19 +762,24 @@ clear_extension(PyObject *self, PyObject *args)
 static PyObject *
 write_perf_map_entry(PyObject *self, PyObject *args)
 {
+    PyObject *code_addr_v;
     const void *code_addr;
     unsigned int code_size;
     const char *entry_name;
 
-    if (!PyArg_ParseTuple(args, "KIs", &code_addr, &code_size, &entry_name))
+    if (!PyArg_ParseTuple(args, "OIs", &code_addr_v, &code_size, &entry_name))
         return NULL;
-
-    int ret = PyUnstable_WritePerfMapEntry(code_addr, code_size, entry_name);
-    if (ret == -1) {
-        PyErr_SetString(PyExc_OSError, "Failed to write performance map entry");
+    code_addr = PyLong_AsVoidPtr(code_addr_v);
+    if (code_addr == NULL) {
         return NULL;
     }
-    return Py_BuildValue("i", ret);
+
+    int ret = PyUnstable_WritePerfMapEntry(code_addr, code_size, entry_name);
+    if (ret < 0) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+    return PyLong_FromLong(ret);
 }
 
 static PyObject *


### PR DESCRIPTION
We can't use `K` format specifier in `PyArg_ParseTuple` to write to a `void *`; it always writes 64 bits, so writes too much on 32-bit systems. Use `O` instead and an explicit call to `PyLong_AsVoidPtr` to get the pointer value.

Also fix the error check so it detects either error code (`-1` or `-2`) and raises a more informative error using `errno`. I verified this error handling by temporarily changing the perf map file path to a nonexistent directory, and the test raised `FileNotFoundError` as expected.

Also simplify the return value to just use `PyLong_FromLong`; we don't need to go through `Py_BuildValue` for such a simple case.


<!-- gh-issue-number: gh-103295 -->
* Issue: gh-103295
<!-- /gh-issue-number -->
