### PR TITLE
gh-102304: Fix Py_INCREF() for limited C API 3.9

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -611,8 +611,14 @@ PyAPI_FUNC(void) _Py_DecRef(PyObject *);
 static inline Py_ALWAYS_INLINE void Py_INCREF(PyObject *op)
 {
 #if defined(Py_REF_DEBUG) && defined(Py_LIMITED_API)
-    // Stable ABI for Python built in debug mode
+    // Stable ABI for Python built in debug mode. _Py_IncRef() was added to
+    // Python 3.10.0a7, use Py_IncRef() on older Python versions. Py_IncRef()
+    // accepts NULL whereas _Py_IncRef() doesn't.
+#  if Py_LIMITED_API+0 >= 0x030a00A7
     _Py_IncRef(op);
+#  else
+    Py_IncRef(op);
+#  endif
 #else
     // Non-limited C API and limited C API for Python 3.9 and older access
     // directly PyObject.ob_refcnt.
@@ -642,9 +648,15 @@ static inline Py_ALWAYS_INLINE void Py_INCREF(PyObject *op)
 #endif
 
 #if defined(Py_REF_DEBUG) && defined(Py_LIMITED_API)
-// Stable ABI for Python built in debug mode
+// Stable ABI for Python built in debug mode. _Py_DecRef() was added to Python
+// 3.10.0a7, use Py_DecRef() on older Python versions. Py_DecRef() accepts NULL
+// whereas _Py_IncRef() doesn't.
 static inline void Py_DECREF(PyObject *op) {
+#  if Py_LIMITED_API+0 >= 0x030a00A7
     _Py_DecRef(op);
+#  else
+    Py_DecRef(op);
+#  endif
 }
 #define Py_DECREF(op) Py_DECREF(_PyObject_CAST(op))
 


### PR DESCRIPTION
When Python is built in debug mode (Py_REF_DEBUG macro), Py_INCREF() and Py_DECREF() of the limited C API 3.9 (and older) now call Py_IncRef() and Py_DecRef(), since _Py_IncRef() and _Py_DecRef() were added to Python 3.10.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102304 -->
* Issue: gh-102304
<!-- /gh-issue-number -->
