### PR TITLE
gh-104635: Eliminate redundant STORE_FAST instructions in the compiler

### DIFF
--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -808,8 +808,9 @@ dis_extended_arg_quick_code = """\
 %3d           2 LOAD_CONST               1 (Ellipsis)
               4 EXTENDED_ARG             1
               6 UNPACK_EX              256
-              8 STORE_FAST_STORE_FAST     0 (_, _)
-             10 RETURN_CONST             0 (None)
+              8 POP_TOP
+             10 STORE_FAST               0 (_)
+             12 RETURN_CONST             0 (None)
 """% (extended_arg_quick.__code__.co_firstlineno,
       extended_arg_quick.__code__.co_firstlineno + 1,)
 

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1114,16 +1114,7 @@ class DirectCfgOptimizerTests(CfgOptimizationTestCase):
             ('STORE_FAST', 1, 6),
             ('RETURN_VALUE', 5)
         ]
-        expected_insts = [
-            ('LOAD_CONST', 0, 1),
-            ('LOAD_CONST', 1, 2),
-            ('LOAD_CONST', 2, 3),
-            ('STORE_FAST', 1, 4),
-            ('STORE_FAST', 1, 5),
-            ('STORE_FAST', 1, 6),
-            ('RETURN_VALUE', 5)
-        ]
-        self.cfg_optimization_test(insts, expected_insts, consts=list(range(3)), nlocals=1)
+        self.cfg_optimization_test(insts, insts, consts=list(range(3)), nlocals=1)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1077,13 +1077,54 @@ class DirectCfgOptimizerTests(CfgOptimizationTestCase):
         expected_insts = [
             ('LOAD_CONST', 0, 1),
             ('LOAD_CONST', 1, 2),
-            ('LOAD_CONST', 2, 3),
-            ('SWAP', 3, 4),
-            ('STORE_FAST_STORE_FAST', 17, 4),
+            ('NOP', 0, 3),
+            ('STORE_FAST', 1, 4),
             ('POP_TOP', 0, 4),
             ('RETURN_VALUE', 5)
         ]
         self.cfg_optimization_test(insts, expected_insts, consts=list(range(3)), nlocals=1)
+
+    def test_dead_store_elimination_in_same_lineno(self):
+        insts = [
+            ('LOAD_CONST', 0, 1),
+            ('LOAD_CONST', 1, 2),
+            ('LOAD_CONST', 2, 3),
+            ('STORE_FAST', 1, 4),
+            ('STORE_FAST', 1, 4),
+            ('STORE_FAST', 1, 4),
+            ('RETURN_VALUE', 5)
+        ]
+        expected_insts = [
+            ('LOAD_CONST', 0, 1),
+            ('LOAD_CONST', 1, 2),
+            ('NOP', 0, 3),
+            ('POP_TOP', 0, 4),
+            ('STORE_FAST', 1, 4),
+            ('RETURN_VALUE', 5)
+        ]
+        self.cfg_optimization_test(insts, expected_insts, consts=list(range(3)), nlocals=1)
+
+    def test_no_dead_store_elimination_in_different_lineno(self):
+        insts = [
+            ('LOAD_CONST', 0, 1),
+            ('LOAD_CONST', 1, 2),
+            ('LOAD_CONST', 2, 3),
+            ('STORE_FAST', 1, 4),
+            ('STORE_FAST', 1, 5),
+            ('STORE_FAST', 1, 6),
+            ('RETURN_VALUE', 5)
+        ]
+        expected_insts = [
+            ('LOAD_CONST', 0, 1),
+            ('LOAD_CONST', 1, 2),
+            ('LOAD_CONST', 2, 3),
+            ('STORE_FAST', 1, 4),
+            ('STORE_FAST', 1, 5),
+            ('STORE_FAST', 1, 6),
+            ('RETURN_VALUE', 5)
+        ]
+        self.cfg_optimization_test(insts, expected_insts, consts=list(range(3)), nlocals=1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-05-23-38-43.gh-issue-104635.VYZhVh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-05-23-38-43.gh-issue-104635.VYZhVh.rst
@@ -1,0 +1,2 @@
+Eliminate redundant :opcode:`STORE_FAST` instructions in the compiler. Patch
+by Dong-hee Na and Carl Meyer.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104635 -->
* Issue: gh-104635
<!-- /gh-issue-number -->


## Benchmarks

```
import pyperf

runner = pyperf.Runner()
runner.timeit(name="bench dead_store",
              stmt="""
_, _, _, a = 1, 2, 3, 4
""")

Mean +- std dev: [base] 11.7 ns +- 0.2 ns -> [opt] 11.1 ns +- 0.1 ns: 1.05x faster
```


```
import pyperf

runner = pyperf.Runner()
runner.timeit(name="bench static swaps",
              stmt="""
_ = f(True, False)
""",
setup="""
def f(x, y):
    a, a = x, y
    return a
""")


Mean +- std dev: [static_base] 27.1 ns +- 0.3 ns -> [static_opt] 26.0 ns +- 0.2 ns: 1.04x faster
```

