### PR TITLE
gh-100227: Add Missing Locks for Specific Global Runtime State

### DIFF
--- a/Include/internal/pycore_atexit.h
+++ b/Include/internal/pycore_atexit.h
@@ -15,6 +15,7 @@ extern "C" {
 typedef void (*atexit_callbackfunc)(void);
 
 struct _atexit_runtime_state {
+    PyThread_type_lock mutex;
 #define NEXITFUNCS 32
     atexit_callbackfunc callbacks[NEXITFUNCS];
     int ncallbacks;

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -18,6 +18,7 @@ typedef struct {
 } debug_alloc_api_t;
 
 struct _pymem_allocators {
+    PyThread_type_lock mutex;
     struct {
         PyMemAllocatorEx raw;
         PyMemAllocatorEx mem;

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -143,7 +143,9 @@ typedef struct pyruntimestate {
     // is called multiple times.
     Py_OpenCodeHookFunction open_code_hook;
     void *open_code_userdata;
-    _Py_AuditHookEntry *audit_hook_head;
+    struct {
+        _Py_AuditHookEntry *head;
+    } audit_hooks;
 
     struct _py_object_runtime_state object_state;
     struct _Py_float_runtime_state float_state;

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -144,6 +144,7 @@ typedef struct pyruntimestate {
     Py_OpenCodeHookFunction open_code_hook;
     void *open_code_userdata;
     struct {
+        PyThread_type_lock mutex;
         _Py_AuditHookEntry *head;
     } audit_hooks;
 

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -25,9 +25,9 @@ extern PyTypeObject _PyExc_MemoryError;
 #define _PyRuntimeState_INIT(runtime) \
     { \
         .allocators = { \
-            _pymem_allocators_standard_INIT(runtime), \
-            _pymem_allocators_debug_INIT, \
-            _pymem_allocators_obj_arena_INIT, \
+            .standard = _pymem_allocators_standard_INIT(runtime), \
+            .debug = _pymem_allocators_debug_INIT, \
+            .obj_arena = _pymem_allocators_obj_arena_INIT, \
         }, \
         .obmalloc = _obmalloc_global_state_INIT, \
         .pyhash_state = pyhash_state_INIT, \

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -23,8 +23,8 @@ static void _PyMem_DebugCheckAddress(const char *func, char api_id, const void *
 
 static void set_up_debug_hooks_domain_unlocked(PyMemAllocatorDomain domain);
 static void set_up_debug_hooks_unlocked(void);
-void get_allocator_unlocked(PyMemAllocatorDomain, PyMemAllocatorEx *);
-void set_allocator_unlocked(PyMemAllocatorDomain, PyMemAllocatorEx *);
+static void get_allocator_unlocked(PyMemAllocatorDomain, PyMemAllocatorEx *);
+static void set_allocator_unlocked(PyMemAllocatorDomain, PyMemAllocatorEx *);
 
 
 /***************************************/
@@ -382,7 +382,7 @@ pymemallocator_eq(PyMemAllocatorEx *a, PyMemAllocatorEx *b)
 }
 
 
-const char*
+static const char*
 get_current_allocator_name_unlocked(void)
 {
     PyMemAllocatorEx malloc_alloc = MALLOC_ALLOC;
@@ -530,7 +530,7 @@ PyMem_SetupDebugHooks(void)
     PyThread_release_lock(ALLOCATORS_MUTEX);
 }
 
-void
+static void
 get_allocator_unlocked(PyMemAllocatorDomain domain, PyMemAllocatorEx *allocator)
 {
     switch(domain)
@@ -548,7 +548,7 @@ get_allocator_unlocked(PyMemAllocatorDomain domain, PyMemAllocatorEx *allocator)
     }
 }
 
-void
+static void
 set_allocator_unlocked(PyMemAllocatorDomain domain, PyMemAllocatorEx *allocator)
 {
     switch(domain)

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1,3 +1,5 @@
+/* Python's malloc wrappers (see pymem.h) */
+
 #include "Python.h"
 #include "pycore_code.h"          // stats
 #include "pycore_pystate.h"       // _PyInterpreterState_GET
@@ -15,13 +17,14 @@
 /* Defined in tracemalloc.c */
 extern void _PyMem_DumpTraceback(int fd, const void *ptr);
 
-
-/* Python's malloc wrappers (see pymem.h) */
-
 static void _PyObject_DebugDumpAddress(const void *p);
 static void _PyMem_DebugCheckAddress(const char *func, char api_id, const void *p);
 
-static void _PyMem_SetupDebugHooksDomain(PyMemAllocatorDomain domain);
+
+static void set_up_debug_hooks_domain_unlocked(PyMemAllocatorDomain domain);
+static void set_up_debug_hooks_unlocked(void);
+void get_allocator_unlocked(PyMemAllocatorDomain, PyMemAllocatorEx *);
+void set_allocator_unlocked(PyMemAllocatorDomain, PyMemAllocatorEx *);
 
 
 /***************************************/
@@ -200,6 +203,7 @@ _PyMem_ArenaFree(void *Py_UNUSED(ctx), void *ptr,
 #endif
 
 
+#define ALLOCATORS_MUTEX (_PyRuntime.allocators.mutex)
 #define _PyMem_Raw (_PyRuntime.allocators.standard.raw)
 #define _PyMem (_PyRuntime.allocators.standard.mem)
 #define _PyObject (_PyRuntime.allocators.standard.obj)
@@ -207,12 +211,16 @@ _PyMem_ArenaFree(void *Py_UNUSED(ctx), void *ptr,
 #define _PyObject_Arena (_PyRuntime.allocators.obj_arena)
 
 
+/***************************/
+/* managing the allocators */
+/***************************/
+
 static int
-pymem_set_default_allocator(PyMemAllocatorDomain domain, int debug,
-                            PyMemAllocatorEx *old_alloc)
+set_default_allocator_unlocked(PyMemAllocatorDomain domain, int debug,
+                               PyMemAllocatorEx *old_alloc)
 {
     if (old_alloc != NULL) {
-        PyMem_GetAllocator(domain, old_alloc);
+        get_allocator_unlocked(domain, old_alloc);
     }
 
 
@@ -232,24 +240,32 @@ pymem_set_default_allocator(PyMemAllocatorDomain domain, int debug,
         /* unknown domain */
         return -1;
     }
-    PyMem_SetAllocator(domain, &new_alloc);
+    set_allocator_unlocked(domain, &new_alloc);
     if (debug) {
-        _PyMem_SetupDebugHooksDomain(domain);
+        set_up_debug_hooks_domain_unlocked(domain);
     }
     return 0;
 }
 
 
+#ifdef Py_DEBUG
+static const int pydebug = 1;
+#else
+static const int pydebug = 0;
+#endif
+
 int
 _PyMem_SetDefaultAllocator(PyMemAllocatorDomain domain,
                            PyMemAllocatorEx *old_alloc)
 {
-#ifdef Py_DEBUG
-    const int debug = 1;
-#else
-    const int debug = 0;
-#endif
-    return pymem_set_default_allocator(domain, debug, old_alloc);
+    if (ALLOCATORS_MUTEX == NULL) {
+        /* The runtime must be initializing. */
+        return set_default_allocator_unlocked(domain, pydebug, old_alloc);
+    }
+    PyThread_acquire_lock(ALLOCATORS_MUTEX, WAIT_LOCK);
+    int res = set_default_allocator_unlocked(domain, pydebug, old_alloc);
+    PyThread_release_lock(ALLOCATORS_MUTEX);
+    return res;
 }
 
 
@@ -289,8 +305,8 @@ _PyMem_GetAllocatorName(const char *name, PyMemAllocatorName *allocator)
 }
 
 
-int
-_PyMem_SetupAllocators(PyMemAllocatorName allocator)
+static int
+set_up_allocators_unlocked(PyMemAllocatorName allocator)
 {
     switch (allocator) {
     case PYMEM_ALLOCATOR_NOT_SET:
@@ -298,15 +314,15 @@ _PyMem_SetupAllocators(PyMemAllocatorName allocator)
         break;
 
     case PYMEM_ALLOCATOR_DEFAULT:
-        (void)_PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, NULL);
-        (void)_PyMem_SetDefaultAllocator(PYMEM_DOMAIN_MEM, NULL);
-        (void)_PyMem_SetDefaultAllocator(PYMEM_DOMAIN_OBJ, NULL);
+        (void)set_default_allocator_unlocked(PYMEM_DOMAIN_RAW, pydebug, NULL);
+        (void)set_default_allocator_unlocked(PYMEM_DOMAIN_MEM, pydebug, NULL);
+        (void)set_default_allocator_unlocked(PYMEM_DOMAIN_OBJ, pydebug, NULL);
         break;
 
     case PYMEM_ALLOCATOR_DEBUG:
-        (void)pymem_set_default_allocator(PYMEM_DOMAIN_RAW, 1, NULL);
-        (void)pymem_set_default_allocator(PYMEM_DOMAIN_MEM, 1, NULL);
-        (void)pymem_set_default_allocator(PYMEM_DOMAIN_OBJ, 1, NULL);
+        (void)set_default_allocator_unlocked(PYMEM_DOMAIN_RAW, 1, NULL);
+        (void)set_default_allocator_unlocked(PYMEM_DOMAIN_MEM, 1, NULL);
+        (void)set_default_allocator_unlocked(PYMEM_DOMAIN_OBJ, 1, NULL);
         break;
 
 #ifdef WITH_PYMALLOC
@@ -314,14 +330,14 @@ _PyMem_SetupAllocators(PyMemAllocatorName allocator)
     case PYMEM_ALLOCATOR_PYMALLOC_DEBUG:
     {
         PyMemAllocatorEx malloc_alloc = MALLOC_ALLOC;
-        PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &malloc_alloc);
+        set_allocator_unlocked(PYMEM_DOMAIN_RAW, &malloc_alloc);
 
         PyMemAllocatorEx pymalloc = PYMALLOC_ALLOC;
-        PyMem_SetAllocator(PYMEM_DOMAIN_MEM, &pymalloc);
-        PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &pymalloc);
+        set_allocator_unlocked(PYMEM_DOMAIN_MEM, &pymalloc);
+        set_allocator_unlocked(PYMEM_DOMAIN_OBJ, &pymalloc);
 
         if (allocator == PYMEM_ALLOCATOR_PYMALLOC_DEBUG) {
-            PyMem_SetupDebugHooks();
+            set_up_debug_hooks_unlocked();
         }
         break;
     }
@@ -331,12 +347,12 @@ _PyMem_SetupAllocators(PyMemAllocatorName allocator)
     case PYMEM_ALLOCATOR_MALLOC_DEBUG:
     {
         PyMemAllocatorEx malloc_alloc = MALLOC_ALLOC;
-        PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &malloc_alloc);
-        PyMem_SetAllocator(PYMEM_DOMAIN_MEM, &malloc_alloc);
-        PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &malloc_alloc);
+        set_allocator_unlocked(PYMEM_DOMAIN_RAW, &malloc_alloc);
+        set_allocator_unlocked(PYMEM_DOMAIN_MEM, &malloc_alloc);
+        set_allocator_unlocked(PYMEM_DOMAIN_OBJ, &malloc_alloc);
 
         if (allocator == PYMEM_ALLOCATOR_MALLOC_DEBUG) {
-            PyMem_SetupDebugHooks();
+            set_up_debug_hooks_unlocked();
         }
         break;
     }
@@ -345,7 +361,17 @@ _PyMem_SetupAllocators(PyMemAllocatorName allocator)
         /* unknown allocator */
         return -1;
     }
+
     return 0;
+}
+
+int
+_PyMem_SetupAllocators(PyMemAllocatorName allocator)
+{
+    PyThread_acquire_lock(ALLOCATORS_MUTEX, WAIT_LOCK);
+    int res = set_up_allocators_unlocked(allocator);
+    PyThread_release_lock(ALLOCATORS_MUTEX);
+    return res;
 }
 
 
@@ -357,7 +383,7 @@ pymemallocator_eq(PyMemAllocatorEx *a, PyMemAllocatorEx *b)
 
 
 const char*
-_PyMem_GetCurrentAllocatorName(void)
+get_current_allocator_name_unlocked(void)
 {
     PyMemAllocatorEx malloc_alloc = MALLOC_ALLOC;
 #ifdef WITH_PYMALLOC
@@ -406,6 +432,15 @@ _PyMem_GetCurrentAllocatorName(void)
     return NULL;
 }
 
+const char*
+_PyMem_GetCurrentAllocatorName(void)
+{
+    PyThread_acquire_lock(ALLOCATORS_MUTEX, WAIT_LOCK);
+    const char *name = get_current_allocator_name_unlocked();
+    PyThread_release_lock(ALLOCATORS_MUTEX);
+    return name;
+}
+
 
 #ifdef WITH_PYMALLOC
 static int
@@ -428,7 +463,7 @@ _PyMem_PymallocEnabled(void)
 
 
 static void
-_PyMem_SetupDebugHooksDomain(PyMemAllocatorDomain domain)
+set_up_debug_hooks_domain_unlocked(PyMemAllocatorDomain domain)
 {
     PyMemAllocatorEx alloc;
 
@@ -437,53 +472,66 @@ _PyMem_SetupDebugHooksDomain(PyMemAllocatorDomain domain)
             return;
         }
 
-        PyMem_GetAllocator(PYMEM_DOMAIN_RAW, &_PyMem_Debug.raw.alloc);
+        get_allocator_unlocked(domain, &_PyMem_Debug.raw.alloc);
         alloc.ctx = &_PyMem_Debug.raw;
         alloc.malloc = _PyMem_DebugRawMalloc;
         alloc.calloc = _PyMem_DebugRawCalloc;
         alloc.realloc = _PyMem_DebugRawRealloc;
         alloc.free = _PyMem_DebugRawFree;
-        PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &alloc);
+        set_allocator_unlocked(domain, &alloc);
     }
     else if (domain == PYMEM_DOMAIN_MEM) {
         if (_PyMem.malloc == _PyMem_DebugMalloc) {
             return;
         }
 
-        PyMem_GetAllocator(PYMEM_DOMAIN_MEM, &_PyMem_Debug.mem.alloc);
+        get_allocator_unlocked(domain, &_PyMem_Debug.mem.alloc);
         alloc.ctx = &_PyMem_Debug.mem;
         alloc.malloc = _PyMem_DebugMalloc;
         alloc.calloc = _PyMem_DebugCalloc;
         alloc.realloc = _PyMem_DebugRealloc;
         alloc.free = _PyMem_DebugFree;
-        PyMem_SetAllocator(PYMEM_DOMAIN_MEM, &alloc);
+        set_allocator_unlocked(domain, &alloc);
     }
     else if (domain == PYMEM_DOMAIN_OBJ)  {
         if (_PyObject.malloc == _PyMem_DebugMalloc) {
             return;
         }
 
-        PyMem_GetAllocator(PYMEM_DOMAIN_OBJ, &_PyMem_Debug.obj.alloc);
+        get_allocator_unlocked(domain, &_PyMem_Debug.obj.alloc);
         alloc.ctx = &_PyMem_Debug.obj;
         alloc.malloc = _PyMem_DebugMalloc;
         alloc.calloc = _PyMem_DebugCalloc;
         alloc.realloc = _PyMem_DebugRealloc;
         alloc.free = _PyMem_DebugFree;
-        PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &alloc);
+        set_allocator_unlocked(domain, &alloc);
     }
 }
 
 
