### PR TITLE
[3.11] gh-103921: Improve typing documentation (GH-104642)

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1440,10 +1440,10 @@ for creating generic types.
 
       DType = TypeVar('DType')
 
-      class Array[DType, *Shape]:  # This is fine
+      class Array(Generic[DType, *Shape]):  # This is fine
           pass
 
-      class Array2[*Shape, DType]:  # This would also be fine
+      class Array2(Generic[*Shape, DType]):  # This would also be fine
           pass
 
       float_array_1d: Array[float, Height] = Array()     # Totally fine

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -430,8 +430,7 @@ to this is that a list of types can be used to substitute a :class:`ParamSpec`::
    >>> Z[int, [dict, float]]
    __main__.Z[int, (<class 'dict'>, <class 'float'>)]
 
-Another difference between :class:`TypeVar` and :class:`ParamSpec` is that a
-generic with only one parameter specification variable will accept
+Furthermore, a generic with only one parameter specification variable will accept
 parameter lists in the forms ``X[[Type1, Type2, ...]]`` and also
 ``X[Type1, Type2, ...]`` for aesthetic reasons.  Internally, the latter is converted
 to the former, so the following are equivalent::
@@ -1364,11 +1363,11 @@ for creating generic types.
 
    .. attribute:: __covariant__
 
-      Whether the type var has been explicitly marked as covariant.
+      Whether the type var has been marked as covariant.
 
    .. attribute:: __contravariant__
 
-      Whether the type var has been explicitly marked as contravariant.
+      Whether the type var has been marked as contravariant.
 
    .. attribute:: __bound__
 
@@ -1431,6 +1430,7 @@ for creating generic types.
    Type variable tuples can be used in the same contexts as normal type
    variables. For example, in class definitions, arguments, and return types::
 
+      Shape = TypeVarTuple("Shape")
       class Array(Generic[*Shape]):
           def __getitem__(self, key: tuple[*Shape]) -> float: ...
           def __abs__(self) -> "Array[*Shape]": ...
@@ -1452,7 +1452,7 @@ for creating generic types.
    However, note that at most one type variable tuple may appear in a single
    list of type arguments or type parameters::
 
-      x: tuple[*Ts, *Ts]            # Not valid
+      x: tuple[*Ts, *Ts]                     # Not valid
       class Array(Generic[*Shape, *Shape]):  # Not valid
           pass
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1177,17 +1177,9 @@ class ParamSpec(_Final, _Immutable, _BoundVarianceMixin, _PickleUsingNameMixin,
            '''Add two numbers together.'''
            return x + y
 
-    Parameter specification variables defined with covariant=True or
-    contravariant=True can be used to declare covariant or contravariant
-    generic types.  These keyword arguments are valid, but their actual semantics
-    are yet to be decided.  See PEP 612 for details.
-
     Parameter specification variables can be introspected. e.g.:
 
        P.__name__ == 'P'
-       P.__bound__ == None
-       P.__covariant__ == False
-       P.__contravariant__ == False
 
     Note that only parameter specification variables defined in global scope can
     be pickled.


### PR DESCRIPTION
(cherry picked from commit 060277d96bf4ba86df8e4d65831a8cbdfeb51fc5)

This backports some of the changes from the PEP 695 documentation PR (#104642) to 3.11, because I ended up making some improvements that are also applicable to older versions of typing:

- Consistent indentation of examples in `typing.rst`
- Document the call signature of TypeVar, ParamSpec, TypeVarTuple
- Omit mention of the variance-related parameters of ParamSpec, which are not meaningful in the type system
- Some wording improvements

<!-- gh-issue-number: gh-103921 -->
* Issue: gh-103921
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105007.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->