### PR TITLE
gh-105375: Improve error handling in sqlite3 collation callback

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-07-00-09-52.gh-issue-105375.Y_9D4n.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-07-00-09-52.gh-issue-105375.Y_9D4n.rst
@@ -1,0 +1,2 @@
+Fix a bug in :mod:`sqlite3` where an exception could be overwritten in the
+:meth:`collation <sqlite3.Connection.create_collation>` callback.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1868,10 +1868,12 @@ collation_callback(void *context, int text1_length, const void *text1_data,
     }
 
     string1 = PyUnicode_FromStringAndSize((const char*)text1_data, text1_length);
+    if (string1 == NULL) {
+        goto finally;
+    }
     string2 = PyUnicode_FromStringAndSize((const char*)text2_data, text2_length);
-
-    if (!string1 || !string2) {
-        goto finally; /* failed to allocate strings */
+    if (string2 == NULL) {
+        goto finally;
     }
 
     callback_context *ctx = (callback_context *)context;


### PR DESCRIPTION
Check for error after each call to PyUnicode_FromStringAndSize().


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
