### PR TITLE
gh-92658: Fix typo in docs and tests for `HV_GUID_PARENT`

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -665,7 +665,7 @@ Constants
           HV_GUID_BROADCAST
           HV_GUID_CHILDREN
           HV_GUID_LOOPBACK
-          HV_GUID_LOOPBACK
+          HV_GUID_PARENT
 
    Constants for Windows Hyper-V sockets for host/guest communications.
 

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -2566,7 +2566,7 @@ class BasicHyperVTest(unittest.TestCase):
         socket.HV_GUID_BROADCAST
         socket.HV_GUID_CHILDREN
         socket.HV_GUID_LOOPBACK
-        socket.HV_GUID_LOOPBACK
+        socket.HV_GUID_PARENT
 
     def testCreateHyperVSocketWithUnknownProtoFailure(self):
         expected = r"\[WinError 10041\]"


### PR DESCRIPTION
While working on https://github.com/python/typeshed/pull/10247 I've noticed that `HV_GUID_LOOPBACK` constant is used twice, while `HV_GUID_PARENT` is not used at all.

Refs https://github.com/python/cpython/pull/92755

<!-- gh-issue-number: gh-92658 -->
* Issue: gh-92658
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105267.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->