### PR TITLE
gh-90026: support XATTRs on Cygwin

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-05-30-02-01-14.gh-issue-90026.FyCXw8.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-30-02-01-14.gh-issue-90026.FyCXw8.rst
@@ -1,0 +1,1 @@
+Define ``USE_XATTRS`` on Cygwin so that XATTR-related functions in the :mod:`os` module become available.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -292,9 +292,15 @@ corresponding Unix manual entries for more information on calls.");
 #  undef HAVE_SCHED_SETAFFINITY
 #endif
 
-#if defined(HAVE_SYS_XATTR_H) && defined(HAVE_LINUX_LIMITS_H) && !defined(__FreeBSD_kernel__) && !defined(__GNU__)
-#  define USE_XATTRS
-#  include <linux/limits.h>  // Needed for XATTR_SIZE_MAX on musl libc.
+#if defined(HAVE_SYS_XATTR_H)
+#  if defined(HAVE_LINUX_LIMITS_H) && !defined(__FreeBSD_kernel__) && !defined(__GNU__)
+#    define USE_XATTRS
+#    include <linux/limits.h>  // Needed for XATTR_SIZE_MAX on musl libc.
+#  endif
+#  if defined(__CYGWIN__)
+#    define USE_XATTRS
+#    include <cygwin/limits.h>  // Needed for XATTR_SIZE_MAX and XATTR_LIST_MAX.
+#  endif
 #endif
 
 #ifdef USE_XATTRS


### PR DESCRIPTION
As described in https://github.com/python/cpython/issues/90026#issuecomment-1567631574 and following comments, CPython’s code for XATTRs seems to already support Cygwin… mostly.

Apart from the changes made by this PR (simply compiling the relevant code), there are however also some changes needed on the Cygwin side (I guess):<br>
Namely, they don't export `XATTR_SIZE_MAX` and `XATTR_LIST_MAX` and so a build of CPython with this commit would fail right now.

I've asked at their mailing list to have them included in their `cygwin/limits.h` (which I think is the proper place - Linux defines them in `linux/limits.h`): https://cygwin.com/pipermail/cygwin/2023-May/253750.html

Right now, he newest Version of CPython in Cygwin is 3.9.9... so unless I can get this change backported, they won't be affected by this (well and even if, ... it would be some more "motivation" to set the missing defines, I guess ;-) ).

I could of course also check whether the symbols are defined, as in:
```
#if defined(HAVE_SYS_XATTR_H)
#  if defined(__linux__) && !defined(__FreeBSD_kernel__) && !defined(__GNU__)
#    define USE_XATTRS
#    include <linux/limits.h>  // Needed for XATTR_SIZE_MAX on musl libc.
#  endif
#  if defined(__CYGWIN__)
#    include <cygwin/limits.h>  // Needed for XATTR_SIZE_MAX and XATTR_LIST_MAX.
#    if defined(XATTR_SIZE_MAX) && defined(XATTR_LIST_MAX)
#      define USE_XATTRS
#    endif
#  endif
#endif
```

I found that to be a bit ugly and overkill,... but if Python developers like it more... I wouldn’t mind to adapt my commit.

Thanks

<!-- gh-issue-number: gh-90026 -->
* Issue: gh-90026
<!-- /gh-issue-number -->
