### PR TITLE
gh-103646: Remove --include-pip-user from default APPX package build

### DIFF
--- a/Misc/NEWS.d/next/Windows/2023-05-29-17-09-31.gh-issue-103646.U8oGQx.rst
+++ b/Misc/NEWS.d/next/Windows/2023-05-29-17-09-31.gh-issue-103646.U8oGQx.rst
@@ -1,0 +1,5 @@
+When installed from the Microsoft Store, ``pip`` no longer defaults to
+per-user installs. However, as the install directory is unwritable, it
+should automatically decide to do a per-user install anyway. This should
+resolve issues when ``pip`` is passed an option that conflicts with
+``--user``.

--- a/PC/layout/support/options.py
+++ b/PC/layout/support/options.py
@@ -41,7 +41,6 @@ PRESETS = {
         "options": [
             "stable",
             "pip",
-            "pip-user",
             "tcltk",
             "idle",
             "venv",


### PR DESCRIPTION


<!-- gh-issue-number: gh-103646 -->
* Issue: gh-103646
<!-- /gh-issue-number -->
