### PR TITLE
gh-105156: Update Unicode C API: remove deprecation

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -272,24 +272,15 @@ These APIs can be used for fast direct character conversions:
 
    Return the character *ch* converted to lower case.
 
-   .. deprecated:: 3.3
-      This function uses simple case mappings.
-
 
 .. c:function:: Py_UCS4 Py_UNICODE_TOUPPER(Py_UCS4 ch)
 
    Return the character *ch* converted to upper case.
 
-   .. deprecated:: 3.3
-      This function uses simple case mappings.
-
 
 .. c:function:: Py_UCS4 Py_UNICODE_TOTITLE(Py_UCS4 ch)
 
    Return the character *ch* converted to title case.
-
-   .. deprecated:: 3.3
-      This function uses simple case mappings.
 
 
 .. c:function:: int Py_UNICODE_TODECIMAL(Py_UCS4 ch)


### PR DESCRIPTION
_PyUnicode_ToLowercase(), _PyUnicode_ToUppercase(), _PyUnicode_ToTitlecase() are no longer deprecated in the documentation. It's no longer needed since they now use Py_UCS4 type, rather than the deprecated Py_UNICODE type.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105156 -->
* Issue: gh-105156
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105379.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->