### PR TITLE
gh-80064: Fix is_valid_wide_char() return type

### DIFF
--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -112,7 +112,7 @@ _Py_device_encoding(int fd)
 }
 
 
-static size_t
+static int
 is_valid_wide_char(wchar_t ch)
 {
 #ifdef HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION


### PR DESCRIPTION
Return a classical int, rather than size_t.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-80064 -->
* Issue: gh-80064
<!-- /gh-issue-number -->
