### PR TITLE
gh-104984: remove kwargs and starargs from Call & ClassDef

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -481,7 +481,7 @@ Expressions
    Comparison operator tokens.
 
 
-.. class:: Call(func, args, keywords, starargs, kwargs)
+.. class:: Call(func, args, keywords)
 
    A function call. ``func`` is the function, which will often be a
    :class:`Name` or :class:`Attribute` object. Of the arguments:
@@ -491,7 +491,7 @@ Expressions
      arguments passed by keyword.
 
    When creating a ``Call`` node, ``args`` and ``keywords`` are required, but
-   they can be empty lists. ``starargs`` and ``kwargs`` are optional.
+   they can be empty lists.
 
    .. doctest::
 
@@ -1820,7 +1820,7 @@ Function and class definitions
             type_ignores=[])
 
 
-.. class:: ClassDef(name, bases, keywords, starargs, kwargs, body, decorator_list)
+.. class:: ClassDef(name, bases, keywords, body, decorator_list)
 
    A class definition.
 
@@ -1829,9 +1829,6 @@ Function and class definitions
    * ``keywords`` is a list of :class:`keyword` nodes, principally for 'metaclass'.
      Other keywords will be passed to the metaclass, as per `PEP-3115
      <https://peps.python.org/pep-3115/>`_.
-   * ``starargs`` and ``kwargs`` are each a single node, as in a function call.
-     starargs will be expanded to join the list of base classes, and kwargs will
-     be passed to the metaclass.
    * ``body`` is a list of nodes representing the code within the class
      definition.
    * ``decorator_list`` is a list of nodes, as in :class:`FunctionDef`.


### PR DESCRIPTION
These fields were removed in https://github.com/python/cpython/commit/025e9ebd0a0a19f50ca83af6ada0ac65be1fa2a1

Resolves: https://github.com/python/cpython/issues/104984

<!-- gh-issue-number: gh-104984 -->
* Issue: gh-104984
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104986.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->