### PR TITLE
GH-104898: Revert pathlib os.PathLike registration change.

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -235,7 +235,7 @@ class _PathParents(Sequence):
         return "<{}.parents>".format(type(self._path).__name__)
 
 
-class PurePath(os.PathLike):
+class PurePath:
     """Base class for manipulating paths without I/O.
 
     PurePath represents a filesystem path and offers operations which
@@ -714,6 +714,9 @@ class PurePath(os.PathLike):
             if not match(part):
                 return False
         return True
+
+# Subclassing os.PathLike makes __instancecheck__ slower. Register instead!
+os.PathLike.register(PurePath)
 
 
 class PurePosixPath(PurePath):

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -715,7 +715,8 @@ class PurePath:
                 return False
         return True
 
-# Subclassing os.PathLike makes __instancecheck__ slower. Register instead!
+# Subclassing os.PathLike makes isinstance() checks slower,
+# which in turn makes Path construction slower. Register instead!
 os.PathLike.register(PurePath)
 
 


### PR DESCRIPTION
Subclassing `os.PathLike` rather than using `register()` makes initialisation slower, due to the additional `__isinstance__` work.

This partially reverts commit bd1b6228d132b8e9836fe352cd8dca2b6c1bd98c.

```
$ ./python -m timeit -s 'from pathlib import PurePath' 'PurePath("a", "b", "c")'
100000 loops, best of 5: 2.12 usec per loop # before
200000 loops, best of 5: 1.69 usec per loop # after
```

<!-- gh-issue-number: gh-104898 -->
* Issue: gh-104898
<!-- /gh-issue-number -->
