### PR TITLE
gh-102251: Explicitly free state for test modules with state in test_import

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2331,7 +2331,6 @@ class SinglephaseInitTests(unittest.TestCase):
             self.assertIs(basic.look_up_self(), basic_lookedup)
             self.assertEqual(basic.initialized_count(), expected_init_count)
 
-
     def test_basic_reloaded(self):
         # m_copy is copied into the existing module object.
         # Global state is not changed.

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2419,7 +2419,6 @@ class SinglephaseInitTests(unittest.TestCase):
 
                 self.assertIs(reloaded.snapshot.cached, reloaded.module)
 
-
     # Currently, for every single-phrase init module loaded
     # in multiple interpreters, those interpreters share a
     # PyModuleDef for that object, which can be a problem.

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2330,6 +2330,9 @@ class SinglephaseInitTests(unittest.TestCase):
             self.assertIs(basic.look_up_self(), basic_lookedup)
             self.assertEqual(basic.initialized_count(), expected_init_count)
 
+            loaded.module._clear_module_state()
+
+
     def test_basic_reloaded(self):
         # m_copy is copied into the existing module object.
         # Global state is not changed.
@@ -2412,6 +2415,11 @@ class SinglephaseInitTests(unittest.TestCase):
                                        loaded.snapshot.state_initialized)
 
                 self.assertIs(reloaded.snapshot.cached, reloaded.module)
+
+                if name == f'{self.NAME}_with_state':
+                    loaded.module._clear_module_state()
+                    reloaded.module._clear_module_state()
+
 
     # Currently, for every single-phrase init module loaded
     # in multiple interpreters, those interpreters share a

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2389,7 +2389,7 @@ class SinglephaseInitTests(unittest.TestCase):
                 loaded = self.load(name)
                 reloaded = self.re_load(name, loaded.module)
 
-                if name == f'{self.NAME}_with_state':
+                if name.endswith("_with_state"):
                     self.addCleanup(loaded.module._clear_module_state)
                     self.addCleanup(reloaded.module._clear_module_state)
 

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2320,6 +2320,7 @@ class SinglephaseInitTests(unittest.TestCase):
         self.add_module_cleanup(name)
         with self.subTest(name):
             loaded = self.load(name)
+            self.addCleanup(loaded.module._clear_module_state)
 
             self.check_common(loaded)
             self.assertIsNot(loaded.snapshot.state_initialized, None)
@@ -2329,8 +2330,6 @@ class SinglephaseInitTests(unittest.TestCase):
             # This should change the cached module for _testsinglephase.
             self.assertIs(basic.look_up_self(), basic_lookedup)
             self.assertEqual(basic.initialized_count(), expected_init_count)
-
-            loaded.module._clear_module_state()
 
 
     def test_basic_reloaded(self):
@@ -2391,6 +2390,10 @@ class SinglephaseInitTests(unittest.TestCase):
                 loaded = self.load(name)
                 reloaded = self.re_load(name, loaded.module)
 
+                if name == f'{self.NAME}_with_state':
+                    self.addCleanup(loaded.module._clear_module_state)
+                    self.addCleanup(reloaded.module._clear_module_state)
+
                 self.check_common(loaded)
                 self.check_common(reloaded)
 
@@ -2415,10 +2418,6 @@ class SinglephaseInitTests(unittest.TestCase):
                                        loaded.snapshot.state_initialized)
 
                 self.assertIs(reloaded.snapshot.cached, reloaded.module)
-
-                if name == f'{self.NAME}_with_state':
-                    loaded.module._clear_module_state()
-                    reloaded.module._clear_module_state()
 
 
     # Currently, for every single-phrase init module loaded

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2380,17 +2380,18 @@ class SinglephaseInitTests(unittest.TestCase):
         # Keep a reference around.
         basic = self.load(self.NAME)
 
-        for name in [
-            f'{self.NAME}_with_reinit',  # m_size == 0
-            f'{self.NAME}_with_state',  # m_size > 0
+        for name, has_state in [
+            (f'{self.NAME}_with_reinit', False),  # m_size == 0
+            (f'{self.NAME}_with_state', True),    # m_size > 0
         ]:
             self.add_module_cleanup(name)
-            with self.subTest(name):
+            with self.subTest(name=name, has_state=has_state):
                 loaded = self.load(name)
-                reloaded = self.re_load(name, loaded.module)
-
-                if name.endswith("_with_state"):
+                if has_state:
                     self.addCleanup(loaded.module._clear_module_state)
+
+                reloaded = self.re_load(name, loaded.module)
+                if has_state:
                     self.addCleanup(reloaded.module._clear_module_state)
 
                 self.check_common(loaded)

--- a/Modules/_testsinglephase.c
+++ b/Modules/_testsinglephase.c
@@ -427,7 +427,7 @@ finally:
 /* the _testsinglephase_with_state module */
 /******************************************/
 
-/* This is a less typical of legacy extensions in the wild:
+/* This is less typical of legacy extensions in the wild:
    - single-phase init  (same as _testsinglephase above)
    - has some module state
    - supports repeated initialization

--- a/Modules/_testsinglephase.c
+++ b/Modules/_testsinglephase.c
@@ -252,8 +252,9 @@ PyDoc_STRVAR(basic__clear_module_state_doc, "_clear_module_state()\n\
 \n\
 Free the module state and set it to uninitialized.");
 
-static PyObject*
-basic__clear_module_state(PyObject *self, PyObject *Py_UNUSED(ignored)) {
+static PyObject *
+basic__clear_module_state(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
     module_state *state = get_module_state(self);
     if (state != NULL) {
         clear_state(state);

--- a/Modules/_testsinglephase.c
+++ b/Modules/_testsinglephase.c
@@ -248,6 +248,24 @@ basic__clear_globals(PyObject *self, PyObject *Py_UNUSED(ignored))
      basic__clear_globals_doc}
 
 
+PyDoc_STRVAR(basic__clear_module_state_doc, "_clear_module_state()\n\
+\n\
+Free the module state and set it to uninitialized.");
+
+static PyObject*
+basic__clear_module_state(PyObject *self, PyObject *Py_UNUSED(ignored)) {
+    module_state *state = get_module_state(self);
+    if (state != NULL) {
+        clear_state(state);
+    }
+    Py_RETURN_NONE;
+}
+
+#define _CLEAR_MODULE_STATE_METHODDEF \
+    {"_clear_module_state", basic__clear_module_state, METH_NOARGS, \
+     basic__clear_module_state_doc}
+
+
 /*********************************************/
 /* the _testsinglephase module (and aliases) */
 /*********************************************/
@@ -408,7 +426,7 @@ finally:
 /* the _testsinglephase_with_state module */
 /******************************************/
 
-/* This ia less typical of legacy extensions in the wild:
+/* This is a less typical of legacy extensions in the wild:
    - single-phase init  (same as _testsinglephase above)
    - has some module state
    - supports repeated initialization
@@ -424,6 +442,7 @@ static PyMethodDef TestMethods_WithState[] = {
     LOOK_UP_SELF_METHODDEF,
     SUM_METHODDEF,
     STATE_INITIALIZED_METHODDEF,
+    _CLEAR_MODULE_STATE_METHODDEF,
     {NULL, NULL}           /* sentinel */
 };
 


### PR DESCRIPTION
The module state is not cleared in the clean-up functions. This PR adds one clean-up function for it.

This fixes the second issue mentioned in https://github.com/python/cpython/issues/103879#issuecomment-1528867646

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102251 -->
* Issue: gh-102251
<!-- /gh-issue-number -->
