### PR TITLE
gh-104924: Fix `read()able` in `http.client` log messages

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1024,7 +1024,7 @@ class HTTPConnection:
             print("send:", repr(data))
         if hasattr(data, "read") :
             if self.debuglevel > 0:
-                print("sendIng a read()able")
+                print("sendIng a readable")
             encode = self._is_textIO(data)
             if encode and self.debuglevel > 0:
                 print("encoding file using iso-8859-1")
@@ -1054,7 +1054,7 @@ class HTTPConnection:
 
     def _read_readable(self, readable):
         if self.debuglevel > 0:
-            print("sendIng a read()able")
+            print("sendIng a readable")
         encode = self._is_textIO(readable)
         if encode and self.debuglevel > 0:
             print("encoding file using iso-8859-1")

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1024,7 +1024,7 @@ class HTTPConnection:
             print("send:", repr(data))
         if hasattr(data, "read") :
             if self.debuglevel > 0:
-                print("sendIng a readable")
+                print("sending a readable")
             encode = self._is_textIO(data)
             if encode and self.debuglevel > 0:
                 print("encoding file using iso-8859-1")
@@ -1054,7 +1054,7 @@ class HTTPConnection:
 
     def _read_readable(self, readable):
         if self.debuglevel > 0:
-            print("sendIng a readable")
+            print("reading a readable")
         encode = self._is_textIO(readable)
         if encode and self.debuglevel > 0:
             print("encoding file using iso-8859-1")


### PR DESCRIPTION
https://github.com/search?q=repo%3Apython%2Fcpython%20read()able&type=code shows no other occurrence of this typo.

<!-- gh-issue-number: gh-104924 -->
* Issue: gh-104924
<!-- /gh-issue-number -->
