### PR TITLE
gh-104855: Update more tk tests for 8.7

### DIFF
--- a/Lib/test/test_tkinter/test_geometry_managers.py
+++ b/Lib/test/test_tkinter/test_geometry_managers.py
@@ -405,6 +405,11 @@ class PlaceTest(AbstractWidgetTest, unittest.TestCase):
         with self.assertRaisesRegex(TclError, 'bad screen distance "abcd"'):
             f2.place_configure(height='abcd')
 
+    def place_err(self, root):
+        tk86 = root.info_patchlevel() < (8, 7)
+        return ('expected floating-point number '
+                f'''{'' if tk86 else 'or "" '}but got "abcd"''')
+
     def test_place_configure_relwidth(self):
         t, f, f2 = self.create2()
         f2.place_configure(in_=f, relwidth=0.5)
@@ -413,8 +418,7 @@ class PlaceTest(AbstractWidgetTest, unittest.TestCase):
         f2.place_configure(relwidth='')
         self.root.update()
         self.assertEqual(f2.winfo_width(), 30)
-        with self.assertRaisesRegex(TclError, 'expected floating-point number '
-                                    'but got "abcd"'):
+        with self.assertRaisesRegex(TclError, self.place_err(self.root)):
             f2.place_configure(relwidth='abcd')
 
     def test_place_configure_relheight(self):
@@ -425,8 +429,7 @@ class PlaceTest(AbstractWidgetTest, unittest.TestCase):
         f2.place_configure(relheight='')
         self.root.update()
         self.assertEqual(f2.winfo_height(), 60)
-        with self.assertRaisesRegex(TclError, 'expected floating-point number '
-                                    'but got "abcd"'):
+        with self.assertRaisesRegex(TclError, self.place_err(self.root)):
             f2.place_configure(relheight='abcd')
 
     def test_place_configure_bordermode(self):

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -489,8 +489,12 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         widget = self.create()
         self.checkParam(widget, 'to', 100.0)
         self.checkFloatParam(widget, 'from', -10, 10.2, 11.7)
-        self.checkInvalidParam(widget, 'from', 200,
-                errmsg='-to value must be greater than -from value')
+        if widget.info_patchlevel() < (8, 7): 
+            self.checkInvalidParam(
+                    widget, 'from', 200,
+                    errmsg='-to value must be greater than -from value')
+        else:
+            self.checkFloatParam(widget, 'from', 200)
 
     def test_configure_increment(self):
         widget = self.create()
@@ -500,8 +504,12 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         widget = self.create()
         self.checkParam(widget, 'from', -100.0)
         self.checkFloatParam(widget, 'to', -10, 10.2, 11.7)
-        self.checkInvalidParam(widget, 'to', -200,
-                errmsg='-to value must be greater than -from value')
+        if widget.info_patchlevel() < (8, 7):
+            self.checkInvalidParam(
+                    widget, 'to', -200,
+                    errmsg='-to value must be greater than -from value')
+        else:
+            self.checkFloatParam(widget, 'to', -200)
 
     def test_configure_values(self):
         # XXX

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -489,7 +489,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         widget = self.create()
         self.checkParam(widget, 'to', 100.0)
         self.checkFloatParam(widget, 'from', -10, 10.2, 11.7)
-        if widget.info_patchlevel() < (8, 7): 
+        if widget.info_patchlevel() < (8, 7):
             self.checkInvalidParam(
                     widget, 'from', 200,
                     errmsg='-to value must be greater than -from value')

--- a/Lib/test/test_tkinter/widget_tests.py
+++ b/Lib/test/test_tkinter/widget_tests.py
@@ -74,8 +74,11 @@ class AbstractWidgetTest(AbstractTkTest):
 
     def checkIntegerParam(self, widget, name, *values, **kwargs):
         self.checkParams(widget, name, *values, **kwargs)
-        self.checkInvalidParam(widget, name, '',
-                errmsg='expected integer but got ""')
+        if tcl_version < (8, 7) or name == 'underline':
+            self.checkInvalidParam(widget, name, '',
+                    errmsg='expected integer but got ""')
+        else:
+            self.checkParams(widget, 'underline', '')
         self.checkInvalidParam(widget, name, '10p',
                 errmsg='expected integer but got "10p"')
         self.checkInvalidParam(widget, name, 3.2,
@@ -152,10 +155,13 @@ class AbstractWidgetTest(AbstractTkTest):
                 errmsg='bad screen distance "spam"')
 
     def checkReliefParam(self, widget, name):
-        self.checkParams(widget, name,
-                         'flat', 'groove', 'raised', 'ridge', 'solid', 'sunken')
-        errmsg='bad relief "spam": must be '\
-               'flat, groove, raised, ridge, solid, or sunken'
+        options = ['flat', 'groove', 'raised', 'ridge', 'solid', 'sunken']
+        if tcl_version >= (8, 7) and name in ('overrelief', 'proxyrelief'):
+            options.append('')
+        self.checkParams(widget, name, *options)
+        lastop = options.pop()
+        opstring = ', '.join(options)
+        errmsg=f'bad relief "spam": must be {opstring}, or {lastop}'
         if tcl_version < (8, 6):
             errmsg = None
         self.checkInvalidParam(widget, name, 'spam',

--- a/Misc/NEWS.d/next/Tests/2023-05-28-21-12-44.gh-issue-104855.viuQsR.rst
+++ b/Misc/NEWS.d/next/Tests/2023-05-28-21-12-44.gh-issue-104855.viuQsR.rst
@@ -1,0 +1,3 @@
+Where applicable update tkinter tests for 8.7 by adding '' to options in
+error messages, testing '' for validity, and testing acceptance of 'to'
+value < 'from' value in a spinbox (which switches the values).


### PR DESCRIPTION
Where applicable:
* Add '' to the valid options in error messages.
* Test that '' is valid.
* Test that 'to' < 'from' is valid instead of invalid.

This PR also addresses gh-104856 .

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104855 -->
* Issue: gh-104855
<!-- /gh-issue-number -->
