### PR TITLE
gh-105530: Handle MIME word-encoded syntax in HTTP headers

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -234,7 +234,7 @@ def _parse_header_lines(header_lines, _class=HTTPMessage):
     to parse.
 
     """
-    hstring = hstring = b''.join(header_lines).decode('iso-8859-1')
+    hstring = b''.join(header_lines).decode('iso-8859-1')
     return email.parser.Parser(_class=_class,
                                policy=email.policy.default).parsestr(hstring)
 

--- a/Misc/NEWS.d/next/Library/2023-06-08-16-21-19.gh-issue-105530.LhDvzs.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-08-16-21-19.gh-issue-105530.LhDvzs.rst
@@ -1,0 +1,2 @@
+Use MIME word-encoded syntax (RFC 2047) for non-ISO-8859-1 characters in
+HTTP headers.


### PR DESCRIPTION
Handle MIME word-encoded syntax (RFC 2047) for non-ISO-8859-1 characters in HTTP headers, for both sendings and receiving.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105530 -->
* Issue: gh-105530
<!-- /gh-issue-number -->
