### PR TITLE
GH-104947: Make pathlib.PureWindowsPath comparisons consistent across platforms

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -421,7 +421,10 @@ class PurePath(os.PathLike):
         try:
             return self._str_normcase_cached
         except AttributeError:
-            self._str_normcase_cached = self._flavour.normcase(str(self))
+            if _is_case_sensitive(self._flavour):
+                self._str_normcase_cached = str(self)
+            else:
+                self._str_normcase_cached = str(self).lower()
             return self._str_normcase_cached
 
     @property

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -904,6 +904,7 @@ class PureWindowsPathTest(_BasePurePathTest, unittest.TestCase):
         self.assertEqual(P('a/B'), P('A/b'))
         self.assertEqual(P('C:a/B'), P('c:A/b'))
         self.assertEqual(P('//Some/SHARE/a/B'), P('//somE/share/A/b'))
+        self.assertEqual(P('\u0130'), P('i\u0307'))
 
     def test_as_uri(self):
         P = self.cls

--- a/Misc/NEWS.d/next/Library/2023-05-25-22-54-20.gh-issue-104947.hi6TUr.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-25-22-54-20.gh-issue-104947.hi6TUr.rst
@@ -1,2 +1,2 @@
 Make comparisons between :class:`pathlib.PureWindowsPath` objects consistent
-across Windows and Posix.
+across Windows and Posix to match 3.11 behavior.

--- a/Misc/NEWS.d/next/Library/2023-05-25-22-54-20.gh-issue-104947.hi6TUr.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-25-22-54-20.gh-issue-104947.hi6TUr.rst
@@ -1,0 +1,2 @@
+Make comparisons between :class:`pathlib.PureWindowsPath` objects consistent
+across Windows and Posix.


### PR DESCRIPTION
Use `str.lower()` rather than `ntpath.normcase()` to normalize case of Windows paths. This restores behaviour from Python 3.11.
<!-- gh-issue-number: gh-104947 -->
* Issue: gh-104947
<!-- /gh-issue-number -->
