### PR TITLE
Fix docstring of `warnings._deprecated` to show correct `remove` value

### DIFF
--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -517,7 +517,7 @@ def _deprecated(name, message=_DEPRECATED_MSG, *, remove, _version=sys.version_i
     the current Python version or the same version but past the alpha.
 
     The *message* argument is formatted with *name* and *remove* as a Python
-    version (e.g. "3.11").
+    version tuple (e.g. (3, 11)).
 
     """
     remove_formatted = f"{remove[0]}.{remove[1]}"


### PR DESCRIPTION
It used to be a string, but actually passing `remove=3.11` will give you a `TypeError`. Example:

```python
>>> import warnings
>>> warnings._deprecated('a', remove='3.11')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sobolev/Desktop/cpython/Lib/warnings.py", line 524, in _deprecated
    if (_version[:2] > remove) or (_version[:2] == remove and _version[3] != "alpha"):
        ^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'tuple' and 'str'
```

So, I've changed it to be a tuple intead, as it should be.

I don't think that this PR is worth an issue / news entry.