### PR TITLE
gh-92536: Argument Clinic no longer emits PyUnicode_READY()

### DIFF
--- a/Lib/test/clinic.test
+++ b/Lib/test/clinic.test
@@ -354,9 +354,6 @@ test_unicode_converter(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("test_unicode_converter", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     a = arg;
     return_value = test_unicode_converter_impl(module, a);
 
@@ -366,7 +363,7 @@ exit:
 
 static PyObject *
 test_unicode_converter_impl(PyObject *module, PyObject *a)
-/*[clinic end generated code: output=18f1e3880c862611 input=aa33612df92aa9c5]*/
+/*[clinic end generated code: output=8c1625cc272c1f3d input=aa33612df92aa9c5]*/
 
 
 /*[clinic input]
@@ -972,9 +969,6 @@ test_int_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("test_int_converter", "argument 3", "a unicode character", args[2]);
         goto exit;
     }
-    if (PyUnicode_READY(args[2])) {
-        goto exit;
-    }
     if (PyUnicode_GET_LENGTH(args[2]) != 1) {
         _PyArg_BadArgument("test_int_converter", "argument 3", "a unicode character", args[2]);
         goto exit;
@@ -996,7 +990,7 @@ exit:
 
 static PyObject *
 test_int_converter_impl(PyObject *module, int a, int b, int c, myenum d)
-/*[clinic end generated code: output=800993036e078c07 input=d20541fc1ca0553e]*/
+/*[clinic end generated code: output=375eedba5ca9a5b3 input=d20541fc1ca0553e]*/
 
 
 /*[clinic input]

--- a/Modules/_io/clinic/_iomodule.c.h
+++ b/Modules/_io/clinic/_iomodule.c.h
@@ -398,13 +398,10 @@ _io_open_code(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
         _PyArg_BadArgument("open_code", "argument 'path'", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     path = args[0];
     return_value = _io_open_code_impl(module, path);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=f387eba3f4c0254a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6800c35366b1a5f3 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/textio.c.h
+++ b/Modules/_io/clinic/textio.c.h
@@ -673,9 +673,6 @@ _io_TextIOWrapper_write(textio *self, PyObject *arg)
         _PyArg_BadArgument("write", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     text = arg;
     return_value = _io_TextIOWrapper_write_impl(self, text);
 
@@ -960,4 +957,4 @@ _io_TextIOWrapper_close(textio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_TextIOWrapper_close_impl(self);
 }
-/*[clinic end generated code: output=42f592331302973f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e1060638b65e8a63 input=a9049054013a1b77]*/

--- a/Modules/_multiprocessing/clinic/posixshmem.c.h
+++ b/Modules/_multiprocessing/clinic/posixshmem.c.h
@@ -67,9 +67,6 @@ _posixshmem_shm_open(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
         _PyArg_BadArgument("shm_open", "argument 'path'", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     path = args[0];
     flags = _PyLong_AsInt(args[1]);
     if (flags == -1 && PyErr_Occurred()) {
@@ -153,9 +150,6 @@ _posixshmem_shm_unlink(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         _PyArg_BadArgument("shm_unlink", "argument 'path'", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     path = args[0];
     return_value = _posixshmem_shm_unlink_impl(module, path);
 
@@ -172,4 +166,4 @@ exit:
 #ifndef _POSIXSHMEM_SHM_UNLINK_METHODDEF
     #define _POSIXSHMEM_SHM_UNLINK_METHODDEF
 #endif /* !defined(_POSIXSHMEM_SHM_UNLINK_METHODDEF) */
-/*[clinic end generated code: output=3f6fee283d5fd0e9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9b67f98885757bc4 input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/connection.c.h
+++ b/Modules/_sqlite/clinic/connection.c.h
@@ -966,9 +966,6 @@ pysqlite_connection_execute(pysqlite_Connection *self, PyObject *const *args, Py
         _PyArg_BadArgument("execute", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     sql = args[0];
     if (nargs < 2) {
         goto skip_optional;
@@ -1006,9 +1003,6 @@ pysqlite_connection_executemany(pysqlite_Connection *self, PyObject *const *args
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("executemany", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
         goto exit;
     }
     sql = args[0];
@@ -1665,4 +1659,4 @@ exit:
 #ifndef DESERIALIZE_METHODDEF
     #define DESERIALIZE_METHODDEF
 #endif /* !defined(DESERIALIZE_METHODDEF) */
-/*[clinic end generated code: output=834a99827555bf1a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d3c6cb9326736ea5 input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/cursor.c.h
+++ b/Modules/_sqlite/clinic/cursor.c.h
@@ -65,9 +65,6 @@ pysqlite_cursor_execute(pysqlite_Cursor *self, PyObject *const *args, Py_ssize_t
         _PyArg_BadArgument("execute", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     sql = args[0];
     if (nargs < 2) {
         goto skip_optional;
@@ -105,9 +102,6 @@ pysqlite_cursor_executemany(pysqlite_Cursor *self, PyObject *const *args, Py_ssi
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("executemany", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
         goto exit;
     }
     sql = args[0];
@@ -319,4 +313,4 @@ pysqlite_cursor_close(pysqlite_Cursor *self, PyObject *Py_UNUSED(ignored))
 {
     return pysqlite_cursor_close_impl(self);
 }
-/*[clinic end generated code: output=1f82e3c9791bb9a5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=831f7bc5256526d3 input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/module.c.h
+++ b/Modules/_sqlite/clinic/module.c.h
@@ -133,9 +133,6 @@ pysqlite_register_converter(PyObject *module, PyObject *const *args, Py_ssize_t 
         _PyArg_BadArgument("register_converter", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     orig_name = args[0];
     callable = args[1];
     return_value = pysqlite_register_converter_impl(module, orig_name, callable);
@@ -211,4 +208,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=39d38c6cfc455042 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e08e6856ae546e7b input=a9049054013a1b77]*/

--- a/Modules/clinic/_codecsmodule.c.h
+++ b/Modules/clinic/_codecsmodule.c.h
@@ -1790,9 +1790,6 @@ _codecs_utf_7_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("utf_7_encode", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     str = args[0];
     if (nargs < 2) {
         goto skip_optional;
@@ -1846,9 +1843,6 @@ _codecs_utf_8_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("utf_8_encode", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
         goto exit;
     }
     str = args[0];
@@ -1905,9 +1899,6 @@ _codecs_utf_16_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("utf_16_encode", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
         goto exit;
     }
     str = args[0];
@@ -1972,9 +1963,6 @@ _codecs_utf_16_le_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         _PyArg_BadArgument("utf_16_le_encode", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     str = args[0];
     if (nargs < 2) {
         goto skip_optional;
@@ -2028,9 +2016,6 @@ _codecs_utf_16_be_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("utf_16_be_encode", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
         goto exit;
     }
     str = args[0];
@@ -2087,9 +2072,6 @@ _codecs_utf_32_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("utf_32_encode", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
         goto exit;
     }
     str = args[0];
@@ -2154,9 +2136,6 @@ _codecs_utf_32_le_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         _PyArg_BadArgument("utf_32_le_encode", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     str = args[0];
     if (nargs < 2) {
         goto skip_optional;
@@ -2210,9 +2189,6 @@ _codecs_utf_32_be_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("utf_32_be_encode", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
         goto exit;
     }
     str = args[0];
@@ -2270,9 +2246,6 @@ _codecs_unicode_escape_encode(PyObject *module, PyObject *const *args, Py_ssize_
         _PyArg_BadArgument("unicode_escape_encode", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     str = args[0];
     if (nargs < 2) {
         goto skip_optional;
@@ -2326,9 +2299,6 @@ _codecs_raw_unicode_escape_encode(PyObject *module, PyObject *const *args, Py_ss
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("raw_unicode_escape_encode", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
         goto exit;
     }
     str = args[0];
@@ -2386,9 +2356,6 @@ _codecs_latin_1_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         _PyArg_BadArgument("latin_1_encode", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     str = args[0];
     if (nargs < 2) {
         goto skip_optional;
@@ -2442,9 +2409,6 @@ _codecs_ascii_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("ascii_encode", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
         goto exit;
     }
     str = args[0];
@@ -2503,9 +2467,6 @@ _codecs_charmap_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         _PyArg_BadArgument("charmap_encode", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     str = args[0];
     if (nargs < 2) {
         goto skip_optional;
@@ -2560,9 +2521,6 @@ _codecs_charmap_build(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("charmap_build", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     map = arg;
     return_value = _codecs_charmap_build_impl(module, map);
 
@@ -2595,9 +2553,6 @@ _codecs_mbcs_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("mbcs_encode", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
         goto exit;
     }
     str = args[0];
@@ -2656,9 +2611,6 @@ _codecs_oem_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("oem_encode", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
         goto exit;
     }
     str = args[0];
@@ -2723,9 +2675,6 @@ _codecs_code_page_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     }
     if (!PyUnicode_Check(args[1])) {
         _PyArg_BadArgument("code_page_encode", "argument 2", "str", args[1]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[1]) == -1) {
         goto exit;
     }
     str = args[1];
@@ -2869,4 +2818,4 @@ exit:
 #ifndef _CODECS_CODE_PAGE_ENCODE_METHODDEF
     #define _CODECS_CODE_PAGE_ENCODE_METHODDEF
 #endif /* !defined(_CODECS_CODE_PAGE_ENCODE_METHODDEF) */
-/*[clinic end generated code: output=603da07cf8dfeb4b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0f52053d31533376 input=a9049054013a1b77]*/

--- a/Modules/clinic/_localemodule.c.h
+++ b/Modules/clinic/_localemodule.c.h
@@ -108,15 +108,9 @@ _locale_strcoll(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("strcoll", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     os1 = args[0];
     if (!PyUnicode_Check(args[1])) {
         _PyArg_BadArgument("strcoll", "argument 2", "str", args[1]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[1]) == -1) {
         goto exit;
     }
     os2 = args[1];
@@ -150,9 +144,6 @@ _locale_strxfrm(PyObject *module, PyObject *arg)
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("strxfrm", "argument", "str", arg);
-        goto exit;
-    }
-    if (PyUnicode_READY(arg) == -1) {
         goto exit;
     }
     str = arg;
@@ -608,4 +599,4 @@ _locale_getencoding(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef _LOCALE_BIND_TEXTDOMAIN_CODESET_METHODDEF
     #define _LOCALE_BIND_TEXTDOMAIN_CODESET_METHODDEF
 #endif /* !defined(_LOCALE_BIND_TEXTDOMAIN_CODESET_METHODDEF) */
-/*[clinic end generated code: output=406842c3441559cb input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9dbd0b4bf5767edd input=a9049054013a1b77]*/

--- a/Modules/clinic/_testclinic.c.h
+++ b/Modules/clinic/_testclinic.c.h
@@ -135,9 +135,6 @@ unicode_converter(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("unicode_converter", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     a = arg;
     return_value = unicode_converter_impl(module, a);
 
@@ -646,9 +643,6 @@ int_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     if (!PyUnicode_Check(args[2])) {
         _PyArg_BadArgument("int_converter", "argument 3", "a unicode character", args[2]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[2])) {
         goto exit;
     }
     if (PyUnicode_GET_LENGTH(args[2]) != 1) {
@@ -3075,4 +3069,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=f58202a6e5df2d16 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0de394419fefe7cf input=a9049054013a1b77]*/

--- a/Modules/clinic/arraymodule.c.h
+++ b/Modules/clinic/arraymodule.c.h
@@ -504,9 +504,6 @@ array_array_fromunicode(arrayobject *self, PyObject *arg)
         _PyArg_BadArgument("fromunicode", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     ustr = arg;
     return_value = array_array_fromunicode_impl(self, ustr);
 
@@ -585,9 +582,6 @@ array__array_reconstructor(PyObject *module, PyObject *const *args, Py_ssize_t n
     arraytype = (PyTypeObject *)args[0];
     if (!PyUnicode_Check(args[1])) {
         _PyArg_BadArgument("_array_reconstructor", "argument 2", "a unicode character", args[1]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[1])) {
         goto exit;
     }
     if (PyUnicode_GET_LENGTH(args[1]) != 1) {
@@ -680,4 +674,4 @@ PyDoc_STRVAR(array_arrayiterator___setstate____doc__,
 
 #define ARRAY_ARRAYITERATOR___SETSTATE___METHODDEF    \
     {"__setstate__", (PyCFunction)array_arrayiterator___setstate__, METH_O, array_arrayiterator___setstate____doc__},
-/*[clinic end generated code: output=69bc1451f7bda234 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=11595e9f38d6d500 input=a9049054013a1b77]*/

--- a/Modules/clinic/grpmodule.c.h
+++ b/Modules/clinic/grpmodule.c.h
@@ -119,9 +119,6 @@ grp_getgrnam(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
         _PyArg_BadArgument("getgrnam", "argument 'name'", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     name = args[0];
     return_value = grp_getgrnam_impl(module, name);
 
@@ -149,4 +146,4 @@ grp_getgrall(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return grp_getgrall_impl(module);
 }
-/*[clinic end generated code: output=0916fdbcdeaf5d7d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e685227ed5d9be9f input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -8282,15 +8282,9 @@ os_putenv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("putenv", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     name = args[0];
     if (!PyUnicode_Check(args[1])) {
         _PyArg_BadArgument("putenv", "argument 2", "str", args[1]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[1]) == -1) {
         goto exit;
     }
     value = args[1];
@@ -8367,9 +8361,6 @@ os_unsetenv(PyObject *module, PyObject *arg)
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("unsetenv", "argument", "str", arg);
-        goto exit;
-    }
-    if (PyUnicode_READY(arg) == -1) {
         goto exit;
     }
     name = arg;
@@ -11990,4 +11981,4 @@ exit:
 #ifndef OS_WAITSTATUS_TO_EXITCODE_METHODDEF
     #define OS_WAITSTATUS_TO_EXITCODE_METHODDEF
 #endif /* !defined(OS_WAITSTATUS_TO_EXITCODE_METHODDEF) */
-/*[clinic end generated code: output=02bece83d20d497b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a7e8c3df2db09717 input=a9049054013a1b77]*/

--- a/Modules/clinic/pwdmodule.c.h
+++ b/Modules/clinic/pwdmodule.c.h
@@ -43,9 +43,6 @@ pwd_getpwnam(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("getpwnam", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     name = arg;
     return_value = pwd_getpwnam_impl(module, name);
 
@@ -80,4 +77,4 @@ pwd_getpwall(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef PWD_GETPWALL_METHODDEF
     #define PWD_GETPWALL_METHODDEF
 #endif /* !defined(PWD_GETPWALL_METHODDEF) */
-/*[clinic end generated code: output=a95bc08653cda56b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1edf1e26cd2762db input=a9049054013a1b77]*/

--- a/Modules/clinic/readline.c.h
+++ b/Modules/clinic/readline.c.h
@@ -447,9 +447,6 @@ readline_replace_history_item(PyObject *module, PyObject *const *args, Py_ssize_
         _PyArg_BadArgument("replace_history_item", "argument 2", "str", args[1]);
         goto exit;
     }
-    if (PyUnicode_READY(args[1]) == -1) {
-        goto exit;
-    }
     line = args[1];
     return_value = readline_replace_history_item_impl(module, entry_number, line);
 
@@ -691,4 +688,4 @@ readline_redisplay(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef READLINE_CLEAR_HISTORY_METHODDEF
     #define READLINE_CLEAR_HISTORY_METHODDEF
 #endif /* !defined(READLINE_CLEAR_HISTORY_METHODDEF) */
-/*[clinic end generated code: output=9097fcb749c19e27 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d66c3df7e72f93c4 input=a9049054013a1b77]*/

--- a/Modules/clinic/syslogmodule.c.h
+++ b/Modules/clinic/syslogmodule.c.h
@@ -69,9 +69,6 @@ syslog_openlog(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObje
             _PyArg_BadArgument("openlog", "argument 'ident'", "str", args[0]);
             goto exit;
         }
-        if (PyUnicode_READY(args[0]) == -1) {
-            goto exit;
-        }
         ident = args[0];
         if (!--noptargs) {
             goto skip_optional_pos;
@@ -254,4 +251,4 @@ syslog_LOG_UPTO(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3b1bdb16565b8fda input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b8124c0977ed6177 input=a9049054013a1b77]*/

--- a/Modules/clinic/unicodedata.c.h
+++ b/Modules/clinic/unicodedata.c.h
@@ -39,9 +39,6 @@ unicodedata_UCD_decimal(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("decimal", "argument 1", "a unicode character", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0])) {
-        goto exit;
-    }
     if (PyUnicode_GET_LENGTH(args[0]) != 1) {
         _PyArg_BadArgument("decimal", "argument 1", "a unicode character", args[0]);
         goto exit;
@@ -86,9 +83,6 @@ unicodedata_UCD_digit(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("digit", "argument 1", "a unicode character", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0])) {
         goto exit;
     }
     if (PyUnicode_GET_LENGTH(args[0]) != 1) {
@@ -138,9 +132,6 @@ unicodedata_UCD_numeric(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("numeric", "argument 1", "a unicode character", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0])) {
-        goto exit;
-    }
     if (PyUnicode_GET_LENGTH(args[0]) != 1) {
         _PyArg_BadArgument("numeric", "argument 1", "a unicode character", args[0]);
         goto exit;
@@ -179,9 +170,6 @@ unicodedata_UCD_category(PyObject *self, PyObject *arg)
         _PyArg_BadArgument("category", "argument", "a unicode character", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg)) {
-        goto exit;
-    }
     if (PyUnicode_GET_LENGTH(arg) != 1) {
         _PyArg_BadArgument("category", "argument", "a unicode character", arg);
         goto exit;
@@ -215,9 +203,6 @@ unicodedata_UCD_bidirectional(PyObject *self, PyObject *arg)
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("bidirectional", "argument", "a unicode character", arg);
-        goto exit;
-    }
-    if (PyUnicode_READY(arg)) {
         goto exit;
     }
     if (PyUnicode_GET_LENGTH(arg) != 1) {
@@ -254,9 +239,6 @@ unicodedata_UCD_combining(PyObject *self, PyObject *arg)
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("combining", "argument", "a unicode character", arg);
-        goto exit;
-    }
-    if (PyUnicode_READY(arg)) {
         goto exit;
     }
     if (PyUnicode_GET_LENGTH(arg) != 1) {
@@ -300,9 +282,6 @@ unicodedata_UCD_mirrored(PyObject *self, PyObject *arg)
         _PyArg_BadArgument("mirrored", "argument", "a unicode character", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg)) {
-        goto exit;
-    }
     if (PyUnicode_GET_LENGTH(arg) != 1) {
         _PyArg_BadArgument("mirrored", "argument", "a unicode character", arg);
         goto exit;
@@ -340,9 +319,6 @@ unicodedata_UCD_east_asian_width(PyObject *self, PyObject *arg)
         _PyArg_BadArgument("east_asian_width", "argument", "a unicode character", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg)) {
-        goto exit;
-    }
     if (PyUnicode_GET_LENGTH(arg) != 1) {
         _PyArg_BadArgument("east_asian_width", "argument", "a unicode character", arg);
         goto exit;
@@ -376,9 +352,6 @@ unicodedata_UCD_decomposition(PyObject *self, PyObject *arg)
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("decomposition", "argument", "a unicode character", arg);
-        goto exit;
-    }
-    if (PyUnicode_READY(arg)) {
         goto exit;
     }
     if (PyUnicode_GET_LENGTH(arg) != 1) {
@@ -421,15 +394,9 @@ unicodedata_UCD_is_normalized(PyObject *self, PyObject *const *args, Py_ssize_t 
         _PyArg_BadArgument("is_normalized", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     form = args[0];
     if (!PyUnicode_Check(args[1])) {
         _PyArg_BadArgument("is_normalized", "argument 2", "str", args[1]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[1]) == -1) {
         goto exit;
     }
     input = args[1];
@@ -468,15 +435,9 @@ unicodedata_UCD_normalize(PyObject *self, PyObject *const *args, Py_ssize_t narg
         _PyArg_BadArgument("normalize", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     form = args[0];
     if (!PyUnicode_Check(args[1])) {
         _PyArg_BadArgument("normalize", "argument 2", "str", args[1]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[1]) == -1) {
         goto exit;
     }
     input = args[1];
@@ -513,9 +474,6 @@ unicodedata_UCD_name(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     }
     if (!PyUnicode_Check(args[0])) {
         _PyArg_BadArgument("name", "argument 1", "a unicode character", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0])) {
         goto exit;
     }
     if (PyUnicode_GET_LENGTH(args[0]) != 1) {
@@ -565,4 +523,4 @@ unicodedata_UCD_lookup(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=aaf601d28b352353 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=43e551ecaa985a40 input=a9049054013a1b77]*/

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -1120,9 +1120,6 @@ bytearray_fromhex(PyTypeObject *type, PyObject *arg)
         _PyArg_BadArgument("fromhex", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     string = arg;
     return_value = bytearray_fromhex_impl(type, string);
 
@@ -1287,4 +1284,4 @@ bytearray_sizeof(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl(self);
 }
-/*[clinic end generated code: output=022698e8b0faa272 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=99fb3e3b9c1f4b15 input=a9049054013a1b77]*/

--- a/Objects/clinic/bytesobject.c.h
+++ b/Objects/clinic/bytesobject.c.h
@@ -875,9 +875,6 @@ bytes_fromhex(PyTypeObject *type, PyObject *arg)
         _PyArg_BadArgument("fromhex", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     string = arg;
     return_value = bytes_fromhex_impl(type, string);
 
@@ -1063,4 +1060,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=31a9e4af85562612 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7b6e4e8b5bc4eb57 input=a9049054013a1b77]*/

--- a/Objects/clinic/codeobject.c.h
+++ b/Objects/clinic/codeobject.c.h
@@ -105,23 +105,14 @@ code_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         _PyArg_BadArgument("code", "argument 11", "str", PyTuple_GET_ITEM(args, 10));
         goto exit;
     }
-    if (PyUnicode_READY(PyTuple_GET_ITEM(args, 10)) == -1) {
-        goto exit;
-    }
     filename = PyTuple_GET_ITEM(args, 10);
     if (!PyUnicode_Check(PyTuple_GET_ITEM(args, 11))) {
         _PyArg_BadArgument("code", "argument 12", "str", PyTuple_GET_ITEM(args, 11));
         goto exit;
     }
-    if (PyUnicode_READY(PyTuple_GET_ITEM(args, 11)) == -1) {
-        goto exit;
-    }
     name = PyTuple_GET_ITEM(args, 11);
     if (!PyUnicode_Check(PyTuple_GET_ITEM(args, 12))) {
         _PyArg_BadArgument("code", "argument 13", "str", PyTuple_GET_ITEM(args, 12));
-        goto exit;
-    }
-    if (PyUnicode_READY(PyTuple_GET_ITEM(args, 12)) == -1) {
         goto exit;
     }
     qualname = PyTuple_GET_ITEM(args, 12);
@@ -373,9 +364,6 @@ code_replace(PyCodeObject *self, PyObject *const *args, Py_ssize_t nargs, PyObje
             _PyArg_BadArgument("replace", "argument 'co_filename'", "str", args[13]);
             goto exit;
         }
-        if (PyUnicode_READY(args[13]) == -1) {
-            goto exit;
-        }
         co_filename = args[13];
         if (!--noptargs) {
             goto skip_optional_kwonly;
@@ -386,9 +374,6 @@ code_replace(PyCodeObject *self, PyObject *const *args, Py_ssize_t nargs, PyObje
             _PyArg_BadArgument("replace", "argument 'co_name'", "str", args[14]);
             goto exit;
         }
-        if (PyUnicode_READY(args[14]) == -1) {
-            goto exit;
-        }
         co_name = args[14];
         if (!--noptargs) {
             goto skip_optional_kwonly;
@@ -397,9 +382,6 @@ code_replace(PyCodeObject *self, PyObject *const *args, Py_ssize_t nargs, PyObje
     if (args[15]) {
         if (!PyUnicode_Check(args[15])) {
             _PyArg_BadArgument("replace", "argument 'co_qualname'", "str", args[15]);
-            goto exit;
-        }
-        if (PyUnicode_READY(args[15]) == -1) {
             goto exit;
         }
         co_qualname = args[15];
@@ -488,4 +470,4 @@ code__varname_from_oparg(PyCodeObject *self, PyObject *const *args, Py_ssize_t n
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=f1fab6e71c785182 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4ca4c0c403dbfa71 input=a9049054013a1b77]*/

--- a/Objects/clinic/complexobject.c.h
+++ b/Objects/clinic/complexobject.c.h
@@ -65,9 +65,6 @@ complex___format__(PyComplexObject *self, PyObject *arg)
         _PyArg_BadArgument("__format__", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     format_spec = arg;
     return_value = complex___format___impl(self, format_spec);
 
@@ -160,4 +157,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=52e85a1e258425d6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d438b7ed87f8459e input=a9049054013a1b77]*/

--- a/Objects/clinic/floatobject.c.h
+++ b/Objects/clinic/floatobject.c.h
@@ -316,13 +316,10 @@ float___format__(PyObject *self, PyObject *arg)
         _PyArg_BadArgument("__format__", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     format_spec = arg;
     return_value = float___format___impl(self, format_spec);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ea329577074911b9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=355c3f5102034a41 input=a9049054013a1b77]*/

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -107,9 +107,6 @@ int___format__(PyObject *self, PyObject *arg)
         _PyArg_BadArgument("__format__", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     format_spec = arg;
     return_value = int___format___impl(self, format_spec);
 
@@ -346,9 +343,6 @@ int_to_bytes(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *
             _PyArg_BadArgument("to_bytes", "argument 'byteorder'", "str", args[1]);
             goto exit;
         }
-        if (PyUnicode_READY(args[1]) == -1) {
-            goto exit;
-        }
         byteorder = args[1];
         if (!--noptargs) {
             goto skip_optional_pos;
@@ -444,9 +438,6 @@ int_from_bytes(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs, PyOb
             _PyArg_BadArgument("from_bytes", "argument 'byteorder'", "str", args[1]);
             goto exit;
         }
-        if (PyUnicode_READY(args[1]) == -1) {
-            goto exit;
-        }
         byteorder = args[1];
         if (!--noptargs) {
             goto skip_optional_pos;
@@ -484,4 +475,4 @@ int_is_integer(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return int_is_integer_impl(self);
 }
-/*[clinic end generated code: output=cfdf35d916158d4f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=75ed306fff493ba1 input=a9049054013a1b77]*/

--- a/Objects/clinic/memoryobject.c.h
+++ b/Objects/clinic/memoryobject.c.h
@@ -195,9 +195,6 @@ memoryview_cast(PyMemoryViewObject *self, PyObject *const *args, Py_ssize_t narg
         _PyArg_BadArgument("cast", "argument 'format'", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     format = args[0];
     if (!noptargs) {
         goto skip_optional_pos;
@@ -416,4 +413,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=01613814112cedd7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a4f6992947bcaf25 input=a9049054013a1b77]*/

--- a/Objects/clinic/moduleobject.c.h
+++ b/Objects/clinic/moduleobject.c.h
@@ -63,9 +63,6 @@ module___init__(PyObject *self, PyObject *args, PyObject *kwargs)
         _PyArg_BadArgument("module", "argument 'name'", "str", fastargs[0]);
         goto exit;
     }
-    if (PyUnicode_READY(fastargs[0]) == -1) {
-        goto exit;
-    }
     name = fastargs[0];
     if (!noptargs) {
         goto skip_optional_pos;
@@ -77,4 +74,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2f897c9e4721f03f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a5a750cc8190576e input=a9049054013a1b77]*/

--- a/Objects/clinic/typeobject.c.h
+++ b/Objects/clinic/typeobject.c.h
@@ -224,9 +224,6 @@ object___format__(PyObject *self, PyObject *arg)
         _PyArg_BadArgument("__format__", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     format_spec = arg;
     return_value = object___format___impl(self, format_spec);
 
@@ -269,4 +266,4 @@ object___dir__(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return object___dir___impl(self);
 }
-/*[clinic end generated code: output=d2fc52440a89f2fa input=a9049054013a1b77]*/
+/*[clinic end generated code: output=43533e6981550e9e input=a9049054013a1b77]*/

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -770,15 +770,9 @@ unicode_replace(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("replace", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     old = args[0];
     if (!PyUnicode_Check(args[1])) {
         _PyArg_BadArgument("replace", "argument 2", "str", args[1]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[1]) == -1) {
         goto exit;
     }
     new = args[1];
@@ -829,9 +823,6 @@ unicode_removeprefix(PyObject *self, PyObject *arg)
         _PyArg_BadArgument("removeprefix", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     prefix = arg;
     return_value = unicode_removeprefix_impl(self, prefix);
 
@@ -863,9 +854,6 @@ unicode_removesuffix(PyObject *self, PyObject *arg)
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("removesuffix", "argument", "str", arg);
-        goto exit;
-    }
-    if (PyUnicode_READY(arg) == -1) {
         goto exit;
     }
     suffix = arg;
@@ -1261,18 +1249,12 @@ unicode_maketrans(void *null, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("maketrans", "argument 2", "str", args[1]);
         goto exit;
     }
-    if (PyUnicode_READY(args[1]) == -1) {
-        goto exit;
-    }
     y = args[1];
     if (nargs < 3) {
         goto skip_optional;
     }
     if (!PyUnicode_Check(args[2])) {
         _PyArg_BadArgument("maketrans", "argument 3", "str", args[2]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[2]) == -1) {
         goto exit;
     }
     z = args[2];
@@ -1376,9 +1358,6 @@ unicode___format__(PyObject *self, PyObject *arg)
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("__format__", "argument", "str", arg);
-        goto exit;
-    }
-    if (PyUnicode_READY(arg) == -1) {
         goto exit;
     }
     format_spec = arg;
@@ -1497,4 +1476,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=05d942840635dadf input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0a71c4aeffdf0bc5 input=a9049054013a1b77]*/

--- a/PC/clinic/_wmimodule.cpp.h
+++ b/PC/clinic/_wmimodule.cpp.h
@@ -63,13 +63,10 @@ _wmi_exec_query(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObj
         _PyArg_BadArgument("exec_query", "argument 'query'", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     query = args[0];
     return_value = _wmi_exec_query_impl(module, query);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7fdf0c0579ddb566 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=923d09bee1d15c5f input=a9049054013a1b77]*/

--- a/PC/clinic/msvcrtmodule.c.h
+++ b/PC/clinic/msvcrtmodule.c.h
@@ -399,9 +399,6 @@ msvcrt_putwch(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("putwch", "argument", "a unicode character", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg)) {
-        goto exit;
-    }
     if (PyUnicode_GET_LENGTH(arg) != 1) {
         _PyArg_BadArgument("putwch", "argument", "a unicode character", arg);
         goto exit;
@@ -475,9 +472,6 @@ msvcrt_ungetwch(PyObject *module, PyObject *arg)
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("ungetwch", "argument", "a unicode character", arg);
-        goto exit;
-    }
-    if (PyUnicode_READY(arg)) {
         goto exit;
     }
     if (PyUnicode_GET_LENGTH(arg) != 1) {
@@ -707,4 +701,4 @@ exit:
 #ifndef MSVCRT_GETERRORMODE_METHODDEF
     #define MSVCRT_GETERRORMODE_METHODDEF
 #endif /* !defined(MSVCRT_GETERRORMODE_METHODDEF) */
-/*[clinic end generated code: output=2db6197608a6aab3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9dd12bf210e362a4 input=a9049054013a1b77]*/

--- a/PC/clinic/winreg.c.h
+++ b/PC/clinic/winreg.c.h
@@ -1458,9 +1458,6 @@ winreg_SetValue(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("SetValue", "argument 4", "str", args[3]);
         goto exit;
     }
-    if (PyUnicode_READY(args[3]) == -1) {
-        goto exit;
-    }
     value_obj = args[3];
     return_value = winreg_SetValue_impl(module, key, sub_key, type, value_obj);
 
@@ -1791,4 +1788,4 @@ exit:
 #ifndef WINREG_QUERYREFLECTIONKEY_METHODDEF
     #define WINREG_QUERYREFLECTIONKEY_METHODDEF
 #endif /* !defined(WINREG_QUERYREFLECTIONKEY_METHODDEF) */
-/*[clinic end generated code: output=bbfdbb8681102d5c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d2bf1f58ad07e5f8 input=a9049054013a1b77]*/

--- a/Python/clinic/_warnings.c.h
+++ b/Python/clinic/_warnings.c.h
@@ -193,9 +193,6 @@ warnings_warn_explicit(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         _PyArg_BadArgument("warn_explicit", "argument 'filename'", "str", args[2]);
         goto exit;
     }
-    if (PyUnicode_READY(args[2]) == -1) {
-        goto exit;
-    }
     filename = args[2];
     lineno = _PyLong_AsInt(args[3]);
     if (lineno == -1 && PyErr_Occurred()) {
@@ -246,4 +243,4 @@ warnings_filters_mutated(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return warnings_filters_mutated_impl(module);
 }
-/*[clinic end generated code: output=20429719d7223bdc input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f8d67e0f75771c36 input=a9049054013a1b77]*/

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -216,9 +216,6 @@ builtin_format(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("format", "argument 2", "str", args[1]);
         goto exit;
     }
-    if (PyUnicode_READY(args[1]) == -1) {
-        goto exit;
-    }
     format_spec = args[1];
 skip_optional:
     return_value = builtin_format_impl(module, value, format_spec);
@@ -1409,4 +1406,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=84a04e7446debf58 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ef2f16ece134d62d input=a9049054013a1b77]*/

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -106,9 +106,6 @@ _imp__fix_co_filename(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("_fix_co_filename", "argument 2", "str", args[1]);
         goto exit;
     }
-    if (PyUnicode_READY(args[1]) == -1) {
-        goto exit;
-    }
     path = args[1];
     return_value = _imp__fix_co_filename_impl(module, code, path);
 
@@ -163,9 +160,6 @@ _imp_init_frozen(PyObject *module, PyObject *arg)
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("init_frozen", "argument", "str", arg);
-        goto exit;
-    }
-    if (PyUnicode_READY(arg) == -1) {
         goto exit;
     }
     name = arg;
@@ -237,9 +231,6 @@ _imp_find_frozen(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyOb
         _PyArg_BadArgument("find_frozen", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     name = args[0];
     if (!noptargs) {
         goto skip_optional_kwonly;
@@ -282,9 +273,6 @@ _imp_get_frozen_object(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         _PyArg_BadArgument("get_frozen_object", "argument 1", "str", args[0]);
         goto exit;
     }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     name = args[0];
     if (nargs < 2) {
         goto skip_optional;
@@ -319,9 +307,6 @@ _imp_is_frozen_package(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("is_frozen_package", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     name = arg;
     return_value = _imp_is_frozen_package_impl(module, name);
 
@@ -351,9 +336,6 @@ _imp_is_builtin(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("is_builtin", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     name = arg;
     return_value = _imp_is_builtin_impl(module, name);
 
@@ -381,9 +363,6 @@ _imp_is_frozen(PyObject *module, PyObject *arg)
 
     if (!PyUnicode_Check(arg)) {
         _PyArg_BadArgument("is_frozen", "argument", "str", arg);
-        goto exit;
-    }
-    if (PyUnicode_READY(arg) == -1) {
         goto exit;
     }
     name = arg;
@@ -648,4 +627,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=b18d46e0036eff49 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a95ec234672280a2 input=a9049054013a1b77]*/

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -282,9 +282,6 @@ sys_intern(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("intern", "argument", "str", arg);
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
     s = arg;
     return_value = sys_intern_impl(module, s);
 
@@ -1415,4 +1412,4 @@ exit:
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=6d598acc26237fbe input=a9049054013a1b77]*/
+/*[clinic end generated code: output=41937e0843c68009 input=a9049054013a1b77]*/

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5522,7 +5522,8 @@ For more information see https://docs.python.org/3/howto/clinic.html""")
                 if rcs_dir in dirs:
                     dirs.remove(rcs_dir)
             for filename in files:
-                if not (filename.endswith('.c') or filename.endswith('.h')):
+                # handle .c, .cpp and .h files
+                if not filename.endswith(('.c', '.cpp', '.h')):
                     continue
                 path = os.path.join(root, filename)
                 if ns.verbose:

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -3266,9 +3266,6 @@ class int_converter(CConverter):
                     _PyArg_BadArgument("{{name}}", {displayname}, "a unicode character", {argname});
                     goto exit;
                 }}}}
-                if (PyUnicode_READY({argname})) {{{{
-                    goto exit;
-                }}}}
                 if (PyUnicode_GET_LENGTH({argname}) != 1) {{{{
                     _PyArg_BadArgument("{{name}}", {displayname}, "a unicode character", {argname});
                     goto exit;
@@ -3728,9 +3725,6 @@ class unicode_converter(CConverter):
             return """
                 if (!PyUnicode_Check({argname})) {{{{
                     _PyArg_BadArgument("{{name}}", {displayname}, "str", {argname});
-                    goto exit;
-                }}}}
-                if (PyUnicode_READY({argname}) == -1) {{{{
                     goto exit;
                 }}}}
                 {paramname} = {argname};


### PR DESCRIPTION
Since Python 3.12, PyUnicode_READY() does nothing and always returns 0.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-92536 -->
* Issue: gh-92536
<!-- /gh-issue-number -->
