### PR TITLE
gh-104783: locale.getencoding() fallback uses FS encoding

### DIFF
--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -616,16 +616,12 @@ def setlocale(category, locale=None):
 try:
     from _locale import getencoding
 except ImportError:
+    # When _locale.getencoding() is missing, locale.getencoding() uses the
+    # Python filesystem encoding.
+    _encoding = sys.getfilesystemencoding()
     def getencoding():
-        if hasattr(sys, 'getandroidapilevel'):
-            # On Android langinfo.h and CODESET are missing, and UTF-8 is
-            # always used in mbstowcs() and wcstombs().
-            return 'utf-8'
-        encoding = _getdefaultlocale()[1]
-        if encoding is None:
-            # LANG not set, default to UTF-8
-            encoding = 'utf-8'
-        return encoding
+        return _encoding
+
 
 try:
     CODESET

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
 from test.support import verbose, is_android, is_emscripten, is_wasi
 from test.support.warnings_helper import check_warnings
+from test.support.import_helper import import_fresh_module
+from unittest import mock
 import unittest
 import locale
 import sys
@@ -522,6 +524,15 @@ class TestMiscellaneous(unittest.TestCase):
         self.assertNotEqual(enc, "")
         # make sure it is valid
         codecs.lookup(enc)
+
+    def test_getencoding_fallback(self):
+        # When _locale.getencoding() is missing, locale.getencoding() uses
+        # the Python filesystem
+        encoding = 'FALLBACK_ENCODING'
+        with mock.patch.object(sys, 'getfilesystemencoding',
+                               return_value=encoding):
+            locale_fallback = import_fresh_module('locale', blocked=['_locale'])
+            self.assertEqual(locale_fallback.getencoding(), encoding)
 
     def test_getpreferredencoding(self):
         # Invoke getpreferredencoding to make sure it does not cause exceptions.


### PR DESCRIPTION
The locale.getencoding() function now uses
sys.getfilesystemencoding() if _locale.getencoding() is missing, instead of calling locale.getdefaultlocale().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104783 -->
* Issue: gh-104783
<!-- /gh-issue-number -->