-void
-PyMem_SetupDebugHooks(void)
+static void
+set_up_debug_hooks_unlocked(void)
 {
-    _PyMem_SetupDebugHooksDomain(PYMEM_DOMAIN_RAW);
-    _PyMem_SetupDebugHooksDomain(PYMEM_DOMAIN_MEM);
-    _PyMem_SetupDebugHooksDomain(PYMEM_DOMAIN_OBJ);
+    set_up_debug_hooks_domain_unlocked(PYMEM_DOMAIN_RAW);
+    set_up_debug_hooks_domain_unlocked(PYMEM_DOMAIN_MEM);
+    set_up_debug_hooks_domain_unlocked(PYMEM_DOMAIN_OBJ);
 }
 
 void
-PyMem_GetAllocator(PyMemAllocatorDomain domain, PyMemAllocatorEx *allocator)
+PyMem_SetupDebugHooks(void)
+{
+    if (ALLOCATORS_MUTEX == NULL) {
+        /* The runtime must not be completely initialized yet. */
+        set_up_debug_hooks_unlocked();
+        return;
+    }
+    PyThread_acquire_lock(ALLOCATORS_MUTEX, WAIT_LOCK);
+    set_up_debug_hooks_unlocked();
+    PyThread_release_lock(ALLOCATORS_MUTEX);
+}
+
+void
+get_allocator_unlocked(PyMemAllocatorDomain domain, PyMemAllocatorEx *allocator)
 {
     switch(domain)
     {
@@ -501,7 +549,7 @@ PyMem_GetAllocator(PyMemAllocatorDomain domain, PyMemAllocatorEx *allocator)
 }
 
 void
-PyMem_SetAllocator(PyMemAllocatorDomain domain, PyMemAllocatorEx *allocator)
+set_allocator_unlocked(PyMemAllocatorDomain domain, PyMemAllocatorEx *allocator)
 {
     switch(domain)
     {
@@ -513,10 +561,75 @@ PyMem_SetAllocator(PyMemAllocatorDomain domain, PyMemAllocatorEx *allocator)
 }
 
 void
+PyMem_GetAllocator(PyMemAllocatorDomain domain, PyMemAllocatorEx *allocator)
+{
+    if (ALLOCATORS_MUTEX == NULL) {
+        /* The runtime must not be completely initialized yet. */
+        get_allocator_unlocked(domain, allocator);
+        return;
+    }
+    PyThread_acquire_lock(ALLOCATORS_MUTEX, WAIT_LOCK);
+    get_allocator_unlocked(domain, allocator);
+    PyThread_release_lock(ALLOCATORS_MUTEX);
+}
+
+void
+PyMem_SetAllocator(PyMemAllocatorDomain domain, PyMemAllocatorEx *allocator)
+{
+    if (ALLOCATORS_MUTEX == NULL) {
+        /* The runtime must not be completely initialized yet. */
+        set_allocator_unlocked(domain, allocator);
+        return;
+    }
+    PyThread_acquire_lock(ALLOCATORS_MUTEX, WAIT_LOCK);
+    set_allocator_unlocked(domain, allocator);
+    PyThread_release_lock(ALLOCATORS_MUTEX);
+}
+
+void
 PyObject_GetArenaAllocator(PyObjectArenaAllocator *allocator)
 {
+    if (ALLOCATORS_MUTEX == NULL) {
+        /* The runtime must not be completely initialized yet. */
+        *allocator = _PyObject_Arena;
+        return;
+    }
+    PyThread_acquire_lock(ALLOCATORS_MUTEX, WAIT_LOCK);
     *allocator = _PyObject_Arena;
+    PyThread_release_lock(ALLOCATORS_MUTEX);
 }
+
+void
+PyObject_SetArenaAllocator(PyObjectArenaAllocator *allocator)
+{
+    if (ALLOCATORS_MUTEX == NULL) {
+        /* The runtime must not be completely initialized yet. */
+        _PyObject_Arena = *allocator;
+        return;
+    }
+    PyThread_acquire_lock(ALLOCATORS_MUTEX, WAIT_LOCK);
+    _PyObject_Arena = *allocator;
+    PyThread_release_lock(ALLOCATORS_MUTEX);
+}
+
+
+/* Note that there is a possible, but very unlikely, race in any place
+ * below where we call one of the allocator functions.  We access two
+ * fields in each case:  "malloc", etc. and "ctx".
+ *
+ * It is unlikely that the allocator will be changed while one of those
+ * calls is happening, much less in that very narrow window.
+ * Furthermore, the likelihood of a race is drastically reduced by the
+ * fact that the allocator may not be changed after runtime init
+ * (except with a wrapper).
+ *
+ * With the above in mind, we currently don't worry about locking
+ * around these uses of the runtime-global allocators state. */
+
+
+/*************************/
+/* the "arena" allocator */
+/*************************/
 
 void *
 _PyObject_VirtualAlloc(size_t size)
@@ -530,11 +643,10 @@ _PyObject_VirtualFree(void *obj, size_t size)
     _PyObject_Arena.free(_PyObject_Arena.ctx, obj, size);
 }
 
-void
-PyObject_SetArenaAllocator(PyObjectArenaAllocator *allocator)
-{
-    _PyObject_Arena = *allocator;
-}
+
+/***********************/
+/* the "raw" allocator */
+/***********************/
 
 void *
 PyMem_RawMalloc(size_t size)
@@ -573,6 +685,10 @@ void PyMem_RawFree(void *ptr)
     _PyMem_Raw.free(_PyMem_Raw.ctx, ptr);
 }
 
