### PR TITLE
[3.12] gh-104825: add omitted idlelib text fix

### DIFF
--- a/Lib/idlelib/idle_test/test_editor.py
+++ b/Lib/idlelib/idle_test/test_editor.py
@@ -201,8 +201,8 @@ class IndentSearcherTest(unittest.TestCase):
         test_info = (# text, (block, indent))
                      ("", (None, None)),
                      ("[1,", (None, None)),  # TokenError
-                     ("if 1:\n", ('if 1:\n', None)),
-                     ("if 1:\n  2\n  3\n", ('if 1:\n', '  2\n')),
+                     ("if 1:\n", ('if 1:', None)),
+                     ("if 1:\n  2\n  3\n", ('if 1:', '  2')),
                      )
         for code, expected_pair in test_info:
             with self.subTest(code=code):


### PR DESCRIPTION
Order of events:
Terry automerged new idlelib test into main.
Ms. I. made a 3.12 backport; tests passed.
Pablo merged the tokenize change with idlelib test fix into main. Pablo merged a 3.12 backport without the idle test fix as the backport of the latter had not yet been been merged. Terry merged the idlelib test backport.  The new test failed on at least 4 3.12 buildbots because of the tokenize change. This PR backports the now needed idlelib test fix.

(cherry picked from commit c8cf9b4)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104825 -->
* Issue: gh-104825
<!-- /gh-issue-number -->
