### PR TITLE
gh-102304: Debug mode no longer supports Limited API 3.9

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1536,13 +1536,10 @@ Build Changes
   :file:`!configure`.
   (Contributed by Christian Heimes in :gh:`89886`.)
 
-* C extensions built with the :ref:`limited C API <limited-c-api>`
-  on :ref:`Python build in debug mode <debug-build>` no longer support Python
-  3.9 and older. In this configuration, :c:func:`Py_INCREF` and
-  :c:func:`Py_DECREF` are now always implemented as opaque function calls,
-  but the called functions were added to Python 3.10. Build C extensions
-  with a release build of Python or with Python 3.12 and older, to keep support
-  for Python 3.9 and older.
+* Python built in debug mode can no longer build C extensions using the
+  :ref:`limited C API <limited-c-api>` version 3.9 and older. Build C
+  extensions with a release build of Python (recommended), or with Python 3.12
+  and older.
   (Contributed by Victor Stinner in :gh:`102304`.)
 
 

--- a/Include/object.h
+++ b/Include/object.h
@@ -62,6 +62,12 @@ whose size is determined when the object is allocated.
 #  error Py_LIMITED_API is incompatible with Py_TRACE_REFS
 #endif
 
+// gh-102304: In debug mode, the limited API implements Py_INCREF() by calling
+// _Py_IncRef() which was added to Python 3.10.
+#if defined(Py_REF_DEBUG) && defined(Py_LIMITED_API) && Py_LIMITED_API+0 < 0x030a0000
+#  error "Python built in debug mode is incompatible with limited C API older than 3.10"
+#endif
+
 #ifdef Py_TRACE_REFS
 /* Define pointers to support a doubly-linked list of all live heap objects. */
 #define _PyObject_HEAD_EXTRA            \

--- a/Lib/test/test_xxlimited.py
+++ b/Lib/test/test_xxlimited.py
@@ -3,7 +3,10 @@ from test.support import import_helper
 import types
 
 xxlimited = import_helper.import_module('xxlimited')
-xxlimited_35 = import_helper.import_module('xxlimited_35')
+try:
+    import xxlimited_35
+except ImportError:
+    xxlimited_35 = None
 
 
 class CommonTests:
@@ -70,6 +73,7 @@ class TestXXLimited(CommonTests, unittest.TestCase):
         self.assertEqual(b2[0], 1)
 
 
+@unittest.skipIf(xxlimited_35 is None, 'need xxlimited_35 extension')
 class TestXXLimited35(CommonTests, unittest.TestCase):
     module = xxlimited_35
 

--- a/Misc/NEWS.d/next/C API/2023-06-06-17-15-55.gh-issue-102304.RPP7AB.rst
+++ b/Misc/NEWS.d/next/C API/2023-06-06-17-15-55.gh-issue-102304.RPP7AB.rst
@@ -1,0 +1,4 @@
+Python built in debug mode can no longer build C extensions using the
+:ref:`limited C API <limited-c-api>` version 3.9 and older. Build C
+extensions with a release build of Python (recommended), or with Python 3.12
+and older. Patch by Victor Stinner.

--- a/configure
+++ b/configure
@@ -30373,7 +30373,7 @@ printf %s "checking for stdlib extension module xxlimited_35... " >&6; }
         if test "$py_cv_module_xxlimited_35" != "n/a"
 then :
 
-    if test "$with_trace_refs" = "no"
+    if test "$with_trace_refs" = "no" -a "$Py_DEBUG" != "true"
 then :
   if test "$ac_cv_func_dlopen" = yes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -7390,7 +7390,9 @@ dnl Limited API template modules.
 dnl The limited C API is not compatible with the Py_TRACE_REFS macro.
 dnl Emscripten does not support shared libraries yet.
 PY_STDLIB_MOD([xxlimited], [test "$with_trace_refs" = "no"], [test "$ac_cv_func_dlopen" = yes])
-PY_STDLIB_MOD([xxlimited_35], [test "$with_trace_refs" = "no"], [test "$ac_cv_func_dlopen" = yes])
+dnl xxlimited_35 cannot be built with Python built in debug mode
+dnl (if the Py_REF_DEBUG macro is defined)
+PY_STDLIB_MOD([xxlimited_35], [test "$with_trace_refs" = "no" -a "$Py_DEBUG" != "true"], [test "$ac_cv_func_dlopen" = yes])
 
 # substitute multiline block, must come after last PY_STDLIB_MOD()
 AC_SUBST([MODULE_BLOCK])


### PR DESCRIPTION
Python built in debug mode can no longer build C extensions using the limited C API version 3.9 and older.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102304 -->
* Issue: gh-102304
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105391.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->