### PR TITLE
gh-105184: document that marshal functions can fail and need to be checked with PyErr_Occurred

### DIFF
--- a/Doc/c-api/marshal.rst
+++ b/Doc/c-api/marshal.rst
@@ -26,7 +26,7 @@ unmarshalling.  Version 2 uses a binary format for floating point numbers.
    native :c:expr:`long` type.  *version* indicates the file format.
 
    This function can fail, in which case it sets the error indicator.
-   Use ``PyErr_Occurred()`` to check for that.
+   Use :c:func:`PyErr_Occurred` to check for that.
 
 .. c:function:: void PyMarshal_WriteObjectToFile(PyObject *value, FILE *file, int version)
 
@@ -34,7 +34,7 @@ unmarshalling.  Version 2 uses a binary format for floating point numbers.
    *version* indicates the file format.
 
    This function can fail, in which case it sets the error indicator.
-   Use ``PyErr_Occurred()`` to check for that.
+   Use :c:func:`PyErr_Occurred` to check for that.
 
 .. c:function:: PyObject* PyMarshal_WriteObjectToString(PyObject *value, int version)
 

--- a/Doc/c-api/marshal.rst
+++ b/Doc/c-api/marshal.rst
@@ -25,12 +25,16 @@ unmarshalling.  Version 2 uses a binary format for floating point numbers.
    the least-significant 32 bits of *value*; regardless of the size of the
    native :c:expr:`long` type.  *version* indicates the file format.
 
+   This function can fail, in which case it sets the error indicator.
+   Use ``PyErr_Occurred()`` to check for that.
 
 .. c:function:: void PyMarshal_WriteObjectToFile(PyObject *value, FILE *file, int version)
 
    Marshal a Python object, *value*, to *file*.
    *version* indicates the file format.
 
+   This function can fail, in which case it sets the error indicator.
+   Use ``PyErr_Occurred()`` to check for that.
 
 .. c:function:: PyObject* PyMarshal_WriteObjectToString(PyObject *value, int version)
 

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -625,6 +625,10 @@ w_clear_refs(WFILE *wf)
 }
 
 /* version currently has no effect for writing ints. */
+/* Note that while the documentation states that this function
+ * can error, currently it never does. Setting an exception in
+ * this function should be regarded as an API-breaking change.
+ */
 void
 PyMarshal_WriteLongToFile(long x, FILE *fp, int version)
 {


### PR DESCRIPTION

@encukou 

As you suggested, I made this PR in order to backport it as far back as we can.  Both of these functions should be changed to have int return values. 

I have one doubt though about what I did here - PyMarshal_WriteLongToFile, as far as I can tell, doesn't actually ever fail. But we don't want to document that, because we want to change it to have int return value and be fallible (in case of future changes). So I think we do want to say in the doc that it can fail, even though now it can't. What do you think?


<!-- gh-issue-number: gh-105184 -->
* Issue: gh-105184
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105185.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->