### PR TITLE
gh-105375: Improve error handling in _elementtree

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-09-21-25-14.gh-issue-105375.95g1eI.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-09-21-25-14.gh-issue-105375.95g1eI.rst
@@ -1,0 +1,1 @@
+Fix bugs in :mod:`!_elementtree` where exceptions could be overwritten.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3262,7 +3262,7 @@ expat_start_handler(XMLParserObject* self, const XML_Char* tag_in,
             if (key == NULL) {
                 Py_DECREF(attrib);
                 Py_DECREF(tag);
-                return
+                return;
             }
             PyObject* value = PyUnicode_DecodeUTF8(attrib_in[1], strlen(attrib_in[1]), "strict");
             if (value == NULL) {

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3264,7 +3264,7 @@ expat_start_handler(XMLParserObject* self, const XML_Char* tag_in,
                 Py_DECREF(tag);
                 return
             }
-            PyObject* value = PyUnicode_DecodeUTF8(attrib_in[1], strlen(attrib_in[1]) "strict");
+            PyObject* value = PyUnicode_DecodeUTF8(attrib_in[1], strlen(attrib_in[1]), "strict");
             if (value == NULL) {
                 Py_DECREF(key);
                 Py_DECREF(attrib);

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3259,10 +3259,14 @@ expat_start_handler(XMLParserObject* self, const XML_Char* tag_in,
         }
         while (attrib_in[0] && attrib_in[1]) {
             PyObject* key = makeuniversal(self, attrib_in[0]);
-            PyObject* value = PyUnicode_DecodeUTF8(attrib_in[1], strlen(attrib_in[1]), "strict");
-            if (!key || !value) {
-                Py_XDECREF(value);
-                Py_XDECREF(key);
+            if (key == NULL) {
+                Py_DECREF(attrib);
+                Py_DECREF(tag);
+                return
+            }
+            PyObject* value = PyUnicode_DecodeUTF8(attrib_in[1], strlen(attrib_in[1]) "strict");
+            if (value == NULL) {
+                Py_DECREF(key);
                 Py_DECREF(attrib);
                 Py_DECREF(tag);
                 return;


### PR DESCRIPTION
Fix bugs where exceptions could be overwritten.


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
