### PR TITLE
GH-103631: Fix `PurePosixPath(PureWindowsPath(...))` separator handling

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -300,6 +300,9 @@ class PurePath(os.PathLike):
         for arg in args:
             if isinstance(arg, PurePath):
                 path = arg._raw_path
+                if arg._flavour is ntpath and self._flavour is posixpath:
+                    # GH-103631: Convert separators for backwards compatibility.
+                    path = path.replace('\\', '/')
             else:
                 try:
                     path = os.fspath(arg)

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -789,6 +789,12 @@ class PurePosixPathTest(_BasePurePathTest, unittest.TestCase):
         pp = P('//a') / '/c'
         self.assertEqual(pp, P('/c'))
 
+    def test_parse_windows_path(self):
+        P = self.cls
+        p = P('c:', 'a', 'b')
+        pp = P(pathlib.PureWindowsPath('c:\\a\\b'))
+        self.assertEqual(p, pp)
+
 
 class PureWindowsPathTest(_BasePurePathTest, unittest.TestCase):
     cls = pathlib.PureWindowsPath

--- a/Misc/NEWS.d/next/Library/2023-05-25-23-34-54.gh-issue-103631.x5Urye.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-25-23-34-54.gh-issue-103631.x5Urye.rst
@@ -1,0 +1,2 @@
+Fix ``pathlib.PurePosixPath(pathlib.PureWindowsPath(...))`` not converting
+path separators.

--- a/Misc/NEWS.d/next/Library/2023-05-25-23-34-54.gh-issue-103631.x5Urye.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-25-23-34-54.gh-issue-103631.x5Urye.rst
@@ -1,2 +1,2 @@
 Fix ``pathlib.PurePosixPath(pathlib.PureWindowsPath(...))`` not converting
-path separators.
+path separators to restore 3.11 compatible behavior.


### PR DESCRIPTION
For backwards compatibility, accept backslashes as path separators in `PurePosixPath` if an instance of `PureWindowsPath` is supplied. This restores behaviour from Python 3.11.

<!-- gh-issue-number: gh-103631 -->
* Issue: gh-103631
<!-- /gh-issue-number -->
