### PR TITLE
[3.12] GH-105113: Improve performance of `pathlib.PurePath.match()`

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -569,6 +569,13 @@ Pure paths provide the following methods and properties:
       >>> PurePath('a/b.py').match('/*.py')
       False
 
+   The *pattern* may be another path object; this speeds up matching the same
+   pattern against multiple files::
+
+      >>> pattern = PurePath('*.py')
+      >>> PurePath('a/b.py').match(pattern)
+      True
+
    As with other methods, case-sensitivity follows platform defaults::
 
       >>> PurePosixPath('b.py').match('*.PY')

--- a/Misc/NEWS.d/next/Library/2023-05-30-21-27-41.gh-issue-105113.bDUPl_.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-30-21-27-41.gh-issue-105113.bDUPl_.rst
@@ -1,0 +1,2 @@
+Improve performance of :meth:`pathlib.PurePath.match` by compiling an
+:class:`re.Pattern` object for the entire pattern.


### PR DESCRIPTION
We now compile an `re.Pattern` object for the entire pattern. This is made more difficult by `fnmatch` not treating directory separators as special when evaluating wildcards (`*`, `?`, etc), and so we arrange the path parts onto separate *lines* in a string, and ensure we don't set `re.DOTALL`.

Partial backport of #101398 (excludes support for `**` wildcards).

<!-- gh-issue-number: gh-105113 -->
* Issue: gh-105113
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105114.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->