### PR TITLE
`typing.NewType` docs: the future performance improvements are now in the past

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -236,9 +236,13 @@ See :pep:`484` for more details.
 .. versionadded:: 3.5.2
 
 .. versionchanged:: 3.10
-   ``NewType`` is now a class rather than a function.  There is some additional
-   runtime cost when calling ``NewType`` over a regular function.  However, this
-   cost will be reduced in 3.11.0.
+   ``NewType`` is now a class rather than a function.  As a result, there is
+   some additional runtime cost when calling ``NewType`` over a regular
+   function.
+
+.. versionchanged:: 3.11
+   The performance of calling ``NewType`` has been restored to its level in
+   Python 3.9.
 
 
 Callable


### PR DESCRIPTION
Alternatively, as Serhiy suggested, we could just delete the bit in the existing `.. versionchanged` note that mentions the performance degradation in Python 3.10.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105354.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->