### PR TITLE
[3.11] Fix two errors in the typing docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1232,7 +1232,7 @@ These can be used as types in annotations using ``[]``, each having a unique syn
 
    * ``Annotated`` cannot be used with an unpacked :class:`TypeVarTuple`::
 
-        type Variadic[*Ts] = Annotated[*Ts, Ann1]  # NOT valid
+        Variadic: TypeAlias = Annotated[*Ts, Ann1]  # NOT valid
 
      This would be equivalent to::
 
@@ -2011,7 +2011,7 @@ These are not used in annotations. They are building blocks for declaring types.
       T = TypeVar('T')
       class XT(X, Generic[T]): pass  # raises TypeError
 
-   A ``TypedDict`` can be generic::
+   A ``TypedDict`` can be generic:
 
    .. testcode::
 


### PR DESCRIPTION
Two small errors were introduced into the 3.11 branch when backporting recent PRs improving the typing docs. These errors don't exist in the `main` branch or the 3.12 branch.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105559.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->