### PR TITLE
gh-87729: add LOAD_SUPER_ATTR to 3.12 What's New

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -899,6 +899,10 @@ Optimizations
   the :mod:`tokenize` module. (Contributed by Marta Gómez Macías and Pablo Galindo
   in :gh:`102856`.)
 
+* Speed up :func:`super` method calls and attribute loads via the
+  new :opcode:`LOAD_SUPER_ATTR` instruction. (Contributed by Carl Meyer and
+  Vladimir Matveev in :gh:`103497`.)
+
 
 CPython bytecode changes
 ========================
@@ -916,6 +920,9 @@ CPython bytecode changes
   Remove the :opcode:`!LOAD_CLASSDEREF` opcode, which can be replaced with
   :opcode:`LOAD_LOCALS` plus :opcode:`LOAD_FROM_DICT_OR_DEREF`. (Contributed
   by Jelle Zijlstra in :gh:`103764`.)
+
+* Add the :opcode:`LOAD_SUPER_ATTR` instruction. (Contributed by Carl Meyer and
+  Vladimir Matveev in :gh:`103497`.)
 
 Demos and Tools
 ===============


### PR DESCRIPTION
Missed this in the original PR, it should be mentioned.

It is both an optimization and a bytecode change, so I mentioned it in both sections.


<!-- gh-issue-number: gh-87729 -->
* Issue: gh-87729
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105125.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->