### PR TITLE
gh-105376: Remove logging.Logger.warn() method

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -275,6 +275,10 @@ is the module's name in the Python package namespace.
       .. versionchanged:: 3.8
          The *stacklevel* parameter was added.
 
+      .. versionchanged:: 3.13
+         Remove the undocumented ``warn()`` method which was an alias to the
+         :meth:`warning` method.
+
 
    .. method:: Logger.info(msg, *args, **kwargs)
 
@@ -286,10 +290,6 @@ is the module's name in the Python package namespace.
 
       Logs a message with level :const:`WARNING` on this logger. The arguments are
       interpreted as for :meth:`debug`.
-
-      .. note:: There is an obsolete method ``warn`` which is functionally
-         identical to ``warning``. As ``warn`` is deprecated, please do not use
-         it - use ``warning`` instead.
 
    .. method:: Logger.error(msg, *args, **kwargs)
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -310,6 +310,12 @@ Removed
   use ``locale.setlocale(locale.LC_ALL, "")`` instead.
   (Contributed by Victor Stinner in :gh:`104783`.)
 
+* Remove the undocumented and untested ``logging.Logger.warn()`` method,
+  deprecated since Python 3.3, which was an alias to the
+  :meth:`logging.Logger.warning` method: use the :meth:`logging.Logger.warning`
+  method instead.
+  (Contributed by Victor Stinner in :gh:`105376`.)
+
 
 Porting to Python 3.13
 ======================

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1550,11 +1550,6 @@ class Logger(Filterer):
         if self.isEnabledFor(WARNING):
             self._log(WARNING, msg, args, **kwargs)
 
-    def warn(self, msg, *args, **kwargs):
-        warnings.warn("The 'warn' method is deprecated, "
-            "use 'warning' instead", DeprecationWarning, 2)
-        self.warning(msg, *args, **kwargs)
-
     def error(self, msg, *args, **kwargs):
         """
         Log 'msg % args' with severity 'ERROR'.

--- a/Misc/NEWS.d/next/Library/2023-06-06-15-32-44.gh-issue-105376.W4oDQp.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-06-15-32-44.gh-issue-105376.W4oDQp.rst
@@ -1,0 +1,4 @@
+Remove the undocumented and untested ``logging.Logger.warn()`` method,
+deprecated since Python 3.3, which was an alias to the
+:meth:`logging.Logger.warning` method: use the :meth:`logging.Logger.warning`
+method instead. Patch by Victor Stinner.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105376 -->
* Issue: gh-105376
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105377.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->