### PR TITLE
gh-87092: remove unused macros

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -37,10 +37,6 @@
 
 #include "opcode_metadata.h"      // _PyOpcode_opcode_metadata, _PyOpcode_num_popped/pushed
 
-#define DEFAULT_CODE_SIZE 128
-#define DEFAULT_LNOTAB_SIZE 16
-#define DEFAULT_CNOTAB_SIZE 32
-
 #define COMP_GENEXP   0
 #define COMP_LISTCOMP 1
 #define COMP_SETCOMP  2
@@ -64,21 +60,6 @@
     if ((X) == -1) {        \
         return ERROR;       \
     }
-
-/* If we exceed this limit, it should
- * be considered a compiler bug.
- * Currently it should be impossible
- * to exceed STACK_USE_GUIDELINE * 100,
- * as 100 is the maximum parse depth.
- * For performance reasons we will
- * want to reduce this to a
- * few hundred in the future.
- *
- * NOTE: Whatever MAX_ALLOWED_STACK_USE is
- * set to, it should never restrict what Python
- * we can write, just how we compile it.
- */
-#define MAX_ALLOWED_STACK_USE (STACK_USE_GUIDELINE * 100)
 
 #define IS_TOP_LEVEL_AWAIT(C) ( \
         ((C)->c_flags.cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT) \


### PR DESCRIPTION
The usages of these macros were removed or moved to assemble.c in the refactor.


<!-- gh-issue-number: gh-87092 -->
* Issue: gh-87092
<!-- /gh-issue-number -->
