### PR TITLE
gh-92536: Remove PyUnicode_READY() calls

### DIFF
--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -266,7 +266,6 @@ _set_char_or_none(const char *name, Py_UCS4 *target, PyObject *src, Py_UCS4 dflt
                     name);
                 return -1;
             }
-            /* PyUnicode_READY() is called in PyUnicode_GetLength() */
             *target = PyUnicode_READ_CHAR(src, 0);
         }
     }
@@ -296,7 +295,6 @@ _set_char(const char *name, Py_UCS4 *target, PyObject *src, Py_UCS4 dflt)
                          name);
             return -1;
         }
-        /* PyUnicode_READY() is called in PyUnicode_GetLength() */
         *target = PyUnicode_READ_CHAR(src, 0);
     }
     return 0;
@@ -316,8 +314,6 @@ _set_str(const char *name, PyObject **target, PyObject *src, const char *dflt)
             return -1;
         }
         else {
-            if (PyUnicode_READY(src) == -1)
-                return -1;
             Py_XSETREF(*target, Py_NewRef(src));
         }
     }
@@ -904,10 +900,6 @@ Reader_iternext(ReaderObj *self)
             Py_DECREF(lineobj);
             return NULL;
         }
-        if (PyUnicode_READY(lineobj) == -1) {
-            Py_DECREF(lineobj);
-            return NULL;
-        }
         ++self->line_num;
         kind = PyUnicode_KIND(lineobj);
         data = PyUnicode_DATA(lineobj);
@@ -1185,8 +1177,6 @@ join_append(WriterObj *self, PyObject *field, int quoted)
     Py_ssize_t rec_len;
 
     if (field != NULL) {
-        if (PyUnicode_READY(field) == -1)
-            return 0;
         field_kind = PyUnicode_KIND(field);
         field_data = PyUnicode_DATA(field);
         field_len = PyUnicode_GET_LENGTH(field);
@@ -1515,8 +1505,6 @@ csv_register_dialect(PyObject *module, PyObject *args, PyObject *kwargs)
                         "dialect name must be a string");
         return NULL;
     }
