### PR TITLE
gh-104992: [What's New in 3.12] Document unittest.TestProgram.usageExit's deprecation

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1015,8 +1015,9 @@ APIs:
 * :func:`locale.getdefaultlocale` (:gh:`90817`)
 * :meth:`!turtle.RawTurtle.settiltangle` (:gh:`50096`)
 * :func:`!unittest.findTestCases` (:gh:`50096`)
-* :func:`!unittest.makeSuite` (:gh:`50096`)
 * :func:`!unittest.getTestCaseNames` (:gh:`50096`)
+* :func:`!unittest.makeSuite` (:gh:`50096`)
+* :meth:`unittest.TestProgram.usageExit` (:gh:`67048`)
 * :class:`!webbrowser.MacOSX` (:gh:`86421`)
 * :class:`classmethod` descriptor chaining (:gh:`89519`)
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1017,7 +1017,7 @@ APIs:
 * :func:`!unittest.findTestCases` (:gh:`50096`)
 * :func:`!unittest.getTestCaseNames` (:gh:`50096`)
 * :func:`!unittest.makeSuite` (:gh:`50096`)
-* :meth:`unittest.TestProgram.usageExit` (:gh:`67048`)
+* :meth:`!unittest.TestProgram.usageExit` (:gh:`67048`)
 * :class:`!webbrowser.MacOSX` (:gh:`86421`)
 * :class:`classmethod` descriptor chaining (:gh:`89519`)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The `unittest.TestProgram.usageExit` method was deprecated in Python 3.11 and scheduled for removal in 3.13.

The deprecation was documented in the [changelog](https://docs.python.org/3/whatsnew/changelog.html?highlight=usageexit#id86) but not in What's New.

For visibility, let's add it to "What's New in 3.12" > "Pending Removal in Python 3.13":

* https://docs.python.org/3.13/whatsnew/3.12.html#pending-removal-in-python-3-13

(Extracted from https://github.com/python/cpython/pull/93986.)


<!-- gh-issue-number: gh-104992 -->
* Issue: gh-104992
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--104995.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->