### PR TITLE
Docs fix-up: Remove references to ProcessPoolExecutor from asyncio-dev.rst

### DIFF
--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -113,10 +113,7 @@ from a different process (such as one started with
 section lists APIs that can read from pipes and watch file descriptors
 without blocking the event loop. In addition, asyncio's
 :ref:`Subprocess <asyncio-subprocess>` APIs provide a way to start a
-process and communicate with it from the event loop. Lastly, the
-aforementioned :meth:`loop.run_in_executor` method can also be used
-with a :class:`concurrent.futures.ProcessPoolExecutor` to execute
-code in a different process.
+process and communicate with it from the event loop.
 
 .. _asyncio-handle-blocking:
 
@@ -128,8 +125,8 @@ if a function performs a CPU-intensive calculation for 1 second,
 all concurrent asyncio Tasks and IO operations would be delayed
 by 1 second.
 
-An executor can be used to run a task in a different thread or even in
-a different process to avoid blocking the OS thread with the
+An executor can be used to run a task in a different thread
+to avoid blocking the OS thread with the
 event loop.  See the :meth:`loop.run_in_executor` method for more
 details.
 


### PR DESCRIPTION
ddd5f36971e2ffe20cc3f4b408425c847d168646 updated asyncio-eventloop.rst, but overlooked other references to using non-ThreadPoolExecutors with `run_in_executor()`.

Ref bpo-43234: Prohibit non-ThreadPoolExecutor in loop.set_default_executor (GH-24540)


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105543.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->