### PR TITLE
gh-104992: [What's New in 3.11] Document unittest.TestProgram.usageExit's deprecation

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1856,6 +1856,10 @@ Standard Library
 
   (Contributed by Erlend E. Aasland in :issue:`5846`.)
 
+* :meth:`~!unittest.TestProgram.usageExit` is marked deprecated, to be removed
+  in 3.13.
+  (Contributed by Carlos Damázio in :gh:`67048`.)
+
 
 .. _whatsnew311-pending-removal:
 .. _whatsnew311-python-api-pending-removal:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The `unittest.TestProgram.usageExit` method was deprecated in Python 3.11 and scheduled for removal in 3.13.

The deprecation was documented in the [changelog](https://docs.python.org/3/whatsnew/changelog.html?highlight=usageexit#id86) but not in What's New.

For visibility, let's add it to the "What's New in 3.11" > Deprecations:

* https://docs.python.org/3.13/whatsnew/3.11.html#deprecated


<!-- gh-issue-number: gh-104992 -->
* Issue: gh-104992
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104994.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->