### PR TITLE
Fix indentation in `json.AttrDict` REPL example

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -559,14 +559,14 @@ Exceptions
 
    .. doctest::
 
-        >>> json_string = '{"mercury": 88, "venus": 225, "earth": 365, "mars": 687}'
-        >>> orbital_period = json.loads(json_string, object_hook=AttrDict)
-        >>> orbital_period['earth']     # Dict style lookup
-        365
-        >>> orbital_period.earth        # Attribute style lookup
-        365
-        >>> orbital_period.keys()       # All dict methods are present
-        dict_keys(['mercury', 'venus', 'earth', 'mars'])
+       >>> json_string = '{"mercury": 88, "venus": 225, "earth": 365, "mars": 687}'
+       >>> orbital_period = json.loads(json_string, object_hook=AttrDict)
+       >>> orbital_period['earth']     # Dict style lookup
+       365
+       >>> orbital_period.earth        # Attribute style lookup
+       365
+       >>> orbital_period.keys()       # All dict methods are present
+       dict_keys(['mercury', 'venus', 'earth', 'mars'])
 
    Attribute style access only works for keys that are valid attribute
    names.  In contrast, dictionary style access works for all keys.  For


### PR DESCRIPTION
This is causing the docs to be rendered incorrectly.

https://docs.python.org/3.12/library/json.html#json.AttrDict

<details>
<summary>Screenshot of current rendering</summary>

![image](https://github.com/python/cpython/assets/66076021/a8525837-7d9f-4300-8dff-03bf6cb1fbc7)

</details>


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104930.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->