### PR TITLE
[3.12] gh-104692: Include commoninstall as a prerequisite for bininstall (GH-104693)

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2014,7 +2014,11 @@ altbininstall: $(BUILDPYTHON) @FRAMEWORKPYTHONW@
 	fi
 
 .PHONY: bininstall
-bininstall: altbininstall
+# We depend on commoninstall here to make sure the installation is already usable
+# before we possibly overwrite the global 'python3' symlink to avoid causing
+# problems for anything else trying to run 'python3' while we install, particularly
+# if we're installing in parallel with -j.
+bininstall: commoninstall altbininstall
 	if test ! -d $(DESTDIR)$(LIBPC); then \
 		echo "Creating directory $(LIBPC)"; \
 		$(INSTALL) -d -m $(DIRMODE) $(DESTDIR)$(LIBPC); \

--- a/Misc/NEWS.d/next/Build/2023-05-20-23-49-30.gh-issue-104692.s5UIu5.rst
+++ b/Misc/NEWS.d/next/Build/2023-05-20-23-49-30.gh-issue-104692.s5UIu5.rst
@@ -1,0 +1,6 @@
+Include ``commoninstall`` as a prerequisite for ``bininstall``
+
+This ensures that ``commoninstall`` is completed before ``bininstall``
+is started when parallel builds are used (``make -j install``), and so
+the ``python3`` symlink is only installed after all standard library
+modules are installed.


### PR DESCRIPTION
This ensures that `commoninstall` is completed before `bininstall` is started when parallel builds are used (`make -j install`), and so the `python3` symlink is only installed after all standard library modules are installed.


(cherry picked from commit 990cb3676c2edb7e5787372d6cbe360a73367f4c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104692 -->
* Issue: gh-104692
<!-- /gh-issue-number -->
