### PR TITLE
gh-104773: Remove OSSAUDIODEV_LIBS variable

### DIFF
--- a/configure
+++ b/configure
@@ -13487,14 +13487,6 @@ LIBS=$save_LIBS
 
 fi
 
-case $ac_sys_system in #(
-  NetBSD*) :
-    OSSAUDIODEV_LIBS="-lossaudio" ;; #(
-  *) :
-    OSSAUDIODEV_LIBS=""
- ;;
-esac
-
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -3916,12 +3916,6 @@ AS_VAR_IF([have_nis], [yes], [
   ])
 ])
 
-dnl On NetBSD, when using OSS audio, you need to link against libossaudio
-AS_CASE([$ac_sys_system],
-  [NetBSD*], [OSSAUDIODEV_LIBS="-lossaudio"],
-  [OSSAUDIODEV_LIBS=""]
-)
-
 dnl detect sqlite3 from Emscripten emport
 PY_CHECK_EMSCRIPTEN_PORT([LIBSQLITE3], [-sUSE_SQLITE3])
 


### PR DESCRIPTION
Update configure script for ossaudiodev removal: remove the OSSAUDIODEV_LIBS variable.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104773 -->
* Issue: gh-104773
<!-- /gh-issue-number -->
