### PR TITLE
gh-105077: Fix test_tkinter refleak checking

### DIFF
--- a/Lib/test/test_tkinter/__init__.py
+++ b/Lib/test/test_tkinter/__init__.py
@@ -1,18 +1,23 @@
 import os.path
 import unittest
-from test import support
-from test.support import import_helper
+
+from test.support import (
+    check_sanitizer,
+    import_helper,
+    load_package_tests,
+    requires,
+    )
 
 
-if support.check_sanitizer(address=True, memory=True):
+if check_sanitizer(address=True, memory=True):
     raise unittest.SkipTest("Tests involving libX11 can SEGFAULT on ASAN/MSAN builds")
 
 # Skip test if _tkinter wasn't built.
 import_helper.import_module('_tkinter')
 
 # Skip test if tk cannot be initialized.
-support.requires('gui')
+requires('gui')
 
 
 def load_tests(*args):
-    return support.load_package_tests(os.path.dirname(__file__), *args)
+    return load_package_tests(os.path.dirname(__file__), *args)


### PR DESCRIPTION
Use specific symbols from `test.support` to avoid having `support`
overwritten by `test_tkinter`'s own `support` submodule.


<!-- gh-issue-number: gh-105077 -->
* Issue: gh-105077
<!-- /gh-issue-number -->
