### PR TITLE
gh-105059: Remove anonymous union from PyObject

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -16,14 +16,13 @@
 #  define _SGI_MP_SOURCE
 #endif
 
-// stdlib.h, stdio.h, errno.h and string.h headers are not used by Python
+// stdlib.h, stdio.h, and errno.h headers are not used by Python
 // headers, but kept for backward compatibility. They are excluded from the
 // limited C API of Python 3.11.
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #  include <stdlib.h>
 #  include <stdio.h>              // FILE*
 #  include <errno.h>              // errno
-#  include <string.h>             // memcpy()
 #endif
 #ifndef MS_WINDOWS
 #  include <unistd.h>
@@ -34,6 +33,7 @@
 
 #include <assert.h>               // assert()
 #include <wchar.h>                // wchar_t
+#include <string.h>               // memcpy()
 
 #include "pyport.h"
 #include "pymacro.h"

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1876,7 +1876,7 @@ PyTypeObject _PyNone_Type = {
 
 PyObject _Py_NoneStruct = {
     _PyObject_EXTRA_INIT
-    { _Py_IMMORTAL_REFCNT },
+    _Py_IMMORTAL_REFCNT,
     &_PyNone_Type
 };
 
@@ -1979,7 +1979,7 @@ PyTypeObject _PyNotImplemented_Type = {
 
 PyObject _Py_NotImplementedStruct = {
     _PyObject_EXTRA_INIT
-    { _Py_IMMORTAL_REFCNT },
+    _Py_IMMORTAL_REFCNT,
     &_PyNotImplemented_Type
 };
 

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2544,6 +2544,6 @@ static PyTypeObject _PySetDummy_Type = {
 
 static PyObject _dummy_struct = {
     _PyObject_EXTRA_INIT
-    { _Py_IMMORTAL_REFCNT },
+    _Py_IMMORTAL_REFCNT,
     &_PySetDummy_Type
 };

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -99,7 +99,7 @@ PyTypeObject PyEllipsis_Type = {
 
 PyObject _Py_EllipsisObject = {
     _PyObject_EXTRA_INIT
-    { _Py_IMMORTAL_REFCNT },
+    _Py_IMMORTAL_REFCNT,
     &PyEllipsis_Type
 };
 


### PR DESCRIPTION
Currently, the use of an anonymous union causes warnings in C++ extensions. This updates the implementation of PyObject to not rely on anonymous unions and remove these warnings.

Current Issue that goes away after this patch:
```
#include <Python.h>
int main (void) { return 0; }

-> gcc -I/path/to/include/python3.13 -std=c99 -pedantic repro.c
In file included from repro.c:1:
In file included from /Users/eelizondo/dev/cpython_no_union/build_install/include/python3.13/Python.h:44:
/Users/eelizondo/dev/cpython_no_union/build_install/include/python3.13/object.h:168:5: warning: anonymous unions are a C11 extension [-Wc11-extensions]
    union {
```

Note: Currently, this is being fixed through the use of a memcpy but a couple of more options will be tried as well. I will also follow-up with benchmark numbers to verify we are not regressing.

<!-- gh-issue-number: gh-105059 -->
* Issue: gh-105059
<!-- /gh-issue-number -->
