### PR TITLE
[3.12] gh-90005: Don't link with libbsd if not needed (#105236)

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-06-06-09-08-10.gh-issue-90005.8mmeJQ.rst
+++ b/Misc/NEWS.d/next/Build/2023-06-06-09-08-10.gh-issue-90005.8mmeJQ.rst
@@ -1,0 +1,1 @@
+Fix a regression in :file:`configure` where we could end up unintentionally linking with ``libbsd``.

--- a/configure
+++ b/configure
@@ -19278,13 +19278,15 @@ fi
 printf "%s\n" "$ac_cv_flock_decl" >&6; }
 if test "x$ac_cv_flock_decl" = xyes
 then :
+
+  for ac_func in flock
+do :
   ac_fn_c_check_func "$LINENO" "flock" "ac_cv_func_flock"
 if test "x$ac_cv_func_flock" = xyes
 then :
   printf "%s\n" "#define HAVE_FLOCK 1" >>confdefs.h
 
-fi
-
+else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for flock in -lbsd" >&5
 printf %s "checking for flock in -lbsd... " >&6; }
 if test ${ac_cv_lib_bsd_flock+y}
@@ -19325,7 +19327,9 @@ then :
   FCNTL_LIBS="-lbsd"
 fi
 
+fi
 
+done
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -4936,9 +4936,8 @@ AC_CACHE_CHECK([for flock declaration], [ac_cv_flock_decl],
 ])
 dnl Linking with libbsd may be necessary on AIX for flock function.
 AS_VAR_IF([ac_cv_flock_decl], [yes],
-  AC_CHECK_FUNCS([flock])
-  AC_CHECK_LIB([bsd], [flock], [FCNTL_LIBS="-lbsd"])
-)
+  [AC_CHECK_FUNCS([flock], [],
+    [AC_CHECK_LIB([bsd], [flock], [FCNTL_LIBS="-lbsd"])])])
 
 PY_CHECK_FUNC([getpagesize], [#include <unistd.h>])
 


### PR DESCRIPTION
The regression was introduced with commit 5b946cada.
Restore pre gh-29696 behaviour.


<!-- gh-issue-number: gh-90005 -->
* Issue: gh-90005
<!-- /gh-issue-number -->
