### PR TITLE
Improve docs for `typing.TypeAlias`

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -849,7 +849,7 @@ These can be used as types in annotations and do not support ``[]``.
 
       T = TypeVar("T")
 
-      # "Container" does not exist yet,
+      # "Box" does not exist yet,
       # so we have to use quotes for the forward reference on Python <3.12.
       # Using ``TypeAlias`` tells the type checker that this is a type alias declaration,
       # not a variable assignment to a string.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -826,11 +826,11 @@ These can be used as types in annotations and do not support ``[]``.
       # so we have to use quotes for the forward reference on Python <3.12.
       # Using `TypeAlias` tells the type checker that this is a type alias declaration,
       # not a variable assignment to a string.
-      ContainerOfInts: TypeAlias = "Container[int]"
+      BoxOfStrings: TypeAlias = "Box[str]"
 
-      class Container(Generic[T]):
+      class Box(Generic[T]):
           @classmethod
-          def make_container_of_ints(cls) -> ContainerOfInts: ...
+          def make_box_of_strings(cls) -> BoxOfStrings: ...
 
    See :pep:`613` for more details.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -824,7 +824,7 @@ These can be used as types in annotations and do not support ``[]``.
 
       # "Container" does not exist yet,
       # so we have to use quotes for the forward reference on Python <3.12.
-      # Using `TypeAlias` tells the type checker that this is a type alias declaration,
+      # Using ``TypeAlias`` tells the type checker that this is a type alias declaration,
       # not a variable assignment to a string.
       ContainerOfInts: TypeAlias = "Container[int]"
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -805,19 +805,41 @@ These can be used as types in annotations and do not support ``[]``.
 .. data:: TypeAlias
 
    Special annotation for explicitly declaring a :ref:`type alias <type-aliases>`.
+
    For example::
 
-    from typing import TypeAlias
+      from typing import TypeAlias
 
-    Factors: TypeAlias = list[int]
+      Factors: TypeAlias = list[int]
 
-   See :pep:`613` for more details about explicit type aliases.
+   ``TypeAlias`` is particularly useful on older Python versions for annotating
+   aliases that make use of forward references, as it can be hard for type
+   checkers to distinguish these from normal variable assignments:
+
+   .. testcode::
+
+      from typing import Generic, TypeAlias, TypeVar
+
+      T = TypeVar("T")
+
+      # "Container" does not exist yet,
+      # so we have to use quotes for the forward reference on Python <3.12.
+      # Using `TypeAlias` tells the type checker that this is a type alias declaration,
+      # not a variable assignment to a string.
+      ContainerOfInts: TypeAlias = "Container[int]"
+
+      class Container(Generic[T]):
+          @classmethod
+          def make_container_of_ints(cls) -> ContainerOfInts: ...
+
+   See :pep:`613` for more details.
 
    .. versionadded:: 3.10
 
    .. deprecated:: 3.12
       :data:`TypeAlias` is deprecated in favor of the :keyword:`type` statement,
-      which creates instances of :class:`TypeAliasType`.
+      which creates instances of :class:`TypeAliasType`
+      and which natively supports forward references.
       Note that while :data:`TypeAlias` and :class:`TypeAliasType` serve
       similar purposes and have similar names, they are distinct and the
       latter is not the type of the former.


### PR DESCRIPTION
The current docs for `typing.TypeAlias` are pretty bare on what the advantages are for doing this:

```py
X: TypeAlias = list[int]
```

Compared to this:

```py
X = list[int]
```

I've added a motivating example in this PR.

While `typing.TypeAlias` is now deprecated following PEP-695, I think it's still worth improving the docs here. Lots of users won't be able to use the new syntax for a while, since it can't be backported to Python <3.12, and many users will want to continue supporting older Python versions for a while to come. Moreover, the fact that `typing.TypeAliasType` (the new mechanism introduce by PEP-695) has such a similar name is pretty confusing, in my opinion. It reinforces the need for us to have good documentation for both the new and the old symbol.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105372.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->