### PR TITLE
gh-105375: Improve error handling in `zoneinfo` module

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-09-21-11-28.gh-issue-105375.4Mxn7t.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-09-21-11-28.gh-issue-105375.4Mxn7t.rst
@@ -1,0 +1,1 @@
+Improve error handling in :mod:`zoneinfo`.

--- a/Misc/NEWS.d/next/Library/2023-06-09-21-11-28.gh-issue-105375.4Mxn7t.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-09-21-11-28.gh-issue-105375.4Mxn7t.rst
@@ -1,1 +1,1 @@
-Improve error handling in :mod:`zoneinfo`.
+Fix bugs in :mod:`zoneinfo` where exceptions could be overwritten.

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -1076,10 +1076,10 @@ load_data(zoneinfo_state *state, PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
     // Load UTC offsets and isdst (size num_ttinfos)
     utcoff = PyMem_Malloc(self->num_ttinfos * sizeof(long));
     isdst = PyMem_Malloc(self->num_ttinfos * sizeof(unsigned char));
+
     if (utcoff == NULL || isdst == NULL) {
         goto error;
     }
-
     for (size_t i = 0; i < self->num_ttinfos; ++i) {
         PyObject *num = PyTuple_GetItem(utcoff_list, i);
         if (num == NULL) {

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -699,7 +699,7 @@ zoneinfo_fromutc(PyObject *obj_self, PyObject *dt)
                 return NULL;
             }
             PyObject *args = PyTuple_New(0);
-            if (replace == NULL) {
+            if (args == NULL) {
                 Py_DECREF(tmp);
                 Py_DECREF(replace);
                 return NULL;

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -693,22 +693,18 @@ zoneinfo_fromutc(PyObject *obj_self, PyObject *dt)
             dt = tmp;
         }
         else {
-            PyObject *replace;
-            PyObject *args;
-            PyObject *kwargs;
-
-            replace = PyObject_GetAttrString(tmp, "replace");
+            PyObject *replace = PyObject_GetAttrString(tmp, "replace");
             if (replace == NULL) {
                 Py_DECREF(tmp);
                 return NULL;
             }
-            args = PyTuple_New(0);
+            PyObject *args = PyTuple_New(0);
             if (replace == NULL) {
                 Py_DECREF(tmp);
                 Py_DECREF(replace);
                 return NULL;
             }
-            kwargs = PyDict_New();
+            PyObject *kwargs = PyDict_New();
             if (kwargs == NULL) {
                 Py_DECREF(tmp);
                 Py_DECREF(replace);

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -694,19 +694,17 @@ zoneinfo_fromutc(PyObject *obj_self, PyObject *dt)
         }
         else {
             PyObject *replace = PyObject_GetAttrString(tmp, "replace");
+            Py_DECREF(tmp);
             if (replace == NULL) {
-                Py_DECREF(tmp);
                 return NULL;
             }
             PyObject *args = PyTuple_New(0);
             if (args == NULL) {
-                Py_DECREF(tmp);
                 Py_DECREF(replace);
                 return NULL;
             }
             PyObject *kwargs = PyDict_New();
             if (kwargs == NULL) {
-                Py_DECREF(tmp);
                 Py_DECREF(replace);
                 Py_DECREF(args);
                 return NULL;

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -1079,11 +1079,8 @@ load_data(zoneinfo_state *state, PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
 
     // Load UTC offsets and isdst (size num_ttinfos)
     utcoff = PyMem_Malloc(self->num_ttinfos * sizeof(long));
-    if (utcoff == NULL) {
-        goto error;
-    }
     isdst = PyMem_Malloc(self->num_ttinfos * sizeof(unsigned char));
-    if (isdst == NULL) {
+    if (utcoff == NULL || isdst == NULL) {
         goto error;
     }
 


### PR DESCRIPTION
I was only able to find one more case of the problem described in the original issue.

<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
