### PR TITLE
gh-103142: Update macOS installer to use OpenSSL 1.1.1u.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -246,9 +246,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.1.1t",
-              url="https://www.openssl.org/source/openssl-1.1.1t.tar.gz",
-              checksum='8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b',
+              name="OpenSSL 1.1.1u",
+              url="https://www.openssl.org/source/openssl-1.1.1u.tar.gz",
+              checksum='e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2023-05-30-23-30-46.gh-issue-103142.55lMXQ.rst
+++ b/Misc/NEWS.d/next/macOS/2023-05-30-23-30-46.gh-issue-103142.55lMXQ.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use OpenSSL 1.1.1u.


### PR DESCRIPTION


<!-- gh-issue-number: gh-103142 -->
* Issue: gh-103142
<!-- /gh-issue-number -->
