### PR TITLE
[3.11] [typing docs] Don't describe `Sized` and `Hashable` as deprecated in the 3.11 docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2421,7 +2421,7 @@ Corresponding to other types in :mod:`collections.abc`
 
 .. class:: Hashable
 
-   Deprecated alias to :class:`collections.abc.Hashable`.
+   Alias to :class:`collections.abc.Hashable`.
 
 .. class:: Reversible(Iterable[T_co])
 
@@ -2433,7 +2433,7 @@ Corresponding to other types in :mod:`collections.abc`
 
 .. class:: Sized
 
-   Deprecated alias to :class:`collections.abc.Sized`.
+   Alias to :class:`collections.abc.Sized`.
 
 Asynchronous programming
 """"""""""""""""""""""""


### PR DESCRIPTION
In #105454, I accidentally backported a change to the docs for these aliases that stated that they were deprecated. But these two aliases were only deprecated in _3.12_, so the change shouldn't have been backported for these two.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105496.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->