### PR TITLE
[3.11] Improve docs for `typing.TypeAlias` (GH-105372).

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -772,13 +772,34 @@ These can be used as types in annotations and do not support ``[]``.
 .. data:: TypeAlias
 
    Special annotation for explicitly declaring a :ref:`type alias <type-aliases>`.
+
    For example::
 
-    from typing import TypeAlias
+      from typing import TypeAlias
 
-    Factors: TypeAlias = list[int]
+      Factors: TypeAlias = list[int]
 
-   See :pep:`613` for more details about explicit type aliases.
+   ``TypeAlias`` is particularly useful on older Python versions for annotating
+   aliases that make use of forward references, as it can be hard for type
+   checkers to distinguish these from normal variable assignments:
+
+   .. testcode::
+
+      from typing import Generic, TypeAlias, TypeVar
+
+      T = TypeVar("T")
+
+      # "Box" does not exist yet,
+      # so we have to use quotes for the forward reference on Python <3.12.
+      # Using ``TypeAlias`` tells the type checker that this is a type alias declaration,
+      # not a variable assignment to a string.
+      BoxOfStrings: TypeAlias = "Box[str]"
+
+      class Box(Generic[T]):
+          @classmethod
+          def make_box_of_strings(cls) -> BoxOfStrings: ...
+
+   See :pep:`613` for more details.
 
    .. versionadded:: 3.10
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -779,7 +779,7 @@ These can be used as types in annotations and do not support ``[]``.
 
       Factors: TypeAlias = list[int]
 
-   ``TypeAlias`` is particularly useful on older Python versions for annotating
+   ``TypeAlias`` is particularly useful for annotating
    aliases that make use of forward references, as it can be hard for type
    checkers to distinguish these from normal variable assignments:
 
@@ -790,7 +790,7 @@ These can be used as types in annotations and do not support ``[]``.
       T = TypeVar("T")
 
       # "Box" does not exist yet,
-      # so we have to use quotes for the forward reference on Python <3.12.
+      # so we have to use quotes for the forward reference.
       # Using ``TypeAlias`` tells the type checker that this is a type alias declaration,
       # not a variable assignment to a string.
       BoxOfStrings: TypeAlias = "Box[str]"


### PR DESCRIPTION
(cherry picked from commit c5ec51ec8f4508e1f01f6d98ac8364a13da9bec7)

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105447.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->