### PR TITLE
gh-97933: add LOAD_FAST_AND_CLEAR to 3.12 What's New bytecode section

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -911,6 +911,9 @@ CPython bytecode changes
 * Remove the :opcode:`!JUMP_IF_FALSE_OR_POP` and :opcode:`!JUMP_IF_TRUE_OR_POP`
   instructions. (Contributed by Irit Katriel in :gh:`102859`.)
 
+* Add the :opcode:`LOAD_FAST_AND_CLEAR` instruction as part of the
+  implementation of :pep:`709`. (Contributed by Carl Meyer in :gh:`101441`.)
+
 * Add the :opcode:`LOAD_FROM_DICT_OR_DEREF`, :opcode:`LOAD_FROM_DICT_OR_GLOBALS`,
   and :opcode:`LOAD_LOCALS` opcodes as part of the implementation of :pep:`695`.
   Remove the :opcode:`!LOAD_CLASSDEREF` opcode, which can be replaced with


### PR DESCRIPTION
This opcode was added as part of PEP 709, it should be documented in the "bytecode changes" section of What's New.


<!-- gh-issue-number: gh-97933 -->
* Issue: gh-97933
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105126.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->