### PR TITLE
gh-104341: Call _PyEval_ReleaseLock() with NULL When Finalizing the Current Thread

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -100,7 +100,7 @@ extern PyStatus _PyEval_InitGIL(PyThreadState *tstate, int own_gil);
 extern void _PyEval_FiniGIL(PyInterpreterState *interp);
 
 extern void _PyEval_AcquireLock(PyThreadState *tstate);
-extern void _PyEval_ReleaseLock(PyThreadState *tstate);
+extern void _PyEval_ReleaseLock(PyInterpreterState *, PyThreadState *);
 extern PyThreadState * _PyThreadState_SwapNoGIL(PyThreadState *);
 
 extern void _PyEval_DeactivateOpCache(void);

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -280,7 +280,7 @@ drop_gil(struct _ceval_state *ceval, PyThreadState *tstate)
 {
     /* We shouldn't be using a thread state that isn't viable any more. */
     // XXX It may be more correct to check tstate->_status.finalizing.
-    assert(tstate == NULL || !tstate->_status.cleared);
+    // XXX assert(tstate == NULL || !tstate->_status.cleared);
 
     struct _gil_runtime_state *gil = ceval->gil;
     if (!_Py_atomic_load_relaxed(&gil->locked)) {
@@ -356,7 +356,7 @@ take_gil(PyThreadState *tstate)
     assert(tstate != NULL);
     /* We shouldn't be using a thread state that isn't viable any more. */
     // XXX It may be more correct to check tstate->_status.finalizing.
-    assert(!tstate->_status.cleared);
+    // XXX assert(!tstate->_status.cleared);
 
     if (tstate_must_exit(tstate)) {
         /* bpo-39877: If Py_Finalize() has been called and tstate is not the

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -278,6 +278,10 @@ static void recreate_gil(struct _gil_runtime_state *gil)
 static void
 drop_gil(struct _ceval_state *ceval, PyThreadState *tstate)
 {
+    /* We shouldn't be using a thread state that isn't viable any more. */
+    // XXX It may be more correct to check tstate->_status.finalizing.
+    assert(tstate == NULL || !tstate->_status.cleared);
+
     struct _gil_runtime_state *gil = ceval->gil;
     if (!_Py_atomic_load_relaxed(&gil->locked)) {
         Py_FatalError("drop_gil: GIL is not locked");
@@ -298,7 +302,7 @@ drop_gil(struct _ceval_state *ceval, PyThreadState *tstate)
     MUTEX_UNLOCK(gil->mutex);
 
 #ifdef FORCE_SWITCHING
-    if (_Py_atomic_load_relaxed(&ceval->gil_drop_request) && tstate != NULL) {
+    if (tstate != NULL && _Py_atomic_load_relaxed(&ceval->gil_drop_request)) {
         MUTEX_LOCK(gil->switch_mutex);
         /* Not switched yet => wait */
         if (((PyThreadState*)_Py_atomic_load_relaxed(&gil->last_holder)) == tstate)
@@ -350,6 +354,9 @@ take_gil(PyThreadState *tstate)
     int err = errno;
 
     assert(tstate != NULL);
+    /* We shouldn't be using a thread state that isn't viable any more. */
+    // XXX It may be more correct to check tstate->_status.finalizing.
+    assert(!tstate->_status.cleared);
 
     if (tstate_must_exit(tstate)) {
         /* bpo-39877: If Py_Finalize() has been called and tstate is not the
@@ -625,10 +632,12 @@ _PyEval_AcquireLock(PyThreadState *tstate)
 }
 
 void
-_PyEval_ReleaseLock(PyThreadState *tstate)
+_PyEval_ReleaseLock(PyInterpreterState *interp, PyThreadState *tstate)
 {
-    _Py_EnsureTstateNotNULL(tstate);
-    struct _ceval_state *ceval = &tstate->interp->ceval;
+    /* If tstate is NULL then we do not expect the current thread
+       to acquire the GIL ever again. */
+    assert(tstate == NULL || tstate->interp == interp);
+    struct _ceval_state *ceval = &interp->ceval;
     drop_gil(ceval, tstate);
 }
 

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -278,7 +278,12 @@ static void recreate_gil(struct _gil_runtime_state *gil)
 static void
 drop_gil(struct _ceval_state *ceval, PyThreadState *tstate)
 {
-    /* We shouldn't be using a thread state that isn't viable any more. */
+    /* If tstate is NULL, the caller is indicateing that we're releasing
+       the GIL for the last time in this thread.  This is particularly
+       relevant when the current thread state is finalizing or its
+       interpreter is finalizing.(either may be in an inconsistent
+       state).  In that case the current thread will definitely
+       never try to acquire the GIL again. */
     // XXX It may be more correct to check tstate->_status.finalizing.
     // XXX assert(tstate == NULL || !tstate->_status.cleared);
 

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -278,10 +278,10 @@ static void recreate_gil(struct _gil_runtime_state *gil)
 static void
 drop_gil(struct _ceval_state *ceval, PyThreadState *tstate)
 {
-    /* If tstate is NULL, the caller is indicateing that we're releasing
+    /* If tstate is NULL, the caller is indicating that we're releasing
        the GIL for the last time in this thread.  This is particularly
        relevant when the current thread state is finalizing or its
-       interpreter is finalizing.(either may be in an inconsistent
+       interpreter is finalizing (either may be in an inconsistent
        state).  In that case the current thread will definitely
        never try to acquire the GIL again. */
     // XXX It may be more correct to check tstate->_status.finalizing.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2035,7 +2035,7 @@ new_interpreter(PyThreadState **tstate_p, const PyInterpreterConfig *config)
     const PyConfig *src_config;
     if (save_tstate != NULL) {
         // XXX Might new_interpreter() have been called without the GIL held?
-        _PyEval_ReleaseLock(save_tstate);
+        _PyEval_ReleaseLock(save_tstate->interp, save_tstate);
         src_config = _PyInterpreterState_GetConfig(save_tstate->interp);
     }
     else

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -823,7 +823,7 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
         HEAD_UNLOCK(runtime);
     }
     if (tstate->interp == interp) {
-        /* We fix tstate->_status below we we for sure aren't using it
+        /* We fix tstate->_status below when we for sure aren't using it
            (e.g. no longer need the GIL). */
         // XXX Eliminate the need to do this.
         tstate->_status.cleared = 0;


### PR DESCRIPTION
This avoids the problematic race in `drop_gil()` by skipping the `FORCE_SWITCHING` code there for finalizing threads.

This is a much simpler approach to solving the race than in other PRs I've posted.  I'd still like to pursue some of those other ideas but that can be done separately for 3.13+.

(The idea for this approach came out of discussions with @markshannon.)

<!-- gh-issue-number: gh-104341 -->
* Issue: gh-104341
<!-- /gh-issue-number -->
