### PR TITLE
gh-111501: venv: do not export PS1 in activate

### DIFF
--- a/Lib/venv/scripts/common/activate
+++ b/Lib/venv/scripts/common/activate
@@ -21,7 +21,6 @@ deactivate () {
 
     if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
         PS1="${_OLD_VIRTUAL_PS1:-}"
-        export PS1
         unset _OLD_VIRTUAL_PS1
     fi
 
@@ -68,7 +67,6 @@ fi
 if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT:-}" ] ; then
     _OLD_VIRTUAL_PS1="${PS1:-}"
     PS1="("__VENV_PROMPT__") ${PS1:-}"
-    export PS1
 fi
 
 # Call hash to forget past commands. Without forgetting

--- a/Misc/NEWS.d/next/Tools-Demos/2024-06-17-13-52-04.gh-issue-111501.syFLAV.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2024-06-17-13-52-04.gh-issue-111501.syFLAV.rst
@@ -1,0 +1,1 @@
+PS1 is no longer exported by venv activate script


### PR DESCRIPTION
PS1 is a global parameter. It does not need (and should not be) exported to the users environment.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111501 -->
* Issue: gh-111501
<!-- /gh-issue-number -->
