### PR TITLE
gh-87092: avoid gcc warning on uninitialized struct field in assemble…

### DIFF
--- a/Python/assemble.c
+++ b/Python/assemble.c
@@ -146,6 +146,7 @@ assemble_exception_table(struct assembler *a, instr_sequence *instrs)
     int ioffset = 0;
     _PyCompile_ExceptHandlerInfo handler;
     handler.h_offset = -1;
+    handler.h_startdepth = -1;
     handler.h_preserve_lasti = -1;
     int start = -1;
     for (int i = 0; i < instrs->s_used; i++) {


### PR DESCRIPTION
….c (part2)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

````

Python/assemble.c: In function ‘_PyAssemble_MakeCodeObject’:
Python/assemble.c:130:9: warning: ‘handler.h_startdepth’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     int depth = handler->h_startdepth - 1;
         ^~~~~
Python/assemble.c:147:34: note: ‘handler.h_startdepth’ was declared here
     _PyCompile_ExceptHandlerInfo handler;
                                  ^~~~~~~
````

<!-- gh-issue-number: gh-87092 -->
* Issue: gh-87092
<!-- /gh-issue-number -->
