### PR TITLE
gh-105333: Preserve trailing spaces on headers for signing

### DIFF
--- a/Lib/email/header.py
+++ b/Lib/email/header.py
@@ -497,6 +497,18 @@ class _ValueFormatter:
             parts[:0] = ['']
         else:
             parts.pop(0)
+
+        # It's possible that the original line ends with a single space
+        # the space would be parsed as fws, which would be removed because
+        # it is considered as an artificial "transition".
+        # Removing the trailing space won't make the message invalid, but
+        # it could affect signing process. We should keep it if we can.
+        # If the last part is empty string and we have more than 2 parts,
+        # that means we have trailing spaces. We just squash the last 3
+        # elements together as a single part
+        if len(parts) > 2 and not parts[-1]:
+           parts[-3:] = ["".join(parts[-3:])]
+
         for fws, part in zip(*[iter(parts)]*2):
             self._append_chunk(fws, part)
 

--- a/Lib/email/header.py
+++ b/Lib/email/header.py
@@ -507,7 +507,7 @@ class _ValueFormatter:
         # that means we have trailing spaces. We just squash the last 3
         # elements together as a single part
         if len(parts) > 2 and not parts[-1]:
-           parts[-3:] = ["".join(parts[-3:])]
+            parts[-3:] = ["".join(parts[-3:])]
 
         for fws, part in zip(*[iter(parts)]*2):
             self._append_chunk(fws, part)

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -5105,6 +5105,9 @@ A very long line that must get split to something other than at the
     def test_whitespace_header(self):
         self.assertEqual(Header(' ').encode(), ' ')
 
+    def test_header_with_trailing_space(self):
+        self.assertEqual(Header('Content-Type: multipart/alternative; \n boundary="--test"').encode(),
+                         'Content-Type: multipart/alternative; \n boundary="--test"')
 
 
 # Test RFC 2231 header parameters (en/de)coding

--- a/Misc/NEWS.d/next/Library/2023-06-08-01-21-49.gh-issue-105333.rC9f9H.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-08-01-21-49.gh-issue-105333.rC9f9H.rst
@@ -1,0 +1,1 @@
+Preserve trailing spaces on headers for :mod:`email` for signing


### PR DESCRIPTION
Currently when you use `email` to parse headers like:

```
Content-Type: multipart/alternative; 
 boundary="------------l1sFYP2m750zRB2cqq59goTA"
```

```python
from email.header import Header
# Notice the trailing space after ;
h = 'Content-Type: multipart/alternative; \n boundary="------------l1sFYP2m750zRB2cqq59goTA"'
print(repr(Header(h).encode()))
```

The trailing space will be removed.

```python
'Content-Type: multipart/alternative;\n boundary="------------l1sFYP2m750zRB2cqq59goTA"'
```

This won't invalidate the message, but could potentially break the signing.

A small modification is introduced to address this issue when parsing headers to preserve the trailing spaces. The impact is limited and all the tests passed.

<!-- gh-issue-number: gh-105333 -->
* Issue: gh-105333
<!-- /gh-issue-number -->
