### PR TITLE
gh-105145: Deprecate Py_GetPath() function

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -430,6 +430,9 @@ Process-wide parameters
    .. versionchanged:: 3.10
       It now returns ``NULL`` if called before :c:func:`Py_Initialize`.
 
+   .. deprecated-removed:: 3.13 3.15
+      Get :data:`sys.executable` instead.
+
 
 .. c:function:: wchar_t* Py_GetPrefix()
 
@@ -448,6 +451,9 @@ Process-wide parameters
 
    .. versionchanged:: 3.10
       It now returns ``NULL`` if called before :c:func:`Py_Initialize`.
+
+   .. deprecated-removed:: 3.13 3.15
+      Get :data:`sys.prefix` instead.
 
 
 .. c:function:: wchar_t* Py_GetExecPrefix()
@@ -490,6 +496,9 @@ Process-wide parameters
    .. versionchanged:: 3.10
       It now returns ``NULL`` if called before :c:func:`Py_Initialize`.
 
+   .. deprecated-removed:: 3.13 3.15
+      Get :data:`sys.exec_prefix` instead.
+
 
 .. c:function:: wchar_t* Py_GetProgramFullPath()
 
@@ -507,6 +516,9 @@ Process-wide parameters
 
    .. versionchanged:: 3.10
       It now returns ``NULL`` if called before :c:func:`Py_Initialize`.
+
+   .. deprecated-removed:: 3.13 3.15
+      Get :data:`sys.executable` instead.
 
 
 .. c:function:: wchar_t* Py_GetPath()
@@ -532,6 +544,9 @@ Process-wide parameters
 
    .. versionchanged:: 3.10
       It now returns ``NULL`` if called before :c:func:`Py_Initialize`.
+
+   .. deprecated-removed:: 3.13 3.15
+      Get :data:`sys.path` instead.
 
 
 .. c:function:: const char* Py_GetVersion()
@@ -615,6 +630,10 @@ Process-wide parameters
 
    .. versionchanged:: 3.10
       It now returns ``NULL`` if called before :c:func:`Py_Initialize`.
+
+   .. deprecated-removed:: 3.13 3.15
+      Get :c:member:`PyConfig.home` or :envvar:`PYTHONHOME` environment
+      variable instead.
 
 
 .. _threads:

--- a/Doc/c-api/sys.rst
+++ b/Doc/c-api/sys.rst
@@ -238,7 +238,7 @@ accessible to C code.  They all work with the current interpreter thread's
    called prior to :c:func:`Py_Initialize`.
 
    .. deprecated-removed:: 3.13 3.15
-      Clear :data:`sys.warnoptions` and :data:`warnings.filters` instead.
+      Clear :data:`sys.warnoptions` and :data:`!warnings.filters` instead.
 
 .. c:function:: void PySys_WriteStdout(const char *format, ...)
 

--- a/Doc/c-api/sys.rst
+++ b/Doc/c-api/sys.rst
@@ -237,6 +237,9 @@ accessible to C code.  They all work with the current interpreter thread's
    Reset :data:`sys.warnoptions` to an empty list. This function may be
    called prior to :c:func:`Py_Initialize`.
 
+   .. deprecated-removed:: 3.13 3.15
+      Clear :data:`sys.warnoptions` and :data:`warnings.filters` instead.
+
 .. c:function:: void PySys_WriteStdout(const char *format, ...)
 
    Write the output string described by *format* to :data:`sys.stdout`.  No

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -357,6 +357,20 @@ Deprecated
   ``PY_UNICODE_TYPE`` are just aliases to ``wchar_t``.
   (Contributed by Victor Stinner in :gh:`105156`.)
 
+* Deprecate old Python initialization functions:
+
+  * :c:func:`PySys_ResetWarnOptions`:
+    clear :data:`sys.warnoptions` and :data:`warnings.filters` instead.
+  * :c:func:`Py_GetExecPrefix`: get :data:`sys.exec_prefix` instead.
+  * :c:func:`Py_GetPath`: get :data:`sys.path` instead.
+  * :c:func:`Py_GetPrefix`: get :data:`sys.prefix` instead.
+  * :c:func:`Py_GetProgramFullPath`: get :data:`sys.executable` instead.
+  * :c:func:`Py_GetProgramName`: get :data:`sys.executable` instead.
+  * :c:func:`Py_GetPythonHome`: get :c:member:`PyConfig.home` or
+    :envvar:`PYTHONHOME` environment variable instead.
+
+  (Contributed by Victor Stinner in :gh:`105145`.)
+
 Removed
 -------
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -360,7 +360,7 @@ Deprecated
 * Deprecate old Python initialization functions:
 
   * :c:func:`PySys_ResetWarnOptions`:
