### PR TITLE
Fix compiler warning in unicodeobject.c

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -236,7 +236,7 @@ static inline PyObject *get_interned_dict(PyInterpreterState *interp)
 }
 
 Py_ssize_t
-_PyUnicode_InternedSize()
+_PyUnicode_InternedSize(void)
 {
     return PyObject_Length(get_interned_dict(_PyInterpreterState_GET()));
 }


### PR DESCRIPTION
Apple clang version 14.0.3 (clang-1403.0.22.14.1)

```
Objects/unicodeobject.c:239:24: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
_PyUnicode_InternedSize()
```