-    if (PyUnicode_READY(name_obj) == -1)
-        return NULL;
     dialect = _call_dialect(module_state, dialect_obj, kwargs);
     if (dialect == NULL)
         return NULL;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2901,9 +2901,6 @@ date_new(PyTypeObject *type, PyObject *args, PyObject *kw)
             }
         }
         else if (PyUnicode_Check(state)) {
-            if (PyUnicode_READY(state)) {
-                return NULL;
-            }
             if (PyUnicode_GET_LENGTH(state) == _PyDateTime_DATE_DATASIZE &&
                 MONTH_IS_SANE(PyUnicode_READ_CHAR(state, 2)))
             {
@@ -4234,9 +4231,6 @@ time_new(PyTypeObject *type, PyObject *args, PyObject *kw)
             }
         }
         else if (PyUnicode_Check(state)) {
-            if (PyUnicode_READY(state)) {
-                return NULL;
-            }
             if (PyUnicode_GET_LENGTH(state) == _PyDateTime_TIME_DATASIZE &&
                 (0x7F & PyUnicode_READ_CHAR(state, 0)) < 24)
             {
@@ -4909,9 +4903,6 @@ datetime_new(PyTypeObject *type, PyObject *args, PyObject *kw)
             }
         }
         else if (PyUnicode_Check(state)) {
-            if (PyUnicode_READY(state)) {
-                return NULL;
-            }
             if (PyUnicode_GET_LENGTH(state) == _PyDateTime_DATETIME_DATASIZE &&
                 MONTH_IS_SANE(PyUnicode_READ_CHAR(state, 2) & 0x7F))
             {

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1934,10 +1934,6 @@ numeric_as_ascii(PyObject *u, int strip_ws, int ignore_underscores)
     Py_ssize_t j, len;
     int d;
 
-    if (PyUnicode_READY(u) == -1) {
-        return NULL;
-    }
-
     kind = PyUnicode_KIND(u);
     data = PyUnicode_DATA(u);
     len =  PyUnicode_GET_LENGTH(u);

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1448,8 +1448,6 @@ _elementtree_Element_iter_impl(ElementObject *self, PyTypeObject *cls,
 /*[clinic end generated code: output=bff29dc5d4566c68 input=f6944c48d3f84c58]*/
 {
     if (PyUnicode_Check(tag)) {
-        if (PyUnicode_READY(tag) < 0)
-            return NULL;
         if (PyUnicode_GET_LENGTH(tag) == 1 && PyUnicode_READ_CHAR(tag, 0) == '*')
             tag = Py_None;
     }

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -1988,9 +1988,6 @@ _hashlib_compare_digest_impl(PyObject *module, PyObject *a, PyObject *b)
 
     /* ASCII unicode string */
     if(PyUnicode_Check(a) && PyUnicode_Check(b)) {
-        if (PyUnicode_READY(a) == -1 || PyUnicode_READY(b) == -1) {
-            return NULL;
-        }
         if (!PyUnicode_IS_ASCII(a) || !PyUnicode_IS_ASCII(b)) {
             PyErr_SetString(PyExc_TypeError,
                             "comparing strings with non-ASCII characters is "

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -200,10 +200,6 @@ write_str(stringio *self, PyObject *obj)
         return -1;
 
     assert(PyUnicode_Check(decoded));
-    if (PyUnicode_READY(decoded)) {
-        Py_DECREF(decoded);
-        return -1;
-    }
     len = PyUnicode_GET_LENGTH(decoded);
     assert(len >= 0);
 
@@ -542,8 +538,6 @@ _io_StringIO_write(stringio *self, PyObject *obj)
                      Py_TYPE(obj)->tp_name);
         return NULL;
     }
-    if (PyUnicode_READY(obj))
-        return NULL;
     CHECK_CLOSED(self);
     size = PyUnicode_GET_LENGTH(obj);
 

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -288,10 +288,6 @@ check_decoded(PyObject *decoded)
         Py_DECREF(decoded);
         return -1;
     }
-    if (PyUnicode_READY(decoded) < 0) {
-        Py_DECREF(decoded);
-        return -1;
-    }
     return 0;
 }
 
@@ -1611,9 +1607,6 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
     int haslf = 0;
     int needflush = 0, text_needflush = 0;
 
-    if (PyUnicode_READY(text) == -1)
-        return NULL;
-
     CHECK_ATTACHED(self);
     CHECK_CLOSED(self);
 
@@ -1972,8 +1965,6 @@ _io_TextIOWrapper_read_impl(textio *self, Py_ssize_t n)
         result = textiowrapper_get_decoded_chars(self, n);
         if (result == NULL)
             goto fail;
-        if (PyUnicode_READY(result) == -1)
-            goto fail;
         remaining -= PyUnicode_GET_LENGTH(result);
 
         /* Keep reading chunks until we have n characters to return */
@@ -2184,8 +2175,6 @@ _textiowrapper_readline(textio *self, Py_ssize_t limit)
             offset_to_buffer = PyUnicode_GET_LENGTH(remaining);
             Py_CLEAR(remaining);
             if (line == NULL)
-                goto error;
-            if (PyUnicode_READY(line) == -1)
                 goto error;
         }
 
@@ -3106,7 +3095,7 @@ textiowrapper_iternext(textio *self)
         }
     }
 
