### PR TITLE
gh-105080: Fixed inconsistent signature on derived classes

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2581,17 +2581,18 @@ def _signature_from_callable(obj, *,
             factory_method = None
             new = _signature_get_user_defined_method(obj, '__new__')
             init = _signature_get_user_defined_method(obj, '__init__')
-            # Now we check if the 'obj' class has an own '__new__' method
-            if '__new__' in obj.__dict__:
-                factory_method = new
-            # or an own '__init__' method
-            elif '__init__' in obj.__dict__:
-                factory_method = init
-            # If not, we take inherited '__new__' or '__init__', if present
-            elif new is not None:
-                factory_method = new
-            elif init is not None:
-                factory_method = init
+
+            # Go through the MRO and see if any class has user-defined
+            # pure Python __new__ or __init__ method
+            for base in obj.__mro__:
+                # Now we check if the 'obj' class has an own '__new__' method
+                if new is not None and '__new__' in base.__dict__:
+                    factory_method = new
+                    break
+                # or an own '__init__' method
+                elif init is not None and '__init__' in base.__dict__:
+                    factory_method = init
+                    break
 
             if factory_method is not None:
                 sig = _get_signature_of(factory_method)

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -3927,6 +3927,24 @@ class TestSignatureObject(unittest.TestCase):
                            ('b', 2, ..., 'positional_or_keyword')),
                           ...))
 
+    def test_signature_on_derived_classes(self):
+        # gh-105080: Make sure that signatures are consistent on derived classes
+
+        class B:
+            def __new__(self, *args, **kwargs):
+                return super().__new__(self)
+            def __init__(self, value):
+                self.value = value
+
+        class D1(B):
+            def __init__(self, value):
+                super().__init__(value)
+
+        class D2(D1):
+            pass
+
+        self.assertEqual(inspect.signature(D2), inspect.signature(D1))
+
 
 class TestParameterObject(unittest.TestCase):
     def test_signature_parameter_kinds(self):

--- a/Misc/NEWS.d/next/Library/2023-06-02-02-38-26.gh-issue-105080.2imGMg.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-02-02-38-26.gh-issue-105080.2imGMg.rst
@@ -1,0 +1,1 @@
+Fixed inconsistent signature on derived classes for :func:`inspect.signature`


### PR DESCRIPTION
```python
class B:
    def __new__(self, *args, **kwargs):
        return super().__new__(self)
    def __init__(self, value):
        self.value = value

class D1(B):
    def __init__(self, value):
        super().__init__(value)

class D2(D1):
    pass
```

For the code above, `inspect.signature(D2)` will give a different result than `inspect.signature(D1)`, which is counter-intuitive. This also affects `help(D2)` vs `help(D1)`.

We should keep the consistency for the signatures for derived classes (of course when the signature is not changed).

This is due to a corner case in `inspect.signature()` where only the direct defined `__init__` and `__new__` method on the class takes priority, then `__new__` is always used if defined on any base classes. This fix searches `__new__` and `__init__` based on MRO and prioritize `__new__` if both are defined on a base class.

<!-- gh-issue-number: gh-105080 -->
* Issue: gh-105080
<!-- /gh-issue-number -->
