### PR TITLE
gh-105373: Remove the PyObject_SetAttr(NULL) deprecation

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -81,9 +81,8 @@ Object Protocol
    return ``0`` on success.  This is the equivalent of the Python statement
    ``o.attr_name = v``.
 
-   If *v* is ``NULL``, the attribute is deleted. This behaviour is deprecated
-   in favour of using :c:func:`PyObject_DelAttr`, but there are currently no
-   plans to remove it.
+   Delete the attribute named *attr_name* if *v* is ``NULL``. The function
+   :c:func:`PyObject_DelAttr` is preferred to delete an attribute.
 
 
 .. c:function:: int PyObject_SetAttrString(PyObject *o, const char *attr_name, PyObject *v)
@@ -93,8 +92,8 @@ Object Protocol
    return ``0`` on success.  This is the equivalent of the Python statement
    ``o.attr_name = v``.
 
-   If *v* is ``NULL``, the attribute is deleted, but this feature is
-   deprecated in favour of using :c:func:`PyObject_DelAttrString`.
+   Delete the attribute named *attr_name* if *v* is ``NULL``. The function
+   :c:func:`PyObject_DelAttrString` is preferred to delete an attribute.
 
 
 .. c:function:: int PyObject_GenericSetAttr(PyObject *o, PyObject *name, PyObject *value)

--- a/Doc/c-api/sequence.rst
+++ b/Doc/c-api/sequence.rst
@@ -69,8 +69,8 @@ Sequence Protocol
    is the equivalent of the Python statement ``o[i] = v``.  This function *does
    not* steal a reference to *v*.
 
-   If *v* is ``NULL``, the element is deleted, but this feature is
-   deprecated in favour of using :c:func:`PySequence_DelItem`.
+   Delete the *i*\ th element if *v* is ``NULL``. The function
+   :c:func:`PySequence_DelItem` is preferred to delete an element.
 
 
 .. c:function:: int PySequence_DelItem(PyObject *o, Py_ssize_t i)
@@ -83,6 +83,9 @@ Sequence Protocol
 
    Assign the sequence object *v* to the slice in sequence object *o* from *i1* to
    *i2*.  This is the equivalent of the Python statement ``o[i1:i2] = v``.
+
+   Delete the  elements if *v* is ``NULL``. The function
+   :c:func:`PySequence_DelSlice` is preferred to delete elements.
 
 
 .. c:function:: int PySequence_DelSlice(PyObject *o, Py_ssize_t i1, Py_ssize_t i2)


### PR DESCRIPTION
Remove the deprecation on the following functions:

* PyObject_SetAttr(obj, attr_name, NULL)
* PyObject_SetAttrString(obj, attr_name, NULL)
* PySequence_SetItem(obj, i, NULL)
* PySequence_SetSlice(obj, i1, i2, NULL)

Deprecation added by commit ed82604e3f74682701afd974b93659fff044d352.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105373 -->
* Issue: gh-105373
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105374.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->