### PR TITLE
gh-104882: Docs: fix description of relationship between `socket.getblocking()` and `socket.gettimeout()`

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1526,7 +1526,7 @@ to sockets.
    Return ``True`` if socket is in blocking mode, ``False`` if in
    non-blocking.
 
-   This is equivalent to checking ``socket.gettimeout() == 0``.
+   This is equivalent to checking ``socket.gettimeout() != 0``.
 
    .. versionadded:: 3.7
 

--- a/Misc/NEWS.d/next/Documentation/2023-05-27-12-48-50.gh-issue-104882.dpAqXV.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-05-27-12-48-50.gh-issue-104882.dpAqXV.rst
@@ -1,0 +1,3 @@
+Fix a typo in the documentation that describes the relationship between
+``socket.getblocking`` and ``socket.gettimeout``, which should be
+equivalence to ``socket.gettimeout() != 0.0.``

--- a/Misc/NEWS.d/next/Documentation/2023-05-27-12-48-50.gh-issue-104882.dpAqXV.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-05-27-12-48-50.gh-issue-104882.dpAqXV.rst
@@ -1,3 +1,0 @@
-Fix a typo in the documentation that describes the relationship between
-``socket.getblocking`` and ``socket.gettimeout``, which should be
-equivalence to ``socket.gettimeout() != 0.0.``


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104882 -->
* Issue: gh-104882
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105026.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->