### PR TITLE
[3.11] gh-103207: The macOS 13 Ventura Installer.app permission problem is fixed by Apple in macOS 13.4.

### DIFF
--- a/Mac/BuildScript/resources/Welcome.rtf
+++ b/Mac/BuildScript/resources/Welcome.rtf
@@ -1,4 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2708
+{\rtf1\ansi\ansicpg1252\cocoartf2709
 \cocoascreenfonts1\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\fswiss\fcharset0 Helvetica-Bold;\f2\fmodern\fcharset0 CourierNewPSMT;
 }
 {\colortbl;\red255\green255\blue255;}
@@ -12,8 +12,9 @@
 \f1\b macOS $MACOSX_DEPLOYMENT_TARGET
 \f0\b0 .\
 \
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
-\f1\b Python for macOS
+\f1\b \cf0 Python for macOS
 \f0\b0  consists of the {\field{\*\fldinst{HYPERLINK "https://www.python.org"}}{\fldrslt Python}} programming language interpreter and its batteries-included standard library to allow easy access to macOS features.  It also includes the Python integrated development environment, 
 \f1\b IDLE
 \f0\b0 .  You can also use the included 
@@ -25,10 +26,10 @@ At the end of this install, click on
 \f0  to install a set of current SSL root certificates.\
 \
 
-\f1\b macOS 13 Ventura users
+\f1\b [UPDATE: fixed in macOS 13.4] macOS 13 Ventura users
 \f0\b0 :  Due to an issue with the macOS 
 \f1\b Installer
-\f0\b0  app, installation of some third-party packages including this Python package may fail with a vague 
+\f0\b0  app in macOS 13 Ventura updates prior to macOS 13.4, installation of some third-party packages including this Python package may fail with a vague 
 \f1\b "The installer encountered an error"
 \f0\b0  message if the 
 \f1\b Installer
@@ -44,6 +45,7 @@ At the end of this install, click on
 \f1\b Installer
 \f0\b0  to expand, and enable 
 \f1\b Downloads Folder
-\f0\b0  by moving the toggle to the right. See {\field{\*\fldinst{HYPERLINK "https://github.com/python/cpython/issues/103207"}}{\fldrslt https://github.com/python/cpython/issues/103207}} for up-to-date information on this issue.\
+\f0\b0  by moving the toggle to the right. See {\field{\*\fldinst{HYPERLINK "https://github.com/python/cpython/issues/103207"}}{\fldrslt https://github.com/python/cpython/issues/103207}} for up-to-date information on this issue.  This problem has been resolved in macOS 13.4.\
+\
 \
 }


### PR DESCRIPTION


<!-- gh-issue-number: gh-103207 -->
* Issue: gh-103207
<!-- /gh-issue-number -->
