### PR TITLE
gh-89412: Add missing attributes (added in 3.10) to traceback module docs

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -266,6 +266,13 @@ capture data for later printing in a lightweight fashion.
 
       For syntax errors - the line number where the error occurred.
 
+   .. attribute:: end_lineno
+
+      For syntax errors - the end line number where the error occurred.
+      Can be ``None`` if not present.
+
+      .. versionadded:: 3.10
+
    .. attribute:: text
 
       For syntax errors - the text where the error occurred.
@@ -273,6 +280,13 @@ capture data for later printing in a lightweight fashion.
    .. attribute:: offset
 
       For syntax errors - the offset into the text where the error occurred.
+
+   .. attribute:: end_offset
+
+      For syntax errors - the end offset into the text where the error occurred.
+      Can be ``None`` if not present.
+
+      .. versionadded:: 3.10
 
    .. attribute:: msg
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -672,8 +672,8 @@ class TracebackException:
       occurred.
     - :attr:`offset` For syntax errors - the offset into the text where the
       error occurred.
-    - :attr:`end_offset` For syntax errors - the offset into the text where the
-      error occurred. Can be `None` if not present.
+    - :attr:`end_offset` For syntax errors - the end offset into the text where
+      the error occurred. Can be `None` if not present.
     - :attr:`msg` For syntax errors - the compiler error message.
     """
 

--- a/Misc/NEWS.d/next/Documentation/2023-05-28-19-08-42.gh-issue-89412.j4cg7K.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-05-28-19-08-42.gh-issue-89412.j4cg7K.rst
@@ -1,1 +1,2 @@
-Add missing documentation for the ``end_lineno`` and ``end_offset`` attributes of the :class:`traceback.TracebackException` class
+Add missing documentation for the ``end_lineno`` and ``end_offset`` attributes
+of the :class:`traceback.TracebackException` class.

--- a/Misc/NEWS.d/next/Documentation/2023-05-28-19-08-42.gh-issue-89412.j4cg7K.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-05-28-19-08-42.gh-issue-89412.j4cg7K.rst
@@ -1,1 +1,1 @@
-Add missing documentation for the ``end_lineno``, and ``end_offset`` attributes of the :class:`traceback.TracebackException` class
+Add missing documentation for the ``end_lineno`` and ``end_offset`` attributes of the :class:`traceback.TracebackException` class

--- a/Misc/NEWS.d/next/Documentation/2023-05-28-19-08-42.gh-issue-89412.j4cg7K.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-05-28-19-08-42.gh-issue-89412.j4cg7K.rst
@@ -1,0 +1,1 @@
+Add missing documentation for the ``end_lineno``, and ``end_offset`` attributes of the :class:`traceback.TracebackException` class


### PR DESCRIPTION
It seems that `end_lineno`, and `end_offset` have been missed when the `SyntaxError` exception was modified in 3.10.

I reused the issue number of the original issue that added these attributes.

<!-- gh-issue-number: gh-89412 -->
* Issue: gh-89412
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105046.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->