-    clear :data:`sys.warnoptions` and :data:`warnings.filters` instead.
+    clear :data:`sys.warnoptions` and :data:`!warnings.filters` instead.
   * :c:func:`Py_GetExecPrefix`: get :data:`sys.exec_prefix` instead.
   * :c:func:`Py_GetPath`: get :data:`sys.path` instead.
   * :c:func:`Py_GetPrefix`: get :data:`sys.prefix` instead.

--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -34,12 +34,12 @@ PyAPI_FUNC(int) Py_Main(int argc, wchar_t **argv);
 PyAPI_FUNC(int) Py_BytesMain(int argc, char **argv);
 
 /* In pathconfig.c */
-PyAPI_FUNC(wchar_t *) Py_GetProgramName(void);
-PyAPI_FUNC(wchar_t *) Py_GetPythonHome(void);
-PyAPI_FUNC(wchar_t *) Py_GetProgramFullPath(void);
-PyAPI_FUNC(wchar_t *) Py_GetPrefix(void);
-PyAPI_FUNC(wchar_t *) Py_GetExecPrefix(void);
-PyAPI_FUNC(wchar_t *) Py_GetPath(void);
+Py_DEPRECATED(3.13) PyAPI_FUNC(wchar_t *) Py_GetProgramName(void);
+Py_DEPRECATED(3.13) PyAPI_FUNC(wchar_t *) Py_GetPythonHome(void);
+Py_DEPRECATED(3.13) PyAPI_FUNC(wchar_t *) Py_GetProgramFullPath(void);
+Py_DEPRECATED(3.13) PyAPI_FUNC(wchar_t *) Py_GetPrefix(void);
+Py_DEPRECATED(3.13) PyAPI_FUNC(wchar_t *) Py_GetExecPrefix(void);
+Py_DEPRECATED(3.13) PyAPI_FUNC(wchar_t *) Py_GetPath(void);
 #ifdef MS_WINDOWS
 int _Py_CheckPython3(void);
 #endif

--- a/Include/sysmodule.h
+++ b/Include/sysmodule.h
@@ -17,7 +17,7 @@ PyAPI_FUNC(void) PySys_WriteStderr(const char *format, ...)
 PyAPI_FUNC(void) PySys_FormatStdout(const char *format, ...);
 PyAPI_FUNC(void) PySys_FormatStderr(const char *format, ...);
 
-PyAPI_FUNC(void) PySys_ResetWarnOptions(void);
+Py_DEPRECATED(3.13) PyAPI_FUNC(void) PySys_ResetWarnOptions(void);
 
 PyAPI_FUNC(PyObject *) PySys_GetXOptions(void);
 

--- a/Misc/NEWS.d/next/C API/2023-06-01-09-40-30.gh-issue-105145.WOOE-w.rst
+++ b/Misc/NEWS.d/next/C API/2023-06-01-09-40-30.gh-issue-105145.WOOE-w.rst
@@ -1,0 +1,11 @@
+Deprecate old Python initialization functions:
+
+* :c:func:`PySys_ResetWarnOptions`
+* :c:func:`Py_GetExecPrefix`
+* :c:func:`Py_GetPath`
+* :c:func:`Py_GetPrefix`
+* :c:func:`Py_GetProgramFullPath`
+* :c:func:`Py_GetProgramName`
+* :c:func:`Py_GetPythonHome`
+
+Patch by Victor Stinner.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -130,11 +130,10 @@ _get_tcl_lib_path(void)
     static int already_checked = 0;
 
     if (already_checked == 0) {
-        PyObject *prefix;
         struct stat stat_buf;
         int stat_return_value;
 
-        prefix = PyUnicode_FromWideChar(Py_GetPrefix(), -1);
+        PyObject *prefix = PySys_GetObject("prefix");  // borrowed reference
         if (prefix == NULL) {
             return NULL;
         }
@@ -3289,8 +3288,8 @@ PyInit__tkinter(void)
 
     /* This helps the dynamic loader; in Unicode aware Tcl versions
        it also helps Tcl find its encodings. */
-    uexe = PyUnicode_FromWideChar(Py_GetProgramName(), -1);
-    if (uexe) {
+    uexe = PySys_GetObject("executable");  // borrowed reference
+    if (uexe && PyUnicode_Check(uexe)) {   // sys.executable can be None
         cexe = PyUnicode_EncodeFSDefault(uexe);
         if (cexe) {
 #ifdef MS_WINDOWS
@@ -3329,7 +3328,6 @@ PyInit__tkinter(void)
 #endif /* MS_WINDOWS */
         }
         Py_XDECREF(cexe);
-        Py_DECREF(uexe);
     }
 
     if (PyErr_Occurred()) {


### PR DESCRIPTION
Deprecate old Python initialization functions:

* PySys_ResetWarnOptions()
* Py_GetExecPrefix()
* Py_GetPath()
* Py_GetPrefix()
* Py_GetProgramFullPath()
* Py_GetProgramName()
* Py_GetPythonHome()

_tkinter uses sys.executable instead of Py_GetProgramName().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105145 -->
* Issue: gh-105145
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105179.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->