### PR TITLE
gh-84976: Add back UTC to datetime.__all__

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -6,4 +6,4 @@ except ImportError:
     from _pydatetime import __doc__
 
 __all__ = ("date", "datetime", "time", "timedelta", "timezone", "tzinfo",
-           "MINYEAR", "MAXYEAR")
+           "MINYEAR", "MAXYEAR", "UTC")


### PR DESCRIPTION
This was mistakenly dropped in #103637

Noticed when updating typeshed for Python 3.12

<!-- gh-issue-number: gh-84976 -->
* Issue: gh-84976
<!-- /gh-issue-number -->
