### PR TITLE
gh-94673: Ensure subtypes are readied only once in math.trunc()

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2067,7 +2067,7 @@ math_trunc(PyObject *module, PyObject *x)
         return PyFloat_Type.tp_as_number->nb_int(x);
     }
 
-    if (_PyType_IsReady(Py_TYPE(x))) {
+    if (!_PyType_IsReady(Py_TYPE(x))) {
         if (PyType_Ready(Py_TYPE(x)) < 0)
             return NULL;
     }


### PR DESCRIPTION
Fixes a typo in d2e2e53f733f8c8098035bbbc452bd1892796cb3.
cc: @ericsnowcurrently


<!-- gh-issue-number: gh-94673 -->
* Issue: gh-94673
<!-- /gh-issue-number -->
