### PR TITLE
gh-105184: add return value indicating success/failure for PyMarshal_WriteLongToFile and PyMarshal_WriteObjectToFile

### DIFF
--- a/Doc/c-api/marshal.rst
+++ b/Doc/c-api/marshal.rst
@@ -19,22 +19,26 @@ unmarshalling.  Version 2 uses a binary format for floating point numbers.
 ``Py_MARSHAL_VERSION`` indicates the current file format (currently 2).
 
 
-.. c:function:: void PyMarshal_WriteLongToFile(long value, FILE *file, int version)
+.. c:function:: int PyMarshal_WriteLongToFile(long value, FILE *file, int version)
 
    Marshal a :c:expr:`long` integer, *value*, to *file*.  This will only write
    the least-significant 32 bits of *value*; regardless of the size of the
    native :c:expr:`long` type.  *version* indicates the file format.
 
-   This function can fail, in which case it sets the error indicator.
-   Use :c:func:`PyErr_Occurred` to check for that.
+   Return 0 on success. Return -1 and set an exception on error.
 
-.. c:function:: void PyMarshal_WriteObjectToFile(PyObject *value, FILE *file, int version)
+   .. versionchanged:: 3.13
+   Added return value.
+
+.. c:function:: int PyMarshal_WriteObjectToFile(PyObject *value, FILE *file, int version)
 
    Marshal a Python object, *value*, to *file*.
    *version* indicates the file format.
 
-   This function can fail, in which case it sets the error indicator.
-   Use :c:func:`PyErr_Occurred` to check for that.
+   Return 0 on success. Return -1 and set an exception on error.
+
+   .. versionchanged:: 3.13
+   Added return value.
 
 .. c:function:: PyObject* PyMarshal_WriteObjectToString(PyObject *value, int version)
 

--- a/Doc/c-api/marshal.rst
+++ b/Doc/c-api/marshal.rst
@@ -28,7 +28,7 @@ unmarshalling.  Version 2 uses a binary format for floating point numbers.
    Return 0 on success. Return -1 and set an exception on error.
 
    .. versionchanged:: 3.13
-   Added return value.
+      Added return value.
 
 .. c:function:: int PyMarshal_WriteObjectToFile(PyObject *value, FILE *file, int version)
 
@@ -38,7 +38,7 @@ unmarshalling.  Version 2 uses a binary format for floating point numbers.
    Return 0 on success. Return -1 and set an exception on error.
 
    .. versionchanged:: 3.13
-   Added return value.
+      Added return value.
 
 .. c:function:: PyObject* PyMarshal_WriteObjectToString(PyObject *value, int version)
 

--- a/Include/marshal.h
+++ b/Include/marshal.h
@@ -20,8 +20,8 @@ PyAPI_FUNC(int) PyMarshal_ReadShortFromFile(FILE *);
 PyAPI_FUNC(PyObject *) PyMarshal_ReadObjectFromFile(FILE *);
 PyAPI_FUNC(PyObject *) PyMarshal_ReadLastObjectFromFile(FILE *);
 
-PyAPI_FUNC(void) PyMarshal_WriteLongToFile(long, FILE *, int);
-PyAPI_FUNC(void) PyMarshal_WriteObjectToFile(PyObject *, FILE *, int);
+PyAPI_FUNC(int) PyMarshal_WriteLongToFile(long, FILE *, int);
+PyAPI_FUNC(int) PyMarshal_WriteObjectToFile(PyObject *, FILE *, int);
 
 #ifdef __cplusplus
 }

--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-02-12-02-42.gh-issue-105184.M4yTzg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-02-12-02-42.gh-issue-105184.M4yTzg.rst
@@ -1,0 +1,3 @@
+Add return value indicating success/failure to
+:c:func:`PyMarshal_WriteLongToFile` and
+:c:func:`PyMarshal_WriteObjectToFile`.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1807,7 +1807,8 @@ pymarshal_write_long_to_file(PyObject* self, PyObject *args)
         return NULL;
     }
 
-    PyMarshal_WriteLongToFile(value, fp, version);
+    int ret = PyMarshal_WriteLongToFile(value, fp, version);
+    assert(ret == 0);
     assert(!PyErr_Occurred());
 
     fclose(fp);
@@ -1832,7 +1833,8 @@ pymarshal_write_object_to_file(PyObject* self, PyObject *args)
         return NULL;
     }
 
-    PyMarshal_WriteObjectToFile(obj, fp, version);
+    int ret = PyMarshal_WriteObjectToFile(obj, fp, version);
+    assert(ret == 0);
     assert(!PyErr_Occurred());
 
     fclose(fp);


### PR DESCRIPTION


<!-- gh-issue-number: gh-105184 -->
* Issue: gh-105184
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105233.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->