### PR TITLE
[3.12] gh-89886: Properly quote Autoconf macro arguments (#105062)

### DIFF
--- a/configure
+++ b/configure
@@ -1847,8 +1847,8 @@ Optional Packages:
                           select hash algorithm for use in Python/pyhash.c
                           (default is SipHash13)
   --with-tzpath=<list of absolute paths separated by pathsep>
-                           Select the default time zone search path for zoneinfo.TZPATH
-
+                          Select the default time zone search path for
+                          zoneinfo.TZPATH
   --with-libs='lib1 ...'  link against additional libs (default is no)
   --with-system-expat     build pyexpat module using an installed expat
                           library, see Doc/library/pyexpat.rst (default is no)
@@ -7392,6 +7392,7 @@ if test "${with_trace_refs+set}" = set; then :
   withval=$with_trace_refs;
 else
   with_trace_refs=no
+
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_trace_refs" >&5
@@ -11193,7 +11194,7 @@ case $ac_sys_system/$ac_sys_release in
 
 $as_echo "#define WITH_DYLD 1" >>confdefs.h
 
-  	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: always on for Darwin" >&5
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: always on for Darwin" >&5
 $as_echo "always on for Darwin" >&6; }
   	;;
   *)
@@ -11750,7 +11751,7 @@ _ACEOF
   LIBS="-ldl $LIBS"
 
 fi
-	# Dynamic linking for SunOS/Solaris and SYSV
+       # Dynamic linking for SunOS/Solaris and SYSV
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for shl_load in -ldld" >&5
 $as_echo_n "checking for shl_load in -ldld... " >&6; }
 if ${ac_cv_lib_dld_shl_load+:} false; then :
@@ -11795,7 +11796,7 @@ _ACEOF
   LIBS="-ldld $LIBS"
 
 fi
-	# Dynamic linking for HP-UX
+    # Dynamic linking for HP-UX
 
 
 
@@ -11810,8 +11811,7 @@ if test "x$ac_cv_header_uuid_h" = xyes; then :
   cat >>confdefs.h <<_ACEOF
 #define HAVE_UUID_H 1
 _ACEOF
-
-  for ac_func in uuid_create uuid_enc_be
+ for ac_func in uuid_create uuid_enc_be
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
@@ -11819,8 +11819,7 @@ if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
 #define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
 _ACEOF
-
-    have_uuid=yes
+ have_uuid=yes
     LIBUUID_CFLAGS=${LIBUUID_CFLAGS-""}
     LIBUUID_LIBS=${LIBUUID_LIBS-""}
 
@@ -11995,11 +11994,9 @@ if test "x$ac_cv_lib_uuid_uuid_generate_time_safe" = xyes; then :
   have_uuid=yes
             $as_echo "#define HAVE_UUID_GENERATE_TIME_SAFE 1" >>confdefs.h
 
-
 fi
 
 LIBS=$py_check_lib_save_LIBS
-
 
 fi
 
@@ -12124,11 +12121,9 @@ if test "x$ac_cv_lib_uuid_uuid_generate_time_safe" = xyes; then :
   have_uuid=yes
             $as_echo "#define HAVE_UUID_GENERATE_TIME_SAFE 1" >>confdefs.h
 
-
 fi
 
 LIBS=$py_check_lib_save_LIBS
-
 
 fi
 
@@ -12154,8 +12149,7 @@ else
 	LIBUUID_LIBS=$pkg_cv_LIBUUID_LIBS
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-
-                  have_uuid=yes
+	            have_uuid=yes
       $as_echo "#define HAVE_UUID_H 1" >>confdefs.h
 
       $as_echo "#define HAVE_UUID_GENERATE_TIME_SAFE 1" >>confdefs.h
@@ -15900,6 +15894,7 @@ if test "${with_valgrind+set}" = set; then :
   withval=$with_valgrind;
 else
   with_valgrind=no
+
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_valgrind" >&5
@@ -16151,7 +16146,7 @@ done
 fi
 
 ac_fn_c_check_decl "$LINENO" "dirfd" "ac_cv_have_decl_dirfd" "#include <sys/types.h>
-       #include <dirent.h>
+               #include <dirent.h>
 "
 if test "x$ac_cv_have_decl_dirfd" = xyes; then :
 
@@ -18794,9 +18789,7 @@ if test "x$ac_cv_lib_bsd_openpty" = xyes; then :
  LIBS="$LIBS -lbsd"
 fi
 
-
 fi
-
 
 fi
 done
@@ -18950,9 +18943,7 @@ if test "x$ac_cv_lib_bsd_forkpty" = xyes; then :
  LIBS="$LIBS -lbsd"
 fi
 
-
 fi
-
 
 fi
 done
@@ -19010,7 +19001,6 @@ $as_echo "#define GETPGRP_HAVE_ARG 1" >>confdefs.h
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
 fi
 done
 
@@ -19038,7 +19028,6 @@ $as_echo "#define SETPGRP_HAVE_ARG 1" >>confdefs.h
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
 fi
 done
 
@@ -20458,7 +20447,6 @@ fi
 
 ac_fn_c_check_func "$LINENO" "gethostbyname_r" "ac_cv_func_gethostbyname_r"
 if test "x$ac_cv_func_gethostbyname_r" = xyes; then :
-
   $as_echo "#define HAVE_GETHOSTBYNAME_R 1" >>confdefs.h
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking gethostbyname_r with 6 args" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ dnl Python's configure.ac file requires autoconf 2.69 and autoconf-archive.
 dnl
 
 # Set VERSION so we only need to edit in one place (i.e., here)
-m4_define(PYTHON_VERSION, 3.12)
+m4_define([PYTHON_VERSION], [3.12])
 
 AC_PREREQ([2.69])
 
