### PR TITLE
[3.7] Workarounds to allow github macOS CI tests to run for 3.7.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,24 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Configure CPython
-      run: SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk ./configure --with-pydebug --with-openssl=/usr/local/opt/openssl --prefix=/opt/python-dev
+      run: |
+        brew install pkg-config openssl@1.1 xz gdbm tcl-tk
+        brew install zlib bzip2 ncurses readline sqlite
+        SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk \
+        CC=clang \
+        CPPFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include \
+            -I$(brew --prefix zlib)/include  -I$(brew --prefix bzip2)/include \
+            -I$(brew --prefix ncurses)/include -I$(brew --prefix readline)/include \
+            -I$(brew --prefix sqlite)/include" \
+        LDFLAGS="-L$(brew --prefix gdbm)/lib -L$(brew --prefix xz)/lib \
+            -L$(brew --prefix zlib)/lib  -L$(brew --prefix bzip2)/lib \
+            -L$(brew --prefix ncurses)/lib -L$(brew --prefix readline)/lib \
+            -L$(brew --prefix sqlite)/lib" \
+        ./configure --prefix=/opt/python-dev \
+            --with-pydebug \
+            --with-openssl="$(brew --prefix openssl@1.1)" \
+            --with-tcltk-libs="$(pkg-config --libs tk)" \
+            --with-tcltk-includes="$(pkg-config --cflags tk)"
     - name: Build CPython
       run: make -j4
     - name: Display build info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,10 @@ jobs:
     runs-on: macos-latest
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
+    env:
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
     - uses: actions/checkout@v2
     - name: Configure CPython


### PR DESCRIPTION
Note that this is intended solely for the current github CI macOS environment, in particular, macOS 12 on Intel-64 only. Out of the box, 3.7.x does not fully support macOS 11 and later systems and does not fully support building or running on Apple Silicon Macs (which were first supported in macOS 11), all of which were released after 3.7 had reached the security-fix-only phase of its life cycle.