### PR TITLE
[3.11] gh-90005: Don't link with libbsd if not needed (#105236)

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-06-06-09-08-10.gh-issue-90005.8mmeJQ.rst
+++ b/Misc/NEWS.d/next/Build/2023-06-06-09-08-10.gh-issue-90005.8mmeJQ.rst
@@ -1,0 +1,1 @@
+Fix a regression in :file:`configure` where we could end up unintentionally linking with ``libbsd``.

--- a/configure
+++ b/configure
@@ -15796,9 +15796,7 @@ if test "x$ac_cv_func_flock" = xyes; then :
 #define HAVE_FLOCK 1
 _ACEOF
 
-fi
-done
-
+else
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for flock in -lbsd" >&5
 $as_echo_n "checking for flock in -lbsd... " >&6; }
 if ${ac_cv_lib_bsd_flock+:} false; then :
@@ -15839,6 +15837,8 @@ if test "x$ac_cv_lib_bsd_flock" = xyes; then :
   FCNTL_LIBS="-lbsd"
 fi
 
+fi
+done
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -4696,9 +4696,8 @@ AC_CACHE_CHECK([for flock declaration], [ac_cv_flock_decl],
 ])
 dnl Linking with libbsd may be necessary on AIX for flock function.
 AS_VAR_IF([ac_cv_flock_decl], [yes],
-  AC_CHECK_FUNCS([flock])
-  AC_CHECK_LIB([bsd], [flock], [FCNTL_LIBS="-lbsd"])
-)
+  [AC_CHECK_FUNCS([flock], [],
+    [AC_CHECK_LIB([bsd], [flock], [FCNTL_LIBS="-lbsd"])])])
 
 PY_CHECK_FUNC([getpagesize], [#include <unistd.h>])
 


### PR DESCRIPTION
The regression was introduced with commit 5b946cada.
Restore pre gh-29696 behaviour.


<!-- gh-issue-number: gh-90005 -->
* Issue: gh-90005
<!-- /gh-issue-number -->
