### PR TITLE
gh-105396: Deprecate PyImport_ImportModuleNoBlock() function

### DIFF
--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -38,6 +38,9 @@ Importing Modules
       to per-module locks for most purposes, so this function's special
       behaviour isn't needed anymore.
 
+   .. deprecated-removed:: 3.13 3.15
+      Use :c:func:`PyImport_ImportModule` instead.
+
 
 .. c:function:: PyObject* PyImport_ImportModuleEx(const char *name, PyObject *globals, PyObject *locals, PyObject *fromlist)
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -393,6 +393,10 @@ Deprecated
 
   (Contributed by Victor Stinner in :gh:`105145`.)
 
+* Deprecate the :c:func:`PyImport_ImportModuleNoBlock` function which is just
+  an alias to :c:func:`PyImport_ImportModule` since Python 3.3.
+  (Contributed by Victor Stinner in :gh:`105396`.)
+
 Removed
 -------
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -395,6 +395,7 @@ Deprecated
 
 * Deprecate the :c:func:`PyImport_ImportModuleNoBlock` function which is just
   an alias to :c:func:`PyImport_ImportModule` since Python 3.3.
+  Scheduled for removal in Python 3.15.
   (Contributed by Victor Stinner in :gh:`105396`.)
 
 Removed

--- a/Include/import.h
+++ b/Include/import.h
@@ -46,7 +46,7 @@ PyAPI_FUNC(PyObject *) PyImport_AddModule(
 PyAPI_FUNC(PyObject *) PyImport_ImportModule(
     const char *name            /* UTF-8 encoded string */
     );
-PyAPI_FUNC(PyObject *) PyImport_ImportModuleNoBlock(
+Py_DEPRECATED(3.13) PyAPI_FUNC(PyObject *) PyImport_ImportModuleNoBlock(
     const char *name            /* UTF-8 encoded string */
     );
 PyAPI_FUNC(PyObject *) PyImport_ImportModuleLevel(

--- a/Misc/NEWS.d/next/C API/2023-06-06-17-43-28.gh-issue-105396.FQJG5B.rst
+++ b/Misc/NEWS.d/next/C API/2023-06-06-17-43-28.gh-issue-105396.FQJG5B.rst
@@ -1,0 +1,3 @@
+Deprecate the :c:func:`PyImport_ImportModuleNoBlock` function which is just
+an alias to :c:func:`PyImport_ImportModule` since Python 3.3. Patch by
+Victor Stinner.

--- a/Python/import.c
+++ b/Python/import.c
@@ -2439,6 +2439,12 @@ PyImport_ImportModule(const char *name)
 PyObject *
 PyImport_ImportModuleNoBlock(const char *name)
 {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+        "PyImport_ImportModuleNoBlock() is deprecated and scheduled for "
+        "removal in Python 3.15. Use PyImport_ImportModule() instead.", 1))
+    {
+        return NULL;
+    }
     return PyImport_ImportModule(name);
 }
 


### PR DESCRIPTION
Deprecate the PyImport_ImportModuleNoBlock() function which is just an alias to PyImport_ImportModule() since Python 3.3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105396 -->
* Issue: gh-105396
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105397.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->