### PR TITLE
gh-105293: Do not call SSL_CTX_set_session_id_context on client side SSL context

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-07-14-14-53-58.gh-issue-105293.kimf_i.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-14-14-53-58.gh-issue-105293.kimf_i.rst
@@ -1,0 +1,2 @@
+Remove call to ``SSL_CTX_set_session_id_context`` during client side context
+creation in the :mod:`ssl` module.


### PR DESCRIPTION


<!-- gh-issue-number: gh-105293 -->
* Issue: gh-105293
<!-- /gh-issue-number -->
