### PR TITLE
gh-105017: Fix including additional NL token when using CRLF

### DIFF
--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -84,6 +84,14 @@ class TokenizeTest(TestCase):
     NEWLINE    '\\n'          (4, 26) (4, 27)
     DEDENT     ''            (5, 0) (5, 0)
     """)
+
+        self.check_tokenize("foo='bar'\r\n", """\
+    NAME       'foo'         (1, 0) (1, 3)
+    OP         '='           (1, 3) (1, 4)
+    STRING     "'bar'"       (1, 4) (1, 9)
+    NEWLINE    '\\n'          (1, 9) (1, 10)
+            """)
+
         indent_error_file = b"""\
 def k(x):
     x += 2

--- a/Misc/NEWS.d/next/Core and Builtins/2023-05-27-16-23-16.gh-issue-105017.KQrsC0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-05-27-16-23-16.gh-issue-105017.KQrsC0.rst
@@ -1,1 +1,1 @@
-Fix including an additional NL token when parsing files having CRLF lines. Patch by Marta Gómez.
+Do not include an additional final ``NL`` token when parsing files having CRLF lines. Patch by Marta Gómez.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-05-27-16-23-16.gh-issue-105017.KQrsC0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-05-27-16-23-16.gh-issue-105017.KQrsC0.rst
@@ -1,0 +1,1 @@
+Fix including an additional NL token when parsing files having CRLF lines.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-05-27-16-23-16.gh-issue-105017.KQrsC0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-05-27-16-23-16.gh-issue-105017.KQrsC0.rst
@@ -1,1 +1,1 @@
-Fix including an additional NL token when parsing files having CRLF lines.
+Fix including an additional NL token when parsing files having CRLF lines. Patch by Marta Gómez.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -800,7 +800,7 @@ translate_newlines(const char *s, int exec_input, struct tok_state *tok) {
     }
     /* If this is exec input, add a newline to the end of the string if
        there isn't one already. */
-    if (exec_input && c != '\n') {
+    if (exec_input && c != '\n' && c != '\0') {
         *current = '\n';
         current++;
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-105017 -->
* Issue: gh-105017
<!-- /gh-issue-number -->
