### PR TITLE
[3.12] gh-105375: Improve errnomodule error handling (#105590)

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-09-21-04-39.gh-issue-105375.bTcqS9.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-09-21-04-39.gh-issue-105375.bTcqS9.rst
@@ -1,0 +1,1 @@
+Fix bugs in :mod:`pickle` where exceptions could be overwritten.

--- a/Modules/errnomodule.c
+++ b/Modules/errnomodule.c
@@ -81,9 +81,12 @@ end:
 static int
 errno_exec(PyObject *module)
 {
-    PyObject *module_dict = PyModule_GetDict(module);
+    PyObject *module_dict = PyModule_GetDict(module);  // Borrowed ref.
+    if (module_dict == NULL) {
+        return -1;
+    }
     PyObject *error_dict = PyDict_New();
-    if (!module_dict || !error_dict) {
+    if (error_dict == NULL) {
         return -1;
     }
     if (PyDict_SetItemString(module_dict, "errorcode", error_dict) < 0) {


### PR DESCRIPTION
(cherry picked from commit eede1d2f48b4fe7f7918952d9ebeb744b58668c1)

Bail immediately if an exception is set, to prevent exceptions from
being overwritten.

Co-authored-by: Erlend E. Aasland <erlend.aasland@protonmail.com>


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