-    if (line == NULL || PyUnicode_READY(line) == -1)
+    if (line == NULL)
         return NULL;
 
     if (PyUnicode_GET_LENGTH(line) == 0) {

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -152,9 +152,6 @@ ascii_escape_unicode(PyObject *pystr)
     Py_UCS1 *output;
     int kind;
 
-    if (PyUnicode_READY(pystr) == -1)
-        return NULL;
-
     input_chars = PyUnicode_GET_LENGTH(pystr);
     input = PyUnicode_DATA(pystr);
     kind = PyUnicode_KIND(pystr);
@@ -217,9 +214,6 @@ escape_unicode(PyObject *pystr)
     const void *input;
     int kind;
     Py_UCS4 maxchar;
-
-    if (PyUnicode_READY(pystr) == -1)
-        return NULL;
 
     maxchar = PyUnicode_MAX_CHAR_VALUE(pystr);
     input_chars = PyUnicode_GET_LENGTH(pystr);
@@ -376,9 +370,6 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
     Py_ssize_t next /* = begin */;
     const void *buf;
     int kind;
-
-    if (PyUnicode_READY(pystr) == -1)
-        return 0;
 
     _PyUnicodeWriter writer;
     _PyUnicodeWriter_Init(&writer);
@@ -675,9 +666,6 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
     int has_pairs_hook = (s->object_pairs_hook != Py_None);
     Py_ssize_t next_idx;
 
-    if (PyUnicode_READY(pystr) == -1)
-        return NULL;
-
     str = PyUnicode_DATA(pystr);
     kind = PyUnicode_KIND(pystr);
     end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
@@ -801,9 +789,6 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
     PyObject *rval;
     Py_ssize_t next_idx;
 
-    if (PyUnicode_READY(pystr) == -1)
-        return NULL;
-
     rval = PyList_New(0);
     if (rval == NULL)
         return NULL;
@@ -905,9 +890,6 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
     PyObject *rval;
     PyObject *numstr = NULL;
     PyObject *custom_func;
-
-    if (PyUnicode_READY(pystr) == -1)
-        return NULL;
 
     str = PyUnicode_DATA(pystr);
     kind = PyUnicode_KIND(pystr);
@@ -1017,9 +999,6 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
     const void *str;
     int kind;
     Py_ssize_t length;
-
-    if (PyUnicode_READY(pystr) == -1)
-        return NULL;
 
     str = PyUnicode_DATA(pystr);
     kind = PyUnicode_KIND(pystr);

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -823,9 +823,6 @@ _operator__compare_digest_impl(PyObject *module, PyObject *a, PyObject *b)
 
     /* ASCII unicode string */
     if(PyUnicode_Check(a) && PyUnicode_Check(b)) {
-        if (PyUnicode_READY(a) == -1 || PyUnicode_READY(b) == -1) {
-            return NULL;
-        }
         if (!PyUnicode_IS_ASCII(a) || !PyUnicode_IS_ASCII(b)) {
             PyErr_SetString(PyExc_TypeError,
                             "comparing strings with non-ASCII characters is "
@@ -1231,10 +1228,6 @@ attrgetter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         if (!PyUnicode_Check(item)) {
             PyErr_SetString(PyExc_TypeError,
                             "attribute name must be a string");
-            Py_DECREF(attr);
-            return NULL;
-        }
-        if (PyUnicode_READY(item)) {
             Py_DECREF(attr);
             return NULL;
         }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -2602,9 +2602,6 @@ raw_unicode_escape(PyObject *obj)
     int kind;
     _PyBytesWriter writer;
 
-    if (PyUnicode_READY(obj))
-        return NULL;
-
     _PyBytesWriter_Init(&writer);
 
     size = PyUnicode_GET_LENGTH(obj);
@@ -2673,9 +2670,6 @@ write_unicode_binary(PicklerObject *self, PyObject *obj)
     PyObject *encoded = NULL;
     Py_ssize_t size;
     const char *data;
-
-    if (PyUnicode_READY(obj))
-        return -1;
 
     data = PyUnicode_AsUTF8AndSize(obj, &size);
     if (data == NULL) {

--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -374,8 +374,6 @@ getstring(PyObject* string, Py_ssize_t* p_length,
     /* Unicode objects do not support the buffer API. So, get the data
        directly instead. */
     if (PyUnicode_Check(string)) {
-        if (PyUnicode_READY(string) == -1)
-            return NULL;
         *p_length = PyUnicode_GET_LENGTH(string);
         *p_charsize = PyUnicode_KIND(string);
         *p_isbytes = 0;

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -962,9 +962,6 @@ AsObj(PyObject *value)
     }
 
     if (PyUnicode_Check(value)) {
-        if (PyUnicode_READY(value) == -1)
-            return NULL;
-
         Py_ssize_t size = PyUnicode_GET_LENGTH(value);
         if (size == 0) {
             return Tcl_NewStringObj("", 0);

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -170,8 +170,6 @@ ascii_buffer_converter(PyObject *arg, Py_buffer *buf)
         return 1;
     }
     if (PyUnicode_Check(arg)) {
-        if (PyUnicode_READY(arg) < 0)
-            return 0;
         if (!PyUnicode_IS_ASCII(arg)) {
             PyErr_SetString(PyExc_ValueError,
                             "string argument should contain only ASCII characters");

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -490,8 +490,6 @@ multibytecodec_encode(const MultibyteCodec *codec,
     int kind;
     const void *data;
 
-    if (PyUnicode_READY(text) < 0)
-        return NULL;
     datalen = PyUnicode_GET_LENGTH(text);
 
     if (datalen == 0 && !(flags & MBENC_RESET))
@@ -603,10 +601,6 @@ _multibytecodec_MultibyteCodec_encode_impl(MultibyteCodecObject *self,
         }
     }
 
-    if (PyUnicode_READY(input) < 0) {
-        Py_XDECREF(ucvt);
-        return NULL;
-    }
     datalen = PyUnicode_GET_LENGTH(input);
 
     errorcb = internal_error_callback(errors);
@@ -809,8 +803,6 @@ encoder_encode_stateful(MultibyteStatefulEncoderContext *ctx,
 
         inbuf = Py_NewRef(unistr);
     }
-    if (PyUnicode_READY(inbuf) < 0)
-        goto errorexit;
     inpos = 0;
     datalen = PyUnicode_GET_LENGTH(inbuf);
 

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1109,7 +1109,7 @@ PyUnknownEncodingHandler(void *encodingHandlerData,
         return XML_STATUS_ERROR;
 
     u = PyUnicode_Decode((const char*) template_buffer, 256, name, "replace");
-    if (u == NULL || PyUnicode_READY(u)) {
+    if (u == NULL) {
         Py_XDECREF(u);
         return XML_STATUS_ERROR;
     }

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1717,9 +1717,6 @@ idna_converter(PyObject *obj, struct maybe_idna *data)
         len = PyByteArray_Size(obj);
     }
     else if (PyUnicode_Check(obj)) {
-        if (PyUnicode_READY(obj) == -1) {
-            return 0;
-        }
         if (PyUnicode_IS_COMPACT_ASCII(obj)) {
             data->buf = PyUnicode_DATA(obj);
             len = PyUnicode_GET_LENGTH(obj);

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -864,10 +864,6 @@ unicodedata_UCD_is_normalized_impl(PyObject *self, PyObject *form,
                                    PyObject *input)
 /*[clinic end generated code: output=11e5a3694e723ca5 input=a544f14cea79e508]*/
 {
-    if (PyUnicode_READY(input) == -1) {
-        return NULL;
-    }
-
     if (PyUnicode_GET_LENGTH(input) == 0) {
         /* special case empty input strings. */
         Py_RETURN_TRUE;

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2367,8 +2367,6 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
     writer.use_bytearray = use_bytearray;
 
     assert(PyUnicode_Check(string));
-    if (PyUnicode_READY(string))
-        return NULL;
     hexlen = PyUnicode_GET_LENGTH(string);
 
     if (!PyUnicode_IS_ASCII(string)) {

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -153,10 +153,6 @@ intern_string_constants(PyObject *tuple, int *modified)
     for (Py_ssize_t i = PyTuple_GET_SIZE(tuple); --i >= 0; ) {
         PyObject *v = PyTuple_GET_ITEM(tuple, i);
         if (PyUnicode_CheckExact(v)) {
-            if (PyUnicode_READY(v) == -1) {
-                return -1;
-            }
-
             if (all_name_chars(v)) {
                 PyObject *w = v;
                 PyUnicode_InternInPlace(&v);
@@ -546,17 +542,6 @@ remove_column_info(PyObject *locations)
 PyCodeObject *
 _PyCode_New(struct _PyCodeConstructor *con)
 {
-    /* Ensure that strings are ready Unicode string */
-    if (PyUnicode_READY(con->name) < 0) {
-        return NULL;
-    }
-    if (PyUnicode_READY(con->qualname) < 0) {
-        return NULL;
-    }
-    if (PyUnicode_READY(con->filename) < 0) {
-        return NULL;
-    }
-
     if (intern_strings(con->names) < 0) {
         return NULL;
     }

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2480,8 +2480,6 @@ my_basename(PyObject *name)
     int kind;
     const void *data;
 
-    if (PyUnicode_READY(name))
-        return NULL;
     kind = PyUnicode_KIND(name);
     data = PyUnicode_DATA(name);
     size = PyUnicode_GET_LENGTH(name);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -560,11 +560,6 @@ PyObject_Repr(PyObject *v)
         Py_DECREF(res);
         return NULL;
     }
-#ifndef Py_DEBUG
-    if (PyUnicode_READY(res) < 0) {
-        return NULL;
-    }
-#endif
     return res;
 }
 
@@ -583,10 +578,6 @@ PyObject_Str(PyObject *v)
     if (v == NULL)
         return PyUnicode_FromString("<NULL>");
     if (PyUnicode_CheckExact(v)) {
-#ifndef Py_DEBUG
-        if (PyUnicode_READY(v) < 0)
-            return NULL;
-#endif
         return Py_NewRef(v);
     }
     if (Py_TYPE(v)->tp_str == NULL)
@@ -618,11 +609,6 @@ PyObject_Str(PyObject *v)
         Py_DECREF(res);
         return NULL;
     }
-#ifndef Py_DEBUG
-    if (PyUnicode_READY(res) < 0) {
-        return NULL;
-    }
-#endif
     assert(_PyUnicode_CheckConsistency(res, 1));
     return res;
 }

--- a/Objects/stringlib/codecs.h
+++ b/Objects/stringlib/codecs.h
@@ -408,9 +408,6 @@ STRINGLIB(utf8_encoder)(_PyBytesWriter *writer,
                 }
                 else {
                     /* rep is unicode */
-                    if (PyUnicode_READY(rep) < 0)
-                        goto error;
-
                     if (!PyUnicode_IS_ASCII(rep)) {
                         raise_encode_exception(&exc, "utf-8", unicode,
                                                startpos, endpos,

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -820,7 +820,7 @@ output_markup(SubString *field_name, SubString *format_spec,
 
     if (conversion != '\0') {
         tmp = do_conversion(fieldobj, conversion);
-        if (tmp == NULL || PyUnicode_READY(tmp) == -1)
+        if (tmp == NULL)
             goto done;
 
         /* do the assignment, transferring ownership: fieldobj = tmp */
@@ -832,7 +832,7 @@ output_markup(SubString *field_name, SubString *format_spec,
     if (format_spec_needs_expanding) {
         tmp = build_string(format_spec, args, kwargs, recursion_depth-1,
                            auto_number);
-        if (tmp == NULL || PyUnicode_READY(tmp) == -1)
+        if (tmp == NULL)
             goto done;
 
         /* note that in the case we're expanding the format string,
@@ -948,10 +948,6 @@ do_string_format(PyObject *self, PyObject *args, PyObject *kwargs)
     int recursion_depth = 2;
 
     AutoNumber auto_number;
-
-    if (PyUnicode_READY(self) == -1)
-        return NULL;
-
     AutoNumber_Init(&auto_number);
     SubString_init(&input, self, 0, PyUnicode_GET_LENGTH(self));
     return build_string(&input, args, kwargs, recursion_depth, &auto_number);
@@ -1110,9 +1106,6 @@ formatter_parser(PyObject *ignored, PyObject *self)
         return NULL;
     }
 
-    if (PyUnicode_READY(self) == -1)
-        return NULL;
-
     it = PyObject_New(formatteriterobject, &PyFormatterIter_Type);
     if (it == NULL)
         return NULL;
@@ -1251,9 +1244,6 @@ formatter_field_name_split(PyObject *ignored, PyObject *self)
         PyErr_Format(PyExc_TypeError, "expected str, got %s", Py_TYPE(self)->tp_name);
         return NULL;
     }
-
-    if (PyUnicode_READY(self) == -1)
-        return NULL;
 
     it = PyObject_New(fieldnameiterobject, &PyFieldNameIter_Type);
     if (it == NULL)

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4901,8 +4901,6 @@ type_setattro(PyTypeObject *type, PyObject *name, PyObject *value)
     }
     if (PyUnicode_Check(name)) {
         if (PyUnicode_CheckExact(name)) {
-            if (PyUnicode_READY(name) == -1)
-                return -1;
             Py_INCREF(name);
         }
         else {

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -122,12 +122,6 @@ _PyPegen_join_names_with_dot(Parser *p, expr_ty first_name, expr_ty second_name)
     PyObject *first_identifier = first_name->v.Name.id;
     PyObject *second_identifier = second_name->v.Name.id;
 
-    if (PyUnicode_READY(first_identifier) == -1) {
-        return NULL;
-    }
-    if (PyUnicode_READY(second_identifier) == -1) {
-        return NULL;
-    }
     const char *first_str = PyUnicode_AsUTF8(first_identifier);
     if (!first_str) {
         return NULL;

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -533,9 +533,6 @@ show_warning(PyThreadState *tstate, PyObject *filename, int lineno,
         Py_UCS4 ch;
         PyObject *truncated;
 
-        if (PyUnicode_READY(sourceline) < 1)
-            goto error;
-
         kind = PyUnicode_KIND(sourceline);
         data = PyUnicode_DATA(sourceline);
         len = PyUnicode_GET_LENGTH(sourceline);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1914,8 +1914,6 @@ builtin_ord(PyObject *module, PyObject *c)
         }
     }
     else if (PyUnicode_Check(c)) {
-        if (PyUnicode_READY(c) == -1)
-            return NULL;
         size = PyUnicode_GET_LENGTH(c);
         if (size == 1) {
             ord = (long)PyUnicode_READ_CHAR(c, 0);

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -982,7 +982,7 @@ format_long_internal(PyObject *value, const InternalFormatSpec *format,
 
         /* Do the hard part, converting to a string in a given base */
         tmp = _PyLong_Format(value, base);
-        if (tmp == NULL || PyUnicode_READY(tmp) == -1)
+        if (tmp == NULL)
             goto done;
 
         inumeric_chars = 0;

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -824,9 +824,6 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
         if (!PyUnicode_Check(arg))
             return converterr("a unicode character", arg, msgbuf, bufsize);
 
-        if (PyUnicode_READY(arg))
-            RETURN_ERR_OCCURRED;
-
         if (PyUnicode_GET_LENGTH(arg) != 1)
             return converterr("a unicode character", arg, msgbuf, bufsize);
 

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -1141,8 +1141,6 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
     case 'U': { /* PyUnicode object */
         PyObject **p = va_arg(*p_va, PyObject **);
         if (PyUnicode_Check(arg)) {
-            if (PyUnicode_READY(arg) == -1)
-                RETURN_ERR_OCCURRED;
             *p = arg;
         }
         else

--- a/Python/import.c
+++ b/Python/import.c
@@ -2610,10 +2610,6 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
         if (!haspath) {
             Py_ssize_t dot;
 
-            if (PyUnicode_READY(package) < 0) {
-                goto error;
-            }
-
             dot = PyUnicode_FindChar(package, '.',
                                         0, PyUnicode_GET_LENGTH(package), -1);
             if (dot == -2) {
@@ -2760,9 +2756,6 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
     if (!PyUnicode_Check(name)) {
         _PyErr_SetString(tstate, PyExc_TypeError,
                          "module name must be a string");
-        goto error;
-    }
-    if (PyUnicode_READY(name) < 0) {
         goto error;
     }
     if (level < 0) {

--- a/Python/intrinsics.c
+++ b/Python/intrinsics.c
@@ -96,11 +96,6 @@ import_all_from(PyThreadState *tstate, PyObject *locals, PyObject *v)
             break;
         }
         if (skip_leading_underscores) {
-            if (PyUnicode_READY(name) == -1) {
-                Py_DECREF(name);
-                err = -1;
-                break;
-            }
             if (PyUnicode_READ_CHAR(name, 0) == '_') {
                 Py_DECREF(name);
                 continue;

--- a/Python/pystrhex.c
+++ b/Python/pystrhex.c
@@ -21,8 +21,6 @@ static PyObject *_Py_strhex_impl(const char* argbuf, const Py_ssize_t arglen,
             return NULL;
         }
         if (PyUnicode_Check(sep)) {
-            if (PyUnicode_READY(sep))
-                return NULL;
             if (PyUnicode_KIND(sep) != PyUnicode_1BYTE_KIND) {
                 PyErr_SetString(PyExc_ValueError, "sep must be ASCII.");
                 return NULL;


### PR DESCRIPTION
Since Python 3.12, PyUnicode_READY() does nothing and always returns 0.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-92536 -->
* Issue: gh-92536
<!-- /gh-issue-number -->
