### PR TITLE
gh-104310: Rename the New Function in importlib.util

### DIFF
--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -116,7 +116,7 @@ def find_spec(name, package=None):
 # is imported by runpy, which means we want to avoid any unnecessary
 # dependencies.  Thus we use a class.
 
-class allowing_all_extensions:
+class _incompatible_extension_module_restrictions:
     """A context manager that can temporarily skip the compatibility check.
 
     NOTE: This function is meant to accommodate an unusual case; one

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -128,8 +128,8 @@ class _incompatible_extension_module_restrictions:
     extension module development.
 
     If "disable_check" is True then the compatibility check will not
-    happen while the context manager is active.  Otherwise (and by
-    default) the check *will* happen.
+    happen while the context manager is active.  Otherwise the check
+    *will* happen.
 
     Normally, extensions that do not support multiple interpreters
     may not be imported in a subinterpreter.  That implies modules
@@ -148,8 +148,8 @@ class _incompatible_extension_module_restrictions:
     support for mulitple interpreters (or per-interpreter GIL).
     """
 
-    def __init__(self, disable_check=False):
-        self.disable_check = disable_check
+    def __init__(self, disable_check):
+        self.disable_check = bool(disable_check)
 
     def __enter__(self):
         self.old = _imp._override_multi_interp_extensions_check(self.override)

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -127,6 +127,10 @@ class allowing_all_extensions:
     unexpected behavior and even crashes.  It should only be used during
     extension module development.
 
+    If "disable_check" is True then the compatibility check will not
+    happen while the context manager is active.  Otherwise (and by
+    default) the check *will* happen.
+
     Normally, extensions that do not support multiple interpreters
     may not be imported in a subinterpreter.  That implies modules
     that do not implement multi-phase init or that explicitly of out.
@@ -144,7 +148,7 @@ class allowing_all_extensions:
     support for mulitple interpreters (or per-interpreter GIL).
     """
 
-    def __init__(self, disable_check=True):
+    def __init__(self, disable_check=False):
         self.disable_check = disable_check
 
     def __enter__(self):

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -148,7 +148,7 @@ class _incompatible_extension_module_restrictions:
     support for mulitple interpreters (or per-interpreter GIL).
     """
 
-    def __init__(self, disable_check):
+    def __init__(self, *, disable_check):
         self.disable_check = bool(disable_check)
 
     def __enter__(self):

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -117,11 +117,19 @@ def find_spec(name, package=None):
 # dependencies.  Thus we use a class.
 
 class allowing_all_extensions:
-    """A context manager that lets users skip the compatibility check.
+    """A context manager that can temporarily skip the compatibility check.
+
+    NOTE: This function is meant to accommodate an unusual case; one
+    which is likely to eventually go away.  There's is a pretty good
+    chance this is not what you were looking for.
+
+    WARNING: Using this function to disable the check can lead to
+    unexpected behavior and even crashes.  It should only be used during
+    extension module development.
 
     Normally, extensions that do not support multiple interpreters
     may not be imported in a subinterpreter.  That implies modules
-    that do not implement multi-phase init.
+    that do not implement multi-phase init or that explicitly of out.
 
     Likewise for modules import in a subinterpeter with its own GIL
     when the extension does not support a per-interpreter GIL.  This
@@ -130,6 +138,10 @@ class allowing_all_extensions:
 
     In both cases, this context manager may be used to temporarily
     disable the check for compatible extension modules.