@@ -73,7 +73,7 @@ dnl PY_CHECK_LIB(LIBRARY, FUNCTION, [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND], [O
 dnl Like AC_CHECK_LIB() but does not modify LIBS
 AC_DEFUN([PY_CHECK_LIB],
 [AS_VAR_COPY([py_check_lib_save_LIBS], [LIBS])]
-[AC_CHECK_LIB($1, $2, $3, $4, $5)]
+[AC_CHECK_LIB([$1], [$2], [$3], [$4], [$5])]
 [AS_VAR_COPY([LIBS], [py_check_lib_save_LIBS])]
 )
 
@@ -91,7 +91,7 @@ AC_DEFUN([PY_CHECK_EMSCRIPTEN_PORT], [
   AS_VAR_POPDEF([py_libs])
 ])
 
-AC_SUBST(BASECPPFLAGS)
+AC_SUBST([BASECPPFLAGS])
 if test "$srcdir" != . -a "$srcdir" != "$(pwd)"; then
     # If we're building out-of-tree, we need to make sure the following
     # resources get picked up before their $srcdir counterparts.
@@ -106,13 +106,13 @@ else
     BASECPPFLAGS=""
 fi
 
-AC_SUBST(GITVERSION)
-AC_SUBST(GITTAG)
-AC_SUBST(GITBRANCH)
+AC_SUBST([GITVERSION])
+AC_SUBST([GITTAG])
+AC_SUBST([GITBRANCH])
 
 if test -e $srcdir/.git
 then
-AC_CHECK_PROG(HAS_GIT, git, found, not-found)
+AC_CHECK_PROG([HAS_GIT], [git], [found], [not-found])
 else
 HAS_GIT=no-repository
 fi
@@ -131,8 +131,8 @@ AC_CONFIG_SRCDIR([Include/object.h])
 AC_CONFIG_HEADERS([pyconfig.h])
 
 AC_CANONICAL_HOST
-AC_SUBST(build)
-AC_SUBST(host)
+AC_SUBST([build])
+AC_SUBST([host])
 
 AS_VAR_IF([cross_compiling], [maybe],
  [AC_MSG_ERROR([Cross compiling required --host=HOST-TUPLE and --build=ARCH])]
@@ -141,8 +141,7 @@ AS_VAR_IF([cross_compiling], [maybe],
 # pybuilddir.txt will be created by --generate-posix-vars in the Makefile
 rm -f pybuilddir.txt
 
-AC_ARG_WITH(
-  [build-python],
+AC_ARG_WITH([build-python],
   [AS_HELP_STRING([--with-build-python=python]PYTHON_VERSION,
                   [path to build python binary for cross compiling (default: _bootstrap_python or python]PYTHON_VERSION[)])],
   [
@@ -204,7 +203,7 @@ AC_SUBST([PYTHON_FOR_BUILD_DEPS])
 AC_CHECK_PROGS([PYTHON_FOR_REGEN],
   [python$PACKAGE_VERSION python3.12 python3.11 python3.10 python3 python],
   [python3])
-AC_SUBST(PYTHON_FOR_REGEN)
+AC_SUBST([PYTHON_FOR_REGEN])
 
 AC_MSG_CHECKING([Python for regen version])
 if command -v "$PYTHON_FOR_REGEN" >/dev/null 2>&1; then
@@ -243,38 +242,40 @@ grep -v 'define PACKAGE_' <confdefs.h >confdefs.h.new
 rm confdefs.h
 mv confdefs.h.new confdefs.h
 
-AC_SUBST(VERSION)
+AC_SUBST([VERSION])
 VERSION=PYTHON_VERSION
 
 # Version number of Python's own shared library file.
-AC_SUBST(SOVERSION)
+AC_SUBST([SOVERSION])
 SOVERSION=1.0
 
 # The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on NetBSD, so we need _NETBSD_SOURCE to re-enable
 # them.
-AC_DEFINE(_NETBSD_SOURCE, 1, [Define on NetBSD to activate all library features])
+AC_DEFINE([_NETBSD_SOURCE], [1],
+          [Define on NetBSD to activate all library features])
 
 # The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on FreeBSD, so we need __BSD_VISIBLE to re-enable
 # them.
-AC_DEFINE(__BSD_VISIBLE, 1, [Define on FreeBSD to activate all library features])
+AC_DEFINE([__BSD_VISIBLE], [1],
+          [Define on FreeBSD to activate all library features])
 
 # The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on Mac OS X, so we need _DARWIN_C_SOURCE to re-enable
 # them.
-AC_DEFINE(_DARWIN_C_SOURCE, 1, [Define on Darwin to activate all library features])
+AC_DEFINE([_DARWIN_C_SOURCE], [1],
+          [Define on Darwin to activate all library features])
 
 
 define_xopen_source=yes
 
 # Arguments passed to configure.
-AC_SUBST(CONFIG_ARGS)
+AC_SUBST([CONFIG_ARGS])
 CONFIG_ARGS="$ac_configure_args"
 
 dnl Allow users to disable pkg-config or require pkg-config
-AC_ARG_WITH(
-  [pkg-config],
+AC_ARG_WITH([pkg-config],
   [AS_HELP_STRING([[--with-pkg-config=[yes|no|check]]],
                   [use pkg-config to detect build options (default is check)])],
   [],
@@ -303,7 +304,7 @@ if test "$with_pkg_config" = yes -a -z "$PKG_CONFIG"; then
 fi
 
 AC_MSG_CHECKING([for --enable-universalsdk])
-AC_ARG_ENABLE(universalsdk,
+AC_ARG_ENABLE([universalsdk],
 	AS_HELP_STRING([--enable-universalsdk@<:@=SDKDIR@:>@],
 	               [create a universal binary build.
 	                SDKDIR specifies which macOS SDK should be used to perform the build,
@@ -344,13 +345,13 @@ AC_ARG_ENABLE(universalsdk,
 ])
 if test -n "${UNIVERSALSDK}"
 then
-	AC_MSG_RESULT(${UNIVERSALSDK})
+	AC_MSG_RESULT([${UNIVERSALSDK}])
 else
-	AC_MSG_RESULT(no)
+	AC_MSG_RESULT([no])
 fi
-AC_SUBST(UNIVERSALSDK)
+AC_SUBST([UNIVERSALSDK])
 
-AC_SUBST(ARCH_RUN_32BIT)
+AC_SUBST([ARCH_RUN_32BIT])
 ARCH_RUN_32BIT=""
 
 # For backward compatibility reasons we prefer to select '32-bit' if available,
@@ -367,10 +368,10 @@ then
 	fi
 fi
 
-AC_SUBST(LIPO_32BIT_FLAGS)
-AC_SUBST(LIPO_INTEL64_FLAGS)
-AC_MSG_CHECKING(for --with-universal-archs)
-AC_ARG_WITH(universal-archs,
+AC_SUBST([LIPO_32BIT_FLAGS])
+AC_SUBST([LIPO_INTEL64_FLAGS])
+AC_MSG_CHECKING([for --with-universal-archs])
+AC_ARG_WITH([universal-archs],
     AS_HELP_STRING([--with-universal-archs=ARCH],
                    [specify the kind of macOS universal binary that should be created.
                     This option is only valid when --enable-universalsdk is set; options are:
@@ -383,12 +384,12 @@ AC_ARG_WITH(universal-archs,
 [])
 if test -n "${UNIVERSALSDK}"
 then
-	AC_MSG_RESULT(${UNIVERSAL_ARCHS})
+	AC_MSG_RESULT([${UNIVERSAL_ARCHS}])
 else
-	AC_MSG_RESULT(no)
+	AC_MSG_RESULT([no])
 fi
 
-AC_ARG_WITH(framework-name,
+AC_ARG_WITH([framework-name],
               AS_HELP_STRING([--with-framework-name=FRAMEWORK],
                              [specify the name for the python framework on macOS
                               only valid when --enable-framework is set. see Mac/README.rst
@@ -403,7 +404,7 @@ AC_ARG_WITH(framework-name,
     PYTHONFRAMEWORKIDENTIFIER=org.python.python
 ])
 dnl quadrigraphs "@<:@" and "@:>@" produce "[" and "]" in the output
-AC_ARG_ENABLE(framework,
+AC_ARG_ENABLE([framework],
               AS_HELP_STRING([--enable-framework@<:@=INSTALLDIR@:>@],
                              [create a Python.framework rather than a traditional Unix install.
                               optional INSTALLDIR specifies the installation path. see Mac/README.rst
@@ -486,10 +487,10 @@ AC_ARG_ENABLE(framework,
 
 		# Add files for Mac specific code to the list of output
 		# files:
-		AC_CONFIG_FILES(Mac/Makefile)
-		AC_CONFIG_FILES(Mac/PythonLauncher/Makefile)
-		AC_CONFIG_FILES(Mac/Resources/framework/Info.plist)
-		AC_CONFIG_FILES(Mac/Resources/app/Info.plist)
+		AC_CONFIG_FILES([Mac/Makefile])
+		AC_CONFIG_FILES([Mac/PythonLauncher/Makefile])
+		AC_CONFIG_FILES([Mac/Resources/framework/Info.plist])
+		AC_CONFIG_FILES([Mac/Resources/app/Info.plist])
 	esac
 	],[
 	PYTHONFRAMEWORK=
@@ -509,24 +510,25 @@ AC_ARG_ENABLE(framework,
 	enable_framework=
 
 ])
-AC_SUBST(PYTHONFRAMEWORK)
-AC_SUBST(PYTHONFRAMEWORKIDENTIFIER)
-AC_SUBST(PYTHONFRAMEWORKDIR)
-AC_SUBST(PYTHONFRAMEWORKPREFIX)
-AC_SUBST(PYTHONFRAMEWORKINSTALLDIR)
-AC_SUBST(FRAMEWORKINSTALLFIRST)
-AC_SUBST(FRAMEWORKINSTALLLAST)
-AC_SUBST(FRAMEWORKALTINSTALLFIRST)
-AC_SUBST(FRAMEWORKALTINSTALLLAST)
-AC_SUBST(FRAMEWORKPYTHONW)
-AC_SUBST(FRAMEWORKUNIXTOOLSPREFIX)
-AC_SUBST(FRAMEWORKINSTALLAPPSPREFIX)
+AC_SUBST([PYTHONFRAMEWORK])
+AC_SUBST([PYTHONFRAMEWORKIDENTIFIER])
+AC_SUBST([PYTHONFRAMEWORKDIR])
+AC_SUBST([PYTHONFRAMEWORKPREFIX])
+AC_SUBST([PYTHONFRAMEWORKINSTALLDIR])
+AC_SUBST([FRAMEWORKINSTALLFIRST])
+AC_SUBST([FRAMEWORKINSTALLLAST])
+AC_SUBST([FRAMEWORKALTINSTALLFIRST])
+AC_SUBST([FRAMEWORKALTINSTALLLAST])
+AC_SUBST([FRAMEWORKPYTHONW])
+AC_SUBST([FRAMEWORKUNIXTOOLSPREFIX])
+AC_SUBST([FRAMEWORKINSTALLAPPSPREFIX])
 
-AC_DEFINE_UNQUOTED(_PYTHONFRAMEWORK, "${PYTHONFRAMEWORK}", [framework name])
+AC_DEFINE_UNQUOTED([_PYTHONFRAMEWORK], ["${PYTHONFRAMEWORK}"],
+                   [framework name])
 
 # Set name for machine-dependent library files
 AC_ARG_VAR([MACHDEP], [name for machine-dependent library files])
-AC_MSG_CHECKING(MACHDEP)
+AC_MSG_CHECKING([MACHDEP])
 if test -z "$MACHDEP"
 then
     # avoid using uname for cross builds
@@ -582,9 +584,9 @@ then
 	'')	MACHDEP="unknown";;
     esac
 fi
-AC_MSG_RESULT("$MACHDEP")
+AC_MSG_RESULT(["$MACHDEP"])
 
-AC_SUBST(_PYTHON_HOST_PLATFORM)
+AC_SUBST([_PYTHON_HOST_PLATFORM])
 if test "$cross_compiling" = yes; then
 	case "$host" in
 	*-*-linux*)
@@ -634,13 +636,15 @@ case $ac_sys_system/$ac_sys_release in
     # OpenBSD undoes our definition of __BSD_VISIBLE if _XOPEN_SOURCE is
     # also defined. This can be overridden by defining _BSD_SOURCE
     # As this has a different meaning on Linux, only define it on OpenBSD
-    AC_DEFINE(_BSD_SOURCE, 1, [Define on OpenBSD to activate all library features])
+    AC_DEFINE([_BSD_SOURCE], [1],
+              [Define on OpenBSD to activate all library features])
     ;;
   OpenBSD/*)
     # OpenBSD undoes our definition of __BSD_VISIBLE if _XOPEN_SOURCE is
     # also defined. This can be overridden by defining _BSD_SOURCE
     # As this has a different meaning on Linux, only define it on OpenBSD
-    AC_DEFINE(_BSD_SOURCE, 1, [Define on OpenBSD to activate all library features])
+    AC_DEFINE([_BSD_SOURCE], [1],
+              [Define on OpenBSD to activate all library features])
     ;;
   # Defining _XOPEN_SOURCE on NetBSD version prior to the introduction of
   # _NETBSD_SOURCE disables certain features (eg. setgroups). Reported by
@@ -696,17 +700,18 @@ esac
 if test $define_xopen_source = yes
 then
   # X/Open 7, incorporating POSIX.1-2008
-  AC_DEFINE(_XOPEN_SOURCE, 700,
-            Define to the level of X/Open that your system supports)
+  AC_DEFINE([_XOPEN_SOURCE], [700],
+            [Define to the level of X/Open that your system supports])
 
   # On Tru64 Unix 4.0F, defining _XOPEN_SOURCE also requires
   # definition of _XOPEN_SOURCE_EXTENDED and _POSIX_C_SOURCE, or else
   # several APIs are not declared. Since this is also needed in some
   # cases for HP-UX, we define it globally.
-  AC_DEFINE(_XOPEN_SOURCE_EXTENDED, 1,
-   	    Define to activate Unix95-and-earlier features)
+  AC_DEFINE([_XOPEN_SOURCE_EXTENDED], [1],
+            [Define to activate Unix95-and-earlier features])
 
-  AC_DEFINE(_POSIX_C_SOURCE, 200809L, Define to activate features from IEEE Stds 1003.1-2008)
+  AC_DEFINE([_POSIX_C_SOURCE], [200809L],
+            [Define to activate features from IEEE Stds 1003.1-2008])
 fi
 
 # On HP-UX mbstate_t requires _INCLUDE__STDC_A1_SOURCE
@@ -719,14 +724,15 @@ esac
 
 if test $define_stdc_a1 = yes
 then
-  AC_DEFINE(_INCLUDE__STDC_A1_SOURCE, 1, Define to include mbstate_t for mbrtowc)
+  AC_DEFINE([_INCLUDE__STDC_A1_SOURCE], [1],
+            [Define to include mbstate_t for mbrtowc])
 fi
 
 # Record the configure-time value of MACOSX_DEPLOYMENT_TARGET,
 # it may influence the way we can build extensions, so distutils
 # needs to check it
-AC_SUBST(CONFIGURE_MACOSX_DEPLOYMENT_TARGET)
-AC_SUBST(EXPORT_MACOSX_DEPLOYMENT_TARGET)
+AC_SUBST([CONFIGURE_MACOSX_DEPLOYMENT_TARGET])
+AC_SUBST([EXPORT_MACOSX_DEPLOYMENT_TARGET])
 CONFIGURE_MACOSX_DEPLOYMENT_TARGET=
 EXPORT_MACOSX_DEPLOYMENT_TARGET='#'
 
@@ -873,16 +879,16 @@ rm -f conftest.c conftest.out
 # _POSIX_SOURCE, _POSIX_1_SOURCE, and more
 AC_USE_SYSTEM_EXTENSIONS
 
-AC_SUBST(CXX)
+AC_SUBST([CXX])
 
 preset_cxx="$CXX"
 if test -z "$CXX"
 then
         case "$CC" in
-        gcc)    AC_PATH_TOOL(CXX, [g++], [g++], [notfound]) ;;
-        cc)     AC_PATH_TOOL(CXX, [c++], [c++], [notfound]) ;;
-        clang|*/clang)     AC_PATH_TOOL(CXX, [clang++], [clang++], [notfound]) ;;
-        icc|*/icc)         AC_PATH_TOOL(CXX, [icpc], [icpc], [notfound]) ;;
+        gcc)    AC_PATH_TOOL([CXX], [g++], [g++], [notfound]) ;;
+        cc)     AC_PATH_TOOL([CXX], [c++], [c++], [notfound]) ;;
+        clang|*/clang)     AC_PATH_TOOL([CXX], [clang++], [clang++], [notfound]) ;;
+        icc|*/icc)         AC_PATH_TOOL([CXX], [icpc], [icpc], [notfound]) ;;
         esac
 	if test "$CXX" = "notfound"
 	then
@@ -891,7 +897,7 @@ then
 fi
 if test -z "$CXX"
 then
-	AC_CHECK_TOOLS(CXX, $CCC c++ g++ gcc CC cxx cc++ cl, notfound)
+	AC_CHECK_TOOLS([CXX], [$CCC c++ g++ gcc CC cxx cc++ cl], [notfound])
 	if test "$CXX" = "notfound"
 	then
 		CXX=""
@@ -1113,12 +1119,12 @@ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
 elif test x$PLATFORM_TRIPLET != x && test x$MULTIARCH = x; then
   MULTIARCH=$PLATFORM_TRIPLET
 fi
-AC_SUBST(PLATFORM_TRIPLET)
+AC_SUBST([PLATFORM_TRIPLET])
 
 if test x$MULTIARCH != x; then
   MULTIARCH_CPPFLAGS="-DMULTIARCH=\\\"$MULTIARCH\\\""
 fi
-AC_SUBST(MULTIARCH_CPPFLAGS)
+AC_SUBST([MULTIARCH_CPPFLAGS])
 
 dnl Support tiers according to https://peps.python.org/pep-0011/
 dnl
@@ -1166,7 +1172,7 @@ AC_CACHE_CHECK([for -Wl,--no-as-needed], [ac_cv_wl_no_as_needed], [
      ac_cv_wl_no_as_needed=no])
   LDFLAGS="$save_LDFLAGS"
 ])
-AC_SUBST(NO_AS_NEEDED)
+AC_SUBST([NO_AS_NEEDED])
 
 AC_MSG_CHECKING([for the Android API level])
 cat > conftest.c <<EOF
@@ -1185,7 +1191,8 @@ if $CPP $CPPFLAGS conftest.c >conftest.out 2>/dev/null; then
   if test -z "$ANDROID_API_LEVEL"; then
     AC_MSG_ERROR([Fatal: you must define __ANDROID_API__])
   fi
-  AC_DEFINE_UNQUOTED(ANDROID_API_LEVEL, $ANDROID_API_LEVEL, [The Android API level.])
+  AC_DEFINE_UNQUOTED([ANDROID_API_LEVEL], [$ANDROID_API_LEVEL],
+                     [The Android API level.])
 
   AC_MSG_CHECKING([for the Android arm ABI])
   AC_MSG_RESULT([$_arm_arch])
@@ -1287,18 +1294,18 @@ AC_MSG_RESULT([$EXEEXT])
 
 # Test whether we're running on a non-case-sensitive system, in which
 # case we give a warning if no ext is given
-AC_SUBST(BUILDEXEEXT)
-AC_MSG_CHECKING(for case-insensitive build directory)
+AC_SUBST([BUILDEXEEXT])
+AC_MSG_CHECKING([for case-insensitive build directory])
 if test ! -d CaseSensitiveTestDir; then
 mkdir CaseSensitiveTestDir
 fi
 
 if test -d casesensitivetestdir && test -z "$EXEEXT"
 then
-    AC_MSG_RESULT(yes)
+    AC_MSG_RESULT([yes])
     BUILDEXEEXT=.exe
 else
-	AC_MSG_RESULT(no)
+	AC_MSG_RESULT([no])
 	BUILDEXEEXT=$EXEEXT
 fi
 rmdir CaseSensitiveTestDir
@@ -1310,13 +1317,13 @@ hp*|HP*)
     esac;;
 esac
 
-AC_SUBST(LIBRARY)
-AC_MSG_CHECKING(LIBRARY)
+AC_SUBST([LIBRARY])
+AC_MSG_CHECKING([LIBRARY])
 if test -z "$LIBRARY"
 then
 	LIBRARY='libpython$(VERSION)$(ABIFLAGS).a'
 fi
-AC_MSG_RESULT($LIBRARY)
+AC_MSG_RESULT([$LIBRARY])
 
 # LDLIBRARY is the name of the library to link against (as opposed to the
 # name of the library into which to insert object files). BLDLIBRARY is also
@@ -1334,14 +1341,14 @@ AC_MSG_RESULT($LIBRARY)
 #
 # LDVERSION is the shared library version number, normally the Python version
 # with the ABI build flags appended.
-AC_SUBST(LDLIBRARY)
-AC_SUBST(DLLLIBRARY)
-AC_SUBST(BLDLIBRARY)
-AC_SUBST(PY3LIBRARY)
-AC_SUBST(LDLIBRARYDIR)
-AC_SUBST(INSTSONAME)
-AC_SUBST(RUNSHARED)
-AC_SUBST(LDVERSION)
+AC_SUBST([LDLIBRARY])
+AC_SUBST([DLLLIBRARY])
+AC_SUBST([BLDLIBRARY])
+AC_SUBST([PY3LIBRARY])
+AC_SUBST([LDLIBRARYDIR])
+AC_SUBST([INSTSONAME])
+AC_SUBST([RUNSHARED])
+AC_SUBST([LDVERSION])
 LDLIBRARY="$LIBRARY"
 BLDLIBRARY='$(LDLIBRARY)'
 INSTSONAME='$(LDLIBRARY)'
@@ -1354,8 +1361,8 @@ LDVERSION="$VERSION"
 # If CXX is set, and if it is needed to link a main function that was
 # compiled with CXX, LINKCC is CXX instead. Always using CXX is undesirable:
 # python might then depend on the C++ runtime
-AC_SUBST(LINKCC)
-AC_MSG_CHECKING(LINKCC)
+AC_SUBST([LINKCC])
+AC_MSG_CHECKING([LINKCC])
 if test -z "$LINKCC"
 then
 	LINKCC='$(PURIFY) $(CC)'
@@ -1366,30 +1373,30 @@ then
 	   LINKCC=qcc;;
 	esac
 fi
-AC_MSG_RESULT($LINKCC)
+AC_MSG_RESULT([$LINKCC])
 
 # EXPORTSYMS holds the list of exported symbols for AIX.
 # EXPORTSFROM holds the module name exporting symbols on AIX.
 EXPORTSYMS=
 EXPORTSFROM=
-AC_SUBST(EXPORTSYMS)
-AC_SUBST(EXPORTSFROM)
-AC_MSG_CHECKING(EXPORTSYMS)
+AC_SUBST([EXPORTSYMS])
+AC_SUBST([EXPORTSFROM])
+AC_MSG_CHECKING([EXPORTSYMS])
 case $ac_sys_system in
 AIX*)
 	EXPORTSYMS="Modules/python.exp"
 	EXPORTSFROM=. # the main executable
 	;;
 esac
-AC_MSG_RESULT($EXPORTSYMS)
+AC_MSG_RESULT([$EXPORTSYMS])
 
 # GNULD is set to "yes" if the GNU linker is used.  If this goes wrong
 # make sure we default having it set to "no": this is used by
 # distutils.unixccompiler to know if it should add --enable-new-dtags
 # to linker command lines, and failing to detect GNU ld simply results
 # in the same behaviour as before.
-AC_SUBST(GNULD)
-AC_MSG_CHECKING(for GNU ld)
+AC_SUBST([GNULD])
+AC_MSG_CHECKING([for GNU ld])
 ac_prog=ld
 if test "$GCC" = yes; then
        ac_prog=`$CC -print-prog-name=ld`
@@ -1400,10 +1407,10 @@ case `"$ac_prog" -V 2>&1 < /dev/null` in
       *)
           GNULD=no;;
 esac
-AC_MSG_RESULT($GNULD)
+AC_MSG_RESULT([$GNULD])
 
-AC_MSG_CHECKING(for --enable-shared)
-AC_ARG_ENABLE(shared,
+AC_MSG_CHECKING([for --enable-shared])
+AC_ARG_ENABLE([shared],
               AS_HELP_STRING([--enable-shared], [enable building a shared Python library (default is no)]))
 
 if test -z "$enable_shared"
@@ -1415,27 +1422,27 @@ then
     enable_shared="no";;
   esac
 fi
-AC_MSG_RESULT($enable_shared)
+AC_MSG_RESULT([$enable_shared])
 
 # --with-static-libpython
 STATIC_LIBPYTHON=1
-AC_MSG_CHECKING(for --with-static-libpython)
-AC_ARG_WITH(static-libpython,
+AC_MSG_CHECKING([for --with-static-libpython])
+AC_ARG_WITH([static-libpython],
   AS_HELP_STRING([--without-static-libpython],
                  [do not build libpythonMAJOR.MINOR.a and do not install python.o (default is yes)]),
 [
 if test "$withval" = no
 then
-  AC_MSG_RESULT(no);
+  AC_MSG_RESULT([no]);
   STATIC_LIBPYTHON=0
 else
-  AC_MSG_RESULT(yes);
+  AC_MSG_RESULT([yes]);
 fi],
-[AC_MSG_RESULT(yes)])
-AC_SUBST(STATIC_LIBPYTHON)
+[AC_MSG_RESULT([yes])])
+AC_SUBST([STATIC_LIBPYTHON])
 
-AC_MSG_CHECKING(for --enable-profiling)
-AC_ARG_ENABLE(profiling,
+AC_MSG_CHECKING([for --enable-profiling])
+AC_ARG_ENABLE([profiling],
               AS_HELP_STRING([--enable-profiling], [enable C-level code profiling with gprof (default is no)]))
 if test "x$enable_profiling" = xyes; then
   ac_save_cc="$CC"
@@ -1447,14 +1454,14 @@ if test "x$enable_profiling" = xyes; then
 else
   enable_profiling=no
 fi
-AC_MSG_RESULT($enable_profiling)
+AC_MSG_RESULT([$enable_profiling])
 
 if test "x$enable_profiling" = xyes; then
   BASECFLAGS="-pg $BASECFLAGS"
   LDFLAGS="-pg $LDFLAGS"
 fi
 
-AC_MSG_CHECKING(LDLIBRARY)
+AC_MSG_CHECKING([LDLIBRARY])
 
 # MacOSX framework builds need more magic. LDLIBRARY is the dynamic
 # library that we build, but we do not want to link against it (we
@@ -1474,7 +1481,8 @@ fi
 # Other platforms follow
 if test $enable_shared = "yes"; then
   PY_ENABLE_SHARED=1
-  AC_DEFINE(Py_ENABLE_SHARED, 1, [Defined if Python is built as a shared library.])
+  AC_DEFINE([Py_ENABLE_SHARED], [1],
+            [Defined if Python is built as a shared library.])
   case $ac_sys_system in
     CYGWIN*)
           LDLIBRARY='libpython$(LDVERSION).dll.a'
@@ -1590,7 +1598,7 @@ if test -n "$HOSTRUNNER"; then
   PYTHON_FOR_BUILD="_PYTHON_HOSTRUNNER='$HOSTRUNNER' $PYTHON_FOR_BUILD"
 fi
 
-AC_MSG_RESULT($LDLIBRARY)
+AC_MSG_RESULT([$LDLIBRARY])
 
 # LIBRARY_DEPS, LINK_PYTHON_OBJS and LINK_PYTHON_DEPS variable
 AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
@@ -1615,16 +1623,16 @@ else
     # Link Python program to object files
     LINK_PYTHON_OBJS='$(LIBRARY_OBJS)'
 fi
-AC_SUBST(LIBRARY_DEPS)
-AC_SUBST(LINK_PYTHON_DEPS)
-AC_SUBST(LINK_PYTHON_OBJS)
+AC_SUBST([LIBRARY_DEPS])
+AC_SUBST([LINK_PYTHON_DEPS])
+AC_SUBST([LINK_PYTHON_OBJS])
 
 # ar program
-AC_SUBST(AR)
-AC_CHECK_TOOLS(AR, ar aal, ar)
+AC_SUBST([AR])
+AC_CHECK_TOOLS([AR], [ar aal], [ar])
 
 # tweak ARFLAGS only if the user didn't set it on the command line
-AC_SUBST(ARFLAGS)
+AC_SUBST([ARFLAGS])
 if test -z "$ARFLAGS"
 then
         ARFLAGS="rcs"
@@ -1642,7 +1650,7 @@ AC_PROG_INSTALL
 AC_PROG_MKDIR_P
 
 # Not every filesystem supports hard links
-AC_SUBST(LN)
+AC_SUBST([LN])
 if test -z "$LN" ; then
 	case $ac_sys_system in
 		CYGWIN*) LN="ln -s";;
@@ -1651,38 +1659,38 @@ if test -z "$LN" ; then
 fi
 
 # For calculating the .so ABI tag.
-AC_SUBST(ABIFLAGS)
+AC_SUBST([ABIFLAGS])
 ABIFLAGS=""
 
 # Check for --with-pydebug
-AC_MSG_CHECKING(for --with-pydebug)
-AC_ARG_WITH(pydebug,
-            AS_HELP_STRING([--with-pydebug], [build with Py_DEBUG defined (default is no)]),
+AC_MSG_CHECKING([for --with-pydebug])
+AC_ARG_WITH([pydebug],
+  [AS_HELP_STRING([--with-pydebug], [build with Py_DEBUG defined (default is no)]) ],
 [
 if test "$withval" != no
 then
-  AC_DEFINE(Py_DEBUG, 1,
+  AC_DEFINE([Py_DEBUG], [1],
   [Define if you want to build an interpreter with many run-time checks.])
-  AC_MSG_RESULT(yes);
+  AC_MSG_RESULT([yes]);
   Py_DEBUG='true'
   ABIFLAGS="${ABIFLAGS}d"
-else AC_MSG_RESULT(no); Py_DEBUG='false'
+else AC_MSG_RESULT([no]); Py_DEBUG='false'
 fi],
-[AC_MSG_RESULT(no)])
+[AC_MSG_RESULT([no])])
 
 # Check for --with-trace-refs
 # --with-trace-refs
-AC_MSG_CHECKING(for --with-trace-refs)
-AC_ARG_WITH(trace-refs,
-  AS_HELP_STRING(
-    [--with-trace-refs],
-    [enable tracing references for debugging purpose (default is no)]),,
-  with_trace_refs=no)
-AC_MSG_RESULT($with_trace_refs)
+AC_MSG_CHECKING([for --with-trace-refs])
+AC_ARG_WITH([trace-refs],
+  [AS_HELP_STRING([--with-trace-refs], [enable tracing references for debugging purpose (default is no)])],
+  [], [with_trace_refs=no]
+)
+AC_MSG_RESULT([$with_trace_refs])
 
 if test "$with_trace_refs" = "yes"
 then
-  AC_DEFINE(Py_TRACE_REFS, 1, [Define if you want to enable tracing references for debugging purpose])
+  AC_DEFINE([Py_TRACE_REFS], [1],
+            [Define if you want to enable tracing references for debugging purpose])
 fi
 
 
@@ -1691,8 +1699,9 @@ AC_MSG_CHECKING([for --enable-pystats])
 AC_ARG_ENABLE([pystats],
   [AS_HELP_STRING(
     [--enable-pystats],
-    [enable internal statistics gathering (default is no)])],,
-  [enable_pystats=no]
+    [enable internal statistics gathering (default is no)]
+  )],
+  [], [enable_pystats=no]
 )
 AC_MSG_RESULT([$enable_pystats])
 
@@ -1703,8 +1712,8 @@ AS_VAR_IF([enable_pystats], [yes], [
 # Check for --with-assertions.
 # This allows enabling assertions without Py_DEBUG.
 assertions='false'
-AC_MSG_CHECKING(for --with-assertions)
-AC_ARG_WITH(assertions,
+AC_MSG_CHECKING([for --with-assertions])
+AC_ARG_WITH([assertions],
             AS_HELP_STRING([--with-assertions],[build with C assertions enabled (default is no)]),
 [
 if test "$withval" != no
@@ -1713,32 +1722,32 @@ then
 fi],
 [])
 if test "$assertions" = 'true'; then
-  AC_MSG_RESULT(yes)
+  AC_MSG_RESULT([yes])
 elif test "$Py_DEBUG" = 'true'; then
   assertions='true'
-  AC_MSG_RESULT(implied by --with-pydebug)
+  AC_MSG_RESULT([implied by --with-pydebug])
 else
-  AC_MSG_RESULT(no)
+  AC_MSG_RESULT([no])
 fi
 
 # Enable optimization flags
-AC_SUBST(DEF_MAKE_ALL_RULE)
-AC_SUBST(DEF_MAKE_RULE)
+AC_SUBST([DEF_MAKE_ALL_RULE])
+AC_SUBST([DEF_MAKE_RULE])
 Py_OPT='false'
-AC_MSG_CHECKING(for --enable-optimizations)
-AC_ARG_ENABLE(optimizations, AS_HELP_STRING(
+AC_MSG_CHECKING([for --enable-optimizations])
+AC_ARG_ENABLE([optimizations], AS_HELP_STRING(
                 [--enable-optimizations],
                 [enable expensive, stable optimizations (PGO, etc.) (default is no)]),
 [
 if test "$enableval" != no
 then
   Py_OPT='true'
-  AC_MSG_RESULT(yes);
+  AC_MSG_RESULT([yes]);
 else
   Py_OPT='false'
-  AC_MSG_RESULT(no);
+  AC_MSG_RESULT([no]);
 fi],
-[AC_MSG_RESULT(no)])
+[AC_MSG_RESULT([no])])
 
 if test "$Py_OPT" = 'true' ; then
   # Intentionally not forcing Py_LTO='true' here.  Too many toolchains do not
@@ -1768,13 +1777,13 @@ else
   DEF_MAKE_RULE="all"
 fi
 
-AC_ARG_VAR(PROFILE_TASK, Python args for PGO generation task)
-AC_MSG_CHECKING(PROFILE_TASK)
+AC_ARG_VAR([PROFILE_TASK], [Python args for PGO generation task])
+AC_MSG_CHECKING([PROFILE_TASK])
 if test -z "$PROFILE_TASK"
 then
 	PROFILE_TASK='-m test --pgo --timeout=$(TESTTIMEOUT)'
 fi
-AC_MSG_RESULT($PROFILE_TASK)
+AC_MSG_RESULT([$PROFILE_TASK])
 
 # Make llvm-related checks work on systems where llvm tools are not installed with their
 # normal names in the default $PATH (ie: Ubuntu).  They exist under the
@@ -1797,28 +1806,29 @@ then
 fi
 
 # Enable LTO flags
-AC_MSG_CHECKING(for --with-lto)
-AC_ARG_WITH(lto, AS_HELP_STRING([--with-lto=@<:@full|thin|no|yes@:>@], [enable Link-Time-Optimization in any build (default is no)]),
+AC_MSG_CHECKING([for --with-lto])
+AC_ARG_WITH([lto],
+  [AS_HELP_STRING([--with-lto=@<:@full|thin|no|yes@:>@], [enable Link-Time-Optimization in any build (default is no)])],
 [
 case "$withval" in
     full)
         Py_LTO='true'
         Py_LTO_POLICY='full'
-        AC_MSG_RESULT(yes)
+        AC_MSG_RESULT([yes])
         ;;
     thin)
         Py_LTO='true'
         Py_LTO_POLICY='thin'
-        AC_MSG_RESULT(yes)
+        AC_MSG_RESULT([yes])
         ;;
     yes)
         Py_LTO='true'
         Py_LTO_POLICY='default'
-        AC_MSG_RESULT(yes)
+        AC_MSG_RESULT([yes])
         ;;
     no)
         Py_LTO='false'
-        AC_MSG_RESULT(no)
+        AC_MSG_RESULT([no])
         ;;
     *)
         Py_LTO='false'
@@ -1826,7 +1836,7 @@ case "$withval" in
         ;;
 esac
 ],
-[AC_MSG_RESULT(no)])
+[AC_MSG_RESULT([no])])
 if test "$Py_LTO" = 'true' ; then
   case $CC in
     *clang*)
@@ -1834,9 +1844,9 @@ if test "$Py_LTO" = 'true' ; then
       dnl Clang linker requires -flto in order to link objects with LTO information.
       dnl Thin LTO is faster and works for object files with full LTO information, too.
       AX_CHECK_COMPILE_FLAG([-flto=thin],[LDFLAGS_NOLTO="-flto=thin"],[LDFLAGS_NOLTO="-flto"])
-      AC_SUBST(LLVM_AR)
-      AC_PATH_TOOL(LLVM_AR, llvm-ar, '', ${llvm_path})
-      AC_SUBST(LLVM_AR_FOUND)
+      AC_SUBST([LLVM_AR])
+      AC_PATH_TOOL([LLVM_AR], [llvm-ar], [''], [${llvm_path}])
+      AC_SUBST([LLVM_AR_FOUND])
       if test -n "${LLVM_AR}" -a -x "${LLVM_AR}"
       then
         LLVM_AR_FOUND="found"
@@ -1930,14 +1940,14 @@ if test "$Py_LTO" = 'true' ; then
 fi
 
 # Enable PGO flags.
-AC_SUBST(PGO_PROF_GEN_FLAG)
-AC_SUBST(PGO_PROF_USE_FLAG)
-AC_SUBST(LLVM_PROF_MERGER)
-AC_SUBST(LLVM_PROF_FILE)
-AC_SUBST(LLVM_PROF_ERR)
-AC_SUBST(LLVM_PROFDATA)
-AC_PATH_TOOL(LLVM_PROFDATA, llvm-profdata, '', ${llvm_path})
-AC_SUBST(LLVM_PROF_FOUND)
+AC_SUBST([PGO_PROF_GEN_FLAG])
+AC_SUBST([PGO_PROF_USE_FLAG])
+AC_SUBST([LLVM_PROF_MERGER])
+AC_SUBST([LLVM_PROF_FILE])
+AC_SUBST([LLVM_PROF_ERR])
+AC_SUBST([LLVM_PROFDATA])
+AC_PATH_TOOL([LLVM_PROFDATA], [llvm-profdata], [''], [${llvm_path}])
+AC_SUBST([LLVM_PROF_FOUND])
 if test -n "${LLVM_PROFDATA}" -a -x "${LLVM_PROFDATA}"
 then
   LLVM_PROF_FOUND="found"
@@ -2007,22 +2017,22 @@ esac
 
 # BOLT optimization. Always configured after PGO since it always runs after PGO.
 Py_BOLT='false'
-AC_MSG_CHECKING(for --enable-bolt)
-AC_ARG_ENABLE(bolt, AS_HELP_STRING(
+AC_MSG_CHECKING([for --enable-bolt])
+AC_ARG_ENABLE([bolt], [AS_HELP_STRING(
                 [--enable-bolt],
-                [enable usage of the llvm-bolt post-link optimizer (default is no)]),
+                [enable usage of the llvm-bolt post-link optimizer (default is no)])],
 [
 if test "$enableval" != no
 then
   Py_BOLT='true'
-  AC_MSG_RESULT(yes);
+  AC_MSG_RESULT([yes]);
 else
   Py_BOLT='false'
-  AC_MSG_RESULT(no);
+  AC_MSG_RESULT([no]);
 fi],
-[AC_MSG_RESULT(no)])
+[AC_MSG_RESULT([no])])
 
-AC_SUBST(PREBOLT_RULE)
+AC_SUBST([PREBOLT_RULE])
 if test "$Py_BOLT" = 'true' ; then
   PREBOLT_RULE="${DEF_MAKE_ALL_RULE}"
   DEF_MAKE_ALL_RULE="bolt-opt"
@@ -2041,27 +2051,27 @@ if test "$Py_BOLT" = 'true' ; then
   CFLAGS_NODIST="$CFLAGS_NODIST -fno-pie"
   # We want to add these no-pie flags to linking executables but not shared libraries:
   LINKCC="$LINKCC -fno-pie -no-pie"
-  AC_SUBST(LLVM_BOLT)
-  AC_PATH_TOOL(LLVM_BOLT, llvm-bolt, '', ${llvm_path})
+  AC_SUBST([LLVM_BOLT])
+  AC_PATH_TOOL([LLVM_BOLT], [llvm-bolt], [''], [${llvm_path}])
   if test -n "${LLVM_BOLT}" -a -x "${LLVM_BOLT}"
   then
-    AC_MSG_RESULT("Found llvm-bolt")
+    AC_MSG_RESULT(["Found llvm-bolt"])
   else
     AC_MSG_ERROR([llvm-bolt is required for a --enable-bolt build but could not be found.])
   fi
 
-  AC_SUBST(MERGE_FDATA)
-  AC_PATH_TOOL(MERGE_FDATA, merge-fdata, '', ${llvm_path})
+  AC_SUBST([MERGE_FDATA])
+  AC_PATH_TOOL([MERGE_FDATA], [merge-fdata], [''], [${llvm_path}])
   if test -n "${MERGE_FDATA}" -a -x "${MERGE_FDATA}"
   then
-    AC_MSG_RESULT("Found merge-fdata")
+    AC_MSG_RESULT(["Found merge-fdata"])
   else
     AC_MSG_ERROR([merge-fdata is required for a --enable-bolt build but could not be found.])
   fi
 fi
 
 dnl Enable BOLT of libpython if built.
-AC_SUBST(BOLT_BINARIES)
+AC_SUBST([BOLT_BINARIES])
 BOLT_BINARIES='$(BUILDPYTHON)'
 AS_VAR_IF([enable_shared], [yes], [
   BOLT_BINARIES="${BOLT_BINARIES} \$(INSTSONAME)"
@@ -2197,8 +2207,8 @@ AS_VAR_IF([ac_cv_cc_supports_og], [yes],
 
 # tweak OPT based on compiler and platform, only if the user didn't set
 # it on the command line
-AC_SUBST(OPT)
-AC_SUBST(CFLAGS_ALIASING)
+AC_SUBST([OPT])
+AC_SUBST([CFLAGS_ALIASING])
 if test "${OPT-unset}" = "unset"
 then
     case $GCC in
@@ -2304,21 +2314,21 @@ AS_CASE([$enable_wasm_dynamic_linking],
   [missing], []
 )
 
-AC_SUBST(BASECFLAGS)
-AC_SUBST(CFLAGS_NODIST)
-AC_SUBST(LDFLAGS_NODIST)
-AC_SUBST(LDFLAGS_NOLTO)
+AC_SUBST([BASECFLAGS])
+AC_SUBST([CFLAGS_NODIST])
+AC_SUBST([LDFLAGS_NODIST])
+AC_SUBST([LDFLAGS_NOLTO])
 AC_SUBST([WASM_ASSETS_DIR])
 AC_SUBST([WASM_STDLIB])
 
 # The -arch flags for universal builds on macOS
 UNIVERSAL_ARCH_FLAGS=
-AC_SUBST(UNIVERSAL_ARCH_FLAGS)
+AC_SUBST([UNIVERSAL_ARCH_FLAGS])
 
 dnl PY_CHECK_CC_WARNING(ENABLE, WARNING, [MSG])
 AC_DEFUN([PY_CHECK_CC_WARNING], [
   AS_VAR_PUSHDEF([py_var], [ac_cv_$1_]m4_normalize($2)[_warning])
-  AC_CACHE_CHECK(m4_ifblank([$3], [if we can $1 $CC $2 warning], [$3]), [py_var], [
+  AC_CACHE_CHECK([m4_ifblank([$3], [if we can $1 $CC $2 warning], [$3])], [py_var], [
     AS_VAR_COPY([py_cflags], [CFLAGS])
     AS_VAR_APPEND([CFLAGS], ["-W$2 -Werror"])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
@@ -2472,7 +2482,7 @@ yes)
         # used to be here, but non-Apple gcc doesn't accept them.
         if test "${CC}" = gcc
         then
-            AC_MSG_CHECKING(which compiler should be used)
+            AC_MSG_CHECKING([which compiler should be used])
             case "${UNIVERSALSDK}" in
             */MacOSX10.4u.sdk)
                 # Build using 10.4 SDK, force usage of gcc when the
@@ -2482,7 +2492,7 @@ yes)
                 CPP=cpp-4.0
                 ;;
             esac
-            AC_MSG_RESULT($CC)
+            AC_MSG_RESULT([$CC])
         fi
 
         LIPO_INTEL64_FLAGS=""
@@ -2559,7 +2569,7 @@ yes)
         #       below to pick either 10.3, 10.4, or 10.5 as the target.
         # 4. If we are running on OS X 10.2 or earlier, good luck!
 
-        AC_MSG_CHECKING(which MACOSX_DEPLOYMENT_TARGET to use)
+        AC_MSG_CHECKING([which MACOSX_DEPLOYMENT_TARGET to use])
         cur_target_major=`sw_vers -productVersion | \
                 sed 's/\([[0-9]]*\)\.\([[0-9]]*\).*/\1/'`
         cur_target_minor=`sw_vers -productVersion | \
@@ -2596,13 +2606,13 @@ yes)
         MACOSX_DEPLOYMENT_TARGET="$CONFIGURE_MACOSX_DEPLOYMENT_TARGET"
         export MACOSX_DEPLOYMENT_TARGET
         EXPORT_MACOSX_DEPLOYMENT_TARGET=''
-        AC_MSG_RESULT($MACOSX_DEPLOYMENT_TARGET)
+        AC_MSG_RESULT([$MACOSX_DEPLOYMENT_TARGET])
 
-        AC_MSG_CHECKING(if specified universal architectures work)
+        AC_MSG_CHECKING([if specified universal architectures work])
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]], [[printf("%d", 42);]])],
-            [AC_MSG_RESULT(yes)],
-            [AC_MSG_RESULT(no)
-             AC_MSG_ERROR(check config.log and use the '--with-universal-archs' option)
+            [AC_MSG_RESULT([yes])],
+            [AC_MSG_RESULT([no])
+             AC_MSG_ERROR([check config.log and use the '--with-universal-archs' option])
         ])
 
         # end of Darwin* tests
@@ -2806,7 +2816,8 @@ dnl AC_MSG_RESULT($cpp_type)
 
 dnl autoconf 2.71 deprecates STDC_HEADERS, keep for backwards compatibility
 dnl assume C99 compilers provide ANSI C headers
-AC_DEFINE(STDC_HEADERS, 1, [Define to 1 if you have the ANSI C header files.])
+AC_DEFINE([STDC_HEADERS], [1],
+          [Define to 1 if you have the ANSI C header files.])
 
 # checks for header files
 AC_CHECK_HEADERS([ \
@@ -2829,7 +2840,7 @@ AC_HEADER_MAJOR
 # http://permalink.gmane.org/gmane.linux.bluez.kernel/22294
 SAVE_CFLAGS=$CFLAGS
 CFLAGS="-std=c99 $CFLAGS"
-AC_CHECK_HEADERS(bluetooth/bluetooth.h)
+AC_CHECK_HEADERS([bluetooth/bluetooth.h])
 CFLAGS=$SAVE_CFLAGS
 
 # On Darwin (OS X) net/if.h requires sys/socket.h to be imported first.
@@ -2843,7 +2854,7 @@ AC_CHECK_HEADERS([net/if.h], [], [],
 ])
 
 # On Linux, netlink.h requires asm/types.h
-AC_CHECK_HEADERS(linux/netlink.h,,,[
+AC_CHECK_HEADERS([linux/netlink.h], [], [], [
 #ifdef HAVE_ASM_TYPES_H
 #include <asm/types.h>
 #endif
@@ -2853,7 +2864,7 @@ AC_CHECK_HEADERS(linux/netlink.h,,,[
 ])
 
 # On Linux, qrtr.h requires asm/types.h
-AC_CHECK_HEADERS(linux/qrtr.h,,,[
+AC_CHECK_HEADERS([linux/qrtr.h], [], [], [
 #ifdef HAVE_ASM_TYPES_H
 #include <asm/types.h>
 #endif
@@ -2862,7 +2873,7 @@ AC_CHECK_HEADERS(linux/qrtr.h,,,[
 #endif
 ])
 
-AC_CHECK_HEADERS(linux/vm_sockets.h,,,[
+AC_CHECK_HEADERS([linux/vm_sockets.h], [], [], [
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
@@ -2870,7 +2881,9 @@ AC_CHECK_HEADERS(linux/vm_sockets.h,,,[
 
 # On Linux, can.h, can/bcm.h, can/j1939.h, can/raw.h require sys/socket.h
 # On NetBSD, netcan/can.h requires sys/socket.h
-AC_CHECK_HEADERS(linux/can.h linux/can/bcm.h linux/can/j1939.h linux/can/raw.h netcan/can.h,,,[
+AC_CHECK_HEADERS(
+[linux/can.h linux/can/bcm.h linux/can/j1939.h linux/can/raw.h netcan/can.h],
+[], [], [
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
@@ -2882,7 +2895,8 @@ AC_CACHE_CHECK([for clock_t in time.h], [ac_cv_clock_t_time_h], [
 ])
 dnl checks for "no"
 AS_VAR_IF([ac_cv_clock_t_time_h], [no], [
-  AC_DEFINE(clock_t, long, [Define to 'long' if <time.h> doesn't define.])
+  AC_DEFINE([clock_t], [long],
+            [Define to 'long' if <time.h> doesn't define.])
 ])
 
 AC_CACHE_CHECK([for makedev], [ac_cv_func_makedev], [
@@ -2900,7 +2914,8 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 ])
 
 AS_VAR_IF([ac_cv_func_makedev], [yes], [
-    AC_DEFINE(HAVE_MAKEDEV, 1, [Define this if you have the makedev macro.])
+    AC_DEFINE([HAVE_MAKEDEV], [1],
+              [Define this if you have the makedev macro.])
 ])
 
 # byte swapping
@@ -2917,7 +2932,8 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 ])
 
 AS_VAR_IF([ac_cv_func_le64toh], [yes], [
-    AC_DEFINE(HAVE_HTOLE64, 1, [Define this if you have le64toh()])
+    AC_DEFINE([HAVE_HTOLE64], [1],
+              [Define this if you have le64toh()])
 ])
 
 use_lfs=yes
@@ -2931,13 +2947,13 @@ if test "$use_lfs" = "yes"; then
 # These may affect some typedefs
 case $ac_sys_system/$ac_sys_release in
 AIX*)
-    AC_DEFINE(_LARGE_FILES, 1,
+    AC_DEFINE([_LARGE_FILES], [1],
     [This must be defined on AIX systems to enable large file support.])
     ;;
 esac
-AC_DEFINE(_LARGEFILE_SOURCE, 1,
+AC_DEFINE([_LARGEFILE_SOURCE], [1],
 [This must be defined on some systems to enable large file support.])
-AC_DEFINE(_FILE_OFFSET_BITS, 64,
+AC_DEFINE([_FILE_OFFSET_BITS], [64],
 [This must be set to 64 on some systems to enable large file support.])
 fi
 
@@ -2956,40 +2972,42 @@ AC_DEFINE_UNQUOTED([RETSIGTYPE],[void],[assume C89 semantics that RETSIGTYPE is 
 AC_TYPE_SIZE_T
 AC_TYPE_UID_T
 
-AC_CHECK_TYPE(ssize_t,
-  AC_DEFINE(HAVE_SSIZE_T, 1, [Define if your compiler provides ssize_t]),,)
-AC_CHECK_TYPE(__uint128_t,
-  AC_DEFINE(HAVE_GCC_UINT128_T, 1, [Define if your compiler provides __uint128_t]),,)
+AC_CHECK_TYPE([ssize_t],
+  AC_DEFINE([HAVE_SSIZE_T], [1],
+            [Define if your compiler provides ssize_t]), [], [])
+AC_CHECK_TYPE([__uint128_t],
+  AC_DEFINE([HAVE_GCC_UINT128_T], [1],
+            [Define if your compiler provides __uint128_t]), [], [])
 
 # Sizes and alignments of various common basic types
 # ANSI C requires sizeof(char) == 1, so no need to check it
-AC_CHECK_SIZEOF(int, 4)
-AC_CHECK_SIZEOF(long, 4)
-AC_CHECK_ALIGNOF(long)
-AC_CHECK_SIZEOF(long long, 8)
-AC_CHECK_SIZEOF(void *, 4)
-AC_CHECK_SIZEOF(short, 2)
-AC_CHECK_SIZEOF(float, 4)
-AC_CHECK_SIZEOF(double, 8)
-AC_CHECK_SIZEOF(fpos_t, 4)
-AC_CHECK_SIZEOF(size_t, 4)
-AC_CHECK_ALIGNOF(size_t)
-AC_CHECK_SIZEOF(pid_t, 4)
-AC_CHECK_SIZEOF(uintptr_t)
-AC_CHECK_ALIGNOF(max_align_t)
+AC_CHECK_SIZEOF([int], [4])
+AC_CHECK_SIZEOF([long], [4])
+AC_CHECK_ALIGNOF([long])
+AC_CHECK_SIZEOF([long long], [8])
+AC_CHECK_SIZEOF([void *], [4])
+AC_CHECK_SIZEOF([short], [2])
+AC_CHECK_SIZEOF([float], [4])
+AC_CHECK_SIZEOF([double], [8])
+AC_CHECK_SIZEOF([fpos_t], [4])
+AC_CHECK_SIZEOF([size_t], [4])
+AC_CHECK_ALIGNOF([size_t])
+AC_CHECK_SIZEOF([pid_t], [4])
+AC_CHECK_SIZEOF([uintptr_t])
+AC_CHECK_ALIGNOF([max_align_t])
 
 AC_TYPE_LONG_DOUBLE
-AC_CHECK_SIZEOF(long double, 16)
+AC_CHECK_SIZEOF([long double], [16])
 
-AC_CHECK_SIZEOF(_Bool, 1)
+AC_CHECK_SIZEOF([_Bool], [1])
 
-AC_CHECK_SIZEOF(off_t, [], [
+AC_CHECK_SIZEOF([off_t], [], [
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
 ])
 
-AC_MSG_CHECKING(whether to enable large file support)
+AC_MSG_CHECKING([whether to enable large file support])
 if test "$ac_cv_sizeof_off_t" -gt "$ac_cv_sizeof_long" -a \
 	"$ac_cv_sizeof_long_long" -ge "$ac_cv_sizeof_off_t"; then
   have_largefile_support="yes"
@@ -3001,17 +3019,17 @@ AS_CASE([$ac_sys_system],
   [Emscripten], [have_largefile_support="no"]
 )
 AS_VAR_IF([have_largefile_support], [yes], [
-  AC_DEFINE(HAVE_LARGEFILE_SUPPORT, 1,
+  AC_DEFINE([HAVE_LARGEFILE_SUPPORT], [1],
   [Defined to enable large file support when an off_t is bigger than a long
    and long long is at least as big as an off_t. You may need
    to add some flags for configuration and compilation to enable this mode.
    (For Solaris and Linux, the necessary defines are already defined.)])
-  AC_MSG_RESULT(yes)
+  AC_MSG_RESULT([yes])
 ], [
-  AC_MSG_RESULT(no)
+  AC_MSG_RESULT([no])
 ])
 
-AC_CHECK_SIZEOF(time_t, [], [
+AC_CHECK_SIZEOF([time_t], [], [
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -3036,7 +3054,7 @@ AC_COMPILE_IFELSE([
 ], [ac_cv_have_pthread_t=yes], [ac_cv_have_pthread_t=no])
 ])
 AS_VAR_IF([ac_cv_have_pthread_t], [yes], [
-  AC_CHECK_SIZEOF(pthread_t, [], [
+  AC_CHECK_SIZEOF([pthread_t], [], [
 #ifdef HAVE_PTHREAD_H
 #include <pthread.h>
 #endif
@@ -3045,7 +3063,7 @@ AS_VAR_IF([ac_cv_have_pthread_t], [yes], [
 
 # Issue #25658: POSIX hasn't defined that pthread_key_t is compatible with int.
 # This checking will be unnecessary after removing deprecated TLS API.
-AC_CHECK_SIZEOF(pthread_key_t, [], [[#include <pthread.h>]])
+AC_CHECK_SIZEOF([pthread_key_t], [], [[#include <pthread.h>]])
 AC_CACHE_CHECK([whether pthread_key_t is compatible with int], [ac_cv_pthread_key_t_is_arithmetic_type], [
 if test "$ac_cv_sizeof_pthread_key_t" -eq "$ac_cv_sizeof_int" ; then
   AC_COMPILE_IFELSE(
@@ -3058,90 +3076,97 @@ else
 fi
 ])
 AS_VAR_IF([ac_cv_pthread_key_t_is_arithmetic_type], [yes], [
-    AC_DEFINE(PTHREAD_KEY_T_IS_COMPATIBLE_WITH_INT, 1,
+    AC_DEFINE([PTHREAD_KEY_T_IS_COMPATIBLE_WITH_INT], [1],
               [Define if pthread_key_t is compatible with int.])
 ])
 
 CC="$ac_save_cc"
 
-AC_MSG_CHECKING(for --enable-framework)
+AC_MSG_CHECKING([for --enable-framework])
 if test "$enable_framework"
 then
 	BASECFLAGS="$BASECFLAGS -fno-common -dynamic"
 	# -F. is needed to allow linking to the framework while
 	# in the build location.
-	AC_DEFINE(WITH_NEXT_FRAMEWORK, 1,
+	AC_DEFINE([WITH_NEXT_FRAMEWORK], [1],
          [Define if you want to produce an OpenStep/Rhapsody framework
          (shared library plus accessory files).])
-	AC_MSG_RESULT(yes)
+	AC_MSG_RESULT([yes])
 	if test $enable_shared = "yes"
 	then
 		AC_MSG_ERROR([Specifying both --enable-shared and --enable-framework is not supported, use only --enable-framework instead])
 	fi
 else
-	AC_MSG_RESULT(no)
+	AC_MSG_RESULT([no])
 fi
 
 # Check for --with-dsymutil
-AC_SUBST(DSYMUTIL)
-AC_SUBST(DSYMUTIL_PATH)
+AC_SUBST([DSYMUTIL])
+AC_SUBST([DSYMUTIL_PATH])
 DSYMUTIL=
 DSYMUTIL_PATH=
-AC_MSG_CHECKING(for --with-dsymutil)
-AC_ARG_WITH(dsymutil,
-            AS_HELP_STRING([--with-dsymutil], [link debug information into final executable with dsymutil in macOS  (default is no)]),
+AC_MSG_CHECKING([for --with-dsymutil])
+AC_ARG_WITH(
+  [dsymutil],
+  [AS_HELP_STRING(
+    [--with-dsymutil],
+    [link debug information into final executable with dsymutil in macOS  (default is no)]
+  )],
 [
 if test "$withval" != no
 then
   if test "$MACHDEP" != "darwin"; then
     AC_MSG_ERROR([dsymutil debug linking is only available in macOS.])
   fi
- AC_MSG_RESULT(yes);
+ AC_MSG_RESULT([yes]);
   DSYMUTIL='true'
-else AC_MSG_RESULT(no); DSYMUTIL=
+else AC_MSG_RESULT([no]); DSYMUTIL=
 fi],
-[AC_MSG_RESULT(no)])
+[AC_MSG_RESULT([no])])
 
 if test "$DSYMUTIL"; then
-  AC_PATH_PROG(DSYMUTIL_PATH, [dsymutil], [not found])
+  AC_PATH_PROG([DSYMUTIL_PATH], [dsymutil], [not found])
   if test "$DSYMUTIL_PATH" = "not found"; then
       AC_MSG_ERROR([dsymutil command not found on \$PATH])
   fi
 fi
 
-AC_MSG_CHECKING(for dyld)
+AC_MSG_CHECKING([for dyld])
 case $ac_sys_system/$ac_sys_release in
   Darwin/*)
-  	AC_DEFINE(WITH_DYLD, 1,
+    AC_DEFINE([WITH_DYLD], [1],
         [Define if you want to use the new-style (Openstep, Rhapsody, MacOS)
          dynamic linker (dyld) instead of the old-style (NextStep) dynamic
          linker (rld). Dyld is necessary to support frameworks.])
-  	AC_MSG_RESULT(always on for Darwin)
+    AC_MSG_RESULT([always on for Darwin])
   	;;
   *)
-	AC_MSG_RESULT(no)
+	AC_MSG_RESULT([no])
 	;;
 esac
 
-AC_MSG_CHECKING(for --with-address-sanitizer)
-AC_ARG_WITH(address_sanitizer,
+AC_MSG_CHECKING([for --with-address-sanitizer])
+AC_ARG_WITH([address_sanitizer],
             AS_HELP_STRING([--with-address-sanitizer],
                            [enable AddressSanitizer memory error detector, 'asan' (default is no)]),
 [
-AC_MSG_RESULT($withval)
+AC_MSG_RESULT([$withval])
 BASECFLAGS="-fsanitize=address -fno-omit-frame-pointer $BASECFLAGS"
 LDFLAGS="-fsanitize=address $LDFLAGS"
 # ASan works by controlling memory allocation, our own malloc interferes.
 with_pymalloc="no"
 ],
-[AC_MSG_RESULT(no)])
+[AC_MSG_RESULT([no])])
 
-AC_MSG_CHECKING(for --with-memory-sanitizer)
-AC_ARG_WITH(memory_sanitizer,
-            AS_HELP_STRING([--with-memory-sanitizer],
-                           [enable MemorySanitizer allocation error detector, 'msan' (default is no)]),
+AC_MSG_CHECKING([for --with-memory-sanitizer])
+AC_ARG_WITH(
+  [memory_sanitizer],
+  [AS_HELP_STRING(
+    [--with-memory-sanitizer],
+    [enable MemorySanitizer allocation error detector, 'msan' (default is no)]
+  )],
 [
-AC_MSG_RESULT($withval)
+AC_MSG_RESULT([$withval])
 AX_CHECK_COMPILE_FLAG([-fsanitize=memory],[
 BASECFLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer $BASECFLAGS"
 LDFLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 $LDFLAGS"
@@ -3149,34 +3174,37 @@ LDFLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 $LDFLAGS"
 # MSan works by controlling memory allocation, our own malloc interferes.
 with_pymalloc="no"
 ],
-[AC_MSG_RESULT(no)])
+[AC_MSG_RESULT([no])])
 
-AC_MSG_CHECKING(for --with-undefined-behavior-sanitizer)
-AC_ARG_WITH(undefined_behavior_sanitizer,
-            AS_HELP_STRING([--with-undefined-behavior-sanitizer],
-                           [enable UndefinedBehaviorSanitizer undefined behaviour detector, 'ubsan' (default is no)]),
+AC_MSG_CHECKING([for --with-undefined-behavior-sanitizer])
+AC_ARG_WITH(
+  [undefined_behavior_sanitizer],
+  [AS_HELP_STRING(
+    [--with-undefined-behavior-sanitizer],
+    [enable UndefinedBehaviorSanitizer undefined behaviour detector, 'ubsan' (default is no)]
+  )],
 [
-AC_MSG_RESULT($withval)
+AC_MSG_RESULT([$withval])
 BASECFLAGS="-fsanitize=undefined $BASECFLAGS"
 LDFLAGS="-fsanitize=undefined $LDFLAGS"
 with_ubsan="yes"
 ],
 [
-AC_MSG_RESULT(no)
+AC_MSG_RESULT([no])
 with_ubsan="no"
 ])
 
 # Set info about shared libraries.
-AC_SUBST(SHLIB_SUFFIX)
-AC_SUBST(LDSHARED)
-AC_SUBST(LDCXXSHARED)
-AC_SUBST(BLDSHARED)
-AC_SUBST(CCSHARED)
-AC_SUBST(LINKFORSHARED)
+AC_SUBST([SHLIB_SUFFIX])
+AC_SUBST([LDSHARED])
+AC_SUBST([LDCXXSHARED])
+AC_SUBST([BLDSHARED])
+AC_SUBST([CCSHARED])
+AC_SUBST([LINKFORSHARED])
 
 # SHLIB_SUFFIX is the extension of shared libraries `(including the dot!)
 # -- usually .so, .sl on HP-UX, .dll on Cygwin
-AC_MSG_CHECKING(the extension of shared libraries)
+AC_MSG_CHECKING([the extension of shared libraries])
 if test -z "$SHLIB_SUFFIX"; then
 	case $ac_sys_system in
 	hp*|HP*)
@@ -3189,13 +3217,13 @@ if test -z "$SHLIB_SUFFIX"; then
 	*)	   SHLIB_SUFFIX=.so;;
 	esac
 fi
-AC_MSG_RESULT($SHLIB_SUFFIX)
+AC_MSG_RESULT([$SHLIB_SUFFIX])
 
 # LDSHARED is the ld *command* used to create shared library
 # -- "cc -G" on SunOS 5.x.
 # (Shared libraries in this instance are shared modules to be loaded into
 # Python, as opposed to building Python itself as a shared library.)
-AC_MSG_CHECKING(LDSHARED)
+AC_MSG_CHECKING([LDSHARED])
 if test -z "$LDSHARED"
 then
 	case $ac_sys_system/$ac_sys_release in
@@ -3327,7 +3355,7 @@ if test "$enable_wasm_dynamic_linking" = "yes" -a "$ac_sys_system" = "Emscripten
   BLDSHARED='$(CC) -shared -sSIDE_MODULE=1'
 fi
 
-AC_MSG_RESULT($LDSHARED)
+AC_MSG_RESULT([$LDSHARED])
 LDCXXSHARED=${LDCXXSHARED-$LDSHARED}
 
 AC_MSG_CHECKING([BLDSHARED flags])
@@ -3336,7 +3364,7 @@ AC_MSG_RESULT([$BLDSHARED])
 
 # CCSHARED are the C *flags* used to create objects to go into a shared
 # library (module) -- this is only needed for a few systems
-AC_MSG_CHECKING(CCSHARED)
+AC_MSG_CHECKING([CCSHARED])
 if test -z "$CCSHARED"
 then
 	case $ac_sys_system/$ac_sys_release in
@@ -3372,10 +3400,10 @@ then
 		CCSHARED="-fpic -D__SO_PICABILINUX__  -ftls-model=global-dynamic"
 	esac
 fi
-AC_MSG_RESULT($CCSHARED)
+AC_MSG_RESULT([$CCSHARED])
 # LINKFORSHARED are the flags passed to the $(CC) command that links
 # the python executable -- this is only needed for a few systems
-AC_MSG_CHECKING(LINKFORSHARED)
+AC_MSG_CHECKING([LINKFORSHARED])
 if test -z "$LINKFORSHARED"
 then
 	case $ac_sys_system/$ac_sys_release in
@@ -3401,8 +3429,8 @@ then
 
     LINKFORSHARED="-Wl,-stack_size,$stack_size $LINKFORSHARED"
 
-    AC_DEFINE_UNQUOTED(THREAD_STACK_SIZE,
-        0x$stack_size,
+    AC_DEFINE_UNQUOTED([THREAD_STACK_SIZE],
+        [0x$stack_size],
         [Custom thread stack size depending on chosen sanitizer runtimes.])
 
 		if test "$enable_framework"
@@ -3441,11 +3469,11 @@ then
 		LINKFORSHARED='-Wl,-export-dynamic';;
 	esac
 fi
-AC_MSG_RESULT($LINKFORSHARED)
+AC_MSG_RESULT([$LINKFORSHARED])
 
 
-AC_SUBST(CFLAGSFORSHARED)
-AC_MSG_CHECKING(CFLAGSFORSHARED)
+AC_SUBST([CFLAGSFORSHARED])
+AC_MSG_CHECKING([CFLAGSFORSHARED])
 if test ! "$LIBRARY" = "$LDLIBRARY"
 then
 	case $ac_sys_system in
@@ -3463,7 +3491,7 @@ AS_VAR_IF([enable_wasm_dynamic_linking], [yes], [
   CFLAGSFORSHARED='$(CCSHARED)'
 ])
 
-AC_MSG_RESULT($CFLAGSFORSHARED)
+AC_MSG_RESULT([$CFLAGSFORSHARED])
 
 # SHLIBS are libraries (except -lc and -lm) to link to the python shared
 # library (with --enable-shared).
@@ -3473,13 +3501,13 @@ AC_MSG_RESULT($CFLAGSFORSHARED)
 # to LIBS. This, in turn, means that applications linking the shared libpython
 # don't need to link LIBS explicitly. The default should be only changed
 # on systems where this approach causes problems.
-AC_SUBST(SHLIBS)
-AC_MSG_CHECKING(SHLIBS)
+AC_SUBST([SHLIBS])
+AC_MSG_CHECKING([SHLIBS])
 case "$ac_sys_system" in
 	*)
 		SHLIBS='$(LIBS)';;
 esac
-AC_MSG_RESULT($SHLIBS)
+AC_MSG_RESULT([$SHLIBS])
 
 dnl perf trampoline is Linux specific and requires an arch-specific
 dnl trampoline in asssembly.
@@ -3503,9 +3531,9 @@ AS_VAR_IF([perf_trampoline], [yes], [
 AC_SUBST([PERF_TRAMPOLINE_OBJ])
 
 # checks for libraries
-AC_CHECK_LIB(sendfile, sendfile)
-AC_CHECK_LIB(dl, dlopen)	# Dynamic linking for SunOS/Solaris and SYSV
-AC_CHECK_LIB(dld, shl_load)	# Dynamic linking for HP-UX
+AC_CHECK_LIB([sendfile], [sendfile])
+AC_CHECK_LIB([dl], [dlopen])       # Dynamic linking for SunOS/Solaris and SYSV
+AC_CHECK_LIB([dld], [shl_load])    # Dynamic linking for HP-UX
 
 
 dnl check for uuid dependencies
@@ -3518,9 +3546,9 @@ dnl AIX provides support for RFC4122 (uuid) in libc.a starting with AIX 6.1
 dnl (anno 2007). FreeBSD and OpenBSD provides support in libc as well.
 dnl Little-endian FreeBSD, OpenBSD and NetBSD needs encoding into an octet
 dnl stream in big-endian byte-order
-AC_CHECK_HEADERS([uuid.h], [
-  AC_CHECK_FUNCS([uuid_create uuid_enc_be], [
-    have_uuid=yes
+AC_CHECK_HEADERS([uuid.h],
+  [AC_CHECK_FUNCS([uuid_create uuid_enc_be],
+    [have_uuid=yes
     LIBUUID_CFLAGS=${LIBUUID_CFLAGS-""}
     LIBUUID_LIBS=${LIBUUID_LIBS-""}
   ])
@@ -3528,8 +3556,8 @@ AC_CHECK_HEADERS([uuid.h], [
 
 AS_VAR_IF([have_uuid], [missing], [
   PKG_CHECK_MODULES(
-    [LIBUUID], [uuid >= 2.20], [
-      dnl linux-util's libuuid has uuid_generate_time_safe() since v2.20 (2011)
+    [LIBUUID], [uuid >= 2.20],
+      [dnl linux-util's libuuid has uuid_generate_time_safe() since v2.20 (2011)
       dnl and provides <uuid.h>.
       have_uuid=yes
       AC_DEFINE([HAVE_UUID_H], [1])
@@ -3540,11 +3568,9 @@ AS_VAR_IF([have_uuid], [missing], [
         LDFLAGS="$LDFLAGS $LIBUUID_LIBS"
         AC_CHECK_HEADERS([uuid/uuid.h], [
           PY_CHECK_LIB([uuid], [uuid_generate_time], [have_uuid=yes])
-          PY_CHECK_LIB([uuid], [uuid_generate_time_safe], [
-            have_uuid=yes
-            AC_DEFINE([HAVE_UUID_GENERATE_TIME_SAFE], [1])
-          ])
-        ])
+          PY_CHECK_LIB([uuid], [uuid_generate_time_safe],
+            [have_uuid=yes
+            AC_DEFINE([HAVE_UUID_GENERATE_TIME_SAFE], [1]) ]) ])
         AS_VAR_IF([have_uuid], [yes], [
           LIBUUID_CFLAGS=${LIBUUID_CFLAGS-""}
           LIBUUID_LIBS=${LIBUUID_LIBS-"-luuid"}
@@ -3570,37 +3596,37 @@ AS_VAR_IF([have_uuid], [missing], [have_uuid=no])
 # 'Real Time' functions on Solaris
 # posix4 on Solaris 2.6
 # pthread (first!) on Linux
-AC_SEARCH_LIBS(sem_init, pthread rt posix4)
+AC_SEARCH_LIBS([sem_init], [pthread rt posix4])
 
 # check if we need libintl for locale functions
-AC_CHECK_LIB(intl, textdomain,
-	[AC_DEFINE(WITH_LIBINTL, 1,
+AC_CHECK_LIB([intl], [textdomain],
+	[AC_DEFINE([WITH_LIBINTL], [1],
 	[Define to 1 if libintl is needed for locale functions.])
         LIBS="-lintl $LIBS"])
 
 # checks for system dependent C++ extensions support
 case "$ac_sys_system" in
-	AIX*)	AC_MSG_CHECKING(for genuine AIX C++ extensions support)
+	AIX*)	AC_MSG_CHECKING([for genuine AIX C++ extensions support])
 		AC_LINK_IFELSE([
 		  AC_LANG_PROGRAM([[#include <load.h>]],
 				  [[loadAndInit("", 0, "")]])
 		],[
-		  AC_DEFINE(AIX_GENUINE_CPLUSPLUS, 1,
+		  AC_DEFINE([AIX_GENUINE_CPLUSPLUS], [1],
                       [Define for AIX if your compiler is a genuine IBM xlC/xlC_r
                        and you want support for AIX C++ shared extension modules.])
-		  AC_MSG_RESULT(yes)
+		  AC_MSG_RESULT([yes])
 		],[
-		  AC_MSG_RESULT(no)
+		  AC_MSG_RESULT([no])
 		])
 dnl The AIX_BUILDDATE is obtained from the kernel fileset - bos.mp64
 # BUILD_GNU_TYPE + AIX_BUILDDATE are used to construct the platform_tag
 # of the AIX system used to build/package Python executable. This tag serves
 # as a baseline for bdist module packages
-               AC_MSG_CHECKING(for the system builddate)
+               AC_MSG_CHECKING([for the system builddate])
                AIX_BUILDDATE=$(lslpp -Lcq bos.mp64 | awk -F:  '{ print $NF }')
                AC_DEFINE_UNQUOTED([AIX_BUILDDATE], [$AIX_BUILDDATE],
                    [BUILD_GNU_TYPE + AIX_BUILDDATE are used to construct the PEP425 tag of the build system.])
-               AC_MSG_RESULT($AIX_BUILDDATE)
+               AC_MSG_RESULT([$AIX_BUILDDATE])
                ;;
 	*) ;;
 esac
@@ -3630,33 +3656,36 @@ if test "$ac_cv_aligned_required" = yes ; then
 fi
 
 # str, bytes and memoryview hash algorithm
-AH_TEMPLATE(Py_HASH_ALGORITHM,
+AH_TEMPLATE([Py_HASH_ALGORITHM],
   [Define hash algorithm for str, bytes and memoryview.
    SipHash24: 1, FNV: 2, SipHash13: 3, externally defined: 0])
 
-AC_MSG_CHECKING(for --with-hash-algorithm)
+AC_MSG_CHECKING([for --with-hash-algorithm])
 dnl quadrigraphs "@<:@" and "@:>@" produce "[" and "]" in the output
-AC_ARG_WITH(hash_algorithm,
-            AS_HELP_STRING([--with-hash-algorithm=@<:@fnv|siphash13|siphash24@:>@],
-                           [select hash algorithm for use in Python/pyhash.c (default is SipHash13)]),
+AC_ARG_WITH(
+  [hash_algorithm],
+  [AS_HELP_STRING(
+    [--with-hash-algorithm=@<:@fnv|siphash13|siphash24@:>@],
+    [select hash algorithm for use in Python/pyhash.c (default is SipHash13)]
+  )],
 [
-AC_MSG_RESULT($withval)
+AC_MSG_RESULT([$withval])
 case "$withval" in
     siphash13)
-        AC_DEFINE(Py_HASH_ALGORITHM, 3)
+        AC_DEFINE([Py_HASH_ALGORITHM], [3])
         ;;
     siphash24)
-        AC_DEFINE(Py_HASH_ALGORITHM, 1)
+        AC_DEFINE([Py_HASH_ALGORITHM], [1])
         ;;
     fnv)
-        AC_DEFINE(Py_HASH_ALGORITHM, 2)
+        AC_DEFINE([Py_HASH_ALGORITHM], [2])
         ;;
     *)
         AC_MSG_ERROR([unknown hash algorithm '$withval'])
         ;;
 esac
 ],
-[AC_MSG_RESULT(default)])
+[AC_MSG_RESULT([default])])
 
 validate_tzpath() {
     # Checks that each element of the path is an absolute path
@@ -3674,10 +3703,13 @@ validate_tzpath() {
 }
 
 TZPATH="/usr/share/zoneinfo:/usr/lib/zoneinfo:/usr/share/lib/zoneinfo:/etc/zoneinfo"
-AC_MSG_CHECKING(for --with-tzpath)
-AC_ARG_WITH(tzpath,
-            AS_HELP_STRING([--with-tzpath=<list of absolute paths separated by pathsep>]
-                           [Select the default time zone search path for zoneinfo.TZPATH]),
+AC_MSG_CHECKING([for --with-tzpath])
+AC_ARG_WITH(
+  [tzpath],
+  [AS_HELP_STRING(
+    [--with-tzpath=<list of absolute paths separated by pathsep>],
+    [Select the default time zone search path for zoneinfo.TZPATH]
+  )],
 [
 case "$withval" in
     yes)
@@ -3686,41 +3718,47 @@ case "$withval" in
     *)
         validate_tzpath "$withval"
         TZPATH="$withval"
-        AC_MSG_RESULT("$withval")
+        AC_MSG_RESULT(["$withval"])
         ;;
 esac
 ],
 [validate_tzpath "$TZPATH"
- AC_MSG_RESULT("$TZPATH")])
-AC_SUBST(TZPATH)
+ AC_MSG_RESULT(["$TZPATH"])])
+AC_SUBST([TZPATH])
 
 # Most SVR4 platforms (e.g. Solaris) need -lsocket and -lnsl.
-AC_CHECK_LIB(nsl, t_open, [LIBS="-lnsl $LIBS"]) # SVR4
-AC_CHECK_LIB(socket, socket, [LIBS="-lsocket $LIBS"], [], $LIBS) # SVR4 sockets
+AC_CHECK_LIB([nsl], [t_open], [LIBS="-lnsl $LIBS"]) # SVR4
+AC_CHECK_LIB([socket], [socket], [LIBS="-lsocket $LIBS"], [], $LIBS) # SVR4 sockets
 
 case $ac_sys_system/$ac_sys_release in
     Haiku*)
-        AC_CHECK_LIB(network, socket, [LIBS="-lnetwork $LIBS"], [], $LIBS)
+        AC_CHECK_LIB([network], [socket], [LIBS="-lnetwork $LIBS"], [], [$LIBS])
     ;;
 esac
 
-AC_MSG_CHECKING(for --with-libs)
-AC_ARG_WITH(libs,
-            AS_HELP_STRING([--with-libs='lib1 ...'], [link against additional libs (default is no)]),
+AC_MSG_CHECKING([for --with-libs])
+AC_ARG_WITH(
+  [libs],
+  [AS_HELP_STRING(
+    [--with-libs='lib1 ...'],
+    [link against additional libs (default is no)]
+  )],
 [
-AC_MSG_RESULT($withval)
+AC_MSG_RESULT([$withval])
 LIBS="$withval $LIBS"
 ],
-[AC_MSG_RESULT(no)])
+[AC_MSG_RESULT([no])])
 
 # Check for use of the system expat library
-AC_MSG_CHECKING(for --with-system-expat)
-AC_ARG_WITH(system_expat,
-            AS_HELP_STRING([--with-system-expat], [build pyexpat module using an installed expat library, see Doc/library/pyexpat.rst (default is no)]),
-            [],
-            [with_system_expat="no"])
+AC_MSG_CHECKING([for --with-system-expat])
+AC_ARG_WITH(
+  [system_expat],
+  [AS_HELP_STRING(
+     [--with-system-expat],
+     [build pyexpat module using an installed expat library, see Doc/library/pyexpat.rst (default is no)]
+  )], [], [with_system_expat="no"])
 
-AC_MSG_RESULT($with_system_expat)
+AC_MSG_RESULT([$with_system_expat])
 
 AS_VAR_IF([with_system_expat], [yes], [
   LIBEXPAT_CFLAGS=${LIBEXPAT_CFLAGS-""}
@@ -3795,12 +3833,16 @@ AS_VAR_IF([have_libffi], [yes], [
 ])
 
 # Check for use of the system libmpdec library
-AC_MSG_CHECKING(for --with-system-libmpdec)
-AC_ARG_WITH(system_libmpdec,
-            AS_HELP_STRING([--with-system-libmpdec], [build _decimal module using an installed libmpdec library, see Doc/library/decimal.rst (default is no)]),
-            [],
-            [with_system_libmpdec="no"])
-AC_MSG_RESULT($with_system_libmpdec)
+AC_MSG_CHECKING([for --with-system-libmpdec])
+AC_ARG_WITH(
+  [system_libmpdec],
+  [AS_HELP_STRING(
+    [--with-system-libmpdec],
+    [build _decimal module using an installed libmpdec library, see Doc/library/decimal.rst (default is no)]
+  )],
+  [],
+  [with_system_libmpdec="no"])
+AC_MSG_RESULT([$with_system_libmpdec])
 
 AS_VAR_IF([with_system_libmpdec], [yes], [
   LIBMPDEC_CFLAGS=${LIBMPDEC_CFLAGS-""}
@@ -3821,22 +3863,26 @@ AC_SUBST([LIBMPDEC_CFLAGS])
 AC_SUBST([LIBMPDEC_INTERNAL])
 
 # Check whether _decimal should use a coroutine-local or thread-local context
-AC_MSG_CHECKING(for --with-decimal-contextvar)
-AC_ARG_WITH(decimal_contextvar,
-            AS_HELP_STRING([--with-decimal-contextvar], [build _decimal module using a coroutine-local rather than a thread-local context (default is yes)]),
-            [],
-            [with_decimal_contextvar="yes"])
+AC_MSG_CHECKING([for --with-decimal-contextvar])
+AC_ARG_WITH(
+  [decimal_contextvar],
+  [AS_HELP_STRING(
+    [--with-decimal-contextvar],
+    [build _decimal module using a coroutine-local rather than a thread-local context (default is yes)]
+  )],
+  [],
+  [with_decimal_contextvar="yes"])
 
 if test "$with_decimal_contextvar" != "no"
 then
-    AC_DEFINE(WITH_DECIMAL_CONTEXTVAR, 1,
+    AC_DEFINE([WITH_DECIMAL_CONTEXTVAR], [1],
       [Define if you want build the _decimal module using a coroutine-local rather than a thread-local context])
 fi
 
-AC_MSG_RESULT($with_decimal_contextvar)
+AC_MSG_RESULT([$with_decimal_contextvar])
 
 # Check for libmpdec machine flavor
-AC_MSG_CHECKING(for decimal libmpdec machine)
+AC_MSG_CHECKING([for decimal libmpdec machine])
 AS_CASE([$ac_sys_system],
   [Darwin*], [libmpdec_system=Darwin],
   [SunOS*], [libmpdec_system=sunos],
@@ -4176,9 +4222,13 @@ AC_CHECK_HEADERS([db.h], [
 
 # Check for --with-dbmliborder
 AC_MSG_CHECKING([for --with-dbmliborder])
-AC_ARG_WITH(dbmliborder,
-            AS_HELP_STRING([--with-dbmliborder=db1:db2:...], [override order to check db backends for dbm; a valid value is a colon separated string with the backend names `ndbm', `gdbm' and `bdb'.]),
-[], [with_dbmliborder=gdbm:ndbm:bdb])
+AC_ARG_WITH(
+  [dbmliborder],
+  [AS_HELP_STRING(
+    [--with-dbmliborder=db1:db2:...],
+    [override order to check db backends for dbm; a valid value is a colon separated string with the backend names `ndbm', `gdbm' and `bdb'.]
+  )],
+  [], [with_dbmliborder=gdbm:ndbm:bdb])
 
 have_gdbm_dbmliborder=no
 as_save_IFS=$IFS
@@ -4234,13 +4284,13 @@ AC_MSG_RESULT([$DBM_CFLAGS $DBM_LIBS])
 
 # Templates for things AC_DEFINEd more than once.
 # For a single AC_DEFINE, no template is needed.
-AH_TEMPLATE(_REENTRANT,
+AH_TEMPLATE([_REENTRANT],
   [Define to force use of thread-safe errno, h_errno, and other functions])
 
 if test "$ac_cv_pthread_is_default" = yes
 then
     # Defining _REENTRANT on system with POSIX threads should not hurt.
-    AC_DEFINE(_REENTRANT)
+    AC_DEFINE([_REENTRANT])
     posix_threads=yes
     if test "$ac_sys_system" = "SunOS"; then
         CFLAGS="$CFLAGS -D_REENTRANT"
@@ -4274,17 +4324,17 @@ else
     # According to the POSIX spec, a pthreads implementation must
     # define _POSIX_THREADS in unistd.h. Some apparently don't
     # (e.g. gnu pth with pthread emulation)
-    AC_MSG_CHECKING(for _POSIX_THREADS in unistd.h)
-    AC_EGREP_CPP(yes,
+    AC_MSG_CHECKING([for _POSIX_THREADS in unistd.h])
+    AC_EGREP_CPP([yes],
     [
 #include <unistd.h>
 #ifdef _POSIX_THREADS
 yes
 #endif
     ], unistd_defines_pthreads=yes, unistd_defines_pthreads=no)
-    AC_MSG_RESULT($unistd_defines_pthreads)
+    AC_MSG_RESULT([$unistd_defines_pthreads])
 
-    AC_DEFINE(_REENTRANT)
+    AC_DEFINE([_REENTRANT])
     # Just looking for pthread_create in libpthread is not enough:
     # on HP/UX, pthread.h renames pthread_create to a different symbol name.
     # So we really have to include pthread.h, and then link.
@@ -4298,26 +4348,26 @@ yes
 
 void * start_routine (void *arg) { exit (0); }]], [[
 pthread_create (NULL, NULL, start_routine, NULL)]])],[
-    AC_MSG_RESULT(yes)
+    AC_MSG_RESULT([yes])
     posix_threads=yes
     ],[
     LIBS=$_libs
-    AC_CHECK_FUNC(pthread_detach, [
+    AC_CHECK_FUNC([pthread_detach], [
     posix_threads=yes
     ],[
-    AC_CHECK_LIB(pthreads, pthread_create, [
+    AC_CHECK_LIB([pthreads], [pthread_create], [
     posix_threads=yes
     LIBS="$LIBS -lpthreads"
     ], [
-    AC_CHECK_LIB(c_r, pthread_create, [
+    AC_CHECK_LIB([c_r], [pthread_create], [
     posix_threads=yes
     LIBS="$LIBS -lc_r"
     ], [
-    AC_CHECK_LIB(pthread, __pthread_create_system, [
+    AC_CHECK_LIB([pthread], [__pthread_create_system], [
     posix_threads=yes
     LIBS="$LIBS -lpthread"
     ], [
-    AC_CHECK_LIB(cma, pthread_create, [
+    AC_CHECK_LIB([cma], [pthread_create], [
     posix_threads=yes
     LIBS="$LIBS -lcma"
     ],[
@@ -4327,7 +4377,7 @@ pthread_create (NULL, NULL, start_routine, NULL)]])],[
     )
     ])])])])])])
 
-    AC_CHECK_LIB(mpc, usconfig, [
+    AC_CHECK_LIB([mpc], [usconfig], [
     LIBS="$LIBS -lmpc"
     ])
 
@@ -4335,23 +4385,23 @@ fi
 
 if test "$posix_threads" = "yes"; then
       if test "$unistd_defines_pthreads" = "no"; then
-         AC_DEFINE(_POSIX_THREADS, 1,
+         AC_DEFINE([_POSIX_THREADS], [1],
          [Define if you have POSIX threads,
           and your system does not define that.])
       fi
 
       # Bug 662787: Using semaphores causes unexplicable hangs on Solaris 8.
       case  $ac_sys_system/$ac_sys_release in
-      SunOS/5.6) AC_DEFINE(HAVE_PTHREAD_DESTRUCTOR, 1,
+      SunOS/5.6) AC_DEFINE([HAVE_PTHREAD_DESTRUCTOR], [1],
                        [Defined for Solaris 2.6 bug in pthread header.])
 		       ;;
-      SunOS/5.8) AC_DEFINE(HAVE_BROKEN_POSIX_SEMAPHORES, 1,
+      SunOS/5.8) AC_DEFINE([HAVE_BROKEN_POSIX_SEMAPHORES], [1],
 		       [Define if the Posix semaphores do not work on your system])
 		       ;;
-      AIX/*) AC_DEFINE(HAVE_BROKEN_POSIX_SEMAPHORES, 1,
+      AIX/*) AC_DEFINE([HAVE_BROKEN_POSIX_SEMAPHORES], [1],
 		       [Define if the Posix semaphores do not work on your system])
 		       ;;
-      NetBSD/*) AC_DEFINE(HAVE_BROKEN_POSIX_SEMAPHORES, 1,
+      NetBSD/*) AC_DEFINE([HAVE_BROKEN_POSIX_SEMAPHORES], [1],
 		       [Define if the Posix semaphores do not work on your system])
 		       ;;
       esac
@@ -4376,16 +4426,17 @@ if test "$posix_threads" = "yes"; then
       [ac_cv_pthread_system_supported=no])
       ])
       if test "$ac_cv_pthread_system_supported" = "yes"; then
-        AC_DEFINE(PTHREAD_SYSTEM_SCHED_SUPPORTED, 1, [Defined if PTHREAD_SCOPE_SYSTEM supported.])
+        AC_DEFINE([PTHREAD_SYSTEM_SCHED_SUPPORTED], [1],
+                  [Defined if PTHREAD_SCOPE_SYSTEM supported.])
       fi
-      AC_CHECK_FUNCS(pthread_sigmask,
+      AC_CHECK_FUNCS([pthread_sigmask],
         [case $ac_sys_system in
         CYGWIN*)
-          AC_DEFINE(HAVE_BROKEN_PTHREAD_SIGMASK, 1,
+          AC_DEFINE([HAVE_BROKEN_PTHREAD_SIGMASK], [1],
             [Define if pthread_sigmask() does not work on your system.])
             ;;
         esac])
-      AC_CHECK_FUNCS(pthread_getcpuclockid)
+      AC_CHECK_FUNCS([pthread_getcpuclockid])
 fi
 
 AS_VAR_IF([posix_threads], [stub], [
@@ -4393,18 +4444,20 @@ AS_VAR_IF([posix_threads], [stub], [
 ])
 
 # Check for enable-ipv6
-AH_TEMPLATE(ENABLE_IPV6, [Define if --enable-ipv6 is specified])
+AH_TEMPLATE([ENABLE_IPV6], [Define if --enable-ipv6 is specified])
 AC_MSG_CHECKING([if --enable-ipv6 is specified])
-AC_ARG_ENABLE(ipv6,
-    AS_HELP_STRING([--enable-ipv6],
-               [enable ipv6 (with ipv4) support, see Doc/library/socket.rst (default is yes if supported)]),
+AC_ARG_ENABLE([ipv6],
+  [AS_HELP_STRING(
+    [--enable-ipv6],
+    [enable ipv6 (with ipv4) support, see Doc/library/socket.rst (default is yes if supported)]
+  )],
 [ case "$enableval" in
   no)
-       AC_MSG_RESULT(no)
+       AC_MSG_RESULT([no])
        ipv6=no
        ;;
-  *)   AC_MSG_RESULT(yes)
-       AC_DEFINE(ENABLE_IPV6)
+  *)   AC_MSG_RESULT([yes])
+       AC_DEFINE([ENABLE_IPV6])
        ipv6=yes
        ;;
   esac ],
@@ -4427,23 +4480,23 @@ AS_CASE([$ac_sys_system],
 AC_MSG_RESULT([$ipv6])
 
 if test "$ipv6" = "yes"; then
-	AC_MSG_CHECKING(if RFC2553 API is available)
+	AC_MSG_CHECKING([if RFC2553 API is available])
 	AC_COMPILE_IFELSE([
 	  AC_LANG_PROGRAM([[#include <sys/types.h>
 #include <netinet/in.h>]],
 			  [[struct sockaddr_in6 x;
 			    x.sin6_scope_id;]])
 	],[
-	  AC_MSG_RESULT(yes)
+	  AC_MSG_RESULT([yes])
 	  ipv6=yes
 	],[
-	  AC_MSG_RESULT(no, IPv6 disabled)
+	  AC_MSG_RESULT([no], [IPv6 disabled])
 	  ipv6=no
 	])
 fi
 
 if test "$ipv6" = "yes"; then
-	AC_DEFINE(ENABLE_IPV6)
+	AC_DEFINE([ENABLE_IPV6])
 fi
 ])
 
@@ -4458,7 +4511,7 @@ if test "$ipv6" = "yes"; then
 		case $i in
 		inria)
 			dnl http://www.kame.net/
-			AC_EGREP_CPP(yes, [
+			AC_EGREP_CPP([yes], [
 #include <netinet/in.h>
 #ifdef IPV6_INRIA_VERSION
 yes
@@ -4467,7 +4520,7 @@ yes
 			;;
 		kame)
 			dnl http://www.kame.net/
-			AC_EGREP_CPP(yes, [
+			AC_EGREP_CPP([yes], [
 #include <netinet/in.h>
 #ifdef __KAME__
 yes
@@ -4479,7 +4532,7 @@ yes
 			;;
 		linux-glibc)
 			dnl http://www.v6.linux.or.jp/
-			AC_EGREP_CPP(yes, [
+			AC_EGREP_CPP([yes], [
 #include <features.h>
 #if defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1) || (__GLIBC__ > 2))
 yes
@@ -4505,7 +4558,7 @@ yes
                         fi
 			;;
 		toshiba)
-			AC_EGREP_CPP(yes, [
+			AC_EGREP_CPP([yes], [
 #include <sys/param.h>
 #ifdef _TOSHIBA_INET6
 yes
@@ -4515,7 +4568,7 @@ yes
 				ipv6libdir=/usr/local/v6/lib])
 			;;
 		v6d)
-			AC_EGREP_CPP(yes, [
+			AC_EGREP_CPP([yes], [
 #include </usr/local/v6/include/sys/v6config.h>
 #ifdef __V6D__
 yes
@@ -4526,7 +4579,7 @@ yes
 				BASECFLAGS="-I/usr/local/v6/include $BASECFLAGS"])
 			;;
 		zeta)
-			AC_EGREP_CPP(yes, [
+			AC_EGREP_CPP([yes], [
 #include <sys/param.h>
 #ifdef _ZETA_MINAMI_INET6
 yes
@@ -4540,7 +4593,7 @@ yes
 			break
 		fi
 	done
-	AC_MSG_RESULT($ipv6type)
+	AC_MSG_RESULT([$ipv6type])
 fi
 
 if test "$ipv6" = "yes" -a "$ipv6lib" != "none"; then
@@ -4569,7 +4622,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ /* CAN_RAW_FD_FRAMES available check */
 [ac_cv_can_raw_fd_frames=no])
 ])
 AS_VAR_IF([ac_cv_can_raw_fd_frames], [yes], [
-    AC_DEFINE(HAVE_LINUX_CAN_RAW_FD_FRAMES, 1, [Define if compiling using Linux 3.6 or later.])
+    AC_DEFINE([HAVE_LINUX_CAN_RAW_FD_FRAMES], [1],
+              [Define if compiling using Linux 3.6 or later.])
 ])
 
 AC_CACHE_CHECK([for CAN_RAW_JOIN_FILTERS], [ac_cv_can_raw_join_filters], [
@@ -4580,28 +4634,31 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 [ac_cv_can_raw_join_filters=no])
 ])
 AS_VAR_IF([ac_cv_can_raw_join_filters], [yes], [
-    AC_DEFINE(HAVE_LINUX_CAN_RAW_JOIN_FILTERS, 1, [Define if compiling using Linux 4.1 or later.])
+    AC_DEFINE([HAVE_LINUX_CAN_RAW_JOIN_FILTERS], [1],
+              [Define if compiling using Linux 4.1 or later.])
 ])
 
 # Check for --with-doc-strings
-AC_MSG_CHECKING(for --with-doc-strings)
-AC_ARG_WITH(doc-strings,
-            AS_HELP_STRING([--with-doc-strings], [enable documentation strings (default is yes)]))
+AC_MSG_CHECKING([for --with-doc-strings])
+AC_ARG_WITH(
+  [doc-strings],
+  [AS_HELP_STRING([--with-doc-strings], [enable documentation strings (default is yes)])])
 
 if test -z "$with_doc_strings"
 then with_doc_strings="yes"
 fi
 if test "$with_doc_strings" != "no"
 then
-    AC_DEFINE(WITH_DOC_STRINGS, 1,
+    AC_DEFINE([WITH_DOC_STRINGS], [1],
       [Define if you want documentation strings in extension modules])
 fi
-AC_MSG_RESULT($with_doc_strings)
+AC_MSG_RESULT([$with_doc_strings])
 
 # Check for Python-specific malloc support
-AC_MSG_CHECKING(for --with-pymalloc)
-AC_ARG_WITH(pymalloc,
-            AS_HELP_STRING([--with-pymalloc], [enable specialized mallocs (default is yes)]))
+AC_MSG_CHECKING([for --with-pymalloc])
+AC_ARG_WITH(
+  [pymalloc],
+  [AS_HELP_STRING([--with-pymalloc], [enable specialized mallocs (default is yes)])])
 
 if test -z "$with_pymalloc"
 then
@@ -4614,16 +4671,17 @@ then
 fi
 if test "$with_pymalloc" != "no"
 then
-    AC_DEFINE(WITH_PYMALLOC, 1,
+    AC_DEFINE([WITH_PYMALLOC], [1],
      [Define if you want to compile in Python-specific mallocs])
 fi
-AC_MSG_RESULT($with_pymalloc)
+AC_MSG_RESULT([$with_pymalloc])
 
 # Check whether objects such as float, tuple and dict are using
 # freelists to optimization memory allocation.
-AC_MSG_CHECKING(for --with-freelists)
-AC_ARG_WITH(freelists,
-            AS_HELP_STRING([--with-freelists], [enable object freelists (default is yes)]))
+AC_MSG_CHECKING([for --with-freelists])
+AC_ARG_WITH(
+  [freelists],
+  [AS_HELP_STRING([--with-freelists], [enable object freelists (default is yes)])])
 
 if test -z "$with_freelists"
 then
@@ -4631,16 +4689,16 @@ then
 fi
 if test "$with_freelists" != "no"
 then
-    AC_DEFINE(WITH_FREELISTS, 1,
+    AC_DEFINE([WITH_FREELISTS], [1],
      [Define if you want to compile in object freelists optimization])
 fi
-AC_MSG_RESULT($with_freelists)
+AC_MSG_RESULT([$with_freelists])
 
 # Check for --with-c-locale-coercion
-AC_MSG_CHECKING(for --with-c-locale-coercion)
-AC_ARG_WITH(c-locale-coercion,
-            AS_HELP_STRING([--with-c-locale-coercion],
-              [enable C locale coercion to a UTF-8 based locale (default is yes)]))
+AC_MSG_CHECKING([for --with-c-locale-coercion])
+AC_ARG_WITH(
+  [c-locale-coercion],
+  [AS_HELP_STRING([--with-c-locale-coercion], [enable C locale coercion to a UTF-8 based locale (default is yes)])])
 
 if test -z "$with_c_locale_coercion"
 then
@@ -4648,16 +4706,18 @@ then
 fi
 if test "$with_c_locale_coercion" != "no"
 then
-    AC_DEFINE(PY_COERCE_C_LOCALE, 1,
+    AC_DEFINE([PY_COERCE_C_LOCALE], [1],
       [Define if you want to coerce the C locale to a UTF-8 based locale])
 fi
-AC_MSG_RESULT($with_c_locale_coercion)
+AC_MSG_RESULT([$with_c_locale_coercion])
 
 # Check for Valgrind support
 AC_MSG_CHECKING([for --with-valgrind])
-AC_ARG_WITH([valgrind],
-  AS_HELP_STRING([--with-valgrind], [enable Valgrind support (default is no)]),,
-  with_valgrind=no)
+AC_ARG_WITH(
+  [valgrind],
+  [AS_HELP_STRING([--with-valgrind], [enable Valgrind support (default is no)])],
+  [], [with_valgrind=no]
+)
 AC_MSG_RESULT([$with_valgrind])
 if test "$with_valgrind" != no; then
     AC_CHECK_HEADER([valgrind/valgrind.h],
@@ -4668,27 +4728,29 @@ if test "$with_valgrind" != no; then
 fi
 
 # Check for DTrace support
-AC_MSG_CHECKING(for --with-dtrace)
-AC_ARG_WITH(dtrace,
-  AS_HELP_STRING([--with-dtrace],[enable DTrace support (default is no)]),,
-  with_dtrace=no)
-AC_MSG_RESULT($with_dtrace)
+AC_MSG_CHECKING([for --with-dtrace])
+AC_ARG_WITH(
+  [dtrace],
+  [AS_HELP_STRING([--with-dtrace], [enable DTrace support (default is no)])],
+  [], [with_dtrace=no])
+AC_MSG_RESULT([$with_dtrace])
 
-AC_SUBST(DTRACE)
-AC_SUBST(DFLAGS)
-AC_SUBST(DTRACE_HEADERS)
-AC_SUBST(DTRACE_OBJS)
+AC_SUBST([DTRACE])
+AC_SUBST([DFLAGS])
+AC_SUBST([DTRACE_HEADERS])
+AC_SUBST([DTRACE_OBJS])
 DTRACE=
 DTRACE_HEADERS=
 DTRACE_OBJS=
 
 if test "$with_dtrace" = "yes"
 then
-    AC_PATH_PROG(DTRACE, [dtrace], [not found])
+    AC_PATH_PROG([DTRACE], [dtrace], [not found])
     if test "$DTRACE" = "not found"; then
         AC_MSG_ERROR([dtrace command not found on \$PATH])
     fi
-    AC_DEFINE(WITH_DTRACE, 1, [Define if you want to compile in DTrace support])
+    AC_DEFINE([WITH_DTRACE], [1],
+              [Define if you want to compile in DTrace support])
     DTRACE_HEADERS="Include/pydtrace_probes.h"
 
     # On OS X, DTrace providers do not need to be explicitly compiled and
@@ -4721,17 +4783,17 @@ AC_SUBST([PLATFORM_HEADERS])
 AC_SUBST([PLATFORM_OBJS])
 
 # -I${DLINCLDIR} is added to the compile rule for importdl.o
-AC_SUBST(DLINCLDIR)
+AC_SUBST([DLINCLDIR])
 DLINCLDIR=.
 
 # the dlopen() function means we might want to use dynload_shlib.o. some
 # platforms have dlopen(), but don't want to use it.
-AC_CHECK_FUNCS(dlopen)
+AC_CHECK_FUNCS([dlopen])
 
 # DYNLOADFILE specifies which dynload_*.o file we will use for dynamic
 # loading of modules.
-AC_SUBST(DYNLOADFILE)
-AC_MSG_CHECKING(DYNLOADFILE)
+AC_SUBST([DYNLOADFILE])
+AC_MSG_CHECKING([DYNLOADFILE])
 if test -z "$DYNLOADFILE"
 then
 	case $ac_sys_system/$ac_sys_release in
@@ -4746,17 +4808,17 @@ then
 	;;
 	esac
 fi
-AC_MSG_RESULT($DYNLOADFILE)
+AC_MSG_RESULT([$DYNLOADFILE])
 if test "$DYNLOADFILE" != "dynload_stub.o"
 then
-	AC_DEFINE(HAVE_DYNAMIC_LOADING, 1,
+	AC_DEFINE([HAVE_DYNAMIC_LOADING], [1],
         [Defined when any dynamic module loading is enabled.])
 fi
 
 # MACHDEP_OBJS can be set to platform-specific object files needed by Python
 
-AC_SUBST(MACHDEP_OBJS)
-AC_MSG_CHECKING(MACHDEP_OBJS)
+AC_SUBST([MACHDEP_OBJS])
+AC_MSG_CHECKING([MACHDEP_OBJS])
 if test -z "$MACHDEP_OBJS"
 then
 	MACHDEP_OBJS=$extra_machdep_objs
@@ -4801,14 +4863,15 @@ AC_CHECK_FUNCS([ \
 # links. Some libc implementations have a stub lchmod implementation that always
 # returns an error.
 if test "$MACHDEP" != linux; then
-  AC_CHECK_FUNCS(lchmod)
+  AC_CHECK_FUNCS([lchmod])
 fi
 
-AC_CHECK_DECL(dirfd,
-    AC_DEFINE(HAVE_DIRFD, 1,
-              Define if you have the 'dirfd' function or macro.), ,
-      [#include <sys/types.h>
-       #include <dirent.h>])
+AC_CHECK_DECL([dirfd],
+              [AC_DEFINE([HAVE_DIRFD], [1],
+                         [Define if you have the 'dirfd' function or macro.])],
+              [],
+              [@%:@include <sys/types.h>
+               @%:@include <dirent.h>])
 
 # For some functions, having a definition is not sufficient, since
 # we want to take their address.
@@ -4882,16 +4945,17 @@ AC_CACHE_CHECK([for broken unsetenv], [ac_cv_broken_unsetenv],
   )
 ])
 AS_VAR_IF([ac_cv_broken_unsetenv], [yes], [
-  AC_DEFINE(HAVE_BROKEN_UNSETENV, 1, [Define if 'unsetenv' does not return an int.])
+  AC_DEFINE([HAVE_BROKEN_UNSETENV], [1],
+            [Define if 'unsetenv' does not return an int.])
 ])
 
 dnl check for true
-AC_CHECK_PROGS(TRUE, true, /bin/true)
+AC_CHECK_PROGS([TRUE], [true], [/bin/true])
 
 dnl On some systems (e.g. Solaris 9), hstrerror and inet_aton are in -lresolv
 dnl On others, they are in the C library, so we to take no action
-AC_CHECK_LIB(c, inet_aton, [$ac_cv_prog_TRUE],
-  AC_CHECK_LIB(resolv, inet_aton)
+AC_CHECK_LIB([c], [inet_aton], [$ac_cv_prog_TRUE],
+  AC_CHECK_LIB([resolv], [inet_aton])
 )
 
 # On Tru64, chflags seems to be present, but calling it will
@@ -4915,7 +4979,8 @@ if test "$ac_cv_have_chflags" = cross ; then
   AC_CHECK_FUNC([chflags], [ac_cv_have_chflags="yes"], [ac_cv_have_chflags="no"])
 fi
 if test "$ac_cv_have_chflags" = yes ; then
-  AC_DEFINE(HAVE_CHFLAGS, 1, [Define to 1 if you have the 'chflags' function.])
+  AC_DEFINE([HAVE_CHFLAGS], [1],
+            [Define to 1 if you have the 'chflags' function.])
 fi
 
 AC_CACHE_CHECK([for lchflags], [ac_cv_have_lchflags], [dnl
@@ -4934,7 +4999,8 @@ if test "$ac_cv_have_lchflags" = cross ; then
   AC_CHECK_FUNC([lchflags], [ac_cv_have_lchflags="yes"], [ac_cv_have_lchflags="no"])
 fi
 if test "$ac_cv_have_lchflags" = yes ; then
-  AC_DEFINE(HAVE_LCHFLAGS, 1, [Define to 1 if you have the 'lchflags' function.])
+  AC_DEFINE([HAVE_LCHFLAGS], [1],
+            [Define to 1 if you have the 'lchflags' function.])
 fi
 
 dnl Check for compression libraries
@@ -5043,36 +5109,38 @@ PY_CHECK_FUNC([setgroups], [
 
 # check for openpty, login_tty, and forkpty
 
-AC_CHECK_FUNCS(openpty,,
-   AC_CHECK_LIB(util,openpty,
-     [AC_DEFINE(HAVE_OPENPTY) LIBS="$LIBS -lutil"],
-     AC_CHECK_LIB(bsd,openpty, [AC_DEFINE(HAVE_OPENPTY) LIBS="$LIBS -lbsd"])
-   )
-)
+AC_CHECK_FUNCS([openpty], [],
+  [AC_CHECK_LIB([util], [openpty],
+    [AC_DEFINE([HAVE_OPENPTY]) LIBS="$LIBS -lutil"],
+    [AC_CHECK_LIB([bsd], [openpty],
+      [AC_DEFINE([HAVE_OPENPTY]) LIBS="$LIBS -lbsd"])])])
 AC_SEARCH_LIBS([login_tty], [util],
  [AC_DEFINE([HAVE_LOGIN_TTY], [1], [Define to 1 if you have the `login_tty' function.])]
 )
-AC_CHECK_FUNCS(forkpty,,
-   AC_CHECK_LIB(util,forkpty,
-     [AC_DEFINE(HAVE_FORKPTY) LIBS="$LIBS -lutil"],
-     AC_CHECK_LIB(bsd,forkpty, [AC_DEFINE(HAVE_FORKPTY) LIBS="$LIBS -lbsd"])
-   )
-)
+AC_CHECK_FUNCS([forkpty], [],
+  [AC_CHECK_LIB([util], [forkpty],
+    [AC_DEFINE([HAVE_FORKPTY]) LIBS="$LIBS -lutil"],
+    [AC_CHECK_LIB([bsd], [forkpty],
+      [AC_DEFINE([HAVE_FORKPTY]) LIBS="$LIBS -lbsd"])])])
 
 # check for long file support functions
-AC_CHECK_FUNCS(fseek64 fseeko fstatvfs ftell64 ftello statvfs)
+AC_CHECK_FUNCS([fseek64 fseeko fstatvfs ftell64 ftello statvfs])
 
-AC_REPLACE_FUNCS(dup2)
-AC_CHECK_FUNCS(getpgrp,
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[getpgrp(0);]])],
-    [AC_DEFINE(GETPGRP_HAVE_ARG, 1, [Define if getpgrp() must be called as getpgrp(0).])],
-    [])
-)
-AC_CHECK_FUNCS(setpgrp,
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[setpgrp(0,0);]])],
-    [AC_DEFINE(SETPGRP_HAVE_ARG, 1, [Define if setpgrp() must be called as setpgrp(0, 0).])],
-    [])
-)
+AC_REPLACE_FUNCS([dup2])
+AC_CHECK_FUNCS([getpgrp],
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([@%:@include <unistd.h>],
+      [getpgrp(0);])],
+    [AC_DEFINE([GETPGRP_HAVE_ARG], [1],
+      [Define if getpgrp() must be called as getpgrp(0).])],
+    [])])
+AC_CHECK_FUNCS([setpgrp],
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([@%:@include <unistd.h>],
+      [setpgrp(0,0);])],
+    [AC_DEFINE([SETPGRP_HAVE_ARG], [1],
+      [Define if setpgrp() must be called as setpgrp(0, 0).])],
+  [])])
 
 # check for namespace functions
 AC_CHECK_FUNCS([setns unshare])
@@ -5119,36 +5187,36 @@ WITH_SAVE_ENV([
   ])
 ])
 
-AC_CHECK_FUNCS(clock_gettime, [], [
-    AC_CHECK_LIB(rt, clock_gettime, [
+AC_CHECK_FUNCS([clock_gettime], [], [
+    AC_CHECK_LIB([rt], [clock_gettime], [
         LIBS="$LIBS -lrt"
-        AC_DEFINE(HAVE_CLOCK_GETTIME, 1)
-        AC_DEFINE(TIMEMODULE_LIB, [rt],
+        AC_DEFINE([HAVE_CLOCK_GETTIME], [1])
+        AC_DEFINE([TIMEMODULE_LIB], [rt],
                   [Library needed by timemodule.c: librt may be needed for clock_gettime()])
     ])
 ])
 
-AC_CHECK_FUNCS(clock_getres, [], [
-    AC_CHECK_LIB(rt, clock_getres, [
-        AC_DEFINE(HAVE_CLOCK_GETRES, 1)
+AC_CHECK_FUNCS([clock_getres], [], [
+    AC_CHECK_LIB([rt], [clock_getres], [
+        AC_DEFINE([HAVE_CLOCK_GETRES], [1])
     ])
 ])
 
-AC_CHECK_FUNCS(clock_settime, [], [
-    AC_CHECK_LIB(rt, clock_settime, [
-        AC_DEFINE(HAVE_CLOCK_SETTIME, 1)
+AC_CHECK_FUNCS([clock_settime], [], [
+    AC_CHECK_LIB([rt], [clock_settime], [
+        AC_DEFINE([HAVE_CLOCK_SETTIME], [1])
     ])
 ])
 
-AC_CHECK_FUNCS(clock_nanosleep, [], [
-    AC_CHECK_LIB(rt, clock_nanosleep, [
-        AC_DEFINE(HAVE_CLOCK_NANOSLEEP, 1)
+AC_CHECK_FUNCS([clock_nanosleep], [], [
+    AC_CHECK_LIB([rt], [clock_nanosleep], [
+        AC_DEFINE([HAVE_CLOCK_NANOSLEEP], [1])
     ])
 ])
 
-AC_CHECK_FUNCS(nanosleep, [], [
-    AC_CHECK_LIB(rt, nanosleep, [
-        AC_DEFINE(HAVE_NANOSLEEP, 1)
+AC_CHECK_FUNCS([nanosleep], [], [
+    AC_CHECK_LIB([rt], [nanosleep], [
+        AC_DEFINE([HAVE_NANOSLEEP], [1])
     ])
 ])
 
@@ -5166,12 +5234,12 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 ]])],[ac_cv_device_macros=yes], [ac_cv_device_macros=no])
 ])
 AS_VAR_IF([ac_cv_device_macros], [yes], [
-  AC_DEFINE(HAVE_DEVICE_MACROS, 1,
+  AC_DEFINE([HAVE_DEVICE_MACROS], [1],
 	    [Define to 1 if you have the device macros.])
 ])
 
 dnl no longer used, now always defined for backwards compatibility
-AC_DEFINE(SYS_SELECT_WITH_SYS_TIME, 1,
+AC_DEFINE([SYS_SELECT_WITH_SYS_TIME], [1],
   [Define if  you can safely include both <sys/select.h> and <sys/time.h>
    (which you can't on SCO ODT 3.0).])
 
@@ -5301,10 +5369,11 @@ then
     ])])
   ])
 else
-	AC_DEFINE(HAVE_GETADDRINFO, 1, [Define if you have the getaddrinfo function.])
+	AC_DEFINE([HAVE_GETADDRINFO], [1],
+      [Define if you have the getaddrinfo function.])
 fi
 
-AC_CHECK_FUNCS(getnameinfo)
+AC_CHECK_FUNCS([getnameinfo])
 
 dnl autoconf 2.71 deprecates AC_HEADER_TIME, keep for backwards compatibility
 dnl TIME_WITH_SYS_TIME works on all supported systems that have sys/time.h
@@ -5334,7 +5403,8 @@ AC_CACHE_CHECK([for time.h that defines altzone], [ac_cv_header_time_altzone], [
     [ac_cv_header_time_altzone=no])
   ])
 if test $ac_cv_header_time_altzone = yes; then
-  AC_DEFINE(HAVE_ALTZONE, 1, [Define this if your time.h defines altzone.])
+  AC_DEFINE([HAVE_ALTZONE], [1],
+    [Define this if your time.h defines altzone.])
 fi
 
 AC_CACHE_CHECK([for addrinfo], [ac_cv_struct_addrinfo],
@@ -5342,7 +5412,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <netdb.h>]], [[struct addrinfo a]]
   [ac_cv_struct_addrinfo=yes],
   [ac_cv_struct_addrinfo=no]))
 if test $ac_cv_struct_addrinfo = yes; then
-	AC_DEFINE(HAVE_ADDRINFO, 1, [struct addrinfo (netdb.h)])
+	AC_DEFINE([HAVE_ADDRINFO], [1], [struct addrinfo (netdb.h)])
 fi
 
 AC_CACHE_CHECK([for sockaddr_storage], [ac_cv_struct_sockaddr_storage],
@@ -5352,7 +5422,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   [ac_cv_struct_sockaddr_storage=yes],
   [ac_cv_struct_sockaddr_storage=no]))
 if test $ac_cv_struct_sockaddr_storage = yes; then
-	AC_DEFINE(HAVE_SOCKADDR_STORAGE, 1, [struct sockaddr_storage (sys/socket.h)])
+	AC_DEFINE([HAVE_SOCKADDR_STORAGE], [1],
+      [struct sockaddr_storage (sys/socket.h)])
 fi
 
 AC_CACHE_CHECK([for sockaddr_alg], [ac_cv_struct_sockaddr_alg],
@@ -5363,7 +5434,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   [ac_cv_struct_sockaddr_alg=yes],
   [ac_cv_struct_sockaddr_alg=no]))
 if test $ac_cv_struct_sockaddr_alg = yes; then
-	AC_DEFINE(HAVE_SOCKADDR_ALG, 1, [struct sockaddr_alg (linux/if_alg.h)])
+	AC_DEFINE([HAVE_SOCKADDR_ALG], [1],
+      [struct sockaddr_alg (linux/if_alg.h)])
 fi
 
 # checks for compiler characteristics
@@ -5375,7 +5447,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[signed char c;]])],
   [ac_cv_working_signed_char_c=yes], [ac_cv_working_signed_char_c=no])
 ])
 AS_VAR_IF([ac_cv_working_signed_char_c], [no], [
-  AC_DEFINE(signed, , [Define to empty if the keyword does not work.])
+  AC_DEFINE([signed], [], [Define to empty if the keyword does not work.])
 ])
 
 AC_CACHE_CHECK([for prototypes], [ac_cv_function_prototypes], [
@@ -5383,7 +5455,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[int foo(int x) { return 0; }]], [[return fo
   [ac_cv_function_prototypes=yes], [ac_cv_function_prototypes=no])
 ])
 AS_VAR_IF([ac_cv_function_prototypes], [yes], [
-  AC_DEFINE(HAVE_PROTOTYPES, 1,
+  AC_DEFINE([HAVE_PROTOTYPES], [1],
      [Define if your compiler supports function prototype])
 ])
 
@@ -5402,15 +5474,16 @@ x.sa_len = 0;]])],
   [ac_cv_struct_sockaddr_sa_len=yes], [ac_cv_struct_sockaddr_sa_len=no])
 ])
 AS_VAR_IF([ac_cv_struct_sockaddr_sa_len], [yes], [
-   AC_DEFINE(HAVE_SOCKADDR_SA_LEN, 1, [Define if sockaddr has sa_len member])
+   AC_DEFINE([HAVE_SOCKADDR_SA_LEN], [1],
+     [Define if sockaddr has sa_len member])
 ])
 
 # sigh -- gethostbyname_r is a mess; it can have 3, 5 or 6 arguments :-(
-AH_TEMPLATE(HAVE_GETHOSTBYNAME_R,
+AH_TEMPLATE([HAVE_GETHOSTBYNAME_R],
   [Define this if you have some version of gethostbyname_r()])
 
-AC_CHECK_FUNC(gethostbyname_r, [
-  AC_DEFINE(HAVE_GETHOSTBYNAME_R)
+AC_CHECK_FUNC([gethostbyname_r],
+  [AC_DEFINE([HAVE_GETHOSTBYNAME_R])
   AC_MSG_CHECKING([gethostbyname_r with 6 args])
   OLD_CFLAGS=$CFLAGS
   CFLAGS="$CFLAGS $MY_CPPFLAGS $MY_THREAD_CPPFLAGS $MY_CFLAGS"
@@ -5425,12 +5498,12 @@ AC_CHECK_FUNC(gethostbyname_r, [
 
     (void) gethostbyname_r(name, he, buffer, buflen, &res, &h_errnop)
   ]])],[
-    AC_DEFINE(HAVE_GETHOSTBYNAME_R)
-    AC_DEFINE(HAVE_GETHOSTBYNAME_R_6_ARG, 1,
+    AC_DEFINE([HAVE_GETHOSTBYNAME_R])
+    AC_DEFINE([HAVE_GETHOSTBYNAME_R_6_ARG], [1],
     [Define this if you have the 6-arg version of gethostbyname_r().])
-    AC_MSG_RESULT(yes)
+    AC_MSG_RESULT([yes])
   ],[
-    AC_MSG_RESULT(no)
+    AC_MSG_RESULT([no])
     AC_MSG_CHECKING([gethostbyname_r with 5 args])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #       include <netdb.h>
@@ -5444,12 +5517,12 @@ AC_CHECK_FUNC(gethostbyname_r, [
         (void) gethostbyname_r(name, he, buffer, buflen, &h_errnop)
       ]])],
       [
-        AC_DEFINE(HAVE_GETHOSTBYNAME_R)
-        AC_DEFINE(HAVE_GETHOSTBYNAME_R_5_ARG, 1,
+        AC_DEFINE([HAVE_GETHOSTBYNAME_R])
+        AC_DEFINE([HAVE_GETHOSTBYNAME_R_5_ARG], [1],
           [Define this if you have the 5-arg version of gethostbyname_r().])
-        AC_MSG_RESULT(yes)
+        AC_MSG_RESULT([yes])
       ], [
-        AC_MSG_RESULT(no)
+        AC_MSG_RESULT([no])
         AC_MSG_CHECKING([gethostbyname_r with 3 args])
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #           include <netdb.h>
@@ -5461,69 +5534,69 @@ AC_CHECK_FUNC(gethostbyname_r, [
             (void) gethostbyname_r(name, he, &data);
           ]])],
           [
-            AC_DEFINE(HAVE_GETHOSTBYNAME_R)
-            AC_DEFINE(HAVE_GETHOSTBYNAME_R_3_ARG, 1,
+            AC_DEFINE([HAVE_GETHOSTBYNAME_R])
+            AC_DEFINE([HAVE_GETHOSTBYNAME_R_3_ARG], [1],
               [Define this if you have the 3-arg version of gethostbyname_r().])
-            AC_MSG_RESULT(yes)
+            AC_MSG_RESULT([yes])
           ], [
-           AC_MSG_RESULT(no)
+           AC_MSG_RESULT([no])
         ])
     ])
   ])
   CFLAGS=$OLD_CFLAGS
 ], [
-  AC_CHECK_FUNCS(gethostbyname)
+  AC_CHECK_FUNCS([gethostbyname])
 ])
-AC_SUBST(HAVE_GETHOSTBYNAME_R_6_ARG)
-AC_SUBST(HAVE_GETHOSTBYNAME_R_5_ARG)
-AC_SUBST(HAVE_GETHOSTBYNAME_R_3_ARG)
-AC_SUBST(HAVE_GETHOSTBYNAME_R)
-AC_SUBST(HAVE_GETHOSTBYNAME)
+AC_SUBST([HAVE_GETHOSTBYNAME_R_6_ARG])
+AC_SUBST([HAVE_GETHOSTBYNAME_R_5_ARG])
+AC_SUBST([HAVE_GETHOSTBYNAME_R_3_ARG])
+AC_SUBST([HAVE_GETHOSTBYNAME_R])
+AC_SUBST([HAVE_GETHOSTBYNAME])
 
 # checks for system services
 # (none yet)
 
 # Linux requires this for correct f.p. operations
-AC_CHECK_FUNC(__fpu_control,
+AC_CHECK_FUNC([__fpu_control],
   [],
-  [AC_CHECK_LIB(ieee, __fpu_control)
+  [AC_CHECK_LIB([ieee], [__fpu_control])
 ])
 
 # check for --with-libm=...
-AC_SUBST(LIBM)
+AC_SUBST([LIBM])
 case $ac_sys_system in
 Darwin) ;;
 *) LIBM=-lm
 esac
-AC_MSG_CHECKING(for --with-libm=STRING)
-AC_ARG_WITH(libm,
-            AS_HELP_STRING([--with-libm=STRING], [override libm math library to STRING (default is system-dependent)]),
+AC_MSG_CHECKING([for --with-libm=STRING])
+AC_ARG_WITH([libm],
+  [AS_HELP_STRING([--with-libm=STRING], [override libm math library to STRING (default is system-dependent)])],
 [
 if test "$withval" = no
 then LIBM=
-     AC_MSG_RESULT(force LIBM empty)
+     AC_MSG_RESULT([force LIBM empty])
 elif test "$withval" != yes
 then LIBM=$withval
-     AC_MSG_RESULT(set LIBM="$withval")
+     AC_MSG_RESULT([set LIBM="$withval"])
 else AC_MSG_ERROR([proper usage is --with-libm=STRING])
 fi],
-[AC_MSG_RESULT(default LIBM="$LIBM")])
+[AC_MSG_RESULT([default LIBM="$LIBM"])])
 
 # check for --with-libc=...
-AC_SUBST(LIBC)
-AC_MSG_CHECKING(for --with-libc=STRING)
-AC_ARG_WITH(libc,
-            AS_HELP_STRING([--with-libc=STRING], [override libc C library to STRING (default is system-dependent)]),
+AC_SUBST([LIBC])
+AC_MSG_CHECKING([for --with-libc=STRING])
+AC_ARG_WITH([libc],
+  [AS_HELP_STRING([--with-libc=STRING], [override libc C library to STRING (default is system-dependent)])],
 [
 if test "$withval" = no
 then LIBC=
-     AC_MSG_RESULT(force LIBC empty)
+     AC_MSG_RESULT([force LIBC empty])
 elif test "$withval" != yes
 then LIBC=$withval
-     AC_MSG_RESULT(set LIBC="$withval")
+     AC_MSG_RESULT([set LIBC="$withval"])
 else AC_MSG_ERROR([proper usage is --with-libc=STRING])
 fi],
-[AC_MSG_RESULT(default LIBC="$LIBC")])
+[AC_MSG_RESULT([default LIBC="$LIBC"])])
 
 # **************************************
 # * Check for gcc x64 inline assembler *
@@ -5537,7 +5610,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[
 ])
 
 AS_VAR_IF([ac_cv_gcc_asm_for_x64], [yes], [
-    AC_DEFINE(HAVE_GCC_ASM_FOR_X64, 1,
+    AC_DEFINE([HAVE_GCC_ASM_FOR_X64], [1],
     [Define if we can use x64 gcc inline assembler])
 ])
 
@@ -5548,12 +5621,12 @@ AS_VAR_IF([ac_cv_gcc_asm_for_x64], [yes], [
 AX_C_FLOAT_WORDS_BIGENDIAN
 if test "$ax_cv_c_float_words_bigendian" = "yes"
 then
-  AC_DEFINE(DOUBLE_IS_BIG_ENDIAN_IEEE754, 1,
+  AC_DEFINE([DOUBLE_IS_BIG_ENDIAN_IEEE754], [1],
   [Define if C doubles are 64-bit IEEE 754 binary format, stored
    with the most significant byte first])
 elif test "$ax_cv_c_float_words_bigendian" = "no"
 then
-  AC_DEFINE(DOUBLE_IS_LITTLE_ENDIAN_IEEE754, 1,
+  AC_DEFINE([DOUBLE_IS_LITTLE_ENDIAN_IEEE754], [1],
   [Define if C doubles are 64-bit IEEE 754 binary format, stored
    with the least significant byte first])
 else
@@ -5563,7 +5636,7 @@ else
   # conversions work.
   # FLOAT_WORDS_BIGENDIAN doesnt actually detect this case, but if it's not big
   # or little, then it must be this?
-  AC_DEFINE(DOUBLE_IS_ARM_MIXED_ENDIAN_IEEE754, 1,
+  AC_DEFINE([DOUBLE_IS_ARM_MIXED_ENDIAN_IEEE754], [1],
   [Define if C doubles are 64-bit IEEE 754 binary format, stored
    in ARM mixed-endian order (byte order 45670123)])
 fi
@@ -5586,7 +5659,7 @@ AC_LINK_IFELSE(   [AC_LANG_PROGRAM([[]], [[
 ]])],[ac_cv_gcc_asm_for_x87=yes],[ac_cv_gcc_asm_for_x87=no])
 ])
 AS_VAR_IF([ac_cv_gcc_asm_for_x87], [yes], [
-    AC_DEFINE(HAVE_GCC_ASM_FOR_X87, 1,
+    AC_DEFINE([HAVE_GCC_ASM_FOR_X87], [1],
     [Define if we can use gcc inline assembler to get and set x87 control word])
 ])
 
@@ -5598,7 +5671,7 @@ AC_LINK_IFELSE(   [AC_LANG_PROGRAM([[]], [[
 ]])],[ac_cv_gcc_asm_for_mc68881=yes],[ac_cv_gcc_asm_for_mc68881=no])
 ])
 AS_VAR_IF([ac_cv_gcc_asm_for_mc68881], [yes], [
-    AC_DEFINE(HAVE_GCC_ASM_FOR_MC68881, 1,
+    AC_DEFINE([HAVE_GCC_ASM_FOR_MC68881], [1],
     [Define if we can use gcc inline assembler to get and set mc68881 fpcr])
 ])
 
@@ -5638,7 +5711,7 @@ CC="$ac_save_cc"
 ])
 
 AS_VAR_IF([ac_cv_x87_double_rounding], [yes], [
-  AC_DEFINE(X87_DOUBLE_ROUNDING, 1,
+  AC_DEFINE([X87_DOUBLE_ROUNDING], [1],
   [Define if arithmetic is subject to x87-style double rounding issue])
 ])
 
@@ -5734,7 +5807,7 @@ AC_CHECK_DECLS([RTLD_LAZY, RTLD_NOW, RTLD_GLOBAL, RTLD_LOCAL, RTLD_NODELETE, RTL
 
 # determine what size digit to use for Python's longs
 AC_MSG_CHECKING([digit size for Python's longs])
-AC_ARG_ENABLE(big-digits,
+AC_ARG_ENABLE([big-digits],
 AS_HELP_STRING([--enable-big-digits@<:@=15|30@:>@],[use big digits (30 or 15 bits) for Python longs (default is 30)]]),
 [case $enable_big_digits in
 yes)
@@ -5746,14 +5819,15 @@ no)
 *)
   AC_MSG_ERROR([bad value $enable_big_digits for --enable-big-digits; value should be 15 or 30]) ;;
 esac
-AC_MSG_RESULT($enable_big_digits)
-AC_DEFINE_UNQUOTED(PYLONG_BITS_IN_DIGIT, $enable_big_digits, [Define as the preferred size in bits of long digits])
+AC_MSG_RESULT([$enable_big_digits])
+AC_DEFINE_UNQUOTED([PYLONG_BITS_IN_DIGIT], [$enable_big_digits],
+  [Define as the preferred size in bits of long digits])
 ],
-[AC_MSG_RESULT(no value specified)])
+[AC_MSG_RESULT([no value specified])])
 
 # check for wchar.h
-AC_CHECK_HEADER(wchar.h, [
-  AC_DEFINE(HAVE_WCHAR_H, 1,
+AC_CHECK_HEADER([wchar.h], [
+  AC_DEFINE([HAVE_WCHAR_H], [1],
   [Define if the compiler provides a wchar.h header file.])
   wchar_h="yes"
 ],
@@ -5763,7 +5837,9 @@ wchar_h="no"
 # determine wchar_t size
 if test "$wchar_h" = yes
 then
-  AC_CHECK_SIZEOF(wchar_t, 4, [#include <wchar.h>])
+  AC_CHECK_SIZEOF([wchar_t], [4], [m4_normalize([
+    #include <wchar.h>
+  ])])
 fi
 
 # check whether wchar_t is signed or not
@@ -5784,18 +5860,18 @@ then
   [ac_cv_wchar_t_signed=yes])])
 fi
 
-AC_MSG_CHECKING(whether wchar_t is usable)
+AC_MSG_CHECKING([whether wchar_t is usable])
 # wchar_t is only usable if it maps to an unsigned type
 if test "$ac_cv_sizeof_wchar_t" -ge 2 \
           -a "$ac_cv_wchar_t_signed" = "no"
 then
-  AC_DEFINE(HAVE_USABLE_WCHAR_T, 1,
+  AC_DEFINE([HAVE_USABLE_WCHAR_T], [1],
   [Define if you have a useable wchar_t type defined in wchar.h; useable
    means wchar_t must be an unsigned type with at least 16 bits. (see
    Include/unicodeobject.h).])
-  AC_MSG_RESULT(yes)
+  AC_MSG_RESULT([yes])
 else
-  AC_MSG_RESULT(no)
+  AC_MSG_RESULT([no])
 fi
 
 case $ac_sys_system/$ac_sys_release in
@@ -5806,7 +5882,7 @@ SunOS/*)
       # bpo-43667: In Oracle Solaris, the internal form of wchar_t in
       # non-Unicode locales is not Unicode and hence cannot be used directly.
       # https://docs.oracle.com/cd/E37838_01/html/E61053/gmwke.html
-      AC_DEFINE(HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION, 1,
+      AC_DEFINE([HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION], [1],
       [Define if the internal form of wchar_t in non-Unicode locales
        is not Unicode.])
     fi
@@ -5832,31 +5908,31 @@ AC_C_BIGENDIAN
 #
 # In Python 3.2 and older, --with-wide-unicode added a 'u' flag.
 # In Python 3.7 and older, --with-pymalloc added a 'm' flag.
-AC_SUBST(SOABI)
-AC_MSG_CHECKING(ABIFLAGS)
-AC_MSG_RESULT($ABIFLAGS)
-AC_MSG_CHECKING(SOABI)
+AC_SUBST([SOABI])
+AC_MSG_CHECKING([ABIFLAGS])
+AC_MSG_RESULT([$ABIFLAGS])
+AC_MSG_CHECKING([SOABI])
 SOABI='cpython-'`echo $VERSION | tr -d .`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
-AC_MSG_RESULT($SOABI)
+AC_MSG_RESULT([$SOABI])
 
 # Release and debug (Py_DEBUG) ABI are compatible, but not Py_TRACE_REFS ABI
 if test "$Py_DEBUG" = 'true' -a "$with_trace_refs" != "yes"; then
   # Similar to SOABI but remove "d" flag from ABIFLAGS
-  AC_SUBST(ALT_SOABI)
+  AC_SUBST([ALT_SOABI])
   ALT_SOABI='cpython-'`echo $VERSION | tr -d .``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
-  AC_DEFINE_UNQUOTED(ALT_SOABI, "${ALT_SOABI}",
+  AC_DEFINE_UNQUOTED([ALT_SOABI], ["${ALT_SOABI}"],
             [Alternative SOABI used in debug build to load C extensions built in release mode])
 fi
 
-AC_SUBST(EXT_SUFFIX)
+AC_SUBST([EXT_SUFFIX])
 EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX}
 
-AC_MSG_CHECKING(LDVERSION)
+AC_MSG_CHECKING([LDVERSION])
 LDVERSION='$(VERSION)$(ABIFLAGS)'
-AC_MSG_RESULT($LDVERSION)
+AC_MSG_RESULT([$LDVERSION])
 
 # On Android and Cygwin the shared libraries must be linked with libpython.
-AC_SUBST(LIBPYTHON)
+AC_SUBST([LIBPYTHON])
 if test "$PY_ENABLE_SHARED" = "1" && ( test -n "$ANDROID_API_LEVEL" || test "$MACHDEP" = "cygwin"); then
   LIBPYTHON="-lpython${VERSION}${ABIFLAGS}"
 else
@@ -5864,18 +5940,21 @@ else
 fi
 
 
-AC_SUBST(BINLIBDEST)
+AC_SUBST([BINLIBDEST])
 BINLIBDEST='$(LIBDIR)/python$(VERSION)'
 
 
 # Check for --with-platlibdir
 # /usr/$LIDIRNAME/python$VERSION
-AC_SUBST(PLATLIBDIR)
+AC_SUBST([PLATLIBDIR])
 PLATLIBDIR="lib"
-AC_MSG_CHECKING(for --with-platlibdir)
-AC_ARG_WITH(platlibdir,
-            AS_HELP_STRING([--with-platlibdir=DIRNAME],
-            [Python library directory name (default is "lib")]),
+AC_MSG_CHECKING([for --with-platlibdir])
+AC_ARG_WITH(
+  [platlibdir],
+  [AS_HELP_STRING(
+    [--with-platlibdir=DIRNAME],
+    [Python library directory name (default is "lib")]
+  )],
 [
 # ignore 3 options:
 #   --with-platlibdir
@@ -5883,39 +5962,42 @@ AC_ARG_WITH(platlibdir,
 #   --without-platlibdir
 if test -n "$withval" -a "$withval" != yes -a "$withval" != no
 then
-  AC_MSG_RESULT(yes)
+  AC_MSG_RESULT([yes])
   PLATLIBDIR="$withval"
   BINLIBDEST='${exec_prefix}/${PLATLIBDIR}/python$(VERSION)'
 else
-  AC_MSG_RESULT(no)
+  AC_MSG_RESULT([no])
 fi],
-[AC_MSG_RESULT(no)])
+[AC_MSG_RESULT([no])])
 
 
 dnl define LIBPL after ABIFLAGS and LDVERSION is defined.
-AC_SUBST(PY_ENABLE_SHARED)
+AC_SUBST([PY_ENABLE_SHARED])
 if test x$PLATFORM_TRIPLET = x; then
   LIBPL='$(prefix)'"/${PLATLIBDIR}/python${VERSION}/config-${LDVERSION}"
 else
   LIBPL='$(prefix)'"/${PLATLIBDIR}/python${VERSION}/config-${LDVERSION}-${PLATFORM_TRIPLET}"
 fi
-AC_SUBST(LIBPL)
+AC_SUBST([LIBPL])
 
 # Check for --with-wheel-pkg-dir=PATH
-AC_SUBST(WHEEL_PKG_DIR)
+AC_SUBST([WHEEL_PKG_DIR])
 WHEEL_PKG_DIR=""
-AC_MSG_CHECKING(for --with-wheel-pkg-dir)
-AC_ARG_WITH(wheel-pkg-dir,
-            AS_HELP_STRING([--with-wheel-pkg-dir=PATH],
-            [Directory of wheel packages used by ensurepip (default: none)]),
+AC_MSG_CHECKING([for --with-wheel-pkg-dir])
+AC_ARG_WITH(
+  [wheel-pkg-dir],
+  [AS_HELP_STRING(
+    [--with-wheel-pkg-dir=PATH],
+    [Directory of wheel packages used by ensurepip (default: none)]
+  )],
 [
 if test -n "$withval"; then
-  AC_MSG_RESULT(yes)
+  AC_MSG_RESULT([yes])
   WHEEL_PKG_DIR="$withval"
 else
-  AC_MSG_RESULT(no)
+  AC_MSG_RESULT([no])
 fi],
-[AC_MSG_RESULT(no)])
+[AC_MSG_RESULT([no])])
 
 # Check whether right shifting a negative integer extends the sign bit
 # or fills with zeros (like the Cray J90, according to Tim Peters).
@@ -5931,7 +6013,7 @@ int main(void)
 [ac_cv_rshift_extends_sign=yes])])
 if test "$ac_cv_rshift_extends_sign" = no
 then
-  AC_DEFINE(SIGNED_RIGHT_SHIFT_ZERO_FILLS, 1,
+  AC_DEFINE([SIGNED_RIGHT_SHIFT_ZERO_FILLS], [1],
   [Define if i>>j for signed int i does not extend the sign bit
    when i < 0])
 fi
@@ -5946,7 +6028,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]], [[
 ]])],[ac_cv_have_getc_unlocked=yes],[ac_cv_have_getc_unlocked=no])])
 if test "$ac_cv_have_getc_unlocked" = yes
 then
-  AC_DEFINE(HAVE_GETC_UNLOCKED, 1,
+  AC_DEFINE([HAVE_GETC_UNLOCKED], [1],
   [Define this if you have flockfile(), getc_unlocked(), and funlockfile()])
 fi
 
@@ -6133,7 +6215,7 @@ int main(void)
 [ac_cv_broken_nice=no])])
 if test "$ac_cv_broken_nice" = yes
 then
-  AC_DEFINE(HAVE_BROKEN_NICE, 1,
+  AC_DEFINE([HAVE_BROKEN_NICE], [1],
   [Define if nice() returns success/failure instead of the new priority.])
 fi
 
@@ -6163,7 +6245,7 @@ int main(void)
 [ac_cv_broken_poll=no]))
 if test "$ac_cv_broken_poll" = yes
 then
-  AC_DEFINE(HAVE_BROKEN_POLL, 1,
+  AC_DEFINE([HAVE_BROKEN_POLL], [1],
       [Define if poll() sets errno on invalid file descriptors.])
 fi
 
@@ -6238,7 +6320,7 @@ int main(void)
 [ac_cv_working_tzset=no])])
 if test "$ac_cv_working_tzset" = yes
 then
-  AC_DEFINE(HAVE_WORKING_TZSET, 1,
+  AC_DEFINE([HAVE_WORKING_TZSET], [1],
   [Define if tzset() actually switches the local timezone in a meaningful way.])
 fi
 
@@ -6252,7 +6334,7 @@ st.st_mtim.tv_nsec = 1;
 [ac_cv_stat_tv_nsec=no]))
 if test "$ac_cv_stat_tv_nsec" = yes
 then
-  AC_DEFINE(HAVE_STAT_TV_NSEC, 1,
+  AC_DEFINE([HAVE_STAT_TV_NSEC], [1],
   [Define if you have struct stat.st_mtim.tv_nsec])
 fi
 
@@ -6266,7 +6348,7 @@ st.st_mtimespec.tv_nsec = 1;
 [ac_cv_stat_tv_nsec2=no]))
 if test "$ac_cv_stat_tv_nsec2" = yes
 then
-  AC_DEFINE(HAVE_STAT_TV_NSEC2, 1,
+  AC_DEFINE([HAVE_STAT_TV_NSEC2], [1],
   [Define if you have struct stat.st_mtimensec])
 fi
 
@@ -6393,7 +6475,7 @@ if test "$cross_compiling" = no; then
 fi
 
 # On Solaris, term.h requires curses.h
-AC_CHECK_HEADERS(term.h,,,[
+AC_CHECK_HEADERS([term.h], [], [], [
 #ifdef HAVE_CURSES_H
 #include <curses.h>
 #endif
@@ -6410,7 +6492,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
 
 if test "$ac_cv_mvwdelch_is_expression" = yes
 then
-  AC_DEFINE(MVWDELCH_IS_EXPRESSION, 1,
+  AC_DEFINE([MVWDELCH_IS_EXPRESSION], [1],
   [Define if mvwdelch in curses.h is an expression.])
 fi
 
@@ -6432,7 +6514,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 
 if test "$ac_cv_window_has_flags" = yes
 then
-  AC_DEFINE(WINDOW_HAS_FLAGS, 1,
+  AC_DEFINE([WINDOW_HAS_FLAGS], [1],
   [Define if WINDOW in curses.h offers a field _flags.])
 fi
 
@@ -6490,14 +6572,14 @@ if test "x$cross_compiling" = xyes; then
   fi
 fi
 
-AC_CHECK_FILE(/dev/ptmx, [], [])
+AC_CHECK_FILE([/dev/ptmx], [], [])
 if test "x$ac_cv_file__dev_ptmx" = xyes; then
-  AC_DEFINE(HAVE_DEV_PTMX, 1,
+  AC_DEFINE([HAVE_DEV_PTMX], [1],
   [Define to 1 if you have the /dev/ptmx device file.])
 fi
-AC_CHECK_FILE(/dev/ptc, [], [])
+AC_CHECK_FILE([/dev/ptc], [], [])
 if test "x$ac_cv_file__dev_ptc" = xyes; then
-  AC_DEFINE(HAVE_DEV_PTC, 1,
+  AC_DEFINE([HAVE_DEV_PTC], [1],
   [Define to 1 if you have the /dev/ptc device file.])
 fi
 
@@ -6506,9 +6588,12 @@ then
 	LIBS="$LIBS -framework CoreFoundation"
 fi
 
-AC_CHECK_TYPE(socklen_t,,
-  AC_DEFINE(socklen_t,int,
-            [Define to `int' if <sys/socket.h> does not define.]),[
+AC_CHECK_TYPE(
+  [socklen_t], [],
+  [AC_DEFINE(
+    [socklen_t], [int],
+    [Define to `int' if <sys/socket.h> does not define.]
+  )], [
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -6534,31 +6619,34 @@ int main(void) {
 [ac_cv_broken_mbstowcs=no]))
 if test "$ac_cv_broken_mbstowcs" = yes
 then
-  AC_DEFINE(HAVE_BROKEN_MBSTOWCS, 1,
+  AC_DEFINE([HAVE_BROKEN_MBSTOWCS], [1],
   [Define if mbstowcs(NULL, "text", 0) does not return the number of
    wide chars that would be converted.])
 fi
 
 # Check for --with-computed-gotos
-AC_MSG_CHECKING(for --with-computed-gotos)
-AC_ARG_WITH(computed-gotos,
-            AS_HELP_STRING([--with-computed-gotos],
-                           [enable computed gotos in evaluation loop (enabled by default on supported compilers)]),
+AC_MSG_CHECKING([for --with-computed-gotos])
+AC_ARG_WITH(
+  [computed-gotos],
+  [AS_HELP_STRING(
+    [--with-computed-gotos],
+    [enable computed gotos in evaluation loop (enabled by default on supported compilers)]
+  )],
 [
 if test "$withval" = yes
 then
-  AC_DEFINE(USE_COMPUTED_GOTOS, 1,
+  AC_DEFINE([USE_COMPUTED_GOTOS], [1],
   [Define if you want to use computed gotos in ceval.c.])
-  AC_MSG_RESULT(yes)
+  AC_MSG_RESULT([yes])
 fi
 if test "$withval" = no
 then
-  AC_DEFINE(USE_COMPUTED_GOTOS, 0,
+  AC_DEFINE([USE_COMPUTED_GOTOS], [0],
   [Define if you want to use computed gotos in ceval.c.])
-  AC_MSG_RESULT(no)
+  AC_MSG_RESULT([no])
 fi
 ],
-[AC_MSG_RESULT(no value specified)])
+[AC_MSG_RESULT([no value specified])])
 
 AC_CACHE_CHECK([whether $CC supports computed gotos], [ac_cv_computed_gotos],
 AC_RUN_IFELSE([AC_LANG_SOURCE([[[
@@ -6581,24 +6669,25 @@ LABEL2:
    ac_cv_computed_gotos=no
  fi]))
 case "$ac_cv_computed_gotos" in yes*)
-  AC_DEFINE(HAVE_COMPUTED_GOTOS, 1,
+  AC_DEFINE([HAVE_COMPUTED_GOTOS], [1],
   [Define if the C compiler supports computed gotos.])
 esac
 
 case $ac_sys_system in
 AIX*)
-  AC_DEFINE(HAVE_BROKEN_PIPE_BUF, 1, [Define if the system reports an invalid PIPE_BUF value.]) ;;
+  AC_DEFINE([HAVE_BROKEN_PIPE_BUF], [1],
+    [Define if the system reports an invalid PIPE_BUF value.]) ;;
 esac
 
 
-AC_SUBST(THREADHEADERS)
+AC_SUBST([THREADHEADERS])
 
 for h in `(cd $srcdir;echo Python/thread_*.h)`
 do
   THREADHEADERS="$THREADHEADERS \$(srcdir)/$h"
 done
 
-AC_SUBST(SRCDIRS)
+AC_SUBST([SRCDIRS])
 SRCDIRS="\
   Modules \
   Modules/_blake2 \
@@ -6621,13 +6710,13 @@ SRCDIRS="\
   Python \
   Python/frozen_modules \
   Python/deepfreeze"
-AC_MSG_CHECKING(for build directories)
+AC_MSG_CHECKING([for build directories])
 for dir in $SRCDIRS; do
     if test ! -d $dir; then
         mkdir $dir
     fi
 done
-AC_MSG_RESULT(done)
+AC_MSG_RESULT([done])
 
 # Availability of -O2:
 AC_CACHE_CHECK([for -O2], [ac_cv_compile_o2], [
@@ -6639,7 +6728,7 @@ CFLAGS="$saved_cflags"
 
 # _FORTIFY_SOURCE wrappers for memmove and bcopy are incorrect:
 # http://sourceware.org/ml/libc-alpha/2010-12/msg00009.html
-AC_MSG_CHECKING(for glibc _FORTIFY_SOURCE/memmove bug)
+AC_MSG_CHECKING([for glibc _FORTIFY_SOURCE/memmove bug])
 saved_cflags="$CFLAGS"
 CFLAGS="-O2 -D_FORTIFY_SOURCE=2"
 if test "$ac_cv_compile_o2" = no; then
@@ -6665,9 +6754,9 @@ int main(void) {
 [have_glibc_memmove_bug=yes],
 [have_glibc_memmove_bug=undefined])
 CFLAGS="$saved_cflags"
-AC_MSG_RESULT($have_glibc_memmove_bug)
+AC_MSG_RESULT([$have_glibc_memmove_bug])
 if test "$have_glibc_memmove_bug" = yes; then
-    AC_DEFINE(HAVE_GLIBC_MEMMOVE_BUG, 1,
+    AC_DEFINE([HAVE_GLIBC_MEMMOVE_BUG], [1],
     [Define if glibc has incorrect _FORTIFY_SOURCE wrappers
      for memmove and bcopy.])
 fi
@@ -6678,7 +6767,7 @@ if test "$ac_cv_gcc_asm_for_x87" = yes; then
     # http://gcc.gnu.org/ml/gcc/2010-11/msg00366.html
     case $CC in
         *gcc*)
-            AC_MSG_CHECKING(for gcc ipa-pure-const bug)
+            AC_MSG_CHECKING([for gcc ipa-pure-const bug])
             saved_cflags="$CFLAGS"
             CFLAGS="-O2"
             AC_RUN_IFELSE([AC_LANG_SOURCE([[
@@ -6702,9 +6791,9 @@ if test "$ac_cv_gcc_asm_for_x87" = yes; then
             [have_ipa_pure_const_bug=yes],
             [have_ipa_pure_const_bug=undefined])
             CFLAGS="$saved_cflags"
-            AC_MSG_RESULT($have_ipa_pure_const_bug)
+            AC_MSG_RESULT([$have_ipa_pure_const_bug])
             if test "$have_ipa_pure_const_bug" = yes; then
-                AC_DEFINE(HAVE_IPA_PURE_CONST_BUG, 1,
+                AC_DEFINE([HAVE_IPA_PURE_CONST_BUG], [1],
                           [Define if gcc has the ipa-pure-const bug.])
             fi
         ;;
@@ -6730,7 +6819,7 @@ AC_LINK_IFELSE(
 ])
 
 AS_VAR_IF([ac_cv_header_stdatomic_h], [yes], [
-    AC_DEFINE(HAVE_STD_ATOMIC, 1,
+    AC_DEFINE([HAVE_STD_ATOMIC], [1],
               [Has stdatomic.h with atomic_int and atomic_uintptr_t])
 ])
 
@@ -6750,12 +6839,13 @@ AC_LINK_IFELSE(
 ])
 
 AS_VAR_IF([ac_cv_builtin_atomic], [yes], [
-    AC_DEFINE(HAVE_BUILTIN_ATOMIC, 1, [Has builtin __atomic_load_n() and __atomic_store_n() functions])
+    AC_DEFINE([HAVE_BUILTIN_ATOMIC], [1],
+      [Has builtin __atomic_load_n() and __atomic_store_n() functions])
 ])
 
 # ensurepip option
-AC_MSG_CHECKING(for ensurepip)
-AC_ARG_WITH(ensurepip,
+AC_MSG_CHECKING([for ensurepip])
+AC_ARG_WITH([ensurepip],
     [AS_HELP_STRING([--with-ensurepip@<:@=install|upgrade|no@:>@],
         ["install" or "upgrade" using bundled pip (default is upgrade)])],
     [],
@@ -6766,13 +6856,13 @@ AC_ARG_WITH(ensurepip,
         [with_ensurepip=upgrade]
       )
     ])
-AS_CASE($with_ensurepip,
+AS_CASE([$with_ensurepip],
     [yes|upgrade],[ENSUREPIP=upgrade],
     [install],[ENSUREPIP=install],
     [no],[ENSUREPIP=no],
     [AC_MSG_ERROR([--with-ensurepip=upgrade|install|no])])
-AC_MSG_RESULT($ENSUREPIP)
-AC_SUBST(ENSUREPIP)
+AC_MSG_RESULT([$ENSUREPIP])
+AC_SUBST([ENSUREPIP])
 
 # check if the dirent structure of a d_type field and DT_UNKNOWN is defined
 AC_CACHE_CHECK([if the dirent structure of a d_type field], [ac_cv_dirent_d_type], [
@@ -6790,7 +6880,7 @@ AC_LINK_IFELSE(
 ])
 
 AS_VAR_IF([ac_cv_dirent_d_type], [yes], [
-    AC_DEFINE(HAVE_DIRENT_D_TYPE, 1,
+    AC_DEFINE([HAVE_DIRENT_D_TYPE], [1],
               [Define to 1 if the dirent structure has a d_type field])
 ])
 
@@ -6817,7 +6907,7 @@ AC_LINK_IFELSE(
 ])
 
 AS_VAR_IF([ac_cv_getrandom_syscall], [yes], [
-    AC_DEFINE(HAVE_GETRANDOM_SYSCALL, 1,
+    AC_DEFINE([HAVE_GETRANDOM_SYSCALL], [1],
               [Define to 1 if the Linux getrandom() syscall is available])
 ])
 
@@ -6843,7 +6933,7 @@ AC_LINK_IFELSE(
 ])
 
 AS_VAR_IF([ac_cv_func_getrandom], [yes], [
-    AC_DEFINE(HAVE_GETRANDOM, 1,
+    AC_DEFINE([HAVE_GETRANDOM], [1],
               [Define to 1 if the getrandom() function is available])
 ])
 
@@ -6878,8 +6968,8 @@ AS_VAR_IF([GNULD], [yes], [
   rpath_arg="-Wl,-rpath="
 ])
 
-AC_MSG_CHECKING(for --with-openssl-rpath)
-AC_ARG_WITH(openssl-rpath,
+AC_MSG_CHECKING([for --with-openssl-rpath])
+AC_ARG_WITH([openssl-rpath],
     AS_HELP_STRING([--with-openssl-rpath=@<:@DIR|auto|no@:>@],
                    [Set runtime library directory (rpath) for OpenSSL libraries,
                     no (default): don't set rpath,
@@ -6889,7 +6979,7 @@ AC_ARG_WITH(openssl-rpath,
     [],
     [with_openssl_rpath=no]
 )
-AS_CASE($with_openssl_rpath,
+AS_CASE([$with_openssl_rpath],
     [auto|yes], [
       OPENSSL_RPATH=auto
       dnl look for linker directories
@@ -6909,7 +6999,7 @@ AS_CASE($with_openssl_rpath,
         AC_MSG_ERROR([--with-openssl-rpath "$with_openssl_rpath" is not a directory]))
     ]
 )
-AC_MSG_RESULT($OPENSSL_RPATH)
+AC_MSG_RESULT([$OPENSSL_RPATH])
 
 # This static linking is NOT OFFICIALLY SUPPORTED and not advertised.
 # Requires static OpenSSL build with position-independent code. Some features
@@ -6990,50 +7080,55 @@ WITH_SAVE_ENV([
 ])
 
 # ssl module default cipher suite string
-AH_TEMPLATE(PY_SSL_DEFAULT_CIPHERS,
+AH_TEMPLATE([PY_SSL_DEFAULT_CIPHERS],
   [Default cipher suites list for ssl module.
    1: Python's preferred selection, 2: leave OpenSSL defaults untouched, 0: custom string])
-AH_TEMPLATE(PY_SSL_DEFAULT_CIPHER_STRING,
+AH_TEMPLATE([PY_SSL_DEFAULT_CIPHER_STRING],
   [Cipher suite string for PY_SSL_DEFAULT_CIPHERS=0]
 )
 
-AC_MSG_CHECKING(for --with-ssl-default-suites)
-AC_ARG_WITH(ssl-default-suites,
-            AS_HELP_STRING([--with-ssl-default-suites=@<:@python|openssl|STRING@:>@],
-                           [override default cipher suites string,
-                            python: use Python's preferred selection (default),
-                            openssl: leave OpenSSL's defaults untouched,
-                            STRING: use a custom string,
-                            python and STRING also set TLS 1.2 as minimum TLS version]),
+AC_MSG_CHECKING([for --with-ssl-default-suites])
+AC_ARG_WITH(
+  [ssl-default-suites],
+  [AS_HELP_STRING(
+    [--with-ssl-default-suites=@<:@python|openssl|STRING@:>@],
+    [override default cipher suites string,
+     python: use Python's preferred selection (default),
+     openssl: leave OpenSSL's defaults untouched,
+     STRING: use a custom string,
+     python and STRING also set TLS 1.2 as minimum TLS version]
+  )],
 [
-AC_MSG_RESULT($withval)
+AC_MSG_RESULT([$withval])
 case "$withval" in
     python)
-        AC_DEFINE(PY_SSL_DEFAULT_CIPHERS, 1)
+        AC_DEFINE([PY_SSL_DEFAULT_CIPHERS], [1])
         ;;
     openssl)
-        AC_DEFINE(PY_SSL_DEFAULT_CIPHERS, 2)
+        AC_DEFINE([PY_SSL_DEFAULT_CIPHERS], [2])
         ;;
     *)
-        AC_DEFINE(PY_SSL_DEFAULT_CIPHERS, 0)
-        AC_DEFINE_UNQUOTED(PY_SSL_DEFAULT_CIPHER_STRING, "$withval")
+        AC_DEFINE([PY_SSL_DEFAULT_CIPHERS], [0])
+        AC_DEFINE_UNQUOTED([PY_SSL_DEFAULT_CIPHER_STRING], ["$withval"])
         ;;
 esac
 ],
 [
-AC_MSG_RESULT(python)
-AC_DEFINE(PY_SSL_DEFAULT_CIPHERS, 1)
+AC_MSG_RESULT([python])
+AC_DEFINE([PY_SSL_DEFAULT_CIPHERS], [1])
 ])
 
 # builtin hash modules
 default_hashlib_hashes="md5,sha1,sha2,sha3,blake2"
 AC_DEFINE([PY_BUILTIN_HASHLIB_HASHES], [], [enabled builtin hash modules]
 )
-AC_MSG_CHECKING(for --with-builtin-hashlib-hashes)
-AC_ARG_WITH(builtin-hashlib-hashes,
-            AS_HELP_STRING([--with-builtin-hashlib-hashes=md5,sha1,sha2,sha3,blake2],
-                           [builtin hash modules,
-                            md5, sha1, sha2, sha3 (with shake), blake2]),
+AC_MSG_CHECKING([for --with-builtin-hashlib-hashes])
+AC_ARG_WITH(
+  [builtin-hashlib-hashes],
+  [AS_HELP_STRING(
+    [--with-builtin-hashlib-hashes=md5,sha1,sha2,sha3,blake2],
+    [builtin hash modules, md5, sha1, sha2, sha3 (with shake), blake2]
+  )],
 [
   AS_CASE([$with_builtin_hashlib_hashes],
     [yes], [with_builtin_hashlib_hashes=$default_hashlib_hashes],
@@ -7041,13 +7136,14 @@ AC_ARG_WITH(builtin-hashlib-hashes,
   )
 ], [with_builtin_hashlib_hashes=$default_hashlib_hashes])
 
-AC_MSG_RESULT($with_builtin_hashlib_hashes)
-AC_DEFINE_UNQUOTED(PY_BUILTIN_HASHLIB_HASHES, "$with_builtin_hashlib_hashes")
+AC_MSG_RESULT([$with_builtin_hashlib_hashes])
+AC_DEFINE_UNQUOTED([PY_BUILTIN_HASHLIB_HASHES],
+  ["$with_builtin_hashlib_hashes"])
 
 as_save_IFS=$IFS
 IFS=,
 for builtin_hash in $with_builtin_hashlib_hashes; do
-    AS_CASE($builtin_hash,
+    AS_CASE([$builtin_hash],
       [md5], [with_builtin_md5=yes],
       [sha1], [with_builtin_sha1=yes],
       [sha2], [with_builtin_sha2=yes],
@@ -7177,7 +7273,7 @@ AC_DEFUN([PY_STDLIB_MOD], [
   m4_pushdef([modstate], [py_cv_module_$1])dnl
   dnl Check if module has been disabled by PY_STDLIB_MOD_SET_NA()
   AS_IF([test "$modstate" != "n/a"], [
-    AS_IF(m4_ifblank([$2], [true], [$2]),
+    AS_IF([m4_ifblank([$2], [true], [$2])],
        [AS_IF([m4_ifblank([$3], [true], [$3])], [modstate=yes], [modstate=missing])],
        [modstate=disabled])
   ])
@@ -7383,8 +7479,16 @@ PY_STDLIB_MOD([xxlimited_35], [test "$with_trace_refs" = "no"], [test "$ac_cv_fu
 AC_SUBST([MODULE_BLOCK])
 
 # generate output files
-AC_CONFIG_FILES(Makefile.pre Misc/python.pc Misc/python-embed.pc Misc/python-config.sh)
-AC_CONFIG_FILES([Modules/Setup.bootstrap Modules/Setup.stdlib])
+AC_CONFIG_FILES(m4_normalize([
+  Makefile.pre
+  Misc/python.pc
+  Misc/python-embed.pc
+  Misc/python-config.sh
+]))
+AC_CONFIG_FILES(m4_normalize([
+  Modules/Setup.bootstrap
+  Modules/Setup.stdlib
+]))
 AC_CONFIG_FILES([Modules/ld_so_aix], [chmod +x Modules/ld_so_aix])
 AC_OUTPUT
 


### PR DESCRIPTION
Autoconf 2.70 macros are picky about argument quotation.


<!-- gh-issue-number: gh-89886 -->
* Issue: gh-89886
<!-- /gh-issue-number -->
