### PR TITLE
gh-105375: Improve array.array exception handling

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-09-21-46-52.gh-issue-105375.yrJelV.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-09-21-46-52.gh-issue-105375.yrJelV.rst
@@ -1,0 +1,2 @@
+Fix a bug in :class:`array.array` where an exception could end up being
+overwritten.

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -767,10 +767,12 @@ array_richcompare(PyObject *v, PyObject *w, int op)
     k = 1;
     for (i = 0; i < Py_SIZE(va) && i < Py_SIZE(wa); i++) {
         vi = getarrayitem(v, i);
+        if (vi == NULL) {
+            return NULL;
+        }
         wi = getarrayitem(w, i);
-        if (vi == NULL || wi == NULL) {
-            Py_XDECREF(vi);
-            Py_XDECREF(wi);
+        if (wi == NULL) {
+            Py_DECREF(vi);
             return NULL;
         }
         k = PyObject_RichCompareBool(vi, wi, Py_EQ);


### PR DESCRIPTION
Fix a bug where 'tp_richcompare' could end up overwriting an exception.


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
