### PR TITLE
gh-98963: Restore the ability to have a dict-less property.

### DIFF
--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -247,20 +247,16 @@ class PropertySubclassTests(unittest.TestCase):
 
     def test_slots_docstring_copy_exception(self):
         # A special case error that we preserve despite the GH-98963 behavior
-        # that would otherwise silence this error and not set a docstr.
-        # This came from https://github.com/python/cpython/commit/b18500d39d791c879e9904ebac293402b4a7cd34
+        # that would otherwise silently ignore this error.
+        # This came from commit b18500d39d791c879e9904ebac293402b4a7cd34
         # as part of https://bugs.python.org/issue5890 which allowed docs to
-        # be set using property subclasses in the first place.
-        try:
+        # be set via property subclasses in the first place.
+        with self.assertRaises(AttributeError):
             class Foo(object):
                 @PropertySubSlots
                 def spam(self):
                     """Trying to copy this docstring will raise an exception"""
                     return 1
-        except AttributeError:
-            pass
-        else:
-            raise Exception("AttributeError not raised")
 
     def test_property_with_slots_no_docstring(self):
         # https://github.com/python/cpython/issues/98963#issuecomment-1574413319
@@ -273,7 +269,7 @@ class PropertySubclassTests(unittest.TestCase):
         def undocumented_getter():
             return 4
 
-        p = slotted_prop(undocumented_getter)  # no AttributeError
+        p = slotted_prop(undocumented_getter)  # New in 3.12: no AttributeError
         self.assertIsNone(getattr(p, "__doc__", None))
 
     @unittest.skipIf(sys.flags.optimize >= 2,
@@ -303,14 +299,14 @@ class PropertySubclassTests(unittest.TestCase):
             __slots__ = ("foo", "__doc__")
 
         p = slotted_prop(doc="what's up")
-        self.assertEqual("what's up", p.__doc__)  # meep meep!
+        self.assertEqual("what's up", p.__doc__)  # new in 3.12: This gets set.
 
         def documented_getter():
             """what's up getter doc?"""
             return 4
 
         p = slotted_prop(documented_getter)
-        self.assertEqual("what's up getter doc?", p.__doc__)  # meep meep!
+        self.assertEqual("what's up getter doc?", p.__doc__)
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")

--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-02-17-39-19.gh-issue-98963.J4wJgk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-02-17-39-19.gh-issue-98963.J4wJgk.rst
@@ -1,0 +1,3 @@
+Restore the ability for a subclass of :class:`property` to define
+``__slots__`` or otherwise be dict-less by ignoring any attempt to set a
+docstring on such a class. This behavior had regressed in 3.12beta1.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-02-17-39-19.gh-issue-98963.J4wJgk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-02-17-39-19.gh-issue-98963.J4wJgk.rst
@@ -1,3 +1,4 @@
-Restore the ability for a subclass of :class:`property` to define
-``__slots__`` or otherwise be dict-less by ignoring any attempt to set a
-docstring on such a class. This behavior had regressed in 3.12beta1.
+Restore the ability for a subclass of :class:`property` to define ``__slots__``
+or otherwise be dict-less by ignoring failures to set a docstring on such a
+class.  This behavior had regressed in 3.12beta1.  An :exc:`AttributeError`
+where there had not previously been one was disruptive to existing code.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1825,14 +1825,10 @@ property_init_impl(propertyobject *self, PyObject *fget, PyObject *fset,
                 // https://github.com/python/cpython/issues/98963#issuecomment-1574413319
                 // Python silently dropped this doc assignment through 3.11.
                 // We preserve that behavior for backwards compatibility.
-                if (prop_doc == Py_None) {
-                    Py_DECREF(prop_doc);
-                    return 0;
-                }
-                // If we ever want to deprecate this behavior, here is where to
-                // raise a DeprecationWarning; do not generate such noise when
-                // prop_doc is None.
-                Py_DECREF(prop_doc);
+		//
+                // If we ever want to deprecate this behavior, only raise a
+		// warning or error when proc_doc is not None so that
+		// property without a specific doc= still works.
                 return 0;
             } else {
                 return -1;

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1831,6 +1831,7 @@ property_init_impl(propertyobject *self, PyObject *fget, PyObject *fset,
         }
         int err = PyObject_SetAttr(
                     (PyObject *)self, &_Py_ID(__doc__), prop_doc);
+        Py_DECREF(prop_doc);
         if (err < 0) {
             assert(PyErr_Occurred());
             if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
@@ -1842,10 +1843,8 @@ property_init_impl(propertyobject *self, PyObject *fget, PyObject *fset,
                 // If we ever want to deprecate this behavior, only raise a
                 // warning or error when proc_doc is not None so that
                 // property without a specific doc= still works.
-                Py_DECREF(prop_doc);
                 return 0;
             } else {
-                Py_DECREF(prop_doc);
                 return -1;
             }
         }

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1825,10 +1825,10 @@ property_init_impl(propertyobject *self, PyObject *fget, PyObject *fset,
                 // https://github.com/python/cpython/issues/98963#issuecomment-1574413319
                 // Python silently dropped this doc assignment through 3.11.
                 // We preserve that behavior for backwards compatibility.
-		//
+                //
                 // If we ever want to deprecate this behavior, only raise a
-		// warning or error when proc_doc is not None so that
-		// property without a specific doc= still works.
+                // warning or error when proc_doc is not None so that
+                // property without a specific doc= still works.
                 return 0;
             } else {
                 return -1;

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1802,8 +1802,8 @@ property_init_impl(propertyobject *self, PyObject *fget, PyObject *fset,
             // See PropertySubclassTest.test_slots_docstring_copy_exception.
             int err = PyObject_SetAttr(
                         (PyObject *)self, &_Py_ID(__doc__), prop_doc);
-            Py_DECREF(prop_doc);
             if (err < 0) {
+                Py_DECREF(prop_doc);  // release our new reference.
                 return -1;
             }
         }


### PR DESCRIPTION
Ignore doc string assignment failures in `property` as has been the behavior of all past Python releases.

Preserves the one situation in which the AttributeError has always been raised for this property subclass situation: 
If the docstring would be applied from a getter function it raises rather than remaining silent.  (see the existing test and code comments)

This undoes a behavior regression present in 3.12beta1 that was causing existing widely used library code (Google protobuf) to fail.

<!-- gh-issue-number: gh-98963 -->
* Issue: gh-98963
<!-- /gh-issue-number -->
