### PR TITLE
gh-105144: abc: Suppress errors raised by unrelated other subclasses

### DIFF
--- a/Lib/_py_abc.py
+++ b/Lib/_py_abc.py
@@ -134,14 +134,20 @@ class ABCMeta(type):
             return True
         # Check if it's a subclass of a registered class (recursive)
         for rcls in cls._abc_registry:
-            if issubclass(subclass, rcls):
-                cls._abc_cache.add(subclass)
-                return True
+            try:
+                if issubclass(subclass, rcls):
+                    cls._abc_cache.add(subclass)
+                    return True
+            except Exception:
+                pass
         # Check if it's a subclass of a subclass (recursive)
         for scls in cls.__subclasses__():
-            if issubclass(subclass, scls):
-                cls._abc_cache.add(subclass)
-                return True
+            try:
+                if issubclass(subclass, scls):
+                    cls._abc_cache.add(subclass)
+                    return True
+            except Exception:
+                pass
         # No dice; update negative cache
         cls._abc_negative_cache.add(subclass)
         return False

--- a/Misc/NEWS.d/next/Library/2023-05-31-09-55-16.gh-issue-105144.fTqfGv.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-31-09-55-16.gh-issue-105144.fTqfGv.rst
@@ -1,0 +1,3 @@
+Subclass checks on :class:`abc.ABC` subclasses no longer propagate errors
+raised by subclass checks on unrelated base classes of the ABC. Patch by
+Jelle Zijlstra.

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -786,7 +786,8 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
             goto end;
         }
         if (r < 0) {
-            goto end;
+            // Ignore subclasses that throw on issubclass().
+            PyErr_Clear();
         }
     }
 
@@ -856,8 +857,7 @@ subclasscheck_check_registry(_abc_data *impl, PyObject *subclass,
         int r = PyObject_IsSubclass(subclass, rkey);
         Py_DECREF(rkey);
         if (r < 0) {
-            ret = -1;
-            break;
+            PyErr_Clear();
         }
         if (r > 0) {
             if (_add_to_weak_set(&impl->_abc_cache, subclass) < 0) {


### PR DESCRIPTION
A more invasive solution for #105144; perhaps better kept for 3.13 only.

<!-- gh-issue-number: gh-105144 -->
* Issue: gh-105144
<!-- /gh-issue-number -->
