### PR TITLE
gh-104614: Make Sure ob_type is Always Set Correctly by PyType_Ready()

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1629,27 +1629,34 @@ class BuiltinStaticTypesTests(unittest.TestCase):
 
 class TestStaticTypes(unittest.TestCase):
 
+    _has_run = False
+
+    @classmethod
+    def setUpClass(cls):
+        # The tests here don't play nice with our approach to refleak
+        # detection, so we bail out in that case.
+        if cls._has_run:
+            raise unittest.SkipTest('these tests do not support re-running')
+        cls._has_run = True
+
+    @contextlib.contextmanager
+    def basic_static_type(self, *args):
+        cls = _testcapi.get_basic_static_type(*args)
+        yield cls
+
     def test_pytype_ready_always_sets_tp_type(self):
         # The point of this test is to prevent something like
         # https://github.com/python/cpython/issues/104614
         # from happening again.
 
-        @contextlib.contextmanager
-        def basic_static_type(*args):
-            cls = _testcapi.get_basic_static_type(*args)
-            try:
-                yield cls
-            finally:
-                _testcapi.clear_basic_static_type(cls)
-
         # First check when tp_base/tp_bases is *not* set before PyType_Ready().
-        with basic_static_type() as cls:
+        with self.basic_static_type() as cls:
             self.assertIs(cls.__base__, object);
             self.assertEqual(cls.__bases__, (object,));
             self.assertIs(type(cls), type(object));
 
         # Then check when we *do* set tp_base/tp_bases first.
-        with basic_static_type(object) as cls:
+        with self.basic_static_type(object) as cls:
             self.assertIs(cls.__base__, object);
             self.assertEqual(cls.__bases__, (object,));
             self.assertIs(type(cls), type(object));

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -306,11 +306,14 @@ clear_tp_bases(PyTypeObject *self)
 {
     if (self->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
         if (_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
-            if (self->tp_bases != NULL
-                && PyTuple_GET_SIZE(self->tp_bases) > 0)
-            {
-                assert(_Py_IsImmortal(self->tp_bases));
-                _Py_ClearImmortal(self->tp_bases);
+            if (self->tp_bases != NULL) {
+                if (PyTuple_GET_SIZE(self->tp_bases) == 0) {
+                    Py_CLEAR(self->tp_bases);
+                }
+                else {
+                    assert(_Py_IsImmortal(self->tp_bases));
+                    _Py_ClearImmortal(self->tp_bases);
+                }
             }
         }
         return;
@@ -352,11 +355,14 @@ clear_tp_mro(PyTypeObject *self)
 {
     if (self->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
         if (_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
-            if (self->tp_mro != NULL
-                && PyTuple_GET_SIZE(self->tp_mro) > 0)
-            {
-                assert(_Py_IsImmortal(self->tp_mro));
-                _Py_ClearImmortal(self->tp_mro);
+            if (self->tp_mro != NULL) {
+                if (PyTuple_GET_SIZE(self->tp_mro) == 0) {
+                    Py_CLEAR(self->tp_mro);
+                }
+                else {
+                    assert(_Py_IsImmortal(self->tp_mro));
+                    _Py_ClearImmortal(self->tp_mro);
+                }
             }
         }
         return;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7045,8 +7045,12 @@ type_ready_set_type(PyTypeObject *type)
 static int
 type_ready_set_bases(PyTypeObject *type)
 {
-    if (lookup_tp_bases(type) != NULL) {
-        return 0;
+    if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
+        if (!_Py_IsMainInterpreter(_PyInterpreterState_GET())) {
+            assert(lookup_tp_bases(type) != NULL);
+            return 0;
+        }
+        assert(lookup_tp_bases(type) == NULL);
     }
 
     PyObject *bases = lookup_tp_bases(type);

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -420,7 +420,8 @@ Modules/_testcapi/watchers.c	-	num_code_object_destroyed_events	-
 Modules/_testcapi/watchers.c	-	pyfunc_watchers	-
 Modules/_testcapi/watchers.c	-	func_watcher_ids	-
 Modules/_testcapi/watchers.c	-	func_watcher_callbacks	-
-Modules/_testcapimodule.c	-	BasicStaticType	-
+Modules/_testcapimodule.c	-	BasicStaticTypes	-
+Modules/_testcapimodule.c	-	num_basic_static_types_used	-
 Modules/_testcapimodule.c	-	ContainerNoGC_members	-
 Modules/_testcapimodule.c	-	ContainerNoGC_type	-
 Modules/_testcapimodule.c	-	FmData	-

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -420,6 +420,7 @@ Modules/_testcapi/watchers.c	-	num_code_object_destroyed_events	-
 Modules/_testcapi/watchers.c	-	pyfunc_watchers	-
 Modules/_testcapi/watchers.c	-	func_watcher_ids	-
 Modules/_testcapi/watchers.c	-	func_watcher_callbacks	-
+Modules/_testcapimodule.c	-	BasicStaticType	-
 Modules/_testcapimodule.c	-	ContainerNoGC_members	-
 Modules/_testcapimodule.c	-	ContainerNoGC_type	-
 Modules/_testcapimodule.c	-	FmData	-


### PR DESCRIPTION
When I added the relevant condition to `type_ready_set_bases()` in gh-103912, I had missed that the function also sets `tp_base` and `ob_type` (if necessary).  That led to problems for third-party static types.

We fix that here, by making those extra operations distinct and by adjusting the condition to be more specific.

<!-- gh-issue-number: gh-104614 -->
* Issue: gh-104614
<!-- /gh-issue-number -->
