### PR TITLE
gh-105172: Fixed functools.lru_cache typed argument docstring.

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -483,8 +483,9 @@ def lru_cache(maxsize=128, typed=False):
     can grow without bound.
 
     If *typed* is True, arguments of different types will be cached separately.
-    For example, f(3.0) and f(3) will be treated as distinct calls with
-    distinct results.
+    For example, f(decimal.Decimal("3.0")) and f(3.0) will be treated as
+    distinct calls with distinct results. Some types such as str and int may
+    be cached separately even when typed is false.
 
     Arguments to the cached function must be hashable.
 

--- a/Misc/NEWS.d/next/Documentation/2023-05-31-23-05-51.gh-issue-105172.SVfvkD.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-05-31-23-05-51.gh-issue-105172.SVfvkD.rst
@@ -1,0 +1,2 @@
+Fixed :func:`functools.lru_cache` docstring accounting for ``typed``
+argument's different handling of str and int. Patch by Bar Harel.


### PR DESCRIPTION
Minor docstring issue, fixed.

<!-- gh-issue-number: gh-105172 -->
* Issue: gh-105172
<!-- /gh-issue-number -->