+
+    You can get the same effect as this function by implementing the
+    basic interface of multi-phase init (PEP 489) and lying about
+    support for mulitple interpreters (or per-interpreter GIL).
     """
 
     def __init__(self, disable_check=True):

--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -679,7 +679,7 @@ class AllowingAllExtensionsTests(unittest.TestCase):
     def test_single_phase_init_module(self):
         script = textwrap.dedent('''
             import importlib.util
-            with importlib.util.allowing_all_extensions():
+            with importlib.util.allowing_all_extensions(True):
                 import _testsinglephase
             ''')
         with self.subTest('check disabled, shared GIL'):
@@ -699,6 +699,15 @@ class AllowingAllExtensionsTests(unittest.TestCase):
             with self.assertRaises(ImportError):
                 self.run_with_own_gil(script)
 
+        script = textwrap.dedent(f'''
+            import importlib.util
+            with importlib.util.allowing_all_extensions():
+                import _testsinglephase
+            ''')
+        with self.subTest('check enabled (default)'):
+            with self.assertRaises(ImportError):
+                self.run_with_shared_gil(script)
+
     @unittest.skipIf(_testmultiphase is None, "test requires _testmultiphase module")
     def test_incomplete_multi_phase_init_module(self):
         prescript = textwrap.dedent(f'''
@@ -714,7 +723,7 @@ class AllowingAllExtensionsTests(unittest.TestCase):
 
         script = prescript + textwrap.dedent('''
             import importlib.util
-            with importlib.util.allowing_all_extensions():
+            with importlib.util.allowing_all_extensions(True):
                 module = module_from_spec(spec)
                 loader.exec_module(module)
             ''')
@@ -739,7 +748,7 @@ class AllowingAllExtensionsTests(unittest.TestCase):
     def test_complete_multi_phase_init_module(self):
         script = textwrap.dedent('''
             import importlib.util
-            with importlib.util.allowing_all_extensions():
+            with importlib.util.allowing_all_extensions(True):
                 import _testmultiphase
             ''')
         with self.subTest('check disabled, shared GIL'):

--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -699,15 +699,6 @@ class IncompatibleExtensionModuleRestrictionsTests(unittest.TestCase):
             with self.assertRaises(ImportError):
                 self.run_with_own_gil(script)
 
-        script = textwrap.dedent(f'''
-            import importlib.util
-            with importlib.util._incompatible_extension_module_restrictions():
-                import _testsinglephase
-            ''')
-        with self.subTest('check enabled (default)'):
-            with self.assertRaises(ImportError):
-                self.run_with_shared_gil(script)
-
     @unittest.skipIf(_testmultiphase is None, "test requires _testmultiphase module")
     def test_incomplete_multi_phase_init_module(self):
         prescript = textwrap.dedent(f'''

--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -653,7 +653,7 @@ class MagicNumberTests(unittest.TestCase):
 
 
 @unittest.skipIf(_interpreters is None, 'subinterpreters required')
-class AllowingAllExtensionsTests(unittest.TestCase):
+class IncompatibleExtensionModuleRestrictionsTests(unittest.TestCase):
 
     ERROR = re.compile("^<class 'ImportError'>: module (.*) does not support loading in subinterpreters")
 
@@ -679,7 +679,7 @@ class AllowingAllExtensionsTests(unittest.TestCase):
     def test_single_phase_init_module(self):
         script = textwrap.dedent('''
             import importlib.util
-            with importlib.util.allowing_all_extensions(True):
+            with importlib.util._incompatible_extension_module_restrictions(True):
                 import _testsinglephase
             ''')
         with self.subTest('check disabled, shared GIL'):
@@ -689,7 +689,7 @@ class AllowingAllExtensionsTests(unittest.TestCase):
 
         script = textwrap.dedent(f'''
             import importlib.util
-            with importlib.util.allowing_all_extensions(False):
+            with importlib.util._incompatible_extension_module_restrictions(False):
                 import _testsinglephase
             ''')
         with self.subTest('check enabled, shared GIL'):
@@ -701,7 +701,7 @@ class AllowingAllExtensionsTests(unittest.TestCase):
 
         script = textwrap.dedent(f'''
             import importlib.util
-            with importlib.util.allowing_all_extensions():
+            with importlib.util._incompatible_extension_module_restrictions():
                 import _testsinglephase
             ''')
         with self.subTest('check enabled (default)'):
@@ -723,7 +723,7 @@ class AllowingAllExtensionsTests(unittest.TestCase):
 
         script = prescript + textwrap.dedent('''
             import importlib.util
-            with importlib.util.allowing_all_extensions(True):
+            with importlib.util._incompatible_extension_module_restrictions(True):
                 module = module_from_spec(spec)
                 loader.exec_module(module)
             ''')
@@ -734,7 +734,7 @@ class AllowingAllExtensionsTests(unittest.TestCase):
 
         script = prescript + textwrap.dedent('''
             import importlib.util
-            with importlib.util.allowing_all_extensions(False):
+            with importlib.util._incompatible_extension_module_restrictions(False):
                 module = module_from_spec(spec)
                 loader.exec_module(module)
             ''')
@@ -748,7 +748,7 @@ class AllowingAllExtensionsTests(unittest.TestCase):
     def test_complete_multi_phase_init_module(self):
         script = textwrap.dedent('''
             import importlib.util
-            with importlib.util.allowing_all_extensions(True):
+            with importlib.util._incompatible_extension_module_restrictions(True):
                 import _testmultiphase
             ''')
         with self.subTest('check disabled, shared GIL'):
@@ -758,7 +758,7 @@ class AllowingAllExtensionsTests(unittest.TestCase):
 
         script = textwrap.dedent(f'''
             import importlib.util
-            with importlib.util.allowing_all_extensions(False):
+            with importlib.util._incompatible_extension_module_restrictions(False):
                 import _testmultiphase
             ''')
         with self.subTest('check enabled, shared GIL'):

--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -678,8 +678,8 @@ class IncompatibleExtensionModuleRestrictionsTests(unittest.TestCase):
     @unittest.skipIf(_testsinglephase is None, "test requires _testsinglephase module")
     def test_single_phase_init_module(self):
         script = textwrap.dedent('''
-            import importlib.util
-            with importlib.util._incompatible_extension_module_restrictions(True):
+            from importlib.util import _incompatible_extension_module_restrictions
+            with _incompatible_extension_module_restrictions(disable_check=True):
                 import _testsinglephase
             ''')
         with self.subTest('check disabled, shared GIL'):
@@ -688,8 +688,8 @@ class IncompatibleExtensionModuleRestrictionsTests(unittest.TestCase):
             self.run_with_own_gil(script)
 
         script = textwrap.dedent(f'''
-            import importlib.util
-            with importlib.util._incompatible_extension_module_restrictions(False):
+            from importlib.util import _incompatible_extension_module_restrictions
+            with _incompatible_extension_module_restrictions(disable_check=False):
                 import _testsinglephase
             ''')
         with self.subTest('check enabled, shared GIL'):
@@ -713,8 +713,8 @@ class IncompatibleExtensionModuleRestrictionsTests(unittest.TestCase):
             ''')
 
         script = prescript + textwrap.dedent('''
-            import importlib.util
-            with importlib.util._incompatible_extension_module_restrictions(True):
+            from importlib.util import _incompatible_extension_module_restrictions
+            with _incompatible_extension_module_restrictions(disable_check=True):
                 module = module_from_spec(spec)
                 loader.exec_module(module)
             ''')
@@ -724,8 +724,8 @@ class IncompatibleExtensionModuleRestrictionsTests(unittest.TestCase):
             self.run_with_own_gil(script)
 
         script = prescript + textwrap.dedent('''
-            import importlib.util
-            with importlib.util._incompatible_extension_module_restrictions(False):
+            from importlib.util import _incompatible_extension_module_restrictions
+            with _incompatible_extension_module_restrictions(disable_check=False):
                 module = module_from_spec(spec)
                 loader.exec_module(module)
             ''')
@@ -738,8 +738,8 @@ class IncompatibleExtensionModuleRestrictionsTests(unittest.TestCase):
     @unittest.skipIf(_testmultiphase is None, "test requires _testmultiphase module")
     def test_complete_multi_phase_init_module(self):
         script = textwrap.dedent('''
-            import importlib.util
-            with importlib.util._incompatible_extension_module_restrictions(True):
+            from importlib.util import _incompatible_extension_module_restrictions
+            with _incompatible_extension_module_restrictions(disable_check=True):
                 import _testmultiphase
             ''')
         with self.subTest('check disabled, shared GIL'):
@@ -748,8 +748,8 @@ class IncompatibleExtensionModuleRestrictionsTests(unittest.TestCase):
             self.run_with_own_gil(script)
 
         script = textwrap.dedent(f'''
-            import importlib.util
-            with importlib.util._incompatible_extension_module_restrictions(False):
+            from importlib.util import _incompatible_extension_module_restrictions
+            with _incompatible_extension_module_restrictions(disable_check=False):
                 import _testmultiphase
             ''')
         with self.subTest('check enabled, shared GIL'):

--- a/Misc/NEWS.d/next/Library/2023-06-02-14-23-41.gh-issue-104310.UamCOB.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-02-14-23-41.gh-issue-104310.UamCOB.rst
@@ -3,5 +3,5 @@ authors, to use when testing their module for support in multiple
 interpreters or under a per-interpreter GIL.  The name of that function has
 changed from ``allowing_all_extensions`` to
 ``_incompatible_extension_module_restrictions``.  The default for the
-"disable_check" argment has change from ``True`` to ``False``, to better
+"disable_check" argument has change from ``True`` to ``False``, to better
 match the new function name.

--- a/Misc/NEWS.d/next/Library/2023-06-02-14-23-41.gh-issue-104310.UamCOB.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-02-14-23-41.gh-issue-104310.UamCOB.rst
@@ -1,0 +1,7 @@
+In the beta 1 release we added a utility function for extension module
+authors, to use when testing their module for support in multiple
+interpreters or under a per-interpreter GIL.  The name of that function has
+changed from ``allowing_all_extensions`` to
+``_incompatible_extension_module_restrictions``.  The default for the
+"disable_check" argment has change from ``True`` to ``False``, to better
+match the new function name.


### PR DESCRIPTION
The original name wasn't as clear as it could have been.  This change includes the following:

* rename the function
* change the default value for "disable_check" to `False`
* add clues to the docstring that folks should probably not use the function

<!-- gh-issue-number: gh-104310 -->
* Issue: gh-104310
<!-- /gh-issue-number -->
