### PR TITLE
[3.12] GH-104996: Defer joining of `pathlib.PurePath()` arguments. (GH-104999)

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-05-26-21-24-06.gh-issue-104996.aaW78g.rst
+++ b/Misc/NEWS.d/next/Library/2023-05-26-21-24-06.gh-issue-104996.aaW78g.rst
@@ -1,0 +1,2 @@
+Improve performance of :class:`pathlib.PurePath` initialisation by
+deferring joining of paths when multiple arguments are given.


### PR DESCRIPTION
Joining of arguments is moved to `_load_parts`, which is called when a normalized path is needed.
(cherry picked from commit ffeaec7e60c88d585deacb10264ba7a96e5e52df)


Co-authored-by: Barney Gale <barney.gale@gmail.com>

<!-- gh-issue-number: gh-104996 -->
* Issue: gh-104996
<!-- /gh-issue-number -->
