### PR TITLE
gh-104372: use == -1 before PyErr_Occurred

### DIFF
--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -200,7 +200,7 @@ convert_fds_to_keep_to_c(PyObject *py_fds_to_keep, int *c_fds_to_keep)
     for (i = 0; i < len; ++i) {
         PyObject* fdobj = PyTuple_GET_ITEM(py_fds_to_keep, i);
         long fd = PyLong_AsLong(fdobj);
-        if (PyErr_Occurred()) {
+        if (fd == -1 && PyErr_Occurred()) {
             return -1;
         }
         if (fd < 0 || fd > INT_MAX) {


### PR DESCRIPTION
The ideal pattern for this.  (already in the 3.11 backport)

<!-- gh-issue-number: gh-104372 -->
* Issue: gh-104372
<!-- /gh-issue-number -->
