### PR TITLE
[3.12] gh-105375: Improve _pickle error handling (#105475)

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-08-08-58-36.gh-issue-105375.bTcqS9.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-08-08-58-36.gh-issue-105375.bTcqS9.rst
@@ -1,0 +1,1 @@
+Fix bugs in :mod:`pickle` where exceptions could be overwritten.


### PR DESCRIPTION
(cherry picked from commit 89aac6f6b7b3af046ec137121c90732289e79efc)

Error handling was deferred in some cases, which could potentially lead
to exceptions being overwritten.

Co-authored-by: Erlend E. Aasland <erlend.aasland@protonmail.com>


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
