### PR TITLE
gh-102304: Remove Py_INCREF() doc change

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1537,15 +1537,6 @@ Build Changes
   :file:`!configure`.
   (Contributed by Christian Heimes in :gh:`89886`.)
 
-* C extensions built with the :ref:`limited C API <limited-c-api>`
-  on :ref:`Python build in debug mode <debug-build>` no longer support Python
-  3.9 and older. In this configuration, :c:func:`Py_INCREF` and
-  :c:func:`Py_DECREF` are now always implemented as opaque function calls,
-  but the called functions were added to Python 3.10. Build C extensions
-  with a release build of Python or with Python 3.12 and older, to keep support
-  for Python 3.9 and older.
-  (Contributed by Victor Stinner in :gh:`102304`.)
-
 
 C API Changes
 =============


### PR DESCRIPTION
Py_INCREF() was made compatible again with Python 3.9 and older in the limited API of Python debug mode.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102304 -->
* Issue: gh-102304
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105552.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->