### PR TITLE
typing docs: Make the PEPs list an expandable section, hidden by default

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -64,7 +64,7 @@ annotations:
 .. raw:: html
 
    <details>
-   <summary><a>Click to see the full list of PEPs</a></summary>
+   <summary><a style="cursor:pointer;">Click to see the full list of PEPs</a></summary>
 
 * :pep:`526`: Syntax for Variable Annotations
      *Introducing* syntax for annotating variables outside of function
@@ -114,6 +114,7 @@ annotations:
 .. raw:: html
 
    </details>
+   <br>
 
 .. _type-aliases:
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -59,7 +59,12 @@ Relevant PEPs
 
 Since the initial introduction of type hints in :pep:`484` and :pep:`483`, a
 number of PEPs have modified and enhanced Python's framework for type
-annotations. These include:
+annotations:
+
+.. raw:: html
+
+   <details>
+   <summary><a>Click to see the full list of PEPs</a></summary>
 
 * :pep:`526`: Syntax for Variable Annotations
      *Introducing* syntax for annotating variables outside of function
@@ -105,6 +110,10 @@ annotations. These include:
     *Introducing* builtin syntax for creating generic functions, classes, and type aliases.
 * :pep:`698`: Adding an override decorator to typing
     *Introducing* the :func:`@override<override>` decorator
+
+.. raw:: html
+
+   </details>
 
 .. _type-aliases:
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -64,7 +64,7 @@ annotations:
 .. raw:: html
 
    <details>
-   <summary><a style="cursor:pointer;">Click to see the full list of PEPs</a></summary>
+   <summary><a style="cursor:pointer;">The full list of PEPs</a></summary>
 
 * :pep:`526`: Syntax for Variable Annotations
      *Introducing* syntax for annotating variables outside of function


### PR DESCRIPTION
The list is a very useful reference, so should be kept near the top. But it's now so long that it's probably quite intimidating for new users.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105353.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->