### PR TITLE
Fix indentation in Parser/tokenizer.c

### DIFF
--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1760,7 +1760,7 @@ tok_get_normal_mode(struct tok_state *tok, tokenizer_mode* current_tok, struct t
     tok->starting_col_offset = tok->col_offset;
 
     /* Return pending indents/dedents */
-   if (tok->pendin != 0) {
+    if (tok->pendin != 0) {
         if (tok->pendin < 0) {
             if (tok->tok_extra_tokens) {
                 p_start = tok->cur;


### PR DESCRIPTION
This is just a simple indentation fix from 3 to 4 spaces which I found just by luck.
