### PR TITLE
Display the sanitizer config in the regrtest header.

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -526,6 +526,26 @@ class Regrtest:
             print("== CPU count:", cpu_count)
         print("== encodings: locale=%s, FS=%s"
               % (locale.getencoding(), sys.getfilesystemencoding()))
+        asan = support.check_sanitizer(address=True)
+        msan = support.check_sanitizer(memory=True)
+        ubsan = support.check_sanitizer(ub=True)
+        # This makes it easier to remember what to set in your local
+        # environment when trying to reproduce a sanitizer failure.
+        if asan or msan or ubsan:
+            names = [n for n in (asan and "address",
+                                 msan and "memory",
+                                 ubsan and "undefined behavior")
+                     if n]
+            print(f"== sanitizers: {', '.join(names)}")
+            a_opts = os.environ.get("ASAN_OPTIONS")
+            if asan and a_opts is not None:
+                print(f"==  ASAN_OPTIONS={a_opts}")
+            m_opts = os.environ.get("ASAN_OPTIONS")
+            if msan and m_opts is not None:
+                print(f"==  MSAN_OPTIONS={m_opts}")
+            ub_opts = os.environ.get("UBSAN_OPTIONS")
+            if ubsan and ub_opts is not None:
+                print(f"==  UBSAN_OPTIONS={ub_opts}")
 
     def no_tests_run(self):
         return not any((self.good, self.bad, self.skipped, self.interrupted,

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -414,7 +414,7 @@ def check_sanitizer(*, address=False, memory=False, ub=False):
     )
     address_sanitizer = (
         '-fsanitize=address' in _cflags or
-        '--with-memory-sanitizer' in _config_args
+        '--with-address-sanitizer' in _config_args
     )
     ub_sanitizer = (
         '-fsanitize=undefined' in _cflags or


### PR DESCRIPTION
Having this in the CI output for tests with the relevant environment variable displayed will help make it easier to do what we need to create an equivalent local test run.

This also "fixes" the address sanitizer check to look for `--with-address-sanitizer` rather than `--with-memory-sanitizer` which appears to have been [a paste error in the original PR that created the test.support.check_sanitizer() function](https://github.com/python/cpython/pull/30889).  It hasn't really mattered as the check for the CFLAGS value is what really gets used in practice.