+
+/***********************/
+/* the "mem" allocator */
+/***********************/
 
 void *
 PyMem_Malloc(size_t size)
@@ -616,6 +732,10 @@ PyMem_Free(void *ptr)
     _PyMem.free(_PyMem.ctx, ptr);
 }
 
+
+/***************************/
+/* pymem utility functions */
+/***************************/
 
 wchar_t*
 _PyMem_RawWcsdup(const wchar_t *str)
@@ -662,6 +782,11 @@ _PyMem_Strdup(const char *str)
     memcpy(copy, str, size);
     return copy;
 }
+
+
+/**************************/
+/* the "object" allocator */
+/**************************/
 
 void *
 PyObject_Malloc(size_t size)

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2973,24 +2973,35 @@ wait_for_thread_shutdown(PyThreadState *tstate)
 
 int Py_AtExit(void (*func)(void))
 {
-    if (_PyRuntime.atexit.ncallbacks >= NEXITFUNCS)
+    struct _atexit_runtime_state *state = &_PyRuntime.atexit;
+    PyThread_acquire_lock(state->mutex, WAIT_LOCK);
+    if (state->ncallbacks >= NEXITFUNCS) {
+        PyThread_release_lock(state->mutex);
         return -1;
-    _PyRuntime.atexit.callbacks[_PyRuntime.atexit.ncallbacks++] = func;
+    }
+    state->callbacks[state->ncallbacks++] = func;
+    PyThread_release_lock(state->mutex);
     return 0;
 }
 
 static void
 call_ll_exitfuncs(_PyRuntimeState *runtime)
 {
+    atexit_callbackfunc exitfunc;
     struct _atexit_runtime_state *state = &runtime->atexit;
+
+    PyThread_acquire_lock(state->mutex, WAIT_LOCK);
     while (state->ncallbacks > 0) {
         /* pop last function from the list */
         state->ncallbacks--;
-        atexit_callbackfunc exitfunc = state->callbacks[state->ncallbacks];
+        exitfunc = state->callbacks[state->ncallbacks];
         state->callbacks[state->ncallbacks] = NULL;
 
+        PyThread_release_lock(state->mutex);
         exitfunc();
+        PyThread_acquire_lock(state->mutex, WAIT_LOCK);
     }
+    PyThread_release_lock(state->mutex);
 
     fflush(stdout);
     fflush(stderr);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -380,7 +380,7 @@ _Py_COMP_DIAG_IGNORE_DEPR_DECLS
 static const _PyRuntimeState initial = _PyRuntimeState_INIT(_PyRuntime);
 _Py_COMP_DIAG_POP
 
-#define NUMLOCKS 5
+#define NUMLOCKS 6
 #define LOCKS_INIT(runtime) \
     { \
         &(runtime)->interpreters.mutex, \
@@ -388,6 +388,7 @@ _Py_COMP_DIAG_POP
         &(runtime)->getargs.mutex, \
         &(runtime)->unicode_state.ids.lock, \
         &(runtime)->imports.extensions.mutex, \
+        &(runtime)->atexit.mutex, \
     }
 
 static int

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -380,7 +380,7 @@ _Py_COMP_DIAG_IGNORE_DEPR_DECLS
 static const _PyRuntimeState initial = _PyRuntimeState_INIT(_PyRuntime);
 _Py_COMP_DIAG_POP
 
-#define NUMLOCKS 7
+#define NUMLOCKS 8
 #define LOCKS_INIT(runtime) \
     { \
         &(runtime)->interpreters.mutex, \
@@ -390,6 +390,7 @@ _Py_COMP_DIAG_POP
         &(runtime)->imports.extensions.mutex, \
         &(runtime)->atexit.mutex, \
         &(runtime)->audit_hooks.mutex, \
+        &(runtime)->allocators.mutex, \
     }
 
 static int

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -432,7 +432,7 @@ init_runtime(_PyRuntimeState *runtime,
 
     runtime->open_code_hook = open_code_hook;
     runtime->open_code_userdata = open_code_userdata;
-    runtime->audit_hook_head = audit_hook_head;
+    runtime->audit_hooks.head = audit_hook_head;
 
     PyPreConfig_InitPythonConfig(&runtime->preconfig);
 
@@ -458,7 +458,7 @@ _PyRuntimeState_Init(_PyRuntimeState *runtime)
        initialization and interpreter initialization. */
     void *open_code_hook = runtime->open_code_hook;
     void *open_code_userdata = runtime->open_code_userdata;
-    _Py_AuditHookEntry *audit_hook_head = runtime->audit_hook_head;
+    _Py_AuditHookEntry *audit_hook_head = runtime->audit_hooks.head;
     // bpo-42882: Preserve next_index value if Py_Initialize()/Py_Finalize()
     // is called multiple times.
     Py_ssize_t unicode_next_index = runtime->unicode_state.ids.next_index;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -381,6 +381,14 @@ static const _PyRuntimeState initial = _PyRuntimeState_INIT(_PyRuntime);
 _Py_COMP_DIAG_POP
 
 #define NUMLOCKS 5
+#define LOCKS_INIT(runtime) \
+    { \
+        &(runtime)->interpreters.mutex, \
+        &(runtime)->xidregistry.mutex, \
+        &(runtime)->getargs.mutex, \
+        &(runtime)->unicode_state.ids.lock, \
+        &(runtime)->imports.extensions.mutex, \
+    }
 
 static int
 alloc_for_runtime(PyThread_type_lock locks[NUMLOCKS])
@@ -427,13 +435,7 @@ init_runtime(_PyRuntimeState *runtime,
 
     PyPreConfig_InitPythonConfig(&runtime->preconfig);
 
-    PyThread_type_lock *lockptrs[NUMLOCKS] = {
-        &runtime->interpreters.mutex,
-        &runtime->xidregistry.mutex,
-        &runtime->getargs.mutex,
-        &runtime->unicode_state.ids.lock,
-        &runtime->imports.extensions.mutex,
-    };
+    PyThread_type_lock *lockptrs[NUMLOCKS] = LOCKS_INIT(runtime);
     for (int i = 0; i < NUMLOCKS; i++) {
         assert(locks[i] != NULL);
         *lockptrs[i] = locks[i];
@@ -512,13 +514,7 @@ _PyRuntimeState_Fini(_PyRuntimeState *runtime)
         LOCK = NULL; \
     }
 
-    PyThread_type_lock *lockptrs[NUMLOCKS] = {
-        &runtime->interpreters.mutex,
-        &runtime->xidregistry.mutex,
-        &runtime->getargs.mutex,
-        &runtime->unicode_state.ids.lock,
-        &runtime->imports.extensions.mutex,
-    };
+    PyThread_type_lock *lockptrs[NUMLOCKS] = LOCKS_INIT(runtime);
     for (int i = 0; i < NUMLOCKS; i++) {
         FREE_LOCK(*lockptrs[i]);
     }
@@ -541,13 +537,7 @@ _PyRuntimeState_ReInitThreads(_PyRuntimeState *runtime)
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
-    PyThread_type_lock *lockptrs[NUMLOCKS] = {
-        &runtime->interpreters.mutex,
-        &runtime->xidregistry.mutex,
-        &runtime->getargs.mutex,
-        &runtime->unicode_state.ids.lock,
-        &runtime->imports.extensions.mutex,
-    };
+    PyThread_type_lock *lockptrs[NUMLOCKS] = LOCKS_INIT(runtime);
     int reinit_err = 0;
     for (int i = 0; i < NUMLOCKS; i++) {
         reinit_err += _PyThread_at_fork_reinit(lockptrs[i]);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -380,7 +380,7 @@ _Py_COMP_DIAG_IGNORE_DEPR_DECLS
 static const _PyRuntimeState initial = _PyRuntimeState_INIT(_PyRuntime);
 _Py_COMP_DIAG_POP
 
-#define NUMLOCKS 6
+#define NUMLOCKS 7
 #define LOCKS_INIT(runtime) \
     { \
         &(runtime)->interpreters.mutex, \
@@ -389,6 +389,7 @@ _Py_COMP_DIAG_POP
         &(runtime)->unicode_state.ids.lock, \
         &(runtime)->imports.extensions.mutex, \
         &(runtime)->atexit.mutex, \
+        &(runtime)->audit_hooks.mutex, \
     }
 
 static int

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -168,10 +168,7 @@ should_audit(PyInterpreterState *interp)
     if (!interp) {
         return 0;
     }
-    PyThread_acquire_lock(interp->runtime->audit_hooks.mutex, WAIT_LOCK);
-    int has_global_hooks = (interp->runtime->audit_hooks.head != NULL);
-    PyThread_release_lock(interp->runtime->audit_hooks.mutex);
-    return (has_global_hooks
+    return (interp->runtime->audit_hooks.head
             || interp->audit_hooks
             || PyDTrace_AUDIT_ENABLED());
 }
@@ -227,10 +224,11 @@ sys_audit_tstate(PyThreadState *ts, const char *event,
         goto exit;
     }
 
-    /* Call global hooks */
-    PyThread_acquire_lock(is->runtime->audit_hooks.mutex, WAIT_LOCK);
+    /* Call global hooks
+     *
+     * We don't worry about any races on hooks getting added,
+     * since that would not leave is in an inconsistent state. */
     _Py_AuditHookEntry *e = is->runtime->audit_hooks.head;
-    PyThread_release_lock(is->runtime->audit_hooks.mutex);
     for (; e; e = e->next) {
         if (e->hookCFunction(event, eventArgs, e->userData) < 0) {
             goto exit;
@@ -358,14 +356,32 @@ _PySys_ClearAuditHooks(PyThreadState *ts)
     _PySys_Audit(ts, "cpython._PySys_ClearAuditHooks", NULL);
     _PyErr_Clear(ts);
 
-    PyThread_acquire_lock(runtime->audit_hooks.mutex, WAIT_LOCK);
+    /* We don't worry about the very unlikely race right here,
+     * since it's entirely benign.  Nothing else removes entries
+     * from the list and adding an entry right now would not cause
+     * any trouble. */
     _Py_AuditHookEntry *e = runtime->audit_hooks.head, *n;
     runtime->audit_hooks.head = NULL;
-    PyThread_release_lock(runtime->audit_hooks.mutex);
     while (e) {
         n = e->next;
         PyMem_RawFree(e);
         e = n;
+    }
+}
+
+static void
+add_audit_hook_entry_unlocked(_PyRuntimeState *runtime,
+                              _Py_AuditHookEntry *entry)
+{
+    if (runtime->audit_hooks.head == NULL) {
+        runtime->audit_hooks.head = entry;
+    }
+    else {
+        _Py_AuditHookEntry *last = runtime->audit_hooks.head;
+        while (last->next) {
+            last = last->next;
+        }
+        last->next = entry;
     }
 }
 
@@ -396,30 +412,27 @@ PySys_AddAuditHook(Py_AuditHookFunction hook, void *userData)
         }
     }
 
-    PyThread_acquire_lock(runtime->audit_hooks.mutex, WAIT_LOCK);
-    _Py_AuditHookEntry *e = runtime->audit_hooks.head;
-    if (!e) {
-        e = (_Py_AuditHookEntry*)PyMem_RawMalloc(sizeof(_Py_AuditHookEntry));
-        runtime->audit_hooks.head = e;
-    } else {
-        while (e->next) {
-            e = e->next;
-        }
-        e = e->next = (_Py_AuditHookEntry*)PyMem_RawMalloc(
+    _Py_AuditHookEntry *e = (_Py_AuditHookEntry*)PyMem_RawMalloc(
             sizeof(_Py_AuditHookEntry));
-    }
-    PyThread_release_lock(runtime->audit_hooks.mutex);
-
     if (!e) {
         if (tstate != NULL) {
             _PyErr_NoMemory(tstate);
         }
         return -1;
     }
-
     e->next = NULL;
     e->hookCFunction = (Py_AuditHookFunction)hook;
     e->userData = userData;
+
+    if (runtime->audit_hooks.mutex == NULL) {
+        /* The runtime must not be initailized yet. */
+        add_audit_hook_entry_unlocked(runtime, e);
+    }
+    else {
+        PyThread_acquire_lock(runtime->audit_hooks.mutex, WAIT_LOCK);
+        add_audit_hook_entry_unlocked(runtime, e);
+        PyThread_release_lock(runtime->audit_hooks.mutex);
+    }
 
     return 0;
 }


### PR DESCRIPTION
We add the locks for the global atexit state, the global list of audit hooks, and the global allocators.  The risk of a race is low in each case, but playing it safe mostly isn't a problem.  (We do avoid using the allocator lock in performance-sensitive cases where the risk of a race is very, very low.)

<!-- gh-issue-number: gh-100227 -->
* Issue: gh-100227
<!-- /gh-issue-number -->
