### PR TITLE
gh-105490: Reject strings longer than 15 characters early by ipaddress.IPv4Address()

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1197,6 +1197,9 @@ class _BaseV4:
         if not ip_str:
             raise AddressValueError('Address cannot be empty')
 
+        if len(ip_str) > 15:
+            raise AddressValueError('Address cannot be more than 15 characters long')
+
         octets = ip_str.split('.')
         if len(octets) != 4:
             raise AddressValueError("Expected 4 octets in %r" % ip_str)

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -224,6 +224,17 @@ class AddressTestCase_v4(BaseTestCase, CommonTestMixin_v4):
         with self.assertAddressError("Unexpected '/' in %r", addr):
             ipaddress.IPv4Address(addr)
 
+    def test_address_length(self):
+        def assertBadLength(addr):
+            with self.assertAddressError("Address cannot be more than 15 characters long"):
+                ipaddress.IPv4Address(addr)
+
+        assertBadLength("1000000000000000")
+        assertBadLength("0x0a.0x0a.0x0a.0x0a")
+        assertBadLength("0xa.0x0a.0x0a.0x0a")
+        assertBadLength("0000.000.000.000")
+        assertBadLength("12345.67899.-54321.-98765")
+
     def test_bad_address_split(self):
         def assertBadSplit(addr):
             with self.assertAddressError("Expected 4 octets in %r", addr):
@@ -250,7 +261,7 @@ class AddressTestCase_v4(BaseTestCase, CommonTestMixin_v4):
         assertBadSplit("bogus")
         assertBadSplit("bogus.com")
         assertBadSplit("1000")
-        assertBadSplit("1000000000000000")
+        assertBadSplit("100000000000000")
         assertBadSplit("192.168.0.1.com")
 
     def test_empty_octet(self):
@@ -268,8 +279,8 @@ class AddressTestCase_v4(BaseTestCase, CommonTestMixin_v4):
             with self.assertAddressError(re.escape(msg)):
                 ipaddress.IPv4Address(addr)
 
-        assertBadOctet("0x0a.0x0a.0x0a.0x0a", "0x0a")
-        assertBadOctet("0xa.0x0a.0x0a.0x0a", "0xa")
+        assertBadOctet("0x0a.0xa.0xa.10", "0x0a")
+        assertBadOctet("0xa.0xa.0xa.0xa", "0xa")
         assertBadOctet("42.42.42.-0", "-0")
         assertBadOctet("42.42.42.+0", "+0")
         assertBadOctet("42.42.42.-42", "-42")
@@ -284,8 +295,8 @@ class AddressTestCase_v4(BaseTestCase, CommonTestMixin_v4):
             with self.assertAddressError(re.escape(msg % (octet, addr))):
                 ipaddress.IPv4Address(addr)
 
-        assertBadOctet("0000.000.000.000", "0000")
-        assertBadOctet("12345.67899.-54321.-98765", "12345")
+        assertBadOctet("0000.000.000.00", "0000")
+        assertBadOctet("1234.5.-543.-98", "1234")
 
     def test_octet_limit(self):
         def assertBadOctet(addr, octet):

--- a/Misc/NEWS.d/next/Library/2023-06-08-15-54-27.gh-issue-105490.ZZoqYA.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-08-15-54-27.gh-issue-105490.ZZoqYA.rst
@@ -1,0 +1,2 @@
+Reject strings longer than 15 characters early when parsing strings with
+ipaddress.IPv4Address


### PR DESCRIPTION
The **_ip_int_from_string()** classmethod of class **_BaseV4** now rejects `ip_str` early if it is longer than 15 characters, the maximum possible length of an IPv4 address.

<!-- gh-issue-number: gh-105490 -->
* Issue: gh-105490
<!-- /gh-issue-number -->
