### PR TITLE
CI: Temporarily skip paths with spaces to avoid error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,20 @@ jobs:
         with:
           filter: |
             Doc/**
-            Misc/**
+            # Temporarily skip paths with spaces
+            # (i.e. "C API", "Core and Builtins")
+            # to avoid "Error: One of your files includes a space".
+            # Pending https://github.com/python/core-workflow/issues/186
+            # Misc/**
+            Misc/NEWS.d/next/Build/**
+            Misc/NEWS.d/next/Documentation/**
+            Misc/NEWS.d/next/IDLE/**
+            Misc/NEWS.d/next/Library/**
+            Misc/NEWS.d/next/Security/**
+            Misc/NEWS.d/next/Tests/**
+            Misc/NEWS.d/next/Tools-Demos/**
+            Misc/NEWS.d/next/Windows/**
+            Misc/NEWS.d/next/macOS/**
             .github/workflows/reusable-docs.yml
       - name: Check for docs changes
         if: >-

--- a/Misc/NEWS.d/next/C API/2023-05-30-21-34-29.gh-issue-105107.1mmbfA.rst
+++ b/Misc/NEWS.d/next/C API/2023-05-30-21-34-29.gh-issue-105107.1mmbfA.rst
@@ -1,0 +1,2 @@
+Dummy news file under "C API" to test the workflow change. This file will be
+deleted before merging.

--- a/Misc/NEWS.d/next/C API/2023-05-30-21-34-29.gh-issue-105107.1mmbfA.rst
+++ b/Misc/NEWS.d/next/C API/2023-05-30-21-34-29.gh-issue-105107.1mmbfA.rst
@@ -1,2 +1,0 @@
-Dummy news file under "C API" to test the workflow change. This file will be
-deleted before merging.


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

PRs like these:

* https://github.com/python/cpython/pull/105072
* https://github.com/python/cpython/pull/105108

Have `NEWS` files in subdirectories containing spaces:

* `Misc/NEWS.d/next/C API/2023-05-30-10-15-13.gh-issue-105071.dPtp7c.rst`
* `Misc/NEWS.d/next/C API/2023-05-30-19-11-09.gh-issue-105107.YQwMnm.rst`

But the https://github.com/Ana06/get-changed-files action (added in https://github.com/python/cpython/pull/103914) fails for such files with:

> Error: One of your files includes a space. Consider using a different output format or removing spaces from your filenames. Please submit an issue on this action's GitHub repo.

We ran into this before and worked around it in https://github.com/python/cpython/pull/103019 by skipping `Misc` and its subdirs.

Let's do something similar here, by replacing `Misc` with a list of its subdirs that are absent a space.

---

See also https://github.com/python/core-workflow/issues/186 to rename the `C API` and `Core and Builtins` directories to `C-API` and `Core-and-Builtins` to avoid this altogether.
