### PR TITLE
[3.11] gh-105096: Reformat wave documentation (#105136) (#105138)

### DIFF
--- a/Doc/library/wave.rst
+++ b/Doc/library/wave.rst
@@ -11,7 +11,8 @@
 
 --------------
 
-The :mod:`wave` module provides a convenient interface to the WAV sound format.
+The :mod:`wave` module provides a convenient interface to the Waveform Audio
+"WAVE" (or "WAV") file format.
 Only files using ``WAVE_FORMAT_PCM`` are supported. Note that this does not
 include files using ``WAVE_FORMAT_EXTENSIBLE`` even if the subformat is PCM.
 
@@ -37,13 +38,12 @@ The :mod:`wave` module defines the following function and exception:
    value for *mode*.
 
    If you pass in a file-like object, the wave object will not close it when its
-   :meth:`close` method is called; it is the caller's responsibility to close
+   ``close()`` method is called; it is the caller's responsibility to close
    the file object.
 
    The :func:`.open` function may be used in a :keyword:`with` statement.  When
-   the :keyword:`!with` block completes, the :meth:`Wave_read.close()
-   <wave.Wave_read.close>` or :meth:`Wave_write.close()
-   <wave.Wave_write.close()>` method is called.
+   the :keyword:`!with` block completes, the :meth:`Wave_read.close()` or
+   :meth:`Wave_write.close()` method is called.
 
    .. versionchanged:: 3.4
       Added support for unseekable files.
@@ -59,87 +59,91 @@ The :mod:`wave` module defines the following function and exception:
 Wave_read Objects
 -----------------
 
-Wave_read objects, as returned by :func:`.open`, have the following methods:
+.. class:: Wave_read
+
+   Read a WAV file.
+
+   Wave_read objects, as returned by :func:`.open`, have the following methods:
 
 
-.. method:: Wave_read.close()
+   .. method:: close()
 
-   Close the stream if it was opened by :mod:`wave`, and make the instance
-   unusable.  This is called automatically on object collection.
-
-
-.. method:: Wave_read.getnchannels()
-
-   Returns number of audio channels (``1`` for mono, ``2`` for stereo).
+      Close the stream if it was opened by :mod:`wave`, and make the instance
+      unusable.  This is called automatically on object collection.
 
 
-.. method:: Wave_read.getsampwidth()
+   .. method:: getnchannels()
 
-   Returns sample width in bytes.
-
-
-.. method:: Wave_read.getframerate()
-
-   Returns sampling frequency.
+      Returns number of audio channels (``1`` for mono, ``2`` for stereo).
 
 
-.. method:: Wave_read.getnframes()
+   .. method:: getsampwidth()
 
-   Returns number of audio frames.
-
-
-.. method:: Wave_read.getcomptype()
-
-   Returns compression type (``'NONE'`` is the only supported type).
+      Returns sample width in bytes.
 
 
-.. method:: Wave_read.getcompname()
+   .. method:: getframerate()
 
-   Human-readable version of :meth:`getcomptype`. Usually ``'not compressed'``
-   parallels ``'NONE'``.
-
-
-.. method:: Wave_read.getparams()
-
-   Returns a :func:`~collections.namedtuple` ``(nchannels, sampwidth,
-   framerate, nframes, comptype, compname)``, equivalent to output of the
-   :meth:`get\*` methods.
+      Returns sampling frequency.
 
 
-.. method:: Wave_read.readframes(n)
+   .. method:: getnframes()
 
-   Reads and returns at most *n* frames of audio, as a :class:`bytes` object.
-
-
-.. method:: Wave_read.rewind()
-
-   Rewind the file pointer to the beginning of the audio stream.
-
-The following two methods are defined for compatibility with the :mod:`aifc`
-module, and don't do anything interesting.
+      Returns number of audio frames.
 
 
-.. method:: Wave_read.getmarkers()
+   .. method:: getcomptype()
 
-   Returns ``None``.
-
-
-.. method:: Wave_read.getmark(id)
-
-   Raise an error.
-
-The following two methods define a term "position" which is compatible between
-them, and is otherwise implementation dependent.
+      Returns compression type (``'NONE'`` is the only supported type).
 
 
-.. method:: Wave_read.setpos(pos)
+   .. method:: getcompname()
 
-   Set the file pointer to the specified position.
+      Human-readable version of :meth:`getcomptype`. Usually ``'not compressed'``
+      parallels ``'NONE'``.
 
 
-.. method:: Wave_read.tell()
+   .. method:: getparams()
 
-   Return current file pointer position.
+      Returns a :func:`~collections.namedtuple` ``(nchannels, sampwidth,
+      framerate, nframes, comptype, compname)``, equivalent to output of the
+      ``get*()`` methods.
+
+
+   .. method:: readframes(n)
+
+      Reads and returns at most *n* frames of audio, as a :class:`bytes` object.
+
+
+   .. method:: rewind()
+
+      Rewind the file pointer to the beginning of the audio stream.
+
+   The following two methods are defined for compatibility with the :mod:`aifc`
+   module, and don't do anything interesting.
+
+
+   .. method:: getmarkers()
+
+      Returns ``None``.
+
+
+   .. method:: getmark(id)
+
+      Raise an error.
+
+   The following two methods define a term "position" which is compatible between
+   them, and is otherwise implementation dependent.
+
+
+   .. method:: setpos(pos)
+
+      Set the file pointer to the specified position.
+
+
+   .. method:: tell()
+
+      Return current file pointer position.
 
 
 .. _wave-write-objects:
@@ -147,97 +151,100 @@ them, and is otherwise implementation dependent.
 Wave_write Objects
 ------------------
 
-For seekable output streams, the ``wave`` header will automatically be updated
-to reflect the number of frames actually written.  For unseekable streams, the
-*nframes* value must be accurate when the first frame data is written.  An
-accurate *nframes* value can be achieved either by calling
-:meth:`~Wave_write.setnframes` or :meth:`~Wave_write.setparams` with the number
-of frames that will be written before :meth:`~Wave_write.close` is called and
-then using :meth:`~Wave_write.writeframesraw` to write the frame data, or by
-calling :meth:`~Wave_write.writeframes` with all of the frame data to be
-written.  In the latter case :meth:`~Wave_write.writeframes` will calculate
-the number of frames in the data and set *nframes* accordingly before writing
-the frame data.
+.. class:: Wave_write
 
-Wave_write objects, as returned by :func:`.open`, have the following methods:
+   Write a WAV file.
 
-.. versionchanged:: 3.4
-   Added support for unseekable files.
+   Wave_write objects, as returned by :func:`.open`.
 
-
-.. method:: Wave_write.close()
-
-   Make sure *nframes* is correct, and close the file if it was opened by
-   :mod:`wave`.  This method is called upon object collection.  It will raise
-   an exception if the output stream is not seekable and *nframes* does not
-   match the number of frames actually written.
-
-
-.. method:: Wave_write.setnchannels(n)
-
-   Set the number of channels.
-
-
-.. method:: Wave_write.setsampwidth(n)
-
-   Set the sample width to *n* bytes.
-
-
-.. method:: Wave_write.setframerate(n)
-
-   Set the frame rate to *n*.
-
-   .. versionchanged:: 3.2
-      A non-integral input to this method is rounded to the nearest
-      integer.
-
-
-.. method:: Wave_write.setnframes(n)
-
-   Set the number of frames to *n*.  This will be changed later if the number
-   of frames actually written is different (this update attempt will
-   raise an error if the output stream is not seekable).
-
-
-.. method:: Wave_write.setcomptype(type, name)
-
-   Set the compression type and description. At the moment, only compression type
-   ``NONE`` is supported, meaning no compression.
-
-
-.. method:: Wave_write.setparams(tuple)
-
-   The *tuple* should be ``(nchannels, sampwidth, framerate, nframes, comptype,
-   compname)``, with values valid for the :meth:`set\*` methods.  Sets all
-   parameters.
-
-
-.. method:: Wave_write.tell()
-
-   Return current position in the file, with the same disclaimer for the
-   :meth:`Wave_read.tell` and :meth:`Wave_read.setpos` methods.
-
-
-.. method:: Wave_write.writeframesraw(data)
-
-   Write audio frames, without correcting *nframes*.
+   For seekable output streams, the ``wave`` header will automatically be updated
+   to reflect the number of frames actually written.  For unseekable streams, the
+   *nframes* value must be accurate when the first frame data is written.  An
+   accurate *nframes* value can be achieved either by calling
+   :meth:`setnframes` or :meth:`setparams` with the number
+   of frames that will be written before :meth:`close` is called and
+   then using :meth:`writeframesraw` to write the frame data, or by
+   calling :meth:`writeframes` with all of the frame data to be
+   written.  In the latter case :meth:`writeframes` will calculate
+   the number of frames in the data and set *nframes* accordingly before writing
+   the frame data.
 
    .. versionchanged:: 3.4
-      Any :term:`bytes-like object` is now accepted.
+      Added support for unseekable files.
+
+   Wave_write objects have the following methods:
+
+   .. method:: close()
+
+      Make sure *nframes* is correct, and close the file if it was opened by
+      :mod:`wave`.  This method is called upon object collection.  It will raise
+      an exception if the output stream is not seekable and *nframes* does not
+      match the number of frames actually written.
 
 
-.. method:: Wave_write.writeframes(data)
+   .. method:: setnchannels(n)
 
-   Write audio frames and make sure *nframes* is correct.  It will raise an
-   error if the output stream is not seekable and the total number of frames
-   that have been written after *data* has been written does not match the
-   previously set value for *nframes*.
-
-   .. versionchanged:: 3.4
-      Any :term:`bytes-like object` is now accepted.
+      Set the number of channels.
 
 
-Note that it is invalid to set any parameters after calling :meth:`writeframes`
-or :meth:`writeframesraw`, and any attempt to do so will raise
-:exc:`wave.Error`.
+   .. method:: setsampwidth(n)
 
+      Set the sample width to *n* bytes.
+
+
+   .. method:: setframerate(n)
+
+      Set the frame rate to *n*.
+
+      .. versionchanged:: 3.2
+         A non-integral input to this method is rounded to the nearest
+         integer.
+
+
+   .. method:: setnframes(n)
+
+      Set the number of frames to *n*.  This will be changed later if the number
+      of frames actually written is different (this update attempt will
+      raise an error if the output stream is not seekable).
+
+
+   .. method:: setcomptype(type, name)
+
+      Set the compression type and description. At the moment, only compression type
+      ``NONE`` is supported, meaning no compression.
+
+
+   .. method:: setparams(tuple)
+
+      The *tuple* should be ``(nchannels, sampwidth, framerate, nframes, comptype,
+      compname)``, with values valid for the ``set*()`` methods.  Sets all
+      parameters.
+
+
+   .. method:: tell()
+
+      Return current position in the file, with the same disclaimer for the
+      :meth:`Wave_read.tell` and :meth:`Wave_read.setpos` methods.
+
+
+   .. method:: writeframesraw(data)
+
+      Write audio frames, without correcting *nframes*.
+
+      .. versionchanged:: 3.4
+         Any :term:`bytes-like object` is now accepted.
+
+
+   .. method:: writeframes(data)
+
+      Write audio frames and make sure *nframes* is correct.  It will raise an
+      error if the output stream is not seekable and the total number of frames
+      that have been written after *data* has been written does not match the
+      previously set value for *nframes*.
+
+      .. versionchanged:: 3.4
+         Any :term:`bytes-like object` is now accepted.
+
+      Note that it is invalid to set any parameters after calling :meth:`writeframes`
+      or :meth:`writeframesraw`, and any attempt to do so will raise
+      :exc:`wave.Error`.

--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -89,6 +89,7 @@ _array_fmts = None, 'b', 'h', None, 'i'
 _wave_params = namedtuple('_wave_params',
                      'nchannels sampwidth framerate nframes comptype compname')
 
+
 def _byteswap(data, width):
     swapped_data = bytearray(len(data))
 
@@ -101,7 +102,6 @@ def _byteswap(data, width):
 
 class _Chunk:
     def __init__(self, file, align=True, bigendian=True, inclheader=False):
-        import struct
         self.closed = False
         self.align = align      # whether to align to word (2-byte) boundaries
         if bigendian:
@@ -209,7 +209,6 @@ class _Chunk:
             dummy = self.read(n)
             if not dummy:
                 raise EOFError
-
 
 
 class Wave_read:
@@ -392,6 +391,7 @@ class Wave_read:
         self._framesize = self._nchannels * self._sampwidth
         self._comptype = 'NONE'
         self._compname = 'not compressed'
+
 
 class Wave_write:
     """Variables used in this class:
@@ -619,6 +619,7 @@ class Wave_write:
         self._file.write(struct.pack('<L', self._datawritten))
         self._file.seek(curpos, 0)
         self._datalength = self._datawritten
+
 
 def open(f, mode=None):
     if mode is None:


### PR DESCRIPTION
gh-105096: Reformat wave documentation (#105136)

Add ".. class::" markups in the wave documentation.

* Reformat also wave.py (minor PEP 8 changes).
* Remove redundant "import struct": it's already imported at top level.
* Remove wave.rst from .nitignore

(cherry picked from commit 85e5d03163cac106ac8ec142ef03f1349a48948b) (cherry picked from commit 01b42f9559b614d729c3f055d09269db13d2433c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105155.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->